### PR TITLE
Rover: Update RTL behaviour and land detection

### DIFF
--- a/src/lib/rtl/rtl_time_estimator.cpp
+++ b/src/lib/rtl/rtl_time_estimator.cpp
@@ -55,7 +55,7 @@ RtlTimeEstimator::RtlTimeEstimator() : ModuleParams(nullptr)
 	_param_fw_sink_rate = param_find("FW_T_SINK_R_SP");
 	_param_fw_airspeed_trim = param_find("FW_AIRSPD_TRIM");
 	_param_mpc_xy_cruise = param_find("MPC_XY_CRUISE");
-	_param_rover_cruise_speed = param_find("GND_SPEED_THR_SC");
+	_param_rover_cruise_speed = param_find("RO_SPEED_LIM");
 };
 
 rtl_time_estimate_s RtlTimeEstimator::getEstimate() const

--- a/src/modules/land_detector/RoverLandDetector.cpp
+++ b/src/modules/land_detector/RoverLandDetector.cpp
@@ -51,41 +51,33 @@ bool RoverLandDetector::_get_ground_contact_state()
 
 bool RoverLandDetector::_get_landed_state()
 {
-	_update_topics();
-	const float distance_to_home = get_distance_to_next_waypoint(_curr_pos(0), _curr_pos(1),
-				       _home_position(0), _home_position(1));
-
+	// If Landing has been requested then say we have landed.
 	if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LAND
 	    || _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_DESCEND) {
-		return true; // If Landing has been requested then say we have landed.
+		return true;
 
-	} else if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL
-		   && distance_to_home < _param_nav_acc_rad.get() && _param_rtl_land_delay.get() > -FLT_EPSILON) {
-		return true; // If the rover reaches the home position during RTL we say we have landed.
-
-	} else {
-		return !_armed;  // If we are armed we are not landed.
 	}
-}
 
-void RoverLandDetector::_update_topics()
-{
-	if (_vehicle_global_position_sub.updated()) {
+	// If we are in RTL and have reached the last valid waypoint then we are landed.
+	if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL) {
 		vehicle_global_position_s vehicle_global_position{};
 		_vehicle_global_position_sub.copy(&vehicle_global_position);
-		_curr_pos = matrix::Vector2d(vehicle_global_position.lat, vehicle_global_position.lon);
+		position_setpoint_triplet_s position_setpoint_triplet{};
+		_position_setpoint_triplet_sub.copy(&position_setpoint_triplet);
+
+		const float distance_to_curr_wp = get_distance_to_next_waypoint(vehicle_global_position.lat,
+						  vehicle_global_position.lon,
+						  position_setpoint_triplet.current.lat, position_setpoint_triplet.current.lon);
+		return distance_to_curr_wp < _param_nav_acc_rad.get() && !position_setpoint_triplet.next.valid;
+
 	}
 
-	if (_home_position_sub.updated()) {
-		home_position_s home_position{};
-		_home_position_sub.copy(&home_position);
-		_home_position = matrix::Vector2d(home_position.lat, home_position.lon);
-	}
+	return !_armed;  // If we are armed we are not landed.
 }
 
 void RoverLandDetector::_set_hysteresis_factor(const int factor)
 {
-	_landed_hysteresis.set_hysteresis_time_from(true, 0_ms);
+	_landed_hysteresis.set_hysteresis_time_from(true, 500_ms);
 }
 
 } // namespace land_detector

