### PR TITLE
[Against another PR] Add NPFG unit tests 

### DIFF
--- a/src/lib/npfg/CourseToAirspeedRefMapper.cpp
+++ b/src/lib/npfg/CourseToAirspeedRefMapper.cpp
@@ -40,11 +40,18 @@ CourseToAirspeedRefMapper::mapCourseSetpointToHeadingSetpoint(const float bearin
 {
 	const Vector2f bearing_vector = Vector2f{cosf(bearing_setpoint), sinf(bearing_setpoint)};
 	const float wind_cross_bearing = wind_vel.cross(bearing_vector);
+	const float wind_dot_bearing = wind_vel.dot(bearing_vector);
 
-	const float airsp_dot_bearing = projectAirspOnBearing(airspeed_sp, wind_cross_bearing);
-	const Vector2f air_vel_ref = solveWindTriangle(wind_cross_bearing, airsp_dot_bearing, bearing_vector);
+	Vector2f air_vel_ref;
 
-	// TODO check if we need to use infeasibleAirVelRef or other mitigation functions in some cases (high wind)
+	if (bearingIsFeasible(wind_cross_bearing, wind_dot_bearing, airspeed_sp, wind_vel.norm())) {
+
+		const float airsp_dot_bearing = projectAirspOnBearing(airspeed_sp, wind_cross_bearing);
+		air_vel_ref = solveWindTriangle(wind_cross_bearing, airsp_dot_bearing, bearing_vector);
+
+	} else {
+		air_vel_ref = infeasibleAirVelRef(wind_vel, bearing_vector, wind_vel.norm(), airspeed_sp);
+	}
 
 	return atan2f(air_vel_ref(1), air_vel_ref(0));
 }
@@ -96,12 +103,12 @@ CourseToAirspeedRefMapper::solveWindTriangle(const float wind_cross_bearing, con
 			wind_cross_bearing * bearing_vec(0) + airsp_dot_bearing * bearing_vec(1)};
 }
 
-// matrix::Vector2f CourseToAirspeedRefMapper::infeasibleAirVelRef(const Vector2f &wind_vel, const Vector2f &bearing_vec,
-// 		const float wind_speed, const float airspeed) const
-// {
-// 	// NOTE: wind speed must be greater than airspeed, and airspeed must be greater than zero to use this function
-// 	// it is assumed that bearing feasibility is checked and found infeasible (e.g. bearingIsFeasible() = false) prior to entering this method
-// 	// otherwise the normalization of the air velocity vector could have a division by zero
-// 	Vector2f air_vel_ref = sqrtf(math::max(wind_speed * wind_speed - airspeed * airspeed, 0.0f)) * bearing_vec - wind_vel;
-// 	return air_vel_ref.normalized() * airspeed;
-// }
+matrix::Vector2f CourseToAirspeedRefMapper::infeasibleAirVelRef(const Vector2f &wind_vel, const Vector2f &bearing_vec,
+		const float wind_speed, const float airspeed) const
+{
+	// NOTE: wind speed must be greater than airspeed, and airspeed must be greater than zero to use this function
+	// it is assumed that bearing feasibility is checked and found infeasible (e.g. bearingIsFeasible() = false) prior to entering this method
+	// otherwise the normalization of the air velocity vector could have a division by zero
+	Vector2f air_vel_ref = sqrtf(math::max(wind_speed * wind_speed - airspeed * airspeed, 0.0f)) * bearing_vec - wind_vel;
+	return air_vel_ref.normalized() * airspeed;
+}

--- a/src/lib/npfg/CourseToAirspeedRefMapper.cpp
+++ b/src/lib/npfg/CourseToAirspeedRefMapper.cpp
@@ -110,5 +110,5 @@ matrix::Vector2f CourseToAirspeedRefMapper::infeasibleAirVelRef(const Vector2f &
 	// it is assumed that bearing feasibility is checked and found infeasible (e.g. bearingIsFeasible() = false) prior to entering this method
 	// otherwise the normalization of the air velocity vector could have a division by zero
 	Vector2f air_vel_ref = sqrtf(math::max(wind_speed * wind_speed - airspeed * airspeed, 0.0f)) * bearing_vec - wind_vel;
-	return air_vel_ref.normalized() * airspeed;
+	return air_vel_ref.normalized();
 }

--- a/src/lib/npfg/NpfgTest.cpp
+++ b/src/lib/npfg/NpfgTest.cpp
@@ -72,12 +72,17 @@ TEST(NpfgTest, NoWind)
 	float airspeed_setpoint = 15.f;
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
-	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel, airspeed_setpoint);
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
+	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted);
+
 	// THEN: expect heading due North with a min airspeed equal to min_ground_speed
