### PR TITLE
uxrce_dds_client - Fix nullptr access in certain cleanup situations

### DIFF
--- a/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
+++ b/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
@@ -222,6 +222,7 @@ bool UxrceddsClient::setup_session(uxrSession *session)
 	}
 
 	if (!got_response) {
+		PX4_ERR("got no ping from agent");
 		return false;
 	}
 

--- a/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
+++ b/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
@@ -354,6 +354,7 @@ bool UxrceddsClient::setup_session(uxrSession *session)
 		}
 
 		if (sync_timeouts > TIMESYNC_MAX_TIMEOUTS) {
+			PX4_ERR("timeout during time synchronization");
 			return false;
 		}
 

--- a/src/modules/uxrce_dds_client/uxrce_dds_client.h
+++ b/src/modules/uxrce_dds_client/uxrce_dds_client.h
@@ -181,9 +181,11 @@ private:
 
 	int _last_payload_tx_rate{}; ///< in B/s
 	int _last_payload_rx_rate{}; ///< in B/s
-	bool _connected{false};
 
+	bool _connected{false};
+	bool _session_created{false};
 	bool _timesync_converged{false};
+	bool _subs_initialized{false};
 
 	Timesync _timesync{timesync_status_s::SOURCE_PROTOCOL_DDS};
 


### PR DESCRIPTION
### Solved Problem
When the uxrce_dds_client is not able to connect it cleans up the current session and retries the connection after a certain time. This works well in most cases, but in certain situations the connection fails even before a session is created. This will cause a nullptr access when trying to clean a session that is not yet created.

### Solution
Only clean the session if it has been created.

### Changelog Entry
For release notes:
```
Bugfix uxrce_dds_client - Fix nullptr access in certain cleanup situations
```

### Test coverage
- Has been tested on the bench