### PR TITLE
ina220 fix max current param name

### DIFF
--- a/src/drivers/power_monitor/ina220/ina220.cpp
+++ b/src/drivers/power_monitor/ina220/ina220.cpp
@@ -56,7 +56,7 @@ INA220::INA220(const I2CSPIDriverConfig &config, int battery_index) :
 {
 	float fvalue = MAX_CURRENT;
 	_max_current = fvalue;
-	param_t ph = (_ch_type == PM_CH_TYPE_VBATT) ? param_find("INA220_CURRENT_BAT") : param_find("INA220_CURRENT_REG");
+	param_t ph = (_ch_type == PM_CH_TYPE_VBATT) ? param_find("INA220_CUR_BAT") : param_find("INA220_CUR_REG");
 
 	if (ph != PARAM_INVALID && param_get(ph, &fvalue) == PX4_OK) {
 		_max_current = fvalue;


### PR DESCRIPTION
### Solved Problem
ina220 max current param names were incorrect and being ignored

### Solution
- Use correct param names in driver INA220_CUR_BAT and INA220_CUR_REG
