### PR TITLE
Ubuntu Versions update and Gazebo Classic deprioritisation

### DIFF
--- a/docs/en/dev_setup/building_px4.md
+++ b/docs/en/dev_setup/building_px4.md
@@ -33,30 +33,20 @@ If needed you can also [get the source code specific to a particular release](..
 First we'll build a simulated target using a console environment.
 This allows us to validate the system setup before moving on to real hardware and an IDE.
 
-Navigate into the **PX4-Autopilot** directory.
-Depending on your operating system you will have installed either [Gazebo SITL](../sim_gazebo_gz/index.md) or [Gazebo Classic SITL](../sim_gazebo_classic/index.md) (if you don't know which you can try both).
-
-:::: tabs
-
-::: tab Gazebo
-Start [Gazebo SITL](../sim_gazebo_gz/index.md) using the following command:
+Navigate into the **PX4-Autopilot** directory and start [Gazebo SITL](../sim_gazebo_gz/index.md) using the following command:
 
 ```sh
 make px4_sitl gz_x500
 ```
 
-:::
-
-::: tab Gazebo-Classic
-Start [Gazebo SITL](../sim_gazebo_gz/index.md) using the following command:
+::: details  If you installed Gazebo Classic
+Start  [Gazebo Classic SITL](../sim_gazebo_classic/index.md) using the following command:
 
 ```sh
 make px4_sitl gazebo-classic
 ```
 
 :::
-
-::::
 
 This will bring up the PX4 console:
 
@@ -73,19 +63,9 @@ The drone can be flown by typing the following command (as shown in the console 
 pxh> commander takeoff
 ```
 
-The vehicle will take off and you'll see this in the simulator UI:
+The vehicle will take off and you'll see this in the Gazebo simulator UI:
 
-:::: tabs
-
-::: tab Gazebo
 ![Gazebo UI with vehicle taking off](../../assets/toolchain/gazebo_takeoff.png)
-:::
-
-::: tab Gazebo-Classic
-![Gazebo Classic UI with vehicle taking off](../../assets/toolchain/gazebo_classic_takeoff.png)
-:::
-
-::::
 
 The drone can be landed by typing `commander land` and the whole simulation can be stopped by doing **CTRL+C** (or by entering `shutdown`).
 

--- a/docs/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/docs/en/dev_setup/dev_env_linux_ubuntu.md
@@ -1,20 +1,23 @@
 # Ubuntu Development Environment
 
-The following instructions use a bash script to set up the PX4 development environment on the [Ubuntu Linux LTS](https://wiki.ubuntu.com/LTS) versions supported by PX4: Ubuntu 22.04 (Jammy Jellyfish), 20.04 (Focal Fossa), and 18.04 (Bionic Beaver).
+The following instructions use a bash script to set up the PX4 development environment on the [Ubuntu Linux LTS](https://wiki.ubuntu.com/LTS) versions supported by PX4: Ubuntu 24.04 (Nimble Numbat) and Ubuntu 22.04 (Jammy Jellyfish).
 
 The environment includes:
 
-- [Gazebo Simulator](../sim_gazebo_gz/index.md) ("Harmonic") on Ubuntu 22.04
-- [Gazebo Classic Simulator](../sim_gazebo_classic/index.md) on Ubuntu 20.04 and Ubuntu 18.04
+- [Gazebo Simulator](../sim_gazebo_gz/index.md) ("Harmonic")
 - [Build toolchain for Pixhawk (and other NuttX-based hardware)](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards).
 
-::: info
-The build toolchain for other flight controllers, simulators, and working with ROS are discussed in the [Other Targets](#other-targets) section below.
-:::
+On Ubuntu 22.04:
 
-::: tip
-if you need to use Gazebo on Ubuntu 20.04 you can [manually install Gazebo "Garden"](../sim_gazebo_gz/index.md#installation-ubuntu-linux), with the caveat that this is end-of-life in November 2024.
-If you want to use Gazebo Classic on Ubuntu 22.04 (say) then you can manually install it by following the instructions in [Gazebo Classic > Installation](../sim_gazebo_classic/index.md#installation).
+- [Gazebo Classic Simulator](../sim_gazebo_classic/index.md) can be used instead of Gazebo.
+  Gazebo is nearing feature-parity with Gazebo-Classic on PX4, and will soon replace it for all use cases.
+
+The build toolchain for other flight controllers, simulators, and working with ROS are discussed in the [Other Targets](#other-targets) section below.
+
+::: details Can I use an older version of Ubuntu?
+PX4 supports the current and last Ubuntu LTS release where possible.
+Older releases are not supported (so you can't raise defects against them), but may still work.
+For example, Gazebo Classic setup is included in our standard build instructions for macOS, Ubuntu 18.04 and 20.04, and Windows on WSL2 for the same hosts.
 :::
 
 ## Simulation and NuttX (Pixhawk) Targets
@@ -38,7 +41,7 @@ To install the toolchain:
    If working with an older version of PX4 you may need to [get the source code specific to your release](../contribute/git_examples.md#get-a-specific-release).
    :::
 
-1. Run the **ubuntu.sh** with no arguments (in a bash shell) to install everything:
+2. Run the **ubuntu.sh** with no arguments (in a bash shell) to install everything:
 
    ```sh
    bash ./PX4-Autopilot/Tools/setup/ubuntu.sh
@@ -47,7 +50,9 @@ To install the toolchain:
    - Acknowledge any prompts as the script progress.
    - You can use the `--no-nuttx` and `--no-sim-tools` options to omit the NuttX and/or simulation tools.
 
-1. Restart the computer on completion.
+3. If you need Gazebo Classic (Ubuntu 22.04 only) then you can manually remove Gazebo and install it by following the instructions in [Gazebo Classic > Installation](../sim_gazebo_classic/index.md#installation).
+
+4. Restart the computer on completion.
 
 :::details Additional notes
 These notes are provided "for information only":
@@ -59,8 +64,8 @@ These notes are provided "for information only":
   ```sh
   $arm-none-eabi-gcc --version
 
-  arm-none-eabi-gcc (GNU Arm Embedded Toolchain 9-2020-q2-update) 9.3.1 20200408 (release)
-  Copyright (C) 2019 Free Software Foundation, Inc.
+  arm-none-eabi-gcc (15:13.2.rel1-2) 13.2.1 20231009
+  Copyright (C) 2023 Free Software Foundation, Inc.
   This is free software; see the source for copying conditions.  There is NO
   warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
   ```
@@ -75,17 +80,6 @@ These notes are provided "for information only":
   ```
 
   :::
-
-## Video Guide
-
-This video shows how to install the toolchain for NuttX and simulation targets ([as covered below](#simulation-and-nuttx-pixhawk-targets)) along with the basic testing covered in [Building PX4 Software](../dev_setup/building_px4.md).
-
-::: warning
-The video suggests that you build source using JMAVSim, entering the command: `make px4_sitl jmavsim`.
-As JMAVSim is now community-supported, you should instead build using Gazebo or Gazebo Classic, as shown in [Building the Code](../dev_setup/building_px4.md#first-build-using-a-simulator)
-:::
-
-<lite-youtube videoid="OtValQdAdrU" title=" Setting up your PX4 development environment on Linux"/>
 
 ## Other Targets
 

--- a/docs/en/dev_setup/vscode.md
+++ b/docs/en/dev_setup/vscode.md
@@ -5,7 +5,7 @@
 There are a number of reasons to use VSCode for PX4 development:
 
 - Getting setup _really_ only takes a few minutes.
-- A rich extension ecosystem that enables a huge range of tools needed for PX4 development: C/C++ (with solid _cmake_ integration), _Python_, _Jinja2_, ROS messages, and even DroneCAN dsdl.
+- A rich extension ecosystem that enables a huge range of tools needed for PX4 development: C/C++ (with solid _cmake_ integration), _Python_, _Jinja2_, ROS messages, and even DroneCAN DSDL.
 - Excellent Github integration.
 
 This topic explains how to setup the IDE and start developing.
@@ -25,7 +25,9 @@ You must already have installed the command line [PX4 developer environment](../
 1. Open VSCode and add the PX4 source code:
 
    - Select _Open folder ..._ option on the welcome page (or using the menu: **File > Open Folder**):
+
      ![Open Folder](../../assets/toolchain/vscode/welcome_open_folder.jpg)
+
    - A file selection dialog will appear.
      Select the **PX4-Autopilot** directory and then press **OK**.
 

--- a/docs/en/sim_gazebo_classic/index.md
+++ b/docs/en/sim_gazebo_classic/index.md
@@ -1,8 +1,9 @@
 # Gazebo Classic Simulation
 
 :::warning
-_Gazebo Classic_ is supported with PX4 up to Ubuntu Linux 20.04.
-In Ubuntu 22.04 and later you must use [Gazebo](../sim_gazebo_gz/index.md) (which was [formerly known](https://www.openrobotics.org/blog/2022/4/6/a-new-era-for-gazebo) as "Gazebo Ignition").
+[Gazebo](../sim_gazebo_gz/index.md) is nearing feature-parity with Gazebo Classic on PX4, and will soon replace it.
+Until then you can continue to use Gazebo-Classic on Ubuntu 22.04 for the few cases where you still need to.
+For more information see [PX4-Autopilot#23602: GZ Feature tracker](https://github.com/PX4/PX4-Autopilot/issues/23602).
 :::
 
 Gazebo Classic is a powerful 3D simulation environment for autonomous robots that is particularly suitable for testing object-avoidance and computer vision.
@@ -32,11 +33,8 @@ See [Simulation](../simulation/index.md) for general information about simulator
 If you plan to use PX4 with ROS you **should follow the** [ROS Instructions](../simulation/ros_interface.md) to install both ROS and Gazebo Classic (and thereby avoid installation conflicts).
 :::
 
-Gazebo Classic setup is included in our [standard build instructions](../dev_setup/dev_env.md) for macOS, Ubuntu 18.04 and 20.04, and Windows on WSL2 for the same hosts.
-
-For Ubuntu 22.04 LTS and later, the installation script ([/Tools/setup/ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh)) installs the [Gazebo](../sim_gazebo_gz/index.md) simulator instead.
-
-If you want to use Gazebo Classic on Ubuntu 22.04 you can use the following commands to remove [Gazebo](../sim_gazebo_gz/index.md) (Harmonic) and then reinstall Gazebo-Classic 11:
+The standard installation script ([/Tools/setup/ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh)) installs the [Gazebo](../sim_gazebo_gz/index.md) (Harmonic) simulator.
+If you want to use Gazebo Classic on _Ubuntu 22.04 (only)_ you can use the following commands to remove Gazebo and then reinstall Gazebo-Classic 11:
 
 ```sh
 sudo apt remove gz-harmonic
@@ -47,10 +45,10 @@ sudo aptitude install gazebo libgazebo11 libgazebo-dev
 Note that `aptitude` is needed because it can resolve dependency conflicts (by removing certain packages) that `apt` is unable to handle.
 
 ::: tip
-You could also modify the installation script to install Gazebo Classic on later versions before it is run for the first time.
-:::
+You could also modify the installation script to install Gazebo Classic on Ubuntu 22.04 before it is run for the first time.
 
 Additional installation instructions can be found on [gazebosim.org](http://gazebosim.org/tutorials?cat=guided_b&tut=guided_b1).
+:::
 
 ## Running the Simulation
 
@@ -281,8 +279,6 @@ To enable/disable GPS noise:
      You can enable it by adding the `gpsNoise` element to the `gps_plugin` section (as shown above).
 
 The next time you build/restart Gazebo Classic it will use the new GPS noise setting.
-
-
 
 ## Loading a Specific World
 
@@ -544,8 +540,6 @@ The code is available on the [sitl_gazebo repository](https://github.com/PX4/PX4
 The build system enforces the correct GIT submodules, including the simulator.
 It will not overwrite changes in files in the directory.
 :::
-
-
 
 ## Further Information
 


### PR DESCRIPTION
PX4 is now working to a model of supporting the current and previous Ubuntu LTS builds: Ubuntu 24.02 and 22.02. We're also working towards Gazebo feature parity with Gazebo-Classic, after which the Classic version will be dropped.

This updates the toolchain installation, build and Gazebo-Classic docs to refer to the new supported OS versions. The Gazebo-Classic is also "deprioritized" in a number of ways - specifically the instructions are "Gazebo first", and the Gazebo-Classic instructions are very much "if you want to do something special then-ish".

Comes out of discussion https://discord.com/channels/1022170275984457759/1357170977582088223

> [!NOTE]
> When Gazebo Classic support is dropped or about to drop a lot more will need to be done. Specifically Gazebo classic is used in a lot of example and cases. Many of those will ne longer be relevant.
At the same point we might also strip out the ROS (1) docs.
