### PR TITLE
spi: Suppress null pointer warning

### DIFF
--- a/platforms/common/spi.cpp
+++ b/platforms/common/spi.cpp
@@ -87,7 +87,12 @@ const px4_spi_bus_t *px4_spi_buses{nullptr};
 
 int px4_find_spi_bus(uint32_t devid)
 {
+// px4_spi_buses is only NULL on certain targets depending on defines
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress"
+
 	for (int i = 0; ((px4_spi_bus_t *) px4_spi_buses) != nullptr && i < SPI_BUS_MAX_BUS_ITEMS; ++i) {
+#pragma GCC diagnostic pop
 		const px4_spi_bus_t &bus_data = px4_spi_buses[i];
 
 		if (bus_data.bus == -1) {


### PR DESCRIPTION
### Solved Problem
Depending on defines px4_spi_buses can be NULL but often it's not and in those cases the compiler correctly warns about it.
Reported in https://github.com/PX4/PX4-Autopilot/pull/23869#issuecomment-2474826808 and https://github.com/PX4/PX4-Autopilot/issues/23963#issuecomment-2484159058

### Solution
Suppress the warning.

### Test coverage
Locally built fmu-v4 on Ubuntu 24.04 with the packaged GCC 13.2.1