### PR TITLE
Shorten messages to prevent clipping in QGroundControl

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/airspeedCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/airspeedCheck.cpp
@@ -92,7 +92,7 @@ void AirspeedChecks::checkAndReport(const Context &context, Report &reporter)
 					events::Log::Error, "Airspeed too high", airspeed_validated.calibrated_airspeed_m_s, arming_max_airspeed_allowed);
 
 			if (reporter.mavlink_log_pub()) {
-				mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Airspeed too high - check airspeed calibration");
+				mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Airspeed too high");
 			}
 		}
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/distanceSensorChecks.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/distanceSensorChecks.cpp
@@ -77,7 +77,7 @@ void DistanceSensorChecks::checkAndReport(const Context &context, Report &report
 								events::Log::Error, "No valid data from distance sensor {1}", instance);
 
 				if (reporter.mavlink_log_pub()) {
-					mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: no valid data from distance sensor %u", instance);
+					mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: No valid distance sensor %u data", instance);
 				}
 			}
 		}

--- a/src/modules/commander/HealthAndArmingChecks/checks/failureDetectorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/failureDetectorCheck.cpp
@@ -90,7 +90,7 @@ void FailureDetectorChecks::checkAndReport(const Context &context, Report &repor
 					    events::Log::Critical, "Failure triggered by external system");
 
 		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Failure triggered by external system");
+			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Failure caused by external system");
 		}
 	}
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.cpp
@@ -95,7 +95,7 @@ void RcAndDataLinkChecks::checkAndReport(const Context &context, Report &reporte
 					    log_level, "No connection to the ground control station");
 
 		if (gcs_connection_required && reporter.mavlink_log_pub()) {
-			mavlink_log_warning(reporter.mavlink_log_pub(), "Preflight Fail: No connection to the ground control station\t");
+			mavlink_log_warning(reporter.mavlink_log_pub(), "Preflight Fail: No connection to the GCS");
 		}
 
 	} else {


### PR DESCRIPTION
### Solved Problem
When I was working with QGroundControl I found that some 'Preflight Fail' messages are clipped (see e.g. attached image).

There's a 50-character limit to these messages defined by the [STATUSTEXT MAVLink message](https://mavlink.io/en/messages/common.html#STATUSTEXT). Longer messages are clipped.

In this PR, I reformulated the messages that are longer than 50 characters.

### Solution
- Reformulate messages longer than 50 characters

### Changelog Entry
For release notes:
```
Fixed clipped messages in QGroundControl
New parameter: -
Documentation: -
```

### Alternatives
We could also increase the character limit of the STATUSTEXT message

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: ...

### Critical bug that needs backporting?
No

### Context
![image](https://github.com/user-attachments/assets/04bcb6dd-8e66-434e-84a5-11f86eb5b85d)
