### PR TITLE
ekf2: tighten terrain validity requirements

### DIFF
--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -146,9 +146,10 @@ void Ekf::controlFusionModes(const imuSample &imu_delayed)
 	// Additional horizontal velocity data from an auxiliary sensor can be fused
 	controlAuxVelFusion(imu_delayed);
 #endif // CONFIG_EKF2_AUXVEL
-	//
+
 #if defined(CONFIG_EKF2_TERRAIN)
 	controlTerrainFakeFusion();
+	updateTerrainValidity();
 #endif // CONFIG_EKF2_TERRAIN
 
 	controlZeroInnovationHeadingUpdate();

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -99,7 +99,7 @@ public:
 
 #if defined(CONFIG_EKF2_TERRAIN)
 	// terrain estimate
-	bool isTerrainEstimateValid() const;
+	bool isTerrainEstimateValid() const { return _terrain_valid; }
 
 	// get the estimated terrain vertical position relative to the NED origin
 	float getTerrainVertPos() const { return _state.terrain; };
@@ -500,6 +500,8 @@ private:
 #if defined(CONFIG_EKF2_TERRAIN)
 	// Terrain height state estimation
 	float _last_on_ground_posD{0.0f};	///< last vertical position when the in_air status was false (m)
+
+	bool _terrain_valid{false};
 #endif // CONFIG_EKF2_TERRAIN
 
 #if defined(CONFIG_EKF2_RANGE_FINDER)
@@ -732,6 +734,8 @@ private:
 	void initTerrain();
 	float getTerrainVPos() const { return isTerrainEstimateValid() ? _state.terrain : _last_on_ground_posD; }
 	void controlTerrainFakeFusion();
+
+	void updateTerrainValidity();
 
 # if defined(CONFIG_EKF2_RANGE_FINDER)
 	// update the terrain vertical position estimate using a height above ground measurement from the range finder


### PR DESCRIPTION
 - require valid fusion from a range finder or optical flow before considering terrain valid again

This partially addresses https://github.com/PX4/PX4-Autopilot/issues/23761 where the terrain estimate was considered valid based on the variance before valid range finder data was available.

![image](https://github.com/user-attachments/assets/87c06777-ce77-4c80-b41c-79e9a9e25458)
