### PR TITLE
estimatorCheck: change back behavior to have global position valid with horizontal validity only

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -748,10 +748,8 @@ void EstimatorChecks::setModeRequirementFlags(const Context &context, bool pre_f
 		}
 	}
 
-	const bool global_pos_valid = gpos.lat_lon_valid && gpos.alt_valid;
-
 	failsafe_flags.global_position_invalid =
-		!checkPosVelValidity(now, global_pos_valid, gpos.eph, lpos_eph_threshold, gpos.timestamp,
+		!checkPosVelValidity(now, gpos.lat_lon_valid, gpos.eph, lpos_eph_threshold, gpos.timestamp,
 				     _last_gpos_fail_time_us, !failsafe_flags.global_position_invalid);
 
 	// Additional warning if the system is about to enter position-loss failsafe after dead-reckoning period


### PR DESCRIPTION
### Solved Problem
When not fusing GPS altitude, the global altitude can be invalid. In that case the entire global position flag now gets invalid which used to check for horizontal validity only before: https://github.com/PX4/PX4-Autopilot/commit/0c451552c7c85bcc2dfe186e1659dd5ea1728a61#diff-61d9b9f86ef33be4a6b79cfa1df04ceb6c2464dc1179de837d661a23e71732afR749

In this case the global position was invalid even though GPS was fused and the horizontal position was available:
![image (20)](https://github.com/user-attachments/assets/13447808-688b-4852-aa3f-e77938eaf916)

### Solution
I suggest to change it back.

### Changelog Entry
```
Bugfix: change back behavior to have global position valid with horizontal validity only
```

### Alternatives
There are multiple alternatives. My only point is that:
Making altitude validity mandatory as well only makes sense if it's impossible to have a global horizontal position without altitude.

### Test coverage
Not specifically tested yet but we had the exact issue described above and I tracked it down to be caused by this condition.

### Context
Related links, screenshot before/after, video
