### PR TITLE
docs_crowdin_download.yml - use secrets 

### DIFF
--- a/.github/workflows/docs_crowdin_download.yml
+++ b/.github/workflows/docs_crowdin_download.yml
@@ -47,4 +47,4 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_DOCS_PROJECT_ID }}
 
           # Visit https://crowdin.com/settings#api-key to create this token
-          CROWDIN_PERSONAL_TOKEN: ${{ secrets.PX4BUILDBOT_CROWDIN_PERSONAL_TOKEN }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.PX4BUILTBOT_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
Update the workflow to use PX4BUILTBOT_PERSONAL_ACCESS_TOKEN, which I have already defined.