### PR TITLE
rtl_direct: loiter hold should track altitude as best effort 

### DIFF
--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -300,6 +300,9 @@ void RtlDirect::set_rtl_item()
 				/* Set the altitude tracking to best effort but not strictly enforce it */
 				altitude_acceptance_radius = FLT_MAX;
 
+				if (_force_heading) {
+					_mission_item.force_heading = true;
+				}
 			}
 
 			break;


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When during the RTL loiter down, the terrain avoidance is triggered and the vehicle is kept on an altitude higher than the indented one, it will try to sink to the indented altitude again at the end of the loiter. This is due to the loiter hold after the loiter down enforcing the altitude again.

### Solution
- The loiter hold should only track the altitude as best effort but accept any altitude error. it should only check on the loiter time.
- Also make sure that the loiter hold forces the heading if necessary. Not an issue per se but it was only implicitely set from the prior mission item

### Changelog Entry
For release notes:
```
Bugfix After RTL terrain avoidance is triggered during the loiter down, make sure to not try to sink again before proceeding to the land destination
```

### Test coverage
- SITL testing: Tested in sitl with faking an altitude difference by setting the loiter hold altitude lower than the loiter down altitude in the code

### Context
Related links, screenshot before/after, video
