### PR TITLE
control_allocator: Added linearization feature for 4 servo swash plates to prevent binding

### DIFF
--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
@@ -105,16 +105,17 @@ void ActuatorEffectivenessHelicopter::updateParams()
 	float max_servo_throw_deg = 0.f;
 	param_get(_param_handles.max_servo_throw, &max_servo_throw_deg);
 
-	if (max_servo_throw_deg > 0.f){
+	if (max_servo_throw_deg > 0.f) {
 		//linearization feature enabled
 		const float max_servo_throw = math::radians(max_servo_throw_deg);
 		_geometry.max_servo_height = sinf(max_servo_throw);
 		_geometry.inverse_max_servo_throw = 1.f / max_servo_throw;
 		_geometry.linearize_servos = 1;
+
 	}  else {
 		// handle any undefined behaviour if disabled
-    		_geometry.max_servo_height = 0.f;
-    		_geometry.inverse_max_servo_throw = 0.f;
+		_geometry.max_servo_height = 0.f;
+		_geometry.inverse_max_servo_throw = 0.f;
 		_geometry.linearize_servos = 0;
 	}
 }

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
@@ -106,11 +106,11 @@ void ActuatorEffectivenessHelicopter::updateParams()
 	int32_t linearize_servos = 0;
 	param_get(_param_handles.linearize_servos, &linearize_servos);
 	_geometry.linearize_servos = (linearize_servos != 0);
