### PR TITLE
cleanup gz_msgs CMakeLists

### DIFF
--- a/src/modules/simulation/gz_msgs/CMakeLists.txt
+++ b/src/modules/simulation/gz_msgs/CMakeLists.txt
@@ -4,52 +4,26 @@
 #
 ############################################################################
 
-# message(FATAL_ERROR "JAKE JAKE JAKE JAKE JAKE JAKE JAKE JAKE JAKE JAKE JAKE JAKE JAKE JAKE JAKE JAKE JAKE JAKE ")
-
-# Check for Gazebo first
-if(NOT DEFINED ENV{GZ_DISTRO})
-    set(GZ_DISTRO "harmonic" CACHE STRING "Gazebo distribution to use")
-else()
-    set(GZ_DISTRO $ENV{GZ_DISTRO})
-endif()
-
-# Set versions based on distribution
-if(GZ_DISTRO STREQUAL "harmonic")
-    set(GZ_CMAKE_VERSION "3")
-    set(GZ_MSGS_VERSION "10")
-    set(GZ_TRANSPORT_VERSION "13")
-elseif(GZ_DISTRO STREQUAL "ionic")
-    set(GZ_CMAKE_VERSION "4")
-    set(GZ_MSGS_VERSION "11")
-    set(GZ_TRANSPORT_VERSION "14")
-else()
-    message(FATAL_ERROR "Unknown Gazebo distribution: ${GZ_DISTRO}")
-endif()
-
 # Find required packages
-find_package(gz-transport${GZ_TRANSPORT_VERSION})
-if(gz-transport${GZ_TRANSPORT_VERSION}_FOUND)
-    find_package(gz-cmake${GZ_CMAKE_VERSION} REQUIRED)
-    find_package(gz-msgs${GZ_MSGS_VERSION} REQUIRED)
-    find_package(Protobuf REQUIRED)
+find_package(Protobuf REQUIRED)
 
-    # Generate protobuf messages
-    file(GLOB MSGS_PROTOS "${CMAKE_CURRENT_SOURCE_DIR}/*.proto")
-    PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${MSGS_PROTOS})
+# Generate protobuf messages
+file(GLOB MSGS_PROTOS "${CMAKE_CURRENT_SOURCE_DIR}/*.proto")
+PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${MSGS_PROTOS})
 
-    # Create library
-    add_library(px4_gz_msgs STATIC
-        ${PROTO_SRCS}
-        ${PROTO_HDRS}
-    )
+# Create library
+add_library(px4_gz_msgs STATIC
+    ${PROTO_SRCS}
+    ${PROTO_HDRS}
+)
 
-    target_include_directories(px4_gz_msgs
-        PUBLIC
-            ${CMAKE_CURRENT_BINARY_DIR}
-            ${Protobuf_INCLUDE_DIRS}
-    )
-    target_link_libraries(px4_gz_msgs PUBLIC ${PROTOBUF_LIBRARIES})
+target_include_directories(px4_gz_msgs
+    PUBLIC
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${Protobuf_INCLUDE_DIRS}
+)
+target_link_libraries(px4_gz_msgs PUBLIC ${PROTOBUF_LIBRARIES})
 
-    # Export the binary dir for other modules
-    set(PX4_GZ_MSGS_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
-endif()
+# Export the binary dir for other modules
+set(PX4_GZ_MSGS_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
+

--- a/src/modules/simulation/gz_msgs/CMakeLists.txt
+++ b/src/modules/simulation/gz_msgs/CMakeLists.txt
@@ -5,25 +5,26 @@
 ############################################################################
 
 # Find required packages
-find_package(Protobuf REQUIRED)
+find_package(Protobuf)
 
-# Generate protobuf messages
-file(GLOB MSGS_PROTOS "${CMAKE_CURRENT_SOURCE_DIR}/*.proto")
-PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${MSGS_PROTOS})
+if (Protobuf_FOUND)
+    # Generate protobuf messages
+    file(GLOB MSGS_PROTOS "${CMAKE_CURRENT_SOURCE_DIR}/*.proto")
+    PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${MSGS_PROTOS})
 
-# Create library
-add_library(px4_gz_msgs STATIC
-    ${PROTO_SRCS}
-    ${PROTO_HDRS}
-)
+    # Create library
+    add_library(px4_gz_msgs STATIC
+        ${PROTO_SRCS}
+        ${PROTO_HDRS}
+    )
 
-target_include_directories(px4_gz_msgs
-    PUBLIC
-        ${CMAKE_CURRENT_BINARY_DIR}
-        ${Protobuf_INCLUDE_DIRS}
-)
-target_link_libraries(px4_gz_msgs PUBLIC ${PROTOBUF_LIBRARIES})
+    target_include_directories(px4_gz_msgs
+        PUBLIC
+            ${CMAKE_CURRENT_BINARY_DIR}
+            ${Protobuf_INCLUDE_DIRS}
+    )
+    target_link_libraries(px4_gz_msgs PUBLIC ${PROTOBUF_LIBRARIES})
 
-# Export the binary dir for other modules
-set(PX4_GZ_MSGS_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
-
+    # Export the binary dir for other modules
+    set(PX4_GZ_MSGS_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
+endif()

--- a/src/modules/simulation/gz_msgs/CMakeLists.txt
+++ b/src/modules/simulation/gz_msgs/CMakeLists.txt
@@ -24,6 +24,9 @@ if (Protobuf_FOUND)
             ${Protobuf_INCLUDE_DIRS}
     )
     target_link_libraries(px4_gz_msgs PUBLIC ${PROTOBUF_LIBRARIES})
+    if (Protobuf_VERSION VERSION_LESS "3.8")
+        target_compile_options(px4_gz_msgs PRIVATE -Wno-error=float-equal)
+    endif()
 
     # Export the binary dir for other modules
     set(PX4_GZ_MSGS_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The gz_msgs CMakeLists just depends on Protobuf and does not have GZ dependencies. The CMakeList also depends on an environment variable and does not build properly for non-harmonic Gazebo versions if not set.

This changed highlighted that building with an older version of protobuf gives a warning. This suppresses the warning for older versions of protobuf to make the build successful. 
The bug has been fixed on newer versions of Protobuf in this Protobuf [PR](https://github.com/protocolbuffers/protobuf/pull/6000) in 2019. 

### Solution
- Remove dependencies that are not required for gz_msgs to build properly. 
- Suppress the float equal warning on older protobuf versions. 

### Test coverage
- Local build on Ubuntu 24.04 with GZ Ionic. 