### PR TITLE
ina238: retry if read fails

### DIFF
--- a/src/drivers/power_monitor/ina238/ina238.cpp
+++ b/src/drivers/power_monitor/ina238/ina238.cpp
@@ -98,17 +98,13 @@ int INA238::read(uint8_t address, uint16_t &data)
 	uint16_t received_bytes;
 	int ret = PX4_ERROR;
 
-	for (size_t i = 0; i < 6; i++) {
-		ret = transfer(&address, 1, (uint8_t *)&received_bytes, sizeof(received_bytes));
+	ret = transfer(&address, 1, (uint8_t *)&received_bytes, sizeof(received_bytes));
 
-		if (ret == PX4_OK) {
-			data = swap16(received_bytes);
-			break;
-
-		} else {
-			perf_count(_comms_errors);
-			PX4_DEBUG("i2c::transfer returned %d", ret);
-		}
+	if (ret == PX4_OK) {
+		data = swap16(received_bytes);
+	} else {
+		perf_count(_comms_errors);
+		PX4_DEBUG("i2c::transfer returned %d", ret);
 	}
 
 	return ret;
@@ -164,6 +160,8 @@ int INA238::Reset()
 {
 
 	int ret = PX4_ERROR;
+
+	_retries = 6;
 
 	if (RegisterWrite(Register::CONFIG, (uint16_t)(ADC_RESET_BIT)) != PX4_OK) {
 		return ret;

--- a/src/drivers/power_monitor/ina238/ina238.cpp
+++ b/src/drivers/power_monitor/ina238/ina238.cpp
@@ -160,7 +160,7 @@ int INA238::Reset()
 
 	int ret = PX4_ERROR;
 
-	_retries = 6;
+	_retries = 3;
 
 	if (RegisterWrite(Register::CONFIG, (uint16_t)(ADC_RESET_BIT)) != PX4_OK) {
 		return ret;

--- a/src/drivers/power_monitor/ina238/ina238.cpp
+++ b/src/drivers/power_monitor/ina238/ina238.cpp
@@ -96,9 +96,7 @@ int INA238::read(uint8_t address, uint16_t &data)
 {
 	// read desired little-endian value via I2C
 	uint16_t received_bytes;
-	int ret = PX4_ERROR;
-
-	ret = transfer(&address, 1, (uint8_t *)&received_bytes, sizeof(received_bytes));
+	const int ret = transfer(&address, 1, (uint8_t *)&received_bytes, sizeof(received_bytes));
 
 	if (ret == PX4_OK) {
 		data = swap16(received_bytes);

--- a/src/drivers/power_monitor/ina238/ina238.cpp
+++ b/src/drivers/power_monitor/ina238/ina238.cpp
@@ -100,6 +100,7 @@ int INA238::read(uint8_t address, uint16_t &data)
 
 	if (ret == PX4_OK) {
 		data = swap16(received_bytes);
+
 	} else {
 		perf_count(_comms_errors);
 		PX4_DEBUG("i2c::transfer returned %d", ret);


### PR DESCRIPTION
Noticing some occasional dropouts of the data with the ARK 12s power modules. Same thing I found on the INA226 a couple of years ago. A single bad I2C read would cause the driver to publish 0's and not connected.

https://github.com/PX4/PX4-Autopilot/pull/19423

Needs to be tested on hardware.

Current behavior
![image](https://github.com/user-attachments/assets/7ac6b3ed-bc65-40bb-819a-a9e8084fd2b7)
