### PR TITLE
uxrce_dds_client: update cmake requirements to match Micro-XRCE-DDS-Client submodule

### DIFF
--- a/src/modules/uxrce_dds_client/CMakeLists.txt
+++ b/src/modules/uxrce_dds_client/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-if(${CMAKE_VERSION} VERSION_LESS "3.11")
+if(${CMAKE_VERSION} VERSION_LESS_EQUAL "3.15")
 	message(WARNING "skipping uxrce_dds_client, Micro-XRCE-DDS-Client needs to be fixed to work with CMAKE_VERSION ${CMAKE_VERSION}")
 
 else()


### PR DESCRIPTION
@slgrobotics this is why the configure was failing. The submodule cmake requirements are out of our control so all we can do is respect them. 

https://github.com/PX4/Micro-XRCE-DDS-Client/blob/711aef423edd1820347b866d1e4164832df35d04/CMakeLists.txt#L18