### PR TITLE
test: in VTOL integration test use VTOL_LAND

### DIFF
--- a/test/mavsdk_tests/vtol_mission_straight_south.plan
+++ b/test/mavsdk_tests/vtol_mission_straight_south.plan
@@ -41,7 +41,7 @@
                 "AltitudeMode": 1,
                 "MISSION_ITEM_ID": "2",
                 "autoContinue": true,
-                "command": 21,
+                "command": 85,
                 "doJumpId": 2,
                 "frame": 3,
                 "params": [


### PR DESCRIPTION
### Solved Problem
We should generally use VTOL_LAND instead of LAND to land a VTOL. Is more specific (first transition to hover, then land vertically). In our case we even enforce it with feasibility checks (not present in mainline PX4).

### Solution
Do a VTOL_LAND instead of a LAND in the VTOL integration test.

### Changelog Entry
For release notes:
```
Improvement: test: in VTOL integration test use VTOL_LAND
```

### Test coverage
I've tested with the VTOL high wind integration test.