### PR TITLE
Add filter generate board

### DIFF
--- a/Tools/ci/generate_board_targets_json.py
+++ b/Tools/ci/generate_board_targets_json.py
@@ -25,9 +25,15 @@ parser.add_argument('-p', '--pretty', dest='pretty', action='store_true',
                     help='Pretty output instead of a single line')
 parser.add_argument('-g', '--groups', dest='group', action='store_true',
                     help='Groups targets')
+parser.add_argument('-f', '--filter', dest='filter', help='comma separated list of board names to use instead of all')
 
 args = parser.parse_args()
 verbose = args.verbose
+
+board_filter = []
+if args.filter:
+    for board in args.filter.split(','):
+        board_filter.append(board)
 
 build_configs = []
 grouped_targets = {}
@@ -140,6 +146,10 @@ for manufacturer in os.scandir(os.path.join(source_dir, '../boards')):
                 board_name = manufacturer.name + '_' + board.name
                 label = files.name[:-9]
                 target_name = manufacturer.name + '_' + board.name + '_' + label
+
+                if board_filter and not board_name in board_filter:
+                    if verbose: print(f'excluding board {board_name} ({target_name})')
+                    continue
 
                 if board_name in excluded_boards:
                     if verbose: print(f'excluding board {board_name} ({target_name})')


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This PR solves actually 2 Problems:

1. There is a bug in the generate_board_targets that drops a few targets when grouping them
2. If someone want to clone and reuse the code, he might not want to build all available targets, only the ones specific for the boards he wants to maintain. Instead of writting his own CI he should be able to reuse most of the CI script and adapt it with specifying the boards

### Solution
- Refactored the grouping code
- Adding an additional board filter input to the scripts. Thus in the CI script one can simply add with the additional filter inputs here https://github.com/PX4/PX4-Autopilot/blob/main/.github/workflows/build_all_targets.yml#L45

### Changelog Entry
For release notes:
```
Bugfix: Make sure all board targets get used in CI for build checks
Feature: Allow the set a board filter for boards which should be build in CI
```

### Test coverage
- Checking verbose output of the command ` ./Tools/ci/generate_board_targets_json.py --group --verbose`
Comparing the original output, it e.g. dropped px4_fmu-v6c_default among others. This is fixed now


Original output:

> =======================
= scanning for boards =
=======================
excluding label stackcheck (px4_fmu-v5_stackcheck)
excluding label test (px4_fmu-v5_test)
excluding board px4_ros2 (px4_ros2_default)
excluding label test (px4_fmu-v4pro_test)
excluding label replay (px4_sitl_replay)
excluding label nolockstep (px4_sitl_nolockstep)
excluding label test (px4_sitl_test)
excluding label test (px4_fmu-v5x_test)
excluding label test (px4_fmu-v4_test)
excluding label test (nxp_fmuk66-v3_test)
excluding label test (cuav_x7pro_test)
excluding board modalai_voxl2 (modalai_voxl2_default)
excluding label test (cubepilot_cubeorangeplus_test)
excluding label test (cubepilot_cubeorange_test)
============================
= Boards found in ./boards =
============================
{'base': {'container': 'px4io/px4-dev-base-focal:2021-09-08',
          'manufacturers': {'px4': ['airframe_metadata',
                                    'parameters_metadata',
                                    'extract_events',
                                    'px4_sitl_default',
                                    'px4_sitl_allyes',
                                    'px4_sitl_zenoh']}},
 'nuttx': {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
           'manufacturers': {'flywoo': ['flywoo_gn-f405_default'],
                             'thepeach': ['thepeach_k1_default',
                                          'thepeach_r1_default'],
                             'px4': ['px4_fmu-v6c_default',
                                     'px4_fmu-v6c_rover',
                                     'px4_fmu-v6c_bootloader',
                                     'px4_fmu-v5_debug',
                                     'px4_fmu-v5_cryptotest',
                                     'px4_fmu-v5_protected',
                                     'px4_fmu-v5_default',
                                     'px4_fmu-v5_lto',
                                     'px4_fmu-v5_rover',
                                     'px4_fmu-v5_cyphal',
                                     'px4_fmu-v5_uavcanv0periph',
                                     'px4_fmu-v3_default',
                                     'px4_fmu-v4pro_default',
                                     'px4_fmu-v6u_default',
                                     'px4_fmu-v6u_rover',
                                     'px4_fmu-v6u_bootloader',
                                     'px4_fmu-v6xrt_default',
                                     'px4_fmu-v6xrt_rover',
                                     'px4_fmu-v6xrt_bootloader',
                                     'px4_fmu-v6xrt_allyes',
                                     'px4_fmu-v5x_default',
                                     'px4_fmu-v5x_rover',
                                     'px4_fmu-v2_multicopter',
                                     'px4_fmu-v2_default',
                                     'px4_fmu-v2_lto',
                                     'px4_fmu-v2_rover',
                                     'px4_fmu-v2_fixedwing',
                                     'px4_fmu-v4_default',
                                     'px4_fmu-v6x_multicopter',
                                     'px4_fmu-v6x_default',
                                     'px4_fmu-v6x_rover',
                                     'px4_fmu-v6x_bootloader',
                                     'px4_fmu-v6x_zenoh',
                                     'px4_io-v2_default'],
                             'nxp': ['nxp_fmuk66-e_socketcan',
                                     'nxp_fmuk66-e_default',
                                     'nxp_ucans32k146_canbootloader',
                                     'nxp_ucans32k146_default',
                                     'nxp_ucans32k146_cyphal',
                                     'nxp_mr-canhubk3_default',
                                     'nxp_mr-canhubk3_fmu',
                                     'nxp_mr-canhubk3_sysview',
                                     'nxp_mr-canhubk3_zenoh',
                                     'nxp_fmuk66-v3_socketcan',
                                     'nxp_fmuk66-v3_default'],
                             'airmind': ['airmind_mindpx-v2_default'],
                             '3dr': ['3dr_ctrl-zero-h7-oem-revg_default',
                                     '3dr_ctrl-zero-h7-oem-revg_bootloader'],
                             'freefly': ['freefly_can-rtk-gps_canbootloader',
                                         'freefly_can-rtk-gps_default'],
                             'sky-drones': ['sky-drones_smartap-airlink_default'],
                             'matek': ['matek_h743-mini_default',
                                       'matek_h743-mini_bootloader',
                                       'matek_h743_default',
                                       'matek_h743_bootloader',
                                       'matek_gnss-m9n-f4_canbootloader',
                                       'matek_gnss-m9n-f4_default',
                                       'matek_h743-slim_default',
                                       'matek_h743-slim_bootloader'],
                             'raspberrypi': ['raspberrypi_pico_default'],
                             'bitcraze': ['bitcraze_crazyflie21_default',
                                          'bitcraze_crazyflie_default'],
                             'cuav': ['cuav_7-nano_default',
                                      'cuav_7-nano_bootloader',
                                      'cuav_x7pro_default',
                                      'cuav_x7pro_bootloader',
                                      'cuav_can-gps-v1_canbootloader',
                                      'cuav_can-gps-v1_default',
                                      'cuav_nora_default',
                                      'cuav_nora_bootloader'],
                             'zeroone': ['zeroone_x6_default',
                                         'zeroone_x6_bootloader'],
                             'x-mav': ['x-mav_ap-h743v2_default',
                                       'x-mav_ap-h743v2_bootloader'],
                             'mro': ['mro_x21_default',
                                     'mro_pixracerpro_default',
                                     'mro_pixracerpro_bootloader',
                                     'mro_ctrl-zero-f7-oem_default',
                                     'mro_ctrl-zero-f7_default',
                                     'mro_x21-777_default',
                                     'mro_ctrl-zero-h7-oem_default',
                                     'mro_ctrl-zero-h7-oem_bootloader',
                                     'mro_ctrl-zero-h7_default',
                                     'mro_ctrl-zero-h7_bootloader',
                                     'mro_ctrl-zero-classic_default',
                                     'mro_ctrl-zero-classic_bootloader'],
                             'av': ['av_x-v1_default'],
                             'omnibus': ['omnibus_f4sd_default',
                                         'omnibus_f4sd_icm20608g'],
                             'uvify': ['uvify_core_default'],
                             'micoair': ['micoair_h743_default',
                                         'micoair_h743_bootloader'],
                             'hkust': ['hkust_nxt-v1_default',
                                       'hkust_nxt-v1_bootloader',
                                       'hkust_nxt-dual_default',
                                       'hkust_nxt-dual_bootloader'],
                             'atl': ['atl_mantis-edu_default'],
                             'modalai': ['modalai_voxl2-io_default',
                                         'modalai_fc-v2_default',
                                         'modalai_fc-v2_bootloader',
                                         'modalai_fc-v1_default'],
                             'holybro': ['holybro_kakuteh7v2_default',
                                         'holybro_kakuteh7v2_bootloader',
                                         'holybro_kakuteh7_default',
                                         'holybro_kakuteh7_bootloader',
                                         'holybro_kakuteh7mini_default',
                                         'holybro_kakuteh7mini_bootloader',
                                         'holybro_h-flow_canbootloader',
                                         'holybro_h-flow_default',
                                         'holybro_kakutef7_default',
                                         'holybro_pix32v5_default',
                                         'holybro_durandal-v1_default',
                                         'holybro_durandal-v1_bootloader',
                                         'holybro_can-gps-v1_canbootloader',
                                         'holybro_can-gps-v1_default'],
                             'diatone': ['diatone_mamba-f405-mk2_default'],
                             'ark': ['ark_can-rtk-gps_canbootloader',
                                     'ark_can-rtk-gps_default',
                                     'ark_pi6x_default',
                                     'ark_pi6x_bootloader',
                                     'ark_can-flow_canbootloader',
                                     'ark_can-flow_default',
                                     'ark_septentrio-gps_canbootloader',
                                     'ark_septentrio-gps_default',
                                     'ark_fpv_default',
                                     'ark_fpv_bootloader',
                                     'ark_can-gps_canbootloader',
                                     'ark_can-gps_default',
                                     'ark_fmu-v6x_default',
                                     'ark_fmu-v6x_bootloader',
                                     'ark_cannode_canbootloader',
                                     'ark_cannode_default'],
                             'siyi': ['siyi_n7_default', 'siyi_n7_bootloader'],
                             'spracing': ['spracing_h7extreme_default'],
                             'cubepilot': ['cubepilot_cubeorangeplus_console',
                                           'cubepilot_cubeorangeplus_default',
                                           'cubepilot_cubeorangeplus_bootloader',
                                           'cubepilot_cubeyellow_default',
                                           'cubepilot_cubeorange_console',
                                           'cubepilot_cubeorange_default',
                                           'cubepilot_cubeorange_bootloader',
                                           'cubepilot_io-v2_default']}},
 'armhf': {'container': 'px4io/px4-dev-armhf:2023-06-26',
           'manufacturers': {'px4': ['px4_raspberrypi_default'],
                             'emlid': ['emlid_navio2_default'],
                             'scumaker': ['scumaker_pilotpi_default'],
                             'beaglebone': ['beaglebone_blue_default']}},
 'aarch64': {'container': 'px4io/px4-dev-aarch64:2022-08-12',
             'manufacturers': {'scumaker': ['scumaker_pilotpi_arm64']}}}
