### PR TITLE
fmu-v6xrt: Don't autostart SF45 by default

### DIFF
--- a/boards/px4/fmu-v6xrt/init/rc.board_defaults
+++ b/boards/px4/fmu-v6xrt/init/rc.board_defaults
@@ -18,6 +18,9 @@ param set-default SENS_EN_INA238 0
 param set-default SENS_EN_INA228 0
 param set-default SENS_EN_INA226 0
 
+# Don't enable SF45 by default
+param set-default SENS_EN_SF45_CFG 0
+
 safety_button start
 
 if param greater -s UAVCAN_ENABLE 0


### PR DESCRIPTION
#24467 Enables SF45 in the V6X-RT builds however the SF45 enables itself by default.
https://github.com/PX4/PX4-Autopilot/blob/9fc9fb56d17908bc00588db70ff33f0257cec8d6/src/drivers/distance_sensor/lightware_sf45_serial/module.yaml#L5-L7

This PR makes sure that by default we don't start the SF45 on TELEM2 by default on the V6XRT.

Another option would be changing the default in the `lightware_sf45_serial/module.yaml`