### PR TITLE
Documentation: Remove defaulting to "John Does" as airframe maintainer

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13030_generic_vtol_quad_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d/airframes/13030_generic_vtol_quad_tiltrotor
@@ -5,8 +5,6 @@
 # @type VTOL Tiltrotor
 # @class VTOL
 #
-# @maintainer
-#
 # @board px4_fmu-v2 exclude
 # @board bitcraze_crazyflie exclude
 # @board holybro_kakutef7 exclude

--- a/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
+++ b/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
@@ -5,7 +5,6 @@
 # @type Quadrotor x
 # @class Copter
 #
-# @maintainer
 # @board px4_fmu-v2 exclude
 # @board cuav_x7pro exclude
 # @board px4_fmu-v4pro exclude

--- a/ROMFS/px4fmu_common/init.d/airframes/59000_generic_ground_vehicle
+++ b/ROMFS/px4fmu_common/init.d/airframes/59000_generic_ground_vehicle
@@ -8,8 +8,6 @@
 # @output Motor1 throttle
 # @output Servo1 steering
 #
-# @maintainer
-#
 # @board bitcraze_crazyflie exclude
 #
 

--- a/Tools/px4airframes/srcparser.py
+++ b/Tools/px4airframes/srcparser.py
@@ -391,7 +391,7 @@ class SourceParser(object):
 
         # Process parsed content
         airframe_type = None
-        maintainer = "John Doe <john@example.com>"
+        maintainer = None
         airframe_name = None
         airframe_class = None
 


### PR DESCRIPTION
### Solved Problem
When looking at airframe documentation @RomanBapst found that it's ridiculous to have "John Doe" as maintainer for many airframes. It's just a mock person and the information doesn't add any value but just clutter the documentation and possibly even cause confusion.

### Solution
Remove the default string for the maintainer defined in the airframe parsing script. If no maintainer is defined then no maintainer should be added.

### Changelog Entry
```
Documentation: Remove defaulting to "John Does" as airframe maintainer
```

### Alternatives
We could also fail the parsing when no maintainer is defined but in my eyes that's too strict and gets into people's way.

### Test coverage
It still parses and builds, we need to check that `None` actually causes the behavior we want or if it needs to be an empty string.

### Context
<img src="https://github.com/user-attachments/assets/d2216020-6a3e-4377-8620-6295cd59bb1c" width="400" />