### PR TITLE
Commander: fix parachute trigger

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1889,8 +1889,7 @@ void Commander::run()
 		_actuator_armed.armed = isArmed();
 		_actuator_armed.prearmed = getPrearmState();
 		_actuator_armed.ready_to_arm = _vehicle_status.pre_flight_checks_pass || isArmed();
-		_actuator_armed.lockdown = ((_vehicle_status.nav_state == _vehicle_status.NAVIGATION_STATE_TERMINATION)
-					    || (_vehicle_status.hil_state == vehicle_status_s::HIL_STATE_ON)
+		_actuator_armed.lockdown = ((_vehicle_status.hil_state == vehicle_status_s::HIL_STATE_ON)
 					    || _multicopter_throw_launch.isThrowLaunchInProgress());
 		// _actuator_armed.manual_lockdown // action_request_s::ACTION_KILL
 		_actuator_armed.force_failsafe = (_vehicle_status.nav_state == _vehicle_status.NAVIGATION_STATE_TERMINATION);


### PR DESCRIPTION
### Solved Problem
Setting `lockdown` disables the actuators. In this mode, `force_failsafe` has no effect as the actuators are disabled, so the parachute is not getting released as it requires the output to change to its failsafe value.

### Solution
Only set the `force_failsafe` (not `lockdown`) flag when in flight termination

### Alternatives
We could change the priority in https://github.com/PX4/PX4-Autopilot/blob/01549a58326c47cf562dc190f7fa6eaf966516cc/src/lib/mixer_module/mixer_module.cpp#L477-L489 but I feel that this could be dangerous in HIL mode where switching to flight termination could trigger a physical parachute.

### Test coverage
Tested on a Pixhawk4 with parachute configured on channel 4 with a failsafe value of 1234. The autopilot is then armed and tilted by 90 degrees to trigger the attitude failure detection.
main:
```
 actuator_armed
    timestamp: 32799326 (0.023821 seconds ago)
    armed: True
    prearmed: False
    ready_to_arm: True
    lockdown: True
    manual_lockdown: False
    force_failsafe: True
    in_esc_calibration_mode: False

nsh> pwm_out status
pwm_out: cycle: 25464 events, 692035us elapsed, 27.18us avg, min 24us max 54us 2.561us rms
pwm_out: interval: 25464 events, 1472.62us avg, min 1131us max 50061us 3298.229us rms
INFO  [mixer_module] Param prefix: PWM_AUX
control latency: 25464 events, 353165400us elapsed, 13869.20us avg, min 291us max 5852269us 230088.969us rms
INFO  [mixer_module] Switched to rate_ctrl work queue
Channel Configuration:
Channel 0: func: 101, value: 1000, failsafe: 1000, disarmed: 1000, min: 1100, max: 1900
Channel 1: func: 102, value: 1000, failsafe: 1000, disarmed: 1000, min: 1100, max: 1900
Channel 2: func: 103, value: 1000, failsafe: 1000, disarmed: 1000, min: 1100, max: 1900
Channel 3: func: 104, value: 1000, failsafe: 1000, disarmed: 1000, min: 1100, max: 1900
Channel 4: func: 401, value: **1000**, failsafe: **1234**, disarmed: 1000, min: 1000, max: 2000 <====
```

This PR:
```
nsh> pwm_out status
pwm_out: cycle: 25464 events, 692035us elapsed, 27.18us avg, min 24us max 54us 2.561us rms
pwm_out: interval: 25464 events, 1472.62us avg, min 1131us max 50061us 3298.229us rms
INFO  [mixer_module] Param prefix: PWM_AUX
control latency: 25464 events, 353165400us elapsed, 13869.20us avg, min 291us max 5852269us 230088.969us rms
INFO  [mixer_module] Switched to rate_ctrl work queue
Channel Configuration:
Channel 0: func: 101, value: 1000, failsafe: 1000, disarmed: 1000, min: 1100, max: 1900
Channel 1: func: 102, value: 1000, failsafe: 1000, disarmed: 1000, min: 1100, max: 1900
Channel 2: func: 103, value: 1000, failsafe: 1000, disarmed: 1000, min: 1100, max: 1900
Channel 3: func: 104, value: 1000, failsafe: 1000, disarmed: 1000, min: 1100, max: 1900
Channel 4: func: 401, value: **1234**, failsafe: **1234**, disarmed: 1000, min: 1000, max: 2000 <====

 ```