### PR TITLE
boards: emlid_navio - support 64-bit OS on Raspberry Pi 4,5

### DIFF
--- a/boards/emlid/navio2/arm64.px4board
+++ b/boards/emlid/navio2/arm64.px4board
@@ -1,5 +1,1 @@
-# To support 64-bit OS on Raspberry Pi 4,5
-# sudo apt install g++-aarch64-linux-gnu
-# use "make emlid_navio2_arm64 upload"
-
 CONFIG_BOARD_TOOLCHAIN="aarch64-linux-gnu"

--- a/boards/emlid/navio2/arm64.px4board
+++ b/boards/emlid/navio2/arm64.px4board
@@ -1,0 +1,5 @@
+# To support 64-bit OS on Raspberry Pi 4,5
+# sudo apt install g++-aarch64-linux-gnu
+# use "make emlid_navio2_arm64 upload"
+
+CONFIG_BOARD_TOOLCHAIN="aarch64-linux-gnu"


### PR DESCRIPTION
### Solved Problem
Raspberry Pi 4,5 support 64-bit OS (Ubuntu) and _"aarch64-linux-gnu"_ toolchain.

This PR adds a single file that optionally allows cross-builds for ARM64 target architecture.

### Solution
- Using a Ubuntu 24.04 Intel or similar desktop machine for builds
- This PR adds file _boards/emlid/navio2/arm64.px4board_
- Install ARM64 toolchain: ```sudo apt install g++-aarch64-linux-gnu```

The 32-bit toolchain can be installed by ```sudo apt install g++-arm-linux-gnueabihf```

Now both 32-bit and 64-bit builds are available:
```
make emlid_navio2 upload
make emlid_navio2_arm64 upload
```
