### PR TITLE
FW Flaps on landing Abort

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -2764,7 +2764,7 @@ FixedwingPositionControl::Run()
 
         		if (_airspeed_valid) {
 
-            			if (_airspeed < _param_rwto_rot_airspd.get() && !flaps_retracted_after_rotation) {
+            			if (_airspeed_eas < _param_rwto_rot_airspd.get() && !flaps_retracted_after_rotation) {
                 		_flaps_setpoint = _param_fw_flaps_lnd_scl.get(); 
 
             			} else if (!flaps_retracted_after_rotation) {

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -1044,6 +1044,7 @@ private:
 		(ParamFloat<px4::params::FW_TKO_AIRSPD>) _param_fw_tko_airspd,
 
 		(ParamFloat<px4::params::RWTO_PSP>) _param_rwto_psp,
+		(ParamFloat<px4::params::RWTO_ROT_AIRSPD>) _param_rwto_rot_airspd,
 		(ParamBool<px4::params::FW_LAUN_DETCN_ON>) _param_fw_laun_detcn_on
 	)
 


### PR DESCRIPTION
Currently when you manually abort an auto-landing, the flaps retract immediately.

This is a problem because you can potentially be below the stall speed of a "clean" (flaps not extended wing). We saw several vehicles crash at MTOW like this.

This PR solves this by keeping flaps set to the landing flaps amount until the rotation airspeed is met.

Landing flap scale (FW_FLAPS_LND_SCL) was chosen rather than takeoff flaps as you may not use flaps on takeoff but are using them on landing.

Rotation speed (RWTO_ROT_AIRSPD) was chosen as that should be a comfortable airspeed at which you are getting ready to climb at the beginning of your mission, min speed didn't make sense given it could be much higher... Also, it is latching so you don't go slightly above rotation speed and then have the flaps retract and extend, I saw that in SITL testing early on.

Concerns would be climbing with flaps and hitting critical AoA of the flap, if that is an issue (or at least a valid concern)  we can divide the landing flap value by 2 here to deploy half the flap amount or add a new param for abort flaps.

This was tested in SITL extensively on 1.14.x to not impact hold mode or scenarios where you were below rot speed and put it into hold, etc.

EDIT: updated airspeed to eas for main.

@sfuhrer 
