### PR TITLE
EKF2: consider height covariance for terrain reset to range

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/range_finder/range_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/range_finder/range_height_control.cpp
@@ -37,6 +37,7 @@
  */
 
 #include "ekf.h"
+#include "ekf_derivation/generated/compute_hagl_h.h"
 #include "ekf_derivation/generated/compute_hagl_innov_var.h"
 
 void Ekf::controlRangeHaglFusion(const imuSample &imu_sample)
@@ -270,13 +271,25 @@ float Ekf::getRngVar() const
 
 void Ekf::resetTerrainToRng(estimator_aid_source1d_s &aid_src)
 {
-	const float new_terrain = _state.pos(2) + aid_src.observation;
-	const float delta_terrain = new_terrain - _state.terrain;
+	// Since the distance is not a direct observation of the terrain state but is based
+	// on the height state, a reset should consider the height uncertainty. This can be
+	// done by manipulating the Kalman gain to inject all the innovation in the terrain state
+	// and create the correct correlation with the terrain state with a covariance update.
+	P.uncorrelateCovarianceSetVariance<State::terrain.dof>(State::terrain.idx, 0.f);
 
-	_state.terrain = new_terrain;
-	P.uncorrelateCovarianceSetVariance<State::terrain.dof>(State::terrain.idx, aid_src.observation_variance);
+	const float old_terrain = _state.terrain;
+
+	VectorState H;
+	sym::ComputeHaglH(&H);
+
+	VectorState K;
+	K(State::terrain.idx) = 1.f; // innovation is forced into the terrain state to create a "reset"
+
+	measurementUpdate(K, H, aid_src.observation_variance, aid_src.innovation);
 
 	// record the state change
+	const float delta_terrain = _state.terrain - old_terrain;
+
 	if (_state_reset_status.reset_count.hagl == _state_reset_count_prev.hagl) {
 		_state_reset_status.hagl_change = delta_terrain;
 
@@ -286,7 +299,6 @@ void Ekf::resetTerrainToRng(estimator_aid_source1d_s &aid_src)
 	}
 
 	_state_reset_status.reset_count.hagl++;
-
 
 	aid_src.time_last_fuse = _time_delayed_us;
 }


### PR DESCRIPTION


### Solved Problem
Range does not provide a direct terrain observation but a measurement relative to the height state. De-correlating those states during initialization brings false information to the filter about the terrain accuracy.

### Solution
Build correlation between the height covariance and terrain by manipulating the Kalman gain (this is possible thanks to the Joseph stabilized covariance update).

By looking at the state covariance matrix after the reset, we can see that a correlation with the vertical velocity, vertical position and vertical accelerometer bias is created. Also, the terrain variance contains both vertical position and range uncertainties.
![Screenshot from 2024-09-23 11-27-23](https://github.com/user-attachments/assets/a4ad2e04-b1fd-4552-adba-c36f269fa4d3)

NOTE: we should do the same for all measurements that are not a direct state observation (e.g.: body vel, airspeed, flow)

### Test coverage
unit tests