### PR TITLE
17002_flightgear_tf-g2: translate FW_THR_CRUISE to FW_THR_TRIM

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/17002_flightgear_tf-g2
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/17002_flightgear_tf-g2
@@ -44,7 +44,7 @@ param set-default FW_R_LIM 30
 
 param set-default FW_MAN_R_MAX 30
 
-param set-default FW_THR_CRUISE 0.8
+param set-default FW_THR_TRIM 0.8
 param set-default FW_THR_IDLE 0
 param set-default COM_DISARM_PRFLT 0
 


### PR DESCRIPTION
### Solved Problem
When translating an older airframe to the new PX4 version I found that @roman-dvorak had missed the translation that had happened around the same time when creating this flightgear airframe.

Flightgear airframe addition:
https://github.com/PX4/PX4-Autopilot/pull/19122 / ed14151734919e81c9303a59adb1ba258735f621
VTOL Parameter translation `FW_THR_CRUISE` to `FW_THR_TRIM`:
https://github.com/PX4/PX4-Autopilot/pull/19623 / 461d0561b8489f84def107cd6b044e8713ec698b

### Solution
Do the correct translation which is a pure rename according to https://github.com/PX4/PX4-Autopilot/commit/461d0561b8489f84def107cd6b044e8713ec698b#diff-5c39db3d2f66f99ba6f87eee1c56ea14ef451be4beff27a948506aeccdedfe58R252

### Changelog Entry
```
Fix: Flightgear tf-g2 fixed wing cruise throttle
```

### Test coverage
I can't test this but since there was a rename and the same translation worked on our vehicle I'm pretty sure this is correct.