### PR TITLE
add write permissions for flash_analysis workflow

### DIFF
--- a/.github/workflows/flash_analysis.yml
+++ b/.github/workflows/flash_analysis.yml
@@ -1,5 +1,9 @@
 name: FLASH usage analysis
 
+permissions:
+  pull-requests: write
+  issues: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
The `flash_analysis` workflow does not work with PRs from forks. I think this will fix it. Can't be sure until it's tested though.

@ramon can you merge this and then I can re-trigger a currently failing PR to see if it passes?
