### PR TITLE
Fix output of param show -q XXX on NuttX shell

### DIFF
--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -560,14 +560,14 @@ do_show_quiet(const char *param_name)
 	switch (param_type(param)) {
 	case PARAM_TYPE_INT32:
 		if (!param_get(param, &ii)) {
-			PARAM_PRINT("%ld", (long)ii);
+			PARAM_PRINT("%ld\n", (long)ii);
 		}
 
 		break;
 
 	case PARAM_TYPE_FLOAT:
 		if (!param_get(param, &ff)) {
-			PARAM_PRINT("%4.4f", (double)ff);
+			PARAM_PRINT("%4.4f\n", (double)ff);
 		}
 
 		break;

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -74,13 +74,6 @@ enum class COMPARE_ERROR_LEVEL {
 	SILENT = 1,
 };
 
-
-#ifdef __PX4_QURT
-#define PARAM_PRINT PX4_INFO
-#else
-#define PARAM_PRINT PX4_INFO_RAW
-#endif
-
 static int 	do_save(const char *param_file_name);
 static int	do_save_default();
 static int 	do_load(const char *param_file_name);
@@ -515,10 +508,10 @@ do_save_default()
 static int
 do_show(const char *search_string, bool only_changed)
 {
-	PARAM_PRINT("Symbols: x = used, + = saved, * = unsaved\n");
+	PX4_INFO_RAW("Symbols: x = used, + = saved, * = unsaved\n");
 	// also show unused params if we show non-default values only
 	param_foreach(do_show_print, (char *)search_string, only_changed, !only_changed);
-	PARAM_PRINT("\n %u/%u parameters used.\n", param_count_used(), param_count());
+	PX4_INFO_RAW("\n %u/%u parameters used.\n", param_count_used(), param_count());
 
 	return 0;
 }
@@ -530,7 +523,7 @@ do_show_for_airframe()
 	int32_t sys_autostart = 0;
 	param_get(param_find("SYS_AUTOSTART"), &sys_autostart);
 	if (sys_autostart != 0) {
-		PARAM_PRINT("# Make sure to add all params from the current airframe (ID=%" PRId32 ") as well\n", sys_autostart);
+		PX4_INFO_RAW("# Make sure to add all params from the current airframe (ID=%" PRId32 ") as well\n", sys_autostart);
 	}
 	return 0;
 }
@@ -538,9 +531,9 @@ do_show_for_airframe()
 static int
 do_show_all()
 {
-	PARAM_PRINT("Symbols: x = used, + = saved, * = unsaved\n");
+	PX4_INFO_RAW("Symbols: x = used, + = saved, * = unsaved\n");
 	param_foreach(do_show_print, nullptr, false, false);
-	PARAM_PRINT("\n %u parameters total, %u used.\n", param_count(), param_count_used());
+	PX4_INFO_RAW("\n %u parameters total, %u used.\n", param_count(), param_count_used());
 
 	return 0;
 }
@@ -560,14 +553,14 @@ do_show_quiet(const char *param_name)
 	switch (param_type(param)) {
 	case PARAM_TYPE_INT32:
 		if (!param_get(param, &ii)) {
-			PARAM_PRINT("%ld\n", (long)ii);
+			PX4_INFO_RAW("%ld\n", (long)ii);
 		}
 
 		break;
 
 	case PARAM_TYPE_FLOAT:
 		if (!param_get(param, &ff)) {
-			PARAM_PRINT("%4.4f\n", (double)ff);
+			PX4_INFO_RAW("%4.4f\n", (double)ff);
 		}
 
 		break;
@@ -589,7 +582,7 @@ do_find(const char *name)
 		return 1;
 	}
 
-	PARAM_PRINT("Found param %s at index %i\n", name, (int)ret);
+	PX4_INFO_RAW("Found param %s at index %i\n", name, (int)ret);
 	return 0;
 }
 
@@ -614,27 +607,27 @@ do_show_index(const char *index, bool used_index)
 		return 1;
 	}
 
-	PARAM_PRINT("index %d: %c %c %s [%d,%d] : ", i, (param_used(param) ? 'x' : ' '),
+	PX4_INFO_RAW("index %d: %c %c %s [%d,%d] : ", i, (param_used(param) ? 'x' : ' '),
 		    param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
 		    param_name(param), param_get_used_index(param), param_get_index(param));
 
 	switch (param_type(param)) {
 	case PARAM_TYPE_INT32:
 		if (!param_get(param, &ii)) {
-			PARAM_PRINT("%ld\n", (long)ii);
+			PX4_INFO_RAW("%ld\n", (long)ii);
 		}
 
 		break;
 
 	case PARAM_TYPE_FLOAT:
 		if (!param_get(param, &ff)) {
-			PARAM_PRINT("%4.4f\n", (double)ff);
+			PX4_INFO_RAW("%4.4f\n", (double)ff);
 		}
 
 		break;
 
 	default:
-		PARAM_PRINT("<unknown type %d>\n", 0 + param_type(param));
+		PX4_INFO_RAW("<unknown type %d>\n", 0 + param_type(param));
 	}
 
 	return 0;
@@ -684,7 +677,7 @@ do_show_print(void *arg, param_t param)
 		}
 	}
 
