### PR TITLE
Make Adis16470 to obey the csb delay

### DIFF
--- a/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
+++ b/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
@@ -50,6 +50,8 @@ ADIS16470::ADIS16470(const I2CSPIDriverConfig &config) :
 	if (_drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME": DRDY missed");
 	}
+
+	set_cs_to_sck_delay(SPI_CS_TO_SCK_PERIOD_NS);
 }
 
 ADIS16470::~ADIS16470()

--- a/src/drivers/imu/analog_devices/adis16470/Analog_Devices_ADIS16470_registers.hpp
+++ b/src/drivers/imu/analog_devices/adis16470/Analog_Devices_ADIS16470_registers.hpp
@@ -67,6 +67,8 @@ static constexpr uint32_t SPI_SPEED_BURST = 1 * 1000 * 1000; // 1 MHz SPI serial
 
 static constexpr uint32_t SPI_STALL_PERIOD = 16; // 16 us Stall period between data
 
+static constexpr uint32_t SPI_CS_TO_SCK_PERIOD_NS = 200; // 200 ns delay from CS to SCK edge
+
 static constexpr uint16_t DIR_WRITE = 0x80;
 
 static constexpr uint16_t Product_identification = 0x4056;

--- a/src/lib/drivers/device/nuttx/SPI.cpp
+++ b/src/lib/drivers/device/nuttx/SPI.cpp
@@ -50,6 +50,10 @@
 # error This driver requires CONFIG_SPI_EXCHANGE
 #endif
 
+#ifndef SPI_CS_TO_SCK_DELAY
+#define SPI_CS_TO_SCK_DELAY(dev, dly_ns) if (dly_ns) px4_udelay(((dly_ns) + 999) / 1000)
+#endif
+
 namespace device
 {
 
@@ -169,6 +173,7 @@ SPI::_transfer(uint8_t *send, uint8_t *recv, unsigned len)
 	SPI_SETMODE(_dev, _mode);
 	SPI_SETBITS(_dev, 8);
 	SPI_SELECT(_dev, _device, true);
+	SPI_CS_TO_SCK_DELAY(_dev, _cs_to_sck_ns);
 
 	/* do the transfer */
 	SPI_EXCHANGE(_dev, send, recv, len);
@@ -221,6 +226,7 @@ SPI::_transferhword(uint16_t *send, uint16_t *recv, unsigned len)
 	SPI_SETMODE(_dev, _mode);
 	SPI_SETBITS(_dev, 16);			/* 16 bit transfer */
 	SPI_SELECT(_dev, _device, true);
+	SPI_CS_TO_SCK_DELAY(_dev, _cs_to_sck_ns);
 
 	/* do the transfer */
 	SPI_EXCHANGE(_dev, send, recv, len);

--- a/src/lib/drivers/device/nuttx/SPI.hpp
+++ b/src/lib/drivers/device/nuttx/SPI.hpp
@@ -161,10 +161,12 @@ protected:
 	 */
 	void		set_lockmode(enum LockMode mode) { _locking_mode = mode; }
 
+	void		set_cs_to_sck_delay(uint32_t delay_ns) { _cs_to_sck_ns = delay_ns; }
 private:
 	uint32_t		_device;
 	enum spi_mode_e		_mode;
 	uint32_t		_frequency;
+	uint32_t		_cs_to_sck_ns {0};
 	struct spi_dev_s	*_dev {nullptr};
 
 	LockMode		_locking_mode{LOCK_THREADS};	/**< selected locking mode */


### PR DESCRIPTION

### Solved Problem

When using adis16470 IMU on a custom HW board, I have experienced a lot of issues in sensor driver initialization and also during runtime.

While measuring the SPI bus, it was found that the bus transactions didn't obey the "chip select to first clock edge delay" timing requirement, which is 200ns for this sensor. There are also other sensors, which have similar requirements, but the delay is typically so short (in range on tens of ns) that the issue has not occured.

### Solution

This PR suggest an addition to PX4 SPI driver, which allows configuring this delay for an SPI device.

The solution has 3 parts:
- A new interface for the SPI driver to set this delay "set_cs_to_sck_delay()". The default delay is 0, there is no effect if the sensor driver doesn't set this.
- Call for this interface from within the ADIS16470 driver, setting the delay to 200ns
- A new macro "SPI_CS_TO_SCK_DELAY", called after setttin the CS in the SPI driver

There is a default implementation for SPI_CS_TO_SCK_DELAY, which uses px4_udelay to implement a delay, in case the delay is set to > 0. The macro can also be defined to call some function of the OS SPI driver, if that driver and/or the HW supports setting this delay without making a busy-loop delay.

### Alternatives

- For some HW platforms it is possible to set a default delay from the start of the trasfer to the first clock edge, for those it could be hard-coded within nuttx SPI driver to have always some default delay. But this is not possible for all chips, and implementing a hard-coded delay in the NuttX SPI driver is also quite hackish. The delay is after all sensor-specific.
- The default implementation of the macro SPI_CS_TO_SCK_DELAY could also be no-op, so that only a platform which experiences this proble would need to define it. This, however, may lead to hard-to find issues if the required timing is not obeyed.

### Test coverage

So far this is only tested on a custom HW, and measured with a logic analyzer.
