### PR TITLE
Added setting default for EKF2_EV_CTRL to 15 for VOXL 2 boards

### DIFF
--- a/boards/modalai/voxl2/target/voxl-px4-start
+++ b/boards/modalai/voxl2/target/voxl-px4-start
@@ -62,6 +62,10 @@ param select /data/px4/param/parameters
 # Load in all of the parameters that have been saved in the file
 param load
 
+# This was the default pre-v1.16.0 and for folks relying on that
+# we set it up here
+param set-default EKF2_EV_CTRL 15
+
 # IMU (accelerometer / gyroscope)
 if [ "$PLATFORM" == "M0104" ]; then
     /bin/echo "Starting IMU driver with rotation 12"


### PR DESCRIPTION
The default value of EKF2_EV_CTRL was 15 pre v1.16.0. It is now 0. For folks changing from an older version to v1.16.x that were relying on that default on VOXL 2 it would cause problems so the default value for VOXL 2 is explicitly set to 15 with this PR. See https://github.com/PX4/PX4-Autopilot/issues/24439