-	EXPECT_NEAR(heading_setpoint, 0.f, FLT_EPSILON);
+	EXPECT_NEAR(heading_setpoint, 0.f, 0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, min_ground_speed, FLT_EPSILON);
 
 	// GIVEN: bearing due South
@@ -86,13 +91,18 @@ TEST(NpfgTest, NoWind)
 	min_ground_speed = 5.0f;
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
-	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
-					   airspeed_setpoint));
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 				   airspeed_max, min_ground_speed);
 
+	airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+					    airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+					   airspeed_setpoint_adapted));
+
+
 	// THEN: expect heading due South with a min airspeed equal to min_ground_speed
-	EXPECT_NEAR(heading_setpoint, -M_PI_F, 2 * FLT_EPSILON); // Why is the 2*FLT_EPS required here to make it pass?
+	EXPECT_NEAR(heading_setpoint, -M_PI_F,  0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, min_ground_speed, FLT_EPSILON);
 }
 
@@ -108,12 +118,17 @@ TEST(NpfgTest, LightCrossWind)
 	float airspeed_setpoint = 15.f;
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
-	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel, airspeed_setpoint);
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
+	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted));
+
 	// THEN: expect heading -0.4115168 with a min airspeed of to 7.8 (sqrt(25+36))
-	EXPECT_NEAR(heading_setpoint, -0.4115168, 0.1f);
+	EXPECT_NEAR(heading_setpoint, -0.4115168,  0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, 7.8f, 0.1f);
 
 	// GIVEN: bearing due South
@@ -122,17 +137,21 @@ TEST(NpfgTest, LightCrossWind)
 	min_ground_speed = 5.0f;
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
-	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
-					   airspeed_setpoint));
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 				   airspeed_max, min_ground_speed);
 
+	airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+					    airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+					   airspeed_setpoint_adapted));
+
 	// THEN: expect heading of -2.73 and a min airspeed of 7.8 (sqrt(25+36))
-	EXPECT_NEAR(heading_setpoint, -2.73f, 0.1f); // Why is the 2*FLT_EPS required here to make it pass?
+	EXPECT_NEAR(heading_setpoint, -2.73f,  0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, 7.8f, 0.1f);
 }
 
-TEST(NpfgTest, StrongHeadWing)
+TEST(NpfgTest, StrongHeadWind)
 {
 	CourseToAirspeedRefMapper _course_to_airspeed;
 
@@ -144,32 +163,57 @@ TEST(NpfgTest, StrongHeadWing)
 	float airspeed_setpoint = 15.f;
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
-	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel, airspeed_setpoint);
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
+	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted));
+
+
 	// THEN: expect heading due North with a min airspeed equal to 16+min_ground_speed
-	EXPECT_NEAR(heading_setpoint, 0.f, 0.1f);
+	EXPECT_NEAR(heading_setpoint, 0.f,  0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, 16 + min_ground_speed, 0.1f);
 
+
+}
+
+TEST(NpfgTest, StrongTailWind)
+{
+
+	CourseToAirspeedRefMapper _course_to_airspeed;
+
 	// GIVEN: bearing due South
-	bearing = M_PI_F;
-	airspeed_max = 25.f;
-	min_ground_speed = 5.0f;
+	const Vector2f wind_vel(-16.f, 0.f);
+	float bearing = M_PI_F;
+	float airspeed_max = 25.f;
+	float min_ground_speed = 5.0f;
+	float airspeed_setpoint = 15.f;
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
-	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
-					   airspeed_setpoint));
-	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
-				   airspeed_max, min_ground_speed);
+	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+					 airspeed_max, min_ground_speed);
+
+	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted));
 
 	// THEN: expect heading due South with a min airspeed at 0
-	EXPECT_NEAR(heading_setpoint, -M_PI_F, 0.1f); // Why is the 2*FLT_EPS required here to make it pass?
+	EXPECT_NEAR(heading_setpoint, -M_PI_F,  0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, 0.f, 0.1f);
 }
 
-TEST(NpfgTest, ExceedingHeadWind)
+
+
+TEST(NpfgTest, ExcessHeadWind)
 {
+
+	// TEST DESCRIPTION: infeasible bearing, with |wind| = |airspeed|. Align with wind
+
 	CourseToAirspeedRefMapper _course_to_airspeed;
 
 	// GIVEN
@@ -180,26 +224,143 @@ TEST(NpfgTest, ExceedingHeadWind)
 	float airspeed_setpoint = 15.f;
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
-	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel, airspeed_setpoint);
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
+	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted));
+
 	// THEN: expect heading sp due North with a min airspeed equal to airspeed_max
-	EXPECT_NEAR(heading_setpoint, 0.f, 0.1f);
+	EXPECT_NEAR(heading_setpoint, 0.f, 0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, airspeed_max, 0.1f);
 
