### PR TITLE
dshot: remove dshot 1200

### DIFF
--- a/src/drivers/drv_dshot.h
+++ b/src/drivers/drv_dshot.h
@@ -88,7 +88,7 @@ typedef enum {
  * @param channel_mask		Bitmask of channels (LSB = channel 0) to enable.
  *				This allows some of the channels to remain configured
  *				as GPIOs or as another function. Already used channels/timers will not be configured as DShot
- * @param dshot_pwm_freq	Frequency of DSHOT signal. Usually DSHOT150, DSHOT300, DSHOT600 or DSHOT1200
+ * @param dshot_pwm_freq	Frequency of DSHOT signal. Usually DSHOT150, DSHOT300, or DSHOT600
  * @return <0 on error, the initialized channels mask.
  */
 __EXPORT extern int up_dshot_init(uint32_t channel_mask, unsigned dshot_pwm_freq, bool enable_bidirectional_dshot);

--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -125,9 +125,6 @@ void DShot::enable_dshot_outputs(const bool enabled)
 			} else if (tim_config == -3) {
 				dshot_frequency_request = DSHOT600;
 
-			} else if (tim_config == -2) {
-				dshot_frequency_request = DSHOT1200;
-
 			} else {
 				_output_mask &= ~channels; // don't use for dshot
 			}
@@ -824,7 +821,7 @@ On startup, the module tries to occupy all available pins for DShot output.
 It skips all pins already in use (e.g. by a camera trigger module).
 
 It supports:
-- DShot150, DShot300, DShot600, DShot1200
+- DShot150, DShot300, DShot600
 - telemetry via separate UART and publishing as esc_status message
 - sending DShot commands via CLI
 

--- a/src/drivers/dshot/DShot.h
+++ b/src/drivers/dshot/DShot.h
@@ -52,7 +52,6 @@ using namespace time_literals;
 static constexpr unsigned int DSHOT150  =  150000u;
 static constexpr unsigned int DSHOT300  =  300000u;
 static constexpr unsigned int DSHOT600  =  600000u;
-static constexpr unsigned int DSHOT1200 = 1200000u;
 
 static constexpr int DSHOT_DISARM_VALUE = 0;
 static constexpr int DSHOT_MIN_THROTTLE = 1;
@@ -107,7 +106,6 @@ private:
 		DShot150  = 150,
 		DShot300  = 300,
 		DShot600  = 600,
-		DShot1200 = 1200,
 	};
 
 	struct Command {

--- a/src/drivers/pwm_out/module.yaml
+++ b/src/drivers/pwm_out/module.yaml
@@ -23,7 +23,6 @@ actuator_output:
             -5: DShot150
             -4: DShot300
             -3: DShot600
-            -2: DShot1200
             -1: OneShot
             50: PWM 50 Hz
             100: PWM 100 Hz


### PR DESCRIPTION
Dshot 1200 was removed from betaflight in 2019.

```
DShot1200 is officially removed from Betaflight 4.1:
1. Dshot1200 is only needed for 32khz looptime, and 32khz looptime isn't supported any more in Betaflight. The highest looptime in Betaflight (in BF4.1) is 8KHz, and Dshot600 is enough for 8khz looptime
2. Dshot1200 was not stable when used with bidirectional DShot which is required for RPM filter, which has a higher priority than DShot1200
```

https://intofpv.com/t-dshot1200-removed-from-betaflight-4-1

https://github.com/betaflight/betaflight/issues/8967