===================
= Generating JSON =
===================
=:Architectures: [dict_keys(['base', 'nuttx', 'armhf', 'aarch64'])]
=:Processing: [base] Last: []
=:Processing: [base][px4]
=:Processing: [base][px4][6][airframe_metadata]
=:Processing: ==Manufacturers can have their own group
=:Processing: Limits[5][10]
=:Processing: [base][px4][6][parameters_metadata]
=:Processing: [base][px4][6][extract_events]
=:Processing: [base][px4][6][px4_sitl_default]
=:Processing: [base][px4][6][px4_sitl_allyes]
=:Processing: [base][px4][6][px4_sitl_zenoh]
=:Processing: [nuttx] Last: [base]
=:Processing: [nuttx][flywoo]
=:Processing: [nuttx][flywoo][1][flywoo_gn-f405_default]
=:Processing: [nuttx][thepeach]
=:Processing: [nuttx][thepeach][2][thepeach_k1_default]
=:Processing: [nuttx][thepeach][2][thepeach_r1_default]
=:Processing: [nuttx][px4]
=:Processing: [nuttx][px4][34][px4_fmu-v6c_default]
=:Processing: [nuttx][px4][34][px4_fmu-v6c_rover]
=:Processing: [nuttx][px4][34][px4_fmu-v6c_bootloader]
=:Processing: [nuttx][px4][34][px4_fmu-v5_debug]
=:Processing: [nuttx][px4][34][px4_fmu-v5_cryptotest]
=:Processing: [nuttx][px4][34][px4_fmu-v5_protected]
=:Processing: [nuttx][px4][34][px4_fmu-v5_default]
=:Processing: [nuttx][px4][34][px4_fmu-v5_lto]
=:Processing: [nuttx][px4][34][px4_fmu-v5_rover]
=:Processing: [nuttx][px4][34][px4_fmu-v5_cyphal]
=:Processing: [nuttx][px4][34][px4_fmu-v5_uavcanv0periph]
=:Processing: [nuttx][px4][34][px4_fmu-v3_default]
=:Processing: [nuttx][px4][34][px4_fmu-v4pro_default]
=:Processing: [nuttx][px4][34][px4_fmu-v6u_default]
=:Processing: [nuttx][px4][34][px4_fmu-v6u_rover]
=:Processing: [nuttx][px4][34][px4_fmu-v6u_bootloader]
=:Processing: [nuttx][px4][34][px4_fmu-v6xrt_default]
=:Processing: [nuttx][px4][34][px4_fmu-v6xrt_rover]
=:Processing: [nuttx][px4][34][px4_fmu-v6xrt_bootloader]
=:Processing: [nuttx][px4][34][px4_fmu-v6xrt_allyes]
=:Processing: [nuttx][px4][34][px4_fmu-v5x_default]
=:Processing: [nuttx][px4][34][px4_fmu-v5x_rover]
=:Processing: [nuttx][px4][34][px4_fmu-v2_multicopter]
=:Processing: [nuttx][px4][34][px4_fmu-v2_default]
=:Processing: [nuttx][px4][34][px4_fmu-v2_lto]
=:Processing: [nuttx][px4][34][px4_fmu-v2_rover]
=:Processing: [nuttx][px4][34][px4_fmu-v2_fixedwing]
=:Processing: [nuttx][px4][34][px4_fmu-v4_default]
=:Processing: [nuttx][px4][34][px4_fmu-v6x_multicopter]
=:Processing: [nuttx][px4][34][px4_fmu-v6x_default]
=:Processing: [nuttx][px4][34][px4_fmu-v6x_rover]
=:Processing: [nuttx][px4][34][px4_fmu-v6x_bootloader]
=:Processing: [nuttx][px4][34][px4_fmu-v6x_zenoh]
=:Processing: [nuttx][px4][34][px4_io-v2_default]
=:Processing: [nuttx][nxp]
=:Processing: [nuttx][nxp][11][nxp_fmuk66-e_socketcan]
=:Processing: [nuttx][nxp][11][nxp_fmuk66-e_default]
=:Processing: [nuttx][nxp][11][nxp_ucans32k146_canbootloader]
=:Processing: [nuttx][nxp][11][nxp_ucans32k146_default]
=:Processing: [nuttx][nxp][11][nxp_ucans32k146_cyphal]
=:Processing: [nuttx][nxp][11][nxp_mr-canhubk3_default]
=:Processing: [nuttx][nxp][11][nxp_mr-canhubk3_fmu]
=:Processing: [nuttx][nxp][11][nxp_mr-canhubk3_sysview]
=:Processing: [nuttx][nxp][11][nxp_mr-canhubk3_zenoh]
=:Processing: [nuttx][nxp][11][nxp_fmuk66-v3_socketcan]
=:Processing: [nuttx][nxp][11][nxp_fmuk66-v3_default]
=:Processing: [nuttx][airmind]
=:Processing: [nuttx][airmind][1][airmind_mindpx-v2_default]
=:Processing: [nuttx][3dr]
=:Processing: [nuttx][3dr][2][3dr_ctrl-zero-h7-oem-revg_default]
=:Processing: [nuttx][3dr][2][3dr_ctrl-zero-h7-oem-revg_bootloader]
=:Processing: [nuttx][freefly]
=:Processing: [nuttx][freefly][2][freefly_can-rtk-gps_canbootloader]
=:Processing: [nuttx][freefly][2][freefly_can-rtk-gps_default]
=:Processing: [nuttx][sky-drones]
=:Processing: [nuttx][sky-drones][1][sky-drones_smartap-airlink_default]
=:Processing: [nuttx][matek]
=:Processing: [nuttx][matek][8][matek_h743-mini_default]
=:Processing: ==Manufacturers can have their own group
=:Processing: Limits[5][10]
=:Processing: [nuttx][matek][8][matek_h743-mini_bootloader]
=:Processing: [nuttx][matek][8][matek_h743_default]
=:Processing: [nuttx][matek][8][matek_h743_bootloader]
=:Processing: [nuttx][matek][8][matek_gnss-m9n-f4_canbootloader]
=:Processing: [nuttx][matek][8][matek_gnss-m9n-f4_default]
=:Processing: [nuttx][matek][8][matek_h743-slim_default]
=:Processing: [nuttx][matek][8][matek_h743-slim_bootloader]
=:Processing: [nuttx][raspberrypi]
=:Processing: [nuttx][raspberrypi][1][raspberrypi_pico_default]
=:Processing: [nuttx][bitcraze]
=:Processing: [nuttx][bitcraze][2][bitcraze_crazyflie21_default]
=:Processing: [nuttx][bitcraze][2][bitcraze_crazyflie_default]
=:Processing: [nuttx][cuav]
=:Processing: [nuttx][cuav][8][cuav_7-nano_default]
=:Processing: ==Manufacturers can have their own group
=:Processing: Limits[5][10]
=:Processing: [nuttx][cuav][8][cuav_7-nano_bootloader]
=:Processing: [nuttx][cuav][8][cuav_x7pro_default]
=:Processing: [nuttx][cuav][8][cuav_x7pro_bootloader]
=:Processing: [nuttx][cuav][8][cuav_can-gps-v1_canbootloader]
=:Processing: [nuttx][cuav][8][cuav_can-gps-v1_default]
=:Processing: [nuttx][cuav][8][cuav_nora_default]
=:Processing: [nuttx][cuav][8][cuav_nora_bootloader]
=:Processing: [nuttx][zeroone]
=:Processing: [nuttx][zeroone][2][zeroone_x6_default]
=:Processing: [nuttx][zeroone][2][zeroone_x6_bootloader]
=:Processing: [nuttx][x-mav]
=:Processing: [nuttx][x-mav][2][x-mav_ap-h743v2_default]
=:Processing: [nuttx][x-mav][2][x-mav_ap-h743v2_bootloader]
=:Processing: [nuttx][mro]
=:Processing: [nuttx][mro][12][mro_x21_default]
=:Processing: [nuttx][mro][12][mro_pixracerpro_default]
=:Processing: [nuttx][mro][12][mro_pixracerpro_bootloader]
=:Processing: [nuttx][mro][12][mro_ctrl-zero-f7-oem_default]
=:Processing: [nuttx][mro][12][mro_ctrl-zero-f7_default]
=:Processing: [nuttx][mro][12][mro_x21-777_default]
=:Processing: [nuttx][mro][12][mro_ctrl-zero-h7-oem_default]
=:Processing: [nuttx][mro][12][mro_ctrl-zero-h7-oem_bootloader]
=:Processing: [nuttx][mro][12][mro_ctrl-zero-h7_default]
=:Processing: [nuttx][mro][12][mro_ctrl-zero-h7_bootloader]
=:Processing: [nuttx][mro][12][mro_ctrl-zero-classic_default]
=:Processing: [nuttx][mro][12][mro_ctrl-zero-classic_bootloader]
=:Processing: [nuttx][av]
=:Processing: [nuttx][av][1][av_x-v1_default]
=:Processing: [nuttx][omnibus]
=:Processing: [nuttx][omnibus][2][omnibus_f4sd_default]
=:Processing: [nuttx][omnibus][2][omnibus_f4sd_icm20608g]
=:Processing: [nuttx][uvify]
=:Processing: [nuttx][uvify][1][uvify_core_default]
=:Processing: [nuttx][micoair]
=:Processing: [nuttx][micoair][2][micoair_h743_default]
=:Processing: [nuttx][micoair][2][micoair_h743_bootloader]
=:Processing: [nuttx][hkust]
=:Processing: [nuttx][hkust][4][hkust_nxt-v1_default]
=:Processing: [nuttx][hkust][4][hkust_nxt-v1_bootloader]
=:Processing: [nuttx][hkust][4][hkust_nxt-dual_default]
=:Processing: [nuttx][hkust][4][hkust_nxt-dual_bootloader]
=:Processing: [nuttx][atl]
=:Processing: [nuttx][atl][1][atl_mantis-edu_default]
=:Processing: [nuttx][modalai]
=:Processing: [nuttx][modalai][4][modalai_voxl2-io_default]
=:Processing: [nuttx][modalai][4][modalai_fc-v2_default]
=:Processing: [nuttx][modalai][4][modalai_fc-v2_bootloader]
=:Processing: [nuttx][modalai][4][modalai_fc-v1_default]
=:Processing: [nuttx][holybro]
=:Processing: [nuttx][holybro][14][holybro_kakuteh7v2_default]
=:Processing: [nuttx][holybro][14][holybro_kakuteh7v2_bootloader]
=:Processing: [nuttx][holybro][14][holybro_kakuteh7_default]
=:Processing: [nuttx][holybro][14][holybro_kakuteh7_bootloader]
=:Processing: [nuttx][holybro][14][holybro_kakuteh7mini_default]
=:Processing: [nuttx][holybro][14][holybro_kakuteh7mini_bootloader]
=:Processing: [nuttx][holybro][14][holybro_h-flow_canbootloader]
=:Processing: [nuttx][holybro][14][holybro_h-flow_default]
=:Processing: [nuttx][holybro][14][holybro_kakutef7_default]
=:Processing: [nuttx][holybro][14][holybro_pix32v5_default]
=:Processing: [nuttx][holybro][14][holybro_durandal-v1_default]
=:Processing: [nuttx][holybro][14][holybro_durandal-v1_bootloader]
=:Processing: [nuttx][holybro][14][holybro_can-gps-v1_canbootloader]
=:Processing: [nuttx][holybro][14][holybro_can-gps-v1_default]
=:Processing: [nuttx][diatone]
=:Processing: [nuttx][diatone][1][diatone_mamba-f405-mk2_default]
=:Processing: [nuttx][ark]
=:Processing: [nuttx][ark][16][ark_can-rtk-gps_canbootloader]
=:Processing: [nuttx][ark][16][ark_can-rtk-gps_default]
=:Processing: [nuttx][ark][16][ark_pi6x_default]
=:Processing: [nuttx][ark][16][ark_pi6x_bootloader]
=:Processing: [nuttx][ark][16][ark_can-flow_canbootloader]
=:Processing: [nuttx][ark][16][ark_can-flow_default]
=:Processing: [nuttx][ark][16][ark_septentrio-gps_canbootloader]
=:Processing: [nuttx][ark][16][ark_septentrio-gps_default]
=:Processing: [nuttx][ark][16][ark_fpv_default]
=:Processing: [nuttx][ark][16][ark_fpv_bootloader]
=:Processing: [nuttx][ark][16][ark_can-gps_canbootloader]
=:Processing: [nuttx][ark][16][ark_can-gps_default]
=:Processing: [nuttx][ark][16][ark_fmu-v6x_default]
=:Processing: [nuttx][ark][16][ark_fmu-v6x_bootloader]
=:Processing: [nuttx][ark][16][ark_cannode_canbootloader]
=:Processing: [nuttx][ark][16][ark_cannode_default]
=:Processing: [nuttx][siyi]
=:Processing: [nuttx][siyi][2][siyi_n7_default]
=:Processing: [nuttx][siyi][2][siyi_n7_bootloader]
=:Processing: [nuttx][spracing]
=:Processing: [nuttx][spracing][1][spracing_h7extreme_default]
=:Processing: [nuttx][cubepilot]
=:Processing: [nuttx][cubepilot][8][cubepilot_cubeorangeplus_console]
=:Processing: ==Manufacturers can have their own group
=:Processing: Limits[5][10]
=:Processing: [nuttx][cubepilot][8][cubepilot_cubeorangeplus_default]
=:Processing: [nuttx][cubepilot][8][cubepilot_cubeorangeplus_bootloader]
=:Processing: [nuttx][cubepilot][8][cubepilot_cubeyellow_default]
=:Processing: [nuttx][cubepilot][8][cubepilot_cubeorange_console]
=:Processing: [nuttx][cubepilot][8][cubepilot_cubeorange_default]
=:Processing: [nuttx][cubepilot][8][cubepilot_cubeorange_bootloader]
=:Processing: [nuttx][cubepilot][8][cubepilot_io-v2_default]
=:Processing: [armhf] Last: [nuttx]
=:Orphan: [armhf][nuttx][siyi_n7_default,siyi_n7_bootloader,spracing_h7extreme_default]
=:Processing: [armhf][px4]
=:Processing: [armhf][px4][1][px4_raspberrypi_default]
=:Processing: [armhf][emlid]
=:Processing: [armhf][emlid][1][emlid_navio2_default]
=:Processing: [armhf][scumaker]
=:Processing: [armhf][scumaker][1][scumaker_pilotpi_default]
=:Processing: [armhf][beaglebone]
=:Processing: [armhf][beaglebone][1][beaglebone_blue_default]
=:Processing: [aarch64] Last: [armhf]
=:Orphan: [aarch64][armhf][px4_raspberrypi_default,emlid_navio2_default,scumaker_pilotpi_default,beaglebone_blue_default]
=:Processing: [aarch64][scumaker]
=:Processing: [aarch64][scumaker][1][scumaker_pilotpi_arm64]
================
= final_groups =
================
[{'container': 'px4io/px4-dev-base-focal:2021-09-08',
  'targets': 'airframe_metadata,parameters_metadata,extract_events,px4_sitl_default,px4_sitl_allyes,px4_sitl_zenoh',
  'arch': 'base',
  'group': 'base-px4',
  'len': 6},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'nxp_fmuk66-e_socketcan,nxp_fmuk66-e_default,nxp_ucans32k146_canbootloader,nxp_ucans32k146_default,nxp_ucans32k146_cyphal,nxp_mr-canhubk3_default,nxp_mr-canhubk3_fmu,nxp_mr-canhubk3_sysview,nxp_mr-canhubk3_zenoh,nxp_fmuk66-v3_socketcan',
  'arch': 'nuttx',
  'group': 'nuttx-nxp-0',
  'len': 10},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'nxp_fmuk66-v3_default',
  'arch': 'nuttx',
  'group': 'nuttx-nxp-1',
  'len': 1},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'flywoo_gn-f405_default,thepeach_k1_default,thepeach_r1_default,airmind_mindpx-v2_default,3dr_ctrl-zero-h7-oem-revg_default,3dr_ctrl-zero-h7-oem-revg_bootloader',
  'arch': 'nuttx',
  'group': 'nuttx-0',
  'len': 6},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'matek_h743-mini_default,matek_h743-mini_bootloader,matek_h743_default,matek_h743_bootloader,matek_gnss-m9n-f4_canbootloader,matek_gnss-m9n-f4_default,matek_h743-slim_default,matek_h743-slim_bootloader',
  'arch': 'nuttx',
  'group': 'nuttx-matek',
  'len': 8},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'freefly_can-rtk-gps_canbootloader,freefly_can-rtk-gps_default,sky-drones_smartap-airlink_default,raspberrypi_pico_default,bitcraze_crazyflie21_default,bitcraze_crazyflie_default',
  'arch': 'nuttx',
  'group': 'nuttx-1',
  'len': 6},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'cuav_7-nano_default,cuav_7-nano_bootloader,cuav_x7pro_default,cuav_x7pro_bootloader,cuav_can-gps-v1_canbootloader,cuav_can-gps-v1_default,cuav_nora_default,cuav_nora_bootloader',
  'arch': 'nuttx',
  'group': 'nuttx-cuav',
  'len': 8},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'mro_x21_default,mro_pixracerpro_default,mro_pixracerpro_bootloader,mro_ctrl-zero-f7-oem_default,mro_ctrl-zero-f7_default,mro_x21-777_default,mro_ctrl-zero-h7-oem_default,mro_ctrl-zero-h7-oem_bootloader,mro_ctrl-zero-h7_default,mro_ctrl-zero-h7_bootloader',
  'arch': 'nuttx',
  'group': 'nuttx-mro-0',
  'len': 10},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'mro_ctrl-zero-classic_default,mro_ctrl-zero-classic_bootloader',
  'arch': 'nuttx',
  'group': 'nuttx-mro-1',
  'len': 2},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'zeroone_x6_default,zeroone_x6_bootloader,x-mav_ap-h743v2_default,x-mav_ap-h743v2_bootloader,av_x-v1_default',
  'arch': 'nuttx',
  'group': 'nuttx-2',
  'len': 5},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'omnibus_f4sd_default,omnibus_f4sd_icm20608g,uvify_core_default,micoair_h743_default,micoair_h743_bootloader',
  'arch': 'nuttx',
  'group': 'nuttx-3',
  'len': 5},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'hkust_nxt-v1_default,hkust_nxt-v1_bootloader,hkust_nxt-dual_default,hkust_nxt-dual_bootloader,atl_mantis-edu_default',
  'arch': 'nuttx',
  'group': 'nuttx-4',
  'len': 5},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'holybro_kakuteh7v2_default,holybro_kakuteh7v2_bootloader,holybro_kakuteh7_default,holybro_kakuteh7_bootloader,holybro_kakuteh7mini_default,holybro_kakuteh7mini_bootloader,holybro_h-flow_canbootloader,holybro_h-flow_default,holybro_kakutef7_default,holybro_pix32v5_default',
  'arch': 'nuttx',
  'group': 'nuttx-holybro-0',
  'len': 10},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'holybro_durandal-v1_default,holybro_durandal-v1_bootloader,holybro_can-gps-v1_canbootloader,holybro_can-gps-v1_default',
  'arch': 'nuttx',
  'group': 'nuttx-holybro-1',
  'len': 4},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'modalai_voxl2-io_default,modalai_fc-v2_default,modalai_fc-v2_bootloader,modalai_fc-v1_default,diatone_mamba-f405-mk2_default',
  'arch': 'nuttx',
  'group': 'nuttx-5',
  'len': 5},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'ark_can-rtk-gps_canbootloader,ark_can-rtk-gps_default,ark_pi6x_default,ark_pi6x_bootloader,ark_can-flow_canbootloader,ark_can-flow_default,ark_septentrio-gps_canbootloader,ark_septentrio-gps_default,ark_fpv_default,ark_fpv_bootloader',
  'arch': 'nuttx',
  'group': 'nuttx-ark-0',
  'len': 10},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'ark_can-gps_canbootloader,ark_can-gps_default,ark_fmu-v6x_default,ark_fmu-v6x_bootloader,ark_cannode_canbootloader,ark_cannode_default',
  'arch': 'nuttx',
  'group': 'nuttx-ark-1',
  'len': 6},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'cubepilot_cubeorangeplus_console,cubepilot_cubeorangeplus_default,cubepilot_cubeorangeplus_bootloader,cubepilot_cubeyellow_default,cubepilot_cubeorange_console,cubepilot_cubeorange_default,cubepilot_cubeorange_bootloader,cubepilot_io-v2_default',
  'arch': 'nuttx',
  'group': 'nuttx-cubepilot',
  'len': 8},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'siyi_n7_default,siyi_n7_bootloader,spracing_h7extreme_default',
  'arch': 'nuttx',
  'group': 'nuttx-6',
  'len': 3},
 {'container': 'px4io/px4-dev-armhf:2023-06-26',
  'targets': 'px4_raspberrypi_default,emlid_navio2_default,scumaker_pilotpi_default,beaglebone_blue_default',
  'arch': 'armhf',
  'group': 'armhf-0',
  'len': 4}]
