### PR TITLE
Takeoff: loiter after takeoff is established where the takeoff mode is completed, not around Home

### DIFF
--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -69,25 +69,6 @@ Takeoff::on_active()
 		_navigator->get_mission_result()->finished = true;
 		_navigator->set_mission_result_updated();
 		_navigator->mode_completed(getNavigatorStateId());
-
-		position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-
-		// set loiter item so position controllers stop doing takeoff logic
-		if (_navigator->get_land_detected()->landed) {
-			_mission_item.nav_cmd = NAV_CMD_IDLE;
-
-		} else {
-			if (pos_sp_triplet->current.valid) {
-				setLoiterItemFromCurrentPositionSetpoint(&_mission_item);
-
-			} else {
-				setLoiterItemFromCurrentPosition(&_mission_item);
-			}
-		}
-
-		mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
-
-		_navigator->set_position_setpoint_triplet_updated();
 	}
 }
 


### PR DESCRIPTION
### Solved Problem
Loiter after takeoff is done around Home instead of at current location, unless the distance to Home is too high at this point, see [this condition](https://github.com/PX4/PX4-Autopilot/blob/0ee592f67c4f52cf8e7a0d9939e00e5f1a3348f6/src/modules/navigator/loiter.cpp#L104C4-L104C6).

### Solution
We already [set loiter position in loiter.cpp](https://github.com/PX4/PX4-Autopilot/blob/0ee592f67c4f52cf8e7a0d9939e00e5f1a3348f6/src/modules/navigator/loiter.cpp#L108-L116), and thus I propose to remove it from the `takeoff::on_active()`. 

What we possibly drop with that [switch is to set IDLE](https://github.com/PX4/PX4-Autopilot/blob/0ee592f67c4f52cf8e7a0d9939e00e5f1a3348f6/src/modules/navigator/takeoff.cpp#L77) when the vehicle is landed after the takeoff is complete. But do we really need it? In [this PR](https://github.com/PX4/PX4-Autopilot/pull/23704) I propose to remove the IDLE setpoint anyway.

### Changelog Entry
For release notes:
```
Bugfix: loiter after takeoff is established at the position where the takeoff mode is completed, not around Home
```

### Alternatives
We could add a if(FW) check in set_takeoff_position(), and only use the existing current setpoint if not a FW. I don't see why it's needed though.

### Test coverage
SITL tested with plane and quad with takeoff command.
Also flight tested on a plane (handlaunch) with takeoff mode.

### Context
Before 
![image](https://github.com/user-attachments/assets/4bbf337f-2257-454b-8785-4f587b04e8b0)

Now
![image](https://github.com/user-attachments/assets/89fd9167-7ee9-408c-96a2-1c93fd0f17b3)

