### PR TITLE
airframes markdownout.py - br rather than p for generated code

### DIFF
--- a/Tools/px4airframes/markdownout.py
+++ b/Tools/px4airframes/markdownout.py
@@ -137,7 +137,7 @@ div.frame_variant td, div.frame_variant th {
                             #print(output_name,value, attribstrs[0].strip(),attribstrs[1].strip())
                     outputs += '</ul>'
                     if has_outputs:
-                        outputs_entry = '<p><b>Specific Outputs:</b>' + outputs + '</p>'
+                        outputs_entry = '<br><b>Specific Outputs:</b>' + outputs
                     else:
                         outputs_entry = ''
 


### PR DESCRIPTION
This makes very minor change to the generated output for the airframe markdown, replacing a section surrounded by `<p>` tags with a single preceding `<br>`.
Both are valid, but for some reason when the former round-trips through crowdin, we end up with an extra opening `p` element, which causes vitepress to crash.

The output from this works (tested).