### PR TITLE
gz: Fix endless wait for gazebo on different worlds

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -154,7 +154,7 @@ int GZBridge::init()
 				return PX4_ERROR;
 			}
 
-			std::string scene_info_service = "/world/default/scene/info";
+			std::string scene_info_service = "/world/" + _world_name + "/scene/info";
 			bool scene_created = false;
 
 			while (scene_created == false) {


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When launching a world in gazebo ignition different from 'default', PX4 does not start up, instead waiting forever for GZ to become available.

This is due to a missing string substitution in https://github.com/PX4/PX4-Autopilot/blob/ebbb880e925628fbf9357a7c5f06cc3982d3f3d6/src/modules/simulation/gz_bridge/GZBridge.cpp#L157

Fixes #23612 

### Solution
- Add the missing world string substitution

### Changelog Entry
For release notes: 
```
Bugfix: Worlds different from 'default' are now correctly working with GZ again
```

### Context
See issue #23612 
