### PR TITLE
Navigator: land: fix when flying without global position estimate

### DIFF
--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -83,8 +83,9 @@ void
 Land::on_active()
 {
 	/* for VTOL update landing location during back transition */
-	if (_navigator->get_vstatus()->is_vtol &&
-	    _navigator->get_vstatus()->in_transition_mode) {
+	if (_navigator->get_vstatus()->is_vtol
+	    && _navigator->get_vstatus()->in_transition_mode
+	    && _navigator->get_local_position()->xy_global) {
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
 		// create a wp in front of the VTOL while in back-transition, based on MPC settings that will apply in MC phase afterwards

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -60,7 +60,7 @@ Land::on_activation()
 
 	if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
 	    && _navigator->get_local_position()->xy_global) { // only execute if global position is valid
-		_navigator->calculate_breaking_stop(_mission_item.lat, _mission_item.lon);
+		_navigator->preproject_stop_point(_mission_item.lat, _mission_item.lon);
 	}
 
 	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
@@ -89,8 +89,7 @@ Land::on_active()
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
 		// create a wp in front of the VTOL while in back-transition, based on MPC settings that will apply in MC phase afterwards
-		_navigator->calculate_breaking_stop(pos_sp_triplet->current.lat, pos_sp_triplet->current.lon);
-
+		_navigator->preproject_stop_point(pos_sp_triplet->current.lat, pos_sp_triplet->current.lon);
 		_navigator->set_position_setpoint_triplet_updated();
 	}
 

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -58,7 +58,8 @@ Land::on_activation()
 	/* convert mission item to current setpoint */
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-	if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+	if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
+	    && _navigator->get_local_position()->xy_global) { // only execute if global position is valid
 		_navigator->calculate_breaking_stop(_mission_item.lat, _mission_item.lon);
 	}
 

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -109,7 +109,7 @@ Loiter::set_loiter_position()
 			setLoiterItemFromCurrentPositionSetpoint(&_mission_item);
 
 		} else if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
-			setLoiterItemFromCurrentPositionWithBreaking(&_mission_item);
+			setLoiterItemFromCurrentPositionWithBraking(&_mission_item);
 
 		} else {
 			setLoiterItemFromCurrentPosition(&_mission_item);

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -772,11 +772,11 @@ MissionBlock::setLoiterItemFromCurrentPosition(struct mission_item_s *item)
 }
 
 void
-MissionBlock::setLoiterItemFromCurrentPositionWithBreaking(struct mission_item_s *item)
+MissionBlock::setLoiterItemFromCurrentPositionWithBraking(struct mission_item_s *item)
 {
 	setLoiterItemCommonFields(item);
 
-	_navigator->calculate_breaking_stop(item->lat, item->lon);
+	_navigator->preproject_stop_point(item->lat, item->lon);
 
 	item->altitude = _navigator->get_global_position()->alt;
 	item->loiter_radius = _navigator->get_loiter_radius();

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -832,8 +832,15 @@ MissionBlock::set_land_item(struct mission_item_s *item)
 	item->nav_cmd = NAV_CMD_LAND;
 
 	// set land item to current position
-	item->lat = _navigator->get_global_position()->lat;
-	item->lon = _navigator->get_global_position()->lon;
+	if (_navigator->get_local_position()->xy_global) {
+		item->lat = _navigator->get_global_position()->lat;
+		item->lon = _navigator->get_global_position()->lon;
+
+	} else {
+		item->lat = (double)NAN;
+		item->lon = (double)NAN;
+	}
+
 	item->yaw = NAN;
 
 	item->altitude = 0;

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -183,7 +183,7 @@ protected:
 	void setLoiterItemFromCurrentPositionSetpoint(struct mission_item_s *item);
 
 	void setLoiterItemFromCurrentPosition(struct mission_item_s *item);
-	void setLoiterItemFromCurrentPositionWithBreaking(struct mission_item_s *item);
+	void setLoiterItemFromCurrentPositionWithBraking(struct mission_item_s *item);
 
 	void setLoiterItemCommonFields(struct mission_item_s *item);
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -278,7 +278,7 @@ public:
 	void release_gimbal_control();
 	void set_gimbal_neutral();
 
-	void calculate_breaking_stop(double &lat, double &lon);
+	void preproject_stop_point(double &lat, double &lon);
 
 	void stop_capturing_images();
 	void disable_camera_trigger();

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -356,7 +356,7 @@ void Navigator::run()
 						if (_vstatus.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
 						    && (get_position_setpoint_triplet()->current.type != position_setpoint_s::SETPOINT_TYPE_TAKEOFF)) {
 
-							calculate_breaking_stop(rep->current.lat, rep->current.lon);
+							preproject_stop_point(rep->current.lat, rep->current.lon);
 
 						} else {
 							// For fixedwings we can use the current vehicle's position to define the loiter point
@@ -467,7 +467,7 @@ void Navigator::run()
 					if (_vstatus.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
 					    && (get_position_setpoint_triplet()->current.type != position_setpoint_s::SETPOINT_TYPE_TAKEOFF)) {
 
-						calculate_breaking_stop(rep->current.lat, rep->current.lon);
+						preproject_stop_point(rep->current.lat, rep->current.lon);
 					}
 
 					if (PX4_ISFINITE(curr->current.loiter_radius) && curr->current.loiter_radius > FLT_EPSILON) {
@@ -1588,7 +1588,7 @@ bool Navigator::geofence_allows_position(const vehicle_global_position_s &pos)
 	return true;
 }
 
-void Navigator::calculate_breaking_stop(double &lat, double &lon)
+void Navigator::preproject_stop_point(double &lat, double &lon)
 {
 	// For multirotors we need to account for the braking distance, otherwise the vehicle will overshoot and go back
 	const float course_over_ground = atan2f(_local_pos.vy, _local_pos.vx);


### PR DESCRIPTION

### Solved Problem
Fixes https://github.com/PX4/PX4-Autopilot/issues/21524
Fixes https://github.com/PX4/PX4-Autopilot/issues/23773
Proposes a partial alternative to https://github.com/PX4/PX4-Autopilot/pull/23839

Land without global position estimate (e.g. GNSS-denied without manually initialized position) was broken since https://github.com/PX4/PX4-Autopilot/pull/21036/commits/efc8c167acd57ca175b9f2eea795b750227263b3. Instead of landing at the current spot it flew to (0/0).

### Solution
Set lat/lon fields of triplet to NAN if global position is not valid. Further I disable the [breaking distance calculation](https://github.com/PX4/PX4-Autopilot/pull/23546) in this case, as it's requiring global position. Will be anyway removed from Navigator with https://github.com/PX4/PX4-Autopilot/pull/23678.

### Changelog Entry
For release notes:
```
Bugfix: Navigator: land: fix when flying without global position estimate
```

### Alternatives


### Test coverage
SITL tested.

### Context
Land without global position only works with MC vehicles, FW requires global position. 
