### PR TITLE
Failure detector use per index esc current

### DIFF
--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -416,10 +416,10 @@ void FailureDetector::updateMotorStatus(const vehicle_status_s &vehicle_status, 
 
 			// Check if ESC current is too low
 			if (cur_esc_report.esc_current > FLT_EPSILON) {
-				_motor_failure_escs_have_current = true;
+				_motor_failure_esc_has_current[i_esc] = true;
 			}
 
-			if (_motor_failure_escs_have_current) {
+			if (_motor_failure_esc_has_current[i_esc]) {
 				float esc_throttle = 0.f;
 
 				if (PX4_ISFINITE(actuator_motors.control[i_esc])) {

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -129,7 +129,7 @@ private:
 	uint8_t _motor_failure_esc_valid_current_mask{};  // ESC 1-8, true if ESC telemetry was valid at some point
 	uint8_t _motor_failure_esc_timed_out_mask{};      // ESC telemetry no longer available -> failure
 	uint8_t _motor_failure_esc_under_current_mask{};  // ESC drawing too little current -> failure
-	bool _motor_failure_escs_have_current{false}; // true if some ESC had non-zero current (some don't support it)
+	bool _motor_failure_esc_has_current[actuator_motors_s::NUM_CONTROLS] {false}; // true if some ESC had non-zero current (some don't support it)
 	hrt_abstime _motor_failure_undercurrent_start_time[actuator_motors_s::NUM_CONTROLS] {};
 
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};


### PR DESCRIPTION
Only check for motor failures on indexes that have had non zero current. 

Fixes https://github.com/PX4/PX4-Autopilot/issues/23734