### PR TITLE
stream ATTITUDE_QUATERNION in low bandwidth mode

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1744,6 +1744,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("CAMERA_TRIGGER", unlimited_rate);
 		configure_stream_local("LOCAL_POSITION_NED", 30.0f);
 		configure_stream_local("ATTITUDE", 20.0f);
+		configure_stream_local("ATTITUDE_QUATERNION", 20.0f);
 		configure_stream_local("ALTITUDE", 10.0f);
 		configure_stream_local("DISTANCE_SENSOR", 10.0f);
 		configure_stream_local("MOUNT_ORIENTATION", 10.0f);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
With Tailsitter VTOL aircraft, the ground station display heading in forward flight is incorrect if `ATTITUDE_QUATERNION` is not streamed. The issue was fixed [here](https://github.com/mavlink/mavlink/pull/1247), but only if we use the quaternion attitude stream. Previously in mavlink mode `ONBOARD_LOW_BANDWIDTH` this was not done.

### Solution
Stream `ATTITUDE_QUATERNION` too.
