### PR TITLE
ADSB: improve testability and small refactor

### DIFF
--- a/src/lib/adsb/AdsbConflict.cpp
+++ b/src/lib/adsb/AdsbConflict.cpp
@@ -111,9 +111,9 @@ void AdsbConflict::remove_icao_address_from_conflict_list(int traffic_index)
 	PX4_INFO("icao_address removed. Buffer Size: %d", (int)_traffic_buffer.timestamp.size());
 }
 
-void AdsbConflict::add_icao_address_from_conflict_list(uint32_t icao_address)
+void AdsbConflict::add_icao_address_from_conflict_list(uint32_t icao_address, hrt_abstime now)
 {
-	_traffic_buffer.timestamp.push_back(hrt_absolute_time());
+	_traffic_buffer.timestamp.push_back(now);
 	_traffic_buffer.icao_address.push_back(icao_address);
 	PX4_INFO("icao_address added. Buffer Size: %d", (int)_traffic_buffer.timestamp.size());
 }
@@ -133,7 +133,7 @@ void AdsbConflict::get_traffic_state(hrt_abstime now)
 	}
 
 	if (new_traffic && _conflict_detected && !_traffic_buffer_full) {
-		add_icao_address_from_conflict_list(_transponder_report.icao_address);
+		add_icao_address_from_conflict_list(_transponder_report.icao_address, now);
 		_traffic_state = TRAFFIC_STATE::ADD_CONFLICT;
 
 	} else if (new_traffic && _conflict_detected && _traffic_buffer_full) {

--- a/src/lib/adsb/AdsbConflict.cpp
+++ b/src/lib/adsb/AdsbConflict.cpp
@@ -183,7 +183,8 @@ bool AdsbConflict::handle_traffic_conflict()
 			take_action = send_traffic_warning((int)(math::degrees(_transponder_report.heading) + 180.f),
 							   (int)fabsf(_crosstrack_error.distance), _transponder_report.flags,
 							   _transponder_report.callsign,
-							   _transponder_report.icao_address);
+							   _transponder_report.icao_address,
+							   now);
 		}
 		break;
 
@@ -233,7 +234,7 @@ void AdsbConflict::set_conflict_detection_params(float crosstrack_separation, fl
 
 
 bool AdsbConflict::send_traffic_warning(int traffic_direction, int traffic_seperation, uint16_t tr_flags,
-					char tr_callsign[UTM_CALLSIGN_LENGTH], uint32_t icao_address)
+					char tr_callsign[UTM_CALLSIGN_LENGTH], uint32_t icao_address, hrt_abstime now)
 {
 
 	switch (_conflict_detection_params.traffic_avoidance_mode) {
@@ -250,7 +251,7 @@ bool AdsbConflict::send_traffic_warning(int traffic_direction, int traffic_seper
 			}
 
 
-			_last_traffic_warning_time = hrt_absolute_time();
+			_last_traffic_warning_time = now;
 
 			break;
 		}
@@ -277,7 +278,7 @@ bool AdsbConflict::send_traffic_warning(int traffic_direction, int traffic_seper
 					"Traffic alert - ICAO Address {1}! Separation Distance {2}, Heading {3}",
 					icao_address, traffic_seperation, traffic_direction);
 
-			_last_traffic_warning_time = hrt_absolute_time();
+			_last_traffic_warning_time = now;
 
 			break;
 		}
@@ -293,7 +294,7 @@ bool AdsbConflict::send_traffic_warning(int traffic_direction, int traffic_seper
 					"Traffic alert - ICAO Address {1}! Separation Distance {2}, Heading {3}, returning home",
 					icao_address, traffic_seperation, traffic_direction);
 
-			_last_traffic_warning_time = hrt_absolute_time();
+			_last_traffic_warning_time = now;
 
 			return true;
 
@@ -311,7 +312,7 @@ bool AdsbConflict::send_traffic_warning(int traffic_direction, int traffic_seper
 					"Traffic alert - ICAO Address {1}! Separation Distance {2}, Heading {3}, landing",
 					icao_address, traffic_seperation, traffic_direction);
 
-			_last_traffic_warning_time = hrt_absolute_time();
+			_last_traffic_warning_time = now;
 
 			return true;
 
@@ -330,7 +331,7 @@ bool AdsbConflict::send_traffic_warning(int traffic_direction, int traffic_seper
 					"Traffic alert - ICAO Address {1}! Separation Distance {2}, Heading {3}, holding position",
 					icao_address, traffic_seperation, traffic_direction);
 
-			_last_traffic_warning_time = hrt_absolute_time();
+			_last_traffic_warning_time = now;
 
 
 			return true;

