### PR TITLE
CI: fix flash_analysis workflow on private forks

### DIFF
--- a/.github/workflows/flash_analysis.yml
+++ b/.github/workflows/flash_analysis.yml
@@ -1,6 +1,7 @@
 name: FLASH usage analysis
 
 permissions:
+  contents: read
   pull-requests: write
   issues: write
 


### PR DESCRIPTION

### Solved Problem
[This previous change](https://github.com/PX4/PX4-Autopilot/pull/24393) explicitly set `pull-requests: write` and `issues: write`, but when defining custom permissions, GitHub removes all default permissions unless explicitly specified. This caused the workflow to fail with "Repository not found" on private forks because `contents: read` was missing, preventing repository access for actions like checkout and git clone.
