### PR TITLE
simulation/gz_bridge: Add support for lidar altitude sensors

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -58,6 +58,7 @@
 #include <uORB/topics/sensor_baro.h>
 #include <uORB/topics/vehicle_odometry.h>
 #include <uORB/topics/wheel_encoders.h>
+#include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/obstacle_distance.h>
 
 #include <gz/math.hh>
@@ -110,7 +111,8 @@ private:
 	void poseInfoCallback(const gz::msgs::Pose_V &pose);
 	void odometryCallback(const gz::msgs::OdometryWithCovariance &odometry);
 	void navSatCallback(const gz::msgs::NavSat &nav_sat);
-	void laserScanCallback(const gz::msgs::LaserScan &scan);
+	void lidarDistanceScanCallback(const gz::msgs::LaserScan &scan);
+	void lidarObstacleScanCallback(const gz::msgs::LaserScan &scan);
 
 	/**
 	 * @brief Call Entityfactory service
@@ -165,6 +167,7 @@ private:
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	//uORB::Publication<differential_pressure_s>    _differential_pressure_pub{ORB_ID(differential_pressure)};
+	uORB::Publication<distance_sensor_s>          _distance_sensor_pub{ORB_ID(distance_sensor)};
 	uORB::Publication<obstacle_distance_s>        _obstacle_distance_pub{ORB_ID(obstacle_distance)};
 	uORB::Publication<vehicle_angular_velocity_s> _angular_velocity_ground_truth_pub{ORB_ID(vehicle_angular_velocity_groundtruth)};
 	uORB::Publication<vehicle_attitude_s>         _attitude_ground_truth_pub{ORB_ID(vehicle_attitude_groundtruth)};


### PR DESCRIPTION
### Solved Problem
While reading the docs I realized that there is currently no support for [distance sensors (rangefinders) for GZ](https://docs.px4.io/main/en/sensor/rangefinders.html#gazebo-simulation). The feature already exists for gazebo-classic so I thought it would be a nice addition for GZ as well.

Altitude sensors would allow for fixed-wing mission landings without tweaking the parameters (to ignore the missing terrains sensor).

The feature should also be a part of #23602. 

### Solution
- Add distance_sensor publisher to gz_bridge based on (1D) gz LaserScan messages
- Rename laserScanCallback() to lidarObstacleScanCallback() as there are now two gz LaserScan subscriptions
- Add lidar distance sensor to rc_cessna and advanced_plane models (https://github.com/PX4/PX4-gazebo-models/pull/58)

### Changelog Entry
For release notes:
```
Feature GZ supports lidar altitude sensors
```

### Alternatives
I don't see any alternatives besides just not implementing the feature.

### Test coverage
- Simulation/hardware testing logs: https://review.px4.io/plot_app?log=9277f0b7-d474-4e53-81f7-e6206213bdc0 (mission auto-land with rc_cessna)
