### PR TITLE
Misc: Matrix: Added Addition and Subtraction to Slices

### DIFF
--- a/src/lib/matrix/matrix/Slice.hpp
+++ b/src/lib/matrix/matrix/Slice.hpp
@@ -119,88 +119,34 @@ public:
 	template<size_t MM, size_t NN>
 	Matrix<Type, P, Q> operator-(const SliceT<const Matrix<Type, MM, NN>, Type, P, Q, MM, NN> &other)
 	{
-		Matrix<Type, P, Q> res;
-		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
-
-		for (size_t i = 0; i < P; i++) {
-			for (size_t j = 0; j < Q; j++) {
-				res(i, j) = self(i, j) - other(i, j);
-			}
-		}
-
-		return res;
+		return Matrix<Type, P, Q> {*this} - other;
 	}
 
 
 	Matrix<Type, P, Q> operator-(const Matrix<Type, P, Q> &other)
 	{
-		Matrix<Type, P, Q> res;
-		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
-
-		for (size_t i = 0; i < P; i++) {
-			for (size_t j = 0; j < Q; j++) {
-				res(i, j) = self(i, j) - other(i, j);
-			}
-		}
-
-		return res;
+		return Matrix<Type, P, Q> {*this} - other;
 	}
 
 	Matrix<Type, P, Q> operator-(const Type &other)
 	{
-		Matrix<Type, P, Q> res;
-		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
-
-		for (size_t i = 0; i < P; i++) {
-			for (size_t j = 0; j < Q; j++) {
-				res(i, j) = self(i, j) - other;
-			}
-		}
-
-		return res;
+		return Matrix<Type, P, Q> {*this} - other;
 	}
 
 	template<size_t MM, size_t NN>
 	Matrix<Type, P, Q> operator+(const SliceT<const Matrix<Type, MM, NN>, Type, P, Q, MM, NN> &other)
 	{
-		Matrix<Type, P, Q> res;
-		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
-
-		for (size_t i = 0; i < P; i++) {
-			for (size_t j = 0; j < Q; j++) {
-				res(i, j) = self(i, j) + other(i, j);
-			}
-		}
-
-		return res;
+		return Matrix<Type, P, Q> {*this} + other;
 	}
 
 	Matrix<Type, P, Q> operator+(const Matrix<Type, P, Q> &other)
 	{
-		Matrix<Type, P, Q> res;
-		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
-
-		for (size_t i = 0; i < P; i++) {
-			for (size_t j = 0; j < Q; j++) {
-				res(i, j) = self(i, j) + other(i, j);
-			}
-		}
-
-		return res;
+		return Matrix<Type, P, Q> {*this} + other;
 	}
 
 	Matrix<Type, P, Q> operator+(const Type &other)
 	{
-		Matrix<Type, P, Q> res;
-		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
-
-		for (size_t i = 0; i < P; i++) {
-			for (size_t j = 0; j < Q; j++) {
-				res(i, j) = self(i, j) + other;
-			}
-		}
-
-		return res;
+		return Matrix<Type, P, Q> {*this} + other;
 	}
 
 	// allow assigning vectors to a slice that are in the axis
@@ -309,29 +255,19 @@ public:
 		return self;
 	}
 
-	SliceT<MatrixT, Type, P, Q, M, N> &operator/=(const Type &other)
+	SliceT<MatrixT, Type, P, Q, M, N> &operator/=(const Type &scalar)
 	{
-		return operator*=(Type(1) / other);
+		return operator*=(Type(1) / scalar);
 	}
 
-	Matrix<Type, P, Q> operator*(const Type &other) const
+	Matrix<Type, P, Q> operator*(const Type &scalar) const
 	{
-		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
-		Matrix<Type, P, Q> res;
-
-		for (size_t i = 0; i < P; i++) {
-			for (size_t j = 0; j < Q; j++) {
-				res(i, j) = self(i, j) * other;
-			}
-		}
-
-		return res;
+		return Matrix<Type, P, Q> {*this} * scalar;
 	}
 
-	Matrix<Type, P, Q> operator/(const Type &other) const
+	Matrix<Type, P, Q> operator/(const Type &scalar) const
 	{
-		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
-		return self * (Type(1) / other);
+		return (*this) * (1 / scalar);
 	}
 
 	template<size_t R, size_t S>

--- a/src/lib/matrix/matrix/Slice.hpp
+++ b/src/lib/matrix/matrix/Slice.hpp
@@ -116,6 +116,93 @@ public:
 		return self;
 	}
 
