### PR TITLE
Bugfix: Use custom MAVLink dialect also in simulator_mavlink

### DIFF
--- a/src/modules/simulation/simulator_mavlink/CMakeLists.txt
+++ b/src/modules/simulation/simulator_mavlink/CMakeLists.txt
@@ -40,9 +40,7 @@ px4_add_module(
 		-Wno-address-of-packed-member # TODO: fix in c_library_v2
 	INCLUDES
 		${CMAKE_BINARY_DIR}/mavlink
-		${CMAKE_BINARY_DIR}/mavlink/development
-		${CMAKE_BINARY_DIR}/mavlink/common
-		${CMAKE_BINARY_DIR}/mavlink/standard
+		${CMAKE_BINARY_DIR}/mavlink/${CONFIG_MAVLINK_DIALECT}
 	SRCS
 		SimulatorMavlink.cpp
 		SimulatorMavlink.hpp


### PR DESCRIPTION
### Solved Problem
When configuring a custom MAVLink dialect in https://github.com/PX4/PX4-Autopilot/blob/0c451552c7c85bcc2dfe186e1659dd5ea1728a61/boards/px4/sitl/default.px4board#L37 I found that `simulator_mavlink` fails building because of some unknown definitions even if I don't use any custom message from that custom dialect in there.

### Solution
Include the right header files from the configured dialect to have the proper dialect hierarchy is in use outside of the default configuration. This is consistent with the main MAVLink module, see https://github.com/PX4/PX4-Autopilot/blob/0c451552c7c85bcc2dfe186e1659dd5ea1728a61/src/modules/mavlink/CMakeLists.txt#L152-L153

### Changelog Entry
```
Bugfix: Use custom MAVLink dialect also in simulator_mavlink
```

### Test coverage
I tested this change first with a custom dialect that failed building before and verified it solves the problem. Then I tested it on main and it doesn't break the build. Let's see if CI has a case I'm not aware of but I'm fairly sure this is how it should be included.

### Context
This is the only exact error I got when building SITL with a custom dialect. I'm not sure why exactly this command should fail to be found. It is available in the common dialect and all other references were found...
![grafik](https://github.com/user-attachments/assets/d00e652f-9e78-413b-9b8e-1a343651f3cb)
