### PR TITLE
GZ RC Cessna: Improve rate tuning

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4003_gz_rc_cessna
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4003_gz_rc_cessna
@@ -24,32 +24,30 @@ param set-default FW_LND_ANG 8
 param set-default NPFG_PERIOD 12
 
 param set-default FW_PR_P 0.9
-param set-default FW_PR_FF 0.5
+param set-default FW_PR_FF 0.2
 param set-default FW_PR_I 0.5
 param set-default TRIM_PITCH -0.15
 
-param set-default FW_PSP_OFF 2
-param set-default FW_P_LIM_MIN -15
-
 param set-default FW_RR_FF 0.5
-param set-default FW_RR_P 0.3
-param set-default FW_RR_I 0.5
+param set-default FW_RR_P 0.4
+param set-default FW_RR_I 0.7
 
-param set-default FW_YR_FF 0.5
-param set-default FW_YR_P 0.6
-param set-default FW_YR_I 0.5
+param set-default FW_YR_FF 0.3
+param set-default FW_YR_P 1.3
+param set-default FW_YR_I 0.7
+
+param set-default FW_PSP_OFF 0
+param set-default FW_P_LIM_MIN -15
 
 param set-default FW_SPOILERS_LND 0.4
 
-param set-default FW_THR_MAX 0.6
-param set-default FW_THR_MIN 0.05
-param set-default FW_THR_TRIM 0.25
-
-param set-default FW_T_CLMB_MAX 8
-param set-default FW_T_SINK_MAX 2.7
-param set-default FW_T_SINK_MIN 2.2
+param set-default FW_T_CLMB_MAX 5
+param set-default FW_T_SINK_MAX 3.5
+param set-default FW_T_SINK_MIN 3
 
 param set-default FW_W_EN 1
+
+param set-default FD_ESCS_EN 0
 
 param set-default MIS_TAKEOFF_ALT 30
 


### PR DESCRIPTION
### Solved Problem
The default gains in the RC Cessna airframe yields poor tracking performance in Gazebo Garden simulation.

### Solution
Tune the gains for the RC Cessna simulation model and update the current default ones stored in the airframe

### Test coverage
- SITL testing on Gazebo Garden

### Context
New tracking behaviour
![Screenshot from 2024-10-02 09-29-08](https://github.com/user-attachments/assets/bfbb4917-fbd7-46f3-b7ff-cd331be4da25)
