### PR TITLE
[Sponsored by CubePilot] Params in flash erase fixes

### DIFF
--- a/src/lib/parameters/flashparams/flashfs32.c
+++ b/src/lib/parameters/flashparams/flashfs32.c
@@ -1128,6 +1128,11 @@ int parameter_flashfs_init(sector_descriptor_t *fconfig, uint8_t *buffer, uint16
 	if (pf == NULL) {
 		// Parameters can't be found, assume sector is corrupt or empty
 		rv = parameter_flashfs_erase();
+
+		// A positive return value means flash space has been erased successfully.
+		if (rv > 0) {
+			rv = 0;
+		}
 	}
 
 	return rv;


### PR DESCRIPTION
This fixes the initial sector erase on STM32H7 for params in flash.

The main bugfix is an off by one bug which prevents the last sector from being erased because a sanity check fails, see this line: https://github.com/PX4/NuttX/pull/329/files#diff-6255d0a0954ab8fb7180dd0dec85833fcbc76db90a92364f6a0a3b9cb3a7e4d1R376

This should fix issues we had seen with Kakute H7 (mini and v2) where a full erase was required to avoid random param issues.

Depends on https://github.com/PX4/NuttX/pull/329 to merged first.