### PR TITLE
AirspeedValidated: add MESSAGE_VERSION

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -45,7 +45,6 @@ set(msg_files
 	ActuatorTest.msg
 	AdcReport.msg
 	Airspeed.msg
-	AirspeedValidated.msg
 	AirspeedWind.msg
 	AutotuneAttitudeControlStatus.msg
 	ButtonEvent.msg
@@ -234,6 +233,7 @@ set(msg_files
 	YawEstimatorStatus.msg
 	versioned/ActuatorMotors.msg
 	versioned/ActuatorServos.msg
+	versioned/AirspeedValidated.msg
 	versioned/ArmingCheckReply.msg
 	versioned/ArmingCheckRequest.msg
 	versioned/BatteryStatus.msg

--- a/msg/versioned/AirspeedValidated.msg
+++ b/msg/versioned/AirspeedValidated.msg
@@ -1,3 +1,5 @@
+uint32 MESSAGE_VERSION = 0
+
 uint64 timestamp				# time since system start (microseconds)
 
 float32 indicated_airspeed_m_s			# indicated airspeed in m/s (IAS), set to NAN if invalid


### PR DESCRIPTION
### Solved Problem
The airspeed_validated topic is an important topic to stream over to ROS, and we're doing that since https://github.com/PX4/PX4-Autopilot/pull/24302. To keep the interface stable and have the translation working, I would version it.

### Solution
Version it.

### Changelog Entry
For release notes:
```
Feature: AirspeedValidated: add MESSAGE_VERSION
```


