### PR TITLE
GNSS: move delay compensation to driver level

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -172,7 +172,8 @@ else
 	# otherwise start simulator (mavlink) module
 
 	# EKF2 specifics
-	param set-default EKF2_GPS_DELAY 10
+	param set-default GPS_1_DELAY 10
+	param set-default GPS_2_DELAY 10
 	param set-default EKF2_MULTI_IMU 3
 	param set-default SENS_IMU_MODE 0
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
+++ b/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
@@ -47,7 +47,6 @@ param set-default EKF2_BCOEF_Y 25.5
 
 param set-default EKF2_DRAG_CTRL 1
 
-param set-default EKF2_GPS_DELAY 100
 param set-default EKF2_GPS_POS_X 0.06
 param set-default EKF2_GPS_V_NOISE 0.5
 
@@ -79,6 +78,7 @@ param set-default EKF2_RNG_POS_Z 0.033
 
 param set-default EKF2_TERR_NOISE 1
 
+param set-default GPS_1_DELAY 100
 
 # Maximum allowed angle velocity in the landed state
 param set-default LNDMC_ROT_MAX 40

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -276,3 +276,33 @@ PARAM_DEFINE_INT32(GPS_1_GNSS, 0);
  * @group GPS
  */
 PARAM_DEFINE_INT32(GPS_2_GNSS, 0);
+
+/**
+ * GPS measurement delay relative to IMU measurements
+ *
+ * Set to -1 if unknown
+ *
+ * @min -1
+ * @max 300
+ * @unit ms
+ * @decimal 1
+ *
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_INT32(GPS_1_DELAY, -1);
+
+/**
+ * GPS measurement delay relative to IMU measurements
+ *
+ * Set to -1 if unknown
+ *
+ * @min -1
+ * @max 300
+ * @unit ms
+ * @decimal 1
+ *
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_INT32(GPS_2_DELAY, -1);

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -320,7 +320,6 @@ struct parameters {
 
 #if defined(CONFIG_EKF2_GNSS)
 	int32_t gnss_ctrl {static_cast<int32_t>(GnssCtrl::HPOS) | static_cast<int32_t>(GnssCtrl::VEL)};
-	float gps_delay_ms{110.0f};             ///< GPS measurement delay relative to the IMU (mSec)
 
 	Vector3f gps_pos_body{};                ///< xyz position of the GPS antenna in body frame (m)
 

--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -178,7 +178,6 @@ void EstimatorInterface::setGpsData(const gnssSample &gnss_sample)
 	}
 
 	const int64_t time_us = gnss_sample.time_us
-				- static_cast<int64_t>(_params.gps_delay_ms * 1000)
 				- static_cast<int64_t>(_dt_ekf_avg * 5e5f); // seconds to microseconds divided by 2
 
 	if (time_us >= static_cast<int64_t>(_gps_buffer->get_newest().time_us + _min_obs_interval_us)) {

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -79,7 +79,6 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_noaid_noise(_params->pos_noaid_noise),
 #if defined(CONFIG_EKF2_GNSS)
 	_param_ekf2_gps_ctrl(_params->gnss_ctrl),
-	_param_ekf2_gps_delay(_params->gps_delay_ms),
 	_param_ekf2_gps_pos_x(_params->gps_pos_body(0)),
 	_param_ekf2_gps_pos_y(_params->gps_pos_body(1)),
 	_param_ekf2_gps_pos_z(_params->gps_pos_body(2)),
@@ -902,14 +901,6 @@ void EKF2::VerifyParams()
 	}
 
 #endif // CONFIG_EKF2_RANGE_FINDER
-
-#if defined(CONFIG_EKF2_GNSS)
-
-	if (_param_ekf2_gps_delay.get() > delay_max) {
-		delay_max = _param_ekf2_gps_delay.get();
-	}
-
-#endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)
 
@@ -2429,7 +2420,7 @@ void EKF2::UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps)
 		}
 
 		gnssSample gnss_sample{
-			.time_us = vehicle_gps_position.timestamp,
+			.time_us = vehicle_gps_position.timestamp_sample,
 			.lat = vehicle_gps_position.latitude_deg,
 			.lon = vehicle_gps_position.longitude_deg,
 			.alt = static_cast<float>(vehicle_gps_position.altitude_msl_m),

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -513,7 +513,6 @@ private:
 
 #if defined(CONFIG_EKF2_GNSS)
 		(ParamExtInt<px4::params::EKF2_GPS_CTRL>) _param_ekf2_gps_ctrl,
-		(ParamExtFloat<px4::params::EKF2_GPS_DELAY>) _param_ekf2_gps_delay,
 
 		(ParamExtFloat<px4::params::EKF2_GPS_POS_X>) _param_ekf2_gps_pos_x,
 		(ParamExtFloat<px4::params::EKF2_GPS_POS_Y>) _param_ekf2_gps_pos_y,

--- a/src/modules/ekf2/params_gnss.yaml
+++ b/src/modules/ekf2/params_gnss.yaml
@@ -17,16 +17,6 @@ parameters:
       default: 7
       min: 0
       max: 15
-    EKF2_GPS_DELAY:
-      description:
-        short: GPS measurement delay relative to IMU measurements
-      type: float
-      default: 110
-      min: 0
-      max: 300
-      unit: ms
-      reboot_required: true
-      decimal: 1
     EKF2_GPS_P_NOISE:
       description:
         short: Measurement noise for GNSS position


### PR DESCRIPTION
### Solved Problem
Different receivers have different delays so we would need to duplicate the `EKF2_GPS_DELAY` params if the two receivers are not identical. Also, the delay parameter is often overlooked by the user and could automatically be set based on the model.

### Solution
Move the delay parameter to the driver level. The GNSS device can automatically set its delay if known. Otherwise, the corresponding parameter can be set manually. If not set by the device and not set by the user, the "old default" delay of 110ms is then used.

QUESTION:
In that PR, the delay parameter has no effect if the underlying GNSS device is already specifying a `timestamp_sample` different than `timestamp`. Should we always let the user adjust the parameter?

### Changelog Entry
For release notes:
```

New parameter: GPS_1_DELAY, GPS_2_DELAY
Documentation: TBD
```

### Test coverage
-
