### PR TITLE
remove serial port default from sf45 module

### DIFF
--- a/src/drivers/distance_sensor/lightware_sf45_serial/module.yaml
+++ b/src/drivers/distance_sensor/lightware_sf45_serial/module.yaml
@@ -4,7 +4,6 @@ serial_config:
       port_config_param:
         name: SENS_EN_SF45_CFG
         group: Sensors
-        default: TEL2
       num_instances: 1
       supports_networking: false
 


### PR DESCRIPTION


### Solved Problem
The SF45 automatically starts on telem2 via the module.yaml

Alternative to https://github.com/PX4/PX4-Autopilot/pull/24525

### Solution
- Remove the default tel2 serial port from the sf45 module

### Changelog Entry
For release notes:
```
Remove default serial port from sf45 lidar driver
```

### Alternatives
https://github.com/PX4/PX4-Autopilot/pull/24525

### Test coverage
- Tested with 6xrt and QGC

### Context