+	template<size_t MM, size_t NN>
+	Matrix<Type, P, Q> operator-(const SliceT<const Matrix<Type, MM, NN>, Type, P, Q, MM, NN> &other)
+	{
+		Matrix<Type, P, Q> res;
+		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
+
+		for (size_t i = 0; i < P; i++) {
+			for (size_t j = 0; j < Q; j++) {
+				res(i, j) = self(i, j) - other(i, j);
+			}
+		}
+
+		return res;
+	}
+
+
+	Matrix<Type, P, Q> operator-(const Matrix<Type, P, Q> &other)
+	{
+		Matrix<Type, P, Q> res;
+		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
+
+		for (size_t i = 0; i < P; i++) {
+			for (size_t j = 0; j < Q; j++) {
+				res(i, j) = self(i, j) - other(i, j);
+			}
+		}
+
+		return res;
+	}
+
+	Matrix<Type, P, Q> operator-(const Type &other)
+	{
+		Matrix<Type, P, Q> res;
+		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
+
+		for (size_t i = 0; i < P; i++) {
+			for (size_t j = 0; j < Q; j++) {
+				res(i, j) = self(i, j) - other;
+			}
+		}
+
+		return res;
+	}
+
+	template<size_t MM, size_t NN>
+	Matrix<Type, P, Q> operator+(const SliceT<const Matrix<Type, MM, NN>, Type, P, Q, MM, NN> &other)
+	{
+		Matrix<Type, P, Q> res;
+		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
+
+		for (size_t i = 0; i < P; i++) {
+			for (size_t j = 0; j < Q; j++) {
+				res(i, j) = self(i, j) + other(i, j);
+			}
+		}
+
+		return res;
+	}
+
+	Matrix<Type, P, Q> operator+(const Matrix<Type, P, Q> &other)
+	{
+		Matrix<Type, P, Q> res;
+		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
+
+		for (size_t i = 0; i < P; i++) {
+			for (size_t j = 0; j < Q; j++) {
+				res(i, j) = self(i, j) + other(i, j);
+			}
+		}
+
+		return res;
+	}
+
+	Matrix<Type, P, Q> operator+(const Type &other)
+	{
+		Matrix<Type, P, Q> res;
+		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
+
+		for (size_t i = 0; i < P; i++) {
+			for (size_t j = 0; j < Q; j++) {
+				res(i, j) = self(i, j) + other;
+			}
+		}
+
+		return res;
+	}
+
 	// allow assigning vectors to a slice that are in the axis
 	template <size_t DUMMY = 1> // make this a template function since it only exists for some instantiations
 	SliceT<MatrixT, Type, 1, Q, M, N> &operator=(const Vector<Type, Q> &other)

--- a/src/lib/matrix/matrix/SquareMatrix.hpp
+++ b/src/lib/matrix/matrix/SquareMatrix.hpp
@@ -317,6 +317,7 @@ public:
 	}
 };
 
+using SquareMatrix2f = SquareMatrix<float, 2>;
 using SquareMatrix3f = SquareMatrix<float, 3>;
 using SquareMatrix3d = SquareMatrix<double, 3>;
 

--- a/src/lib/matrix/matrix/Vector2.hpp
+++ b/src/lib/matrix/matrix/Vector2.hpp
@@ -102,7 +102,6 @@ public:
 
 };
 
-
 using Vector2f = Vector2<float>;
 using Vector2d = Vector2<double>;
 

--- a/src/lib/matrix/test/MatrixSliceTest.cpp
+++ b/src/lib/matrix/test/MatrixSliceTest.cpp
@@ -268,28 +268,35 @@ TEST(MatrixSliceTest, SliceAdditions)
 			 4, 5, 6,
 			 7, 8, 10
 			};
-	SquareMatrix<float, 3> A(data);
+	SquareMatrix3f A{data};
 
-	// addition
-	SquareMatrix<float, 3> O = SquareMatrix3f(data);
-	float operand_data [4] = {2, 1, -3, -1};
-	const SquareMatrix<float, 2> operand(operand_data);
+	float operand_data [4] = {2, 1,
+				  -3, -1
+				 };
+	const SquareMatrix2f operand(operand_data);
 
-	auto res_1 = O.slice<2, 2>(1, 0) + operand;
-	float res_1_check_data[4] = {6, 6, 4, 7};
-	EXPECT_EQ(res_1, (SquareMatrix<float, 2>(res_1_check_data)));
+	// 2x2 Slice + 2x2 Matrix
+	SquareMatrix2f res_1 = A.slice<2, 2>(1, 0) + operand;
+	float res_1_check_data[4] = {6, 6,
+				     4, 7
+				    };
+	EXPECT_EQ(res_1, (SquareMatrix2f(res_1_check_data)));
 
