### PR TITLE
rover: offboard support through trajectorySetpoint.msg

### DIFF
--- a/src/modules/rover_ackermann/RoverAckermann.hpp
+++ b/src/modules/rover_ackermann/RoverAckermann.hpp
@@ -50,7 +50,8 @@
 #include <uORB/topics/rover_ackermann_setpoint.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_attitude.h>
-
+#include <uORB/topics/trajectory_setpoint.h>
+#include <uORB/topics/offboard_control_mode.h>
 
 // Standard library includes
 #include <math.h>
@@ -108,6 +109,8 @@ private:
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
+	uORB::Subscription _trajectory_setpoint_sub{ORB_ID(trajectory_setpoint)};
+	uORB::Subscription _offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
 
 	// uORB publications
 	uORB::Publication<rover_ackermann_setpoint_s> _rover_ackermann_setpoint_pub{ORB_ID(rover_ackermann_setpoint)};
@@ -138,7 +141,8 @@ private:
 		(ParamFloat<px4::params::RA_MAX_STR_ANG>) _param_ra_max_steer_angle,
 		(ParamFloat<px4::params::RA_MAX_SPEED>) _param_ra_max_speed,
 		(ParamFloat<px4::params::RA_MAX_LAT_ACCEL>) _param_ra_max_lat_accel,
-		(ParamFloat<px4::params::PP_LOOKAHD_MAX>) _param_pp_lookahd_max
+		(ParamFloat<px4::params::PP_LOOKAHD_MAX>) _param_pp_lookahd_max,
+		(ParamFloat<px4::params::NAV_ACC_RAD>) _param_nav_acc_rad
 
 	)
 

--- a/src/modules/rover_differential/RoverDifferential.hpp
+++ b/src/modules/rover_differential/RoverDifferential.hpp
@@ -51,6 +51,8 @@
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/rover_differential_setpoint.h>
+#include <uORB/topics/trajectory_setpoint.h>
+#include <uORB/topics/offboard_control_mode.h>
 
 // Standard libraries
 #include <matrix/matrix/math.hpp>
@@ -105,6 +107,8 @@ private:
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::Subscription _trajectory_setpoint_sub{ORB_ID(trajectory_setpoint)};
+	uORB::Subscription _offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
 
 	// uORB Publications
 	uORB::Publication<rover_differential_setpoint_s> _rover_differential_setpoint_pub{ORB_ID(rover_differential_setpoint)};
@@ -133,6 +137,8 @@ private:
 		(ParamFloat<px4::params::RD_MAX_YAW_RATE>)  _param_rd_max_yaw_rate,
 		(ParamFloat<px4::params::RD_MAX_THR_YAW_R>) _param_rd_max_thr_yaw_r,
 		(ParamFloat<px4::params::RD_MAX_SPEED>)     _param_rd_max_speed,
-		(ParamFloat<px4::params::PP_LOOKAHD_MAX>)   _param_pp_lookahd_max
+		(ParamFloat<px4::params::PP_LOOKAHD_MAX>)   _param_pp_lookahd_max,
+		(ParamFloat<px4::params::RD_TRANS_TRN_DRV>) _param_rd_trans_trn_drv,
+		(ParamFloat<px4::params::NAV_ACC_RAD>) _param_nav_acc_rad
 	)
 };

--- a/src/modules/rover_mecanum/RoverMecanum.hpp
+++ b/src/modules/rover_mecanum/RoverMecanum.hpp
@@ -51,6 +51,8 @@
 #include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/rover_mecanum_setpoint.h>
+#include <uORB/topics/trajectory_setpoint.h>
+#include <uORB/topics/offboard_control_mode.h>
 
 // Standard libraries
 #include <lib/pid/PID.hpp>
@@ -106,6 +108,8 @@ private:
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::Subscription _trajectory_setpoint_sub{ORB_ID(trajectory_setpoint)};
+	uORB::Subscription _offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
 
 	// uORB Publications
 	uORB::Publication<rover_mecanum_setpoint_s> _rover_mecanum_setpoint_pub{ORB_ID(rover_mecanum_setpoint)};
@@ -136,6 +140,7 @@ private:
 		(ParamFloat<px4::params::RM_MAX_SPEED>) _param_rm_max_speed,
 		(ParamFloat<px4::params::RM_MAN_YAW_SCALE>) _param_rm_man_yaw_scale,
 		(ParamFloat<px4::params::RM_MAX_YAW_RATE>) _param_rm_max_yaw_rate,
-		(ParamFloat<px4::params::PP_LOOKAHD_MAX>) _param_pp_lookahd_max
+		(ParamFloat<px4::params::PP_LOOKAHD_MAX>) _param_pp_lookahd_max,
+		(ParamFloat<px4::params::NAV_ACC_RAD>) _param_nav_acc_rad
 	)
 };


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The rover modules currently do not support offboard control through the trajectorySetpoint.msg
Fixes [#23663](https://github.com/PX4/PX4-Autopilot/issues/23663)

### Solution
Add a translation layer for the rover modules to turn the trajectorySetpoint.msg into rover setpoints:
- **Mecanum**: Supports `position`, `velocity`, `yaw` and `yaw speed` setpoints.
The setpoints are prioritized in the following descending order `position` -> `velocity` and `yaw` -> `yaw speed`.
Higher priority setpoints override lower priority ones due to the fact that they can't be achieved simultaneously.
- **Differential**: Supports `position`, `velocity`, `yaw` and `yaw speed` setpoints.
The setpoints are prioritized in the following descending order `position` -> `velocity` -> `yaw` -> `yaw speed`.
Higher priority setpoints override lower priority ones due to the fact that they can't be achieved simultaneously.
- **Ackermann**: Supports position setpoints.

### Test coverage
- Tested in simulation using ROS2

### Context
Related links, screenshot before/after, video
