### PR TITLE
PR: baro auto calibration

### DIFF
--- a/msg/EstimatorStatus.msg
+++ b/msg/EstimatorStatus.msg
@@ -121,3 +121,5 @@ float32 mag_inclination_deg
 float32 mag_inclination_ref_deg
 float32 mag_strength_gs
 float32 mag_strength_ref_gs
+
+uint8 hgt_ref	# enum to indicate the current source of the height reference

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1850,6 +1850,8 @@ void EKF2::PublishStatus(const hrt_abstime &timestamp)
 			    status.mag_strength_ref_gs);
 #endif // CONFIG_EKF2_MAGNETOMETER
 
+	status.hgt_ref = (uint8_t)_ekf.getHeightSensorRef();
+
 	status.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 	_estimator_status_pub.publish(status);
 }

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -239,33 +239,6 @@ void VehicleAirData::Run()
 		}
 	}
 
-	// when baros dont get calibrated, set the offset in respect to the current sensor
-	// this avoids height jumps when switching to a new sensor
-	if (_selected_sensor_sub_index >= 0
-	    && fabsf(_calibration[_selected_sensor_sub_index].offset() - _selected_baro_offset) > FLT_EPSILON) {
-
-		sensor_baro_s report;
-		_selected_baro_offset = _calibration[_selected_sensor_sub_index].offset();
-		_sensor_sub[_selected_sensor_sub_index].copy(&report);
-		const float selected_baro_pressure = report.pressure;
-
-		for (int instance = 0; instance < MAX_SENSOR_COUNT; instance++) {
-			if (instance != _selected_sensor_sub_index && _advertised[instance]) {
-
-				_sensor_sub[instance].copy(&report);
-				const float offset = report.pressure - selected_baro_pressure;
-
-				// avoid ParameterSave if difference is not significant (<10Pa)
-				if (fabsf(_calibration[instance].offset() - offset) > 10.f) {
-					_calibration[instance].set_offset(offset);
-					_calibration[instance].ParametersSave(instance);
-				}
-			}
-		}
-
-		ParametersUpdate(true);
-	}
-
 	// Publish
 	if (_param_sens_baro_rate.get() > 0) {
 		int interval_us = 1e6f / _param_sens_baro_rate.get();

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -239,6 +239,33 @@ void VehicleAirData::Run()
 		}
 	}
 
+	// when baros dont get calibrated, set the offset in respect to the current sensor
+	// this avoids height jumps when switching to a new sensor
+	if (_selected_sensor_sub_index >= 0
+	    && fabsf(_calibration[_selected_sensor_sub_index].offset() - _selected_baro_offset) > FLT_EPSILON) {
+
+		sensor_baro_s report;
+		_selected_baro_offset = _calibration[_selected_sensor_sub_index].offset();
+		_sensor_sub[_selected_sensor_sub_index].copy(&report);
+		const float selected_baro_pressure = report.pressure;
+
+		for (int instance = 0; instance < MAX_SENSOR_COUNT; instance++) {
+			if (instance != _selected_sensor_sub_index && _advertised[instance]) {
+
+				_sensor_sub[instance].copy(&report);
+				const float offset = report.pressure - selected_baro_pressure;
+
+				// avoid ParameterSave if difference is not significant (<10Pa)
+				if (fabsf(_calibration[instance].offset() - offset) > 10.f) {
+					_calibration[instance].set_offset(offset);
+					_calibration[instance].ParametersSave(instance);
+				}
+			}
+		}
+
+		ParametersUpdate(true);
+	}
+
 	// Publish
 	if (_param_sens_baro_rate.get() > 0) {
 		int interval_us = 1e6f / _param_sens_baro_rate.get();

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -123,6 +123,8 @@ private:
 
 	float _air_temperature_celsius{20.f}; // initialize with typical 20degC ambient temperature
 
+	float _selected_baro_offset{0.01f};
+
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::SENS_BARO_QNH>) _param_sens_baro_qnh,
 		(ParamFloat<px4::params::SENS_BARO_RATE>) _param_sens_baro_rate

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -123,6 +123,9 @@ private:
 
 	float _air_temperature_celsius{20.f}; // initialize with typical 20degC ambient temperature
 
+	bool _calibration_done{false};
+	uint64_t _calibration_delay{0};
+
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::SENS_BARO_QNH>) _param_sens_baro_qnh,
 		(ParamFloat<px4::params::SENS_BARO_RATE>) _param_sens_baro_rate

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -123,8 +123,6 @@ private:
 
 	float _air_temperature_celsius{20.f}; // initialize with typical 20degC ambient temperature
 
-	float _selected_baro_offset{0.01f};
-
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::SENS_BARO_QNH>) _param_sens_baro_qnh,
 		(ParamFloat<px4::params::SENS_BARO_RATE>) _param_sens_baro_rate


### PR DESCRIPTION


### Solved Problem
When we have multiple barometers, we currently do not perform any calibration. There already exists a do_baro_calibration function, but I guess nobody used it since the function call of getAltitudeFromPressure had the wrong arguments.

This fix adds a calibration procedure for handling relative offsets between multiple baros, avoiding vertical position jumps when one switches between baros mid-flight.
When GNSS is set as the height reference, the calibration offset is calculated in respect to the absolute height (currently in baro-bias).

The offset is now stored in the offset parameter since it's static and not a changing bias.

I checked various flight logs with durations of more than 3000s and could not observe non systematic drifts between baros. Therefore frequent recalibration does not make any sense.

with GNSS, calibration triggered at t=34:
![Screenshot from 2025-01-15 17-43-09](https://github.com/user-attachments/assets/c6617d22-f322-497f-b19d-94bdc54a0484)

Switch from baro0 to baro1:
![Screenshot from 2025-01-15 17-17-03](https://github.com/user-attachments/assets/bae36f16-00fc-4d33-a6c3-f4491020a274)


---
Feedback needed: 
I now trigger the calibration 1s after the first baro measurement. At this point in time the GNSS is not sending any data yet. Therefore a manual trigger from the user is necessary to perform an absolute calibration. This wouldnt be a problem though, since the baro bias would still handle this case... Should I change something about this?
