### PR TITLE
Handle loss of position during backtransition

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -768,9 +768,6 @@ FixedwingPositionControl::set_control_mode_current(const hrt_abstime &now)
 			// we handle loss of position control during backtransition as a special case
 			_control_mode_current = FW_POSCTRL_MODE_TRANSITON;
 
-		} else if (_param_nav_gpsf_lt.get() > 0.f && _vehicle_status.in_transition_mode) {
-			_control_mode_current = FW_POSCTRL_MODE_AUTO_ALTITUDE;
-
 		} else if (hrt_elapsed_time(&_time_in_fixed_bank_loiter) < (_param_nav_gpsf_lt.get() * 1_s)
 			   && !_vehicle_status.in_transition_mode) {
 			if (commanded_position_control_mode != FW_POSCTRL_MODE_AUTO_ALTITUDE) {


### PR DESCRIPTION
### Solved Problem
When the estimator declares local position invalid during a VTOL backtransition in an autonomous mode, the vehicle enters a fixed bank loiter. This is not desired during a backtransition, as the vehicle will start to turn.

### Solution
Explicitly handle the case where we don't control position during the backtransition by setting the roll setpoint to zero.

### Changelog Entry
For release notes:
```
Bugfix: Prevent fixed bank loiter during backtransition when we lose local position.
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
