### PR TITLE
serial: change fsync to tcdrain

### DIFF
--- a/platforms/nuttx/src/px4/common/SerialImpl.cpp
+++ b/platforms/nuttx/src/px4/common/SerialImpl.cpp
@@ -339,7 +339,7 @@ ssize_t SerialImpl::write(const void *buffer, size_t buffer_size)
 	}
 
 	int written = ::write(_serial_fd, buffer, buffer_size);
-	::fsync(_serial_fd);
+	tcdrain(_serial_fd); // Wait until all output is transmitted
 
 	if (written < 0) {
 		PX4_ERR("%s write error %d", _port, written);


### PR DESCRIPTION
Calling serial::write() in quick succession was blowing away the previous buffer, fsync does not guarantee that data is transmitted on serial lines. On the other hand tcdrain waits until the output buffer is empty.

I tested on nuttx, probably need to update posix as well. @katzfey was the intention with fsync to flush the output buffer? I discovered this issue in a custom module where I am updating the firmware of a device, reading a firmware file from the file system and writing chunks of 512 bytes at a time. I was discovering that it was rapidly looping and not actually writing each 512 byte chunk to completion.