### PR TITLE
dds_topics: add vtol_vehicle_status

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -74,6 +74,9 @@ publications:
   - topic: /fmu/out/airspeed_validated
     type: px4_msgs::msg::AirspeedValidated
 
+  - topic: /fmu/out/vtol_vehicle_status
+    type: px4_msgs::msg::VtolVehicleStatus
+
   - topic: /fmu/out/home_position
     type: px4_msgs::msg::HomePosition
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -205,6 +205,7 @@ private:
 	vehicle_local_position_setpoint_s	_local_pos_sp{};
 	vehicle_status_s 			_vehicle_status{};
 	vtol_vehicle_status_s 			_vtol_vehicle_status{};
+	vtol_vehicle_status_s 			_prev_published_vtol_vehicle_status{};
 	float _home_position_z{NAN};
 
 	float _air_density{atmosphere::kAirDensitySeaLevelStandardAtmos};	// [kg/m^3]


### PR DESCRIPTION
So that external ROS flight modes can more easily observe VTOL state of PX4. 

This is mostly available / inferrable from the main VehicleStatus -- using the separate message makes handling easier on the receiving end at the cost of extra bandwidth. 

Tested in simulation, correct output with `/fmu/out/vtol_vehicle_status`. 