### PR TITLE
[against other PR] Move airspeed handling to FWLatLongControl and simplify

### DIFF
--- a/msg/LongitudinalControlLimits.msg
+++ b/msg/LongitudinalControlLimits.msg
@@ -6,8 +6,6 @@ float32 throttle_min 			# [0,1]
 float32 throttle_max 			# [0,1]
 float32 climb_rate_target 		# [m/s] target climbrate used to change altitude
 float32 sink_rate_target 		# [m/s] target sinkrate used to change altitude
-float32 equivalent_airspeed_min 	# [m/s]
-float32 equivalent_airspeed_max 	# [m/s]
 float32 speed_weight 			# [0,2], 0=pitch controls altitude only, 2=pitch controls airspeed only
 bool enforce_low_height_condition 	# if true, total energy controller will use lower altitude control time constant
 bool disable_underspeed_protection 	# if true, underspeed handling is disabled in the total energy controller

--- a/src/lib/fw_performance_model/PerformanceModel.cpp
+++ b/src/lib/fw_performance_model/PerformanceModel.cpp
@@ -144,17 +144,18 @@ float PerformanceModel::getCalibratedTrimAirspeed() const
 	return math::constrain(_param_fw_airspd_trim.get() * sqrtf(getWeightRatio()), _param_fw_airspd_min.get(),
 			       _param_fw_airspd_max.get());
 }
-float PerformanceModel::getMinimumCalibratedAirspeed(float load_factor) const
+float PerformanceModel::getMinimumCalibratedAirspeed(float load_factor, float flaps_setpoint) const
 {
-
 	load_factor = math::max(load_factor, FLT_EPSILON);
-	return _param_fw_airspd_min.get() * sqrtf(getWeightRatio() * load_factor);
+	const float airspeed_flap_factor = math::lerp(1.f, _param_fw_airspd_flp_sc.get(), flaps_setpoint);
+	return (_param_fw_airspd_min.get() * airspeed_flap_factor) * sqrtf(getWeightRatio() * load_factor);
 }
 
-float PerformanceModel::getCalibratedStallAirspeed(float load_factor) const
+float PerformanceModel::getCalibratedStallAirspeed(float load_factor, float flaps_setpoint) const
 {
 	load_factor = math::max(load_factor, FLT_EPSILON);
-	return _param_fw_airspd_stall.get() * sqrtf(getWeightRatio() * load_factor);
+	const float airspeed_flap_factor = math::lerp(1.f, _param_fw_airspd_flp_sc.get(), flaps_setpoint);
+	return (_param_fw_airspd_stall.get() * airspeed_flap_factor) * sqrtf(getWeightRatio() * load_factor);
 }
 
 float PerformanceModel::getMaximumCalibratedAirspeed() const

--- a/src/lib/fw_performance_model/PerformanceModel.hpp
+++ b/src/lib/fw_performance_model/PerformanceModel.hpp
@@ -96,7 +96,7 @@ public:
 	/**
 	 * Get the minimum airspeed compensated for weight, load factor due to bank angle and flaps.
 	 * @param load_factor due to banking
-	 * @param flaps_setpoint Flaps setpoint
+	 * @param flaps_setpoint Flaps setpoint, normalized in range [0,1]
 	 * @return calibrated minimum airspeed in m/s
 	 */
 	float getMinimumCalibratedAirspeed(float load_factor, float flaps_setpoint) const;
@@ -110,7 +110,7 @@ public:
 	/**
 	 * get the stall airspeed compensated for load factor due to bank angle.
 	 * @param load_factor load factor due to banking
-	 * @param flaps_setpoint Flaps setpoint
+	 * @param flaps_setpoint Flaps setpoint, normalized in range [0,1]
 	 * @return calibrated stall airspeed in m/s
 	 */
 	float getCalibratedStallAirspeed(float load_factor, float flaps_setpoint) const;

--- a/src/lib/fw_performance_model/PerformanceModel.hpp
+++ b/src/lib/fw_performance_model/PerformanceModel.hpp
@@ -94,11 +94,12 @@ public:
 	float getCalibratedTrimAirspeed() const;
 
 	/**
-	 * Get the minimum airspeed compensated for weight and load factor due to bank angle.
+	 * Get the minimum airspeed compensated for weight, load factor due to bank angle and flaps.
 	 * @param load_factor due to banking
+	 * @param flaps_setpoint Flaps setpoint
 	 * @return calibrated minimum airspeed in m/s
 	 */
-	float getMinimumCalibratedAirspeed(float load_factor = 1.0f) const;
+	float getMinimumCalibratedAirspeed(float load_factor, float flaps_setpoint) const;
 
 	/**
 	 * Get the maximum airspeed.
@@ -109,9 +110,10 @@ public:
 	/**
 	 * get the stall airspeed compensated for load factor due to bank angle.
 	 * @param load_factor load factor due to banking
+	 * @param flaps_setpoint Flaps setpoint
 	 * @return calibrated stall airspeed in m/s
 	 */
-	float getCalibratedStallAirspeed(float load_factor) const;
+	float getCalibratedStallAirspeed(float load_factor, float flaps_setpoint) const;
 
 	/**
 	 * Run some checks on parameters and detect unfeasible combinations.
@@ -134,7 +136,9 @@ private:
 		(ParamFloat<px4::params::FW_THR_MAX>) _param_fw_thr_max,
 		(ParamFloat<px4::params::FW_THR_MIN>) _param_fw_thr_min,
 		(ParamFloat<px4::params::FW_THR_ASPD_MIN>) _param_fw_thr_aspd_min,
-		(ParamFloat<px4::params::FW_THR_ASPD_MAX>) _param_fw_thr_aspd_max)
+		(ParamFloat<px4::params::FW_THR_ASPD_MAX>) _param_fw_thr_aspd_max,
+		(ParamFloat<px4::params::FW_AIRSPD_FLP_SC>) _param_fw_airspd_flp_sc
+	)
 
 	/**
 	 * Get the sea level trim throttle for a given calibrated airspeed setpoint.

--- a/src/lib/fw_performance_model/performance_model_params.c
+++ b/src/lib/fw_performance_model/performance_model_params.c
@@ -212,3 +212,16 @@ PARAM_DEFINE_FLOAT(FW_AIRSPD_MIN, 10.0f);
  * @group FW Performance
  */
 PARAM_DEFINE_FLOAT(FW_AIRSPD_MAX, 20.0f);
+
+/**
+ * Airspeed scale with full flaps
+ *
+ * Factor applied to min and stall speed when flaps are fully deployed.
+ *
+ * @min 0.5
+ * @max 1
+ * @decimal 2
+ * @increment 0.01
+ * @group FW Performance
+ */
+PARAM_DEFINE_FLOAT(FW_AIRSPD_FLP_SC, 1.f);

--- a/src/lib/npfg/CMakeLists.txt
+++ b/src/lib/npfg/CMakeLists.txt
@@ -41,3 +41,4 @@ px4_add_library(npfg
 )
 
 target_link_libraries(npfg PRIVATE geo)
+px4_add_unit_gtest(SRC NpfgTest.cpp LINKLIBS npfg)

--- a/src/lib/npfg/CourseToAirspeedRefMapper.cpp
+++ b/src/lib/npfg/CourseToAirspeedRefMapper.cpp
@@ -40,11 +40,18 @@ CourseToAirspeedRefMapper::mapCourseSetpointToHeadingSetpoint(const float bearin
 {
 	const Vector2f bearing_vector = Vector2f{cosf(bearing_setpoint), sinf(bearing_setpoint)};
 	const float wind_cross_bearing = wind_vel.cross(bearing_vector);
+	const float wind_dot_bearing = wind_vel.dot(bearing_vector);
 
-	const float airsp_dot_bearing = projectAirspOnBearing(airspeed_sp, wind_cross_bearing);
-	const Vector2f air_vel_ref = solveWindTriangle(wind_cross_bearing, airsp_dot_bearing, bearing_vector);
+	Vector2f air_vel_ref;
 
-	// TODO check if we need to use infeasibleAirVelRef or other mitigation functions in some cases (high wind)
+	if (bearingIsFeasible(wind_cross_bearing, wind_dot_bearing, airspeed_sp, wind_vel.norm())) {
+
+		const float airsp_dot_bearing = projectAirspOnBearing(airspeed_sp, wind_cross_bearing);
+		air_vel_ref = solveWindTriangle(wind_cross_bearing, airsp_dot_bearing, bearing_vector);
+
+	} else {
+		air_vel_ref = infeasibleAirVelRef(wind_vel, bearing_vector, wind_vel.norm(), airspeed_sp);
+	}
 
 	return atan2f(air_vel_ref(1), air_vel_ref(0));
 }
@@ -96,12 +103,12 @@ CourseToAirspeedRefMapper::solveWindTriangle(const float wind_cross_bearing, con
 			wind_cross_bearing * bearing_vec(0) + airsp_dot_bearing * bearing_vec(1)};
 }
 
-// matrix::Vector2f CourseToAirspeedRefMapper::infeasibleAirVelRef(const Vector2f &wind_vel, const Vector2f &bearing_vec,
-// 		const float wind_speed, const float airspeed) const
-// {
-// 	// NOTE: wind speed must be greater than airspeed, and airspeed must be greater than zero to use this function
-// 	// it is assumed that bearing feasibility is checked and found infeasible (e.g. bearingIsFeasible() = false) prior to entering this method
-// 	// otherwise the normalization of the air velocity vector could have a division by zero
-// 	Vector2f air_vel_ref = sqrtf(math::max(wind_speed * wind_speed - airspeed * airspeed, 0.0f)) * bearing_vec - wind_vel;
-// 	return air_vel_ref.normalized() * airspeed;
-// }
+matrix::Vector2f CourseToAirspeedRefMapper::infeasibleAirVelRef(const Vector2f &wind_vel, const Vector2f &bearing_vec,
+		const float wind_speed, const float airspeed) const
+{
+	// NOTE: wind speed must be greater than airspeed, and airspeed must be greater than zero to use this function
+	// it is assumed that bearing feasibility is checked and found infeasible (e.g. bearingIsFeasible() = false) prior to entering this method
+	// otherwise the normalization of the air velocity vector could have a division by zero
+	Vector2f air_vel_ref = sqrtf(math::max(wind_speed * wind_speed - airspeed * airspeed, 0.0f)) * bearing_vec - wind_vel;
+	return air_vel_ref.normalized() * airspeed;
+}

--- a/src/lib/npfg/CourseToAirspeedRefMapper.cpp
+++ b/src/lib/npfg/CourseToAirspeedRefMapper.cpp
@@ -36,42 +36,49 @@ using matrix::Vector2f;
 
 float
 CourseToAirspeedRefMapper::mapCourseSetpointToHeadingSetpoint(const float bearing_setpoint, const Vector2f &wind_vel,
-		float airspeed_true) const
+		float airspeed_sp) const
 {
-
-	Vector2f bearing_vector = Vector2f{cosf(bearing_setpoint), sinf(bearing_setpoint)};
+	const Vector2f bearing_vector = Vector2f{cosf(bearing_setpoint), sinf(bearing_setpoint)};
 	const float wind_cross_bearing = wind_vel.cross(bearing_vector);
-	const float wind_dot_bearing = wind_vel.dot(bearing_vector);
 
-	const Vector2f air_vel_ref = refAirVelocity(wind_vel, bearing_vector, wind_cross_bearing,
-				     wind_dot_bearing, wind_vel.norm(), airspeed_true);
+	const float airsp_dot_bearing = projectAirspOnBearing(airspeed_sp, wind_cross_bearing);
+	const Vector2f air_vel_ref = solveWindTriangle(wind_cross_bearing, airsp_dot_bearing, bearing_vector);
+
+	// TODO check if we need to use infeasibleAirVelRef or other mitigation functions in some cases (high wind)
 
 	return atan2f(air_vel_ref(1), air_vel_ref(0));
 }
 
