### PR TITLE
drivers ulanding: fix link in description to user guide section

### DIFF
--- a/src/drivers/distance_sensor/ulanding_radar/ulanding_radar_main.cpp
+++ b/src/drivers/distance_sensor/ulanding_radar/ulanding_radar_main.cpp
@@ -102,7 +102,7 @@ static int usage()
 
 Serial bus driver for the Aerotenna uLanding radar.
 
-Setup/usage information: https://docs.px4.io/v1.9.0/en/sensor/ulanding_radar.html
+Setup/usage information: https://docs.px4.io/main/en/sensor/ulanding_radar.html
 
 ### Examples
 


### PR DESCRIPTION
Stumbled upon this deprecated link. 