### PR TITLE
bootloader: robustify uploader detection

### DIFF
--- a/platforms/nuttx/src/bootloader/common/bl.c
+++ b/platforms/nuttx/src/bootloader/common/bl.c
@@ -153,6 +153,7 @@
 #define STATE_ALLOWS_REBOOT       (STATE_ALLOWS_ERASE|STATE_PROTO_PROG_MULTI|STATE_PROTO_GET_CRC)
 #  define SET_BL_STATE(s) bl_state |= (s)
 #endif
+#define STATE_ALLOWS_BOOTLOADER   (STATE_PROTO_GET_SYNC|STATE_PROTO_GET_DEVICE)
 
 static uint8_t bl_type;
 static uint8_t last_input;
@@ -1107,9 +1108,10 @@ bootloader(unsigned timeout)
 			continue;
 		}
 
-		// we got a command worth syncing, so kill the timeout because
-		// we are probably talking to the uploader
-		timeout = 0;
+		// We got a sync command as well as a get_device command, we are very likely talking to the uploader.
+		if ((bl_state & STATE_ALLOWS_BOOTLOADER) == STATE_ALLOWS_BOOTLOADER) {
+			timeout = 0;
+		}
 
 		// Set the bootloader port based on the port from which we received the first valid command
 		if (bl_type == NONE) {


### PR DESCRIPTION
The bootloader can often get stuck parsing random MAVLink traffic, thinking it had seen a GET_SYNC.

Therefore, this commits adds a two step check which requires a GET_SYNC followed by a GET_DEVICE to make sure it's really an uploader script talking to it, and not just random data.