===============
= JSON output =
===============
{"include": [{"container": "px4io/px4-dev-base-focal:2021-09-08", "targets": "airframe_metadata,parameters_metadata,extract_events,px4_sitl_default,px4_sitl_allyes,px4_sitl_zenoh", "arch": "base", "group": "base-px4", "len": 6}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "nxp_fmuk66-e_socketcan,nxp_fmuk66-e_default,nxp_ucans32k146_canbootloader,nxp_ucans32k146_default,nxp_ucans32k146_cyphal,nxp_mr-canhubk3_default,nxp_mr-canhubk3_fmu,nxp_mr-canhubk3_sysview,nxp_mr-canhubk3_zenoh,nxp_fmuk66-v3_socketcan", "arch": "nuttx", "group": "nuttx-nxp-0", "len": 10}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "nxp_fmuk66-v3_default", "arch": "nuttx", "group": "nuttx-nxp-1", "len": 1}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "flywoo_gn-f405_default,thepeach_k1_default,thepeach_r1_default,airmind_mindpx-v2_default,3dr_ctrl-zero-h7-oem-revg_default,3dr_ctrl-zero-h7-oem-revg_bootloader", "arch": "nuttx", "group": "nuttx-0", "len": 6}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "matek_h743-mini_default,matek_h743-mini_bootloader,matek_h743_default,matek_h743_bootloader,matek_gnss-m9n-f4_canbootloader,matek_gnss-m9n-f4_default,matek_h743-slim_default,matek_h743-slim_bootloader", "arch": "nuttx", "group": "nuttx-matek", "len": 8}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "freefly_can-rtk-gps_canbootloader,freefly_can-rtk-gps_default,sky-drones_smartap-airlink_default,raspberrypi_pico_default,bitcraze_crazyflie21_default,bitcraze_crazyflie_default", "arch": "nuttx", "group": "nuttx-1", "len": 6}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "cuav_7-nano_default,cuav_7-nano_bootloader,cuav_x7pro_default,cuav_x7pro_bootloader,cuav_can-gps-v1_canbootloader,cuav_can-gps-v1_default,cuav_nora_default,cuav_nora_bootloader", "arch": "nuttx", "group": "nuttx-cuav", "len": 8}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "mro_x21_default,mro_pixracerpro_default,mro_pixracerpro_bootloader,mro_ctrl-zero-f7-oem_default,mro_ctrl-zero-f7_default,mro_x21-777_default,mro_ctrl-zero-h7-oem_default,mro_ctrl-zero-h7-oem_bootloader,mro_ctrl-zero-h7_default,mro_ctrl-zero-h7_bootloader", "arch": "nuttx", "group": "nuttx-mro-0", "len": 10}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "mro_ctrl-zero-classic_default,mro_ctrl-zero-classic_bootloader", "arch": "nuttx", "group": "nuttx-mro-1", "len": 2}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "zeroone_x6_default,zeroone_x6_bootloader,x-mav_ap-h743v2_default,x-mav_ap-h743v2_bootloader,av_x-v1_default", "arch": "nuttx", "group": "nuttx-2", "len": 5}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "omnibus_f4sd_default,omnibus_f4sd_icm20608g,uvify_core_default,micoair_h743_default,micoair_h743_bootloader", "arch": "nuttx", "group": "nuttx-3", "len": 5}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "hkust_nxt-v1_default,hkust_nxt-v1_bootloader,hkust_nxt-dual_default,hkust_nxt-dual_bootloader,atl_mantis-edu_default", "arch": "nuttx", "group": "nuttx-4", "len": 5}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "holybro_kakuteh7v2_default,holybro_kakuteh7v2_bootloader,holybro_kakuteh7_default,holybro_kakuteh7_bootloader,holybro_kakuteh7mini_default,holybro_kakuteh7mini_bootloader,holybro_h-flow_canbootloader,holybro_h-flow_default,holybro_kakutef7_default,holybro_pix32v5_default", "arch": "nuttx", "group": "nuttx-holybro-0", "len": 10}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "holybro_durandal-v1_default,holybro_durandal-v1_bootloader,holybro_can-gps-v1_canbootloader,holybro_can-gps-v1_default", "arch": "nuttx", "group": "nuttx-holybro-1", "len": 4}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "modalai_voxl2-io_default,modalai_fc-v2_default,modalai_fc-v2_bootloader,modalai_fc-v1_default,diatone_mamba-f405-mk2_default", "arch": "nuttx", "group": "nuttx-5", "len": 5}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "ark_can-rtk-gps_canbootloader,ark_can-rtk-gps_default,ark_pi6x_default,ark_pi6x_bootloader,ark_can-flow_canbootloader,ark_can-flow_default,ark_septentrio-gps_canbootloader,ark_septentrio-gps_default,ark_fpv_default,ark_fpv_bootloader", "arch": "nuttx", "group": "nuttx-ark-0", "len": 10}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "ark_can-gps_canbootloader,ark_can-gps_default,ark_fmu-v6x_default,ark_fmu-v6x_bootloader,ark_cannode_canbootloader,ark_cannode_default", "arch": "nuttx", "group": "nuttx-ark-1", "len": 6}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "cubepilot_cubeorangeplus_console,cubepilot_cubeorangeplus_default,cubepilot_cubeorangeplus_bootloader,cubepilot_cubeyellow_default,cubepilot_cubeorange_console,cubepilot_cubeorange_default,cubepilot_cubeorange_bootloader,cubepilot_io-v2_default", "arch": "nuttx", "group": "nuttx-cubepilot", "len": 8}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "siyi_n7_default,siyi_n7_bootloader,spracing_h7extreme_default", "arch": "nuttx", "group": "nuttx-6", "len": 3}, {"container": "px4io/px4-dev-armhf:2023-06-26", "targets": "px4_raspberrypi_default,emlid_navio2_default,scumaker_pilotpi_default,beaglebone_blue_default", "arch": "armhf", "group": "armhf-0", "len": 4}]}


