### PR TITLE
Differential: Improve closed loop yaw rate and speed control

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4009_gz_r1_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4009_gz_r1_rover
@@ -16,11 +16,12 @@ param set-default RD_WHEEL_TRACK 0.3
 param set-default RD_MAN_YAW_SCALE 0.1
 param set-default RD_MAX_ACCEL 6
 param set-default RD_MAX_JERK 30
-param set-default RD_MAX_SPEED 7
-param set-default RD_YAW_RATE_P 5
+param set-default RD_MAX_THR_YAW_R 5
+param set-default RD_YAW_RATE_P 0.1
 param set-default RD_YAW_RATE_I 0
 param set-default RD_YAW_P 5
 param set-default RD_YAW_I 0
+param set-default RD_MAX_THR_SPD 7
 param set-default RD_SPEED_P 1
 param set-default RD_SPEED_I 0
 param set-default RD_MAX_YAW_RATE 180

--- a/ROMFS/px4fmu_common/init.d/airframes/50001_aion_robotics_r1_rover
+++ b/ROMFS/px4fmu_common/init.d/airframes/50001_aion_robotics_r1_rover
@@ -25,12 +25,13 @@ param set-default RBCLW_REV 1 # reverse right wheels
 param set-default RD_WHEEL_TRACK 0.3
 param set-default RD_MAN_YAW_SCALE 1
 param set-default RD_MAX_ACCEL 5
-param set-default RD_MAX_JERK 50
-param set-default RD_MAX_SPEED 2
+param set-default RD_MAX_JERK 10
+param set-default RD_MAX_THR_YAW_R 4
 param set-default RD_YAW_RATE_P 0.1
 param set-default RD_YAW_RATE_I 0
 param set-default RD_YAW_P 5
 param set-default RD_YAW_I 0
+param set-default RD_MAX_THR_SPD 2
 param set-default RD_SPEED_P 0.5
 param set-default RD_SPEED_I 0.1
 param set-default RD_MAX_YAW_RATE 300

--- a/msg/RoverDifferentialStatus.msg
+++ b/msg/RoverDifferentialStatus.msg
@@ -1,11 +1,13 @@
 uint64 timestamp # time since system start (microseconds)
 
-float32 actual_speed	       # [m/s] Actual forward speed of the rover
-float32 actual_yaw_deg         # [deg] Actual yaw of the rover
-float32 actual_yaw_rate_deg_s  # [deg/s] Actual yaw rate of the rover
-float32 desired_yaw_rate_deg_s # [deg/s] Yaw rate setpoint for the closed loop yaw rate controller
-float32 pid_yaw_integral       # Integral of the PID for the closed loop yaw controller
-float32 pid_yaw_rate_integral  # Integral of the PID for the closed loop yaw rate controller
-float32 pid_throttle_integral  # Integral of the PID for the closed loop speed controller
+float32 actual_speed	         # [m/s] Actual forward speed of the rover
+float32 actual_yaw               # [rad] Actual yaw of the rover
+float32 actual_yaw_rate          # [rad/s] Actual yaw rate of the rover
+float32 desired_yaw_rate         # [rad/s] Yaw rate setpoint for the closed loop yaw rate controller
+float32 forward_speed_normalized # [-1, 1] Normalized forward speed setpoint
+float32 speed_diff_normalized    # [-1, 1] Normalized speed difference setpoint between the left and right motor
+float32 pid_yaw_integral         # Integral of the PID for the closed loop yaw controller
+float32 pid_yaw_rate_integral    # Integral of the PID for the closed loop yaw rate controller
+float32 pid_throttle_integral    # Integral of the PID for the closed loop speed controller
 
 # TOPICS rover_differential_status

--- a/src/modules/rover_differential/RoverDifferential.cpp
+++ b/src/modules/rover_differential/RoverDifferential.cpp
@@ -142,7 +142,7 @@ void RoverDifferential::updateSubscriptions()
 	if (_vehicle_angular_velocity_sub.updated()) {
 		vehicle_angular_velocity_s vehicle_angular_velocity{};
 		_vehicle_angular_velocity_sub.copy(&vehicle_angular_velocity);
-		_vehicle_yaw_rate = vehicle_angular_velocity.xyz[2];
+		_vehicle_yaw_rate = fabsf(vehicle_angular_velocity.xyz[2]) > YAW_RATE_THRESHOLD ? vehicle_angular_velocity.xyz[2] : 0.f;
 	}
 
 	if (_vehicle_attitude_sub.updated()) {
@@ -157,7 +157,7 @@ void RoverDifferential::updateSubscriptions()
 		_vehicle_local_position_sub.copy(&vehicle_local_position);
 		Vector3f velocity_in_local_frame(vehicle_local_position.vx, vehicle_local_position.vy, vehicle_local_position.vz);
 		Vector3f velocity_in_body_frame = _vehicle_attitude_quaternion.rotateVectorInverse(velocity_in_local_frame);
-		_vehicle_forward_speed = velocity_in_body_frame(0);
+		_vehicle_forward_speed = fabsf(velocity_in_body_frame(0)) > SPEED_THRESHOLD ? velocity_in_body_frame(0) : 0.f;
 	}
 }
 

--- a/src/modules/rover_differential/RoverDifferential.hpp
+++ b/src/modules/rover_differential/RoverDifferential.hpp
@@ -113,6 +113,12 @@ private:
 	int _nav_state{0};
 	bool _armed{false};
 
