### PR TITLE
Fix arm authorization spamming

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -594,7 +594,7 @@ transition_result_t Commander::arm(arm_disarm_reason_t calling_reason, bool run_
 			return TRANSITION_DENIED;
 		}
 
-		_health_and_arming_checks.update();
+		_health_and_arming_checks.update(false, true);
 
 		if (!_health_and_arming_checks.canArm(_vehicle_status.nav_state)) {
 			tune_negative(true);

--- a/src/modules/commander/HealthAndArmingChecks/Common.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/Common.hpp
@@ -128,10 +128,15 @@ public:
 
 	bool isArmed() const { return _status.arming_state == vehicle_status_s::ARMING_STATE_ARMED; }
 
+	bool isArmingRequest() const { return _is_arming_request; }
+
+	void setIsArmingRequest(bool is_arming_request) { _is_arming_request = is_arming_request; }
+
 	const vehicle_status_s &status() const { return _status; }
 
 private:
 	const vehicle_status_s &_status;
+	bool _is_arming_request{false};	// true if we currently have an arming request
 };
 
 

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.cpp
@@ -50,11 +50,13 @@ HealthAndArmingChecks::HealthAndArmingChecks(ModuleParams *parent, vehicle_statu
 	_failsafe_flags.home_position_invalid = true;
 }
 
-bool HealthAndArmingChecks::update(bool force_reporting)
+bool HealthAndArmingChecks::update(bool force_reporting, bool is_arming_request)
 {
 	_reporter.reset();
 
 	_reporter.prepare(_context.status().vehicle_type);
+
+	_context.setIsArmingRequest(is_arming_request);
 
 	for (unsigned i = 0; i < sizeof(_checks) / sizeof(_checks[0]); ++i) {
 		if (!_checks[i]) {

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
@@ -83,9 +83,10 @@ public:
 	 * Run arming checks and report if necessary.
 	 * This should be called regularly (e.g. 1Hz).
 	 * @param force_reporting if true, force reporting even if nothing changed
+	 * @param is_arming_request if true, then we are running the checks based on an actual arming request
 	 * @return true if there was a report (also when force_reporting=true)
 	 */
-	bool update(bool force_reporting = false);
+	bool update(bool force_reporting = false, bool is_arming_request = false);
 
 	/**
 	 * Whether arming is possible for a given navigation mode

--- a/src/modules/commander/HealthAndArmingChecks/checks/systemCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/systemCheck.cpp
@@ -172,7 +172,7 @@ void SystemChecks::checkAndReport(const Context &context, Report &reporter)
 	}
 
 	// Arm Requirements: authorization
-	if (_param_com_arm_auth_req.get() != 0 && !context.isArmed()) {
+	if (_param_com_arm_auth_req.get() != 0 && !context.isArmed() && context.isArmingRequest()) {
 		if (arm_auth_check() != vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED) {
 			/* EVENT
 			 */


### PR DESCRIPTION
### Solved Problem
At the moment arm authorization checks are run at a regular interval and not only as part of an arming request. If the companion computer has not booted or the system is not yet in general, this creates a lot of arm authorization error messages in the ground station.

### Solution
I have tried to figure out if we actually want the checks to run always or just when we get an arm request. Based on this [comment](https://github.com/PX4/PX4-Autopilot/pull/15754#discussion_r492680698) in [this PR](https://github.com/PX4/PX4-Autopilot/pull/15754), I made the conclusion that only arm requests should trigger it. This is also somewhat consistent with the [documentation](https://mavlink.io/en/services/arm_authorization.html).

### Changelog Entry
For release notes:
```
Bugfix: Only run arm authorization on arming request, fix spamming before companion computer is ready to do checks.
```

### Alternatives

### Test coverage
Tested on physical vehicle which uses arm authorization.
### Context
Related links, screenshot before/after, video
