### PR TITLE
MPC: LAND: adapt land logic to consider emergency braking, and vehicle velocity

### DIFF
--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -54,15 +54,21 @@ Land::on_activation()
 	_navigator->get_mission_result()->finished = false;
 	_navigator->set_mission_result_updated();
 	reset_mission_item_reached();
-
 	/* convert mission item to current setpoint */
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
 
 	if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
-		_navigator->calculate_breaking_stop(_mission_item.lat, _mission_item.lon);
+		// set the lat and lon to NAN, as the target setpoint for landing is handeled in FlightTaskAuto, not in the navigator
+		pos_sp_triplet->current.lat = NAN;
+		pos_sp_triplet->current.lon = NAN;
+		pos_sp_triplet->previous.lat = NAN;
+		pos_sp_triplet->previous.lon = NAN;
+		pos_sp_triplet->next.lat = NAN;
+		pos_sp_triplet->next.lon = NAN;
 	}
 
-	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+
 	pos_sp_triplet->previous.valid = false;
 	pos_sp_triplet->next.valid = false;
 


### PR DESCRIPTION


### Solved Problem
![image](https://github.com/user-attachments/assets/53c3d369-0eb0-4fa2-b05b-d5ef18549eaf)
The https://github.com/PX4/PX4-Autopilot/pull/23546 did not consider the case when we trigger land from Altitude or Manual FlightTask, where the comanded velocity can greatly exceed the velocity possible in FlightTaskAuto.
For such cases FlightTaskAuto has the emergency braking feature.

This PR moves the landing setpoint logic from navigator back to FlightTaskAuto, and is able to adjust the setpoint depending on if EmergencyBraking is active or not.
When ... I found that ...
#### Downsides
While emergency braking, im forcing the Position of `_position_smoothing` to be the current vehicle position, meaning we are unable to compensate wind. is probably a conercase as wind compensation while emergency braking is not the most important aspect. and emergency braking only triggers above 15 m/s (54 km/h) with default settings.


### Changelog Entry

### Alternatives
We could also create FlightTaskLand, to take all landing related tasks out of FlightTaskAuto

### Test coverage
-  Tested in SITL

### Context
![image](https://github.com/user-attachments/assets/2609a9c0-daff-4d28-96fe-b1044872b944)
