### PR TITLE
position control reset tilt limit and hover thrust in non-position mode

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -593,6 +593,15 @@ void MulticopterPositionControl::Run()
 			// an update is necessary here because otherwise the takeoff state doesn't get skipped with non-altitude-controlled modes
 			_takeoff.updateTakeoffState(_vehicle_control_mode.flag_armed, _vehicle_land_detected.landed, false, 10.f, true,
 						    vehicle_local_position.timestamp_sample);
+
+			const float tilt_limit_deg = (_takeoff.getTakeoffState() < TakeoffState::flight)
+						     ? _param_mpc_tiltmax_lnd.get() : _param_mpc_tiltmax_air.get();
+			_tilt_limit_slew_rate.update(math::radians(tilt_limit_deg), dt);
+
+			if (_takeoff.getTakeoffState() < TakeoffState::flight) {
+				_control.setHoverThrust(_param_mpc_thr_hover.get());
+			}
+
 			_control.resetIntegral();
 		}
 


### PR DESCRIPTION
### Solved Problem
When flying in non position mode, the position control tilt limit is not updated.
Taking off in another mode (in my case offboard attitude control) and changing to a position control mode during flight (in my case pilot take over by RC in position mode) will result in tilt clamping following the takeoff slew rate.

### Solution
Update the tilt limit slew rate even if not in position mode ("flag_multicopter_position_control_enabled") as if it was.

With the same reasoning, I have also added a condition to reset the hover thrust as done in position control mode.

### Test coverage
- developed and tested on older branch
- back ported here and test in SITL 