--- a/src/lib/adsb/AdsbConflict.h
+++ b/src/lib/adsb/AdsbConflict.h
@@ -118,7 +118,7 @@ public:
 
 
 	bool send_traffic_warning(int traffic_direction, int traffic_seperation, uint16_t tr_flags,
-				  char tr_callsign[UTM_CALLSIGN_LENGTH], uint32_t icao_address);
+				  char tr_callsign[UTM_CALLSIGN_LENGTH], uint32_t icao_address, hrt_abstime now);
 
 	transponder_report_s _transponder_report{};
 

--- a/src/lib/adsb/AdsbConflict.h
+++ b/src/lib/adsb/AdsbConflict.h
@@ -111,7 +111,7 @@ public:
 
 	void add_icao_address_from_conflict_list(uint32_t icao_address);
 
-	void get_traffic_state();
+	void get_traffic_state(hrt_abstime now);
 
 	void set_conflict_detection_params(float crosstrack_separation, float vertical_separation,
 					   int collision_time_threshold, uint8_t traffic_avoidance_mode);

--- a/src/lib/adsb/AdsbConflict.h
+++ b/src/lib/adsb/AdsbConflict.h
@@ -109,7 +109,7 @@ public:
 
 	void remove_icao_address_from_conflict_list(int traffic_index);
 
-	void add_icao_address_from_conflict_list(uint32_t icao_address);
+	void add_icao_address_from_conflict_list(uint32_t icao_address, hrt_abstime now);
 
 	void get_traffic_state(hrt_abstime now);
 
@@ -129,8 +129,7 @@ public:
 			  float hor_velocity, float ver_velocity, int emitter_type, uint32_t icao_address, double lat_uav, double lon_uav,
 			  float &alt_uav);
 
-	void run_fake_traffic(double &lat_uav, double &lon_uav,
-			      float &alt_uav);
+	void run_fake_traffic(double &lat_uav, double &lon_uav, float &alt_uav);
 
 	void remove_expired_conflicts();
 

--- a/src/lib/adsb/AdsbConflictTest.cpp
+++ b/src/lib/adsb/AdsbConflictTest.cpp
@@ -4,7 +4,6 @@
 
 #include "AdsbConflictTest.h"
 
-
 class TestAdsbConflict : public AdsbConflict
 {
 public:
@@ -25,8 +24,6 @@ public:
 
 TEST_F(AdsbConflictTest, detectTrafficConflict)
 {
-
-
 	int collision_time_threshold = 60;
 
 	float crosstrack_separation = 500.0f;
@@ -42,19 +39,15 @@ TEST_F(AdsbConflictTest, detectTrafficConflict)
 
 	uint32_t traffic_dataset_size = sizeof(traffic_dataset) / sizeof(traffic_dataset[0]);
 
-
 	TestAdsbConflict 	adsb_conflict;
 
 	adsb_conflict.set_conflict_detection_params(crosstrack_separation, vertical_separation, collision_time_threshold, 1);
 
 	for (uint32_t i = 0; i < traffic_dataset_size; i++) {
 
-
-		//printf("---------------%d--------------\n", i);
-
 		struct traffic_data_s traffic = traffic_dataset[i];
 
-
+		// GIVEN traffic dataset (which should result in conflict)
 		adsb_conflict._transponder_report.lat = traffic.lat_traffic;
 		adsb_conflict._transponder_report.lon = traffic.lon_traffic;
 		adsb_conflict._transponder_report.altitude = traffic.alt_traffic;
@@ -62,22 +55,17 @@ TEST_F(AdsbConflictTest, detectTrafficConflict)
 		adsb_conflict._transponder_report.hor_velocity = traffic.vxy_traffic;
 		adsb_conflict._transponder_report.ver_velocity = traffic.vz_traffic;
 
+		// WHEN detect traffic conflict is called
 		adsb_conflict.detect_traffic_conflict(lat_now, lon_now, alt_now, vx_now, vy_now, vz_now);
 
-		//printf("conflict_detected %d \n", adsb_conflict._conflict_detected);
-
-		//printf("------------------------------\n");
-		//printf("------------------------------\n \n");
-
+		// THEN expect conflict to be detected
 		EXPECT_TRUE(adsb_conflict._conflict_detected == traffic.in_conflict);
 	}
-
 }
 
 
 TEST_F(AdsbConflictTest, trafficAlerts)
 {
-
 	struct	traffic_buffer_s used_buffer;
 	used_buffer.icao_address.push_back(2345);
 	used_buffer.icao_address.push_back(1234);
@@ -116,84 +104,98 @@ TEST_F(AdsbConflictTest, trafficAlerts)
 	full_buffer.timestamp.push_back(1000_s);
 	full_buffer.timestamp.push_back(58943_s);
 
-
-
 	struct traffic_buffer_s empty_buffer = {};
-
 
 	TestAdsbConflict 	adsb_conflict;
 
+	// GIVEN used buffer
 	adsb_conflict.set_traffic_buffer(used_buffer);
 
+	// WHEN no conflict detected
 	bool conflict_detected  = false;
 	hrt_abstime now = 0_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 00001;
 	adsb_conflict.get_traffic_state(now);
 
+	// THEN expect no conflict
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::NO_CONFLICT);
 
+	// GIVEN conflict detected
 	conflict_detected  = true;
 	now = 1_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 9876;
 	adsb_conflict.get_traffic_state(now);
 
+	// THEN expect conflict to be added to buffer
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::ADD_CONFLICT);
 
