### PR TITLE
ekf2: GNSS checks relax pos/vel req once passing

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_checks.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_checks.cpp
@@ -68,12 +68,17 @@ bool Ekf::runGnssChecks(const gnssSample &gps)
 	// Check the position dilution of precision
 	_gps_check_fail_status.flags.pdop = (gps.pdop > _params.req_pdop);
 
-	// Check the reported horizontal and vertical position accuracy
-	_gps_check_fail_status.flags.hacc = (gps.hacc > _params.req_hacc);
-	_gps_check_fail_status.flags.vacc = (gps.vacc > _params.req_vacc);
+	// Check the reported horizontal position accuracy (relaxed once passing)
+	const float max_horiz_accuracy = _control_status.flags.gps ? 2.f * _params.req_hacc : _params.req_hacc;
+	_gps_check_fail_status.flags.hacc = (gps.hacc > max_horiz_accuracy);
 
-	// Check the reported speed accuracy
-	_gps_check_fail_status.flags.sacc = (gps.sacc > _params.req_sacc);
+	// Check the reported vertical position accuracy (relaxed once passing)
+	const float max_vert_accuracy = _control_status.flags.gps ? 2.f * _params.req_vacc : _params.req_vacc;
+	_gps_check_fail_status.flags.vacc = (gps.vacc > max_vert_accuracy);
+
+	// Check the reported speed accuracy (relaxed once passing)
+	const float max_speed_accuracy = _control_status.flags.gps ? 2.f * _params.req_sacc : _params.req_sacc;
+	_gps_check_fail_status.flags.sacc = (gps.sacc > max_speed_accuracy);
 
 	// Calculate time lapsed since last update, limit to prevent numerical errors and calculate a lowpass filter coefficient
 	constexpr float filt_time_const = 10.0f;


### PR DESCRIPTION
Starting with something crude and simple to get the conversation going this PR proposes that we relax the ekf2 GNSS checks for position and velocity accuracy once GNSS is active (passed initial checks) .

@dakejahl @bresch @haumarco 

Related to https://github.com/PX4/PX4-Autopilot/issues/24355, but not a full solution.
