### PR TITLE
differential: reset controllers and setpoints on disarm

### DIFF
--- a/src/modules/rover_differential/RoverDifferential.cpp
+++ b/src/modules/rover_differential/RoverDifferential.cpp
@@ -115,6 +115,10 @@ void RoverDifferential::Run()
 		break;
 	}
 
+	if (!_armed) { // Reset on disarm
+		_rover_differential_control.resetControllers();
+	}
+
 	_rover_differential_control.computeMotorCommands(_vehicle_yaw, _vehicle_yaw_rate, _vehicle_forward_speed);
 
 }
@@ -132,6 +136,7 @@ void RoverDifferential::updateSubscriptions()
 		vehicle_status_s vehicle_status{};
 		_vehicle_status_sub.copy(&vehicle_status);
 		_nav_state = vehicle_status.nav_state;
+		_armed = vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED;
 	}
 
 	if (_vehicle_angular_velocity_sub.updated()) {

--- a/src/modules/rover_differential/RoverDifferential.hpp
+++ b/src/modules/rover_differential/RoverDifferential.hpp
@@ -111,6 +111,7 @@ private:
 	float _vehicle_yaw{0.f};
 	float _max_yaw_rate{0.f};
 	int _nav_state{0};
+	bool _armed{false};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::RD_MAN_YAW_SCALE>) _param_rd_man_yaw_scale,

--- a/src/modules/rover_differential/RoverDifferentialControl/RoverDifferentialControl.cpp
+++ b/src/modules/rover_differential/RoverDifferentialControl/RoverDifferentialControl.cpp
@@ -174,3 +174,10 @@ matrix::Vector2f RoverDifferentialControl::computeInverseKinematics(float forwar
 	return Vector2f(forward_speed_normalized - speed_diff_normalized,
 			forward_speed_normalized + speed_diff_normalized);
 }
+
+void RoverDifferentialControl::resetControllers()
+{
+	pid_reset_integral(&_pid_throttle);
+	pid_reset_integral(&_pid_yaw_rate);
+	pid_reset_integral(&_pid_yaw);
+}

--- a/src/modules/rover_differential/RoverDifferentialControl/RoverDifferentialControl.hpp
+++ b/src/modules/rover_differential/RoverDifferentialControl/RoverDifferentialControl.hpp
@@ -72,6 +72,11 @@ public:
 	 */
 	void computeMotorCommands(float vehicle_yaw, float vehicle_yaw_rate, float vehicle_forward_speed);
 
+	/**
+	 * @brief Reset PID controllers
+	 */
+	void resetControllers();
+
 protected:
 	/**
 	 * @brief Update the parameters of the module.


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This PR adds a way for the differential rover module to handle disarm.
If the vehicle is disarmed it will reset the integrators of all PID controllers and publish zero setpoints for foward speed and steering. This ensures that all motor commands are set to zero before arming again, removing any undefined behaviour caused by "residual" setpoints or integrators.

### Test Coverage
Tested in SITL and with hardware.