Output from PR:

> =======================
= scanning for boards =
=======================
excluding label stackcheck (px4_fmu-v5_stackcheck)
excluding label test (px4_fmu-v5_test)
excluding board px4_ros2 (px4_ros2_default)
excluding label test (px4_fmu-v4pro_test)
excluding label replay (px4_sitl_replay)
excluding label nolockstep (px4_sitl_nolockstep)
excluding label test (px4_sitl_test)
excluding label test (px4_fmu-v5x_test)
excluding label test (px4_fmu-v4_test)
excluding label test (nxp_fmuk66-v3_test)
excluding label test (cuav_x7pro_test)
excluding board modalai_voxl2 (modalai_voxl2_default)
excluding label test (cubepilot_cubeorangeplus_test)
excluding label test (cubepilot_cubeorange_test)
============================
= Boards found in ./boards =
============================
{'base': {'container': 'px4io/px4-dev-base-focal:2021-09-08',
          'manufacturers': {'px4': ['airframe_metadata',
                                    'parameters_metadata',
                                    'extract_events',
                                    'px4_sitl_default',
                                    'px4_sitl_allyes',
                                    'px4_sitl_zenoh']}},
 'nuttx': {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
           'manufacturers': {'flywoo': ['flywoo_gn-f405_default'],
                             'thepeach': ['thepeach_k1_default',
                                          'thepeach_r1_default'],
                             'px4': ['px4_fmu-v6c_default',
                                     'px4_fmu-v6c_rover',
                                     'px4_fmu-v6c_bootloader',
                                     'px4_fmu-v5_debug',
                                     'px4_fmu-v5_cryptotest',
                                     'px4_fmu-v5_protected',
                                     'px4_fmu-v5_default',
                                     'px4_fmu-v5_lto',
                                     'px4_fmu-v5_rover',
                                     'px4_fmu-v5_cyphal',
                                     'px4_fmu-v5_uavcanv0periph',
                                     'px4_fmu-v3_default',
                                     'px4_fmu-v4pro_default',
                                     'px4_fmu-v6u_default',
                                     'px4_fmu-v6u_rover',
                                     'px4_fmu-v6u_bootloader',
                                     'px4_fmu-v6xrt_default',
                                     'px4_fmu-v6xrt_rover',
                                     'px4_fmu-v6xrt_bootloader',
                                     'px4_fmu-v6xrt_allyes',
                                     'px4_fmu-v5x_default',
                                     'px4_fmu-v5x_rover',
                                     'px4_fmu-v2_multicopter',
                                     'px4_fmu-v2_default',
                                     'px4_fmu-v2_lto',
                                     'px4_fmu-v2_rover',
                                     'px4_fmu-v2_fixedwing',
                                     'px4_fmu-v4_default',
                                     'px4_fmu-v6x_multicopter',
                                     'px4_fmu-v6x_default',
                                     'px4_fmu-v6x_rover',
                                     'px4_fmu-v6x_bootloader',
                                     'px4_fmu-v6x_zenoh',
                                     'px4_io-v2_default'],
                             'nxp': ['nxp_fmuk66-e_socketcan',
                                     'nxp_fmuk66-e_default',
                                     'nxp_ucans32k146_canbootloader',
                                     'nxp_ucans32k146_default',
                                     'nxp_ucans32k146_cyphal',
                                     'nxp_mr-canhubk3_default',
                                     'nxp_mr-canhubk3_fmu',
                                     'nxp_mr-canhubk3_sysview',
                                     'nxp_mr-canhubk3_zenoh',
                                     'nxp_fmuk66-v3_socketcan',
                                     'nxp_fmuk66-v3_default'],
                             'airmind': ['airmind_mindpx-v2_default'],
                             '3dr': ['3dr_ctrl-zero-h7-oem-revg_default',
                                     '3dr_ctrl-zero-h7-oem-revg_bootloader'],
                             'freefly': ['freefly_can-rtk-gps_canbootloader',
                                         'freefly_can-rtk-gps_default'],
                             'sky-drones': ['sky-drones_smartap-airlink_default'],
                             'matek': ['matek_h743-mini_default',
                                       'matek_h743-mini_bootloader',
                                       'matek_h743_default',
                                       'matek_h743_bootloader',
                                       'matek_gnss-m9n-f4_canbootloader',
                                       'matek_gnss-m9n-f4_default',
                                       'matek_h743-slim_default',
                                       'matek_h743-slim_bootloader'],
                             'raspberrypi': ['raspberrypi_pico_default'],
                             'bitcraze': ['bitcraze_crazyflie21_default',
                                          'bitcraze_crazyflie_default'],
                             'cuav': ['cuav_7-nano_default',
                                      'cuav_7-nano_bootloader',
                                      'cuav_x7pro_default',
                                      'cuav_x7pro_bootloader',
                                      'cuav_can-gps-v1_canbootloader',
                                      'cuav_can-gps-v1_default',
                                      'cuav_nora_default',
                                      'cuav_nora_bootloader'],
                             'zeroone': ['zeroone_x6_default',
                                         'zeroone_x6_bootloader'],
                             'x-mav': ['x-mav_ap-h743v2_default',
                                       'x-mav_ap-h743v2_bootloader'],
                             'mro': ['mro_x21_default',
                                     'mro_pixracerpro_default',
                                     'mro_pixracerpro_bootloader',
                                     'mro_ctrl-zero-f7-oem_default',
                                     'mro_ctrl-zero-f7_default',
                                     'mro_x21-777_default',
                                     'mro_ctrl-zero-h7-oem_default',
                                     'mro_ctrl-zero-h7-oem_bootloader',
                                     'mro_ctrl-zero-h7_default',
                                     'mro_ctrl-zero-h7_bootloader',
                                     'mro_ctrl-zero-classic_default',
                                     'mro_ctrl-zero-classic_bootloader'],
                             'av': ['av_x-v1_default'],
                             'omnibus': ['omnibus_f4sd_default',
                                         'omnibus_f4sd_icm20608g'],
                             'uvify': ['uvify_core_default'],
                             'micoair': ['micoair_h743_default',
                                         'micoair_h743_bootloader'],
                             'hkust': ['hkust_nxt-v1_default',
                                       'hkust_nxt-v1_bootloader',
                                       'hkust_nxt-dual_default',
                                       'hkust_nxt-dual_bootloader'],
                             'atl': ['atl_mantis-edu_default'],
                             'modalai': ['modalai_voxl2-io_default',
                                         'modalai_fc-v2_default',
                                         'modalai_fc-v2_bootloader',
                                         'modalai_fc-v1_default'],
                             'holybro': ['holybro_kakuteh7v2_default',
                                         'holybro_kakuteh7v2_bootloader',
                                         'holybro_kakuteh7_default',
                                         'holybro_kakuteh7_bootloader',
                                         'holybro_kakuteh7mini_default',
                                         'holybro_kakuteh7mini_bootloader',
                                         'holybro_h-flow_canbootloader',
                                         'holybro_h-flow_default',
                                         'holybro_kakutef7_default',
                                         'holybro_pix32v5_default',
                                         'holybro_durandal-v1_default',
                                         'holybro_durandal-v1_bootloader',
                                         'holybro_can-gps-v1_canbootloader',
                                         'holybro_can-gps-v1_default'],
                             'diatone': ['diatone_mamba-f405-mk2_default'],
                             'ark': ['ark_can-rtk-gps_canbootloader',
                                     'ark_can-rtk-gps_default',
                                     'ark_pi6x_default',
                                     'ark_pi6x_bootloader',
                                     'ark_can-flow_canbootloader',
                                     'ark_can-flow_default',
                                     'ark_septentrio-gps_canbootloader',
                                     'ark_septentrio-gps_default',
                                     'ark_fpv_default',
                                     'ark_fpv_bootloader',
                                     'ark_can-gps_canbootloader',
                                     'ark_can-gps_default',
                                     'ark_fmu-v6x_default',
                                     'ark_fmu-v6x_bootloader',
                                     'ark_cannode_canbootloader',
                                     'ark_cannode_default'],
                             'siyi': ['siyi_n7_default', 'siyi_n7_bootloader'],
                             'spracing': ['spracing_h7extreme_default'],
                             'cubepilot': ['cubepilot_cubeorangeplus_console',
                                           'cubepilot_cubeorangeplus_default',
                                           'cubepilot_cubeorangeplus_bootloader',
                                           'cubepilot_cubeyellow_default',
                                           'cubepilot_cubeorange_console',
                                           'cubepilot_cubeorange_default',
                                           'cubepilot_cubeorange_bootloader',
                                           'cubepilot_io-v2_default']}},
 'armhf': {'container': 'px4io/px4-dev-armhf:2023-06-26',
           'manufacturers': {'px4': ['px4_raspberrypi_default'],
                             'emlid': ['emlid_navio2_default'],
                             'scumaker': ['scumaker_pilotpi_default'],
                             'beaglebone': ['beaglebone_blue_default']}},
 'aarch64': {'container': 'px4io/px4-dev-aarch64:2022-08-12',
             'manufacturers': {'scumaker': ['scumaker_pilotpi_arm64']}}}
