### PR TITLE
vtol_type: remove unused variable and function for deceleration pitch integral

### DIFF
--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -100,8 +100,6 @@ void VtolType::parameters_update()
 
 void VtolType::update_mc_state()
 {
-	resetAccelToPitchPitchIntegrator();
-
 	// copy virtual attitude setpoint to real attitude setpoint
 	memcpy(_v_att_sp, _mc_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
 
@@ -113,7 +111,6 @@ void VtolType::update_mc_state()
 
 void VtolType::update_fw_state()
 {
-	resetAccelToPitchPitchIntegrator();
 	_last_thr_in_fw_mode =  _vehicle_thrust_setpoint_virtual_fw->xyz[0];
 
 	// copy virtual attitude setpoint to real attitude setpoint

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -313,8 +313,6 @@ protected:
 
 	float _quadchute_ref_alt{NAN};	// altitude (AMSL) reference to compute quad-chute altitude loss condition
 
-	float _accel_to_pitch_integ = 0;
-
 	bool _quadchute_command_treated{false};
 
 	bool isFrontTransitionCompleted();
@@ -364,7 +362,6 @@ protected:
 private:
 	hrt_abstime _throttle_blend_start_ts{0};	// time at which we start blending between transition throttle and fixed wing throttle
 
-	void resetAccelToPitchPitchIntegrator() { _accel_to_pitch_integ = 0.f; }
 	bool shouldBlendThrottleAfterFrontTransition() { return _throttle_blend_start_ts != 0; };
 
 	void stopBlendingThrottleAfterFrontTransition() { _throttle_blend_start_ts = 0; }


### PR DESCRIPTION
### Solved Problem
This functionality was moved to FlightTaskTransition and the variable was forgotten in https://github.com/PX4/PX4-Autopilot/pull/23731 (079b756f1b79866720c76417b8edd24547894703)

### Solution
Remove the leftovers.

### Test coverage
Still compiles `make px4_sitl` for me locally.