### PR TITLE
Mag cal: automatically disable internal mags if external ones are available

### DIFF
--- a/src/lib/sensor_calibration/Magnetometer.hpp
+++ b/src/lib/sensor_calibration/Magnetometer.hpp
@@ -85,6 +85,7 @@ public:
 	int8_t calibration_index() const { return _calibration_index; }
 	uint32_t device_id() const { return _device_id; }
 	bool enabled() const { return (_priority > 0); }
+	void disable() { _priority = 0; }
 	bool external() const { return _external; }
 	const matrix::Vector3f &offset() const { return _offset; }
 	const int32_t &priority() const { return _priority; }

--- a/src/modules/commander/HealthAndArmingChecks/checks/magnetometerCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/magnetometerCheck.cpp
@@ -47,9 +47,6 @@ void MagnetometerChecks::checkAndReport(const Context &context, Report &reporter
 	int num_enabled_and_valid_calibration = 0;
 
 	for (int instance = 0; instance < _sensor_mag_sub.size(); instance++) {
-		bool is_mag_fault = false;
-		const bool is_required = instance == 0 || isMagRequired(instance, is_mag_fault);
-
 		const bool exists = _sensor_mag_sub[instance].advertised();
 		bool is_valid = false;
 		bool is_calibration_valid = false;
@@ -80,7 +77,9 @@ void MagnetometerChecks::checkAndReport(const Context &context, Report &reporter
 		}
 
 		// Do not raise errors if a mag is not required
-		if (!is_required) {
+		bool is_mag_fault = false;
+
+		if (!isMagRequired(instance, is_mag_fault)) {
 			continue;
 		}
 

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -209,6 +209,19 @@ void VehicleMagnetometer::UpdateMagBiasEstimate()
 		if (_magnetometer_bias_estimate_sub.copy(&mag_bias_est)) {
 			bool parameters_notify = false;
 
+			bool external_mag_available = false;
+
+			for (unsigned mag_index = 0; mag_index < MAX_SENSOR_COUNT; mag_index++) {
+				if (_calibration[mag_index].external()
+				    && _calibration[mag_index].enabled()
+				    && mag_bias_est.valid[mag_index]
+				    && mag_bias_est.stable[mag_index]) {
+
+					external_mag_available = true;
+					break;
+				}
+			}
+
 			for (int mag_index = 0; mag_index < MAX_SENSOR_COUNT; mag_index++) {
 				if (mag_bias_est.valid[mag_index] && (mag_bias_est.timestamp > _last_calibration_update)) {
 
@@ -228,6 +241,11 @@ void VehicleMagnetometer::UpdateMagBiasEstimate()
 						const Vector3f offset = _calibration[mag_index].BiasCorrectedSensorOffset(_calibration_estimator_bias[mag_index]);
 
 						if (_calibration[mag_index].set_offset(offset)) {
+							if (external_mag_available && !_calibration[mag_index].external()) {
+								// automatically disable the internal mags as they should not be used for navigation
+								_calibration[mag_index].disable();
+							}
+
 							// save parameters with preferred calibration slot to current sensor index
 							_calibration[mag_index].ParametersSave(mag_index);
 


### PR DESCRIPTION

### Solved Problem
Magnetometers inside the autopilot are almost always highly affected by varying magnetic fields generated by the drone due to their location inside the drone.
The internal mag is useful for initial autopilot bench testing, before it gets integrated inside a drone, and when performing the calibration of the external one to automatically detect the rotation parameter. However, it then only causes issues as it often triggers false warnings (mag inconsistency) and in case of an in-air failure of the external mag, a fallback to the internal mag can lead to worse performance than not using a mag at all. 

### Solution
Automatically disable all internal mags just after calibration if an external one is available.

### Changelog Entry
For release notes:
```
New parameter: -
Documentation: todo
```

### Test coverage
Bench tested