### PR TITLE
FW defaults: remove EKF2_GPS_CHECK custom FW setting

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.fw_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_defaults
@@ -24,7 +24,6 @@ param set-default COM_DISARM_PRFLT -1
 
 param set-default EKF2_ARSP_THR 8
 param set-default EKF2_FUSE_BETA 1
-param set-default EKF2_GPS_CHECK 21
 param set-default EKF2_MAG_ACCLIM 0
 param set-default EKF2_REQ_EPH 10
 param set-default EKF2_REQ_EPV 10


### PR DESCRIPTION
We want to align the default over all vehicle types for this param. There are still some thresholds that are increased for FW.
