### PR TITLE
hkust_nxt-dual: fix ADC_BATTERY_CURRENT channel mismatch

### DIFF
--- a/boards/hkust/nxt-dual/src/board_config.h
+++ b/boards/hkust/nxt-dual/src/board_config.h
@@ -95,7 +95,7 @@
 /* Define GPIO pins used as ADC N.B. Channel numbers must match below  */
 /* Define Channel numbers must match above GPIO pin IN(n)*/
 #define ADC_BATTERY_VOLTAGE_CHANNEL             ADC12_CH(4)
-#define ADC_BATTERY_CURRENT_CHANNEL             ADC12_CH(5)
+#define ADC_BATTERY_CURRENT_CHANNEL             ADC12_CH(8)
 
 #define ADC_CHANNELS \
 	((1 << ADC_BATTERY_VOLTAGE_CHANNEL) | \


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Fix HKUST_NXT dual version ADC channel mismatch with the hardware design.

### Solution
Change ADC_BATTERY_CURRENT_CHANNEL from 5 to 8
