### PR TITLE
Remove wheel control related fields from main FW control topics

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -123,7 +123,7 @@ set(msg_files
 	LandingGearWheel.msg
 	LandingTargetInnovations.msg
 	LandingTargetPose.msg
-		LateralControlLimits.msg
+	LateralControlLimits.msg
 	LaunchDetectionStatus.msg
 	LedControl.msg
 	LoggerStatus.msg

--- a/msg/FwLateralControlSetpoint.msg
+++ b/msg/FwLateralControlSetpoint.msg
@@ -1,12 +1,13 @@
 uint64 timestamp
 
 # NOTE: At least one of course_setpoint, airspeed_reference_direction, or lateral_acceleration_setpoint must be finite
-float32 course_setpoint # NAN if not controlled directly, [-pi, pi]
-float32 airspeed_reference_direction    # angle of desired airspeed vector, NAN if not controlled directly, used as feedforward if course setpoint is finite, [-pi, pi],
-float32 lateral_acceleration_setpoint # NAN if not controlled directly, used as feedforward if either course setpoint or airspeed_reference_direction is finite, [m/s^2]
-float32 roll_sp # TODO: remove, only for testing
 
-float32 heading_sp_runway_takeoff # [-pi, pi] heading setpoint for runway takeoff
-bool reset_integral # TODO: remove, resets rate controller integrals
+float32 course_setpoint 		# [-pi, pi], NAN if not controlled directly
+float32 airspeed_reference_direction    # [-pi, pi], angle of desired airspeed vector, NAN if not controlled directly, used as feedforward if course setpoint is finite
+float32 lateral_acceleration_setpoint 	# [m/s^2], NAN if not controlled directly, used as feedforward if either course setpoint or airspeed_reference_direction is finite
+float32 roll_sp 			# TODO: remove, only for testing
+
+float32 heading_sp_runway_takeoff 	# [-pi, pi], heading setpoint for runway takeoff
+bool reset_integral 			# TODO: remove, resets rate controller integrals
 
 # TOPICS fw_lateral_control_setpoint fw_lateral_control_status

--- a/msg/FwLateralControlSetpoint.msg
+++ b/msg/FwLateralControlSetpoint.msg
@@ -7,6 +7,4 @@ float32 airspeed_reference_direction    # [-pi, pi], angle of desired airspeed v
 float32 lateral_acceleration_setpoint 	# [m/s^2], NAN if not controlled directly, used as feedforward if either course setpoint or airspeed_reference_direction is finite
 float32 roll_sp 			# TODO: remove, only for testing
 
-float32 heading_sp_runway_takeoff 	# [-pi, pi], heading setpoint for runway takeoff
-
 # TOPICS fw_lateral_control_setpoint fw_lateral_control_status

--- a/msg/FwLateralControlSetpoint.msg
+++ b/msg/FwLateralControlSetpoint.msg
@@ -8,6 +8,5 @@ float32 lateral_acceleration_setpoint 	# [m/s^2], NAN if not controlled directly
 float32 roll_sp 			# TODO: remove, only for testing
 
 float32 heading_sp_runway_takeoff 	# [-pi, pi], heading setpoint for runway takeoff
-bool reset_integral 			# TODO: remove, resets rate controller integrals
 
 # TOPICS fw_lateral_control_setpoint fw_lateral_control_status

--- a/msg/versioned/VehicleAttitudeSetpoint.msg
+++ b/msg/versioned/VehicleAttitudeSetpoint.msg
@@ -11,6 +11,4 @@ float32[4] q_d			# Desired quaternion for quaternion control
 # For fixed wings thrust_x is the throttle demand and thrust_y, thrust_z will usually be zero.
 float32[3] thrust_body		# Normalized thrust command in body FRD frame [-1,1]
 
-bool fw_control_yaw_wheel	# control heading with steering wheel (used for auto takeoff on runway)
-
 # TOPICS vehicle_attitude_setpoint mc_virtual_attitude_setpoint fw_virtual_attitude_setpoint

--- a/msg/versioned/VehicleAttitudeSetpoint.msg
+++ b/msg/versioned/VehicleAttitudeSetpoint.msg
@@ -11,8 +11,6 @@ float32[4] q_d			# Desired quaternion for quaternion control
 # For fixed wings thrust_x is the throttle demand and thrust_y, thrust_z will usually be zero.
 float32[3] thrust_body		# Normalized thrust command in body FRD frame [-1,1]
 
-bool reset_integral	# Reset roll/pitch/yaw integrals (navigation logic change)
-
 bool fw_control_yaw_wheel	# control heading with steering wheel (used for auto takeoff on runway)
 
 # TOPICS vehicle_attitude_setpoint mc_virtual_attitude_setpoint fw_virtual_attitude_setpoint

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -108,8 +108,6 @@ FixedwingAttitudeControl::vehicle_manual_poll(const float yaw_body)
 				const Quatf q(Eulerf(roll_body, pitch_body, yaw_body));
 				q.copyTo(_att_sp.q_d);
 
-				_att_sp.reset_integral = false;
-
 				_att_sp.timestamp = hrt_absolute_time();
 
 				_attitude_sp_pub.publish(_att_sp);
@@ -283,11 +281,10 @@ void FixedwingAttitudeControl::Run()
 
 		if (_vcontrol_mode.flag_control_rates_enabled) {
 
-			/* Reset integrators if commanded by attitude setpoint, or the aircraft is on ground
+			/* Reset integrators if the aircraft is on ground
 			 * or a multicopter (but not transitioning VTOL or tailsitter)
 			 */
-			if (_att_sp.reset_integral
-			    || _landed
+			if (_landed
 			    || !_in_fw_or_transition_wo_tailsitter_transition) {
 
 				_rates_sp.reset_integral = true;

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -269,7 +269,8 @@ void FixedwingAttitudeControl::Run()
 
 		bool wheel_control = false;
 
-		if (_param_fw_w_en.get() && _att_sp.fw_control_yaw_wheel && _vcontrol_mode.flag_control_auto_enabled) {
+		// TODO listen to a runway_takeoff_status to determine when to control wheel
+		if (_param_fw_w_en.get() && _vcontrol_mode.flag_control_auto_enabled) {
 			wheel_control = true;
 		}
 

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -249,7 +249,6 @@ void FwLateralLongitudinalControl::Run()
 				roll_sp = mapLateralAccelerationToRollAngle(lateral_accel_sp);
 			}
 
-			_att_sp.reset_integral = _lat_control_sp.reset_integral;
 			_att_sp.fw_control_yaw_wheel = PX4_ISFINITE(_lat_control_sp.heading_sp_runway_takeoff);
 			yaw_sp = _lat_control_sp.heading_sp_runway_takeoff;
 

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -249,8 +249,6 @@ void FwLateralLongitudinalControl::Run()
 				roll_sp = mapLateralAccelerationToRollAngle(lateral_accel_sp);
 			}
 
-			yaw_sp = _lat_control_sp.heading_sp_runway_takeoff;
-
 			fw_lateral_control_setpoint_s status = {
 				.timestamp = _lat_control_sp.timestamp,
 				.course_setpoint = _lat_control_sp.course_setpoint,

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -249,7 +249,6 @@ void FwLateralLongitudinalControl::Run()
 				roll_sp = mapLateralAccelerationToRollAngle(lateral_accel_sp);
 			}
 
-			_att_sp.fw_control_yaw_wheel = PX4_ISFINITE(_lat_control_sp.heading_sp_runway_takeoff);
 			yaw_sp = _lat_control_sp.heading_sp_runway_takeoff;
 
 			fw_lateral_control_setpoint_s status = {

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -1326,9 +1326,6 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 		_runway_takeoff.update(now, takeoff_airspeed, _airspeed_eas, _current_altitude - _takeoff_ground_alt,
 				       clearance_altitude_amsl - _takeoff_ground_alt);
 
-		// yaw control is disabled once in "taking off" state
-		_att_sp.fw_control_yaw_wheel = _runway_takeoff.controlYaw();
-
 		// XXX: hacky way to pass through manual nose-wheel incrementing. need to clean this interface.
 		if (_param_rwto_nudge.get()) {
 			_att_sp.yaw_sp_move_rate = _manual_control_setpoint.yaw;
@@ -1680,9 +1677,6 @@ FixedwingPositionControl::control_auto_landing_straight(const hrt_abstime &now, 
 		longitudinal_control_limits.throttle_max = throttle_max;
 		longitudinal_control_limits.disable_underspeed_protection = true;
 
-		// enable direct yaw control using rudder/wheel
-		_att_sp.fw_control_yaw_wheel = true;
-
 		// XXX: hacky way to pass through manual nose-wheel incrementing. need to clean this interface.
 		if (_param_fw_lnd_nudge.get() > LandingNudgingOption::kNudgingDisabled) {
 			_att_sp.yaw_sp_move_rate = _manual_control_setpoint.yaw;
@@ -1739,9 +1733,6 @@ FixedwingPositionControl::control_auto_landing_straight(const hrt_abstime &now, 
 		longitudinal_control_limits.throttle_min = _param_fw_thr_idle.get();
 		longitudinal_control_limits.throttle_max = _landed ? _param_fw_thr_idle.get() : NAN;
 		longitudinal_control_limits.sink_rate_target = desired_max_sinkrate;
-
-		// enable direct yaw control using rudder/wheel
-		_att_sp.fw_control_yaw_wheel = false;
 	}
 
 	_longitudinal_ctrl_limits_pub.publish(longitudinal_control_limits);
@@ -2359,10 +2350,6 @@ FixedwingPositionControl::Run()
 		// by default no flaps/spoilers, is overwritten below in certain modes
 		_flaps_setpoint = 0.f;
 		_spoilers_setpoint = 0.f;
-
-
-		// by default we don't want yaw to be contoller directly with rudder
-		_att_sp.fw_control_yaw_wheel = false;
 
 		// default to zero - is used (IN A HACKY WAY) to pass direct nose wheel steering via yaw stick to the actuators during auto takeoff
 		_att_sp.yaw_sp_move_rate = 0.0f;

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -48,7 +48,7 @@ using matrix::Vector2d;
 using matrix::Vector3f;
 using matrix::wrap_pi;
 
-const fw_lateral_control_setpoint_s empty_lateral_control_setpoint = {.timestamp = 0, .course_setpoint = NAN, .airspeed_reference_direction = NAN, .lateral_acceleration_setpoint = NAN, .roll_sp = NAN, .heading_sp_runway_takeoff = NAN};
+const fw_lateral_control_setpoint_s empty_lateral_control_setpoint = {.timestamp = 0, .course_setpoint = NAN, .airspeed_reference_direction = NAN, .lateral_acceleration_setpoint = NAN, .roll_sp = NAN};
 const fw_longitudinal_control_setpoint_s empty_longitudinal_control_setpoint = {.timestamp = 0, .altitude_setpoint = NAN, .height_rate_setpoint = NAN, .equivalent_airspeed_setpoint = NAN, .pitch_sp = NAN, .thrust_sp = NAN};
 const longitudinal_control_limits_s empty_longitudinal_control_limits = {.timestamp = 0, .pitch_min = NAN, .pitch_max = NAN, .throttle_min = NAN, .throttle_max = NAN, .climb_rate_target = NAN, .sink_rate_target = NAN, .equivalent_airspeed_min = NAN, .equivalent_airspeed_max = NAN, .speed_weight = NAN, .enforce_low_height_condition = false, .disable_underspeed_protection = false };
 const lateral_control_limits_s empty_lateral_control_limits = {.timestamp = 0, .lateral_accel_max = NAN};
@@ -1311,7 +1311,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 
 	if (_runway_takeoff.runwayTakeoffEnabled()) {
 		if (!_runway_takeoff.isInitialized()) {
-			_runway_takeoff.init(now, _yaw, global_position);
+			_runway_takeoff.init(now, global_position);
 			_takeoff_ground_alt = _current_altitude;
 			_launch_current_yaw = _yaw;
 			_airspeed_slew_rate_controller.setForcedValue(takeoff_airspeed);
@@ -1364,8 +1364,6 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 		fw_lateral_ctrl_sp.timestamp = hrt_absolute_time();
 		fw_lateral_ctrl_sp.course_setpoint = sp.course_setpoint;
 		fw_lateral_ctrl_sp.lateral_acceleration_setpoint = sp.lateral_acceleration_feedforward;
-		fw_lateral_ctrl_sp.heading_sp_runway_takeoff = _runway_takeoff.controlYaw() ? _runway_takeoff.getYaw(
-					sp.course_setpoint) : NAN;
 
 		// this overrides the roll setpoint, until the vehicle starts the climbout
 		fw_lateral_ctrl_sp.roll_sp = _runway_takeoff.getRoll();
@@ -1621,7 +1619,6 @@ FixedwingPositionControl::control_auto_landing_straight(const hrt_abstime &now, 
 		fw_lateral_ctrl_sp.timestamp = hrt_absolute_time();
 		fw_lateral_ctrl_sp.course_setpoint = sp.course_setpoint;
 		fw_lateral_ctrl_sp.lateral_acceleration_setpoint = sp.lateral_acceleration_feedforward;
-		fw_lateral_ctrl_sp.heading_sp_runway_takeoff = sp.course_setpoint;
 		_lateral_ctrl_sp_pub.publish(fw_lateral_ctrl_sp);
 
 		const float roll_wingtip_strike = getMaxRollAngleNearGround(_current_altitude, terrain_alt);
@@ -1827,7 +1824,6 @@ FixedwingPositionControl::control_auto_landing_circular(const hrt_abstime &now, 
 		fw_lateral_ctrl_sp.timestamp = hrt_absolute_time();
 		fw_lateral_ctrl_sp.course_setpoint = sp.course_setpoint;
 		fw_lateral_ctrl_sp.lateral_acceleration_setpoint = sp.lateral_acceleration_feedforward;
-		fw_lateral_ctrl_sp.heading_sp_runway_takeoff = sp.course_setpoint;
 
 		_lateral_ctrl_sp_pub.publish(fw_lateral_ctrl_sp);
 		/* longitudinal guidance */

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -1109,7 +1109,7 @@ FixedwingPositionControl::control_auto_loiter(const float control_interval, cons
 		} else {
 			// continue straight until vehicle has sufficient altitude
 			lateral_limits.lateral_accel_max = 0.f;
-      
+
       // keep flaps in landing configuration if the airspeed is below the min airspeed (keep deployed if airspeed not valid)
 			if (!_airspeed_valid || _airspeed_eas < _performance_model.getMinimumCalibratedAirspeed()) {
 				_flaps_setpoint =  _param_fw_flaps_lnd_scl.get();
@@ -2357,8 +2357,6 @@ FixedwingPositionControl::Run()
 
 		// restore lateral-directional guidance parameters (changed in takeoff mode)
 		_directional_guidance.setPeriod(_param_npfg_period.get());
-
-		_att_sp.reset_integral = false;
 
 		// by default no flaps/spoilers, is overwritten below in certain modes
 		_flaps_setpoint = 0.f;

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -48,7 +48,7 @@ using matrix::Vector2d;
 using matrix::Vector3f;
 using matrix::wrap_pi;
 
-const fw_lateral_control_setpoint_s empty_lateral_control_setpoint = {.timestamp = 0, .course_setpoint = NAN, .airspeed_reference_direction = NAN, .lateral_acceleration_setpoint = NAN, .roll_sp = NAN, .heading_sp_runway_takeoff = NAN, .reset_integral = false};
+const fw_lateral_control_setpoint_s empty_lateral_control_setpoint = {.timestamp = 0, .course_setpoint = NAN, .airspeed_reference_direction = NAN, .lateral_acceleration_setpoint = NAN, .roll_sp = NAN, .heading_sp_runway_takeoff = NAN};
 const fw_longitudinal_control_setpoint_s empty_longitudinal_control_setpoint = {.timestamp = 0, .altitude_setpoint = NAN, .height_rate_setpoint = NAN, .equivalent_airspeed_setpoint = NAN, .pitch_sp = NAN, .thrust_sp = NAN};
 const longitudinal_control_limits_s empty_longitudinal_control_limits = {.timestamp = 0, .pitch_min = NAN, .pitch_max = NAN, .throttle_min = NAN, .throttle_max = NAN, .climb_rate_target = NAN, .sink_rate_target = NAN, .equivalent_airspeed_min = NAN, .equivalent_airspeed_max = NAN, .speed_weight = NAN, .enforce_low_height_condition = false, .disable_underspeed_protection = false };
 const lateral_control_limits_s empty_lateral_control_limits = {.timestamp = 0, .lateral_accel_max = NAN};
@@ -1367,7 +1367,6 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 		fw_lateral_ctrl_sp.timestamp = hrt_absolute_time();
 		fw_lateral_ctrl_sp.course_setpoint = sp.course_setpoint;
 		fw_lateral_ctrl_sp.lateral_acceleration_setpoint = sp.lateral_acceleration_feedforward;
-		fw_lateral_ctrl_sp.reset_integral = _runway_takeoff.resetIntegrators();
 		fw_lateral_ctrl_sp.heading_sp_runway_takeoff = _runway_takeoff.controlYaw() ? _runway_takeoff.getYaw(
 					sp.course_setpoint) : NAN;
 
@@ -1497,7 +1496,6 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 			fw_lateral_ctrl_sp.timestamp = hrt_absolute_time();
 			fw_lateral_ctrl_sp.lateral_acceleration_setpoint = 0.f;
 			/* Tell the attitude controller to stop integrating while we are waiting for the launch */
-			fw_lateral_ctrl_sp.reset_integral = true;
 			_lateral_ctrl_sp_pub.publish(fw_lateral_ctrl_sp);
 
 			fw_longitudinal_control_setpoint_s long_control_sp{empty_longitudinal_control_setpoint};

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -1331,12 +1331,6 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 			_att_sp.yaw_sp_move_rate = _manual_control_setpoint.yaw;
 		}
 
-		// tune up the lateral position control guidance when on the ground
-		if (_runway_takeoff.controlYaw()) {
-			_directional_guidance.setPeriod(_param_rwto_npfg_period.get());
-
-		}
-
 		const Vector2f start_pos_local = _global_local_proj_ref.project(_runway_takeoff.getStartPosition()(0),
 						 _runway_takeoff.getStartPosition()(1));
 		const Vector2f takeoff_waypoint_local = _global_local_proj_ref.project(pos_sp_curr.lat, pos_sp_curr.lon);
@@ -1604,12 +1598,6 @@ FixedwingPositionControl::control_auto_landing_straight(const hrt_abstime &now, 
 						      1.0f);
 
 		/* lateral guidance first, because npfg will adjust the airspeed setpoint if necessary */
-
-		// tune up the lateral position control guidance when on the ground
-		const float ground_roll_npfg_period = flare_ramp_interpolator * _param_rwto_npfg_period.get() +
-						      (1.0f - flare_ramp_interpolator) * _param_npfg_period.get();
-		_directional_guidance.setPeriod(ground_roll_npfg_period);
-
 		const Vector2f local_approach_entrance = local_land_point - landing_approach_vector;
 
 		const DirectionalGuidanceOutput sp = navigateLine(local_approach_entrance, local_land_point, local_position,
@@ -1810,13 +1798,6 @@ FixedwingPositionControl::control_auto_landing_circular(const hrt_abstime &now, 
 						      1.0f);
 
 		/* lateral guidance first, because npfg will adjust the airspeed setpoint if necessary */
-
-		// tune up the lateral position control guidance when on the ground
-		const float ground_roll_npfg_period = flare_ramp_interpolator * _param_rwto_npfg_period.get() +
-						      (1.0f - flare_ramp_interpolator) * _param_npfg_period.get();
-
-		_directional_guidance.setPeriod(ground_roll_npfg_period);
-
 		const DirectionalGuidanceOutput sp = navigateLoiter(local_landing_orbit_center, local_position, loiter_radius,
 						     pos_sp_curr.loiter_direction_counter_clockwise,
 						     ground_speed, _wind_vel);

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -914,7 +914,6 @@ private:
 		(ParamFloat<px4::params::FW_WING_SPAN>) _param_fw_wing_span,
 		(ParamFloat<px4::params::FW_WING_HEIGHT>) _param_fw_wing_height,
 
-		(ParamFloat<px4::params::RWTO_NPFG_PERIOD>) _param_rwto_npfg_period,
 		(ParamBool<px4::params::RWTO_NUDGE>) _param_rwto_nudge,
 
 		(ParamFloat<px4::params::FW_LND_FL_TIME>) _param_fw_lnd_fl_time,

--- a/src/modules/fw_pos_control/runway_takeoff/RunwayTakeoff.cpp
+++ b/src/modules/fw_pos_control/runway_takeoff/RunwayTakeoff.cpp
@@ -159,12 +159,6 @@ float RunwayTakeoff::getThrottle(const float idle_throttle) const
 	return throttle;
 }
 
-bool RunwayTakeoff::resetIntegrators()
-{
-	// reset integrators if we're still on runway
-	return takeoff_state_ < RunwayTakeoffState::CLIMBOUT;
-}
-
 float RunwayTakeoff::getMinPitch(float min_pitch_in_climbout, float min_pitch) const
 {
 	if (takeoff_state_ < RunwayTakeoffState::CLIMBOUT) {

--- a/src/modules/fw_pos_control/runway_takeoff/RunwayTakeoff.cpp
+++ b/src/modules/fw_pos_control/runway_takeoff/RunwayTakeoff.cpp
@@ -98,12 +98,6 @@ void RunwayTakeoff::update(const hrt_abstime &time_now, const float takeoff_airs
 	}
 }
 
-bool RunwayTakeoff::controlYaw()
-{
-	// keep controlling yaw directly until we start navigation
-	return takeoff_state_ < RunwayTakeoffState::CLIMBOUT;
-}
-
 float RunwayTakeoff::getPitch()
 {
 	if (takeoff_state_ <= RunwayTakeoffState::CLAMPED_TO_RUNWAY) {

--- a/src/modules/fw_pos_control/runway_takeoff/RunwayTakeoff.cpp
+++ b/src/modules/fw_pos_control/runway_takeoff/RunwayTakeoff.cpp
@@ -51,9 +51,8 @@ using namespace time_literals;
 namespace runwaytakeoff
 {
 
-void RunwayTakeoff::init(const hrt_abstime &time_now, const float initial_yaw, const matrix::Vector2d &start_pos_global)
+void RunwayTakeoff::init(const hrt_abstime &time_now, const matrix::Vector2d &start_pos_global)
 {
-	initial_yaw_ = initial_yaw;
 	start_pos_global_ = start_pos_global;
 	takeoff_state_ = RunwayTakeoffState::THROTTLE_RAMP;
 	initialized_ = true;
@@ -122,16 +121,6 @@ float RunwayTakeoff::getRoll()
 	}
 
 	return NAN;
-}
-
-float RunwayTakeoff::getYaw(float external_yaw_setpoint)
-{
-	if (param_rwto_hdg_.get() == 0 && takeoff_state_ < RunwayTakeoffState::CLIMBOUT) {
-		return initial_yaw_;
-
-	} else {
-		return external_yaw_setpoint;
-	}
 }
 
 float RunwayTakeoff::getThrottle(const float idle_throttle) const

--- a/src/modules/fw_pos_control/runway_takeoff/RunwayTakeoff.h
+++ b/src/modules/fw_pos_control/runway_takeoff/RunwayTakeoff.h
@@ -102,11 +102,6 @@ public:
 	bool runwayTakeoffEnabled() { return param_rwto_tkoff_.get(); }
 
 	/**
-	 * @return The vehicle should control yaw via rudder or nose gear
-	 */
-	bool controlYaw();
-
-	/**
 	 * @param external_pitch_setpoint Externally commanded pitch angle setpoint (usually from TECS) [rad]
 	 * @return Pitch angle setpoint (limited while plane is on runway) [rad]
 	 */

--- a/src/modules/fw_pos_control/runway_takeoff/RunwayTakeoff.h
+++ b/src/modules/fw_pos_control/runway_takeoff/RunwayTakeoff.h
@@ -70,10 +70,9 @@ public:
 	 * @brief Initializes the state machine.
 	 *
 	 * @param time_now Absolute time since system boot [us]
-	 * @param initial_yaw Vehicle yaw angle at time of initialization [us]
 	 * @param start_pos_global Vehicle global (lat, lon) position at time of initialization [deg]
 	 */
-	void init(const hrt_abstime &time_now, const float initial_yaw, const matrix::Vector2d &start_pos_global);
+	void init(const hrt_abstime &time_now, const matrix::Vector2d &start_pos_global);
 
 	/**
 	 * @brief Updates the state machine based on the current vehicle condition.
@@ -103,11 +102,6 @@ public:
 	bool runwayTakeoffEnabled() { return param_rwto_tkoff_.get(); }
 
 	/**
-	 * @return Initial vehicle yaw angle [rad]
-	 */
-	float getInitYaw() { return initial_yaw_; }
-
-	/**
 	 * @return The vehicle should control yaw via rudder or nose gear
 	 */
 	bool controlYaw();
@@ -123,17 +117,6 @@ public:
 	 * @return Roll angle setpoint [rad]
 	 */
 	float getRoll();
-
-	/**
-	 * @brief Returns the appropriate yaw angle setpoint.
-	 *
-	 * In heading hold mode (_heading_mode == 0), it returns initial yaw as long as it's on the runway.
-	 * When it has enough ground clearance we start navigation towards WP.
-	 *
-	 * @param external_yaw_setpoint Externally commanded yaw angle setpoint [rad]
-	 * @return Yaw angle setpoint [rad]
-	 */
-	float getYaw(float external_yaw_setpoint);
 
 	/**
 	 * @brief Returns the throttle setpoint.
@@ -207,12 +190,6 @@ private:
 	hrt_abstime takeoff_time_{0};
 
 	/**
-	 * Initial yaw of the vehicle on first pass through the runway takeoff state machine.
-	 * used for heading hold mode. [rad]
-	 */
-	float initial_yaw_{0.f};
-
-	/**
 	 * The global (lat, lon) position of the vehicle on first pass through the runway takeoff state machine. The
 	 * takeoff path emanates from this point to correct for any GNSS uncertainty from the planned takeoff point. The
 	 * vehicle should accordingly be set on the center of the runway before engaging the mission. [deg]
@@ -221,7 +198,6 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamBool<px4::params::RWTO_TKOFF>) param_rwto_tkoff_,
-		(ParamInt<px4::params::RWTO_HDG>) param_rwto_hdg_,
 		(ParamFloat<px4::params::RWTO_MAX_THR>) param_rwto_max_thr_,
 		(ParamFloat<px4::params::RWTO_PSP>) param_rwto_psp_,
 		(ParamFloat<px4::params::RWTO_RAMP_TIME>) param_rwto_ramp_time_,

--- a/src/modules/fw_pos_control/runway_takeoff/RunwayTakeoff.h
+++ b/src/modules/fw_pos_control/runway_takeoff/RunwayTakeoff.h
@@ -169,12 +169,6 @@ public:
 	void forceSetFlyState() { takeoff_state_ = RunwayTakeoffState::FLY; }
 
 	/**
-	 * @return If the attitude / rate control integrators should be continually reset.
-	 * This is the case during ground roll.
-	 */
-	bool resetIntegrators();
-
-	/**
 	 * @brief Reset the state machine.
 	 */
 	void reset();

--- a/src/modules/fw_pos_control/runway_takeoff/runway_takeoff_params.c
+++ b/src/modules/fw_pos_control/runway_takeoff/runway_takeoff_params.c
@@ -48,21 +48,6 @@
 PARAM_DEFINE_INT32(RWTO_TKOFF, 0);
 
 /**
- * Specifies which heading should be held during the runway takeoff ground roll.
- *
- * 0: airframe heading when takeoff is initiated
- * 1: position control along runway direction (bearing defined from vehicle position on takeoff initiation to MAV_CMD_TAKEOFF
- *    position defined by operator)
- *
- * @value 0 Airframe
- * @value 1 Runway
- * @min 0
- * @max 1
- * @group Runway Takeoff
- */
-PARAM_DEFINE_INT32(RWTO_HDG, 0);
-
-/**
  * Max throttle during runway takeoff.
  *
  * @unit norm

--- a/src/modules/fw_pos_control/runway_takeoff/runway_takeoff_params.c
+++ b/src/modules/fw_pos_control/runway_takeoff/runway_takeoff_params.c
@@ -88,18 +88,6 @@ PARAM_DEFINE_FLOAT(RWTO_PSP, 0.0);
 PARAM_DEFINE_FLOAT(RWTO_RAMP_TIME, 2.0f);
 
 /**
- * NPFG period while steering on runway
- *
- * @unit s
- * @min 1.0
- * @max 100.0
- * @decimal 1
- * @increment 0.1
- * @group Runway Takeoff
- */
-PARAM_DEFINE_FLOAT(RWTO_NPFG_PERIOD, 5.0f);
-
-/**
  * Enable use of yaw stick for nudging the wheel during runway ground roll
  *
  * This is useful when map, GNSS, or yaw errors on ground are misaligned with what the operator intends for takeoff course.

--- a/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
@@ -63,7 +63,6 @@ TEST(PositionControlTest, EmptySetpoint)
 	EXPECT_FLOAT_EQ(attitude.yaw_sp_move_rate, 0.f);
 	EXPECT_EQ(Quatf(attitude.q_d), Quatf(1.f, 0.f, 0.f, 0.f));
 	EXPECT_EQ(Vector3f(attitude.thrust_body), Vector3f(0.f, 0.f, 0.f));
-	EXPECT_EQ(attitude.reset_integral, false);
 	EXPECT_EQ(attitude.fw_control_yaw_wheel, false);
 }
 

--- a/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
@@ -63,7 +63,6 @@ TEST(PositionControlTest, EmptySetpoint)
 	EXPECT_FLOAT_EQ(attitude.yaw_sp_move_rate, 0.f);
 	EXPECT_EQ(Quatf(attitude.q_d), Quatf(1.f, 0.f, 0.f, 0.f));
 	EXPECT_EQ(Vector3f(attitude.thrust_body), Vector3f(0.f, 0.f, 0.f));
-	EXPECT_EQ(attitude.fw_control_yaw_wheel, false);
 }
 
 class PositionControlBasicTest : public ::testing::Test


### PR DESCRIPTION
This should be replaced with dedicated messages for wheel control (published by the takeoff handler and used in the FW attitude controller).