### PR TITLE
removed defaults for min & max motors

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4019_x500_v2
+++ b/ROMFS/px4fmu_common/init.d/airframes/4019_x500_v2
@@ -22,11 +22,6 @@ param set-default MC_PITCHRATE_I 0.3
 param set-default MC_ROLLRATE_D 0.004
 param set-default MC_PITCHRATE_D 0.004
 
-param set-default PWM_MAIN_FUNC1 101
-param set-default PWM_MAIN_FUNC2 102
-param set-default PWM_MAIN_FUNC3 103
-param set-default PWM_MAIN_FUNC4 104
-
 # Square quadrotor X PX4 numbering
 param set-default CA_ROTOR_COUNT 4
 param set-default CA_ROTOR0_PX 1


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
x500 v2 bringup set disarm and min pwm to the same value.

Fixes #{Github issue ID}

### Solution
https://github.com/PX4/PX4-Autopilot/issues/24449

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
