### PR TITLE
SIM: GZ: Added mono_cam_down and aruco world

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4014_gz_x500_mono_cam_down
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4014_gz_x500_mono_cam_down
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# @name Gazebo x500 mono cam
+#
+# @type Quadrotor
+#
+
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500_mono_cam_down}
+
+. ${R}etc/init.d-posix/airframes/4001_gz_x500

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -85,6 +85,7 @@ px4_add_romfs_files(
 	4011_gz_lawnmower
 	4012_gz_rover_ackermann
 	4013_gz_x500_lidar
+	4014_gz_x500_mono_cam_down
 
 	6011_gazebo-classic_typhoon_h480
 	6011_gazebo-classic_typhoon_h480.post

--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -93,6 +93,7 @@ if(gz-transport_FOUND)
 		windy
 		baylands
   		lawn
+		aruco
 		rover
 	)
 


### PR DESCRIPTION
## Problem 
`make px4_sitl_default gz_x500_mono_cam_down_aruco`
didnt work although theres a gazebo  for it introduced in https://github.com/PX4/PX4-gazebo-models/pull/48.
## Solution 
adds the gazebo model for `x500_mono_cam_down`
adds the aruco world to the CmakeLists

