### PR TITLE
Cleanup: remove unused MOT_SLEW_MAX parameter

### DIFF
--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -295,7 +295,6 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::MC_AIRMODE>) _param_mc_airmode,   ///< multicopter air-mode
-		(ParamFloat<px4::params::MOT_SLEW_MAX>) _param_mot_slew_max,
 		(ParamFloat<px4::params::THR_MDL_FAC>) _param_thr_mdl_fac ///< thrust to motor control signal modelling factor
 	)
 };

--- a/src/lib/mixer_module/motor_params.c
+++ b/src/lib/mixer_module/motor_params.c
@@ -38,22 +38,6 @@
  *
  */
 
-
-/**
- * Minimum motor rise time (slew rate limit).
- *
- * Minimum time allowed for the motor input signal to pass through
- * a range of 1000 PWM units. A value x means that the motor signal
- * can only go from 1000 to 2000 PWM in minimum x seconds.
- *
- * Zero means that slew rate limiting is disabled.
- *
- * @min 0.0
- * @unit s/(1000*PWM)
- * @group PWM Outputs
- */
-PARAM_DEFINE_FLOAT(MOT_SLEW_MAX, 0.0f);
-
 /**
  * Thrust to motor control signal model parameter
  *

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -732,7 +732,7 @@ PARAM_DEFINE_INT32(COM_FORCE_SAFETY, 0);
 PARAM_DEFINE_INT32(COM_MOT_TEST_EN, 1);
 
 /**
- * Timeout value for disarming when kill switch is engaged
+ * Timeout value for disarming after kill switch is engaged
  *
  * @group Commander
  * @unit s


### PR DESCRIPTION
### Solved Problem
When checking what modeling we do on the motor outputs e.g. the thrust model factor I found that the motor slew rate parameter is not used anymore. I think the functionality was only ever available with static mixing and got removed in:
https://github.com/PX4/PX4-Autopilot/commit/a7bbcd5b04b13b68fc131debdd17e9e130534a2c#diff-d9872cc7cc8b541d8ae4eba7aec74a170cd1abda6595bcf473b6fef65560069eL559
(src/lib/mixer_module/mixer_module.cpp:559)

For reference this feature was introduced in https://github.com/PX4/PX4-Autopilot/commit/66ddea01d144aff29a6f815c9cedeb29947b7289

### Solution
1. Remove the parameter definition to avoid confusion.
2. I adapted the disarm after kill parameter description after @hamishwillee 's wording from https://github.com/PX4/PX4-user_guide/pull/3316/files#diff-f90fa3c222fed8cbf7d2705f83d15cd2205261c2b7263de3cdf1871f35baaa26R326

### Changelog Entry
```
Cleanup: remove unused MOT_SLEW_MAX parameter
```

### Test coverage
It compiles also without the definition.