### PR TITLE
sim: gz: remove Garden from cmake

### DIFF
--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -32,8 +32,8 @@
 ############################################################################
 
 # Find the gz_Transport library
-# Look for GZ Ionic, Harmonic, and Garden library options in that order
-find_package(gz-transport NAMES gz-transport14 gz-transport13 gz-transport12)
+# Look for GZ Ionic or Harmonic
+find_package(gz-transport NAMES gz-transport14 gz-transport13)
 
 if(gz-transport_FOUND)
 


### PR DESCRIPTION
removes garden from cmake, since build will fail due to airspeed message 