### PR TITLE
Draft: Remove gz-garden from Ubuntu Installation as it reached EOL

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -179,17 +179,6 @@ if [[ $INSTALL_SIM == "true" ]]; then
 			gazebo_classic_version=11
 			gazebo_packages="gazebo$gazebo_classic_version libgazebo$gazebo_classic_version-dev"
 		fi
-	elif [[ "${UBUNTU_RELEASE}" == "21.3" ]]; then
-		echo "Gazebo (Garden) will be installed"
-		echo "Earlier versions will be removed"
-		# Add Gazebo binary repository
-		sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
-		echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable jammy main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
-
-		sudo apt-get update -y --quiet
-
-		# Install Gazebo
-		gazebo_packages="gz-garden"
 	else
 		# Expects Ubuntu 22.04 > by default
 		echo "Gazebo (Harmonic) will be installed"


### PR DESCRIPTION
### Solved Problem
- gz garden reached EOL nov 2024, so it should no longer be supported: https://gazebosim.org/docs/latest/releases/

- gz-harmonic should be supported on Ubuntu Jammy https://gazebosim.org/docs/harmonic/getstarted/

- and finally Linux Mint version 21.3 is built on top of Ubuntu Jammy https://linuxmint.com/download_all.php 

### Test coverage
- not yet tested

