### PR TITLE
gz: publish sensor_gps

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500
@@ -13,7 +13,7 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500}
 
 param set-default SIM_GZ_EN 1
 
-param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_GPSSIM 0
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500
@@ -13,8 +13,6 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500}
 
 param set-default SIM_GZ_EN 1
 
-param set-default SENS_EN_GPSSIM 0
-param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 
 param set-default CA_AIRFRAME 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4003_gz_rc_cessna
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4003_gz_rc_cessna
@@ -12,8 +12,6 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=rc_cessna}
 
 param set-default SIM_GZ_EN 1
 
-param set-default SENS_EN_GPSSIM 0
-param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 1
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4003_gz_rc_cessna
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4003_gz_rc_cessna
@@ -12,7 +12,7 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=rc_cessna}
 
 param set-default SIM_GZ_EN 1
 
-param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_GPSSIM 0
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
@@ -13,7 +13,7 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=standard_vtol}
 
 param set-default SIM_GZ_EN 1
 
-param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_GPSSIM 0
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
@@ -13,8 +13,6 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=standard_vtol}
 
 param set-default SIM_GZ_EN 1
 
-param set-default SENS_EN_GPSSIM 0
-param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 1
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4006_gz_px4vision
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4006_gz_px4vision
@@ -14,7 +14,7 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=px4vision}
 
 param set-default SIM_GZ_EN 1
 
-param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_GPSSIM 0
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4006_gz_px4vision
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4006_gz_px4vision
@@ -14,8 +14,6 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=px4vision}
 
 param set-default SIM_GZ_EN 1
 
-param set-default SENS_EN_GPSSIM 0
-param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 
 # Commander Parameters

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4008_gz_advanced_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4008_gz_advanced_plane
@@ -11,7 +11,7 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=advanced_plane}
 
 param set-default SIM_GZ_EN 1
 
-param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_GPSSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 1
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4008_gz_advanced_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4008_gz_advanced_plane
@@ -11,7 +11,6 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=advanced_plane}
 
 param set-default SIM_GZ_EN 1
 
-param set-default SENS_EN_GPSSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 1
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4009_gz_r1_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4009_gz_r1_rover
@@ -46,10 +46,7 @@ param set-default PP_LOOKAHD_MAX 10
 param set-default PP_LOOKAHD_MIN 1
 
 # Simulated sensors
-param set-default SENS_EN_GPSSIM 0
-param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
-param set-default SENS_EN_ARSPDSIM 0
 
 # Actuator mapping
 param set-default SIM_GZ_WH_FUNC1 101 # right wheel

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4009_gz_r1_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4009_gz_r1_rover
@@ -46,7 +46,7 @@ param set-default PP_LOOKAHD_MAX 10
 param set-default PP_LOOKAHD_MIN 1
 
 # Simulated sensors
-param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_GPSSIM 0
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
@@ -12,7 +12,7 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=lawnmower}
 param set-default SIM_GZ_EN 1 # Gazebo bridge
 
 # Simulated sensors
-param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_GPSSIM 0
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
@@ -12,10 +12,7 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=lawnmower}
 param set-default SIM_GZ_EN 1 # Gazebo bridge
 
 # Simulated sensors
-param set-default SENS_EN_GPSSIM 0
-param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
-param set-default SENS_EN_ARSPDSIM 0
 # We can arm and drive in manual mode when it slides and GPS check fails:
 param set-default COM_ARM_WO_GPS 1
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4012_gz_rover_ackermann
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4012_gz_rover_ackermann
@@ -45,7 +45,7 @@ param set-default PP_LOOKAHD_MAX 10
 param set-default PP_LOOKAHD_MIN 1
 
 # Simulated sensors
-param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_GPSSIM 0
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4012_gz_rover_ackermann
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4012_gz_rover_ackermann
@@ -45,10 +45,7 @@ param set-default PP_LOOKAHD_MAX 10
 param set-default PP_LOOKAHD_MIN 1
 
 # Simulated sensors
