### PR TITLE
mavlink_main: stream attitude as quaternion if HIL

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -672,6 +672,7 @@ Mavlink::set_hil_enabled(bool hil_enabled)
 			configure_stream("HIL_STATE_QUATERNION", 25.0f); // ground truth to display the SIH
 			// stream attitude also as quaternion for correct display
 			configure_stream("ATTITUDE_QUATERNION", 20.0f);
+
 		} else {
 			configure_stream("HIL_STATE_QUATERNION", 0.0f);
 		}

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -670,7 +670,8 @@ Mavlink::set_hil_enabled(bool hil_enabled)
 
 		if (_param_sys_hitl.get() == 2) {		// Simulation in Hardware enabled ?
 			configure_stream("HIL_STATE_QUATERNION", 25.0f); // ground truth to display the SIH
-
+			// stream attitude also as quaternion for correct display
+			configure_stream("ATTITUDE_QUATERNION", 20.0f);
 		} else {
 			configure_stream("HIL_STATE_QUATERNION", 0.0f);
 		}


### PR DESCRIPTION
### Solved Problem
Previously with SIH, for some VTOL airframes (e.g. SIH Tailsitter Duo, 1102) the attitude display on the ground station was wrong due to the body frame in forward flight differing from the usual convention. 


### Solution
The rotation of the body frame is already accounted for (see [this PR](https://github.com/mavlink/mavlink/pull/1247)) when sending the attitude as quaternion [1] over mavlink, but not when sending it as euler angles [2]. Therefore, if in SIH/HIL we always send it as a quaternion as well. 


1: [src/modules/mavlink/streams/ATTITUDE_QUATERNION.hpp](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/streams/ATTITUDE_QUATERNION.hpp)
2: [src/modules/mavlink/streams/ALTITUDE.hpp](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/streams/ATTITUDE.hpp)

### Alternatives 
 - add similar logic as in [1] to [2] so display attitude is correct regardless of numerical representation
 - enable sending quaternions only for the relevant VTOL airframes

### Test coverage
 - SIH test with SIH Tailsitter Duo (1102)