### PR TITLE
Pure Pursuit: Handle edge case and add logging message

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -173,6 +173,7 @@ set(msg_files
 	PowerButtonState.msg
 	PowerMonitor.msg
 	PpsCapture.msg
+	PurePursuit.msg
 	PwmInput.msg
 	Px4ioStatus.msg
 	QshellReq.msg

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -184,13 +184,10 @@ set(msg_files
 	RcParameterMap.msg
 	RegisterExtComponentReply.msg
 	RegisterExtComponentRequest.msg
-	RoverAckermannGuidanceStatus.msg
 	RoverAckermannSetpoint.msg
 	RoverAckermannStatus.msg
-	RoverDifferentialGuidanceStatus.msg
 	RoverDifferentialSetpoint.msg
 	RoverDifferentialStatus.msg
-	RoverMecanumGuidanceStatus.msg
 	RoverMecanumSetpoint.msg
 	RoverMecanumStatus.msg
 	Rpm.msg

--- a/msg/PurePursuit.msg
+++ b/msg/PurePursuit.msg
@@ -1,0 +1,8 @@
+uint64 timestamp # time since system start (microseconds)
+
+float32 lookahead_distance   # [m] Lookahead distance of pure the pursuit controller
+float32 target_bearing       # [rad] Target bearing calculated by the pure pursuit controller
+float32 crosstrack_error     # [m] Shortest distance from the vehicle to the path (Positiv: Right of the path, Negativ: Left of the path)
+float32 distance_to_waypoint # [m] Distance from the vehicle to the current waypoint
+
+# TOPICS pure_pursuit

--- a/msg/RoverAckermannGuidanceStatus.msg
+++ b/msg/RoverAckermannGuidanceStatus.msg
@@ -1,6 +1,0 @@
-uint64 timestamp # time since system start (microseconds)
-
-float32 lookahead_distance 	# [m] Lookahead distance of pure the pursuit controller
-float32 heading_error 		# [deg] Heading error of the pure pursuit controller
-
-# TOPICS rover_ackermann_guidance_status

--- a/msg/RoverDifferentialGuidanceStatus.msg
+++ b/msg/RoverDifferentialGuidanceStatus.msg
@@ -1,7 +1,0 @@
-uint64 timestamp # time since system start (microseconds)
-
-float32 lookahead_distance    # [m] Lookahead distance of pure the pursuit controller
-float32 heading_error_deg 	      # [deg] Heading error of the pure pursuit controller
-uint8   state_machine         # Driving state of the rover [0: SPOT_TURNING, 1: DRIVING, 2: GOAL_REACHED]
-
-# TOPICS rover_differential_guidance_status

--- a/msg/RoverMecanumGuidanceStatus.msg
+++ b/msg/RoverMecanumGuidanceStatus.msg
@@ -1,7 +1,0 @@
-uint64 timestamp # time since system start (microseconds)
-
-float32 lookahead_distance # [m] Lookahead distance of pure the pursuit controller
-float32 heading_error      # [rad] Heading error of the pure pursuit controller
-float32 desired_speed      # [m/s] Desired velocity magnitude (speed)
-
-# TOPICS rover_mecanum_guidance_status

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -104,13 +104,10 @@ void LoggedTopics::add_default_topics()
 	add_topic("position_setpoint_triplet", 200);
 	add_optional_topic("px4io_status");
 	add_topic("radio_status");
-	add_optional_topic("rover_ackermann_guidance_status", 100);
 	add_optional_topic("rover_ackermann_setpoint", 100);
 	add_optional_topic("rover_ackermann_status", 100);
-	add_optional_topic("rover_differential_guidance_status", 100);
 	add_optional_topic("rover_differential_setpoint", 100);
 	add_optional_topic("rover_differential_status", 100);
-	add_optional_topic("rover_mecanum_guidance_status", 100);
 	add_optional_topic("rover_mecanum_setpoint", 100);
 	add_optional_topic("rover_mecanum_status", 100);
 	add_topic("rtl_time_estimate", 1000);

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -99,6 +99,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("parameter_update");
 	add_topic("position_controller_status", 500);
 	add_topic("position_controller_landing_status", 100);
+	add_optional_topic("pure_pursuit", 100);
 	add_topic("goto_setpoint", 200);
 	add_topic("position_setpoint_triplet", 200);
 	add_optional_topic("px4io_status");

--- a/src/modules/rover_ackermann/RoverAckermann.cpp
+++ b/src/modules/rover_ackermann/RoverAckermann.cpp
@@ -129,7 +129,7 @@ void RoverAckermann::Run()
 
 					// Construct a 'target waypoint' for course control s.t. it is never within the maximum lookahead of the rover
 					const float vector_scaling = sqrtf(powf(_param_pp_lookahd_max.get(),
-										2) + powf(_posctl_pure_pursuit.getCrosstrackError(), 2)) + _posctl_pure_pursuit.getDistanceOnLineSegment();
+										2) + powf(_posctl_pure_pursuit.getCrosstrackError(), 2)) + _posctl_pure_pursuit.getDistanceAlongPath();
 					const Vector2f target_waypoint_ned = _pos_ctl_start_position_ned + sign(
 							rover_ackermann_setpoint.forward_speed_setpoint) *
 									     vector_scaling * _pos_ctl_course_direction;

