### PR TITLE
GZ Advanced Plane: improved rate/TECS tuning

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4008_gz_advanced_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4008_gz_advanced_plane
@@ -19,21 +19,22 @@ param set-default FW_LND_ANG 8
 param set-default NPFG_PERIOD 12
 
 param set-default FW_MAN_P_MAX 30
-param set-default FW_PR_P 0.9
-param set-default FW_PR_FF 0.5
-param set-default FW_PR_I 0.5
+
+param set-default FW_PR_FF 0.08
+param set-default FW_PR_I 0.3
+param set-default FW_PR_P 0.08
+
+param set-default FW_RR_FF 0.05
+param set-default FW_RR_I 0.2
+param set-default FW_RR_P 0.03
+
+param set-default FW_YR_FF 0.3
+param set-default FW_YR_I 0.4
+param set-default FW_YR_P 0.2
 
 param set-default FW_PSP_OFF 2
 param set-default FW_P_LIM_MAX 32
 param set-default FW_P_LIM_MIN -15
-
-param set-default FW_RR_FF 0.5
-param set-default FW_RR_P 0.3
-param set-default FW_RR_I 0.5
-
-param set-default FW_YR_FF 0.5
-param set-default FW_YR_P 0.6
-param set-default FW_YR_I 0.5
 
 param set-default FW_SPOILERS_LND 0.4
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4008_gz_advanced_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4008_gz_advanced_plane
@@ -16,9 +16,6 @@ param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 1
 
 param set-default FW_LND_ANG 8
-param set-default NPFG_PERIOD 12
-
-param set-default FW_MAN_P_MAX 30
 
 param set-default FW_PR_FF 0.08
 param set-default FW_PR_I 0.3
@@ -47,9 +44,6 @@ param set-default FW_T_SINK_MIN 2.2
 
 param set-default FW_W_EN 1
 
-param set-default MIS_TAKEOFF_ALT 30
-
-param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2
 
 param set-default RWTO_TKOFF 1
@@ -57,7 +51,6 @@ param set-default RWTO_TKOFF 1
 param set-default CA_AIRFRAME 1
 
 param set-default CA_ROTOR_COUNT 1
-param set-default CA_ROTOR0_PX 0.3
 
 param set-default CA_SV_CS_COUNT 6
 param set-default CA_SV_CS0_TRQ_R -0.5

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4008_gz_advanced_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4008_gz_advanced_plane
@@ -37,8 +37,10 @@ param set-default FW_SPOILERS_LND 0.4
 
 param set-default FW_THR_MIN 0.05
 param set-default FW_THR_TRIM 0.25
+param set-default FW_THR_MAX 0.6
 
-param set-default FW_T_CLMB_MAX 8
+param set-default FW_T_CLMB_R_SP 5
+param set-default FW_T_CLMB_MAX 6
 param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
 


### PR DESCRIPTION
### Solved Problem
The default gains in the Advanced Plane airframe yields poor tracking performance in Gazebo Garden simulation

### Solution
Tune the gains for the Advanced Plane simulation model and update the current default ones stored in the airframe

### Test coverage
- SITL testing on Gazebo Garden

### Context
New tracking behaviour
![image (1)](https://github.com/user-attachments/assets/6ba8cd7b-0649-42d9-9099-f4ea491c65dd)

