### PR TITLE
ci: disable publishing PR images to docker hub

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -44,7 +45,7 @@ jobs:
         with:
           images: |
             ghcr.io/PX4/px4-dev
-            px4io/px4-dev
+            ${{ (github.event_name != 'pull_request') && 'px4io/px4-dev' || '' }}
           tags: |
             type=schedule
             type=semver,pattern={{version}}

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -25,6 +25,11 @@ jobs:
           submodules: false
           fetch-depth: 0
 
+      - name: Set PX4 Tag
+        id: px4-tag
+        run: |
+          echo "tag=$(git describe --tags --match 'v[0-9]*')" >> $GITHUB_OUTPUT
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
@@ -47,14 +52,13 @@ jobs:
             ghcr.io/PX4/px4-dev
             ${{ (github.event_name != 'pull_request') && 'px4io/px4-dev' || '' }}
           tags: |
-            type=schedule
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=ref,event=branch,suffix=-{{date 'YYYYMMDD'}},priority=600
+            type=ref,event=branch,value=${{ steps.px4-tag.outputs.tag }},priority=700
+            type=ref,event=branch,suffix=-{{date 'YYYY-MM-DD'}},priority=600
             type=ref,event=branch,suffix=,priority=500
             type=ref,event=pr
-            type=sha
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Docker hub is rate limiting our API access, as a result tests are failing for no apparent reason. This change will decrease the API calls by at least 80%

We have applied for an Open Source account with greater API limits, I will come back to this and update as necessary when and if they grant us access to their program.

This PR also introduces the PX4 git tags, as a tagging mechanism for images, eg:

```
px4-dev:v1.16.0-alpha2-27-g8e6e401972
```