+	// Thresholds to avoid moving at rest due to measurement noise
+	static constexpr float YAW_RATE_THRESHOLD =
+		0.02f; // [rad/s] The minimum threshold for the yaw rate measurement not to be interpreted as zero
+	static constexpr float SPEED_THRESHOLD =
+		0.1f; // [m/s] The minimum threshold for the speed measurement not to be interpreted as zero
+
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::RD_MAN_YAW_SCALE>) _param_rd_man_yaw_scale,
 		(ParamFloat<px4::params::RD_MAX_YAW_RATE>) _param_rd_max_yaw_rate

--- a/src/modules/rover_differential/RoverDifferentialControl/RoverDifferentialControl.hpp
+++ b/src/modules/rover_differential/RoverDifferentialControl/RoverDifferentialControl.hpp
@@ -113,7 +113,8 @@ private:
 	// Parameters
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::RD_WHEEL_TRACK>) _param_rd_wheel_track,
-		(ParamFloat<px4::params::RD_MAX_SPEED>) _param_rd_max_speed,
+		(ParamFloat<px4::params::RD_MAX_THR_SPD>) _param_rd_max_thr_spd,
+		(ParamFloat<px4::params::RD_MAX_THR_YAW_R>) _param_rd_max_thr_yaw_r,
 		(ParamFloat<px4::params::RD_MAX_YAW_RATE>) _param_rd_max_yaw_rate,
 		(ParamFloat<px4::params::RD_YAW_RATE_P>) _param_rd_yaw_rate_p,
 		(ParamFloat<px4::params::RD_YAW_RATE_I>) _param_rd_yaw_rate_i,

--- a/src/modules/rover_differential/RoverDifferentialGuidance/RoverDifferentialGuidance.cpp
+++ b/src/modules/rover_differential/RoverDifferentialGuidance/RoverDifferentialGuidance.cpp
@@ -216,7 +216,7 @@ void RoverDifferentialGuidance::updateWaypoints()
 
 	// Waypoint cruising speed
 	if (position_setpoint_triplet.current.cruising_speed > 0.f) {
-		_max_forward_speed = math::constrain(position_setpoint_triplet.current.cruising_speed, 0.f, _param_rd_max_speed.get());
+		_max_forward_speed = position_setpoint_triplet.current.cruising_speed;
 
 	} else {
 		_max_forward_speed = _param_rd_miss_spd_def.get();

--- a/src/modules/rover_differential/RoverDifferentialGuidance/RoverDifferentialGuidance.hpp
+++ b/src/modules/rover_differential/RoverDifferentialGuidance/RoverDifferentialGuidance.hpp
@@ -140,7 +140,6 @@ private:
 
 	// Parameters
 	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::RD_MAX_SPEED>) _param_rd_max_speed,
 		(ParamFloat<px4::params::NAV_ACC_RAD>) _param_nav_acc_rad,
 		(ParamFloat<px4::params::RD_MAX_JERK>) _param_rd_max_jerk,
 		(ParamFloat<px4::params::RD_MAX_ACCEL>) _param_rd_max_accel,

--- a/src/modules/rover_differential/module.yaml
+++ b/src/modules/rover_differential/module.yaml
@@ -113,10 +113,14 @@ parameters:
         decimal: 2
         default: 0.5
 
-      RD_MAX_SPEED:
+      RD_MAX_THR_SPD:
         description:
-          short: Maximum speed the rover can drive
-          long: This parameter is used to map desired speeds to normalized motor commands.
+          short: Speed the rover drives at maximum throttle
+          long: |
+            This parameter is used to calculate the feedforward term of the closed loop speed control which linearly
+            maps desired speeds to normalized motor commands [-1. 1].
+            A good starting point is the observed ground speed when the rover drives at maximum throttle in manual mode.
+            Increase this parameter if the rover is faster than the setpoint, and decrease if the rover is slower.
         type: float
         unit: m/s
         min: 0
@@ -137,6 +141,23 @@ parameters:
         increment: 0.01
         decimal: 2
         default: 90
+
+      RD_MAX_THR_YAW_R:
+        description:
+          short: Yaw rate turning left/right wheels at max speed in opposite directions
+          long: |
+            This parameter is used to calculate the feedforward term of the closed loop yaw rate control.
+            The controller first calculates the required speed difference between the left and right motor to achieve the desired yaw rate.
+            This desired speed difference is then linearly mapped to normalized motor commands.
+            A good starting point is twice the speed the rover drives at maximum throttle (RD_MAX_THR_SPD)).
+            Increase this parameter if the rover turns faster than the setpoint, and decrease if the rover turns slower.
+        type: float
+        unit: m/s
+        min: 0
+        max: 100
+        increment: 0.01
+        decimal: 2
+        default: 2
 
       RD_MISS_SPD_DEF:
         description:


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Currently closed loop yaw rate and speed control is disabled if the setpoints are zero. This leads to issues such as when driving in a straight line in acro mode (zero yaw rate setpoint) as it will not counteract disturbances.
Initially this was done to stop the rover from moving at stand still due to measurement noise. This is now fixed by adding minimum thresholds on the yaw rate and speed measurements.

This PR also adds an improvement for the tuning process for the closed loop control by adding individual parameters for tuning the feed forward part of both yaw rate and speed.