### PR TITLE
Documentation: Remove comment about default use of AUX 1-3 input channels

### DIFF
--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2025 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1592,8 +1592,6 @@ PARAM_DEFINE_INT32(RC_MAP_FLTM_BTN, 0);
 /**
  * AUX1 Passthrough RC channel
  *
- * Default function: Camera pitch
- *
  * @min 0
  * @max 18
  * @group Radio Calibration
@@ -1622,8 +1620,6 @@ PARAM_DEFINE_INT32(RC_MAP_AUX1, 0);
 /**
  * AUX2 Passthrough RC channel
  *
- * Default function: Camera roll
- *
  * @min 0
  * @max 18
  * @group Radio Calibration
@@ -1651,8 +1647,6 @@ PARAM_DEFINE_INT32(RC_MAP_AUX2, 0);
 
 /**
  * AUX3 Passthrough RC channel
- *
- * Default function: Camera azimuth / yaw
  *
  * @min 0
  * @max 18


### PR DESCRIPTION
### Solved Problem
When helping @Perrrewi with auxiliary channel mapping we found that the documentation is confusing because it's mentioning AUX1 is "Default function: Camera pitch". I think this is only there because there used to be static mixing of RC passthrough which was intended to be used for gimbal control. But this is obsolete now since the actuator functions can be mapped in any way and there's no default use for the AUX1 channel anymore.

### Solution
Remove the confusing comment. I can't find any implementation anymore that would justify the comment.

### Changelog Entry
```
Documentation: Remove comment about default use of AUX 1-3 input channels
```

### Context
This comment first occurred in 2012:
https://github.com/PX4/PX4-Autopilot/commit/f5bad08bd0f4e0f6506deeac9d369b2b9c2d9e32#diff-f3c9d446d29b39e4ce08d76016d215d513a14e19773d1972d093dcf17ac9e8b5R186
and was taken over to the parameter metadata in 2014:
https://github.com/PX4/PX4-Autopilot/commit/7441efde4745c0dddc08a36a0bbf83307f82948a#diff-601479e497679baeecc319b1fdd43d148b1dee7965619568f32fe8d828124825R619
and the static dependency was revoked with the introduction of the dynamic mixer configuration in 2021 here:
https://github.com/PX4/PX4-Autopilot/commit/a65533b46986e32254b64b7c92469afb8178e370#diff-cdbc310b47e9f8baaa9198133a1adc0cb4ae571a0ca91c2ef3df45db4a1e216dL44

https://docs.px4.io/main/en/advanced_config/parameter_reference.html#RC_MAP_AUX1
![image](https://github.com/user-attachments/assets/eb68595f-806b-4461-acdb-e1fd49bde33b)

