### PR TITLE
differential: speed setpoint feasibility and slow down effect in mission mode

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4009_gz_r1_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4009_gz_r1_rover
@@ -26,7 +26,6 @@ param set-default RD_MAX_THR_SPD 2.15
 param set-default RD_SPEED_P 0.1
 param set-default RD_SPEED_I 0.01
 param set-default RD_MAX_YAW_RATE 180
-param set-default RD_MISS_SPD_DEF 2
 param set-default RD_TRANS_DRV_TRN 0.349066
 param set-default RD_TRANS_TRN_DRV 0.174533
 param set-default RD_MAX_YAW_ACCEL 1000

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
@@ -29,7 +29,6 @@ param set-default RD_MAX_SPEED 8
 param set-default RD_YAW_P 5
 param set-default RD_YAW_I 0.1
 param set-default RD_MAX_YAW_RATE 30
-param set-default RD_MISS_SPD_DEF 8
 param set-default RD_TRANS_DRV_TRN 0.349066
 param set-default RD_TRANS_TRN_DRV 0.174533
 

--- a/ROMFS/px4fmu_common/init.d/airframes/50001_aion_robotics_r1_rover
+++ b/ROMFS/px4fmu_common/init.d/airframes/50001_aion_robotics_r1_rover
@@ -31,7 +31,6 @@ param set-default RD_MAX_THR_SPD 1.9
 param set-default RD_MAX_THR_YAW_R 0.7
 param set-default RD_MAX_YAW_ACCEL 600
 param set-default RD_MAX_YAW_RATE 250
-param set-default RD_MISS_SPD_DEF 1.5
 param set-default RD_SPEED_P 0.1
 param set-default RD_SPEED_I 0.01
 param set-default RD_TRANS_DRV_TRN 0.785398

--- a/src/modules/rover_differential/RoverDifferentialControl/RoverDifferentialControl.cpp
+++ b/src/modules/rover_differential/RoverDifferentialControl/RoverDifferentialControl.cpp
@@ -116,6 +116,20 @@ void RoverDifferentialControl::computeMotorCommands(const float vehicle_yaw, con
 	float forward_speed_normalized{0.f};
 
 	if (PX4_ISFINITE(_rover_differential_setpoint.forward_speed_setpoint)) {
+		if (_param_rd_max_thr_spd.get() > FLT_EPSILON) {
+
+			forward_speed_normalized = math::interpolate<float>(_rover_differential_setpoint.forward_speed_setpoint,
+						   -_param_rd_max_thr_spd.get(), _param_rd_max_thr_spd.get(), -1.f, 1.f);
+
+			if (fabsf(forward_speed_normalized) > 1.f -
+			    fabsf(speed_diff_normalized)) { // Adjust forward speed setpoint if it is infeasible due to the desired speed difference of the left/right wheels
+				_rover_differential_setpoint.forward_speed_setpoint = sign(_rover_differential_setpoint.forward_speed_setpoint) *
+						math::interpolate<float>(1.f - fabsf(speed_diff_normalized), -1.f, 1.f,
+								-_param_rd_max_thr_spd.get(), _param_rd_max_thr_spd.get());
+			}
+		}
+
+
 		forward_speed_normalized = calcNormalizedSpeedSetpoint(_rover_differential_setpoint.forward_speed_setpoint,
 					   vehicle_forward_speed, _param_rd_max_thr_spd.get(), _forward_speed_setpoint_with_accel_limit, _pid_throttle,
 					   _param_rd_max_accel.get(), _param_rd_max_decel.get(), dt, false);

--- a/src/modules/rover_differential/RoverDifferentialGuidance/RoverDifferentialGuidance.hpp
+++ b/src/modules/rover_differential/RoverDifferentialGuidance/RoverDifferentialGuidance.hpp
@@ -144,9 +144,8 @@ private:
 		(ParamFloat<px4::params::RD_MAX_JERK>)      _param_rd_max_jerk,
 		(ParamFloat<px4::params::RD_MAX_DECEL>)     _param_rd_max_decel,
 		(ParamFloat<px4::params::RD_MAX_SPEED>)     _param_rd_max_speed,
-		(ParamFloat<px4::params::RD_MISS_SPD_DEF>)  _param_rd_miss_spd_def,
 		(ParamFloat<px4::params::RD_TRANS_TRN_DRV>) _param_rd_trans_trn_drv,
-		(ParamFloat<px4::params::RD_TRANS_DRV_TRN>) _param_rd_trans_drv_trn
-
+		(ParamFloat<px4::params::RD_TRANS_DRV_TRN>) _param_rd_trans_drv_trn,
+		(ParamFloat<px4::params::RD_MISS_SPD_GAIN>) _param_rd_miss_spd_gain
 	)
 };

--- a/src/modules/rover_differential/module.yaml
+++ b/src/modules/rover_differential/module.yaml
@@ -191,17 +191,6 @@ parameters:
         decimal: 2
         default: 2
 
-      RD_MISS_SPD_DEF:
-        description:
-          short: Default forward speed for the rover during auto modes
-        type: float
-        unit: m/s
-        min: 0
-        max: 100
-        increment: 0.01
-        decimal: 2
-        default: 1
-
       RD_TRANS_TRN_DRV:
         description:
             short: Yaw error threshhold to switch from spot turning to driving
@@ -228,3 +217,19 @@ parameters:
         increment: 0.01
         decimal: 3
         default: 0.174533
+
+      RD_MISS_SPD_GAIN:
+        description:
+          short: Tuning parameter for the speed reduction during waypoint transition
+          long: |
+            The waypoint transition speed is calculated as:
+            Transition_speed = Maximum_speed * (1 - normalized_transition_angle * RM_MISS_VEL_GAIN)
+            The normalized transition angle is the angle between the line segment from prev-curr WP and curr-next WP
+            interpolated from [0, 180] -> [0, 1].
+            Higher value -> More speed reduction during waypoint transitions.
+        type: float
+        min: 0.05
+        max: 100
+        increment: 0.01
+        decimal: 2
+        default: 1


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This PR adds these 2 updates to the differential rover module:
1. The controller prioritizes yaw rate over forward speed. A high yaw rate setpoint can therefor make the forward speed setpoint infeasible due to actuator limitations. This leads the integrator of the speed controller to build up. This problem is fixed in this PR by adjusting the speed setpoint based on the amount of control effort that is “occupied” by the yaw rate setpoint.

2. Adds a tunable slow down effect in mission mode. As the rover approaches a waypoint it will slow down with the following logic: If the angle between the prev-curr-wp and curr-next-wp lines is bigger than  `RD_TRANS_DRV_TRN` the rover will come to a full stop at the waypoint and then turn on the spot (this is not new). If this angle is lower then it will slow down s.t. it arrives at the waypoint with the following speed (this is new):  
$v_{transition} = v_{max} \cdot (1 - \theta_{normalized} \cdot k) $

   with

   - $v_{transition}:$ Transition speed
   - $v_{max}:$ Maximum speed 'RD_MAX_SPEED`
   - $\theta_{normalized}:$ Angle between the linesegment of prev-curr and curr-next waypoints normalized from $[0\degree, 180\degree]$ to $[1, 0]$
   - $k:$ Tuning parameter `RD_MISS_VEL_GAIN`
   This adds the new parameter `RD_MISS_VEL_GAIN` and also deprecates `RD_MISS_SPD_DEF`

### Test coverage
- Tested in SITL
- Tested on hardware