### PR TITLE
cannode: safety_button: fix compatibility with Ardupilot

### DIFF
--- a/src/drivers/uavcannode/Publishers/SafetyButton.hpp
+++ b/src/drivers/uavcannode/Publishers/SafetyButton.hpp
@@ -75,7 +75,8 @@ public:
 			if (safety_button.triggered) {
 				ardupilot::indication::Button Button{};
 				Button.button = ardupilot::indication::Button::BUTTON_SAFETY;
-				Button.press_time = UINT8_MAX;
+				// NOTE: Ardupilot checks that the press time is exactly 10, PX4 checks >= 10
+				Button.press_time = 10;
 				uavcan::Publisher<ardupilot::indication::Button>::broadcast(Button);
 			}
 		}


### PR DESCRIPTION
Ardupilot checks for an exact 1s press_count. PX4 checks for 1s or greater. 
https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_BoardConfig/AP_BoardConfig.cpp#L499