### PR TITLE
Tecs: restore pitch integrator when fat descends ends

### DIFF
--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -535,6 +535,7 @@ private:
 	// State
 	AlphaFilter<float> _ste_rate_estimate_filter;		///< Low pass filter for the specific total energy rate.
 	float _pitch_integ_state{0.0f};				///< Pitch integrator state [rad].
+	float _pitch_integ_reset_val{NAN};
 	float _throttle_integ_state{0.0f};			///< Throttle integrator state [-].
 
 	// Output


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When engaging fast descend the pitch integrator usually changes to pitch, as the pitch control loop controls the airspeed. When the fast descend ends and the AV approaches the target altitude, the Av thus tends to undershoot it a bit until the pitch integrator is back close to the original value.

Fixes #{Github issue ID}

### Solution
- Save the pitch integrator value, when first entering the fast descend mode and restore its value when leaving fast descend
- Make sure that the transition is smooth by interpolating the integrator value when switching

### Changelog Entry
For release notes:
```
Bugfix: Avoid undershoot when leaving the fat descend mode by resetting the pitch integrator value
```

### Test coverage
Flight log of integrator without the fix:

Flight log with integrator fix:

**Still needs to be tested!**
