### PR TITLE
Cleanup: remove unnecessary subscription in multicopter attitude controller

### DIFF
--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -101,7 +101,6 @@ private:
 
 	uORB::Subscription _hover_thrust_estimate_sub{ORB_ID(hover_thrust_estimate)};
 	uORB::Subscription _vehicle_attitude_setpoint_sub{ORB_ID(vehicle_attitude_setpoint)};
-	uORB::Subscription _v_control_mode_sub{ORB_ID(vehicle_control_mode)};
 	uORB::Subscription _autotune_attitude_control_status_sub{ORB_ID(autotune_attitude_control_status)};
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};


### PR DESCRIPTION
### Solved Problem
When I looked at #19633 specifically the merged commit 28fa04438616d16363306878e6bfee0473c77afc which I didn't have the opportunity to review, I realized that a seemingly random subscription instance was added and I couldn't find why. 

### Solution
This was probably mistakenly added so I suggest to remove again.

### Changelog Entry
```
Cleanup: remove unnecessary subscription in multicopter attitude controller
```

### Test coverage
I'ts not used anywhere and still compiles without.