### PR TITLE
ci: introduce px4-dev container with multi arch support

### DIFF
--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -17,12 +17,14 @@ on:
     paths-ignore:
       - 'docs/**'
       - '.github/**'
+      - 'Tools/**'
   pull_request:
     branches:
       - '*'
     paths-ignore:
       - 'docs/**'
       - '.github/**'
+      - 'Tools/**'
 
 jobs:
   group_targets:
@@ -32,7 +34,6 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       timestamp: ${{ steps.set-timestamp.outputs.timestamp }}
-      tagname: ${{ steps.set-tag.outputs.tagname }}
       branchname: ${{ steps.set-branch.outputs.branchname }}
     steps:
       - uses: actions/checkout@v4
@@ -63,9 +64,9 @@ jobs:
           echo "$(./Tools/ci/generate_board_targets_json.py --group --verbose)"
 
   setup:
-    name: Build Group [${{ matrix.group }}]
+    name: Build Group [${{ matrix.group }}][${{ matrix.arch == 'nuttx' && 'x86' || 'arm64' }}]
     # runs-on: ubuntu-latest
-    runs-on: [runs-on,runner=8cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}",spot=false]
+    runs-on: [runs-on,"runner=8cpu-linux-x64","image=ubuntu24-full-x64","run-id=${{ github.run_id }}",spot=false]
     needs: group_targets
     strategy:
       matrix: ${{ fromJson(needs.group_targets.outputs.matrix) }}
@@ -100,7 +101,7 @@ jobs:
 
       - name: Building [${{ matrix.group }}]
         run: |
-            ./Tools/ci/build_all_runner.sh ${{matrix.targets}}
+            ./Tools/ci/build_all_runner.sh ${{matrix.targets}} ${{matrix.arch}}
 
       - name: Arrange Build Artifacts
         run: |
@@ -118,7 +119,7 @@ jobs:
   artifacts:
     name: Upload Artifacts to S3
     # runs-on: ubuntu-latest
-    runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}",spot=false]
+    runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false]
     needs: [setup, group_targets]
     if: contains(fromJSON('["main", "stable", "beta"]'), needs.group_targets.outputs.branchname)
     steps:
@@ -146,10 +147,12 @@ jobs:
 
   release:
     name: Create Release and Upload Artifacts
+    permissions:
+      contents: write
     # runs-on: ubuntu-latest
-    runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}",spot=false]
+    runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false]
     needs: [setup, group_targets]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/compile_ubuntu.yml
+++ b/.github/workflows/compile_ubuntu.yml
@@ -17,6 +17,9 @@ on:
       - 'docs/**'
       - '.github/**'
 
+env:
+  RUNS_IN_DOCKER: true
+
 jobs:
   build_and_test:
     name: Build and Test

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -10,35 +10,124 @@ on:
       - 'release/**'
     tags:
       - 'v*'
-    paths-ignore:
-      - 'docs/**'
-      - '.github/**'
+    paths:
+      - 'Tools/setup/ubuntu.sh'
+      - 'Tools/setup/requirements.txt'
+      - 'Tools/setup/Dockerfile'
+      - 'Tools/setup/docker-entrypoint.sh'
   pull_request:
     branches:
       - '*'
-    paths-ignore:
-      - 'docs/**'
-      - '.github/**'
+    paths:
+      - 'Tools/setup/ubuntu.sh'
+      - 'Tools/setup/requirements.txt'
+      - 'Tools/setup/Dockerfile'
+      - 'Tools/setup/docker-entrypoint.sh'
 
 jobs:
