### PR TITLE
HealthAndArmingChecks: improve messaging for position estimate failure

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/modeCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/modeCheck.cpp
@@ -77,29 +77,35 @@ void ModeChecks::checkAndReport(const Context &context, Report &reporter)
 
 	if (local_position_modes != NavModes::None) {
 		/* EVENT
+		 * @description
+		 * The available positioning data is not sufficient to execute the selected mode.
 		 */
 		reporter.armingCheckFailure(local_position_modes, health_component_t::local_position_estimate,
 					    events::ID("check_modes_local_pos"),
-					    events::Log::Error, "No valid local position estimate");
+					    events::Log::Error, "Navigation error: No valid local position estimate");
 		reporter.clearCanRunBits(local_position_modes);
 	}
 
 	if (reporter.failsafeFlags().global_position_invalid && reporter.failsafeFlags().mode_req_global_position != 0) {
 		/* EVENT
+		 * @description
+		 * The available positioning data is not sufficient to execute the selected mode.
 		 */
 		reporter.armingCheckFailure((NavModes)reporter.failsafeFlags().mode_req_global_position,
 					    health_component_t::global_position_estimate,
 					    events::ID("check_modes_global_pos"),
-					    events::Log::Error, "No valid global position estimate");
+					    events::Log::Error, "Navigation error: No valid global position estimate");
 		reporter.clearCanRunBits((NavModes)reporter.failsafeFlags().mode_req_global_position);
 	}
 
 	if (reporter.failsafeFlags().local_altitude_invalid && reporter.failsafeFlags().mode_req_local_alt != 0) {
 		/* EVENT
+		 * @description
+		 * The available positioning data is not sufficient to execute the selected mode.
 		 */
 		reporter.armingCheckFailure((NavModes)reporter.failsafeFlags().mode_req_local_alt, health_component_t::system,
 					    events::ID("check_modes_local_alt"),
-					    events::Log::Critical, "No valid altitude estimate");
+					    events::Log::Critical, "Navigation error: No valid altitude estimate");
 		reporter.clearCanRunBits((NavModes)reporter.failsafeFlags().mode_req_local_alt);
 	}
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/modeCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/modeCheck.cpp
@@ -82,7 +82,7 @@ void ModeChecks::checkAndReport(const Context &context, Report &reporter)
 		 */
 		reporter.armingCheckFailure(local_position_modes, health_component_t::local_position_estimate,
 					    events::ID("check_modes_local_pos"),
-					    events::Log::Error, "Navigation error: No valid local position estimate");
+					    events::Log::Error, "Navigation error: No valid position estimate");
 		reporter.clearCanRunBits(local_position_modes);
 	}
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/systemCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/systemCheck.cpp
@@ -80,12 +80,13 @@ void SystemChecks::checkAndReport(const Context &context, Report &reporter)
 			 * <profile name="dev">
 			 * This check can be configured via <param>COM_ARM_WO_GPS</param> parameter.
 			 * </profile>
+			 * The available positioning data is not sufficient to determine the vehicle's global position.
 			 */
 			reporter.armingCheckFailure(NavModes::All, health_component_t::system, events::ID("check_system_no_global_pos"),
-						    events::Log::Error, "Global position required");
+						    events::Log::Error, "Global position estimate required");
 
 			if (reporter.mavlink_log_pub()) {
-				mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Global position required");
+				mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Global position estimate required");
 			}
 
 		} else if (reporter.failsafeFlags().home_position_invalid) {


### PR DESCRIPTION

### Solved Problem
The messaging in case of estimation failures (local and global position, altitude) is very minimalistic and not end-user friendly. 

### Solution
- add "Navigation error" before failure message
- add description

This is how the notification would look like now:

Expanded event (with description):
![image](https://github.com/user-attachments/assets/8bd9124f-50fc-4549-9bbf-26118fef4878)
This is the raw notification, that also pops up in yellow on screen:
![image](https://github.com/user-attachments/assets/2c4bf36e-f773-4005-8153-1b8b7ba8e6d6)

### Changelog Entry
For release notes:
```
Improvement: HealthAndArmingChecks: improve messaging for position estimate failure
```