### PR TITLE
Fix board target generation 

### DIFF
--- a/Tools/ci/generate_board_targets_json.py
+++ b/Tools/ci/generate_board_targets_json.py
@@ -73,7 +73,7 @@ def process_target(px4board_file, target_name):
         px4board_file.endswith("bootloader.px4board"):
         kconf.load_config(px4board_file, replace=True)
     else: # Merge config with default.px4board
-        default_kconfig = re.sub(r'[a-zA-Z\d_]+\.px4board', 'default.px4board', px4board_file)
+        default_kconfig = re.sub(r'[a-zA-Z\d_-]+\.px4board', 'default.px4board', px4board_file)
         kconf.load_config(default_kconfig, replace=True)
         kconf.load_config(px4board_file, replace=False)
 


### PR DESCRIPTION
### Solved Problem
The following PR: https://github.com/PX4/PX4-Autopilot/pull/24072 added a new target called `flash-analysis.px4board`. This naming convention does not cause any problems with KConfig or Make, it does however break _generate_board_targets_json.py_ as it does not expect such a naming convention.

### Solution
Adapted the contained regex to also consider targets that contain a `-`
