### PR TITLE
msg: fix comments in SensorOpticalFlow and VehicleOpticalFlow

### DIFF
--- a/msg/SensorOpticalFlow.msg
+++ b/msg/SensorOpticalFlow.msg
@@ -3,9 +3,9 @@ uint64 timestamp_sample
 
 uint32 device_id               # unique device ID for the sensor that does not change between power cycles
 
-float32[2] pixel_flow          # (radians) optical flow in radians where a positive value is produced by a RH rotation about the body axis
+float32[2] pixel_flow          # (radians) optical flow in radians where a negative value is produced by a RH rotation about the body axis
 
-float32[3] delta_angle         # (radians) accumulated gyro radians where a positive value is produced by a RH rotation about the body axis. Set to NaN if flow sensor does not have 3-axis gyro data.
+float32[3] delta_angle         # (radians) accumulated gyro radians where a negative value is produced by a RH rotation about the body axis. Set to NaN if flow sensor does not have 3-axis gyro data.
 bool delta_angle_available
 
 float32 distance_m             # (meters) Distance to the center of the flow field

--- a/msg/VehicleOpticalFlow.msg
+++ b/msg/VehicleOpticalFlow.msg
@@ -5,9 +5,9 @@ uint64 timestamp_sample
 
 uint32 device_id               # unique device ID for the sensor that does not change between power cycles
 
-float32[2] pixel_flow          # (radians) accumulated optical flow in radians where a positive value is produced by a RH rotation about the body axis
+float32[2] pixel_flow          # (radians) accumulated optical flow in radians where a negative value is produced by a RH rotation about the body axis
 
-float32[3] delta_angle         # (radians) accumulated gyro radians where a positive value is produced by a RH rotation about the body axis. (NAN if unavailable)
+float32[3] delta_angle         # (radians) accumulated gyro radians where a negative value is produced by a RH rotation about the body axis. (NAN if unavailable)
 
 float32 distance_m             # (meters) Distance to the center of the flow field (NAN if unavailable)
 


### PR DESCRIPTION
The EKF uses this convention but the raw sensor input data uses the opposite convention.

See comments in code about this

sensors
https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp#L291-L292
ekf2
https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/ekf2/EKF2.cpp#L2342-L2343
