### PR TITLE
PR: add optical flow arming check

### DIFF
--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -241,6 +241,19 @@ PARAM_DEFINE_INT32(SYS_HAS_NUM_ASPD, 0);
 PARAM_DEFINE_INT32(SYS_HAS_NUM_DIST, 0);
 
 /**
+ * Control if the vehicle has an optical flow sensor
+ *
+ * 0: Preflight checks will not check for the presence of an optical flow sensor.
+ * 1: Require the presence of an optical flow sensor for preflight check to pass.
+ *
+ * @group System
+ * @min 0
+ * @max 1
+ */
+
+PARAM_DEFINE_INT32(SYS_HAS_NUM_OF, 0);
+
+/**
  * Enable factory calibration mode
  *
  * If enabled, future sensor calibrations will be stored to /fs/mtd_caldata.

--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -241,10 +241,9 @@ PARAM_DEFINE_INT32(SYS_HAS_NUM_ASPD, 0);
 PARAM_DEFINE_INT32(SYS_HAS_NUM_DIST, 0);
 
 /**
- * Control if the vehicle has an optical flow sensor
+ * Number of optical flow sensors required to be available
  *
- * 0: Preflight checks will not check for the presence of an optical flow sensor.
- * 1: Require the presence of an optical flow sensor for preflight check to pass.
+ * The preflight check will fail if fewer than this number of optical flow sensors with valid data are present.
  *
  * @group System
  * @min 0

--- a/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
+++ b/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
@@ -42,6 +42,7 @@ px4_add_library(health_and_arming_checks
 	checks/batteryCheck.cpp
 	checks/cpuResourceCheck.cpp
 	checks/distanceSensorChecks.cpp
+	checks/opticalFlowCheck.cpp
 	checks/escCheck.cpp
 	checks/estimatorCheck.cpp
 	checks/failureDetectorCheck.cpp

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
@@ -46,6 +46,7 @@
 #include "checks/baroCheck.hpp"
 #include "checks/cpuResourceCheck.hpp"
 #include "checks/distanceSensorChecks.hpp"
+#include "checks/opticalFlowCheck.hpp"
 #include "checks/escCheck.hpp"
 #include "checks/estimatorCheck.hpp"
 #include "checks/failureDetectorCheck.hpp"
@@ -130,6 +131,7 @@ private:
 	BaroChecks _baro_checks;
 	CpuResourceChecks _cpu_resource_checks;
 	DistanceSensorChecks _distance_sensor_checks;
+	OpticalFlowCheck _optical_flow_check;
 	EscChecks _esc_checks;
 	EstimatorChecks _estimator_checks;
 	FailureDetectorChecks _failure_detector_checks;
@@ -169,6 +171,7 @@ private:
 		&_baro_checks,
 		&_cpu_resource_checks,
 		&_distance_sensor_checks,
+		&_optical_flow_check,
 		&_esc_checks,
 		&_estimator_checks,
 		&_failure_detector_checks,

--- a/src/modules/commander/HealthAndArmingChecks/checks/opticalFlowCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/opticalFlowCheck.cpp
@@ -1,0 +1,77 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "opticalFlowCheck.hpp"
+
+void OpticalFlowCheck::checkAndReport(const Context &context, Report &reporter)
+{
+	if (!_param_sys_has_num_of.get()) {
+		return;
+	}
+
+	const bool exists = _vehicle_optical_flow_sub.advertised();
+	bool valid = false;
+
+	if (exists) {
+		vehicle_optical_flow_s flow_sens;
+		valid = _vehicle_optical_flow_sub.copy(&flow_sens) && (hrt_elapsed_time(&flow_sens.timestamp) < 1_s);
+		reporter.setIsPresent(health_component_t::optical_flow);
+	}
+
+	if (!exists) {
+		/* EVENT
+		 * @description
+		 * <profile name="dev">
+		 * This check can be configured via <param>SYS_HAS_NUM_OF</param> parameter.
+		 * </profile>
+		 */
+		reporter.healthFailure(NavModes::All, health_component_t::optical_flow,
+				       events::ID("check_optical_sensor_missing"),
+				       events::Log::Error, "Optical flow sensor missing");
+
+		if (reporter.mavlink_log_pub()) {
+			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Optical Flow Sensor missing");
+		}
+
+	} else if (!valid) {
+		/* EVENT
+		 */
+		reporter.healthFailure(NavModes::All, health_component_t::optical_flow,
+				       events::ID("check_optical_flow_sensor_invalid"),
+				       events::Log::Error, "No valid data from optical flow sensor");
+
+		if (reporter.mavlink_log_pub()) {
+			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: no valid data from optical flow sensor");
+		}
+	}
+}