-	float max_sevo_throw = 0.f;
-	param_get(_param_handles.max_sevo_throw, &max_sevo_throw);
-	max_sevo_throw *=  M_PI_F / 180.0f;  //converting deg to rad
-	_geometry.max_sevo_height = sinf(max_sevo_throw);
-	_geometry.inverse_max_servo_throw = 1/max_sevo_throw;
+	float max_servo_throw_deg = 0.f;
+	param_get(_param_handles.max_servo_throw, &max_servo_throw_deg);
+	const float max_servo_throw = math::radians(max_servo_throw)
+	_geometry.max_servo_height = sinf(max_servo_throw);
+	_geometry.inverse_max_servo_throw = 1.f / max_servo_throw;
 }
 
 bool ActuatorEffectivenessHelicopter::getEffectivenessMatrix(Configuration &configuration,
@@ -197,13 +197,12 @@ void ActuatorEffectivenessHelicopter::updateSetpoint(const matrix::Vector<float,
 
 float ActuatorEffectivenessHelicopter::getLinearServoOutput(float input) const
 {
-
 	input = math::constrain(input, -1.0f, 1.0f);
 
 	//servo output is calculated by normalizing input to arm rotation of CA_MAX_SVO_THROW degrees as full input for a linear throw
 	float svo_height = _geometry.max_sevo_height * input;
 
-	if (std::isnan(svo_height)) {
+	if (!PX4_ISFINITE(svo_height)) {
 		svo_height = 0.0f;
 	}
 

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
@@ -108,7 +108,7 @@ void ActuatorEffectivenessHelicopter::updateParams()
 	_geometry.linearize_servos = (linearize_servos != 0);
 	float max_servo_throw_deg = 0.f;
 	param_get(_param_handles.max_servo_throw, &max_servo_throw_deg);
-	const float max_servo_throw = math::radians(max_servo_throw);
+	const float max_servo_throw = math::radians(max_servo_throw_deg);
 	_geometry.max_servo_height = sinf(max_servo_throw);
 	_geometry.inverse_max_servo_throw = 1.f / max_servo_throw;
 }

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
@@ -65,6 +65,8 @@ ActuatorEffectivenessHelicopter::ActuatorEffectivenessHelicopter(ModuleParams *p
 	_param_handles.yaw_throttle_scale = param_find("CA_HELI_YAW_TH_S");
 	_param_handles.yaw_ccw = param_find("CA_HELI_YAW_CCW");
 	_param_handles.spoolup_time = param_find("COM_SPOOLUP_TIME");
+	_param_handles.linearize_servos = param_find("CA_LIN_SERVO");
+	_param_handles.max_sevo_throw = param_find("CA_MAX_SVO_THROW");
 
 	updateParams();
 }
@@ -101,6 +103,14 @@ void ActuatorEffectivenessHelicopter::updateParams()
 	int32_t yaw_ccw = 0;
 	param_get(_param_handles.yaw_ccw, &yaw_ccw);
 	_geometry.yaw_sign = (yaw_ccw == 1) ? -1.f : 1.f;
+	int32_t linearize_servos = 0;
+	param_get(_param_handles.linearize_servos, &linearize_servos);
+	_geometry.linearize_servos = (linearize_servos != 0);
+	float max_sevo_throw = 0.f;
+	param_get(_param_handles.max_sevo_throw, &max_sevo_throw);
+	max_sevo_throw *=  M_PI_F / 180.0f;  //converting deg to rad
+	_geometry.max_sevo_height = sinf(max_sevo_throw);
+	_geometry.inverse_max_servo_throw = 1/max_sevo_throw;
 }
 
 bool ActuatorEffectivenessHelicopter::getEffectivenessMatrix(Configuration &configuration,
@@ -168,6 +178,11 @@ void ActuatorEffectivenessHelicopter::updateSetpoint(const matrix::Vector<float,
 				- control_sp(ControlAxis::ROLL) * roll_coeff
 				+ _geometry.swash_plate_servos[i].trim;
 
+		// Apply linearzsation to the actuator setpoint if enabled
+		if (_geometry.linearize_servos) {
+		actuator_sp(_first_swash_plate_servo_index + i) = getLinearServoOutput(actuator_sp(_first_swash_plate_servo_index + i));
+		}
+
 		// Saturation check for roll & pitch
 		if (actuator_sp(_first_swash_plate_servo_index + i) < actuator_min(_first_swash_plate_servo_index + i)) {
 			setSaturationFlag(roll_coeff, _saturation_flags.roll_pos, _saturation_flags.roll_neg);
@@ -178,6 +193,22 @@ void ActuatorEffectivenessHelicopter::updateSetpoint(const matrix::Vector<float,
 			setSaturationFlag(pitch_coeff, _saturation_flags.pitch_pos, _saturation_flags.pitch_neg);
 		}
 	}
+}
+
+float ActuatorEffectivenessHelicopter::getLinearServoOutput(float input) const
+{
+
+	input = math::constrain(input, -1.0f, 1.0f);
+
+	//servo output is calculated by normalizing input to arm rotation of CA_MAX_SVO_THROW degrees as full input for a linear throw
+	float svo_height = _geometry.max_sevo_height * input;
+
+	if (std::isnan(svo_height)) {
+		svo_height = 0.0f;
+	}
+
+	// mulitply by 1 over max arm roation in radians to normalise
+	return _geometry.inverse_max_servo_throw * asinf(svo_height);
 }
 
 bool ActuatorEffectivenessHelicopter::mainMotorEnaged()

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
@@ -108,7 +108,7 @@ void ActuatorEffectivenessHelicopter::updateParams()
 	_geometry.linearize_servos = (linearize_servos != 0);
 	float max_servo_throw_deg = 0.f;
 	param_get(_param_handles.max_servo_throw, &max_servo_throw_deg);
-	const float max_servo_throw = math::radians(max_servo_throw)
+	const float max_servo_throw = math::radians(max_servo_throw);
 	_geometry.max_servo_height = sinf(max_servo_throw);
 	_geometry.inverse_max_servo_throw = 1.f / max_servo_throw;
 }

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
@@ -65,7 +65,6 @@ ActuatorEffectivenessHelicopter::ActuatorEffectivenessHelicopter(ModuleParams *p
 	_param_handles.yaw_throttle_scale = param_find("CA_HELI_YAW_TH_S");
 	_param_handles.yaw_ccw = param_find("CA_HELI_YAW_CCW");
 	_param_handles.spoolup_time = param_find("COM_SPOOLUP_TIME");
-	_param_handles.linearize_servos = param_find("CA_LIN_SERVO");
 	_param_handles.max_servo_throw = param_find("CA_MAX_SVO_THROW");
 
 	updateParams();
@@ -103,14 +102,20 @@ void ActuatorEffectivenessHelicopter::updateParams()
 	int32_t yaw_ccw = 0;
 	param_get(_param_handles.yaw_ccw, &yaw_ccw);
 	_geometry.yaw_sign = (yaw_ccw == 1) ? -1.f : 1.f;
-	int32_t linearize_servos = 0;
-	param_get(_param_handles.linearize_servos, &linearize_servos);
-	_geometry.linearize_servos = (linearize_servos != 0);
 	float max_servo_throw_deg = 0.f;
 	param_get(_param_handles.max_servo_throw, &max_servo_throw_deg);
-	const float max_servo_throw = math::radians(max_servo_throw_deg);
-	_geometry.max_servo_height = sinf(max_servo_throw);
-	_geometry.inverse_max_servo_throw = 1.f / max_servo_throw;
+
+	if (max_servo_throw_deg > 0.f){
+		const float max_servo_throw = math::radians(max_servo_throw_deg);
+		_geometry.max_servo_height = sinf(max_servo_throw);
+		_geometry.inverse_max_servo_throw = 1.f / max_servo_throw;
+		_geometry.linearize_servos = 1;
+	}  else {
+		// handle any undefined behaviour
+    		_geometry.max_servo_height = 0.f;
+    		_geometry.inverse_max_servo_throw = 0.f;
+		_geometry.linearize_servos = 0;
+	}
 }
 
 bool ActuatorEffectivenessHelicopter::getEffectivenessMatrix(Configuration &configuration,

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
@@ -106,12 +106,13 @@ void ActuatorEffectivenessHelicopter::updateParams()
 	param_get(_param_handles.max_servo_throw, &max_servo_throw_deg);
 
 	if (max_servo_throw_deg > 0.f){
+		//linearization feature enabled
 		const float max_servo_throw = math::radians(max_servo_throw_deg);
 		_geometry.max_servo_height = sinf(max_servo_throw);
 		_geometry.inverse_max_servo_throw = 1.f / max_servo_throw;
 		_geometry.linearize_servos = 1;
 	}  else {
-		// handle any undefined behaviour
+		// handle any undefined behaviour if disabled
     		_geometry.max_servo_height = 0.f;
     		_geometry.inverse_max_servo_throw = 0.f;
 		_geometry.linearize_servos = 0;
@@ -183,7 +184,7 @@ void ActuatorEffectivenessHelicopter::updateSetpoint(const matrix::Vector<float,
 				- control_sp(ControlAxis::ROLL) * roll_coeff
 				+ _geometry.swash_plate_servos[i].trim;
 
-		// Apply linearzsation to the actuator setpoint if enabled
+		// Apply linearization to the actuator setpoint if enabled
 		if (_geometry.linearize_servos) {
 			actuator_sp(_first_swash_plate_servo_index + i) = getLinearServoOutput(actuator_sp(_first_swash_plate_servo_index + i));
 		}

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
@@ -208,10 +208,6 @@ float ActuatorEffectivenessHelicopter::getLinearServoOutput(float input) const
 	// make sure a the maximal input of [-1,1] maps to the maximal vertical deflection the servo can reach of sin(CA_MAX_SVO_THROW)
 	float servo_height = _geometry.max_servo_height * input;
 
-	if (!PX4_ISFINITE(servo_height)) {
-		servo_height = 0.f;
-	}
-
 	// mulitply by 1 over max arm roation in radians to normalise
 	return _geometry.inverse_max_servo_throw * asinf(servo_height);
 }

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
@@ -66,7 +66,7 @@ ActuatorEffectivenessHelicopter::ActuatorEffectivenessHelicopter(ModuleParams *p
 	_param_handles.yaw_ccw = param_find("CA_HELI_YAW_CCW");
 	_param_handles.spoolup_time = param_find("COM_SPOOLUP_TIME");
 	_param_handles.linearize_servos = param_find("CA_LIN_SERVO");
-	_param_handles.max_sevo_throw = param_find("CA_MAX_SVO_THROW");
+	_param_handles.max_servo_throw = param_find("CA_MAX_SVO_THROW");
 
 	updateParams();
 }
@@ -200,7 +200,7 @@ float ActuatorEffectivenessHelicopter::getLinearServoOutput(float input) const
 	input = math::constrain(input, -1.0f, 1.0f);
 
 	//servo output is calculated by normalizing input to arm rotation of CA_MAX_SVO_THROW degrees as full input for a linear throw
-	float svo_height = _geometry.max_sevo_height * input;
+	float svo_height = _geometry.max_servo_height * input;
 
 	if (!PX4_ISFINITE(svo_height)) {
 		svo_height = 0.0f;

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
@@ -180,7 +180,7 @@ void ActuatorEffectivenessHelicopter::updateSetpoint(const matrix::Vector<float,
 
 		// Apply linearzsation to the actuator setpoint if enabled
 		if (_geometry.linearize_servos) {
-		actuator_sp(_first_swash_plate_servo_index + i) = getLinearServoOutput(actuator_sp(_first_swash_plate_servo_index + i));
+			actuator_sp(_first_swash_plate_servo_index + i) = getLinearServoOutput(actuator_sp(_first_swash_plate_servo_index + i));
 		}
 
 		// Saturation check for roll & pitch

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.hpp
@@ -122,7 +122,6 @@ private:
 		param_t spoolup_time;
 		param_t linearize_servos;
 		param_t max_servo_throw;
-		param_t inverse_max_servo_throw;
 	};
 	ParamHandles _param_handles{};
 

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.hpp
@@ -120,7 +120,6 @@ private:
 		param_t yaw_throttle_scale;
 		param_t yaw_ccw;
 		param_t spoolup_time;
-		param_t linearize_servos;
 		param_t max_servo_throw;
 	};
 	ParamHandles _param_handles{};

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.hpp
@@ -67,7 +67,7 @@ public:
 		float yaw_sign;
 		float spoolup_time;
 		int linearize_servos;
-		float max_sevo_height;
+		float max_servo_height;
 		float inverse_max_servo_throw;
 	};
 
@@ -121,7 +121,7 @@ private:
 		param_t yaw_ccw;
 		param_t spoolup_time;
 		param_t linearize_servos;
-		param_t max_sevo_throw;
+		param_t max_servo_throw;
 		param_t inverse_max_servo_throw;
 	};
 	ParamHandles _param_handles{};

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.hpp
@@ -66,6 +66,9 @@ public:
 		float yaw_throttle_scale;
 		float yaw_sign;
 		float spoolup_time;
+		int linearize_servos;
+		float max_sevo_height;
+		float inverse_max_servo_throw;
 	};
 
 	ActuatorEffectivenessHelicopter(ModuleParams *parent, ActuatorType tail_actuator_type);
@@ -86,6 +89,7 @@ public:
 private:
 	float throttleSpoolupProgress();
 	bool mainMotorEnaged();
+	float getLinearServoOutput(float input) const;
 
 	void updateParams() override;
 
@@ -116,6 +120,9 @@ private:
 		param_t yaw_throttle_scale;
 		param_t yaw_ccw;
 		param_t spoolup_time;
+		param_t linearize_servos;
+		param_t max_sevo_throw;
+		param_t inverse_max_servo_throw;
 	};
 	ParamHandles _param_handles{};
 

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -566,11 +566,13 @@ parameters:
           default: 0.0
         CA_MAX_SVO_THROW:
           description:
