### PR TITLE
Adding gimbal rate in gz simulation

### DIFF
--- a/src/modules/simulation/gz_bridge/GZGimbal.cpp
+++ b/src/modules/simulation/gz_bridge/GZGimbal.cpp
@@ -104,6 +104,14 @@ void GZGimbal::gimbalIMUCallback(const gz::msgs::IMU &IMU_data)
 					   IMU_data.orientation().z());
 	_q_gimbal = q_FLU_to_FRD * q_gimbal_FLU * q_FLU_to_FRD.inversed();
 
+	matrix::Vector3f rate = q_FLU_to_FRD.rotateVector(matrix::Vector3f(IMU_data.angular_velocity().x(),
+				IMU_data.angular_velocity().y(),
+				IMU_data.angular_velocity().z()));
+
+	_gimbal_rate[0] = rate(0);
+	_gimbal_rate[1] = rate(1);
+	_gimbal_rate[2] = rate(2);
+
 	pthread_mutex_unlock(&_node_mutex);
 }
 


### PR DESCRIPTION
### Solved Problem
When I tested the gimbal device I notice the angular velocity data wasn't updated in the gimbal device attitude status.

### Test coverage
Tested with QGC

### Context
The original PR with results and description: 
- [x] https://github.com/PX4/PX4-Autopilot/pull/23382
- [x] https://github.com/PX4/PX4-gazebo-models/pull/71

Below is the result of the gimbal in motion and corresponding angular velocities in the gimbal device attitude status.
[07112024pr-gz-gimbal-sim.webm](https://github.com/user-attachments/assets/e1c4269e-4c7b-4020-a22b-27597983ec47)


