### PR TITLE
Fix jobs count detection in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 # Get -j or --jobs argument as suggested in:
 # https://stackoverflow.com/a/33616144/8548472
 MAKE_PID := $(shell echo $$PPID)
-j := $(shell ps T | sed -n 's|.*$(MAKE_PID).*$(MAKE).* \(-j\|--jobs\) *\([0-9][0-9]*\).*|\2|p')
+j := $(shell ps T | sed -n 's%.*$(MAKE_PID).*$(MAKE).* \(-j\|--jobs\) *\([0-9][0-9]*\).*%\2%p')
 
 # Default j for clang-tidy
 j_clang_tidy := $(or $(j),4)


### PR DESCRIPTION
### Solved Problem
The jobs count detection script in Makefile cannot detect the `-j` or `--jobs` flags due to the delimiter character '|'. This character is also used in the "or" clause in regular expression `(-j|--jobs)`.

### Solution
 - Change the sed delimiter character from `|` to `%`.

### Changelog Entry
For release notes:
```
Fix: Change sed delimiter character to prevent ambiguity with regular expression
```