-	auto res_2 = O.slice<2, 1>(1, 1) + operand.slice<2, 1>(0, 0);
-	float res_2_check_data[2] = {7, 5};
-	EXPECT_EQ(res_2, (Matrix<float, 2, 1>(res_2_check_data)));
+	// 2x1 Slice + 2x1 Slice
+	Vector2f res_2 = A.slice<2, 1>(1, 1) + operand.slice<2, 1>(0, 0);
+	EXPECT_EQ(res_2, Vector2f(7, 5));
 
-	auto res_3 = O.slice<3, 3>(0, 0) + -1;
-	float res_3_check_data[9] = {-1, 1, 2, 3, 4, 5, 6, 7, 9};
-	EXPECT_EQ(res_3, (SquareMatrix<float, 3>(res_3_check_data)));
+	// 3x3 Slice + Scalar
+	SquareMatrix3f res_3 = A.slice<3, 3>(0, 0) + (-1);
+	float res_3_check_data[9] = {-1, 1, 2,
+				     3, 4, 5,
+				     6, 7, 9
+				    };
+	EXPECT_EQ(res_3, (SquareMatrix3f(res_3_check_data)));
 
-	auto res_4 = O.col(1) + Vector3f{1, -2, 3};
-	float res_4_check_data[3] = {3, 3, 11};
-	EXPECT_EQ(res_4, (Vector3f(res_4_check_data)));
+	// 3x1 Slice + 3 Vector
+	Vector3f res_4 = A.col(1) + Vector3f(1, -2, 3);
+	EXPECT_EQ(res_4, Vector3f(3, 3, 11));
 
 }
 TEST(MatrixSliceTest, SliceSubtractions)
@@ -298,28 +305,35 @@ TEST(MatrixSliceTest, SliceSubtractions)
 			 4, 5, 6,
 			 7, 8, 10
 			};
-	SquareMatrix<float, 3> A(data);
+	SquareMatrix3f A{data};
 
-	// subtraction
-	SquareMatrix<float, 3> O = SquareMatrix3f(data);
-	float operand_data[4] = {2, 1, -3, -1};
-	const SquareMatrix<float, 2> operand(operand_data);
+	float operand_data[4] = {2, 1,
+				 -3, -1
+				};
+	const SquareMatrix2f operand(operand_data);
 
-	auto res_1 = O.slice<2, 2>(1, 0) - operand;
-	float res_1_check_data[4] = {2, 4, 10, 9};
-	EXPECT_EQ(res_1, (SquareMatrix<float, 2>(res_1_check_data)));
+	// 2x2 Slice - 2x2 Matrix
+	SquareMatrix2f res_1 = A.slice<2, 2>(1, 0) - operand;
+	float res_1_check_data[4] = {2, 4,
+				     10, 9
+				    };
+	EXPECT_EQ(res_1, (SquareMatrix2f(res_1_check_data)));
 
-	auto res_2 = O.slice<2, 1>(1, 1) - operand.slice<2, 1>(0, 0);
-	float res_2_check_data[2] = {3, 11};
-	EXPECT_EQ(res_2, (Matrix<float, 2, 1>(res_2_check_data)));
+	// 2x1 Slice - 2x1 Slice
+	Vector2f res_2 = A.slice<2, 1>(1, 1) - operand.slice<2, 1>(0, 0);
+	EXPECT_EQ(res_2, Vector2f(3, 11));
 
-	auto res_3 = O.slice<3, 3>(0, 0) - -1;
-	float res_3_check_data[9] = {1, 3, 4, 5, 6, 7, 8, 9, 11};
-	EXPECT_EQ(res_3, (SquareMatrix<float, 3>(res_3_check_data)));
+	// 3x3 Slice - Scalar
+	SquareMatrix3f res_3 = A.slice<3, 3>(0, 0) - (-1);
+	float res_3_check_data[9] = {1, 3, 4,
+				     5, 6, 7,
+				     8, 9, 11
+				    };
+	EXPECT_EQ(res_3, (SquareMatrix3f(res_3_check_data)));
 
-	auto res_4 = O.col(1) - Vector3f{1, -2, 3};
-	float res_4_check_data[3] = {1, 7, 5};
-	EXPECT_EQ(res_4, (Vector3f(res_4_check_data)));
+	// 3x1 Slice - 3 Vector
+	Vector3f res_4 = A.col(1) - Vector3f(1, -2, 3);
+	EXPECT_EQ(res_4, Vector3f(1, 7, 5));
 }
 
 TEST(MatrixSliceTest, XYAssignmentTest)

--- a/src/lib/matrix/test/MatrixSliceTest.cpp
+++ b/src/lib/matrix/test/MatrixSliceTest.cpp
@@ -262,6 +262,65 @@ TEST(MatrixSliceTest, Slice)
 	float O_check_data_12 [4] = {2.5, 3, 4, 5};
 	EXPECT_EQ(res_12, (SquareMatrix<float, 2>(O_check_data_12)));
 }
