### PR TITLE
ci: fix dev container builds

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -96,6 +96,6 @@ jobs:
           platforms: |
             linux/amd64
           provenance: mode=max
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
           cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max


### PR DESCRIPTION
We are currently pushing a container build on every pull request commit, this is causing our API token to reach its limit very easily daily, and as a result we now have failures on CI actions.

This PR changes the behavior from pushing every commit on PR, to only when we push to main. Hopefully this eases the burden on the API token.