### PR TITLE
[RELEASE/1.15] Septentrio: disable default assignment of GPS1

### DIFF
--- a/src/drivers/gnss/septentrio/module.yaml
+++ b/src/drivers/gnss/septentrio/module.yaml
@@ -10,7 +10,6 @@ serial_config:
       port_config_param:
         name: SEP_PORT1_CFG
         group: Septentrio
-        default: GPS1
       label: GPS Port
 
 parameters:


### PR DESCRIPTION
backport of https://github.com/PX4/PX4-Autopilot/pull/23718
fixes https://github.com/PX4/PX4-Autopilot/issues/23714