### PR TITLE
Add BAT_DISC_OVRD to control battery connected

### DIFF
--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -178,3 +178,14 @@ parameters:
             decimal: 2
             increment: 0.1
             default: 15
+
+        BAT_DISC_OVRD:
+            description:
+                short: Allow battery status message to set connected to false.
+                long: |
+                    If true, receiving a mavlink battery_status message can set
+                    the battery state to disconnected if all the voltages are UINT16_MAX - 1.
+            type: int32
+            min: 0
+            max: 1
+            default: 0

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1812,6 +1812,18 @@ MavlinkReceiver::handle_message_battery_status(mavlink_message_t *msg)
 	battery_status.temperature = (float)battery_mavlink.temperature;
 	battery_status.connected = true;
 
+	if (_param_disc_ovrd.get()) {
+		battery_status.connected = false;
+		for (int i = 0; i < MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN; ++i)
+		{
+			if (battery_mavlink.voltages[i] != UINT16_MAX - 1)
+			{
+				battery_status.connected = true;
+				break;
+			}
+		}
+	}
+
 	// Set the battery warning based on remaining charge.
 	//  Note: Smallest values must come first in evaluation.
 	if (battery_status.remaining < _param_bat_emergen_thr.get()) {

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -412,7 +412,8 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::BAT_CRIT_THR>)     _param_bat_crit_thr,
 		(ParamFloat<px4::params::BAT_EMERGEN_THR>)  _param_bat_emergen_thr,
-		(ParamFloat<px4::params::BAT_LOW_THR>)      _param_bat_low_thr
+		(ParamFloat<px4::params::BAT_LOW_THR>)      _param_bat_low_thr,
+		(ParamBool<px4::params::BAT_DISC_OVRD>)     _param_disc_ovrd
 	);
 
 	// Disallow copy construction and move assignment.


### PR DESCRIPTION
Upon receiving a mavlink battery status message, if BAT_DISC_OVRD is true and all the voltages are UINT16_MAX - 1 then
battery_status.connected is set to false.


### Solved Problem

Trying to calibrate ESC without battery status is not possible currently (https://github.com/PX4/PX4-Autopilot/blob/da8827883fe248960ab5a3490e9a263ea98e2d72/src/modules/commander/esc_calibration.cpp#L59)


### Solution
Upon receiving a mavlink `battery_status` message, the field `connected` could be set to false for a special state of the mavlink message.
Since no such field exist in the mavlink message, I propose the unlikely state where all voltages are set to UINT16_MAX - 1.

This is flag-guarded by the added parameter `BAT_DISC_OVRD`


The calibration procedure does not change at all in QGC but it could be completed with mavsdk as follows:

```
def f(d: mavsdk.System):
  from pymavlink.dialects.v20 import ardupilotmega as ml
  conn = mavutil.mavlink_connection(
      'TARGET', source_system=1, source_component=3
  )

  conn.mav.battery_status_send(
      id=124,
      battery_function=ml.MAV_BATTERY_FUNCTION_UNKNOWN,
      type=ml.MAV_BATTERY_TYPE_LION,
      temperature=45_00,
      voltages=[2**16-1] * 10,
      mode=ml.MAV_BATTERY_MODE_UNKNOWN,
      current_battery=1_000,
      current_consumed=100,
      energy_consumed=-1,
      battery_remaining=-1
  )
  await asyncio.sleep(0.1)


  async for x in d.calibration.calibrate_esc(False): # Note: this does not exist (yet)

    if x.status_text == 'Connect battery now':
      input('Connect battery now')
      conn.mav.battery_status_send(
          id=124,
          battery_function=ml.MAV_BATTERY_FUNCTION_UNKNOWN,
          type=ml.MAV_BATTERY_TYPE_LION,
          temperature=45_00,
          voltages=[10_000] * 10,
          mode=ml.MAV_BATTERY_MODE_UNKNOWN,
          current_battery=1_000,
          current_consumed=100,
          energy_consumed=-1,
          battery_remaining=-1
      )
```