### PR TITLE
params: flash: erase corrupt sector

### DIFF
--- a/src/lib/parameters/flashparams/flashfs32.c
+++ b/src/lib/parameters/flashparams/flashfs32.c
@@ -1126,7 +1126,7 @@ int parameter_flashfs_init(sector_descriptor_t *fconfig, uint8_t *buffer, uint16
 	/*  No paramaters */
 
 	if (pf == NULL) {
-		// Parameters can't be found, assume sector is corrupt
+		// Parameters can't be found, assume sector is corrupt or empty
 		rv = parameter_flashfs_erase();
 	}
 

--- a/src/lib/parameters/flashparams/flashfs32.c
+++ b/src/lib/parameters/flashparams/flashfs32.c
@@ -1126,19 +1126,8 @@ int parameter_flashfs_init(sector_descriptor_t *fconfig, uint8_t *buffer, uint16
 	/*  No paramaters */
 
 	if (pf == NULL) {
-		size_t total_size = size + sizeof(flash_entry_header_t);
-		size_t alignment = 31;//32-byte flash line - 1
-		size_t  size_adjust = ((total_size + alignment) & ~alignment) - total_size;
-		total_size += size_adjust;
-
-		/* Do we have free space ?*/
-
-		if (find_free(total_size) == NULL) {
-
-			/* No parameters and no free space => need erase */
-
-			rv  = parameter_flashfs_erase();
-		}
+		// Parameters can't be found, assume sector is corrupt
+		rv = parameter_flashfs_erase();
 	}
 
 	return rv;


### PR DESCRIPTION
**Problem**
When updating from Ardupilot to PX4 on a board that uses flash based params PX4 will fail to load params. It will continue to fail until the MCU is mass erased. This is because the params sector contains the Ardupilot param format. 

**Solution**
Erase parameter sector if `parameters_token` is not found. This essentially tells us that the sector is not in the proper format and therefore we assume it is generally "corrupted". This is what Ardupilot does and doesn't have this issue.

**Testing**
Tested on an ARK FPV. 