### PR TITLE
UAVCAN: Read servo telemetry over CAN bus and publish to uorb

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -63,6 +63,7 @@ set(msg_files
 	DebugKeyValue.msg
 	DebugValue.msg
 	DebugVect.msg
+	DeviceTemperature.msg
 	DifferentialPressure.msg
 	DistanceSensor.msg
 	DistanceSensorModeChangeRequest.msg
@@ -202,6 +203,9 @@ set(msg_files
 	SensorsStatusImu.msg
 	SensorUwb.msg
 	SensorAirflow.msg
+	ServoReport.msg
+	ServoStatus.msg
+	ServoTemperature.msg
 	SystemPower.msg
 	TakeoffStatus.msg
 	TaskStackInfo.msg

--- a/msg/DeviceTemperature.msg
+++ b/msg/DeviceTemperature.msg
@@ -1,0 +1,8 @@
+uint64 timestamp			# time since system start (microseconds)
+uint8 actuator_id			# actuator id of current servo (in most cases 1-8)
+uint8 node_id				# Node ID of device on CAN bus
+float32 temperature			# in kelvin
+uint8 error_flags
+
+uint8 ERROR_FLAG_OVERHEATING = 1
+uint8 ERROR_FLAG_OVERCOOLING = 2

--- a/msg/ServoReport.msg
+++ b/msg/ServoReport.msg
@@ -1,0 +1,7 @@
+uint64 timestamp					# time since system start (microseconds)
+uint8 servo_actuator_id					# actuator id of current servo (in most cases 1-8)
+uint8 servo_node_id					# Node ID of device on CAN bus
+float32 servo_position					# meter or radian
+float32 servo_force					# Newton or Newton metre
+float32 servo_speed					# meter per second or radian per second
+uint8 servo_power_rating_pct				# 0 - unloaded, 100 - full load

--- a/msg/ServoStatus.msg
+++ b/msg/ServoStatus.msg
@@ -1,0 +1,25 @@
+uint64 timestamp					# time since system start (microseconds)
+uint8 CONNECTED_SERVO_MAX = 8				# The number of SERVOs supported via UAVCAN
+
+uint8 SERVO_CONNECTION_TYPE_PPM = 0			# Traditional PPM SERVO
+uint8 SERVO_CONNECTION_TYPE_SERIAL = 1			# Serial Bus connected SERVO
+uint8 SERVO_CONNECTION_TYPE_ONESHOT = 2			# One Shot PPM
+uint8 SERVO_CONNECTION_TYPE_I2C = 3			# I2C
+uint8 SERVO_CONNECTION_TYPE_CAN = 4			# CAN-Bus
+uint8 SERVO_CONNECTION_TYPE_DSHOT = 5			# DShot
+
+uint16 counter  					# incremented by the writing thread everytime new data is stored
+
+uint8 servo_connectiontype				# how SERVOs connected to the system. Currently only CAN supports servo telemtry
+
+uint8 servo_online_flags					# Bitmask indicating which SERVO is online/offline
+# servo_online_flags bit 0 : Set to 1 if SERVO0 is online
+# servo_online_flags bit 1 : Set to 1 if SERVO1 is online
+# servo_online_flags bit 2 : Set to 1 if SERVO2 is online
+# servo_online_flags bit 3 : Set to 1 if SERVO3 is online
+# servo_online_flags bit 4 : Set to 1 if SERVO4 is online
+# servo_online_flags bit 5 : Set to 1 if SERVO5 is online
+# servo_online_flags bit 6 : Set to 1 if SERVO6 is online
+# servo_online_flags bit 7 : Set to 1 if SERVO7 is online
+
+ServoReport[8] servo

--- a/msg/ServoTemperature.msg
+++ b/msg/ServoTemperature.msg
@@ -1,0 +1,6 @@
+uint64 timestamp					# time since system start (microseconds)
+uint8 CONNECTED_SERVO_MAX = 8				# The number of SERVOs supported via UAVCAN
+
+uint16 counter  					# incremented by the writing thread everytime new data is stored
+
+DeviceTemperature[8] servo

--- a/src/drivers/uavcan/actuators/servo.hpp
+++ b/src/drivers/uavcan/actuators/servo.hpp
@@ -36,9 +36,12 @@
 #include <uavcan/uavcan.hpp>
 #include <uavcan/equipment/actuator/Status.hpp>
 #include <uavcan/equipment/actuator/ArrayCommand.hpp>
+#include <uavcan/equipment/device/Temperature.hpp>
 #include <lib/perf/perf_counter.h>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/actuator_outputs.h>
+#include <uORB/topics/servo_status.h>
+#include <uORB/topics/servo_temperature.h>
 #include <drivers/drv_hrt.h>
 #include <lib/mixer_module/mixer_module.hpp>
 
@@ -48,13 +51,61 @@ public:
 	static constexpr int MAX_ACTUATORS = 8;
 	static constexpr unsigned MAX_RATE_HZ = 50;
 	static constexpr unsigned UAVCAN_COMMAND_TRANSFER_PRIORITY = 6;	///< 0..31, inclusive, 0 - highest, 31 - lowest
+	static_assert(uavcan::equipment::actuator::ArrayCommand::FieldTypes::commands::MaxSize >= MAX_ACTUATORS,
+		      "Too many actuators");
 
 	UavcanServoController(uavcan::INode &node);
 	~UavcanServoController() = default;
 
+	int init();
 	void update_outputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs);
 
+	servo_status_s &servo_status() { return _servo_status; }
+	servo_temperature_s &servo_temperature() { return _servo_temperature; }
+
+
 private:
+
+	/**
+	 * Servo status message reception will be reported via this callback.
+	 */
+	void servo_status_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::actuator::Status> &msg);
+
+	/**
+	 * Servo temperature message reception will be reported via this callback.
+	 */
+	void servo_temperature_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::device::Temperature> &msg);
+
+
+	/**
+	 * Checks all the servo freshness based on timestamp, if an servo exceeds the timeout then is flagged offline.
+	 */
+	uint8_t check_servos_status();
+
+	typedef uavcan::MethodBinder<UavcanServoController *,
+		void (UavcanServoController::*)(const uavcan::ReceivedDataStructure<uavcan::equipment::actuator::Status>&)>
+		StatusCbBinder;
+
+	typedef uavcan::MethodBinder<UavcanServoController *,
+		void (UavcanServoController::*)(const uavcan::ReceivedDataStructure<uavcan::equipment::device::Temperature>&)>
+		TemperatureCbBinder;
+
+	typedef uavcan::MethodBinder<UavcanServoController *,
+		void (UavcanServoController::*)(const uavcan::TimerEvent &)> TimerCbBinder;
+
+	servo_status_s	_servo_status{};
+	servo_temperature_s _servo_temperature{};
+
+	uORB::PublicationMulti<servo_status_s> _servo_status_pub{ORB_ID(servo_status)};
+	uORB::PublicationMulti<servo_temperature_s> _servo_temperature_pub{ORB_ID(servo_temperature)};
+
+	/*
+	 * libuavcan related things
+	 */
+
 	uavcan::INode								&_node;
 	uavcan::Publisher<uavcan::equipment::actuator::ArrayCommand> _uavcan_pub_array_cmd;
