### PR TITLE
SIH airframes: clean up config

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10040_sihsim_quadx
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10040_sihsim_quadx
@@ -16,10 +16,6 @@ param set-default SENS_EN_GPSSIM 1
 param set-default SENS_EN_BAROSIM 1
 param set-default SENS_EN_MAGSIM 1
 
-# disable some checks to allow to fly:
-# - without real battery
-param set-default CBRK_SUPPLY_CHK 894281
-
 # Square quadrotor X PX4 numbering
 param set-default CA_ROTOR_COUNT 4
 param set-default CA_ROTOR0_PX 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
@@ -16,12 +16,6 @@ param set-default SENS_EN_BAROSIM 1
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 1
 
-# disable some checks to allow to fly:
-# - with usb
-param set-default CBRK_USB_CHK 197848
-# - without real battery
-param set-default CBRK_SUPPLY_CHK 894281
-
 param set-default SIH_T_MAX 6
 param set-default SIH_MASS 0.3
 param set-default SIH_IXX 0.00402

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
@@ -28,10 +28,6 @@ param set-default MC_PITCH_P 5
 
 param set-default MAV_TYPE 19
 
-# disable some checks to allow to fly:
-# - without real battery
-param set-default CBRK_SUPPLY_CHK 894281
-
 param set-default SIH_T_MAX 2
 param set-default SIH_Q_MAX 0.0165
 param set-default SIH_MASS 0.2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10043_sihsim_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10043_sihsim_standard_vtol
@@ -10,7 +10,7 @@
 # @output Motor3 MC motor front left
 # @output Motor4 MC motor back right
 # @output Motor5 Forward thrust motor
-# @output Servo1 Aileron
+# @output Servo1 Ailerons (single channel)
 # @output Servo2 Elevator
 # @output Servo3 Rudder
 #
@@ -19,26 +19,16 @@
 
 . ${R}etc/init.d/rc.vtol_defaults
 
-# SIH in SITL changes. could we source these from a common file?  {{{
-# inspired by: diff ROMFS/px4fmu_common/init.d/airframes/4001_quad_x ROMFS/px4fmu_common/init.d-posix/airframes/10040_sihsim_quadx
-
 PX4_SIMULATOR=${PX4_SIMULATOR:=sihsim}
 PX4_SIM_MODEL=${PX4_SIM_MODEL:=standard_vtol}
 
 param set-default SENS_EN_GPSSIM 1
 param set-default SENS_EN_BAROSIM 1
 param set-default SENS_EN_MAGSIM 1
+param set-default SENS_EN_ARSPDSIM 1
 
 param set-default EKF2_GPS_DELAY 0
 
-# battery check disabled below already
-# HIL_ACT_FUNC* set below -- do we need PWM_MAIN_FUNC* as well?
-# SIH_VEHICLE_TYPE set below too.
-
-# }}}
-
-param set-default VT_B_TRANS_DUR 5
-param set-default VT_ELEV_MC_LOCK 0
 param set-default VT_TYPE 2
 param set-default MPC_MAN_Y_MAX 60
 param set-default MC_PITCH_P 5
@@ -57,8 +47,6 @@ param set-default CA_ROTOR2_KM -0.05
 param set-default CA_ROTOR3_PX -0.2
 param set-default CA_ROTOR3_PY 0.2
 param set-default CA_ROTOR3_KM -0.05
-
-
 param set-default CA_ROTOR4_PX -0.3
 param set-default CA_ROTOR4_KM 0.05
 param set-default CA_ROTOR4_AX 1
@@ -73,9 +61,9 @@ param set-default CA_SV_CS1_TYPE 3  # elevator
 param set-default CA_SV_CS2_TRQ_Y 1
 param set-default CA_SV_CS2_TYPE 4  # rudder
 
-param set-default FW_AIRSPD_MAX 12
 param set-default FW_AIRSPD_MIN 7
 param set-default FW_AIRSPD_TRIM 10
