### PR TITLE
crowdin - add back in the ignore

### DIFF
--- a/docs/crowdin_docs.yml
+++ b/docs/crowdin_docs.yml
@@ -7,6 +7,7 @@
 "files": [
   {
     "source": "docs/en/**/*.md",
+    "ignore": ["/docs/en/_sidebar.md"],
     "translation": "docs/%two_letters_code%/**/%original_file_name%"
   }
 ]


### PR DESCRIPTION
This adds back in the ignore option for the test sidebar. That gets created automatically from SUMMARY.md, so does not need to round-trip translate.