-matrix::Vector2f CourseToAirspeedRefMapper::refAirVelocity(const Vector2f &wind_vel, const Vector2f &bearing_vec,
-		const float wind_cross_bearing, const float wind_dot_bearing,
-		const float wind_speed, float airspeed_true) const
+float
+CourseToAirspeedRefMapper::getMinAirspeedForCurrentBearing(const float bearing_setpoint, const Vector2f &wind_vel,
+		float airspeed_max, float min_ground_speed) const
 {
-	Vector2f air_vel_ref;
+	const Vector2f bearing_vector = Vector2f{cosf(bearing_setpoint), sinf(bearing_setpoint)};
+	const float wind_cross_bearing = wind_vel.cross(bearing_vector);
+	const float wind_dot_bearing = wind_vel.dot(bearing_vector);
 
-	if (bearingIsFeasible(wind_cross_bearing, wind_dot_bearing, airspeed_true, wind_speed)) {
-		const float airsp_dot_bearing = projectAirspOnBearing(airspeed_true, wind_cross_bearing);
-		air_vel_ref = solveWindTriangle(wind_cross_bearing, airsp_dot_bearing, bearing_vec);
+	const bool wind_along_bearing_is_below_min_ground_speed = min_ground_speed > wind_dot_bearing;
 
-	} else {
-		air_vel_ref = infeasibleAirVelRef(wind_vel, bearing_vec, wind_speed, airspeed_true);
+	float airspeed_min = 0.f; // return 0 if no min airspeed is necessary
+
+	if (wind_along_bearing_is_below_min_ground_speed) {
+		// airspeed required to achieve minimum ground speed along bearing vector (5.18)
+		airspeed_min = sqrtf((min_ground_speed - wind_dot_bearing) * (min_ground_speed - wind_dot_bearing) +
+				     wind_cross_bearing * wind_cross_bearing);
+
 	}
 
-	return air_vel_ref;
+	return math::min(airspeed_min, airspeed_max);
 }
 
-float CourseToAirspeedRefMapper::projectAirspOnBearing(const float airspeed, const float wind_cross_bearing) const
+float CourseToAirspeedRefMapper::projectAirspOnBearing(const float airspeed_true, const float wind_cross_bearing) const
 {
 	// NOTE: wind_cross_bearing must be less than airspeed to use this function
 	// it is assumed that bearing feasibility is checked and found feasible (e.g. bearingIsFeasible() = true) prior to entering this method
 	// otherwise the return will be erroneous
-	return sqrtf(math::max(airspeed * airspeed - wind_cross_bearing * wind_cross_bearing, 0.0f));
+
+	// 3.5.8
+	return sqrtf(math::max(airspeed_true * airspeed_true - wind_cross_bearing * wind_cross_bearing, 0.0f));
 }
 
 int CourseToAirspeedRefMapper::bearingIsFeasible(const float wind_cross_bearing, const float wind_dot_bearing,
@@ -89,12 +96,12 @@ CourseToAirspeedRefMapper::solveWindTriangle(const float wind_cross_bearing, con
 			wind_cross_bearing * bearing_vec(0) + airsp_dot_bearing * bearing_vec(1)};
 }
 
-matrix::Vector2f CourseToAirspeedRefMapper::infeasibleAirVelRef(const Vector2f &wind_vel, const Vector2f &bearing_vec,
-		const float wind_speed, const float airspeed) const
-{
-	// NOTE: wind speed must be greater than airspeed, and airspeed must be greater than zero to use this function
-	// it is assumed that bearing feasibility is checked and found infeasible (e.g. bearingIsFeasible() = false) prior to entering this method
-	// otherwise the normalization of the air velocity vector could have a division by zero
-	Vector2f air_vel_ref = sqrtf(math::max(wind_speed * wind_speed - airspeed * airspeed, 0.0f)) * bearing_vec - wind_vel;
-	return air_vel_ref.normalized() * airspeed;
-}
+// matrix::Vector2f CourseToAirspeedRefMapper::infeasibleAirVelRef(const Vector2f &wind_vel, const Vector2f &bearing_vec,
+// 		const float wind_speed, const float airspeed) const
+// {
+// 	// NOTE: wind speed must be greater than airspeed, and airspeed must be greater than zero to use this function
+// 	// it is assumed that bearing feasibility is checked and found infeasible (e.g. bearingIsFeasible() = false) prior to entering this method
+// 	// otherwise the normalization of the air velocity vector could have a division by zero
+// 	Vector2f air_vel_ref = sqrtf(math::max(wind_speed * wind_speed - airspeed * airspeed, 0.0f)) * bearing_vec - wind_vel;
+// 	return air_vel_ref.normalized() * airspeed;
+// }

--- a/src/lib/npfg/CourseToAirspeedRefMapper.cpp
+++ b/src/lib/npfg/CourseToAirspeedRefMapper.cpp
@@ -110,5 +110,5 @@ matrix::Vector2f CourseToAirspeedRefMapper::infeasibleAirVelRef(const Vector2f &
 	// it is assumed that bearing feasibility is checked and found infeasible (e.g. bearingIsFeasible() = false) prior to entering this method
 	// otherwise the normalization of the air velocity vector could have a division by zero
 	Vector2f air_vel_ref = sqrtf(math::max(wind_speed * wind_speed - airspeed * airspeed, 0.0f)) * bearing_vec - wind_vel;
-	return air_vel_ref.normalized() * airspeed;
+	return air_vel_ref.normalized();
 }

--- a/src/lib/npfg/CourseToAirspeedRefMapper.cpp
+++ b/src/lib/npfg/CourseToAirspeedRefMapper.cpp
@@ -110,5 +110,5 @@ matrix::Vector2f CourseToAirspeedRefMapper::infeasibleAirVelRef(const Vector2f &
 	// it is assumed that bearing feasibility is checked and found infeasible (e.g. bearingIsFeasible() = false) prior to entering this method
 	// otherwise the normalization of the air velocity vector could have a division by zero
 	Vector2f air_vel_ref = sqrtf(math::max(wind_speed * wind_speed - airspeed * airspeed, 0.0f)) * bearing_vec - wind_vel;
-	return air_vel_ref.normalized();
+	return air_vel_ref.normalized() * airspeed;
 }

--- a/src/lib/npfg/CourseToAirspeedRefMapper.hpp
+++ b/src/lib/npfg/CourseToAirspeedRefMapper.hpp
@@ -78,18 +78,6 @@ public:
 
 private:
 	/*
-	 * Determines a reference air velocity *without curvature compensation, but
-	 * including "optimal" true airspeed reference compensation in excess wind conditions.
-	 * Nominal and maximum true airspeed member variables must be set before using this method.
-	 *
-	 * @param[in] wind_vel Wind velocity vector [m/s]
-	 * @param[in] bearing_setpoint Bearing
-	 * @param[in] airspeed_true True airspeed setpoint[m/s]
-	 * @return Air velocity vector [m/s]
-	 */
-	matrix::Vector2f refAirVelocity(const matrix::Vector2f &wind_vel, const float bearing_setpoint,
-					float airspeed_true, float min_ground_speed) const;
-	/*
 	 * Projection of the air velocity vector onto the bearing line considering
 	 * a connected wind triangle.
 	 *

--- a/src/lib/npfg/CourseToAirspeedRefMapper.hpp
+++ b/src/lib/npfg/CourseToAirspeedRefMapper.hpp
@@ -72,7 +72,9 @@ public:
 	~CourseToAirspeedRefMapper() = default;
 
 	float mapCourseSetpointToHeadingSetpoint(const float bearing_setpoint,
-			const matrix::Vector2f &wind_vel, float airspeed_true) const;
+			const matrix::Vector2f &wind_vel, float airspeed_sp) const;
+	float getMinAirspeedForCurrentBearing(const float bearing_setpoint,
+					      const matrix::Vector2f &wind_vel, float max_airspeed, float min_ground_speed) const;
 
 private:
 	/*
@@ -81,21 +83,17 @@ private:
 	 * Nominal and maximum true airspeed member variables must be set before using this method.
 	 *
 	 * @param[in] wind_vel Wind velocity vector [m/s]
-	 * @param[in] bearing_vec Bearing vector
-	 * @param[in] wind_cross_bearing 2D cross product of wind velocity and bearing vector [m/s]
-	 * @param[in] wind_dot_bearing 2D dot product of wind velocity and bearing vector [m/s]
-	 * @param[in] wind_speed Wind speed [m/s]
-	 * @param[in] airspeed_true True airspeed [m/s]
+	 * @param[in] bearing_setpoint Bearing
+	 * @param[in] airspeed_true True airspeed setpoint[m/s]
 	 * @return Air velocity vector [m/s]
 	 */
-	matrix::Vector2f refAirVelocity(const matrix::Vector2f &wind_vel, const matrix::Vector2f &bearing_vec,
-					const float wind_cross_bearing, const float wind_dot_bearing,
-					const float wind_speed, float airspeed_true) const;
+	matrix::Vector2f refAirVelocity(const matrix::Vector2f &wind_vel, const float bearing_setpoint,
+					float airspeed_true, float min_ground_speed) const;
 	/*
 	 * Projection of the air velocity vector onto the bearing line considering
 	 * a connected wind triangle.
 	 *
-	 * @param[in] airspeed Vehicle true airspeed [m/s]
+	 * @param[in] airspeed Vehicle true airspeed setpoint [m/s]
 	 * @param[in] wind_cross_bearing 2D cross product of wind velocity and bearing vector [m/s]
 	 * @return Projection of air velocity vector on bearing vector [m/s]
 	 */
@@ -118,7 +116,7 @@ private:
 	 * @param[in] wind_cross_bearing 2D cross product of wind velocity and bearing vector [m/s]
 	 * @param[in] airsp_dot_bearing 2D dot product of air velocity (solution) and bearing vector [m/s]
 	 * @param[in] bearing_vec Bearing vector
-	 * @return Air velocity vector [m/s]
+	 * @return Air velocity reference vector [m/s]
 	 */
 	matrix::Vector2f solveWindTriangle(const float wind_cross_bearing, const float airsp_dot_bearing,
 					   const matrix::Vector2f &bearing_vec) const;

--- a/src/lib/npfg/NpfgTest.cpp
+++ b/src/lib/npfg/NpfgTest.cpp
@@ -1,0 +1,205 @@
+
+/****************************************************************************
+ *
+ *   Copyright (C) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/******************************************************************
+ * Test code for the NPFG algorithm
+ * Run this test only using "make tests TESTFILTER=Npfg"
+ *
+ *
+ * NOTE:
+ *
+ *
+******************************************************************/
+
+#include <gtest/gtest.h>
+#include <lib/npfg/CourseToAirspeedRefMapper.hpp>
+
+using namespace matrix;
+
+TEST(NpfgTest, Test)
+{
+	//      V   C
+	//         /
+	//  	  /
+	//	 /
+	//	P
+	const Vector2f curr_wp_ned(10.f, 10.f);
+	float target_bearing1 = NAN;
+	// NaN speed
+	EXPECT_FALSE(PX4_ISFINITE(target_bearing1));
+}
+
+TEST(NpfgTest, NoWind)
+{
+	CourseToAirspeedRefMapper _course_to_airspeed;
+
+	// GIVEN
+	const Vector2f wind_vel(0.f, 0.f);
+	float bearing = 0.f;
+	float airspeed_max = 20.f;
+	float min_ground_speed = 5.0f;
+	float airspeed_setpoint = 15.f;
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel, airspeed_setpoint);
+	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+					 airspeed_max, min_ground_speed);
+
+	// THEN: expect heading due North with a min airspeed equal to min_ground_speed
+	EXPECT_NEAR(heading_setpoint, 0.f, FLT_EPSILON);
+	EXPECT_NEAR(min_airspeed_for_bearing, min_ground_speed, FLT_EPSILON);
+
+	// GIVEN: bearing due South
+	bearing = M_PI_F;
+	airspeed_max = 20.f;
+	min_ground_speed = 5.0f;
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+					   airspeed_setpoint));
+	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+				   airspeed_max, min_ground_speed);
+
+	// THEN: expect heading due South with a min airspeed equal to min_ground_speed
+	EXPECT_NEAR(heading_setpoint, -M_PI_F, 2 * FLT_EPSILON); // Why is the 2*FLT_EPS required here to make it pass?
+	EXPECT_NEAR(min_airspeed_for_bearing, min_ground_speed, FLT_EPSILON);
+}
+
+TEST(NpfgTest, LightCrossWind)
+{
+	CourseToAirspeedRefMapper _course_to_airspeed;
+
+	// GIVEN
+	const Vector2f wind_vel(0.f, 6.f);
+	float bearing = 0.f;
+	float airspeed_max = 20.f;
+	float min_ground_speed = 5.0f;
+	float airspeed_setpoint = 15.f;
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel, airspeed_setpoint);
+	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+					 airspeed_max, min_ground_speed);
+
+	// THEN: expect heading -0.4115168 with a min airspeed of to 7.8 (sqrt(25+36))
+	EXPECT_NEAR(heading_setpoint, -0.4115168, 0.1f);
+	EXPECT_NEAR(min_airspeed_for_bearing, 7.8f, 0.1f);
+
+	// GIVEN: bearing due South
+	bearing = M_PI_F;
+	airspeed_max = 20.f;
+	min_ground_speed = 5.0f;
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+					   airspeed_setpoint));
+	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+				   airspeed_max, min_ground_speed);
+
+	// THEN: expect heading of -2.73 and a min airspeed of 7.8 (sqrt(25+36))
+	EXPECT_NEAR(heading_setpoint, -2.73f, 0.1f); // Why is the 2*FLT_EPS required here to make it pass?
+	EXPECT_NEAR(min_airspeed_for_bearing, 7.8f, 0.1f);
+}
+
+TEST(NpfgTest, StrongHeadWing)
+{
+	CourseToAirspeedRefMapper _course_to_airspeed;
+
+	// GIVEN
+	const Vector2f wind_vel(-16.f, 0.f);
+	float bearing = 0.f;
+	float airspeed_max = 25.f;
+	float min_ground_speed = 5.0f;
+	float airspeed_setpoint = 15.f;
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel, airspeed_setpoint);
+	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+					 airspeed_max, min_ground_speed);
+
+	// THEN: expect heading due North with a min airspeed equal to 16+min_ground_speed
+	EXPECT_NEAR(heading_setpoint, 0.f, 0.1f);
+	EXPECT_NEAR(min_airspeed_for_bearing, 16 + min_ground_speed, 0.1f);
+
+	// GIVEN: bearing due South
+	bearing = M_PI_F;
+	airspeed_max = 25.f;
+	min_ground_speed = 5.0f;
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+					   airspeed_setpoint));
+	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+				   airspeed_max, min_ground_speed);
+
+	// THEN: expect heading due South with a min airspeed at 0
+	EXPECT_NEAR(heading_setpoint, -M_PI_F, 0.1f); // Why is the 2*FLT_EPS required here to make it pass?
+	EXPECT_NEAR(min_airspeed_for_bearing, 0.f, 0.1f);
+}
+
+TEST(NpfgTest, ExceedingHeadWind)
+{
+	CourseToAirspeedRefMapper _course_to_airspeed;
+
+	// GIVEN
+	const Vector2f wind_vel(-25.f, 0.f);
+	float bearing = 0.f;
+	float airspeed_max = 25.f;
+	float min_ground_speed = 5.0f;
+	float airspeed_setpoint = 15.f;
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel, airspeed_setpoint);
+	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+					 airspeed_max, min_ground_speed);
+
+	// THEN: expect heading sp due North with a min airspeed equal to airspeed_max
+	EXPECT_NEAR(heading_setpoint, 0.f, 0.1f);
+	EXPECT_NEAR(min_airspeed_for_bearing, airspeed_max, 0.1f);
+
+	// GIVEN: bearing due South
+	bearing = M_PI_F;
+	airspeed_max = 25.f;
+	min_ground_speed = 5.0f;
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+					   airspeed_setpoint));
+	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+				   airspeed_max, min_ground_speed);
+
+	// THEN: expect heading due South with a min airspeed equal at 0
+	EXPECT_NEAR(heading_setpoint, -M_PI_F, 0.1f); // Why is the 2*FLT_EPS required here to make it pass?
+	EXPECT_NEAR(min_airspeed_for_bearing, 0.f, 0.1f);
+}