--- a/src/modules/land_detector/RoverLandDetector.h
+++ b/src/modules/land_detector/RoverLandDetector.h
@@ -33,7 +33,7 @@
 
 /**
  * @file RoverLandDetector.h
- * Land detection implementation for VTOL also called hybrids.
+ * Land detection implementation for rovers.
  *
  * @author Roman Bapst <bapstr@gmail.com>
  * @author Julian Oes <julian@oes.ch>
@@ -44,7 +44,7 @@
 #include "LandDetector.h"
 #include <lib/geo/geo.h>
 #include <uORB/topics/vehicle_global_position.h>
-#include <uORB/topics/home_position.h>
+#include <uORB/topics/position_setpoint_triplet.h>
 
 namespace land_detector
 {
@@ -59,17 +59,13 @@ protected:
 	bool _get_ground_contact_state() override;
 	bool _get_landed_state() override;
 	void _set_hysteresis_factor(const int factor) override;
-	void _update_topics() override;
 
 private:
 	uORB::Subscription _vehicle_global_position_sub{ORB_ID(vehicle_global_position)};
-	uORB::Subscription _home_position_sub{ORB_ID(home_position)};
-	matrix::Vector2d _curr_pos{};
-	matrix::Vector2d _home_position{};
+	uORB::Subscription _position_setpoint_triplet_sub{ORB_ID(position_setpoint_triplet)};
 
 	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::NAV_ACC_RAD>) _param_nav_acc_rad,
-		(ParamFloat<px4::params::RTL_LAND_DELAY>) _param_rtl_land_delay
+		(ParamFloat<px4::params::NAV_ACC_RAD>) _param_nav_acc_rad
 	)
 
 };

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -77,7 +77,12 @@ void RtlDirect::on_activation()
 
 	parameters_update();
 
-	_rtl_state = getActivationLandState();
+	if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROVER) {
+		_rtl_state = RTLState::LAND;
+
+	} else {
+		_rtl_state = getActivationLandState();
+	}
 
 	// reset cruising speed and throttle to default for RTL
 	_navigator->reset_cruising_speed();

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -77,12 +77,7 @@ void RtlDirect::on_activation()
 
 	parameters_update();
 
-	if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROVER) {
-		_rtl_state = RTLState::LAND;
-
-	} else {
-		_rtl_state = getActivationLandState();
-	}
+	_rtl_state = getActivationState();
 
 	// reset cruising speed and throttle to default for RTL
 	_navigator->reset_cruising_speed();
@@ -410,24 +405,28 @@ void RtlDirect::set_rtl_item()
 	publish_rtl_direct_navigator_mission_item(); // for logging
 }
 
-RtlDirect::RTLState RtlDirect::getActivationLandState()
+RtlDirect::RTLState RtlDirect::getActivationState()
 {
 	_land_detected_sub.update();
 
-	RTLState land_state;
+	RTLState activation_state;
 
-	if (_land_detected_sub.get().landed) {
+	if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROVER) {
+		// Skip to LAND state if we are a rover
+		activation_state = RTLState::LAND;
+
+	} else if (_land_detected_sub.get().landed) {
 		// For safety reasons don't go into RTL if landed.
-		land_state = RTLState::IDLE;
+		activation_state = RTLState::IDLE;
 
 	} else if ((_global_pos_sub.get().alt < _rtl_alt) || _enforce_rtl_alt) {
-		land_state = RTLState::CLIMBING;
+		activation_state = RTLState::CLIMBING;
 
 	} else {
-		land_state = RTLState::MOVE_TO_LOITER;
+		activation_state = RTLState::MOVE_TO_LOITER;
 	}
 
-	return land_state;
+	return activation_state;
 }
 
 rtl_time_estimate_s RtlDirect::calc_rtl_time_estimate()
@@ -443,7 +442,7 @@ rtl_time_estimate_s RtlDirect::calc_rtl_time_estimate()
 		start_state_for_estimate = _rtl_state;
 
 	} else {
-		start_state_for_estimate = getActivationLandState();
+		start_state_for_estimate = getActivationState();
 	}
 
 	// Calculate RTL time estimate only when there is a valid destination

--- a/src/modules/navigator/rtl_direct.h
+++ b/src/modules/navigator/rtl_direct.h
@@ -159,7 +159,7 @@ private:
 	 */
 	void publish_rtl_direct_navigator_mission_item();
 
-	RTLState getActivationLandState();
+	RTLState getActivationState();
 
 	void setLoiterPosition();
 

--- a/src/modules/navigator/rtl_mission_fast_reverse.cpp
+++ b/src/modules/navigator/rtl_mission_fast_reverse.cpp
@@ -269,6 +269,7 @@ void RtlMissionFastReverse::handleLanding(WorkItemType &new_work_item_type)
 				_mission_item.altitude = _home_pos_sub.get().alt;
 				_mission_item.altitude_is_relative = false;
 				_navigator->reset_position_setpoint(pos_sp_triplet->previous);
+				_navigator->reset_position_setpoint(pos_sp_triplet->next);
 
 				_mission_item.land_precision = _param_rtl_pld_md.get();
 
@@ -278,6 +279,7 @@ void RtlMissionFastReverse::handleLanding(WorkItemType &new_work_item_type)
 				}
 			}
 		}
+
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
1. All the states prior to `LAND` in the direct RTL state machine are unnecessary if the vehicle is of type `ROVER`.
2. The parameter used for RTL time calculation for rovers is outdated
3. In mission fast reverse there is a hanging `NEXT` waypoint.
4. Rover land detection only detects landing during RTL if the return point is home, which does not work if the vehicle is supposed to return to a rally point etc.

### Solution
1. Direclty skip to `LAND` state on activation if the vehicle type is `ROVER`.
2. Replace with correct parameter `RO_SPEED_LIM`.
3. Reset the `NEXT` waypoint when landing starts.
4. During RTL check if the `NEXT` waypoint is invalid which indicates that the `CURRENT` waypoint is the final waypoint.
    Set the vehicle to `LANDED` if the distance to the current waypoint is less than `NAV_ACC_RAD` 
