### PR TITLE
f7: reduce LOGGER_BUF to 40 if UAVCAN is enabled

### DIFF
--- a/platforms/nuttx/init/stm32f7/rc.board_arch_defaults
+++ b/platforms/nuttx/init/stm32f7/rc.board_arch_defaults
@@ -13,4 +13,4 @@ param set-default -s MC_AT_EN 1
 
 param set-default -s UAVCAN_ENABLE 2
 
-set LOGGER_BUF 64
+set LOGGER_BUF 40


### PR DESCRIPTION
### Solved Problem
With current main, VTOLs with UACAN enabled use close to maximum of the RAM  (around 97%) on F7 (tested on v5x).

### Solution
Reduce the `LOGGER_BUF` if UAVCAN is enabled, similar to what is already done [here](https://github.com/PX4/PX4-Autopilot/blob/f32f821f0220d4c8c4391534fc71594bb454e239/platforms/nuttx/init/s32k1xx/rc.board_arch_defaults#L8). I for now reduce the logger buffer by 24, which is close to 5% RAM reduction on the F7 and pushes my specific setup below the 95% RAM limit (v5x, VTOL, UAVCAN enabled, 3 mavlink instances). 

### Changelog Entry
For release notes:
```
Improvement: f7: reduce LOGGER_BUF to 40 if UAVCAN is enabled
```

### Alternatives
Save RAM in other areas, especially in the UAVCAN driver.