-param set-default SENS_EN_GPSSIM 0
-param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
-param set-default SENS_EN_ARSPDSIM 0
 
 # Wheels
 param set-default SIM_GZ_WH_FUNC1 101

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4015_gz_r1_rover_mecanum
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4015_gz_r1_rover_mecanum
@@ -45,7 +45,7 @@ param set-default PP_LOOKAHD_MAX 10
 param set-default PP_LOOKAHD_MIN 1
 
 # Simulated sensors
-param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_GPSSIM 0
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4015_gz_r1_rover_mecanum
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4015_gz_r1_rover_mecanum
@@ -45,10 +45,7 @@ param set-default PP_LOOKAHD_MAX 10
 param set-default PP_LOOKAHD_MIN 1
 
 # Simulated sensors
-param set-default SENS_EN_GPSSIM 0
-param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
-param set-default SENS_EN_ARSPDSIM 0
 
 # Actuator mapping
 param set-default SIM_GZ_WH_FUNC1 102 # right wheel front

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4018_gz_quadtailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4018_gz_quadtailsitter
@@ -13,11 +13,7 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=quadtailsitter}
 
 param set-default SIM_GZ_EN 1 # Gazebo bridge
 
-param set-default SENS_EN_GPSSIM 0
-param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
-param set-default SENS_EN_ARSPDSIM 0
-
 
 param set-default MAV_TYPE 20
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4018_gz_quadtailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4018_gz_quadtailsitter
@@ -13,7 +13,7 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=quadtailsitter}
 
 param set-default SIM_GZ_EN 1 # Gazebo bridge
 
-param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_GPSSIM 0
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4020_gz_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4020_gz_tiltrotor
@@ -13,7 +13,7 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=tiltrotor}
 
 param set-default SIM_GZ_EN 1 # Gazebo bridge
 
-param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_GPSSIM 0
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4020_gz_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4020_gz_tiltrotor
@@ -13,10 +13,7 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=tiltrotor}
 
 param set-default SIM_GZ_EN 1 # Gazebo bridge
 
-param set-default SENS_EN_GPSSIM 0
-param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
-param set-default SENS_EN_ARSPDSIM 0
 
 param set-default MAV_TYPE 21
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/71002_gz_spacecraft_2d
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/71002_gz_spacecraft_2d
@@ -15,8 +15,8 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=spacecraft_2d}
 
 param set-default SIM_GZ_EN 1
 
-param set-default SENS_EN_GPSSIM 1
-param set-default SENS_EN_BAROSIM 1
+param set-default SENS_EN_GPSSIM 0
+param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default COM_ARM_CHK_ESCS 0  # We don't have ESCs
 param set-default FD_ESCS_EN 0 # We don't have ESCs - but maybe we need this later?

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/71002_gz_spacecraft_2d
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/71002_gz_spacecraft_2d
@@ -15,8 +15,6 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=spacecraft_2d}
 
 param set-default SIM_GZ_EN 1
 
-param set-default SENS_EN_GPSSIM 0
-param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default COM_ARM_CHK_ESCS 0  # We don't have ESCs
 param set-default FD_ESCS_EN 0 # We don't have ESCs - but maybe we need this later?

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/8011_gz_omnicopter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/8011_gz_omnicopter
@@ -83,8 +83,6 @@ param set-default CA_ROTOR7_AY -0.211325
 param set-default CA_ROTOR7_AZ -0.57735
 
 param set-default SIM_GZ_EN 1
-param set-default SENS_EN_GPSSIM 0
-param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 
 param set-default SIM_GZ_EC_FUNC1 101

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/8011_gz_omnicopter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/8011_gz_omnicopter
@@ -83,7 +83,7 @@ param set-default CA_ROTOR7_AY -0.211325
 param set-default CA_ROTOR7_AZ -0.57735
 
 param set-default SIM_GZ_EN 1
-param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_GPSSIM 0
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 

