### PR TITLE
feat(mavlink): Support MAV_CMD_DO_SET_GLOBAL_ORIGIN 

### DIFF
--- a/msg/versioned/VehicleCommand.msg
+++ b/msg/versioned/VehicleCommand.msg
@@ -128,6 +128,7 @@ uint32 VEHICLE_CMD_PX4_INTERNAL_START = 65537 # Start of PX4 internal only vehic
 uint32 VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN = 100000 # Sets the GPS coordinates of the vehicle local origin (0,0,0) position. |Unused|Unused|Unused|Unused|Latitude (WGS-84)|Longitude (WGS-84)|[m] Altitude (AMSL from GNSS, positive above ground)|
 uint32 VEHICLE_CMD_SET_NAV_STATE = 100001 # Change mode by specifying nav_state directly. |nav_state|Unused|Unused|Unused|Unused|Unused|Unused|
 
+uint16 VEHICLE_CMD_DO_SET_GLOBAL_ORIGIN = 611 # Sets GNSS coordinates of the vehicle local origin (0,0,0) position. Send as COMMAND_INT with MAV_FRAME_GLOBAL_INT. |Unused|Unused|Unused|Unused|Latitude (WGS-84)|Longitude (WGS-84)|[m] Altitude (AMSL)|
 uint16 VEHICLE_CMD_GUIDED_CHANGE_HEADING = 43002 # Change heading/course. param1: heading type (0=course-over-ground, 1=heading). param2: target [deg]. param3: max rate [deg/s]. |Heading type (HEADING_TYPE enum)|[deg] Target bearing [0..360]|[deg/s] Max rate of change|Unused|Unused|Unused|Unused|
 
 uint8 VEHICLE_MOUNT_MODE_RETRACT = 0 # Load and keep safe position (Roll,Pitch,Yaw) from permanent memory and stop stabilization.

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1707,6 +1707,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 	case vehicle_command_s::VEHICLE_CMD_DO_SET_ROI_NONE:
 	case vehicle_command_s::VEHICLE_CMD_INJECT_FAILURE:
 	case vehicle_command_s::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN:
+	case vehicle_command_s::VEHICLE_CMD_DO_SET_GLOBAL_ORIGIN:
 	case vehicle_command_s::VEHICLE_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
 	case vehicle_command_s::VEHICLE_CMD_DO_GIMBAL_MANAGER_CONFIGURE:
 	case vehicle_command_s::VEHICLE_CMD_CONFIGURE_ACTUATOR:

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -520,7 +520,8 @@ void EKF2::Run()
 			command_ack.target_system = vehicle_command.source_system;
 			command_ack.target_component = vehicle_command.source_component;
 
