### PR TITLE
Navigator: RTL: Enable precision landing for all RTL types but only start if enabled

### DIFF
--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -483,7 +483,8 @@ private:
 	mission_item_s _last_camera_trigger_item {};
 	mission_item_s _last_speed_change_item {};
 
-	DEFINE_PARAMETERS(
+	DEFINE_PARAMETERS_CUSTOM_PARENT(
+		ModuleParams,
 		(ParamFloat<px4::params::MIS_DIST_1WP>) _param_mis_dist_1wp,
 		(ParamInt<px4::params::MIS_MNT_YAW_CTL>) _param_mis_mnt_yaw_ctl
 	)

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -485,7 +485,6 @@ private:
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(
 		ModuleParams,
-		(ParamFloat<px4::params::MIS_DIST_1WP>) _param_mis_dist_1wp,
 		(ParamInt<px4::params::MIS_MNT_YAW_CTL>) _param_mis_mnt_yaw_ctl
 	)
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -978,7 +978,7 @@ void MissionBlock::startPrecLand(uint16_t land_precision)
 		_navigator->get_precland()->set_mode(PrecLandMode::Opportunistic);
 		_navigator->get_precland()->on_activation();
 
-	} else { //_mission_item.land_precision == 2
+	} else if (_mission_item.land_precision == 2) {
 		_navigator->get_precland()->set_mode(PrecLandMode::Required);
 		_navigator->get_precland()->on_activation();
 	}

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -110,7 +110,7 @@ void RtlDirect::on_active()
 		updateAltToAvoidTerrainCollisionAndRepublishTriplet(_mission_item);
 	}
 
-	if (_rtl_state == RTLState::LAND && _param_rtl_pld_md.get() > 0) {
+	if (_rtl_state == RTLState::LAND && _mission_item.land_precision > 0) {
 		// Need to update the position and type on the current setpoint triplet.
 		_navigator->get_precland()->on_active();
 

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -369,7 +369,9 @@ void RtlDirect::set_rtl_item()
 
 			_mission_item.land_precision = _param_rtl_pld_md.get();
 
-			startPrecLand(_mission_item.land_precision);
+			if (_mission_item.land_precision > 0) {
+				startPrecLand(_mission_item.land_precision);
+			}
 
 			mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: land at destination\t");
 			events::send(events::ID("rtl_land_at_destination"), events::Log::Info, "RTL: land at destination");

--- a/src/modules/navigator/rtl_mission_fast_reverse.cpp
+++ b/src/modules/navigator/rtl_mission_fast_reverse.cpp
@@ -269,6 +269,13 @@ void RtlMissionFastReverse::handleLanding(WorkItemType &new_work_item_type)
 				_mission_item.altitude = _home_pos_sub.get().alt;
 				_mission_item.altitude_is_relative = false;
 				_navigator->reset_position_setpoint(pos_sp_triplet->previous);
+
+				_mission_item.land_precision = _param_rtl_pld_md.get();
+
+				if (_mission_item.land_precision > 0) {
+					startPrecLand(_mission_item.land_precision);
+					new_work_item_type = WorkItemType::WORK_ITEM_TYPE_PRECISION_LAND;
+				}
 			}
 		}
 	}

--- a/src/modules/navigator/rtl_mission_fast_reverse.h
+++ b/src/modules/navigator/rtl_mission_fast_reverse.h
@@ -74,4 +74,8 @@ private:
 	bool _in_landing_phase{false};
 
 	uORB::SubscriptionData<home_position_s> _home_pos_sub{ORB_ID(home_position)};		/**< home position subscription */
+	DEFINE_PARAMETERS_CUSTOM_PARENT(
+		RtlBase,
+		(ParamInt<px4::params::RTL_PLD_MD>)       _param_rtl_pld_md
+	)
 };

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -139,6 +139,7 @@ PARAM_DEFINE_INT32(RTL_CONE_ANG, 45);
  * RTL precision land mode
  *
  * Use precision landing when doing an RTL landing phase.
+ * This setting does not apply for RTL destinations planned as part of a mission.
  *
  * @value 0 No precision landing
  * @value 1 Opportunistic precision landing


### PR DESCRIPTION
### Solved Problem
- Found by chance that precision landing is always started atm in RTL direct. It doesn't have any negative effect currently from why I see but still seems wrong.
- No precision landing possible in RTL_TYPE=2 and no mission landing planned (RtlMissionFastReverse)

### Solution
- Check for the setting of `RTL_PLD_MD` and only `startPrecLand()` if precision landing is enabled, plus harden `startPrecLand()` to not do anything if not precision landing is not enabled.
- check `RTL_PLD_MD` in RtlMissionFastReverse and execute precision landing if set accordingly (similar logic as in RtlDirect)

### Changelog Entry
For release notes: 
```
Bugfix: Navigator: RTL_direct: onyl start precision land if param is set to enabled
Bugfix: Navigator: RTL: use precision landing if enabled in param RTL_PLD_MD also for reverse mission RTL
```

