### PR TITLE
gtest cmake: fix unit test filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,14 +408,15 @@ include(px4_add_gtest)
 if(BUILD_TESTING)
 	include(gtest)
 
-	set(TESTFILTERARG "")
-
+	# Ensure there's no -R without any filter expression since that trips newer ctest versions
 	if(TESTFILTER)
-		set(TESTFILTERARG "-R ${TESTFILTER}")
+		set(TESTFILTERARG "-R")
+	else()
+		set(TESTFILTERARG "")
 	endif()
 
 	add_custom_target(test_results
-			COMMAND GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} --output-on-failure -T Test ${TESTFILTERARG}
+			COMMAND GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} --output-on-failure -T Test ${TESTFILTERARG} ${TESTFILTER}
 			DEPENDS
 				px4
 				examples__dyn_hello


### PR DESCRIPTION
### Solved Problem
Unit test filtering doesn't work anymore on main since https://github.com/PX4/PX4-Autopilot/pull/23869/files#r1841024972

### Solution
Seems that apparently the parameters cannot be assembled in a CMake string variable like that so I'll just explicitly add the `-r` argument in the separate already existing `TESTFILTERARG` variable.

### Changelog Entry
```
Fix: Unit test filter
```

### Test coverage
Works again like expected on 22.04. @mrpollo please check if it makes the error you described in https://github.com/PX4/PX4-Autopilot/pull/23869/files#r1841089807 reappear. I couldn't guess where you had it but it should still be fixed.
