### PR TITLE
Non-Inline function to save 4kB Flash

### DIFF
--- a/src/lib/conversion/rotation.cpp
+++ b/src/lib/conversion/rotation.cpp
@@ -56,3 +56,31 @@ get_rot_quaternion(enum Rotation rot)
 			math::radians((float)rot_lookup[rot].pitch),
 			math::radians((float)rot_lookup[rot].yaw)}};
 }
+
+__EXPORT void
+rotate_3i(enum Rotation rot, int16_t &x, int16_t &y, int16_t &z)
+{
+	if (!rotate_3(rot, x, y, z)) {
+		// otherwise use full rotation matrix for valid rotations
+		if (rot < ROTATION_MAX) {
+			const matrix::Vector3f r{get_rot_matrix(rot) *matrix::Vector3f{(float)x, (float)y, (float)z}};
+			x = math::constrain(roundf(r(0)), (float)INT16_MIN, (float)INT16_MAX);
+			y = math::constrain(roundf(r(1)), (float)INT16_MIN, (float)INT16_MAX);
+			z = math::constrain(roundf(r(2)), (float)INT16_MIN, (float)INT16_MAX);
+		}
+	}
+}
+
+__EXPORT void
+rotate_3f(enum Rotation rot, float &x, float &y, float &z)
+{
+	if (!rotate_3(rot, x, y, z)) {
+		// otherwise use full rotation matrix for valid rotations
+		if (rot < ROTATION_MAX) {
+			const matrix::Vector3f r{get_rot_matrix(rot) *matrix::Vector3f{x, y, z}};
+			x = r(0);
+			y = r(1);
+			z = r(2);
+		}
+	}
+}

--- a/src/lib/conversion/rotation.h
+++ b/src/lib/conversion/rotation.h
@@ -157,8 +157,18 @@ __EXPORT matrix::Dcmf get_rot_matrix(enum Rotation rot);
  */
 __EXPORT matrix::Quatf get_rot_quaternion(enum Rotation rot);
 
+/**
+ * rotate a 3 element int16_t vector in-place
+ */
+__EXPORT void rotate_3i(enum Rotation rot, int16_t &x, int16_t &y, int16_t &z);
+
+/**
+ * rotate a 3 element float vector in-place
+ */
+__EXPORT void rotate_3f(enum Rotation rot, float &x, float &y, float &z);
+
 template<typename T>
-static constexpr bool rotate_3(enum Rotation rot, T &x, T &y, T &z)
+static bool rotate_3(enum Rotation rot, T &x, T &y, T &z)
 {
 	switch (rot) {
 	case ROTATION_NONE:
@@ -370,36 +380,4 @@ static constexpr bool rotate_3(enum Rotation rot, T &x, T &y, T &z)
 	}
 
 	return false;
-}
-
-/**
- * rotate a 3 element int16_t vector in-place
- */
-__EXPORT inline void rotate_3i(enum Rotation rot, int16_t &x, int16_t &y, int16_t &z)
-{
-	if (!rotate_3(rot, x, y, z)) {
-		// otherwise use full rotation matrix for valid rotations
-		if (rot < ROTATION_MAX) {
-			const matrix::Vector3f r{get_rot_matrix(rot) *matrix::Vector3f{(float)x, (float)y, (float)z}};
-			x = math::constrain(roundf(r(0)), (float)INT16_MIN, (float)INT16_MAX);
-			y = math::constrain(roundf(r(1)), (float)INT16_MIN, (float)INT16_MAX);
-			z = math::constrain(roundf(r(2)), (float)INT16_MIN, (float)INT16_MAX);
-		}
-	}
-}
-
-/**
- * rotate a 3 element float vector in-place
- */
-__EXPORT inline void rotate_3f(enum Rotation rot, float &x, float &y, float &z)
-{
-	if (!rotate_3(rot, x, y, z)) {
-		// otherwise use full rotation matrix for valid rotations
-		if (rot < ROTATION_MAX) {
-			const matrix::Vector3f r{get_rot_matrix(rot) *matrix::Vector3f{x, y, z}};
-			x = r(0);
-			y = r(1);
-			z = r(2);
-		}
-	}
 }

