### PR TITLE
navigator : Waypoint acceptance radius usable for all vehicle type

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/3011_jsbsim_hexarotor_x
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/3011_jsbsim_hexarotor_x
@@ -52,3 +52,5 @@ param set-default PWM_MAIN_FUNC3 103
 param set-default PWM_MAIN_FUNC4 104
 param set-default PWM_MAIN_FUNC5 105
 param set-default PWM_MAIN_FUNC6 106
+
+param set-default NAV_USE_WP_RAD 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/6011_gazebo-classic_typhoon_h480
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/6011_gazebo-classic_typhoon_h480
@@ -63,3 +63,5 @@ param set-default PWM_MAIN_FUNC9 422
 # Landing gear
 param set-default PWM_MAIN_FUNC10 400
 param set-default PWM_MAIN_FUNC11 400
+
+param set-default NAV_USE_WP_RAD 1

--- a/ROMFS/px4fmu_common/init.d/airframes/11001_hexa_cox
+++ b/ROMFS/px4fmu_common/init.d/airframes/11001_hexa_cox
@@ -44,3 +44,5 @@ param set-default CA_ROTOR4_KM -0.05
 param set-default CA_ROTOR5_PX 0.25
 param set-default CA_ROTOR5_PY -0.433
 param set-default CA_ROTOR5_PZ 0.05
+
+param set-default NAV_USE_WP_RAD 1

--- a/ROMFS/px4fmu_common/init.d/airframes/12001_octo_cox
+++ b/ROMFS/px4fmu_common/init.d/airframes/12001_octo_cox
@@ -53,3 +53,5 @@ param set-default CA_ROTOR7_KM -0.05
 param set-default CA_ROTOR7_PX -0.35
 param set-default CA_ROTOR7_PY -0.35
 param set-default CA_ROTOR7_PZ 0.05
+
+param set-default NAV_USE_WP_RAD 1

--- a/ROMFS/px4fmu_common/init.d/airframes/14001_generic_mc_with_tilt
+++ b/ROMFS/px4fmu_common/init.d/airframes/14001_generic_mc_with_tilt
@@ -32,3 +32,5 @@ param set-default CA_SV_TL0_MAXA 45
 param set-default CA_SV_TL0_MINA -45
 param set-default CA_SV_TL0_TD 90
 param set-default CA_SV_TL_COUNT 1
+
+param set-default NAV_USE_WP_RAD 1

--- a/ROMFS/px4fmu_common/init.d/airframes/6001_hexa_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/6001_hexa_x
@@ -31,3 +31,5 @@ param set-default CA_ROTOR4_PY 0.25
 param set-default CA_ROTOR5_PX -0.43
 param set-default CA_ROTOR5_PY -0.25
 param set-default CA_ROTOR5_KM -0.05
+
+param set-default NAV_USE_WP_RAD 1

--- a/ROMFS/px4fmu_common/init.d/airframes/6002_draco_r
+++ b/ROMFS/px4fmu_common/init.d/airframes/6002_draco_r
@@ -123,3 +123,5 @@ param set-default PWM_MAIN_FUNC6 106
 param set-default PWM_MAIN_TIM0 -1
 param set-default PWM_MAIN_TIM1 -1
 param set-default PWM_MAIN_TIM2 -1
+
+param set-default NAV_USE_WP_RAD 1

--- a/ROMFS/px4fmu_common/init.d/airframes/7001_hexa_+
+++ b/ROMFS/px4fmu_common/init.d/airframes/7001_hexa_+
@@ -31,3 +31,5 @@ param set-default CA_ROTOR4_PY -0.43
 param set-default CA_ROTOR5_PX -0.25
 param set-default CA_ROTOR5_PY 0.43
 param set-default CA_ROTOR5_KM -0.05
+
+param set-default NAV_USE_WP_RAD 1

--- a/ROMFS/px4fmu_common/init.d/airframes/8001_octo_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/8001_octo_x
@@ -36,3 +36,5 @@ param set-default CA_ROTOR6_PY -0.46
 param set-default CA_ROTOR7_KM -0.05
 param set-default CA_ROTOR7_PX -0.19
 param set-default CA_ROTOR7_PY 0.46
+
+param set-default NAV_USE_WP_RAD 1

--- a/ROMFS/px4fmu_common/init.d/airframes/9001_octo_+
+++ b/ROMFS/px4fmu_common/init.d/airframes/9001_octo_+
@@ -36,3 +36,5 @@ param set-default CA_ROTOR6_PY -0.5
 param set-default CA_ROTOR7_KM -0.05
 param set-default CA_ROTOR7_PX 0
 param set-default CA_ROTOR7_PY 0.5
