### PR TITLE
Control allocation: make heli rpm control an optional build flag disabled by default

### DIFF
--- a/src/modules/control_allocator/Kconfig
+++ b/src/modules/control_allocator/Kconfig
@@ -10,3 +10,10 @@ menuconfig USER_CONTROL_ALLOCATOR
 	depends on BOARD_PROTECTED && MODULES_CONTROL_ALLOCATOR
 	---help---
 		Put control_allocator in userspace memory
+
+menuconfig CONTROL_ALLOCATOR_RPM_CONTROL
+	bool "Include RPM control for Helicopter rotor"
+	default n
+	depends on MODULES_CONTROL_ALLOCATOR
+	---help---
+		Add support for controlling the helicopter main rotor rpm

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
@@ -135,11 +135,15 @@ void ActuatorEffectivenessHelicopter::updateSetpoint(const matrix::Vector<float,
 	_saturation_flags = {};
 
 	const float spoolup_progress = throttleSpoolupProgress();
+	float rpm_control_output = 0;
+#if CONTROL_ALLOCATOR_RPM_CONTROL
 	_rpm_control.setSpoolupProgress(spoolup_progress);
+	rpm_control_output = _rpm_control.getActuatorCorrection();
+#endif // CONTROL_ALLOCATOR_RPM_CONTROL
 
 	// throttle/collective pitch curve
-	const float throttle = (math::interpolateN(-control_sp(ControlAxis::THRUST_Z),
-				_geometry.throttle_curve) + _rpm_control.getActuatorCorrection()) * spoolup_progress;
+	const float throttle = (math::interpolateN(-control_sp(ControlAxis::THRUST_Z), _geometry.throttle_curve)
+				+ rpm_control_output) * spoolup_progress;
 	const float collective_pitch = math::interpolateN(-control_sp(ControlAxis::THRUST_Z), _geometry.pitch_curve);
 
 	// actuator mapping

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.hpp
@@ -134,5 +134,7 @@ private:
 
 	const ActuatorType _tail_actuator_type;
 
-	RpmControl _rpm_control{this};
+#if CONTROL_ALLOCATOR_RPM_CONTROL
+	RpmControl _rpm_control {this};
+#endif // CONTROL_ALLOCATOR_RPM_CONTROL
 };


### PR DESCRIPTION
### Solved Problem
After I merged https://github.com/PX4/PX4-Autopilot/pull/24096/ @bresch reminded me that v6x now overflows flash.

### Solution
Make heli rpm control a separate optional build flag (for now).
The rpm capture driver is also disabled on default releases.

### Changelog Entry
```
Save flash by removing helicopter rpm control from default builds
```

### Alternatives
- Remove avoidance: https://github.com/PX4/PX4-Autopilot/pull/24172
- Switch to ARM GCC 13
- Split up the control allocation module into the last part of vehicle specific controllers

### Test coverage
For me locally `make px4_fmu-v6x` comes down from `1744 bytes` to `304 bytes` overflowed 😬
so it doesn't free enough flash because it seems we were exactly at the limit before that pr or added more flash use since.