### PR TITLE
Reduce dependency of gstreamer for gz simulation

### DIFF
--- a/src/modules/simulation/gz_plugins/CMakeLists.txt
+++ b/src/modules/simulation/gz_plugins/CMakeLists.txt
@@ -57,5 +57,9 @@ if (gz-transport_FOUND)
     add_subdirectory(gstreamer)
 
     # Add an alias target for each plugin
-    add_custom_target(px4_gz_plugins ALL DEPENDS OpticalFlowSystem TemplatePlugin GstCameraSystem)
+    if (TARGET GstCameraSystem)
+        add_custom_target(px4_gz_plugins ALL DEPENDS OpticalFlowSystem TemplatePlugin GstCameraSystem)
+    else()
+        add_custom_target(px4_gz_plugins ALL DEPENDS OpticalFlowSystem TemplatePlugin)
+    endif()
 endif()

--- a/src/modules/simulation/gz_plugins/gstreamer/CMakeLists.txt
+++ b/src/modules/simulation/gz_plugins/gstreamer/CMakeLists.txt
@@ -35,32 +35,36 @@ project(GstCameraSystem)
 
 # Find required packages
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0)
-pkg_check_modules(GSTREAMER_APP REQUIRED gstreamer-app-1.0)
+pkg_check_modules(GSTREAMER gstreamer-1.0)
+pkg_check_modules(GSTREAMER_APP gstreamer-app-1.0)
 
-add_library(${PROJECT_NAME} SHARED
-    GstCameraSystem.cpp
-)
+if (NOT GSTREAMER_FOUND OR NOT GSTREAMER_APP_FOUND)
+    message(WARNING "GStreamer and Gstreamer App are required to build this plugin.")
+else()
+    add_library(${PROJECT_NAME} SHARED
+        GstCameraSystem.cpp
+    )
 
-target_link_libraries(${PROJECT_NAME}
-    PUBLIC px4_gz_msgs
-    PUBLIC gz-sensors${gz-sensors_VERSION_MAJOR}::gz-sensors${gz-sensors_VERSION_MAJOR}
-    PUBLIC gz-plugin${gz-plugin_VERSION_MAJOR}::gz-plugin${gz-plugin_VERSION_MAJOR}
-    PUBLIC gz-sim${gz-sim_VERSION_MAJOR}::gz-sim${gz-sim_VERSION_MAJOR}
-    PUBLIC gz-transport${gz-transport_VERSION_MAJOR}::gz-transport${gz-transport_VERSION_MAJOR}
-    PUBLIC ${GSTREAMER_LIBRARIES}
-    PUBLIC ${GSTREAMER_APP_LIBRARIES}
-)
+    target_link_libraries(${PROJECT_NAME}
+        PUBLIC px4_gz_msgs
+        PUBLIC gz-sensors${gz-sensors_VERSION_MAJOR}::gz-sensors${gz-sensors_VERSION_MAJOR}
+        PUBLIC gz-plugin${gz-plugin_VERSION_MAJOR}::gz-plugin${gz-plugin_VERSION_MAJOR}
+        PUBLIC gz-sim${gz-sim_VERSION_MAJOR}::gz-sim${gz-sim_VERSION_MAJOR}
+        PUBLIC gz-transport${gz-transport_VERSION_MAJOR}::gz-transport${gz-transport_VERSION_MAJOR}
+        PUBLIC ${GSTREAMER_LIBRARIES}
+        PUBLIC ${GSTREAMER_APP_LIBRARIES}
+    )
 
-target_include_directories(${PROJECT_NAME}
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-    PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
-    PUBLIC px4_gz_msgs
-    PUBLIC ${GSTREAMER_INCLUDE_DIRS}
-    PUBLIC ${GSTREAMER_APP_INCLUDE_DIRS}
-)
+    target_include_directories(${PROJECT_NAME}
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+        PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
+        PUBLIC px4_gz_msgs
+        PUBLIC ${GSTREAMER_INCLUDE_DIRS}
+        PUBLIC ${GSTREAMER_APP_INCLUDE_DIRS}
+    )
 
-target_compile_options(${PROJECT_NAME}
-    PRIVATE ${GSTREAMER_CFLAGS}
-    PRIVATE ${GSTREAMER_APP_CFLAGS}
-)
+    target_compile_options(${PROJECT_NAME}
+        PRIVATE ${GSTREAMER_CFLAGS}
+        PRIVATE ${GSTREAMER_APP_CFLAGS}
+    )
+endif()


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
It was impossible to run a gazebo simulation without gstreamer being installed, even if the gstreamer plugin was not necessary.

### Solution
- Remove the `REQUIRED` dependency of gstreamer and check if it is found.
- Don't built the gstreamer plugin if gstreamer is not installed issue a warning message.

### Test coverage
- Simulation test on a machine without gstreamer and a machine with gstreamer. Both are able to run `make px4_sitl gz_x500` now without issues. 
