### PR TITLE
Commander: fix wrong ack reporting for VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1512,6 +1512,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 	case vehicle_command_s::VEHICLE_CMD_REQUEST_MESSAGE:
 	case vehicle_command_s::VEHICLE_CMD_DO_WINCH:
 	case vehicle_command_s::VEHICLE_CMD_DO_GRIPPER:
+	case vehicle_command_s::VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE:
 		/* ignore commands that are handled by other parts of the system */
 		break;
 


### PR DESCRIPTION

### Solved Problem
![image](https://github.com/user-attachments/assets/20dbcf9c-7d25-434d-9483-e182e9365bb3)
One ack from Commander (with VEHICLE_CMD_RESULT_UNSUPPORTED), and then one from EKF2 (with VEHICLE_CMD_RESULT_ACCEPTED). Gives you a warning in the GCS.

### Solution
Add VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE to the list of commands that is not handled by Commander.

### Changelog Entry
For release notes:
```
Bugfix: Commander: fix wrong ack reporting for VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE
```


