### PR TITLE
lib/mixer_module: remove unused param MOT_SLEW_MAX

### DIFF
--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -295,7 +295,6 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::MC_AIRMODE>) _param_mc_airmode,   ///< multicopter air-mode
-		(ParamFloat<px4::params::MOT_SLEW_MAX>) _param_mot_slew_max,
 		(ParamFloat<px4::params::THR_MDL_FAC>) _param_thr_mdl_fac ///< thrust to motor control signal modelling factor
 	)
 };

--- a/src/lib/mixer_module/motor_params.c
+++ b/src/lib/mixer_module/motor_params.c
@@ -38,22 +38,6 @@
  *
  */
 
-
-/**
- * Minimum motor rise time (slew rate limit).
- *
- * Minimum time allowed for the motor input signal to pass through
- * a range of 1000 PWM units. A value x means that the motor signal
- * can only go from 1000 to 2000 PWM in minimum x seconds.
- *
- * Zero means that slew rate limiting is disabled.
- *
- * @min 0.0
- * @unit s/(1000*PWM)
- * @group PWM Outputs
- */
-PARAM_DEFINE_FLOAT(MOT_SLEW_MAX, 0.0f);
-
 /**
  * Thrust to motor control signal model parameter
  *


### PR DESCRIPTION
Parameter **MOT_SLEW_MAX** doesn't seems to be used anymore.