### PR TITLE
Reload mission for RTL_TYPE 2

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -585,6 +585,8 @@ void RTL::init_rtl_mission_type()
 		_set_rtl_mission_type = RtlType::NONE;
 	}
 
+	mission_s new_mission = _mission_sub.get();
+
 	switch (new_rtl_mission_type) {
 	case RtlType::RTL_DIRECT_MISSION_LAND:
 		_rtl_mission_type_handle = new RtlDirectMissionLand(_navigator);
@@ -593,13 +595,13 @@ void RTL::init_rtl_mission_type()
 		break;
 
 	case RtlType::RTL_MISSION_FAST:
-		_rtl_mission_type_handle = new RtlMissionFast(_navigator);
+		_rtl_mission_type_handle = new RtlMissionFast(_navigator, new_mission);
 		_set_rtl_mission_type = RtlType::RTL_MISSION_FAST;
 		_rtl_type = RtlType::RTL_MISSION_FAST;
 		break;
 
 	case RtlType::RTL_MISSION_FAST_REVERSE:
-		_rtl_mission_type_handle = new RtlMissionFastReverse(_navigator);
+		_rtl_mission_type_handle = new RtlMissionFastReverse(_navigator, new_mission);
 		_set_rtl_mission_type = RtlType::RTL_MISSION_FAST_REVERSE;
 		_rtl_type = RtlType::RTL_MISSION_FAST_REVERSE;
 		break;

--- a/src/modules/navigator/rtl_mission_fast.cpp
+++ b/src/modules/navigator/rtl_mission_fast.cpp
@@ -46,10 +46,10 @@
 
 static constexpr int32_t DEFAULT_MISSION_FAST_CACHE_SIZE = 5;
 
-RtlMissionFast::RtlMissionFast(Navigator *navigator) :
+RtlMissionFast::RtlMissionFast(Navigator *navigator, mission_s mission) :
 	RtlBase(navigator, DEFAULT_MISSION_FAST_CACHE_SIZE)
 {
-
+	_mission = mission;
 }
 
 void RtlMissionFast::on_inactive()

--- a/src/modules/navigator/rtl_mission_fast.h
+++ b/src/modules/navigator/rtl_mission_fast.h
@@ -52,7 +52,7 @@ class Navigator;
 class RtlMissionFast : public RtlBase
 {
 public:
-	RtlMissionFast(Navigator *navigator);
+	RtlMissionFast(Navigator *navigator, mission_s mission);
 	~RtlMissionFast() = default;
 
 	void on_activation() override;

--- a/src/modules/navigator/rtl_mission_fast_reverse.cpp
+++ b/src/modules/navigator/rtl_mission_fast_reverse.cpp
@@ -46,10 +46,10 @@
 
 static constexpr int32_t DEFAULT_MISSION_FAST_REVERSE_CACHE_SIZE = 5;
 
-RtlMissionFastReverse::RtlMissionFastReverse(Navigator *navigator) :
+RtlMissionFastReverse::RtlMissionFastReverse(Navigator *navigator, mission_s mission) :
 	RtlBase(navigator, -DEFAULT_MISSION_FAST_REVERSE_CACHE_SIZE)
 {
-
+	_mission = mission;
 }
 
 void RtlMissionFastReverse::on_inactive()

--- a/src/modules/navigator/rtl_mission_fast_reverse.h
+++ b/src/modules/navigator/rtl_mission_fast_reverse.h
@@ -52,7 +52,7 @@ class Navigator;
 class RtlMissionFastReverse : public RtlBase
 {
 public:
-	RtlMissionFastReverse(Navigator *navigator);
+	RtlMissionFastReverse(Navigator *navigator, mission_s mission);
 	~RtlMissionFastReverse() = default;
 
 	void on_activation() override;


### PR DESCRIPTION
### Solved Problem
When uploading missions to be flown with RTL_TYPE=2 as a return path, PX4 sometimes claims there is no mission when RTL is triggered:

```
# WARN  [navigator] No valid mission available, loitering	
# ERROR [dataman_client] readSync failed! status=3, item=2, index=4294967295, length=56
# WARN  [navigator] Mission item could not be set.	
# WARN  [navigator] No valid mission available, loitering	
```

### Solution

Turns out that when these specific RTL handlers are initialized, they don't initialize their mission member variable. Because of that the RTL handlers essentially work with an empty mission where the index is -1, hence the dataman error.

The solution is to load the existing mission after initializing the handlers. I decided to pass the variables via constructor to contain the logic of obtaining the mission from the uORB queue all in rtl.cpp. This way the information flow is more visible in my opinion.

```
switch (new_rtl_mission_type) {
	case RtlType::RTL_DIRECT_MISSION_LAND:
		_rtl_mission_type_handle = new RtlDirectMissionLand(_navigator);
		_set_rtl_mission_type = RtlType::RTL_DIRECT_MISSION_LAND;
		// RTL type is either direct or mission land have to set it later.
		break;

	case RtlType::RTL_MISSION_FAST:
		_rtl_mission_type_handle = new RtlMissionFast(_navigator, new_mission);
		_set_rtl_mission_type = RtlType::RTL_MISSION_FAST;
		_rtl_type = RtlType::RTL_MISSION_FAST;
		break;

	case RtlType::RTL_MISSION_FAST_REVERSE:
		_rtl_mission_type_handle = new RtlMissionFastReverse(_navigator, new_mission);
		_set_rtl_mission_type = RtlType::RTL_MISSION_FAST_REVERSE;
		_rtl_type = RtlType::RTL_MISSION_FAST_REVERSE;
		break;
```

### Changelog Entry

For release notes:
```
Bugfix: "No valid mission available" error with RTL_TYPE=2 
New parameter: -
Documentation: -
```

### Test coverage

Tested with SITL where mission 1 is executed, mission 2 uploaded and then RTL triggered.

Bug on main branch: https://logs.px4.io/plot_app?log=6af3f82a-ec03-4f8e-95d7-f949697ecd00
Fix from this PR: https://logs.px4.io/plot_app?log=03c990f1-0601-4142-8a9b-f6b42b9cc1ef
