### PR TITLE
setup: clear up base os and gcc in CI

### DIFF
--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -22,7 +22,7 @@ jobs:
   group_targets:
     name: Scan for Board Targets
     # runs-on: ubuntu-latest
-    runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}",spot=false]
+    runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false]
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       timestamp: ${{ steps.set-timestamp.outputs.timestamp }}
@@ -59,7 +59,7 @@ jobs:
   setup:
     name: Build Group [${{ matrix.group }}]
     # runs-on: ubuntu-latest
-    runs-on: [runs-on,runner=8cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}",spot=false]
+    runs-on: [runs-on,runner=8cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false]
     needs: group_targets
     strategy:
       matrix: ${{ fromJson(needs.group_targets.outputs.matrix) }}
@@ -112,7 +112,7 @@ jobs:
   artifacts:
     name: Upload Artifacts to S3
     # runs-on: ubuntu-latest
-    runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}",spot=false]
+    runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false]
     needs: [setup, group_targets]
     if: contains(fromJSON('["main", "stable", "beta"]'), needs.group_targets.outputs.branchname)
     steps:
@@ -141,7 +141,7 @@ jobs:
   release:
     name: Create Release and Upload Artifacts
     # runs-on: ubuntu-latest
-    runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}",spot=false]
+    runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false]
     needs: [setup, group_targets]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:

--- a/.github/workflows/compile_ubuntu.yml
+++ b/.github/workflows/compile_ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['ubuntu:22.04', 'ubuntu:24.04']
+        version: ['ubuntu:22.04', 'ubuntu:24.04', 'ubuntu:25.04']
     runs-on: [runs-on,runner=8cpu-linux-x64,"image=ubuntu24-full-x64","run-id=${{ github.run_id }}",spot=false]
     container:
       image: ${{ matrix.version }}

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -118,7 +118,7 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		build-essential \
 		flex \
 		g++-multilib \
-		gcc-arm-none-eabi \
+		gcc-arm-none-eabi=15:13.2.rel1-2 \
 		gcc-multilib \
 		gdb-multiarch \
 		genromfs \


### PR DESCRIPTION
* We are leaving the gcc cross compiler version open to whatever the default is shipped/found in Ubuntu
* Official PX4 binaries are going to be built with the default GCC compiler found in the latest Ubuntu LTS,  as of today that is Ubuntu 24.04
* Trying to future proof ourselves by adding Ubuntu 25.04, and ArchLinux base