### PR TITLE
drivers/magnetometer/ak09916: Add support to AK09915

### DIFF
--- a/src/drivers/magnetometer/akm/ak09916/AK09916.hpp
+++ b/src/drivers/magnetometer/akm/ak09916/AK09916.hpp
@@ -64,6 +64,30 @@ public:
 	void print_status() override;
 
 private:
+	enum class AKTYPE : uint8_t {
+		AK09916 = 0X09,
+		AK09915 = 0X10,
+		AK09918 = 0x0c,
+	};
+
+	constexpr char const *device_name()
+	{
+		switch (_device) {
+		case AKTYPE::AK09916:
+			return "AK09916";
+
+		case AKTYPE::AK09915:
+			return "AK09915";
+
+		case AKTYPE::AK09918:
+			return "AK09918";
+
+		default:
+			return "Unknown";
+
+		};
+	}
+
 	struct register_config_t {
 		Register reg;
 		uint8_t set_bits{0};
@@ -107,5 +131,5 @@ private:
 		{ Register::CNTL2,   CNTL2_BIT::MODE3_SET, CNTL2_BIT::MODE3_CLEAR },
 	};
 
-	bool _is_ak09918 {false};
+	AKTYPE _device;
 };

--- a/src/drivers/magnetometer/akm/ak09916/AKM_AK09916_registers.hpp
+++ b/src/drivers/magnetometer/akm/ak09916/AKM_AK09916_registers.hpp
@@ -59,8 +59,6 @@ static constexpr uint32_t I2C_SPEED = 400 * 1000; // 400 kHz I2C serial interfac
 static constexpr uint8_t I2C_ADDRESS_DEFAULT = 0b0001100;
 
 static constexpr uint8_t Company_ID = 0x48;
-static constexpr uint8_t Device_ID = 0x09;
-static constexpr uint8_t Device_ID_AK09918 = 0x0C;
 
 enum class Register : uint8_t {
 	WIA1  = 0x00, // Company ID of AKM


### PR DESCRIPTION
The only difference between the ak09915 and ak09916 is the communication method

### Solved Problem
There is no support to AK09915 

### Solution
- Add AK09915 support
- Refactor the code to support AK09915, AK09916, AK09918

### Changelog Entry
For release notes:
```
Feature/Bugfix: Add support to ak09915
```

### Alternatives
Not add support to it `¯\_(ツ)_/¯`

### Test coverage
- Unit/integration test: Tested in real hardware ([Navigator](https://bluerobotics.com/store/comm-control-power/control/navigator/))
- Simulation/hardware testing logs: https://review.px4.io/

### Context
[AK09915 Datasheet](https://bluerobotics.com/wp-content/uploads/2022/05/AK09915-DATASHEET.pdf)
[AK09916 Datasheet](https://www.y-ic.es/datasheet/78/SMDSW.020-2OZ.pdf)
