### PR TITLE
src/lib/parameters/parameters.cpp: Remove conversion of unaligned pointers

### DIFF
--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -305,11 +305,11 @@ param_get(param_t param, void *val)
 
 		switch (param_type(param)) {
 		case PARAM_TYPE_INT32:
-			*(int32_t *)val = retrieve_value.i;
+			memcpy(val, &retrieve_value.i, sizeof(retrieve_value.i));
 			return PX4_OK;
 
 		case PARAM_TYPE_FLOAT:
-			*(float *)val = retrieve_value.f;
+			memcpy(val, &retrieve_value.f, sizeof(retrieve_value.f));
 			return PX4_OK;
 		}
 	}
@@ -327,13 +327,17 @@ param_get_default_value_internal(param_t param, void *default_val)
 
 	if (default_val) {
 		switch (param_type(param)) {
-		case PARAM_TYPE_INT32:
-			*(int32_t *) default_val = runtime_defaults.get(param).i;
-			return PX4_OK;
+		case PARAM_TYPE_INT32: {
+				int32_t val = runtime_defaults.get(param).i;
+				memcpy(default_val, &val, sizeof(val));
+				return PX4_OK;
+			}
 
-		case PARAM_TYPE_FLOAT:
-			*(float *) default_val = runtime_defaults.get(param).f;
-			return PX4_OK;
+		case PARAM_TYPE_FLOAT: {
+				float val = runtime_defaults.get(param).f;
+				memcpy(default_val, &val, sizeof(val));
+				return PX4_OK;
+			}
 		}
 	}
 
@@ -418,13 +422,13 @@ param_set_internal(param_t param, const void *val, bool mark_saved, bool notify_
 
 	switch (param_type(param)) {
 	case PARAM_TYPE_INT32:
-		param_changed = user_config_value.i != *(int32_t *)val;
-		new_value.i = *(int32_t *)val;
+		memcpy(&new_value.i, val, sizeof(new_value.i));
+		param_changed = user_config_value.i != new_value.i;
 		break;
 
 	case PARAM_TYPE_FLOAT:
-		param_changed = fabsf(user_config_value.f - * (float *) val) > FLT_EPSILON;
-		new_value.f = *(float *) val;
+		memcpy(&new_value.f, val, sizeof(new_value.f));
+		param_changed = fabsf(user_config_value.f - new_value.f) > FLT_EPSILON;
 		break;
 
 	default: {
@@ -548,13 +552,19 @@ int param_set_default_value(param_t param, const void *val)
 	const param_value_u firmware_default_value = firmware_defaults.get(param);
 
 	switch (param_type(param)) {
-	case PARAM_TYPE_INT32:
-		setting_to_static_default = (firmware_default_value.i == *(int32_t *)val);
-		break;
+	case PARAM_TYPE_INT32: {
+			int32_t new_value;
+			memcpy(&new_value, val, sizeof(new_value));
+			setting_to_static_default = firmware_default_value.i == new_value;
+			break;
+		}
 
-	case PARAM_TYPE_FLOAT:
-		setting_to_static_default = (fabsf(firmware_default_value.f - * (float *)val) <= FLT_EPSILON);
-		break;
+	case PARAM_TYPE_FLOAT: {
+			float new_value;
+			memcpy(&new_value, val, sizeof(new_value));
+			setting_to_static_default = fabsf(firmware_default_value.f - new_value) <= FLT_EPSILON;
+			break;
+		}
 	}
 
 	if (setting_to_static_default) {
@@ -567,12 +577,12 @@ int param_set_default_value(param_t param, const void *val)
 
 		switch (param_type(param)) {
 		case PARAM_TYPE_INT32: {
-				new_value.i = *(int32_t *) val;
+				memcpy(&new_value.i, val, sizeof(new_value.i));
 				break;
 			}
 
 		case PARAM_TYPE_FLOAT: {
-				new_value.f = *(float *) val;
+				memcpy(&new_value.f, val, sizeof(new_value.f));
 				break;
 			}
 


### PR DESCRIPTION

### Solved Problem

When switching to 1.15.3 based PX4 on some of TII's RISC-V based platforms, I found out that parameters crash on unaligned pointer access. This is due to some components, such as Logger, directly placing parameter values into a character buffer. The parameters component simply casts a non 32-bit aligned pointer value into float or int32, and accesses the value through that. As not all HW platforms support making such pointer dereferences, this crashes.

### Solution

Previously in v1.14 these accesses were (correctly) done by memcpy, which handles the alignment. This PR changes those back to memcpy.

### Alternatives

We could also change the interface to the parameter to be int32 *, or an union {int32, float] pointer, and hence pushing the alignment to the users of parameters interface.

### Test coverage

Tested on a custom microchip polarfire soc fpga platform
