### PR TITLE
tools: px_uploader.py: ardupilot compatibility

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -708,7 +708,7 @@ class uploader:
                 # https://github.com/PX4/Firmware/blob/master/src/drivers/boards/common/stm32/board_mcu_version.c#L125-L144
 
                 if self.fw_maxsize > fw.property('image_maxsize') and not force:
-                    raise RuntimeError(f"Board can accept larger flash images ({self.fw_maxsize} bytes) than board config ({fw.property('image_maxsize')} bytes). Please use the correct board configuration to avoid lacking critical functionality.")
+                    print(f"WARNING: Board can accept larger flash images ({self.fw_maxsize} bytes) than board config ({fw.property('image_maxsize')} bytes)")
         else:
             # If we're still on bootloader v4 on a Pixhawk, we don't know if we
             # have the silicon errata and therefore need to flash px4_fmu-v2


### PR DESCRIPTION
This fixes an issue with flashing Ardupilot binaries for targets that use flash based params.

**Problem**
Ardupilot always uses 2 sectors for flash based params. PX4 only uses 1 sector. This means that in Ardupilot binaries the `image_maxsize` property will always be 128k smaller than the property in the PX4 binary.

**Alternate solutions**
I could instead use the `--force` flag, but that skips over the board type check as well which is not desirable. 