### PR TITLE
gz: set realtime clock at startup

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -182,7 +182,16 @@ void GZBridge::clockCallback(const gz::msgs::Clock &msg)
 	struct timespec ts;
 	ts.tv_sec = msg.sim().sec();
 	ts.tv_nsec = msg.sim().nsec();
-	px4_clock_settime(CLOCK_MONOTONIC, &ts);
+
+	if (!_realtime_clock_set) {
+		// Set initial real time clock at startup
+		px4_clock_settime(CLOCK_REALTIME, &ts);
+		_realtime_clock_set = true;
+
+	} else {
+		// Keep monotonic clock synchronized
+		px4_clock_settime(CLOCK_MONOTONIC, &ts);
+	}
 }
 
 void GZBridge::opticalFlowCallback(const px4::msgs::OpticalFlow &msg)

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -162,6 +162,7 @@ private:
 
 	float _temperature{288.15};  // 15 degrees
 
+	bool _realtime_clock_set{false};
 	gz::transport::Node _node;
 
 	// GPS noise model


### PR DESCRIPTION
Fixed model spawning issue only to discover that the realtime was not being set. Adds a conditional to set realtime clock at system startup. 