### PR TITLE
InternalCombustionEngineControl - doc corrections

### DIFF
--- a/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.cpp
+++ b/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.cpp
@@ -358,10 +358,6 @@ int InternalCombustionEngineControl::print_usage(const char *reason)
 		
 The module controls internal combustion engine (ICE) features including:
 ignition (on/off), throttle and choke level, starter engine delay, and user request.
-The module publishes [InternalCombustionEngineControl.msg](../msg_docs/InternalCombustionEngineControl.md).
-		
-The architecture is as shown below:
-![Architecture](../../assets/diagrams/ice_control_diagram.png)
 
 ### Enabling
 
@@ -374,15 +370,23 @@ CONFIG_DRIVERS_RPM_CAPTURE=y
 ```
 
 Additionally, to enable the module:
+
 - Set [ICE_EN](../advanced_config/parameter_reference.md#ICE_EN)
-to true and adjust the other module parameters ICE_ according to your needs.
+to true and adjust the other `ICE_` module parameters according to your needs.
 - Set [RPM_CAP_ENABLE](../advanced_config/parameter_reference.md#RPM_CAP_ENABLE) to true.
+
+The module outputs control signals for ignition, throttle, and choke,
+and takes inputs from an RPM sensor.
+These must be mapped to AUX outputs/inputs in the [Actuator configuration](../config/actuators.md),
+similar to the setup shown below.
+
+![Actuator setup for ICE](../../assets/hardware/ice/ice_actuator_setup.png)
 
 ### Implementation
 
 The ICE is implemented with a (4) state machine:
 
-![Architecture](../../assets/diagrams/ice_control_state_machine.png)
+![Architecture](../../assets/hardware/ice/ice_control_state_machine.png)
 
 The state machine:
 		
@@ -390,6 +394,12 @@ The state machine:
 - Allows for user inputs from:
   - AUX{N}
   - Arming state in [VehicleStatus.msg](../msg_docs/VehicleStatus.md)
+
+The module publishes [InternalCombustionEngineControl.msg](../msg_docs/InternalCombustionEngineControl.md).
+		
+The architecture is as shown below:
+
+![Architecture](../../assets/hardware/ice/ice_control_diagram.png)
 		
 <a id="internal_combustion_engine_control_usage"></a>
 )DESCR_STR");

--- a/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.cpp
+++ b/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.cpp
@@ -355,31 +355,42 @@ int InternalCombustionEngineControl::print_usage(const char *reason)
 	PRINT_MODULE_DESCRIPTION(
 		R"DESCR_STR(
 ### Description
+		
 The module controls internal combustion engine (ICE) features including:
-ignition (on/off),throttle and choke level, starter engine delay, and user request.
+ignition (on/off), throttle and choke level, starter engine delay, and user request.
 The module publishes [InternalCombustionEngineControl.msg](../msg_docs/InternalCombustionEngineControl.md).
-The architecture is as shown below.:
+		
+The architecture is as shown below:
 ![Architecture](../../assets/diagrams/ice_control_diagram.png)
 
 ### Enabling
+
 This feature is not enabled by default needs to be configured in the
 build target for your board together with the rpm capture driver:
+
+```
 CONFIG_MODULES_INTERNAL_COMBUSTION_ENGINE_CONTROL=y
 CONFIG_DRIVERS_RPM_CAPTURE=y
+```
 
 Additionally, to enable the module:
-- set [ICE_EN](https://docs.px4.io/main/en/advanced_config/parameter_reference.html#ICE_EN)
+- Set [ICE_EN](../advanced_config/parameter_reference.md#ICE_EN)
 to true and adjust the other module parameters ICE_ according to your needs.
-- set [RPM_CAP_ENABLE](https://docs.px4.io/main/en/advanced_config/parameter_reference.html#RPM_CAP_ENABLE) to true.
+- Set [RPM_CAP_ENABLE](../advanced_config/parameter_reference.md#RPM_CAP_ENABLE) to true.
 
 ### Implementation
+
 The ICE is implemented with a (4) state machine:
+
 ![Architecture](../../assets/diagrams/ice_control_state_machine.png)
+
 The state machine:
-- checks if [Rpm.msg](../msg_docs/Rpm.md) is updated to know if the engine is running
-- allows for user inputs from
-- AUX{N}
-- Arming state in [VehicleStatus.msg(../msg_docs/VehicleStatus.md)
+		
+- Checks if [Rpm.msg](../msg_docs/Rpm.md) is updated to know if the engine is running
+- Allows for user inputs from:
+  - AUX{N}
+  - Arming state in [VehicleStatus.msg](../msg_docs/VehicleStatus.md)
+		
 <a id="internal_combustion_engine_control_usage"></a>
 )DESCR_STR");
 


### PR DESCRIPTION
This follows on from #24055 proposing some docs corrections. Note that some of these might not be possible/might irritate the code formatter but they are "better markdown", and a few are necessary. I've added notes of explanation so we can work out where compromise is needed.

@Perrrewi I've also moved the images, and added the Actuator setup instructions, without which this is a little confusing. That information would _also_ appear in an ICE setup section. I moved the architecture down to the implementation section - most users don't need it.

Hope this all makes sense!