-	PARAM_PRINT("%c %c %s [%d,%d] : ", (param_used(param) ? 'x' : ' '),
+	PX4_INFO_RAW("%c %c %s [%d,%d] : ", (param_used(param) ? 'x' : ' '),
 		    param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
 		    param_name(param), param_get_used_index(param), param_get_index(param));
 
@@ -695,7 +688,7 @@ do_show_print(void *arg, param_t param)
 	switch (param_type(param)) {
 	case PARAM_TYPE_INT32:
 		if (!param_get(param, &i)) {
-			PARAM_PRINT("%ld\n", (long)i);
+			PX4_INFO_RAW("%ld\n", (long)i);
 			return;
 		}
 
@@ -703,18 +696,18 @@ do_show_print(void *arg, param_t param)
 
 	case PARAM_TYPE_FLOAT:
 		if (!param_get(param, &f)) {
-			PARAM_PRINT("%4.4f\n", (double)f);
+			PX4_INFO_RAW("%4.4f\n", (double)f);
 			return;
 		}
 
 		break;
 
 	default:
-		PARAM_PRINT("<unknown type %d>\n", 0 + param_type(param));
+		PX4_INFO_RAW("<unknown type %d>\n", 0 + param_type(param));
 		return;
 	}
 
-	PARAM_PRINT("<error fetching parameter %lu>\n", (unsigned long)param);
+	PX4_INFO_RAW("<error fetching parameter %lu>\n", (unsigned long)param);
 }
 
 static void
@@ -739,12 +732,12 @@ do_show_print_for_airframe(void *arg, param_t param)
 
 	int32_t i;
 	float f;
-	PARAM_PRINT("param set-default %s ", p_name);
+	PX4_INFO_RAW("param set-default %s ", p_name);
 
 	switch (param_type(param)) {
 	case PARAM_TYPE_INT32:
 		if (!param_get(param, &i)) {
-			PARAM_PRINT("%ld\n", (long)i);
+			PX4_INFO_RAW("%ld\n", (long)i);
 			return;
 		}
 
@@ -752,7 +745,7 @@ do_show_print_for_airframe(void *arg, param_t param)
 
 	case PARAM_TYPE_FLOAT:
 		if (!param_get(param, &f)) {
-			PARAM_PRINT("%4.4f\n", (double)f);
+			PX4_INFO_RAW("%4.4f\n", (double)f);
 			return;
 		}
 
@@ -762,7 +755,7 @@ do_show_print_for_airframe(void *arg, param_t param)
 		return;
 	}
 
-	PARAM_PRINT("<error fetching parameter %lu>\n", (unsigned long)param);
+	PX4_INFO_RAW("<error fetching parameter %lu>\n", (unsigned long)param);
 }
 
 static int
@@ -792,12 +785,12 @@ do_set(const char *name, const char *val, bool fail_on_not_found)
 			int32_t newval = strtol(val, &end, 10);
 
 			if (i != newval) {
-				PARAM_PRINT("%c %s: ",
+				PX4_INFO_RAW("%c %s: ",
 					    param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
 					    param_name(param));
-				PARAM_PRINT("curr: %ld", (long)i);
+				PX4_INFO_RAW("curr: %ld", (long)i);
 				param_set(param, &newval);
-				PARAM_PRINT(" -> new: %ld\n", (long)newval);
+				PX4_INFO_RAW(" -> new: %ld\n", (long)newval);
 			}
 		}
 
@@ -814,12 +807,12 @@ do_set(const char *name, const char *val, bool fail_on_not_found)
 
 			if (f != newval) {
 #pragma GCC diagnostic pop
-				PARAM_PRINT("%c %s: ",
+				PX4_INFO_RAW("%c %s: ",
 					    param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
 					    param_name(param));
-				PARAM_PRINT("curr: %4.4f", (double)f);
+				PX4_INFO_RAW("curr: %4.4f", (double)f);
 				param_set(param, &newval);
-				PARAM_PRINT(" -> new: %4.4f\n", (double)newval);
+				PX4_INFO_RAW(" -> new: %4.4f\n", (double)newval);
 			}
 
 		}


### PR DESCRIPTION
### Solved Problem
When using e.g. `param show -q SYS_AUTOSTART` on the NuttX shell I found that it actually doesn't output anything. After looking into the code it prints the same way as other `params show` variants but without any newline.

### Solution
1. Adding a newline makes it work. So the assumption was that without a newline there's no flush to the output console until the task ends. @dagar confirmed that when we talked today and we tried to add `fflush(stdout);` instead of a newline which also works. But adding the newline should be ok since the standard says trailing newlines get stripped from shell substitutions so we stick with the newline.
2. While at it @dagar suggested removing the legacy `PARAM_PRINT` defines.

### Changelog Entry
```
Fix output of param show -q XXX on NuttX shell
```

### Test coverage
I tested on `fmu-v5x` and the parameters show on the MAVLink shell.

SITL SIH still loads, the startup script uses the substitution: https://github.com/PX4/PX4-Autopilot/blob/da8827883fe248960ab5a3490e9a263ea98e2d72/ROMFS/px4fmu_common/init.d-posix/rcS#L209