### PR TITLE
Added VTOL check for airspeed increase during front transition

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -147,7 +147,7 @@ PARAM_DEFINE_FLOAT(VT_ARSP_TRANS, 10.0f);
 /**
  * Front transition timeout
  *
- * Time in seconds after which transition will be cancelled. Disabled if set to 0.
+ * Time in seconds after which transition will be cancelled.
  *
  * @unit s
  * @min 0.1

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -273,6 +273,8 @@ PARAM_DEFINE_INT32(VT_FW_QC_HMAX, 0);
  * Airspeed-less front transition time (open loop)
  *
  * The duration of the front transition when there is no airspeed feedback available.
+ * When airspeed is used, transition timeout is declared if airspeed does not
+ * reach VT_ARSP_BLEND after this time.
  *
  * @unit s
  * @min 1.0

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -329,10 +329,13 @@ bool VtolType::isRollExceeded()
 bool VtolType::isFrontTransitionTimeout()
 {
 	// check front transition timeout
-	if (getFrontTransitionTimeout()  > FLT_EPSILON && _common_vtol_mode == mode::TRANSITION_TO_FW) {
+	if (_common_vtol_mode == mode::TRANSITION_TO_FW) {
+		// when we use airspeed, we can timeout earlier if airspeed is not increasing fast enough
+		if (_param_fw_use_airspd.get() && _time_since_trans_start > getOpenLoopFrontTransitionTime()
+		    && _airspeed_validated->calibrated_airspeed_m_s < getBlendAirspeed()) {
+			return true;
 
-		if (_time_since_trans_start > getFrontTransitionTimeout()) {
-			// transition timeout occured, abort transition
+		} else if (_time_since_trans_start > getFrontTransitionTimeout()) {
 			return true;
 		}
 	}


### PR DESCRIPTION
### Solved Problem
When the airspeed sensor is blocked, a VTOL will remain in the front transition until the transition times out (duration defiend by parameter). During this time the vehicle can speed up considerably and the rate controller can go into a limit cycle since the airspeed scaling does not work properly anymore.
Furthermore, the airspeed validator does not check against airspeed failures during the transition.

### Solution
If the vehicle uses airspeed, then we can be more strict on the transition timeout logic, by requiring that the airspeed should have reached at least the blending airspeed after the open loop transition time. The open loop transition time is usually set to the expected transition time and the airspeed blend parameter is usually well below the transition airspeed. Therefore, this condition should be quite robust and should not cause any false positives when the system is working as expected.

### Changelog Entry
For release notes:
```
Feature: For VTOL front transition with an airspeed sensor, require airspeed to reach blend airspeed after openloop transition time, otherwhise transition timeout will be triggered.
New parameter: XYZ_Z
Documentation: Add section in VTOL tuning guide which explains the change.
```

### Test coverage
Tested on standard VTOL and in SITL.
### Context
Related links, screenshot before/after, video
