### PR TITLE
COM_THROW_SPEED - arm or start motors clarification

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -986,9 +986,9 @@ PARAM_DEFINE_INT32(COM_THROW_EN, 0);
 /**
  * Minimum speed for the throw start
  *
- * When the throw launch is enabled, the drone will only arm after this speed is exceeded before detecting
- * the freefall. This is a safety feature to ensure the drone does not turn on after accidental drop or
- * a rapid movement before the throw.
+ * When the throw launch is enabled, the drone will only allow motors to spin after this speed
+ * is exceeded before detecting the freefall. This is a safety feature to ensure the drone does
+ * not turn on after accidental drop or a rapid movement before the throw.
  *
  * Set to 0 to disable.
  *


### PR DESCRIPTION
This is a change to request clarification of the term "arm" as it is used in the slow throw mode.

The process to launch in throw mode is to arm the vehicle (send the arm command/switch), then throw the vehicle. The motors only spin when you exceed a speed and then enter free-fall. 

Now normally "arm" means "power the motors and they start spinning", but there it means like a prearm state - motors are powered but they don't spin. The problem is that in this param we use arm to mean start the motors spinning, but at this point we have already sent the arm command so the vehicle is "armed".

I'd like to be precise because the term confused a new user in  https://discord.com/channels/1022170275984457759/1022186188255285399/threads/1295828271186972742

@sfuhrer @MaEtUgR How does this work? My guess is that either there is an extra hidden state that we enter like "pending armed" when we get the arm command and then we arm on the freefall trigger. Or it may be that we arm on the command, but there is an extra interlock on the motors.
