### PR TITLE
Clarify SYS_HAS_MAG parameter description

### DIFF
--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -189,11 +189,10 @@ PARAM_DEFINE_INT32(SYS_CAL_TMAX, 10);
 PARAM_DEFINE_INT32(SYS_HAS_GPS, 1);
 
 /**
- * Control if the vehicle has a magnetometer
+ * Control if and how many magnetometers are expected
  *
- * Set this to 0 if the board has no magnetometer.
- * If set to 0, the preflight checks will not check for the presence of a
- * magnetometer, otherwise N sensors are required.
+ * 0: System has no magnetometer, preflight checks should pass without one.
+ * 1-N: Require the presence of N magnetometer sensors for check to pass.
  *
  * @reboot_required true
  * @group System


### PR DESCRIPTION
### Solved Problem
after answering the questions:
Ah, the value can be 2? Should I set the number of magnetometers the board has or include the external ones?

### Solution
I tried to find a concise description that should cover the confusion. Please correct if it's not clear.

### Changelog Entry
```
Clarify SYS_HAS_MAG parameter description
```