### PR TITLE
[tfmini] Configure range and FoV via parameters

### DIFF
--- a/src/drivers/distance_sensor/tfmini/TFMINI.cpp
+++ b/src/drivers/distance_sensor/tfmini/TFMINI.cpp
@@ -33,6 +33,7 @@
 
 #include "TFMINI.hpp"
 
+#include <lib/parameters/param.h>
 #include <lib/drivers/device/Device.hpp>
 #include <fcntl.h>
 
@@ -72,7 +73,8 @@ TFMINI::~TFMINI()
 int
 TFMINI::init()
 {
-	int32_t hw_model = 1; // only one model so far...
+	int32_t hw_model = 1;
+	param_get(param_find("SENS_TFMINI_HW"), &hw_model);
 
 	switch (hw_model) {
 	case 1: // TFMINI (12m, 100 Hz)
@@ -83,8 +85,19 @@ TFMINI::init()
 		// So we set 0.4 as valid minimum.
 		_px4_rangefinder.set_min_distance(0.4f);
 		_px4_rangefinder.set_max_distance(12.0f);
-		_px4_rangefinder.set_fov(math::radians(1.15f));
+		_px4_rangefinder.set_fov(math::radians(2.3f));
+		break;
 
+	case 2: // ISTRA24 (50m, 100 Hz)
+		_px4_rangefinder.set_min_distance(0.3f);
+		_px4_rangefinder.set_max_distance(50.0f);
+		_px4_rangefinder.set_fov(math::radians(20));
+		break;
+
+	case 3: // ISTRA24 (100m, 100 Hz)
+		_px4_rangefinder.set_min_distance(0.3f);
+		_px4_rangefinder.set_max_distance(100.0f);
+		_px4_rangefinder.set_fov(math::radians(20));
 		break;
 
 	default:

--- a/src/drivers/distance_sensor/tfmini/module.yaml
+++ b/src/drivers/distance_sensor/tfmini/module.yaml
@@ -4,3 +4,20 @@ serial_config:
       port_config_param:
         name: SENS_TFMINI_CFG
         group: Sensors
+
+parameters:
+    - group: Sensors
+      definitions:
+        SENS_TFMINI_HW:
+            description:
+                short: Hardware Model
+                long: Models differ in range and FoV.
+            type: enum
+            values:
+                1: TFMINI
+                2: ISTRA24
+                3: ISTRA24_100m
+            min: 1
+            max: 3
+            default: 1
+            reboot_required: true

--- a/src/drivers/distance_sensor/tfmini/tfmini_main.cpp
+++ b/src/drivers/distance_sensor/tfmini/tfmini_main.cpp
@@ -132,7 +132,6 @@ $ tfmini stop
 	PRINT_MODULE_USAGE_PARAM_INT('R', 25, 0, 25, "Sensor rotation - downward facing by default", true);
 	PRINT_MODULE_USAGE_COMMAND_DESCR("status","Driver status");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("stop","Stop driver");
-	PRINT_MODULE_USAGE_COMMAND_DESCR("test","Test driver (basic functional tests)");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("status","Print driver status");
 	return PX4_OK;
 }


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

We have a CUAV ISTRA24 radar altimeter that conforms to the FT03 protocol, thus can be used with the `tfmini` driver. However, the min/max/fov values are all different.

### Solution

This adds parameters to allow the user to finetune these settings, rather than hardcoding them.

### Alternatives
We could also add a hardware model parameter (as the code implies), however, the customers want to limit the radar min/max distance depending on use-case and thus this solution is more flexible.

### Test coverage

Tested in hardware on a FMUv6x via TELEM1.

### Context
Related links, screenshot before/after, video
