### PR TITLE
Dev Container: build multiarch images for x86, and arm64

### DIFF
--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -71,6 +71,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install ccache
+        run: |
+          apt-get --quiet -y update && DEBIAN_FRONTEND=noninteractive apt-get --quiet -y install \
+            ccache
+
       - name: Git ownership workaround
         run: git config --system --add safe.directory '*'
 
@@ -92,9 +97,16 @@ jobs:
             ccache -s
             ccache -z
 
+      - name: Missing dependencies for ${{ matrix.arch }}
+        if: contains(fromJSON('["aarch64", "armhf"]'), matrix.arch)
+        run: |
+          apt-get --quiet -y update && DEBIAN_FRONTEND=noninteractive apt-get --quiet -y install \
+            g++-aarch64-linux-gnu \
+            g++-arm-linux-gnueabihf
+
       - name: Building [${{ matrix.group }}]
         run: |
-            ./Tools/ci/build_all_runner.sh ${{matrix.targets}}
+            ./Tools/ci/build_all_runner.sh ${{matrix.targets}} ${{matrix.arch}}
 
       - name: Arrange Build Artifacts
         run: |

--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -71,11 +71,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install ccache
-        run: |
-          apt-get --quiet -y update && DEBIAN_FRONTEND=noninteractive apt-get --quiet -y install \
-            ccache
-
       - name: Git ownership workaround
         run: git config --system --add safe.directory '*'
 
@@ -152,10 +147,12 @@ jobs:
 
   release:
     name: Create Release and Upload Artifacts
+    permissions:
+      contents: write
     # runs-on: ubuntu-latest
     runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}",spot=false]
     needs: [setup, group_targets]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -92,13 +92,6 @@ jobs:
             ccache -s
             ccache -z
 
-      - name: Missing dependencies for ${{ matrix.arch }}
-        if: contains(fromJSON('["aarch64", "armhf"]'), matrix.arch)
-        run: |
-          apt-get --quiet -y update && DEBIAN_FRONTEND=noninteractive apt-get --quiet -y install \
-            g++-aarch64-linux-gnu \
-            g++-arm-linux-gnueabihf
-
       - name: Building [${{ matrix.group }}]
         run: |
             ./Tools/ci/build_all_runner.sh ${{matrix.targets}} ${{matrix.arch}}

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -17,8 +17,9 @@ on:
 jobs:
   build:
     name: Build and Push Container
