### PR TITLE
Integrate Additional Logging of Information Received Over DroneCAN

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -74,6 +74,10 @@ set(msg_files
 	DifferentialPressure.msg
 	DistanceSensor.msg
 	DistanceSensorModeChangeRequest.msg
+	DronecanEscStatusExtended.msg
+	DronecanEscStatusExtendedData.msg
+	DronecanNodeStatus.msg
+	DronecanNodeStatusData.msg
 	Ekf2Timestamps.msg
 	EscReport.msg
 	EscStatus.msg

--- a/msg/DronecanEscStatusExtended.msg
+++ b/msg/DronecanEscStatusExtended.msg
@@ -1,0 +1,5 @@
+uint64 timestamp						# time since system start (microseconds)
+
+uint8 CONNECTED_ESC_MAX = 8					# The number of ESCs supported. To be consistent with ESC Status, limit it to 8.
+
+DronecanEscStatusExtendedData[8] extended_esc_status_data	# An array of up to CONNECTED_ESC_MAX DronecanEscStatusExtendedData instances

--- a/msg/DronecanEscStatusExtendedData.msg
+++ b/msg/DronecanEscStatusExtendedData.msg
@@ -1,0 +1,9 @@
+uint64 timestamp					# time since system start (microseconds)
+
+# From the StatusExtended.uavcan message
+uint8 input_percent					# Input command to ESC, in percent, which is commanded using the setpoint messages. Range 0% to 100%.
+uint8 output_percent					# Output command from ESC to motor, in percent. Range 0% to 100%.
+int16 motor_temperature_deg_c  				# Temperature of connected motor, in Celsius. Range is -256 to +255 C.
+uint16 motor_angle             				# Measured angle of connected angle sensor, in degrees. Range is 0 to 360.
+uint32 status_flags           				# Manufacturer-specific status flags currently active.
+uint8 esc_index               				# Index of currently reporting ESC.

--- a/msg/DronecanNodeStatus.msg
+++ b/msg/DronecanNodeStatus.msg
@@ -1,0 +1,5 @@
+uint64 timestamp						# time since system start (microseconds)
+
+uint8 MAX_NODE_STATUSES_LOGGED = 8				# Hold up to 8 nodes worth of Node Status data in the logs. Limited to 8 to avoid needlessly large log files.
+
+DronecanNodeStatusData[8] node_status_id			# An array of up to MAX_NODE_STATUSES_LOGGED DronecanNodeStatusData instances

--- a/msg/DronecanNodeStatusData.msg
+++ b/msg/DronecanNodeStatusData.msg
@@ -1,0 +1,41 @@
+uint64 timestamp					# time since system start (microseconds)
+
+# From the uavcan.protocol.NodeStatus message
+uint32 uptime_sec					# Node uptime
+
+uint16 node_id			# The node ID which this data comes from
+
+#
+# Abstract node health.
+#
+uint8 HEALTH_OK         = 0     # The node is functioning properly.
+uint8 HEALTH_WARNING    = 1     # A critical parameter went out of range or the node encountered a minor failure.
+uint8 HEALTH_ERROR      = 2     # The node encountered a major failure.
+uint8 HEALTH_CRITICAL   = 3     # The node suffered a fatal malfunction.
+uint8 health
+
+#
+# Current mode.
+#
+# Mode OFFLINE can be actually reported by the node to explicitly inform other network
+# participants that the sending node is about to shutdown. In this case other nodes will not
+# have to wait OFFLINE_TIMEOUT_MS before they detect that the node is no longer available.
+#
+# Reserved values can be used in future revisions of the specification.
+#
+uint8 MODE_OPERATIONAL      = 0         # Normal operating mode.
+uint8 MODE_INITIALIZATION   = 1         # Initialization is in progress; this mode is entered immediately after startup.
+uint8 MODE_MAINTENANCE      = 2         # E.g. calibration, the bootloader is running, etc.
+uint8 MODE_SOFTWARE_UPDATE  = 3         # New software/firmware is being loaded.
+uint8 MODE_OFFLINE          = 7         # The node is no longer available.
+uint8 mode
+
+#
+# Not used currently, keep zero when publishing, ignore when receiving.
+#
+uint8 sub_mode
+
+#
+# Optional, vendor-specific node status code, e.g. a fault code or a status bitmask.
+#
+uint16 vendor_specific_status_code

--- a/src/drivers/uavcan/actuators/esc.hpp
+++ b/src/drivers/uavcan/actuators/esc.hpp
@@ -47,12 +47,14 @@
 #include <uavcan/uavcan.hpp>
 #include <uavcan/equipment/esc/RawCommand.hpp>
 #include <uavcan/equipment/esc/Status.hpp>
+#include <uavcan/equipment/esc/StatusExtended.hpp>
 #include <lib/perf/perf_counter.h>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/actuator_outputs.h>
 #include <uORB/topics/esc_status.h>
 #include <drivers/drv_hrt.h>
 #include <lib/mixer_module/mixer_module.hpp>
+#include <uORB/topics/dronecan_esc_status_extended.h>
 
 class UavcanEscController
 {
@@ -87,6 +89,12 @@ private:
 	void esc_status_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::esc::Status> &msg);
 
 	/**
+	 * ESC status extended message reception will be reported via this callback.
+	 */
+	void esc_status_extended_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::esc::StatusExtended>
+					&received_status_extended_msg);
+
+	/**
 	 * Checks all the ESCs freshness based on timestamp, if an ESC exceeds the timeout then is flagged offline.
 	 */
 	uint8_t check_escs_status();