===================
= Generating JSON =
===================
=:Architectures: [dict_keys(['base', 'nuttx', 'armhf', 'aarch64'])]
=:Processing: [base]
=:Processing: [base][px4]
=:Processing: [base][px4][6]==Manufacturers can have their own group
=:Processing: [nuttx]
=:Processing: [nuttx][flywoo]
=:Processing: [nuttx][flywoo][1]==Manufacturers too small group with others
=:Processing: [nuttx][thepeach]
=:Processing: [nuttx][thepeach][2]==Manufacturers too small group with others
=:Processing: [nuttx][px4]
=:Processing: [nuttx][px4][34]==Manufacturers has multiple own groups
=:Processing: [nuttx][nxp]
=:Processing: [nuttx][nxp][11]==Manufacturers has multiple own groups
=:Processing: [nuttx][airmind]
=:Processing: [nuttx][airmind][1]==Manufacturers too small group with others
=:Processing: [nuttx][3dr]
=:Processing: [nuttx][3dr][2]==Manufacturers too small group with others
=:Processing: [nuttx][freefly]
=:Processing: [nuttx][freefly][2]==Manufacturers too small group with others
=:Processing: [nuttx][sky-drones]
=:Processing: [nuttx][sky-drones][1]==Manufacturers too small group with others
=:Processing: [nuttx][matek]
=:Processing: [nuttx][matek][8]==Manufacturers can have their own group
=:Processing: [nuttx][raspberrypi]
=:Processing: [nuttx][raspberrypi][1]==Manufacturers too small group with others
=:Processing: [nuttx][bitcraze]
=:Processing: [nuttx][bitcraze][2]==Manufacturers too small group with others
=:Processing: [nuttx][cuav]
=:Processing: [nuttx][cuav][8]==Manufacturers can have their own group
=:Processing: [nuttx][zeroone]
=:Processing: [nuttx][zeroone][2]==Manufacturers too small group with others
=:Processing: [nuttx][x-mav]
=:Processing: [nuttx][x-mav][2]==Manufacturers too small group with others
=:Processing: [nuttx][mro]
=:Processing: [nuttx][mro][12]==Manufacturers has multiple own groups
=:Processing: [nuttx][av]
=:Processing: [nuttx][av][1]==Manufacturers too small group with others
=:Processing: [nuttx][omnibus]
=:Processing: [nuttx][omnibus][2]==Manufacturers too small group with others
=:Processing: [nuttx][uvify]
=:Processing: [nuttx][uvify][1]==Manufacturers too small group with others
=:Processing: [nuttx][micoair]
=:Processing: [nuttx][micoair][2]==Manufacturers too small group with others
=:Processing: [nuttx][hkust]
=:Processing: [nuttx][hkust][4]==Manufacturers too small group with others
=:Processing: [nuttx][atl]
=:Processing: [nuttx][atl][1]==Manufacturers too small group with others
=:Processing: [nuttx][modalai]
=:Processing: [nuttx][modalai][4]==Manufacturers too small group with others
=:Processing: [nuttx][holybro]
=:Processing: [nuttx][holybro][14]==Manufacturers has multiple own groups
=:Processing: [nuttx][diatone]
=:Processing: [nuttx][diatone][1]==Manufacturers too small group with others
=:Processing: [nuttx][ark]
=:Processing: [nuttx][ark][16]==Manufacturers has multiple own groups
=:Processing: [nuttx][siyi]
=:Processing: [nuttx][siyi][2]==Manufacturers too small group with others
=:Processing: [nuttx][spracing]
=:Processing: [nuttx][spracing][1]==Manufacturers too small group with others
=:Processing: [nuttx][cubepilot]
=:Processing: [nuttx][cubepilot][8]==Manufacturers can have their own group
=:Processing: [nuttx][orphan][35]==Leftover arch can has multpile group
=:Processing: [armhf]
=:Processing: [armhf][px4]
=:Processing: [armhf][px4][1]==Manufacturers too small group with others
=:Processing: [armhf][emlid]
=:Processing: [armhf][emlid][1]==Manufacturers too small group with others
=:Processing: [armhf][scumaker]
=:Processing: [armhf][scumaker][1]==Manufacturers too small group with others
=:Processing: [armhf][beaglebone]
=:Processing: [armhf][beaglebone][1]==Manufacturers too small group with others
=:Processing: [armhf][orphan][4]==Leftover arch can have their own group
=:Processing: [aarch64]
=:Processing: [aarch64][scumaker]
=:Processing: [aarch64][scumaker][1]==Manufacturers too small group with others
=:Processing: [aarch64][orphan][1]==Leftover arch can have their own group
================
= final_groups =
================
[{'container': 'px4io/px4-dev-base-focal:2021-09-08',
  'targets': 'airframe_metadata,parameters_metadata,extract_events,px4_sitl_default,px4_sitl_allyes,px4_sitl_zenoh',
  'arch': 'base',
  'group': 'base-px4',
  'len': 6},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'px4_fmu-v6c_default,px4_fmu-v6c_rover,px4_fmu-v6c_bootloader,px4_fmu-v5_debug,px4_fmu-v5_cryptotest,px4_fmu-v5_protected,px4_fmu-v5_default,px4_fmu-v5_lto,px4_fmu-v5_rover,px4_fmu-v5_cyphal',
  'arch': 'nuttx',
  'group': 'nuttx-px4-0',
  'len': 10},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'px4_fmu-v5_uavcanv0periph,px4_fmu-v3_default,px4_fmu-v4pro_default,px4_fmu-v6u_default,px4_fmu-v6u_rover,px4_fmu-v6u_bootloader,px4_fmu-v6xrt_default,px4_fmu-v6xrt_rover,px4_fmu-v6xrt_bootloader,px4_fmu-v6xrt_allyes',
  'arch': 'nuttx',
  'group': 'nuttx-px4-1',
  'len': 10},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'px4_fmu-v5x_default,px4_fmu-v5x_rover,px4_fmu-v2_multicopter,px4_fmu-v2_default,px4_fmu-v2_lto,px4_fmu-v2_rover,px4_fmu-v2_fixedwing,px4_fmu-v4_default,px4_fmu-v6x_multicopter,px4_fmu-v6x_default',
  'arch': 'nuttx',
  'group': 'nuttx-px4-2',
  'len': 10},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'px4_fmu-v6x_rover,px4_fmu-v6x_bootloader,px4_fmu-v6x_zenoh,px4_io-v2_default',
  'arch': 'nuttx',
  'group': 'nuttx-px4-3',
  'len': 4},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'nxp_fmuk66-e_socketcan,nxp_fmuk66-e_default,nxp_ucans32k146_canbootloader,nxp_ucans32k146_default,nxp_ucans32k146_cyphal,nxp_mr-canhubk3_default,nxp_mr-canhubk3_fmu,nxp_mr-canhubk3_sysview,nxp_mr-canhubk3_zenoh,nxp_fmuk66-v3_socketcan',
  'arch': 'nuttx',
  'group': 'nuttx-nxp-0',
  'len': 10},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'nxp_fmuk66-v3_default',
  'arch': 'nuttx',
  'group': 'nuttx-nxp-1',
  'len': 1},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'matek_h743-mini_default,matek_h743-mini_bootloader,matek_h743_default,matek_h743_bootloader,matek_gnss-m9n-f4_canbootloader,matek_gnss-m9n-f4_default,matek_h743-slim_default,matek_h743-slim_bootloader',
  'arch': 'nuttx',
  'group': 'nuttx-matek',
  'len': 8},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'cuav_7-nano_default,cuav_7-nano_bootloader,cuav_x7pro_default,cuav_x7pro_bootloader,cuav_can-gps-v1_canbootloader,cuav_can-gps-v1_default,cuav_nora_default,cuav_nora_bootloader',
  'arch': 'nuttx',
  'group': 'nuttx-cuav',
  'len': 8},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'mro_x21_default,mro_pixracerpro_default,mro_pixracerpro_bootloader,mro_ctrl-zero-f7-oem_default,mro_ctrl-zero-f7_default,mro_x21-777_default,mro_ctrl-zero-h7-oem_default,mro_ctrl-zero-h7-oem_bootloader,mro_ctrl-zero-h7_default,mro_ctrl-zero-h7_bootloader',
  'arch': 'nuttx',
  'group': 'nuttx-mro-0',
  'len': 10},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'mro_ctrl-zero-classic_default,mro_ctrl-zero-classic_bootloader',
  'arch': 'nuttx',
  'group': 'nuttx-mro-1',
  'len': 2},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'holybro_kakuteh7v2_default,holybro_kakuteh7v2_bootloader,holybro_kakuteh7_default,holybro_kakuteh7_bootloader,holybro_kakuteh7mini_default,holybro_kakuteh7mini_bootloader,holybro_h-flow_canbootloader,holybro_h-flow_default,holybro_kakutef7_default,holybro_pix32v5_default',
  'arch': 'nuttx',
  'group': 'nuttx-holybro-0',
  'len': 10},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'holybro_durandal-v1_default,holybro_durandal-v1_bootloader,holybro_can-gps-v1_canbootloader,holybro_can-gps-v1_default',
  'arch': 'nuttx',
  'group': 'nuttx-holybro-1',
  'len': 4},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'ark_can-rtk-gps_canbootloader,ark_can-rtk-gps_default,ark_pi6x_default,ark_pi6x_bootloader,ark_can-flow_canbootloader,ark_can-flow_default,ark_septentrio-gps_canbootloader,ark_septentrio-gps_default,ark_fpv_default,ark_fpv_bootloader',
  'arch': 'nuttx',
  'group': 'nuttx-ark-0',
  'len': 10},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'ark_can-gps_canbootloader,ark_can-gps_default,ark_fmu-v6x_default,ark_fmu-v6x_bootloader,ark_cannode_canbootloader,ark_cannode_default',
  'arch': 'nuttx',
  'group': 'nuttx-ark-1',
  'len': 6},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'cubepilot_cubeorangeplus_console,cubepilot_cubeorangeplus_default,cubepilot_cubeorangeplus_bootloader,cubepilot_cubeyellow_default,cubepilot_cubeorange_console,cubepilot_cubeorange_default,cubepilot_cubeorange_bootloader,cubepilot_io-v2_default',
  'arch': 'nuttx',
  'group': 'nuttx-cubepilot',
  'len': 8},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'flywoo_gn-f405_default,thepeach_k1_default,thepeach_r1_default,airmind_mindpx-v2_default,3dr_ctrl-zero-h7-oem-revg_default,3dr_ctrl-zero-h7-oem-revg_bootloader,freefly_can-rtk-gps_canbootloader,freefly_can-rtk-gps_default,sky-drones_smartap-airlink_default,raspberrypi_pico_default',
  'arch': 'nuttx',
  'group': 'nuttx-0',
  'len': 10},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'bitcraze_crazyflie21_default,bitcraze_crazyflie_default,zeroone_x6_default,zeroone_x6_bootloader,x-mav_ap-h743v2_default,x-mav_ap-h743v2_bootloader,av_x-v1_default,omnibus_f4sd_default,omnibus_f4sd_icm20608g,uvify_core_default',
  'arch': 'nuttx',
  'group': 'nuttx-1',
  'len': 10},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'micoair_h743_default,micoair_h743_bootloader,hkust_nxt-v1_default,hkust_nxt-v1_bootloader,hkust_nxt-dual_default,hkust_nxt-dual_bootloader,atl_mantis-edu_default,modalai_voxl2-io_default,modalai_fc-v2_default,modalai_fc-v2_bootloader',
  'arch': 'nuttx',
  'group': 'nuttx-2',
  'len': 10},
 {'container': 'px4io/px4-dev-nuttx-focal:2022-08-12',
  'targets': 'modalai_fc-v1_default,diatone_mamba-f405-mk2_default,siyi_n7_default,siyi_n7_bootloader,spracing_h7extreme_default',
  'arch': 'nuttx',
  'group': 'nuttx-3',
  'len': 5},
 {'container': 'px4io/px4-dev-armhf:2023-06-26',
  'targets': 'px4_raspberrypi_default,emlid_navio2_default,scumaker_pilotpi_default,beaglebone_blue_default',
  'arch': 'armhf',
  'group': 'armhf-0',
  'len': 4},
 {'container': 'px4io/px4-dev-aarch64:2022-08-12',
  'targets': 'scumaker_pilotpi_arm64',
  'arch': 'aarch64',
  'group': 'aarch64-0',
  'len': 1}]
