### PR TITLE
Baro fallback follow up, avoid consecutive triggers

### DIFF
--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -200,7 +200,7 @@ void VehicleAirData::Run()
 					}
 
 					if (estimator_status_flags_updated && _selected_sensor_sub_index >= 0 && _selected_sensor_sub_index == uorb_index
-					    && estimator_status_flags.cs_baro_fault) {
+					    && estimator_status_flags.cs_baro_fault && !_last_status_baro_fault) {
 						_priority[uorb_index] = 1; // 1 is min priority while still being enabled
 					}
 
@@ -223,6 +223,10 @@ void VehicleAirData::Run()
 				}
 			}
 		}
+	}
+
+	if (estimator_status_flags_updated) {
+		_last_status_baro_fault = estimator_status_flags.cs_baro_fault;
 	}
 
 	// check for the current best sensor

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -126,6 +126,8 @@ private:
 
 	float _air_temperature_celsius{20.f}; // initialize with typical 20degC ambient temperature
 
+	bool _last_status_baro_fault{false};
+
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::SENS_BARO_QNH>) _param_sens_baro_qnh,
 		(ParamFloat<px4::params::SENS_BARO_RATE>) _param_sens_baro_rate


### PR DESCRIPTION
### Solved Problem
Reacting to https://github.com/PX4/PX4-Autopilot/pull/24260#issuecomment-2626261008.

> A more immediate problem with this is the race condition with ekf2 declaring a baro fault, then sensors/vehicle_air_data changing the priority (likely causing a switch). 

We discussed first that we need to listen to the _baro_device_id_, published in the _control_status_. This could still be an issue since this id gets changed within the _VehicleAirData.cpp_ as well.

### Solution
Only trigger the sensor fallback when the _baro_fault_ flag switches from 0 -> 1. This ensures that the sensor-reset has reached the EKF, which sets the flag to 0 in this case...
