### PR TITLE
Fixed-wing: loiter after takeoff is established at current position, not around Home

### DIFF
--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -77,7 +77,8 @@ Takeoff::on_active()
 			_mission_item.nav_cmd = NAV_CMD_IDLE;
 
 		} else {
-			if (pos_sp_triplet->current.valid) {
+			if (pos_sp_triplet->current.valid
+			    && _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
 				setLoiterItemFromCurrentPositionSetpoint(&_mission_item);
 
 			} else {

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -69,6 +69,25 @@ Takeoff::on_active()
 		_navigator->get_mission_result()->finished = true;
 		_navigator->set_mission_result_updated();
 		_navigator->mode_completed(getNavigatorStateId());
+
+		position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+
+		// set loiter item so position controllers stop doing takeoff logic
+		if (_navigator->get_land_detected()->landed) {
+			_mission_item.nav_cmd = NAV_CMD_IDLE;
+
+		} else {
+			if (pos_sp_triplet->current.valid) {
+				setLoiterItemFromCurrentPositionSetpoint(&_mission_item);
+
+			} else {
+				setLoiterItemFromCurrentPosition(&_mission_item);
+			}
+		}
+
+		mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+
+		_navigator->set_position_setpoint_triplet_updated();
 	}
 }
 


### PR DESCRIPTION
Alternative to https://github.com/PX4/PX4-Autopilot/pull/24454, fixes https://github.com/PX4/PX4-Autopilot/issues/24496#issuecomment-2719544023

### Solved Problem
See https://github.com/PX4/PX4-Autopilot/pull/24454

### Solution
Do a if(MC) check, and keep current logic only for MC, while for FW establish loiter always at current position. 
Reason for differentiation MC/FW: And MC takeoff is considered complete before reaching set altitude, while for [FW it has to achieve the altitude fully](https://github.com/PX4/PX4-Autopilot/blob/e0d15b7a8042cfb38dcba6a064eb8685646526c0/src/modules/navigator/mission_block.cpp#L205). 

### Changelog Entry
For release notes:
```
Bugfix: fixed-wing: loiter after takeoff is established at current position, not around Home
```

### Alternatives
- We could add a method `setLoiterItemFromCurrentAltitudeSetpoint()` which sets a loiter at the current lateral position but doesn't overwrite the existing altitude setpoint field. 
- align FW/MC in that the takeoff altitude always has to be fully reached before declaring the takeoff completed. 