### PR TITLE
crowdin.yml - fix ignore to be an array

### DIFF
--- a/docs/crowdin.yml
+++ b/docs/crowdin.yml
@@ -7,7 +7,7 @@
 "files": [
   {
     "source": "docs/en/**/*.md",
-    "ignore": "docs/en/_sidebar.md",
+    "ignore": ["docs/en/_sidebar.md"],
     "translation": "docs/%two_letters_code%/**/%original_file_name%"
   }
 ]


### PR DESCRIPTION
This is to fix an error in the crowdin download of translations