### PR TITLE
Allow arming with critical battery by setting COM_ARM_BAT_MIN lower than BAT_CRIT_THR

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -181,7 +181,7 @@ param set-default TRIG_INTERFACE 3
 param set-default SYS_FAILURE_EN 1
 # Enable low-battery actions by default for (automated) testing. Battery sim
 # does not go below 50% by default, but failure injection can trigger failsafes.
-param set-default COM_LOW_BAT_ACT 2
+param set-default COM_LOW_BAT_ACT 3
 
 
 # Adapt timeout parameters if simulation runs faster or slower than realtime.

--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
@@ -211,8 +211,8 @@ void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 			mavlink_log_emergency(reporter.mavlink_log_pub(), "Low battery level\t");
 		}
 
-	} else if (!context.isArmed() && _param_arm_battery_level_min.get() > FLT_EPSILON
-		   && worst_battery_remaining < _param_arm_battery_level_min.get()) {
+	} else if (!context.isArmed() && _param_com_arm_bat_min.get() > FLT_EPSILON
+		   && worst_battery_remaining < _param_com_arm_bat_min.get()) {
 		// if not armed, additionally check if the battery is below the separately configurable preflight threshold
 		/* EVENT
 		 * @description

--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
@@ -191,17 +191,23 @@ void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 		reporter.failsafeFlags().battery_warning = worst_warning;
 	}
 
-	if (reporter.failsafeFlags().battery_warning > battery_status_s::BATTERY_WARNING_NONE
-	    && reporter.failsafeFlags().battery_warning < battery_status_s::BATTERY_WARNING_FAILED) {
+	const bool battery_warning = reporter.failsafeFlags().battery_warning > battery_status_s::BATTERY_WARNING_NONE
+				     && reporter.failsafeFlags().battery_warning < battery_status_s::BATTERY_WARNING_FAILED;
+	const bool configured_arm_threshold_in_use = !context.isArmed() && (_param_com_arm_bat_min.get() >= -FLT_EPSILON);
+	const bool below_configured_arm_threshold = (worst_battery_remaining < _param_com_arm_bat_min.get());
+
+	if (battery_warning || (configured_arm_threshold_in_use && below_configured_arm_threshold)) {
 		const bool critical_or_higher = reporter.failsafeFlags().battery_warning >= battery_status_s::BATTERY_WARNING_CRITICAL;
-		NavModes affected_modes = critical_or_higher ? NavModes::All : NavModes::None;
-		events::LogLevel log_level = critical_or_higher ? events::Log::Critical : events::Log::Warning;
+		NavModes affected_modes = (!configured_arm_threshold_in_use && critical_or_higher)
+					  || (configured_arm_threshold_in_use && below_configured_arm_threshold) ? NavModes::All : NavModes::None;
+		events::LogLevel log_level = critical_or_higher || below_configured_arm_threshold
+					     ? events::Log::Critical : events::Log::Warning;
 		/* EVENT
 		 * @description
-		 * The battery state of charge of the worst battery is below the warning threshold.
+		 * The battery state of charge of the worst battery is below the threshold.
 		 *
 		 * <profile name="dev">
-		 * This check can be configured via <param>BAT_LOW_THR</param>, <param>BAT_CRIT_THR</param> and <param>BAT_EMERGEN_THR</param> parameters.
+		 * This check can be configured via <param>BAT_LOW_THR</param>, <param>BAT_CRIT_THR</param>, <param>BAT_EMERGEN_THR</param> and <param>COM_ARM_BAT_MIN</param> parameters.
 		 * </profile>
 		 */
 		reporter.armingCheckFailure(affected_modes, health_component_t::battery, events::ID("check_battery_low"), log_level,
@@ -211,24 +217,6 @@ void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 			mavlink_log_emergency(reporter.mavlink_log_pub(), "Low battery level\t");
 		}
 
-	} else if (!context.isArmed() && _param_com_arm_bat_min.get() > FLT_EPSILON
-		   && worst_battery_remaining < _param_com_arm_bat_min.get()) {
-		// if not armed, additionally check if the battery is below the separately configurable preflight threshold
-		/* EVENT
-		 * @description
-		 * The battery state of charge of the worst battery is below the preflight threshold.
-		 *
-		 * <profile name="dev">
-		 * This check can be configured via <param>COM_ARM_BAT_MIN</param> parameter.
-		 * </profile>
-		 */
-		reporter.armingCheckFailure(NavModes::All, health_component_t::battery, events::ID("check_battery_preflight_low"),
-					    events::Log::Critical,
-					    "Low battery");
-
-		if (reporter.mavlink_log_pub()) {
-			mavlink_log_emergency(reporter.mavlink_log_pub(), "Low battery level\t");
-		}
 	}
 
 	rtlEstimateCheck(context, reporter, worst_battery_time_s);