--- a/src/modules/commander/HealthAndArmingChecks/checks/opticalFlowCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/opticalFlowCheck.cpp
@@ -46,9 +46,16 @@ void OpticalFlowCheck::checkAndReport(const Context &context, Report &reporter)
 		vehicle_optical_flow_s flow_sens;
 		valid = _vehicle_optical_flow_sub.copy(&flow_sens) && (hrt_elapsed_time(&flow_sens.timestamp) < 1_s);
 		reporter.setIsPresent(health_component_t::optical_flow);
-	}
 
-	if (!exists) {
+		if (!valid) {
+			/* EVENT
+			 */
+			reporter.healthFailure(NavModes::All, health_component_t::optical_flow,
+					       events::ID("check_optical_flow_sensor_invalid"),
+					       events::Log::Error, "No valid data from optical flow sensor");
+		}
+
+	} else {
 		/* EVENT
 		 * @description
 		 * <profile name="dev">
@@ -58,12 +65,5 @@ void OpticalFlowCheck::checkAndReport(const Context &context, Report &reporter)
 		reporter.healthFailure(NavModes::All, health_component_t::optical_flow,
 				       events::ID("check_optical_sensor_missing"),
 				       events::Log::Error, "Optical flow sensor missing");
-
-	} else if (!valid) {
-		/* EVENT
-		 */
-		reporter.healthFailure(NavModes::All, health_component_t::optical_flow,
-				       events::ID("check_optical_flow_sensor_invalid"),
-				       events::Log::Error, "No valid data from optical flow sensor");
 	}
 }

--- a/src/modules/commander/HealthAndArmingChecks/checks/opticalFlowCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/opticalFlowCheck.cpp
@@ -59,19 +59,11 @@ void OpticalFlowCheck::checkAndReport(const Context &context, Report &reporter)
 				       events::ID("check_optical_sensor_missing"),
 				       events::Log::Error, "Optical flow sensor missing");
 
-		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Optical Flow Sensor missing");
-		}
-
 	} else if (!valid) {
 		/* EVENT
 		 */
 		reporter.healthFailure(NavModes::All, health_component_t::optical_flow,
 				       events::ID("check_optical_flow_sensor_invalid"),
 				       events::Log::Error, "No valid data from optical flow sensor");
-
-		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: no valid data from optical flow sensor");
-		}
 	}
 }

--- a/src/modules/commander/HealthAndArmingChecks/checks/opticalFlowCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/opticalFlowCheck.hpp
@@ -1,0 +1,55 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "../Common.hpp"
+
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/vehicle_optical_flow.h>
+
+class OpticalFlowCheck : public HealthAndArmingCheckBase
+{
+public:
+	OpticalFlowCheck() = default;
+	~OpticalFlowCheck() = default;
+
+	void checkAndReport(const Context &context, Report &reporter) override;
+
+private:
+	uORB::Subscription _vehicle_optical_flow_sub{ORB_ID::vehicle_optical_flow};
+
+	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
+					(ParamInt<px4::params::SYS_HAS_NUM_OF>) _param_sys_has_num_of
+				       )
+};


### PR DESCRIPTION


### Solved Problem & Solution
Currently an arming check for the optical flow sensor does not exist and I now added it. One can specify if the check should be included with the `SYS_HAS_NUM_OF` parameter. I already named it `SYS_HAS_NUM_OF` instead of `SYS_HAS_OF` to make the param future proof for having multiple OF-sensors at some point.

### Changelog Entry
For release notes:
```
New parameter: SYS_HAS_NUM_OF ; New sensor requirement check for OF-sensor.
```

### Test coverage
tested on hardware
