### PR TITLE
Tools: improve uploader output in scripts

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -428,7 +428,8 @@ class uploader:
 
         percent = (float(progress) / float(maxVal)) * 100.0
 
-        sys.stdout.write("\r%s: [%-20s] %.1f%%" % (label, '='*int(percent/5.0), percent))
+        redraw = "\r" if sys.stdout.isatty() else "\n"
+        sys.stdout.write("%s%s: [%-20s] %.1f%%" % (redraw, label, '='*int(percent/5.0), percent))
         sys.stdout.flush()
 
     # send the CHIP_ERASE command and wait for the bootloader to become ready


### PR DESCRIPTION
When the px_uploader.py is used scripted, so without an interactive shell, the progress bar doesn't update. Therefore, I suggest to print a new line instead of a carriage return for the non-interactive shell case.