-  build:
-    name: Build and Push Container
-    runs-on: [runs-on,runner=8cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false]
+  setup:
+    name: Set Tags and Variables
+    runs-on: [runs-on,"runner=1cpu-linux-x64","image=ubuntu24-full-x64","run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
+    outputs:
+      px4_version: ${{ steps.px4_version.outputs.px4_version }}
+      meta_tags: ${{ steps.meta.outputs.tags }}
+      meta_labels: ${{ steps.meta.outputs.labels }}
     steps:
+      - uses: runs-on/action@v1
       - uses: actions/checkout@v4
         with:
           fetch-tags: true
           submodules: false
           fetch-depth: 0
 
-      - name: Set PX4 Tag
-        id: px4-tag
+      - name: Set PX4 Tag Version
+        id: px4_version
         run: |
-          echo "tag=$(git describe --tags --match 'v[0-9]*')" >> $GITHUB_OUTPUT
+          echo "px4_version=$(git describe --tags --match 'v[0-9]*')" >> $GITHUB_OUTPUT
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/PX4/px4-dev
+            px4io/px4-dev
+          tags: |
+            type=raw,enable=true,value=${{ steps.px4_version.outputs.px4_version }},priority=1000
+
+  build:
+    name: Build Container (${{ matrix.arch }})
+    needs: setup
+    strategy:
+      matrix:
+        include:
+          - platform: linux/arm64
+            arch: arm64
+            runner: arm64
+          - platform: linux/amd64
+            arch: amd64
+            runner: x64
+    runs-on: [runs-on,"runner=8cpu-linux-${{ matrix.runner }}","image=ubuntu24-full-${{ matrix.runner }}","run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
+    steps:
+      - uses: runs-on/action@v1
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          submodules: false
+          fetch-depth: 0
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: github.event_name != 'pull_request'
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+          platforms: ${{ matrix.platform }}
+
+      - name: Build and Load Container Image
+        uses: docker/build-push-action@v6
+        id: docker
+        with:
+          context: Tools/setup
+          tags: |
+            ghcr.io/px4/px4-dev:${{ needs.setup.outputs.px4_version }}-${{ matrix.arch }}
+            px4io/px4-dev:${{ needs.setup.outputs.px4_version }}-${{ matrix.arch }}
+          labels: ${{ needs.setup.outputs.meta_labels }}
+          platforms: ${{ matrix.platform }}
+          load: false
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          provenance: false
+          cache-from: type=gha,version=1
+          cache-to: type=gha,version=1,mode=max
+
+  deploy:
+    name: Deploy To Registry
+    runs-on: [runs-on,"runner=8cpu-linux-x64","image=ubuntu24-full-x64","run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
+    needs: [build, setup]
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    steps:
+      - uses: runs-on/action@v1
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          submodules: false
+          fetch-depth: 0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -50,58 +139,31 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ghcr.io/PX4/px4-dev
-            ${{ (github.event_name != 'pull_request') && 'px4io/px4-dev' || '' }}
-          tags: |
-            type=raw,enable=true,value=${{ steps.px4-tag.outputs.tag }},priority=1000
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and load container image
-        uses: docker/build-push-action@v6
-        id: docker
-        with:
-          context: Tools/setup
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: |
-            linux/amd64
-          load: true
-          push: false
-          cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
-
-      - name: Get Tag Name
-        id: tag_name
+      - name: Verify Images Exist Before Creating Manifest
         run: |
-          echo "::set-output name=tag_name::$(echo '${{ fromJSON(steps.docker.outputs.metadata)['image.name'] }}' | sed 's/,.*$//')"
+          docker manifest inspect px4io/px4-dev:${{ needs.setup.outputs.px4_version }}-arm64 || echo "⚠️ Warning: No ARM64 image found!"
+          docker manifest inspect px4io/px4-dev:${{ needs.setup.outputs.px4_version }}-amd64 || echo "⚠️ Warning: No AMD64 image found!"
+          docker manifest inspect ghcr.io/px4/px4-dev:${{ needs.setup.outputs.px4_version }}-arm64 || echo "⚠️ Warning: No ARM64 image found!"
+          docker manifest inspect ghcr.io/px4/px4-dev:${{ needs.setup.outputs.px4_version }}-amd64 || echo "⚠️ Warning: No AMD64 image found!"
 
-      - name: make quick_check
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ steps.tag_name.outputs.tag_name }}
-          options: -v ${{ github.workspace }}:/workspace
-          run: |
-            cd /workspace
-            git config --global --add safe.directory /workspace
-            make px4_sitl_default
-            make px4_fmu-v6x_default
+      - name: Create and Push Multi-Arch Manifest for Docker Hub
+        run: |
+          docker manifest create px4io/px4-dev:${{ needs.setup.outputs.px4_version }} \
+            --amend px4io/px4-dev:${{ needs.setup.outputs.px4_version }}-arm64 \
+            --amend px4io/px4-dev:${{ needs.setup.outputs.px4_version }}-amd64
 
-      - name: Push container image
-        uses: docker/build-push-action@v6
-        with:
-          context: Tools/setup
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: |
-            linux/amd64
-          provenance: mode=max
-          push: ${{ github.event_name != 'pull_request' }}
-          cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+          docker manifest annotate px4io/px4-dev:${{ needs.setup.outputs.px4_version }} px4io/px4-dev:${{ needs.setup.outputs.px4_version }}-arm64 --arch arm64
+          docker manifest annotate px4io/px4-dev:${{ needs.setup.outputs.px4_version }} px4io/px4-dev:${{ needs.setup.outputs.px4_version }}-amd64 --arch amd64
+
+          docker manifest push px4io/px4-dev:${{ needs.setup.outputs.px4_version }}
+
+      - name: Create and Push Multi-Arch Manifest for GHCR
+        run: |
+          docker manifest create ghcr.io/px4/px4-dev:${{ needs.setup.outputs.px4_version }} \
+            --amend ghcr.io/px4/px4-dev:${{ needs.setup.outputs.px4_version }}-arm64 \
+            --amend ghcr.io/px4/px4-dev:${{ needs.setup.outputs.px4_version }}-amd64
+
+          docker manifest annotate ghcr.io/px4/px4-dev:${{ needs.setup.outputs.px4_version }} ghcr.io/px4/px4-dev:${{ needs.setup.outputs.px4_version }}-arm64 --arch arm64
+          docker manifest annotate ghcr.io/px4/px4-dev:${{ needs.setup.outputs.px4_version }} ghcr.io/px4/px4-dev:${{ needs.setup.outputs.px4_version }}-amd64 --arch amd64
+
+          docker manifest push ghcr.io/px4/px4-dev:${{ needs.setup.outputs.px4_version }}

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -27,6 +27,8 @@ on:
 jobs:
   setup:
     name: Set Tags and Variables
+    permissions:
+      contents: read
     runs-on: [runs-on,"runner=1cpu-linux-x64","image=ubuntu24-full-x64","run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
     outputs:
       px4_version: ${{ steps.px4_version.outputs.px4_version }}
@@ -57,6 +59,9 @@ jobs:
 
   build:
     name: Build Container (${{ matrix.arch }})
+    permissions:
+      contents: read
+      packages: write
     needs: setup
     strategy:
       matrix:
@@ -115,6 +120,9 @@ jobs:
 
   deploy:
     name: Deploy To Registry
+    permissions:
+      contents: read
+      packages: write
     runs-on: [runs-on,"runner=8cpu-linux-x64","image=ubuntu24-full-x64","run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
     needs: [build, setup]
     if: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/Tools/ci/generate_board_targets_json.py
+++ b/Tools/ci/generate_board_targets_json.py
@@ -87,19 +87,25 @@ def process_target(px4board_file, target_name):
 
     if platform not in excluded_platforms:
         # get the container based on the platform and toolchain
+        # TODO enable once newer container is validated
+        # container = 'ghcr.io/px4/px4-dev:v1.16.0-alpha2-419-gd48631e2ce'
         if platform == 'posix':
+            # TODO remove once newer container is validated
             container = 'px4io/px4-dev-base-focal:2021-09-08'
             group = 'base'
             if toolchain:
                 if toolchain.startswith('aarch64'):
+                    # TODO remove once newer container is validated
                     container = 'px4io/px4-dev-aarch64:2022-08-12'
                     group = 'aarch64'
                 elif toolchain == 'arm-linux-gnueabihf':
+                    # TODO remove once newer container is validated
                     container = 'px4io/px4-dev-armhf:2023-06-26'
                     group = 'armhf'
                 else:
                     if verbose: print(f'unmatched toolchain: {toolchain}')
         elif platform == 'nuttx':
+            # TODO remove once newer container is validated
             container = 'px4io/px4-dev-nuttx-focal:2022-08-12'
             group = 'nuttx'
         else:
@@ -124,7 +130,10 @@ if(verbose):
 # - Events
 metadata_targets = ['airframe_metadata', 'parameters_metadata', 'extract_events']
 grouped_targets['base'] = {}
+# TODO remove once newer container is validated
 grouped_targets['base']['container'] = 'px4io/px4-dev-base-focal:2021-09-08'
+# TODO enable once newer container is validated
+#grouped_targets['base']['container'] = 'ghcr.io/px4/px4-dev:v1.16.0-alpha2-419-gd48631e2ce'
 grouped_targets['base']['manufacturers'] = {}
 grouped_targets['base']['manufacturers']['px4'] = []
 grouped_targets['base']['manufacturers']['px4'] += metadata_targets

--- a/Tools/ci/package_build_artifacts.sh
+++ b/Tools/ci/package_build_artifacts.sh
@@ -4,8 +4,9 @@ mkdir artifacts
 cp **/**/*.px4 artifacts/
 cp **/**/*.elf artifacts/
 for build_dir_path in build/*/ ; do
+  build_dir_path=${build_dir_path::${#build_dir_path}-1}
   build_dir=${build_dir_path#*/}
-  build_dir=${build_dir::${#build_dir}-1}
+  target_name=$build_dir
   mkdir artifacts/$build_dir
   find artifacts/ -maxdepth 1 -type f -name "*$build_dir*"
   # Airframe
@@ -26,21 +27,23 @@ for build_dir_path in build/*/ ; do
   echo "----------"
 done
 
-# general metadata
-mkdir artifacts/_general/
-cp artifacts/px4_sitl_default/airframes.xml artifacts/_general/
-# Airframe
-cp artifacts/px4_sitl_default/airframes.xml artifacts/_general/
-# Parameters
-cp artifacts/px4_sitl_default/parameters.xml artifacts/_general/
-cp artifacts/px4_sitl_default/parameters.json artifacts/_general/
-cp artifacts/px4_sitl_default/parameters.json.xz artifacts/_general/
-# Actuators
-cp artifacts/px4_sitl_default/actuators.json artifacts/_general/
-cp artifacts/px4_sitl_default/actuators.json.xz artifacts/_general/
-# Events
-cp artifacts/px4_sitl_default/events/all_events.json.xz artifacts/_general/
-# ROS 2 msgs
-cp artifacts/px4_sitl_default/events/all_events.json.xz artifacts/_general/
-# Module Docs
-ls -la artifacts/_general/
+if [ -d artifacts/px4_sitl_default ]; then
+  # general metadata
+  mkdir artifacts/_general/
+  cp artifacts/px4_sitl_default/airframes.xml artifacts/_general/
+  # Airframe
+  cp artifacts/px4_sitl_default/airframes.xml artifacts/_general/
+  # Parameters
+  cp artifacts/px4_sitl_default/parameters.xml artifacts/_general/
+  cp artifacts/px4_sitl_default/parameters.json artifacts/_general/
+  cp artifacts/px4_sitl_default/parameters.json.xz artifacts/_general/
+  # Actuators
+  cp artifacts/px4_sitl_default/actuators.json artifacts/_general/
+  cp artifacts/px4_sitl_default/actuators.json.xz artifacts/_general/
+  # Events
+  cp artifacts/px4_sitl_default/events/all_events.json.xz artifacts/_general/
+  # ROS 2 msgs
+  cp artifacts/px4_sitl_default/events/all_events.json.xz artifacts/_general/
+  # Module Docs
+  ls -la artifacts/_general/
+fi

--- a/Tools/ci/package_build_artifacts.sh
+++ b/Tools/ci/package_build_artifacts.sh
@@ -6,7 +6,6 @@ cp **/**/*.elf artifacts/
 for build_dir_path in build/*/ ; do
   build_dir_path=${build_dir_path::${#build_dir_path}-1}
   build_dir=${build_dir_path#*/}
-  target_name=$build_dir
   mkdir artifacts/$build_dir
   find artifacts/ -maxdepth 1 -type f -name "*$build_dir*"
   # Airframe

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -15,7 +15,7 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 		# posix_rpi_cross, posix_bebop_default
 		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2023-06-26"
 	elif [[ $@ =~ .*clang.* ]] || [[ $@ =~ .*scan-build.* ]]; then
-		# clang tools
+    # clang tools
 		PX4_DOCKER_REPO="px4io/px4-dev-clang:2021-02-04"
 	elif [[ $@ =~ .*tests* ]]; then
 		# run all tests with simulation
@@ -33,10 +33,10 @@ fi
 # docker hygiene
 
 #Delete all stopped containers (including data-only containers)
-#docker rm $(docker ps -a -q)
+# docker container prune
 
 #Delete all 'untagged/dangling' (<none>) images
-#docker rmi $(docker images -q -f dangling=true)
+# docker image prune
 
 echo "PX4_DOCKER_REPO: $PX4_DOCKER_REPO";
 

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -15,7 +15,7 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 		# posix_rpi_cross, posix_bebop_default
 		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2023-06-26"
 	elif [[ $@ =~ .*clang.* ]] || [[ $@ =~ .*scan-build.* ]]; then
-    # clang tools
+		# clang tools
 		PX4_DOCKER_REPO="px4io/px4-dev-clang:2021-02-04"
 	elif [[ $@ =~ .*tests* ]]; then
 		# run all tests with simulation

--- a/Tools/setup/Dockerfile
+++ b/Tools/setup/Dockerfile
@@ -8,22 +8,25 @@ ENV LC_ALL=C.UTF-8
 ENV DISPLAY=:99
 ENV TERM=xterm
 ENV TZ=UTC
+ENV RUNS_IN_DOCKER=true
 
 # SITL UDP PORTS
 EXPOSE 14556/udp
 EXPOSE 14557/udp
 
+# Install Shell Script Entrypoint
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # Install PX4 Requirements
 COPY requirements.txt /tmp/requirements.txt
 COPY ubuntu.sh /tmp/ubuntu.sh
-RUN touch /.dockerenv
+
 RUN bash /tmp/ubuntu.sh --no-sim-tools
 
+# Make sure git is ok with your local copy
 RUN git config --global --add safe.directory '*'
 
-# create user with id 1001 (jenkins docker workflow default)
+# Create user with id 1001 (jenkins docker workflow default)
 RUN useradd --shell /bin/bash -u 1001 -c "" -m user && usermod -a -G dialout user
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/Tools/setup/docker-entrypoint.sh
+++ b/Tools/setup/docker-entrypoint.sh
@@ -1,19 +1,27 @@
 #!/bin/bash
 
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+SCRIPTID="${GREEN}[docker-entrypoint.sh]${NC}"
+
+echo -e "$SCRIPTID Starting"
+
 # Start virtual X server in the background
 # - DISPLAY default is :99, set in dockerfile
 # - Users can override with `-e DISPLAY=` in `docker run` command to avoid
 #   running Xvfb and attach their screen
 if [[ -x "$(command -v Xvfb)" && "$DISPLAY" == ":99" ]]; then
-	echo "[docker-entrypoint.sh] Starting Xvfb"
+	echo -e "$SCRIPTID Starting Xvfb"
 	Xvfb :99 -screen 0 1600x1200x24+32 &
 fi
 
 # Check if the ROS_DISTRO is passed and use it
 # to source the ROS environment
 if [ -n "${ROS_DISTRO}" ]; then
-	echo "[docker-entrypoint.sh] ROS: ${ROS_DISTRO}"
+	echo -e "$SCRIPTID ROS: ${ROS_DISTRO}"
 	source "/opt/ros/$ROS_DISTRO/setup.bash"
 fi
+
+echo -e "$SCRIPTID ($( uname -m ))"
 
 exec "$@"

--- a/Tools/setup/docker-entrypoint.sh
+++ b/Tools/setup/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 GREEN='\033[0;32m'
-NC='\033[0m' # No Color
-SCRIPTID="${GREEN}[docker-entrypoint.sh]${NC}"
+NO_COLOR='\033[0m' # No Color
+SCRIPTID="${GREEN}[docker-entrypoint.sh]${NO_COLOR}"
 
 echo -e "$SCRIPTID Starting"
 

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -110,7 +110,7 @@ fi
 if [[ $INSTALL_NUTTX == "true" ]]; then
 
 	echo
-	echo "[ubuntu.sh] NuttX Installing Dependencies"
+	echo "[ubuntu.sh] NuttX Installing Dependencies ($INSTALL_ARCH)"
 	sudo apt-get update -y --quiet
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		automake \
@@ -144,10 +144,6 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		util-linux \
 		vim-common \
 		;
-
-
-	echo
-	echo "[ubuntu.sh] NuttX Installing Dependencies ($INSTALL_ARCH)"
 
 	if [[ "${INSTALL_ARCH}" == "x86_64" ]]; then
 		sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -118,6 +118,9 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		bison \
 		build-essential \
 		curl \
+		clang \
+		clang-tidy \
+		clang-format \
 		flex \
 		gdb-multiarch \
 		genromfs \
@@ -137,6 +140,8 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		libstdc++-arm-none-eabi-newlib \
 		libtool \
 		libunwind-dev \
+		lldb \
+		lld \
 		pkg-config \
 		screen \
 		texinfo \

--- a/src/drivers/uavcan/libdronecan/libuavcan/src/transport/uc_frame.cpp
+++ b/src/drivers/uavcan/libdronecan/libuavcan/src/transport/uc_frame.cpp
@@ -2,6 +2,10 @@
  * Copyright (C) 2014 Pavel Kirienko <pavel.kirienko@gmail.com>
  */
 
+#if defined(__GNUC__) && __GNUC__ >= 12
+# pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+
 #include <uavcan/transport/frame.hpp>
 #include <uavcan/transport/can_io.hpp>
 #include <uavcan/transport/crc.hpp>


### PR DESCRIPTION
Use the px4-dev container to build and publish all targets

* builds x86, and arm64 px4-dev images
  * conditional to changes in either **ubuntu.sh** or **requirements.txt**
* updates **ubuntu.sh** for installing under both architectures
* fixes a stringop-overflow issue with gcc > 12
* uses the px4-dev container to build the build matrix of all boards