### PR TITLE
Holybro PRM02d - fix up to make it clear there is only one variant now

### DIFF
--- a/docs/en/power_module/holybro_pm02d.md
+++ b/docs/en/power_module/holybro_pm02d.md
@@ -1,7 +1,6 @@
 # Holybro PM02D Power Module
 
 The Holybro PM02D digital power module provides regulated power to flight controller and power distribution board, and sends information to the autopilot about battery voltage and current supplied to the flight controller and the motors.
-There are two versions: high voltage (12S/14S) and low voltage (6S).
 
 The power module is connected using the I2C protocol.
 It is designed for flight controllers based on the Pixhawk FMUv5X and FMUv6X open standard, including the [Pixhawk 5X](../flight_controller/pixhawk5x.md).
@@ -22,7 +21,7 @@ The PM is **NOT** compatible with flight controllers that require an analog powe
 - **Communication protocol**: I2C
 - **Switching regulator outputs**: 5.2V and 3A max
 - **Weight**: 20g
-- **IC Used**: TI INA226 (LV), TI INA228 (HV)
+- **IC Used**: TI INA228
 
 ## Package Contents
 
@@ -41,15 +40,15 @@ Additional wiring and connection information can be found in: [Holybro Pixhawk 5
 
 ## PX4 Configuration
 
-Low voltage (6S) Digital Power Module
-- Enable parameter [SENS_EN_INA226](../advanced_config/parameter_reference.md#SENS_EN_INA226)
+Enable parameter [SENS_EN_INA228](../advanced_config/parameter_reference.md#SENS_EN_INA228)
 
-High Voltage (12S/14S) Digital Power Module:
-- Enable parameter [SENS_EN_INA228](../advanced_config/parameter_reference.md#SENS_EN_INA228)
+::: warning
+There is an out-of-production low voltage version (6S) of this module with the same name, which uses the TI INA226 IC.
+For this module you must instead enable parameter [SENS_EN_INA226](../advanced_config/parameter_reference.md#SENS_EN_INA226).
+:::
 
 Note that the current divider and voltage divider should not be set in the [Battery Configuration](../config/battery.md) (the default values are accurate within 5%).
 
 ## See Also
 
 - [Digital Power Module (PM) Setup](https://docs.holybro.com/power-module-and-pdb/power-module/digital-power-module-pm-setup#px4-setup) (Manufacturer guide)
-


### PR DESCRIPTION
As per https://github.com/PX4/PX4-user_guide/pull/3640#issuecomment-2725420013 there is only one PM02D - a current one and a legacy one. They vary in configuration.

This fixes up the doc so it is centred around the current variant. The only difference is in the configuration, so I've added a warning for that case. 