### PR TITLE
RTL: fix RTL time estimation of MC landing phase

### DIFF
--- a/src/lib/rtl/rtl_time_estimator.cpp
+++ b/src/lib/rtl/rtl_time_estimator.cpp
@@ -51,7 +51,6 @@ RtlTimeEstimator::RtlTimeEstimator() : ModuleParams(nullptr)
 {
 	_param_mpc_z_v_auto_up = param_find("MPC_Z_V_AUTO_UP");
 	_param_mpc_z_v_auto_dn = param_find("MPC_Z_V_AUTO_DN");
-	_param_mpc_land_speed = param_find("MPC_LAND_SPEED");
 	_param_fw_climb_rate = param_find("FW_T_CLMB_R_SP");
 	_param_fw_sink_rate = param_find("FW_T_SINK_R_SP");
 	_param_fw_airspeed_trim = param_find("FW_AIRSPD_TRIM");
@@ -130,17 +129,6 @@ void RtlTimeEstimator::addWait(float time_s)
 	}
 }
 
-void RtlTimeEstimator::addDescendMCLand(float alt)
-{
-	if (PX4_ISFINITE(alt)) {
-		_is_valid = true;
-
-		if (alt < -FLT_EPSILON && PX4_ISFINITE(alt)) {
-			_time_estimate += -alt / getHoverLandSpeed();
-		}
-	}
-}
-
 float RtlTimeEstimator::getCruiseGroundSpeed(const matrix::Vector2f &direction_norm)
 {
 	float cruise_speed = getCruiseSpeed();
@@ -200,17 +188,6 @@ float RtlTimeEstimator::getCruiseSpeed()
 		if (_param_rover_cruise_speed == PARAM_INVALID || param_get(_param_rover_cruise_speed, &ret) != PX4_OK) {
 			ret = 1e6f;
 		}
-	}
-
-	return ret;
-}
-
-float RtlTimeEstimator::getHoverLandSpeed()
-{
-	float ret = 1e6f;
-
-	if (_param_mpc_land_speed == PARAM_INVALID || param_get(_param_mpc_land_speed, &ret) != PX4_OK) {
-		ret = 1e6f;
 	}
 
 	return ret;

--- a/src/lib/rtl/rtl_time_estimator.h
+++ b/src/lib/rtl/rtl_time_estimator.h
@@ -68,7 +68,6 @@ public:
 	void addDistance(float hor_dist, const matrix::Vector2f &hor_direction, float vert_dist);
 	void addVertDistance(float alt);
 	void addWait(float time_s);
-	void addDescendMCLand(float alt);
 
 private:
 	/**
@@ -107,13 +106,6 @@ private:
 	float getCruiseSpeed();
 
 	/**
-	 * @brief Get the Hover Land Speed
-	 *
-	 * @return Hover land speed [m/s]
-	 */
-	float getHoverLandSpeed();
-
-	/**
 	 * @brief Get the horizontal wind velocity
 	 *
 	 * @return horizontal wind velocity.
@@ -130,7 +122,6 @@ private:
 
 	param_t		_param_mpc_z_v_auto_up{PARAM_INVALID}; 	/**< MC climb velocity parameter */
 	param_t		_param_mpc_z_v_auto_dn{PARAM_INVALID};  /**< MC descend velocity parameter */
-	param_t		_param_mpc_land_speed{PARAM_INVALID};   /**< MC land descend speed parameter */
 	param_t		_param_fw_climb_rate{PARAM_INVALID};    /**< FW climb speed parameter */
 	param_t		_param_fw_sink_rate{PARAM_INVALID};     /**< FW descend speed parameter */
 

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -73,7 +73,6 @@ void RtlDirect::on_inactivation()
 void RtlDirect::on_activation()
 {
 	_global_pos_sub.update();
-	_land_detected_sub.update();
 	_vehicle_status_sub.update();
 
 	parameters_update();

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -126,32 +126,29 @@ void RtlDirect::setRtlPosition(PositionYawSetpoint rtl_position, loiter_point_s 
 
 	parameters_update();
 
-	// Only allow to set a new approach if the mode is not activated yet.
-	if (!isActive()) {
-		_destination = rtl_position;
-		_force_heading = false;
+	_destination = rtl_position;
+	_force_heading = false;
 
-		// Input sanitation
-		if (!PX4_ISFINITE(_destination.lat) || !PX4_ISFINITE(_destination.lon)) {
-			// We don't have a valid rtl position, use the home position instead.
-			_destination.lat = _home_pos_sub.get().lat;
-			_destination.lon = _home_pos_sub.get().lon;
-			_destination.alt = _home_pos_sub.get().alt;
-			_destination.yaw = _home_pos_sub.get().yaw;
-		}
+	// Input sanitation
+	if (!PX4_ISFINITE(_destination.lat) || !PX4_ISFINITE(_destination.lon)) {
+		// We don't have a valid rtl position, use the home position instead.
+		_destination.lat = _home_pos_sub.get().lat;
+		_destination.lon = _home_pos_sub.get().lon;
+		_destination.alt = _home_pos_sub.get().alt;
+		_destination.yaw = _home_pos_sub.get().yaw;
+	}
 
-		if (!PX4_ISFINITE(_destination.alt)) {
-			// Not a valid rtl land altitude. Assume same altitude as home position.
-			_destination.alt = _home_pos_sub.get().alt;
-		}
+	if (!PX4_ISFINITE(_destination.alt)) {
+		// Not a valid rtl land altitude. Assume same altitude as home position.
+		_destination.alt = _home_pos_sub.get().alt;
+	}
 
-		_land_approach = sanitizeLandApproach(loiter_pos);
+	_land_approach = sanitizeLandApproach(loiter_pos);
 
-		const float dist_to_destination{get_distance_to_next_waypoint(_land_approach.lat, _land_approach.lon, _destination.lat, _destination.lon)};
+	const float dist_to_destination{get_distance_to_next_waypoint(_land_approach.lat, _land_approach.lon, _destination.lat, _destination.lon)};
 
-		if (dist_to_destination > _navigator->get_acceptance_radius()) {
-			_force_heading = true;
-		}
+	if (dist_to_destination > _navigator->get_acceptance_radius()) {
+		_force_heading = true;
 	}
 }
 

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -523,7 +523,7 @@ rtl_time_estimate_s RtlDirect::calc_rtl_time_estimate()
 					initial_altitude = loiter_altitude;
 				}
 
-				_rtl_time_estimator.addDescendMCLand(_destination.alt - initial_altitude);
+				_rtl_time_estimator.addVertDistance(_destination.alt - initial_altitude);
 			}
 
 			break;
@@ -556,7 +556,6 @@ loiter_point_s RtlDirect::sanitizeLandApproach(loiter_point_s land_approach) con
 	if (!PX4_ISFINITE(land_approach.lat) || !PX4_ISFINITE(land_approach.lon)) {
 		sanitized_land_approach.lat = _destination.lat;
 		sanitized_land_approach.lon = _destination.lon;
-
 	}
 
 	if (!PX4_ISFINITE(land_approach.height_m)) {

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -426,7 +426,7 @@ rtl_time_estimate_s RtlDirect::calc_rtl_time_estimate()
 
 	RTLState start_state_for_estimate;
 
-	if (isActive()) {
+	if (_vehicle_status_sub.get().nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL) {
 		start_state_for_estimate = _rtl_state;
 
 	} else {

--- a/src/modules/navigator/rtl_direct_mission_land.cpp
+++ b/src/modules/navigator/rtl_direct_mission_land.cpp
@@ -354,8 +354,8 @@ rtl_time_estimate_s RtlDirectMissionLand::calc_rtl_time_estimate()
 								// For VTOL, Rotary, go there horizontally first, then land
 								_rtl_time_estimator.addDistance(hor_dist, direction, 0.f);
 
-								_rtl_time_estimator.addDescendMCLand(get_absolute_altitude_for_item(next_position_mission_item) -
-												     altitude_at_calculation_point);
+								_rtl_time_estimator.addVertDistance(get_absolute_altitude_for_item(next_position_mission_item) -
+												    altitude_at_calculation_point);
 							}
 
 							break;


### PR DESCRIPTION

### Solved Problem
The RTL time estimate increases while in the last phase of a MC RTL.
```
time_estimate: 29.370251
time_estimate: 28.087288
INFO  [navigator] RTL: land at destination
time_estimate: 28.194275
time_estimate: 29.103222
time_estimate: 30.055092
```

### Solution
Issues found:
- `isActive()` actually isn't from the rlt mode but from mission (rtl direct doesn't inherit from rtl but from mission). Thus [this condition](https://github.com/PX4/PX4-Autopilot/blob/dbba9adb14b5210498287168396333d57ffb2fb9/src/modules/navigator/rtl_direct.cpp#L429) is always invalid, leading to always pick the `getActivationLandState()` instead of current altitude.
- `isActive()` is also used in another part of rtl_direct. I don't think it caused issues but I remove the check here, as I don't see how it would be necessary
- the loiter_altitude used for [the calculation the remaining time when already being in the last phase](https://github.com/PX4/PX4-Autopilot/blob/dbba9adb14b5210498287168396333d57ffb2fb9/src/modules/navigator/rtl_direct.cpp#L530C25-L530C41) is set to `RTL_DESCEND_ALT`, and it is wrongly assumed that 1) vehicle starts this last LAND phase really only at this altitude and 2) that in this phase it sinks with `MPC_LAND_SPEED` all the way. Instead the sink speed is only reduced when in the last few meters of the landing, as is linked to distance sensor data usually. For the sake of simplicity I removed the distinction between land and sink speed, as I don't think it really matters. The RTL time estimate will anyway always be a few seconds off, and if we want to change that we need to feed in distance sensor data etc. Not worth IMO. IF we remove the distinction then the still wrong assumption of "LAND phase starting below RTL_DESCEND_ALTITUDE" . 

Maybe https://github.com/PX4/PX4-Autopilot/pull/23689 introduced some of the issues, or at least surfaced the bugs.

### Changelog Entry
For release notes: 
```
Bugfix: RTL: fix RTL time estimation of MC landing phase
```


### Test coverage
RTL direct tested in SITL (multicopter).