+	uavcan::Subscriber<uavcan::equipment::actuator::Status, StatusCbBinder>	_uavcan_sub_status;
+	uavcan::Subscriber<uavcan::equipment::device::Temperature, TemperatureCbBinder> _uavcan_sub_temperature;
+
 };

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -527,7 +527,7 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 
 #endif
 
-	// Actuators
+	// ESC's
 #if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
 	ret = _esc_controller.init();
 
@@ -536,6 +536,19 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 	}
 
 #endif
+
+	// Servos
+#if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
+
+
+	ret = _servo_controller.init();
+
+	if (ret < 0) {
+		return ret;
+	}
+
+#endif
+
 
 #if defined(CONFIG_UAVCAN_HARDPOINT_CONTROLLER)
 	ret = _hardpoint_controller.init();

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -121,6 +121,8 @@ void LoggedTopics::add_default_topics()
 	add_topic("sensor_selection");
 	add_topic("sensors_status_imu", 200);
 	add_optional_topic("spoilers_setpoint", 1000);
+	add_optional_topic("servo_status", 10);
+	add_optional_topic("servo_temperature", 10);
 	add_topic("system_power", 500);
 	add_optional_topic("takeoff_status", 1000);
 	add_optional_topic("tecs_status", 200);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
While integrating [Currawong CBS20 ](https://www.currawongeng.com/can-servo/) servos into an airframe I wanted to monitor their performance to check for overheating, binding and general performance. PX4 has the ability to log ESC telemetry, so I added the ability to log servo telemetry over UAVCAN too. 

### Solution
The currawong servos publish the following [telemetry messages ](https://dronecan.github.io/Specification/7._List_of_standard_data_types/) to the can bus at different frequencies:
```
uavcan.equipment.actuator.Status
uavcan.equipment.power.CircuitStatus
uavcan.equipment.device.Temperature
```

[MKS](https://mks-servo.com/MKS-DroneCAN-Intro) seem to publish the same message set and [hitek](http://support.hitecrcd.net:7700/index.php/CanServo/Protocol/UAVCAN) appears to publish the `uavcan.equipment.actuator.Status` so I'm hoping this is a general solution - but haven't tested them myself.

I created 2 callbacks to read the `actuator.Status` and `device.Temperature`  messages, and publish them to two uorb messages `servo_status` and `servo_temperature`. The uavcan messages are published at different rates so thought it better not to combine them into one uorb message. I have tried to follow the same style as the `esc_status` message for consistency and used the [uavcan esc telemetry implementation](https://github.com/PX4/PX4-Autopilot/blob/main/src/drivers/uavcan/actuators/esc.cpp) as a guide on how to implement this.

I am new to UAVCAN so any feedback is very welcome :)

![Screenshot from 2025-03-21 13-42-19](https://github.com/user-attachments/assets/aabffdf2-2a32-4a2d-97f3-f00984b329fe)


### Changelog Entry

```
Feature: Add support for servo telemetry over UAVCAN
```

### Alternatives
We could also ...

### Test coverage
Tested with a Skynode and holybro v6x.

### Context
Related links, screenshot before/after, video