@@ -95,11 +103,18 @@ private:
 		void (UavcanEscController::*)(const uavcan::ReceivedDataStructure<uavcan::equipment::esc::Status>&)> StatusCbBinder;
 
 	typedef uavcan::MethodBinder<UavcanEscController *,
+		void (UavcanEscController::*)(const uavcan::ReceivedDataStructure<uavcan::equipment::esc::StatusExtended>&)>
+		StatusExtendedCbBinder;
+
+	typedef uavcan::MethodBinder<UavcanEscController *,
 		void (UavcanEscController::*)(const uavcan::TimerEvent &)> TimerCbBinder;
 
 	esc_status_s	_esc_status{};
+	dronecan_esc_status_extended_s _status_extended{};
+
 
 	uORB::PublicationMulti<esc_status_s> _esc_status_pub{ORB_ID(esc_status)};
+	uORB::Publication<dronecan_esc_status_extended_s> _status_extended_pub{ORB_ID(dronecan_esc_status_extended)};
 
 	uint8_t		_rotor_count{0};
 
@@ -110,6 +125,7 @@ private:
 	uavcan::INode								&_node;
 	uavcan::Publisher<uavcan::equipment::esc::RawCommand>			_uavcan_pub_raw_cmd;
 	uavcan::Subscriber<uavcan::equipment::esc::Status, StatusCbBinder>	_uavcan_sub_status;
