### PR TITLE
Optical flow: add scale factor parameter

### DIFF
--- a/src/modules/sensors/sensor_params_flow.c
+++ b/src/modules/sensors/sensor_params_flow.c
@@ -111,3 +111,13 @@ PARAM_DEFINE_FLOAT(SENS_FLOW_MAXR, 8.f);
  *
  */
 PARAM_DEFINE_FLOAT(SENS_FLOW_RATE, 70.0f);
+
+/**
+ * Optical flow scale factor
+ *
+ * @min 0.5
+ * @max 1.5
+ * @decimal 2
+ * @group Sensors
+ */
+PARAM_DEFINE_FLOAT(SENS_FLOW_SCALE, 1.f);

--- a/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp
+++ b/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp
@@ -226,6 +226,7 @@ void VehicleOpticalFlow::Run()
 			vehicle_optical_flow.timestamp_sample = sensor_optical_flow.timestamp_sample;
 			vehicle_optical_flow.device_id = sensor_optical_flow.device_id;
 
+			_flow_integral *= _param_sens_flow_scale.get();
 			_flow_integral.copyTo(vehicle_optical_flow.pixel_flow);
 			_delta_angle.copyTo(vehicle_optical_flow.delta_angle);
 

--- a/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.hpp
+++ b/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.hpp
@@ -141,7 +141,8 @@ private:
 		(ParamFloat<px4::params::SENS_FLOW_MINHGT>) _param_sens_flow_minhgt,
 		(ParamFloat<px4::params::SENS_FLOW_MAXHGT>) _param_sens_flow_maxhgt,
 		(ParamFloat<px4::params::SENS_FLOW_MAXR>) _param_sens_flow_maxr,
-		(ParamFloat<px4::params::SENS_FLOW_RATE>) _param_sens_flow_rate
+		(ParamFloat<px4::params::SENS_FLOW_RATE>) _param_sens_flow_rate,
+		(ParamFloat<px4::params::SENS_FLOW_SCALE>) _param_sens_flow_scale
 	)
 };
 }; // namespace sensors


### PR DESCRIPTION
### Solved Problem
Earlier this year we were investigating position oscillations in flow-only operations and came up with a couple of improvements (e.g.: [terrain state](https://github.com/PX4/PX4-Autopilot/pull/23263)). This made the situation better but I've seen the issue resurrecting recently.

This was with a FW version containing the new terrain state. The plot below shows a flight with optical flow fused but without distance sensor (and without GNSS). The flight was perfectly fine (no oscillations) and we can see that the `dist_bottom` estimate is lower than the measurement from the distance sensor. Calculating the ratio of those two values gives us a guess about the optical flow scale factor (between 0.85 and 0.9 in our case). Note that the GNSS altitude also shows that the distance sensor is more correct than our `dist_bottom` estimate.
![Screenshot from 2024-11-13 14-22-01](https://github.com/user-attachments/assets/503049bd-59a7-45f2-af3f-ea388d14a8ef)

A next flight was conducted with the distance measurement fused and the drone did oscillate in position. The `estimator_optical_flow_vel` also shows a flow velocity over-estimated (compared to GNSS velocity).
![image](https://github.com/user-attachments/assets/4c0db3bd-878e-4e08-ba44-55a9041a8c6b)

It seems that despite having a correct scale in the driver, there is still a scale factor error.

### Solution
Add an optical flow scale factor parameter to scale up or down the raw optical flow data.

### Changelog Entry
For release notes:
```
New parameter: SENS_FLOW_SCALE
Documentation: 
```

@AlexKlimaj This was observed on the ArkFlow, could you please have a try? i.e.: set `SENS_FLOW_SCALE` to 0.85 and fly without GNSS