### PR TITLE
EKF2: allow sideslip fusion to always start with airspeed fusion

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/sideslip/sideslip_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/sideslip/sideslip_fusion.cpp
@@ -50,7 +50,7 @@
 void Ekf::controlBetaFusion(const imuSample &imu_delayed)
 {
 	_control_status.flags.fuse_beta = _params.beta_fusion_enabled
-					  && _control_status.flags.fixed_wing
+					  && (_control_status.flags.fixed_wing || _control_status.flags.fuse_aspd)
 					  && _control_status.flags.in_air
 					  && !_control_status.flags.fake_pos;
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -573,12 +573,9 @@ private:
 #endif // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_SIDESLIP)
-		(ParamExtFloat<px4::params::EKF2_BETA_GATE>)
-		_param_ekf2_beta_gate, ///< synthetic sideslip innovation consistency gate size (STD)
-		(ParamExtFloat<px4::params::EKF2_BETA_NOISE>) _param_ekf2_beta_noise, ///< synthetic sideslip noise (rad)
-
-		(ParamExtInt<px4::params::EKF2_FUSE_BETA>)
-		_param_ekf2_fuse_beta, ///< Controls synthetic sideslip fusion, 0 disables, 1 enables
+		(ParamExtFloat<px4::params::EKF2_BETA_GATE>) _param_ekf2_beta_gate,
+		(ParamExtFloat<px4::params::EKF2_BETA_NOISE>) _param_ekf2_beta_noise,
+		(ParamExtInt<px4::params::EKF2_FUSE_BETA>) _param_ekf2_fuse_beta,
 #endif // CONFIG_EKF2_SIDESLIP
 
 #if defined(CONFIG_EKF2_MAGNETOMETER)

--- a/src/modules/ekf2/params_sideslip.yaml
+++ b/src/modules/ekf2/params_sideslip.yaml
@@ -6,8 +6,8 @@ parameters:
       description:
         short: Enable synthetic sideslip fusion
         long: 'For reliable wind estimation both sideslip and airspeed fusion (see
-          EKF2_ARSP_THR) should be enabled. Only applies to fixed-wing vehicles (or
-          VTOLs in fixed-wing mode). Note: side slip fusion is currently not supported
+          EKF2_ARSP_THR) should be enabled. Only applies to vehicles in fixed-wing mode
+          or with airspeed fusion active. Note: side slip fusion is currently not supported
           for tailsitters.'
       type: boolean
       default: 0


### PR DESCRIPTION
### Solved Problem
During front transition, the drone is still considered as a multirotor. Airspeed fusion can start when there is enough wind-relative velocity but sideslip fusion is still strictly relying on the fixed-wing flag. This causes race conditions in commander when the transition to fixedwing occurs as the ekf needs to receive the message before activating the sideslip fusion. 

### Solution
The sideslip fusion parameter tells the EKF that this fusion type is possible on this vehicle. We know that it's only possible when airspeed is significant so we can let it start when the airspeed fusion starts as well (regardless of the vehicle type).
This also gives us a bit more flexibility as a multirotor with a vertical stabilizer and an airspeed sensor could also enable sideslip fusion.


### Test coverage
-

