### PR TITLE
Fix spelling of airflow sensor msg comments

### DIFF
--- a/msg/SensorAirflow.msg
+++ b/msg/SensorAirflow.msg
@@ -1,5 +1,5 @@
 uint64 timestamp		# time since system start (microseconds)
 uint32 device_id                # unique device ID for the sensor that does not change between power cycles
 float32 speed			# the speed being reported by the wind / airflow sensor
-float32 direction		# the direction bein report by the wind / airflow sensor
+float32 direction		# the direction being reported by the wind / airflow sensor
 uint8 status			# Status code from the sensor


### PR DESCRIPTION
### Solved Problem
I found there was a smell typo in the airsim px4 msgs. This just makes a small spelling fix.

### Solution
- Fix typo in SensorAirflow message