### PR TITLE
GPS Dump timeout increase + GPS overflow fix

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -85,7 +85,8 @@ using namespace device;
 using namespace time_literals;
 
 #define TIMEOUT_1HZ		1300	//!< Timeout time in mS, 1000 mS (1Hz) + 300 mS delta for error
-#define TIMEOUT_5HZ		500		//!< Timeout time in mS,  200 mS (5Hz) + 300 mS delta for error
+#define TIMEOUT_5HZ		500	//!< Timeout time in mS,  200 mS (5Hz) + 300 mS delta for error
+#define TIMEOUT_DUMP_ADD	450	//!< Additional time in mS to account for RTCM3 parsing and dumping
 #define RATE_MEASUREMENT_PERIOD 5_s
 
 enum class gps_driver_mode_t {
@@ -963,6 +964,12 @@ GPS::run()
 				/* The MB rover will wait as long as possible to compute a navigation solution,
 				 * possibly lowering the navigation rate all the way to 1 Hz while doing so. */
 				receive_timeout = TIMEOUT_1HZ;
+			}
+
+			if (_dump_communication_mode != gps_dump_comm_mode_t::Disabled) {
+				/* Dumping the RTCM3/UBX data requires additional parsing and storing of data via uORB.
+				 * Without additional time this can lead to timeouts. */
+				receive_timeout += TIMEOUT_DUMP_ADD;
 			}
 
 			while ((helper_ret = _helper->receive(receive_timeout)) > 0 && !should_exit()) {


### PR DESCRIPTION
### Solved Problem
When testing with the following setup, consistent GPS timeouts were observed:
- F9P with reduced output rate (https://github.com/PX4/PX4-GPSDrivers/commit/bbdd5767a961cc17bdcc577c79b1c708d2a7999a)
- NTRIP RTCM3 injection (15Hz)
- RTK dumping

Looking through the code revealed multiple causes for this:
- The UBX parser could get stuck in an invalid state, due to a buffer overflow (https://github.com/PX4/PX4-GPSDrivers/commit/91e3dbb296d74b2a6d4f8f3c7f2fddd3c6705495)
- Due to RTK dumping, the GPS outputs both UBX + RTCM3 on the UART. In some cases the parser parsed an invalid RTCM3 length, which caused it to read a lot of data (> 900 byte) and afterwards dumping all of that data. As it read invalid data, the parser was out of sync and it took quite some time for it to find the next valid UBX / RTCM3 data. This is worse now on the F9P, as the output rate is not 10Hz anymore (where more sync data was available).

The problem can be seen in the following plot, which plots the remaining GPS timeout:
![Screenshot from 2025-03-12 11-12-57](https://github.com/user-attachments/assets/fe607cd6-ba58-4404-8e69-f22635ded526)

As can be seen these dips correspond to the RTCM3 parser parsing a lot of data (due to having read an invalid length):
![Screenshot from 2025-03-12 11-14-19](https://github.com/user-attachments/assets/8de808f4-63b3-4a7b-a9e0-14f3a49b8d5b)

When RTK dumping is not enabled, this is not a problem at all, as only one kind of stream needs to be parsed, which results in none of those timeout dips.


### Solution
This is a short term solution, to avoid such systems failing the whole time
- Fixes the buffer overflow, which causes the decoder to enter an invalid state
- Increase the timeout in case of RTK dumping
  - The timeout was set by conducting tests and logging the remaining timeout. Afterwards I set the timeout high enough to still have some safety margin

For a long term solution:
- The parsing should be improved to avoid the inconsistent processing time
- Injection can also be improved, as it occurs in bursts now, which also causes inconsistent processing time


### Changelog Entry
For release notes:
```
Bugfix Fix UBX overflow and increase GPS timeouts in case of RTK dumping
```

### Test coverage
- Tested with the system described above
