### PR TITLE
[IST8310] Probe all I2C addresses on startup

### DIFF
--- a/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
+++ b/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
@@ -85,31 +85,31 @@ void IST8310::print_status()
 
 int IST8310::probe()
 {
-	uint8_t id = RegisterRead(Register::WAI);
+	// Reading the WAI register is not always reliable, it can return 0xff or
+	// other values if the sensor has been powered up in a certain way. In
+	// addition, the I2C address is not always correct, sometimes it boots with
+	// 0x0C rather than 0x0E.
+	const auto start_time = hrt_absolute_time();
 
-	if (id != Device_ID) {
-		DEVICE_DEBUG("unexpected WAI 0x%02x", id);
+	while (hrt_elapsed_time(&start_time) < 50_ms) {
+		set_device_address(I2C_ADDRESS_DEFAULT);
+		const int WAI = RegisterRead(Register::WAI);
 
-		// Apparently, the IST8310's WHOAMI register is writeable. Presumably,
-		// this can get corrupted by bus noise. It is only reset if powered off
-		// for 30s or by a reset.
-		RegisterWrite(Register::CNTL2, CNTL2_BIT::SRST);
-
-		auto start_time = hrt_absolute_time();
-
-		while (hrt_elapsed_time(&start_time) < 50_ms) {
-			px4_usleep(10'000);
-			id = RegisterRead(Register::WAI);
-
-			if (id == Device_ID) {
-				return PX4_OK;
-			}
+		if (WAI == Device_ID) {
+			// Device has the right I2C address and register content
+			return PX4_OK;
 		}
 
-		return PX4_ERROR;
+		// send reset command to all four possible addresses
+		for (uint8_t addr = 0x0C; addr <= 0x0F; addr++) {
+			set_device_address(addr);
+			RegisterWrite(Register::CNTL2, CNTL2_BIT::SRST);
+		}
+
+		px4_usleep(10'000);
 	}
 
-	return PX4_OK;
+	return PX4_ERROR;
 }
 
 void IST8310::RunImpl()
@@ -290,11 +290,14 @@ bool IST8310::RegisterCheck(const register_config_t &reg_cfg)
 	return success;
 }
 
-uint8_t IST8310::RegisterRead(Register reg)
+int IST8310::RegisterRead(Register reg)
 {
 	const uint8_t cmd = static_cast<uint8_t>(reg);
 	uint8_t buffer{};
-	transfer(&cmd, 1, &buffer, 1);
+	const int ret = transfer(&cmd, 1, &buffer, 1);
+
+	if (ret != OK) { return -1; }
+
 	return buffer;
 }
 

--- a/src/drivers/magnetometer/isentek/ist8310/IST8310.hpp
+++ b/src/drivers/magnetometer/isentek/ist8310/IST8310.hpp
@@ -79,7 +79,7 @@ private:
 
 	bool RegisterCheck(const register_config_t &reg_cfg);
 
-	uint8_t RegisterRead(Register reg);
+	int RegisterRead(Register reg);
 	void RegisterWrite(Register reg, uint8_t value);
 	void RegisterSetAndClearBits(Register reg, uint8_t setbits, uint8_t clearbits);
 


### PR DESCRIPTION
Reading the WAI register is unreliable as the chip sometimes returns wrong values but functions otherwise correctly. In addition, the chip may not have read the chip select pins correctly and responds to 0x0C instead of 0x0E. These problems go away after a software reset.

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

IST8310 sensor inside the CUAV IST8 external compass would sometimes not be detected properly. 

### Solution

In these cases the sensor had an I2C address of 0x0C, thus the software reset of 0x0E doesn't work.
Sending the reset command to all possible I2C addresses works in any case.

### Alternatives

Not really.

### Test coverage

- [x] Tested in hardware on upstream on a F9P GPS
- [x] Tested in hardware on older private fork

### Context

Our suspicion is that the sensor powers up incorrectly through the pullup resistors of the I2C lines, which are powered for ~1s before the 5V rail is switched on. This might have caused the I2C address selection pins to be misread as both GND (0x0C) instead of 0x0E. Weird.

<img width="971" src="https://github.com/user-attachments/assets/589fb60f-6797-445a-aa8d-62c8ee5231e8" />
