### PR TITLE
Commander: COM_MODE_ARM_CHK parameter to allow mode registration while armed

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -4,6 +4,9 @@
 # Simulator IMU data provided at 250 Hz
 param set-default IMU_INTEG_RATE 250
 
+# For simulation, allow registering modes while armed for developer convenience
+param set-default COM_MODE_ARM_CHK 1
+
 if [ "$PX4_SIMULATOR" = "sihsim" ] || [ "$(param show -q SYS_AUTOSTART)" -eq "0" ]; then
 
 	echo "INFO  [init] SIH simulator"

--- a/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.hpp
@@ -111,6 +111,6 @@ private:
 
 	uORB::Publication<arming_check_request_s> _arming_check_request_pub{ORB_ID(arming_check_request)};
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
-		(ParamBool<px4::params::COM_MODE_ARM_CHK>) _param_com_mode_arm_chk
-	);
+					(ParamBool<px4::params::COM_MODE_ARM_CHK>) _param_com_mode_arm_chk
+				       );
 };

--- a/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.hpp
@@ -110,7 +110,7 @@ private:
 	uORB::Subscription _arming_check_reply_sub{ORB_ID(arming_check_reply)};
 
 	uORB::Publication<arming_check_request_s> _arming_check_request_pub{ORB_ID(arming_check_request)};
-	DEFINE_PARAMETERS(
+	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
 		(ParamBool<px4::params::COM_MODE_ARM_CHK>) _param_com_mode_arm_chk
 	);
 };

--- a/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.hpp
@@ -38,6 +38,7 @@
 #include <uORB/topics/arming_check_reply.h>
 #include <uORB/Subscription.hpp>
 #include <uORB/Publication.hpp>
+#include <px4_platform_common/module_params.h>
 
 static_assert((1ull << arming_check_reply_s::HEALTH_COMPONENT_INDEX_AVOIDANCE) == (uint64_t)
 	      health_component_t::avoidance, "enum definition missmatch");
@@ -66,7 +67,7 @@ public:
 	void update();
 
 	bool isUnresponsive(int registration_id);
-
+	bool allowUpdateWhileArmed() const { return _param_com_mode_arm_chk.get(); }
 private:
 	static constexpr hrt_abstime REQUEST_TIMEOUT = 50_ms;
 	static constexpr hrt_abstime UPDATE_INTERVAL = 300_ms;
@@ -109,4 +110,7 @@ private:
 	uORB::Subscription _arming_check_reply_sub{ORB_ID(arming_check_reply)};
 
 	uORB::Publication<arming_check_request_s> _arming_check_request_pub{ORB_ID(arming_check_request)};
+	DEFINE_PARAMETERS(
+			(ParamInt<px4::params::COM_MODE_ARM_CHK>) _param_com_mode_arm_chk
+		);
 };

--- a/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.hpp
@@ -111,6 +111,6 @@ private:
 
 	uORB::Publication<arming_check_request_s> _arming_check_request_pub{ORB_ID(arming_check_request)};
 	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::COM_MODE_ARM_CHK>) _param_com_mode_arm_chk
+		(ParamBool<px4::params::COM_MODE_ARM_CHK>) _param_com_mode_arm_chk
 	);
 };

--- a/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.hpp
@@ -111,6 +111,6 @@ private:
 
 	uORB::Publication<arming_check_request_s> _arming_check_request_pub{ORB_ID(arming_check_request)};
 	DEFINE_PARAMETERS(
-			(ParamInt<px4::params::COM_MODE_ARM_CHK>) _param_com_mode_arm_chk
-		);
+		(ParamInt<px4::params::COM_MODE_ARM_CHK>) _param_com_mode_arm_chk
+	);
 };