--- a/src/lib/npfg/NpfgTest.cpp
+++ b/src/lib/npfg/NpfgTest.cpp
@@ -72,12 +72,17 @@ TEST(NpfgTest, NoWind)
 	float airspeed_setpoint = 15.f;
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
-	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel, airspeed_setpoint);
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
+	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted);
+
 	// THEN: expect heading due North with a min airspeed equal to min_ground_speed
-	EXPECT_NEAR(heading_setpoint, 0.f, FLT_EPSILON);
+	EXPECT_NEAR(heading_setpoint, 0.f, 0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, min_ground_speed, FLT_EPSILON);
 
 	// GIVEN: bearing due South
@@ -86,13 +91,18 @@ TEST(NpfgTest, NoWind)
 	min_ground_speed = 5.0f;
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
-	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
-					   airspeed_setpoint));
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 				   airspeed_max, min_ground_speed);
 
+	airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+					    airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+					   airspeed_setpoint_adapted));
+
+
 	// THEN: expect heading due South with a min airspeed equal to min_ground_speed
-	EXPECT_NEAR(heading_setpoint, -M_PI_F, 2 * FLT_EPSILON); // Why is the 2*FLT_EPS required here to make it pass?
+	EXPECT_NEAR(heading_setpoint, -M_PI_F,  0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, min_ground_speed, FLT_EPSILON);
 }
 
@@ -108,12 +118,17 @@ TEST(NpfgTest, LightCrossWind)
 	float airspeed_setpoint = 15.f;
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
-	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel, airspeed_setpoint);
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
+	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted));
+
 	// THEN: expect heading -0.4115168 with a min airspeed of to 7.8 (sqrt(25+36))
-	EXPECT_NEAR(heading_setpoint, -0.4115168, 0.1f);
+	EXPECT_NEAR(heading_setpoint, -0.4115168,  0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, 7.8f, 0.1f);
 
 	// GIVEN: bearing due South
@@ -122,17 +137,21 @@ TEST(NpfgTest, LightCrossWind)
 	min_ground_speed = 5.0f;
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
-	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
-					   airspeed_setpoint));
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 				   airspeed_max, min_ground_speed);
 
+	airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+					    airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+					   airspeed_setpoint_adapted));
+
 	// THEN: expect heading of -2.73 and a min airspeed of 7.8 (sqrt(25+36))
-	EXPECT_NEAR(heading_setpoint, -2.73f, 0.1f); // Why is the 2*FLT_EPS required here to make it pass?
+	EXPECT_NEAR(heading_setpoint, -2.73f,  0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, 7.8f, 0.1f);
 }
 
-TEST(NpfgTest, StrongHeadWing)
+TEST(NpfgTest, StrongHeadWind)
 {
 	CourseToAirspeedRefMapper _course_to_airspeed;
 
@@ -144,32 +163,57 @@ TEST(NpfgTest, StrongHeadWing)
 	float airspeed_setpoint = 15.f;
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
-	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel, airspeed_setpoint);
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
+	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted));
+
+
 	// THEN: expect heading due North with a min airspeed equal to 16+min_ground_speed
-	EXPECT_NEAR(heading_setpoint, 0.f, 0.1f);
+	EXPECT_NEAR(heading_setpoint, 0.f,  0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, 16 + min_ground_speed, 0.1f);
 
+
+}
+
+TEST(NpfgTest, StrongTailWind)
+{
+
+	CourseToAirspeedRefMapper _course_to_airspeed;
+
 	// GIVEN: bearing due South
-	bearing = M_PI_F;
-	airspeed_max = 25.f;
-	min_ground_speed = 5.0f;
+	const Vector2f wind_vel(-16.f, 0.f);
+	float bearing = M_PI_F;
+	float airspeed_max = 25.f;
+	float min_ground_speed = 5.0f;
+	float airspeed_setpoint = 15.f;
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
-	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
-					   airspeed_setpoint));
-	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
-				   airspeed_max, min_ground_speed);
+	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+					 airspeed_max, min_ground_speed);
+
+	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted));
 
 	// THEN: expect heading due South with a min airspeed at 0
-	EXPECT_NEAR(heading_setpoint, -M_PI_F, 0.1f); // Why is the 2*FLT_EPS required here to make it pass?
+	EXPECT_NEAR(heading_setpoint, -M_PI_F,  0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, 0.f, 0.1f);
 }
 
-TEST(NpfgTest, ExceedingHeadWind)
+
+
+TEST(NpfgTest, ExcessHeadWind)
 {
+
+	// TEST DESCRIPTION: infeasible bearing, with |wind| = |airspeed|. Align with wind
+
 	CourseToAirspeedRefMapper _course_to_airspeed;
 
 	// GIVEN
@@ -180,26 +224,143 @@ TEST(NpfgTest, ExceedingHeadWind)
 	float airspeed_setpoint = 15.f;
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
-	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel, airspeed_setpoint);
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
+	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted));
+
 	// THEN: expect heading sp due North with a min airspeed equal to airspeed_max
-	EXPECT_NEAR(heading_setpoint, 0.f, 0.1f);
+	EXPECT_NEAR(heading_setpoint, 0.f, 0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, airspeed_max, 0.1f);
 
-	// GIVEN: bearing due South
-	bearing = M_PI_F;
-	airspeed_max = 25.f;
-	min_ground_speed = 5.0f;
+	// WHEN: we increase the maximum airspeed
+	airspeed_max = 35.f;
 
-	// WHEN: we update bearing and airspeed magnitude augmentation
-	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
-					   airspeed_setpoint));
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 				   airspeed_max, min_ground_speed);
 
