### PR TITLE
Increase EKF2_RNG_FOG by default, keep reduced for MC

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -21,3 +21,6 @@ param set-default RTL_RETURN_ALT 30
 param set-default RTL_DESCEND_ALT 10
 
 param set-default GPS_UBX_DYNMODEL 6
+
+# lower RNG_FOG since MC are expected to fly closer over obstacles
+param set-default EKF2_RNG_FOG 1.0

--- a/src/modules/ekf2/params_range_finder.yaml
+++ b/src/modules/ekf2/params_range_finder.yaml
@@ -158,7 +158,7 @@ parameters:
           If there's a jump from larger than RNG_FOG to smaller than EKF2_RNG_FOG, the
           measurement may gets rejected. 0 - disabled
       type: float
-      default: 1.0
+      default: 3.0
       min: 0.0
       max: 20.0
       unit: m


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
We encountered several instances where the fog detector did not get triggered during foggy conditions on VTOLs because the limit was not optimally set.

The initial default value was primarily based on multicopter flight logs. It also makes sense to maintain this value for MC since they are expected to fly over obstacles that are much closer compared to FW or VTOL.