### PR TITLE
docs_deploy.yml - bigger deployment runner

### DIFF
--- a/.github/workflows/docs_crowdin_upload.yml
+++ b/.github/workflows/docs_crowdin_upload.yml
@@ -8,18 +8,18 @@ on:
       - main
     paths:
       - 'docs/en/**'
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
-    paths:
-      - 'docs/en/**'
+  #pull_request:
+  #  types:
+  #    - closed
+  #  branches:
+  #    - main
+  #  paths:
+  #    - 'docs/en/**'
   workflow_dispatch:
 
 jobs:
   upload-to-crowdin:
-    if: github.event.pull_request.merged == true || github.event_name == 'push'  || github.event_name == 'workflow_dispatch'
+    #if: github.event.pull_request.merged == true || github.event_name == 'push'  || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - 'main'
       - 'release/**'
-    tags:
-      - 'v*'
     paths:
       - 'docs/en/**'
   pull_request:
@@ -70,7 +68,7 @@ jobs:
   deploy:
     if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged) || github.event_name == 'workflow_dispatch' }}
     needs: build
-    runs-on: [runs-on,runner=2cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false]
+    runs-on: [runs-on,runner=8cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false]
 
     steps:
       - name: Download Artifact


### PR DESCRIPTION
Deployment step once docs built is taking about three times longer on PX4-Autopilots than it was with PX4_user guide repo. The only difference in the deploy step for the old and new is that the older user guide version used ubuntu-latest while the new one runs on runs-on: `[runs-on,runner=2cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false]` - the zip is the same and generates in the same time.

This increases the runner to 8cpu to see if that makes a difference.

Also updated docs_crowdin_upload.yml to only run when something goes into main