### PR TITLE
gz: remove model spawn offset

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -95,12 +95,6 @@ int GZBridge::init()
 				model_pose_v.push_back(0.0);
 			}
 
-			// If model position z is less equal than 0, move above floor to prevent floor glitching
-			if (model_pose_v[2] <= 0.0) {
-				PX4_INFO("Model position z is less or equal 0.0, moving upwards");
-				model_pose_v[2] = 0.5;
-			}
-
 			gz::msgs::Pose *p = req.mutable_pose();
 			gz::msgs::Vector3d *position = p->mutable_position();
 			position->set_x(model_pose_v[0]);


### PR DESCRIPTION
The spawning of the model in the air is confusing in logs and right now is potentially impacting the EKF during initialization (specifically rangefinder alt source as primary). This was added in https://github.com/PX4/PX4-Autopilot/pull/22400 but IMO it would be better to fix the offending models on a case by case basis. In a perfect world the maintainer of a model/world would have the flexibility to spawn their model wherever they want.