### PR TITLE
fix(ftp): List empty directory

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -399,17 +399,11 @@ MavlinkFTP::_workList(PayloadHeader *payload)
 				payload->data[offset++] = kDirentSkip;
 				*((char *)&payload->data[offset]) = '\0';
 				offset++;
-				payload->size = offset;
-				closedir(dp);
+				errorCode = kErrFailErrno;
 
-				return errorCode;
-			}
-
-			// FIXME: does this ever happen? I would assume readdir always sets errno.
-			// no more entries?
-			if (payload->offset != 0 && offset == 0) {
+			} else if (offset == 0) {
 				// User is requesting subsequent dir entries but there were none. This means the user asked
-				// to seek past EOF.
+				// to seek past EOF. This can happen with `payload->offset == 0` if the directory is empty.
 				errorCode = kErrEOF;
 			}
 


### PR DESCRIPTION
### Solved Problem

When trying to list an empty directory, I found that the mavlink ftp implementation does not return EOF.


### Solution
`payload->offset == 0` should be checked as well for EOF.
This also changes the behavior to return `kErrFailErrno` when retrieving a dir entry fails, instead of failing silently (while removing duplicated `payload->size` and `closedir` logic).

### Changelog Entry
For release notes:
```
Bugfix mavlink ftp not returning EOF on empty directory list.
```

