### PR TITLE
[Against another PR] Address CI Failures 

### DIFF
--- a/msg/px4_msgs_old/msg/VehicleAttitudeSetpointV0.msg
+++ b/msg/px4_msgs_old/msg/VehicleAttitudeSetpointV0.msg
@@ -1,4 +1,4 @@
-uint32 MESSAGE_VERSION = 1
+uint32 MESSAGE_VERSION = 0
 
 uint64 timestamp		# time since system start (microseconds)
 
@@ -10,5 +10,9 @@ float32[4] q_d			# Desired quaternion for quaternion control
 # For clarification: For multicopters thrust_body[0] and thrust[1] are usually 0 and thrust[2] is the negative throttle demand.
 # For fixed wings thrust_x is the throttle demand and thrust_y, thrust_z will usually be zero.
 float32[3] thrust_body		# Normalized thrust command in body FRD frame [-1,1]
+
+bool reset_integral	# Reset roll/pitch/yaw integrals (navigation logic change)
+
+bool fw_control_yaw_wheel	# control heading with steering wheel (used for auto takeoff on runway)
 
 # TOPICS vehicle_attitude_setpoint mc_virtual_attitude_setpoint fw_virtual_attitude_setpoint

--- a/msg/translation_node/translations/all_translations.h
+++ b/msg/translation_node/translations/all_translations.h
@@ -11,3 +11,4 @@
 //#include "example_translation_service_v1.h"
 
 #include "translation_vehicle_status_v1.h"
+#include "translation_vehicle_attitude_setpoint_v1.h"

--- a/msg/translation_node/translations/translation_vehicle_attitude_setpoint_v1.h
+++ b/msg/translation_node/translations/translation_vehicle_attitude_setpoint_v1.h
@@ -1,0 +1,53 @@
+/****************************************************************************
+ * Copyright (c) 2025 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+#pragma once
+
+// Translate VehicleAttitudeSetpoint v0 <--> v1
+#include <px4_msgs_old/msg/vehicle_attitude_setpoint_v0.hpp>
+#include <px4_msgs/msg/vehicle_attitude_setpoint.hpp>
+
+class VehicleAttitudeSetpointV1Translation {
+public:
+	using MessageOlder = px4_msgs_old::msg::VehicleAttitudeSetpointV0;
+	static_assert(MessageOlder::MESSAGE_VERSION == 0);
+
+	using MessageNewer = px4_msgs::msg::VehicleAttitudeSetpoint;
+	static_assert(MessageNewer::MESSAGE_VERSION == 1);
+
+	static constexpr const char* kTopic = "fmu/in/vehicle_attitude_setpoint";
+
+	static void fromOlder(const MessageOlder &msg_older, MessageNewer &msg_newer) {
+		// Set msg_newer from msg_older
+		msg_newer.timestamp = msg_older.timestamp;
+		msg_newer.yaw_sp_move_rate = msg_older.yaw_sp_move_rate;
+		msg_newer.q_d[0] = msg_older.q_d[0];
+		msg_newer.q_d[1] = msg_older.q_d[1];
+		msg_newer.q_d[2] = msg_older.q_d[2];
+		msg_newer.q_d[3] = msg_older.q_d[3];
+		msg_newer.thrust_body[0] = msg_older.thrust_body[0];
+		msg_newer.thrust_body[1] = msg_older.thrust_body[1];
+		msg_newer.thrust_body[2] = msg_older.thrust_body[2];
+
+	}
+
+	static void toOlder(const MessageNewer &msg_newer, MessageOlder &msg_older) {
+		// Set msg_older from msg_newer
+		msg_older.timestamp = msg_newer.timestamp;
+		msg_older.yaw_sp_move_rate = msg_newer.yaw_sp_move_rate;
+		msg_older.q_d[0] = msg_newer.q_d[0];
+		msg_older.q_d[1] = msg_newer.q_d[1];
+		msg_older.q_d[2] = msg_newer.q_d[2];
+		msg_older.q_d[3] = msg_newer.q_d[3];
+		msg_older.thrust_body[0] = msg_newer.thrust_body[0];
+		msg_older.thrust_body[1] = msg_newer.thrust_body[1];
+		msg_older.thrust_body[2] = msg_newer.thrust_body[2];
+
+		msg_older.reset_integral = false;
+		msg_older.fw_control_yaw_wheel = false;
+
+	}
+};
+
+REGISTER_TOPIC_TRANSLATION_DIRECT(VehicleAttitudeSetpointV1Translation);

--- a/src/modules/fw_pos_control/ControlLimitsHandler.hpp
+++ b/src/modules/fw_pos_control/ControlLimitsHandler.hpp
@@ -82,11 +82,7 @@ public:
 private:
 	bool booleanValueChanged(bool new_value, bool current_value)
 	{
-		if (current_value != new_value) {
-			return true;
-		}
-
-		return false;
+		return current_value != new_value;
 	}
 
 	bool floatValueChanged(float new_value, float current_value)


### PR DESCRIPTION
Two commits: 

1. Clang tidy failure: redundant boolean in  `floatValueChanged` function in `ControlLimitsHandler.hpp` 
2. ROS translation node: bump msg version of `VehicleAttitudeSetpoint.msg` and add translation header. 

**Current base is main so the CI tests are against the correct branch.** 