+	uavcan::Subscriber<uavcan::equipment::esc::StatusExtended, StatusExtendedCbBinder>	_uavcan_sub_status_extended;
 
 	/*
 	 * ESC states

--- a/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/protocol/node_status_monitor.hpp
+++ b/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/protocol/node_status_monitor.hpp
@@ -10,8 +10,6 @@
 #include <uavcan/node/subscriber.hpp>
 #include <uavcan/node/timer.hpp>
 #include <uavcan/protocol/NodeStatus.hpp>
-#include <uORB/Publication.hpp>
-#include <uORB/topics/dronecan_node_status.h>
 #include <cassert>
 #include <cstdlib>
 
@@ -68,6 +66,25 @@ public:
         { }
     };
 
+    bool HasFreshNodeStatus(){
+        return _has_fresh_node_status_data;
+    }
+
+    uint8_t GetLastNodeStatusData(protocol::NodeStatus * node_status_to_fill){
+        //Just go ahead and fill in the data with whatever we heard last. It's up to whoever is getting the data to do something with it.
+        node_status_to_fill->uptime_sec = _last_received_node_status_data.uptime_sec;
+        node_status_to_fill->health = _last_received_node_status_data.health;
+        node_status_to_fill->mode = _last_received_node_status_data.mode;
+        node_status_to_fill->sub_mode = _last_received_node_status_data.sub_mode;
+        node_status_to_fill->vendor_specific_status_code = _last_received_node_status_data.vendor_specific_status_code;
+
+        //Someone read the data, it's no longer fresh
+         _has_fresh_node_status_data = false;
+
+        //Return the node ID responsible for this data
+        return _last_received_node_status_id;
+    }
+
 private:
     enum { TimerPeriodMs100 = 2 };
 
@@ -79,13 +96,11 @@ private:
 
     Subscriber<protocol::NodeStatus, NodeStatusCallback> sub_;
 
-    dronecan_node_status_s	_node_status{};
-    uORB::Publication<dronecan_node_status_s> _node_status_pub{ORB_ID(dronecan_node_status)};
+    protocol::NodeStatus _last_received_node_status_data;
+    uint8_t _last_received_node_status_id;
+    bool _has_fresh_node_status_data;
 
     TimerEventForwarder<TimerCallback> timer_;
-
-    uint8_t _module_id_to_logging_index[dronecan_node_status_s::MAX_NODE_STATUSES_LOGGED]; //Only handle as many node statuses as the DronecanNodeStatus message tells us we can
-    uint8_t _module_ids_being_logged = 0; //Keep track of how many node statuses are in play
 
     struct Entry
     {
@@ -127,43 +142,6 @@ private:
         entry = new_entry_value;
     }
 
-    bool loggingModuleIdNodeStatus(uint8_t reporting_node_id)
-    {
-        for(uint8_t array_index = 0; array_index < dronecan_node_status_s::MAX_NODE_STATUSES_LOGGED; array_index++){
-            if(_module_id_to_logging_index[array_index] == reporting_node_id){
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    bool addModuleIdToLoggedStatuses(uint8_t module_id_to_add)
-    {
-        if(_module_ids_being_logged < dronecan_node_status_s::MAX_NODE_STATUSES_LOGGED){
-            _module_id_to_logging_index[_module_ids_being_logged] = module_id_to_add;
-            _module_ids_being_logged++;
-
-            return true;
-        }
-
-        return false;
-    }
-
-    uint8_t getModuleIdLogIndex(uint8_t module_id)
-    {
-        uint8_t return_array_index = 0;
-
-        for(uint8_t array_index = 0; array_index < dronecan_node_status_s::MAX_NODE_STATUSES_LOGGED; array_index++){
-            if(_module_id_to_logging_index[array_index] == module_id){
-                return_array_index = array_index;
-                break;
-            }
-        }
-
-        return return_array_index;
-    }
-
     void handleNodeStatus(const ReceivedDataStructure<protocol::NodeStatus>& msg)
     {
         Entry new_entry;
@@ -176,32 +154,18 @@ private:
 
         handleNodeStatusMessage(msg);
 
-        uint8_t received_node_id = msg.getSrcNodeID().get();
+        //Update our last received data so the outside world can come get it
+        _last_received_node_status_data.uptime_sec = msg.uptime_sec;
+        _last_received_node_status_data.health = msg.health;
+        _last_received_node_status_data.mode = msg.mode;
+        _last_received_node_status_data.sub_mode = msg.sub_mode;
+        _last_received_node_status_data.vendor_specific_status_code = msg.vendor_specific_status_code;
 
-        //Check to see if we're logging this ID already. Use it to determine our next steps
-        bool already_logging_this_id = loggingModuleIdNodeStatus(received_node_id);
+        //Make sure to record who sent this data
+        _last_received_node_status_id = msg.getSrcNodeID().get();
 
-        //Check to see if we're already logging this module ID, if not, try to add it to our list of module IDs to log.
-        //If we are, deal with publishing a new message
-        if(!already_logging_this_id){
-            addModuleIdToLoggedStatuses(received_node_id);
-        }else if(already_logging_this_id){
-            //Make a new message with the data we've got
-            auto &node_status_message = _node_status.node_status_id[getModuleIdLogIndex(received_node_id)];
-
-            //Fill in the actual node's status information
-            node_status_message.timestamp = hrt_absolute_time();
-            node_status_message.uptime_sec = msg.uptime_sec;
-            node_status_message.node_id = received_node_id;
-            node_status_message.health = msg.health;
-            node_status_message.mode = msg.mode;
-            node_status_message.sub_mode = msg.sub_mode;
-            node_status_message.vendor_specific_status_code = msg.vendor_specific_status_code;
-
-            _node_status.timestamp = hrt_absolute_time();
-
-            _node_status_pub.publish(_node_status);
-        }
+        //Make sure to mark our stored data as new
+        _has_fresh_node_status_data = true;
     }
 
     void handleTimerEvent(const TimerEvent&)
@@ -269,7 +233,6 @@ public:
         {
             timer_.setCallback(TimerCallback(this, &NodeStatusMonitor::handleTimerEvent));
             timer_.startPeriodic(MonotonicDuration::fromMSec(TimerPeriodMs100 * 100));
-            _node_status_pub.advertise();
         }
         return res;
     }

--- a/src/drivers/uavcan/uavcan_main.hpp
+++ b/src/drivers/uavcan/uavcan_main.hpp
@@ -105,6 +105,7 @@
 #include <uORB/topics/uavcan_parameter_request.h>
 #include <uORB/topics/uavcan_parameter_value.h>
 #include <uORB/topics/vehicle_command_ack.h>
+#include <uORB/topics/dronecan_node_status.h>
 
 using namespace time_literals;
 
@@ -318,6 +319,10 @@ private:
 	uORB::Publication<uavcan_parameter_value_s> _param_response_pub{ORB_ID(uavcan_parameter_value)};
 	uORB::Publication<vehicle_command_ack_s>	_command_ack_pub{ORB_ID(vehicle_command_ack)};
 	uORB::PublicationMulti<can_interface_status_s> _can_status_pub{ORB_ID(can_interface_status)};
+	uORB::Publication<dronecan_node_status_s> _node_status_pub{ORB_ID(dronecan_node_status)};
+	dronecan_node_status_s	_node_status{};
+	uint8_t _node_id_to_logging_index[dronecan_node_status_s::MAX_NODE_STATUSES_LOGGED]; //Only handle as many node statuses as the DronecanNodeStatus message tells us we can
+	uint8_t _node_ids_being_logged; //Keep track of how many node statuses are in play
 
 	hrt_abstime _last_can_status_pub{0};
 	orb_advert_t _can_status_pub_handles[UAVCAN_NUM_IFACES] = {nullptr};
@@ -358,6 +363,11 @@ private:
 	uavcan::ServiceClient<uavcan::protocol::RestartNode, RestartNodeCallback> _param_restartnode_client;
 	void param_count(uavcan::NodeID node_id);
 	void param_opcode(uavcan::NodeID node_id);
+
+	// A few functions that will help us properly log Node Status information
+	bool check_if_already_logging_node_id_status(uint8_t reporting_node_id);
+	bool add_node_id_to_logged_statuses(uint8_t node_id_to_add);
+	uint8_t get_node_id_log_index(uint8_t node_id);
 
 	uint8_t get_next_active_node_id(uint8_t base);
 	uint8_t get_next_dirty_node_id(uint8_t base);

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -59,6 +59,8 @@ void LoggedTopics::add_default_topics()
 	add_topic("config_overrides");
 	add_topic("cpuload");
 	add_topic("distance_sensor_mode_change_request");
+	add_optional_topic("dronecan_esc_status_extended", 250);
+	add_optional_topic("dronecan_node_status", 250);
 	add_optional_topic("external_ins_attitude");
 	add_optional_topic("external_ins_global_position");
 	add_optional_topic("external_ins_local_position");


### PR DESCRIPTION
This PR brings in support for the logging of additional DroneCAN information. First, it allows for the logging of DroneCAN nodes' Node Status information. At the moment, PX4 accepts and monitors node statuses, but it is helpful to be able to review additional information after a flight. Next, I've introduced support for the (fairly new) DroneCAN ESC Status Extended message. Like DroneCAN ESC Status, the Status Extended message provides information about connected DroneCAN ESCs. The extended message adds input and output throttle percentages, motor temperature in degrees Celsius, the ESC index reporting, and additional vendor specific status flags. This PR adds support for both receiving and logging information received by ESCs that report the Status Extended message.

Here are a couple of logs that include logged Node Status and Status Extended from 3 connected ESCs. 
The first is an application of logging these two data sets as part of the rest of the basic logging topics: [extended_and_node_status_demo.zip](https://github.com/user-attachments/files/17603281/extended_and_node_status_demo.zip)

The second has configured the SD card to only log the DroneCAN ESC Status Extended and DroneCAN Node Status messages
[extended_and_node_status_logged_only.zip](https://github.com/user-attachments/files/17603285/extended_and_node_status_logged_only.zip)