### PR TITLE
MissionBase: replay change speed on resume immediately if not going to  previous

### DIFF
--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -236,7 +236,7 @@ MissionBase::on_activation()
 	}
 
 	if (!resume_mission_on_previous) {
-		// Only replay speed changes immedietly if we are not resuming the mission at the previous position item.
+		// Only replay speed changes immediately if we are not resuming the mission at the previous position item.
 		// Otherwise it must be handled in the on_active() method once we reach the previous position item.
 		replayCachedSpeedChangeItems();
 		_speed_replayed_on_activation = true;

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -218,6 +218,8 @@ MissionBase::on_activation()
 
 	int32_t resume_index = _inactivation_index > 0 ? _inactivation_index : 0;
 
+	bool resume_mission_on_previous = false;
+
 	if (_inactivation_index > 0 && cameraWasTriggering()) {
 		size_t num_found_items{0U};
 		getPreviousPositionItems(_inactivation_index - 1, &resume_index, num_found_items, 1U);
@@ -229,7 +231,18 @@ MissionBase::on_activation()
 			setMissionIndex(resume_index);
 
 			_align_heading_necessary = true;
+			resume_mission_on_previous = true;
 		}
+	}
+
+	if (!resume_mission_on_previous) {
+		// Only replay speed changes immedietly if we are not resuming the mission at the previous position item.
+		// Otherwise it must be handled in the on_active() method once we reach the previous position item.
+		replayCachedSpeedChangeItems();
+		_speed_replayed_on_activation = true;
+
+	} else {
+		_speed_replayed_on_activation = false;
 	}
 
 	checkClimbRequired(_mission.current_seq);
@@ -304,14 +317,16 @@ MissionBase::on_active()
 		replayCachedGimbalItems();
 	}
 
-	// Replay cached mission commands once the last mission waypoint is re-reached after the mission interruption.
-	// Each replay function also clears the cached items afterwards
+	// Replay cached trigger commands once the last mission waypoint is re-reached after the mission resume
 	if (_mission.current_seq > _mission_activation_index) {
 		// replay trigger commands
 		if (cameraWasTriggering()) {
 			replayCachedTriggerItems();
 		}
+	}
 
+	if (!_speed_replayed_on_activation && _mission.current_seq > _mission_activation_index) {
+		// replay speed change items if not already done on mission (re-)activation
 		replayCachedSpeedChangeItems();
 	}
 

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -332,6 +332,7 @@ protected:
 	float _mission_init_climb_altitude_amsl{NAN}; 		/**< altitude AMSL the vehicle will climb to when mission starts */
 	int _inactivation_index{-1}; // index of mission item at which the mission was paused. Used to resume survey missions at previous waypoint to not lose images.
 	int _mission_activation_index{-1};					/**< Index of the mission item that will bring the vehicle back to a mission waypoint */
+	bool _speed_replayed_on_activation{false};			/**< Flag indicating if the speed change items have been replayed on activation */
 
 	int32_t _load_mission_index{-1}; /**< Mission inted of loaded mission items in dataman cache*/
 	int32_t _dataman_cache_size_signed; /**< Size of the dataman cache. A negativ value indicates that previous mission items should be loaded, a positiv value the next mission items*/


### PR DESCRIPTION

### Solved Problem
This fixes an issue where the speed was not correctly set at the beginning of a survey (with first wp having a DO_CHANGE_SPEED attached) when the user paused and resumed the mission prior to reaching the first waypoint.

See following screen recording: mission is paused before reaching the survey, and on resume the survey speed is not applied.

https://github.com/user-attachments/assets/10b6ff69-2af9-4749-86a5-003cdd038ec9

Digging further down: when resuming the mission, the previous DO_CHANGE_SPEED are not immediately replayed but only once the next waypoint is reached. In the case here, this coincides with the next DO_CHANGE_SPEED (12) of the survey, which is thus overwritten by the previous DO_CHANGE_SPEED (5), and the survey is flown at 5m/s instead of 12.

### Solution
Replay DO_CHANGE_SPEED setpoints immediately on mission resume unless the vehicle first has to go back to previous waypoint.

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Test coverage
SITL tests with quad and survey pattern (which has a different mission speed defined as rest of mission).

### Context
This is a follow up to https://github.com/PX4/PX4-Autopilot/pull/23484.
