### PR TITLE
control_allocator: param update avoid temporary

### DIFF
--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessControlSurfaces.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessControlSurfaces.cpp
@@ -69,14 +69,10 @@ void ActuatorEffectivenessControlSurfaces::updateParams()
 {
 	ModuleParams::updateParams();
 
-	int32_t count = 0;
-
-	if (param_get(_count_handle, &count) != 0) {
+	if (param_get(_count_handle, &_count) != PX4_OK) {
 		PX4_ERR("param_get failed");
 		return;
 	}
-
-	_count = count;
 
 	for (int i = 0; i < _count; i++) {
 		param_get(_param_handles[i].type, (int32_t *)&_params[i].type);

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessControlSurfaces.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessControlSurfaces.hpp
@@ -107,7 +107,7 @@ private:
 	param_t _count_handle;
 
 	Params _params[MAX_COUNT] {};
-	int _count{0};
+	int32_t _count{0};
 
 	SlewRate<float> _flaps_setpoint_with_slewrate;
 	SlewRate<float> _spoilers_setpoint_with_slewrate;

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
@@ -73,14 +73,13 @@ void ActuatorEffectivenessHelicopter::updateParams()
 {
 	ModuleParams::updateParams();
 
-	int32_t count = 0;
-
-	if (param_get(_param_handles.num_swash_plate_servos, &count) != 0) {
+	if (param_get(_param_handles.num_swash_plate_servos, &_geometry.num_swash_plate_servos) != PX4_OK) {
 		PX4_ERR("param_get failed");
 		return;
 	}
 
-	_geometry.num_swash_plate_servos = math::constrain((int)count, 3, NUM_SWASH_PLATE_SERVOS_MAX);
+	_geometry.num_swash_plate_servos = math::constrain(_geometry.num_swash_plate_servos,
+					   (int32_t)3, (int32_t)NUM_SWASH_PLATE_SERVOS_MAX);
 
 	for (int i = 0; i < _geometry.num_swash_plate_servos; ++i) {
 		float angle_deg{};

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopter.hpp
@@ -58,7 +58,7 @@ public:
 
 	struct Geometry {
 		SwashPlateGeometry swash_plate_servos[NUM_SWASH_PLATE_SERVOS_MAX];
-		int num_swash_plate_servos{0};
+		int32_t num_swash_plate_servos{0};
 		float throttle_curve[NUM_CURVE_POINTS];
 		float pitch_curve[NUM_CURVE_POINTS];
 		float yaw_collective_pitch_scale;

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopterCoaxial.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopterCoaxial.cpp
@@ -60,14 +60,13 @@ void ActuatorEffectivenessHelicopterCoaxial::updateParams()
 {
 	ModuleParams::updateParams();
 
-	int32_t count = 0;
-
-	if (param_get(_param_handles.num_swash_plate_servos, &count) != 0) {
+	if (param_get(_param_handles.num_swash_plate_servos, &_geometry.num_swash_plate_servos) != PX4_OK) {
 		PX4_ERR("param_get failed");
 		return;
 	}
 
-	_geometry.num_swash_plate_servos = math::constrain((int)count, 2, NUM_SWASH_PLATE_SERVOS_MAX);
+	_geometry.num_swash_plate_servos = math::constrain(_geometry.num_swash_plate_servos,
+					   (int32_t)2, (int32_t)NUM_SWASH_PLATE_SERVOS_MAX);
 
 	for (int i = 0; i < _geometry.num_swash_plate_servos; ++i) {
 		float angle_deg{};

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopterCoaxial.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessHelicopterCoaxial.hpp
@@ -55,7 +55,7 @@ public:
 
 	struct Geometry {
 		SwashPlateGeometry swash_plate_servos[NUM_SWASH_PLATE_SERVOS_MAX];
-		int num_swash_plate_servos{0};
+		int32_t num_swash_plate_servos{0};
 		float spoolup_time;
 	};
 


### PR DESCRIPTION
 - this is a harmless workaround for a GCC warning (-Wdangling-pointer) false positive


![image](https://github.com/user-attachments/assets/f1193a95-99b9-49b4-a0ed-096cfb995b7f)