+TEST(MatrixSliceTest, SliceAdditions)
+{
+	float data[9] = {0, 2, 3,
+			 4, 5, 6,
+			 7, 8, 10
+			};
+	SquareMatrix<float, 3> A(data);
+
+	// addition
+	SquareMatrix<float, 3> O = SquareMatrix3f(data);
+	float operand_data [4] = {2, 1, -3, -1};
+	const SquareMatrix<float, 2> operand(operand_data);
+
+	auto res_1 = O.slice<2, 2>(1, 0) + operand;
+	float res_1_check_data[4] = {6, 6, 4, 7};
+	EXPECT_EQ(res_1, (SquareMatrix<float, 2>(res_1_check_data)));
+
+	auto res_2 = O.slice<2, 1>(1, 1) + operand.slice<2, 1>(0, 0);
+	float res_2_check_data[2] = {7, 5};
+	EXPECT_EQ(res_2, (Matrix<float, 2, 1>(res_2_check_data)));
+
+	auto res_3 = O.slice<3, 3>(0, 0) + -1;
+	float res_3_check_data[9] = {-1, 1, 2, 3, 4, 5, 6, 7, 9};
+	EXPECT_EQ(res_3, (SquareMatrix<float, 3>(res_3_check_data)));
+
+	auto res_4 = O.col(1) + Vector3f{1, -2, 3};
+	float res_4_check_data[3] = {3, 3, 11};
+	EXPECT_EQ(res_4, (Vector3f(res_4_check_data)));
+
+}
+TEST(MatrixSliceTest, SliceSubtractions)
+{
+	float data[9] = {0, 2, 3,
+			 4, 5, 6,
+			 7, 8, 10
+			};
+	SquareMatrix<float, 3> A(data);
+
+	// subtraction
+	SquareMatrix<float, 3> O = SquareMatrix3f(data);
+	float operand_data[4] = {2, 1, -3, -1};
+	const SquareMatrix<float, 2> operand(operand_data);
+
+	auto res_1 = O.slice<2, 2>(1, 0) - operand;
+	float res_1_check_data[4] = {2, 4, 10, 9};
+	EXPECT_EQ(res_1, (SquareMatrix<float, 2>(res_1_check_data)));
+
+	auto res_2 = O.slice<2, 1>(1, 1) - operand.slice<2, 1>(0, 0);
+	float res_2_check_data[2] = {3, 11};
+	EXPECT_EQ(res_2, (Matrix<float, 2, 1>(res_2_check_data)));
+
+	auto res_3 = O.slice<3, 3>(0, 0) - -1;
+	float res_3_check_data[9] = {1, 3, 4, 5, 6, 7, 8, 9, 11};
+	EXPECT_EQ(res_3, (SquareMatrix<float, 3>(res_3_check_data)));
+
+	auto res_4 = O.col(1) - Vector3f{1, -2, 3};
+	float res_4_check_data[3] = {1, 7, 5};
+	EXPECT_EQ(res_4, (Vector3f(res_4_check_data)));
+}
 
 TEST(MatrixSliceTest, XYAssignmentTest)
 {

--- a/src/lib/matrix/test/MatrixVector3Test.cpp
+++ b/src/lib/matrix/test/MatrixVector3Test.cpp
@@ -80,4 +80,13 @@ TEST(MatrixVector3Test, Vector3)
 	Vector3f m2(3.1f, 4.1f, 5.1f);
 	EXPECT_EQ(m2, m1 + 2.1f);
 	EXPECT_EQ(m2 - 2.1f, m1);
+
+	// Test Addition and Subtraction of Slices
+	Vector3f v1(3, 13, 0);
+	Vector3f v2(42, 6, 256);
+
+	EXPECT_EQ(v1.xy() - v2.xy(), Vector2f(-39, 7));
+	EXPECT_EQ(v1.xy() + v2.xy(), Vector2f(45, 19));
+	EXPECT_EQ(v1.xy() + 2.f, Vector2f(5, 15));
+	EXPECT_EQ(v1.xy() - 2.f, Vector2f(1, 11));
 }


### PR DESCRIPTION
### Solved Problem
The problem was that addition and subtraction with slices didnt work. 
calculation as such didnt work
```
pos_error = _position.xy() - _position_setpoint.xy()
```


### Solution
Added Addition and Subtraction to the Matrix Slice class

### Changelog Entry
For release notes:
```
Feature Added: added Addition and Subtraction to matrix slices
```

### Test coverage
- Wrote Automatic Tests
