### PR TITLE
Fill out MISSION_CURRENT.mission_state for MAVlink

### DIFF
--- a/msg/MissionResult.msg
+++ b/msg/MissionResult.msg
@@ -16,5 +16,3 @@ bool failure			# true if the mission cannot continue or be completed for some re
 bool item_do_jump_changed	# true if the number of do jumps remaining has changed
 uint16 item_changed_index	# indicate which item has changed
 uint16 item_do_jump_remaining	# set to the number of do jumps remaining for that item
-
-uint8 execution_mode	# indicates the mode in which the mission is executed

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -201,7 +201,7 @@ private:
 	 *
 	 *  @param seq The waypoint sequence number the MAV should fly to.
 	 */
-	void send_mission_current(uint16_t seq);
+	void send_mission_current(uint16_t seq, mission_result_s mission_result);
 
 	void send_mission_count(uint8_t sysid, uint8_t compid, uint16_t count, MAV_MISSION_TYPE mission_type,
 				uint32_t opaque_id);


### PR DESCRIPTION
### Solved Problem
@cmic0 brought up to me that we should populate the field `MISSION_CURRENT.mission_state` which is sent out via MAVLink.

### Solution
I started populating it based on the uORB message `mission_result` with the main goal to at least see if there is a mission at all and when it is finished. But there are many uncovered cases still:
1. What happens when there's no update of `mission_result` on uORB, the message is then zero initialized and wrong data gets populated.
2. When exactly to fill the states `NOT_STARTED`, `ACTIVE`, `PAUSED` because the `mission_result` is also updated in land, takeoff, VTOL takeoff situations and not just mission mode, also mission mode would need to be checked separately which together with the scheduling on `mission_result` updates wouldn't work out well. So I think the structure needs to be changed and the mission state kept and updated as part of the mission interface for these to be correct.

### Changelog Entry
```
Fill out MISSION_CURRENT.mission_state for MAVlink
```

### Test coverage
This is work in progress and needs further case handling and testing. We could just will the states we know like e.g. finished only and leave the rest for now 🤔