### PR TITLE
BMP581: Collect data using normal mode

### DIFF
--- a/src/drivers/barometer/bmp581/bmp581.cpp
+++ b/src/drivers/barometer/bmp581/bmp581.cpp
@@ -97,31 +97,24 @@ void BMP581::print_status()
 
 void BMP581::start()
 {
-	_collect_phase = false;
+	measure();
 
 	ScheduleOnInterval(_measure_interval, _measure_interval * 3);
 }
 
 void BMP581::RunImpl()
 {
-
-	if (_collect_phase) {
-		collect();
-	}
-
-	measure();
+	collect();
 }
 
 int BMP581::measure()
 {
 	int ret;
 
-	_collect_phase = true;
-
 	perf_begin(_measure_perf);
 
 	/* start measurement */
-	ret = set_power_mode(BMP5_POWERMODE_FORCED);
+	ret = set_power_mode(BMP5_POWERMODE_NORMAL);
 
 	if (ret != PX4_OK) {
 		PX4_DEBUG("failed to set power mode");
@@ -137,8 +130,6 @@ int BMP581::measure()
 
 int BMP581::collect()
 {
-	_collect_phase = false;
-
 	bmp5_sensor_data data{};
 
 	uint8_t int_status;

--- a/src/drivers/barometer/bmp581/bmp581.h
+++ b/src/drivers/barometer/bmp581/bmp581.h
@@ -287,8 +287,6 @@ private:
 	perf_counter_t 		_measure_perf;
 	perf_counter_t 		_comms_errors;
 
-	bool			_collect_phase{false};
-
 	uint8_t			_chip_id{0};
 	uint8_t			_chip_rev_id{0};
 


### PR DESCRIPTION
In forced mode, the I2C interface requires longer intervals for proper data reading, whereas using extended intervals with the SPI interface may lead to altitude anomalies. This issue can be resolved by switching to normal mode for data acquisition.