### PR TITLE
MC auto: fix land nudging

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -159,6 +159,11 @@ bool FlightTaskAuto::update()
 	_checkEmergencyBraking();
 	Vector3f waypoints[] = {_prev_wp, _position_setpoint, _next_wp};
 
+	if (isTargetModified()) {
+		// In case the target has been modified, we take this as the next waypoints
+		waypoints[2] = _position_setpoint;
+	}
+
 	const bool should_wait_for_yaw_align = _param_mpc_yaw_mode.get() == int32_t(yaw_mode::towards_waypoint_yaw_first)
 					       && !_yaw_sp_aligned;
 	const bool force_zero_velocity_setpoint = should_wait_for_yaw_align || _is_emergency_braking_active;
@@ -757,6 +762,15 @@ bool FlightTaskAuto::_generateHeadingAlongTraj()
 	}
 
 	return res;
+}
+
+bool FlightTaskAuto::isTargetModified() const
+{
+	const bool xy_modified = (_target - _position_setpoint).xy().longerThan(FLT_EPSILON);
+	const bool z_valid = PX4_ISFINITE(_position_setpoint(2));
+	const bool z_modified =  z_valid && std::fabs((_target - _position_setpoint)(2)) > FLT_EPSILON;
+
+	return xy_modified || z_modified;
 }
 
 void FlightTaskAuto::_updateTrajConstraints()

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -108,6 +108,7 @@ protected:
 
 	void _checkEmergencyBraking();
 	bool _generateHeadingAlongTraj(); /**< Generates heading along trajectory. */
+	bool isTargetModified() const;
 	void _updateTrajConstraints();
 
 	void rcHelpModifyYaw(float &yaw_sp);


### PR DESCRIPTION
### Solved Problem
Nudging during landing (RC help) wasn't working correctly anymore due to https://github.com/PX4/PX4-Autopilot/pull/24172/commits/22fc4acfd63c02d6d8a84b5d97b752a055756a98 . In fact, the comment was misleading as this logic was also required for nudging.

### Solution
Revert removal of isTargetModified as this is required when the target is changed by "RC help" (nudging) during landing.

### Alternatives
Make it more explicit directly in the nudging logic

### Test coverage
Tested in SITL
