### PR TITLE
ObstacleMath: move repeated/static code in SF45 & CollisionPrevention to ObstacleMath library

### DIFF
--- a/src/drivers/distance_sensor/lightware_sf45_serial/lightware_sf45_serial.cpp
+++ b/src/drivers/distance_sensor/lightware_sf45_serial/lightware_sf45_serial.cpp
@@ -620,7 +620,8 @@ void SF45LaserSerial::sf45_process_replies()
 			float distance_m = raw_distance * SF45_SCALE_FACTOR;
 			_current_bin_dist = ((uint16_t)raw_distance < _current_bin_dist) ? (uint16_t)raw_distance : _current_bin_dist;
 
-			uint8_t current_bin = sf45_convert_angle(scaled_yaw);
+			// Find bin index for the current sensor yaw angle (in sensor frame)
+			const int current_bin = ObstacleMath::get_bin_at_angle(_obstacle_distance.increment, scaled_yaw_sensor_frame);
 
 			if (current_bin != _previous_bin) {
 				PX4_DEBUG("scaled_yaw: \t %f, \t current_bin: \t %d, \t distance: \t %8.4f\n", (double)scaled_yaw, current_bin,
@@ -700,21 +701,6 @@ void SF45LaserSerial::_handle_missed_bins(uint8_t current_bin, uint8_t previous_
 		_obstacle_distance.distances[bin_index] = measurement;
 		_data_timestamps[bin_index] = now;
 	}
-}
-
-
-uint8_t SF45LaserSerial::sf45_convert_angle(const int16_t yaw)
-{
-	uint8_t mapped_sector = 0;
-	float adjusted_yaw = sf45_wrap_360(yaw - _obstacle_distance.angle_offset);
-	mapped_sector = floor(adjusted_yaw / _obstacle_distance.increment);
-
-	return mapped_sector;
-}
-
-float SF45LaserSerial::sf45_wrap_360(float f)
-{
-	return matrix::wrap(f, 0.f, 360.f);
 }
 
 uint16_t SF45LaserSerial::sf45_format_crc(uint16_t crc, uint8_t data_val)

--- a/src/drivers/distance_sensor/lightware_sf45_serial/lightware_sf45_serial.hpp
+++ b/src/drivers/distance_sensor/lightware_sf45_serial/lightware_sf45_serial.hpp
@@ -74,10 +74,6 @@ enum SF45_PARSED_STATE {
 };
 
 enum SensorOrientation {	  // Direction the sensor faces from MAV_SENSOR_ORIENTATION enum
-	ROTATION_FORWARD_FACING = 0,  // MAV_SENSOR_ROTATION_NONE
-	ROTATION_RIGHT_FACING = 2,    // MAV_SENSOR_ROTATION_YAW_90
-	ROTATION_BACKWARD_FACING = 4, // MAV_SENSOR_ROTATION_YAW_180
-	ROTATION_LEFT_FACING = 6,     // MAV_SENSOR_ROTATION_YAW_270
 	ROTATION_UPWARD_FACING = 24,  // MAV_SENSOR_ROTATION_PITCH_90
 	ROTATION_DOWNWARD_FACING = 25 // MAV_SENSOR_ROTATION_PITCH_270
 };
@@ -95,8 +91,6 @@ public:
 	void				sf45_send(uint8_t msg_id, bool r_w, int32_t *data, uint8_t data_len);
 	uint16_t			sf45_format_crc(uint16_t crc, uint8_t data_value);
 	void				sf45_process_replies();
-	uint8_t				sf45_convert_angle(const int16_t yaw);
-	float				sf45_wrap_360(float f);
 
 private:
 	obstacle_distance_s 			_obstacle_distance{};

--- a/src/lib/collision_prevention/CollisionPrevention.hpp
+++ b/src/lib/collision_prevention/CollisionPrevention.hpp
@@ -205,13 +205,6 @@ private:
 	)
 
 	/**
-	 * Transforms the sensor orientation into a yaw in the local frame
-	 * @param distance_sensor, distance sensor message
-	 * @param angle_offset, sensor body frame offset
-	 */
-	float _sensorOrientationToYawOffset(const distance_sensor_s &distance_sensor, float angle_offset) const;
-
-	/**
 	 * Computes collision free setpoints
 	 * @param setpoint, setpoint before collision prevention intervention
 	 * @param curr_pos, current vehicle position
@@ -238,6 +231,4 @@ private:
 	 */
 	void _publishVehicleCmdDoLoiter();
 
-	static float _wrap_360(const float f);
-	static int _wrap_bin(int i);
 };

--- a/src/lib/collision_prevention/ObstacleMath.cpp
+++ b/src/lib/collision_prevention/ObstacleMath.cpp
@@ -57,13 +57,19 @@ int get_bin_at_angle(float bin_width, float angle)
 	return wrap_bin(bin_at_angle, 360 / bin_width);
 }
 
+float get_lower_bound_angle(int bin, float bin_width, float angle_offset)
+{
+	bin = wrap_bin(bin, 360 / bin_width);
+	return wrap_360(bin * bin_width + angle_offset - bin_width / 2.f);
+}
+
 int get_offset_bin_index(int bin, float bin_width, float angle_offset)
 {
 	int offset = get_bin_at_angle(bin_width, angle_offset);
 	return wrap_bin(bin - offset, 360 / bin_width);
 }
 
