### PR TITLE
Refactor esc calibration

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -43,7 +43,6 @@
 /* commander module headers */
 #include "Arming/ArmAuthorization/ArmAuthorization.h"
 #include "commander_helper.h"
-#include "esc_calibration.h"
 #define DEFINE_GET_PX4_CUSTOM_MODE
 #include "px4_custom_mode.h"
 #include "ModeUtil/control_mode.hpp"
@@ -1339,23 +1338,19 @@ Commander::handle_command(const vehicle_command_s &cmd)
 
 				} else if ((int)(cmd.param7) == 1) {
 					/* do esc calibration */
-					if (check_battery_disconnected(&_mavlink_log_pub)) {
-						answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED);
+					answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED);
 
-						if (_safety.isButtonAvailable() && !_safety.isSafetyOff()) {
-							mavlink_log_critical(&_mavlink_log_pub, "ESC calibration denied! Press safety button first\t");
-							events::send(events::ID("commander_esc_calibration_denied"), events::Log::Critical,
-								     "ESCs calibration denied");
-
-						} else {
-							_vehicle_status.calibration_enabled = true;
-							_actuator_armed.in_esc_calibration_mode = true;
-							_worker_thread.startTask(WorkerThread::Request::ESCCalibration);
-						}
+					if (_safety.isButtonAvailable() && !_safety.isSafetyOff()) {
+						mavlink_log_critical(&_mavlink_log_pub, "ESC calibration denied! Press safety button first\t");
+						events::send(events::ID("commander_esc_calibration_denied"), events::Log::Critical,
+								"ESCs calibration denied");
 
 					} else {
-						answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_DENIED);
+						_vehicle_status.calibration_enabled = true;
+						_actuator_armed.in_esc_calibration_mode = true;
+						_worker_thread.startTask(WorkerThread::Request::ESCCalibration);
 					}
+
 
 				} else if ((int)(cmd.param4) == 0) {
 					/* RC calibration ended - have we been in one worth confirming? */

--- a/src/modules/commander/esc_calibration.h
+++ b/src/modules/commander/esc_calibration.h
@@ -46,6 +46,4 @@
 
 int do_esc_calibration(orb_advert_t *mavlink_log_pub);
 
-bool check_battery_disconnected(orb_advert_t *mavlink_log_pub);
-
 #endif


### PR DESCRIPTION
### Solved Problem

Simplification/refacto of the ESC calibration code.

1. `check_battery_disconnected` is done in the calibration process, not in the commander call
2. early exit for better readability

For 1., no need to leak the calibration logic to the Commander - it's equivalent to launching the calibration process and then potentially fail directly if the battery is not connected (`VEHICLE_CMD_RESULT_DENIED` is ignored by QGC)

For 2., the code with `goto` more cleanly represent the state machine of the test than with the numerous `if (!calibration_failed)`

### Context
ESC calibration is a process that requires user interaction / sending of feedback messages (eg disconnect/connect battery).
Mavlink commands offer a percentage based progress but not sending text. As such, MAV_RESULT_ACCEPTED is sent instantly and the progress/interaction is done through STATUSTEXT mavlink messages, with the "[cal]" prefix.


