### PR TITLE
ci: disable fail fast for build targets job

### DIFF
--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -75,6 +75,7 @@ jobs:
     needs: group_targets
     strategy:
       matrix: ${{ fromJson(needs.group_targets.outputs.matrix) }}
+      fail-fast: false
     container:
       image: ${{ matrix.container }}
     steps:


### PR DESCRIPTION
This change will allow the build all variants ci workflow to continue building other targets when a failure is detected, this is good so you can determine which target failed building instead of having to guess by looking into each one. This change is harmless and can be merged now.