### PR TITLE
reset dist_to_ground_lock if dist_to_bottom is not valid

### DIFF
--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -129,6 +129,7 @@ void FlightTaskManualAltitude::_updateAltitudeLock()
 
 				} else {
 					_position_setpoint(2) = _position(2);
+					_dist_to_ground_lock = NAN;
 				}
 			}
 


### PR DESCRIPTION
### Solved Problem
The multicopter flies in position mode, after the user gives throttle down input, the drone flew back up to the previous position without any input!
![Screenshot from 2025-02-12 15-59-15](https://github.com/user-attachments/assets/43d12470-e47d-424e-8ca3-93ead3d98a22)

The issue is within the terrain_hold feature where the drone tries to hold its vertical position in respect to the `dist_to_bottom`. The `dist_to_ground_lock` gets set while the `dist_to_bottom` is still valid. Now the interesting thing happens. The `dist_to_bottom` gets invald, the user applies throttle input. After releasing the throttle the multicopter still has not stopped yet (still slowing down), therefore no new reference distance (`dist_to_ground_lock`) was set. Now the `dist_to_bottom` gets valid again and the `position_setpoint` gets reset to the `dist_to_ground_lock` which is out of date.

### Solution
Always `dist_to_ground_lock` when the dist_to_bottom gets invalid.

### Changelog Entry
`in FlightTaskManualAltitude: reset dist_to_ground_lock if dist_to_bottom is not valid`

### Test coverage
The issue is really difficult to reproduce since its really edge-case, also in sim. I need to do some test flights to ensure it does not break anything else.