### PR TITLE
RTL: Always publish available approaches from home and rally points 

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -360,14 +360,7 @@ void RTL::setRtlTypeAndDestination()
 	_rtl_status_pub.get().timestamp = hrt_absolute_time();
 	_rtl_status_pub.get().safe_points_id = _safe_points_id;
 	_rtl_status_pub.get().is_evaluation_pending = _dataman_state != DatamanState::UpdateRequestWait;
-	_rtl_status_pub.get().has_vtol_approach = false;
-
-	if ((_param_rtl_type.get() == 0) || (_param_rtl_type.get() == 3)) {
-		_rtl_status_pub.get().has_vtol_approach = _home_has_land_approach || _one_rally_point_has_land_approach;
-
-	} else if (_param_rtl_type.get() == 1) {
-		_rtl_status_pub.get().has_vtol_approach = _one_rally_point_has_land_approach;
-	}
+	_rtl_status_pub.get().has_vtol_approach = _home_has_land_approach || _one_rally_point_has_land_approach;
 
 	_rtl_status_pub.get().rtl_type = static_cast<uint8_t>(_rtl_type);
 	_rtl_status_pub.get().safe_point_index = safe_point_index;


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
If the takeoff_land_req parameter is set to 5 you can't upload a mission without landing, although approaches are defined in certain situation (e.g. RTL_TYPE=1). 

Fixes #{Github issue ID}

### Solution
- Make sure that the RTL module always publishes that land approaches are available for home or rally points. As even for RTL_TYPE=1 it would use the home approach if nothing else is defined.

### Changelog Entry
For release notes:
```
Bugfix Make sure that mission landing is not required when home approaches are set in while MIS_TKO_LAND_REQ=5
```

### Test coverage
- Tested in SITL

### Context
Related links, screenshot before/after, video
