### PR TITLE
commander: ensure health report is always sent out before failsafe notificaation

### DIFF
--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -200,6 +200,9 @@ private:
 
 	void modeManagementUpdate();
 
+	static void onFailsafeNotifyUserTrampoline(void *arg);
+	void onFailsafeNotifyUser();
+
 	enum class PrearmedMode {
 		DISABLED = 0,
 		SAFETY_BUTTON = 1,

--- a/src/modules/commander/HealthAndArmingChecks/Common.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/Common.cpp
@@ -219,7 +219,7 @@ bool Report::finalize()
 	return _results_changed;
 }
 
-bool Report::report(bool is_armed, bool force)
+bool Report::report(bool force)
 {
 	const hrt_abstime now = hrt_absolute_time();
 	const bool has_difference = _had_unreported_difference || _results_changed;
@@ -318,10 +318,10 @@ bool Report::report(bool is_armed, bool force)
 	return true;
 }
 
-bool Report::reportIfUnreportedDifferences(bool is_armed)
+bool Report::reportIfUnreportedDifferences()
 {
 	if (_had_unreported_difference) {
-		return report(is_armed, true);
+		return report(true);
 	}
 
 	return false;

--- a/src/modules/commander/HealthAndArmingChecks/Common.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/Common.cpp
@@ -317,3 +317,12 @@ bool Report::report(bool is_armed, bool force)
 			       current_results.health.error, current_results.health.warning);
 	return true;
 }
+
+bool Report::reportIfUnreportedDifferences(bool is_armed)
+{
+	if (_had_unreported_difference) {
+		return report(is_armed, true);
+	}
+
+	return false;
+}

--- a/src/modules/commander/HealthAndArmingChecks/Common.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/Common.hpp
@@ -339,6 +339,11 @@ private:
 
 	bool report(bool is_armed, bool force);
 
+	/**
+	 * Send out any unreported changes if there are any
+	 */
+	bool reportIfUnreportedDifferences(bool is_armed);
+
 	const hrt_abstime _min_reporting_interval;
 
 	/// event buffer: stores current events + arguments.

--- a/src/modules/commander/HealthAndArmingChecks/Common.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/Common.hpp
@@ -337,12 +337,12 @@ private:
 	 */
 	bool finalize();
 
-	bool report(bool is_armed, bool force);
+	bool report(bool force);
 
 	/**
 	 * Send out any unreported changes if there are any
 	 */
-	bool reportIfUnreportedDifferences(bool is_armed);
+	bool reportIfUnreportedDifferences();
 
 	const hrt_abstime _min_reporting_interval;
 

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.cpp
@@ -67,7 +67,7 @@ bool HealthAndArmingChecks::update(bool force_reporting, bool is_arming_request)
 	}
 
 	const bool results_changed = _reporter.finalize();
-	const bool reported = _reporter.report(_context.isArmed(), force_reporting);
+	const bool reported = _reporter.report(force_reporting);
 
 	if (reported) {
 
@@ -89,7 +89,7 @@ bool HealthAndArmingChecks::update(bool force_reporting, bool is_arming_request)
 		}
 
 		_reporter.finalize();
-		_reporter.report(_context.isArmed(), false);
+		_reporter.report(false);
 		_reporter._mavlink_log_pub = nullptr;
 		// LEGACY end
 
@@ -123,5 +123,5 @@ void HealthAndArmingChecks::updateParams()
 
 bool HealthAndArmingChecks::reportIfUnreportedDifferences()
 {
-	return _reporter.reportIfUnreportedDifferences(_context.isArmed());
+	return _reporter.reportIfUnreportedDifferences();
 }

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.cpp
@@ -120,3 +120,8 @@ void HealthAndArmingChecks::updateParams()
 		_checks[i]->updateParams();
 	}
 }
+
+bool HealthAndArmingChecks::reportIfUnreportedDifferences()
+{
+	return _reporter.reportIfUnreportedDifferences(_context.isArmed());
+}

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
@@ -88,6 +88,8 @@ public:
 	 */
 	bool update(bool force_reporting = false, bool is_arming_request = false);
 
+	bool reportIfUnreportedDifferences();
+
 	/**
 	 * Whether arming is possible for a given navigation mode
 	 */

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecksTest.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecksTest.cpp
@@ -69,7 +69,7 @@ TEST_F(ReporterTest, basic_no_checks)
 
 	reporter.reset();
 	reporter.finalize();
-	reporter.report(false, false);
+	reporter.report(false);
 
 	ASSERT_TRUE(reporter.canArm(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION));
 	ASSERT_EQ((uint8_t)reporter.armingCheckResults().can_arm, 0xff);
