### PR TITLE
version: Change this IF statement to a SWITCH statement

### DIFF
--- a/src/lib/version/version.c
+++ b/src/lib/version/version.c
@@ -75,27 +75,48 @@ uint32_t version_tag_to_number(const char *tag)
 	int firmware_type = FIRMWARE_TYPE_RELEASE;
 
 	for (size_t i = 0; i < strlen(tag); i++) {
-		if (tag[i] == '-') {
+		switch (tag[i]) {
+		case '-':
 			dash_count++;
+			break;
 
-		} else if (tag[i] == '.') {
+		case '.':
 			point_count++;
-		}
+			break;
 
-		if (tag[i] == 'r' && i < strlen(tag) - 1 && tag[i + 1] == 'c') {
-			firmware_type = FIRMWARE_TYPE_RC;
+		case 'r':
+			if (i < strlen(tag) - 1 && tag[i + 1] == 'c') {
+				firmware_type = FIRMWARE_TYPE_RC;
 
-		} else if (tag[i] == 'p') {
+			}
+
+			break;
+
+		case 'p':
 			firmware_type = FIRMWARE_TYPE_ALPHA;
+			break;
 
-		} else if (tag[i] == 't' && i < strlen(tag) - 1 && tag[i + 1] == 'y') {
-			firmware_type = FIRMWARE_TYPE_DEV;
+		case 't':
+			if (i < strlen(tag) - 1 && tag[i + 1] == 'y') {
+				firmware_type = FIRMWARE_TYPE_DEV;
 
-		} else if (tag[i] == 't') {
-			firmware_type = FIRMWARE_TYPE_BETA;
+			} else {
+				firmware_type = FIRMWARE_TYPE_BETA;
 
-		} else if (tag[i] == 'v' && i > 0) {
-			firmware_type = FIRMWARE_TYPE_DEV;
+			}
+
+			break;
+
+		case 'v':
+			if (i > 0) {
+				firmware_type = FIRMWARE_TYPE_DEV;
+
+			}
+
+			break;
+
+		default:
+			break;
 		}
 	}
 
@@ -163,27 +184,48 @@ uint32_t version_tag_to_vendor_version_number(const char *tag)
 	int firmware_type = FIRMWARE_TYPE_RELEASE;
 
 	for (size_t i = 0; i < strlen(tag); i++) {
-		if (tag[i] == '-') {
+		switch (tag[i]) {
+		case '-':
 			dash_count++;
+			break;
 
-		} else if (tag[i] == '.') {
+		case '.':
 			point_count++;
-		}
+			break;
 
-		if (tag[i] == 'r' && i < strlen(tag) - 1 && tag[i + 1] == 'c') {
-			firmware_type = FIRMWARE_TYPE_RC;
+		case 'r':
+			if (i < strlen(tag) - 1 && tag[i + 1] == 'c') {
+				firmware_type = FIRMWARE_TYPE_RC;
 
-		} else if (tag[i] == 'p') {
+			}
+
+			break;
+
+		case 'p':
 			firmware_type = FIRMWARE_TYPE_ALPHA;
+			break;
 
-		} else if (tag[i] == 't' && i < strlen(tag) - 1 && tag[i + 1] == 'y') {
-			firmware_type = FIRMWARE_TYPE_DEV;
+		case 't':
+			if (i < strlen(tag) - 1 && tag[i + 1] == 'y') {
+				firmware_type = FIRMWARE_TYPE_DEV;
 
-		} else if (tag[i] == 't') {
-			firmware_type = FIRMWARE_TYPE_BETA;
+			} else {
+				firmware_type = FIRMWARE_TYPE_BETA;
 
-		} else if (tag[i] == 'v' && i > 0) {
-			firmware_type = FIRMWARE_TYPE_DEV;
+			}
+
+			break;
+
+		case 'v':
+			if (i > 0) {
+				firmware_type = FIRMWARE_TYPE_DEV;
+
+			}
+
+			break;
+
+		default:
+			break;
 		}
 	}
 


### PR DESCRIPTION
### Solved Problem

The version was specified using a GIT tag, but the QGC version was displayed as 0.0.0. Upon investigation, it was found that the version was being determined using an IF statement to check the string.

### Solution

I will clarify the pattern by changing the IF statement to a SWITCH statement

### Changelog Entry

none

### Alternatives

none

### Test coverage

No build errors occur, OK.

### Context

Test pattern: v11.45.99-1.2.3-alpha3-7-g7e282f57

![Screenshot from 2024-09-22 11-10-56](https://github.com/user-attachments/assets/f803c7ac-0437-4d93-9d4d-a86199f7252b)
