### PR TITLE
Simplify gz bridge CMakeLists and add GZ Ionic

### DIFF
--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -32,13 +32,8 @@
 ############################################################################
 
 # Find the gz_Transport library
-# First look for GZ Harmonic libraries
-find_package(gz-transport NAMES gz-transport13)
-
-# If Harmonic not found, look for GZ Garden libraries
-if(NOT gz-transport_FOUND)
-	find_package(gz-transport NAMES gz-transport12)
-endif()
+# Look for GZ Ionic, Harmonic, and Garden library options in that order
+find_package(gz-transport NAMES gz-transport14 gz-transport13 gz-transport12)
 
 if(gz-transport_FOUND)
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Gazebo simulation did not run on 24.04 with the latest version of Gazebo Ionic.

### Solution
- Add `gz-transport14` to the options of `gz-transport` libraries to find in the CMakeLists
- Refactor the find_package to be simpler and just use the NAMES instead of the clunkier if statement

### Changelog Entry
For release notes:
```
Feature: Add support for Gazebo Ionic
```

### Test coverage
- Ubuntu 24.04 with Gazebo Ionic - tested with the X500
- Ubuntu 22.04 with Gazebo Harmonic - tested with the X500

I didn't see any issues building or running the simulation for these two configurations. 