-	// GIVEN: bearing due South
-	bearing = M_PI_F;
-	airspeed_max = 25.f;
-	min_ground_speed = 5.0f;
+	// WHEN: we increase the maximum airspeed
+	airspeed_max = 35.f;
 
-	// WHEN: we update bearing and airspeed magnitude augmentation
-	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
-					   airspeed_setpoint));
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 				   airspeed_max, min_ground_speed);
 
-	// THEN: expect heading due South with a min airspeed equal at 0
-	EXPECT_NEAR(heading_setpoint, -M_PI_F, 0.1f); // Why is the 2*FLT_EPS required here to make it pass?
+	// THEN: expect the minimum airspeed to be high enough to maintain minimum groundspeed
+	EXPECT_NEAR(min_airspeed_for_bearing, 30.f, 0.1f);
+
+	// TEST DESCRIPTION: infeasible bearing, with |wind| = |airspeed|. Align with wind
+
+	// GIVEN: bearing east
+	bearing = M_PI_F / 2.f;
+	airspeed_max = 25.f;
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+					 airspeed_max, min_ground_speed);
+
+	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted));
+
+	// THEN: expect heading sp due North with a min airspeed equal to airspeed_max
+	EXPECT_NEAR(heading_setpoint, 0.f, 0.01f);
+	EXPECT_NEAR(min_airspeed_for_bearing, airspeed_max, 0.1f);
+
+
+	// TEST DESCRIPTION: infeasible bearing, with |wind| > |airspeed|. Aircraft should have a heading between the target bearing
+	// and wind direction to minimize drift while still attempting to reach the bearing.
+
+	// GIVEN: bearing NE
+	bearing = M_PI_F / 4.f;
+	airspeed_max = 20.f;
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+		airspeed_max, min_ground_speed);
+
+	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+		airspeed_setpoint_adapted));
+
+	// THEN: expect heading setpoint to be between the target bearing and the cross wind
+	// & the minimum airspeed to be = maximum airspeed
+	EXPECT_TRUE((heading_setpoint > -M_PI_F / 2.f) && (heading_setpoint < bearing));
+	EXPECT_NEAR(min_airspeed_for_bearing, airspeed_max, 0.1f);
+
+}
+
+TEST(NpfgTest, ExcessTailWind)
+{
+
+	CourseToAirspeedRefMapper _course_to_airspeed;
+
+	// GIVEN: bearing due South
+	const Vector2f wind_vel(-25.f, 0.f);
+	float bearing = M_PI_F;
+	float airspeed_max = 25.f;
+	float min_ground_speed = 5.0f;
+	float airspeed_setpoint = 15.f;
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+					 airspeed_max, min_ground_speed);
+
+	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
+			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted));
+
+	// THEN: expect heading due South with a min airspeed equal to 0
+	EXPECT_NEAR(heading_setpoint, -M_PI_F, 0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, 0.f, 0.1f);
+
+}
+
+TEST(NpfgTest, ExcessCrossWind)
+{
+
+	// TEST DESCRIPTION: infeasible bearing, with |wind| > |airspeed|. Aircraft should have a heading between the target bearing
+	// and wind direction to minimize drift while still attempting to reach the bearing.
+
+	CourseToAirspeedRefMapper _course_to_airspeed;
+
+	// GIVEN
+	const Vector2f wind_vel(0, 30.f);
+	float bearing = 0.f;
+	float airspeed_max = 25.f;
+	float min_ground_speed = 5.f;
+	float airspeed_setpoint = 15.f;
+
+
+	// WHEN: we update bearing and airspeed magnitude augmentation
+	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+					 airspeed_max, min_ground_speed);
+
+	float airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+				 airspeed_setpoint_adapted));
+
+	// THEN: expect heading setpoint to be between the target bearing and the cross wind
+	// & the minimum airspeed to be = maximum airspeed
+	EXPECT_TRUE((heading_setpoint > -M_PI_F / 2.f) && (heading_setpoint < bearing));
+	EXPECT_NEAR(min_airspeed_for_bearing, airspeed_max, 0.1f);
+
+
+	// TEST DESCRIPTION: infeasible bearing, with |wind| = |airspeed|. Align with wind.
+
+	airspeed_max = 30.f;
+
+	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
+		airspeed_max, min_ground_speed);
+
+	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+
+	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
+		airspeed_setpoint_adapted));
+
+	EXPECT_NEAR(heading_setpoint, -M_PI_F / 2.f, 0.01f);
+	EXPECT_NEAR(min_airspeed_for_bearing, airspeed_max, 0.1f);
+
 }

