### PR TITLE
Refactor: reduce use of automatic type deduction for readability, torque setpoint naming

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1970,7 +1970,7 @@ void Commander::checkForMissionUpdate()
 	if (_mission_result_sub.updated()) {
 		const mission_result_s &mission_result = _mission_result_sub.get();
 
-		const auto prev_mission_mission_id = mission_result.mission_id;
+		const uint32_t prev_mission_mission_id = mission_result.mission_id;
 		_mission_result_sub.update();
 
 		// if mission_result is valid for the current mission
@@ -2155,9 +2155,10 @@ void Commander::vtolStatusUpdate()
 	if (_vtol_vehicle_status_sub.update(&_vtol_vehicle_status) && is_vtol(_vehicle_status)) {
 
 		// Check if there has been any change while updating the flags (transition = rotary wing status)
-		const auto new_vehicle_type = _vtol_vehicle_status.vehicle_vtol_state == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW ?
-					      vehicle_status_s::VEHICLE_TYPE_FIXED_WING :
-					      vehicle_status_s::VEHICLE_TYPE_ROTARY_WING;
+		const uint8_t new_vehicle_type =
+			_vtol_vehicle_status.vehicle_vtol_state == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW ?
+			vehicle_status_s::VEHICLE_TYPE_FIXED_WING :
+			vehicle_status_s::VEHICLE_TYPE_ROTARY_WING;
 
 		if (new_vehicle_type != _vehicle_status.vehicle_type) {
 			_vehicle_status.vehicle_type = new_vehicle_type;

--- a/src/modules/commander/HomePosition.cpp
+++ b/src/modules/commander/HomePosition.cpp
@@ -170,7 +170,7 @@ void HomePosition::fillGlobalHomePos(home_position_s &home, double lat, double l
 
 void HomePosition::setInAirHomePosition()
 {
-	auto &home = _home_position_pub.get();
+	home_position_s &home = _home_position_pub.get();
 
 	if (home.manual_home || (home.valid_lpos && home.valid_hpos && home.valid_alt)) {
 		return;
@@ -251,13 +251,13 @@ void HomePosition::setInAirHomePosition()
 
 bool HomePosition::setManually(double lat, double lon, float alt, float yaw)
 {
-	const auto &vehicle_local_position = _local_position_sub.get();
+	const vehicle_local_position_s &vehicle_local_position = _local_position_sub.get();
 
 	if (!vehicle_local_position.xy_global || !vehicle_local_position.z_global) {
 		return false;
 	}
 
-	auto &home = _home_position_pub.get();
+	home_position_s &home = _home_position_pub.get();
 	home.manual_home = true;
 
 	home.lat = lat;
@@ -328,7 +328,7 @@ void HomePosition::update(bool set_automatically, bool check_if_changed)
 	}
 
 	const vehicle_local_position_s &lpos = _local_position_sub.get();
-	const auto &home = _home_position_pub.get();
+	const home_position_s &home = _home_position_pub.get();
 
 	if (lpos.heading_reset_counter != _heading_reset_counter) {
 		if (_valid && set_automatically) {

--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -253,7 +253,7 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 
 		for (unsigned uorb_index = 0; uorb_index < MAX_GYROS; uorb_index++) {
 
-			auto &calibration = worker_data.calibrations[uorb_index];
+			calibration::Gyroscope &calibration = worker_data.calibrations[uorb_index];
 
 			if (calibration.device_id() != 0) {
 				calibration.set_offset(worker_data.offset[uorb_index]);

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -905,7 +905,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 
 		for (unsigned cur_mag = 0; cur_mag < MAX_MAGS; cur_mag++) {
 
-			auto &current_cal = worker_data.calibration[cur_mag];
+			calibration::Magnetometer &current_cal = worker_data.calibration[cur_mag];
 
 			if (current_cal.device_id() != 0) {
 				if (worker_data.append_to_existing_calibration) {

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -214,7 +214,8 @@ MulticopterRateControl::Run()
 			}
 
 			// run rate controller
-			const Vector3f att_control = _rate_control.update(rates, _rates_setpoint, angular_accel, dt, _maybe_landed || _landed);
+			const Vector3f torque_setpoint =
+				_rate_control.update(rates, _rates_setpoint, angular_accel, dt, _maybe_landed || _landed);
 
 			// publish rate controller status
 			rate_ctrl_status_s rate_ctrl_status{};
@@ -227,9 +228,9 @@ MulticopterRateControl::Run()
 			vehicle_torque_setpoint_s vehicle_torque_setpoint{};
 
 			_thrust_setpoint.copyTo(vehicle_thrust_setpoint.xyz);
-			vehicle_torque_setpoint.xyz[0] = PX4_ISFINITE(att_control(0)) ? att_control(0) : 0.f;
-			vehicle_torque_setpoint.xyz[1] = PX4_ISFINITE(att_control(1)) ? att_control(1) : 0.f;
-			vehicle_torque_setpoint.xyz[2] = PX4_ISFINITE(att_control(2)) ? att_control(2) : 0.f;
+			vehicle_torque_setpoint.xyz[0] = PX4_ISFINITE(torque_setpoint(0)) ? torque_setpoint(0) : 0.f;
+			vehicle_torque_setpoint.xyz[1] = PX4_ISFINITE(torque_setpoint(1)) ? torque_setpoint(1) : 0.f;
+			vehicle_torque_setpoint.xyz[2] = PX4_ISFINITE(torque_setpoint(2)) ? torque_setpoint(2) : 0.f;
 
 			// scale setpoints by battery status if enabled
 			if (_param_mc_bat_scale_en.get()) {


### PR DESCRIPTION
### Solved Problem
When working on https://github.com/PX4/PX4-Autopilot/compare/main...pid-class I found some parts were unnecessarily cumbersome to read partly because of wrong naming and partly because of automatic type deduction for sometimes even just an integer. I would use that only for the convenient for loops and types that really clutter everything without improving readability.

### Solution
- Change the multicopter torque setpoint's name from `att_control` to `torque_setpoint`
- Replace `auto` in Commander with the actual type in places that don't fit the above criteria.

### Changelog Entry
```
Small refactor automatic type dedution and naming
```

### Test coverage
It compiles, the refactor should only be able to cause a compilation error.