### PR TITLE
logger: always log can_interface_status

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -53,7 +53,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("autotune_attitude_control_status", 100);
 	add_optional_topic("camera_capture");
 	add_optional_topic("camera_trigger");
-	add_optional_topic("can_interface_status", 10);
+	add_topic("can_interface_status", 10);
 	add_topic("cellular_status", 200);
 	add_topic("commander_state");
 	add_topic("config_overrides");

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -53,7 +53,6 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("autotune_attitude_control_status", 100);
 	add_optional_topic("camera_capture");
 	add_optional_topic("camera_trigger");
-	add_topic("can_interface_status", 10);
 	add_topic("cellular_status", 200);
 	add_topic("commander_state");
 	add_topic("config_overrides");
@@ -251,6 +250,10 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic_multi("yaw_estimator_status");
 
 #endif /* CONFIG_ARCH_BOARD_PX4_SITL */
+
+#ifdef CONFIG_BOARD_UAVCAN_INTERFACES
+	add_topic_multi("can_interface_status", 100, CONFIG_BOARD_UAVCAN_INTERFACES);
+#endif
 }
 
 void LoggedTopics::add_high_rate_topics()


### PR DESCRIPTION
There's a caveat with `LoggedTopics::add_optional_topic`, it will fail to log topics that don't exist at the time of the logger instantiation. So any sensor that publishes later (CAN nodes for example) won't be logged. Namely the newish CanInterfaceStatus message, the status of the CAN interfaces is not logged since a CAN node will typically take longer to boot than the FC does.