### PR TITLE
fix air data publication rate

### DIFF
--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -243,7 +243,7 @@ void VehicleAirData::Run()
 
 				const hrt_abstime timestamp_sample = _timestamp_sample_sum[instance] / _data_sum_count[instance];
 
-				if (timestamp_sample >= _last_publication_timestamp[instance] + interval_us) {
+				if (time_now_us >= _last_publication_timestamp[instance] + interval_us) {
 
 					bool publish = (time_now_us <= timestamp_sample + 1_s);
 
@@ -278,7 +278,7 @@ void VehicleAirData::Run()
 						_vehicle_air_data_pub.publish(out);
 					}
 
-					_last_publication_timestamp[instance] = timestamp_sample;
+					_last_publication_timestamp[instance] = time_now_us;
 
 					// reset
 					_timestamp_sample_sum[instance] = 0;


### PR DESCRIPTION
### Solved Problem
VehicleAirData is responsible for down sampling the baro (in my case MS5611 with default settings from ~100Hz to 20Hz).
I found that the `vehicle_air_data` topic was published at the expected average rate (20Hz) but with a high variation : publication period is going from 10ms to 90ms):
![image](https://github.com/user-attachments/assets/d09ac3b5-900d-47be-99b2-b272763cefda)

The result is a high apparent noise on the barometer as some samples are not the average of multiple real sensor measurements.
 
What happen is that the module takes some measurements during 90ms and publishes the average, then take 1 measurement and publishes it, then the average during 90ms again, then1 measurement, etc

I found that the publication was triggered using the average measurement timestamp. The default configuration give a publication period of 50ms. So to make the average timestamp to increase of 50ms, we have to wait about 100ms. Then it can publish the data and take a new measurement which timestamp is already more the 50ms older than the previous average so ti is published instantly. Then we have to wait about 100ms again to have the average timestamp increased of 50ms, etc

### Solution
I propose to publish the air data every 50ms (or 1/SENS_BARO_RATE) if new data is received not using the measurement average timestamp but the actual timestamp.

It result in good publication rate and reduce the apparent baro noise as each air data publication is the average of the expected number of real measurement.


![image](https://github.com/user-attachments/assets/28d88a40-bbf5-45c7-994d-f2a2c6d9b974)



