### PR TITLE
container: remove pr container push to registry

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -58,7 +58,6 @@ jobs:
             type=ref,event=branch,value=${{ steps.px4-tag.outputs.tag }},priority=700
             type=ref,event=branch,suffix=-{{date 'YYYY-MM-DD'}},priority=600
             type=ref,event=branch,suffix=,priority=500
-            type=ref,event=pr
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
we supported uploading container builds for pull requests so users could download and test, but we are facing issues with the github api, and as a result we are having [CI failures](https://github.com/PX4/PX4-Autopilot/actions/runs/12283238253/job/34276255629#step:13:274)

Given we don't have users taking advantage of this feature, I decided to remove it.

https://github.com/PX4/PX4-Autopilot/pkgs/container/px4-dev