### PR TITLE
Mission: Replay gimbal cached items before reaching mission waypoint

### DIFF
--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -299,15 +299,14 @@ MissionBase::on_active()
 		replayCachedCameraModeItems();
 	}
 
+	// Replay cached gimbal commands immediately upon mission resume, but only after the vehicle has reached the final target altitude
+	if (haveCachedGimbalItems() && _work_item_type != WorkItemType::WORK_ITEM_TYPE_CLIMB) {
+		replayCachedGimbalItems();
+	}
 
 	// Replay cached mission commands once the last mission waypoint is re-reached after the mission interruption.
 	// Each replay function also clears the cached items afterwards
 	if (_mission.current_seq > _mission_activation_index) {
-		// replay gimbal commands
-		if (haveCachedGimbalItems()) {
-			replayCachedGimbalItems();
-		}
-
 		// replay trigger commands
 		if (cameraWasTriggering()) {
 			replayCachedTriggerItems();


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When flying patterns, photos are sometimes taken while the gimbal is pitching up or down.

### Solution
To address this, we orient the gimbal before reaching the mission waypoint, allowing more time to complete the action. Additionally, we verify if the vehicle is climbing to avoid orienting the gimbal while on the ground.

### Test coverage
Tested in SITL.