+	// GIVEN empty buffer
 	adsb_conflict.set_traffic_buffer(empty_buffer);
 
+	// WHEN conflict detected
 	conflict_detected  = true;
 	now = 0_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 9876;
 	adsb_conflict.get_traffic_state(now);
 
+	// THEN expect conflict to be added to buffer
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::ADD_CONFLICT);
 
+	// GIVEN full buffer
 	adsb_conflict.set_traffic_buffer(full_buffer);
 
+	// WHEN conflict detected
 	conflict_detected  = true;
 	now = 1_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 7777;
 	adsb_conflict.get_traffic_state(now);
 
+	// THEN expect buffer full
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::BUFFER_FULL);
 
+	// WHEN conflict set to false again
 	conflict_detected  = false;
 	now = 2_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 7777;
 	adsb_conflict.get_traffic_state(now);
 
+	// THEN expect no conflict message
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::NO_CONFLICT);
 
+	// WHEN existing conflict is set to false
 	conflict_detected  = false;
 	now = 3_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 8685;
 	adsb_conflict.get_traffic_state(now);
 
+	// THEN expect conflict to be removed from buffer
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::REMOVE_OLD_CONFLICT);
 
+	// GIVEN used buffer
 	adsb_conflict.set_traffic_buffer(used_buffer);
 
+	// WHEN conflict is set to false again
 	conflict_detected  = false;
 	now = 0_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 8685;
 	adsb_conflict.get_traffic_state(now);
 
+	// THEN expect conflict to be removed from buffer
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::REMOVE_OLD_CONFLICT);
-
 }
 
 TEST_F(AdsbConflictTest, trafficReminder)
@@ -236,65 +238,77 @@ TEST_F(AdsbConflictTest, trafficReminder)
 	full_buffer.timestamp.push_back(100_s);
 	full_buffer.timestamp.push_back(5843_s);
 
-
 	TestAdsbConflict 	adsb_conflict;
 
+	// GIVEN buffer with 8685 at t=100
 	adsb_conflict.set_traffic_buffer(used_buffer);
 
+	// WHEN conflict detected at t=200
 	bool conflict_detected  = true;
 	hrt_abstime now = 200_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 8685;
 	adsb_conflict.get_traffic_state(now);
 
+	// THEN expect conflict reminder
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::REMIND_CONFLICT);
 
+	// WHEN INSTEAD conflict is detected only 1s later
 	conflict_detected  = true;
 	now = 201_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 8685;
 	adsb_conflict.get_traffic_state(now);
 
+	// THEN do not sent conflict notification again
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::NO_CONFLICT);
 
+	// GIVEN full buffer with 8685 at t=100
 	adsb_conflict.set_traffic_buffer(full_buffer);
 
+	// WHEN conflict detected at t=400
 	conflict_detected  = true;
 	now = 400_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 8685;
 	adsb_conflict.get_traffic_state(now);
 
+	// THEN expect conflict reminder
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::REMIND_CONFLICT);
 
+	// WHEN INSTEAD conflict is detected only 1s later
 	conflict_detected  = true;
 	now = 401_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 8685;
 	adsb_conflict.get_traffic_state(now);
 
+	// THEN do not sent conflict notification again
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::NO_CONFLICT);
 
+	// WHEN conflict is set to false
 	conflict_detected  = false;
 	now = 600_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 8685;
 	adsb_conflict.get_traffic_state(now);
 
+	// THEN expect conflict to be removed from buffer
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::REMOVE_OLD_CONFLICT);
 
+	// WHEN new conflict is detected
 	conflict_detected  = true;
 	now = 700_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 7777;
 	adsb_conflict.get_traffic_state(now);
 
+	// THEN expect new conflict to be added to buffer
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::ADD_CONFLICT);
-
 }

