### PR TITLE
[control_allocation] add parameter MC_REDUCE_THRUST to disable thrust reduction when desaturating 

### DIFF
--- a/src/lib/mixer_module/params.c
+++ b/src/lib/mixer_module/params.c
@@ -16,3 +16,20 @@
  * @group Mixer Output
  */
 PARAM_DEFINE_INT32(MC_AIRMODE, 0);
+
+/**
+ * Multicopter Reduce Thrust
+ *
+ * The default behavior for multicopters is to trade altitude (z-thrust) for attitude automatically.
+ *
+ * This gives an alternative to the default behavior where z-thrust is never sacrificed for
+ * attitude. The idea is to leave it up to the pilot to sacrifice altitude for attitude.
+ *
+ * If false, Z-thrust is never sacrificed for attitude (roll, pitch, yaw).
+ * If true, default behavior. Z-thrust is reduced to make room for roll, pitch, and yaw
+ * 	setpoints).
+ *
+ * @boolean
+ * @group Mixer Output
+ */
+PARAM_DEFINE_INT32(MC_REDUCE_THRUST, 1);

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturation.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturation.cpp
@@ -192,8 +192,10 @@ ControlAllocationSequentialDesaturation::mixAirmodeDisabled()
 		pitch(i) = _mix(i, ControlAxis::PITCH);
 	}
 
-	// only reduce thrust
-	desaturateActuators(_actuator_sp, thrust_z, true);
+	if (_param_mc_reduce_thrust.get()) {
+		// only reduce thrust
+		desaturateActuators(_actuator_sp, thrust_z, true);
+	}
 
 	// Reduce roll/pitch acceleration if needed to unsaturate
 	desaturateActuators(_actuator_sp, roll);
@@ -219,12 +221,20 @@ ControlAllocationSequentialDesaturation::mixYaw()
 	// Change yaw acceleration to unsaturate the outputs if needed (do not change roll/pitch),
 	// and allow some yaw response at maximum thrust
 	ActuatorVector max_prev = _actuator_max;
-	_actuator_max += (_actuator_max - _actuator_min) * 0.15f;
+
+	if (_param_mc_reduce_thrust.get()) {
+		// Increase max so that yaw can be desaturated as if there was more thrust margin.
+		// Then after yaw desaturation, reset the max and desaturate the thrust.
+		_actuator_max += (_actuator_max - _actuator_min) * MINIMUM_YAW_MARGIN;
+	}
+
 	desaturateActuators(_actuator_sp, yaw);
 	_actuator_max = max_prev;
 
-	// reduce thrust only
-	desaturateActuators(_actuator_sp, thrust_z, true);
+	if (_param_mc_reduce_thrust.get()) {
+		// reduce thrust only
+		desaturateActuators(_actuator_sp, thrust_z, true);
+	}
 }
 
 void


### PR DESCRIPTION
### Solved Problem
Control allocation desaturation can cause altitude loss when attitude demands are high, due to an intentional trade-off between attitude and altitude actuation. 

### Solution
This change adds a new parameter MC_REDUCE_THRUST that allows a user to turn off the aforementioned trade-off between attitude and altitude to reduce the risk of altitude loss that is not commanded by the pilot. The pilot can then choose to reduce thrust in order to increase attitude actuation as desired.

### Changelog Entry
For release notes:
```
New parameter: MC_REDUCE_THRUST
```

### Test coverage
Unit tests were added to verify that thrust is not reduced when actuators are saturated.