### PR TITLE
ARK Cannodes disable mag bias estimator by default

### DIFF
--- a/boards/ark/can-gps/init/rc.board_defaults
+++ b/boards/ark/can-gps/init/rc.board_defaults
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------
 
 param set-default CBRK_IO_SAFETY 0
-param set-default MBE_ENABLE 1
+param set-default MBE_ENABLE 0
 param set-default SENS_IMU_CLPNOTI 0
 
 safety_button start

--- a/boards/ark/can-rtk-gps/init/rc.board_defaults
+++ b/boards/ark/can-rtk-gps/init/rc.board_defaults
@@ -7,7 +7,7 @@ param set-default CBRK_IO_SAFETY 0
 param set-default CANNODE_SUB_MBD 1
 param set-default CANNODE_SUB_RTCM 1
 param set-default GPS_1_GNSS 63
-param set-default MBE_ENABLE 1
+param set-default MBE_ENABLE 0
 param set-default SENS_IMU_CLPNOTI 0
 
 safety_button start

--- a/boards/ark/cannode/init/rc.board_defaults
+++ b/boards/ark/cannode/init/rc.board_defaults
@@ -3,6 +3,7 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
+param set-default MBE_ENABLE 0
 param set-default SENS_IMU_CLPNOTI 0
 
 pwm_out start

--- a/boards/ark/septentrio-gps/init/rc.board_defaults
+++ b/boards/ark/septentrio-gps/init/rc.board_defaults
@@ -6,7 +6,7 @@
 param set-default CBRK_IO_SAFETY 0
 param set-default CANNODE_SUB_MBD 1
 param set-default CANNODE_SUB_RTCM 1
-param set-default MBE_ENABLE 1
+param set-default MBE_ENABLE 0
 param set-default SENS_IMU_CLPNOTI 0
 
 safety_button start

--- a/boards/ark/teseo-gps/init/rc.board_defaults
+++ b/boards/ark/teseo-gps/init/rc.board_defaults
@@ -6,7 +6,7 @@
 param set-default CBRK_IO_SAFETY 0
 param set-default CANNODE_SUB_MBD 1
 param set-default CANNODE_SUB_RTCM 1
-param set-default MBE_ENABLE 1
+param set-default MBE_ENABLE 0
 param set-default SENS_IMU_CLPNOTI 0
 
 tone_alarm start


### PR DESCRIPTION
We have been seeing some strange mag calibration results on cannode GPS recently. It looks to be caused or made worse by the mag bias estimator.