### PR TITLE
Parameterize choke during starting state

### DIFF
--- a/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.cpp
+++ b/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.cpp
@@ -319,7 +319,8 @@ void InternalCombustionEngineControl::controlEngineStartup(const hrt_abstime now
 
 	_ignition_on = true;
 	_throttle_control = _param_ice_strt_thr.get();
-	_choke_control = now < _state_start_time + (choke_duration + ignition_delay) * 1_s ? 1.f : 0.f;
+	_choke_control = now < _state_start_time + (choke_duration + ignition_delay) * 1_s ? math::constrain(
+				 _param_ice_strt_choke.get(), 0.f, 1.f) : 0.f;
 	_starter_engine_control = now > _state_start_time + (ignition_delay * 1_s) ? 1.f : 0.f;
 	const hrt_abstime cycle_timeout_duration = (ignition_delay + choke_duration + starter_duration) * 1_s;
 
@@ -355,7 +356,7 @@ int InternalCombustionEngineControl::print_usage(const char *reason)
 	PRINT_MODULE_DESCRIPTION(
 		R"DESCR_STR(
 ### Description
-		
+
 The module controls internal combustion engine (ICE) features including:
 ignition (on/off), throttle and choke level, starter engine delay, and user request.
 
@@ -389,18 +390,18 @@ The ICE is implemented with a (4) state machine:
 ![Architecture](../../assets/hardware/ice/ice_control_state_machine.png)
 
 The state machine:
-		
+
 - Checks if [Rpm.msg](../msg_docs/Rpm.md) is updated to know if the engine is running
 - Allows for user inputs from:
   - AUX{N}
   - Arming state in [VehicleStatus.msg](../msg_docs/VehicleStatus.md)
 
 The module publishes [InternalCombustionEngineControl.msg](../msg_docs/InternalCombustionEngineControl.md).
-		
+
 The architecture is as shown below:
 
 ![Architecture](../../assets/hardware/ice/ice_control_diagram.png)
-		
+
 <a id="internal_combustion_engine_control_usage"></a>
 )DESCR_STR");
 

--- a/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.hpp
+++ b/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.hpp
@@ -152,7 +152,8 @@ private:
 		(ParamFloat<px4::params::ICE_STRT_THR>) _param_ice_strt_thr,
 		(ParamInt<px4::params::ICE_STOP_CHOKE>) _param_ice_stop_choke,
 		(ParamFloat<px4::params::ICE_THR_SLEW>) _param_ice_thr_slew,
-		(ParamFloat<px4::params::ICE_IGN_DELAY>) _param_ice_ign_delay
+		(ParamFloat<px4::params::ICE_IGN_DELAY>) _param_ice_ign_delay,
+		(ParamFloat<px4::params::ICE_STRT_CHOKE>) _param_ice_strt_choke
 	)
 };
 

--- a/src/modules/internal_combustion_engine_control/module.yaml
+++ b/src/modules/internal_combustion_engine_control/module.yaml
@@ -118,3 +118,14 @@ parameters:
         decimal: 1
         increment: 0.1
         default: 0
+
+      ICE_STRT_CHOKE:
+        description:
+          short: Choke position during startup, 1 for fully choked.
+        type: float
+        unit: norm
+        min: 0
+        max: 1
+        decimal: 0
+        increment: 0.01
+        default: 0.8

--- a/src/modules/internal_combustion_engine_control/module.yaml
+++ b/src/modules/internal_combustion_engine_control/module.yaml
@@ -121,11 +121,13 @@ parameters:
 
       ICE_STRT_CHOKE:
         description:
-          short: Choke position during startup, 1 for fully choked.
+          short: Choke position during startup, 100 % for fully choked.
+          long: |
+              If the engine does not fire fully choked, open the choke slightly to allow for more air into the fuel/air mixture by reducing a few percentages until fire.
         type: float
         unit: norm
         min: 0
         max: 1
         decimal: 0
         increment: 0.01
-        default: 0.8
+        default: 1.0


### PR DESCRIPTION
### Solved Problem
When testing the ICE module it was noticed that choke on/off is not enough to have efficient fuel/air mix into the engine. Depending on engine one might need a bit of air whereas for others full choke to have the the best mix of air/fuel for starting the engine. Hence adding a parameter to allow for more flexibility en improve suction of fuel into the engine.

### Test coverage
- Simulation/hardware testing logs: bench test

