### PR TITLE
Fix generate component regex escape sequence

### DIFF
--- a/src/lib/component_information/generate_component_general.py
+++ b/src/lib/component_information/generate_component_general.py
@@ -20,7 +20,7 @@ version_file = args.version_file
 version_dir = ''
 if version_file is not None:
     for line in open(version_file, "r"):
-        version_search = re.search('PX4_GIT_TAG_OR_BRANCH_NAME\s+"(.+)"', line)
+        version_search = re.search(r'PX4_GIT_TAG_OR_BRANCH_NAME\s+"(.+)"', line)
         if version_search:
             version_dir = version_search.group(1)
             break


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Doing a build, I saw the following syntax warning:
```
PX4-Autopilot/src/lib/component_information/generate_component_general.py:23: SyntaxWarning: invalid escape sequence '\s'
  version_search = re.search('PX4_GIT_TAG_OR_BRANCH_NAME\s+"(.+)"', line)
```

### Solution
- This fixes the issue by making it a raw literal string so the `\` isn't treated as an escape character. 

### Test coverage
- Building with this change removes the SyntaxWarning. 
