### PR TITLE
EKF2: improve optical flow stability near the ground

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_fusion.cpp
@@ -125,15 +125,13 @@ float Ekf::predictFlowHagl() const
 
 	// calculate the height above the ground of the optical flow camera. Since earth frame is NED
 	// a positive offset in earth frame leads to a smaller height above the ground.
-	float height_above_gnd_est = getHagl() - pos_offset_earth(2);
+	const float height_above_gnd_est = fabsf(getHagl() - pos_offset_earth(2));
 
-	constexpr float min_hagl = FLT_EPSILON;
+	// Never return a really small value to avoid generating insanely large flow innovations
+	// that could destabilize the filter
+	constexpr float min_hagl = 1e-2f;
 
-	if (fabsf(height_above_gnd_est) < min_hagl) {
-		height_above_gnd_est = signNoZero(height_above_gnd_est) * min_hagl;
-	}
-
-	return fabsf(height_above_gnd_est);
+	return fmaxf(height_above_gnd_est, min_hagl);
 }
 float Ekf::predictFlowRange() const
 {

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -791,6 +791,7 @@ private:
 	// calculate optical flow body angular rate compensation
 	void calcOptFlowBodyRateComp(const flowSample &flow_sample);
 
+	float predictFlowHagl() const;
 	float predictFlowRange() const;
 	Vector2f predictFlow(const Vector3f &flow_gyro) const;
 

--- a/src/modules/ekf2/test/test_EKF_flow_generated.cpp
+++ b/src/modules/ekf2/test/test_EKF_flow_generated.cpp
@@ -71,3 +71,22 @@ TEST(FlowGenerated, distBottom0y)
 	sym::ComputeFlowYInnovVarAndH(state.vector(), P, R, FLT_EPSILON, &innov_var, &H);
 	EXPECT_GT(innov_var, 1e12);
 }
+
+TEST(FlowGenerated, distBottomNeg)
+{
+	// GIVEN: a small negative distance to the ground (singularity)
+	StateSample state{};
+	state.quat_nominal = Quatf();
+	state.pos(2) = 1e-3f;
+
+	const float R = sq(radians(sq(0.5f)));
+	SquareMatrixState P = createRandomCovarianceMatrix();
+
+	VectorState H;
+	Vector2f innov_var;
+	sym::ComputeFlowXyInnovVarAndHx(state.vector(), P, R, FLT_EPSILON, &innov_var, &H);
+	EXPECT_GT(innov_var(0), 1e6);
+	EXPECT_GT(innov_var(1), 1e6);
+	sym::ComputeFlowYInnovVarAndH(state.vector(), P, R, FLT_EPSILON, &innov_var(1), &H);
+	EXPECT_GT(innov_var(1), 1e6);
+}


### PR DESCRIPTION
### Solved Problem
Some EKF stability issues were occurring near the ground, where the optical flow measurement is near its singularity point (0 distance).

### Solution
- Adjust the optical flow prediction model to exactly match the one used in the derivation
- Avoid unnecessary double division in flow measurement prediction
- Limit flow measurement prediction magnitude by limiting the minimum predicted distance to 1cm
- Re-calculate innovation test ratio after having fused the flow X axis. As we operate close to the singularity, fusing the Y axis without checking the new test ratio can lead to over-corrections as the innovation might be really large

### Test coverage
I was able to trigger issue on a bench setup with high baro drift and by allowing the EKF to start the flow fusion without range finder. The flow fusion then starts with a high terrain height uncertainty and I was able to trigger instabilities by suddenly moving above a discontinuous ground (table to floor) several times. 
The instability was reproducible in replay and this PR was able to fix the issues. Several tests were then conducted with those changes and the EKF always stayed stable.