### PR TITLE
Commander: handle mode change rejection the same for RC and MAVLink

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1696,7 +1696,7 @@ void Commander::executeActionRequest(const action_request_s &action_request)
 
 	case action_request_s::ACTION_SWITCH_MODE:
 
-		if (!_user_mode_intention.change(action_request.mode, ModeChangeSource::User, true)) {
+		if (!_user_mode_intention.change(action_request.mode, ModeChangeSource::User, false)) {
 			printRejectMode(action_request.mode);
 		}
 


### PR DESCRIPTION

### Solved Problem
Previously, when requesting a mode switch to Position without a valid position estimate through an RC button, the mode change to Position mode was not rejected if `COM_POSCTL_NAVL` was set to 1 and instead the system switched to Altitude mode.
If the mode request instead came in through MAVLink it was rejected.


### Solution
This PR aligns the two ways ([MAVLink](https://github.com/PX4/PX4-Autopilot/blob/ba31054992b00a5e59b73d1a1ce22b5b02efe312/src/modules/commander/Commander.cpp#L899), [RC](https://github.com/PX4/PX4-Autopilot/blob/ba31054992b00a5e59b73d1a1ce22b5b02efe312/src/modules/commander/Commander.cpp#L1699)) of changing a flight mode (passing `false` for the `allow_fallback` argument).

### Changelog Entry
For release notes:
```
Bugfix: Fix flight mode Position not rejected correctly if change requested through RC switch
```

### Alternatives
We could also remove remove the [auto fallback to Altitude on mode switch logic](https://github.com/PX4/PX4-Autopilot/blob/ba31054992b00a5e59b73d1a1ce22b5b02efe312/src/modules/commander/UserModeIntention.cpp#L63-L68) all together, though then stick override would not do anything if position is invalid, and it would need [a parameter description change](https://github.com/PX4/PX4-Autopilot/blob/ba31054992b00a5e59b73d1a1ce22b5b02efe312/src/modules/commander/commander_params.c#L419). Given that you can only really end up in this situation when in Descend mode I would argue that switching to Altitude mode is still better than rejecting the override and would thus leave it as it is.

### Test coverage
Bench tested.

FYI @eyeam3 , thanks for the report!