### PR TITLE
SIH: clean up control surface configuration

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
@@ -33,18 +33,19 @@ param set-default SIH_KDV 0.2
 param set-default SIH_VEHICLE_TYPE 1 	# sih as fixed wing
 param set-default RWTO_TKOFF 1  # enable takeoff from runway (as opposed to launched)
 
-
 param set-default CA_AIRFRAME 1
-
 param set-default CA_ROTOR_COUNT 1
+param set-default CA_ROTOR0_PX 0.3
 
+# SIH for now hardcodes this configuration which we need to match in the airframe files.
 param set-default CA_SV_CS_COUNT 3
-param set-default CA_SV_CS0_TRQ_R -0.5
-param set-default CA_SV_CS0_TYPE 1
+param set-default CA_SV_CS0_TRQ_R 1
+param set-default CA_SV_CS0_TYPE 15  # single channel aileron
 param set-default CA_SV_CS1_TRQ_P 1
-param set-default CA_SV_CS1_TYPE 3
+param set-default CA_SV_CS1_TYPE 3  # elevator
 param set-default CA_SV_CS2_TRQ_Y 1
-param set-default CA_SV_CS2_TYPE 4
+param set-default CA_SV_CS2_TYPE 4  # rudder
+
 param set-default PWM_MAIN_FUNC1 201
 param set-default PWM_MAIN_FUNC2 202
 param set-default PWM_MAIN_FUNC3 203

--- a/ROMFS/px4fmu_common/init.d/airframes/1101_rc_plane_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1101_rc_plane_sih.hil
@@ -17,13 +17,15 @@ param set UAVCAN_ENABLE 0
 param set-default CA_AIRFRAME 1
 param set-default CA_ROTOR_COUNT 1
 param set-default CA_ROTOR0_PX 0.3
+
+# SIH for now hardcodes this configuration which we need to match in the airframe files.
 param set-default CA_SV_CS_COUNT 3
-param set-default CA_SV_CS0_TRQ_R -0.5
-param set-default CA_SV_CS0_TYPE 1
+param set-default CA_SV_CS0_TRQ_R 1
+param set-default CA_SV_CS0_TYPE 15  # single channel aileron
 param set-default CA_SV_CS1_TRQ_P 1
-param set-default CA_SV_CS1_TYPE 3
+param set-default CA_SV_CS1_TYPE 3  # elevator
 param set-default CA_SV_CS2_TRQ_Y 1
-param set-default CA_SV_CS2_TYPE 4
+param set-default CA_SV_CS2_TYPE 4  # rudder
 
 param set HIL_ACT_FUNC1 201
 param set HIL_ACT_FUNC2 202

--- a/ROMFS/px4fmu_common/init.d/airframes/1101_rc_plane_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1101_rc_plane_sih.hil
@@ -25,7 +25,6 @@ param set-default CA_SV_CS1_TYPE 3
 param set-default CA_SV_CS2_TRQ_Y 1
 param set-default CA_SV_CS2_TYPE 4
 
-param set HIL_ACT_REV 1
 param set HIL_ACT_FUNC1 201
 param set HIL_ACT_FUNC2 202
 param set HIL_ACT_FUNC3 203

--- a/ROMFS/px4fmu_common/init.d/airframes/1103_standard_vtol_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1103_standard_vtol_sih.hil
@@ -41,20 +41,19 @@ param set-default CA_ROTOR3_PX -0.2
 param set-default CA_ROTOR3_PY 0.2
 param set-default CA_ROTOR3_KM -0.05
 
-
 param set-default CA_ROTOR4_PX -0.3
 param set-default CA_ROTOR4_KM 0.05
 param set-default CA_ROTOR4_AX 1
 param set-default CA_ROTOR4_AZ 0
 
+# SIH for now hardcodes this configuration which we need to match in the airframe files.
 param set-default CA_SV_CS_COUNT 3
-param set-default CA_SV_CS0_TRQ_R 0.5
-param set-default CA_SV_CS0_TYPE 2
+param set-default CA_SV_CS0_TRQ_R 1
+param set-default CA_SV_CS0_TYPE 15  # single channel aileron
 param set-default CA_SV_CS1_TRQ_P 1