--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -456,10 +456,6 @@ void GZBridge::barometerCallback(const gz::msgs::FluidPressure &air_pressure)
 
 void GZBridge::airspeedCallback(const gz::msgs::AirSpeed &air_speed)
 {
-	if (hrt_absolute_time() == 0) {
-		return;
-	}
-
 	const uint64_t time_us = (air_speed.header().stamp().sec() * 1000000)
 				 + (air_speed.header().stamp().nsec() / 1000);
 
@@ -478,10 +474,6 @@ void GZBridge::airspeedCallback(const gz::msgs::AirSpeed &air_speed)
 
 void GZBridge::imuCallback(const gz::msgs::IMU &imu)
 {
-	if (hrt_absolute_time() == 0) {
-		return;
-	}
-
 	const uint64_t time_us = (imu.header().stamp().sec() * 1000000) + (imu.header().stamp().nsec() / 1000);
 
 	if (time_us > _world_time_us.load()) {
@@ -539,10 +531,6 @@ void GZBridge::imuCallback(const gz::msgs::IMU &imu)
 
 void GZBridge::poseInfoCallback(const gz::msgs::Pose_V &pose)
 {
-	if (hrt_absolute_time() == 0) {
-		return;
-	}
-
 	for (int p = 0; p < pose.pose_size(); p++) {
 		if (pose.pose(p).name() == _model_name) {
 
@@ -650,10 +638,6 @@ void GZBridge::poseInfoCallback(const gz::msgs::Pose_V &pose)
 
 void GZBridge::odometryCallback(const gz::msgs::OdometryWithCovariance &odometry)
 {
-	if (hrt_absolute_time() == 0) {
-		return;
-	}
-
 	const uint64_t time_us = (odometry.header().stamp().sec() * 1000000) + (odometry.header().stamp().nsec() / 1000);
 
 	if (time_us > _world_time_us.load()) {
@@ -792,10 +776,6 @@ void GZBridge::addRealisticGpsNoise(double &latitude, double &longitude, double 
 
 void GZBridge::navSatCallback(const gz::msgs::NavSat &nav_sat)
 {
-	if (hrt_absolute_time() == 0) {
-		return;
-	}
-
 	const uint64_t time_us = (nav_sat.header().stamp().sec() * 1000000) + (nav_sat.header().stamp().nsec() / 1000);
 
 	if (time_us > _world_time_us.load()) {
@@ -894,10 +874,6 @@ void GZBridge::navSatCallback(const gz::msgs::NavSat &nav_sat)
 
 void GZBridge::laserScantoLidarSensorCallback(const gz::msgs::LaserScan &scan)
 {
-	if (hrt_absolute_time() == 0) {
-		return;
-	}
-
 	distance_sensor_s distance_sensor{};
 	distance_sensor.timestamp = hrt_absolute_time();
 	device::Device::DeviceId id;

--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -1,20 +1,20 @@
 /****************************************************************************
  *
- *   Copyright (c) 2022-2023 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
- *	notice, this list of conditions and the following disclaimer.
+ *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
- *	notice, this list of conditions and the following disclaimer in
- *	the documentation and/or other materials provided with the
- *	distribution.
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
  * 3. Neither the name PX4 nor the names of its contributors may be
- *	used to endorse or promote products derived from this software
- *	without specific prior written permission.
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -736,42 +736,36 @@ static float generate_wgn()
 }
 
 void GZBridge::addRealisticGpsNoise(double &latitude, double &longitude, double &altitude,
-                          float &vel_north, float &vel_east, float &vel_down)
+				    float &vel_north, float &vel_east, float &vel_down)
 {
-    // Position noise model - first order Markov process with occasional jumps
-    // Markov process: more persistence, less random walk
-    _gps_pos_noise_n = _pos_markov_time * _gps_pos_noise_n +
-                       _pos_random_walk * generate_wgn() * _pos_noise_amplitude -
-                       0.02f * _gps_pos_noise_n;
+	_gps_pos_noise_n = _pos_markov_time * _gps_pos_noise_n +
+			   _pos_random_walk * generate_wgn() * _pos_noise_amplitude -
+			   0.02f * _gps_pos_noise_n;
 
-    _gps_pos_noise_e = _pos_markov_time * _gps_pos_noise_e +
-                       _pos_random_walk * generate_wgn() * _pos_noise_amplitude -
-                       0.02f * _gps_pos_noise_e;
+	_gps_pos_noise_e = _pos_markov_time * _gps_pos_noise_e +
+			   _pos_random_walk * generate_wgn() * _pos_noise_amplitude -
+			   0.02f * _gps_pos_noise_e;
 
-    _gps_pos_noise_d = _pos_markov_time * _gps_pos_noise_d +
-                       _pos_random_walk * generate_wgn() * _pos_noise_amplitude * 1.5f -
-                       0.02f * _gps_pos_noise_d;
+	_gps_pos_noise_d = _pos_markov_time * _gps_pos_noise_d +
+			   _pos_random_walk * generate_wgn() * _pos_noise_amplitude * 1.5f -
+			   0.02f * _gps_pos_noise_d;
 
-    // Apply the correlated noise to positions
-    latitude += math::degrees((double)_gps_pos_noise_n / CONSTANTS_RADIUS_OF_EARTH);
-    longitude += math::degrees((double)_gps_pos_noise_e / CONSTANTS_RADIUS_OF_EARTH);
-    altitude += (double)_gps_pos_noise_d;
+	latitude += math::degrees((double)_gps_pos_noise_n / CONSTANTS_RADIUS_OF_EARTH);
+	longitude += math::degrees((double)_gps_pos_noise_e / CONSTANTS_RADIUS_OF_EARTH);
+	altitude += (double)_gps_pos_noise_d;
 
-    // Velocity noise model - F9P has ~0.05 m/s velocity accuracy
-    // More stable, less high-frequency noise
-    _gps_vel_noise_n = _vel_markov_time * _gps_vel_noise_n +
-                       _vel_noise_density * generate_wgn() * _vel_noise_amplitude;
+	_gps_vel_noise_n = _vel_markov_time * _gps_vel_noise_n +
+			   _vel_noise_density * generate_wgn() * _vel_noise_amplitude;
 
-    _gps_vel_noise_e = _vel_markov_time * _gps_vel_noise_e +
-                       _vel_noise_density * generate_wgn() * _vel_noise_amplitude;
+	_gps_vel_noise_e = _vel_markov_time * _gps_vel_noise_e +
+			   _vel_noise_density * generate_wgn() * _vel_noise_amplitude;
 
-    _gps_vel_noise_d = _vel_markov_time * _gps_vel_noise_d +
-                       _vel_noise_density * generate_wgn() * _vel_noise_amplitude * 1.2f;
+	_gps_vel_noise_d = _vel_markov_time * _gps_vel_noise_d +
+			   _vel_noise_density * generate_wgn() * _vel_noise_amplitude * 1.2f;
 
-    // Apply velocity noise
-    vel_north += _gps_vel_noise_n;
-    vel_east += _gps_vel_noise_e;
-    vel_down += _gps_vel_noise_d;
+	vel_north += _gps_vel_noise_n;
+	vel_east += _gps_vel_noise_e;
+	vel_down += _gps_vel_noise_d;
 }
 
 void GZBridge::navSatCallback(const gz::msgs::NavSat &nav_sat)

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2022-2023 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -170,9 +170,8 @@ private:
 
 	bool callPhysicsMsgService(const std::string &service, const gz::msgs::Physics &req);
 
-
 	void addRealisticGpsNoise(double &latitude, double &longitude, double &altitude,
-                          float &vel_north, float &vel_east, float &vel_down);
+				  float &vel_north, float &vel_east, float &vel_down);
 
 	uORB::SubscriptionInterval                    _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
@@ -217,25 +216,19 @@ private:
 
 	gz::transport::Node _node;
 
-    // Position noise state variables
-    float _gps_pos_noise_n = 0.0f;  // North position noise state [m]
-    float _gps_pos_noise_e = 0.0f;  // East position noise state [m]
-    float _gps_pos_noise_d = 0.0f;  // Down position noise state [m]
-
-    // Velocity noise state variables
-    float _gps_vel_noise_n = 0.0f;  // North velocity noise state [m/s]
-    float _gps_vel_noise_e = 0.0f;  // East velocity noise state [m/s]
-    float _gps_vel_noise_d = 0.0f;  // Down velocity noise state [m/s]
-
-    // Noise configuration parameters (could be made configurable)
-    const float _pos_noise_amplitude = 0.8f;    // Position noise amplitude [m]
-    const float _pos_noise_density = 0.1f;      // Position noise process density
-    const float _pos_random_walk = 0.01f;       // Position random walk coefficient
-    const float _pos_markov_time = 0.95f;       // Position Markov process coefficient
-
-    const float _vel_noise_amplitude = 0.05f;   // Velocity noise amplitude [m/s]
-    const float _vel_noise_density = 0.2f;      // Velocity noise process density
-    const float _vel_markov_time = 0.85f;       // Velocity Markov process coefficient
+	// GPS noise model
+	float _gps_pos_noise_n = 0.0f;
+	float _gps_pos_noise_e = 0.0f;
+	float _gps_pos_noise_d = 0.0f;
+	float _gps_vel_noise_n = 0.0f;
+	float _gps_vel_noise_e = 0.0f;
+	float _gps_vel_noise_d = 0.0f;
+	const float _pos_noise_amplitude = 0.8f;    // Position noise amplitude [m]
+	const float _pos_random_walk = 0.01f;       // Position random walk coefficient
+	const float _pos_markov_time = 0.95f;       // Position Markov process coefficient
+	const float _vel_noise_amplitude = 0.05f;   // Velocity noise amplitude [m/s]
+	const float _vel_noise_density = 0.2f;      // Velocity noise process density
+	const float _vel_markov_time = 0.85f;       // Velocity Markov process coefficient
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::SIM_GPS_USED>) _sim_gps_used

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -119,56 +119,13 @@ private:
 	void laserScantoLidarSensorCallback(const gz::msgs::LaserScan &scan);
 	void laserScanCallback(const gz::msgs::LaserScan &scan);
 
-	/**
-	 * @brief Call Entityfactory service
-	 *
-	 * @param req
-	 * @return true
-	 * @return false
-	 */
 	bool callEntityFactoryService(const std::string &service, const gz::msgs::EntityFactory &req);
-
-
-	/**
-	 * @brief Call scene info service
-	 *
-	 * @param service
-	 * @param req
-	 * @return true
-	 * @return false
-	 */
 	bool callSceneInfoMsgService(const std::string &service);
-
-	/**
-	 * @brief Call String service
-	 *
-	 * @param service
-	 * @param req
-	 * @return true
-	 * @return false
-	 */
 	bool callStringMsgService(const std::string &service, const gz::msgs::StringMsg &req);
-
-	/**
-	 * @brief Call Vector3d Service
-	 *
-	 * @param service
-	 * @param req
-	 * @return true
-	 * @return false
-	 */
 	bool callVector3dService(const std::string &service, const gz::msgs::Vector3d &req);
-	/**
-	*
-	* Convert a quaterion from FLU_to_ENU frames (ROS convention)
-	* to FRD_to_NED frames (PX4 convention)
-	*
-	* @param q_FRD_to_NED output quaterion in PX4 conventions
-	* @param q_FLU_to_ENU input quaterion in ROS conventions
-	*/
-	static void rotateQuaternion(gz::math::Quaterniond &q_FRD_to_NED, const gz::math::Quaterniond q_FLU_to_ENU);
-
 	bool callPhysicsMsgService(const std::string &service, const gz::msgs::Physics &req);
+
+	static void rotateQuaternion(gz::math::Quaterniond &q_FRD_to_NED, const gz::math::Quaterniond q_FLU_to_ENU);
 
 	void addRealisticGpsNoise(double &latitude, double &longitude, double &altitude,
 				  float &vel_north, float &vel_east, float &vel_down);


### PR DESCRIPTION
- Disable `sensor_gps_sim` module in gz airframes (SENS_EN_GPSSIM 0)
- Publish `sensor_gps` directly from GZBridge. Implemented first order markov process for GPS noise model.
- Update gz models submodule to include updated IMU and Baro noise parameters 
https://github.com/PX4/PX4-gazebo-models/pull/81

- Removed mutex in gz topic callbacks. Callbacks run synchronously from gz and there are no shared resources with Run().
- Removed `hrt_absolute_time() == 0` check in topic callbacks. Not sure why it was there. If we need to validate that PX4-SITL has started before callbacks run we should do that before subscribing.
