### PR TITLE
Enable flash analysis comments again for non-fork PRs

### DIFF
--- a/.github/workflows/flash_analysis.yml
+++ b/.github/workflows/flash_analysis.yml
@@ -95,62 +95,61 @@ jobs:
           echo "$EOF" >> $GITHUB_OUTPUT
 
   # TODO:
-  # This part of the workflow is causing errors, we should find a way to fix this and enable this test again
+  # This part of the workflow is causing errors for forks. We should find a way to fix this and enable it again for forks.
   # Track this issue https://github.com/PX4/PX4-Autopilot/issues/24408
-  #
-  #post_pr_comment:
-    #name: Publish Results
-    #runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false]
-    #needs: [analyze_flash]
-    #env:
-      #V5X-SUMMARY-MAP-ABS: ${{ fromJSON(fromJSON(needs.analyze_flash.outputs.px4_fmu-v5x-bloaty-summary-map).vm-absolute) }}
-      #V5X-SUMMARY-MAP-PERC: ${{ fromJSON(fromJSON(needs.analyze_flash.outputs.px4_fmu-v5x-bloaty-summary-map).vm-percentage) }}
-      #V6X-SUMMARY-MAP-ABS: ${{ fromJSON(fromJSON(needs.analyze_flash.outputs.px4_fmu-v6x-bloaty-summary-map).vm-absolute) }}
-      #V6X-SUMMARY-MAP-PERC: ${{ fromJSON(fromJSON(needs.analyze_flash.outputs.px4_fmu-v6x-bloaty-summary-map).vm-percentage) }}
-    #if: ${{ github.event.pull_request }}
-    #steps:
-      #- name: Find Comment
-        #uses: peter-evans/find-comment@v3
-        #id: fc
-        #with:
-          #issue-number: ${{ github.event.pull_request.number }}
-          #comment-author: 'github-actions[bot]'
-          #body-includes: FLASH Analysis
+  post_pr_comment:
+    name: Publish Results
+    runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false]
+    needs: [analyze_flash]
+    env:
+      V5X-SUMMARY-MAP-ABS: ${{ fromJSON(fromJSON(needs.analyze_flash.outputs.px4_fmu-v5x-bloaty-summary-map).vm-absolute) }}
+      V5X-SUMMARY-MAP-PERC: ${{ fromJSON(fromJSON(needs.analyze_flash.outputs.px4_fmu-v5x-bloaty-summary-map).vm-percentage) }}
+      V6X-SUMMARY-MAP-ABS: ${{ fromJSON(fromJSON(needs.analyze_flash.outputs.px4_fmu-v6x-bloaty-summary-map).vm-absolute) }}
+      V6X-SUMMARY-MAP-PERC: ${{ fromJSON(fromJSON(needs.analyze_flash.outputs.px4_fmu-v6x-bloaty-summary-map).vm-percentage) }}
+    if: github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: FLASH Analysis
 
-      #- name: Set Build Time
-        #id: bt
-        #run: |
-          #echo "timestamp=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
+      - name: Set Build Time
+        id: bt
+        run: |
+          echo "timestamp=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
 
-      #- name: Create or update comment
-        ## This can't be moved to the job-level conditions, as GH actions don't allow a job-level if condition to access the env.
-        #if: |
-          #steps.fc.outputs.comment-id != '' ||
-          #env.V5X-SUMMARY-MAP-ABS >= fromJSON(env.MIN_FLASH_POS_DIFF_FOR_COMMENT) ||
-          #env.V5X-SUMMARY-MAP-ABS <= fromJSON(env.MIN_FLASH_NEG_DIFF_FOR_COMMENT) ||
-          #env.V6X-SUMMARY-MAP-ABS >= fromJSON(env.MIN_FLASH_POS_DIFF_FOR_COMMENT) ||
-          #env.V6X-SUMMARY-MAP-ABS <= fromJSON(env.MIN_FLASH_NEG_DIFF_FOR_COMMENT)
-        #uses: peter-evans/create-or-update-comment@v4
-        #with:
-          #comment-id: ${{ steps.fc.outputs.comment-id }}
-          #issue-number: ${{ github.event.pull_request.number }}
-          #body: |
-            ### 🔎 FLASH Analysis
-            #<details>
-              #<summary>px4_fmu-v5x [Total VM Diff: ${{ env.V5X-SUMMARY-MAP-ABS }} byte (${{ env.V5X-SUMMARY-MAP-PERC}} %)]</summary>
+      - name: Create or update comment
+        # This can't be moved to the job-level conditions, as GH actions don't allow a job-level if condition to access the env.
+        if: |
+          steps.fc.outputs.comment-id != '' ||
+          env.V5X-SUMMARY-MAP-ABS >= fromJSON(env.MIN_FLASH_POS_DIFF_FOR_COMMENT) ||
+          env.V5X-SUMMARY-MAP-ABS <= fromJSON(env.MIN_FLASH_NEG_DIFF_FOR_COMMENT) ||
+          env.V6X-SUMMARY-MAP-ABS >= fromJSON(env.MIN_FLASH_POS_DIFF_FOR_COMMENT) ||
+          env.V6X-SUMMARY-MAP-ABS <= fromJSON(env.MIN_FLASH_NEG_DIFF_FOR_COMMENT)
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## 🔎 FLASH Analysis
+            <details>
+              <summary>px4_fmu-v5x [Total VM Diff: ${{ env.V5X-SUMMARY-MAP-ABS }} byte (${{ env.V5X-SUMMARY-MAP-PERC}} %)]</summary>
 
-              #```
-              #${{ needs.analyze_flash.outputs.px4_fmu-v5x-bloaty-output }}
-              #```
-            #</details>
+              ```
+              ${{ needs.analyze_flash.outputs.px4_fmu-v5x-bloaty-output }}
+              ```
+            </details>
 
-            #<details>
-              #<summary>px4_fmu-v6x [Total VM Diff: ${{ env.V6X-SUMMARY-MAP-ABS }} byte (${{ env.V6X-SUMMARY-MAP-PERC }} %)]</summary>
+            <details>
+              <summary>px4_fmu-v6x [Total VM Diff: ${{ env.V6X-SUMMARY-MAP-ABS }} byte (${{ env.V6X-SUMMARY-MAP-PERC }} %)]</summary>
 
-              #```
-              #${{ needs.analyze_flash.outputs.px4_fmu-v6x-bloaty-output }}
-              #```
-            #</details>
+              ```
+              ${{ needs.analyze_flash.outputs.px4_fmu-v6x-bloaty-output }}
+              ```
+            </details>
 
-            #**Updated: _${{ steps.bt.outputs.timestamp }}_**
-          #edit-mode: replace
+            **Updated: _${{ steps.bt.outputs.timestamp }}_**
+          edit-mode: replace


### PR DESCRIPTION
### Solved Problem
I received multiple comments that people want back the flash analysis comment, as it was working just fine for them as long as one worked on a non-fork branch.

### Solution
This re-enables the flash analysis comment for non-fork PRs (via: `github.event.pull_request.head.repo.full_name == github.repository`, as described here: https://github.com/orgs/community/discussions/25217). A solution for fork PRs requires a bigger re-work for the flash analysis job (need to use `pull_request_target` as described here: https://github.com/PX4/PX4-Autopilot/issues/24408). This way we have incremental progress, until the complete solution is available.
