### PR TITLE
Allow airspeed fusion when airspeed is above defined threshold

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/airspeed/airspeed_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/airspeed/airspeed_fusion.cpp
@@ -97,7 +97,6 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 			_aid_src_airspeed.innovation_rejected; // TODO: remove this redundant flag
 
 		const bool continuing_conditions_passing = _control_status.flags.in_air
-				&& _control_status.flags.fixed_wing
 				&& !_control_status.flags.fake_pos;
 
 		const bool is_airspeed_significant = airspeed_sample.true_airspeed > _params.arsp_thr;


### PR DESCRIPTION
### Solved Problem
When transitioning a VTOL which relies only on optical flow, airspeed fusion only starts after the transition.
In cases where we rely on wind dead-reckoning for navigation, airspeed fusion is not starting quickly enough in order to avoid triggering a failsafe due to exceeding the maximum height above ground constraint.
It's essentially a race condition and does not always happen.

Fixes #{Github issue ID

### Solution
Allow airspeed fusion to start based on threshold defined via parameter.
 `EKF2_ARSP_THR`
### Changelog Entry
For release notes:
```
Allow airspeed fusion to commence based on airspeed threshold, don't require aero mode. Enables airspeed fusion to start during transition.
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
