### PR TITLE
PX4Magnetometer.cpp: Workaround for sensors not initializing with all the magnetometers

### DIFF
--- a/src/lib/drivers/magnetometer/PX4Magnetometer.cpp
+++ b/src/lib/drivers/magnetometer/PX4Magnetometer.cpp
@@ -40,6 +40,17 @@ PX4Magnetometer::PX4Magnetometer(uint32_t device_id, enum Rotation rotation) :
 	_device_id{device_id},
 	_rotation{rotation}
 {
+	// Publish initial 0 data just for the sensors module to find
+	// this device, in case "sensors" module start up before initialization
+	// of the magnetometer is not fully complete
+
+	// This workaround also forces the magnetometer numbering to follow
+	// the driver start order, by creating the uORB already
+	// when the driver is created
+
+	sensor_mag_s report = {};
+	report.device_id = _device_id;
+	_sensor_pub.publish(report);
 }
 
 PX4Magnetometer::~PX4Magnetometer()


### PR DESCRIPTION
This PR is a workaround for two issues I am having with the magnetometers. I am running still on 1.14.3, and I tried to study if there are related fixes in 1.15, but didn't find any. So I am offering this one to upstream as well.

If there are better ways to fix these issues, or if they are somehow fixed already and I missed it, please let me know / reject this PR.

So, I am having 2 issues with magnetometers using the following setup:

2 magnetometers in the drone, one internal (bmm350) and one external (ist8310). BMM350 is started first in the rc scripts, ist8310 is started second.

**1st issue:**

The magnetometers get initialized with state machines running in a work queue, and the initializing RC script runs in parallel to the work queue. On a slightly faster FMU, the ist8310 magnetometer (started second in the rc script) manages to advertise it's uORB before the bmm350. So on this HW the external mag becomes "MAG_0", while on the slightly slower FMU the bmm350 (which was started first by the RC script) manages to advertise it's uORB first, so on that HW the internal mag becomes "MAG_0". With a very bad luck, the numbering becomes *random*, that is, it varies from boot to boot which one is 0 and which one is 1. This breaks many things (like calibration) and confuses people.

**2nd issue**

On a certain drone chassis I want to disable the internal magnetometer. I am doing that by setting parameter "CAL_MAG0_PRIO" to 0 ( now assuming that it happens to be 0, considering the first issue above ).

Now, RC script is still running in parallel with the work queues running the magnetometer initialization. It may happen that the "sensors" module gets started by the RC script before my "MAG_1" publishes it's first data. For some reason, the sensors module is not taking the newly appearing magnetometer into account any more.

** workaround for the issues above **

This patch publishes some initial "0" data right at the time of constructing the magnetometer driver. If the probing of the sensor fails, the orb gets anyhow unadvertised, so there is no extra sensor data lying around in the case the magnetometer is not present.

This also forces the magnetometer numbering to follow the startup order; without advertising the data the orb numbering depends on magnetometer initialization sequence - a magnetometer started later in the init scripts may publish it's first data before some other mag, which was started earlier. This is especially problematic when using the same scripts on different HW platforms which run on different speeds.