-            short:  Defines max/min throw of servo for linearization
+            short: Throw angle of swashplate servo at maximum commands for linearization
             long: |
-              Defines min/max throw of servo. Used to linearize mechanical output of servo attached to a 4-servo swashplate. Setting to zero disables feature.
+              Used to linearize mechanical output of swashplate servos to avoid axis coupling and binding with 4 servo redundancy.
+              This requires a symmetric setup where the servo horn is exactly centered with a 0 command.
+              Setting to zero disables feature.
           type: float
-          decimal: 3
+          decimal: 1
           unit: deg
           increment: 0.1
           min: 0

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -575,7 +575,7 @@ parameters:
           description:
             short: Defines max/min throw of servo.
             long: |
-              Defines max/min throw of servo when linearizing servo output. Only used when CA_LIN_SERVO is enabled.
+              Defines min/max throw of servo when linearizing servo output. Only used when CA_LIN_SERVO is enabled.
           type: float
           decimal: 3
           unit: deg
@@ -1147,9 +1147,9 @@ mixer:
                         name: CA_HELI_YAW_CCW
                       - label: 'Throttle spoolup time'
                         name: COM_SPOOLUP_TIME
-                      - label: 'linearize servos'
+                      - label: 'Linearize servos'
                         name: CA_LIN_SERVO
