### PR TITLE
Navigator: add optional delay after gimbal mission items

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -142,14 +142,11 @@ MissionBlock::is_mission_item_reached_or_completed()
 		break;
 
 	case NAV_CMD_DO_WINCH: {
-			const float payload_deploy_elasped_time_s = (now - _payload_deployed_time) *
-					1E-6f; // TODO: Add proper microseconds_to_seconds function
-
 			if (_payload_deploy_ack_successful) {
 				PX4_DEBUG("Winch has acknowledged, resume mission");
 				return true;
 
-			} else if (payload_deploy_elasped_time_s > _payload_deploy_timeout_s) {
+			} else if (now > _payload_deployed_time + (_payload_deploy_timeout_s * 1_s)) {
 				PX4_DEBUG("Winch timed out, resume mission");
 				return true;
 
@@ -160,9 +157,7 @@ MissionBlock::is_mission_item_reached_or_completed()
 		}
 
 	case NAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW: {
-			const float gimbal_command_elasped_time_s = (now - _gimbal_command_time) * 1E-6f;
-
-			if (gimbal_command_elasped_time_s > _gimbal_wait_time) {
+			if (now > _gimbal_command_time + (_gimbal_wait_time * 1_s)) {
 				PX4_DEBUG("Gimbal aligned, resume mission");
 				return true;
 			}
@@ -172,13 +167,11 @@ MissionBlock::is_mission_item_reached_or_completed()
 		}
 
 	case NAV_CMD_DO_GRIPPER: {
-			const float payload_deploy_elasped_time_s = (now - _payload_deployed_time) * 1E-6f;
-
 			if (_payload_deploy_ack_successful) {
 				PX4_DEBUG("Gripper has acknowledged, resume mission");
 				return true;
 
-			} else if (payload_deploy_elasped_time_s > _payload_deploy_timeout_s) {
+			} else if (now > _payload_deployed_time + (_payload_deploy_timeout_s * 1_s)) {
 				PX4_DEBUG("Gripper timed out, resume mission");
 				return true;
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -146,11 +146,11 @@ MissionBlock::is_mission_item_reached_or_completed()
 					1E-6f; // TODO: Add proper microseconds_to_seconds function
 
 			if (_payload_deploy_ack_successful) {
-				PX4_DEBUG("Winch Deploy Ack received! Resuming mission");
+				PX4_DEBUG("Winch has acknowledged, resume mission");
 				return true;
 
 			} else if (payload_deploy_elasped_time_s > _payload_deploy_timeout_s) {
-				PX4_DEBUG("Winch Deploy Timed out, resuming mission!");
+				PX4_DEBUG("Winch timed out, resume mission");
 				return true;
 
 			}
@@ -161,26 +161,25 @@ MissionBlock::is_mission_item_reached_or_completed()
 
 	case NAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW: {
 			const float gimbal_command_elasped_time_s = (now - _gimbal_command_time) * 1E-6f;
-			if (gimbal_command_elasped_time_s > _gimbal_wait_time) {
-				PX4_DEBUG("Waited %.2f seconds for the gimbal to reach the desired orientation, resuming mission!", (double) _gimbal_wait_time);
-				return true;
 
+			if (gimbal_command_elasped_time_s > _gimbal_wait_time) {
+				PX4_DEBUG("Gimbal aligned, resume mission");
+				return true;
 			}
 
 			// We are still waiting the desired delay for the gimbal
 			return false;
 		}
 
-
 	case NAV_CMD_DO_GRIPPER: {
 			const float payload_deploy_elasped_time_s = (now - _payload_deployed_time) * 1E-6f;
 
 			if (_payload_deploy_ack_successful) {
-				PX4_DEBUG("Gripper Deploy Ack received! Resuming mission");
+				PX4_DEBUG("Gripper has acknowledged, resume mission");
 				return true;
 
 			} else if (payload_deploy_elasped_time_s > _payload_deploy_timeout_s) {
-				PX4_DEBUG("Gripper Deploy Timed out, resuming mission!");
+				PX4_DEBUG("Gripper timed out, resume mission");
 				return true;
 
 			}
@@ -609,8 +608,7 @@ MissionBlock::issue_command(const mission_item_s &item)
 
 		// Register the Gimbal control command (NAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW) timestamp so to wait
 		// for the gimbal to reach the desired position
-		if (item.nav_cmd == NAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW)
-		{
+		if (item.nav_cmd == NAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW) {
 			_gimbal_command_time = hrt_absolute_time();
 		}
 

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -134,6 +134,19 @@ public:
 	}
 
 	/**
+	 * @brief Set the gimbal wait time
+	 *
+	 * Accessed in Navigator to set the appropriate time to wait for the gimbal to reach
+	 * the desired orientation before resuming the mission
+	 *
+	 * @param wait_time Wait time in seconds
+	 */
+	void set_gimbal_wait_time(const float wait_time)
+	{
+		_gimbal_wait_time = wait_time;
+	}
+
+	/**
 	 * Copies position from setpoint if valid, otherwise copies current position
 	 */
 	void copy_position_if_valid(struct mission_item_s *const mission_item,
@@ -251,6 +264,10 @@ protected:
 	bool _payload_deploy_ack_successful{false};	// Flag to keep track of whether we received an acknowledgement for a successful payload deployment
 	hrt_abstime _payload_deployed_time{0};		// Last payload deployment start time to handle timeouts
 	float _payload_deploy_timeout_s{0.0f};		// Timeout for payload deployment in Mission class, to prevent endless loop if successful deployment ack is never received
+
+	/* Gimbal commands time variables are used in case of NAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW to wait for the gimbal movement */
+	hrt_abstime _gimbal_command_time{0};		// Last gimbal command timestamp
+	float _gimbal_wait_time{0.0f};			// Time to wait for the gimbal to reach the desired configuration
 
 private:
 	void updateMaxHaglFailsafe();

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -108,43 +108,11 @@ public:
 	static bool item_contains_marker(const mission_item_s &item);
 
 	/**
-	 * @brief Set the payload deployment successful flag object
+	 * Set the item_has_timeout() command timeout
 	 *
-	 * Function is accessed in Navigator (navigator_main.cpp) to flag when a successful
-	 * payload deployment ack command has been received. Which in turn allows the mission item
-	 * to continue to the next in the 'is_mission_item_reached_or_completed' function below
+	 * @param timeout Timeout in seconds
 	 */
-	void set_payload_depolyment_successful_flag(bool payload_deploy_result)
-	{
-		_payload_deploy_ack_successful = payload_deploy_result;
-	}
-
-	/**
-	 * @brief Set the payload deployment timeout
-	 *
-	 * Accessed in Navigator to set the appropriate timeout to wait for while waiting for a successful
-	 * payload delivery acknowledgement. If the payload deployment takes longer than timeout, mission will
-	 * continue into the next item automatically.
-	 *
-	 * @param timeout_s Timeout in seconds
-	 */
-	void set_payload_deployment_timeout(const float timeout_s)
-	{
-		_payload_deploy_timeout_s = timeout_s;
-	}
-
-	/**
-	 * @brief Set the gimbal wait time
-	 *
-	 * Accessed in Navigator to set the appropriate time to wait for the gimbal to reach
-	 * the desired orientation before resuming the mission
-	 *
-	 * @param wait_time Wait time in seconds
-	 */
-	void set_gimbal_wait_time(const float wait_time)
-	{
-		_gimbal_wait_time = wait_time;
-	}
+	void set_command_timeout(const float timeout) { _command_timeout = timeout; }
 
 	/**
 	 * Copies position from setpoint if valid, otherwise copies current position
@@ -260,16 +228,10 @@ protected:
 
 	hrt_abstime _time_wp_reached{0};
 
-	/* Payload Deploy internal states are used by two NAV_CMDs: DO_WINCH and DO_GRIPPER */
-	bool _payload_deploy_ack_successful{false};	// Flag to keep track of whether we received an acknowledgement for a successful payload deployment
-	hrt_abstime _payload_deployed_time{0};		// Last payload deployment start time to handle timeouts
-	float _payload_deploy_timeout_s{0.0f};		// Timeout for payload deployment in Mission class, to prevent endless loop if successful deployment ack is never received
-
-	/* Gimbal commands time variables are used in case of NAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW to wait for the gimbal movement */
-	hrt_abstime _gimbal_command_time{0};		// Last gimbal command timestamp
-	float _gimbal_wait_time{0.0f};			// Time to wait for the gimbal to reach the desired configuration
+	// Mission items that have a timeout to allow the payload e.g. gripper, winch, gimbal executing the command see item_has_timeout()
+	hrt_abstime _timestamp_command_timeout{0}; ///< Timestamp when the current item_has_timeout() command was started
+	float _command_timeout{0.f}; ///< Time in seconds any item_has_timeout() command should be waited for before continuing the mission
 
 private:
 	void updateMaxHaglFailsafe();
-
 };

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -133,17 +133,6 @@ PARAM_DEFINE_FLOAT(MIS_YAW_TMT, -1.0f);
 PARAM_DEFINE_FLOAT(MIS_YAW_ERR, 12.0f);
 
 /**
- * Timeout for a successful payload deployment acknowledgement
- *
- * @unit s
- * @min 0
- * @decimal 1
- * @increment 1
- * @group Mission
- */
-PARAM_DEFINE_FLOAT(MIS_PD_TO, 5.0f);
-
-/**
  * Landing abort min altitude
  *
  * Minimum altitude above landing point that the vehicle will climb to after an aborted landing.
@@ -157,14 +146,19 @@ PARAM_DEFINE_FLOAT(MIS_PD_TO, 5.0f);
 PARAM_DEFINE_INT32(MIS_LND_ABRT_ALT, 30);
 
 /**
- * Time in seconds allowed for the gimbal to reach its commanded attitude before the mission resumes.
+ * Timeout to allow the payload to execute the mission command
  *
- * Time allocated for a gimbal command to execute within a mission before resuming.
- * This ensures the gimbal has reached the commanded orientation before beginning to take pictures.
+ * Ensure:
+ *   gripper: NAV_CMD_DO_GRIPPER
+ *     has released before continuing mission.
+ *   winch: CMD_DO_WINCH
+ *     has delivered before continuing mission.
+ *   gimbal: CMD_DO_GIMBAL_MANAGER_PITCHYAW
+ *     has reached the commanded orientation before beginning to take pictures.
  *
  * @unit s
  * @min 0
  * @decimal 1
  * @group Mission
  */
-PARAM_DEFINE_FLOAT(MIS_GIM_WAIT_T, 0.0f);
+PARAM_DEFINE_FLOAT(MIS_COMMAND_TOUT, 0.f);

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -155,3 +155,16 @@ PARAM_DEFINE_FLOAT(MIS_PD_TO, 5.0f);
  * @group Mission
  */
 PARAM_DEFINE_INT32(MIS_LND_ABRT_ALT, 30);
+
+/**
+ * Time in seconds allowed for the gimbal to reach its commanded attitude before the mission resumes.
+ *
+ * Time allocated for a gimbal command to execute within a mission before resuming.
+ * This ensures the gimbal has reached the commanded orientation before beginning to take pictures.
+ *
+ * @unit s
+ * @min 0
+ * @decimal 1
+ * @group Mission
+ */
+PARAM_DEFINE_FLOAT(MIS_GIM_WAIT_T, 0.0f);

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -424,10 +424,11 @@ private:
 		_param_nav_min_gnd_dist,	/**< minimum distance to ground (Mission and RTL)*/
 
 		// non-navigator parameters: Mission (MIS_*)
-		(ParamFloat<px4::params::MIS_TAKEOFF_ALT>) _param_mis_takeoff_alt,
-		(ParamFloat<px4::params::MIS_YAW_TMT>)     _param_mis_yaw_tmt,
-		(ParamFloat<px4::params::MIS_YAW_ERR>)     _param_mis_yaw_err,
-		(ParamFloat<px4::params::MIS_PD_TO>)       _param_mis_payload_delivery_timeout,
-		(ParamInt<px4::params::MIS_LND_ABRT_ALT>)  _param_mis_lnd_abrt_alt
+		(ParamFloat<px4::params::MIS_TAKEOFF_ALT>)    _param_mis_takeoff_alt,
+		(ParamFloat<px4::params::MIS_YAW_TMT>)        _param_mis_yaw_tmt,
+		(ParamFloat<px4::params::MIS_YAW_ERR>)        _param_mis_yaw_err,
+		(ParamFloat<px4::params::MIS_PD_TO>)          _param_mis_payload_delivery_timeout,
+		(ParamInt<px4::params::MIS_LND_ABRT_ALT>)     _param_mis_lnd_abrt_alt,
+		(ParamFloat<px4::params::MIS_GIM_WAIT_T>)  _param_mis_gimbal_wait_t
 	)
 };

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -427,8 +427,7 @@ private:
 		(ParamFloat<px4::params::MIS_TAKEOFF_ALT>)    _param_mis_takeoff_alt,
 		(ParamFloat<px4::params::MIS_YAW_TMT>)        _param_mis_yaw_tmt,
 		(ParamFloat<px4::params::MIS_YAW_ERR>)        _param_mis_yaw_err,
-		(ParamFloat<px4::params::MIS_PD_TO>)          _param_mis_payload_delivery_timeout,
 		(ParamInt<px4::params::MIS_LND_ABRT_ALT>)     _param_mis_lnd_abrt_alt,
-		(ParamFloat<px4::params::MIS_GIM_WAIT_T>)  _param_mis_gimbal_wait_t
+		(ParamFloat<px4::params::MIS_COMMAND_TOUT>) _param_mis_command_tout
 	)
 };

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -117,6 +117,7 @@ Navigator::Navigator() :
 
 	// Update the timeout used in mission_block (which can't hold it's own parameters)
 	_mission.set_payload_deployment_timeout(_param_mis_payload_delivery_timeout.get());
+	_mission.set_gimbal_wait_time(_param_mis_gimbal_wait_t.get());
 
 	_adsb_conflict.set_conflict_detection_params(_param_nav_traff_a_hor_ct.get(),
 			_param_nav_traff_a_ver.get(),
@@ -150,6 +151,8 @@ void Navigator::params_update()
 	}
 
 	_mission.set_payload_deployment_timeout(_param_mis_payload_delivery_timeout.get());
+	_mission.set_gimbal_wait_time(_param_mis_gimbal_wait_t.get());
+
 }
 
 void Navigator::run()

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -115,14 +115,6 @@ Navigator::Navigator() :
 	_distance_sensor_mode_change_request_pub.get().request_on_off = distance_sensor_mode_change_request_s::REQUEST_OFF;
 	_distance_sensor_mode_change_request_pub.update();
 
-	// Update the timeout used in mission_block (which can't hold it's own parameters)
-	_mission.set_payload_deployment_timeout(_param_mis_payload_delivery_timeout.get());
-	_mission.set_gimbal_wait_time(_param_mis_gimbal_wait_t.get());
-
-	_adsb_conflict.set_conflict_detection_params(_param_nav_traff_a_hor_ct.get(),
-			_param_nav_traff_a_ver.get(),
-			_param_nav_traff_collision_time.get(), _param_nav_traff_avoid.get());
-
 	reset_triplets();
 }
 