===============
= JSON output =
===============
{"include": [{"container": "px4io/px4-dev-base-focal:2021-09-08", "targets": "airframe_metadata,parameters_metadata,extract_events,px4_sitl_default,px4_sitl_allyes,px4_sitl_zenoh", "arch": "base", "group": "base-px4", "len": 6}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "px4_fmu-v6c_default,px4_fmu-v6c_rover,px4_fmu-v6c_bootloader,px4_fmu-v5_debug,px4_fmu-v5_cryptotest,px4_fmu-v5_protected,px4_fmu-v5_default,px4_fmu-v5_lto,px4_fmu-v5_rover,px4_fmu-v5_cyphal", "arch": "nuttx", "group": "nuttx-px4-0", "len": 10}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "px4_fmu-v5_uavcanv0periph,px4_fmu-v3_default,px4_fmu-v4pro_default,px4_fmu-v6u_default,px4_fmu-v6u_rover,px4_fmu-v6u_bootloader,px4_fmu-v6xrt_default,px4_fmu-v6xrt_rover,px4_fmu-v6xrt_bootloader,px4_fmu-v6xrt_allyes", "arch": "nuttx", "group": "nuttx-px4-1", "len": 10}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "px4_fmu-v5x_default,px4_fmu-v5x_rover,px4_fmu-v2_multicopter,px4_fmu-v2_default,px4_fmu-v2_lto,px4_fmu-v2_rover,px4_fmu-v2_fixedwing,px4_fmu-v4_default,px4_fmu-v6x_multicopter,px4_fmu-v6x_default", "arch": "nuttx", "group": "nuttx-px4-2", "len": 10}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "px4_fmu-v6x_rover,px4_fmu-v6x_bootloader,px4_fmu-v6x_zenoh,px4_io-v2_default", "arch": "nuttx", "group": "nuttx-px4-3", "len": 4}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "nxp_fmuk66-e_socketcan,nxp_fmuk66-e_default,nxp_ucans32k146_canbootloader,nxp_ucans32k146_default,nxp_ucans32k146_cyphal,nxp_mr-canhubk3_default,nxp_mr-canhubk3_fmu,nxp_mr-canhubk3_sysview,nxp_mr-canhubk3_zenoh,nxp_fmuk66-v3_socketcan", "arch": "nuttx", "group": "nuttx-nxp-0", "len": 10}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "nxp_fmuk66-v3_default", "arch": "nuttx", "group": "nuttx-nxp-1", "len": 1}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "matek_h743-mini_default,matek_h743-mini_bootloader,matek_h743_default,matek_h743_bootloader,matek_gnss-m9n-f4_canbootloader,matek_gnss-m9n-f4_default,matek_h743-slim_default,matek_h743-slim_bootloader", "arch": "nuttx", "group": "nuttx-matek", "len": 8}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "cuav_7-nano_default,cuav_7-nano_bootloader,cuav_x7pro_default,cuav_x7pro_bootloader,cuav_can-gps-v1_canbootloader,cuav_can-gps-v1_default,cuav_nora_default,cuav_nora_bootloader", "arch": "nuttx", "group": "nuttx-cuav", "len": 8}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "mro_x21_default,mro_pixracerpro_default,mro_pixracerpro_bootloader,mro_ctrl-zero-f7-oem_default,mro_ctrl-zero-f7_default,mro_x21-777_default,mro_ctrl-zero-h7-oem_default,mro_ctrl-zero-h7-oem_bootloader,mro_ctrl-zero-h7_default,mro_ctrl-zero-h7_bootloader", "arch": "nuttx", "group": "nuttx-mro-0", "len": 10}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "mro_ctrl-zero-classic_default,mro_ctrl-zero-classic_bootloader", "arch": "nuttx", "group": "nuttx-mro-1", "len": 2}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "holybro_kakuteh7v2_default,holybro_kakuteh7v2_bootloader,holybro_kakuteh7_default,holybro_kakuteh7_bootloader,holybro_kakuteh7mini_default,holybro_kakuteh7mini_bootloader,holybro_h-flow_canbootloader,holybro_h-flow_default,holybro_kakutef7_default,holybro_pix32v5_default", "arch": "nuttx", "group": "nuttx-holybro-0", "len": 10}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "holybro_durandal-v1_default,holybro_durandal-v1_bootloader,holybro_can-gps-v1_canbootloader,holybro_can-gps-v1_default", "arch": "nuttx", "group": "nuttx-holybro-1", "len": 4}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "ark_can-rtk-gps_canbootloader,ark_can-rtk-gps_default,ark_pi6x_default,ark_pi6x_bootloader,ark_can-flow_canbootloader,ark_can-flow_default,ark_septentrio-gps_canbootloader,ark_septentrio-gps_default,ark_fpv_default,ark_fpv_bootloader", "arch": "nuttx", "group": "nuttx-ark-0", "len": 10}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "ark_can-gps_canbootloader,ark_can-gps_default,ark_fmu-v6x_default,ark_fmu-v6x_bootloader,ark_cannode_canbootloader,ark_cannode_default", "arch": "nuttx", "group": "nuttx-ark-1", "len": 6}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "cubepilot_cubeorangeplus_console,cubepilot_cubeorangeplus_default,cubepilot_cubeorangeplus_bootloader,cubepilot_cubeyellow_default,cubepilot_cubeorange_console,cubepilot_cubeorange_default,cubepilot_cubeorange_bootloader,cubepilot_io-v2_default", "arch": "nuttx", "group": "nuttx-cubepilot", "len": 8}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "flywoo_gn-f405_default,thepeach_k1_default,thepeach_r1_default,airmind_mindpx-v2_default,3dr_ctrl-zero-h7-oem-revg_default,3dr_ctrl-zero-h7-oem-revg_bootloader,freefly_can-rtk-gps_canbootloader,freefly_can-rtk-gps_default,sky-drones_smartap-airlink_default,raspberrypi_pico_default", "arch": "nuttx", "group": "nuttx-0", "len": 10}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "bitcraze_crazyflie21_default,bitcraze_crazyflie_default,zeroone_x6_default,zeroone_x6_bootloader,x-mav_ap-h743v2_default,x-mav_ap-h743v2_bootloader,av_x-v1_default,omnibus_f4sd_default,omnibus_f4sd_icm20608g,uvify_core_default", "arch": "nuttx", "group": "nuttx-1", "len": 10}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "micoair_h743_default,micoair_h743_bootloader,hkust_nxt-v1_default,hkust_nxt-v1_bootloader,hkust_nxt-dual_default,hkust_nxt-dual_bootloader,atl_mantis-edu_default,modalai_voxl2-io_default,modalai_fc-v2_default,modalai_fc-v2_bootloader", "arch": "nuttx", "group": "nuttx-2", "len": 10}, {"container": "px4io/px4-dev-nuttx-focal:2022-08-12", "targets": "modalai_fc-v1_default,diatone_mamba-f405-mk2_default,siyi_n7_default,siyi_n7_bootloader,spracing_h7extreme_default", "arch": "nuttx", "group": "nuttx-3", "len": 5}, {"container": "px4io/px4-dev-armhf:2023-06-26", "targets": "px4_raspberrypi_default,emlid_navio2_default,scumaker_pilotpi_default,beaglebone_blue_default", "arch": "armhf", "group": "armhf-0", "len": 4}, {"container": "px4io/px4-dev-aarch64:2022-08-12", "targets": "scumaker_pilotpi_arm64", "arch": "aarch64", "group": "aarch64-0", "len": 1}]}