### PR TITLE
doc: Improve I2C devices links and explanation

### DIFF
--- a/docs/en/sensor_bus/i2c_general.md
+++ b/docs/en/sensor_bus/i2c_general.md
@@ -82,7 +82,7 @@ I2C bus accelerators are separate circuits that can be used to support longer wi
 They work by physically dividing an I2C network into 2 parts and using their own transistors to amplify I2C signals.
 
 Available accelerators include:
-- [Thunderfly TFI2CEXT01](https://github.com/ThunderFly-aerospace/TFI2CEXT01):
+- [Thunderfly TFI2CEXT01](https://docs.thunderfly.cz/avionics/TFI2CEXT01/):
   ![I2C bus extender](../../assets/peripherals/i2c_tfi2cext/tfi2cext01a_bottom.jpg)
   - This has Dronecode connectors and is hence very easy to add to a Pixhawk I2C setup.
   - The module has no settings (it works out of the box).

--- a/docs/en/sensor_bus/i2c_general.md
+++ b/docs/en/sensor_bus/i2c_general.md
@@ -4,15 +4,15 @@
 
 It is recommended for:
 
-* Connecting offboard components that require low bandwidth and low latency communication, e.g. [rangefinders](../sensor/rangefinders.md), [magnetometers](../gps_compass/magnetometer.md), [airspeed sensors](../sensor/airspeed.md) and [tachometers](../sensor/tachometers.md) .
+* Connecting offboard components that require low bandwidth and low latency communication, e.g. [rangefinders](../sensor/rangefinders.md), [magnetometers](../gps_compass/magnetometer.md), [airspeed sensors](../sensor/airspeed.md) and [tachometers](../sensor/tachometers.md).
 * Compatibility with peripheral devices that only support I2C.
 * Allowing multiple devices to attach to a single bus, which is useful for conserving ports.
 
 I2C allows multiple master devices to connect to multiple slave devices using only 2 wires per connection (SDA, SCL).
-in theory a bus can support 128 devices, each accessed via its unique address.
+in theory, a bus can support 128 devices, each accessed via its unique address.
 
 ::: info
-UAVCAN would normally be preferred where higher data rates are required, and on larger vehicles where sensors are be mounted further from the flight controller.
+UAVCAN would normally be preferred where higher data rates are required, and on larger vehicles where sensors are mounted further from the flight controller.
 :::
 
 
@@ -20,7 +20,7 @@ UAVCAN would normally be preferred where higher data rates are required, and on 
 
 I2C uses a pair of wires: SDA (serial data) and SCL (serial clock).
 The bus is of open-drain type, meaning that devices ground the data line.
-It uses a pullup resistor to push it to `log.1` (idle state) - every wire has it usually located on the bus terminating devices.
+It uses a pull-up resistor to push it to `log.1` (idle state) - every wire has it usually located on the bus terminating devices.
 One bus can connect to multiple I2C devices.
 The individual devices are connected without any crossing.
 
@@ -52,33 +52,32 @@ If two I2C devices on a bus have the same ID there will be a clash, and neither 
 This usually occurs because a user needs to attach two sensors of the same type to the bus, but may also happen if devices use duplicate addresses by default.
 
 Particular I2C devices may allow you to select a new address for one of the devices to avoid the clash.
-Some devices do not support this option, or do not have broad options for the addresses that can be used (i.e. cannot be used to avoid a clash).
+Some devices do not support this option or do not have broad options for the addresses that can be used (i.e. cannot be used to avoid a clash).
 
 If you can't change the addresses, one option is to use an [I2C Address Translator](#i2c-address-translators).
 
 ### Insufficient Transfer Capacity
 
-The bandwidth available for each individual device generally decreases as more devices are added. The exact decrease depends on the bandwidth used by each individual device. Therefore it is possible to connect many low bandwidth devices, like [tachometers](../sensor/tachometers.md).
+The bandwidth available for each device generally decreases as more devices are added. The exact decrease depends on the bandwidth used by each individual device. Therefore it is possible to connect many low-bandwidth devices, like [tachometers](../sensor/tachometers.md).
 If too many devices are added, it can cause transmission errors and network unreliability.
 
 There are several ways to reduce the problem:
-* Dividing the devices into groups, each with approximately the same number of devices and connecting each group to one autopilot port
+* Dividing the devices into groups, each with approximately the same number of devices, and connecting each group to one autopilot port
 * Increase bus speed limit (usually set to 100kHz for external I2C bus)
 
 ### Excessive Wiring Capacitance
 
-The electrical capacity of bus wiring increases as more devices/wires are added. The exact decrease depends on total length of bus wiring and wiring specific capacitance.
+The electrical capacity of bus wiring increases as more devices/wires are added. The exact decrease depends on the total length of bus wiring and wiring-specific capacitance.
 The problem can be analyzed using an oscilloscope, where we see that the edges of SDA/SCL signals are no longer sharp.
 
 There are several ways to reduce the problem:
-* Dividing the devices into groups, each with approximately the same number of devices and connecting each group to one autopilot port
-* Using the shortest and the highest quality I2C cables possible
-* Separating the devices with a weak open-drain driver to smaller bus with lower capacitance
-* [I2C Bus Accelerators](#i2c-bus-accelerators)
+* Dividing the devices into groups, each with approximately the same number of devices, and connecting each group to one autopilot port
+* Using the shorter and higher quality I2C cables, see the [cable wiring page](../assembly/cable_wiring.md#i2c-cables) for details
+* Separating the devices with a weak open-drain driver to smaller buses with lower capacitance by using [I2C Bus Accelerators](#i2c-bus-accelerators)
 
 ## I2C Bus Accelerators
 
-I2C bus accelerators are separate circuits that can be used to support longer wiring length on an I2C bus.
+I2C bus accelerators are separate circuits that can be used to support longer wiring lengths on an I2C bus.
 They work by physically dividing an I2C network into 2 parts and using their own transistors to amplify I2C signals.
 
 Available accelerators include:
@@ -87,6 +86,10 @@ Available accelerators include:
   - This has Dronecode connectors and is hence very easy to add to a Pixhawk I2C setup.
   - The module has no settings (it works out of the box).
 
+### I2C Level Converter function
+
+Some I2C devices have 5V on the data lines, while the Pixhawk connector standard port expects these lines to be 3.3 V.
+You can use the TFI2CEXT01 as a level converter to connect 5V devices to a Pixhawk I2C port. This feature is possible because the SCL and SDA lines of TFI2CEXT01 are 5V tolerant. 
 
 ## I2C Address Translators
 
@@ -96,21 +99,12 @@ The work by listening for I2C communication and transforming the address when a 
 Supported I2C Address Translators include:
 
 - [Thunderfly TFI2CADT01](../sensor_bus/translator_tfi2cadt.md)
-
+  - This has Dronecode connectors and is very easy to add to a Pixhawk I2C setup.
 
 ## I2C Bus Splitters
 
-I2C Bus Splitters are circuit boards that split the I2C port on your flight controller into multiple ports.
-They are useful if you want to use multiple I2C peripherals on a flight controller that has only one I2C port (or too few), such as an airspeed sensor and a distance sensor.
-
-You can find an appropriate board using an internet search.
-
-## I2C Level Converter
-
-Some I2C devices have 5V on the data lines, while the Pixhawk connector standard port expects these lines to be 3.3 V.
-You can use an I2C level converter to connect 5V devices to a Pixhawk I2C port.
-
-You can find an appropriate covnerter using an internet search.
+I2C Bus Splitters are devices that split the I2C port on your flight controller into multiple connectors.
+They are useful if you want to use multiple I2C peripherals on a flight controller that has only one I2C port (or too few), such as an airspeed sensor and a distance sensor. Both devices [I2C Address Translator](../sensor_bus/translator_tfi2cadt.md) and [I2C Bus Accelerators](#i2c-bus-accelerators) could also be used as I2C splitters because they have multiple I2C connectors for connecting additional I2C devices.
 
 ## I2C Development
 

--- a/docs/en/sensor_bus/translator_tfi2cadt.md
+++ b/docs/en/sensor_bus/translator_tfi2cadt.md
@@ -1,12 +1,11 @@
 # TFI2CADT01 - I²C Address Translator
 
-[TFI2CADT01](https://github.com/ThunderFly-aerospace/TFI2CADT01) is an address translator module that is compatible with Pixhawk and PX4.
+[TFI2CADT01](https://docs.thunderfly.cz/avionics/TFI2CADT01/) is an address translator module that is compatible with Pixhawk and PX4.
 
 Address translation allows multiple I2C devices with the same address to coexist on an I2C network.
 The module may be needed if using several devices that have the same hard-coded address.
 
-The module has an input and an output side.
-A sensor is connected to the master device on one side.
+The module has an input and an output side and a sensor is connected to the master device on one side.
 On the output side sensors, whose addresses are to be translated, can be connected.
 The module contains two pairs of connectors, each pair responsible for different translations.
 
@@ -14,7 +13,7 @@ The module contains two pairs of connectors, each pair responsible for different
 
 ::: info
 [TFI2CADT01](https://github.com/ThunderFly-aerospace/TFI2CADT01) is designed as open-source hardware with GPLv3 license.
-It is commercially available from [ThunderFly](https://www.thunderfly.cz/) company or from [Tindie eshop](https://www.tindie.com/products/thunderfly/tfi2cadt01-i2c-address-translator/).
+It is commercially available from [ThunderFly](https://www.thunderfly.cz/) company or from [Tindie eshop](https://www.tindie.com/products/26353/).
 :::
 
 ## Address Translation Method
@@ -31,7 +30,7 @@ If you need your own value for address translation, changing the configuration r
 The tachometer sensor [TFRPM01](../sensor/thunderfly_tachometer.md) can be set to two different addresses using a solder jumper.
 If the autopilot has three buses, only 6 sensors can be connected and no bus remains free (2 available addresses * 3 I2C ports).
 In some multicopters or VTOL solutions, there is a need to measure the RPM of 8 or more elements.
-The [TFI2CADT01](https://www.tindie.com/products/thunderfly/tfi2cadt01-i2c-address-translator/) is highly recommended in this case.
+The [TFI2CADT01](https://www.tindie.com/products/26353/) is highly recommended in this case.
 
 ![Multiple sensors](../../assets/peripherals/i2c_tfi2cadt/tfi2cadt01_multi_tfrpm01.jpg)
 
@@ -58,7 +57,7 @@ graph TD
 
 ::: info
 TFI2CADT01 does not contain any I2C buffer or accelerator.
-As it adds additional capacitance on the bus, we advise combining it with some bus booster, e.g. [TFI2CEXT01](https://github.com/ThunderFly-aerospace/TFI2CEXT01).
+As it adds additional capacitance on the bus, we advise combining it with some bus booster, e.g. [TFI2CEXT01](https://docs.thunderfly.cz/avionics/TFI2CEXT01/).
 :::
 
 ### Other Resources


### PR DESCRIPTION
### Solved Problem

The docs pages related to I2C have obsolete links and descriptions.

### Solution

Links were updated to the product documentation. The explanatory text was also updated. 

### Changelog Entry
For release notes:
```
Docs: improve I2C wiring documentation and links
```

