### PR TITLE
always allow disabling uncalibrated baro

### DIFF
--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -169,14 +169,6 @@ void VehicleAirData::Run()
 			while ((sensor_sub_updates < sensor_baro_s::ORB_QUEUE_LENGTH) && _sensor_sub[uorb_index].update(&report)) {
 				sensor_sub_updates++;
 
-				if (_calibration[uorb_index].device_id() != report.device_id) {
-					_calibration[uorb_index].set_device_id(report.device_id);
-					_priority[uorb_index] = _calibration[uorb_index].priority();
-					calibration::SetCalibrationParam(_calibration[uorb_index].SensorString(), "ID", uorb_index, report.device_id);
-					calibration::SetCalibrationParam(_calibration[uorb_index].SensorString(), "PRIO", uorb_index,
-									 (int32_t)_priority[uorb_index]);
-				}
-
 				if (_calibration[uorb_index].enabled()) {
 
 					if (!was_advertised) {
@@ -192,6 +184,8 @@ void VehicleAirData::Run()
 						}
 
 						ParametersUpdate(true);
+						_calibration[uorb_index].set_device_id(report.device_id);
+						_calibration[uorb_index].ParametersSave(uorb_index);
 					}
 
 					// pressure corrected with offset (if available)

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -37,7 +37,7 @@
 #include <px4_platform_common/events.h>
 #include <lib/geo/geo.h>
 #include <lib/atmosphere/atmosphere.h>
-
+#include <sensor_calibration/Utilities.hpp>
 
 namespace sensors
 {
@@ -172,6 +172,9 @@ void VehicleAirData::Run()
 				if (_calibration[uorb_index].device_id() != report.device_id) {
 					_calibration[uorb_index].set_device_id(report.device_id);
 					_priority[uorb_index] = _calibration[uorb_index].priority();
+					calibration::SetCalibrationParam(_calibration[uorb_index].SensorString(), "ID", uorb_index, report.device_id);
+					calibration::SetCalibrationParam(_calibration[uorb_index].SensorString(), "PRIO", uorb_index,
+									 (int32_t)_priority[uorb_index]);
 				}
 
 				if (_calibration[uorb_index].enabled()) {

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -37,7 +37,6 @@
 #include <px4_platform_common/events.h>
 #include <lib/geo/geo.h>
 #include <lib/atmosphere/atmosphere.h>
-#include <sensor_calibration/Utilities.hpp>
 
 namespace sensors
 {
@@ -169,6 +168,11 @@ void VehicleAirData::Run()
 			while ((sensor_sub_updates < sensor_baro_s::ORB_QUEUE_LENGTH) && _sensor_sub[uorb_index].update(&report)) {
 				sensor_sub_updates++;
 
+				if (_calibration[uorb_index].device_id() != report.device_id) {
+					_calibration[uorb_index].set_device_id(report.device_id);
+					_priority[uorb_index] = _calibration[uorb_index].priority();
+				}
+
 				if (_calibration[uorb_index].enabled()) {
 
 					if (!was_advertised) {
@@ -183,9 +187,13 @@ void VehicleAirData::Run()
 							_sensor_sub[uorb_index].registerCallback();
 						}
 
+						if (!_calibration[uorb_index].calibrated()) {
+							_calibration[uorb_index].set_device_id(report.device_id);
+							_calibration[uorb_index].ParametersSave(uorb_index);
+							param_notify_changes();
+						}
+
 						ParametersUpdate(true);
-						_calibration[uorb_index].set_device_id(report.device_id);
-						_calibration[uorb_index].ParametersSave(uorb_index);
 					}
 
 					// pressure corrected with offset (if available)


### PR DESCRIPTION


### Solved Problem
When the barometer is not getting calibrated (IMO: not really common to do) one cannot disable it through the parameters. By setting the calibration parameter in the very beginning one can always disable or switch to a different barometer manually.
