### PR TITLE
boards: fixed board ap-h743v2 ADC_BATTERY_CURRENT_CHANNEL issue, the …

### DIFF
--- a/boards/x-mav/ap-h743v2/src/board_config.h
+++ b/boards/x-mav/ap-h743v2/src/board_config.h
@@ -86,7 +86,7 @@
 /* Define GPIO pins used as ADC N.B. Channel numbers must match below  */
 /* Define Channel numbers must match above GPIO pin IN(n)*/
 #define ADC_BATTERY_VOLTAGE_CHANNEL             ADC12_CH(4)
-#define ADC_BATTERY_CURRENT_CHANNEL             ADC12_CH(5)
+#define ADC_BATTERY_CURRENT_CHANNEL             ADC12_CH(8)
 
 #define ADC_CHANNELS \
 	((1 << ADC_BATTERY_VOLTAGE_CHANNEL) | \


### PR DESCRIPTION
Fixed adc channel issue of  ADC_BATTERY_CURRENT_CHANNEL.
