### PR TITLE
Remove circular dependency if ControlAllocation and ActuatorEffectiveness

### DIFF
--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectiveness.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectiveness.cpp
@@ -32,7 +32,6 @@
  ****************************************************************************/
 
 #include "ActuatorEffectiveness.hpp"
-#include "../ControlAllocation/ControlAllocation.hpp"
 
 #include <px4_platform_common/log.h>
 
@@ -51,12 +50,12 @@ int ActuatorEffectiveness::Configuration::addActuator(ActuatorType type, const m
 		return -1;
 	}
 
-	effectiveness_matrices[selected_matrix](ControlAllocation::ControlAxis::ROLL, actuator_idx) = torque(0);
-	effectiveness_matrices[selected_matrix](ControlAllocation::ControlAxis::PITCH, actuator_idx) = torque(1);
-	effectiveness_matrices[selected_matrix](ControlAllocation::ControlAxis::YAW, actuator_idx) = torque(2);
-	effectiveness_matrices[selected_matrix](ControlAllocation::ControlAxis::THRUST_X, actuator_idx) = thrust(0);
-	effectiveness_matrices[selected_matrix](ControlAllocation::ControlAxis::THRUST_Y, actuator_idx) = thrust(1);
-	effectiveness_matrices[selected_matrix](ControlAllocation::ControlAxis::THRUST_Z, actuator_idx) = thrust(2);
+	effectiveness_matrices[selected_matrix](ActuatorEffectiveness::ControlAxis::ROLL, actuator_idx) = torque(0);
+	effectiveness_matrices[selected_matrix](ActuatorEffectiveness::ControlAxis::PITCH, actuator_idx) = torque(1);
+	effectiveness_matrices[selected_matrix](ActuatorEffectiveness::ControlAxis::YAW, actuator_idx) = torque(2);
+	effectiveness_matrices[selected_matrix](ActuatorEffectiveness::ControlAxis::THRUST_X, actuator_idx) = thrust(0);
+	effectiveness_matrices[selected_matrix](ActuatorEffectiveness::ControlAxis::THRUST_Y, actuator_idx) = thrust(1);
+	effectiveness_matrices[selected_matrix](ActuatorEffectiveness::ControlAxis::THRUST_Z, actuator_idx) = thrust(2);
 	matrix_selection_indexes[totalNumActuators()] = selected_matrix;
 	++num_actuators[(int)type];
 	return num_actuators_matrix[selected_matrix]++;


### PR DESCRIPTION
... and actuator effectiveness

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
`ControlAllocation` lib depends on `ActuatorEffectivenss` lib. However, the base class of `ActuatorEffectiveness` was using an enum defined in `ControlAllocation`

### Solution
Remove circular dependency 

### Changelog Entry
For release notes:
```
Feature/Bugfix Removed circular dependency of ActuatorEffectiveness and ControlAllocation
```

### Alternatives
We could also just look the other way. To make life more interesting, maybe we can chain multiple libraries to then form a longer circular dependency. This would be harder to spot.

### Test coverage
SITL builds.
```
make px4_sitl gazebo-classic
```

