### PR TITLE
FIX: fixed-wing airspeed and wind estimation problem in SITL

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -230,6 +230,7 @@ set(msg_files
 	VelocityLimits.msg
 	WheelEncoders.msg
 	Wind.msg
+	WindGz.msg
 	YawEstimatorStatus.msg
 	versioned/ActuatorMotors.msg
 	versioned/ActuatorServos.msg

--- a/msg/WindGz.msg
+++ b/msg/WindGz.msg
@@ -1,0 +1,8 @@
+uint64 timestamp		# time since system start (microseconds)
+uint64 timestamp_sample         # the timestamp of the raw data (microseconds)
+
+float32 x		# Wind component in north / X direction (m/sec)
+float32 y		# Wind component in east / Y direction (m/sec)
+float32 z		# Wind component in vertical / Z direction (m/sec)
+
+

--- a/msg/WindGz.msg
+++ b/msg/WindGz.msg
@@ -5,4 +5,4 @@ float32 x		# Wind component in north / X direction (m/sec)
 float32 y		# Wind component in east / Y direction (m/sec)
 float32 z		# Wind component in vertical / Z direction (m/sec)
 
-
+# TOPICS wind_gz

--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -263,7 +263,7 @@ int GZBridge::init()
 		PX4_ERR("failed to subscribe to %s", nav_sat_topic.c_str());
 		return PX4_ERROR;
 	}
-	
+
 	// Wind: /world/$WORLD/wind_info
 	std::string wind_topic = "/world/" + _world_name + "/wind_info";
 

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -62,6 +62,7 @@
 #include <uORB/topics/vehicle_odometry.h>
 #include <uORB/topics/wheel_encoders.h>
 #include <uORB/topics/obstacle_distance.h>
+#include <uORB/topics/wind_gz.h>
 
 #include <gz/math.hh>
 #include <gz/msgs.hh>
@@ -75,6 +76,7 @@
 #include <gz/msgs/laserscan.pb.h>
 #include <gz/msgs/stringmsg.pb.h>
 #include <gz/msgs/scene.pb.h>
+#include <gz/msgs/wind.pb.h>
 
 using namespace time_literals;
 
@@ -116,6 +118,7 @@ private:
 	void navSatCallback(const gz::msgs::NavSat &nav_sat);
 	void laserScantoLidarSensorCallback(const gz::msgs::LaserScan &scan);
 	void laserScanCallback(const gz::msgs::LaserScan &scan);
+	void windCallback(const gz::msgs::Wind &wind);
 
 	/**
 	 * @brief Call Entityfactory service
@@ -171,6 +174,7 @@ private:
 	// Subscriptions
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
+	uORB::Publication<wind_gz_s>        	      _wind_gz_pub{ORB_ID(wind_gz)};
 	uORB::Publication<distance_sensor_s>          _distance_sensor_pub{ORB_ID(distance_sensor)};
 	uORB::Publication<differential_pressure_s>    _differential_pressure_pub{ORB_ID(differential_pressure)};
 	uORB::Publication<obstacle_distance_s>        _obstacle_distance_pub{ORB_ID(obstacle_distance)};

--- a/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.cpp
+++ b/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.cpp
@@ -110,7 +110,8 @@ void SensorAirspeedSim::Run()
 		// if the gazebo world includes windEffects plugin,
 		// calculate the airspeed from the true wind velocity by wind triangle
 
-		if (_vehicle_local_position_sub.updated() && _vehicle_global_position_sub.updated() && _vehicle_attitude_sub.updated()) {
+		if (_vehicle_local_position_sub.updated() && _vehicle_global_position_sub.updated()
+		    && _vehicle_attitude_sub.updated()) {
 
 			vehicle_local_position_s lpos{};
 			_vehicle_local_position_sub.copy(&lpos);
@@ -143,16 +144,17 @@ void SensorAirspeedSim::Run()
 			float diff_pressure;
 
 			// calculate true airspeed by wind triangle if wind is available
-			if (_wind_gz_sub.updated()){
+			if (_wind_gz_sub.updated()) {
 				wind_gz_s wind_true{};
 				_wind_gz_sub.copy(&wind_true);
 				Vector3f wind_velocity = Vector3f{wind_true.x, wind_true.y, wind_true.z};
 				Vector3f Va_vec = local_velocity - wind_velocity;  // calculate true airspeed by wind triangle
 				float Va = Va_vec.norm();
 				diff_pressure = sign(Va) * 0.005f * air_density  * Va * Va + diff_pressure_noise;
-			}
-			else{
-				diff_pressure = sign(body_velocity(0)) * 0.005f * air_density  * body_velocity(0) * body_velocity(0) + diff_pressure_noise;
+
+			} else {
+				diff_pressure = sign(body_velocity(0)) * 0.005f * air_density  * body_velocity(0) * body_velocity(
+							0) + diff_pressure_noise;
 			}
 
 			differential_pressure_s differential_pressure{};

--- a/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.hpp
+++ b/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.hpp
@@ -47,6 +47,8 @@
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_local_position.h>
 
+#include <uORB/topics/wind_gz.h>
+
 using namespace time_literals;
 
 static constexpr float TEMPERATURE_MSL = 288.15; // temperature at MSL [K] (15 [C])
@@ -84,7 +86,8 @@ private:
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_global_position_sub{ORB_ID(vehicle_global_position_groundtruth)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position_groundtruth)};
-
+	uORB::Subscription _wind_gz_sub{ORB_ID(wind_gz)};
+	
 	uORB::PublicationMulti<differential_pressure_s> _differential_pressure_pub{ORB_ID(differential_pressure)};
 
 	perf_counter_t _loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};

--- a/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.hpp
+++ b/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.hpp
@@ -87,7 +87,7 @@ private:
 	uORB::Subscription _vehicle_global_position_sub{ORB_ID(vehicle_global_position_groundtruth)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position_groundtruth)};
 	uORB::Subscription _wind_gz_sub{ORB_ID(wind_gz)};
-	
+
 	uORB::PublicationMulti<differential_pressure_s> _differential_pressure_pub{ORB_ID(differential_pressure)};
 
 	perf_counter_t _loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

Fixes #23756

### Solution
- The wind information publishing property has been added to `windEffect.cc` plugin in Gazebo sim `ionic`
   https://github.com/gazebosim/gz-sim/pull/2767
- if the wind plugin is activated, the airspeed will be calculated using the wind triangle; otherwise, the airspeed will be calculated default by x-axis of body velocity.
### Changelog Entry
N/A

### Alternatives
N/A

### Test coverage
N/A

### Context
N/A
