### PR TITLE
EKF2: rework amsl to ellipsoid altitude conversion

### DIFF
--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -44,6 +44,7 @@
 #include "EKF/ekf.h"
 
 #include "EKF2Selector.hpp"
+#include "mathlib/math/filter/AlphaFilter.hpp"
 
 #include <float.h>
 
@@ -210,10 +211,8 @@ private:
 	bool UpdateExtVisionSample(ekf2_timestamps_s &ekf2_timestamps);
 #endif // CONFIG_EKF2_EXTERNAL_VISION
 #if defined(CONFIG_EKF2_GNSS)
-	/*
-	 * Calculate filtered WGS84 height from estimated AMSL height
-	 */
-	float filter_altitude_ellipsoid(float amsl_hgt);
+	float altEllipsoidToAmsl(float ellipsoid_alt) const;
+	float altAmslToEllipsoid(float amsl_alt) const;
 
 	void PublishGpsStatus(const hrt_abstime &timestamp);
 	void PublishGnssHgtBias(const hrt_abstime &timestamp);
@@ -445,10 +444,10 @@ private:
 #endif // CONFIG_EKF2_WIND
 
 #if defined(CONFIG_EKF2_GNSS)
-	uint64_t _gps_time_usec {0};
-	int32_t _gps_alttitude_ellipsoid{0};			///< altitude in 1E-3 meters (millimeters) above ellipsoid
-	uint64_t _gps_alttitude_ellipsoid_previous_timestamp{0}; ///< storage for previous timestamp to compute dt
-	float   _wgs84_hgt_offset = 0;  ///< height offset between AMSL and WGS84
+
+	uint64_t _last_geoid_height_update_us{0};
+	static constexpr float kGeoidHeightLpfTimeConstant = 10.f;
+	AlphaFilter<float> _geoid_height_lpf;  ///< height offset between AMSL and ellipsoid
 
 	hrt_abstime _last_gps_status_published{0};
 


### PR DESCRIPTION
### Solved Problem
I would like to change the ekf altitude datum from amsl to wgs84 but I didn't really like the current implementation of the conversion from amsl to wgs84.

### Solution
Estimate the geoid height by using the filtered difference the GNSS alt and alt_ellipsoid values. Then use this geoid height to convert altitude between amsl and wgs84.

Convention is:
`ellipsoid_height = amsl_height + geoid_height` ([ref](https://www.ngs.noaa.gov/PUBS_LIB/gislis96.html#:~:text=It%20is%20a%20straightforward%20procedure,H%20%3D%20h%20%2D%20N%20.))

Tested in SITL with a geoid height of 29m
![image](https://github.com/user-attachments/assets/c6ca63e3-604a-4c15-bf93-46f1974af2fe)
