### PR TITLE
MPC: AUTO: Emergency Braking velocity setpoint fix

### DIFF
--- a/msg/VehicleConstraints.msg
+++ b/msg/VehicleConstraints.msg
@@ -5,5 +5,6 @@ uint64 timestamp # time since system start (microseconds)
 
 float32 speed_up # in meters/sec
 float32 speed_down # in meters/sec
+float32 speed_xy # in meters/sec
 
 bool want_takeoff # tell the controller to initiate takeoff when idling (ignored during flight)

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -525,12 +525,12 @@ void MulticopterPositionControl::Run()
 					       PX4_ISFINITE(_vehicle_constraints.speed_up) ? _vehicle_constraints.speed_up : _param_mpc_z_vel_max_up.get());
 			const float speed_down = PX4_ISFINITE(_vehicle_constraints.speed_down) ? _vehicle_constraints.speed_down :
 						 _param_mpc_z_vel_max_dn.get();
-
 			// Allow ramping from zero thrust on takeoff
 			const float minimum_thrust = flying ? _param_mpc_thr_min.get() : 0.f;
 			_control.setThrustLimits(minimum_thrust, _param_mpc_thr_max.get());
 
-			float max_speed_xy = _param_mpc_xy_vel_max.get();
+			float max_speed_xy = PX4_ISFINITE(_vehicle_constraints.speed_down) ? _vehicle_constraints.speed_xy :
+					     _param_mpc_xy_vel_max.get();
 
 			if (PX4_ISFINITE(vehicle_local_position.vxy_max)) {
 				max_speed_xy = math::min(max_speed_xy, vehicle_local_position.vxy_max);


### PR DESCRIPTION
### Problem
Emergency braking was implemented to slow down the vehicle when switching from a manual flighttask into FlightTaskAuto with velocities higher than the maximum allowed velocity allowed in FlightTaskAuto.
There is currently a problem that there is a discrepancy between the velocities allowed in the PositionController and the FlightTask, meaning that the trajectory generator is able to generate trajectories which are not possible with the PositionController resulting in high errors between the velocity and velocity setpoint.

With this PR, i'm extending the vehicle constraints to also consider the xy speed, and increase this constraint while emergency braking is possible.

![image](https://github.com/user-attachments/assets/8c493cf7-5abe-4be4-aad2-e5077b4ea952)




### Solution
With the proposed Solution, the Velocity setpoint corresponds more closely with what trajectory setpoint from the 
![image](https://github.com/user-attachments/assets/863c4593-4564-4a8f-9cf5-de370c3bd946)


### Test coverage

- [X] Tested in SITL
