### PR TITLE
Send heartbeat from mavlink_ulog_streaming.py to enable log streaming

### DIFF
--- a/Tools/mavlink_ulog_streaming.py
+++ b/Tools/mavlink_ulog_streaming.py
@@ -39,6 +39,7 @@ class MavlinkLogStreaming():
         self.buf = ''
         self.debug("Connecting with MAVLink to %s ..." % portname)
         self.mav = mavutil.mavlink_connection(portname, autoreconnect=True, baud=baudrate)
+        self.mav.mav.heartbeat_send(mavutil.mavlink.MAV_TYPE_GENERIC, mavutil.mavlink.MAV_AUTOPILOT_INVALID, 0, 0, 0)
         self.mav.wait_heartbeat()
         self.debug("HEARTBEAT OK\n")
         self.debug("Locked serial device\n")


### PR DESCRIPTION
### Solved Problem
When running the mavlink_ulog_streaming.py script after drone startup, I found that it would freeze after printing "Connecting to MAVLINK..." It appears as if the ulog streaming script hangs on waiting for heartbeat.

Fixes # (I don't think there was an issue for this)

### Solution
- Adding a line to the MavlinkLogStreaming __init__ that sends a heartbeat before waiting for a heartbeat lets the script run as expected. No refactor needed; just add that line.

### Changelog Entry
For release notes:
```
Feature/Bugfix uLog Streaming Hangs
New parameter: Send Heartbeat in ULog Streaming
```