### PR TITLE
Open file locally respects frontmatter

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -89,7 +89,11 @@ export default defineConfig({
               : (c) =>
                   `${
                     window.location.origin
-                  }/__open-in-editor?file=${encodeURIComponent(c.filePath)}`,
+                  }/__open-in-editor?file=${encodeURIComponent(
+                    c.frontmatter.newEditLink
+                      ? c.frontmatter.newEditLink
+                      : c.filePath
+                  )}`,
         },
       },
     },


### PR DESCRIPTION
This fixes vitepress config so that the file to open in the front matter is respected when you open it locally (not just on github).