--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.hpp
@@ -57,7 +57,7 @@ private:
 	bool _battery_connected_at_arming[battery_status_s::MAX_INSTANCES] {};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
-					(ParamFloat<px4::params::COM_ARM_BAT_MIN>) _param_arm_battery_level_min,
+					(ParamFloat<px4::params::COM_ARM_BAT_MIN>) _param_com_arm_bat_min,
 					(ParamInt<px4::params::CBRK_SUPPLY_CHK>) _param_cbrk_supply_chk
 				       )
 };

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -960,19 +960,18 @@ PARAM_DEFINE_INT32(COM_ARMABLE, 1);
 /**
  * Minimum battery level for arming
  *
- * Additional battery level check that only allows arming if the state of charge of the emptiest
- *  connected battery is above this value.
+ * Threshold for battery percentage below arming is prohibited.
  *
- * A value of 0 disables the check.
+ * A negative value means BAT_CRIT_THR is the threshold.
  *
  * @unit norm
- * @min 0
+ * @min -1
  * @max 0.9
  * @decimal 2
  * @increment 0.01
  * @group Commander
  */
-PARAM_DEFINE_FLOAT(COM_ARM_BAT_MIN, 0.f);
+PARAM_DEFINE_FLOAT(COM_ARM_BAT_MIN, -1.f);
 
 /**
  * Enable throw-start

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -173,6 +173,7 @@ private:
 	hrt_abstime _armed_time{0};
 	bool _was_armed{false};
 	bool _manual_control_lost_at_arming{false}; ///< true if manual control was lost at arming time
+	uint8_t _battery_warning_at_arming{0}; ///< low battery state at arming time
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FailsafeBase,
 					(ParamInt<px4::params::NAV_DLL_ACT>) 	_param_nav_dll_act,


### PR DESCRIPTION
### Solved Problem
When trying to fullfil the requirement "vehicle needs to still be aramable with critical battery" I found that it's not as easy anymore to do that with the new checks and failsafe state machine.

PX4 historically allows arming with low battery state (first level) but not with critical or emergency battery state (2., 3. level). Previously changing this behavior was a one-line change and we left it at this.

### Solution
1. `COM_ARM_BAT_MIN` introduced in https://github.com/PX4/PX4-Autopilot/pull/22175 can be set lower than the critical or emergency threshold percentage now and based on that it allows arming. If it's set to zero (previous default) it always allows arming and hence a negative value disables using this threshold. @sfuhrer I hope this slight change in definition and default is ok.
2. I realized that even if arming is allowed with critical battery the result is an immediate failsafe even if there was a failsafe triggered already in the previous flight. The new state machine resets after a flight, then triggers immediately again and makes arming again pretty useless since the vehicle lands again while still on the ground. I made an exception for this case to only trigger an action on the battery warning getting worse than what it was when arming. It still fails the check and warns the user.

### Changelog Entry
```
Feature: Allow arming with critical battery by setting COM_ARM_BAT_MIN lower than BAT_CRIT_THR
```

### Alternatives
We could also ...

### Test coverage
I did SIH based testing with manually set battery sate of charge for the cases:
- `COM_ARM_BAT_MIN` set negative, default everything as before
- `COM_ARM_BAT_MIN` > `BAT_CRIT_THR`, arming is disallowed earlier
- `COM_ARM_BAT_MIN` < `BAT_CRIT_THR`, arming is still allowed and leads to an immediate warning on takeoff and red UI but no action on the existing warning only on the next worse one -> emergency battery state.