--- a/src/lib/world_magnetic_model/geo_mag_declination.cpp
+++ b/src/lib/world_magnetic_model/geo_mag_declination.cpp
@@ -53,7 +53,7 @@
 
 using math::constrain;
 
-static constexpr unsigned get_lookup_table_index(float *val, float min, float max)
+static unsigned get_lookup_table_index(float *val, float min, float max)
 {
 	/* for the rare case of hitting the bounds exactly
 	 * the rounding logic wouldn't fit, so enforce it.
@@ -66,7 +66,7 @@ static constexpr unsigned get_lookup_table_index(float *val, float min, float ma
 	return static_cast<unsigned>((-(min) + *val) / SAMPLING_RES);
 }
 
-static constexpr float get_table_data(float latitude_deg, float longitude_deg, const int16_t table[LAT_DIM][LON_DIM])
+static float get_table_data(float latitude_deg, float longitude_deg, const int16_t table[LAT_DIM][LON_DIM])
 {
 	latitude_deg = math::constrain(latitude_deg, SAMPLING_MIN_LAT, SAMPLING_MAX_LAT);
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

Flash usage is always high, we compile large parts of PX4 with `-O3` optimization level, which inlines functions aggressively. Often these functions can be un-inlined without changing CPU usage.

### Solution

@alexcekay "un-inlined" some functions that appear safe. The changes and FLASH save is as follows:

**Original:**
```
Memory region         Used Size  Region Size  %age Used
      FLASH_ITCM:           0 B      2016 KB      0.00%
      FLASH_AXIM:     1956312 B      2016 KB     94.76%
        ITCM_RAM:           0 B        16 KB      0.00%
        DTCM_RAM:           0 B       128 KB      0.00%
           SRAM1:       97988 B       368 KB     26.00%
           SRAM2:           0 B        16 KB      0.00%
```

**With the un-inline**
```
Memory region         Used Size  Region Size  %age Used
      FLASH_ITCM:           0 B      2016 KB      0.00%
      FLASH_AXIM:     1951936 B      2016 KB     94.55%
        ITCM_RAM:           0 B        16 KB      0.00%
        DTCM_RAM:           0 B       128 KB      0.00%
           SRAM1:       97988 B       368 KB     26.00%
           SRAM2:           0 B        16 KB      0.00%
```

Saves 4.4K of FLASH on FMUv5x

### Alternatives

We could use `-O3` only on files/functions that really matter for CPU speed, currently it's a bit of a blanket solution.
We're also working on more tooling to more easily gauge the resource usage.

### Test coverage

Only the non-inlining has runtime impact:
- Peak at 64% CPU usage when armed with and without changes
- uORB top shows same rate for accel and gyro as before


### Context

[Inline Function Usage Analyzer](https://auterion.github.io/embedded-debug-tools/emdbg/analyze/inline.html)

<details>
<summary>Example Output</summary>

```
 $ python -m emdbg.analyze.inline -f build/px4_fmu-v6x_default/px4_fmu-v6x_default.elf --overhead 16

src/lib/conversion/rotation.h:161 -- Total Size: 4248 (3.55%) -- Total Size without instruction overhead: 4120 (14.85%)
                                                                  ╷                               ╷           ╷      ╷                           ╷
  Translation unit                                                │ File name                     │ File line │ Size │ Call instruction overhead │ %
 ═════════════════════════════════════════════════════════════════╪═══════════════════════════════╪═══════════╪══════╪═══════════════════════════╪═══════
  src/drivers/optical_flow/pmw3901/PMW3901.cpp                    │ src/lib/conversion/rotation.h │ 396       │ 482  │ 16                        │ 11.35
  src/modules/commander/mag_calibration.cpp                       │ src/lib/conversion/rotation.h │ 396       │ 274  │ 16                        │ 6.45
  src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp │ src/lib/conversion/rotation.h │ 396       │ 242  │ 16                        │ 5.70
  src/lib/drivers/magnetometer/PX4Magnetometer.cpp                │ src/lib/conversion/rotation.h │ 396       │ 298  │ 16                        │ 7.02
  src/lib/drivers/accelerometer/PX4Accelerometer.cpp              │ src/lib/conversion/rotation.h │ 380       │ 1046 │ 16                        │ 24.62
  src/lib/drivers/accelerometer/PX4Accelerometer.cpp              │ src/lib/conversion/rotation.h │ 396       │ 430  │ 16                        │ 10.12
  src/lib/drivers/gyroscope/PX4Gyroscope.cpp                      │ src/lib/conversion/rotation.h │ 380       │ 1046 │ 16                        │ 24.62
  src/lib/drivers/gyroscope/PX4Gyroscope.cpp                      │ src/lib/conversion/rotation.h │ 396       │ 430  │ 16                        │ 10.12
                                                                  ╵                               ╵           ╵      ╵                           ╵

src/lib/conversion/rotation.h:378 -- Total Size: 2672 (2.23%) -- Total Size without instruction overhead: 2640 (9.52%)
                                                     ╷                                                    ╷           ╷      ╷                           ╷
  Translation unit                                   │ File name                                          │ File line │ Size │ Call instruction overhead │ %
 ════════════════════════════════════════════════════╪════════════════════════════════════════════════════╪═══════════╪══════╪═══════════════════════════╪═══════
  src/lib/drivers/accelerometer/PX4Accelerometer.cpp │ src/lib/drivers/accelerometer/PX4Accelerometer.cpp │ 144       │ 1336 │ 16                        │ 50.00
  src/lib/drivers/gyroscope/PX4Gyroscope.cpp         │ src/lib/drivers/gyroscope/PX4Gyroscope.cpp         │ 143       │ 1336 │ 16                        │ 50.00
                                                     ╵                                                    ╵           ╵      ╵                           ╵

src/lib/world_magnetic_model/geo_mag_declination.cpp:69 -- Total Size: 2068 (1.73%) -- Total Size without instruction overhead: 2004 (7.22%)
                                                       ╷                                                      ╷           ╷      ╷                           ╷
  Translation unit                                     │ File name                                            │ File line │ Size │ Call instruction overhead │ %
 ══════════════════════════════════════════════════════╪══════════════════════════════════════════════════════╪═══════════╪══════╪═══════════════════════════╪═══════
  src/lib/world_magnetic_model/geo_mag_declination.cpp │ src/lib/world_magnetic_model/geo_mag_declination.cpp │ 125       │ 522  │ 16                        │ 25.24
  src/lib/world_magnetic_model/geo_mag_declination.cpp │ src/lib/world_magnetic_model/geo_mag_declination.cpp │ 113       │ 514  │ 16                        │ 24.85
  src/lib/world_magnetic_model/geo_mag_declination.cpp │ src/lib/world_magnetic_model/geo_mag_declination.cpp │ 107       │ 514  │ 16                        │ 24.85
  src/lib/world_magnetic_model/geo_mag_declination.cpp │ src/lib/world_magnetic_model/geo_mag_declination.cpp │ 125       │ 518  │ 16                        │ 25.05
                                                       ╵                                                      ╵           ╵      ╵                           ╵

src/lib/conversion/rotation.h:394 -- Total Size: 2016 (1.69%) -- Total Size without instruction overhead: 1936 (6.98%)
                                                                  ╷                                                                 ╷           ╷      ╷                           ╷
  Translation unit                                                │ File name                                                       │ File line │ Size │ Call instruction overhead │ %
 ═════════════════════════════════════════════════════════════════╪═════════════════════════════════════════════════════════════════╪═══════════╪══════╪═══════════════════════════╪═══════
  src/modules/commander/mag_calibration.cpp                       │ src/modules/commander/mag_calibration.cpp                       │ 785       │ 330  │ 16                        │ 16.37
  src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp │ src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp │ 276       │ 304  │ 16                        │ 15.08
  src/lib/drivers/magnetometer/PX4Magnetometer.cpp                │ src/lib/drivers/magnetometer/PX4Magnetometer.cpp                │ 72        │ 374  │ 16                        │ 18.55
  src/lib/drivers/accelerometer/PX4Accelerometer.cpp              │ src/lib/drivers/accelerometer/PX4Accelerometer.cpp              │ 117       │ 504  │ 16                        │ 25.00
  src/lib/drivers/gyroscope/PX4Gyroscope.cpp                      │ src/lib/drivers/gyroscope/PX4Gyroscope.cpp                      │ 117       │ 504  │ 16                        │ 25.00
                                                                  ╵                                                                 ╵           ╵      ╵                           ╵

...
```

</details>
