### PR TITLE
Adis16470 startup fixes

### DIFF
--- a/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
+++ b/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
@@ -465,6 +465,7 @@ uint16_t ADIS16470::RegisterRead(Register reg)
 	uint16_t cmd[1];
 	cmd[0] = (static_cast<uint16_t>(reg) << 8);
 
+	px4_udelay(1);
 	transferhword(cmd, nullptr, 1);
 	px4_udelay(SPI_STALL_PERIOD);
 	transferhword(nullptr, cmd, 1);
@@ -480,6 +481,7 @@ void ADIS16470::RegisterWrite(Register reg, uint16_t value)
 	cmd[0] = (((static_cast<uint16_t>(reg))     | DIR_WRITE) << 8) | ((0x00FF & value));
 	cmd[1] = (((static_cast<uint16_t>(reg) + 1) | DIR_WRITE) << 8) | ((0xFF00 & value) >> 8);
 
+	px4_udelay(1);
 	transferhword(cmd, nullptr, 1);
 	px4_udelay(SPI_STALL_PERIOD);
 	transferhword(cmd + 1, nullptr, 1);

--- a/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
+++ b/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
@@ -405,7 +405,7 @@ bool ADIS16470::DataReadyInterruptConfigure()
 	}
 
 	// Setup data ready on falling edge
-	return px4_arch_gpiosetevent(_drdy_gpio, false, true, false, &DataReadyInterruptCallback, this) == 0;
+	return px4_arch_gpiosetevent(_drdy_gpio, false, true, true, &DataReadyInterruptCallback, this) == 0;
 }
 
 bool ADIS16470::DataReadyInterruptDisable()

--- a/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
+++ b/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
@@ -135,34 +135,37 @@ void ADIS16470::RunImpl()
 		_reset_timestamp = now;
 		_failure_count = 0;
 		_state = STATE::WAIT_FOR_RESET;
-		ScheduleDelayed(193_ms); // 193 ms Software Reset Recovery Time
+		// 193 ms Software Reset Recovery Time + 20 ms measured delay for register write to take effect
+		ScheduleDelayed(193_ms + 20_ms);
 		break;
 
 	case STATE::WAIT_FOR_RESET:
 
-		if (_self_test_passed) {
-			if ((RegisterRead(Register::PROD_ID) == Product_identification)) {
+		if ((RegisterRead(Register::PROD_ID) != Product_identification)) {
+			// RESET not complete
+			if (hrt_elapsed_time(&_reset_timestamp) > 1000_ms) {
+				PX4_DEBUG("Reset failed, retrying");
+				_state = STATE::RESET;
+
+			} else {
+				PX4_DEBUG("Reset not complete, check again in 100 ms");
+			}
+
+			ScheduleDelayed(100_ms);
+
+		} else {
+			if (_self_test_passed) {
 				// if reset succeeded then configure
 				_state = STATE::CONFIGURE;
 				ScheduleNow();
 
 			} else {
-				// RESET not complete
-				if (hrt_elapsed_time(&_reset_timestamp) > 1000_ms) {
-					PX4_DEBUG("Reset failed, retrying");
-					_state = STATE::RESET;
-					ScheduleDelayed(100_ms);
+				RegisterWrite(Register::GLOB_CMD, GLOB_CMD_BIT::Sensor_self_test);
+				_state = STATE::SELF_TEST_CHECK;
 
-				} else {
-					PX4_DEBUG("Reset not complete, check again in 100 ms");
-					ScheduleDelayed(100_ms);
-				}
+				// Self Test Time + measured delay for register write to take effect
+				ScheduleDelayed(14_ms + 10_ms);
 			}
-
-		} else {
-			RegisterWrite(Register::GLOB_CMD, GLOB_CMD_BIT::Sensor_self_test);
-			_state = STATE::SELF_TEST_CHECK;
-			ScheduleDelayed(14_ms); // Self Test Time
 		}
 
 		break;
@@ -173,13 +176,15 @@ void ADIS16470::RunImpl()
 
 			if (DIAG_STAT != 0) {
 				PX4_ERR("DIAG_STAT: %#X", DIAG_STAT);
+				_state = STATE::RESET;
 
 			} else {
 				PX4_DEBUG("self test passed");
 				_self_test_passed = true;
-				_state = STATE::RESET;
-				ScheduleNow();
+				_state = STATE::CONFIGURE;
 			}
+
+			ScheduleNow();
 		}
 		break;
 
@@ -379,6 +384,9 @@ bool ADIS16470::Configure()
 	for (const auto &reg_cfg : _register_cfg) {
 		RegisterSetAndClearBits(reg_cfg.reg, reg_cfg.set_bits, reg_cfg.clear_bits);
 	}
+
+	// wait for register set to get into use
+	px4_udelay(100);
 
 	// now check that all are configured
 	bool success = true;

--- a/src/drivers/imu/analog_devices/adis16470/ADIS16470.hpp
+++ b/src/drivers/imu/analog_devices/adis16470/ADIS16470.hpp
@@ -121,9 +121,10 @@ private:
 	} _state{STATE::RESET};
 
 	uint8_t _checked_register{0};
+	static constexpr uint16_t msc_ctrl_val = 0xC1 & ~MSC_CTRL_BIT::DR_polarity;
 	static constexpr uint8_t size_register_cfg{1};
 	register_config_t _register_cfg[size_register_cfg] {
 		// Register              | Set bits, Clear bits
-		{ Register::MSC_CTRL,    0, MSC_CTRL_BIT::DR_polarity },
+		{ Register::MSC_CTRL,    msc_ctrl_val, (uint16_t)~msc_ctrl_val},
 	};
 };


### PR DESCRIPTION
This is a collection of patches for adis16470 driver from TII repository for the following issues:

- DRDY interrupt is not working on all platforms; it works only on those which enable the interrupt regardless of the "event" parameter to the px4_arch_gpiosetevent call. The "event" should be set to "true" to enable the interrupt.
- If there are errors in the startup sequence, the driver still published the data between IMU resets. This caused very low frequency data publishing initially, which locks the "sensors" module to run rate control at low frequency.
- There are additional delays in the ADIS16470 sensor which are not specified in the datasheet. Basically delays between setting a register/writing a command to the action to start. These are reverse engineered with oscilloscope/logic analyzer and added to the driver
- Before starting the self test after SW reset, there was no check that the IMU has woken up from the reset. Combined to the too small delays this caused the self-test command to be sent to inactive IMU, and reading back a 0 value which was again interpreted as "success".
- The IMU requires > 1 us inactive CS period between register reads/writes. Again this is not specified in the datasheet, but was found via testing. This causes random erroneous register checks on faster CPU:s
- The MSC_CTRL register check only checked if the Bit0 was read out as 0. If the register read returns whatever garbage, or the register value was changed to something strange, it was not detected - as long as the Bit0 was 0...

On faster CPUs there is still a need to ensure >  200ns CS to SCK delay to ensure stable operation, for that there is a draft PR https://github.com/PX4/PX4-Autopilot/pull/23905 . But that is an independent issue which most likely doesn't show on any slower (i.e. existing commercial) devices.
