### PR TITLE
Added interrupt pin selection to BMI088

### DIFF
--- a/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.hpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.hpp
@@ -124,8 +124,13 @@ private:
 		{ Register::FIFO_WTM_1,            0, 0 },
 		{ Register::FIFO_CONFIG_0,         FIFO_CONFIG_0_BIT::BIT1_ALWAYS | FIFO_CONFIG_0_BIT::FIFO_mode, 0 },
 		{ Register::FIFO_CONFIG_1,         FIFO_CONFIG_1_BIT::BIT4_ALWAYS | FIFO_CONFIG_1_BIT::Acc_en, 0 },
+# if defined(CONFIG_BMI088_ACCELEROMETER_INT1)
 		{ Register::INT1_IO_CONF,          INT1_IO_CONF_BIT::int1_out, 0 },
 		{ Register::INT1_INT2_MAP_DATA,    INT1_INT2_MAP_DATA_BIT::int1_fwm, 0},
+# elif defined(CONFIG_BMI088_ACCELEROMETER_INT2)
+		{ Register::INT2_IO_CONF,	   INT2_IO_CONF_BIT::int2_out, 0 },
+		{ Register::INT1_INT2_MAP_DATA,	   INT1_INT2_MAP_DATA_BIT::int2_fwm, 0},
+# endif
 	};
 };
 

--- a/src/drivers/imu/bosch/bmi088/BMI088_Gyroscope.hpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088_Gyroscope.hpp
@@ -113,11 +113,16 @@ private:
 		{ Register::GYRO_RANGE,             GYRO_RANGE_BIT::gyro_range_2000_dps, 0 },
 		{ Register::GYRO_BANDWIDTH,         0, GYRO_BANDWIDTH_BIT::gyro_bw_532_Hz },
 		{ Register::GYRO_INT_CTRL,          GYRO_INT_CTRL_BIT::fifo_en, 0 },
-		{ Register::INT3_INT4_IO_CONF,      0, INT3_INT4_IO_CONF_BIT::Int3_od | INT3_INT4_IO_CONF_BIT::Int3_lvl },
-		{ Register::INT3_INT4_IO_MAP,       INT3_INT4_IO_MAP_BIT::Int3_fifo, 0 },
 		{ Register::FIFO_WM_ENABLE,         FIFO_WM_ENABLE_BIT::fifo_wm_enable, 0 },
 		{ Register::FIFO_CONFIG_0,          0, 0 }, // fifo_water_mark_level_trigger_retain<6:0>
 		{ Register::FIFO_CONFIG_1,          FIFO_CONFIG_1_BIT::FIFO_MODE, 0 },
+#if defined(CONFIG_BMI088_GYROSCOPE_INT3)
+		{ Register::INT3_INT4_IO_CONF,      0, INT3_INT4_IO_CONF_BIT::Int3_od | INT3_INT4_IO_CONF_BIT::Int3_lvl },
+		{ Register::INT3_INT4_IO_MAP,       INT3_INT4_IO_MAP_BIT::Int3_fifo, 0 },
+# elif defined(CONFIG_BMI088_GYROSCOPE_INT4)
+		{ Register::INT3_INT4_IO_CONF,      0, INT3_INT4_IO_CONF_BIT::Int4_od | INT3_INT4_IO_CONF_BIT::Int4_lvl },
+		{ Register::INT3_INT4_IO_MAP,       INT3_INT4_IO_MAP_BIT::Int4_fifo, 0 },
+# endif
 	};
 };
 

