### PR TITLE
Add synthetic airspeed based on thrust

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
+++ b/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
@@ -7,6 +7,7 @@
 #
 # @board px4_fmu-v2 exclude
 # @board bitcraze_crazyflie exclude
+# @board px4_fmu-v6x exclude
 #
 
 . ${R}etc/init.d/rc.mc_defaults

--- a/docs/assets/airframes/fw/reptile_dragon_2/reptile_dragon_2_params.params
+++ b/docs/assets/airframes/fw/reptile_dragon_2/reptile_dragon_2_params.params
@@ -1,5 +1,5 @@
 param set-default ASPD_DO_CHECKS 19
-param set-default ASPD_FALLBACK_GW 1
+param set-default ASPD_FALLBACK 1
 param set-default BAT1_N_CELLS 4
 param set-default BAT1_V_CHARGED 4.2000
 param set-default BAT1_V_EMPTY 2.9000

--- a/docs/assets/airframes/fw/turbo_timber_evolution/tteparams.params
+++ b/docs/assets/airframes/fw/turbo_timber_evolution/tteparams.params
@@ -1,5 +1,5 @@
 param set-default ASPD_DO_CHECKS 19
-param set-default ASPD_FALLBACK_GW 1
+param set-default ASPD_FALLBACK 1
 param set-default BAT1_N_CELLS 4
 param set-default BAT1_V_CHARGED 4.2000
 param set-default BAT1_V_EMPTY 2.5000

--- a/msg/px4_msgs_old/msg/AirspeedValidatedV0.msg
+++ b/msg/px4_msgs_old/msg/AirspeedValidatedV0.msg
@@ -1,0 +1,18 @@
+uint32 MESSAGE_VERSION = 0
+
+uint64 timestamp				# time since system start (microseconds)
+
+float32 indicated_airspeed_m_s			# indicated airspeed in m/s (IAS), set to NAN if invalid
+float32 calibrated_airspeed_m_s     		# calibrated airspeed in m/s (CAS, accounts for instrumentation errors), set to NAN if invalid
+float32 true_airspeed_m_s			# true filtered airspeed in m/s (TAS), set to NAN if invalid
+
+float32 calibrated_ground_minus_wind_m_s 	# CAS calculated from groundspeed - windspeed, where windspeed is estimated based on a zero-sideslip assumption, set to NAN if invalid
+float32 true_ground_minus_wind_m_s 		# TAS calculated from groundspeed - windspeed, where windspeed is estimated based on a zero-sideslip assumption, set to NAN if invalid
+
+bool airspeed_sensor_measurement_valid 		# True if data from at least one airspeed sensor is declared valid.
+
+int8 selected_airspeed_index 			# 1-3: airspeed sensor index, 0: groundspeed-windspeed, -1: airspeed invalid
+
+float32 airspeed_derivative_filtered		# filtered indicated airspeed derivative [m/s/s]
+float32 throttle_filtered			# filtered fixed-wing throttle [-]
+float32 pitch_filtered				# filtered pitch [rad]

--- a/msg/translation_node/translations/all_translations.h
+++ b/msg/translation_node/translations/all_translations.h
@@ -11,3 +11,4 @@
 //#include "example_translation_service_v1.h"
 
 #include "translation_vehicle_status_v1.h"
+#include "translation_airspeed_validated_v1.h"

