### PR TITLE
boards: disable multi ekf on all ark flight controllers

### DIFF
--- a/boards/ark/fmu-v6x/init/rc.board_defaults
+++ b/boards/ark/fmu-v6x/init/rc.board_defaults
@@ -3,6 +3,8 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
+param set-default EKF2_MULTI_IMU 0
+
 # Mavlink ethernet (CFG 1000)
 param set-default MAV_2_CONFIG 1000
 param set-default MAV_2_BROADCAST 1
@@ -17,6 +19,7 @@ param set-default SENS_EN_INA228 0
 param set-default SENS_EN_INA226 1
 
 param set-default SENS_EN_THERMAL 1
+param set-default SENS_IMU_MODE 1
 param set-default SENS_IMU_TEMP 10.0
 #param set-default SENS_IMU_TEMP_FF 0.0
 #param set-default SENS_IMU_TEMP_I 0.025

--- a/boards/ark/pi6x/init/rc.board_defaults
+++ b/boards/ark/pi6x/init/rc.board_defaults
@@ -32,10 +32,11 @@ then
 	param set-default SENS_TEMP_ID 2490378
 fi
 
-param set-default EKF2_MULTI_IMU 2
+param set-default EKF2_MULTI_IMU 0
 param set-default EKF2_OF_CTRL 1
 param set-default EKF2_OF_N_MIN 0.05
 param set-default EKF2_RNG_A_HMAX 25
 param set-default EKF2_RNG_QLTY_T 0.1
 
 param set-default SENS_FLOW_RATE 150
+param set-default SENS_IMU_MODE 1


### PR DESCRIPTION
Multi EKF doesn't appear to have SITL CI testing and can have large divergence when not using GPS. 