### PR TITLE
src/lib/airspeed/CMakeLists.txt: Link to "atmosphere" library

### DIFF
--- a/src/lib/airspeed/CMakeLists.txt
+++ b/src/lib/airspeed/CMakeLists.txt
@@ -32,3 +32,4 @@
 ############################################################################
 
 px4_add_library(airspeed airspeed.cpp)
+target_link_libraries(airspeed PRIVATE atmosphere)


### PR DESCRIPTION

### Solved Problem

I am experiencing a link error with airspeed library, which calls "getDensityFromPressureAndTemp" from "atmosphere", but there is no linking dependency to that library

### Solution

Add "target_link_libraries" to add the link dependency

### Test coverage

Tested that this change eliminates the linking issue in TII/SSRCs CI
