### PR TITLE
dds_topics: add home_position

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -74,6 +74,9 @@ publications:
   - topic: /fmu/out/airspeed_validated
     type: px4_msgs::msg::AirspeedValidated
 
+  - topic: /fmu/out/home_position
+    type: px4_msgs::msg::HomePosition
+
 # Create uORB::Publication
 subscriptions:
   - topic: /fmu/in/register_ext_component_request


### PR DESCRIPTION
So that external ROS flight modes can make use of it, e.g. for return-to-launch features, reasoning about line-of-sight, or similar. 

Tested in simulation, correct output with `ros2 topic echo /fmu/out/home_position`.