### PR TITLE
batteryCheck: fix enabling circuit breaker still causing battery failsafes

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
@@ -75,6 +75,10 @@ static constexpr const char *battery_fault_reason_str(battery_fault_reason_t bat
 void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 {
 	if (circuit_breaker_enabled_by_val(_param_cbrk_supply_chk.get(), CBRK_SUPPLY_CHK_KEY)) {
+		// Reset related failsafe flags otherwise failures from before disabling the check cause failsafes without reported reason
+		reporter.failsafeFlags().battery_unhealthy = false;
+		reporter.failsafeFlags().battery_low_remaining_time = false;
+		reporter.failsafeFlags().battery_warning = battery_status_s::BATTERY_WARNING_NONE;
 		return;
 	}
 


### PR DESCRIPTION
### Solved Problem
When having battery checks fail in a bench test I found that enabling the circuit breaker allowed following arm attempts but the vehicle would immediately failsafe and disarm again without reporting any reason.

Failing checks caused failsafe flags to stay true when enabling the circuit breaker but not rebooting.

This should have been part of https://github.com/PX4/PX4-Autopilot/pull/23431/files#diff-1f54f0a80d365c804b5828d657946655fd70a397a3adf52102015ea31fea7a7bR75-R79

### Solution
Resetting the failsafe flags state when the circuit breaker is set resolves this issue.

### Changelog Entry
```
Fix: Power circuit breaker immediately passes battery checks without reboot
```

### Test coverage
We found this was the actual issue by running `listener failsafe_flags` and seeing `battery_unhealthy` still being true after just having set the circuit breaker. I verified that the exact case is solved by this pr. The `battery_low_remaining_time` and `battery_warning` states I reset for completeness and to avoid any future corner case confusion.