--- a/src/lib/npfg/NpfgTest.cpp
+++ b/src/lib/npfg/NpfgTest.cpp
@@ -75,8 +75,7 @@ TEST(NpfgTest, NoWind)
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
-	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	float airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	float heading_setpoint = _course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 				 airspeed_setpoint_adapted);
@@ -94,8 +93,7 @@ TEST(NpfgTest, NoWind)
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 				   airspeed_max, min_ground_speed);
 
-	airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-					    airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 					   airspeed_setpoint_adapted));
@@ -121,8 +119,7 @@ TEST(NpfgTest, LightCrossWind)
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
-	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	float airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 				 airspeed_setpoint_adapted));
@@ -140,8 +137,7 @@ TEST(NpfgTest, LightCrossWind)
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 				   airspeed_max, min_ground_speed);
 
-	airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-					    airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 					   airspeed_setpoint_adapted));
@@ -166,8 +162,7 @@ TEST(NpfgTest, StrongHeadWind)
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
-	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	float airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 				 airspeed_setpoint_adapted));
@@ -196,8 +191,7 @@ TEST(NpfgTest, StrongTailWind)
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
-	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	float airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 				 airspeed_setpoint_adapted));
@@ -227,8 +221,7 @@ TEST(NpfgTest, ExcessHeadWind)
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
-	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	float airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 				 airspeed_setpoint_adapted));
@@ -254,12 +247,12 @@ TEST(NpfgTest, ExcessHeadWind)
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
-					 airspeed_max, min_ground_speed);
+				   airspeed_max, min_ground_speed);
 
 	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
-				 airspeed_setpoint_adapted));
+					   airspeed_setpoint_adapted));
 
 	// THEN: expect heading sp due North with a min airspeed equal to airspeed_max
 	EXPECT_NEAR(heading_setpoint, 0.f, 0.01f);
@@ -275,12 +268,12 @@ TEST(NpfgTest, ExcessHeadWind)
 
 	// WHEN: we update bearing and airspeed magnitude augmentation
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
-		airspeed_max, min_ground_speed);
+				   airspeed_max, min_ground_speed);
 
 	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
-		airspeed_setpoint_adapted));
+					   airspeed_setpoint_adapted));
 
 	// THEN: expect heading setpoint to be between the target bearing and the cross wind
 	// & the minimum airspeed to be = maximum airspeed
@@ -305,8 +298,7 @@ TEST(NpfgTest, ExcessTailWind)
 	float min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
 					 airspeed_max, min_ground_speed);
 
-	float airspeed_setpoint_adapted = (min_airspeed_for_bearing > airspeed_max) ? airspeed_max : math::constrain(
-			airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
+	float airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	float heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
 				 airspeed_setpoint_adapted));
@@ -353,12 +345,12 @@ TEST(NpfgTest, ExcessCrossWind)
 	airspeed_max = 30.f;
 
 	min_airspeed_for_bearing = _course_to_airspeed.getMinAirspeedForCurrentBearing(bearing, wind_vel,
-		airspeed_max, min_ground_speed);
+				   airspeed_max, min_ground_speed);
 
 	airspeed_setpoint_adapted = math::constrain(airspeed_setpoint, min_airspeed_for_bearing, airspeed_max);
 
 	heading_setpoint = matrix::wrap_pi(_course_to_airspeed.mapCourseSetpointToHeadingSetpoint(bearing, wind_vel,
-		airspeed_setpoint_adapted));
+					   airspeed_setpoint_adapted));
 
 	EXPECT_NEAR(heading_setpoint, -M_PI_F / 2.f, 0.01f);
 	EXPECT_NEAR(min_airspeed_for_bearing, airspeed_max, 0.1f);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->
Add unit tests to NPFG library.  

### Changelog Entry

- Extend NPFG unit tests. 
- CourseToAirspeedRefMapper: Add infeasible bearing check back into logic. 


### NPFG Behaviour 

#### CourseToAirspeedRefMapper:

 Interaction between CourseToAirspeedRefMapper class and LatLong controller: 

![CourseToAirspeedRefMapper](https://github.com/user-attachments/assets/e3dddea7-6907-472f-8ea2-f36ea6063c8d)

\* we need to check for feasibility because: the `projectAirspOnBearing` returns zero when the cross wind is > airspeed. This results in a heading that aligns the aircraft against the wind, rather than trying to achieve the bearing/minimize drift. 

\** My understanding of the infeasibleAirVelRef function is as follows (could be wrong): 

The infeasible bearing heading is defined by two components: (1) Into the bearing & (2) Into the wind. The weight of the component into the bearing direction (1) is determined by the magnitude of excess windspeed w.r.t our airspeed_sp. This ensures that we minimize the drift from the bearing setpoint in the excess wind condition.  

