### PR TITLE
ekf2: reduce bad accel probation time 10s->3s

### DIFF
--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -79,7 +79,7 @@ static constexpr uint64_t MAG_MAX_INTERVAL      =
 
 // bad accelerometer detection and mitigation
 static constexpr uint64_t BADACC_PROBATION =
-	10e6; ///< Period of time that accel data declared bad must continuously pass checks to be declared good again (uSec)
+	3e6; ///< Period of time that accel data declared bad must continuously pass checks to be declared good again (uSec)
 static constexpr float BADACC_BIAS_PNOISE =
 	4.9f;  ///< The delta velocity process noise is set to this when accel data is declared bad (m/sec**2)
 


### PR DESCRIPTION
During the bad accel probation period height sources will accept otherwise rejected innovations.https://github.com/PX4/PX4-Autopilot/blob/652bb82603c5f54b611b8a705123bc1e526b07d1/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp#L205-L211

I'm not sure if I can justify this one way or the other, but a 10 second probation time feels way too long, especially if caused by brief periods of accel clipping.