--- a/src/drivers/imu/bosch/bmi088/Bosch_BMI088_Accelerometer_Registers.hpp
+++ b/src/drivers/imu/bosch/bmi088/Bosch_BMI088_Accelerometer_Registers.hpp
@@ -72,6 +72,7 @@ enum class Register : uint8_t {
 	FIFO_CONFIG_1      = 0x49,
 
 	INT1_IO_CONF       = 0x53,
+	INT2_IO_CONF       = 0x54,
 
 	INT1_INT2_MAP_DATA = 0x58,
 
@@ -113,8 +114,16 @@ enum FIFO_CONFIG_1_BIT : uint8_t {
 enum INT1_IO_CONF_BIT : uint8_t {
 	int1_in  = Bit4,
 	int1_out = Bit3,
-
+	int1_od  = Bit2,
 	int1_lvl = Bit1,
+};
+
+// INT2_IO_CONF
+enum INT2_IO_CONF_BIT : uint8_t {
+	int2_io	 = Bit4,
+	int2_out = Bit3,
+	int2_od  = Bit2,
+	int2_lvl = Bit1,
 };
 
 // INT1_INT2_MAP_DATA

--- a/src/drivers/imu/bosch/bmi088/Bosch_BMI088_Gyroscope_Registers.hpp
+++ b/src/drivers/imu/bosch/bmi088/Bosch_BMI088_Gyroscope_Registers.hpp
@@ -98,6 +98,8 @@ enum GYRO_INT_CTRL_BIT : uint8_t {
 
 // INT3_INT4_IO_CONF
 enum INT3_INT4_IO_CONF_BIT : uint8_t {
+	Int4_od  = Bit3, // '0' Push-pull
+	Int4_lvl = Bit2, // '0' Active low
 	Int3_od  = Bit1, // ‘0’ Push-pull
 	Int3_lvl = Bit0, // ‘0’ Active low
 };

--- a/src/drivers/imu/bosch/bmi088/Kconfig
+++ b/src/drivers/imu/bosch/bmi088/Kconfig
@@ -7,7 +7,7 @@ menuconfig DRIVERS_IMU_BOSCH_BMI088
 if DRIVERS_IMU_BOSCH_BMI088
 
 choice
-	prompt "BMI088 accelerometer intterupt pin"
+	prompt "BMI088 accelerometer interrupt pin"
 	default BMI088_ACCELEROMETER_INT1
 
 config BMI088_ACCELEROMETER_INT_NONE

--- a/src/drivers/imu/bosch/bmi088/Kconfig
+++ b/src/drivers/imu/bosch/bmi088/Kconfig
@@ -3,3 +3,47 @@ menuconfig DRIVERS_IMU_BOSCH_BMI088
 	default n
 	---help---
 		Enable support for bosch bmi088
+
+if DRIVERS_IMU_BOSCH_BMI088
+
+choice
+	prompt "BMI088 accelerometer intterupt pin"
+	default BMI088_ACCELEROMETER_INT1
+
+config BMI088_ACCELEROMETER_INT_NONE
+	bool "No interrupts"
+	---help---
+		No pin on the BMI088 will output accelerometer interrupts
+
+config BMI088_ACCELEROMETER_INT1
+	bool "INT1"
+	---help---
+		Use INT1 pin of the BMI088 to output accelerometer interrupts
+
+config BMI088_ACCELEROMETER_INT2
+	bool "INT2"
+	---help---
+		Use INT2 pin of the BMI088 to output accelerometer interrupts
+endchoice
+
+choice
+	prompt "BMI088 gyroscope interrupt pin"
+	default BMI088_GYROSCOPE_INT3
+
+config BMI088_GYROSCOPE_INT_NONE
+	bool "No interrupts"
+	---help---
+		No pin on the BMI088 will output gyroscope interrupts
+
+config BMI088_GYROSCOPE_INT3
+	bool "INT3"
+	---help---
+		Use INT3 pin of the BMI088 to output gyroscope interrupts
+
+config BMI088_GYROSCOPE_INT4
+	bool "INT4"
+	---help---
+		Use INT4 pin of the BMI088 to output gyroscope interrupts
+endchoice
+
+endif


### PR DESCRIPTION
### Solved Problem
The BMI088 sensor has 4 interrupt pins. PIN 1 & 2 can be used for accelerometer interrupts and PIN 3 & 4 for gyroscope interrupts. Currently the driver only allows to use PIN 1 for accelerometer interrupts and PIN 3 for gyroscope interrupts.

### Solution
The change adds a KConfig based selection of which pin to use for accelerometer interrupts and which pin to use for gyroscope interrupts (or don't use any pin at all)

### Changelog Entry
For release notes:
```
Feature Added interrupt pin selection to BMI088
```

### Test coverage
- Tested on the bench with a Skynode v5x
