### PR TITLE
Add micoair h743 compile settings

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -77,6 +77,7 @@ pipeline {
                      "matek_h743-mini_default",
                      "matek_h743-slim_default",
                      "matek_h743_default",
+                     "micoair_h743_default",
                      "modalai_fc-v1_default",
                      "modalai_fc-v2_default",
                      "mro_ctrl-zero-classic_default",

--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -286,6 +286,11 @@ CONFIG:
       buildType: MiniSizeRel
       settings:
         CONFIG: matek_gnss-m9n-f4_default
+    micoair_h743_default:
+      short: micoair_h743
+      buildType: MinSizeRel
+      settings:
+        CONFIG: micoair_h743_default
     modalai_fc-v1_default:
       short: modalai_fc-v1
       buildType: MinSizeRel

--- a/Makefile
+++ b/Makefile
@@ -340,6 +340,7 @@ bootloaders_update: \
 	matek_h743_bootloader \
 	matek_h743-mini_bootloader \
 	matek_h743-slim_bootloader \
+        micoair_h743_bootloader \
 	modalai_fc-v2_bootloader \
 	mro_ctrl-zero-classic_bootloader \
 	mro_ctrl-zero-h7_bootloader \


### PR DESCRIPTION
Dear PX4-Autopilot Developers.

I am about to test v1.15.0-rc2 with VIO and upload my flight LOG. And then I found that the MicoAir743 board is missing compile settings. So I added them in this PR.
