### PR TITLE
Hotfix: stop gazebo simulation from spamming multicast packets on the network

### DIFF
--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -129,14 +129,14 @@ if (gz-transport${GZ_TRANSPORT_VERSION}_FOUND)
 
 			if(world_name STREQUAL "default")
 				add_custom_target(gz_${model_name}
-					COMMAND ${CMAKE_COMMAND} -E env PX4_SIM_MODEL=gz_${model_name} $<TARGET_FILE:px4>
+					COMMAND ${CMAKE_COMMAND} -E env PX4_SIM_MODEL=gz_${model_name} GZ_IP=127.0.0.1 $<TARGET_FILE:px4>
 					WORKING_DIRECTORY ${SITL_WORKING_DIR}
 					USES_TERMINAL
 					DEPENDS px4 px4_gz_plugins
 				)
 			else()
 				add_custom_target(gz_${model_name}_${world_name}
-					COMMAND ${CMAKE_COMMAND} -E env PX4_SIM_MODEL=gz_${model_name} PX4_GZ_WORLD=${world_name} $<TARGET_FILE:px4>
+					COMMAND ${CMAKE_COMMAND} -E env PX4_SIM_MODEL=gz_${model_name} PX4_GZ_WORLD=${world_name} GZ_IP=127.0.0.1 $<TARGET_FILE:px4>
 					WORKING_DIRECTORY ${SITL_WORKING_DIR}
 					USES_TERMINAL
 					DEPENDS px4 px4_gz_plugins


### PR DESCRIPTION
### Solved Problem
When inspecting the network with Wireshark I found that gazebo sends out a gigantic amount of multicast messages to everyone on the network containing ASCII string information about computer name, topic names, values for all kinds of sensor samples, commands, UI interactions. The problem with this is that they influence other systems and if there are enough simulations running can even bring down network performance significantly.

Note: When running the gazebo simultion in WSL the multicast packets never get routed away from the machine but on Linux the messages are sent out to all networks.

Reproduce:
1. Run `make px4_sitl gz_x500`
2. Check with Wireshark any network adapter on the computer the simulation is running (or any other computer in the same network).
3. See tons of spam
![image](https://github.com/user-attachments/assets/ba836cb2-b86e-4afa-9c34-543f3afcfb06)

### Solution
I'm not a gazebo expert but with the help of @mbjd and @StefanoColli I figured some environmental variables configure that unwanted default behavior. Apparently setting the `GZ_IP` stops spamming multicast but delivers data only to localhost and that should IMHO be the default. 

### Changelog Entry
```
Hotfix: stop gazebo simulation from spamming multicast packets on the network
```

### Alternatives
- @StefanoColli pointed out that whatever fix we decide to go with should probably also go here: https://github.com/PX4/PX4-gazebo-models/blob/main/simulation-gazebo#L93 or better even we call the same wrapper everywhere such that there's no such duplication of the `gz` commands.
- Gazebo classic probably needs a similar fix since @haumarco saw some multicast also with the old gazebo but it was much less data getting sent out.

### Test coverage
When I monitor my WSL outgoing interface this change causes the spam to disappear and I'm left with only the MAVLink messages between Windows and WSL.