### PR TITLE
Logger:  combined encrypted ulog&key file

### DIFF
--- a/Tools/decrypt_ulog.py
+++ b/Tools/decrypt_ulog.py
@@ -1,62 +1,91 @@
 #!/usr/bin/env python3
 
+import sys
+
+try:
+    from Crypto.Cipher import ChaCha20
+except ImportError as e:
+    print("Failed to import crypto: " + str(e))
+    print("")
+    print("You may need to install it using:")
+    print("    pip3 install --user pycryptodome")
+    print("")
+    sys.exit(1)
+
 from Crypto.PublicKey import RSA
 from Crypto.Cipher import PKCS1_OAEP
-from Crypto.Cipher import ChaCha20
 from Crypto.Hash import SHA256
-import binascii
+from pathlib import Path
 import argparse
-#from pathlib import Path
-import sys
+
 
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="""CLI tool to decrypt an ulog file\n""")
-    parser.add_argument("ulog_file", help=".ulog file", nargs='?', default=None)
-    parser.add_argument("ulog_key", help=".ulogk, encrypted key", nargs='?', default=None)
+    parser.add_argument("ulog_file", help=".ulge/.ulgc, encrypted log file", nargs='?', default=None)
+    parser.add_argument("ulog_key", help=".ulgk, legacy encrypted key (give empty string '' to ignore for .ulge)", nargs='?', default=None)
     parser.add_argument("rsa_key", help=".pem format key for decrypting the ulog key", nargs='?', default=None)
 
     args = parser.parse_args()
 
-    # Only generate a key pair, don't sign
-    if not args.ulog_file or not args.ulog_key or not args.rsa_key:
-        print('Need all arguments, the encrypted ulog file, the key and the key decryption key')
-        sys.exit(1);
+    # Check all arguments are given
+    if not args.rsa_key:
+        print('Need all arguments, the encrypted ulog file, key file (or empty string if not needed) and the key decryption key (.pem)')
+        sys.exit(1)
 
     # Read the private RSA key to decrypt the cahcha key
     with open(args.rsa_key, 'rb') as f:
         r = RSA.importKey(f.read(), passphrase='')
 
-    # Read the encrypted xchacha key and the nonce
-    with open(args.ulog_key, 'rb') as f:
+    if args.ulog_key == "":
+        key_data_filename = args.ulog_file
+        magic = "ULogEnc"
+    else:
+        key_data_filename = args.ulog_key
+        magic = "ULogKey"
+
+    with open(key_data_filename, 'rb') as f:
+        # Read the encrypted xchacha key and the nonce
         ulog_key_header = f.read(22)
 
         # Parse the header
         try:
             # magic
-            if not ulog_key_header.startswith(bytearray("ULogKey".encode())):
+            if not ulog_key_header.startswith(bytearray(magic.encode())):
+                print("Incorrect header magic")
                 raise Exception()
             # version
             if ulog_key_header[7] != 1:
+                print("Unsupported header version")
                 raise Exception()
             # expected key exchange algorithm (RSA_OAEP)
             if ulog_key_header[16] != 4:
+                print("Unsupported key algorithm")
                 raise Exception()
-            key_size = ulog_key_header[19] << 8 | ulog_key_header[18];
-            nonce_size = ulog_key_header[21] << 8 | ulog_key_header[20];
+            key_size = ulog_key_header[19] << 8 | ulog_key_header[18]
+            nonce_size = ulog_key_header[21] << 8 | ulog_key_header[20]
             ulog_key_cipher = f.read(key_size)
             nonce = f.read(nonce_size)
         except:
-            print("Keyfile format error")
-            sys.exit(1);
+            print("Keydata format error")
+            sys.exit(1)
+
+    if magic == "ULogEnc":
+        data_offset = 22 + key_size + nonce_size
+    else:
+        data_offset = 0
 
     # Decrypt the xchacha key
     cipher_rsa = PKCS1_OAEP.new(r,SHA256)
     ulog_key = cipher_rsa.decrypt(ulog_key_cipher)
     #print(binascii.hexlify(ulog_key))
 
-    # Read and decrypt the .ulgc
+    # Read and decrypt the ulog data
     cipher = ChaCha20.new(key=ulog_key, nonce=nonce)
+
+    outfilename = Path(args.ulog_file).stem + ".ulog"
     with open(args.ulog_file, 'rb') as f:
-        with open(args.ulog_file.rstrip(args.ulog_file[-1]), 'wb') as out:
+        if data_offset > 0:
+            f.seek(data_offset)
+        with open(outfilename, 'wb') as out:
             out.write(cipher.decrypt(f.read()))

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1307,7 +1307,7 @@ int Logger::get_log_file_name(LogType type, char *file_name, size_t file_name_si
 #if defined(PX4_CRYPTO)
 
 	if (_param_sdlog_crypto_algorithm.get() != 0) {
-		crypto_suffix = "c";
+		crypto_suffix = "e";
 	}
 
 #endif


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When downloading the encrypted log files with QGC, there is no robust way to know which symmetric key files and encrypted ulog data files are related ones. Only way currently is to look at consecutive log files and assume that the smaller file (around 300bytes) is the key and the related ulog file is the next immediate file after that. This makes it a bit difficult to automate the log gathering.

### Solution
To improve the situation, the encrypted/wrapped symmetric key data could be combine with the encrypted ulog data into one single file. Then the key is always kept in the same place with corresponding encrypted ulog data, so it cannot be mixed with other keys.

### Changelog Entry
For release notes:
```
Feature: Ulog encryption changed to combine the wrapped symmetric key and ulog data into one file (.ulge)
Documentation: docs.px4.io
```

### Alternatives
Change mavlink_log_handler to either combine the key&data files or align/change names of the key&data entries to make more reliable way to link them together after download.

### Test coverage
- Tested with fmu-v5. Log entry generated using 'logger on/off' commands. Log entry downloaded using QGC and decrypted with Tools/decrypt_ulog.py tool. Verified the ulog output by uploading it to Flight Review tool.

### Context
https://docs.px4.io/main/en/dev_log/log_encryption.html
documentation change PR: https://github.com/PX4/PX4-user_guide/pull/3468
