### PR TITLE
EKF2: consider GNSS vel as horizontal velocity aiding

### DIFF
--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -624,7 +624,8 @@ int EstimatorInterface::getNumberOfActiveHorizontalPositionAidingSources() const
 
 int EstimatorInterface::getNumberOfActiveHorizontalVelocityAidingSources() const
 {
-	return int(_control_status.flags.opt_flow)
+	return int(_control_status.flags.gnss_vel)
+	       + int(_control_status.flags.opt_flow)
 	       + int(_control_status.flags.ev_vel)
 	       // Combined airspeed and sideslip fusion allows sustained wind relative dead reckoning
 	       // and so is treated as a single aiding source.


### PR DESCRIPTION
follows https://github.com/PX4/PX4-Autopilot/pull/24472

### Solved Problem
GNSS velocity was not considered in `getNumberOfActiveHorizontalVelocityAidingSources`

### Solution
add it
