### PR TITLE
JenkinsFile - move metadata into docs path of PX4-Autopilot

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,11 @@ pipeline {
           branch 'pr-jenkins' // for testing
         }
       }
+      not {
+        changeSet {
+          files('docs/**') // Don't run for changes under 'docs'
+        }
+      }
       parallel {
 
         stage('Airframe') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,22 +167,22 @@ pipeline {
             unstash 'failsafe_sim'
             unstash 'uorb_graph'
             withCredentials([usernamePassword(credentialsId: 'px4buildbot_github_personal_token', passwordVariable: 'GIT_PASS', usernameVariable: 'GIT_USER')]) {
-              sh('git clone https://${GIT_USER}:${GIT_PASS}@github.com/PX4/PX4-user_guide.git')
-              sh('cp airframes.md PX4-user_guide/en/airframes/airframe_reference.md')
-              sh('cp parameters.md PX4-user_guide/en/advanced_config/parameter_reference.md')
-              sh('cp -R modules/*.md PX4-user_guide/en/modules/')
-              sh('cp -R graph_*.json PX4-user_guide/public/middleware/')  // vitepress
-              sh('cp -R msg_docs/*.md PX4-user_guide/en/msg_docs/')
-              sh('cp -R failsafe_sim/* PX4-user_guide/public/config/failsafe')  // vitepress
-              sh('cd PX4-user_guide; git status; git add .; git commit -a -m "Update PX4 Firmware metadata `date`" || true')
-              sh('cd PX4-user_guide; git push origin main || true')
-              sh('rm -rf PX4-user_guide')
+              sh('git clone https://${GIT_USER}:${GIT_PASS}@github.com/PX4/PX4-Autopilot.git')
+              sh('cp airframes.md PX4-Autopilot/docs/en/airframes/airframe_reference.md')
+              sh('cp parameters.md PX4-Autopilot/docs/en/advanced_config/parameter_reference.md')
+              sh('cp -R modules/*.md PX4-Autopilot/docs/en/modules/')
+              sh('cp -R graph_*.json PX4-Autopilot/docs/public/middleware/')  // vitepress
+              sh('cp -R msg_docs/*.md PX4-Autopilot/docs/en/msg_docs/')
+              sh('cp -R failsafe_sim/* PX4-Autopilot/docs/public/config/failsafe')  // vitepress
+              sh('cd PX4-Autopilot; git status; git add .; git commit -a -m "Update UserGuide with PX4-Autopilot metadata `date`" || true')
+              sh('cd PX4-Autopilot; git push origin main || true')
+              sh('rm -rf PX4-Autopilot')
             }
           }
           when {
             anyOf {
               branch 'main'
-              branch 'master' // should be removed, but in case there is something going on...
+              //branch 'master' // should be removed, but in case there is something going on...
               branch 'pr-jenkins' // for testing
             }
           }


### PR DESCRIPTION
We've moved the docs into PX4-Autopilot so we need to copy the built metadata into the new tree. This uses exactly the same strategy as before but pushes into the right locations in the PX4-Autopilot tree (i.e. unstash metadata, clone repo, copy metadata in, and push PR).

I've also attempted to disable it running on Jenkins for docs (fix was an AI suggestion). This is logical, but needed anyway because otherwise the triggered update from docs would trigger another update.

@mrpollo Can you review/sanity check?