### PR TITLE
Battery: Cleanup & added hysteresis for connected state

### DIFF
--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -402,11 +402,12 @@ Syslink::handle_message(syslink_message_t *msg)
 
 		float vbat; //, iset;
 		memcpy(&vbat, &msg->data[1], sizeof(float));
-		//memcpy(&iset, &msg->data[5], sizeof(float));
 
-		_battery.setConnected(true);
-		_battery.updateVoltage(vbat);
-		_battery.updateAndPublishBatteryStatus(t);
+		Battery::InputSample sample{
+			.timestamp = t,
+			.voltage_v = vbat,
+		};
+		_battery.updateAndPublishBatteryStatus(sample);
 
 		// Update battery charge state
 		if (charging) {

--- a/src/drivers/actuators/voxl_esc/voxl_esc.cpp
+++ b/src/drivers/actuators/voxl_esc/voxl_esc.cpp
@@ -569,15 +569,16 @@ int VoxlEsc::parse_response(uint8_t *buf, uint8_t len, bool print_feedback)
 
 				// Limit the frequency of battery status reports
 				if (_parameters.publish_battery_status) {
-					_battery.setConnected(true);
-					_battery.updateVoltage(voltage);
-					_battery.updateCurrent(current);
-
 					hrt_abstime current_time = hrt_absolute_time();
 
 					if ((current_time - _last_battery_report_time) >= _battery_report_interval) {
 						_last_battery_report_time = current_time;
-						_battery.updateAndPublishBatteryStatus(current_time);
+						Battery::InputSample sample{
+							.timestamp = current_time,
+							.voltage_v = voltage,
+							.current_a = current
+						};
+						_battery.updateAndPublishBatteryStatus(sample);
 					}
 				}
 

--- a/src/drivers/power_monitor/ina226/ina226.h
+++ b/src/drivers/power_monitor/ina226/ina226.h
@@ -188,9 +188,7 @@ private:
 	perf_counter_t 		_measure_errors;
 
 	int16_t           _bus_voltage{0};
-	int16_t           _power{0};
 	int16_t           _current{0};
-	int16_t           _shunt{0};
 	int16_t           _cal{0};
 	bool              _mode_triggered{false};
 

--- a/src/drivers/power_monitor/ina228/ina228.h
+++ b/src/drivers/power_monitor/ina228/ina228.h
@@ -341,7 +341,6 @@ private:
 	int64_t           _power{0};
 	int32_t           _current{0};
 	int16_t           _temperature{0};
-	int32_t           _shunt{0};
 	int16_t           _cal{0};
 	int16_t           _range{INA228_ADCRANGE_HIGH};
 	bool              _mode_triggered{false};

--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -230,10 +230,12 @@ void
 UavcanBatteryBridge::filterData(const uavcan::ReceivedDataStructure<uavcan::equipment::power::BatteryInfo> &msg,
 				uint8_t instance)
 {
-	_battery[instance]->setConnected(true);
-	_battery[instance]->updateVoltage(msg.voltage);
-	_battery[instance]->updateCurrent(msg.current);
-	_battery[instance]->updateBatteryStatus(hrt_absolute_time());
+	Battery::InputSample sample {
+		.timestamp = hrt_absolute_time(),
+		.voltage_v = msg.voltage,
+		.current_a = msg.current
+	};
+	_battery[instance]->updateBatteryStatus(sample);
 
 	/* Override data that is expected to arrive from UAVCAN msg*/
 	_battery_status[instance] = _battery[instance]->getBatteryStatus();

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -100,7 +100,8 @@ Battery::Battery(int index, ModuleParams *parent, const int sample_interval_us, 
 
 void  Battery::updateBatteryStatus(const InputSample &sample)
 {
-	_connected_state_hysteresis.set_state_and_update(sample.valid(), sample.timestamp);
+	const bool battery_connected = sample.valid() && sample.voltage_v >= LITHIUM_BATTERY_RECOGNITION_VOLTAGE;
+	_connected_state_hysteresis.set_state_and_update(battery_connected, sample.timestamp);
 
 	if (!sample.valid()) {
 		_last_valid_current_timestamp = 0;

--- a/src/lib/hysteresis/hysteresis.h
+++ b/src/lib/hysteresis/hysteresis.h
@@ -59,6 +59,8 @@ public:
 
 	bool get_state() const { return _state; }
 
+	hrt_abstime get_last_time_to_change_state() const { return _last_time_to_change_state; };
+
 	void set_hysteresis_time_from(const bool from_state, const hrt_abstime new_hysteresis_time_us);
 
 	void set_state_and_update(const bool new_state, const hrt_abstime &now_us);

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -79,10 +79,16 @@ AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, 
 	const bool connected = voltage_v > BOARD_ADC_OPEN_CIRCUIT_V &&
 			       (BOARD_ADC_OPEN_CIRCUIT_V <= BOARD_VALID_UV || is_valid());
 
-	Battery::setConnected(connected);
-	Battery::updateVoltage(voltage_v);
-	Battery::updateCurrent(current_a);
-	Battery::updateAndPublishBatteryStatus(timestamp);
+	Battery::InputSample sample{
+		.timestamp = timestamp,
+	};
+
+	if (connected) {
+		sample.voltage_v = voltage_v;
+		sample.current_a = current_a;
+	}
+
+	Battery::updateAndPublishBatteryStatus(sample);
 }
 
 bool AnalogBattery::is_valid()

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -101,10 +101,13 @@ EscBattery::Run()
 
 		average_voltage_v /= online_esc_count;
 
-		_battery.setConnected(true);
-		_battery.updateVoltage(average_voltage_v);
-		_battery.updateCurrent(total_current_a);
-		_battery.updateAndPublishBatteryStatus(esc_status.timestamp);
+		Battery::InputSample sample {
+			.timestamp = esc_status.timestamp,
+			.voltage_v = average_voltage_v,
+			.current_a = total_current_a
+		};
+
+		_battery.updateAndPublishBatteryStatus(sample);
 	}
 }
 

--- a/src/modules/simulation/battery_simulator/BatterySimulator.cpp
+++ b/src/modules/simulation/battery_simulator/BatterySimulator.cpp
@@ -108,10 +108,12 @@ void BatterySimulator::Run()
 
 	vbatt *= _battery.cell_count();
 
-	_battery.setConnected(true);
-	_battery.updateVoltage(vbatt);
-	_battery.updateCurrent(ibatt);
-	_battery.updateAndPublishBatteryStatus(now_us);
+	Battery::InputSample sample{
+		.timestamp = hrt_absolute_time(),
+		.voltage_v = vbatt,
+		.current_a = ibatt
+	};
+	_battery.updateAndPublishBatteryStatus(sample);
 
 	perf_end(_loop_perf);
 }


### PR DESCRIPTION
### Solved Problem
Currently the battery connected state toggles as soon as there is a single transfer error from the battery driver.

### Solution
Add a two second hysteresis to make sure that single transfer errors don't change the battery connected state.

### Changelog Entry
For release notes:
```
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
