### PR TITLE
Run upload on workflow dispatch if we want.

### DIFF
--- a/.github/workflows/docs_crowdin_upload.yml
+++ b/.github/workflows/docs_crowdin_upload.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   upload-to-crowdin:
-    if: github.event.pull_request.merged == true || github.event_name == 'push'
+    if: github.event.pull_request.merged == true || github.event_name == 'push'  || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Because we can.