### PR TITLE
[rcS] Only start CDC/ACM when the module is enabled

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -488,11 +488,14 @@ else
 	rc_input start $RC_INPUT_ARGS
 
 	# Manages USB interface
-	if ! cdcacm_autostart start
+	if param greater -s SYS_USB_AUTO -1
 	then
-		sercon
-		echo "Starting MAVLink on /dev/ttyACM0"
-		mavlink start -d /dev/ttyACM0
+		if ! cdcacm_autostart start
+		then
+			sercon
+			echo "Starting MAVLink on /dev/ttyACM0"
+			mavlink start -d /dev/ttyACM0
+		fi
 	fi
 
 	#


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

When `CONFIG_DRIVERS_CDCACM_AUTOSTART` is disabled, the console tries to start mavlink on a non-existing port.

The cause is that `cdcacm_autostart start` will fail, since the app does not exist and then executes the branch:

```sh
if ! cdcacm_autostart start
then
	sercon
	echo "Starting MAVLink on /dev/ttyACM0"
	mavlink start -d /dev/ttyACM0
fi
```

Example output of the issue:
```
nsh: cdcacm_autostart: command not found
nsh: sercon: command not found
Starting MAVLink on /dev/ttyACM0
ERROR [mavlink] Device /dev/ttyACM0 does not exist
Usage: mavlink <command> [arguments...]
 Commands:

   start         Start a new instance
     [-d <val>]  Select Serial Device
                 values: <file:dev>, default: /dev/ttyS1
     [-b <val>]  Baudrate (can also be p:<param_name>)
                 default: 57600
     [-r <val>]  Maximum sending data rate in B/s (if 0, use baudrate / 20)
                 default: 0
     [-p]        Enable Broadcast
     [-u <val>]  Select UDP Network Port (local)
                 default: 14556
     [-o <val>]  Select UDP Network Port (remote)
                 default: 14550
     [-t <val>]  Partner IP (broadcasting can be enabled via -p flag)
                 default: 127.0.0.1
     [-m <val>]  Mode: sets default streams and rates
                 values: custom|camera|onboard|osd|magic|config|iridium|minimal|extvision|extvisionmin|gimbal|uavionix, defaul
     [-n <val>]  wifi/ethernet interface name
                 values: <interface_name>
     [-F <val>]  Sets the transmission frequency for iridium mode
                 default: 0.0
     [-f]        Enable message forwarding to other Mavlink instances
     [-w]        Wait to send, until first message received
     [-x]        Enable FTP
     [-z]        Force hardware flow control always on
     [-Z]        Force hardware flow control always off

   stop-all      Stop all instances

   stop          Stop a running instance
     [-u <val>]  Select Mavlink instance via local Network Port
     [-d <val>]  Select Mavlink instance via Serial Device
                 values: <file:dev>

   status        Print status for all instances
     [streams  ] Print all enabled streams

   stream        Configure the sending rate of a stream for a running instance
     [-u <val>]  Select Mavlink instance via local Network Port
     [-d <val>]  Select Mavlink instance via Serial Device
                 values: <file:dev>
     -s <val>    Mavlink stream to configure
     -r <val>    Rate in Hz (0 = turn off, -1 = set to default)

   boot_complete Enable sending of messages. (Must be) called as last step in startup script.
```

### Solution

I'm checking if the `SYS_USB_AUTO` param is > -1, since it's in the range of 0-2. That fixes the problem for my target and doesn't break it for others.

```sh
if param greater -s SYS_USB_AUTO -1
then
	if ! cdcacm_autostart start
	then
		sercon
		echo "Starting MAVLink on /dev/ttyACM0"
		mavlink start -d /dev/ttyACM0
	fi
fi
```

### Changelog Entry
For release notes:
```
Fix: Only autostart CDC/ACM when module is enabled
```

### Alternatives

I tried to find a nsh command that checks if commands exists, but didn't find it.
Something like this could also work:

```sh
if app_exists cdcacm_autostart
then
	if ! cdcacm_autostart start
	then
		sercon
		echo "Starting MAVLink on /dev/ttyACM0"
		mavlink start -d /dev/ttyACM0
	fi
fi
```

### Test coverage

- Tested in hardware on Skynode X (with `CONFIG_DRIVERS_CDCACM_AUTOSTART`)
- Tested in hardware on Skynode S (without `CONFIG_DRIVERS_CDCACM_AUTOSTART`)
