### PR TITLE
MC auto: improve behavior of RC help during landing

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -243,6 +243,7 @@ void FlightTaskAuto::_prepareLandSetpoints()
 		_land_heading = _yaw_setpoint;
 		_stick_acceleration_xy.resetPosition(Vector2f(_target(0), _target(1)));
 		_initial_land_position = Vector3f(_target(0), _target(1), NAN);
+		_land_position_modified = false;
 	}
 
 	// Update xy-position in case of landing position changes (etc. precision landing)
@@ -253,9 +254,17 @@ void FlightTaskAuto::_prepareLandSetpoints()
 		// Stick full up -1 -> stop, stick full down 1 -> double the speed
 		vertical_speed *= (1 - _sticks.getThrottleZeroCenteredExpo());
 
+		Vector2f sticks_xy = _sticks.getPitchRollExpo();
+
+		if (sticks_xy.longerThan(FLT_EPSILON)) {
+			if (!_land_position_modified) {
+				// Hold current heading to avoid unexpected flight path
+				_land_heading = _yaw_sp_prev;
+			}
+		}
+
 		rcHelpModifyYaw(_land_heading);
 
-		Vector2f sticks_xy = _sticks.getPitchRollExpo();
 		Vector2f sticks_ne = sticks_xy;
 		Sticks::rotateIntoHeadingFrameXY(sticks_ne, _yaw, _land_heading);
 

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -204,6 +204,7 @@ private:
 	WeatherVane _weathervane{this}; /**< weathervane library, used to implement a yaw control law that turns the vehicle nose into the wind */
 
 	matrix::Vector3f _initial_land_position;
+	bool _land_position_modified{false};
 
 	void _limitYawRate(); /**< Limits the rate of change of the yaw setpoint. */
 	bool _evaluateTriplets(); /**< Checks and sets triplets. */


### PR DESCRIPTION
### Solved Problem
Letting the autopilot set the heading during landing while the pilot is nudging the vehicle leads to a weird UX as the vehicle would make a turn instead of translating.

To reproduce:
- enable `MPC_LAND_RC_HELP`
- fly sideways in position mode
- trigger land

-> the vehicle yaws 90 degrees as it's trying to face the land waypoint that was projected sideways. Since the user still has the RC stick deflected, the drone makes a turn instead of continuing in the same direction as the body frame rotates.
![image](https://github.com/user-attachments/assets/7790b4e9-3806-4a26-a1f6-bbe1788c05ea)


### Solution
With this PR, the initial land heading is immediately overridden when the pilot begins to adjust the drone's position, providing the sensation of full control.

![image](https://github.com/user-attachments/assets/41c360bb-01d2-4ed4-a8d9-e05da793eebf)


### Test coverage
- SITL tested
