### PR TITLE
Doc: Clarify `PPS_CAP_ENABLE` description

### DIFF
--- a/src/drivers/pps_capture/pps_capture_params.c
+++ b/src/drivers/pps_capture/pps_capture_params.c
@@ -32,15 +32,9 @@
  ****************************************************************************/
 
 /**
- * @file pps_capture_params.c
- * PPS Capture params
- */
-/**
- * PPS Capture Enable
+ * PPS capture enable
  *
- * Enables the PPS capture module.
- * This switches mode of FMU channel 7 to be the
- * PPS input channel.
+ * Enables the PPS capture module to refine the GPS time from pulses detected on a PWM pin configured as "PPS Input".
  *
  * @boolean
  * @group GPS


### PR DESCRIPTION
### Solved Problem
When talking to @tobias-auterion about GPS configuration options I found that the description of `PPS_CAP_ENABLE` seems outdated. It mentions a fixed PWM pin which is not hardcoded anymore but can be configured.

### Solution
I clarify the description taking example from https://github.com/PX4/PX4-Autopilot/pull/24368

### Changelog Entry
```
Doc: Clarify `PPS_CAP_ENABLE` description
```