### PR TITLE
FW rate controller: Don't constrain airspeed for scaling to maximum airspeed

### DIFF
--- a/src/modules/fw_rate_control/FixedwingRateControl.cpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.cpp
@@ -183,8 +183,7 @@ float FixedwingRateControl::get_airspeed_and_update_scaling()
 
 	if (_param_fw_arsp_scale_en.get()) {
 		const float min_airspeed = math::max(_param_fw_airspd_stall.get(), 0.1f);
-		const float max_airspeed = 1000.0f;
-		const float airspeed_constrained = constrain(airspeed, min_airspeed, max_airspeed);
+		const float airspeed_constrained = math::max(airspeed, min_airspeed);
 		_airspeed_scaling = _param_fw_airspd_trim.get() / airspeed_constrained;
 
 	} else {

--- a/src/modules/fw_rate_control/FixedwingRateControl.cpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.cpp
@@ -179,10 +179,17 @@ float FixedwingRateControl::get_airspeed_and_update_scaling()
 	 *
 	 * Forcing the scaling to this value allows reasonable handheld tests.
 	 */
-	const float airspeed_constrained = constrain(constrain(airspeed, _param_fw_airspd_stall.get(),
-					   _param_fw_airspd_max.get()), 0.1f, 1000.0f);
 
-	_airspeed_scaling = (_param_fw_arsp_scale_en.get()) ? (_param_fw_airspd_trim.get() / airspeed_constrained) : 1.0f;
+
+	if (_param_fw_arsp_scale_en.get()) {
+		const float min_airspeed = max(_param_fw_airspd_stall.get(), 0.1f);
+		const float max_airspeed = 1000.0f;
+		const float airspeed_constrained = constrain(airspeed, min_airspeed, max_airspeed);
+		_airspeed_scaling = _param_fw_airspd_trim.get() / airspeed_constrained;
+
+	} else {
+		_airspeed_scaling = 1.0f;
+	}
 
 	return airspeed;
 }

--- a/src/modules/fw_rate_control/FixedwingRateControl.cpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.cpp
@@ -182,7 +182,7 @@ float FixedwingRateControl::get_airspeed_and_update_scaling()
 
 
 	if (_param_fw_arsp_scale_en.get()) {
-		const float min_airspeed = max(_param_fw_airspd_stall.get(), 0.1f);
+		const float min_airspeed = math::max(_param_fw_airspd_stall.get(), 0.1f);
 		const float max_airspeed = 1000.0f;
 		const float airspeed_constrained = constrain(airspeed, min_airspeed, max_airspeed);
 		_airspeed_scaling = _param_fw_airspd_trim.get() / airspeed_constrained;


### PR DESCRIPTION
### Solved Problem
The maximum airspeed parameter (FW_AIRSPD_MAX) is not a guarantee that the actual vehicle airspeed will not exceed it's value. Either a mechanical failure or a misconfiguration can cause such a situation and therefore it does not make sense to limit the airspeed for the actuator scaling to the maximum airspeed parameter.
This can cause structural damage to the vehicle caused by rate controller limit cycling.

Fixes #{Github issue ID}

### Solution
Remove the parameter limit.

### Changelog Entry
For release notes:
```
Removed FW_AIRSPD_MAX as upper airspeed limit for control surface scale calculation.
```
