### PR TITLE
Set gz_command variable before standalone check in `px4-rc.simulator`

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -50,6 +50,8 @@ elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" = "1" ]; then
 
 	echo "INFO  [init] Gazebo simulator"
 
+	gz_command="gz"
+
 	if [ -z "${PX4_GZ_STANDALONE}" ]; then
 
 		# Enforce minimum gz version as Harmonic (gz-sim8)
@@ -63,7 +65,6 @@ elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" = "1" ]; then
 
 		# Use sort compare, check that MIN_GZ_VERSION is ordered last
 		if [ "$(printf '%s\n' "$GZ_SIM_VERSION" "$MIN_GZ_VERSION" | sort -V | head -n1)" = "$MIN_GZ_VERSION" ]; then
-			gz_command="gz"
 			gz_sub_command="sim"
 
 			# Specify render engine if `GZ_SIM_RENDER_ENGINE` is set


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When running PX4 sitl with gazebo harmonic, I found that the variable `gz_command` is only set if not running with `PX4_GZ_STANDALONE` not set.

But changes from [24421](https://github.com/PX4/PX4-Autopilot/pull/24421) require `gz_command` later in the script with or without `PX4_GZ_STANDALONE`. If running in standalone mode, [px4-rc.simulator:144](https://github.com/PX4/PX4-Autopilot/pull/24421/files#diff-0d4c77fd4a6b4056f7689aa9e02d5d52525f4a0e6108bc32cbd8b8b880bcccfdR140) fails, as `gz_command` is not set.

### Solution
- Add `gz_command` earlier.

### Changelog Entry
For release notes:
```
Bugfix Set gz_command variable before standalone check in `px4-rc.simulator`
```

### Test coverage
- Simulation/testing
