### PR TITLE
Revert "FLightTaskAuto: limit nudging speed based on distance sensor"

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -282,12 +282,6 @@ void FlightTaskAuto::_prepareLandSetpoints()
 			sticks_xy.setZero();
 		}
 
-		// If ground distance estimate valid (distance sensor) during nudging then limit horizontal speed
-		if (PX4_ISFINITE(_dist_to_bottom)) {
-			// Below 50cm no horizontal speed, above allow per meter altitude 0.5m/s speed
-			max_speed = math::max(0.f, math::min(max_speed, (_dist_to_bottom - .5f) * .5f));
-		}
-
 		_stick_acceleration_xy.setVelocityConstraint(max_speed);
 		_stick_acceleration_xy.generateSetpoints(sticks_xy, _yaw, _land_heading, _position,
 				_velocity_setpoint_feedback.xy(), _deltatime);


### PR DESCRIPTION
### Solved Problem
I got the feedback from @jongell that the feature I introduced in https://github.com/PX4/PX4-Autopilot/pull/22690 is not generally useful but necessary on a specific platform so I suggest to remove it again and only have the few lines on that platform.

### Solution
This reverts commit 97cb933cff6d837e59dd55123804cd78abdca22a.

### Changelog Entry
For release notes:
```
Remove feature: Limit land nudging horizontal speed close to the ground
```

### Alternatives
I could leave it, make it configurable and disabled by default but in my eyes that's not worth it and just adds dead code complexity for everyone.