### PR TITLE
Add descend mode as a failsafe.

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -271,6 +271,9 @@ PARAM_DEFINE_INT32(COM_DISARM_MAN, 1);
  * @value 0 Warning
  * @value 2 Land mode
  * @value 3 Return at critical level, land at emergency level
+ * @value 4 Descend mode
+ * @min 0
+ * @max 4
  */
 PARAM_DEFINE_INT32(COM_LOW_BAT_ACT, 0);
 
@@ -304,6 +307,7 @@ PARAM_DEFINE_FLOAT(COM_FAIL_ACT_T, 5.f);
  * @value 0 Warning
  * @value 1 Return
  * @value 2 Land
+ * @value 3 Descend
  * @increment 1
  */
 PARAM_DEFINE_INT32(COM_IMB_PROP_ACT, 0);
@@ -328,6 +332,7 @@ PARAM_DEFINE_FLOAT(COM_OF_LOSS_T, 1.0f);
  * @value  0 Return mode
  * @value  1 Land mode
  * @value  2 Hold mode
+ * @value  3 Descend mode
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_QC_ACT, 0);
@@ -346,6 +351,9 @@ PARAM_DEFINE_INT32(COM_QC_ACT, 0);
  * @value 5 Hold mode
  * @value 6 Terminate
  * @value 7 Disarm
+ * @value 8 Descend
+ * @min 0
+ * @max 8
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_OBL_RC_ACT, 0);
@@ -596,8 +604,9 @@ PARAM_DEFINE_INT32(COM_TAKEOFF_ACT, 0);
  * @value 3 Land mode
  * @value 5 Terminate
  * @value 6 Disarm
+ * @value 7 Descend
  * @min 0
- * @max 6
+ * @max 7
  *
  * @group Commander
  */
@@ -615,8 +624,9 @@ PARAM_DEFINE_INT32(NAV_DLL_ACT, 0);
  * @value 3 Land mode
  * @value 5 Terminate
  * @value 6 Disarm
+ * @value 7 Descend
  * @min 1
- * @max 6
+ * @max 7
  *
  * @group Commander
  */
@@ -649,6 +659,7 @@ PARAM_DEFINE_INT32(COM_RCL_EXCEPT, 0);
  * @value 2 Land mode
  * @value 3 Return mode
  * @value 4 Terminate
+ * @value 5 Descend
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_ACT_FAIL_ACT, 0);
@@ -923,6 +934,7 @@ PARAM_DEFINE_FLOAT(COM_WIND_MAX, -1.f);
  * @value 3 Return
  * @value 4 Terminate
  * @value 5 Land
+ * @value 6 Descend
  * @increment 1
  */
 PARAM_DEFINE_INT32(COM_WIND_MAX_ACT, 0);

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -64,7 +64,8 @@ private:
 		Warning = 0,        // Warning
 		Return = 1,         // Return mode (deprecated)
 		Land = 2,           // Land mode
-		ReturnOrLand = 3    // Return mode at critically low level, Land mode at current position if reaching dangerously low levels
+		ReturnOrLand = 3,   // Return mode at critically low level, Land mode at current position if reaching dangerously low levels
+		Descend = 4,        // Land without using position
 	};
 
 	enum class offboard_loss_failsafe_mode : int32_t {
@@ -76,6 +77,7 @@ private:
 		Hold_mode = 5,
 		Terminate = 6,
 		Disarm = 7,
+		Descend = 8,
 	};
 
 	enum class position_control_navigation_loss_response : int32_t {
@@ -89,6 +91,7 @@ private:
 		Land_mode = 2,
 		Return_mode = 3,
 		Terminate = 4,
+		Descend_mode = 5,
 	};
 
 	enum class imbalanced_propeller_failsafe_mode : int32_t {
@@ -96,6 +99,7 @@ private:
 		Warning = 0,
 		Return = 1,
 		Land = 2,
+		Descend = 3,
 	};
 
 	enum class geofence_violation_action : int32_t {
@@ -105,6 +109,7 @@ private:
 		Return_mode = 3,
 		Terminate = 4,
 		Land_mode = 5,
+		Descend_mode = 6,
 	};
 
 	enum class gcs_connection_loss_failsafe_mode : int32_t {
@@ -114,6 +119,7 @@ private:
 		Land_mode = 3,
 		Terminate = 5,
 		Disarm = 6,
+		Descend = 7,
 	};
 
 	enum class command_after_quadchute : int32_t {
@@ -121,6 +127,7 @@ private:
 		Return_mode = 0,
 		Land_mode = 1,
 		Hold_mode = 2,
+		Descend_mode = 3,
 	};
 
 	// COM_RC_IN_MODE parameter values
@@ -138,7 +145,8 @@ private:
 		Hold_mode = 2,
 		Return_mode = 3,
 		Terminate = 4,
-		Land_mode = 5
+		Land_mode = 5,
+		Descend = 6,
 	};
 
 	enum class command_after_remaining_flight_time_low : int32_t {

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -57,6 +57,7 @@
  * @value 3 Return mode
  * @value 4 Terminate
  * @value 5 Land mode
+ * @value 6 Descend mode
  * @group Geofence
  */
 PARAM_DEFINE_INT32(GF_ACTION, 2);


### PR DESCRIPTION
The land mode supposes we have a GPS causing issues when flying with a local position (such as mocap or vision)
This adds the alternative to use the descend mode.

### Solved Problem
When working on local position systems such as a vision localization, the land mode doesn't fit the need when the localization is failing as we want a way to land.

Furthermore, the current Land mode supposes the use of GPS which is not present using vision/flow/mocap, making the drone try to land at (0,0) with a heading of 0°, which is not the expectation.

Fixes #23773
Fixes #21524

### Solution
- Add the use of Descend mode for all failsafe actions

### Changelog Entry
For release notes:
```
Feature: Failsafe modes now include the descend mode
```

### Alternatives
There could be an automatic demotion from Land to Descend

### Context
Related links, screenshot before/after, video
