### PR TITLE
Navigator: remove custom "FLT_EPSILONs"

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -626,7 +626,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 			    _navigator->get_loiter_radius();
 	sp->loiter_direction_counter_clockwise = item.loiter_radius < 0;
 
-	if (item.acceptance_radius > 0.001f && PX4_ISFINITE(item.acceptance_radius)) {
+	if (item.acceptance_radius > FLT_EPSILON && PX4_ISFINITE(item.acceptance_radius)) {
 		// if the mission item has a specified acceptance radius, overwrite the default one from parameters
 		sp->acceptance_radius = item.acceptance_radius;
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -622,7 +622,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 	sp->lon = item.lon;
 	sp->alt = get_absolute_altitude_for_item(item);
 	sp->yaw = item.yaw;
-	sp->loiter_radius = (fabsf(item.loiter_radius) > NAV_EPSILON_POSITION) ? fabsf(item.loiter_radius) :
+	sp->loiter_radius = (fabsf(item.loiter_radius) > FLT_EPSILON) ? fabsf(item.loiter_radius) :
 			    _navigator->get_loiter_radius();
 	sp->loiter_direction_counter_clockwise = item.loiter_radius < 0;
 

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -56,8 +56,6 @@
 #  define NUM_MISSIONS_SUPPORTED 500
 #endif
 
-#define NAV_EPSILON_POSITION	0.001f	/**< Anything smaller than this is considered zero */
-
 /* compatible to mavlink MAV_CMD */
 enum NAV_CMD {
 	NAV_CMD_IDLE = 0,


### PR DESCRIPTION
### Solved Problem
Not a specific problem, but noticed that in the Navigator we in two cases use 0.001 instead of FLT_EPSILON to compare a float to zero. 

Original contributions:
- [to compare the loiter radius setpoint to zero](https://github.com/PX4/PX4-Autopilot/commit/590f00f56089cf6afa62b7f4df07527c014da559)
- [acceptance radius comparison to zero](https://github.com/PX4/PX4-Autopilot/pull/20171)

### Solution
Consistently use x > FLT_EPSILON for floating point comparisons against 0.

In there any risk in these fields somehow being e.g. 0.00001? Because then >FLT_EPSILON will now be true, while previously it was false. 