### PR TITLE
FW Position Control: keep flaps in landing config during abort

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -1316,7 +1316,15 @@ FixedwingPositionControl::control_auto_loiter(const float control_interval, cons
 
 		} else {
 			// continue straight until vehicle has sufficient altitude
+			// keep flaps in landing configuration if the airspeed is below the min airspeed (keep deployed if airspeed not valid)
 			roll_body = 0.0f;
+
+			if (!_airspeed_valid || _airspeed_eas < _performance_model.getMinimumCalibratedAirspeed()) {
+				_flaps_setpoint =  _param_fw_flaps_lnd_scl.get();
+
+			} else {
+				_flaps_setpoint = 0.f;
+			}
 		}
 
 		is_low_height = true; // In low-height flight, TECS will control altitude tighter


### PR DESCRIPTION
Alternative to https://github.com/PX4/PX4-Autopilot/pull/23795

### Solved Problem
Vehicle could stall during landing abort because flaps are currently instantly retracted.

### Solution
Keep flaps in landing configuration until the abort altitude is cleared.
EDIT: if airspeed is valid, only keep flaps deployed until the airspeed is above FW_AIRSPD_MIN (which is the speed where the vehicle should be able to fly safely without any flap deployed).

### Changelog Entry
For release notes:
```
Improvement: FW Position Control: keep flaps in landing config during abort
```

### Test coverage
SITL tested
![image](https://github.com/user-attachments/assets/c0b1896e-ab79-4295-bb53-73e8b8350521)

