### PR TITLE
Don't allow spacecraft module parameters for VOXL 2 builds

### DIFF
--- a/src/lib/parameters/CMakeLists.txt
+++ b/src/lib/parameters/CMakeLists.txt
@@ -62,6 +62,10 @@ if(DISABLE_PARAMS_MODULE_SCOPING)
 		# allow those timer configurations to be skipped.
 		if ((${PX4_BOARD_NAME} MATCHES "MODALAI_VOXL2") AND (file_path MATCHES pwm_out))
 			message(STATUS "Skipping pwm file path ${file_path} for VOXL2")
+		# Spacecraft has duplicate parameter names which kills the VOXL 2 build. VOXL 2 does not
+		# support the spacecraft module so we skip adding the parameters.
+		elseif ((${PX4_BOARD_NAME} MATCHES "MODALAI_VOXL2") AND (file_path MATCHES spacecraft))
+			message(STATUS "Skipping spacecraft file path ${file_path} for VOXL2")
 		else()
 			list(APPEND module_config_files "${file_path}")
 		endif()


### PR DESCRIPTION
VOXL 2 builds use DISABLE_PARAMS_MODULE_SCOPING for parameters. The new spacecraft module has duplicate symbols with the control_allocator module and so this kills the VOXL 2 build. This PR simply disallows the spacecraft parameters for VOXL 2 to fix the build. This means that VOXL 2 cannot use the spacecraft module until the underlying issue is addressed.