### PR TITLE
ci: disable docker hub access

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -25,12 +25,6 @@ jobs:
           submodules: false
           fetch-depth: 0
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
for some reason docker hub api is failing today, we will bring this back to docker hub soon.