### PR TITLE
SIH-as-SITL: add  Standard VTOL Airframe

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10043_sihsim_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10043_sihsim_standard_vtol
@@ -1,0 +1,116 @@
+#!/bin/sh
+#
+# @name SIH Standard VTOL
+#
+# @type Simulation
+# @class VTOL
+#
+# @output Motor1 MC motor front right
+# @output Motor2 MC motor back left
+# @output Motor3 MC motor front left
+# @output Motor4 MC motor back right
+# @output Motor5 Forward thrust motor
+# @output Servo1 Aileron
+# @output Servo2 Elevator
+# @output Servo3 Rudder
+#
+# @board px4_fmu-v2 exclude
+#
+
+. ${R}etc/init.d/rc.vtol_defaults
+
+# SIH in SITL changes. could we source these from a common file?  {{{
+# inspired by: diff ROMFS/px4fmu_common/init.d/airframes/4001_quad_x ROMFS/px4fmu_common/init.d-posix/airframes/10040_sihsim_quadx
+
+PX4_SIMULATOR=${PX4_SIMULATOR:=sihsim}
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=standard_vtol}
+
+param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_BAROSIM 1
+param set-default SENS_EN_MAGSIM 1
+
+param set-default EKF2_GPS_DELAY 0
+
+# battery check disabled below already
+# HIL_ACT_FUNC* set below -- do we need PWM_MAIN_FUNC* as well?
+# SIH_VEHICLE_TYPE set below too.
+
+# }}}
+
+param set-default VT_B_TRANS_DUR 5
+param set-default VT_ELEV_MC_LOCK 0
+param set-default VT_TYPE 2
+param set-default MPC_MAN_Y_MAX 60
+param set-default MC_PITCH_P 5
+
+param set-default CA_AIRFRAME 2
+param set-default CA_ROTOR_COUNT 5
+param set-default CA_ROTOR0_KM 0.05
+param set-default CA_ROTOR0_PX 0.2
+param set-default CA_ROTOR0_PY 0.2
+param set-default CA_ROTOR1_KM 0.05
+param set-default CA_ROTOR1_PX -0.2
+param set-default CA_ROTOR1_PY -0.2
+param set-default CA_ROTOR2_PX 0.2
+param set-default CA_ROTOR2_PY -0.2
+param set-default CA_ROTOR2_KM -0.05
+param set-default CA_ROTOR3_PX -0.2
+param set-default CA_ROTOR3_PY 0.2
+param set-default CA_ROTOR3_KM -0.05
+
+
+param set-default CA_ROTOR4_PX -0.3
+param set-default CA_ROTOR4_KM 0.05
+param set-default CA_ROTOR4_AX 1
+param set-default CA_ROTOR4_AZ 0
+
+# SIH for now hardcodes this configuration which we need to match in the airframe files.
+param set-default CA_SV_CS_COUNT 3
+param set-default CA_SV_CS0_TRQ_R 1
+param set-default CA_SV_CS0_TYPE 15  # single channel aileron
+param set-default CA_SV_CS1_TRQ_P 1
+param set-default CA_SV_CS1_TYPE 3  # elevator
+param set-default CA_SV_CS2_TRQ_Y 1
+param set-default CA_SV_CS2_TYPE 4  # rudder
+
+param set-default FW_AIRSPD_MAX 12
+param set-default FW_AIRSPD_MIN 7
+param set-default FW_AIRSPD_TRIM 10
+
+param set-default PWM_MAIN_FUNC1 101
+param set-default PWM_MAIN_FUNC2 102
+param set-default PWM_MAIN_FUNC3 103
+param set-default PWM_MAIN_FUNC4 104
+param set-default PWM_MAIN_FUNC5 201
+param set-default PWM_MAIN_FUNC6 202
+param set-default PWM_MAIN_FUNC7 203
+param set-default PWM_MAIN_FUNC8 105
+
+param set-default MAV_TYPE 22
+
+# set SYS_HITL to 2 to start the SIH and avoid sensors startup
+# param set-default SYS_HITL 2
+
+# disable some checks to allow to fly:
+# - without real battery
+param set-default CBRK_SUPPLY_CHK 894281
+# - without safety switch
+param set-default CBRK_IO_SAFETY 22027
+
+param set-default SENS_DPRES_OFF 0.001
+
+param set SIH_T_MAX 2.0
+param set SIH_Q_MAX 0.0165
+param set SIH_MASS 0.2
+# IXX and IZZ are inverted from the thesis as the body frame is pitched by 90 deg
+param set SIH_IXX 0.00354
+param set SIH_IYY 0.000625
+param set SIH_IZZ 0.00300
+param set SIH_IXZ 0
+param set SIH_KDV 0.2
+param set SIH_L_ROLL 0.145
+
+# sih as standard vtol
+param set SIH_VEHICLE_TYPE 3
+
+param set-default VT_ARSP_TRANS 6

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -109,6 +109,7 @@ px4_add_romfs_files(
 	10040_sihsim_quadx
 	10041_sihsim_airplane
 	10042_sihsim_xvert
+	10043_sihsim_standard_vtol
 
 	17001_flightgear_tf-g1
 	17002_flightgear_tf-g2

--- a/src/modules/simulation/simulator_sih/CMakeLists.txt
+++ b/src/modules/simulation/simulator_sih/CMakeLists.txt
@@ -53,6 +53,7 @@ if(PX4_PLATFORM MATCHES "posix")
 		airplane
 		quadx
 		xvert
+		standard_vtol
 	)
 
 	# find corresponding airframes

--- a/src/modules/simulation/simulator_sih/sih.hpp
+++ b/src/modules/simulation/simulator_sih/sih.hpp
@@ -220,7 +220,12 @@ private:
 
 	float       _u[NUM_ACTUATORS_MAX] {};         // thruster signals
 
+	// MC = Multicopter
+	// FW = Fixed Wing
+	// TS = Tailsitter VTOL
+	// SVTOL = Standard VTOL
 	enum class VehicleType {MC, FW, TS, SVTOL};
+
 	VehicleType _vehicle = VehicleType::MC;
 
 	// aerodynamic segments for the fixedwing


### PR DESCRIPTION
### Solved Problem
We can now simulate all major airframes in [SIH-as-SITL](https://docs.px4.io/main/en/sim_sih/index.html#sih-as-sitl-no-fc) (meaning, both PX4 and PX4-internal sim running on PC). In the future this will allow for depreciation of gazebo in the context of automated tests, making them much faster and simpler. 

### Solution
Add new airframe file, and add it to build system in relevant places. New make target: `make px4_sitl sihsim_svtol`.

### Changelog Entry
For release notes:
```
Add standard VTOL airframe for SIH-as-SITL. 
```

