### PR TITLE
SENSORS: Lanbao PSK-CM8JL65-CC5 Orientation fix

### DIFF
--- a/src/drivers/distance_sensor/cm8jl65/module.yaml
+++ b/src/drivers/distance_sensor/cm8jl65/module.yaml
@@ -18,7 +18,7 @@ parameters:
             values:
                 25: ROTATION_DOWNWARD_FACING
                 24: ROTATION_UPWARD_FACING
-                12: ROTATION_BACKWARD_FACING
+                4: ROTATION_BACKWARD_FACING
                 0: ROTATION_FORWARD_FACING
                 6: ROTATION_LEFT_FACING
                 2: ROTATION_RIGHT_FACING


### PR DESCRIPTION
The parameter value for `ROTATION_BACKWARD_FACING` was wrong, it was 12 which corresponds with [`MAV_SENSOR_ROTATION_PITCH_180`](https://mavlink.io/en/messages/common.html#MAV_SENSOR_ROTATION_PITCH_180) which is the same orientation, but not used in the `DistanceSensor.msg`
### Tests


- [x] Tested on Hardware