### PR TITLE
aiframes: remove setting of CBRK_IO_SAFETY to enabeld, as that's already the param default

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10040_sihsim_quadx
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10040_sihsim_quadx
@@ -19,8 +19,6 @@ param set-default SENS_EN_MAGSIM 1
 # disable some checks to allow to fly:
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
-# - without safety switch
-param set-default CBRK_IO_SAFETY 22027
 
 # Square quadrotor X PX4 numbering
 param set-default CA_ROTOR_COUNT 4

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
@@ -21,8 +21,6 @@ param set-default SENS_EN_ARSPDSIM 1
 param set-default CBRK_USB_CHK 197848
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
-# - without safety switch
-param set-default CBRK_IO_SAFETY 22027
 
 param set-default SIH_T_MAX 6
 param set-default SIH_MASS 0.3

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
@@ -30,8 +30,6 @@ param set-default MAV_TYPE 19
 # disable some checks to allow to fly:
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
-# - without safety switch
-param set-default CBRK_IO_SAFETY 22027
 
 param set-default SIH_T_MAX 2
 param set-default SIH_Q_MAX 0.0165

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4006_gz_px4vision
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4006_gz_px4vision
@@ -97,11 +97,6 @@ param set-default IMU_GYRO_CUTOFF 100
 
 # Power Parameters
 param set-default BAT1_N_CELLS 4
-# param set-default BAT1_A_PER_V 36.364		Not found
-# param set-default BAT1_V_DIV 18.182		Not found
-
-# Circuit breakers
-param set-default CBRK_IO_SAFETY 22027
 
 param set-default THR_MDL_FAC 0.3
 

--- a/ROMFS/px4fmu_common/init.d/airframes/1001_rc_quad_x.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1001_rc_quad_x.hil
@@ -18,8 +18,6 @@ param set UAVCAN_ENABLE 0
 # disable some checks to allow to fly
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
-# - without safety switch
-param set-default CBRK_IO_SAFETY 22027
 
 # Square quadrotor X PX4 numbering
 param set-default CA_ROTOR_COUNT 4

--- a/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
@@ -96,7 +96,5 @@ param set UAVCAN_ENABLE 0
 # disable some checks to allow to fly
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
-# - without safety switch
-param set-default CBRK_IO_SAFETY 22027
 
 param set-default MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/airframes/1100_rc_quad_x_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1100_rc_quad_x_sih.hil
@@ -20,8 +20,6 @@ param set SYS_HITL 2
 # disable some checks to allow to fly:
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
-# - without safety switch
-param set-default CBRK_IO_SAFETY 22027
 
 param set SIH_VEHICLE_TYPE 0
 

--- a/ROMFS/px4fmu_common/init.d/airframes/1101_rc_plane_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1101_rc_plane_sih.hil
@@ -41,8 +41,6 @@ param set-default SYS_HITL 2
 # disable some checks to allow to fly:
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
-# - without safety switch
-param set-default CBRK_IO_SAFETY 22027
 
 param set SIH_T_MAX 6
 param set SIH_MASS 0.3

--- a/ROMFS/px4fmu_common/init.d/airframes/1102_tailsitter_duo_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1102_tailsitter_duo_sih.hil
@@ -63,8 +63,6 @@ param set-default SYS_HITL 2
 # disable some checks to allow to fly:
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
-# - without safety switch
-param set-default CBRK_IO_SAFETY 22027
 
 param set-default SENS_DPRES_OFF 0.001
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -29,7 +29,6 @@ param set-default BAT1_N_CELLS 4
 param set-default BAT1_R_INTERNAL 0.0025
 
 param set-default SYS_HAS_NUM_ASPD 0
-param set-default CBRK_IO_SAFETY 22027
 
 param set-default EKF2_GPS_POS_X -0.12
 param set-default EKF2_IMU_POS_X -0.12

--- a/ROMFS/px4fmu_common/init.d/airframes/18001_TF-B1
+++ b/ROMFS/px4fmu_common/init.d/airframes/18001_TF-B1
@@ -16,7 +16,6 @@
 . ${R}etc/init.d/rc.balloon_defaults
 
 param set-default COM_PREARM_MODE 2  # always in prearm state
-param set-default CBRK_IO_SAFETY 22027
 param set-default SDLOG_PROFILE 17
 param set-default SDLOG_MODE 2
 param set-default MAV_0_MODE 1

--- a/ROMFS/px4fmu_common/init.d/airframes/2507_cloudship
+++ b/ROMFS/px4fmu_common/init.d/airframes/2507_cloudship
@@ -16,7 +16,6 @@
 . ${R}etc/init.d/rc.airship_defaults
 
 param set-default COM_PREARM_MODE 2
