### PR TITLE
Remove mode_req_local_alt from Descend mode and handle it in FW position controller

### DIFF
--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -115,7 +115,6 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	// NAVIGATION_STATE_DESCEND
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_DESCEND, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_DESCEND, flags.mode_req_attitude);
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_DESCEND, flags.mode_req_local_alt);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_DESCEND, flags.mode_req_prevent_arming);
 
 	// NAVIGATION_STATE_TERMINATION

--- a/src/modules/flight_mode_manager/tasks/Descend/FlightTaskDescend.cpp
+++ b/src/modules/flight_mode_manager/tasks/Descend/FlightTaskDescend.cpp
@@ -55,7 +55,7 @@ bool FlightTaskDescend::update()
 	} else {
 		// descend with constant acceleration (crash landing)
 		_velocity_setpoint(2) = NAN;
-		_acceleration_setpoint(2) = .15f;
+		_acceleration_setpoint(2) = .3f;
 	}
 
 	// Nudging
@@ -69,7 +69,7 @@ bool FlightTaskDescend::update()
 		_acceleration_setpoint(2) -= _sticks.getThrottleZeroCentered() * 10.f;
 
 	} else {
-		_acceleration_setpoint = matrix::Vector3f(0.f, 0.f, NAN); // stay level to minimize horizontal drift
+		_acceleration_setpoint.xy() = matrix::Vector2f(0.f, 0.f); // stay level to minimize horizontal drift
 		_yawspeed_setpoint = NAN;
 
 		// keep heading


### PR DESCRIPTION

### Solved Problem
I recently crashed a VTOL vehicle  in FW after disabling both GPS and baro fusion in air, which made it switch from AUTO to TERMINATE mode.

### Solution
- remove mode requirement for a valid altitude estimate from DESCEND
- similar to [what is done for MC](https://github.com/PX4/PX4-Autopilot/blob/e234b583b75b0500e1584ca4c2dbcceef15eb52e/src/modules/flight_mode_manager/tasks/Descend/FlightTaskDescend.cpp#L50-L59) handle invalid v/vz in the FW position controller. For FW we in case of invalid v/vz measurements would likely just want the thrust to be 0, such that the vehicle glides down to the ground while still tracking the loiter (assuming it doesn't stall).

### Changelog Entry
For release notes:
```
Improvement: Remove mode_req_local_alt from Descend mode and handle it in FW position controller
```


### Test coverage
Can be easily tested in SITL: Disable Baro fusion (EKF2_BARO_CTRL), then takeoff in auto mode, then disable GPS fusion --> with current main it goes to Termination mode, with this PR to Descend.


