### PR TITLE
Fix SITL build when Gazebo garden is still installed

### DIFF
--- a/src/modules/simulation/gz_plugins/CMakeLists.txt
+++ b/src/modules/simulation/gz_plugins/CMakeLists.txt
@@ -34,7 +34,7 @@
 project(px4_gz_plugins)
 
 if(NOT DEFINED ENV{GZ_DISTRO} OR NOT "$ENV{GZ_DISTRO}"  STREQUAL "harmonic")
-    find_package(gz-transport NAMES gz-transport14 gz-transport13 gz-transport12)
+    find_package(gz-transport NAMES gz-transport14 gz-transport13)
     find_package(gz-sim NAMES gz-sim9 gz-sim8)
     find_package(gz-sensors NAMES gz-sensors9 gz-sensors8)
     find_package(gz-plugin NAMES gz-plugin3 gz-plugin2 COMPONENTS register)


### PR DESCRIPTION
### Solved Problem
Fixes https://github.com/PX4/PX4-Autopilot/issues/24631

### Solution
This tries to build the plugins and breaks the SITL build if you have Gazebo garden installed even if you're not trying to simulate with Gazebo.

### Changelog Entry
```
Fix SITL build when Gazebo garden is still installed
```

### Test coverage
`make px4_sitl` works and
`make px4_sitl gz_x500` fails because I don't have the correct Gazebo version