### PR TITLE
ReplayEKF: reduce effect of IMU time slip

### DIFF
--- a/src/modules/replay/Replay.cpp
+++ b/src/modules/replay/Replay.cpp
@@ -902,6 +902,7 @@ Replay::run()
 
 	PX4_INFO("Replay in progress...");
 
+	// Find and add all subscriptions
 	ulog_message_header_s message_header;
 	replay_file.seekg(_data_section_start);
 
@@ -910,21 +911,22 @@ Replay::run()
 		replay_file.read((char *)&message_header, ULOG_MSG_HEADER_LEN);
 
 		if (!replay_file) {
+			// end of file
 			break;
 		}
 
 		if (message_header.msg_type == (int)ULogMessageType::ADD_LOGGED_MSG) {
 			readAndAddSubscription(replay_file, message_header.msg_size);
 
-		} else if (message_header.msg_type == (int)ULogMessageType::DATA) {
-			// End of Definition & Data Section Message Header section
-			break;
-
 		} else {
 			// Not important for now, skip
 			replay_file.seekg(message_header.msg_size, ios::cur);
 		}
 	}
+
+	// Rewind back to the begining of the data section
+	replay_file.seekg(_data_section_start);
+	replay_file.clear();
 
 	const uint64_t timestamp_offset = getTimestampOffset();
 	uint32_t nr_published_messages = 0;

--- a/src/modules/replay/Replay.hpp
+++ b/src/modules/replay/Replay.hpp
@@ -201,8 +201,7 @@ protected:
 	/**
 	 * Find next data message for this subscription, starting with the stored file offset.
 	 * Skip the first message, and if found, read the timestamp and store the new file offset.
-	 * This also takes care of new subscriptions and parameter updates. When reaching EOF,
-	 * the subscription is set to invalid.
+	 * When reaching EOF, the subscription is set to invalid.
 	 * File seek position is arbitrary after this call.
 	 * @return false on file error
 	 */

--- a/src/modules/replay/ReplayEkf2.cpp
+++ b/src/modules/replay/ReplayEkf2.cpp
@@ -160,6 +160,15 @@ ReplayEkf2::publishEkf2Topics(sensor_combined_s &sensor_combined, std::ifstream 
 	findTimestampAndPublish(sensor_combined.timestamp, _aux_global_position_msg_id, replay_file);
 
 	// sensor_combined: publish last because ekf2 is polling on this
+	if (_last_sensor_combined_timestamp > 0) {
+		// Some samples might be missing so compensate for this by holding the last value
+		const uint32_t true_dt = static_cast<uint32_t>(sensor_combined.timestamp - _last_sensor_combined_timestamp);
+		sensor_combined.gyro_integral_dt = true_dt;
+		sensor_combined.accelerometer_integral_dt = true_dt;
+	}
+
+	_last_sensor_combined_timestamp = sensor_combined.timestamp;
+
 	publishTopic(*_subscriptions[_sensor_combined_msg_id], &sensor_combined);
 
 	return true;

--- a/src/modules/replay/ReplayEkf2.hpp
+++ b/src/modules/replay/ReplayEkf2.hpp
@@ -100,6 +100,7 @@ private:
 	uint16_t _vehicle_attitude_groundtruth_msg_id = msg_id_invalid;
 
 	bool _ekf2_timestamps_exists{false};
+	uint64_t _last_sensor_combined_timestamp{0};
 };
 
 } //namespace px4


### PR DESCRIPTION
### Solved Problem
The INS part of the EKF relies on the `integral_dt` of the `sensors_combined` message to perform the integration. This doesn't cause issues in the real-time system as we don't miss any sample, but it causes issues in the "Best effort replay" where the data is not logged at full rate, accumulating a large time slip.

### Solution
Adjust the integral_dt (gyro and accel) to match the time between 2 sensor_combined logged samples.

### Test coverage
Left: main, right: this PR
We can see that the time slip creates navigation issues that can be resolved with this PR.
![Screenshot from 2025-03-13 10-45-27](https://github.com/user-attachments/assets/0bd8ba8b-cf93-407c-862b-1a7127cd2e0c)