--- a/msg/translation_node/translations/translation_airspeed_validated_v1.h
+++ b/msg/translation_node/translations/translation_airspeed_validated_v1.h
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * Copyright (c) 2025 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+#pragma once
+
+// Translate AirspeedValidated v0 <--> v1
+#include <px4_msgs_old/msg/airspeed_validated_v0.hpp>
+#include <px4_msgs/msg/airspeed_validated.hpp>
+
+class AirspeedValidatedV1Translation {
+public:
+	using MessageOlder = px4_msgs_old::msg::AirspeedValidatedV0;
+	static_assert(MessageOlder::MESSAGE_VERSION == 0);
+
+	using MessageNewer = px4_msgs::msg::AirspeedValidated;
+	static_assert(MessageNewer::MESSAGE_VERSION == 1);
+
+	static constexpr const char* kTopic = "fmu/out/airspeed_validated";
+
+	static void fromOlder(const MessageOlder &msg_older, MessageNewer &msg_newer) {
+		// Set msg_newer from msg_older
+		msg_newer.timestamp = msg_older.timestamp;
+		msg_newer.indicated_airspeed_m_s = msg_older.indicated_airspeed_m_s;
+		msg_newer.calibrated_airspeed_m_s = msg_older.calibrated_airspeed_m_s;
+		msg_newer.true_airspeed_m_s = msg_older.true_airspeed_m_s;
+		msg_newer.airspeed_source = msg_older.selected_airspeed_index;
+		msg_newer.calibrated_ground_minus_wind_m_s = msg_older.calibrated_ground_minus_wind_m_s;
+		msg_newer.calibraded_airspeed_synth_m_s = NAN;
+		msg_newer.airspeed_derivative_filtered = msg_older.airspeed_derivative_filtered;
+		msg_newer.throttle_filtered = msg_older.throttle_filtered;
+		msg_newer.pitch_filtered = msg_older.pitch_filtered;
+	}
+
+	static void toOlder(const MessageNewer &msg_newer, MessageOlder &msg_older) {
+		// Set msg_older from msg_newer
+		msg_older.timestamp = msg_newer.timestamp;
+		msg_older.indicated_airspeed_m_s = msg_newer.indicated_airspeed_m_s;
+		msg_older.calibrated_airspeed_m_s = msg_newer.calibrated_airspeed_m_s;
+		msg_older.true_airspeed_m_s = msg_newer.true_airspeed_m_s;
+		msg_older.calibrated_ground_minus_wind_m_s = msg_newer.calibrated_ground_minus_wind_m_s;
+		msg_older.true_ground_minus_wind_m_s = msg_newer.calibrated_ground_minus_wind_m_s;
+		msg_older.airspeed_sensor_measurement_valid = msg_newer.airspeed_source > 0 && msg_newer.airspeed_source <= 3;
+		msg_older.selected_airspeed_index = msg_newer.airspeed_source;
+		msg_older.airspeed_derivative_filtered = msg_newer.airspeed_derivative_filtered;
+		msg_older.throttle_filtered = msg_newer.throttle_filtered;
+		msg_older.pitch_filtered = msg_newer.pitch_filtered;
+	}
+};
+
+REGISTER_TOPIC_TRANSLATION_DIRECT(AirspeedValidatedV1Translation);

--- a/msg/versioned/AirspeedValidated.msg
+++ b/msg/versioned/AirspeedValidated.msg
@@ -1,18 +1,22 @@
-uint32 MESSAGE_VERSION = 0
+uint32 MESSAGE_VERSION = 1
 
 uint64 timestamp				# time since system start (microseconds)
 
-float32 indicated_airspeed_m_s			# indicated airspeed in m/s (IAS), set to NAN if invalid
-float32 calibrated_airspeed_m_s     		# calibrated airspeed in m/s (CAS, accounts for instrumentation errors), set to NAN if invalid
-float32 true_airspeed_m_s			# true filtered airspeed in m/s (TAS), set to NAN if invalid
+float32 indicated_airspeed_m_s			# [m/s] Indicated airspeed (IAS), set to NAN if invalid
+float32 calibrated_airspeed_m_s     		# [m/s] Calibrated airspeed (CAS), set to NAN if invalid
+float32 true_airspeed_m_s			# [m/s] True airspeed (TAS), set to NAN if invalid
 
+int8 airspeed_source				# Source of currently published airspeed values
+int8 DISABLED = -1
+int8 GROUND_MINUS_WIND = 0
+int8 SENSOR_1 = 1
+int8 SENSOR_2 = 2
+int8 SENSOR_3 = 3
+int8 SYNTHETIC = 4
+
+# debug states
 float32 calibrated_ground_minus_wind_m_s 	# CAS calculated from groundspeed - windspeed, where windspeed is estimated based on a zero-sideslip assumption, set to NAN if invalid
-float32 true_ground_minus_wind_m_s 		# TAS calculated from groundspeed - windspeed, where windspeed is estimated based on a zero-sideslip assumption, set to NAN if invalid
-
-bool airspeed_sensor_measurement_valid 		# True if data from at least one airspeed sensor is declared valid.
-
-int8 selected_airspeed_index 			# 1-3: airspeed sensor index, 0: groundspeed-windspeed, -1: airspeed invalid
-
+float32 calibraded_airspeed_synth_m_s		# synthetic airspeed in m/s, set to NAN if invalid
 float32 airspeed_derivative_filtered		# filtered indicated airspeed derivative [m/s/s]
 float32 throttle_filtered			# filtered fixed-wing throttle [-]
 float32 pitch_filtered				# filtered pitch [rad]

