### PR TITLE
bugfix: NMEA GPS update rate was 0 since num_bytes_read was not being…

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -475,6 +475,9 @@ int GPS::pollOrRead(uint8_t *buf, size_t buf_length, int timeout)
 
 	if (_interface == GPSHelper::Interface::UART) {
 		ret = _uart.readAtLeast(buf, buf_length, math::min(character_count, buf_length), timeout_adjusted);
+		if (ret > 0) {
+			_num_bytes_read += ret;
+		}
 
 // SPI is only supported on LInux
 #if defined(__PX4_LINUX)


### PR DESCRIPTION
### Solved Problem
When using NMEA GPS format, the GPS updates rate was always shown as 0. This was due to the _num_bytes_read field not being updated when the serial messages were read/parsed.

Fixes #23903

### Solution
- Added update for the received stat variable

### Changelog Entry
For release notes:
```
Feature/Bugfix PR-23903 fixed NMEA stats not being reported
```