@@ -150,9 +142,10 @@ void Navigator::params_update()
 		param_get(_handle_mpc_acc_hor, &_param_mpc_acc_hor);
 	}
 
-	_mission.set_payload_deployment_timeout(_param_mis_payload_delivery_timeout.get());
-	_mission.set_gimbal_wait_time(_param_mis_gimbal_wait_t.get());
-
+	_mission.set_command_timeout(_param_mis_command_tout.get());
+	_adsb_conflict.set_conflict_detection_params(_param_nav_traff_a_hor_ct.get(),
+			_param_nav_traff_a_ver.get(),
+			_param_nav_traff_collision_time.get(), _param_nav_traff_avoid.get());
 }
 
 void Navigator::run()
@@ -1270,9 +1263,7 @@ void Navigator::run_fake_traffic()
 
 void Navigator::check_traffic()
 {
-
 	if (_traffic_sub.updated()) {
-
 		_traffic_sub.copy(&_adsb_conflict._transponder_report);
 
 		uint16_t required_flags = transponder_report_s::PX4_ADSB_FLAGS_VALID_COORDS |
@@ -1291,7 +1282,6 @@ void Navigator::check_traffic()
 	}
 
 	_adsb_conflict.remove_expired_conflicts();
-
 }
 
 bool Navigator::abort_landing()


### PR DESCRIPTION
### Solved Problem
In a mission with a move gimbal item followed by a take picture item, the picture is taken while the gimbal is still moving

### Solution
After a `CMD_DO_GIMBAL_MANAGER_PITCHYAW` wait for a timeout before resuming the mission to be sure that the gimbal reached the desired orientation. 
Since we already have `CMD_DO_WINCH` and `NAV_CMD_DO_GRIPPER` following a similar pattern, we defined a common timeout parameter (`MIS_COMMAND_TOUT`) for these 3 mission items. Furthermore, we unified the logic handling such mission items simplifying the navigator code.

### Changelog Entry
For release notes:
```
Removed parameter: MIS_PD_TO (substituted by MIS_COMMAND_TOUT)
New parameter: MIS_COMMAND_TOUT
```
### Test coverage
- SITL testing
