### PR TITLE
Always start board_adc

### DIFF
--- a/boards/ark/fmu-v6x/init/rc.board_sensors
+++ b/boards/ark/fmu-v6x/init/rc.board_sensors
@@ -14,6 +14,7 @@ fi
 if param compare -s ADC_ADS1115_EN 1
 then
 	ads1115 start -X
+	board_adc start -n
 else
 	board_adc start
 fi

--- a/boards/px4/fmu-v6xrt/init/rc.board_sensors
+++ b/boards/px4/fmu-v6xrt/init/rc.board_sensors
@@ -26,6 +26,7 @@ fi
 if param compare -s ADC_ADS1115_EN 1
 then
 	ads1115 start -X
+	board_adc start -n
 else
 	board_adc start
 fi


### PR DESCRIPTION
### Solved Problem
To solve https://github.com/PX4/PX4-Autopilot/issues/22474 it is required that the `board_adc` does always startup to publish the `system_power` message.

### Solution
The PR solves the problem by always starting the `board_adc`. To avoid that both the `board_adc` and the `ads1115` report adc messages the `-n` flag is used to stop the `board_adc` from reporting it as described in the linked issue.

This solution is already used for some boards but was not rolled-out to each board. This PR adds it to the remaining boards.