### PR TITLE
Fix cellular_status message definition

### DIFF
--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -35,5 +35,5 @@ uint8 CELLULAR_NETWORK_RADIO_TYPE_LTE = 4
 
 uint8 quality # Cellular network RSSI/RSRP, absolute value [dBm]
 uint16 mcc # Mobile country code. [@invalid UINT16_MAX]
-uint16 mnc # Mobile network code. UINT16_MAX if unknown
+uint16 mnc # Mobile network code. [@invalid UINT16_MAX]
 uint16 lac # Location area code. [@invalid 0]

--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -1,28 +1,34 @@
-uint64 timestamp	# time since system start (microseconds)
+uint64 timestamp # time since system start [us]
 
-uint8 CELLULAR_STATUS_FLAG_UNKNOWN=0 # State unknown or not reportable
-uint8 CELLULAR_STATUS_FLAG_FAILED=1 # velocity setpoint
-uint8 CELLULAR_STATUS_FLAG_INITIALIZING=2 # Modem is being initialized
-uint8 CELLULAR_STATUS_FLAG_LOCKED=3	# Modem is locked
-uint8 CELLULAR_STATUS_FLAG_DISABLED=4	# Modem is not enabled and is powered down
-uint8 CELLULAR_STATUS_FLAG_DISABLING=5	# Modem is currently transitioning to the CELLULAR_STATUS_FLAG_DISABLED state
-uint8 CELLULAR_STATUS_FLAG_ENABLING=6 	# Modem is currently transitioning to the CELLULAR_STATUS_FLAG_ENABLED state
-uint8 CELLULAR_STATUS_FLAG_ENABLED=7  # Modem is enabled and powered on but not registered with a network provider and not available for data connections
-uint8 CELLULAR_STATUS_FLAG_SEARCHING=8  # Modem is searching for a network provider to register
-uint8 CELLULAR_STATUS_FLAG_REGISTERED=9  # Modem is registered with a network provider, and data connections and messaging may be available for use
-uint8 CELLULAR_STATUS_FLAG_DISCONNECTING=10  # Modem is disconnecting and deactivating the last active packet data bearer. This state will not be entered if more than one packet data bearer is active and one of the active bearers is deactivated
-uint8 CELLULAR_STATUS_FLAG_CONNECTING=11  # Modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered
-uint8 CELLULAR_STATUS_FLAG_CONNECTED=12  # One or more packet data bearers is active and connected
+uint16 status # Status bitmap 1: Roaming is active
+uint16 STATUS_FLAG_UNKNOWN = 1 # State unknown or not reportable
+uint16 STATUS_FLAG_FAILED = 2 # Modem is unusable
+uint16 STATUS_FLAG_INITIALIZING = 4 # Modem is being initialized
+uint16 STATUS_FLAG_LOCKED = 8 # Modem is locked
+uint16 STATUS_FLAG_DISABLED = 16 # Modem is not enabled and is powered down
+uint16 STATUS_FLAG_DISABLING = 32 # Modem is currently transitioning to the STATUS_FLAG_DISABLED state
+uint16 STATUS_FLAG_ENABLING = 64 # Modem is currently transitioning to the STATUS_FLAG_ENABLED state
+uint16 STATUS_FLAG_ENABLED = 128 # Modem is enabled and powered on but not registered with a network provider and not available for data connections
+uint16 STATUS_FLAG_SEARCHING = 256 # Modem is searching for a network provider to register
+uint16 STATUS_FLAG_REGISTERED = 512 # Modem is registered with a network provider, and data connections and messaging may be available for use
+uint16 STATUS_FLAG_DISCONNECTING = 1024 # Modem is disconnecting and deactivating the last active packet data bearer. This state will not be entered if more than one packet data bearer is active and one of the active bearers is deactivated
+uint16 STATUS_FLAG_CONNECTING = 2048 # Modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered
+uint16 STATUS_FLAG_CONNECTED = 4096 # One or more packet data bearers is active and connected
 
-uint8 CELLULAR_NETWORK_FAILED_REASON_NONE=0 # No error
-uint8 CELLULAR_NETWORK_FAILED_REASON_UNKNOWN=1 # Error state is unknown
-uint8 CELLULAR_NETWORK_FAILED_REASON_SIM_MISSING=2 # SIM is required for the modem but missing
-uint8 CELLULAR_NETWORK_FAILED_REASON_SIM_ERROR=3 # SIM is available, but not usable for connection
+uint8 failure_reason # Failure reason for status STATUS_FLAG_FAILED
+uint8 FAILURE_REASON_NONE = 0 # No error
+uint8 FAILURE_REASON_UNKNOWN = 1 # Error state is unknown
+uint8 FAILURE_REASON_SIM_MISSING = 2 # SIM is required for the modem but missing
+uint8 FAILURE_REASON_SIM_ERROR = 3 # SIM is available, but not usable for connection
 
