### PR TITLE
Commander: add option to re-enable GPS fusion on link loss

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2840,6 +2840,13 @@ void Commander::dataLinkCheck()
 				     "Connection to ground control station lost");
 
 			_status_changed = true;
+
+			if (_param_com_dll_gnss_ctl.get() && _actuator_armed.armed) {
+				// Reset GPS control setting to parameter default if link is lost
+				_param_ekf2_gps_ctrl.reset();
+				_param_ekf2_gps_ctrl.commit();
+				PX4_INFO("Link loss, reset EKF2_GPS_CTRL");
+			}
 		}
 	}
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2843,8 +2843,7 @@ void Commander::dataLinkCheck()
 
 			if (_param_com_dll_gnss_ctl.get() && _actuator_armed.armed) {
 				// Reset GPS control setting to parameter default if link is lost
-				_param_ekf2_gps_ctrl.reset();
-				_param_ekf2_gps_ctrl.commit();
+				param_reset(param_find("EKF2_GPS_CTRL"));
 				PX4_INFO("Link loss, reset EKF2_GPS_CTRL");
 			}
 		}

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -349,6 +349,8 @@ private:
 		(ParamInt<px4::params::COM_RC_OVERRIDE>)    _param_com_rc_override,
 		(ParamInt<px4::params::COM_FLIGHT_UUID>)    _param_com_flight_uuid,
 		(ParamInt<px4::params::COM_TAKEOFF_ACT>)    _param_com_takeoff_act,
-		(ParamFloat<px4::params::COM_CPU_MAX>)      _param_com_cpu_max
+		(ParamFloat<px4::params::COM_CPU_MAX>)      _param_com_cpu_max,
+		(ParamInt<px4::params::EKF2_GPS_CTRL>)      _param_ekf2_gps_ctrl,
+		(ParamBool<px4::params::COM_DLL_GNSS_CTL>)  _param_com_dll_gnss_ctl
 	)
 };

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1018,3 +1018,15 @@ PARAM_DEFINE_FLOAT(COM_THROW_SPEED, 5);
  * @increment 1
  */
 PARAM_DEFINE_INT32(COM_FLTT_LOW_ACT, 3);
+
+/**
+ * Reset GNSS control setting on link loss
+ *
+ * When losing the data link connection to the vehicle,
+ * it may be desirable to re-enable GNSS fusion such that
+ * the vehicle can continue fully autonomously.
+ *
+ * @group Commander
+ * @boolean
+ */
+PARAM_DEFINE_INT32(COM_DLL_GNSS_CTL, 0);


### PR DESCRIPTION
### Solved Problem
In case of GPS spoofing or jamming, or simply for testing purposes, operators can disable the GPS fusion (`EKF2_GPS_CTRL`) to purely rely on other means of navigation. In case of link loss, they have no more way to change system settings, and in some cases it is beneficial if then the system switches back the GPS fusion setting as it was at the moment of takeoff.

### Solution
New param: `COM_DLL_GPS_CTRL`.

In case the data link is lost and the GPS fusion parameter (`EKF2_GPS_CTRL`) is changed while arming, the fusion parameter is reset to the value before arming.

### Changelog Entry
For release notes:
```
Feature: Commander: add option to re-enable GPS fusion on link loss...
```

### Test coverage
SITL tested: VTOL: 
- takeoff, transition to FW, Hold mode, 
- set `COM_DLL_GNSS_CTL` to 1
- set `EKF2_GPS_CTRL` to 0 
- close the ground station
--> vehicle will RTL and set `EKF2_GPS_CTRL` back to 7
