### PR TITLE
Commander: Never clear link loss failsafe automatically, also not when action is Hold

### DIFF
--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -51,6 +51,7 @@ FailsafeBase::ActionOptions Failsafe::fromNavDllOrRclActParam(int param_value)
 
 	case gcs_connection_loss_failsafe_mode::Hold_mode:
 		options.action = Action::Hold;
+		options.clear_condition = ClearCondition::OnModeChangeOrDisarm;
 		break;
 
 	case gcs_connection_loss_failsafe_mode::Return_mode:


### PR DESCRIPTION

### Solved Problem
When `NAV_DLL_ACT` or `NAV_RCL_ACT` is set to "Hold" and the link is re-gained after losing it, it will currently automatically switch back to the previous mode (e.g. Manual Position mode). If the user isn't aware of that it can easily result in a crash. 

### Solution
Like we already do for the other actions options (RTL, Land), stay in that mode if the link loss failsafe gets cleared, until the user actively takes over again.


### Changelog Entry
For release notes:
```
Improvement:  Never clear link loss failsafe automatically, also not when action is Hold. Require user input to go back to original mode.
```

### Test coverage
SITL tested. 

