### PR TITLE
SIM: MPC: add two x500 lidar airframes

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4013_gz_x500_lidar_2d
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4013_gz_x500_lidar_2d
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# @name Gazebo x500 lidar 2d
+#
+# @type Quadrotor
+#
+
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500_lidar_2d}
+
+. ${R}etc/init.d-posix/airframes/4001_gz_x500

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4016_gz_x500_lidar_down
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4016_gz_x500_lidar_down
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# @name Gazebo x500 lidar down
+#
+# @type Quadrotor
+#
+
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500_lidar_down}
+
+. ${R}etc/init.d-posix/airframes/4001_gz_x500

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4017_gz_x500_lidar_front
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4017_gz_x500_lidar_front
@@ -1,10 +1,10 @@
 #!/bin/sh
 #
-# @name Gazebo x500 lidar
+# @name Gazebo x500 lidar front
 #
 # @type Quadrotor
 #
 
-PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500_lidar}
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500_lidar_front}
 
 . ${R}etc/init.d-posix/airframes/4001_gz_x500

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -84,9 +84,11 @@ px4_add_romfs_files(
 	4010_gz_x500_mono_cam
 	4011_gz_lawnmower
 	4012_gz_rover_ackermann
-	4013_gz_x500_lidar
+	4013_gz_x500_lidar_2d
 	4014_gz_x500_mono_cam_down
 	4015_gz_r1_rover_mecanum
+	4016_gz_x500_lidar_down
+	4017_gz_x500_lidar_front
 
 	6011_gazebo-classic_typhoon_h480
 	6011_gazebo-classic_typhoon_h480.post

--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -218,6 +218,14 @@ int GZBridge::init()
 		PX4_WARN("failed to subscribe to %s", laser_scan_topic.c_str());
 	}
 
+	// Distance Sensor(AFBRS50): optional
+	std::string lidar_sensor = "/world/" + _world_name + "/model/" + _model_name +
+				   "/link/lidar_sensor_link/sensor/lidar/scan";
+
+	if (!_node.Subscribe(lidar_sensor, &GZBridge::laserScantoLidarSensorCallback, this)) {
+		PX4_WARN("failed to subscribe to %s", lidar_sensor.c_str());
+	}
+
 #if 0
 	// Airspeed: /world/$WORLD/model/$MODEL/link/airspeed_link/sensor/air_speed/air_speed
 	std::string airpressure_topic = "/world/" + _world_name + "/model/" + _model_name +
@@ -761,6 +769,44 @@ void GZBridge::navSatCallback(const gz::msgs::NavSat &nav_sat)
 	}
 
 	pthread_mutex_unlock(&_node_mutex);
+}
+void GZBridge::laserScantoLidarSensorCallback(const gz::msgs::LaserScan &scan)
+{
+	if (hrt_absolute_time() == 0) {
+		return;
+	}
+
+	distance_sensor_s distance_sensor{};
+	distance_sensor.timestamp = hrt_absolute_time();
+	distance_sensor.device_id = 0;
+	distance_sensor.min_distance = static_cast<float>(scan.range_min());
+	distance_sensor.max_distance = static_cast<float>(scan.range_max());
+	distance_sensor.current_distance = static_cast<float>(scan.ranges()[0]);
+	distance_sensor.variance = 0.0f;
+	distance_sensor.signal_quality = -1;
+	distance_sensor.type = distance_sensor_s::MAV_DISTANCE_SENSOR_LASER;
+
+	gz::msgs::Quaternion pose_orientation = scan.world_pose().orientation();
+	gz::math::Quaterniond q_sensor = gz::math::Quaterniond(
+			pose_orientation.w(),
+			pose_orientation.x(),
+			pose_orientation.y(),
+			pose_orientation.z());
+
+	const gz::math::Quaterniond q_front(0.7071068, 0.7071068, 0, 0);
+	const gz::math::Quaterniond q_down(0, 1, 0, 0);
+
+	if (q_sensor.Equal(q_front, 0.03)) {
+		distance_sensor.orientation = distance_sensor_s::ROTATION_FORWARD_FACING;
+
+	} else if (q_sensor.Equal(q_down, 0.03)) {
+		distance_sensor.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
+
+	} else {
+		distance_sensor.orientation = distance_sensor_s::ROTATION_CUSTOM;
+	}
+
+	_distance_sensor_pub.publish(distance_sensor);
 }
 
 void GZBridge::laserScanCallback(const gz::msgs::LaserScan &scan)

