### PR TITLE
CI: fix Python checks

### DIFF
--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v1
       with:
@@ -18,7 +18,7 @@ jobs:
     - name: Install Python3
       run: sudo apt-get install python3 python3-setuptools python3-pip -y
     - name: Install tools
-      run: pip3 install --user mypy types-requests flake8
+      run: python3 -m pip install mypy types-requests flake8 --break-system-packages
     - name: Check MAVSDK test scripts with mypy
       run: $HOME/.local/bin/mypy --strict test/mavsdk_tests/*.py
     - name: Check MAVSDK test scripts with flake8


### PR DESCRIPTION
Now that ubuntu-latest has been pushed to Ubuntu 24.04, we need to fix up the pip install.

While at it, we might as well pin to the ubuntu 24.04 version, so we don't have this happen to use out of the blue again.
