### PR TITLE
[v1.15] gps: revert ubx changes, point to 1.15 branch

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -934,8 +934,7 @@ GPS::run()
 						set_device_type(DRV_GPS_DEVTYPE_UBX_9);
 						break;
 
-					case GPSDriverUBX::Board::u_blox9_F9P_L1L2:
-					case GPSDriverUBX::Board::u_blox9_F9P_L1L5:
+					case GPSDriverUBX::Board::u_blox9_F9P:
 						set_device_type(DRV_GPS_DEVTYPE_UBX_F9P);
 						break;
 


### PR DESCRIPTION
This reverts UBX changes that we don't want to backport into v1.15.

We now point to a release/1.15 branch within the PX4-GPSDrivers submodule.
