### PR TITLE
SHT3X driver: change state timer variable from uint32 to uint64.

### DIFF
--- a/src/drivers/hygrometer/sht3x/sht3x.h
+++ b/src/drivers/hygrometer/sht3x/sht3x.h
@@ -110,7 +110,7 @@ private:
 
 	float measured_temperature = 0;
 	float measured_humidity = 0;
-	uint32_t measurement_time = 0;
+	uint64_t measurement_time = 0;
 	uint16_t measurement_index = 0;
 
 	sht_info _sht_info;


### PR DESCRIPTION
Prevents current behaviour of repeated entry into 'init' state and associated log spamming after +-72 minutes.

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When the SHT3X driver is run for longer than 72 minutes (or UINT32_MAX amount of microseconds),  I found that the driver spams a "Connecting to sensor.." message. On further inspection it seems that the variable "measurement_time" is a uint32 and after 72 minutes goes into overflow and thus triggers the driver to go back into "INIT" state at each iteration. 

### Solution
- By changing the "measurement_time" from uint32 to uint64, the overflow limit becomes unreachable. It is also consistent with the hrt_absolute_time() return type.

### Alternatives
We could also change up the logic of the state machine in the driver to not rely on this value. 

### Test coverage
- All default px4 builds have built successfully (locally).
- In flight as well as "at desk" testing has shown the lack of log spamming after 72 minutes. 