### PR TITLE
[cdcacm_autostart] set file descriptor to -1 after close()

### DIFF
--- a/src/drivers/cdcacm_autostart/cdcacm_autostart.cpp
+++ b/src/drivers/cdcacm_autostart/cdcacm_autostart.cpp
@@ -76,6 +76,7 @@ CdcAcmAutostart::~CdcAcmAutostart()
 
 	if (_ttyacm_fd >= 0) {
 		px4_close(_ttyacm_fd);
+		_ttyacm_fd = -1;
 	}
 
 	ScheduleClear();
@@ -344,6 +345,7 @@ void CdcAcmAutostart::state_disconnecting()
 
 	if (_ttyacm_fd > 0) {
 		px4_close(_ttyacm_fd);
+		_ttyacm_fd = -1;
 	}
 
 	// Disconnect serial


### PR DESCRIPTION
The `fd` needs to be set to -1 after calling close(), otherwise a loss of VBUS will kick the module back into the `connecting` state but will immediately pass the `open()` check since `fd` is still valid. 