### PR TITLE
make format: ignore libuavcan

### DIFF
--- a/Tools/astyle/files_to_check_code_style.sh
+++ b/Tools/astyle/files_to_check_code_style.sh
@@ -12,6 +12,7 @@ exec find boards msg src platforms test \
     -path platforms/qurt/dspal -prune -o \
     -path src/drivers/ins/vectornav/libvnc -prune -o \
     -path src/drivers/uavcan/libdronecan -prune -o \
+    -path src/drivers/uavcan/libuavcan -prune -o \
     -path src/drivers/uavcan/uavcan_drivers/kinetis/driver/include/uavcan_kinetis -prune -o \
     -path src/drivers/cyphal/libcanard -prune -o \
     -path src/lib/crypto/monocypher -prune -o \


### PR DESCRIPTION
When going back and forth between older branches or releases, make format tried to reformat libuavcan.