### PR TITLE
Mavlink: dont broadcast during unit-testing

### DIFF
--- a/posix-configs/SITL/init/test/cmd_template.in
+++ b/posix-configs/SITL/init/test/cmd_template.in
@@ -15,7 +15,7 @@ pwm_out_sim start
 
 ver all
 
-mavlink start -x -u 14556 -r 2000000 -p
+mavlink start -x -u 14556 -r 2000000
 mavlink boot_complete
 
 @cmd_name@ start

--- a/posix-configs/SITL/init/test/test_mavlink
+++ b/posix-configs/SITL/init/test/test_mavlink
@@ -15,7 +15,7 @@ pwm_out_sim start
 
 ver all
 
-mavlink start -x -u 14556 -r 2000000 -p
+mavlink start -x -u 14556 -r 2000000
 mavlink boot_complete
 
 mavlink_tests


### PR DESCRIPTION
### Solved Problem
Mavlink unit-tests started publishing messages to the first available network, causing issues with devices which were hooked up to the same network.
@eyeam3 