### PR TITLE
EKF2: always publish global position

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1164,7 +1164,7 @@ void EKF2::PublishEventFlags(const hrt_abstime &timestamp)
 
 void EKF2::PublishGlobalPosition(const hrt_abstime &timestamp)
 {
-	if (_ekf.global_position_is_valid()) {
+	if (_ekf.global_origin_valid() && _ekf.control_status().flags.yaw_align) {
 		const Vector3f position{_ekf.getPosition()};
 
 		// generate and publish global position data


### PR DESCRIPTION
### Solved Problem
Previously, the global position was not being published when there was no valid local position. As a result, when a vehicle lost its external sensors (e.g., optical flow) and continued flying using inertial dead reckoning, the global position would stop being published, even though a rough estimate still existed. The presence of the topic alone should not imply the validity of the global position.

The solution is to relax this condition and allow the global position to be published as long as the global origin is set and yaw alignment is complete.