### PR TITLE
valid git tags needs format vx.y.z

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ include(px4_parse_function_args)
 include(px4_git)
 
 execute_process(
-	COMMAND git describe --exclude ext/* --match v[0-9]*.[0-9]*.[0-9]* --abbrev=0 --tags
+	COMMAND git describe --exclude ext/* --match v[0-9]*.[0-9]*.[0-9]* --tags
 	OUTPUT_VARIABLE PX4_GIT_TAG
 	OUTPUT_STRIP_TRAILING_WHITESPACE
 	RESULTS_VARIABLE GIT_DESCRIBE_RESULT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ include(px4_parse_function_args)
 include(px4_git)
 
 execute_process(
-	COMMAND git describe --exclude ext/* --tags --match "v[0-9]*"
+	COMMAND git describe --exclude ext/* --match v[0-9]*.[0-9]*.[0-9]* --abbrev=0 --tags
 	OUTPUT_VARIABLE PX4_GIT_TAG
 	OUTPUT_STRIP_TRAILING_WHITESPACE
 	RESULTS_VARIABLE GIT_DESCRIBE_RESULT

--- a/Tools/px4.py
+++ b/Tools/px4.py
@@ -65,7 +65,7 @@ def get_version():
 
     if os.path.isdir(os.path.join(px4_dir, '.git')):
         # If inside a clone PX4 Firmware repository, get version from "git describe"
-        cmd = 'git describe --exclude ext/* --abbrev=0 --tags'
+        cmd = 'git describe --exclude ext/* --match v[0-9]*.[0-9]*.[0-9]* --abbrev=0 --tags'
         try:
             version = subprocess.check_output(
                 cmd, cwd=px4_dir, shell=True).decode().strip()

--- a/src/lib/version/px_update_git_header.py
+++ b/src/lib/version/px_update_git_header.py
@@ -40,7 +40,7 @@ header = """
 if args.git_tag:
     git_tag = args.git_tag
 else:
-    git_describe_cmd = 'git describe --exclude ext/* --always --tags --dirty'
+    git_describe_cmd = 'git describe --exclude ext/* --match v[0-9]*.[0-9]*.[0-9]* --abbrev=0 --tags'
     git_tag = subprocess.check_output(git_describe_cmd.split(),
                                   stderr=subprocess.STDOUT).decode('utf-8').strip()
 

--- a/src/lib/version/px_update_git_header.py
+++ b/src/lib/version/px_update_git_header.py
@@ -40,7 +40,7 @@ header = """
 if args.git_tag:
     git_tag = args.git_tag
 else:
-    git_describe_cmd = 'git describe --exclude ext/* --match v[0-9]*.[0-9]*.[0-9]* --tags'
+    git_describe_cmd = 'git describe --exclude ext/* --match v[0-9]*.[0-9]*.[0-9]* --tags --dirty'
     git_tag = subprocess.check_output(git_describe_cmd.split(),
                                   stderr=subprocess.STDOUT).decode('utf-8').strip()
 

--- a/src/lib/version/px_update_git_header.py
+++ b/src/lib/version/px_update_git_header.py
@@ -40,7 +40,7 @@ header = """
 if args.git_tag:
     git_tag = args.git_tag
 else:
-    git_describe_cmd = 'git describe --exclude ext/* --match v[0-9]*.[0-9]*.[0-9]* --abbrev=0 --tags'
+    git_describe_cmd = 'git describe --exclude ext/* --match v[0-9]*.[0-9]*.[0-9]* --tags'
     git_tag = subprocess.check_output(git_describe_cmd.split(),
                                   stderr=subprocess.STDOUT).decode('utf-8').strip()
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When someone wants to make a tag for internal purposes other than a release, it can still mess up the building process as part of the building process uses git describe to search for a valid tag. Also synchronizes the search for the valid_tag between different scripts.

### Solution
- Make sure that a tag must start with vX.Y.Z where X Y Z are numbers

### Alternatives
Due to how globbing works we cannot guarantee that X.Y.Z are numbers, so far it only checks if it starts with a number. A regex would be better but is not directly supported by the command.

### Context
Related links, screenshot before/after, video
