### PR TITLE
Update index.md - Aerium Lumen/Pascal baseboards

### DIFF
--- a/docs/en/companion_computer/index.md
+++ b/docs/en/companion_computer/index.md
@@ -41,12 +41,14 @@ Larger high power examples:
 - [ModalAI VOXL 2](https://docs.modalai.com/voxl2-external-flight-controller/)
 - [NXP NavQPlus](https://nxp.gitbook.io/navqplus/user-contributed-content/ros2/microdds)
 - [Nvidia Jetson TX2](https://developer.nvidia.com/embedded/jetson-tx2)
-* [Intel NUC](https://www.intel.com/content/www/us/en/products/details/nuc.html)
-* [Gigabyte Brix](https://www.gigabyte.com/Mini-PcBarebone/BRIX)
+- [Intel NUC](https://www.intel.com/content/www/us/en/products/details/nuc.html)
+- [Gigabyte Brix](https://www.gigabyte.com/Mini-PcBarebone/BRIX)
+- [Aerium Lumen - NVIDIA Jetson Baseboard](https://www.aerium.co.il/product-page/lumen) ([Documentation](https://aerium.bitbucket.io/documentation/Product%20Manuals/Lumen/))
 
 Small/lower power examples:
 
 - [Raspberry Pi](../companion_computer/pixhawk_rpi.md)
+- [Aerium Pascal - Raspberry Pi CM4/CM5 Baseboard](https://www.aerium.co.il/product-page/pascal-cm4-carrier) ([Documentation](https://aerium.bitbucket.io/documentation/Product%20Manuals/Pascal/))
 
 ::: info
 The choice of computer will depend on the usual tradeoffs: cost, weight, power consumption, ease of setup, and computational resources required.


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Added links for Aerium baseboards for NVIDIA Jetson and Raspberry Pi CM4/CM5 including documentation.

Continuing the [PR](https://github.com/PX4/PX4-user_guide/pull/3650).
Regarding the comments, these boards are pure companion computer without PAB support, so I think they are positioned correctly.
But I may be wrong, let me know if other modifications are needed.

Regarding the documentation, we can copy our documentation pages and commit them on the PX4 docs if you prefer.
Currently we added a link to our public docs.
