### PR TITLE
[TEST] Disable Multi-EKF for SITL to see if CI failures are related

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
@@ -44,10 +44,6 @@ param set-default PWM_MAIN_FUNC6 201
 param set-default PWM_MAIN_FUNC7 202
 param set-default PWM_MAIN_REV 96 # invert both elevons
 
-# Single-EKF (for replay)
-param set-default EKF2_MULTI_IMU 0
-param set-default SENS_IMU_MODE 1
-
 param set-default FW_P_TC 0.6
 
 param set-default FW_PR_FF 0.0

--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -173,8 +173,6 @@ else
 
 	# EKF2 specifics
 	param set-default EKF2_GPS_DELAY 10
-	param set-default EKF2_MULTI_IMU 3
-	param set-default SENS_IMU_MODE 0
 
 	simulator_tcp_port=$((4560+px4_instance))
 


### PR DESCRIPTION
### Solved Problem
https://github.com/PX4/PX4-Autopilot/issues/23965#issuecomment-2491827454
I think multi EKF is at least related since missing data is only possible if the selector message is not available or the status of the primary estimator: https://github.com/PX4/PX4-Autopilot/blob/2f65644aeb5cb4c2023e43ac45d8a9b01d0584ba/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp#L74-L100
and I checked a failing log, both topics are there. So where does it fail? Too many topics? There's only one instance of EKF in the log.

![grafik](https://github.com/user-attachments/assets/e712fe82-eeb6-4159-9a65-a5bd7816e795)


Now that I have a closer look the error is probably gone without multi EKF because it's always there before the selector data is available 🤦‍♂️ Why is the selector data not available earlier?

### Test coverage
Let's see 👀 