-    runs-on: [runs-on,runner=8cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false]
+    runs-on: [runs-on,runner=8cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
     steps:
+      - uses: runs-on/action@v1
       - uses: actions/checkout@v4
         with:
           fetch-tags: true
@@ -65,12 +66,11 @@ jobs:
           context: Tools/setup
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: |
-            linux/amd64
+          platforms: linux/amd64,linux/arm64
           load: true
           push: false
-          cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Get Tag Name
         id: tag_name
@@ -99,5 +99,5 @@ jobs:
             linux/amd64
           provenance: mode=max
           push: true
-          cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -32,13 +32,14 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: github.event_name != 'pull_request'
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -89,6 +90,7 @@ jobs:
 
       - name: Push container image
         uses: docker/build-push-action@v6
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:
           context: Tools/setup
           tags: ${{ steps.meta.outputs.tags }}
@@ -96,6 +98,6 @@ jobs:
           platforms: |
             linux/amd64
           provenance: mode=max
-          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          push: true
           cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
           cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -96,6 +96,6 @@ jobs:
           platforms: |
             linux/amd64
           provenance: mode=max
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
           cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
           cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -33,14 +33,14 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        # if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        # if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -90,7 +90,7 @@ jobs:
 
       - name: Push container image
         uses: docker/build-push-action@v6
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        # if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:
           context: Tools/setup
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -66,7 +66,7 @@ jobs:
           context: Tools/setup
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           load: true
           push: false
           cache-from: type=gha
@@ -95,8 +95,7 @@ jobs:
           context: Tools/setup
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: |
-            linux/amd64
+          platforms: linux/amd64,linux/arm64
           provenance: mode=max
           push: true
           cache-from: type=gha

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -16,8 +16,11 @@ on:
 
 jobs:
   build:
-    name: Build and Push Container
-    runs-on: [runs-on,runner=8cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
+    name: Build and Push Container (${{ matrix.arch }})
+    strategy:
+      matrix:
+        arch: [x64, arm64]
+    runs-on: [runs-on,"runner=8cpu-linux-${{ matrix.arch }}","image=ubuntu24-full-${{ matrix.arch }}","run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
     steps:
       - uses: runs-on/action@v1
       - uses: actions/checkout@v4
@@ -66,7 +69,7 @@ jobs:
           context: Tools/setup
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
+          platforms: linux/${{ matrix.arch == 'x64' && 'amd64' || 'arm64' }}
           load: true
           push: false
           cache-from: type=gha
@@ -95,7 +98,7 @@ jobs:
           context: Tools/setup
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.arch == 'x64' && 'amd64' || 'arm64' }}
           provenance: mode=max
           push: true
           cache-from: type=gha

--- a/Tools/ci/generate_board_targets_json.py
+++ b/Tools/ci/generate_board_targets_json.py
@@ -87,20 +87,17 @@ def process_target(px4board_file, target_name):
 
     if platform not in excluded_platforms:
         # get the container based on the platform and toolchain
+        container = 'ghcr.io/px4/px4-dev:main'
         if platform == 'posix':
-            container = 'px4io/px4-dev-base-focal:2021-09-08'
             group = 'base'
             if toolchain:
                 if toolchain.startswith('aarch64'):
-                    container = 'px4io/px4-dev-aarch64:2022-08-12'
                     group = 'aarch64'
                 elif toolchain == 'arm-linux-gnueabihf':
-                    container = 'px4io/px4-dev-armhf:2023-06-26'
                     group = 'armhf'
                 else:
                     if verbose: print(f'unmatched toolchain: {toolchain}')
         elif platform == 'nuttx':
-            container = 'px4io/px4-dev-nuttx-focal:2022-08-12'
             group = 'nuttx'
         else:
             if verbose: print(f'unmatched platform: {platform}')
@@ -124,7 +121,7 @@ if(verbose):
 # - Events
 metadata_targets = ['airframe_metadata', 'parameters_metadata', 'extract_events']
 grouped_targets['base'] = {}
-grouped_targets['base']['container'] = 'px4io/px4-dev-base-focal:2021-09-08'
+grouped_targets['base']['container'] = 'ghcr.io/px4/px4-dev:main'
 grouped_targets['base']['manufacturers'] = {}
 grouped_targets['base']['manufacturers']['px4'] = []
 grouped_targets['base']['manufacturers']['px4'] += metadata_targets

--- a/Tools/ci/package_build_artifacts.sh
+++ b/Tools/ci/package_build_artifacts.sh
@@ -4,8 +4,9 @@ mkdir artifacts
 cp **/**/*.px4 artifacts/
 cp **/**/*.elf artifacts/
 for build_dir_path in build/*/ ; do
+  build_dir_path=${build_dir_path::${#build_dir_path}-1}
   build_dir=${build_dir_path#*/}
