### PR TITLE
 Add cleanup function for SITL Gazebo on macOS

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -1,6 +1,16 @@
 #!/bin/sh
 # shellcheck disable=SC2154
 
+# Function to handle cleanup
+if [ "$(uname)" = "Darwin" ]; then
+    cleanup() {
+        echo "INFO  [init] Cleaning up on macOS..."
+        pkill -f "gz sim" || true  # Ignore errors if no process is found
+        trap - INT TERM  # Clear the trap to prevent re-triggering
+        exit 0  # Exit gracefully
+    }
+fi
+
 # Simulator IMU data provided at 250 Hz
 param set-default IMU_INTEG_RATE 250
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When running PX4 SITL on macOS, pressing Ctrl+C would not always cleanly stop the simulation processes (e.g., gz sim). This often forced users to press Ctrl+C multiple times or manually kill processes.



### Solution
- Added a `cleanup()` function guarded by `if [ "$(uname)" = "Darwin" ]`.
- Within `cleanup()`, use `pkill -f "gz sim" || true` to stop Gazebo simulation processes.
- Clear the `trap` for `INT TERM` signals right before `exit 0`.

### Changelog Entry
For release notes:
```
New Gazebo Harmonic SITL on MacOS 
```

### Alternatives
We could also add a `kill 0` call or a broader signal handling mechanism, but `pkill -f "gz sim"` suffices for macOS SITL with minimal side effects.

### Test coverage
- Local testing on macOS Sequoia. 


### Context
N/A


I cannot add reviewers here. @mrpollo @MaEtUgR @ThomasDebrunner you might want to try. 