### PR TITLE
Add mavlink stream for plan_cam model

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1031_gazebo-classic_plane_cam.post
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1031_gazebo-classic_plane_cam.post
@@ -1,0 +1,1 @@
+mavlink start -x -u 14558 -r 4000 -f -m onboard -o 14530 -p

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -49,6 +49,7 @@ px4_add_romfs_files(
 	1022_gazebo-classic_uuv_bluerov2_heavy
 	1030_gazebo-classic_plane
 	1031_gazebo-classic_plane_cam
+	1031_gazebo-classic_plane_cam.post
 	1032_gazebo-classic_plane_catapult
 	1033_jsbsim_rascal
 	1034_flightgear_rascal-electric


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The images taken during a survey was not being saved in the designated directory.

This is due to the mavlink stream at the camera port (14530) not being streamed for the `plane_cam` model.

Fixes https://github.com/PX4/PX4-Autopilot/issues/24073, https://github.com/PX4/PX4-SITL_gazebo-classic/issues/1059

### Solution
Add a mavlink stream to the simulated camera


### Test coverage
Tested in SITL

```
make px4_sitl gazebo-classic_plane_cam
```