--- a/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.cpp
+++ b/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.cpp
@@ -40,7 +40,6 @@ using namespace time_literals;
 
 RoverAckermannGuidance::RoverAckermannGuidance(ModuleParams *parent) : ModuleParams(parent)
 {
-	_rover_ackermann_guidance_status_pub.advertise();
 	updateParams();
 }
 
@@ -90,14 +89,9 @@ void RoverAckermannGuidance::computeGuidance(const float vehicle_forward_speed,
 
 	}
 
-	// Publish ackermann controller status (logging)
-	hrt_abstime timestamp = hrt_absolute_time();
-	_rover_ackermann_guidance_status.timestamp = timestamp;
-	_rover_ackermann_guidance_status_pub.publish(_rover_ackermann_guidance_status);
-
 	// Publish speed and steering setpoints
 	rover_ackermann_setpoint_s rover_ackermann_setpoint{};
-	rover_ackermann_setpoint.timestamp = timestamp;
+	rover_ackermann_setpoint.timestamp = hrt_absolute_time();
 	rover_ackermann_setpoint.forward_speed_setpoint = _desired_speed;
 	rover_ackermann_setpoint.forward_speed_setpoint_normalized = NAN;
 	rover_ackermann_setpoint.steering_setpoint = NAN;
@@ -288,10 +282,6 @@ float RoverAckermannGuidance::calcDesiredSteering(PurePursuit &pure_pursuit, con
 				      desired_speed);
 	const float lookahead_distance = pure_pursuit.getLookaheadDistance();
 	const float heading_error = matrix::wrap_pi(desired_heading - vehicle_yaw);
-	// For logging
-	_rover_ackermann_guidance_status.lookahead_distance = lookahead_distance;
-	_rover_ackermann_guidance_status.heading_error = (heading_error * 180.f) / (M_PI_F);
-
 	float desired_steering{0.f};
 
 	if (!armed) {

--- a/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.hpp
+++ b/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.hpp
@@ -40,7 +40,6 @@
 // uORB includes
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
-#include <uORB/topics/rover_ackermann_guidance_status.h>
 #include <uORB/topics/rover_ackermann_setpoint.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/vehicle_global_position.h>
@@ -167,9 +166,7 @@ private:
 
 	// uORB publications
 	uORB::Publication<rover_ackermann_setpoint_s> _rover_ackermann_setpoint_pub{ORB_ID(rover_ackermann_setpoint)};
-	uORB::Publication<rover_ackermann_guidance_status_s> _rover_ackermann_guidance_status_pub{ORB_ID(rover_ackermann_guidance_status)};
 	uORB::Publication<position_controller_status_s>	_position_controller_status_pub{ORB_ID(position_controller_status)};
-	rover_ackermann_guidance_status_s _rover_ackermann_guidance_status{};
 
 	// Class instances
 	MapProjection _global_ned_proj_ref{}; // Transform global to NED coordinates

--- a/src/modules/rover_differential/RoverDifferential.cpp
+++ b/src/modules/rover_differential/RoverDifferential.cpp
@@ -173,12 +173,12 @@ void RoverDifferential::Run()
 
 					// Construct a 'target waypoint' for course control s.t. it is never within the maximum lookahead of the rover
 					const float vector_scaling = sqrtf(powf(_param_pp_lookahd_max.get(),
-										2) + powf(_posctl_pure_pursuit.getCrosstrackError(), 2)) + _posctl_pure_pursuit.getDistanceOnLineSegment();
+										2) + powf(_posctl_pure_pursuit.getCrosstrackError(), 2)) + _posctl_pure_pursuit.getDistanceAlongPath();
 					const Vector2f target_waypoint_ned = _pos_ctl_start_position_ned + sign(
 							rover_differential_setpoint.forward_speed_setpoint) *
 									     vector_scaling * _pos_ctl_course_direction;
 					// Calculate yaw setpoint
