### PR TITLE
bmp280: disable device filter

### DIFF
--- a/src/drivers/barometer/bmp280/BMP280.cpp
+++ b/src/drivers/barometer/bmp280/BMP280.cpp
@@ -67,7 +67,7 @@ BMP280::init()
 
 	// set config, recommended settings
 	_interface->set_reg(_curr_ctrl, BMP280_ADDR_CTRL);
-	_interface->set_reg(BMP280_CONFIG_F16, BMP280_ADDR_CONFIG);
+	_interface->set_reg(BMP280_CONFIG_F0, BMP280_ADDR_CONFIG);
 
 	// get calibration and pre process them
 	_cal = _interface->get_calibration(BMP280_ADDR_CAL);


### PR DESCRIPTION
It looks like the BMP280 was heavily filtered, leading to a step response of around 3 seconds. Comparing it to baro logs of BMP388 and MS5611, it looks very slow.

I therefore suggest to disable the on device IIR filter which makes the log data look more like the other baros.

![baro-comparison](https://github.com/user-attachments/assets/9fbd13c5-5c97-4220-aead-32e80420f8b7)
