### PR TITLE
Require relaxed local pos for AUTO_LAND

### DIFF
--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -140,7 +140,7 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_attitude);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_local_alt);
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_local_position);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_local_position_relaxed);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_prevent_arming);
 
 	// NAVIGATION_STATE_AUTO_FOLLOW_TARGET


### PR DESCRIPTION
### Solved Problem
When the only aiding source for local position is an optical flow sensor, the local position is deemed invalid  and thus auto land mode does not work. This is not ideal, because the system will remain in descend mode (assuming the user does not manually take over), which does not stabilize horizontal velocity. In practice there will be a lot of drift, even though the vehicle could stabilize the horizontal velocity, given the flow sensor.

Fixes #{Github issue ID}

### Solution
The auto land mode should just require relaxed local position, which will allow it to engage with only an optical flow sensor as aiding source.

### Changelog Entry
For release notes:
```
Feature: Enable auto land mode with optical flow only.
```


### Test coverage
So far this is SITL tested, but will test also on real vehicle. Problem was discovered on real hardware.

### Context
Image showing vehicle remaining in descend mode after the backtransition, due to local position being invalid:
![local_pos_invalid](https://github.com/user-attachments/assets/96363f7f-a2b4-437c-9c8d-521fc1561f50)

Image showing vehicle switching to auto land, as soon as the optical flow sensor is in range. In this case the distance sensor becomes valid at 15m dist to ground.

![local_pos_relaxed](https://github.com/user-attachments/assets/80b1180f-7d2e-439d-9442-f04f626b8cd2)



