### PR TITLE
[Against another PR] fw-pos-ctrl: check nav state before running

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -246,6 +246,8 @@ private:
 
 	// VEHICLE STATES
 
+	uint8_t _nav_state;
+
 	double _current_latitude{0};
 	double _current_longitude{0};
 	float _current_altitude{0.f};


### PR DESCRIPTION
**Solved Problem**

FW position controller `Run()` function runs regardless of flight mode. As a consequence: 
- `fixed_wing_lateral_status` is [continuously published](https://github.com/PX4/PX4-Autopilot/blob/pr-fw_ctrl_api/src/modules/fw_pos_control/FixedwingPositionControl.cpp#L2292) (undesirable)
-  the lateral and longitudinal [control limits are (incorrectly) updated ](https://github.com/PX4/PX4-Autopilot/blob/pr-fw_ctrl_api/src/modules/fw_pos_control/FixedwingPositionControl.cpp#L2287)every second 

when we are not using the position controller. 

**Solution** 

Current fix checks that we are not in an external flight mode before running position controller (temporary fix) 

To consider:
- Still runs even when in stabilized/manual. But could add these nav states as well to the run condition. (If desired)  
