### PR TITLE
publish validated airspeed topic

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -74,6 +74,9 @@ publications:
   - topic: /fmu/out/vehicle_trajectory_waypoint_desired
     type: px4_msgs::msg::VehicleTrajectoryWaypoint
 
+  - topic: /fmu/out/airspeed_validated
+    type: px4_msgs::msg::AirspeedValidate
+
 # Create uORB::Publication
 subscriptions:
   - topic: /fmu/in/register_ext_component_request

--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -75,7 +75,7 @@ publications:
     type: px4_msgs::msg::VehicleTrajectoryWaypoint
 
   - topic: /fmu/out/airspeed_validated
-    type: px4_msgs::msg::AirspeedValidate
+    type: px4_msgs::msg::AirspeedValidated
 
 # Create uORB::Publication
 subscriptions:


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This PR adds the `AirspeeValidated` msg under published dds topics in `dds_topics.yaml`. ROS2 applications with fixed-wing vehicles can with this change receive airspeed information. 

#### To-do: 
- [ ] attach simulation test
- [ ] compare Tx rates before/after this change
- [ ] edit PR description

Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
