### PR TITLE
ci: flash_analysis: work with PRs from forks

### DIFF
--- a/.github/workflows/flash_analysis.yml
+++ b/.github/workflows/flash_analysis.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - 'main'
-  pull_request:
+  pull_request_target:
     branches:
       - '*'
 


### PR DESCRIPTION
Fixes an issue with the flash_analysis workflow which would fail on the `post_pr_comment` step on PRs from forks. Currently all PRs from forks fail CI due to this workflow.

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

> Warning
For workflows that are triggered by the pull_request_target event, the GITHUB_TOKEN is granted read/write repository permission unless the permissions key is specified and the workflow can access secrets, even when it is triggered from a fork. Although the workflow runs in the context of the base of the pull request, you should make sure that you do not check out, build, or run untrusted code from the pull request with this event. Additionally, any caches share the same scope as the base branch. To help prevent cache poisoning, you should not save the cache if there is a possibility that the cache contents were altered. For more information, see [Keeping your GitHub Actions and workflows secure: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests) on the GitHub Security Lab website.

It seems like a security issue though.. Can someone who has more experience with github workflows help me out with this?