### PR TITLE
Prevent overflow of dt in Integrator class

### DIFF
--- a/msg/VehicleImu.msg
+++ b/msg/VehicleImu.msg
@@ -9,8 +9,8 @@ uint32 gyro_device_id           # Gyroscope unique device ID for the sensor that
 float32[3] delta_angle          # delta angle about the FRD body frame XYZ-axis in rad over the integration time frame (delta_angle_dt)
 float32[3] delta_velocity       # delta velocity in the FRD body frame XYZ-axis in m/s over the integration time frame (delta_velocity_dt)
 
-uint16 delta_angle_dt           # integration period in microseconds
-uint16 delta_velocity_dt        # integration period in microseconds
+uint32 delta_angle_dt           # integration period in microseconds
+uint32 delta_velocity_dt        # integration period in microseconds
 
 uint8 CLIPPING_X = 1
 uint8 CLIPPING_Y = 2

--- a/src/modules/sensors/Integrator.hpp
+++ b/src/modules/sensors/Integrator.hpp
@@ -55,7 +55,7 @@ public:
 	~Integrator() = default;
 
 	static constexpr float DT_MIN{1e-6f}; // 1 microsecond
-	static constexpr float DT_MAX{static_cast<float>(UINT16_MAX) * 1e-6f};
+	static constexpr float DT_MAX{static_cast<float>(UINT32_MAX) * 1e-6f};
 
 	/**
 	 * Put an item into the integral.
@@ -111,7 +111,7 @@ public:
 	 * @param integral_dt	Get the dt in us of the current integration.
 	 * @return		true if integral valid
 	 */
-	bool reset(matrix::Vector3f &integral, uint16_t &integral_dt)
+	bool reset(matrix::Vector3f &integral, uint32_t &integral_dt)
 	{
 		if (integral_ready()) {
 			integral = _alpha;
@@ -200,7 +200,7 @@ public:
 	 * @param integral_dt	Get the dt in us of the current integration.
 	 * @return		true if integral valid
 	 */
-	bool reset(matrix::Vector3f &integral, uint16_t &integral_dt)
+	bool reset(matrix::Vector3f &integral, uint32_t &integral_dt)
 	{
 		if (Integrator::reset(integral, integral_dt)) {
 			// apply coning corrections

--- a/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp
+++ b/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp
@@ -161,7 +161,7 @@ void VehicleOpticalFlow::Run()
 			}
 
 			Vector3f delta_angle{NAN, NAN, NAN};
-			uint16_t delta_angle_dt;
+			uint32_t delta_angle_dt;
 
 			if (_gyro_integrator.reset(delta_angle, delta_angle_dt)) {
 				_delta_angle += delta_angle;


### PR DESCRIPTION
### Solved Problem
I was using the integrator class for a sensor which published at 12 Hz, which equals a dt of roughly 80'000 us.
The integrator dt varialbe was using a uint16, which overflows at around 65'500.

### Solution
Use an uint32 variable.

### Changelog Entry
For release notes:
```
Improvement: Prevent overflow of dt variable in Integrator class for sensors with low sampling rates.
```