-                      - label: 'max/min throw of servo in degrees'
+                      - label: 'Min/max servo throw in degrees'
                         name: CA_MAX_SVO_THROW
 
             11: # Helicopter (tail Servo)
@@ -1180,9 +1180,9 @@ mixer:
                       name: CA_HELI_YAW_CCW
                     - label: 'Throttle spoolup time'
                       name: COM_SPOOLUP_TIME
-                    - label: 'linearize servos'
+                    - label: 'Linearize servos'
                       name: CA_LIN_SERVO
-                    - label: 'max/min throw of servo in degrees'
+                    - label: 'Min/max servo throw in degrees'
                       name: CA_MAX_SVO_THROW
 
 

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -566,7 +566,7 @@ parameters:
           default: 0.0
         CA_MAX_SVO_THROW:
           description:
-            short:  Defines max/min throw of servo for linearization. Set to zero to disable.
+            short:  Defines max/min throw of servo for linearization
             long: |
               Defines min/max throw of servo. Used to linearize mechanical output of servo attached to a 4-servo swashplate. Setting to zero disables feature.
           type: float

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -1185,7 +1185,6 @@ mixer:
                     - label: 'Min/max servo throw in degrees'
                       name: CA_MAX_SVO_THROW
 
-
             12: # Helicopter (Coaxial)
                 actuators:
                   - actuator_type: 'motor'

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -568,7 +568,7 @@ parameters:
           description:
             short: linearize servo output
             long: |
