### PR TITLE
publish vehicle rates setpoint topic

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -74,6 +74,9 @@ publications:
   - topic: /fmu/out/vehicle_trajectory_waypoint_desired
     type: px4_msgs::msg::VehicleTrajectoryWaypoint
 
+  - topic: /fmu/out/vehicle_thrust_setpoint
+    type: px4_msgs::msg::VehicleThrustSetpoint
+
 # Create uORB::Publication
 subscriptions:
   - topic: /fmu/in/register_ext_component_request

--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -74,8 +74,8 @@ publications:
   - topic: /fmu/out/vehicle_trajectory_waypoint_desired
     type: px4_msgs::msg::VehicleTrajectoryWaypoint
 
-  - topic: /fmu/out/vehicle_thrust_setpoint
-    type: px4_msgs::msg::VehicleThrustSetpoint
+  - topic: /fmu/out/vehicle_rates_setpoint
+    type: px4_msgs::msg::VehicleRatesSetpoint
 
 # Create uORB::Publication
 subscriptions:


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This PR adds the `vehicle_rates_setpoint` under published dds topics. ROS2 applications can with this change subscribe to thrust and rate setpoints. 

Expected terminal output: 
```
[uxrce_dds_client] successfully created rt/fmu/out/vehicle_rates_setpoint data writer, topic id: 266
```

Fixes #{Github issue ID}

### Solution
- Add ... for ...
- Refactor ...

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- [x] sitl, [link to log](https://review.px4.io/plot_app?log=d8000994-43a1-456c-85d5-7261d8b2c552) 
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
