### PR TITLE
fix failsafe behavior after RC loss and mode switch

### DIFF
--- a/src/modules/commander/UserModeIntention.cpp
+++ b/src/modules/commander/UserModeIntention.cpp
@@ -45,7 +45,6 @@ bool UserModeIntention::change(uint8_t user_intended_nav_state, ModeChangeSource
 			       bool force)
 {
 	_ever_had_mode_change = true;
-	_had_mode_change = true;
 
 	if (_handler) {
 		// If a replacement mode is selected, select the internal one instead. The replacement will be selected after.


### PR DESCRIPTION

### Solved Problem
Scenario:
	- drone in altitude mode and switches to RTL failsafe after RC loss
	- while in RTL, the user selects "position mode", the vehicle command gets rejected because of missing manual mode
	- the vehicle switches to altitude mode, despite not having any manual control input!

### Solution
I removed the `_had_mode_change = true;` which always indicated that the "intended mode" has change even when it got rejected.

Now the scenario would look like:
	- drone in altitude mode and switches to RTL failsafe after RC loss
	- while in RTL, the user selects "position mode", the vehicle command gets rejected because of missing manual mode
	- the vehicle stays in RTL
	- RC connects again, vehicle stays in RTL until mode gets switched again or switches to position mode if user gives stick input (depending on COM_RC_STICK_OV)
	



