### PR TITLE
Upstream follw-up: Fix python dependency installation in CI

### DIFF
--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -36,12 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Update python packaging to avoid canonicalize_version() error
-        run: |
-            pip3 install -U packaging
-
       - name: Install Python Dependencies
-        uses: py-actions/py-dependency-install@v4
+        uses: MaEtUgR/py-dependency-install@maetugr/fix-packaging-incompatibility
         with:
           path: "./Tools/setup/requirements.txt"
 


### PR DESCRIPTION
### Solved Problem
Upstream pull request for the local workaround I found in https://github.com/PX4/PX4-Autopilot/pull/23991

### Solution
https://github.com/py-actions/py-dependency-install/pull/255
If that solution is accepted we can use it and I'll update this pr to use the merged version.

### Test coverage
This pr is to check if it works.