-uint16 status 	# Status bitmap 1: Roaming is active
-uint8 failure_reason #Failure reason when status in in CELLUAR_STATUS_FAILED
-uint8 type 	# Cellular network radio type 0: none 1: gsm 2: cdma 3: wcdma 4: lte
-uint8 quality	# Cellular network RSSI/RSRP in dBm, absolute value
-uint16 mcc	# Mobile country code. If unknown, set to: UINT16_MAX
-uint16 mnc	# Mobile network code. If unknown, set to: UINT16_MAX
-uint16 lac	# Location area code. If unknown, set to: 0
+uint8 type # Cellular network radio type 0: none 1: gsm 2: cdma 3: wcdma 4: lte
+uint8 CELLULAR_NETWORK_RADIO_TYPE_NONE = 0
+uint8 CELLULAR_NETWORK_RADIO_TYPE_GSM = 1
+uint8 CELLULAR_NETWORK_RADIO_TYPE_CDMA = 2
+uint8 CELLULAR_NETWORK_RADIO_TYPE_WCDMA = 3
+uint8 CELLULAR_NETWORK_RADIO_TYPE_LTE = 4
+
+uint8 quality # Cellular network RSSI/RSRP in dBm, absolute value
+uint16 mcc # Mobile country code. UINT16_MAX if unknown
+uint16 mnc # Mobile network code. UINT16_MAX if unknown
+uint16 lac # Location area code. 0 if unknown

--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -5,7 +5,7 @@
 
 uint64 timestamp # Time since system start [us]
 
-uint16 status # Status bitmap 1: Roaming is active
+uint16 status # Status bitmap 1: Roaming is active [@enum STATUS_FLAG]
 uint16 STATUS_FLAG_UNKNOWN = 1 # State unknown or not reportable
 uint16 STATUS_FLAG_FAILED = 2 # Modem is unusable
 uint16 STATUS_FLAG_INITIALIZING = 4 # Modem is being initialized

--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -28,7 +28,7 @@ uint8 CELLULAR_NETWORK_RADIO_TYPE_CDMA = 2
 uint8 CELLULAR_NETWORK_RADIO_TYPE_WCDMA = 3
 uint8 CELLULAR_NETWORK_RADIO_TYPE_LTE = 4
 
-uint8 quality # Cellular network RSSI/RSRP in dBm, absolute value
+uint8 quality # Cellular network RSSI/RSRP, absolute value [dBm]
 uint16 mcc # Mobile country code. [@invalid UINT16_MAX]
 uint16 mnc # Mobile network code. UINT16_MAX if unknown
 uint16 lac # Location area code. [@invalid 0]

--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -31,4 +31,4 @@ uint8 CELLULAR_NETWORK_RADIO_TYPE_LTE = 4
 uint8 quality # Cellular network RSSI/RSRP in dBm, absolute value
 uint16 mcc # Mobile country code. UINT16_MAX if unknown
 uint16 mnc # Mobile network code. UINT16_MAX if unknown
-uint16 lac # Location area code. 0 if unknown
+uint16 lac # Location area code. [@invalid 0]

--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -1,7 +1,6 @@
 # Cellular status
 #
-# This is currently used only for logging cell status
-# from MAVLink.
+# This is currently used only for logging cell status from MAVLink.
 
 uint64 timestamp # Time since system start [us]
 

--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -20,7 +20,7 @@ uint16 STATUS_FLAG_DISCONNECTING = 1024 # Modem is disconnecting and deactivatin
 uint16 STATUS_FLAG_CONNECTING = 2048 # Modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered
 uint16 STATUS_FLAG_CONNECTED = 4096 # One or more packet data bearers is active and connected
 
-uint8 failure_reason # Failure reason for status STATUS_FLAG_FAILED
+uint8 failure_reason # Failure reason [@enum STATUS_FLAG_FAILED]
 uint8 FAILURE_REASON_NONE = 0 # No error
 uint8 FAILURE_REASON_UNKNOWN = 1 # Error state is unknown
 uint8 FAILURE_REASON_SIM_MISSING = 2 # SIM is required for the modem but missing

