### PR TITLE
mission_base: do not make terrain avoidance check on idle

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -1030,6 +1030,7 @@ void MissionBlock::updateAltToAvoidTerrainCollisionAndRepublishTriplet(mission_i
 
 	if (_navigator->get_nav_min_gnd_dist_param() > FLT_EPSILON && _mission_item.nav_cmd != NAV_CMD_LAND
 	    && _mission_item.nav_cmd != NAV_CMD_VTOL_LAND && _mission_item.nav_cmd != NAV_CMD_DO_VTOL_TRANSITION
+	    && _mission_item.nav_cmd != NAV_CMD_IDLE
 	    && _navigator->get_local_position()->dist_bottom_valid
 	    && _navigator->get_local_position()->dist_bottom < _navigator->get_nav_min_gnd_dist_param()
 	    && _navigator->get_local_position()->vz > FLT_EPSILON


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Currently the terrain avoidance check in the mission is always run when the mission mode is activated. it is even run when the mission has ended and the mission mode sets the idle navigation item. 

Fixes #{Github issue ID}

### Solution
- Do not make terrain avoidance check on idle mission item

### Changelog Entry
For release notes:
```
Bugfix: Do not make terrain avoidance check on idle mission item
```

### Alternatives
We could also check that we are landed and prevent the terrain avoidance check then or do not call the function on these conditions.
