### PR TITLE
standard_modes: add vehicle-type specific standard modes

### DIFF
--- a/src/lib/modes/standard_modes.hpp
+++ b/src/lib/modes/standard_modes.hpp
@@ -47,11 +47,10 @@ enum class StandardMode : uint8_t {
 	ORBIT = 2,
 	CRUISE = 3,
 	ALTITUDE_HOLD = 4,
-	RETURN_HOME = 5,
-	SAFE_RECOVERY = 6,
-	MISSION = 7,
-	LAND = 8,
-	TAKEOFF = 9,
+	SAFE_RECOVERY = 5,
+	MISSION = 6,
+	LAND = 7,
+	TAKEOFF = 8,
 };
 
 /**
@@ -60,7 +59,7 @@ enum class StandardMode : uint8_t {
 static inline StandardMode getStandardModeFromNavState(uint8_t nav_state, uint8_t vehicle_type, bool is_vtol)
 {
 	switch (nav_state) {
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_RTL: return StandardMode::RETURN_HOME;
+	case vehicle_status_s::NAVIGATION_STATE_AUTO_RTL: return StandardMode::SAFE_RECOVERY;
 
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION: return StandardMode::MISSION;
 
@@ -105,7 +104,7 @@ static inline StandardMode getStandardModeFromNavState(uint8_t nav_state, uint8_
 static inline uint8_t getNavStateFromStandardMode(StandardMode mode, uint8_t vehicle_type, bool is_vtol)
 {
 	switch (mode) {
-	case StandardMode::RETURN_HOME: return vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
+	case StandardMode::SAFE_RECOVERY: return vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
 
 	case StandardMode::MISSION: return vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION;
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1450,7 +1450,8 @@ Commander::handle_command(const vehicle_command_s &cmd)
 
 	case vehicle_command_s::VEHICLE_CMD_DO_SET_STANDARD_MODE: {
 			mode_util::StandardMode standard_mode = (mode_util::StandardMode) roundf(cmd.param1);
-			uint8_t nav_state = mode_util::getNavStateFromStandardMode(standard_mode);
+			uint8_t nav_state = mode_util::getNavStateFromStandardMode(standard_mode, _vehicle_status.vehicle_type,
+					    _vehicle_status.is_vtol);
 
 			if (nav_state == vehicle_status_s::NAVIGATION_STATE_MAX) {
 				answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_FAILED);

--- a/src/modules/mavlink/streams/AVAILABLE_MODES.hpp
+++ b/src/modules/mavlink/streams/AVAILABLE_MODES.hpp
@@ -86,7 +86,8 @@ private:
 		const bool cannot_be_selected = (vehicle_status.can_set_nav_states_mask & (1u << nav_state)) == 0;
 
 		// Set the mode name if not a standard mode
-		available_modes.standard_mode = (uint8_t)mode_util::getStandardModeFromNavState(nav_state);
+		available_modes.standard_mode = (uint8_t)mode_util::getStandardModeFromNavState(nav_state, vehicle_status.vehicle_type,
+						vehicle_status.is_vtol);
 
 		if (mode_util::isAdvanced(nav_state)) {
 			available_modes.properties |= MAV_MODE_PROPERTY_ADVANCED;

--- a/src/modules/mavlink/streams/CURRENT_MODE.hpp
+++ b/src/modules/mavlink/streams/CURRENT_MODE.hpp
@@ -66,7 +66,8 @@ private:
 			mavlink_current_mode_t current_mode{};
 			current_mode.custom_mode = get_px4_custom_mode(vehicle_status.nav_state).data;
 			current_mode.intended_custom_mode = get_px4_custom_mode(vehicle_status.nav_state_user_intention).data;
-			current_mode.standard_mode = (uint8_t) mode_util::getStandardModeFromNavState(vehicle_status.nav_state);
+			current_mode.standard_mode = (uint8_t) mode_util::getStandardModeFromNavState(vehicle_status.nav_state,
+						     vehicle_status.vehicle_type, vehicle_status.is_vtol);
 			mavlink_msg_current_mode_send_struct(_mavlink->get_channel(), &current_mode);
 			return true;
 		}


### PR DESCRIPTION
See https://mavlink.io/en/messages/development.html#MAV_STANDARD_MODE. The only standard mode that is not set is MAV_STANDARD_MODE_SAFE_RECOVERY, as PX4 uses RTL for that (with configuration parameters).


### Changelog Entry
For release notes:
```
Implement vehicle-type specific MAVLink standard modes.
```

