### PR TITLE
Navigator: land: fix when flying without global position estimate

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -827,8 +827,15 @@ MissionBlock::set_land_item(struct mission_item_s *item)
 	item->nav_cmd = NAV_CMD_LAND;
 
 	// set land item to current position
-	item->lat = _navigator->get_global_position()->lat;
-	item->lon = _navigator->get_global_position()->lon;
+	if (_navigator->get_local_position()->xy_global) {
+		item->lat = _navigator->get_global_position()->lat;
+		item->lon = _navigator->get_global_position()->lon;
+
+	} else {
+		item->lat = (double)NAN;
+		item->lon = (double)NAN;
+	}
+
 	item->yaw = NAN;
 
 	item->altitude = 0;


### PR DESCRIPTION
Port of https://github.com/PX4/PX4-Autopilot/pull/23845

I only ported the first commit, as the other two are not direct bug fixes.