--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -26,7 +26,7 @@ uint8 FAILURE_REASON_UNKNOWN = 1 # Error state is unknown
 uint8 FAILURE_REASON_SIM_MISSING = 2 # SIM is required for the modem but missing
 uint8 FAILURE_REASON_SIM_ERROR = 3 # SIM is available, but not usable for connection
 
-uint8 type # Cellular network radio type 0: none 1: gsm 2: cdma 3: wcdma 4: lte
+uint8 type # Cellular network radio type [@enum CELLULAR_NETWORK_RADIO_TYPE]
 uint8 CELLULAR_NETWORK_RADIO_TYPE_NONE = 0
 uint8 CELLULAR_NETWORK_RADIO_TYPE_GSM = 1
 uint8 CELLULAR_NETWORK_RADIO_TYPE_CDMA = 2

--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -5,7 +5,7 @@
 
 uint64 timestamp # Time since system start [us]
 
-uint16 status # Status bitmap 1: Roaming is active [@enum STATUS_FLAG]
+uint16 status # Status bitmap [@enum STATUS_FLAG]
 uint16 STATUS_FLAG_UNKNOWN = 1 # State unknown or not reportable
 uint16 STATUS_FLAG_FAILED = 2 # Modem is unusable
 uint16 STATUS_FLAG_INITIALIZING = 4 # Modem is being initialized

--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -29,6 +29,6 @@ uint8 CELLULAR_NETWORK_RADIO_TYPE_WCDMA = 3
 uint8 CELLULAR_NETWORK_RADIO_TYPE_LTE = 4
 
 uint8 quality # Cellular network RSSI/RSRP in dBm, absolute value
-uint16 mcc # Mobile country code. UINT16_MAX if unknown
+uint16 mcc # Mobile country code. [@invalid UINT16_MAX]
 uint16 mnc # Mobile network code. UINT16_MAX if unknown
 uint16 lac # Location area code. [@invalid 0]

--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -1,4 +1,4 @@
-uint64 timestamp # time since system start [us]
+uint64 timestamp # Time since system start [us]
 
 uint16 status # Status bitmap 1: Roaming is active
 uint16 STATUS_FLAG_UNKNOWN = 1 # State unknown or not reportable

--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -1,7 +1,7 @@
 # Cellular status
 #
-# This is currently used only for logging a cell status
-# provided over MAVLink.
+# This is currently used only for logging cell status
+# from MAVLink.
 
 uint64 timestamp # Time since system start [us]
 

--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -20,7 +20,7 @@ uint16 STATUS_FLAG_DISCONNECTING = 1024 # Modem is disconnecting and deactivatin
 uint16 STATUS_FLAG_CONNECTING = 2048 # Modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered
 uint16 STATUS_FLAG_CONNECTED = 4096 # One or more packet data bearers is active and connected
 
-uint8 failure_reason # Failure reason [@enum STATUS_FLAG_FAILED]
+uint8 failure_reason # Failure reason [@enum FAILURE_REASON]
 uint8 FAILURE_REASON_NONE = 0 # No error
 uint8 FAILURE_REASON_UNKNOWN = 1 # Error state is unknown
 uint8 FAILURE_REASON_SIM_MISSING = 2 # SIM is required for the modem but missing

--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -1,3 +1,8 @@
+# Cellular status
+#
+# This is currently used only for logging a cell status
+# provided over MAVLink.
+
 uint64 timestamp # Time since system start [us]
 
 uint16 status # Status bitmap 1: Roaming is active


### PR DESCRIPTION
### Solved Problem
When discussing about message documentation in https://discordapp.com/channels/1022170275984457759/1354222673953030376/1354222677577044171 I found that there are plenty of bad examples so I picked one that's even somewhat debatable why we keep it in PX4 to just check how I'd improve the description without even knowing the exact was the message is used. This is just an example.

### Solution
- enums have field name prefix and ar listed directly below
- enum option values have the type of the field
- for bit fields the individual flag's definition has the value to mask that bit
- fields that are defined as enum like `type` here actually have the options properly defined
- `FLAG_FAILED=1 # velocity setpoint` wtf?
- no dubious alignment attempts, one space to separate names, operators, comments

### Changelog Entry
```
Fix cellular_status message definition
```

### Test coverage
This compiles and should not change the usage within PX4, also it's not a versioned message and I didn't change any field name.