### PR TITLE
MPC: reset velocity integrators when not in use

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -556,6 +556,13 @@ void MulticopterPositionControl::Run()
 				states.velocity(2) = vehicle_local_position.z_deriv * weighting + vehicle_local_position.vz * (1.f - weighting);
 			}
 
+			if ((!PX4_ISFINITE(_setpoint.velocity[0]) || !PX4_ISFINITE(_setpoint.velocity[1]))
+			    && (!PX4_ISFINITE(_setpoint.position[0]) || !PX4_ISFINITE(_setpoint.position[1]))) {
+				// Horizontal velocity is not controlled, reset the integrators to avoid
+				// over-corrections when starting again.
+				_control.resetIntegralXY();
+			}
+
 			_control.setState(states);
 
 			// Run position control
@@ -586,6 +593,7 @@ void MulticopterPositionControl::Run()
 			// an update is necessary here because otherwise the takeoff state doesn't get skipped with non-altitude-controlled modes
 			_takeoff.updateTakeoffState(_vehicle_control_mode.flag_armed, _vehicle_land_detected.landed, false, 10.f, true,
 						    vehicle_local_position.timestamp_sample);
+			_control.resetIntegral();
 		}
 
 		// Publish takeoff status

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -162,6 +162,7 @@ public:
 	 * @see _vel_int
 	 */
 	void resetIntegral() { _vel_int.setZero(); }
+	void resetIntegralXY() { _vel_int.xy() = matrix::Vector2f(); }
 
 	/**
 	 * If set, the tilt setpoint is computed by assuming no vertical acceleration


### PR DESCRIPTION

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
In some cases the velocity integrator can be strongly loaded when switching out of position control (e.g.: switch during braking or strong wind). When resuming position control, the drone is disturbed by this pre-loaded integrator since the conditions changed.

Reproduced in SITL:
fly fast in altitude mode, briefly switch into position mode, then stop the drone and re-engage pos control
![Screenshot from 2024-09-27 10-55-52](https://github.com/user-attachments/assets/7a58c267-b8dc-4dc5-b4c4-b87f155b2bcb)

### Solution
Reset all integrators when not in a position controlled mode (e.g.: stabilized)
![Screenshot from 2024-09-27 13-40-14](https://github.com/user-attachments/assets/db4919f0-bb7b-4d93-8643-7a49deb3f9dd)

Reset the xy integrators when in altitude mode
![Screenshot from 2024-09-27 13-38-23](https://github.com/user-attachments/assets/424b0eae-d234-4644-b32b-92aa860bf234)

Tested using https://github.com/PX4/PX4-Autopilot/pull/19649 to see the integrators.

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Test coverage
SITL