### PR TITLE
boards: ark_fpv: ADC payload scale 12V

### DIFF
--- a/boards/ark/fpv/src/board_config.h
+++ b/boards/ark/fpv/src/board_config.h
@@ -177,6 +177,7 @@
 #define BOARD_BATTERY1_V_DIV	 (21.0f) // (20k + 1k) / 1k = 21
 
 #define ADC_SCALED_PAYLOAD_SENSE ADC_SCALED_12V_CHANNEL
+#define ADC_PAYLOAD_V_FULL_SCALE (12.0f)
 
 /* HW has to large of R termination on ADC todo:change when HW value is chosen */
 


### PR DESCRIPTION
Scales the ADC_SCALED_PAYLOAD_SENSE channel to 12V (default is 25V)