### PR TITLE
Standard VTOL: Remove scaling of fw torque setpoint during transition

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -334,9 +334,9 @@ void Standard::fill_actuator_outputs()
 		_thrust_setpoint_0->xyz[2] = _vehicle_thrust_setpoint_virtual_mc->xyz[2] * _mc_throttle_weight;
 
 		// FW actuators
-		_torque_setpoint_1->xyz[0] = _vehicle_torque_setpoint_virtual_fw->xyz[0] * (1.f - _mc_roll_weight);
-		_torque_setpoint_1->xyz[1] = _vehicle_torque_setpoint_virtual_fw->xyz[1] * (1.f - _mc_pitch_weight);
-		_torque_setpoint_1->xyz[2] = _vehicle_torque_setpoint_virtual_fw->xyz[2] * (1.f - _mc_yaw_weight);
+		_torque_setpoint_1->xyz[0] = _vehicle_torque_setpoint_virtual_fw->xyz[0];
+		_torque_setpoint_1->xyz[1] = _vehicle_torque_setpoint_virtual_fw->xyz[1];
+		_torque_setpoint_1->xyz[2] = _vehicle_torque_setpoint_virtual_fw->xyz[2];
 		_thrust_setpoint_0->xyz[0] = _pusher_throttle;
 
 		break;


### PR DESCRIPTION
### Solved Problem
We noticed on a standard VTOL configuration that the vehicle would start spinning in yaw during the backtransition. Currently, we blend in the multicopter torque and blend out the fw torque. 

### Solution
In practice it seems to make more sense to allow the fw control surfaces to generate torque, rather than just blending them out. We were able to solve the backtransition issue completely with this change.
I also verified, that the scaling was not present in older PX4 versions and explains why this issue only appear on newer PX4 version.s

### Changelog Entry
For release notes:
```
Removed scaling on fixed wing torque setpoints for VTOL transitions.
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
