### PR TITLE
RPM sensing from GPIO (PWM pin) pulses

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -354,6 +354,11 @@ else
 	then
 		pps_capture start
 	fi
+	# RPM capture driver
+	if param greater -s RPM_CAP_ENABLE 0
+	then
+		rpm_capture start
+	fi
 	# Camera capture driver
 	if param greater -s CAM_CAP_FBACK 0
 	then

--- a/Tools/kconfig/allyesconfig.py
+++ b/Tools/kconfig/allyesconfig.py
@@ -40,6 +40,7 @@ exception_list = [
     'DRIVERS_DISTANCE_SENSOR_SRF05', # Requires hardcoded GPIO_ULTRASOUND
     'DRIVERS_PPS_CAPTURE', # Requires PPS GPIO config
     'DRIVERS_PWM_INPUT', # Requires PWM config
+    'DRIVERS_RPM_CAPTURE', # Requires PPS GPIO config
     'DRIVERS_TEST_PPM', # PIN config not portable
     'DRIVERS_TATTU_CAN', # Broken needs fixing
     'MODULES_REPLAY', # Fails on NuttX targets maybe force POSIX dependency?

--- a/msg/Rpm.msg
+++ b/msg/Rpm.msg
@@ -1,7 +1,4 @@
-uint64 timestamp                      # time since system start (microseconds)
+uint64 timestamp # time since system start (microseconds)
 
-float32 indicated_frequency_rpm       # indicated rotor Frequency in Revolution per minute
-float32 estimated_accurancy_rpm       # estimated accuracy in Revolution per minute
-
+float32 rpm_estimate # filtered revolutions per minute
 float32 rpm_raw # measured rpm
-float32 rpm_estimate # filtered rpm

--- a/msg/Rpm.msg
+++ b/msg/Rpm.msg
@@ -1,4 +1,4 @@
 uint64 timestamp # time since system start (microseconds)
 
 float32 rpm_estimate # filtered revolutions per minute
-float32 rpm_raw # measured rpm
+float32 rpm_raw

--- a/msg/Rpm.msg
+++ b/msg/Rpm.msg
@@ -2,3 +2,6 @@ uint64 timestamp                      # time since system start (microseconds)
 
 float32 indicated_frequency_rpm       # indicated rotor Frequency in Revolution per minute
 float32 estimated_accurancy_rpm       # estimated accuracy in Revolution per minute
+
+float32 rpm_raw # measured rpm
+float32 rpm_estimate # filtered rpm

--- a/platforms/nuttx/src/px4/nxp/imxrt/include/px4_arch/io_timer.h
+++ b/platforms/nuttx/src/px4/nxp/imxrt/include/px4_arch/io_timer.h
@@ -68,7 +68,8 @@ typedef enum io_timer_channel_mode_t {
 	IOTimerChanMode_Dshot   = 6,
 	IOTimerChanMode_LED     = 7,
 	IOTimerChanMode_PPS     = 8,
-	IOTimerChanMode_Other   = 9,
+	IOTimerChanMode_RPM     = 9,
+	IOTimerChanMode_Other   = 10,
 	IOTimerChanModeSize
 } io_timer_channel_mode_t;
 

--- a/platforms/nuttx/src/px4/nxp/kinetis/include/px4_arch/io_timer.h
+++ b/platforms/nuttx/src/px4/nxp/kinetis/include/px4_arch/io_timer.h
@@ -67,7 +67,8 @@ typedef enum io_timer_channel_mode_t {
 	IOTimerChanMode_Dshot   = 6,
 	IOTimerChanMode_LED     = 7,
 	IOTimerChanMode_PPS     = 8,
-	IOTimerChanMode_Other   = 9,
+	IOTimerChanMode_RPM     = 9,
+	IOTimerChanMode_Other   = 10,
 	IOTimerChanModeSize
 } io_timer_channel_mode_t;
 

--- a/platforms/nuttx/src/px4/nxp/rt106x/include/px4_arch/io_timer.h
+++ b/platforms/nuttx/src/px4/nxp/rt106x/include/px4_arch/io_timer.h
@@ -68,7 +68,8 @@ typedef enum io_timer_channel_mode_t {
 	IOTimerChanMode_Dshot   = 6,
 	IOTimerChanMode_LED     = 7,
 	IOTimerChanMode_PPS     = 8,
-	IOTimerChanMode_Other   = 9,
+	IOTimerChanMode_RPM     = 9,
+	IOTimerChanMode_Other   = 10,
 	IOTimerChanModeSize
 } io_timer_channel_mode_t;
 

--- a/platforms/nuttx/src/px4/nxp/s32k1xx/include/px4_arch/io_timer.h
+++ b/platforms/nuttx/src/px4/nxp/s32k1xx/include/px4_arch/io_timer.h
@@ -63,7 +63,8 @@ typedef enum io_timer_channel_mode_t {
 	IOTimerChanMode_Dshot   = 6,
 	IOTimerChanMode_LED     = 7,
 	IOTimerChanMode_PPS     = 8,
-	IOTimerChanMode_Other   = 9,
+	IOTimerChanMode_RPM     = 9,
+	IOTimerChanMode_Other   = 10,
 	IOTimerChanModeSize
 } io_timer_channel_mode_t;
 

--- a/platforms/nuttx/src/px4/nxp/s32k3xx/include/px4_arch/io_timer.h
+++ b/platforms/nuttx/src/px4/nxp/s32k3xx/include/px4_arch/io_timer.h
@@ -63,7 +63,8 @@ typedef enum io_timer_channel_mode_t {
 	IOTimerChanMode_Dshot   = 6,
 	IOTimerChanMode_LED     = 7,
 	IOTimerChanMode_PPS     = 8,
-	IOTimerChanMode_Other   = 9,
+	IOTimerChanMode_RPM     = 9,
+	IOTimerChanMode_Other   = 10,
 	IOTimerChanModeSize
 } io_timer_channel_mode_t;
 

--- a/platforms/nuttx/src/px4/rpi/rpi_common/include/px4_arch/io_timer.h
+++ b/platforms/nuttx/src/px4/rpi/rpi_common/include/px4_arch/io_timer.h
@@ -73,6 +73,10 @@ typedef enum io_timer_channel_mode_t {
 	IOTimerChanMode_OneShot = 4,
 	IOTimerChanMode_Trigger = 5,
 	IOTimerChanMode_Dshot   = 6,
+	IOTimerChanMode_LED     = 7,
+	IOTimerChanMode_PPS     = 8,
+	IOTimerChanMode_RPM     = 9,
+	IOTimerChanMode_Other   = 10,
 	IOTimerChanModeSize
 } io_timer_channel_mode_t;
 

--- a/platforms/nuttx/src/px4/stm/stm32_common/include/px4_arch/io_timer.h
+++ b/platforms/nuttx/src/px4/stm/stm32_common/include/px4_arch/io_timer.h
@@ -79,7 +79,8 @@ typedef enum io_timer_channel_mode_t {
 	IOTimerChanMode_Dshot   = 6,
 	IOTimerChanMode_LED     = 7,
 	IOTimerChanMode_PPS     = 8,
-	IOTimerChanMode_Other   = 9,
+	IOTimerChanMode_RPM     = 9,
+	IOTimerChanMode_Other   = 10,
 	IOTimerChanModeSize
 } io_timer_channel_mode_t;
 

--- a/src/drivers/camera_capture/camera_capture.cpp
+++ b/src/drivers/camera_capture/camera_capture.cpp
@@ -71,7 +71,7 @@ CameraCapture::CameraCapture() :
 	_p_camera_capture_edge = param_find("CAM_CAP_EDGE");
 	param_get(_p_camera_capture_edge, &_camera_capture_edge);
 
-	for (unsigned i = 0; i < 16 && _capture_channel == -1; ++i) {
+	for (unsigned i = 0; i < PWM_OUTPUT_MAX_CHANNELS && _capture_channel == -1; ++i) {
 		char param_name[17];
 		snprintf(param_name, sizeof(param_name), "%s_%s%d", PARAM_PREFIX, "FUNC", i + 1);
 		param_t function_handle = param_find(param_name);

--- a/src/drivers/camera_capture/camera_capture.cpp
+++ b/src/drivers/camera_capture/camera_capture.cpp
@@ -81,7 +81,7 @@ CameraCapture::CameraCapture() :
 		int32_t function;
 
 		if (function_handle != PARAM_INVALID && param_get(function_handle, &function) == 0) {
-			if (function == 2032) { // Camera_Capture
+			if (function == 2032) { // Camera_Capture see mixer_module/output_functions.yaml parameter metadata definition
 				_capture_channel = i;
 			}
 		}

--- a/src/drivers/camera_capture/camera_capture.cpp
+++ b/src/drivers/camera_capture/camera_capture.cpp
@@ -71,9 +71,6 @@ CameraCapture::CameraCapture() :
 	_p_camera_capture_edge = param_find("CAM_CAP_EDGE");
 	param_get(_p_camera_capture_edge, &_camera_capture_edge);
 
-	// get the capture channel from function configuration params
-	_capture_channel = -1;
-
 	for (unsigned i = 0; i < 16 && _capture_channel == -1; ++i) {
 		char param_name[17];
 		snprintf(param_name, sizeof(param_name), "%s_%s%d", PARAM_PREFIX, "FUNC", i + 1);

--- a/src/drivers/camera_capture/camera_capture.hpp
+++ b/src/drivers/camera_capture/camera_capture.hpp
@@ -96,7 +96,7 @@ public:
 	static struct work_s	_work_publisher;
 
 private:
-	int _capture_channel = 5; ///< by default, use FMU output 6
+	int _capture_channel{-1};
 
 	// Publishers
 	uORB::Publication<vehicle_command_ack_s>	_command_ack_pub{ORB_ID(vehicle_command_ack)};

--- a/src/drivers/camera_trigger/interfaces/src/camera_interface.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/camera_interface.cpp
@@ -51,7 +51,7 @@ void CameraInterface::get_pins()
 		int32_t function;
 
 		if (function_handle != PARAM_INVALID && param_get(function_handle, &function) == 0) {
-			if (function == 2000) { // Camera_Trigger
+			if (function == 2000) { // Camera_Trigger see mixer_module/output_functions.yaml parameter metadata definition
 				_pins[pin_index++] = i;
 			}
 		}

--- a/src/drivers/camera_trigger/interfaces/src/camera_interface.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/camera_interface.cpp
@@ -32,6 +32,7 @@
  ****************************************************************************/
 
 #include "camera_interface.h"
+#include <drivers/drv_pwm_output.h>
 #include <px4_platform_common/log.h>
 #include <board_config.h>
 
@@ -44,7 +45,7 @@ void CameraInterface::get_pins()
 
 	unsigned pin_index = 0;
 
-	for (unsigned i = 0; i < 16 && pin_index < arraySize(_pins); ++i) {
+	for (unsigned i = 0; i < PWM_OUTPUT_MAX_CHANNELS && pin_index < arraySize(_pins); ++i) {
 		char param_name[17];
 		snprintf(param_name, sizeof(param_name), "%s_%s%d", PARAM_PREFIX, "FUNC", i + 1);
 		param_t function_handle = param_find(param_name);

--- a/src/drivers/pps_capture/PPSCapture.cpp
+++ b/src/drivers/pps_capture/PPSCapture.cpp
@@ -70,7 +70,7 @@ bool PPSCapture::init()
 		int32_t function;
 
 		if (function_handle != PARAM_INVALID && param_get(function_handle, &function) == 0) {
-			if (function == 2064) { // PPS_Input
+			if (function == 2064) { // PPS_Input see mixer_module/output_functions.yaml parameter metadata definition
 				_channel = i;
 			}
 		}

--- a/src/drivers/pps_capture/PPSCapture.cpp
+++ b/src/drivers/pps_capture/PPSCapture.cpp
@@ -63,7 +63,7 @@ bool PPSCapture::init()
 {
 	bool success = false;
 
-	for (unsigned i = 0; i < 16; ++i) {
+	for (unsigned i = 0; i < PWM_OUTPUT_MAX_CHANNELS; ++i) {
 		char param_name[17];
 		snprintf(param_name, sizeof(param_name), "%s_%s%d", PARAM_PREFIX, "FUNC", i + 1);
 		param_t function_handle = param_find(param_name);

--- a/src/drivers/rpm/pcf8583/PCF8583.cpp
+++ b/src/drivers/rpm/pcf8583/PCF8583.cpp
@@ -196,12 +196,10 @@ void PCF8583::RunImpl()
 
 	// Calculate RPM and accuracy estimation
 	float indicated_rpm = (((float)diffCount / _param_pcf8583_magnet.get()) / ((float)diffTime / 1e6f)) * 60.f;
-	float estimated_accurancy = 1 / (float)_param_pcf8583_magnet.get() / ((float)diffTime / 1e6f) * 60.f;
 
 	// publish data to uorb
 	rpm_s msg{};
-	msg.indicated_frequency_rpm = indicated_rpm;
-	msg.estimated_accurancy_rpm = estimated_accurancy;
+	msg.rpm_estimate = indicated_rpm;
 	msg.timestamp = hrt_absolute_time();
 	_rpm_pub.publish(msg);
 

--- a/src/drivers/rpm/rpm_simulator/rpm_simulator.cpp
+++ b/src/drivers/rpm/rpm_simulator/rpm_simulator.cpp
@@ -66,8 +66,7 @@ int rpm_simulator_main(int argc, char *argv[])
 
 	// prpepare RPM data message
 	rpm.timestamp = timestamp_us;
-	rpm.indicated_frequency_rpm = frequency;
-	rpm.estimated_accurancy_rpm = frequency / 100.0f;
+	rpm.rpm_estimate = frequency;
 
 	// Publish data and let the user know what was published
 	rpm_pub.publish(rpm);

--- a/src/drivers/rpm_capture/CMakeLists.txt
+++ b/src/drivers/rpm_capture/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2024 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/drivers/rpm_capture/CMakeLists.txt
+++ b/src/drivers/rpm_capture/CMakeLists.txt
@@ -1,0 +1,47 @@
+############################################################################
+#
+#   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+set(PARAM_PREFIX PWM_MAIN)
+
+if(CONFIG_BOARD_IO)
+	set(PARAM_PREFIX PWM_AUX)
+endif()
+
+px4_add_module(
+	MODULE drivers__rpm_capture
+	MAIN rpm_capture
+	COMPILE_FLAGS
+		-DPARAM_PREFIX="${PARAM_PREFIX}"
+	SRCS
+		RPMCapture.cpp
+	)

--- a/src/drivers/rpm_capture/Kconfig
+++ b/src/drivers/rpm_capture/Kconfig
@@ -1,0 +1,5 @@
+menuconfig DRIVERS_RPM_CAPTURE
+	bool "rpm_capture"
+	default n
+	---help---
+		Enable support for rpm_capture

--- a/src/drivers/rpm_capture/RPMCapture.cpp
+++ b/src/drivers/rpm_capture/RPMCapture.cpp
@@ -138,7 +138,7 @@ void RPMCapture::Run()
 	const float dt = math::constrain((now - _timestamp_last_update) * 1e-6f, 0.01f, 1.f);
 	_timestamp_last_update = now;
 	_rpm_filter.setParameters(dt, 0.5f);
-	_rpm_filter.update(rpm_raw);
+	_rpm_filter.update(_rpm_median_filter.apply(rpm_raw));
 
 	rpm_s rpm{};
 	rpm.timestamp = now;

--- a/src/drivers/rpm_capture/RPMCapture.cpp
+++ b/src/drivers/rpm_capture/RPMCapture.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2024 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,7 +66,7 @@ bool RPMCapture::init()
 		int32_t function;
 
 		if (function_handle != PARAM_INVALID && param_get(function_handle, &function) == 0) {
-			if (function == 2070) { // RPM_Input
+			if (function == 2070) { // RPM_Input see mixer_module/output_functions.yaml parameter metadata definition
 				_channel = i;
 			}
 		}

--- a/src/drivers/rpm_capture/RPMCapture.cpp
+++ b/src/drivers/rpm_capture/RPMCapture.cpp
@@ -122,6 +122,7 @@ void RPMCapture::Run()
 	} else {
 		// Timeout for no interrupts
 		_period = 0;
+		ScheduleDelayed(RPM_PULSE_TIMEOUT);
 	}
 
 	float rpm_raw{0.f};

--- a/src/drivers/rpm_capture/RPMCapture.cpp
+++ b/src/drivers/rpm_capture/RPMCapture.cpp
@@ -136,7 +136,7 @@ void RPMCapture::Run()
 
 	if (rpm_raw < RPM_MAX_VALUE) {
 		// Don't update RPM filter with outliers
-		const float dt = math::constrain((now - _timestamp_last_update) * 1e-6f, 0.01f, 1.f);
+		const float dt = math::min((now - _timestamp_last_update) * 1e-6f, 1.f);
 		_timestamp_last_update = now;
 		_rpm_filter.setParameters(dt, 0.5f);
 		_rpm_filter.update(_rpm_median_filter.apply(rpm_raw));

--- a/src/drivers/rpm_capture/RPMCapture.cpp
+++ b/src/drivers/rpm_capture/RPMCapture.cpp
@@ -129,6 +129,9 @@ void RPMCapture::Run()
 	if (_period < RPM_PULSE_TIMEOUT) {
 		// 1'000'000 / [us] -> pulses per second * 60 -> pulses per minute
 		rpm_raw = 60.f * 1e6f / static_cast<float>(_param_rpm_puls_per_rev.get() * _period);
+
+	} else {
+		_rpm_filter.reset(rpm_raw);
 	}
 
 	if (rpm_raw < RPM_MAX_VALUE) {

--- a/src/drivers/rpm_capture/RPMCapture.cpp
+++ b/src/drivers/rpm_capture/RPMCapture.cpp
@@ -1,0 +1,179 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+
+#include "RPMCapture.hpp"
+#include <px4_arch/io_timer.h>
+#include <board_config.h>
+#include <parameters/param.h>
+#include <px4_platform_common/events.h>
+#include <systemlib/mavlink_log.h>
+
+RPMCapture::RPMCapture() :
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default)
+{
+	_pwm_input_pub.advertise();
+}
+
+RPMCapture::~RPMCapture()
+{
+	if (_channel >= 0) {
+		io_timer_unallocate_channel(_channel);
+		px4_arch_gpiosetevent(_rpm_capture_gpio, false, false, false, nullptr, nullptr);
+	}
+}
+
+bool RPMCapture::init()
+{
+	bool success = false;
+
+	for (unsigned i = 0; i < 16; ++i) {
+		char param_name[17];
+		snprintf(param_name, sizeof(param_name), "%s_%s%d", PARAM_PREFIX, "FUNC", i + 1);
+		param_t function_handle = param_find(param_name);
+		int32_t function;
+
+		if (function_handle != PARAM_INVALID && param_get(function_handle, &function) == 0) {
+			if (function == 2070) { // RPM_Input
+				_channel = i;
+			}
+		}
+	}
+
+	if (_channel == -1) {
+		PX4_WARN("No RPM channel configured");
+		return false;
+	}
+
+	int ret = io_timer_allocate_channel(_channel, IOTimerChanMode_Other); // TODO: add IOTimerChanMode_RPM
+
+	if (ret != PX4_OK) {
+		PX4_ERR("gpio alloc failed (%i) for RPM at channel (%d)", ret, _channel);
+		return false;
+	}
+
+	_rpm_capture_gpio = PX4_MAKE_GPIO_EXTI(io_timer_channel_get_as_pwm_input(_channel));
+	int ret_val = px4_arch_gpiosetevent(_rpm_capture_gpio, true, false, true, &RPMCapture::gpio_interrupt_callback, this);
+
+	if (ret_val == PX4_OK) {
+		success = true;
+	}
+
+	return success;
+}
+
+void RPMCapture::Run()
+{
+	if (should_exit()) {
+		exit_and_cleanup();
+		return;
+	}
+
+	pwm_input_s pwm_input{};
+	pwm_input.timestamp = hrt_absolute_time();
+	pwm_input.period = _hrt_timestamp - _hrt_timestamp_prev;
+	pwm_input.error_count = _error_count;
+	_hrt_timestamp_prev = _hrt_timestamp;
+	_value_processed.store(true);
+	_pwm_input_pub.publish(pwm_input);
+}
+
+int RPMCapture::gpio_interrupt_callback(int irq, void *context, void *arg)
+{
+	RPMCapture *instance = static_cast<RPMCapture *>(arg);
+
+	if (!instance->_value_processed.load()) {
+		++instance->_error_count;
+	}
+
+	instance->_hrt_timestamp = hrt_absolute_time();
+	instance->_value_processed.store(false);
+	instance->ScheduleNow();
+
+	return PX4_OK;
+}
+
+int RPMCapture::task_spawn(int argc, char *argv[])
+{
+	RPMCapture *instance = new RPMCapture();
+
+	if (instance) {
+		_object.store(instance);
+		_task_id = task_id_is_work_queue;
+
+		if (instance->init()) {
+			return PX4_OK;
+		}
+
+	} else {
+		PX4_ERR("alloc failed");
+	}
+
+	delete instance;
+	_object.store(nullptr);
+	_task_id = -1;
+
+	return PX4_ERROR;
+}
+
+int RPMCapture::custom_command(int argc, char *argv[])
+{
+	return print_usage("unknown command");
+}
+
+int RPMCapture::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_USAGE_NAME("rpm_capture", "driver");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+	return 0;
+}
+
+void RPMCapture::stop()
+{
+	exit_and_cleanup();
+}
+
+extern "C" __EXPORT int rpm_capture_main(int argc, char *argv[])
+{
+	if (argc >= 2 && !strcmp(argv[1], "stop") && RPMCapture::is_running()) {
+		RPMCapture::stop();
+	}
+
+	return RPMCapture::main(argc, argv);
+}

--- a/src/drivers/rpm_capture/RPMCapture.cpp
+++ b/src/drivers/rpm_capture/RPMCapture.cpp
@@ -119,16 +119,14 @@ void RPMCapture::Run()
 		pwm_input.error_count = _error_count;
 		_pwm_input_pub.publish(pwm_input);
 
-		// Schedule for next timeout
-		ScheduleClear();
-		ScheduleDelayed(RPM_PULSE_TIMEOUT);
+		ScheduleClear(); // Do not run on previously scheduled timeout
 
 	} else {
 		// Timeout for no interrupts
 		_period = UINT32_MAX;
-		ScheduleDelayed(RPM_PULSE_TIMEOUT);
 	}
 
+	ScheduleDelayed(RPM_PULSE_TIMEOUT); // Schule a new timeout
 
 	if (_period > _min_pulse_period_us) {
 		// Only update if the period is above the min pulse period threshold

--- a/src/drivers/rpm_capture/RPMCapture.cpp
+++ b/src/drivers/rpm_capture/RPMCapture.cpp
@@ -125,7 +125,7 @@ void RPMCapture::Run()
 
 	} else {
 		// Timeout for no interrupts
-		_period = 0;
+		_period = UINT32_MAX;
 		ScheduleDelayed(RPM_PULSE_TIMEOUT);
 	}
 

--- a/src/drivers/rpm_capture/RPMCapture.cpp
+++ b/src/drivers/rpm_capture/RPMCapture.cpp
@@ -77,7 +77,7 @@ bool RPMCapture::init()
 		return false;
 	}
 
-	int ret = io_timer_allocate_channel(_channel, IOTimerChanMode_Other); // TODO: add IOTimerChanMode_RPM
+	int ret = io_timer_allocate_channel(_channel, IOTimerChanMode_RPM);
 
 	if (ret != PX4_OK) {
 		PX4_ERR("gpio alloc failed (%i) for RPM at channel (%d)", ret, _channel);

--- a/src/drivers/rpm_capture/RPMCapture.cpp
+++ b/src/drivers/rpm_capture/RPMCapture.cpp
@@ -90,6 +90,7 @@ bool RPMCapture::init()
 		success = true;
 	}
 
+	success = success && _rpm_pub.advertise();
 	return success;
 }
 

--- a/src/drivers/rpm_capture/RPMCapture.cpp
+++ b/src/drivers/rpm_capture/RPMCapture.cpp
@@ -40,7 +40,8 @@
 #include <systemlib/mavlink_log.h>
 
 RPMCapture::RPMCapture() :
-	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default)
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default),
+	ModuleParams(nullptr)
 {
 	_pwm_input_pub.advertise();
 	ScheduleNow();
@@ -58,8 +59,8 @@ bool RPMCapture::init()
 {
 	bool success = false;
 
-	param_get(param_find("RPM_PULSES_PER_REV"), &_pulses_per_revolution);
-	_min_pulse_period_us = static_cast<uint32_t>(60.f * 1e6f / static_cast<float>(RPM_MAX_VALUE * _pulses_per_revolution));
+	_min_pulse_period_us = static_cast<uint32_t>(60.f * 1e6f / static_cast<float>(RPM_MAX_VALUE *
+			       _param_rpm_puls_per_rev.get()));
 
 	for (unsigned i = 0; i < 16; ++i) {
 		char param_name[17];
@@ -135,7 +136,7 @@ void RPMCapture::Run()
 
 		if (_period < RPM_PULSE_TIMEOUT) {
 			// 1'000'000 / [us] -> pulses per second * 60 -> pulses per minute
-			rpm_raw = 60.f * 1e6f / static_cast<float>(_pulses_per_revolution * _period);
+			rpm_raw = 60.f * 1e6f / static_cast<float>(_param_rpm_puls_per_rev.get() * _period);
 		}
 
 		const float dt = math::constrain((now - _timestamp_last_update) * 1e-6f, 0.01f, 1.f);

--- a/src/drivers/rpm_capture/RPMCapture.cpp
+++ b/src/drivers/rpm_capture/RPMCapture.cpp
@@ -59,7 +59,7 @@ bool RPMCapture::init()
 {
 	bool success = false;
 
-	for (unsigned i = 0; i < 16; ++i) {
+	for (unsigned i = 0; i < PWM_OUTPUT_MAX_CHANNELS; ++i) {
 		char param_name[17];
 		snprintf(param_name, sizeof(param_name), "%s_%s%d", PARAM_PREFIX, "FUNC", i + 1);
 		param_t function_handle = param_find(param_name);
@@ -138,7 +138,7 @@ void RPMCapture::Run()
 		// Don't update RPM filter with outliers
 		const float dt = math::min((now - _timestamp_last_update) * 1e-6f, 1.f);
 		_timestamp_last_update = now;
-		_rpm_filter.setParameters(dt, 0.5f);
+		_rpm_filter.setParameters(dt, RPM_FILTER_TIME_CONSTANT);
 		_rpm_filter.update(_rpm_median_filter.apply(rpm_raw));
 	}
 

--- a/src/drivers/rpm_capture/RPMCapture.hpp
+++ b/src/drivers/rpm_capture/RPMCapture.hpp
@@ -85,7 +85,7 @@ private:
 	hrt_abstime _hrt_timestamp_prev{0};
 	uint32_t _period{UINT32_MAX};
 	uint32_t _error_count{0};
-	px4::atomic<bool> _value_processed{true};
+	px4::atomic<bool> _interrupt_happened{false};
 
 	hrt_abstime _timestamp_last_update{0}; ///< to caluclate dt
 	AlphaFilter<float> _rpm_filter;

--- a/src/drivers/rpm_capture/RPMCapture.hpp
+++ b/src/drivers/rpm_capture/RPMCapture.hpp
@@ -1,0 +1,79 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <drivers/drv_hrt.h>
+#include <px4_arch/micro_hal.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/pwm_input.h>
+
+using namespace time_literals;
+
+class RPMCapture : public ModuleBase<RPMCapture>, public px4::ScheduledWorkItem
+{
+public:
+	RPMCapture();
+	virtual ~RPMCapture();
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	bool init();
+
+	static int gpio_interrupt_callback(int irq, void *context, void *arg);
+
+	/** RPMCapture is an interrupt-driven task and needs to be manually stopped */
+	static void stop();
+
+private:
+	void Run() override;
+
+	int _channel{-1};
+	uint32_t _rpm_capture_gpio{0};
+	uORB::Publication<pwm_input_s>	_pwm_input_pub{ORB_ID(pwm_input)};
+
+	hrt_abstime _hrt_timestamp{0};
+	hrt_abstime _hrt_timestamp_prev{0};
+	uint32_t _error_count{0};
+	px4::atomic<bool> _value_processed{true};
+};

--- a/src/drivers/rpm_capture/RPMCapture.hpp
+++ b/src/drivers/rpm_capture/RPMCapture.hpp
@@ -35,6 +35,7 @@
 
 #include <drivers/drv_hrt.h>
 #include <lib/mathlib/math/filter/AlphaFilter.hpp>
+#include <lib/mathlib/math/filter/MedianFilter.hpp>
 #include <px4_arch/micro_hal.h>
 #include <px4_platform_common/module.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
@@ -85,4 +86,5 @@ private:
 
 	hrt_abstime _timestamp_last_update{0}; ///< to caluclate dt
 	AlphaFilter<float> _rpm_filter;
+	MedianFilter<float, 5> _rpm_median_filter;
 };

--- a/src/drivers/rpm_capture/RPMCapture.hpp
+++ b/src/drivers/rpm_capture/RPMCapture.hpp
@@ -83,7 +83,7 @@ private:
 
 	hrt_abstime _hrt_timestamp{0};
 	hrt_abstime _hrt_timestamp_prev{0};
-	uint32_t _period{0};
+	uint32_t _period{UINT32_MAX};
 	uint32_t _error_count{0};
 	px4::atomic<bool> _value_processed{true};
 

--- a/src/drivers/rpm_capture/RPMCapture.hpp
+++ b/src/drivers/rpm_capture/RPMCapture.hpp
@@ -71,13 +71,12 @@ public:
 
 private:
 	static constexpr hrt_abstime RPM_PULSE_TIMEOUT = 1_s;
-	static constexpr uint32_t RPM_MAX_VALUE = 15000;
+	static constexpr float RPM_MAX_VALUE = 50e3f;
 
 	void Run() override;
 
 	int _channel{-1};
 	uint32_t _rpm_capture_gpio{0};
-	uint32_t _min_pulse_period_us{1};	///< [us] minimum pulse period
 	uORB::Publication<pwm_input_s> _pwm_input_pub{ORB_ID(pwm_input)};
 	uORB::PublicationMulti<rpm_s> _rpm_pub{ORB_ID(rpm)};
 

--- a/src/drivers/rpm_capture/RPMCapture.hpp
+++ b/src/drivers/rpm_capture/RPMCapture.hpp
@@ -68,6 +68,8 @@ public:
 	static void stop();
 
 private:
+	static constexpr hrt_abstime RPM_PULSE_TIMEOUT = 1_s;
+
 	void Run() override;
 
 	int _channel{-1};

--- a/src/drivers/rpm_capture/RPMCapture.hpp
+++ b/src/drivers/rpm_capture/RPMCapture.hpp
@@ -72,6 +72,7 @@ public:
 private:
 	static constexpr hrt_abstime RPM_PULSE_TIMEOUT = 1_s;
 	static constexpr float RPM_MAX_VALUE = 50e3f;
+	static constexpr float RPM_FILTER_TIME_CONSTANT = .5f;
 
 	void Run() override;
 

--- a/src/drivers/rpm_capture/RPMCapture.hpp
+++ b/src/drivers/rpm_capture/RPMCapture.hpp
@@ -34,12 +34,14 @@
 #pragma once
 
 #include <drivers/drv_hrt.h>
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
 #include <px4_arch/micro_hal.h>
 #include <px4_platform_common/module.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/pwm_input.h>
+#include <uORB/topics/rpm.h>
 
 using namespace time_literals;
 
@@ -71,9 +73,13 @@ private:
 	int _channel{-1};
 	uint32_t _rpm_capture_gpio{0};
 	uORB::Publication<pwm_input_s>	_pwm_input_pub{ORB_ID(pwm_input)};
+	uORB::Publication<rpm_s>	_rpm_pub{ORB_ID(rpm)};
 
 	hrt_abstime _hrt_timestamp{0};
 	hrt_abstime _hrt_timestamp_prev{0};
 	uint32_t _error_count{0};
 	px4::atomic<bool> _value_processed{true};
+
+	hrt_abstime _timestamp_last_update{0}; ///< to caluclate dt
+	AlphaFilter<float> _rpm_filter;
 };

--- a/src/drivers/rpm_capture/RPMCapture.hpp
+++ b/src/drivers/rpm_capture/RPMCapture.hpp
@@ -70,11 +70,14 @@ public:
 
 private:
 	static constexpr hrt_abstime RPM_PULSE_TIMEOUT = 1_s;
+	static constexpr uint32_t RPM_MAX_VALUE = 15000;
 
 	void Run() override;
 
 	int _channel{-1};
 	uint32_t _rpm_capture_gpio{0};
+	uint32_t _pulses_per_revolution{1};
+	uint32_t _min_pulse_period_us{1};	///< [us] minimum pulse period
 	uORB::Publication<pwm_input_s> _pwm_input_pub{ORB_ID(pwm_input)};
 	uORB::PublicationMulti<rpm_s> _rpm_pub{ORB_ID(rpm)};
 

--- a/src/drivers/rpm_capture/RPMCapture.hpp
+++ b/src/drivers/rpm_capture/RPMCapture.hpp
@@ -38,6 +38,7 @@
 #include <lib/mathlib/math/filter/MedianFilter.hpp>
 #include <px4_arch/micro_hal.h>
 #include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/Publication.hpp>
 #include <uORB/PublicationMulti.hpp>
@@ -46,7 +47,7 @@
 
 using namespace time_literals;
 
-class RPMCapture : public ModuleBase<RPMCapture>, public px4::ScheduledWorkItem
+class RPMCapture : public ModuleBase<RPMCapture>, public px4::ScheduledWorkItem, public ModuleParams
 {
 public:
 	RPMCapture();
@@ -76,7 +77,6 @@ private:
 
 	int _channel{-1};
 	uint32_t _rpm_capture_gpio{0};
-	uint32_t _pulses_per_revolution{1};
 	uint32_t _min_pulse_period_us{1};	///< [us] minimum pulse period
 	uORB::Publication<pwm_input_s> _pwm_input_pub{ORB_ID(pwm_input)};
 	uORB::PublicationMulti<rpm_s> _rpm_pub{ORB_ID(rpm)};
@@ -90,4 +90,8 @@ private:
 	hrt_abstime _timestamp_last_update{0}; ///< to caluclate dt
 	AlphaFilter<float> _rpm_filter;
 	MedianFilter<float, 5> _rpm_median_filter;
+
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::RPM_PULS_PER_REV>) _param_rpm_puls_per_rev
+	)
 };

--- a/src/drivers/rpm_capture/RPMCapture.hpp
+++ b/src/drivers/rpm_capture/RPMCapture.hpp
@@ -77,6 +77,7 @@ private:
 
 	hrt_abstime _hrt_timestamp{0};
 	hrt_abstime _hrt_timestamp_prev{0};
+	uint32_t _period{0};
 	uint32_t _error_count{0};
 	px4::atomic<bool> _value_processed{true};
 

--- a/src/drivers/rpm_capture/RPMCapture.hpp
+++ b/src/drivers/rpm_capture/RPMCapture.hpp
@@ -39,7 +39,7 @@
 #include <px4_platform_common/module.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/Publication.hpp>
-#include <uORB/Subscription.hpp>
+#include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/pwm_input.h>
 #include <uORB/topics/rpm.h>
 
@@ -72,8 +72,8 @@ private:
 
 	int _channel{-1};
 	uint32_t _rpm_capture_gpio{0};
-	uORB::Publication<pwm_input_s>	_pwm_input_pub{ORB_ID(pwm_input)};
-	uORB::Publication<rpm_s>	_rpm_pub{ORB_ID(rpm)};
+	uORB::Publication<pwm_input_s> _pwm_input_pub{ORB_ID(pwm_input)};
+	uORB::PublicationMulti<rpm_s> _rpm_pub{ORB_ID(rpm)};
 
 	hrt_abstime _hrt_timestamp{0};
 	hrt_abstime _hrt_timestamp_prev{0};

--- a/src/drivers/rpm_capture/RPMCapture.hpp
+++ b/src/drivers/rpm_capture/RPMCapture.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2024 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/drivers/rpm_capture/rpm_capture_params.c
+++ b/src/drivers/rpm_capture/rpm_capture_params.c
@@ -41,3 +41,15 @@
  * @reboot_required true
  */
 PARAM_DEFINE_INT32(RPM_CAP_ENABLE, 0);
+
+/**
+ * RPM Pulses per Revolution
+ *
+ * Number of pulses per revolution for the RPM sensor.
+ *
+ * @group System
+ * @min 1
+ * @max 50
+ * @reboot_required true
+ */
+PARAM_DEFINE_INT32(RPM_PULSES_PER_REV, 1);

--- a/src/drivers/rpm_capture/rpm_capture_params.c
+++ b/src/drivers/rpm_capture/rpm_capture_params.c
@@ -43,13 +43,13 @@
 PARAM_DEFINE_INT32(RPM_CAP_ENABLE, 0);
 
 /**
- * RPM Pulses per Revolution
+ * Voltage pulses per revolution
  *
- * Number of pulses per revolution for the RPM sensor.
+ * Number of voltage pulses per one rotor revolution on the capturing pin.
  *
  * @group System
  * @min 1
  * @max 50
  * @reboot_required true
  */
-PARAM_DEFINE_INT32(RPM_PULSES_PER_REV, 1);
+PARAM_DEFINE_INT32(RPM_PULS_PER_REV, 1);

--- a/src/drivers/rpm_capture/rpm_capture_params.c
+++ b/src/drivers/rpm_capture/rpm_capture_params.c
@@ -1,0 +1,43 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * RPM Capture Enable
+ *
+ * Enables the RPM capture module on FMU channel 5.
+ *
+ * @boolean
+ * @group System
+ * @reboot_required true
+ */
+PARAM_DEFINE_INT32(RPM_CAP_ENABLE, 0);

--- a/src/drivers/rpm_capture/rpm_capture_params.c
+++ b/src/drivers/rpm_capture/rpm_capture_params.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2024 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/lib/mixer_module/output_functions.yaml
+++ b/src/lib/mixer_module/output_functions.yaml
@@ -60,3 +60,9 @@ functions:
         condition: "PPS_CAP_ENABLE==0"
         text: "PPS needs to be enabled via PPS_CAP_ENABLE parameter."
       exclude_from_actuator_testing: true
+    RPM_Input:
+      start: 2070
+      note:
+        condition: "RPM_CAP_ENABLE==0"
+        text: "RPM needs to be enabled via RPM_CAP_ENABLE parameter."
+      exclude_from_actuator_testing: true

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1777,6 +1777,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("PING", 0.1f);
 		configure_stream_local("POSITION_TARGET_GLOBAL_INT", 1.5f);
 		configure_stream_local("POSITION_TARGET_LOCAL_NED", 1.5f);
+		configure_stream_local("RAW_RPM", 5.0f);
 		configure_stream_local("RC_CHANNELS", 20.0f);
 		configure_stream_local("SERVO_OUTPUT_RAW_0", 1.0f);
 		configure_stream_local("SYS_STATUS", 5.0f);

--- a/src/modules/mavlink/streams/RAW_RPM.hpp
+++ b/src/modules/mavlink/streams/RAW_RPM.hpp
@@ -68,7 +68,7 @@ private:
 				mavlink_raw_rpm_t msg{};
 
 				msg.index = i;
-				msg.frequency = rpm.indicated_frequency_rpm;
+				msg.frequency = rpm.rpm_estimate;
 
 				mavlink_msg_raw_rpm_send_struct(_mavlink->get_channel(), &msg);
 				updated = true;

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
@@ -388,14 +388,12 @@ void SimulatorMavlink::handle_message(const mavlink_message_t *msg)
 		break;
 
 	case MAVLINK_MSG_ID_RAW_RPM:
-		mavlink_raw_rpm_t rpm;
-		mavlink_msg_raw_rpm_decode(msg, &rpm);
-		rpm_s rpmmsg{};
-		rpmmsg.timestamp = hrt_absolute_time();
-		rpmmsg.indicated_frequency_rpm = rpm.frequency;
-		rpmmsg.estimated_accurancy_rpm = 0;
-
-		_rpm_pub.publish(rpmmsg);
+		mavlink_raw_rpm_t rpm_mavlink;
+		mavlink_msg_raw_rpm_decode(msg, &rpm_mavlink);
+		rpm_s rpm_uorb{};
+		rpm_uorb.timestamp = hrt_absolute_time();
+		rpm_uorb.rpm_estimate = rpm_mavlink.frequency;
+		_rpm_pub.publish(rpm_uorb);
 		break;
 	}
 }


### PR DESCRIPTION
### Solved Problem
When wokring on helicopter rpm control I found that RPM sensing is "easily" possible but requires work. @bkueng provided the nice configurable capture part for that effort and I used the output directly in the heli-specific controller. But now I think we should enable generic RPM capturing for use in control, log, UI reporting.

### Solution
~As a draft, I added the hardcoded logic we used to process the RPM.
Note: This doesn't work well out of the box because it cannot detect a timeout if the interrupt is never called anymore.~
The solution in the meantime has:
- timeout
- outlier rejection
- pule per revolution configuration

Thanks for all the help from @oravla5, @sfuhrer and @bresch behind the scenes.

### Changelog Entry
```
Feature: Easy to use RPM sensing from GPIO pulses
```

### Test coverage
This logic was used on a heli to control RPM before porting it to latest main and moving the processing to the rpm capture driver. EDIT: and changing it completely again.

~We need to follow up with further testing, settling the interface, implementing the timeout... FYI @sfuhrer~
We did testing on an RC helicopter with high pulse per revolution count + noisy signal and a combustion engine with outliers.