### PR TITLE
Include distance sensor in dds topics

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -97,6 +97,9 @@ subscriptions:
   - topic: /fmu/in/config_control_setpoints
     type: px4_msgs::msg::VehicleControlMode
 
+  - topic: /fmu/in/distance_sensor
+    type: px4_msgs::msg::DistanceSensor
+
   - topic: /fmu/in/manual_control_input
     type: px4_msgs::msg::ManualControlSetpoint
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The current dds topics yaml file does not include input of distance sensor messages, leaving only obstacle distance.

Obstacle map messages are cumbersome for offboard point-lidar sensors. It would be better to pass in the distance sensor messages instead of trying to configure the obstacle distance array in the offboard code.

For non-point lidars (e.g. radar or rotating lidar) one could feed in the quaternion along with the distance data similar to this [branch](https://github.com/PX4/PX4-Autopilot/commit/b7a8b64a6e219b5c0f30e075a1c246db72bc1f40#diff-0e95f3c35895702b8f78bf4fe6849e1cc8aaf71236c4efa7c964511490210d61R653)

With [increasingly complex lidar sensors ](https://www.mouser.com/new/stmicroelectronics/stmicroelectronics-vl53lp-tof-modules/)whose drivers are too large or compute intensive for PX4 Firmware or , this is a simpler alternative to the obstacle distance message

### Solution
- Add distance_sensor to the dds topics yaml

### Changelog Entry
For release notes:
```
Feature/Bugfix distance_sensor message in dds topics
```

### Alternatives
None

### Test coverage
- PX4 SITL

### Context
Related links, screenshot before/after, video
![dds_distance](https://github.com/user-attachments/assets/ea3e9ae2-d83d-45d7-9adf-e4c5d3c07732)