+param set-default FW_AIRSPD_MAX 12
 
 param set-default PWM_MAIN_FUNC1 101
 param set-default PWM_MAIN_FUNC2 102
@@ -91,12 +79,6 @@ param set-default MAV_TYPE 22
 # set SYS_HITL to 2 to start the SIH and avoid sensors startup
 # param set-default SYS_HITL 2
 
-# disable some checks to allow to fly:
-# - without real battery
-param set-default CBRK_SUPPLY_CHK 894281
-# - without safety switch
-param set-default CBRK_IO_SAFETY 22027
-
 param set-default SENS_DPRES_OFF 0.001
 
 param set SIH_T_MAX 2.0
@@ -108,9 +90,7 @@ param set SIH_IYY 0.000625
 param set SIH_IZZ 0.00300
 param set SIH_IXZ 0
 param set SIH_KDV 0.2
-param set SIH_L_ROLL 0.145
+param set SIH_L_ROLL 0.2
 
 # sih as standard vtol
 param set SIH_VEHICLE_TYPE 3
-
-param set-default VT_ARSP_TRANS 6

--- a/ROMFS/px4fmu_common/init.d/airframes/1103_standard_vtol_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1103_standard_vtol_sih.hil
@@ -10,7 +10,7 @@
 # @output Motor3 MC motor front left
 # @output Motor4 MC motor back right
 # @output Motor5 Forward thrust motor
-# @output Servo1 Aileron
+# @output Servo1 Ailerons (single channel)
 # @output Servo2 Elevator
 # @output Servo3 Rudder
 #
@@ -20,8 +20,7 @@
 . ${R}etc/init.d/rc.vtol_defaults
 
 param set UAVCAN_ENABLE 0
-param set-default VT_B_TRANS_DUR 5
-param set-default VT_ELEV_MC_LOCK 0
+
 param set-default VT_TYPE 2
 param set-default MPC_MAN_Y_MAX 60
 param set-default MC_PITCH_P 5
@@ -40,7 +39,6 @@ param set-default CA_ROTOR2_KM -0.05
 param set-default CA_ROTOR3_PX -0.2
 param set-default CA_ROTOR3_PY 0.2
 param set-default CA_ROTOR3_KM -0.05
-
 param set-default CA_ROTOR4_PX -0.3
 param set-default CA_ROTOR4_KM 0.05
 param set-default CA_ROTOR4_AX 1
@@ -55,9 +53,9 @@ param set-default CA_SV_CS1_TYPE 3  # elevator
 param set-default CA_SV_CS2_TRQ_Y 1
 param set-default CA_SV_CS2_TYPE 4  # rudder
 
-param set-default FW_AIRSPD_MAX 12
 param set-default FW_AIRSPD_MIN 7
 param set-default FW_AIRSPD_TRIM 10
+param set-default FW_AIRSPD_MAX 12
 
 param set-default HIL_ACT_FUNC1 101
 param set-default HIL_ACT_FUNC2 102
@@ -70,16 +68,12 @@ param set-default HIL_ACT_FUNC8 105
 
 param set-default MAV_TYPE 22
 
-
-
 # set SYS_HITL to 2 to start the SIH and avoid sensors startup
 param set-default SYS_HITL 2
 
 # disable some checks to allow to fly:
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
-# - without safety switch
-param set-default CBRK_IO_SAFETY 22027
 
 param set-default SENS_DPRES_OFF 0.001
 
@@ -92,9 +86,7 @@ param set SIH_IYY 0.000625
 param set SIH_IZZ 0.00300
 param set SIH_IXZ 0
 param set SIH_KDV 0.2
-param set SIH_L_ROLL 0.145
+param set SIH_L_ROLL 0.2
 
 # sih as standard vtol
 param set SIH_VEHICLE_TYPE 3
-
-param set-default VT_ARSP_TRANS 6


### PR DESCRIPTION
Removed unnecessary params in all sihsim airframe files, as well as standard VTOL for SIH on FC (1103).


