### PR TITLE
Add back motor slew rate

### DIFF
--- a/src/lib/mixer_module/functions/FunctionMotors.hpp
+++ b/src/lib/mixer_module/functions/FunctionMotors.hpp
@@ -35,7 +35,6 @@
 
 #include "FunctionProviderBase.hpp"
 
-#include <lib/slew_rate/SlewRate.hpp>
 #include <uORB/topics/actuator_motors.h>
 
 /**
@@ -56,7 +55,7 @@ public:
 	{
 		for (int i = 0; i < actuator_motors_s::NUM_CONTROLS; ++i) {
 			_data.control[i] = NAN;
-			_output_slewrates[i].setForcedValue(NAN);
+			_last_control[i] = NAN;
 		}
 	}
 
@@ -71,17 +70,15 @@ public:
 		if (_motor_rise_time > FLT_EPSILON) { // also makes sure to not divide by zero
 			hrt_abstime now = hrt_absolute_time();
 			const float dt = (now - _timestamp_last_update) / 1e6f;
+			// (rise time [-1,1] = 2 / slew) -> (slew = 2 / rise time [-1,1])
+			const float delta_max = 2.f / _motor_rise_time * dt;
 
 			for (int i = 0; i < actuator_motors_s::NUM_CONTROLS; ++i) {
-				// (rise time [-1,1] = 2 / slew) -> (slew = 2 / rise time [-1,1])
-				_output_slewrates[i].setSlewRate(2.f / _motor_rise_time);
-
-				if (!PX4_ISFINITE(_output_slewrates[i].getState())) {
-					_output_slewrates[i].setForcedValue(_data.control[i]);
-
-				} else {
-					_data.control[i] = _output_slewrates[i].update(_data.control[i], dt);
+				if (PX4_ISFINITE(_last_control[i])) {
+					_data.control[i] = _last_control[i] + math::constrain(_data.control[i] - _last_control[i], -delta_max, delta_max);
 				}
+
+				_last_control[i] = _data.control[i];
 			}
 
 			_timestamp_last_update = now;
@@ -143,6 +140,6 @@ private:
 	actuator_motors_s _data{};
 	const float &_thrust_factor;
 	const float &_motor_rise_time; // Parameter to configure slew rate
-	SlewRate<float> _output_slewrates[actuator_motors_s::NUM_CONTROLS];
+	float _last_control[actuator_motors_s::NUM_CONTROLS]; // for slew rate
 	hrt_abstime _timestamp_last_update{0};
 };

--- a/src/lib/mixer_module/functions/FunctionMotors.hpp
+++ b/src/lib/mixer_module/functions/FunctionMotors.hpp
@@ -35,6 +35,7 @@
 
 #include "FunctionProviderBase.hpp"
 
+#include <lib/slew_rate/SlewRate.hpp>
 #include <uORB/topics/actuator_motors.h>
 
 /**
@@ -50,10 +51,12 @@ public:
 
 	FunctionMotors(const Context &context) :
 		_topic(&context.work_item, ORB_ID(actuator_motors)),
-		_thrust_factor(context.thrust_factor)
+		_thrust_factor(context.thrust_factor),
+		_motor_rise_time(context.motor_rise_time)
 	{
 		for (int i = 0; i < actuator_motors_s::NUM_CONTROLS; ++i) {
 			_data.control[i] = NAN;
+			_output_slewrates[i].setForcedValue(NAN);
 		}
 	}
 
@@ -63,6 +66,25 @@ public:
 	{
 		if (_topic.update(&_data)) {
 			updateValues(_data.reversible_flags, _thrust_factor, _data.control, actuator_motors_s::NUM_CONTROLS);
+		}
+
+		if (_motor_rise_time > FLT_EPSILON) { // also makes sure to not divide by zero
+			hrt_abstime now = hrt_absolute_time();
+			const float dt = (now - _timestamp_last_update) / 1e6f;
+
+			for (int i = 0; i < actuator_motors_s::NUM_CONTROLS; ++i) {
+				// (rise time [-1,1] = 2 / slew) -> (slew = 2 / rise time [-1,1])
+				_output_slewrates[i].setSlewRate(2.f / _motor_rise_time);
+
+				if (!PX4_ISFINITE(_output_slewrates[i].getState())) {
+					_output_slewrates[i].setForcedValue(_data.control[i]);
+
+				} else {
+					_data.control[i] = _output_slewrates[i].update(_data.control[i], dt);
+				}
+			}
+
+			_timestamp_last_update = now;
 		}
 	}
 
@@ -120,4 +142,7 @@ private:
 	uORB::SubscriptionCallbackWorkItem _topic;
 	actuator_motors_s _data{};
 	const float &_thrust_factor;
+	const float &_motor_rise_time; // Parameter to configure slew rate
+	SlewRate<float> _output_slewrates[actuator_motors_s::NUM_CONTROLS];
+	hrt_abstime _timestamp_last_update{0};
 };

--- a/src/lib/mixer_module/functions/FunctionProviderBase.hpp
+++ b/src/lib/mixer_module/functions/FunctionProviderBase.hpp
@@ -48,6 +48,7 @@ public:
 	struct Context {
 		px4::WorkItem &work_item;
 		const float &thrust_factor;
+		const float &motor_rise_time;
 	};
 
 	FunctionProviderBase() = default;

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -259,7 +259,7 @@ bool MixingOutput::updateSubscriptions(bool allow_wq_switch)
 
 	cleanupFunctions();
 
-	const FunctionProviderBase::Context context{_interface, _param_thr_mdl_fac.reference()};
+	const FunctionProviderBase::Context context{_interface, _param_thr_mdl_fac.reference(), _param_mot_slew_max.reference()};
 	int provider_indexes[MAX_ACTUATORS] {};
 	int next_provider = 0;
 	int subscription_callback_provider_index = INT_MAX;

--- a/src/lib/mixer_module/motor_params.c
+++ b/src/lib/mixer_module/motor_params.c
@@ -38,6 +38,21 @@
  *
  */
 