-param set-default CA_SV_CS1_TYPE 3
+param set-default CA_SV_CS1_TYPE 3  # elevator
 param set-default CA_SV_CS2_TRQ_Y 1
-
-param set HIL_ACT_REV 16
+param set-default CA_SV_CS2_TYPE 4  # rudder
 
 param set-default FW_AIRSPD_MAX 12
 param set-default FW_AIRSPD_MIN 7

--- a/ROMFS/px4fmu_common/init.d/airframes/1103_standard_vtol_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1103_standard_vtol_sih.hil
@@ -54,7 +54,7 @@ param set-default CA_SV_CS1_TRQ_P 1
 param set-default CA_SV_CS1_TYPE 3
 param set-default CA_SV_CS2_TRQ_Y 1
 
-param set HIL_ACT_REV 32
+param set HIL_ACT_REV 16
 
 param set-default FW_AIRSPD_MAX 12
 param set-default FW_AIRSPD_MIN 7

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -358,10 +358,10 @@ void Sih::generate_fw_aerodynamics(const float roll_cmd, const float pitch_cmd, 
 	const Vector3f v_B = _q_E.rotateVectorInverse(_v_E);
 	const float &alt = _lla.altitude();
 
-	_wing_l.update_aero(v_B, _w_B, alt, roll_cmd * FLAP_MAX);
-	_wing_r.update_aero(v_B, _w_B, alt, -roll_cmd * FLAP_MAX);
+	_wing_l.update_aero(v_B, _w_B, alt, -roll_cmd * FLAP_MAX);
+	_wing_r.update_aero(v_B, _w_B, alt, roll_cmd * FLAP_MAX);
 
-	_tailplane.update_aero(v_B, _w_B, alt, pitch_cmd * FLAP_MAX, _T_MAX * throttle_cmd);
+	_tailplane.update_aero(v_B, _w_B, alt, -pitch_cmd * FLAP_MAX, _T_MAX * throttle_cmd);
 	_fin.update_aero(v_B, _w_B, alt, yaw_cmd * FLAP_MAX, _T_MAX * throttle_cmd);
 	_fuselage.update_aero(v_B, _w_B, alt);
 

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -358,8 +358,8 @@ void Sih::generate_fw_aerodynamics(const float roll_cmd, const float pitch_cmd, 
 	const Vector3f v_B = _q_E.rotateVectorInverse(_v_E);
 	const float &alt = _lla.altitude();
 
-	_wing_l.update_aero(v_B, _w_B, alt, -roll_cmd * FLAP_MAX);
-	_wing_r.update_aero(v_B, _w_B, alt, roll_cmd * FLAP_MAX);
+	_wing_l.update_aero(v_B, _w_B, alt, roll_cmd * FLAP_MAX);
+	_wing_r.update_aero(v_B, _w_B, alt, -roll_cmd * FLAP_MAX);
 
 	_tailplane.update_aero(v_B, _w_B, alt, -pitch_cmd * FLAP_MAX, _T_MAX * throttle_cmd);
 	_fin.update_aero(v_B, _w_B, alt, yaw_cmd * FLAP_MAX, _T_MAX * throttle_cmd);


### PR DESCRIPTION
### Solved Problem 

In PR https://github.com/PX4/PX4-Autopilot/pull/24175, I changed the control surface deflection signs in generate_fw_aerodynamics to make the 1103 airframe work correctly. However, this breaks the 1101 airframe, introducing sing errors there.

### Solution

The change in generate_fw_aerodynamics is reverted to the state before PR #24175. Instead, the signs are set correctly by using the HIL_ACT_REV bitfield in the respective airframe config files.

### Test coverage
Simulation logs. Stable forward flight, therefore correct signs for control surface outputs:
 - With 1101 airframe (fixed wing): https://review.px4.io/plot_app?log=a6e02012-2eac-4d7e-92a2-17f3f24b62c7
 - With 1103 airframe (standard VTOL): https://review.px4.io/plot_app?log=cfbccab7-a08e-4048-a101-755c1c1de0eb

