### PR TITLE
gnss: disable default assignment of GPS1

### DIFF
--- a/src/drivers/gnss/septentrio/module.yaml
+++ b/src/drivers/gnss/septentrio/module.yaml
@@ -10,7 +10,6 @@ serial_config:
       port_config_param:
         name: SEP_PORT1_CFG
         group: Septentrio
-        default: GPS1
       label: GPS Port
 
 parameters:


### PR DESCRIPTION
Fixes assignment of GPS1 by default

https://github.com/PX4/PX4-Autopilot/issues/23714#issuecomment-2370671684