### PR TITLE
Make multicopter position control parameter descriptions more concise

### DIFF
--- a/src/modules/mc_pos_control/multicopter_altitude_mode_params.c
+++ b/src/modules/mc_pos_control/multicopter_altitude_mode_params.c
@@ -73,15 +73,13 @@ PARAM_DEFINE_FLOAT(MPC_MAN_Y_TAU, 0.08f);
 /**
  * Altitude reference mode
  *
- * Set to 0 to control height relative to the earth frame origin. This origin may move up and down in
- * flight due to sensor drift.
- * Set to 1 to control height relative to estimated distance to ground. The vehicle will move up and down
- * with terrain height variation. Requires a distance to ground sensor. The height controller will
- * revert to using height above origin if the distance to ground estimate becomes invalid as indicated
- * by the local_position.distance_bottom_valid message being false.
- * Set to 2 to control height relative to ground (requires a distance sensor) when stationary and relative
- * to earth frame origin when moving horizontally.
- * The speed threshold is controlled by the MPC_HOLD_MAX_XY parameter.
+ * Control height
+ * 0: relative earth frame origin which may drift due to sensors
+ * 1: relative to ground (requires distance sensor) which changes with terrain variation.
+ * It will revert to relative earth frame if the distance to ground estimate becomes invalid.
+ * 2: relative to ground (requires distance sensor) when stationary
+ * and relative to earth frame when moving horizontally.
+ * The speed threshold is MPC_HOLD_MAX_XY
  *
  * @min 0
  * @max 2

--- a/src/modules/mc_pos_control/multicopter_position_mode_params.c
+++ b/src/modules/mc_pos_control/multicopter_position_mode_params.c
@@ -35,12 +35,12 @@
  * Position/Altitude mode variant
  *
  * The supported sub-modes are:
- * - "Direct velocity":
+ * Direct velocity:
  *   Sticks directly map to velocity setpoints without smoothing.
  *   Also applies to vertical direction and Altitude mode.
  *   Useful for velocity control tuning.
- *  - "Acceleration based":
- *  Sticks map to acceleration and there's a virtual brake drag
+ * Acceleration based:
+ *   Sticks map to acceleration and there's a virtual brake drag
  *
  * @value 0 Direct velocity
  * @value 4 Acceleration based
@@ -114,9 +114,8 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR_MAX, 5.f);
 /**
  * Maximum horizontal and vertical jerk in Position/Altitude mode
  *
- * Limit the maximum jerk of the vehicle (how fast the acceleration can change).
- * A lower value leads to smoother motions but limits agility
- * (how fast it can change directions or break).
+ * Limit the maximum jerk (acceleration change) of the vehicle.
+ * A lower value leads to smoother motions but limits agility.
  *
  * Setting this to the maximum value essentially disables the limit.
  *

--- a/src/modules/mc_pos_control/multicopter_stabilized_mode_params.c
+++ b/src/modules/mc_pos_control/multicopter_stabilized_mode_params.c
@@ -75,18 +75,16 @@ PARAM_DEFINE_FLOAT(MPC_MANTHR_MIN, 0.08f);
 /**
  * Thrust curve mapping in Stabilized Mode
  *
- * This parameter defines how the throttle stick input is mapped to collective thrust
- * in Stabilized mode.
+ * Defines how the throttle stick is mapped to collective thrust in Stabilized mode.
  *
- * In case the default is used ('Rescale to hover thrust'), the stick input is linearly
- * rescaled, such that a centered stick corresponds to the hover throttle (see MPC_THR_HOVER).
+ * Rescale to hover thrust:
+ *   Stick input is linearly rescaled, such that a centered stick corresponds to the hover throttle (see MPC_THR_HOVER).
  *
- * Select 'No Rescale' to directly map the stick 1:1 to the output. This can be useful
- * in case the hover thrust is very low and the default would lead to too much distortion
- * (e.g. if hover thrust is set to 20%, then 80% of the upper thrust range is squeezed into the
- * upper half of the stick range).
+ * No Rescale:
+ *   Directly map the stick 1:1 to the output.
+ *   Can be useful with very low hover thrust which leads to much distortion and the upper half getting sensitive.
  *
- * Note: In case MPC_THR_HOVER is set to 50%, the modes 0 and 1 are the same.
+ * With MPC_THR_HOVER 0.5 both modes are the same.
  *
  * @value 0 Rescale to hover thrust
  * @value 1 No Rescale


### PR DESCRIPTION
### Solved Problem
When working on https://github.com/PX4/PX4-Autopilot/pull/24041 I found that Kakute F7 runs out of flash so @sfuhrer told me easiest is to save on some parameter description strings. But I think does are not included in flash-contained builds.

Even though there is no effect on that particular build I think cleaning up is worthwhile.

### Solution
I shortened the texts to contain the essential information but avoid language decorations.

### Changelog Entry
```
Improvement: Make multicopter position control parameter descriptions more concise
```