-              This linearizes the swashplate servo's mechanical output to account for nonlinear output due to arm rotation. Should only be necessary with specific swashplate setups using 4 servos and requires specific setup to work properly. The servo arm must be centered on the mechanical throw at the servo trim position and the servo trim position kept as close to 1500 as possible. If the spline on the servo control horn is not allowing you to get the servo arm perpendicular to the shaft, the use the servo trim parameters to make them perpendicular to the shaft. Leveling the swashplate can only be done using the linkages. set your linkages so that the swashplate in its mid position will give you required collective for hover.
+              Linearize the servo's mechanical output attached to a 4-servos swashplate. Requires setting the servo range of motion using CA_MAX_SVO_THROW.
           type: boolean
           default: 0
         CA_MAX_SVO_THROW:

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -1140,8 +1140,6 @@ mixer:
                         name: CA_HELI_YAW_CCW
                       - label: 'Throttle spoolup time'
                         name: COM_SPOOLUP_TIME
-                      - label: 'Min/max servo throw in degrees'
-                        name: CA_MAX_SVO_THROW
 
             11: # Helicopter (tail Servo)
               actuators:
@@ -1171,8 +1169,6 @@ mixer:
                       name: CA_HELI_YAW_CCW
                     - label: 'Throttle spoolup time'
                       name: COM_SPOOLUP_TIME
-                    - label: 'Min/max servo throw in degrees'
-                      name: CA_MAX_SVO_THROW
 
             12: # Helicopter (Coaxial)
                 actuators:

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -564,25 +564,18 @@ parameters:
           min: 0
           max: 10
           default: 0.0
-        CA_LIN_SERVO:
-          description:
-            short: linearize servo output
-            long: |
-              Linearize the servo's mechanical output attached to a 4-servos swashplate. Requires setting the servo range of motion using CA_MAX_SVO_THROW.
-          type: boolean
-          default: 0
         CA_MAX_SVO_THROW:
           description:
-            short: Defines max/min throw of servo.
+            short:  Defines max/min throw of servo for linearization. Set to zero to disable.
             long: |
-              Defines min/max throw of servo when linearizing servo output. Only used when CA_LIN_SERVO is enabled.
+              Defines min/max throw of servo. Used to linearize mechanical output of servo attached to a 4-servo swashplate. Setting to zero to disables feature.
           type: float
           decimal: 3
           unit: deg
           increment: 0.1
-          min: 5
+          min: 0
           max: 75
-          default: 50.0
+          default: 0.0
 
         # Others
         CA_FAILURE_MODE:
@@ -1147,8 +1140,6 @@ mixer:
                         name: CA_HELI_YAW_CCW
                       - label: 'Throttle spoolup time'
                         name: COM_SPOOLUP_TIME
-                      - label: 'Linearize servos'
-                        name: CA_LIN_SERVO
                       - label: 'Min/max servo throw in degrees'
                         name: CA_MAX_SVO_THROW
 
@@ -1180,8 +1171,6 @@ mixer:
                       name: CA_HELI_YAW_CCW
                     - label: 'Throttle spoolup time'
                       name: COM_SPOOLUP_TIME
-                    - label: 'Linearize servos'
-                      name: CA_LIN_SERVO
                     - label: 'Min/max servo throw in degrees'
                       name: CA_MAX_SVO_THROW
 

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -568,7 +568,7 @@ parameters:
           description:
             short:  Defines max/min throw of servo for linearization. Set to zero to disable.
             long: |