-			if (vehicle_command.command == vehicle_command_s::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN) {
+			if (vehicle_command.command == vehicle_command_s::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN
+			    || vehicle_command.command == vehicle_command_s::VEHICLE_CMD_DO_SET_GLOBAL_ORIGIN) {
 				double latitude = vehicle_command.param5;
 				double longitude = vehicle_command.param6;
 				float altitude = vehicle_command.param7;

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -175,7 +175,8 @@ void BlockLocalPositionEstimator::Run()
 		vehicle_command_s vehicle_command;
 
 		if (_vehicle_command_sub.update(&vehicle_command)) {
-			if (vehicle_command.command == vehicle_command_s::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN) {
+			if (vehicle_command.command == vehicle_command_s::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN
+			    || vehicle_command.command == vehicle_command_s::VEHICLE_CMD_DO_SET_GLOBAL_ORIGIN) {
 				const double latitude = vehicle_command.param5;
 				const double longitude = vehicle_command.param6;
 				const float altitude = vehicle_command.param7;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -550,6 +550,9 @@ MavlinkReceiver::command_has_location(uint16_t command)
 	case MAV_CMD_DO_SET_ROI:                             // 201
 	case MAV_CMD_PAYLOAD_PREPARE_DEPLOY:                 // 30001
 	case MAV_CMD_EXTERNAL_POSITION_ESTIMATE:             // 43003
+#ifdef MAVLINK_ENABLED_DEVELOPMENT
+	case MAV_CMD_DO_SET_GLOBAL_ORIGIN:                   // 611
+#endif
 		return true;
 
 	// Not supported by PX4 as COMMAND_INT (mission items or unimplemented)
@@ -575,7 +578,6 @@ MavlinkReceiver::command_has_location(uint16_t command)
 	// case MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION:          // 5003
 	// case MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION:          // 5004
 	// case MAV_CMD_NAV_RALLY_POINT:                     // 5100
-	// case MAV_CMD_DO_SET_GLOBAL_ORIGIN:                // 611
 	// case MAV_CMD_WAYPOINT_USER_1:                     // 31000
 	// case MAV_CMD_WAYPOINT_USER_2:                     // 31001
 	// case MAV_CMD_WAYPOINT_USER_3:                     // 31002


### PR DESCRIPTION
`MAV_CMD_DO_SET_GLOBAL_ORIGIN` was added in https://github.com/mavlink/mavlink/pull/2247 to replace the old message version `SET_GPS_GLOBAL_ORIGIN`. 
This has the same behaviour - it sets the origin, emits an ACK if the command succeeded, emitting `GPS_GLOBAL_ORIGIN`.
Note that this ACKs if the origin is not changed and still emits the message.

I have tested this by sending the command with different and same values and noting that the message is emitted in both cases.

Note:
- Unsupported params are not rejected - which we can fix with https://github.com/PX4/PX4-Autopilot/pull/27541
- Invalid NaN altitude is ignored. We should perhaps fix that @julianoes ?
- Invalid lat-lon and NaN lat/lon are passed to EFK2 and then failed, not denied. @julianoes We can wait on the MAVLink update to be reviewed to test invalid lat-lon, but that won't fix that passing NaN to Lat/Lon is invalid in this message. Should we fix that particular case here?

Claude deetail on all this is below in details. The short version though is that this adds a VehicleCommand.msg enum for the command, then handles it everywhere that the old message is handled. 

Also see:
- https://github.com/mavlink/qgroundcontrol/pull/14566

<details>

PX4 already handles the legacy SET_GPS_GLOBAL_ORIGIN MAVLink message (ID 48) via
 handle_message_set_gps_global_origin(), which converts it to the internal
 VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN (100000) and publishes it for EKF2 to process.

 MAV_CMD_DO_SET_GLOBAL_ORIGIN (command ID 611, development dialect) is the newer
 COMMAND_INT-based replacement that supersedes the legacy message. It is currently
 commented out in command_has_location() as "not supported". Adding support requires:

 - Correct lat/lon decoding from COMMAND_INT's int32 degreeE7 format
 - A new vehicle_command constant for the command ID so EKF2 can check for it without
 depending on MAVLink headers
 - EKF2 (and the legacy estimator) handling the new command ID, so acks are sent back
 with the correct command ID (611, not 100000)

 MAV_CMD_DO_SET_GLOBAL_ORIGIN is only defined in the MAVLink development dialect
 (MAVLINK_ENABLED_DEVELOPMENT). Boards that don't use the development dialect must not
 fail to compile.

 Files to Modify

 1. msg/versioned/VehicleCommand.msg

 Add a constant for 611 near the other standard MAVLink commands (before line 126 where
 PX4-internal commands begin):

 uint16 VEHICLE_CMD_DO_SET_GLOBAL_ORIGIN = 611  # Sets GNSS coordinates of the vehicle local origin. Supersedes
 SET_GPS_GLOBAL_ORIGIN message. |Unused|Unused|Unused|Unused|Latitude (WGS-84)|Longitude (WGS-84)|[m] Altitude
 (AMSL)|

 2. src/modules/mavlink/mavlink_receiver.cpp

 In command_has_location() (line 537-553): Move MAV_CMD_DO_SET_GLOBAL_ORIGIN from
 the commented-out "not supported" block into the supported return true section, guarded
 so it only compiles when the development dialect is active:

 case MAV_CMD_EXTERNAL_POSITION_ESTIMATE:             // 43003
 #ifdef MAVLINK_ENABLED_DEVELOPMENT
 case MAV_CMD_DO_SET_GLOBAL_ORIGIN:                   // 611
 #endif
     return true;

 No changes are needed to handle_message_command_both() — the command naturally falls
 through to the default _cmd_pub.publish(vehicle_command) branch (line 856) with
 send_ack = false, so EKF2 handles the ack.

 3. src/modules/ekf2/EKF2.cpp

 In the command handler (line 523): Add the new vehicle command constant alongside
 the legacy one:

 if (vehicle_command.command == vehicle_command_s::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN
     || vehicle_command.command == vehicle_command_s::VEHICLE_CMD_DO_SET_GLOBAL_ORIGIN) {

 Because command_ack.command = vehicle_command.command (line 519), the ack will echo
 back 611 to the GCS when the new command is used, and 100000 for the legacy path.

 4. src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp

 In the command handler (line 178): Same pattern as EKF2:

 if (vehicle_command.command == vehicle_command_s::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN
     || vehicle_command.command == vehicle_command_s::VEHICLE_CMD_DO_SET_GLOBAL_ORIGIN) {

 Data Flow After Change

 GCS sends COMMAND_INT (id=611, frame=GLOBAL, x=lat_1e7, y=lon_1e7, z=alt_m)
   → handle_message_command_int()
   → command_has_location(611) == true  [new]
   → param5 = x / 1e7  (double degrees)
   → param6 = y / 1e7  (double degrees)
   → param7 = z        (float meters)
   → vehicle_command.command = 611, published to uORB
   → EKF2 checks: command == 100000 || command == 611  [new: matches]
   → _ekf.setEkfGlobalOrigin(lat, lon, alt)
   → command_ack.command = 611, published
   → MAVLink streams COMMAND_ACK(611, ACCEPTED) back to GCS ✓

 Legacy SET_GPS_GLOBAL_ORIGIN message path is unchanged (still uses 100000).

 Frame note (MAVLink PR #2530)

 Per mavlink/mavlink#2530, the correct
 frame for MAV_CMD_DO_SET_GLOBAL_ORIGIN when sent as COMMAND_INT is MAV_FRAME_GLOBAL_INT
 Because command_ack.command = vehicle_command.command (line 519), the ack will echo
 back 611 to the GCS when the new command is used, and 100000 for the legacy path.

 4. src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp

 In the command handler (line 178): Same pattern as EKF2:

 if (vehicle_command.command == vehicle_command_s::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN
     || vehicle_command.command == vehicle_command_s::VEHICLE_CMD_DO_SET_GLOBAL_ORIGIN) {

 Data Flow After Change

 GCS sends COMMAND_INT (id=611, frame=GLOBAL, x=lat_1e7, y=lon_1e7, z=alt_m)
   → handle_message_command_int()
   → command_has_location(611) == true  [new]
   → param5 = x / 1e7  (double degrees)
   → param6 = y / 1e7  (double degrees)
   → param7 = z        (float meters)
   → vehicle_command.command = 611, published to uORB
   → EKF2 checks: command == 100000 || command == 611  [new: matches]
   → _ekf.setEkfGlobalOrigin(lat, lon, alt)
   → command_ack.command = 611, published
   → MAVLink streams COMMAND_ACK(611, ACCEPTED) back to GCS ✓

 Legacy SET_GPS_GLOBAL_ORIGIN message path is unchanged (still uses 100000).

 Frame note (MAVLink PR #2530)

 Per mavlink/mavlink#2530, the correct
 frame for MAV_CMD_DO_SET_GLOBAL_ORIGIN when sent as COMMAND_INT is MAV_FRAME_GLOBAL_INT
 (5), not MAV_FRAME_GLOBAL (0). Both are handled identically in PX4 — handle_message_command_int()
 divides x/y by 1e7 for any non-LOCAL frame (the else branch at line 637) — so no
 special frame handling is needed. The test code below uses the correct frame.

 Verification
  description and fix in a follow-up.

  2. NaN altitude accepted

  This is by EKF design — there's even a // altitude is optional comment on line 95 of ekf_helper.cpp.
  setAltOrigin() returns false for NaN (via checkAltitudeValidity()), but setEkfGlobalOrigin() ignores that
  return value and returns true, so EKF2 sends ACCEPTED with the altitude origin unchanged. The MAVLink spec for
  MAV_CMD_DO_SET_GLOBAL_ORIGIN says altitude is required, so this is a spec divergence. However, the same
  behaviour applies to the legacy path. Don't fix here — it needs an EKF-level decision about whether altitude
  remains optional.

  3. Non-NaN param1-4

  PR #27541 is the right home for this — it builds a command lookup table for exactly this kind of param
  validation. Once #27541 merges, add MAV_CMD_DO_SET_GLOBAL_ORIGIN to its table. Don't duplicate that mechanism
  here.

  Summary: Keep this PR focused on what it does — adding COMMAND_INT reception support. Document the three known
  limitations in the PR description and link to #27541 for param1-4.

</details>