### PR TITLE
Mixer: FunctionMotors: leave NAN control values at NAN with non-zero THR_MDL_FAC

### DIFF
--- a/src/lib/mixer_module/functions/FunctionMotors.hpp
+++ b/src/lib/mixer_module/functions/FunctionMotors.hpp
@@ -76,7 +76,7 @@ public:
 
 	static inline void updateValues(uint32_t reversible, float thrust_factor, float *values, int num_values)
 	{
-		if (thrust_factor > 0.f && thrust_factor <= 1.f) {
+		if (thrust_factor > FLT_EPSILON && thrust_factor <= 1.f) {
 			// thrust factor
 			//  rel_thrust = factor * x^2 + (1-factor) * x,
 			const float a = thrust_factor;
@@ -88,17 +88,15 @@ public:
 
 			for (int i = 0; i < num_values; ++i) {
 
-				float control = values[i];
+				const float control = values[i];
 
 				if (PX4_ISFINITE(control)) {
-					if (control > 0.f) {
+					if (control > FLT_EPSILON) {
 						values[i] = -tmp1 + sqrtf(tmp2 + (control / a));
 
-					} else if (control < -0.f) {
+					} else if (control < -FLT_EPSILON) {
 						values[i] =  tmp1 - sqrtf(tmp2 - (control / a));
 
-					} else {
-						values[i] = 0.f;
 					}
 				}
 			}

--- a/src/lib/mixer_module/functions/FunctionMotors.hpp
+++ b/src/lib/mixer_module/functions/FunctionMotors.hpp
@@ -87,16 +87,19 @@ public:
 			const float tmp2 = b * b / (4.f * a * a);
 
 			for (int i = 0; i < num_values; ++i) {
+
 				float control = values[i];
 
-				if (control > 0.f) {
-					values[i] = -tmp1 + sqrtf(tmp2 + (control / a));
+				if (PX4_ISFINITE(control)) {
+					if (control > 0.f) {
+						values[i] = -tmp1 + sqrtf(tmp2 + (control / a));
 
-				} else if (control < -0.f) {
-					values[i] =  tmp1 - sqrtf(tmp2 - (control / a));
+					} else if (control < -0.f) {
+						values[i] =  tmp1 - sqrtf(tmp2 - (control / a));
 
-				} else {
-					values[i] = 0.f;
+					} else {
+						values[i] = 0.f;
+					}
 				}
 			}
 		}


### PR DESCRIPTION

### Solved Problem
Fixes https://github.com/PX4/PX4-Autopilot/issues/24083.

### Solution
Leave NAN untouched, even if THR_MOD_FAC is set.

### Changelog Entry
For release notes: Mixer:  leave NAN control values at NAN with non-zero THR_MDL_FAC to fix VTOL motors not turning off correctly.
```
Bugfix: 
```

### Alternatives
Should the whole THR_MOD_FAC logic not live in the control allocation? Why is it handled by the mixer?

### Test coverage
SITL tested.

