### PR TITLE
logger: fix file open issue if crypto algorithm is disabled

### DIFF
--- a/src/modules/logger/log_writer_file.h
+++ b/src/modules/logger/log_writer_file.h
@@ -224,7 +224,7 @@ private:
 	pthread_cond_t		_cv;
 	pthread_t _thread = 0;
 #if defined(PX4_CRYPTO)
-	bool init_logfile_encryption(const char *filename);
+	bool init_logfile_encryption(const LogType type);
 	PX4Crypto _crypto;
 	int _min_blocksize;
 	px4_crypto_algorithm_t _algorithm;


### PR DESCRIPTION
Open log file only once to avoid conflicts.

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Fixes [#24155](https://github.com/PX4/PX4-Autopilot/issues/24155)

### Solution
- The init_logfile_encryption() call is moved after the buffer's start_log() is called. This way file is opened only once and is already open when storing possible key data into the beginning of the file.

### Changelog Entry
For release notes:
```
Bugfix: Fix logger file open when SDLOG_ALGORITHM is 0 (crypto disabled)
```

### Alternatives
Could also add "append" parameter to start_log() function to select whether file needs to be opened as APPEND or CREATE flag. Another option is to store the keydata into temporary memory buffer and store it to file when opened in buffer's start_log() method.

### Test coverage
- Unit/integration test: Logging functionality with encryption enabled and disabled verified with Pixhawk4 and px4_fmu-v5_cryptotest target

