### PR TITLE
Automatic relative baro calibration

### DIFF
--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -251,6 +251,10 @@ void VehicleAirData::Run()
 		}
 	}
 
+	if (!_relative_calibration_done) {
+		UpdateRelativeCalibrations(time_now_us);
+	}
+
 	// Publish
 	if (_param_sens_baro_rate.get() > 0) {
 		int interval_us = 1e6f / _param_sens_baro_rate.get();
@@ -317,6 +321,31 @@ void VehicleAirData::Run()
 	ScheduleDelayed(50_ms);
 
 	perf_end(_cycle_perf);
+}
+
+void VehicleAirData::UpdateRelativeCalibrations(const hrt_abstime time_now_us)
+{
+	// delay calibration to allow all drivers to start up
+	_calibration_t_first = _calibration_t_first == 0 ? time_now_us : _calibration_t_first;
+
+	if (time_now_us - _calibration_t_first > 1_s) {
+		_relative_calibration_done = true;
+		const float pressure_primary = _data_sum[_selected_sensor_sub_index] / _data_sum_count[_selected_sensor_sub_index];
+
+		for (int instance = 0; instance < MAX_SENSOR_COUNT; ++instance) {
+
+			if (instance != _selected_sensor_sub_index
+			    && _calibration[instance].device_id() != 0
+			    && _data_sum_count[instance] > 0) {
+				const float pressure_secondary = _data_sum[instance] / _data_sum_count[instance];
+				const float new_offset = pressure_secondary - pressure_primary + _calibration[instance].offset();
+				_calibration[instance].set_offset(new_offset);
+				_calibration[instance].ParametersSave(instance);
+				param_notify_changes();
+				ParametersUpdate(true);
+			}
+		}
+	}
 }
 
 void VehicleAirData::CheckFailover(const hrt_abstime &time_now_us)

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -252,7 +252,7 @@ void VehicleAirData::Run()
 	}
 
 	if (!_relative_calibration_done) {
-		UpdateRelativeCalibrations(time_now_us);
+		_relative_calibration_done = UpdateRelativeCalibrations(time_now_us);
 	}
 
 	// Publish
@@ -323,13 +323,14 @@ void VehicleAirData::Run()
 	perf_end(_cycle_perf);
 }
 
-void VehicleAirData::UpdateRelativeCalibrations(const hrt_abstime time_now_us)
+bool VehicleAirData::UpdateRelativeCalibrations(const hrt_abstime time_now_us)
 {
 	// delay calibration to allow all drivers to start up
-	_calibration_t_first = _calibration_t_first == 0 ? time_now_us : _calibration_t_first;
+	if (_calibration_t_first == 0) {
+		_calibration_t_first = time_now_us;
+	}
 
 	if (time_now_us - _calibration_t_first > 1_s) {
-		_relative_calibration_done = true;
 		const float pressure_primary = _data_sum[_selected_sensor_sub_index] / _data_sum_count[_selected_sensor_sub_index];
 
 		for (int instance = 0; instance < MAX_SENSOR_COUNT; ++instance) {
@@ -342,10 +343,13 @@ void VehicleAirData::UpdateRelativeCalibrations(const hrt_abstime time_now_us)
 				_calibration[instance].set_offset(new_offset);
 				_calibration[instance].ParametersSave(instance);
 				param_notify_changes();
-				ParametersUpdate(true);
 			}
 		}
+
+		return true;
 	}
+
+	return false;
 }
 
 void VehicleAirData::CheckFailover(const hrt_abstime &time_now_us)

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -79,6 +79,7 @@ private:
 	void CheckFailover(const hrt_abstime &time_now_us);
 	bool ParametersUpdate(bool force = false);
 	void UpdateStatus();
+	void UpdateRelativeCalibrations(hrt_abstime time_now_us);
 
 	static constexpr int MAX_SENSOR_COUNT = 4;
 
@@ -127,6 +128,9 @@ private:
 	float _air_temperature_celsius{20.f}; // initialize with typical 20degC ambient temperature
 
 	bool _last_status_baro_fault{false};
+
+	bool _relative_calibration_done{false};
+	uint64_t _calibration_t_first{0};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::SENS_BARO_QNH>) _param_sens_baro_qnh,

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -79,7 +79,7 @@ private:
 	void CheckFailover(const hrt_abstime &time_now_us);
 	bool ParametersUpdate(bool force = false);
 	void UpdateStatus();
-	void UpdateRelativeCalibrations(hrt_abstime time_now_us);
+	bool UpdateRelativeCalibrations(hrt_abstime time_now_us);
 
 	static constexpr int MAX_SENSOR_COUNT = 4;
 


### PR DESCRIPTION
### Solved Problem & Solution
Splitting up this https://github.com/PX4/PX4-Autopilot/pull/24220 into two parts.
The global calibration will get added within a different PR since we had some discussions about it's requirements and implementation.

This fix adds a calibration procedure for handling relative offsets between multiple baros, avoiding vertical position jumps when one switches between baros mid-flight.
The offset is now stored in the offset parameter since it's static and not a changing bias.
I checked various flight logs with durations of more than 3000s and could not observe non systematic drifts between baros. Therefore frequent recalibration does not make any sense.

### Changelog Entry
`Always trigger automatic relative barometer calibration 1s after startup`

### Test coverage
Tested on hardware.