### PR TITLE
voxl2-slpi: Removed bogus protocol check in custom Spektrum RC driver

### DIFF
--- a/boards/modalai/voxl2-slpi/src/drivers/spektrum_rc/spektrum_rc.cpp
+++ b/boards/modalai/voxl2-slpi/src/drivers/spektrum_rc/spektrum_rc.cpp
@@ -152,16 +152,11 @@ void task_main(int argc, char *argv[])
 		newbytes = read(uart_fd, &rx_buf[0], sizeof(rx_buf));
 #endif
 
-		uint8_t protocol_version = rx_buf[1] & 0x0F;
-
 		if (newbytes <= 0) {
 			if (print_msg) { PX4_INFO("Spektrum RC: Read no bytes from UART"); }
 
-		} else if (((newbytes != DSM_FRAME_SIZE) ||
-			    ((protocol_version != 0x02) && (protocol_version != 0x01))) &&
-			   (! first_correct_frame_received)) {
-			PX4_ERR("Spektrum RC: Invalid DSM frame. %d bytes. Protocol byte 0x%.2x",
-				newbytes, rx_buf[1]);
+		} else if ((newbytes != DSM_FRAME_SIZE) && (! first_correct_frame_received)) {
+			PX4_ERR("Invalid DSM frame size: %d bytes", newbytes);
 
 		} else {
 			if (print_msg) { PX4_INFO("Spektrum RC: Read %d bytes from UART", newbytes); }


### PR DESCRIPTION
The custom Spektrum RC driver for VOXL2 SLPI target has a protocol byte check in it that fails with certain Spektrum transmitters. Those transmitters work fine without the protocol byte check. The DSM library does not do this check. So, it was removed from the custom driver to make it compatible with more Spektrum receivers.