### PR TITLE
VTOL Takeoff: use vehicle altitude instead of Home for altitude setpoint calculation

### DIFF
--- a/src/modules/navigator/vtol_takeoff.cpp
+++ b/src/modules/navigator/vtol_takeoff.cpp
@@ -118,7 +118,7 @@ VtolTakeoff::on_active()
 				_mission_item.time_inside = 1.f;
 				_mission_item.loiter_radius = _navigator->get_loiter_radius();
 				_mission_item.acceptance_radius  = _navigator->get_acceptance_radius();
-				_mission_item.altitude = _navigator->get_home_position()->alt + _param_loiter_alt.get();
+				_mission_item.altitude = _takeoff_alt_msl + _param_loiter_alt.get();
 
 				mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
 				pos_sp_triplet->current.lat = _loiter_location(0);
@@ -169,6 +169,8 @@ VtolTakeoff::set_takeoff_position()
 {
 	// set current mission item to takeoff
 	set_takeoff_item(&_mission_item, _transition_alt_amsl);
+
+	_takeoff_alt_msl = _navigator->get_global_position()->alt;
 
 	_mission_item.lat = _navigator->get_global_position()->lat;
 	_mission_item.lon = _navigator->get_global_position()->lon;

--- a/src/modules/navigator/vtol_takeoff.h
+++ b/src/modules/navigator/vtol_takeoff.h
@@ -70,6 +70,7 @@ private:
 	} _takeoff_state;
 
 	float _transition_alt_amsl{0.f};	// absolute altitude at which vehicle will transition to forward flight
+	float _takeoff_alt_msl{0.f};
 	matrix::Vector2d _loiter_location;
 	float _loiter_height{0};
 


### PR DESCRIPTION
### Solved Problem
The VTOL takeoff navigation mode was using the home altitude to calculate the climbout altitude. However, the vehicle does not necessarily need to be at the home point at the time it takes off and thus, the ground alatitude and the home altitude could be very different.

In fact, if the ground altitude at the home position is much lower than the ground altitude at the takeoff point, then the vehicle would fly into the ground after the transition.

### Solution
Store the current altitude before takeoff and use that as reference for the climbout altitude.

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives


### Test coverage
SITL

### Context
Related links, screenshot before/after, video