--- a/src/drivers/osd/msp_osd/uorb_to_msp.cpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.cpp
@@ -267,9 +267,9 @@ msp_raw_gps_t construct_RAW_GPS(const sensor_gps_s &vehicle_gps_position,
 	//raw_gps.hdop = vehicle_gps_position_struct.hdop
 	raw_gps.numSat = vehicle_gps_position.satellites_used;
 
-	if (airspeed_validated.airspeed_sensor_measurement_valid
+	if (airspeed_validated.airspeed_source >= airspeed_validated_s::GROUND_MINUS_WIND
 	    && PX4_ISFINITE(airspeed_validated.indicated_airspeed_m_s)
-	    && airspeed_validated.indicated_airspeed_m_s > 0) {
+	    && airspeed_validated.indicated_airspeed_m_s > 0.f) {
 		raw_gps.groundSpeed = airspeed_validated.indicated_airspeed_m_s * 100;
 
 	} else {

--- a/src/lib/airspeed/airspeed.cpp
+++ b/src/lib/airspeed/airspeed.cpp
@@ -214,3 +214,8 @@ float calc_calibrated_from_true_airspeed(float speed_true, float air_density)
 {
 	return speed_true * sqrtf(air_density / kAirDensitySeaLevelStandardAtmos);
 }
+
+float calc_true_from_calibrated_airspeed(float speed_calibrated, float air_density)
+{
+	return speed_calibrated * sqrtf(kAirDensitySeaLevelStandardAtmos / air_density);
+}

--- a/src/lib/airspeed/airspeed.h
+++ b/src/lib/airspeed/airspeed.h
@@ -137,6 +137,8 @@ __EXPORT float calc_TAS(float total_pressure, float static_pressure, float tempe
  */
 __EXPORT float calc_calibrated_from_true_airspeed(float speed_true, float air_density);
 
+__EXPORT float calc_true_from_calibrated_airspeed(float speed_calibrated, float air_density);
+
 __END_DECLS
 
 #endif

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -142,5 +142,13 @@ param_modify_on_import_ret param_modify_on_import(bson_node_t node)
 		}
 	}
 
+	// 2025-03-19: translate ASPD_FALLBACK_GW to ASPD_FALLBACK
+	{
+		if (strcmp("ASPD_FALLBACK_GW", node->name) == 0) {
+			strcpy(node->name, "ASPD_FALLBACK");
+			PX4_INFO("copying %s -> %s", "ASPD_FALLBACK_GW", "ASPD_FALLBACK");
+		}
+	}
+
 	return param_modify_on_import_ret::PARAM_NOT_MODIFIED;
 }

--- a/src/modules/airspeed_selector/AirspeedValidator.hpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.hpp
@@ -68,7 +68,7 @@ struct airspeed_validator_update_data {
 	float vel_test_ratio;
 	float hdg_test_ratio;
 	bool in_fixed_wing_flight;
-	float fixed_wing_tecs_throttle;
+	float fixed_wing_throttle_filtered;
 	float fixed_wing_tecs_throttle_trim;
 	uint64_t tecs_timestamp;
 };
@@ -89,7 +89,6 @@ public:
 	bool get_airspeed_valid() { return _airspeed_valid; }
 	float get_CAS_scale_validated() {return _CAS_scale_validated;}
 	float get_airspeed_derivative() { return _IAS_derivative.getState(); }
-	float get_throttle_filtered() { return _throttle_filtered.getState(); }
 	float get_pitch_filtered() { return _pitch_filtered.getState(); }
 
 	airspeed_wind_s get_wind_estimator_states(uint64_t timestamp);
@@ -181,7 +180,6 @@ private:
 	bool _first_principle_check_failed{false}; ///< first principle check has detected failure
 	float _aspd_fp_t_window{0.f}; ///< time window for first principle check
 	FilteredDerivative<float> _IAS_derivative; ///< indicated airspeed derivative for first principle check
-	AlphaFilter<float> _throttle_filtered; ///< filtered throttle for first principle check
 	AlphaFilter<float> _pitch_filtered; ///< filtered pitch for first principle check
 	hrt_abstime _time_last_first_principle_check{0}; ///< time airspeed first principle was last checked (uSec)
 	hrt_abstime _time_last_first_principle_check_passing{0}; ///< time airspeed first principle was last passing (uSec)

--- a/src/modules/airspeed_selector/airspeed_selector_params.c
+++ b/src/modules/airspeed_selector/airspeed_selector_params.c
@@ -136,6 +136,7 @@ PARAM_DEFINE_FLOAT(ASPD_SCALE_3, 1.0f);
  * @value 1 First airspeed sensor
  * @value 2 Second airspeed sensor
  * @value 3 Third airspeed sensor
+ * @value 4 Thrust based airspeed
  *
  * @reboot_required true
  * @group Airspeed Validator
@@ -160,17 +161,14 @@ PARAM_DEFINE_INT32(ASPD_PRIMARY, 1);
 PARAM_DEFINE_INT32(ASPD_DO_CHECKS, 7);
 
 /**
- * Enable fallback to sensor-less airspeed estimation
+ * Fallback options
  *
- * If set to true and airspeed checks are enabled, it will use a sensor-less airspeed estimation based on groundspeed
- * minus windspeed if no other airspeed sensor available to fall back to.
- *
- * @value 0 Disable fallback to sensor-less estimation
- * @value 1 Enable fallback to sensor-less estimation
- * @boolean
+ * @value 0 Fallback only to other airspeed sensors
+ * @value 1 Fallback to groundspeed-minus-windspeed airspeed estimation
+ * @value 2 Fallback to thrust based airspeed estimation
  * @group Airspeed Validator
  */
-PARAM_DEFINE_INT32(ASPD_FALLBACK_GW, 0);
+PARAM_DEFINE_INT32(ASPD_FALLBACK, 0);
 
 /**
  * Airspeed failure innovation threshold

--- a/src/modules/commander/HealthAndArmingChecks/checks/airspeedCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/airspeedCheck.cpp
@@ -54,6 +54,12 @@ void AirspeedChecks::checkAndReport(const Context &context, Report &reporter)
 
 		reporter.setIsPresent(health_component_t::differential_pressure);
 
+		const bool airspeed_from_sensor = airspeed_validated.airspeed_source == airspeed_validated_s::SENSOR_1
+						  || airspeed_validated.airspeed_source == airspeed_validated_s::SENSOR_2
+						  || airspeed_validated.airspeed_source == airspeed_validated_s::SENSOR_3;
+
+		const float airspeed_calibrated_from_sensor = airspeed_from_sensor ? airspeed_validated.calibrated_airspeed_m_s : NAN;
+
 		// Maximally allow the airspeed reading to be at FW_AIRSPD_MAX when arming. This is to catch very badly calibrated
 		// airspeed sensors, but also high wind conditions that prevent a forward flight of the vehicle.
 		float arming_max_airspeed_allowed = 20.f;
@@ -62,7 +68,7 @@ void AirspeedChecks::checkAndReport(const Context &context, Report &reporter)
 		/*
 		 * Check if airspeed is declared valid or not by airspeed selector.
 		 */
-		if (!PX4_ISFINITE(airspeed_validated.calibrated_airspeed_m_s)) {
+		if (!PX4_ISFINITE(airspeed_calibrated_from_sensor)) {
 
 			/* EVENT
 			 */
@@ -75,7 +81,7 @@ void AirspeedChecks::checkAndReport(const Context &context, Report &reporter)
 			}
 		}
 
-		if (!context.isArmed() && fabsf(airspeed_validated.calibrated_airspeed_m_s) > arming_max_airspeed_allowed) {
+		if (!context.isArmed() && airspeed_calibrated_from_sensor > arming_max_airspeed_allowed) {
 			/* EVENT
 			 * @description
 			 * Current airspeed reading too high. Check if wind is below maximum airspeed and redo airspeed

--- a/src/modules/ekf2/EKF/aid_sources/airspeed/airspeed_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/airspeed/airspeed_fusion.cpp
@@ -131,7 +131,7 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 			if (_control_status.flags.inertial_dead_reckoning && !is_airspeed_consistent) {
 				resetVelUsingAirspeed(airspeed_sample);
 
-			} else if (!_external_wind_init
+			} else if (!_external_wind_init && !_synthetic_airspeed
 				   && (!_control_status.flags.wind
 				       || getWindVelocityVariance().longerThan(sq(_params.initial_wind_uncertainty)))) {
 				resetWindUsingAirspeed(airspeed_sample);
@@ -210,6 +210,10 @@ void Ekf::fuseAirspeed(const airspeedSample &airspeed_sample, estimator_aid_sour
 		const Vector2f K_wind = K.slice<State::wind_vel.dof, 1>(State::wind_vel.idx, 0);
 		K.setZero();
 		K.slice<State::wind_vel.dof, 1>(State::wind_vel.idx, 0) = K_wind;
+	}
+
+	if (_synthetic_airspeed) {
+		K.slice<State::wind_vel.dof, 1>(State::wind_vel.idx, 0) = 0.f;
 	}
 
 	measurementUpdate(K, H, aid_src.observation_variance, aid_src.innovation);

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -1259,16 +1259,6 @@ void Ekf::clearInhibitedStateKalmanGains(VectorState &K) const
 	}
 
 #endif // CONFIG_EKF2_MAGNETOMETER
-
-#if defined(CONFIG_EKF2_WIND)
-
-	if (!_control_status.flags.wind) {
-		for (unsigned i = 0; i < State::wind_vel.dof; i++) {
-			K(State::wind_vel.idx + i) = 0.f;
-		}
-	}
-
-#endif // CONFIG_EKF2_WIND
 }
 
 float Ekf::getHeadingInnov() const

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -105,6 +105,7 @@ public:
 
 #if defined(CONFIG_EKF2_AIRSPEED)
 	void setAirspeedData(const airspeedSample &airspeed_sample);
+	void setSyntheticAirspeed(const bool synthetic_airspeed) { _synthetic_airspeed = synthetic_airspeed; }
 #endif // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_RANGE_FINDER)
@@ -435,6 +436,7 @@ protected:
 
 #if defined(CONFIG_EKF2_AIRSPEED)
 	RingBuffer<airspeedSample> *_airspeed_buffer {nullptr};
+	bool _synthetic_airspeed{false};
 #endif // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2066,8 +2066,11 @@ void EKF2::UpdateAirspeedSample(ekf2_timestamps_s &ekf2_timestamps)
 		if (_airspeed_validated_sub.update(&airspeed_validated)) {
 
 			if (PX4_ISFINITE(airspeed_validated.true_airspeed_m_s)
-			    && (airspeed_validated.selected_airspeed_index > 0)
+			    && (airspeed_validated.airspeed_source > airspeed_validated_s::GROUND_MINUS_WIND)
 			   ) {
+
+				_ekf.setSyntheticAirspeed(airspeed_validated.airspeed_source == airspeed_validated_s::SYNTHETIC);
+
 				float cas2tas = 1.f;
 
 				if (PX4_ISFINITE(airspeed_validated.calibrated_airspeed_m_s)

--- a/src/modules/ekf2/test/test_EKF_airspeed.cpp
+++ b/src/modules/ekf2/test/test_EKF_airspeed.cpp
@@ -218,7 +218,7 @@ TEST_F(EkfAirspeedTest, testAirspeedDeadReckoning)
 
 	EXPECT_TRUE(_ekf_wrapper.isWindVelocityEstimated());
 	const Vector3f vel = _ekf->getVelocity();
-	EXPECT_NEAR(vel.norm(), airspeed_body.norm(), 1e-2f);
+	EXPECT_NEAR(vel.norm(), airspeed_body.norm(), 0.05f);
 	const Vector2f vel_wind_earth = _ekf->getWindVelocity();
 	EXPECT_NEAR(vel_wind_earth(0), 0.f, .1f);
 	EXPECT_NEAR(vel_wind_earth(1), 0.f, .1f);

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -214,8 +214,10 @@ FixedwingPositionControl::airspeed_poll()
 
 		_eas2tas = 1.0f; //this is the default value, taken in case of invalid airspeed
 
+		// do not use synthetic airspeed as this would create a thrust loop
 		if (PX4_ISFINITE(airspeed_validated.calibrated_airspeed_m_s)
-		    && PX4_ISFINITE(airspeed_validated.true_airspeed_m_s)) {
+		    && PX4_ISFINITE(airspeed_validated.true_airspeed_m_s)
+		    && airspeed_validated.airspeed_source != airspeed_validated_s::SYNTHETIC) {
 
 			airspeed_valid = true;
 

--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -93,10 +93,15 @@ bool FixedwingLandDetector::_get_landed_state()
 		airspeed_validated_s airspeed_validated{};
 		_airspeed_validated_sub.copy(&airspeed_validated);
 
+		const bool airspeed_from_sensor = airspeed_validated.airspeed_source == airspeed_validated_s::SENSOR_1
+						  || airspeed_validated.airspeed_source == airspeed_validated_s::SENSOR_2
+						  || airspeed_validated.airspeed_source == airspeed_validated_s::SENSOR_3;
+
 		bool airspeed_invalid = false;
 
-		// set _airspeed_filtered to 0 if airspeed data is invalid
-		if (!PX4_ISFINITE(airspeed_validated.true_airspeed_m_s) || hrt_elapsed_time(&airspeed_validated.timestamp) > 1_s) {
+		// set _airspeed_filtered to 0 if airspeed data is invalid or not from an actual airspeed sensor
+		if (!airspeed_from_sensor || !PX4_ISFINITE(airspeed_validated.true_airspeed_m_s)
+		    || hrt_elapsed_time(&airspeed_validated.timestamp) > 1_s) {
 			_airspeed_filtered = 0.0f;
 			airspeed_invalid = true;
 

--- a/src/modules/mavlink/streams/VFR_HUD.hpp
+++ b/src/modules/mavlink/streams/VFR_HUD.hpp
@@ -82,9 +82,13 @@ private:
 
 			airspeed_validated_s airspeed_validated{};
 			_airspeed_validated_sub.copy(&airspeed_validated);
+			const bool airspeed_from_sensor = airspeed_validated.airspeed_source == airspeed_validated_s::SENSOR_1
+							  || airspeed_validated.airspeed_source == airspeed_validated_s::SENSOR_2
+							  || airspeed_validated.airspeed_source == airspeed_validated_s::SENSOR_3;
 
 			mavlink_vfr_hud_t msg{};
-			msg.airspeed = airspeed_validated.calibrated_airspeed_m_s;
+			// display NAN in case of source not being one of the sensors
+			msg.airspeed = airspeed_from_sensor ? airspeed_validated.calibrated_airspeed_m_s : NAN;
 			msg.groundspeed = sqrtf(lpos.vx * lpos.vx + lpos.vy * lpos.vy);
 			msg.heading = math::degrees(matrix::wrap_2pi(lpos.heading));
 

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -104,8 +104,8 @@ void Standard::update_vtol_state()
 				const Vector3f vel = R_to_body * Vector3f(_local_pos->vx, _local_pos->vy, _local_pos->vz);
 				exit_backtransition_speed_condition = vel(0) < _param_mpc_xy_cruise.get();
 
-			} else if (PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)) {
-				exit_backtransition_speed_condition = _airspeed_validated->calibrated_airspeed_m_s < _param_mpc_xy_cruise.get();
+			} else if (PX4_ISFINITE(_attc->get_calibrated_airspeed())) {
+				exit_backtransition_speed_condition = _attc->get_calibrated_airspeed() < _param_mpc_xy_cruise.get();
 			}
 
 			const bool exit_backtransition_time_condition = _time_since_trans_start > _param_vt_b_trans_dur.get();
@@ -220,19 +220,18 @@ void Standard::update_transition_state()
 
 		// do blending of mc and fw controls if a blending airspeed has been provided and the minimum transition time has passed
 		if (_airspeed_trans_blend_margin > 0.0f &&
-		    PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s) &&
-		    _airspeed_validated->calibrated_airspeed_m_s > 0.0f &&
-		    _airspeed_validated->calibrated_airspeed_m_s >= getBlendAirspeed() &&
+		    PX4_ISFINITE(_attc->get_calibrated_airspeed()) &&
+		    _attc->get_calibrated_airspeed() > 0.0f &&
+		    _attc->get_calibrated_airspeed() >= getBlendAirspeed() &&
 		    _time_since_trans_start > getMinimumFrontTransitionTime()) {
 
-			mc_weight = 1.0f - fabsf(_airspeed_validated->calibrated_airspeed_m_s - getBlendAirspeed()) /
+			mc_weight = 1.0f - fabsf(_attc->get_calibrated_airspeed() - getBlendAirspeed()) /
 				    _airspeed_trans_blend_margin;
 			// time based blending when no airspeed sensor is set
 
-		} else if (!_param_fw_use_airspd.get() || !PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)) {
+		} else if (!PX4_ISFINITE(_attc->get_calibrated_airspeed())) {
 			mc_weight = 1.0f - _time_since_trans_start / getMinimumFrontTransitionTime();
 			mc_weight = math::constrain(2.0f * mc_weight, 0.0f, 1.0f);
-
 		}
 
 		// ramp up FW_PSP_OFF

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -336,15 +336,14 @@ void Tailsitter::fill_actuator_outputs()
 
 bool Tailsitter::isFrontTransitionCompletedBase()
 {
-	const bool airspeed_triggers_transition = PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)
-			&& _param_fw_use_airspd.get();
+	const bool airspeed_triggers_transition = PX4_ISFINITE(_attc->get_calibrated_airspeed());
 
 	bool transition_to_fw = false;
 	const float pitch = Eulerf(Quatf(_v_att->q)).theta();
 
 	if (pitch <= PITCH_THRESHOLD_AUTO_TRANSITION_TO_FW) {
 		if (airspeed_triggers_transition) {
-			transition_to_fw = _airspeed_validated->calibrated_airspeed_m_s >= _param_vt_arsp_trans.get() ;
+			transition_to_fw = _attc->get_calibrated_airspeed() >= _param_vt_arsp_trans.get() ;
 
 		} else {
 			transition_to_fw = true;

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -104,8 +104,8 @@ void Tiltrotor::update_vtol_state()
 				const Vector3f vel = R_to_body * Vector3f(_local_pos->vx, _local_pos->vy, _local_pos->vz);
 				exit_backtransition_speed_condition = vel(0) < _param_mpc_xy_cruise.get() ;
 
-			} else if (PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)) {
-				exit_backtransition_speed_condition = _airspeed_validated->calibrated_airspeed_m_s < _param_mpc_xy_cruise.get() ;
+			} else if (PX4_ISFINITE(_attc->get_calibrated_airspeed())) {
+				exit_backtransition_speed_condition = _attc->get_calibrated_airspeed() < _param_mpc_xy_cruise.get() ;
 			}
 
 			const bool exit_backtransition_time_condition = _time_since_trans_start > _param_vt_b_trans_dur.get() ;
@@ -251,14 +251,14 @@ void Tiltrotor::update_transition_state()
 		_mc_roll_weight = 1.0f;
 		_mc_yaw_weight = 1.0f;
 
-		if (_param_fw_use_airspd.get()  && PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s) &&
-		    _airspeed_validated->calibrated_airspeed_m_s >= getBlendAirspeed()) {
-			_mc_roll_weight = 1.0f - (_airspeed_validated->calibrated_airspeed_m_s - getBlendAirspeed()) /
+		if (PX4_ISFINITE(_attc->get_calibrated_airspeed()) &&
+		    _attc->get_calibrated_airspeed() >= getBlendAirspeed()) {
+			_mc_roll_weight = 1.0f - (_attc->get_calibrated_airspeed() - getBlendAirspeed()) /
 					  (getTransitionAirspeed()  - getBlendAirspeed());
 		}
 
 		// without airspeed do timed weight changes
-		if ((!_param_fw_use_airspd.get() || !PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)) &&
+		if ((!PX4_ISFINITE(_attc->get_calibrated_airspeed())) &&
 		    _time_since_trans_start > getMinimumFrontTransitionTime()) {
 			_mc_roll_weight = 1.0f - (_time_since_trans_start - getMinimumFrontTransitionTime()) /
 					  (getOpenLoopFrontTransitionTime() - getMinimumFrontTransitionTime());

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -128,7 +128,6 @@ public:
 	struct vehicle_thrust_setpoint_s		*get_vehicle_thrust_setpoint_virtual_mc() {return &_vehicle_thrust_setpoint_virtual_mc;}
 	struct vehicle_thrust_setpoint_s		*get_vehicle_thrust_setpoint_virtual_fw() {return &_vehicle_thrust_setpoint_virtual_fw;}
 
-	struct airspeed_validated_s 			*get_airspeed() {return &_airspeed_validated;}
 	struct position_setpoint_triplet_s		*get_pos_sp_triplet() {return &_pos_sp_triplet;}
 	struct tecs_status_s 				*get_tecs_status() {return &_tecs_status;}
 	struct vehicle_attitude_s 			*get_att() {return &_vehicle_attitude;}
@@ -144,7 +143,9 @@ public:
 	struct vehicle_thrust_setpoint_s 		*get_thrust_setpoint_0() {return &_thrust_setpoint_0;}
 	struct vehicle_thrust_setpoint_s 		*get_thrust_setpoint_1() {return &_thrust_setpoint_1;}
 	struct vtol_vehicle_status_s			*get_vtol_vehicle_status() {return &_vtol_vehicle_status;}
+
 	float get_home_position_z() { return _home_position_z; }
+	float get_calibrated_airspeed() { return _calibrated_airspeed; }
 
 private:
 	void Run() override;
@@ -196,7 +197,6 @@ private:
 	vehicle_thrust_setpoint_s		_thrust_setpoint_0{};
 	vehicle_thrust_setpoint_s		_thrust_setpoint_1{};
 
-	airspeed_validated_s 			_airspeed_validated{};
 	position_setpoint_triplet_s		_pos_sp_triplet{};
 	tecs_status_s				_tecs_status{};
 	vehicle_attitude_s			_vehicle_attitude{};
@@ -208,6 +208,8 @@ private:
 	vtol_vehicle_status_s 			_vtol_vehicle_status{};
 	vtol_vehicle_status_s 			_prev_published_vtol_vehicle_status{};
 	float _home_position_z{NAN};
+	float _calibrated_airspeed{NAN};
+	hrt_abstime _time_last_airspeed_update{0};
 
 	float _air_density{atmosphere::kAirDensitySeaLevelStandardAtmos};	// [kg/m^3]
 
@@ -242,6 +244,7 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::VT_TYPE>) _param_vt_type,
-		(ParamFloat<px4::params::VT_SPOILER_MC_LD>) _param_vt_spoiler_mc_ld
+		(ParamFloat<px4::params::VT_SPOILER_MC_LD>) _param_vt_spoiler_mc_ld,
+		(ParamBool<px4::params::FW_USE_AIRSPD>) _param_fw_use_airspd
 	)
 };

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -78,7 +78,6 @@ VtolType::VtolType(VtolAttitudeControl *att_controller) :
 	_thrust_setpoint_1 = _attc->get_thrust_setpoint_1();
 	_local_pos = _attc->get_local_pos();
 	_local_pos_sp = _attc->get_local_pos_sp();
-	_airspeed_validated = _attc->get_airspeed();
 	_tecs_status = _attc->get_tecs_status();
 	_land_detected = _attc->get_land_detected();
 }
@@ -175,8 +174,7 @@ bool VtolType::isFrontTransitionCompleted()
 bool VtolType::isFrontTransitionCompletedBase()
 {
 	// continue the transition to fw mode while monitoring airspeed for a final switch to fw mode
-	const bool airspeed_triggers_transition = PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)
-			&& _param_fw_use_airspd.get();
+	const bool airspeed_triggers_transition = PX4_ISFINITE(_attc->get_calibrated_airspeed());
 	const bool minimum_trans_time_elapsed = _time_since_trans_start > getMinimumFrontTransitionTime();
 	const bool openloop_trans_time_elapsed = _time_since_trans_start > getOpenLoopFrontTransitionTime();
 
@@ -184,7 +182,7 @@ bool VtolType::isFrontTransitionCompletedBase()
 
 	if (airspeed_triggers_transition) {
 		transition_to_fw = minimum_trans_time_elapsed
-				   && _airspeed_validated->calibrated_airspeed_m_s >= getTransitionAirspeed();
+				   && _attc->get_calibrated_airspeed() >= getTransitionAirspeed();
 
 	} else {
 		transition_to_fw = openloop_trans_time_elapsed;
@@ -331,8 +329,8 @@ bool VtolType::isFrontTransitionTimeout()
 	// check front transition timeout
 	if (_common_vtol_mode == mode::TRANSITION_TO_FW) {
 		// when we use airspeed, we can timeout earlier if airspeed is not increasing fast enough
-		if (_param_fw_use_airspd.get() && _time_since_trans_start > getOpenLoopFrontTransitionTime()
-		    && _airspeed_validated->calibrated_airspeed_m_s < getBlendAirspeed()) {
+		if (PX4_ISFINITE(_attc->get_calibrated_airspeed()) && _time_since_trans_start > getOpenLoopFrontTransitionTime()
+		    && _attc->get_calibrated_airspeed() < getBlendAirspeed()) {
 			return true;
 
 		} else if (_time_since_trans_start > getFrontTransitionTimeout()) {

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -338,7 +338,6 @@ protected:
 					(ParamFloat<px4::params::VT_ARSP_TRANS>) _param_vt_arsp_trans,
 					(ParamFloat<px4::params::VT_F_TRANS_THR>) _param_vt_f_trans_thr,
 					(ParamFloat<px4::params::VT_ARSP_BLEND>) _param_vt_arsp_blend,
-					(ParamBool<px4::params::FW_USE_AIRSPD>) _param_fw_use_airspd,
 					(ParamFloat<px4::params::VT_TRANS_TIMEOUT>) _param_vt_trans_timeout,
 					(ParamFloat<px4::params::MPC_XY_CRUISE>) _param_mpc_xy_cruise,
 					(ParamInt<px4::params::VT_FW_DIFTHR_EN>) _param_vt_fw_difthr_en,


### PR DESCRIPTION

### Solved Problem
Currently, when an airspeed sensor failure occurs while flying without GNSS/OF/EV, the system triggers a failsafe after five seconds of inertial dead reckoning. However, with a properly tuned system, it is possible to estimate airspeed based on thrust input.

### Solution
Synthetic airspeed is estimated based on interpolation between the current thrust and the FW_AIRSPD_xx, FW_THR_ASPD_xx parameter values. For the system to use synthetic airspeed, the ASPD_FALLBACK parameter needs to be adjusted accordingly. The user still receives an airspeed sensor failure warning (RTL recommended) but can continue flying with a valid local position estimate.
### Changelog Entry
For release notes:
```
Feature/Bugfix Add synthetic airspeed
Parameter ASPD_FALLBACK and uorb msg AirspeedValidated were changed.
```

### Test coverage
- Currently only SITL, hardware tests will follow
