### PR TITLE
Fix: Allow offboard acceleration control with only attitude and no horizontal velocity estimate

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/offboardCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/offboardCheck.cpp
@@ -56,7 +56,7 @@ void OffboardChecks::checkAndReport(const Context &context, Report &reporter)
 		} else if (offboard_control_mode.velocity && reporter.failsafeFlags().local_velocity_invalid) {
 			offboard_available = false;
 
-		} else if (offboard_control_mode.acceleration && reporter.failsafeFlags().local_velocity_invalid) {
+		} else if (offboard_control_mode.acceleration && reporter.failsafeFlags().attitude_invalid) {
 			// OFFBOARD acceleration handled by position controller
 			offboard_available = false;
 		}


### PR DESCRIPTION
### Solved Problem
When "ra1nyu" brought up https://discuss.px4.io/t/why-does-acceleration-control-in-offboard-mode-need-velocity-estimate/42512 in the developer call we found in the discussion that offboard pure acceleration control should not depend on a velocity estimate but only on vehicle attitude control.

### Solution
Change requirement to pass check for acceleration setpoints when an attitude is available.

### Changelog Entry
```
Fix: Allow offboard acceleration control with only attitude and no horizontal velocity estimate
```

### Alternatives
I honestly did not go back in history to check why this dependency exists. I can still do that.

### Test coverage
Not tested, I only made the pr while already looking at the code and discussing it.