### PR TITLE
uavcannode rangefinder: too far or too close, less than or greater than, not equal to

### DIFF
--- a/src/drivers/uavcannode/Publishers/RangeSensorMeasurement.hpp
+++ b/src/drivers/uavcannode/Publishers/RangeSensorMeasurement.hpp
@@ -100,10 +100,10 @@ public:
 			}
 
 			// reading_type
-			if (dist.current_distance >= dist.max_distance) {
+			if (dist.current_distance > dist.max_distance) {
 				range_sensor.reading_type = uavcan::equipment::range_sensor::Measurement::READING_TYPE_TOO_FAR;
 
-			} else if (dist.current_distance <= dist.min_distance) {
+			} else if (dist.current_distance < dist.min_distance) {
 				range_sensor.reading_type = uavcan::equipment::range_sensor::Measurement::READING_TYPE_TOO_CLOSE;
 
 			} else if (dist.signal_quality != 0) {


### PR DESCRIPTION
Publishing reading too close will cause Ardupilot to deploy landing gear. The AFBR min range is set to 0. In the current case, publishing 0 range, even with a 0 quality, will cause the reading too close to be published. This should publish an undefined reading instead of too close. 