### PR TITLE
cmake: update python detection to FindPython3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,13 +173,15 @@ set(config_module_list)
 set(config_kernel_list)
 
 # Find Python
-find_package(PythonInterp 3)
+find_package(Python3)
 # We have a custom error message to tell users how to install python3.
-if(NOT PYTHONINTERP_FOUND)
+if(NOT Python3_FOUND)
 	message(FATAL_ERROR "Python 3 not found. Please install Python 3:\n"
 		"    Ubuntu: sudo apt install python3 python3-dev python3-pip\n"
 		"    macOS: brew install python")
 endif()
+
+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 
 option(PYTHON_COVERAGE "Python code coverage" OFF)
 if(PYTHON_COVERAGE)

--- a/src/drivers/uavcan/libdronecan/libuavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/libdronecan/libuavcan/CMakeLists.txt
@@ -21,7 +21,7 @@ endif ()
 
 project(libuavcan)
 
-find_package(PythonInterp)
+find_package(Python3 REQUIRED)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(COMPILER_IS_GCC_COMPATIBLE 1)


### PR DESCRIPTION
fixes this deprecation warning
```
CMake Warning (dev) at CMakeLists.txt:176 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

This warning is for project developers.  Use -Wno-dev to suppress it.
```