### PR TITLE
python requirements: less strict empy version specifier

### DIFF
--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -1,7 +1,7 @@
 argcomplete
 cerberus
 coverage
-empy==3.3.4
+empy>=3.3,<4
 future
 jinja2>=2.8
 jsonschema


### PR DESCRIPTION
### Solved Problem
![grafik](https://github.com/user-attachments/assets/334e6778-d987-468c-ad1e-94a53e9a4342)

### Solution
Try being less specific following https://peps.python.org/pep-0440/#version-specifiers

### Test coverage
Let's see if that works 👀 
