### PR TITLE
SDLOG_ALGORITHM - AES option not implemented

### DIFF
--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -184,7 +184,7 @@ PARAM_DEFINE_INT32(SDLOG_UUID, 1);
  *
  * @value 0 Disabled
  * @value 2 XChaCha20
- * @value 3 AES
+ * @value 3 AES (Not implemented)
  *
  * @group SD Logging
  */

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -184,7 +184,6 @@ PARAM_DEFINE_INT32(SDLOG_UUID, 1);
  *
  * @value 0 Disabled
  * @value 2 XChaCha20
- * @value 3 AES (Not implemented)
  *
  * @group SD Logging
  */


### PR DESCRIPTION
Apparently the AES option to `SDLOG_ALGORITHM` parameter is a placeholder for a desirable implementation.
However there is no way to know that unless you know that ....

So this adds the words `(Not implemented)` after the parameter.

@jlaitine Can you confirm the statement and the solution here?


This fell out of https://github.com/PX4/PX4-user_guide/pull/3401