### PR TITLE
[BACKPORT v1.15] gps: heading fixes for NMEA/Unicore

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -934,7 +934,8 @@ GPS::run()
 						set_device_type(DRV_GPS_DEVTYPE_UBX_9);
 						break;
 
-					case GPSDriverUBX::Board::u_blox9_F9P:
+					case GPSDriverUBX::Board::u_blox9_F9P_L1L2:
+					case GPSDriverUBX::Board::u_blox9_F9P_L1L5:
 						set_device_type(DRV_GPS_DEVTYPE_UBX_F9P);
 						break;
 


### PR DESCRIPTION
Backport of #24077.

Needs testing.