### PR TITLE
Commander: Rover failsafe and hold without gps

### DIFF
--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -92,12 +92,14 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION, flags.mode_req_wind_and_flight_time_compliance);
 
 	// NAVIGATION_STATE_AUTO_LOITER
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_angular_velocity);
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_attitude);
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_local_position);
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_global_position);
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_local_alt);
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_wind_and_flight_time_compliance);
+	if (vehicle_type != vehicle_status_s::VEHICLE_TYPE_ROVER) {
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_angular_velocity);
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_attitude);
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_local_position);
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_global_position);
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_local_alt);
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_wind_and_flight_time_compliance);
+	}
 
 	// NAVIGATION_STATE_AUTO_RTL
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_RTL, flags.mode_req_angular_velocity);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -637,6 +637,30 @@ PARAM_DEFINE_INT32(NAV_RCL_ACT, 2);
 PARAM_DEFINE_INT32(COM_RCL_EXCEPT, 0);
 
 /**
+ * Set the mode failure failsafe mode
+ *
+ * Specify mode to use if current mode requirements fails
+ *
+ * See: https://docs.px4.io/main/en/config/safety.html#failsafe-actions
+ *
+ * @min 0
+ * @max 10
+ * @value 0 None
+ * @value 1 Warn
+ * @value 2 Position mode
+ * @value 3 Altitude mode
+ * @value 4 Stabilized
+ * @value 5 Hold mode
+ * @value 6 Return mode
+ * @value 7 Land mode
+ * @value 8 Descend
+ * @value 9 Disarm
+ * @value 10 Terminate
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(COM_MOD_FAIL_ACT, 6);
+
+/**
  * Set the actuator failure failsafe mode
  *
  * Note: actuator failure needs to be enabled and configured via FD_ACT_*

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -153,6 +153,50 @@ FailsafeBase::ActionOptions Failsafe::fromImbalancedPropActParam(int param_value
 	return options;
 }
 
+FailsafeBase::Action Failsafe::fromModeFailureActParam(int param_value,  uint8_t &user_intended_mode)
+{
+	Action action = Action(param_value);
+
+	switch (action) {
+	case Action::FallbackPosCtrl:
+		user_intended_mode = vehicle_status_s::NAVIGATION_STATE_POSCTL;
+		break;
+
+	case Action::FallbackAltCtrl:
+		user_intended_mode = vehicle_status_s::NAVIGATION_STATE_ALTCTL;
+		break;
+
+	case Action::FallbackStab:
+		user_intended_mode = vehicle_status_s::NAVIGATION_STATE_STAB;
+		break;
+
+	case Action::Hold:
+		user_intended_mode = vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER;
+		break;
+
+	case Action::RTL:
+		user_intended_mode = vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
+		break;
+
+	case Action::Land:
+		user_intended_mode = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
+		break;
+
+	case Action::Descend:
+		user_intended_mode = vehicle_status_s::NAVIGATION_STATE_DESCEND;
+		break;
+
+	case Action::Terminate:
+		user_intended_mode = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
+		break;
+
+	default:
+		break;
+	}
+
+	return action;
+}
+
 FailsafeBase::ActionOptions Failsafe::fromActuatorFailureActParam(int param_value)
 {
 	ActionOptions options{};
@@ -628,8 +672,7 @@ FailsafeBase::Action Failsafe::checkModeFallback(const failsafe_flags_s &status_
 
 	// Last, check can_run for intended mode
 	if (!modeCanRun(status_flags, user_intended_mode)) {
-		action = Action::RTL;
-		user_intended_mode = vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
+		action = fromModeFailureActParam(_param_com_mod_failure_act.get(), user_intended_mode);
 	}
 
 	return action;

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -151,6 +151,7 @@ private:
 
 	static ActionOptions fromGfActParam(int param_value);
 	static ActionOptions fromImbalancedPropActParam(int param_value);
+	static Action fromModeFailureActParam(int param_value, uint8_t &user_intended_mode);
 	static ActionOptions fromActuatorFailureActParam(int param_value);
 	static ActionOptions fromBatteryWarningActParam(int param_value, uint8_t battery_warning);
 	static ActionOptions fromQuadchuteActParam(int param_value);
@@ -185,6 +186,7 @@ private:
 					(ParamInt<px4::params::COM_IMB_PROP_ACT>) _param_com_imb_prop_act,
 					(ParamFloat<px4::params::COM_LKDOWN_TKO>) _param_com_lkdown_tko,
 					(ParamInt<px4::params::CBRK_FLIGHTTERM>) _param_cbrk_flightterm,
+					(ParamInt<px4::params::COM_MOD_FAIL_ACT>) _param_com_mod_failure_act,
 					(ParamInt<px4::params::COM_ACT_FAIL_ACT>) _param_com_actuator_failure_act,
 					(ParamInt<px4::params::COM_LOW_BAT_ACT>) _param_com_low_bat_act,
 					(ParamInt<px4::params::COM_OBL_RC_ACT>) _param_com_obl_rc_act,


### PR DESCRIPTION
### Solved Problem
I needed my rover to use hold mode if it lost gps accuracy while in mission and I found that Hold mode requires position information.
Also if mode requirements are not met, then RTL is triggered and has a higher priority than Hold mode, and because I was trying it for gps loss, descend was activated, which is not the most appropriate mode for a rover.

### Solution
- Remove requirements for hold mode if in rover because it doesn't move and so doesn't need reposition
- Add new parameter to choose the mode to use if mode requirements are not met

### Changelog Entry
For release notes:
```
New parameter: COM_MOD_FAIL_ACT
```

### Test coverage
- Simulation SITL and Failsafe State Machine Simulation
