### PR TITLE
src/drivers/px4io/px4io.cpp: Fix compilation errors from printf modifiers

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -705,7 +705,7 @@ void PX4IO::update_params()
 						if (output_function >= (int)OutputFunction::Servo1
 						    && output_function <= (int)OutputFunction::ServoMax) { // Function got set to a servo
 							int32_t val = 1500;
-							PX4_INFO("Setting channel %i disarmed to %i", i + 1, (int)val);
+							PX4_INFO("Setting channel %i disarmed to %i", (int)i + 1, (int)val);
 							param_set(_mixing_output.disarmedParamHandle(i), &val);
 
 							// If the whole timer group was not set previously, then set the pwm rate to 50 Hz
@@ -737,10 +737,10 @@ void PX4IO::update_params()
 						if (output_function >= (int)OutputFunction::Motor1
 						    && output_function <= (int)OutputFunction::MotorMax) { // Function got set to a motor
 							int32_t val = 1100;
-							PX4_INFO("Setting channel %i minimum to %i", i + 1, (int)val);
+							PX4_INFO("Setting channel %i minimum to %i", (int)i + 1, (int)val);
 							param_set(_mixing_output.minParamHandle(i), &val);
 							val = 1900;
-							PX4_INFO("Setting channel %i maximum to %i", i + 1, (int)val);
+							PX4_INFO("Setting channel %i maximum to %i", (int)i + 1, (int)val);
 							param_set(_mixing_output.maxParamHandle(i), &val);
 						}
 					}


### PR DESCRIPTION

### Solved Problem

I was getting compilation errors on some of TII's 64-bit px4 targets

### Solution

Cast the printf argument to int, expected by %i

### Changelog Entry

N/A

### Test coverage

Tested that compilation passes in CI
