### PR TITLE
EKF2: split GNSS pos/vel flags

### DIFF
--- a/Tools/ecl_ekf/analyse_logdata_ekf.py
+++ b/Tools/ecl_ekf/analyse_logdata_ekf.py
@@ -111,13 +111,13 @@ def find_checks_that_apply(
         innov_fail_checks.append('yaw')
 
     # Velocity Sensor Checks
-    if (np.amax(estimator_status_flags['cs_gps']) > 0.5):
+    if (np.amax(estimator_status_flags['cs_gnss_vel']) > 0.5):
         sensor_checks.append('vel')
         innov_fail_checks.append('velh')
         innov_fail_checks.append('velv')
 
     # Position Sensor Checks
-    if (pos_checks_when_sensors_not_fused or (np.amax(estimator_status_flags['cs_gps']) > 0.5)
+    if (pos_checks_when_sensors_not_fused or (np.amax(estimator_status_flags['cs_gnss_pos']) > 0.5)
         or (np.amax(estimator_status_flags['cs_ev_pos']) > 0.5)):
         sensor_checks.append('pos')
         innov_fail_checks.append('posh')

--- a/Tools/ecl_ekf/plotting/pdf_report.py
+++ b/Tools/ecl_ekf/plotting/pdf_report.py
@@ -185,7 +185,7 @@ def create_pdf_report(ulog: ULog, multi_instance: int, output_plot_filename: str
         # plot control mode summary A
         data_plot = ControlModeSummaryPlot(
             status_flags_time, estimator_status_flags, [['cs_tilt_align', 'cs_yaw_align'],
-            ['cs_gps', 'cs_opt_flow', 'cs_ev_pos'], ['cs_baro_hgt', 'cs_gps_hgt',
+            ['cs_gnss_pos', 'cs_opt_flow', 'cs_ev_pos'], ['cs_baro_hgt', 'cs_gps_hgt',
              'cs_rng_hgt', 'cs_ev_hgt'], ['cs_mag_hdg', 'cs_mag_3d', 'cs_mag_dec']],
             x_label='time (sec)', y_labels=['aligned', 'pos aiding', 'hgt aiding', 'mag aiding'],
             annotation_text=[['tilt alignment', 'yaw alignment'], ['GPS aiding', 'optical flow aiding',

--- a/msg/EstimatorStatus.msg
+++ b/msg/EstimatorStatus.msg
@@ -20,7 +20,7 @@ uint8 GPS_CHECK_FAIL_SPOOFED = 10		# 10 : GPS signal is spoofed
 uint64 control_mode_flags	# Bitmask to indicate EKF logic state
 uint8 CS_TILT_ALIGN = 0		# 0 - true if the filter tilt alignment is complete
 uint8 CS_YAW_ALIGN = 1		# 1 - true if the filter yaw alignment is complete
-uint8 CS_GPS = 2		# 2 - true if GPS measurements are being fused
+uint8 CS_GNSS_POS = 2		# 2 - true if GNSS position measurements are being fused
 uint8 CS_OPT_FLOW = 3		# 3 - true if optical flow measurements are being fused
 uint8 CS_MAG_HDG = 4		# 4 - true if a simple magnetic yaw heading is being fused
 uint8 CS_MAG_3D = 5		# 5 - true if 3-axis magnetometer measurement are being fused
@@ -47,6 +47,7 @@ uint8 CS_SYNTHETIC_MAG_Z = 25	# 25 - true when we are using a synthesized measur
 uint8 CS_VEHICLE_AT_REST = 26	# 26 - true when the vehicle is at rest
 uint8 CS_GPS_YAW_FAULT = 27	# 27 - true when the GNSS heading has been declared faulty and is no longer being used
 uint8 CS_RNG_FAULT = 28		# 28 - true when the range finder has been declared faulty and is no longer being used
+uint8 CS_GNSS_VEL = 44		# 44 - true if GNSS velocity measurements are being fused
 
 uint32 filter_fault_flags	# Bitmask to indicate EKF internal faults
 # 0 - true if the fusion of the magnetometer X-axis has encountered a numerical error

--- a/msg/EstimatorStatusFlags.msg
+++ b/msg/EstimatorStatusFlags.msg
@@ -6,7 +6,7 @@ uint64 timestamp_sample                   # the timestamp of the raw data (micro
 uint32 control_status_changes # number of filter control status (cs) changes
 bool cs_tilt_align            #  0 - true if the filter tilt alignment is complete
 bool cs_yaw_align             #  1 - true if the filter yaw alignment is complete
-bool cs_gps                   #  2 - true if GPS measurement fusion is intended
+bool cs_gnss_pos              #  2 - true if GNSS position measurement fusion is intended
 bool cs_opt_flow              #  3 - true if optical flow measurements fusion is intended
 bool cs_mag_hdg               #  4 - true if a simple magnetic yaw heading fusion is intended
 bool cs_mag_3d                #  5 - true if 3-axis magnetometer measurement fusion is intended
@@ -48,6 +48,7 @@ bool cs_opt_flow_terrain        # 40 - true if we are fusing flow data for terra
 bool cs_valid_fake_pos          # 41 - true if a valid constant position is being fused
 bool cs_constant_pos            # 42 - true if the vehicle is at a constant position
 bool cs_baro_fault	        # 43 - true when the current baro has been declared faulty and is no longer being used
+bool cs_gnss_vel                # 44 - true if GNSS velocity measurement fusion is intended
 
 # fault status
 uint32 fault_status_changes   # number of filter fault status (fs) changes

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -561,7 +561,7 @@ void AirspeedModule::poll_topics()
 	_gnss_lpos_valid = (_time_now_usec - _vehicle_local_position.timestamp < 1_s)
 			   && (_vehicle_local_position.timestamp > 0)
 			   && _vehicle_local_position.v_xy_valid
-			   && _estimator_status.control_mode_flags & (1 << estimator_status_s::CS_GPS);
+			   && _estimator_status.control_mode_flags & (1 << estimator_status_s::CS_GNSS_POS);
 }
 
 void AirspeedModule::update_wind_estimator_sideslip()

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -224,7 +224,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 
 	// If GPS aiding is required, declare fault condition if the required GPS quality checks are failing
 	if (_param_sys_has_gps.get()) {
-		const bool ekf_gps_fusion = estimator_status.control_mode_flags & (1 << estimator_status_s::CS_GPS);
+		const bool ekf_gps_fusion = estimator_status.control_mode_flags & (1 << estimator_status_s::CS_GNSS_POS);
 		const bool ekf_gps_check_fail = estimator_status.gps_check_fail_flags > 0;
 
 		if (ekf_gps_fusion) {

--- a/src/modules/ekf2/EKF/aid_sources/external_vision/ev_yaw_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/external_vision/ev_yaw_control.cpp
@@ -72,8 +72,8 @@ void Ekf::controlEvYawFusion(const imuSample &imu_sample, const extVisionSample 
 					     && PX4_ISFINITE(aid_src.observation)
 					     && PX4_ISFINITE(aid_src.observation_variance);
 
-	// if GPS enabled don't allow EV yaw if EV isn't NED
-	if (_control_status.flags.gps && _control_status.flags.yaw_align
+	// if GNSS is enabled don't allow EV yaw if EV isn't NED
+	if ((_control_status.flags.gnss_vel || _control_status.flags.gnss_pos) && _control_status.flags.yaw_align
 	    && (ev_sample.pos_frame != PositionFrame::LOCAL_FRAME_NED)
 	   ) {
 		continuing_conditions_passing = false;

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_yaw_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_yaw_control.cpp
@@ -96,11 +96,10 @@ void Ekf::controlGnssYawFusion(const gnssSample &gnss_sample)
 		} else {
 			if (starting_conditions_passing) {
 				// Try to activate GNSS yaw fusion
-				const bool not_using_ne_aiding = !_control_status.flags.gps && !_control_status.flags.aux_gpos;
 
 				if (!_control_status.flags.in_air
 				    || !_control_status.flags.yaw_align
-				    || not_using_ne_aiding) {
+				    || !isNorthEastAidingActive()) {
 
 					// Reset before starting the fusion
 					if (resetYawToGnss(gnss_sample.yaw, gnss_sample.yaw_offset)) {

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -566,7 +566,7 @@ union filter_control_status_u {
 	struct {
 		uint64_t tilt_align              : 1; ///< 0 - true if the filter tilt alignment is complete
 		uint64_t yaw_align               : 1; ///< 1 - true if the filter yaw alignment is complete
-		uint64_t gps                     : 1; ///< 2 - true if GPS measurement fusion is intended
+		uint64_t gnss_pos                : 1; ///< 2 - true if GNSS position measurement fusion is intended
 		uint64_t opt_flow                : 1; ///< 3 - true if optical flow measurements fusion is intended
 		uint64_t mag_hdg                 : 1; ///< 4 - true if a simple magnetic yaw heading fusion is intended
 		uint64_t mag_3D                  : 1; ///< 5 - true if 3-axis magnetometer measurement fusion is intended
@@ -620,8 +620,8 @@ uint64_t mag_heading_consistent  :
 		uint64_t opt_flow_terrain        : 1; ///< 40 - true if we are fusing flow data for terrain
 		uint64_t valid_fake_pos          : 1; ///< 41 - true if a valid constant position is being fused
 		uint64_t constant_pos            : 1; ///< 42 - true if the vehicle is at a constant position
-		uint64_t baro_fault	      : 1; ///< 43 - true when the baro has been declared faulty and is no longer being used
-
+		uint64_t baro_fault              : 1; ///< 43 - true when the baro has been declared faulty and is no longer being used
+		uint64_t gnss_vel                : 1; ///< 44 - true if GNSS velocity measurement fusion is intended
 	} flags;
 	uint64_t value;
 };

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -862,7 +862,11 @@ private:
 #if defined(CONFIG_EKF2_GNSS)
 	// control fusion of GPS observations
 	void controlGpsFusion(const imuSample &imu_delayed);
-	void stopGpsFusion();
+	void controlGnssVelFusion(estimator_aid_source3d_s &aid_src, bool force_reset);
+	void controlGnssPosFusion(estimator_aid_source2d_s &aid_src, const bool force_reset);
+	void stopGnssFusion();
+	void stopGnssVelFusion();
+	void stopGnssPosFusion();
 	void updateGnssVel(const imuSample &imu_sample, const gnssSample &gnss_sample, estimator_aid_source3d_s &aid_src);
 	void updateGnssPos(const gnssSample &gnss_sample, estimator_aid_source2d_s &aid_src);
 	void controlGnssYawEstimator(estimator_aid_source3d_s &aid_src_vel);

--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -617,7 +617,7 @@ bool EstimatorInterface::isOtherSourceOfHorizontalPositionAidingThan(const bool 
 
 int EstimatorInterface::getNumberOfActiveHorizontalPositionAidingSources() const
 {
-	return int(_control_status.flags.gps)
+	return int(_control_status.flags.gnss_pos)
 	       + int(_control_status.flags.ev_pos)
 	       + int(_control_status.flags.aux_gpos);
 }
@@ -672,8 +672,15 @@ bool EstimatorInterface::isVerticalVelocityAidingActive() const
 
 int EstimatorInterface::getNumberOfActiveVerticalVelocityAidingSources() const
 {
-	return int(_control_status.flags.gps)
+	return int(_control_status.flags.gnss_vel)
 	       + int(_control_status.flags.ev_vel);
+}
+
+bool EstimatorInterface::isNorthEastAidingActive() const
+{
+	return _control_status.flags.gnss_pos
+	       || _control_status.flags.gnss_vel
+	       || _control_status.flags.aux_gpos;
 }
 
 void EstimatorInterface::printBufferAllocationFailed(const char *buffer_name)

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -227,6 +227,7 @@ public:
 	// the flags considered are opt_flow, gps, ev_vel and ev_pos
 	bool isHorizontalAidingActive() const;
 	bool isVerticalAidingActive() const;
+	bool isNorthEastAidingActive() const;
 
 	int getNumberOfActiveHorizontalAidingSources() const;
 	int getNumberOfActiveHorizontalPositionAidingSources() const;

--- a/src/modules/ekf2/EKF/height_control.cpp
+++ b/src/modules/ekf2/EKF/height_control.cpp
@@ -205,7 +205,7 @@ Likelihood Ekf::estimateInertialNavFallingLikelihood() const
 		checks[1] = {ReferenceType::GNSS, _aid_src_gnss_hgt.innovation, _aid_src_gnss_hgt.innovation_variance};
 	}
 
-	if (_control_status.flags.gps) {
+	if (_control_status.flags.gnss_vel) {
 		checks[2] = {ReferenceType::GNSS, _aid_src_gnss_vel.innovation[2], _aid_src_gnss_vel.innovation_variance[2]};
 	}
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -533,7 +533,8 @@ void EKF2::Run()
 			} else if (vehicle_command.command == vehicle_command_s::VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE) {
 
 				if ((_ekf.control_status_flags().wind_dead_reckoning || _ekf.control_status_flags().inertial_dead_reckoning
-				     || (!_ekf.control_status_flags().in_air && !_ekf.control_status_flags().gps)) && PX4_ISFINITE(vehicle_command.param2)
+				     || (!_ekf.control_status_flags().in_air && !_ekf.control_status_flags().gnss_pos))
+				    && PX4_ISFINITE(vehicle_command.param2)
 				    && PX4_ISFINITE(vehicle_command.param5) && PX4_ISFINITE(vehicle_command.param6)
 				   ) {
 
@@ -1892,7 +1893,7 @@ void EKF2::PublishStatusFlags(const hrt_abstime &timestamp)
 		status_flags.control_status_changes   = _filter_control_status_changes;
 		status_flags.cs_tilt_align            = _ekf.control_status_flags().tilt_align;
 		status_flags.cs_yaw_align             = _ekf.control_status_flags().yaw_align;
-		status_flags.cs_gps                   = _ekf.control_status_flags().gps;
+		status_flags.cs_gnss_pos              = _ekf.control_status_flags().gnss_pos;
 		status_flags.cs_opt_flow              = _ekf.control_status_flags().opt_flow;
 		status_flags.cs_mag_hdg               = _ekf.control_status_flags().mag_hdg;
 		status_flags.cs_mag_3d                = _ekf.control_status_flags().mag_3D;
@@ -1934,6 +1935,7 @@ void EKF2::PublishStatusFlags(const hrt_abstime &timestamp)
 		status_flags.cs_valid_fake_pos      = _ekf.control_status_flags().valid_fake_pos;
 		status_flags.cs_constant_pos        = _ekf.control_status_flags().constant_pos;
 		status_flags.cs_baro_fault	    = _ekf.control_status_flags().baro_fault;
+		status_flags.cs_gnss_vel            = _ekf.control_status_flags().gnss_vel;
 
 		status_flags.fault_status_changes     = _filter_fault_status_changes;
 		status_flags.fs_bad_mag_x             = _ekf.fault_status_flags().bad_mag_x;

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -117,7 +117,7 @@ void EkfWrapper::disableGpsFusion()
 
 bool EkfWrapper::isIntendingGpsFusion() const
 {
-	return _ekf->control_status_flags().gps;
+	return _ekf->control_status_flags().gnss_vel || _ekf->control_status_flags().gnss_pos;
 }
 
 void EkfWrapper::enableGpsHeadingFusion()

--- a/src/modules/ekf2/test/test_EKF_basics.cpp
+++ b/src/modules/ekf2/test/test_EKF_basics.cpp
@@ -103,7 +103,8 @@ TEST_F(EkfBasicsTest, initialControlMode)
 	// THEN: EKF control status should be reasonable
 	EXPECT_EQ(1, (int) _ekf->control_status_flags().tilt_align);
 	EXPECT_EQ(1, (int) _ekf->control_status_flags().yaw_align);
-	EXPECT_EQ(0, (int) _ekf->control_status_flags().gps);
+	EXPECT_EQ(0, (int) _ekf->control_status_flags().gnss_pos);
+	EXPECT_EQ(0, (int) _ekf->control_status_flags().gnss_vel);
 	EXPECT_EQ(0, (int) _ekf->control_status_flags().opt_flow);
 	EXPECT_EQ(1, (int) _ekf->control_status_flags().mag_hdg);
 	EXPECT_EQ(0, (int) _ekf->control_status_flags().mag_3D);
@@ -158,7 +159,8 @@ TEST_F(EkfBasicsTest, gpsFusion)
 	// THEN: EKF should fuse GPS, but no other position sensor
 	EXPECT_EQ(1, (int) _ekf->control_status_flags().tilt_align);
 	EXPECT_EQ(1, (int) _ekf->control_status_flags().yaw_align);
-	EXPECT_EQ(1, (int) _ekf->control_status_flags().gps);
+	EXPECT_EQ(1, (int) _ekf->control_status_flags().gnss_pos);
+	EXPECT_EQ(1, (int) _ekf->control_status_flags().gnss_vel);
 	EXPECT_EQ(0, (int) _ekf->control_status_flags().opt_flow);
 	EXPECT_EQ(1, (int) _ekf->control_status_flags().mag_hdg);
 	EXPECT_EQ(0, (int) _ekf->control_status_flags().mag_3D);


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
GNSS velocity and position can be selected independently in the control parameter, so there is no reason why they should share the same flag.

### Solution
Split velocity and position control logic. This also allows other part of the system to properly understand if position or/and velocity is aided by the GNSS measurements (the rest of the EKF was assuming that the global position is known if the `gps` flag was set, which is incorrect when only velocity measurements are fused).

### Test coverage
unit tests
basic SITL flight

