### PR TITLE
EKF2: constrain max variance by zero innovation update

### DIFF
--- a/src/modules/ekf2/EKF/covariance.cpp
+++ b/src/modules/ekf2/EKF/covariance.cpp
@@ -280,7 +280,17 @@ void Ekf::constrainStateVariances()
 void Ekf::constrainStateVar(const IdxDof &state, float min, float max)
 {
 	for (unsigned i = state.idx; i < (state.idx + state.dof); i++) {
-		P(i, i) = math::constrain(P(i, i), min, max);
+		if (P(i, i) < min) {
+			P(i, i) = min;
+
+		} else if (P(i, i) > max) {
+			// Constrain the variance growth by fusing zero innovation as clipping the variance
+			// would artifically increase the correlation between states and destabilize the filter.
+			const float innov = 0.f;
+			const float R = 10.f * P(i, i); // This reduces the variance by ~10% as K = P / (P + R)
+			const float innov_var = P(i, i) + R;
+			fuseDirectStateMeasurement(innov, innov_var, R, i);
+		}
 	}
 }
 
@@ -298,9 +308,7 @@ void Ekf::constrainStateVarLimitRatio(const IdxDof &state, float min, float max,
 	float limited_max = math::constrain(state_var_max, min, max);
 	float limited_min = math::constrain(limited_max / max_ratio, min, max);
 
-	for (unsigned i = state.idx; i < (state.idx + state.dof); i++) {
-		P(i, i) = math::constrain(P(i, i), limited_min, limited_max);
-	}
+	constrainStateVar(state, limited_min, limited_max);
 }
 
 void Ekf::resetQuatCov(const float yaw_noise)


### PR DESCRIPTION
### Solved Problem
We cannot let the covariance of a temporarily unobservable state grow for ever due to numerical issues that will arise when the the matrix is getting ill-conditioned but the current method of clipping the variance  has a destabilizing effect as it increases the correlation between the states. (recall: `correlation = cov_xy / (sqrt(var_x) * sqrt(var_y)` so if `cov_xy` grows but `var_x` or `var_y` increases, `correlation` increases)

This can be observed on the position state when flying without GNSS (e.g.: navigating with optical flow or airspeed data). When the position variance reaches the limit of 1e6, clipping it causes the correlation with the velocity state to increase and when a single position observation is fused (here sent via a manual position update), the velocity variance collapses (over-correction).
In reality, the calculated velocity variance is negative but artificially clipped to a minimum value of 1e-6.

![Screenshot from 2025-01-14 16-05-17](https://github.com/user-attachments/assets/fbfc3928-44d5-4d77-8996-718619c9cda4)

Note that there is no problem in artificially limiting the minimum value of a state variance as this is similar to having a higher process noise and reduces the correlation with other states without causing instabilities.

### Solution
Run a "zero innovation update" to keep the variance of a state below the "numerical stability threshold".
We can see that after the manual position update, the velocity variance is updated to a reasonable value.
![Screenshot from 2025-01-14 16-01-22](https://github.com/user-attachments/assets/7b148da9-5052-4755-9214-7d317141b2f2)

### Alternatives
The UDU formulation should avoid the need for an upper variance limit.

### Test coverage
SITL tests

