### PR TITLE
ekf2 : Minimum required gps fix type parameter

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_checks.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_checks.cpp
@@ -88,7 +88,7 @@ bool Ekf::runGnssChecks(const gnssSample &gps)
 	_gps_check_fail_status.flags.spoofed = gps.spoofed;
 
 	// Check the fix type
-	_gps_check_fail_status.flags.fix = (gps.fix_type < 3);
+	_gps_check_fail_status.flags.fix = ((int32_t)(gps.fix_type) < _params.req_fix);
 
 	// Check the number of satellites
 	_gps_check_fail_status.flags.nsats = (gps.nsats < _params.req_nsats);

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -334,6 +334,7 @@ struct parameters {
 	// these parameters control the strictness of GPS quality checks used to determine if the GPS is
 	// good enough to set a local origin and commence aiding
 	int32_t gps_check_mask{21};             ///< bitmask used to control which GPS quality checks are used
+	int32_t req_fix{3};                     ///< maximum acceptable horizontal position error (m)
 	float req_hacc{5.0f};                   ///< maximum acceptable horizontal position error (m)
 	float req_vacc{8.0f};                   ///< maximum acceptable vertical position error (m)
 	float req_sacc{1.0f};                   ///< maximum acceptable speed error (m/s)

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -88,6 +88,7 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_gps_p_gate(_params->gps_pos_innov_gate),
 	_param_ekf2_gps_v_gate(_params->gps_vel_innov_gate),
 	_param_ekf2_gps_check(_params->gps_check_mask),
+	_param_ekf2_req_fix(_params->req_fix),
 	_param_ekf2_req_eph(_params->req_hacc),
 	_param_ekf2_req_epv(_params->req_vacc),
 	_param_ekf2_req_sacc(_params->req_sacc),

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -526,6 +526,7 @@ private:
 		(ParamExtFloat<px4::params::EKF2_GPS_V_GATE>) _param_ekf2_gps_v_gate,
 
 		(ParamExtInt<px4::params::EKF2_GPS_CHECK>) _param_ekf2_gps_check,
+		(ParamExtInt<px4::params::EKF2_REQ_FIX>)      _param_ekf2_req_fix,
 		(ParamExtFloat<px4::params::EKF2_REQ_EPH>)    _param_ekf2_req_eph,
 		(ParamExtFloat<px4::params::EKF2_REQ_EPV>)    _param_ekf2_req_epv,
 		(ParamExtFloat<px4::params::EKF2_REQ_SACC>)   _param_ekf2_req_sacc,

--- a/src/modules/ekf2/params_gnss.yaml
+++ b/src/modules/ekf2/params_gnss.yaml
@@ -109,6 +109,21 @@ parameters:
       default: 1023
       min: 0
       max: 1023
+    EKF2_REQ_FIX:
+      description:
+        short: Required fix to use GPS
+      type: int32
+      default: 3
+      min: 1
+      max: 8
+      values:
+        1: Fix type None
+        2: Fix type 2D
+        3: Fix type 3D
+        4: Fix type RTCM Code Differential
+        5: Fix type RTK Float
+        6: Fix type RTK Fixed
+        8: Fix type Extrapolated
     EKF2_REQ_EPH:
       description:
         short: Required EPH to use GPS


### PR DESCRIPTION
### Solved Problem
The minimum required fix type for gps was hardcoded as 3, and couldn't be set for a rtk value.

### Solution
- Add a new parameter **EKF2_REQ_FIX** used to set the minimum required fix for the gps
- If the gps fix is under EKF2_REQ_FIX then activate fail status flag
- Default value set to 3 to work as before

### Changelog Entry
For release notes:
```
New parameter: EKF2_REQ_FIX
```

### Test coverage
- SITL test with a fix under EKF2_REQ_FIX -> unable to arm
- SITL test with a fix under EKF2_REQ_FIX after starting mission -> activate failsafe
(Modified SensorGpsSim.cpp to change the fix type)