-param set-default CBRK_IO_SAFETY 22027
 
 param set-default CA_AIRFRAME 9
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
+++ b/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
@@ -92,9 +92,6 @@ param set-default BAT1_N_CELLS 4
 param set-default BAT1_A_PER_V 36.364
 param set-default BAT1_V_DIV 18.182
 
-# Circuit breakers
-param set-default CBRK_IO_SAFETY 22027
-
 param set-default THR_MDL_FAC 0.3
 
 # Square quadrotor X PX4 numbering

--- a/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
+++ b/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
@@ -93,9 +93,6 @@ param set-default BAT1_N_CELLS 4
 param set-default BAT1_A_PER_V 36.364
 param set-default BAT1_V_DIV 18.182
 
-# Circuit breakers
-param set-default CBRK_IO_SAFETY 22027
-
 param set-default THR_MDL_FAC 0.3
 
 # Square quadrotor X PX4 numbering

--- a/ROMFS/px4fmu_common/init.d/airframes/60002_uuv_bluerov2_heavy
+++ b/ROMFS/px4fmu_common/init.d/airframes/60002_uuv_bluerov2_heavy
@@ -23,9 +23,6 @@
 . ${R}etc/init.d/rc.uuv_defaults
 
 
-# companion computer is connected via USB permanently
-param set-default CBRK_IO_SAFETY 22027
-
 param set-default MAV_1_CONFIG 102
 
 param set-default BAT1_A_PER_V 37.8798

--- a/ROMFS/px4fmu_common/init.d/airframes/6002_draco_r
+++ b/ROMFS/px4fmu_common/init.d/airframes/6002_draco_r
@@ -73,8 +73,6 @@ param set-default SENS_EN_PX4FLOW 1
 param set-default SENS_EN_LL40LS 2
 param set-default SENS_FLOW_ROT 2
 
-#
-param set-default CBRK_IO_SAFETY 22027
 param set-default COM_DISARM_LAND 3
 
 # Battery

--- a/boards/diatone/mamba-f405-mk2/init/rc.board_defaults
+++ b/boards/diatone/mamba-f405-mk2/init/rc.board_defaults
@@ -6,7 +6,4 @@
 # system_power unavailable
 param set-default CBRK_SUPPLY_CHK 894281
 
-# Disable safety switch by default
-param set-default CBRK_IO_SAFETY 22027
-
 param set-default SYS_HAS_MAG 0

--- a/boards/flywoo/gn-f405/init/rc.board_defaults
+++ b/boards/flywoo/gn-f405/init/rc.board_defaults
@@ -9,9 +9,6 @@ param set-default SYS_AUTOSTART 4001
 # system_power unavailable
 param set-default CBRK_SUPPLY_CHK 894281
 
-# Disable safety switch by default
-param set-default CBRK_IO_SAFETY 22027
-
 param set-default EKF2_MAG_TYPE 5
 param set-default SENS_BOARD_ROT 6
 

--- a/boards/omnibus/f4sd/init/rc.board_defaults
+++ b/boards/omnibus/f4sd/init/rc.board_defaults
@@ -9,7 +9,4 @@ param set-default BAT1_A_PER_V 31
 # system_power unavailable
 param set-default CBRK_SUPPLY_CHK 894281
 
-# Disable safety switch by default
-param set-default CBRK_IO_SAFETY 22027
-
 param set-default SYS_HAS_MAG 0

--- a/boards/raspberrypi/pico/init/rc.board_defaults
+++ b/boards/raspberrypi/pico/init/rc.board_defaults
@@ -8,6 +8,3 @@ param set-default BAT1_A_PER_V 36.367515152
 
 # system_power unavailable
 param set-default CBRK_SUPPLY_CHK 894281
-
-# Disable safety switch by default
-param set-default CBRK_IO_SAFETY 22027

--- a/boards/sky-drones/smartap-airlink/init/rc.board_defaults
+++ b/boards/sky-drones/smartap-airlink/init/rc.board_defaults
@@ -21,9 +21,6 @@ param set-default BAT1_A_PER_V 36.00
 
 param set-default BAT_V_OFFS_CURR 0.413
 
-# Disable safety switch
-param set-default CBRK_IO_SAFETY 22027
-
 safety_button start
 
 set LOGGER_BUF 32


### PR DESCRIPTION
Since https://github.com/PX4/PX4-Autopilot/pull/16847, `CBRK_IO_SAFETY` is already enabled by default, but still was set in many airframes. 