### PR TITLE
MAV_CMD_SET_MESSAGE_INTERVAL reject non-zero values for unused params

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -593,7 +593,7 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 		result = handle_request_message_command(MAVLINK_MSG_ID_STORAGE_INFORMATION);
 
 	} else if (cmd_mavlink.command == MAV_CMD_SET_MESSAGE_INTERVAL) {
-		if (set_message_interval((int)roundf(cmd_mavlink.param1), cmd_mavlink.param2, 0, cmd_mavlink.param3, cmd_mavlink.param4,
+		if (set_message_interval((int)roundf(cmd_mavlink.param1), cmd_mavlink.param2, cmd_mavlink.param3, cmd_mavlink.param4,
 					 (int)roundf(vehicle_command.param5), (int)roundf(vehicle_command.param6), (int)roundf(vehicle_command.param7))) {
 			result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_FAILED;
 		}
@@ -2274,8 +2274,8 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 }
 
 int
-MavlinkReceiver::set_message_interval(int msgId, float interval, int data_rate, float param3, float param4, int param5,
-				      int param6, int response_target)
+MavlinkReceiver::set_message_interval(int msgId, float interval, float param3, float param4, int param5, int param6,
+				      int response_target)
 {
 	if (msgId == MAVLINK_MSG_ID_HEARTBEAT) {
 		return PX4_ERROR;
@@ -2284,10 +2284,6 @@ MavlinkReceiver::set_message_interval(int msgId, float interval, int data_rate, 
 	if ((int)roundf(param3) || (int)roundf(param4) || param5 || param6 || response_target) {
 		// At least one of the unsupported params is non-zero
 		return PX4_ERROR;
-	}
-
-	if (data_rate > 0) {
-		_mavlink.set_data_rate(data_rate);
 	}
 
 	// configure_stream wants a rate (msgs/second), so convert here.

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -593,7 +593,8 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 		result = handle_request_message_command(MAVLINK_MSG_ID_STORAGE_INFORMATION);
 
 	} else if (cmd_mavlink.command == MAV_CMD_SET_MESSAGE_INTERVAL) {
-		if (set_message_interval((int)roundf(cmd_mavlink.param1), cmd_mavlink.param2, cmd_mavlink.param3)) {
+		if (set_message_interval((int)roundf(cmd_mavlink.param1), cmd_mavlink.param2, 0, cmd_mavlink.param3, cmd_mavlink.param4,
+					 (int)roundf(vehicle_command.param5), (int)roundf(vehicle_command.param6), (int)roundf(vehicle_command.param7))) {
 			result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_FAILED;
 		}
 
@@ -2273,9 +2274,15 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 }
 
 int
-MavlinkReceiver::set_message_interval(int msgId, float interval, int data_rate)
+MavlinkReceiver::set_message_interval(int msgId, float interval, int data_rate, float param3, float param4, int param5,
+				      int param6, int response_target)
 {
 	if (msgId == MAVLINK_MSG_ID_HEARTBEAT) {
+		return PX4_ERROR;
+	}
+
+	if ((int)roundf(param3) || (int)roundf(param4) || param5 || param6 || response_target) {
+		// At least one of the unsupported params is non-zero
 		return PX4_ERROR;
 	}
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -593,13 +593,13 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 		result = handle_request_message_command(MAVLINK_MSG_ID_STORAGE_INFORMATION);
 
 	} else if (cmd_mavlink.command == MAV_CMD_SET_MESSAGE_INTERVAL) {
-		if (set_message_interval((int)roundf(cmd_mavlink.param1), cmd_mavlink.param2, cmd_mavlink.param3, cmd_mavlink.param4,
-					 (int)roundf(vehicle_command.param5), (int)roundf(vehicle_command.param6), (int)roundf(vehicle_command.param7))) {
+		if (set_message_interval((int)(cmd_mavlink.param1 + 0.5f), cmd_mavlink.param2, cmd_mavlink.param3, cmd_mavlink.param4,
+					 (int)(vehicle_command.param5 + 0.5), (int)(vehicle_command.param6 + 0.5), (int)(vehicle_command.param7 + 0.5f))) {
 			result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_FAILED;
 		}
 
 	} else if (cmd_mavlink.command == MAV_CMD_GET_MESSAGE_INTERVAL) {
-		get_message_interval((int)roundf(cmd_mavlink.param1));
+		get_message_interval((int)(cmd_mavlink.param1 + 0.5f));
 
 	} else if (cmd_mavlink.command == MAV_CMD_REQUEST_MESSAGE) {
 
@@ -2281,7 +2281,7 @@ MavlinkReceiver::set_message_interval(int msgId, float interval, float param3, f
 		return PX4_ERROR;
 	}
 
-	if ((int)roundf(param3) || (int)roundf(param4) || param5 || param6 || response_target) {
+	if ((int)(param3 + 0.5f) || (int)(param4 + 0.5f) || param5 || param6 || response_target) {
 		// At least one of the unsupported params is non-zero
 		return PX4_ERROR;
 	}

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -234,7 +234,8 @@ private:
 	 *
 	 * @return PX4_OK on success, PX4_ERROR on fail.
 	 */
-	int set_message_interval(int msgId, float interval, int data_rate = -1);
+	int set_message_interval(int msgId, float interval, int data_rate = -1, float param3 = 0.0f, float param4 = 0.0f,
+				 int param5 = 0, int param6 = 0, int response_target = 0);
 	void get_message_interval(int msgId);
 
 	bool evaluate_target_ok(int command, int target_system, int target_component);

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -230,12 +230,11 @@ private:
 	 *
 	 * @param msgId The ID of the message interval to be set.
 	 * @param interval The interval in usec to send the message.
-	 * @param data_rate The total link data rate in bytes per second.
 	 *
 	 * @return PX4_OK on success, PX4_ERROR on fail.
 	 */
-	int set_message_interval(int msgId, float interval, int data_rate = -1, float param3 = 0.0f, float param4 = 0.0f,
-				 int param5 = 0, int param6 = 0, int response_target = 0);
+	int set_message_interval(int msgId, float interval, float param3 = 0.0f, float param4 = 0.0f, int param5 = 0,
+				 int param6 = 0, int response_target = 0);
 	void get_message_interval(int msgId);
 
 	bool evaluate_target_ok(int command, int target_system, int target_component);


### PR DESCRIPTION
MAVLink recently added additional params to allow specific instances of messages to be streamed with [MAV_CMD_SET_MESSAGE_INTERVAL](https://mavlink.io/en/messages/common.html#MAV_CMD_SET_MESSAGE_INTERVAL) following the same pattern as [MAV_CMD_REQUEST_MESSAGE](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE) in https://github.com/mavlink/mavlink/pull/2148

Specifically, this allows us to tell as specific camera attached to a flight stack that we want it to stream, but it can be used for any purpose.

This updates PX4 to reject the command if it has non-zero values for unused parameters.

A couple of notes:
1. Param 3 was being used to set overall data rates if the value was `> 0`. This is non-compliant with the spec and not documented anywhere (not even sure how it would work). If this is needed then MAVLink needs to be updated. I have removed this from being set from param3.
   @julianoes This is a concern. Do we need to try make this data_rate thing actually be in MAVLink? Any thoughts on how to check if it is used?
2. param7, response_target is supposed to set where the response is returned. `0` means "do whatever you like". If any other value is set, this now returns 0.
3. param 3, 4, 5, 6 all return error of denied if the params are non-zero. So at least a recipient knows that these are not supported. We can fix up if we do want to allow specific cases to return ids.


@julianoes No urgency. Added you as a reviewer because you know my C++ is weak and will look at this properly.