-float sensor_orientation_to_yaw_offset(const SensorOrientation orientation)
+float sensor_orientation_to_yaw_offset(const SensorOrientation orientation, const float q[4])
 {
 	float offset = 0.0f;
 
@@ -99,6 +105,13 @@ float sensor_orientation_to_yaw_offset(const SensorOrientation orientation)
 	case SensorOrientation::ROTATION_YAW_315:
 		offset = -M_PI_F / 4.0f;
 		break;
+
+	case SensorOrientation::ROTATION_CUSTOM:
+		if (q != nullptr) {
+			offset = Eulerf(Quatf(q)).psi();
+		}
+
+		break;
 	}
 
 	return offset;
@@ -107,6 +120,11 @@ float sensor_orientation_to_yaw_offset(const SensorOrientation orientation)
 int wrap_bin(int bin, int bin_count)
 {
 	return (bin + bin_count) % bin_count;
+}
+
+float wrap_360(const float angle)
+{
+	return matrix::wrap(angle, 0.0f, 360.0f);
 }
 
 } // ObstacleMath

--- a/src/lib/collision_prevention/ObstacleMath.hpp
+++ b/src/lib/collision_prevention/ObstacleMath.hpp
@@ -45,6 +45,7 @@ enum SensorOrientation {
 	ROTATION_YAW_225 = 5,	  // MAV_SENSOR_ROTATION_YAW_225
 	ROTATION_YAW_270 = 6,	  // MAV_SENSOR_ROTATION_YAW_270
 	ROTATION_YAW_315 = 7,	  // MAV_SENSOR_ROTATION_YAW_315
+	ROTATION_CUSTOM  = 100,	  // MAV_SENSOR_ROTATION_CUSTOM
 
 	ROTATION_FORWARD_FACING  = 0, // MAV_SENSOR_ROTATION_NONE
 	ROTATION_RIGHT_FACING    = 2, // MAV_SENSOR_ROTATION_YAW_90
@@ -56,7 +57,7 @@ enum SensorOrientation {
  * Converts a sensor orientation to a yaw offset
  * @param orientation sensor orientation
  */
-float sensor_orientation_to_yaw_offset(const SensorOrientation orientation);
+float sensor_orientation_to_yaw_offset(const SensorOrientation orientation, const float q[4] = nullptr);
 
 /**
  * Scales a distance measurement taken in the vehicle body horizontal plane onto the world horizontal plane
@@ -74,6 +75,14 @@ void project_distance_on_horizontal_plane(float &distance, const float yaw, cons
 int get_bin_at_angle(float bin_width, float angle);
 
 /**
+ * Returns lower bound angle of a bin
+ * @param bin bin index
+ * @param bin_width width of a bin in degrees
+ * @param angle_offset clockwise angle offset in degrees
+ */
+float get_lower_bound_angle(int bin, float bin_width, float angle_offset);
+
+/**
  * Returns bin index for the current bin after an angle offset
  * @param bin current bin index
  * @param bin_width width of a bin in degrees
@@ -87,5 +96,12 @@ int get_offset_bin_index(int bin, float bin_width, float angle_offset);
  * @param bin_count number of bins
  */
 int wrap_bin(int bin, int bin_count);
+
+/**
+ * Wraps an angle to the range [0, 360)
+ * @param angle angle in degrees
+ */
+float wrap_360(const float angle);
+
 
 } // ObstacleMath

--- a/src/lib/collision_prevention/ObstacleMathTest.cpp
+++ b/src/lib/collision_prevention/ObstacleMathTest.cpp
@@ -133,6 +133,22 @@ TEST(ObstacleMathTest, GetBinAtAngle)
 	EXPECT_EQ(bin_index, 18);
 }
 
+TEST(ObstacleMathTest, GetLowerBound)
+{
+	// GIVEN: an invalid bin index, non-integer bin width, and a negative non-integer angle offset
+	int      bin          = -1;
+	float    bin_width    =  7.5f;
+	float    angle_offset = -4.3f;
+
+	// WHEN: we calculate the lower bound angle of the bin
+	float lower_bound = ObstacleMath::get_lower_bound_angle(bin, bin_width, angle_offset);
+
+	// THEN: the lower bound angle should be correct. The bin index is wrapped to the end and
+	// the angle offset is applied in the counter-clockwise direction.
+	EXPECT_FLOAT_EQ(lower_bound, 344.45);
+
+}
+
 
 TEST(ObstacleMathTest, OffsetBinIndex)
 {


### PR DESCRIPTION

No functional change, only refactoring.

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

Some repeated code across `CollisionPrevention.cpp` and `lightware_sf45_serial.cpp`. 

### Solution
 
Move some repeated/static code to ObstacleMath library. 

Part of this was already done in the following pr's: 
1. https://github.com/PX4/PX4-Autopilot/pull/24142  
2. https://github.com/PX4/PX4-Autopilot/pull/24248


### Test coverage
- Pure refactoring, no functional change. 

### Context
- In the long run the SF45 driver should no longer publish obstacle maps. rather just a distance measurement and an associated orientation. The map logic should be separated. The functions in the ObstacleMath library were created with this in mind. 