--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -371,10 +371,6 @@ void ModeManagement::update(bool armed, uint8_t user_intended_nav_state, bool fa
 	_external_checks.update();
 
 	bool allow_update_while_armed = _external_checks.allowUpdateWhileArmed();
-#if defined(CONFIG_ARCH_BOARD_PX4_SITL)
-	// For simulation, allow registering modes while armed for developer convenience
-	allow_update_while_armed = true;
-#endif
 
 	if (armed && !allow_update_while_armed) {
 		// Reject registration requests

--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -370,7 +370,7 @@ void ModeManagement::update(bool armed, uint8_t user_intended_nav_state, bool fa
 	_failsafe_action_active = failsafe_action_active;
 	_external_checks.update();
 
-	bool allow_update_while_armed = false;
+	bool allow_update_while_armed = _external_checks.allowUpdateWhileArmed();
 #if defined(CONFIG_ARCH_BOARD_PX4_SITL)
 	// For simulation, allow registering modes while armed for developer convenience
 	allow_update_while_armed = true;

--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -404,7 +404,8 @@ void ModeManagement::update(bool armed, uint8_t user_intended_nav_state, bool fa
 			}
 		}
 
-		// As we're disarmed we can use the user intended mode, as no failsafe will be active
+		// As we're disarmed we can use the user intended mode, as no failsafe will be active.
+		// Note that this might not be true if COM_MODE_ARM_CHK is set
 		checkNewRegistrations(update_request);
 		checkUnregistrations(user_intended_nav_state, update_request);
 	}

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1022,7 +1022,7 @@ PARAM_DEFINE_INT32(COM_FLTT_LOW_ACT, 3);
 /**
 + * Allow external mode registration while armed.
 + *
-+ *  By default disabled. 0: Mode registration is not allowed while armed. 1: Mode registration is allowed while armed.
++ *  By default disabled for safety reasons
 + *
 + * @group Commander
 + * @value 0 Disabled

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1018,3 +1018,15 @@ PARAM_DEFINE_FLOAT(COM_THROW_SPEED, 5);
  * @increment 1
  */
 PARAM_DEFINE_INT32(COM_FLTT_LOW_ACT, 3);
+
+/**
+ * Condition to enable external mode registration while armed
+ *
+ * By default, mode registration is disabled while armed.
+ *
+ * @value 0 Disabled
+ * @value 1 Enabled
+ *
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(COM_MODE_ARM_CHK, 0);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1020,13 +1020,13 @@ PARAM_DEFINE_FLOAT(COM_THROW_SPEED, 5);
 PARAM_DEFINE_INT32(COM_FLTT_LOW_ACT, 3);
 
 /**
- * Condition to enable external mode registration while armed
++ * Allow external mode registration while armed.
++ *
++ *  By default disabled. 0: Mode registration is not allowed while armed. 1: Mode registration is allowed while armed.
++ *
++ * @group Commander
++ * @value 0 Disabled
++ * @value 1 Enabled
  *
- * By default, mode registration is disabled while armed.
- *
- * @value 0 Disabled
- * @value 1 Enabled
- *
- * @group Commander
  */
 PARAM_DEFINE_INT32(COM_MODE_ARM_CHK, 0);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1020,12 +1020,12 @@ PARAM_DEFINE_FLOAT(COM_THROW_SPEED, 5);
 PARAM_DEFINE_INT32(COM_FLTT_LOW_ACT, 3);
 
 /**
-+ * Allow external mode registration while armed.
-+ *
-+ *  By default disabled for safety reasons
-+ *
-+ * @group Commander
-+ * @boolean
+ * Allow external mode registration while armed.
+ *
+ * By default disabled for safety reasons
+ *
+ * @group Commander
+ * @boolean
  *
  */
 PARAM_DEFINE_INT32(COM_MODE_ARM_CHK, 0);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1025,8 +1025,7 @@ PARAM_DEFINE_INT32(COM_FLTT_LOW_ACT, 3);
 + *  By default disabled for safety reasons
 + *
 + * @group Commander
-+ * @value 0 Disabled
-+ * @value 1 Enabled
++ * @boolean
  *
  */
 PARAM_DEFINE_INT32(COM_MODE_ARM_CHK, 0);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
A new parameter `COM_MODE_ARM_CHK` is defined to allow mode registrations while vehicle is armed. In the current implementation, by default, external mode registrations are only allowed while disarmed and therefore parameter default is set to reject mode registrations while armed. 

Fixes #{Github issue ID}

### Solution
[`allow_update_while_armed`](https://github.com/PX4/PX4-Autopilot/blob/07e7c64e6035015dbad3559e715ceaeee1dac345/src/modules/commander/ModeManagement.cpp#L376) variable was previously hard-coded and disabled. To provide users the option to allow -external- mode registrations while vehicle is armed, this variable is parameterized as `COM_MODE_ARM_CHK`, a boolean PX4 parameter under commander group.   


### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- [x] Skynode
- [x] [SITL](https://review.px4.io/plot_app?log=c0cf9496-3ba1-49e2-8069-8bbc47fda8ee)  
- Unit/integration test: ...
- Simulation/hardware testing logs: 

### Context
Related links, screenshot before/after, video
