### PR TITLE
Take 2: Cleanup circular dependencies ActuatorEffectiveness

### DIFF
--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessFixedWing.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessFixedWing.cpp
@@ -32,7 +32,6 @@
  ****************************************************************************/
 
 #include "ActuatorEffectivenessFixedWing.hpp"
-#include <ControlAllocation/ControlAllocation.hpp>
 
 using namespace matrix;
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRoverAckermann.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRoverAckermann.cpp
@@ -32,7 +32,6 @@
  ****************************************************************************/
 
 #include "ActuatorEffectivenessRoverAckermann.hpp"
-#include <ControlAllocation/ControlAllocation.hpp>
 
 using namespace matrix;
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.cpp
@@ -32,7 +32,6 @@
  ****************************************************************************/
 
 #include "ActuatorEffectivenessStandardVTOL.hpp"
-#include <ControlAllocation/ControlAllocation.hpp>
 
 using namespace matrix;
 


### PR DESCRIPTION
... and actuator effectiveness

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
`ControlAllocation` lib depends on `ActuatorEffectivenss` lib. However, some of the vehicle specific `ActuatorEffectiveness`  was including `ControlAllocation` while nothing was used.

### Solution
Remove circular dependency 

### Changelog Entry
For release notes:
```
Feature/Bugfix Removed circular dependency of ActuatorEffectiveness and ControlAllocation
```

### Alternatives
We could also just look the other way. To make life more interesting, maybe we can chain multiple libraries to then form a longer circular dependency. This would be harder to spot.

### Test coverage
SITL builds.
```
make px4_sitl gazebo-classic
```

### Context
- Follow up of https://github.com/PX4/PX4-Autopilot/pull/24195