### PR TITLE
increase NUM_NO_REPLY_UNTIL_UNRESPONSIVE to 6

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.hpp
@@ -71,7 +71,7 @@ private:
 	static constexpr hrt_abstime REQUEST_TIMEOUT = 50_ms;
 	static constexpr hrt_abstime UPDATE_INTERVAL = 300_ms;
 	static_assert(REQUEST_TIMEOUT < UPDATE_INTERVAL, "keep timeout < update interval");
-	static constexpr int NUM_NO_REPLY_UNTIL_UNRESPONSIVE = 3; ///< Mode timeout = this value * UPDATE_INTERVAL
+	static constexpr int NUM_NO_REPLY_UNTIL_UNRESPONSIVE = 6; ///< Mode timeout = this value * UPDATE_INTERVAL
 	/// Timeout directly after registering (in some cases ROS can take a while until the subscription gets the first
 	/// sample, around 800ms was observed)
 	static constexpr int NUM_NO_REPLY_UNTIL_UNRESPONSIVE_INIT = 10;


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
To make sure latency or other issues between the FMU and the mission computer do not cause a mode registration problem, number of no replies to raise [the mode unresponsive flag](NUM_NO_REPLY_UNTIL_UNRESPONSIVE) is increased to 6. This change is added after observing mission computer latency issues due to overheating and increasing this value relatively increased the chance of successful mode registrations. 

Fixes #{Github issue ID}

### Solution
- Mode unresponsive flag counter `NUM_NO_REPLY_UNTIL_UNRESPONSIVE` is increased from 3 to 6. 

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
By enabling mode registration while armed, an unresponsive mode can be re-registered and any undesired mode unresponsive flag can be resolved. Please see, #24249 

### Test coverage

- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
