### PR TITLE
ci: container tag pattern updates

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -38,6 +38,14 @@ jobs:
         with:
           images: |
             ghcr.io/PX4/px4-dev
+          tags: |
+            type=schedule
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=branch,suffix=-{{date 'YYYYMMDD'}}
+            type=ref,event=pr
+            type=sha
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -82,6 +82,7 @@ jobs:
 
       - name: Push container image
         uses: docker/build-push-action@v6
+        if: ${{ github.event_name == 'push' }}
         with:
           context: Tools/setup
           tags: ${{ steps.meta.outputs.tags }}
@@ -89,6 +90,6 @@ jobs:
           platforms: |
             linux/amd64
           provenance: mode=max
-          push: ${{ github.event_name == 'push' }}
+          push: true
           cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
           cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max


### PR DESCRIPTION
This updates the docker image tag for the px4-dev container, from `px4-dev:main` to `px4-dev:main-{{YYYYMMDD}}` so we can lock down per date instead of having a constantly updating container