-              Defines min/max throw of servo. Used to linearize mechanical output of servo attached to a 4-servo swashplate. Setting to zero to disables feature.
+              Defines min/max throw of servo. Used to linearize mechanical output of servo attached to a 4-servo swashplate. Setting to zero disables feature.
           type: float
           decimal: 3
           unit: deg

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -564,6 +564,25 @@ parameters:
           min: 0
           max: 10
           default: 0.0
+        CA_LIN_SERVO:
+          description:
+            short: linearize servo output
+            long: |
+              This linearizes the swashplate servo's mechanical output to account for nonlinear output due to arm rotation. Should only be necessary with specific swashplate setups using 4 servos and requires specific setup to work properly. The servo arm must be centered on the mechanical throw at the servo trim position and the servo trim position kept as close to 1500 as possible. If the spline on the servo control horn is not allowing you to get the servo arm perpendicular to the shaft, the use the servo trim parameters to make them perpendicular to the shaft. Leveling the swashplate can only be done using the linkages. set your linkages so that the swashplate in its mid position will give you required collective for hover.
+          type: boolean
+          default: 0
+        CA_MAX_SVO_THROW:
+          description:
+            short: Defines max/min throw of servo.
+            long: |
+              Defines max/min throw of servo when linearizing servo output. Only used when CA_LIN_SERVO is enabled.
+          type: float
+          decimal: 3
+          unit: deg
+          increment: 0.1
+          min: 5
+          max: 75
+          default: 50.0
 
         # Others
         CA_FAILURE_MODE:
@@ -1128,6 +1147,10 @@ mixer:
                         name: CA_HELI_YAW_CCW
                       - label: 'Throttle spoolup time'
                         name: COM_SPOOLUP_TIME
+                      - label: 'linearize servos'
+                        name: CA_LIN_SERVO
+                      - label: 'max/min throw of servo in degrees'
+                        name: CA_MAX_SVO_THROW
 
             11: # Helicopter (tail Servo)
               actuators:
@@ -1157,6 +1180,11 @@ mixer:
                       name: CA_HELI_YAW_CCW
                     - label: 'Throttle spoolup time'
                       name: COM_SPOOLUP_TIME
+                    - label: 'linearize servos'
+                      name: CA_LIN_SERVO
+                    - label: 'max/min throw of servo in degrees'
+                      name: CA_MAX_SVO_THROW
+
 
             12: # Helicopter (Coaxial)
                 actuators:


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When using a 4 servo swash plate, non-linearity due to the rotation of the servo arm can cause servo misalignment and binding, particularly at high collective + cyclic inputs. This results in higher loads on servos.

### Solution
Add 2 parameters, `CA_LIN_SERVO` and `CA_MAX_SVO_THROW`, to account for the nonlinear output due to servo-arm rotation.

 `CA_LIN_SERVO`: Enables the feature.
`CA_MAX_SVO_THROW`: Allows you to define the maximum throw of the servos in degrees. Set to 50 degrees by default.

The feature works as follows:
- Calculate the max linear movement of a servo arm of unit length based on the max servo throw. This corresponds to a PWM value of 1000/2000 (max/min control input). 
- Calculate the servo arm angle required to achieve desired linear output with arcsin(max_servo_height * input) (input is requested from the controller).
- The arm angle is normalized by dividing it by `CA_MAX_SVO_THROW` (in radians)

This feature was implemented in Ardupilot a while ago. I have used the same logic and added a parameter to adjust the max servo throw. The following links provide further information.
- **https://discuss.ardupilot.org/t/linearizing-servo-mechanical-output/28074/8**
- https://discuss.ardupilot.org/t/four-servo-swashplate-support/37936/13
- https://ardupilot.org/copter/docs/traditional-helicopter-swashplate-setup.html#leveling-swashplate-using-linearize-servo-feature

This requires a specific setup to work correctly. It assumes that the servo is centered on its physical throw and the swash plate in its mid position will give hover collective. The above links provide more detail about this.


### Test coverage
- Tested on a skynode (v5x) with a 4-servo swash plate
- Disconnected one of the 4 linkages from the swash plate.
- Commanded max collective/cyclic with `CA_LIN_SERVO` disabled and observed poor alignment of disconnected linkage and swash plate.
![Image (5)](https://github.com/user-attachments/assets/29f2cc8e-ce15-4658-b495-a6f8906639e1)

- Commanded max collective/cyclic with `CA_LIN_SERVO` enabled and observed improvement in alignment between disconnected linkage and swash plate.
![Image (6)](https://github.com/user-attachments/assets/09b82068-fc40-4200-92cd-bc07710b405e)

