### PR TITLE
Fix large vehicle mag calibration

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
@@ -75,6 +75,12 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 			_mag_lpf.reset(mag_sample.mag);
 			_mag_counter = 1;
 
+			if (!_control_status.flags.in_air) {
+				// Assume that a reset on the ground is caused by a change in mag calibration
+				// Clear alignment to force a clean reset
+				_control_status.flags.yaw_align = false;
+			}
+
 		} else {
 			_mag_lpf.update(mag_sample.mag);
 			_mag_counter++;

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -191,6 +191,13 @@ bool VehicleMagnetometer::ParametersUpdate(bool force)
 
 			if (calibration_updated) {
 				_last_calibration_update = hrt_absolute_time();
+
+				for (int instance = 0; instance < MAX_SENSOR_COUNT; instance++) {
+					// avoid mixing data currected using old calibration
+					_timestamp_sample_sum[instance] = 0;
+					_data_sum[instance].zero();
+					_data_sum_count[instance] = 0;
+				}
 			}
 		}
 


### PR DESCRIPTION


### Solved Problem
The heading after a quick mag cal (large vehicle mag calibration) is sometimes off by up to 10-15 degrees, but correct after a reboot.

### Solution
I found that the reset counter was not properly in sync with the data corrected by the new calibration. If fact, it's because part of the data in the down-sampler is corrected using the "old" calibration.
![Screenshot from 2025-03-25 14-20-42](https://github.com/user-attachments/assets/2d5ea513-ee74-4020-ab5a-b15b519bec89)

Clearing the buffer makes it work correctly:
![Screenshot from 2025-03-25 14-21-01](https://github.com/user-attachments/assets/ed510260-aa8e-4ec1-a99c-3b66121b2908)

Additionally, I changed the EKF to automatically perform a heading reset when the new calibration is applied.

### Test coverage
tested in SITL, on v5 and v5x

