### PR TITLE
ci: fix container image name when multiple given

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -62,10 +62,15 @@ jobs:
           cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
           cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
 
+      - name: Get Tag Name
+        id: tag_name
+        run: |
+          echo "::set-output name=tag_name::$(echo '${{ fromJSON(steps.docker.outputs.metadata)['image.name'] }}' | sed 's/,.*$//')"
+
       - name: make quick_check
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ fromJSON(steps.docker.outputs.metadata)['image.name'] }}
+          image: ${{ steps.tag_name.outputs.tag_name }}
           options: -v ${{ github.workspace }}:/workspace
           run: |
             cd /workspace


### PR DESCRIPTION
When this workflow triggered by a tag push event, then it tags the image in multiple ways eg:

    "image.name": "ghcr.io/px4/px4-dev:v1.16.0-alpha1,ghcr.io/px4/px4-dev:latest"

Having multiple names messes up the execution of the next step in the chain since we depend on its name to complete the testing.

Error https://github.com/PX4/PX4-Autopilot/actions/runs/11943677314/job/33293165630#step:10:3
