### PR TITLE
Commander: remove not used include of blocks.hpp

### DIFF
--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -44,7 +44,6 @@
 #include "UserModeIntention.hpp"
 #include "worker_thread.hpp"
 
-#include <lib/controllib/blocks.hpp>
 #include <lib/hysteresis/hysteresis.h>
 #include <lib/mathlib/mathlib.h>
 #include <lib/perf/perf_counter.h>


### PR DESCRIPTION
It's been a while that blocks.hpp is not used by Commander, though it currently is still in the include list.

Since https://github.com/PX4/PX4-Autopilot/pull/23131 blocks.hpp is only used by the [LPE](https://github.com/PX4/PX4-Autopilot/blob/326d4863971e1b773aca2e94c79db748bbca25d7/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp#L7). And afaik only very specific methods of it. Should we go through https://github.com/PX4/PX4-Autopilot/blob/main/src/lib/controllib/blocks.hpp#L55 and remove the ones that are not used in the LPE?