### PR TITLE
dataman: clarify default storage backend

### DIFF
--- a/src/modules/dataman/parameters.c
+++ b/src/modules/dataman/parameters.c
@@ -34,10 +34,14 @@
 /**
  * Dataman storage backend
  *
+ * If the board supports persistent storage (i.e., the KConfig variable DATAMAN_PERSISTENT_STORAGE is set),
+ * the 'Default storage' backend uses a file on persistent storage. If not supported, this backend uses
+ * non-persistent storage in RAM.
+ *
  * @group System
- * @value -1 Disabled
- * @value 0 default (SD card)
- * @value 1 RAM (not persistent)
+ * @value -1 Dataman disabled
+ * @value 0 Default storage
+ * @value 1 RAM storage
  * @boolean
  * @reboot_required true
  */


### PR DESCRIPTION
### Solved Problem
As discussed in https://github.com/PX4/PX4-Autopilot/pull/24412#issuecomment-2685210532 the `Default storage` option behaves differently depending on whether or not the board supports persistent storage. This can be confusing for users.

### Solution
Explain the behavior in the parameter documentation. This will cost us some FLASH for the documentation (72 byte), but this way the behavior is explained where it can be configured, so users can directly see the impact this parameter has.

