### PR TITLE
gz: remove transport12 from plugins

### DIFF
--- a/src/modules/simulation/gz_plugins/CMakeLists.txt
+++ b/src/modules/simulation/gz_plugins/CMakeLists.txt
@@ -34,7 +34,7 @@
 project(px4_gz_plugins)
 
 if(NOT DEFINED ENV{GZ_DISTRO} OR NOT "$ENV{GZ_DISTRO}"  STREQUAL "harmonic")
-    find_package(gz-transport NAMES gz-transport14 gz-transport13 gz-transport12)
+    find_package(gz-transport NAMES gz-transport14 gz-transport13)
     find_package(gz-sim NAMES gz-sim9 gz-sim8)
     find_package(gz-sensors NAMES gz-sensors9 gz-sensors8)
     find_package(gz-plugin NAMES gz-plugin3 gz-plugin2 COMPONENTS register)


### PR DESCRIPTION
transport12 slipped in in https://github.com/PX4/PX4-Autopilot/pull/24518, which is unsupported for Harmonic or later

fixes https://github.com/PX4/PX4-Autopilot/issues/24631

@MaEtUgR can you check?
