### PR TITLE
mixer module: remove unused functions

### DIFF
--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -170,8 +170,6 @@ public:
 	void setAllMinValues(uint16_t value);
 	void setAllMaxValues(uint16_t value);
 
-	uint16_t &reverseOutputMask() { return _reverse_output_mask; }
-	uint16_t &failsafeValue(int index) { return _failsafe_value[index]; }
 	/** Disarmed values: disarmedValue < minValue needs to hold */
 	uint16_t &disarmedValue(int index) { return _disarmed_value[index]; }
 	uint16_t &minValue(int index) { return _min_value[index]; }


### PR DESCRIPTION
Came across these two function definitions that don't seem to be used anywhere anymore.