@@ -92,7 +92,7 @@ TEST_F(ReporterTest, basic_fail_all_modes)
 		reporter.armingCheckFailure(NavModes::All, health_component_t::remote_control,
 					    events::ID("arming_test_basic_fail_all_modes_fail1"), events::Log::Info, "");
 		reporter.finalize();
-		reporter.report(false, false);
+		reporter.report(false);
 
 		ASSERT_FALSE(reporter.canArm(nav_state));
 		ASSERT_TRUE(reporter.canRun(nav_state));
@@ -113,7 +113,7 @@ TEST_F(ReporterTest, arming_checks_mode_category)
 			       events::ID("arming_test_arming_checks_mode_category_fail2"), events::Log::Info, "");
 	reporter.setIsPresent(health_component_t::battery);
 	reporter.finalize();
-	reporter.report(false, false);
+	reporter.report(false);
 
 	ASSERT_TRUE(reporter.canArm(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION));
 	ASSERT_TRUE(reporter.canRun(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION));
@@ -138,7 +138,7 @@ TEST_F(ReporterTest, arming_checks_mode_category2)
 	reporter.healthFailure(NavModes::Mission, health_component_t::remote_control,
 			       events::ID("arming_test_arming_checks_mode_category2_fail1"), events::Log::Warning, "");
 	reporter.finalize();
-	reporter.report(false, false);
+	reporter.report(false);
 
 	ASSERT_FALSE(reporter.canArm(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION));
 
@@ -178,7 +178,7 @@ TEST_F(ReporterTest, reporting)
 			}
 
 			reporter.finalize();
-			reporter.report(false, false);
+			reporter.report(false);
 			ASSERT_FALSE(reporter.canArm(vehicle_status_s::NAVIGATION_STATE_POSCTL));
 
 			if (i == 0) {
@@ -219,7 +219,7 @@ TEST_F(ReporterTest, reporting)
 			}
 
 			reporter.finalize();
-			reporter.report(false, false);
+			reporter.report(false);
 			ASSERT_FALSE(reporter.canArm(vehicle_status_s::NAVIGATION_STATE_POSCTL));
 
 			if (i == 0) {
@@ -265,7 +265,7 @@ TEST_F(ReporterTest, reporting_multiple)
 		reporter.armingCheckFailure<uint8_t>(NavModes::All, health_component_t::remote_control,
 						     events::ID("arming_test_reporting_multiple_fail3"), events::Log::Warning, "", 55);
 		reporter.finalize();
-		reporter.report(false, false);
+		reporter.report(false);
 		ASSERT_FALSE(reporter.canArm(vehicle_status_s::NAVIGATION_STATE_POSCTL));
 
 		if (i == 0) {

--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -170,6 +170,10 @@ void FailsafeBase::removeActions(ClearCondition condition)
 
 void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action delayed_action, Cause cause)
 {
+	if (_on_notify_user_cb) {
+		_on_notify_user_cb(_on_notify_user_arg);
+	}
+
 	int delay_s = (_current_delay + 500_ms) / 1_s;
 	PX4_DEBUG("User notification: failsafe triggered (action=%i, delayed_action=%i, cause=%i, delay=%is)", (int)action,
 		  (int)delayed_action, (int)cause, delay_s);

--- a/src/modules/commander/failsafe/framework.h
+++ b/src/modules/commander/failsafe/framework.h
@@ -165,6 +165,17 @@ public:
 	bool getDeferFailsafes() const { return _defer_failsafes; }
 	bool failsafeDeferred() const { return _failsafe_defer_started != 0; }
 
+	using UserCallback = void(*)(void *);
+
+	/**
+	 * Register a callback that is called before notifying the user.
+	 */
+	void setOnNotifyUserCallback(UserCallback callback, void *arg)
+	{
+		_on_notify_user_cb = callback;
+		_on_notify_user_arg = arg;
+	}
+
 protected:
 	enum class UserTakeoverAllowed {
 		Always, ///< allow takeover (immediately)
@@ -277,6 +288,9 @@ private:
 	bool _duplicate_reported_once{false};
 
 	orb_advert_t _mavlink_log_pub{nullptr};
+
+	UserCallback _on_notify_user_cb{nullptr};
+	void *_on_notify_user_arg{nullptr};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(ModuleParams,
 					(ParamFloat<px4::params::COM_FAIL_ACT_T>) 	_param_com_fail_act_t


### PR DESCRIPTION
As the failsafe message can reference the health report, the health report needs to be sent out first. This is generally the case, except there is a rate limiter set to 2 seconds. So if the report changes quickly, it is sent out delayed (potentially after the failsafe report).
