### PR TITLE
ESC check: Avoid unsigned timestamp underflow in telemtry timeout

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/escCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/escCheck.cpp
@@ -77,7 +77,7 @@ void EscChecks::checkAndReport(const Context &context, Report &reporter)
 
 	esc_status_s esc_status;
 
-	if (_esc_status_sub.copy(&esc_status) && now < esc_telemetry_timeout + esc_status.timestamp) {
+	if (_esc_status_sub.copy(&esc_status) && (now < esc_status.timestamp + esc_telemetry_timeout)) {
 
 		checkEscStatus(context, reporter, esc_status);
 		reporter.setIsPresent(health_component_t::motors_escs);


### PR DESCRIPTION
### Solved Problem
During several flights a warning of ESC telemetry missing appear. 

### Solution
Changing the logic of the if statement to avoid unsigned int underflow.

### Test coverage
Tested on a drone with QGC

### Context
The tasks are prioritized and the driver has a higher priority than the commander checks. If anything delays driver, then the difference between the absolute time `now` and the latest published sample time from the esc status `esc_status.timestamp` might cause an unsigned integer underflow as the `esc_status.timestamp` becomes greater than `now`.

To test this hypothesis a sleep was introduced as below:
![Screenshot from 2024-12-03 14-29-50](https://github.com/user-attachments/assets/6a40cdb2-56d7-45f4-8d52-bd24c30e746f)
with following printout:
![Screenshot from 2024-12-03 14-29-01](https://github.com/user-attachments/assets/abea8244-1ca6-4341-9aa1-b208fa1d29bd)

By changing the formula as in the commit, the if statement would fail ones the `esc_status.timestamp` stop being published, and if there is a delay the new line of code will avoid the wrapping of the negative subtraction:
![Screenshot from 2024-12-03 14-30-09](https://github.com/user-attachments/assets/38ce6489-5f77-402b-8447-4fe74addfddd)

Even with 1 s of sleep there was no telemetry missing message:
![Screenshot from 2024-12-03 14-31-49](https://github.com/user-attachments/assets/4f6b8033-4747-4271-b1ae-546a7a5db469)


