### PR TITLE
Expect radians for DO_GIMBAL_MANAGER_PITCHYAW msg

### DIFF
--- a/src/modules/gimbal/input_mavlink.cpp
+++ b/src/modules/gimbal/input_mavlink.cpp
@@ -879,11 +879,9 @@ InputMavlinkGimbalV2::_process_command(ControlData &control_data, const vehicle_
 		if (vehicle_command.source_system == control_data.sysid_primary_control &&
 		    vehicle_command.source_component == control_data.compid_primary_control) {
 
-			const matrix::Eulerf euler(0.0f, math::radians(vehicle_command.param1),
-						   math::radians(vehicle_command.param2));
+			const matrix::Eulerf euler(0.0f, vehicle_command.param1, vehicle_command.param2);
 			const matrix::Quatf q(euler);
-			const matrix::Vector3f angular_velocity(NAN, math::radians(vehicle_command.param3),
-								math::radians(vehicle_command.param4));
+			const matrix::Vector3f angular_velocity(NAN, vehicle_command.param3, vehicle_command.param4);
 			const uint32_t flags = vehicle_command.param5;
 
 			// TODO: support gimbal device id for multiple gimbals


### PR DESCRIPTION
Expect values to be in radians for the DO_GIMBAL_MANAGER_PITCHYAW msg (units are specified as radians in the MAVLINK message definition)

note: QGC is also setting the message fields using degrees when it should be using radians. The PR for that fix can be seen here: https://github.com/mavlink/qgroundcontrol/pull/12232

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)