### PR TITLE
Broken link to the ARKV6X on the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ These boards fully comply with Pixhawk Standard, and are maintained by the PX4-A
 
 These boards are maintained to be compatible with PX4-Autopilot by the Manufacturers.
 
-* [ARK Electronics ARKV6X](https://docs.px4.io/main/en/flight_controller/arkv6x.html)
+* [ARK Electronics ARKV6X](https://docs.px4.io/main/en/flight_controller/ark_v6x.html)
 * [CubePilot Cube Orange+](https://docs.px4.io/main/en/flight_controller/cubepilot_cube_orangeplus.html)
 * [CubePilot Cube Orange](https://docs.px4.io/main/en/flight_controller/cubepilot_cube_orange.html)
 * [CubePilot Cube Yellow](https://docs.px4.io/main/en/flight_controller/cubepilot_cube_yellow.html)


### PR DESCRIPTION
### Solved Problem
I found a broken link on the README.md

### Solution
I fixed the broken link

### Changelog Entry

### Alternatives

### Test coverage

### Context
