### PR TITLE
cmake: for vscode launch fallback to gdb-multiarch

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -506,6 +506,11 @@ if(NOT NUTTX_DIR MATCHES "external")
 		message(STATUS "Found SVD: ${DEBUG_SVD_FILE_PATH}")
 	endif()
 
+	if(NOT CMAKE_GDB)
+		find_program(CMAKE_GDB gdb-multiarch)
+		message(STATUS "Found GDB: ${CMAKE_GDB}")
+	endif()
+
 	if(DEBUG_DEVICE)
 		configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/launch.json.in ${PX4_SOURCE_DIR}/.vscode/launch.json @ONLY)
 	endif()


### PR DESCRIPTION
Newer toolchains don't ship with arm-none-eabi-gdb hence we should use gdb-multiarch instead.
This fixes vscode cortex-debug with ubuntu 24.04 on a clean install