--- a/src/lib/adsb/AdsbConflictTest.cpp
+++ b/src/lib/adsb/AdsbConflictTest.cpp
@@ -126,17 +126,19 @@ TEST_F(AdsbConflictTest, trafficAlerts)
 	adsb_conflict.set_traffic_buffer(used_buffer);
 
 	bool conflict_detected  = false;
+	hrt_abstime now = 0_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 00001;
-	adsb_conflict.get_traffic_state();
+	adsb_conflict.get_traffic_state(now);
 
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::NO_CONFLICT);
 
 	conflict_detected  = true;
+	now = 1_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 9876;
-	adsb_conflict.get_traffic_state();
+	adsb_conflict.get_traffic_state(now);
 
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::ADD_CONFLICT);
@@ -144,9 +146,10 @@ TEST_F(AdsbConflictTest, trafficAlerts)
 	adsb_conflict.set_traffic_buffer(empty_buffer);
 
 	conflict_detected  = true;
+	now = 0_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 9876;
-	adsb_conflict.get_traffic_state();
+	adsb_conflict.get_traffic_state(now);
 
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::ADD_CONFLICT);
@@ -154,25 +157,28 @@ TEST_F(AdsbConflictTest, trafficAlerts)
 	adsb_conflict.set_traffic_buffer(full_buffer);
 
 	conflict_detected  = true;
+	now = 1_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 7777;
-	adsb_conflict.get_traffic_state();
+	adsb_conflict.get_traffic_state(now);
 
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::BUFFER_FULL);
 
 	conflict_detected  = false;
+	now = 2_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 7777;
-	adsb_conflict.get_traffic_state();
+	adsb_conflict.get_traffic_state(now);
 
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::NO_CONFLICT);
 
 	conflict_detected  = false;
+	now = 3_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 8685;
-	adsb_conflict.get_traffic_state();
+	adsb_conflict.get_traffic_state(now);
 
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::REMOVE_OLD_CONFLICT);
@@ -180,9 +186,10 @@ TEST_F(AdsbConflictTest, trafficAlerts)
 	adsb_conflict.set_traffic_buffer(used_buffer);
 
 	conflict_detected  = false;
+	now = 0_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 8685;
-	adsb_conflict.get_traffic_state();
+	adsb_conflict.get_traffic_state(now);
 
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::REMOVE_OLD_CONFLICT);
@@ -235,17 +242,19 @@ TEST_F(AdsbConflictTest, trafficReminder)
 	adsb_conflict.set_traffic_buffer(used_buffer);
 
 	bool conflict_detected  = true;
+	hrt_abstime now = 200_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 8685;
-	adsb_conflict.get_traffic_state();
+	adsb_conflict.get_traffic_state(now);
 
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::REMIND_CONFLICT);
 
 	conflict_detected  = true;
+	now = 201_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 8685;
-	adsb_conflict.get_traffic_state();
+	adsb_conflict.get_traffic_state(now);
 
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::NO_CONFLICT);
@@ -253,33 +262,37 @@ TEST_F(AdsbConflictTest, trafficReminder)
 	adsb_conflict.set_traffic_buffer(full_buffer);
 
 	conflict_detected  = true;
+	now = 400_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 8685;
-	adsb_conflict.get_traffic_state();
+	adsb_conflict.get_traffic_state(now);
 
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::REMIND_CONFLICT);
 
 	conflict_detected  = true;
+	now = 401_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 8685;
-	adsb_conflict.get_traffic_state();
+	adsb_conflict.get_traffic_state(now);
 
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::NO_CONFLICT);
 
 	conflict_detected  = false;
+	now = 600_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 8685;
-	adsb_conflict.get_traffic_state();
+	adsb_conflict.get_traffic_state(now);
 
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::REMOVE_OLD_CONFLICT);
 
 	conflict_detected  = true;
+	now = 700_s;
 	adsb_conflict.set_conflict(conflict_detected);
 	adsb_conflict._transponder_report.icao_address = 7777;
-	adsb_conflict.get_traffic_state();
+	adsb_conflict.get_traffic_state(now);
 
 	printf("adsb_conflict._traffic_state %d \n", adsb_conflict._traffic_state);
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::ADD_CONFLICT);


### PR DESCRIPTION
### Solved Problem
Some of the unit tests for ADSB failed in our fork of PX4. My best guess is that it has something to do with timing. I don't understand how it is working atm without passing the "current time" to the unit test when the ADSB functionality we're testing is depending on the exact timing of the incoming faked conflicts. 

### Solution
In unit tests define time of reception of new/removed conflict input.

### Changelog Entry
For release notes:
```
Improvement: ADSB: improve testability and small refactor
```

