### PR TITLE
ci: publish px4-dev container to docker hub

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -90,7 +90,6 @@ jobs:
 
       - name: Push container image
         uses: docker/build-push-action@v6
-        if: ${{ github.event_name == 'push' }}
         with:
           context: Tools/setup
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -43,7 +43,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=ref,event=branch,suffix=-{{date 'YYYYMMDD'}}
+            type=ref,event=branch,suffix=-{{date 'YYYYMMDD'}},priority=600
+            type=ref,event=branch,suffix=,priority=500
             type=ref,event=pr
             type=sha
 

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -25,6 +25,12 @@ jobs:
           submodules: false
           fetch-depth: 0
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -38,6 +44,7 @@ jobs:
         with:
           images: |
             ghcr.io/PX4/px4-dev
+            px4io/px4-dev
           tags: |
             type=schedule
             type=semver,pattern={{version}}


### PR DESCRIPTION
Publishes the px4-dev container to docker hub, and updates tags

Docker Hub
https://hub.docker.com/repository/docker/px4io/px4-dev/general

GitHub Registry
https://github.com/PX4/PX4-Autopilot/pkgs/container/px4-dev

Updated Tags:

- ghcr.io/px4/px4-dev:pr-24027
- ghcr.io/px4/px4-dev:sha-b1b98d1
- px4io/px4-dev:pr-24027
- px4io/px4-dev:sha-b1b98d1