+
+param set-default NAV_USE_WP_RAD 1

--- a/ROMFS/px4fmu_common/init.d/rc.heli_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.heli_defaults
@@ -15,3 +15,5 @@ param set-default COM_SPOOLUP_TIME 10
 
 # No need for minimum collective pitch (or airmode) to keep torque authority
 param set-default MPC_MANTHR_MIN 0
+
+param set-default NAV_USE_WP_RAD 1

--- a/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -21,3 +21,5 @@ param set-default RTL_RETURN_ALT 30
 param set-default RTL_DESCEND_ALT 10
 
 param set-default GPS_UBX_DYNMODEL 6
+
+param set-default NAV_USE_WP_RAD 1

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -332,9 +332,9 @@ MissionBlock::is_mission_item_reached_or_completed()
 
 			// We use the acceptance radius of the mission item if it has been set (not NAN)
 			// but only for multicopter.
-			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
-			    && PX4_ISFINITE(_mission_item.acceptance_radius) && _mission_item.acceptance_radius > FLT_EPSILON) {
-				acceptance_radius = _mission_item.acceptance_radius;
+			if (_navigator->use_waypoint_acceptance_radius() && PX4_ISFINITE(_mission_item.acceptance_radius)
+			    && _mission_item.acceptance_radius > FLT_EPSILON) {
+				acceptance_radius = math::max(acceptance_radius, _mission_item.acceptance_radius);
 			}
 
 			float alt_acc_rad_m = _navigator->get_altitude_acceptance_radius();

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -177,6 +177,8 @@ public:
 
 	float get_loiter_radius() { return _param_nav_loiter_rad.get(); }
 
+	bool use_waypoint_acceptance_radius() { return _param_nav_use_wp_rad.get(); }
+
 	/**
 	 * Returns the default acceptance radius defined by the parameter
 	 */
@@ -405,6 +407,7 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::NAV_LOITER_RAD>)   _param_nav_loiter_rad,	/**< loiter radius for fixedwing */
 		(ParamFloat<px4::params::NAV_ACC_RAD>)      _param_nav_acc_rad,		/**< acceptance for takeoff */
+		(ParamInt<px4::params::NAV_USE_WP_RAD>)     _param_nav_use_wp_rad,	/**< use waypoint acceptance radius */
 		(ParamFloat<px4::params::NAV_FW_ALT_RAD>)   _param_nav_fw_alt_rad,	/**< acceptance rad for fixedwing alt */
 		(ParamFloat<px4::params::NAV_FW_ALTL_RAD>)
 		_param_nav_fw_altl_rad,	/**< acceptance rad for fixedwing alt before landing*/

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -57,7 +57,7 @@ PARAM_DEFINE_FLOAT(NAV_LOITER_RAD, 80.0f);
 /**
  * Acceptance Radius
  *
- * Default acceptance radius, overridden by acceptance radius of waypoint if set.
+ * Default acceptance radius, can be overridden by acceptance radius of waypoint if NAV_USE_WP_ACC_RAD is enabled.
  * For fixed wing the npfg switch distance is used for horizontal acceptance.
  *
  * @unit m
@@ -68,6 +68,16 @@ PARAM_DEFINE_FLOAT(NAV_LOITER_RAD, 80.0f);
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(NAV_ACC_RAD, 10.0f);
+
+/**
+ * Use Waypoint Acceptance Radius
+ *
+ * Use the waypoint acceptance radius if it is bigger than the default acceptance radius defined by NAV_ACC_RAD.
+ *
+ * @boolean
+ * @group Mission
+ */
+PARAM_DEFINE_INT32(NAV_USE_WP_RAD, 0);
 
 /**
  * FW Altitude Acceptance Radius


### PR DESCRIPTION
### Solved Problem
I wanted to make it possible to use the acceptance radius defined by a waypoint for the new ackermann module, and found that there was a condition in navigator module allowing it only for rotary wing vehicles.

### Solution
- Add a new parameter NAV_USE_WP_RAD
- if parameter NAV_USE_WP_RAD is enabled, use the max between waypoint acceptance radius and NAV_ACC_RAD (NAV_ACC_RAD acting as the minimal acceptance radius usable)
- NAV_USE_WP_RAD disabled by default, and enabled in airframes of rotary wing vehicles to make it works as before.

### Changelog Entry
For release notes:
```
New parameter: NAV_USE_WP_RAD
```

### Test coverage
- SITL with x500 with NAV_USE_WP_RAD enabled and disabled

