### PR TITLE
ekf-agp: fix timeout

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.cpp
@@ -73,7 +73,7 @@ void AuxGlobalPosition::update(Ekf &ekf, const estimator::imuSample &imu_delayed
 			return;
 		}
 
-		estimator_aid_source2d_s aid_src{};
+		estimator_aid_source2d_s &aid_src = _aid_src_aux_global_position;
 		const LatLonAlt position(sample.latitude, sample.longitude, sample.altitude_amsl);
 		const Vector2f innovation = (ekf.getLatLonAlt() - position).xy(); // altitude measurements are not used
 

--- a/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.hpp
+++ b/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.hpp
@@ -92,6 +92,7 @@ private:
 		uint8_t lat_lon_reset_counter{};
 	};
 
+	estimator_aid_source2d_s _aid_src_aux_global_position{};
 	RingBuffer<AuxGlobalPositionSample> _aux_global_position_buffer{20}; // TODO: size with _obs_buffer_length and actual publication rate
 	uint64_t _time_last_buffer_push{0};
 


### PR DESCRIPTION

### Solved Problem
AGP was not waiting for the timeout to perform a reset when a sample wasn't passing the test ratio as the `time_last_fused` is always reset to 0 as `aid_src` is not a member variable but re-instantiated at every loop.

### Solution
Make the aux global position "aid_src" structure a member variable to remember when the last fusion occurred.

