### PR TITLE
mavlink_receiver: don't publish out of range joystick input

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2138,25 +2138,36 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 	}
 
 	manual_control_setpoint_s manual_control_setpoint{};
-	manual_control_setpoint.pitch = mavlink_manual_control.x / 1000.f;
-	manual_control_setpoint.roll = mavlink_manual_control.y / 1000.f;
+
+	if (math::isInRange((int)mavlink_manual_control.x, -1000, 1000)) { manual_control_setpoint.pitch = mavlink_manual_control.x / 1000.f; }
+
+	if (math::isInRange((int)mavlink_manual_control.y, -1000, 1000)) { manual_control_setpoint.roll = mavlink_manual_control.y / 1000.f; }
+
 	// For backwards compatibility at the moment interpret throttle in range [0,1000]
-	manual_control_setpoint.throttle = ((mavlink_manual_control.z / 1000.f) * 2.f) - 1.f;
-	manual_control_setpoint.yaw = mavlink_manual_control.r / 1000.f;
+	if (math::isInRange((int)mavlink_manual_control.z, 0, 1000)) { manual_control_setpoint.throttle = ((mavlink_manual_control.z / 1000.f) * 2.f) - 1.f; }
+
+	if (math::isInRange((int)mavlink_manual_control.r, -1000, 1000)) { manual_control_setpoint.yaw = mavlink_manual_control.r / 1000.f; }
+
 	// Pass along the button states
 	manual_control_setpoint.buttons = mavlink_manual_control.buttons;
 
-	if (mavlink_manual_control.enabled_extensions & (1u << 2)) { manual_control_setpoint.aux1 = mavlink_manual_control.aux1 / 1000.0f; }
+	if (mavlink_manual_control.enabled_extensions & (1u << 2)
+	    && math::isInRange((int)mavlink_manual_control.aux1, -1000, 1000)) { manual_control_setpoint.aux1 = mavlink_manual_control.aux1 / 1000.0f; }
 
-	if (mavlink_manual_control.enabled_extensions & (1u << 3)) { manual_control_setpoint.aux2 = mavlink_manual_control.aux2 / 1000.0f; }
+	if (mavlink_manual_control.enabled_extensions & (1u << 3)
+	    && math::isInRange((int)mavlink_manual_control.aux2, -1000, 1000)) { manual_control_setpoint.aux2 = mavlink_manual_control.aux2 / 1000.0f; }
 
-	if (mavlink_manual_control.enabled_extensions & (1u << 4)) { manual_control_setpoint.aux3 = mavlink_manual_control.aux3 / 1000.0f; }
+	if (mavlink_manual_control.enabled_extensions & (1u << 4)
+	    && math::isInRange((int)mavlink_manual_control.aux3, -1000, 1000)) { manual_control_setpoint.aux3 = mavlink_manual_control.aux3 / 1000.0f; }
 
-	if (mavlink_manual_control.enabled_extensions & (1u << 5)) { manual_control_setpoint.aux4 = mavlink_manual_control.aux4 / 1000.0f; }
+	if (mavlink_manual_control.enabled_extensions & (1u << 5)
+	    && math::isInRange((int)mavlink_manual_control.aux4, -1000, 1000)) { manual_control_setpoint.aux4 = mavlink_manual_control.aux4 / 1000.0f; }
 
-	if (mavlink_manual_control.enabled_extensions & (1u << 6)) { manual_control_setpoint.aux5 = mavlink_manual_control.aux5 / 1000.0f; }
+	if (mavlink_manual_control.enabled_extensions & (1u << 6)
+	    && math::isInRange((int)mavlink_manual_control.aux5, -1000, 1000)) { manual_control_setpoint.aux5 = mavlink_manual_control.aux5 / 1000.0f; }
 
-	if (mavlink_manual_control.enabled_extensions & (1u << 7)) { manual_control_setpoint.aux6 = mavlink_manual_control.aux6 / 1000.0f; }
+	if (mavlink_manual_control.enabled_extensions & (1u << 7)
+	    && math::isInRange((int)mavlink_manual_control.aux6, -1000, 1000)) { manual_control_setpoint.aux6 = mavlink_manual_control.aux6 / 1000.0f; }
 
 	manual_control_setpoint.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_0 + _mavlink.get_instance_id();
 	manual_control_setpoint.timestamp = manual_control_setpoint.timestamp_sample = hrt_absolute_time();


### PR DESCRIPTION
### Solved Problem
When I was asked if a joystick with only 3 axes would work with PX4 I figured I'd check what the ground station should send and if it's handled correctly. Mavlink says ["A value of INT16_MAX indicates that this axis is invalid."](https://mavlink.io/en/messages/common.html#MANUAL_CONTROL) but if that's done then PX4 publishes a 3276.7% stick deflection 😱 

### Solution
Do not accept any out of range input. For now publish 0 when out of range.

### Alternatives
I still have to go through and make sure all consumers can handle NAN. I promised to do that already here: https://github.com/PX4/PX4-Autopilot/pull/22108#discussion_r1684065823


### Changelog Entry
```
Bugfix: Handle invalid stick axes from MANUAL_CONTROL MAVLink messages.
```

### Test coverage
I tested in SITL SIH for `x`, `y`, `z`, `r` that out-of-range values lead to zero deflection and valid values including -1000 and 1000 lead to the expected deflections published.

### Context
![image (16)](https://github.com/user-attachments/assets/953c37ed-f868-4592-9941-c35e1264ea34)