-  build_dir=${build_dir::${#build_dir}-1}
+  target_name=$build_dir
   mkdir artifacts/$build_dir
   find artifacts/ -maxdepth 1 -type f -name "*$build_dir*"
   # Airframe
@@ -26,21 +27,23 @@ for build_dir_path in build/*/ ; do
   echo "----------"
 done
 
-# general metadata
-mkdir artifacts/_general/
-cp artifacts/px4_sitl_default/airframes.xml artifacts/_general/
-# Airframe
-cp artifacts/px4_sitl_default/airframes.xml artifacts/_general/
-# Parameters
-cp artifacts/px4_sitl_default/parameters.xml artifacts/_general/
-cp artifacts/px4_sitl_default/parameters.json artifacts/_general/
-cp artifacts/px4_sitl_default/parameters.json.xz artifacts/_general/
-# Actuators
-cp artifacts/px4_sitl_default/actuators.json artifacts/_general/
-cp artifacts/px4_sitl_default/actuators.json.xz artifacts/_general/
-# Events
-cp artifacts/px4_sitl_default/events/all_events.json.xz artifacts/_general/
-# ROS 2 msgs
-cp artifacts/px4_sitl_default/events/all_events.json.xz artifacts/_general/
-# Module Docs
-ls -la artifacts/_general/
+if [ -d artifacts/px4_sitl_default ]; then
+  # general metadata
+  mkdir artifacts/_general/
+  cp artifacts/px4_sitl_default/airframes.xml artifacts/_general/
+  # Airframe
+  cp artifacts/px4_sitl_default/airframes.xml artifacts/_general/
+  # Parameters
+  cp artifacts/px4_sitl_default/parameters.xml artifacts/_general/
+  cp artifacts/px4_sitl_default/parameters.json artifacts/_general/
+  cp artifacts/px4_sitl_default/parameters.json.xz artifacts/_general/
+  # Actuators
+  cp artifacts/px4_sitl_default/actuators.json artifacts/_general/
+  cp artifacts/px4_sitl_default/actuators.json.xz artifacts/_general/
+  # Events
+  cp artifacts/px4_sitl_default/events/all_events.json.xz artifacts/_general/
+  # ROS 2 msgs
+  cp artifacts/px4_sitl_default/events/all_events.json.xz artifacts/_general/
+  # Module Docs
+  ls -la artifacts/_general/
+fi

--- a/Tools/setup/docker-entrypoint.sh
+++ b/Tools/setup/docker-entrypoint.sh
@@ -1,19 +1,27 @@
 #!/bin/bash
 
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+FILE_DESCRIPTOR="${GREEN}[docker-entrypoint.sh]${NC}"
+
+echo -e "$FILE_DESCRIPTOR Starting"
+
 # Start virtual X server in the background
 # - DISPLAY default is :99, set in dockerfile
 # - Users can override with `-e DISPLAY=` in `docker run` command to avoid
 #   running Xvfb and attach their screen
 if [[ -x "$(command -v Xvfb)" && "$DISPLAY" == ":99" ]]; then
-	echo "[docker-entrypoint.sh] Starting Xvfb"
+	echo -e "$FILE_DESCRIPTOR Starting Xvfb"
 	Xvfb :99 -screen 0 1600x1200x24+32 &
 fi
 
 # Check if the ROS_DISTRO is passed and use it
 # to source the ROS environment
 if [ -n "${ROS_DISTRO}" ]; then
-	echo "[docker-entrypoint.sh] ROS: ${ROS_DISTRO}"
+	echo -e "$FILE_DESCRIPTOR ROS: ${ROS_DISTRO}"
 	source "/opt/ros/$ROS_DISTRO/setup.bash"
 fi
+
+echo -e "$FILE_DESCRIPTOR ($( uname -m ))"
 
 exec "$@"

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -27,9 +27,12 @@ do
 	fi
 done
 
+echo "[ubuntu.sh] Starting..."
+echo "[ubuntu.sh] arch: ${GREEN}$INSTALL_ARCH${NC}"
+
 # detect if running in docker
 if [ -f /.dockerenv ]; then
-	echo "Running within docker, installing initial dependencies";
+	echo "[ubuntu.sh] Running within docker, installing initial dependencies";
 	apt-get --quiet -y update && DEBIAN_FRONTEND=noninteractive apt-get --quiet -y install \
 		ca-certificates \
 		gnupg \
@@ -47,7 +50,7 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # check requirements.txt exists (script not run in source tree)
 REQUIREMENTS_FILE="requirements.txt"
 if [[ ! -f "${DIR}/${REQUIREMENTS_FILE}" ]]; then
-	echo "FAILED: ${REQUIREMENTS_FILE} needed in same directory as ubuntu.sh (${DIR})."
+	echo "[ubuntu.sh] FAILED: ${REQUIREMENTS_FILE} needed in same directory as ubuntu.sh (${DIR})."
 	return 1
 fi
 
@@ -55,10 +58,8 @@ fi
 # check ubuntu version
 # otherwise warn and point to docker?
 UBUNTU_RELEASE="`lsb_release -rs`"
-echo "Ubuntu ${UBUNTU_RELEASE}"
-
-echo
-echo "Installing PX4 general dependencies"
+echo "[ubuntu.sh] Ubuntu ${GREEN}${UBUNTU_RELEASE}${NC}"
+echo "[ubuntu.sh] Installing PX4 general dependencies"
 
 sudo apt-get update -y --quiet
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
@@ -91,7 +92,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends i
 
 # Python3 dependencies
 echo
-echo "Installing PX4 Python3 dependencies"
+echo "[ubuntu.sh] Installing PX4 Python3 dependencies"
 PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
 REQUIRED_VERSION="3.11"
 if [[ "$(printf '%s\n' "$REQUIRED_VERSION" "$PYTHON_VERSION" | sort -V | head -n1)" == "$REQUIRED_VERSION" ]]; then
@@ -109,8 +110,8 @@ fi
 if [[ $INSTALL_NUTTX == "true" ]]; then
 
 	echo
-	echo "Installing NuttX dependencies"
-
+	echo "[ubuntu.sh] NuttX Installing Dependencies"
+	sudo apt-get update -y --quiet
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		automake \
 		binutils-dev \
@@ -118,9 +119,6 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		build-essential \
 		curl \
 		flex \
-		g++-multilib \
-		gcc-arm-none-eabi \
-		gcc-multilib \
 		gdb-multiarch \
 		genromfs \
 		gettext \
@@ -147,6 +145,25 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		vim-common \
 		;
 
+
+	echo
+	echo "[ubuntu.sh] NuttX Installing Dependencies ($INSTALL_ARCH)"
+
+	if [[ "${INSTALL_ARCH}" == "x86_64" ]]; then
+		sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
+			g++-multilib \
+			gcc-arm-none-eabi \
+			gcc-multilib \
+			;
+	fi
+
+	if [[ "${INSTALL_ARCH}" == "aarch64" ]]; then
+		sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
+			g++-aarch64-linux-gnu \
+			g++-arm-linux-gnueabihf \
+			;
+	fi
+
 	if [ -n "$USER" ]; then
 		# add user to dialout group (serial port access)
 		sudo usermod -aG dialout $USER
@@ -157,7 +174,7 @@ fi
 if [[ $INSTALL_SIM == "true" ]]; then
 
 	echo
-	echo "Installing PX4 simulation dependencies"
+	echo "[ubuntu.sh] Installing PX4 simulation dependencies"
 
 	# General simulation dependencies
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
@@ -182,8 +199,8 @@ if [[ $INSTALL_SIM == "true" ]]; then
 		fi
 	else
 		# Expects Ubuntu 22.04 > by default
-		echo "Gazebo (Harmonic) will be installed"
-		echo "Earlier versions will be removed"
+		echo "[ubuntu.sh] Gazebo (Harmonic) will be installed"
+		echo "[ubuntu.sh] Earlier versions will be removed"
 		# Add Gazebo binary repository
 		sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
 		echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null


### PR DESCRIPTION
This changes a few things beyond adding multiarch container images:

* `px4-dev` container images will only be pushed to registry on tag push events (releases)
* [caches the docker build container layers in S3](https://runs-on.com/caching/magic-cache/), but defaults to local cache if the workflow is not run within a RunsOn stack (runs-on.com) like the Dronecode Infra is, making it safe to use for downstream forks.
* builds and pushes multi-arch images for Github and Docker registries.