+
+/**
+ * Minimum motor rise time (slew rate limit)
+ *
+ * Forces the motor output signal to take at least the configured time (in seconds)
+ * to traverse its full range, either [0%, 100%] or [-100%, 100%].
+ *
+ * A value of zero disables the limit.
+ *
+ * @min 0.0
+ * @unit s
+ * @group Motors
+ */
+PARAM_DEFINE_FLOAT(MOT_SLEW_MAX, 0.0f);
+
 /**
  * Thrust to motor control signal model parameter
  *
@@ -52,6 +67,6 @@
  * @max 1.0
  * @decimal 1
  * @increment 0.1
- * @group PWM Outputs
+ * @group Motors
  */
 PARAM_DEFINE_FLOAT(THR_MDL_FAC, 0.0f);


### PR DESCRIPTION
### Solved Problem
Like @Igor-Misic and me almost simultaneously found out the motor slew rate does not take effect anymore in the dynamic control allocation which is what the mixer now uses for some time:
https://github.com/PX4/PX4-Autopilot/pull/23794
https://github.com/PX4/PX4-Autopilot/pull/23798

I would have been fine with that since I don't think there should be a slew rate on the motor outputs but the ESCs should deal with the feasibility of commands. But in practise they apparently do not always do that and since there are users of this feature I don't want to leave it away.

### Solution
1. I added back a motor slew rate in the motor function (it used to be in the simple and multicopter mixer of the old static mixing) and recovered the `MOT_SLEW_MAX` parameter with its original meaning but a new PWM independent description for backward compatibility. The slew rate reinitializes when there are NAN values in the motor command so they could in theory still jump from NAN to a different value since the motor function does not know what NAN (output protol-specific disarmed value) maps to.
2. I optimized it a bit since depending on the setup if the slew rate is enabled things get called at multiple kilohertz and that has some visible impact on the flight control CPU load e.g. in my test it was ~0.4% difference and not easily visible anymore after the second commit.

### Changelog Entry
```
Feature: Bring back motor slew rate
```

### Alternatives
I would suggest not to use this feature if not urgently necessary but rather make sure:
a) the ESC keeps up stable operation no matter what
b) the sensor noise is filtered adequately to not propagate problems
c) the setpoints are smooth such that there are no crazy jumps in normal operation

### Test coverage
SITL SIH test checking that the timing e.g. 10 seconds from -1 to 1 is correct and the initialization in case of NAN values works.
Real vehicle test to see that on PWM as well as CAN output the same slew rate is percievably in action.