### PR TITLE
Robustify Ulanding Radar

### DIFF
--- a/src/drivers/distance_sensor/ulanding_radar/AerotennaULanding.cpp
+++ b/src/drivers/distance_sensor/ulanding_radar/AerotennaULanding.cpp
@@ -125,10 +125,15 @@ int AerotennaULanding::collect()
 
 			index--;
 		}
+
+	} else {
+		return -EAGAIN;
 	}
 
 	if (!checksum_passed) {
-		return -EAGAIN;
+		perf_count(_comms_errors);
+		perf_end(_sample_perf);
+		return -EBADMSG;
 	}
 
 	_px4_rangefinder.update(timestamp_sample, distance_m);

--- a/src/drivers/distance_sensor/ulanding_radar/AerotennaULanding.hpp
+++ b/src/drivers/distance_sensor/ulanding_radar/AerotennaULanding.hpp
@@ -56,7 +56,7 @@
 
 using namespace time_literals;
 
-#define ULANDING_MEASURE_INTERVAL       10_ms
+#define ULANDING_MEASURE_INTERVAL       12_ms
 #define ULANDING_MAX_DISTANCE	        50.0f
 #define ULANDING_MIN_DISTANCE	        0.315f
 #define ULANDING_VERSION	        1


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

We measured 50%-100% message drop, which could lead to repeated timeouts.
The issue was that the driver is written with the assumption that the entire message is received.
However the sensor sends a message every 10ms and when the driver samples every 10ms, only parts of the message will be received.

### Solution

This workaround fixes this by setting the sample rate to 12ms, since 11ms still had single digit message drops.

### Alternatives

The driver would have to be rewritten as a proper state machine to find the full message. For now this fix is sufficient.

### Test coverage

- Tested in hardware

### Context

The sensor does not perform byte stuffing, thus the header must be searched together with the CRC.