-	// THEN: expect heading due South with a min airspeed equal at 0
-	EXPECT_NEAR(heading_setpoint, -M_PI_F, 0.1f); // Why is the 2*FLT_EPS required here to make it pass?
+	// THEN: expect the minimum airspeed to be high enough to maintain minimum groundspeed
+	EXPECT_NEAR(min_airspeed_for_bearing, 30.f, 0.1f);
+
+	// TEST DESCRIPTION: infeasible bearing, with |wind| = |airspeed|. Align with wind
+
+	// GIVEN: bearing east
+	bearing = M_PI_F / 2.f;
+	airspeed_max = 25.f;
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+					 airspeed_max, min_ground_speed);
+
+	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted));
+
+	// THEN: expect heading sp due North with a min airspeed equal to airspeed_max
+	EXPECT_NEAR(heading_setpoint, 0.f, 0.01f);
+	EXPECT_NEAR(min_airspeed_for_bearing, airspeed_max, 0.1f);
+
+
+	// TEST DESCRIPTION: infeasible bearing, with |wind| > |airspeed|. Aircraft should have a heading between the target bearing
+	// and wind direction to minimize drift while still attempting to reach the bearing.
+
+	// GIVEN: bearing NE
+	bearing = M_PI_F / 4.f;
+	airspeed_max = 20.f;
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+		airspeed_max, min_ground_speed);
+
+	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+		airspeed_setpoint_adapted));
+
+	// THEN: expect heading setpoint to be between the target bearing and the cross wind
+	// & the minimum airspeed to be = maximum airspeed
+	EXPECT_TRUE((heading_setpoint > -M_PI_F / 2.f) && (heading_setpoint < bearing));
+	EXPECT_NEAR(min_airspeed_for_bearing, airspeed_max, 0.1f);
+
+}
+
+TEST(NpfgTest, ExcessTailWind)
+{
+
+	CourseToAirspeedRefMapper _course_to_airspeed;
+
+	// GIVEN: bearing due South
+	const Vector2f wind_vel(-25.f, 0.f);
+	float bearing = M_PI_F;
+	float airspeed_max = 25.f;
+	float min_ground_speed = 5.0f;
+	float airspeed_setpoint = 15.f;
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+					 airspeed_max, min_ground_speed);
+
+	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted));
+
+	// THEN: expect heading due South with a min airspeed equal to 0
+	EXPECT_NEAR(heading_setpoint, -M_PI_F, 0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, 0.f, 0.1f);
+
+}
+
+TEST(NpfgTest, ExcessCrossWind)
+{
+
+	// TEST DESCRIPTION: infeasible bearing, with |wind| > |airspeed|. Aircraft should have a heading between the target bearing
+	// and wind direction to minimize drift while still attempting to reach the bearing.
+
+	CourseToAirspeedRefMapper _course_to_airspeed;
+
+	// GIVEN
+	const Vector2f wind_vel(0, 30.f);
+	float bearing = 0.f;
+	float airspeed_max = 25.f;
+	float min_ground_speed = 5.f;
+	float airspeed_setpoint = 15.f;
+
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+					 airspeed_max, min_ground_speed);
+
+	float airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted));
+
+	// THEN: expect heading setpoint to be between the target bearing and the cross wind
+	// & the minimum airspeed to be = maximum airspeed
+	EXPECT_TRUE((heading_setpoint > -M_PI_F / 2.f) && (heading_setpoint < bearing));
+	EXPECT_NEAR(min_airspeed_for_bearing, airspeed_max, 0.1f);
+
+
+	// TEST DESCRIPTION: infeasible bearing, with |wind| = |airspeed|. Align with wind.
+
+	airspeed_max = 30.f;
+
+	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+		airspeed_max, min_ground_speed);
+
+	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+		airspeed_setpoint_adapted));
+
+	EXPECT_NEAR(heading_setpoint, -M_PI_F / 2.f, 0.01f);
+	EXPECT_NEAR(min_airspeed_for_bearing, airspeed_max, 0.1f);
+
 }

--- a/src/lib/npfg/NpfgTest.cpp
+++ b/src/lib/npfg/NpfgTest.cpp
@@ -75,8 +75,7 @@ TEST(NpfgTest, NoWind)
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
-	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	float airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 				 airspeed_setpoint_adapted);
@@ -94,8 +93,7 @@ TEST(NpfgTest, NoWind)
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 				   airspeed_max, min_ground_speed);
 
-	airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-					    airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 					   airspeed_setpoint_adapted));
@@ -121,8 +119,7 @@ TEST(NpfgTest, LightCrossWind)
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
-	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	float airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 				 airspeed_setpoint_adapted));
@@ -140,8 +137,7 @@ TEST(NpfgTest, LightCrossWind)
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 				   airspeed_max, min_ground_speed);
 
-	airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-					    airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 					   airspeed_setpoint_adapted));
@@ -166,8 +162,7 @@ TEST(NpfgTest, StrongHeadWind)
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
-	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	float airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 				 airspeed_setpoint_adapted));
@@ -196,8 +191,7 @@ TEST(NpfgTest, StrongTailWind)
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
-	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	float airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 				 airspeed_setpoint_adapted));
@@ -227,8 +221,7 @@ TEST(NpfgTest, ExcessHeadWind)
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
-	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	float airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 				 airspeed_setpoint_adapted));
@@ -254,12 +247,12 @@ TEST(NpfgTest, ExcessHeadWind)
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
-					 airspeed_max, min_ground_speed);
+				   airspeed_max, min_ground_speed);
 
 	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
-				 airspeed_setpoint_adapted));
+					   airspeed_setpoint_adapted));
 
 	// THEN: expect heading sp due North with a min airspeed equal to airspeed_max
 	EXPECT_NEAR(heading_setpoint, 0.f, 0.01f);
@@ -275,12 +268,12 @@ TEST(NpfgTest, ExcessHeadWind)
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
-		airspeed_max, min_ground_speed);
+				   airspeed_max, min_ground_speed);
 
 	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
-		airspeed_setpoint_adapted));
+					   airspeed_setpoint_adapted));
 
 	// THEN: expect heading setpoint to be between the target bearing and the cross wind
 	// & the minimum airspeed to be = maximum airspeed
@@ -305,8 +298,7 @@ TEST(NpfgTest, ExcessTailWind)
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
-	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	float airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 				 airspeed_setpoint_adapted));
@@ -353,12 +345,12 @@ TEST(NpfgTest, ExcessCrossWind)
 	airspeed_max = 30.f;
 
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
-		airspeed_max, min_ground_speed);
+				   airspeed_max, min_ground_speed);
 
 	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
-		airspeed_setpoint_adapted));
+					   airspeed_setpoint_adapted));
 
 	EXPECT_NEAR(heading_setpoint, -M_PI_F / 2.f, 0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, airspeed_max, 0.1f);

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -132,7 +132,6 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::FW_AIRSPD_MAX>) _param_fw_airspd_max,
-		(ParamFloat<px4::params::FW_AIRSPD_MIN>) _param_fw_airspd_min,
 		(ParamFloat<px4::params::FW_AIRSPD_STALL>) _param_fw_airspd_stall,
 		(ParamFloat<px4::params::FW_AIRSPD_TRIM>) _param_fw_airspd_trim,
 		(ParamBool<px4::params::FW_USE_AIRSPD>) _param_fw_use_airspd,

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -61,6 +61,8 @@ static constexpr uint64_t ROLL_WARNING_TIMEOUT = 2_s;
 // [-] Can-run threshold needed to trigger the roll-constraining failsafe warning
 static constexpr float ROLL_WARNING_CAN_RUN_THRESHOLD = 0.9f;
 
+// [m/s/s] slew rate limit for airspeed setpoint changes
+static constexpr float ASPD_SP_SLEW_RATE = 1.f;
 
 FwLateralLongitudinalControl::FwLateralLongitudinalControl(bool is_vtol) :
 	ModuleParams(nullptr),
@@ -72,6 +74,7 @@ FwLateralLongitudinalControl::FwLateralLongitudinalControl(bool is_vtol) :
 	_flight_phase_estimation_pub.advertise();
 	_fixed_wing_lateral_status_pub.advertise();
 	parameters_update();
+	_airspeed_slew_rate_controller.setSlewRate(ASPD_SP_SLEW_RATE);
 }
 
 FwLateralLongitudinalControl::~FwLateralLongitudinalControl()
@@ -184,6 +187,8 @@ void FwLateralLongitudinalControl::Run()
 					 || _vehicle_status_sub.get().in_transition_mode);
 
 		if (should_run) {
+
+			// ----- Longitudinal ------
 			float pitch_sp{NAN};
 			float throttle_sp{NAN};
 
@@ -191,14 +196,11 @@ void FwLateralLongitudinalControl::Run()
 				_fw_longitudinal_ctrl_sub.copy(&_long_control_sp);
 			}
 