--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -778,7 +778,12 @@ void GZBridge::laserScantoLidarSensorCallback(const gz::msgs::LaserScan &scan)
 
 	distance_sensor_s distance_sensor{};
 	distance_sensor.timestamp = hrt_absolute_time();
-	distance_sensor.device_id = 0;
+	device::Device::DeviceId id;
+	id.devid_s.bus_type = device::Device::DeviceBusType::DeviceBusType_SIMULATION;
+	id.devid_s.bus = 0;
+	id.devid_s.address = 0;
+	id.devid_s.devtype = DRV_DIST_DEVTYPE_SIM;
+	distance_sensor.device_id = id.devid;
 	distance_sensor.min_distance = static_cast<float>(scan.range_min());
 	distance_sensor.max_distance = static_cast<float>(scan.range_max());
 	distance_sensor.current_distance = static_cast<float>(scan.ranges()[0]);

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -50,6 +50,7 @@
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/differential_pressure.h>
 #include <uORB/topics/distance_sensor.h>
+#include <lib/drivers/device/Device.hpp>
 #include <uORB/topics/sensor_accel.h>
 #include <uORB/topics/sensor_gyro.h>
 #include <uORB/topics/vehicle_angular_velocity.h>

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -49,6 +49,7 @@
 #include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/differential_pressure.h>
+#include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/sensor_accel.h>
 #include <uORB/topics/sensor_gyro.h>
 #include <uORB/topics/vehicle_angular_velocity.h>
@@ -110,6 +111,7 @@ private:
 	void poseInfoCallback(const gz::msgs::Pose_V &pose);
 	void odometryCallback(const gz::msgs::OdometryWithCovariance &odometry);
 	void navSatCallback(const gz::msgs::NavSat &nav_sat);
+	void laserScantoLidarSensorCallback(const gz::msgs::LaserScan &scan);
 	void laserScanCallback(const gz::msgs::LaserScan &scan);
 
 	/**
@@ -165,6 +167,7 @@ private:
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	//uORB::Publication<differential_pressure_s>    _differential_pressure_pub{ORB_ID(differential_pressure)};
+	uORB::Publication<distance_sensor_s>          _distance_sensor_pub{ORB_ID(distance_sensor)};
 	uORB::Publication<obstacle_distance_s>        _obstacle_distance_pub{ORB_ID(obstacle_distance)};
 	uORB::Publication<vehicle_angular_velocity_s> _angular_velocity_ground_truth_pub{ORB_ID(vehicle_angular_velocity_groundtruth)};
 	uORB::Publication<vehicle_attitude_s>         _attitude_ground_truth_pub{ORB_ID(vehicle_attitude_groundtruth)};


### PR DESCRIPTION
Partly Tracked in https://github.com/PX4/PX4-Autopilot/issues/23602
To be merged only when following PR is merged
- [x] https://github.com/PX4/PX4-gazebo-models/pull/62 

**other relevant PR's**
- [ ] https://github.com/PX4/PX4-user_guide/pull/3452

### Overview
This PR Adds two X500 models, one with a front facing rangefinder for collision prevention, and one down facing lidar for normal rangefinder use case testing.
I also renamed the x500_lidar to x500_lidar_2d, to better differentiate the three

### Changes:
**New Models:**
`x500_lidar_front`
`x500_lidar_front`
**Changes:**
`x500_lidar `--> `x500_lidar_2d`

### Changelog Entry
For release notes:
```
Feature: Added front and downfacing MPC Models for SITL Testing
Documentation: read docs.px4.io/main/en/sim_gazebo_gz/vehicles.html
```

### Test coverage
- [x] Tested in SITL

### Open Tasks:
- [x] Update the Docs 
- [x] Update the Git Submodules, once the models have been merged.
- [x] Add Meshes to the sensors.
