### PR TITLE
enable terrain_hold when not moving vertically

### DIFF
--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -134,7 +134,7 @@ void FlightTaskManualAltitude::_updateAltitudeLock()
 			}
 
 		} else {
-			bool not_moving = spd_xy < 0.5f * _param_mpc_hold_max_xy.get();
+			bool not_moving = spd_xy < 0.5f * _param_mpc_hold_max_xy.get() && stopped;
 
 			if (!stick_input && not_moving && PX4_ISFINITE(_dist_to_bottom)) {
 				// Start using distance to ground


### PR DESCRIPTION

### Solved Problem
When switching from RTL to position mode while the drone was ascending, the distance lock was set while still moving vertically. This resulted in the drone stopping its vertical motion first and then descending again to the distance-lock height.

### Solution
We only lock the distance as soon as the vertical velocity is small enough...

before:
![Screenshot from 2025-03-18 11-27-06](https://github.com/user-attachments/assets/7184ca2b-e3bd-4a56-8e7e-7eddcae0e17e)
after:
![Screenshot from 2025-03-18 11-27-17](https://github.com/user-attachments/assets/ff4bc1f5-1e51-4cd0-ab26-691228b7daed)


### Test coverage
STIL