-			float airspeed_sp = PX4_ISFINITE(_long_control_sp.equivalent_airspeed) ?
-					    _long_control_sp.equivalent_airspeed :
-					    _performance_model.getCalibratedTrimAirspeed();
-
-			airspeed_sp = math::constrain(airspeed_sp, _long_limits.equivalent_airspeed_min, _long_limits.equivalent_airspeed_max);
+			const float airspeed_sp_eas = adapt_airspeed_setpoint(control_interval, _long_control_sp.equivalent_airspeed,
+						      _min_airspeed_from_guidance, _lateral_control_state.wind_speed.length());
 
 			tecs_update_pitch_throttle(control_interval, _long_control_sp.altitude,
-						   airspeed_sp,
+						   airspeed_sp_eas,
 						   _long_limits.pitch_min,
 						   _long_limits.pitch_max,
 						   _long_limits.throttle_min,
@@ -213,6 +215,7 @@ void FwLateralLongitudinalControl::Run()
 			throttle_sp = PX4_ISFINITE(_long_control_sp.throttle_direct) ? _long_control_sp.throttle_direct :
 				      _tecs.get_throttle_setpoint();
 
+			// ----- Lateral ------
 			float roll_sp {NAN};
 
 			if (_fw_lateral_ctrl_sub.updated()) {
@@ -228,7 +231,18 @@ void FwLateralLongitudinalControl::Run()
 			if (PX4_ISFINITE(_lat_control_sp.course)) {
 				airspeed_direction_sp = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(
 								_lat_control_sp.course, _lateral_control_state.wind_speed,
-								airspeed_vector.norm());
+								airspeed_sp_eas);
+
+				// Note: the here updated _min_airspeed_from_guidance is only used in the next iteration
+				// in the longitudinal controller.
+				const float max_true_airspeed = _performance_model.getMaximumCalibratedAirspeed() * _long_control_state.eas2tas;
+				_min_airspeed_from_guidance = _course_to_airspeed.getMinAirspeedForCurrentBearing(
+								      _lat_control_sp.course, _lateral_control_state.wind_speed,
+								      max_true_airspeed, _param_fw_gnd_spd_min.get())
+							      / _long_control_state.eas2tas;
+
+			} else {
+				_min_airspeed_from_guidance = 0.f; // reset if no longer in course control
 			}
 
 			if (PX4_ISFINITE(_lat_control_sp.airspeed_direction)) {
@@ -585,8 +599,77 @@ void FwLateralLongitudinalControl::updateAirspeed() {
 	// no airspeed updates for one second --> declare invalid
 	const bool airspeed_valid = hrt_elapsed_time(&_time_airspeed_last_valid) < 1_s;
 
+	if (!airspeed_valid) {
+		_long_control_state.eas2tas = 1.f;
+	}
+
 	_tecs.enable_airspeed(airspeed_valid);
 }
+
+float
+FwLateralLongitudinalControl::adapt_airspeed_setpoint(const float control_interval, float calibrated_airspeed_setpoint,
+		float calibrated_min_airspeed_guidance, float wind_speed)
+{
+	float system_min_airspeed = _performance_model.getMinimumCalibratedAirspeed(getLoadFactor());
+
+	const float system_max_airspeed = _performance_model.getMaximumCalibratedAirspeed();
+
+	// airspeed setpoint adjustments
+	if (!PX4_ISFINITE(calibrated_airspeed_setpoint) || calibrated_airspeed_setpoint <= FLT_EPSILON) {
+		calibrated_airspeed_setpoint = _performance_model.getCalibratedTrimAirspeed();
+
+		// Aditional option to increase the min airspeed setpoint based on wind estimate for more stability in higher winds.
+		if (_wind_valid && _param_fw_wind_arsp_sc.get() > FLT_EPSILON) {
+			system_min_airspeed = math::min(system_min_airspeed + _param_fw_wind_arsp_sc.get() *
+			wind_speed, system_max_airspeed);
+		}
+	}
+
+	// increase setpoint to at what's at least required for the lateral guidance
+	calibrated_airspeed_setpoint = math::max(calibrated_airspeed_setpoint, calibrated_min_airspeed_guidance);
+
+	// constrain airspeed to feasible range
+	calibrated_airspeed_setpoint = math::constrain(calibrated_airspeed_setpoint, system_min_airspeed, system_max_airspeed);
+
+	if (!PX4_ISFINITE(_airspeed_slew_rate_controller.getState())) {
+
+		// initialize the airspeed setpoint
+		if (PX4_ISFINITE(_long_control_state.airspeed_eas) && _long_control_state.airspeed_eas < system_min_airspeed) {
+			// current airpseed is below minimum - init with minimum
+			_airspeed_slew_rate_controller.setForcedValue(system_min_airspeed);
+
+		} else if (PX4_ISFINITE(_long_control_state.airspeed_eas) && _long_control_state.airspeed_eas > system_max_airspeed) {
+			// current airpseed is above maximum - init with maximum
+			_airspeed_slew_rate_controller.setForcedValue(system_max_airspeed);
+
+		} else if (PX4_ISFINITE(_long_control_state.airspeed_eas)) {
+			// current airpseed is between min and max - init with current
+			_airspeed_slew_rate_controller.setForcedValue(_long_control_state.airspeed_eas);
+
+		} else {
+			// current airpseed is invalid - init with setpoint
+			_airspeed_slew_rate_controller.setForcedValue(calibrated_airspeed_setpoint);
+		}
+	} else {
+		// update slew rate state
+		if (_airspeed_slew_rate_controller.getState() < system_min_airspeed) {
+			// current airpseed setpoint is below minimum - reset to minimum
+			_airspeed_slew_rate_controller.setForcedValue(system_min_airspeed);
+
+		} else if (_airspeed_slew_rate_controller.getState() > system_max_airspeed) {
+			// current airpseed setpoint is above maximum - reset to maximum
+			_airspeed_slew_rate_controller.setForcedValue(system_max_airspeed);
+
+		} else if (PX4_ISFINITE(_long_control_state.airspeed_eas)) {
+			// current airpseed setpoint is between min and max - update
+			_airspeed_slew_rate_controller.update(calibrated_airspeed_setpoint, control_interval);
+
+		}
+	}
+
+	return _airspeed_slew_rate_controller.getState();
+}
+
 bool FwLateralLongitudinalControl::checkLowHeightConditions() const
 {
 	// Are conditions for low-height
@@ -677,8 +760,6 @@ float FwLateralLongitudinalControl::mapLateralAccelerationToRollAngle(float late
 
 void FwLateralLongitudinalControl::setDefaultLongitudinalControlLimits() {
 	_long_limits.timestamp = hrt_absolute_time();
-	_long_limits.equivalent_airspeed_min = _performance_model.getMinimumCalibratedAirspeed();
-	_long_limits.equivalent_airspeed_max = _performance_model.getMaximumCalibratedAirspeed();
 	_long_limits.pitch_min = radians(_param_fw_p_lim_min.get());
 	_long_limits.pitch_max = radians(_param_fw_p_lim_max.get());
 	_long_limits.throttle_min = _param_fw_thr_min.get();
@@ -691,17 +772,6 @@ void FwLateralLongitudinalControl::setDefaultLongitudinalControlLimits() {
 
 void FwLateralLongitudinalControl::updateLongitudinalControlLimits(const longitudinal_control_limits_s &limits_in) {
 	_long_limits.timestamp = limits_in.timestamp;
-	if(PX4_ISFINITE(limits_in.equivalent_airspeed_min) ) {
-		_long_limits.equivalent_airspeed_min = math::constrain(limits_in.equivalent_airspeed_min, _performance_model.getMinimumCalibratedAirspeed(), _performance_model.getCalibratedTrimAirspeed());
-	} else {
-		_long_limits.equivalent_airspeed_min = _performance_model.getMinimumCalibratedAirspeed();
-	}
-
-	if (PX4_ISFINITE(limits_in.equivalent_airspeed_max)) {
-		_long_limits.equivalent_airspeed_max = math::constrain(limits_in.equivalent_airspeed_max, _performance_model.getCalibratedTrimAirspeed(), _performance_model.getMaximumCalibratedAirspeed());
-	} else {
-		_long_limits.equivalent_airspeed_max = _performance_model.getMaximumCalibratedAirspeed();
-	}
 
 	if (PX4_ISFINITE(limits_in.pitch_min)) {
 		_long_limits.pitch_min = math::constrain(limits_in.pitch_min, radians(_param_fw_p_lim_min.get()), radians(_param_fw_p_lim_max.get()));
@@ -738,6 +808,19 @@ void FwLateralLongitudinalControl::updateLongitudinalControlLimits(const longitu
 	} else {
 		_long_limits.sink_rate_target = _param_sinkrate_target.get();
 	}
+}
+
+float FwLateralLongitudinalControl::getLoadFactor() const
+{
+	float load_factor_from_bank_angle = 1.f;
+
+	const float roll_body = Eulerf(Quatf(_att_sp.q_d)).phi();
+
+	if (PX4_ISFINITE(roll_body)) {
+		load_factor_from_bank_angle = 1.f / math::max(cosf(roll_body), FLT_EPSILON);
+	}
+
+	return load_factor_from_bank_angle;
 }
 
 extern "C" __EXPORT int fw_lat_lon_control_main(int argc, char *argv[])

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -89,7 +89,7 @@ FwLateralLongitudinalControl::parameters_update()
 	_tecs.set_max_sink_rate(_param_fw_t_sink_max.get());
 	_tecs.set_min_sink_rate(_performance_model.getMinimumSinkRate(_air_density));
 	_tecs.set_equivalent_airspeed_trim(_performance_model.getCalibratedTrimAirspeed());
-	_tecs.set_equivalent_airspeed_min(_performance_model.getMinimumCalibratedAirspeed());
+	_tecs.set_equivalent_airspeed_min(_performance_model.getMinimumCalibratedAirspeed(getLoadFactor(), _flaps_setpoint));
 	_tecs.set_equivalent_airspeed_max(_performance_model.getMaximumCalibratedAirspeed());
 	_tecs.set_throttle_damp(_param_fw_t_thr_damping.get());
 	_tecs.set_integrator_gain_throttle(_param_fw_t_thr_integ.get());
@@ -168,6 +168,13 @@ void FwLateralLongitudinalControl::Run()
 
 		_vehicle_status_sub.update();
 		_control_mode_sub.update();
+
+		if (_flaps_setpoint_sub.updated()) {
+			normalized_unsigned_setpoint_s flaps_setpoint{};
+			_flaps_setpoint_sub.copy(&flaps_setpoint);
+			_flaps_setpoint = flaps_setpoint.normalized_setpoint;
+		}
+
 		update_control_state();
 
 		if (_control_mode_sub.get().flag_control_manual_enabled && _control_mode_sub.get().flag_control_altitude_enabled
@@ -610,7 +617,7 @@ float
 FwLateralLongitudinalControl::adapt_airspeed_setpoint(const float control_interval, float calibrated_airspeed_setpoint,
 		float calibrated_min_airspeed_guidance, float wind_speed)
 {
-	float system_min_airspeed = _performance_model.getMinimumCalibratedAirspeed(getLoadFactor());
+	float system_min_airspeed = _performance_model.getMinimumCalibratedAirspeed(getLoadFactor(), _flaps_setpoint);
 
 	const float system_max_airspeed = _performance_model.getMaximumCalibratedAirspeed();
 

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
@@ -66,6 +66,7 @@
 #include <uORB/topics/fixed_wing_lateral_setpoint.h>
 #include <uORB/topics/fixed_wing_lateral_status.h>
 #include <uORB/topics/fixed_wing_longitudinal_setpoint.h>
+#include <uORB/topics/normalized_unsigned_setpoint.h>
 #include <uORB/topics/flight_phase_estimation.h>
 #include <uORB/topics/lateral_control_limits.h>
 #include <uORB/topics/longitudinal_control_limits.h>
@@ -110,6 +111,7 @@ private:
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	uORB::Subscription _airspeed_validated_sub{ORB_ID(airspeed_validated)};
+	uORB::Subscription _flaps_setpoint_sub{ORB_ID(flaps_setpoint)};
 	uORB::Subscription _wind_sub{ORB_ID(wind)};
 	uORB::SubscriptionData<vehicle_control_mode_s> _control_mode_sub{ORB_ID(vehicle_control_mode)};
 	uORB::SubscriptionData<vehicle_air_data_s> _vehicle_air_data_sub{ORB_ID(vehicle_air_data)};
@@ -126,6 +128,7 @@ private:
 	longitudinal_control_limits_s _long_limits{};
 	fixed_wing_lateral_setpoint_s _lat_control_sp{empty_lateral_control_setpoint};
 	lateral_control_limits_s _lateral_limits{};
+	float _flaps_setpoint{0.f};
 
 	uORB::Publication <vehicle_attitude_setpoint_s> _attitude_sp_pub;
 	uORB::Publication <tecs_status_s> _tecs_status_pub{ORB_ID(tecs_status)};

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
@@ -162,7 +162,9 @@ private:
 		(ParamFloat<px4::params::FW_THR_MIN>) _param_fw_thr_min,
 		(ParamFloat<px4::params::FW_THR_SLEW_MAX>) _param_fw_thr_slew_max,
 		(ParamFloat<px4::params::FW_LND_THRTC_SC>) _param_fw_thrtc_sc,
-		(ParamFloat<px4::params::FW_T_THR_LOW_HGT>) _param_fw_t_thr_low_hgt
+		(ParamFloat<px4::params::FW_T_THR_LOW_HGT>) _param_fw_t_thr_low_hgt,
+		(ParamFloat<px4::params::FW_WIND_ARSP_SC>) _param_fw_wind_arsp_sc,
+		(ParamFloat<px4::params::FW_GND_SPD_MIN>) _param_fw_gnd_spd_min
 	)
 
 	hrt_abstime _last_time_loop_ran{};
@@ -191,9 +193,9 @@ private:
 	hrt_abstime _time_since_first_reduced_roll{0U}; ///< absolute time since start when entering reduced roll angle for the first time
 	hrt_abstime _time_since_last_npfg_call{0U}; 	///< absolute time since start when the npfg reduced roll angle calculations was last performed
 	vehicle_attitude_setpoint_s _att_sp{};
-
 	bool _landed{false};
 	float _can_run_factor{0.f};
+	SlewRate<float> _airspeed_slew_rate_controller;
 
 	perf_counter_t _loop_perf; // loop performance counter
 
@@ -201,6 +203,8 @@ private:
 	TECS _tecs;
 	CourseToAirspeedRefMapper _course_to_airspeed;
 	AirspeedReferenceController _airspeed_ref_control;
+
+	float _min_airspeed_from_guidance{0.f}; // need to store it bc we only update after running longitudinal controller
 
 	void parameters_update();
 	void update_control_state();
@@ -236,6 +240,21 @@ private:
 	void updateLongitudinalControlLimits(const longitudinal_control_limits_s &limits_in);
 
 	void updateControlLimits();
+
+	float getLoadFactor() const;
+
+	/**
+	 * @brief Returns an adapted calibrated airspeed setpoint
+	 *
+	 * Adjusts the setpoint for wind, accelerated stall, and slew rates.
+	 *
+	 * @param control_interval Time since the last position control update [s]
+	 * @param calibrated_airspeed_setpoint Calibrated airspeed septoint (generally from the position setpoint) [m/s]
+	 * @param calibrated_min_airspeed_guidance Minimum airspeed required for lateral guidance [m/s]
+	 * @return Adjusted calibrated airspeed setpoint [m/s]
+	 */
+	float adapt_airspeed_setpoint(const float control_interval, float calibrated_airspeed_setpoint,
+				      float calibrated_min_airspeed_guidance, float wind_speed);
 };
 
 #endif //PX4_FWLATERALLONGITUDINALCONTROL_HPP

--- a/src/modules/fw_pos_control/ControlLimitsHandler.cpp
+++ b/src/modules/fw_pos_control/ControlLimitsHandler.cpp
@@ -54,10 +54,6 @@ void CombinedControlLimitHandler::update(const hrt_abstime now)
 				 _longitudinal_publisher.get().throttle_max);
 	_longitudinal_updated |= floatValueChanged(_longitudinal_limits_current_cycle.speed_weight,
 				 _longitudinal_publisher.get().speed_weight);
-	_longitudinal_updated |= floatValueChanged(_longitudinal_limits_current_cycle.equivalent_airspeed_min,
-				 _longitudinal_publisher.get().equivalent_airspeed_min);
-	_longitudinal_updated |= floatValueChanged(_longitudinal_limits_current_cycle.equivalent_airspeed_max,
-				 _longitudinal_publisher.get().equivalent_airspeed_max);
 	_longitudinal_updated |= floatValueChanged(_longitudinal_limits_current_cycle.climb_rate_target,
 				 _longitudinal_publisher.get().climb_rate_target);
 	_longitudinal_updated |= floatValueChanged(_longitudinal_limits_current_cycle.sink_rate_target,
@@ -100,16 +96,6 @@ void CombinedControlLimitHandler::setThrottleMin(float throttle_min)
 void CombinedControlLimitHandler::setSpeedWeight(float speed_weight)
 {
 	_longitudinal_limits_current_cycle.speed_weight = speed_weight;
-}
-
-void CombinedControlLimitHandler::setMinimumAirspeed(const float airspeed_min)
-{
-	_longitudinal_limits_current_cycle.equivalent_airspeed_min = airspeed_min;
-}
-
-void CombinedControlLimitHandler::setMaximumAirspeed(const float airspeed_max)
-{
-	_longitudinal_limits_current_cycle.equivalent_airspeed_max = airspeed_max;
 }
 
 void CombinedControlLimitHandler::setPitchMin(const float pitch_min)

--- a/src/modules/fw_pos_control/ControlLimitsHandler.hpp
+++ b/src/modules/fw_pos_control/ControlLimitsHandler.hpp
@@ -43,7 +43,7 @@
 #include <uORB/Publication.hpp>
 #include <lib/mathlib/mathlib.h>
 
-const longitudinal_control_limits_s empty_longitudinal_control_limits = {.timestamp = 0, .pitch_min = NAN, .pitch_max = NAN, .throttle_min = NAN, .throttle_max = NAN, .climb_rate_target = NAN, .sink_rate_target = NAN, .equivalent_airspeed_min = NAN, .equivalent_airspeed_max = NAN, .speed_weight = NAN, .enforce_low_height_condition = false, .disable_underspeed_protection = false };
+const longitudinal_control_limits_s empty_longitudinal_control_limits = {.timestamp = 0, .pitch_min = NAN, .pitch_max = NAN, .throttle_min = NAN, .throttle_max = NAN, .climb_rate_target = NAN, .sink_rate_target = NAN, .speed_weight = NAN, .enforce_low_height_condition = false, .disable_underspeed_protection = false };
 const lateral_control_limits_s empty_lateral_control_limits = {.timestamp = 0, .lateral_accel_max = NAN};
 
 
@@ -62,10 +62,6 @@ public:
 	void setThrottleMin(float throttle_min);
 
 	void setSpeedWeight(float speed_weight);
-
-	void setMinimumAirspeed(const float airspeed_min);
-
-	void setMaximumAirspeed(const float airspeed_max);
 
 	void setPitchMin(const float pitch_min);
 

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -2626,19 +2626,6 @@ fw_pos_control is the fixed-wing position controller.
 
 	return 0;
 }
-float FixedwingPositionControl::getLoadFactor() const
-{
-	float load_factor_from_bank_angle = 1.0f;
-
-	float roll_body = Eulerf(Quatf(_att_sp.q_d)).phi();
-
-	if (PX4_ISFINITE(roll_body)) {
-		load_factor_from_bank_angle = 1.0f / math::max(cosf(roll_body), FLT_EPSILON);
-	}
-
-	return load_factor_from_bank_angle;
-
-}
 
 extern "C" __EXPORT int fw_pos_control_main(int argc, char *argv[])
 {

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -72,8 +72,6 @@ FixedwingPositionControl::FixedwingPositionControl(bool vtol) :
 	_spoilers_setpoint_pub.advertise();
 	_fixed_wing_lateral_guidance_status_pub.advertise();
 
-	_airspeed_slew_rate_controller.setSlewRate(ASPD_SP_SLEW_RATE);
-
 	parameters_update();
 }
 
@@ -97,7 +95,6 @@ void
 FixedwingPositionControl::parameters_update()
 {
 	updateParams();
-	_performance_model.updateParameters();
 
 	_directional_guidance.setPeriod(_param_npfg_period.get());
 	_directional_guidance.setDamping(_param_npfg_damping.get());
@@ -174,6 +171,7 @@ FixedwingPositionControl::airspeed_poll()
 	}
 
 	// no airspeed updates for one second --> declare invalid
+	// this flag is used for some logic like: exiting takeoff, flaps retraction
 	_airspeed_valid = hrt_elapsed_time(&_time_airspeed_last_valid) < 1_s;
 }
 
@@ -265,80 +263,20 @@ FixedwingPositionControl::vehicle_attitude_poll()
 float
 FixedwingPositionControl::get_manual_airspeed_setpoint()
 {
-	float altctrl_airspeed = _performance_model.getCalibratedTrimAirspeed();
+	float manual_airspeed_setpoint = NAN;
 
 	if (_param_fw_pos_stk_conf.get() & STICK_CONFIG_ENABLE_AIRSPEED_SP_MANUAL_BIT) {
 		// neutral throttle corresponds to trim airspeed
-		return math::interpolateNXY(_manual_control_setpoint_for_airspeed,
+		manual_airspeed_setpoint = math::interpolateNXY(_manual_control_setpoint_for_airspeed,
 		{-1.f, 0.f, 1.f},
-		{_performance_model.getMinimumCalibratedAirspeed(getLoadFactor()), altctrl_airspeed, _performance_model.getMaximumCalibratedAirspeed()});
+		{_param_fw_airspd_min.get(), _param_fw_airspd_trim.get(), _param_fw_airspd_max.get()});
 
 	} else if (PX4_ISFINITE(_commanded_manual_airspeed_setpoint)) {
 		// override stick by commanded airspeed
-		altctrl_airspeed = constrain(_commanded_manual_airspeed_setpoint,
-					     _performance_model.getMinimumCalibratedAirspeed(getLoadFactor()),
-					     _performance_model.getMaximumCalibratedAirspeed());
+		manual_airspeed_setpoint = _commanded_manual_airspeed_setpoint;
 	}
 
-	return altctrl_airspeed;
-}
-
-float
-FixedwingPositionControl::adapt_airspeed_setpoint(const float control_interval, float calibrated_airspeed_setpoint,
-		float calibrated_min_airspeed, const Vector2f &ground_speed, bool in_takeoff_situation)
-{
-	// --- airspeed *constraint adjustments ---
-
-	// Aditional option to increase the min airspeed setpoint based on wind estimate for more stability in higher winds.
-	if (!in_takeoff_situation && _airspeed_valid && _wind_valid && _param_fw_wind_arsp_sc.get() > FLT_EPSILON) {
-		calibrated_min_airspeed = math::min(calibrated_min_airspeed + _param_fw_wind_arsp_sc.get() *
-						    _wind_vel.length(), _performance_model.getMaximumCalibratedAirspeed());
-	}
-
-	// --- airspeed *setpoint adjustments ---
-
-	if (!PX4_ISFINITE(calibrated_airspeed_setpoint) || calibrated_airspeed_setpoint <= FLT_EPSILON) {
-		calibrated_airspeed_setpoint = _performance_model.getCalibratedTrimAirspeed();
-	}
-
-	// Adapt cruise airspeed when otherwise the min groundspeed couldn't be maintained
-	if (!_wind_valid && !in_takeoff_situation) {
-		/*
-		 * This error value ensures that a plane (as long as its throttle capability is
-		 * not exceeded) travels towards a waypoint (and is not pushed more and more away
-		 * by wind). Not countering this would lead to a fly-away. Only non-zero in presence
-		 * of sufficient wind. "minimum ground speed undershoot".
-		 */
-		const float ground_speed_body = _body_velocity_x;
-
-		if (ground_speed_body < _param_fw_gnd_spd_min.get()) {
-			calibrated_airspeed_setpoint += _param_fw_gnd_spd_min.get() - ground_speed_body;
-		}
-	}
-
-	calibrated_airspeed_setpoint = constrain(calibrated_airspeed_setpoint, calibrated_min_airspeed,
-				       _performance_model.getMaximumCalibratedAirspeed());
-
-	// initialize the airspeed setpoint to the max(current airsped, min airspeed)
-	if (!PX4_ISFINITE(_airspeed_slew_rate_controller.getState())) {
-		_airspeed_slew_rate_controller.setForcedValue(math::max(calibrated_min_airspeed, _airspeed_eas));
-	}
-
-	// reset the airspeed setpoint to the min airspeed if the min airspeed changes while in operation
-	if (_airspeed_slew_rate_controller.getState() < calibrated_min_airspeed) {
-		_airspeed_slew_rate_controller.setForcedValue(calibrated_min_airspeed);
-	}
-
-	if (control_interval > FLT_EPSILON) {
-		// constrain airspeed setpoint changes with slew rate of ASPD_SP_SLEW_RATE m/s/s
-		_airspeed_slew_rate_controller.update(calibrated_airspeed_setpoint, control_interval);
-	}
-
-	if (_airspeed_slew_rate_controller.getState() > _performance_model.getMaximumCalibratedAirspeed()) {
-		_airspeed_slew_rate_controller.setForcedValue(_performance_model.getMaximumCalibratedAirspeed());
-	}
-
-	return _airspeed_slew_rate_controller.getState();
+	return manual_airspeed_setpoint;
 }
 
 void
@@ -416,7 +354,7 @@ void
 FixedwingPositionControl::updateManualTakeoffStatus()
 {
 	if (!_completed_manual_takeoff) {
-		const bool at_controllable_airspeed = _airspeed_eas > _performance_model.getMinimumCalibratedAirspeed(getLoadFactor())
+		const bool at_controllable_airspeed = _airspeed_eas > _param_fw_airspd_min.get()
 						      || !_airspeed_valid;
 		const bool is_hovering = _vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
 					 && _control_mode.flag_armed;
@@ -699,7 +637,7 @@ FixedwingPositionControl::control_auto_fixed_bank_alt_hold()
 		.timestamp = now,
 		.altitude = _current_altitude,
 		.height_rate = NAN,
-		.equivalent_airspeed = _performance_model.getCalibratedTrimAirspeed(),
+		.equivalent_airspeed = NAN,
 		.pitch_direct = NAN,
 		.throttle_direct = NAN
 	};
@@ -736,7 +674,7 @@ FixedwingPositionControl::control_auto_descend()
 		.timestamp = now,
 		.altitude = NAN,
 		.height_rate = -descend_rate,
-		.equivalent_airspeed = _performance_model.getCalibratedTrimAirspeed(),
+		.equivalent_airspeed = NAN,
 		.pitch_direct = NAN,
 		.throttle_direct = NAN
 	};
@@ -818,6 +756,8 @@ FixedwingPositionControl::control_auto_position(const float control_interval, co
 		throttle_max = 0.0;
 	}
 
+	const float target_airspeed = pos_sp_curr.cruising_speed > FLT_EPSILON ? pos_sp_curr.cruising_speed : NAN;
+
 	// waypoint is a plain navigation waypoint
 	float position_sp_alt = pos_sp_curr.alt;
 
@@ -852,9 +792,6 @@ FixedwingPositionControl::control_auto_position(const float control_interval, co
 			}
 		}
 	}
-
-	const float target_airspeed = adapt_airspeed_setpoint(control_interval, pos_sp_curr.cruising_speed,
-				      _performance_model.getMinimumCalibratedAirspeed(getLoadFactor()), ground_speed);
 
 	const fixed_wing_longitudinal_setpoint_s fw_longitudinal_control_sp = {
 		.timestamp = hrt_absolute_time(),
@@ -899,9 +836,6 @@ FixedwingPositionControl::control_auto_velocity(const float control_interval, co
 	Vector2f target_velocity{pos_sp_curr.vx, pos_sp_curr.vy};
 	const float target_bearing = wrap_pi(atan2f(target_velocity(1), target_velocity(0)));
 
-	float target_airspeed = adapt_airspeed_setpoint(control_interval, pos_sp_curr.cruising_speed,
-				_performance_model.getMinimumCalibratedAirspeed(getLoadFactor()), ground_speed);
-
 	const Vector2f curr_pos_local{_local_pos.x, _local_pos.y};
 	const DirectionalGuidanceOutput sp = navigateBearing(curr_pos_local, target_bearing, ground_speed, _wind_vel);
 
@@ -910,6 +844,8 @@ FixedwingPositionControl::control_auto_velocity(const float control_interval, co
 	fw_lateral_ctrl_sp.course = sp.course_setpoint;
 	fw_lateral_ctrl_sp.lateral_acceleration = sp.lateral_acceleration_feedforward;
 	_lateral_ctrl_sp_pub.publish(fw_lateral_ctrl_sp);
+
+	const float target_airspeed = pos_sp_curr.cruising_speed > FLT_EPSILON ? pos_sp_curr.cruising_speed : NAN;
 
 	const fixed_wing_longitudinal_setpoint_s fw_longitudinal_control_sp = {
 		.timestamp = hrt_absolute_time(),
@@ -937,14 +873,6 @@ FixedwingPositionControl::control_auto_loiter(const float control_interval, cons
 	// current waypoint (the one currently heading for)
 	const Vector2d curr_wp = Vector2d(pos_sp_curr.lat, pos_sp_curr.lon);
 
-	float airspeed_sp = -1.f;
-
-	if (PX4_ISFINITE(pos_sp_curr.cruising_speed) &&
-	    pos_sp_curr.cruising_speed > FLT_EPSILON) {
-
-		airspeed_sp = pos_sp_curr.cruising_speed;
-	}
-
 	float loiter_radius = pos_sp_curr.loiter_radius;
 
 	if (fabsf(pos_sp_curr.loiter_radius) < FLT_EPSILON) {
@@ -960,22 +888,23 @@ FixedwingPositionControl::control_auto_loiter(const float control_interval, cons
 
 	bool enforce_low_height{false};
 
+	float target_airspeed = pos_sp_curr.cruising_speed > FLT_EPSILON ? pos_sp_curr.cruising_speed : NAN;
+
 	if (pos_sp_next.type == position_setpoint_s::SETPOINT_TYPE_LAND && _position_setpoint_next_valid
 	    && close_to_circle && _param_fw_lnd_earlycfg.get()) {
 		// We're in a loiter directly before a landing WP. Enable our landing configuration (flaps,
 		// landing airspeed and potentially tighter altitude control) already such that we don't
 		// have to do this switch (which can cause significant altitude errors) close to the ground.
 		enforce_low_height = true;
-		airspeed_sp = (_param_fw_lnd_airspd.get() > FLT_EPSILON) ? _param_fw_lnd_airspd.get() :
-			      _performance_model.getMinimumCalibratedAirspeed(getLoadFactor());
+
+		if (_param_fw_lnd_airspd.get() > FLT_EPSILON) {
+			target_airspeed = _param_fw_lnd_airspd.get();
+		}
+
 		_flaps_setpoint = _param_fw_flaps_lnd_scl.get();
 		_spoilers_setpoint = _param_fw_spoilers_lnd.get();
 		_new_landing_gear_position = landing_gear_s::GEAR_DOWN;
 	}
-
-	float target_airspeed = adapt_airspeed_setpoint(control_interval, airspeed_sp,
-				_performance_model.getMinimumCalibratedAirspeed(getLoadFactor()),
-				ground_speed);
 
 	const DirectionalGuidanceOutput sp = navigateLoiter(curr_wp_local, curr_pos_local, loiter_radius,
 					     pos_sp_curr.loiter_direction_counter_clockwise,
@@ -999,7 +928,7 @@ FixedwingPositionControl::control_auto_loiter(const float control_interval, cons
 			_ctrl_limits_handler.setLateralAccelMax(0.0f);
 
 			// keep flaps in landing configuration if the airspeed is below the min airspeed (keep deployed if airspeed not valid)
-			if (!_airspeed_valid || _airspeed_eas < _performance_model.getMinimumCalibratedAirspeed()) {
+			if (!_airspeed_valid || _airspeed_eas < _param_fw_airspd_min.get()) {
 				_flaps_setpoint = _param_fw_flaps_lnd_scl.get();
 
 			} else {
@@ -1036,8 +965,7 @@ FixedwingPositionControl::controlAutoFigureEight(const float control_interval, c
 		const Vector2f &ground_speed, const position_setpoint_s &pos_sp_curr)
 {
 	// airspeed settings
-	float target_airspeed = adapt_airspeed_setpoint(control_interval, pos_sp_curr.cruising_speed,
-				_performance_model.getMinimumCalibratedAirspeed(), ground_speed);
+	const float target_airspeed = pos_sp_curr.cruising_speed > FLT_EPSILON ? pos_sp_curr.cruising_speed : NAN;
 
 	Vector2f curr_pos_local{_local_pos.x, _local_pos.y};
 
@@ -1097,8 +1025,7 @@ void
 FixedwingPositionControl::control_auto_path(const float control_interval, const Vector2d &curr_pos,
 		const Vector2f &ground_speed, const position_setpoint_s &pos_sp_curr)
 {
-	float target_airspeed = adapt_airspeed_setpoint(control_interval, pos_sp_curr.cruising_speed,
-				_performance_model.getMinimumCalibratedAirspeed(getLoadFactor()), ground_speed);
+	const float target_airspeed = pos_sp_curr.cruising_speed > FLT_EPSILON ? pos_sp_curr.cruising_speed : NAN;
 
 	Vector2f curr_pos_local{_local_pos.x, _local_pos.y};
 	Vector2f curr_wp_local = _global_local_proj_ref.project(pos_sp_curr.lat, pos_sp_curr.lon);
@@ -1154,15 +1081,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 	const Vector2f local_2D_position{_local_pos.x, _local_pos.y};
 
 	const float takeoff_airspeed = (_param_fw_tko_airspd.get() > FLT_EPSILON) ? _param_fw_tko_airspd.get() :
-				       _performance_model.getMinimumCalibratedAirspeed(getLoadFactor());
-
-	float adjusted_min_airspeed = _performance_model.getMinimumCalibratedAirspeed(getLoadFactor());
-
-	if (takeoff_airspeed < adjusted_min_airspeed) {
-		// adjust underspeed detection bounds for takeoff airspeed
-		_ctrl_limits_handler.setMinimumAirspeed(takeoff_airspeed);
-		adjusted_min_airspeed = takeoff_airspeed;
-	}
+				       _param_fw_airspd_min.get();
 
 	if (_runway_takeoff.runwayTakeoffEnabled()) {
 		if (!_runway_takeoff.isInitialized()) {
@@ -1170,7 +1089,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 			_takeoff_init_position = global_position;
 			_takeoff_ground_alt = _current_altitude;
 			_launch_current_yaw = _yaw;
-			_airspeed_slew_rate_controller.setForcedValue(takeoff_airspeed);
+			// _airspeed_slew_rate_controller.setForcedValue(takeoff_airspeed); // TODO
 
 			events::send(events::ID("fixedwing_position_control_takeoff"), events::Log::Info, "Takeoff on runway");
 		}
@@ -1202,10 +1121,6 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 			}
 		}
 
-		const float target_airspeed = adapt_airspeed_setpoint(control_interval, takeoff_airspeed, adjusted_min_airspeed,
-					      ground_speed,
-					      true);
-
 		const DirectionalGuidanceOutput sp = navigateLine(start_pos_local, takeoff_bearing, local_2D_position, ground_speed,
 						     _wind_vel);
 
@@ -1228,7 +1143,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 			.timestamp = now,
 			.altitude = altitude_setpoint_amsl,
 			.height_rate = NAN,
-			.equivalent_airspeed = target_airspeed,
+			.equivalent_airspeed = takeoff_airspeed,
 			.pitch_direct = _runway_takeoff.getPitch(),
 			.throttle_direct = _runway_takeoff.getThrottle(_param_fw_thr_idle.get())
 		};
@@ -1237,7 +1152,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 
 		_ctrl_limits_handler.setPitchMin(pitch_min);
 		_ctrl_limits_handler.setPitchMax(pitch_max);
-		_ctrl_limits_handler.setClimbRateTarget(_performance_model.getMaximumClimbRate(_air_density));
+		_ctrl_limits_handler.setClimbRateTarget(_param_fw_t_clmb_max.get());
 		_ctrl_limits_handler.setDisableUnderspeedProtection(true);
 
 		_flaps_setpoint = _param_fw_flaps_to_scl.get();
@@ -1269,7 +1184,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 			_takeoff_init_position = global_position;
 			_takeoff_ground_alt = _current_altitude;
 			_launch_current_yaw = _yaw;
-			_airspeed_slew_rate_controller.setForcedValue(takeoff_airspeed);
+			// _airspeed_slew_rate_controller.setForcedValue(takeoff_airspeed); // TODO
 		}
 
 		const Vector2f launch_local_position = _global_local_proj_ref.project(_takeoff_init_position(0),
@@ -1292,9 +1207,6 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 		if (_launchDetector.getLaunchDetected() > launch_detection_status_s::STATE_WAITING_FOR_LAUNCH) {
 			/* Launch has been detected, hence we have to control the plane. */
 
-			float target_airspeed = adapt_airspeed_setpoint(control_interval, takeoff_airspeed, adjusted_min_airspeed, ground_speed,
-						true);
-
 			const DirectionalGuidanceOutput sp = navigateLine(launch_local_position, takeoff_bearing, local_2D_position,
 							     ground_speed,
 							     _wind_vel);
@@ -1315,7 +1227,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 				.timestamp = now,
 				.altitude = altitude_setpoint_amsl,
 				.height_rate = NAN,
-				.equivalent_airspeed = target_airspeed,
+				.equivalent_airspeed = takeoff_airspeed,
 				.pitch_direct = NAN,
 				.throttle_direct = NAN
 			};
@@ -1325,7 +1237,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 
 			_ctrl_limits_handler.setPitchMin(radians(_takeoff_pitch_min.get()));
 			_ctrl_limits_handler.setThrottleMax(max_takeoff_throttle);
-			_ctrl_limits_handler.setClimbRateTarget(_performance_model.getMaximumClimbRate(_air_density));
+			_ctrl_limits_handler.setClimbRateTarget(_param_fw_t_clmb_max.get());
 			_ctrl_limits_handler.setDisableUnderspeedProtection(true);
 
 			//float yaw_body = _yaw; // yaw is not controlled, so set setpoint to current yaw
@@ -1361,21 +1273,10 @@ void
 FixedwingPositionControl::control_auto_landing_straight(const hrt_abstime &now, const float control_interval,
 		const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr)
 {
-	// first handle non-position things like airspeed and tecs settings
 	const float airspeed_land = (_param_fw_lnd_airspd.get() > FLT_EPSILON) ? _param_fw_lnd_airspd.get() :
-				    _performance_model.getMinimumCalibratedAirspeed(getLoadFactor());
-	float adjusted_min_airspeed = _performance_model.getMinimumCalibratedAirspeed(getLoadFactor());
+				    _param_fw_airspd_min.get();
 
 	_ctrl_limits_handler.setEnforceLowHeightCondition(true);
-
-	if (airspeed_land < adjusted_min_airspeed) {
-		// adjust underspeed detection bounds for landing airspeed
-		adjusted_min_airspeed = airspeed_land;
-		_ctrl_limits_handler.setMinimumAirspeed(airspeed_land);
-	}
-
-	const float target_airspeed = adapt_airspeed_setpoint(control_interval, airspeed_land, adjusted_min_airspeed,
-				      ground_speed);
 
 	// now handle position
 	const Vector2f local_position{_local_pos.x, _local_pos.y};
@@ -1494,7 +1395,7 @@ FixedwingPositionControl::control_auto_landing_straight(const hrt_abstime &now, 
 			.timestamp = now,
 			.altitude = altitude_setpoint,
 			.height_rate = height_rate_setpoint,
-			.equivalent_airspeed = target_airspeed,
+			.equivalent_airspeed = airspeed_land,
 			.pitch_direct = NAN,
 			.throttle_direct = NAN
 		};
@@ -1552,7 +1453,7 @@ FixedwingPositionControl::control_auto_landing_straight(const hrt_abstime &now, 
 			.timestamp = hrt_absolute_time(),
 			.altitude = altitude_setpoint,
 			.height_rate = NAN,
-			.equivalent_airspeed = target_airspeed,
+			.equivalent_airspeed = airspeed_land,
 			.pitch_direct = NAN,
 			.throttle_direct = NAN
 		};
@@ -1581,19 +1482,10 @@ void
 FixedwingPositionControl::control_auto_landing_circular(const hrt_abstime &now, const float control_interval,
 		const Vector2f &ground_speed, const position_setpoint_s &pos_sp_curr)
 {
-	// first handle non-position things like airspeed and tecs settings
 	const float airspeed_land = (_param_fw_lnd_airspd.get() > FLT_EPSILON) ? _param_fw_lnd_airspd.get() :
-				    _performance_model.getMinimumCalibratedAirspeed(getLoadFactor());
-	float adjusted_min_airspeed = _performance_model.getMinimumCalibratedAirspeed(getLoadFactor());
+				    _param_fw_airspd_min.get();
 
-	if (airspeed_land < adjusted_min_airspeed) {
-		// adjust underspeed detection bounds for landing airspeed
-		adjusted_min_airspeed = airspeed_land;
-		_ctrl_limits_handler.setMinimumAirspeed(airspeed_land);
-	}
-
-	const float target_airspeed = adapt_airspeed_setpoint(control_interval, airspeed_land, adjusted_min_airspeed,
-				      ground_speed);
+	_ctrl_limits_handler.setEnforceLowHeightCondition(true);
 
 
 	const Vector2f local_position{_local_pos.x, _local_pos.y};
@@ -1679,7 +1571,7 @@ FixedwingPositionControl::control_auto_landing_circular(const hrt_abstime &now, 
 			.timestamp = now,
 			.altitude = NAN,
 			.height_rate = height_rate_setpoint,
-			.equivalent_airspeed = target_airspeed,
+			.equivalent_airspeed = airspeed_land,
 			.pitch_direct = NAN,
 			.throttle_direct = NAN
 		};
@@ -1731,7 +1623,7 @@ FixedwingPositionControl::control_auto_landing_circular(const hrt_abstime &now, 
 			.timestamp = now,
 			.altitude = NAN,
 			.height_rate = -glide_slope_sink_rate,
-			.equivalent_airspeed = target_airspeed,
+			.equivalent_airspeed = airspeed_land,
 			.pitch_direct = NAN,
 			.throttle_direct = NAN
 		};
@@ -1763,8 +1655,6 @@ FixedwingPositionControl::control_manual_altitude(const float control_interval, 
 {
 	updateManualTakeoffStatus();
 
-	const float calibrated_airspeed_sp = adapt_airspeed_setpoint(control_interval, get_manual_airspeed_setpoint(),
-					     _performance_model.getMinimumCalibratedAirspeed(getLoadFactor()), ground_speed, !_completed_manual_takeoff);
 	const float height_rate_sp = getManualHeightRateSetpoint();
 
 	// TECS may try to pitch down to gain airspeed if we underspeed, constrain the pitch when underspeeding if we are
@@ -1783,7 +1673,7 @@ FixedwingPositionControl::control_manual_altitude(const float control_interval, 
 		.timestamp = hrt_absolute_time(),
 		.altitude = NAN,
 		.height_rate = height_rate_sp,
-		.equivalent_airspeed = calibrated_airspeed_sp,
+		.equivalent_airspeed = get_manual_airspeed_setpoint(),
 		.pitch_direct = NAN,
 		.throttle_direct = NAN
 	};
@@ -1809,8 +1699,6 @@ FixedwingPositionControl::control_manual_position(const hrt_abstime now, const f
 {
 	updateManualTakeoffStatus();
 
-	const float calibrated_airspeed_sp = adapt_airspeed_setpoint(control_interval, get_manual_airspeed_setpoint(),
-					     _performance_model.getMinimumCalibratedAirspeed(getLoadFactor()), ground_speed, !_completed_manual_takeoff);
 	const float height_rate_sp = getManualHeightRateSetpoint();
 
 	// TECS may try to pitch down to gain airspeed if we underspeed, constrain the pitch when underspeeding if we are
@@ -1881,7 +1769,7 @@ FixedwingPositionControl::control_manual_position(const hrt_abstime now, const f
 		.timestamp = hrt_absolute_time(),
 		.altitude = NAN,
 		.height_rate = height_rate_sp,
-		.equivalent_airspeed = calibrated_airspeed_sp,
+		.equivalent_airspeed = get_manual_airspeed_setpoint(),
 		.pitch_direct = NAN,
 		.throttle_direct = NAN
 	};
@@ -2112,12 +2000,6 @@ FixedwingPositionControl::Run()
 		vehicle_command_poll();
 		vehicle_control_mode_poll();
 		wind_poll(now);
-
-		vehicle_air_data_s air_data;
-
-		if (_vehicle_air_data_sub.update(&air_data)) {
-			_air_density = PX4_ISFINITE(air_data.rho) ? air_data.rho : _air_density;
-		}
 
 		if (_vehicle_land_detected_sub.updated()) {
 			vehicle_land_detected_s vehicle_land_detected;

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -426,7 +426,6 @@ private:
 	void landing_status_publish();
 
 	void publishLocalPositionSetpoint(const position_setpoint_s &current_waypoint);
-	float getLoadFactor() const;
 
 	/**
 	 * @brief Sets the landing abort status and publishes landing status.

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -48,7 +48,6 @@
 #include <drivers/drv_hrt.h>
 #include <lib/geo/geo.h>
 #include <lib/atmosphere/atmosphere.h>
-#include <lib/fw_performance_model/PerformanceModel.hpp>
 #include <lib/npfg/DirectionalGuidance.hpp>
 #include <lib/mathlib/mathlib.h>
 #include <lib/perf/perf_counter.h>
@@ -78,7 +77,6 @@
 #include <uORB/topics/position_controller_status.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/trajectory_setpoint.h>
-#include <uORB/topics/vehicle_air_data.h>
 #include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
@@ -123,9 +121,6 @@ static constexpr hrt_abstime TERRAIN_ALT_FIRST_MEASUREMENT_TIMEOUT = 10_s;
 
 // [.] max throttle from user which will not lead to motors spinning up in altitude controlled modes
 static constexpr float THROTTLE_THRESH = -.9f;
-
-// [m/s/s] slew rate limit for airspeed setpoint changes
-static constexpr float ASPD_SP_SLEW_RATE = 1.f;
 
 // [us] time after which the wind estimate is disabled if no longer updating
 static constexpr hrt_abstime WIND_EST_TIMEOUT = 10_s;
@@ -187,7 +182,6 @@ private:
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription _pos_sp_triplet_sub{ORB_ID(position_setpoint_triplet)};
 	uORB::Subscription _trajectory_setpoint_sub{ORB_ID(trajectory_setpoint)};
-	uORB::Subscription _vehicle_air_data_sub{ORB_ID(vehicle_air_data)};
 	uORB::Subscription _vehicle_angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};
@@ -359,7 +353,6 @@ private:
 
 	float _airspeed_eas{0.f};
 	bool _airspeed_valid{false};
-	float _air_density{atmosphere::kAirDensitySeaLevelStandardAtmos};
 
 	// [us] last time airspeed was received. used to detect timeouts.
 	hrt_abstime _time_airspeed_last_valid{0};
@@ -388,8 +381,6 @@ private:
 
 	// nonlinear path following guidance - lateral-directional position control
 	DirectionalGuidance _directional_guidance;
-
-	PerformanceModel _performance_model;
 
 	// LANDING GEAR
 	int8_t _new_landing_gear_position{landing_gear_s::GEAR_KEEP};
@@ -648,21 +639,6 @@ private:
 
 	float get_manual_airspeed_setpoint();
 
-	/**
-	 * @brief Returns an adapted calibrated airspeed setpoint
-	 *
-	 * Adjusts the setpoint for wind, accelerated stall, and slew rates.
-	 *
-	 * @param control_interval Time since the last position control update [s]
-	 * @param calibrated_airspeed_setpoint Calibrated airspeed septoint (generally from the position setpoint) [m/s]
-	 * @param calibrated_min_airspeed Minimum calibrated airspeed [m/s]
-	 * @param ground_speed Vehicle ground velocity vector (NE) [m/s]
-	 * @param in_takeoff_situation Vehicle is currently in a takeoff situation
-	 * @return Adjusted calibrated airspeed setpoint [m/s]
-	 */
-	float adapt_airspeed_setpoint(const float control_interval, float calibrated_airspeed_setpoint,
-				      float calibrated_min_airspeed, const Vector2f &ground_speed, bool in_takeoff_situation = false);
-
 	void reset_takeoff_state();
 	void reset_landing_state();
 
@@ -676,8 +652,6 @@ private:
 	void set_control_mode_current(const hrt_abstime &now);
 
 	void publishOrbitStatus(const position_setpoint_s pos_sp);
-
-	SlewRate<float> _airspeed_slew_rate_controller;
 
 	float getMaxRollAngleNearGround(const float altitude, const float terrain_altitude) const;
 
@@ -842,7 +816,6 @@ private:
 	float rollAngleToLateralAccel(float roll_body) const;
 
 	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::FW_GND_SPD_MIN>) _param_fw_gnd_spd_min,
 		(ParamFloat<px4::params::FW_R_LIM>) _param_fw_r_lim,
 
 		(ParamFloat<px4::params::NPFG_PERIOD>) _param_npfg_period,
@@ -890,10 +863,13 @@ private:
 		(ParamFloat<px4::params::FW_LND_TD_OFF>) _param_fw_lnd_td_off,
 		(ParamInt<px4::params::FW_LND_NUDGE>) _param_fw_lnd_nudge,
 		(ParamInt<px4::params::FW_LND_ABORT>) _param_fw_lnd_abort,
-		(ParamFloat<px4::params::FW_WIND_ARSP_SC>) _param_fw_wind_arsp_sc,
 		(ParamFloat<px4::params::FW_TKO_AIRSPD>) _param_fw_tko_airspd,
 		(ParamFloat<px4::params::RWTO_PSP>) _param_rwto_psp,
-		(ParamBool<px4::params::FW_LAUN_DETCN_ON>) _param_fw_laun_detcn_on
+		(ParamBool<px4::params::FW_LAUN_DETCN_ON>) _param_fw_laun_detcn_on,
+		(ParamFloat<px4::params::FW_AIRSPD_MAX>) _param_fw_airspd_max,
+		(ParamFloat<px4::params::FW_AIRSPD_MIN>) _param_fw_airspd_min,
+		(ParamFloat<px4::params::FW_AIRSPD_TRIM>) _param_fw_airspd_trim,
+		(ParamFloat<px4::params::FW_T_CLMB_MAX>) _param_fw_t_clmb_max
 	)
 };
 


### PR DESCRIPTION
### Solved Problem
- airspeed handing split up between FW Position Control and LatLong Control
- both modules need performance model
- airspeed constraints are a bit awkward (e.g. not clear if they should override FW_AIRSPD_MIN/MAX or not), and unclear if they later then should be load_factor and weight adapted
- no min ground speed/ course feasibility handling

### Solution
- FW Pos/LatLong Control: move airspeed handling to LatLongControl
- only optionally set airspeed setpoint in FWPosControl (through mission item or
    in takeoff/landing modes)
- LatLongLimits: remove min/max airspeed limits (to be replaced with flap-based scaling)
- remove performance model form FWPosControl
- CourseToAirspeed: bring back option to increase airspeed to achieve bearing
- perfromance model: add FW_AIRSPD_FLP_SC option to reduce speed limit when flaps are deployed
- CourseToAirspeed: split up heading and min_airspeed calculation: first do heading reference calculation based on current true airspeed setpoint (which in turn contains the minimum airspeed required from lateral guidance), then update the minimum airspeed reference and use it for the next controller run