### PR TITLE
Fix duplicate entry in gz_worlds list

### DIFF
--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -90,7 +90,6 @@ if(gz-transport_FOUND)
   		lawn
 		aruco
 		rover
-		aruco
 	)
 
 	# find corresponding airframes


### PR DESCRIPTION
### Solved Problem
`src/modules/simulation/gz_bridge/CMakeLists.txt` contains a duplicate entry in the `gz_worlds` list, causing build errors due to conflicting target definitions.

### Solution
- Removed the duplicate `aruco `entry from the `gz_worlds` list..

### Changelog Entry
```
Bugfix: Fixed duplicate world entry in `gz_worlds` list causing build failure for simulation targets.
```

### Test coverage
- make test 
