### PR TITLE
fmu-v6x: disable external baro ms5611

### DIFF
--- a/boards/px4/fmu-v6x/init/rc.board_sensors
+++ b/boards/px4/fmu-v6x/init/rc.board_sensors
@@ -168,8 +168,8 @@ else
 	bmp388 -X start
 fi
 
-# Baro on I2C3
-ms5611 -X start
+# Don't try to start external baro on I2C3 as it can conflict with the MS5525DSO airspeed sensor.
+#ms5611 -X start
 
 unset INA_CONFIGURED
 unset HAVE_PM2


### PR DESCRIPTION
### Solved Problem

It turns out that the airspeed sensor MS5525DSO (e.g. https://holybro.com/products/digital-air-speed-sensor-ms5525dso) uses the same I2C address as the ms5611 potentially connected on the external I2C 3 bus, and so the two conflict and don't work properly.

Fixes #23434.

### Solution

The suggestion is to just disable the potential external ms5611 for 6X.

### Changelog Entry
For release notes:
```
Disable external ms5611 on Pixhawk 6x to avoid conflicts with MS5525DSO.
```

### Alternatives
We could also consider disabling it only if `SENS_EN_MS5525DS` is set to `1` but start it otherwise.

### Test coverage
Bench tested.

FYI @vincentpoont2 