-					const float yaw_setpoint = _posctl_pure_pursuit.calcDesiredHeading(target_waypoint_ned,
+					const float yaw_setpoint = _posctl_pure_pursuit.calcTargetBearing(target_waypoint_ned,
 								   _pos_ctl_start_position_ned, _curr_pos_ned, fabsf(_vehicle_forward_speed));
 					rover_differential_setpoint.yaw_setpoint = sign(rover_differential_setpoint.forward_speed_setpoint) >= 0 ?
 							yaw_setpoint : matrix::wrap_pi(M_PI_F + yaw_setpoint); // Flip yaw setpoint when driving backwards

--- a/src/modules/rover_differential/RoverDifferentialControl/RoverDifferentialControl.cpp
+++ b/src/modules/rover_differential/RoverDifferentialControl/RoverDifferentialControl.cpp
@@ -105,7 +105,7 @@ void RoverDifferentialControl::computeMotorCommands(const float vehicle_yaw, con
 					_param_rd_max_thr_yaw_r.get(), _max_yaw_accel, _param_rd_wheel_track.get(), dt, _yaw_rate_with_accel_limit,
 					_pid_yaw_rate, false);
 
-	} else { // Use normalized setpoint
+	} else if (PX4_ISFINITE(_rover_differential_setpoint.speed_diff_setpoint_normalized)) { // Use normalized setpoint
 		speed_diff_normalized = calcNormalizedSpeedDiff(_rover_differential_setpoint.speed_diff_setpoint_normalized,
 					vehicle_yaw_rate,
 					_param_rd_max_thr_yaw_r.get(), _max_yaw_accel, _param_rd_wheel_track.get(), dt, _yaw_rate_with_accel_limit,

--- a/src/modules/rover_differential/RoverDifferentialGuidance/RoverDifferentialGuidance.cpp
+++ b/src/modules/rover_differential/RoverDifferentialGuidance/RoverDifferentialGuidance.cpp
@@ -62,7 +62,7 @@ void RoverDifferentialGuidance::computeGuidance(const float vehicle_yaw, const f
 	}
 
 	// State machine
-	float desired_yaw = _pure_pursuit.calcDesiredHeading(_curr_wp_ned, _prev_wp_ned, _curr_pos_ned,
+	float desired_yaw = _pure_pursuit.updatePurePursuit(_curr_wp_ned, _prev_wp_ned, _curr_pos_ned,
 			    math::max(forward_speed, 0.f));
 	const float heading_error = matrix::wrap_pi(desired_yaw - vehicle_yaw);
 
@@ -193,7 +193,7 @@ void RoverDifferentialGuidance::updateWaypoints()
 		_curr_wp = Vector2d(position_setpoint_triplet.current.lat, position_setpoint_triplet.current.lon);
 
 	} else {
-		_curr_wp = Vector2d(0, 0);
+		_curr_wp = _curr_pos;
 	}
 
 	if (position_setpoint_triplet.previous.valid && PX4_ISFINITE(position_setpoint_triplet.previous.lat)

--- a/src/modules/rover_differential/RoverDifferentialGuidance/RoverDifferentialGuidance.cpp
+++ b/src/modules/rover_differential/RoverDifferentialGuidance/RoverDifferentialGuidance.cpp
@@ -41,7 +41,6 @@ RoverDifferentialGuidance::RoverDifferentialGuidance(ModuleParams *parent) : Mod
 {
 	updateParams();
 	_max_forward_speed = _param_rd_max_speed.get();
-	_rover_differential_guidance_status_pub.advertise();
 }
 
 void RoverDifferentialGuidance::updateParams()
@@ -125,18 +124,9 @@ void RoverDifferentialGuidance::computeGuidance(const float vehicle_yaw, const f
 
 	}
 
-	// Publish differential guidance status (logging)
-	hrt_abstime timestamp = hrt_absolute_time();
-	rover_differential_guidance_status_s rover_differential_guidance_status{};
-	rover_differential_guidance_status.timestamp = timestamp;
-	rover_differential_guidance_status.lookahead_distance = _pure_pursuit.getLookaheadDistance();
-	rover_differential_guidance_status.heading_error_deg = M_RAD_TO_DEG_F * heading_error;
-	rover_differential_guidance_status.state_machine = (uint8_t) _currentState;
-	_rover_differential_guidance_status_pub.publish(rover_differential_guidance_status);
-
 	// Publish setpoints
 	rover_differential_setpoint_s rover_differential_setpoint{};
-	rover_differential_setpoint.timestamp = timestamp;
+	rover_differential_setpoint.timestamp = hrt_absolute_time();
 	rover_differential_setpoint.forward_speed_setpoint = desired_forward_speed;
 	rover_differential_setpoint.forward_speed_setpoint_normalized = NAN;
 	rover_differential_setpoint.yaw_rate_setpoint = NAN;

--- a/src/modules/rover_differential/RoverDifferentialGuidance/RoverDifferentialGuidance.hpp
+++ b/src/modules/rover_differential/RoverDifferentialGuidance/RoverDifferentialGuidance.hpp
@@ -46,7 +46,6 @@
 #include <uORB/topics/mission_result.h>
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/vehicle_status.h>
-#include <uORB/topics/rover_differential_guidance_status.h>
 #include <uORB/topics/rover_differential_setpoint.h>
 
 // Standard libraries
@@ -114,7 +113,6 @@ private:
 
 	// uORB publications
 	uORB::Publication<rover_differential_setpoint_s> _rover_differential_setpoint_pub{ORB_ID(rover_differential_setpoint)};
-	uORB::Publication<rover_differential_guidance_status_s> _rover_differential_guidance_status_pub{ORB_ID(rover_differential_guidance_status)};
 
 	// Variables
 	MapProjection _global_ned_proj_ref{}; // Transform global to ned coordinates.

--- a/src/modules/rover_mecanum/RoverMecanum.cpp
+++ b/src/modules/rover_mecanum/RoverMecanum.cpp
@@ -209,9 +209,9 @@ void RoverMecanum::Run()
 
 					// Construct a 'target waypoint' for course control s.t. it is never within the maximum lookahead of the rover
 					const float vector_scaling = sqrtf(powf(_param_pp_lookahd_max.get(),
-										2) + powf(_posctl_pure_pursuit.getCrosstrackError(), 2)) + _posctl_pure_pursuit.getDistanceOnLineSegment();
+										2) + powf(_posctl_pure_pursuit.getCrosstrackError(), 2)) + _posctl_pure_pursuit.getDistanceAlongPath();
 					const Vector2f target_waypoint_ned = _pos_ctl_start_position_ned + vector_scaling * _pos_ctl_course_direction;
-					const float desired_heading = _posctl_pure_pursuit.calcDesiredHeading(target_waypoint_ned, _pos_ctl_start_position_ned,
+					const float desired_heading = _posctl_pure_pursuit.calcTargetBearing(target_waypoint_ned, _pos_ctl_start_position_ned,
 								      _curr_pos_ned, desired_velocity_magnitude);
 					const float heading_error = matrix::wrap_pi(desired_heading - _vehicle_yaw);
 					const Vector2f desired_velocity = desired_velocity_magnitude * Vector2f(cosf(heading_error), sinf(heading_error));

--- a/src/modules/rover_mecanum/RoverMecanumControl/RoverMecanumControl.cpp
+++ b/src/modules/rover_mecanum/RoverMecanumControl/RoverMecanumControl.cpp
@@ -111,7 +111,7 @@ void RoverMecanumControl::computeMotorCommands(const float vehicle_yaw, const fl
 					_pid_yaw_rate, false);
 		_rover_mecanum_status.adjusted_yaw_rate_setpoint = _yaw_rate_with_accel_limit.getState();
 
-	} else { // Use normalized setpoint
+	} else if (PX4_ISFINITE(_rover_mecanum_setpoint.speed_diff_setpoint_normalized)) { // Use normalized setpoint
 		speed_diff_normalized = calcNormalizedSpeedDiff(_rover_mecanum_setpoint.speed_diff_setpoint_normalized,
 					vehicle_yaw_rate,
 					_param_rm_max_thr_yaw_r.get(), _max_yaw_accel, _param_rm_wheel_track.get(), dt, _yaw_rate_with_accel_limit,

--- a/src/modules/rover_mecanum/RoverMecanumGuidance/RoverMecanumGuidance.cpp
+++ b/src/modules/rover_mecanum/RoverMecanumGuidance/RoverMecanumGuidance.cpp
@@ -72,7 +72,7 @@ void RoverMecanumGuidance::computeGuidance(const float yaw, const int nav_state)
 
 
 	// Calculate heading error
-	const float desired_heading = _pure_pursuit.calcDesiredHeading(_curr_wp_ned, _prev_wp_ned, _curr_pos_ned,
+	const float desired_heading = _pure_pursuit.updatePurePursuit(_curr_wp_ned, _prev_wp_ned, _curr_pos_ned,
 				      desired_velocity_magnitude);
 	const float heading_error = matrix::wrap_pi(desired_heading - yaw);
 
@@ -163,7 +163,7 @@ void RoverMecanumGuidance::updateWaypoints()
 		_curr_wp = Vector2d(position_setpoint_triplet.current.lat, position_setpoint_triplet.current.lon);
 
 	} else {
-		_curr_wp = Vector2d(0, 0);
+		_curr_wp = _curr_pos;
 	}
 
 	if (position_setpoint_triplet.previous.valid && PX4_ISFINITE(position_setpoint_triplet.previous.lat)

--- a/src/modules/rover_mecanum/RoverMecanumGuidance/RoverMecanumGuidance.cpp
+++ b/src/modules/rover_mecanum/RoverMecanumGuidance/RoverMecanumGuidance.cpp
@@ -42,7 +42,6 @@ RoverMecanumGuidance::RoverMecanumGuidance(ModuleParams *parent) : ModuleParams(
 {
 	updateParams();
 	_max_velocity_magnitude = _param_rm_max_speed.get();
-	_rover_mecanum_guidance_status_pub.advertise();
 }
 
 void RoverMecanumGuidance::updateParams()
@@ -91,20 +90,9 @@ void RoverMecanumGuidance::computeGuidance(const float yaw, const int nav_state)
 		desired_velocity = desired_velocity_magnitude * Vector2f(cosf(heading_error), sinf(heading_error));
 	}
 
-	// Timestamp
-	hrt_abstime timestamp = hrt_absolute_time();
-
-	// Publish mecanum controller status (logging)
-	rover_mecanum_guidance_status_s rover_mecanum_guidance_status{};
-	rover_mecanum_guidance_status.timestamp = timestamp;
-	rover_mecanum_guidance_status.lookahead_distance = _pure_pursuit.getLookaheadDistance();
-	rover_mecanum_guidance_status.heading_error = heading_error;
-	rover_mecanum_guidance_status.desired_speed = desired_velocity_magnitude;
-	_rover_mecanum_guidance_status_pub.publish(rover_mecanum_guidance_status);
-
 	// Publish setpoints
 	rover_mecanum_setpoint_s rover_mecanum_setpoint{};
-	rover_mecanum_setpoint.timestamp = timestamp;
+	rover_mecanum_setpoint.timestamp = hrt_absolute_time();;
 	rover_mecanum_setpoint.forward_speed_setpoint = desired_velocity(0);
 	rover_mecanum_setpoint.forward_speed_setpoint_normalized = NAN;
 	rover_mecanum_setpoint.lateral_speed_setpoint = desired_velocity(1);

--- a/src/modules/rover_mecanum/RoverMecanumGuidance/RoverMecanumGuidance.hpp
+++ b/src/modules/rover_mecanum/RoverMecanumGuidance/RoverMecanumGuidance.hpp
@@ -46,7 +46,6 @@
 #include <uORB/topics/mission_result.h>
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/vehicle_status.h>
-#include <uORB/topics/rover_mecanum_guidance_status.h>
 #include <uORB/topics/rover_mecanum_setpoint.h>
 
 // Standard libraries
@@ -105,7 +104,6 @@ private:
 	uORB::Subscription _home_position_sub{ORB_ID(home_position)};
 
 	// uORB publications
-	uORB::Publication<rover_mecanum_guidance_status_s> _rover_mecanum_guidance_status_pub{ORB_ID(rover_mecanum_guidance_status)};
 	uORB::Publication<rover_mecanum_setpoint_s> _rover_mecanum_setpoint_pub{ORB_ID(rover_mecanum_setpoint)};
 
 	// Variables


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
#### Pure pursuit edge case
The pure pursuit library can now handle the following edge case:
If the acceptance radius of a waypoint is bigger than the lookahead radius of the pure pursuit controller the following edge case can happen:
![rover_graphics-pure_pursuit_edge_case drawio](https://github.com/user-attachments/assets/8c3b5b29-9b67-4e15-99cc-a61cc5a87e7f)

The linesegment is outside of the lookahead which makes the rover default to calculating the bearing towards the closest point on the _extended_ line segment (red dot). However, in this edge case this leads the rover to take a suboptimal path (red). The rover will now instead directly target the previous waypoint if the closest point on the path is not on the actual line segment leading to the more direct path (yellow).
In the same fashion, if the closest point on the path is ahead of the line segment the rover will target the current waypoint instead.

#### Logging message
This PR also adds a message for the purePursuit library to log relevant values.
This makes tuning of the pure pursuit algorithm easier and also deprecates the 3 `[rover_type]_guidance_status.msg` messages.

To use the library and publish the pure pursuit message the function 'updatePurePursuit' has to be called.
If the logging is not required then the function `calcTargetBearing` (renamed from `calcDesiredHeading`) can also be called direclty, which will return the target bearing without publishing the pure pursuit message.

### Test coverage
- SITL tested