### PR TITLE
MAV_CMD_DO_SET_MODE - add support

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -605,6 +605,9 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 			result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_DENIED;
 			send_ack = true;
 		}
+		
+	} else if (cmd_mavlink.command == MAV_CMD_DO_SET_MODE) {
+		_cmd_pub.publish(vehicle_command);
 
 	} else if (cmd_mavlink.command == MAV_CMD_DO_AUTOTUNE_ENABLE) {
 


### PR DESCRIPTION
The `SET_MODE` message has been replaced by a `MAV_CMD_DO_SET_MODE` (many years ago).

This adds support. 

All it does is set publish the command. After factoring out the code to turn the message into a command, that is all the  SET_MODE message hander does in https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_receiver.cpp#L920-L946 too .

I have tested this and the mode can be changed. An ACK is received (i.e. it is no long "unsupported).

The only problem is that it always seems to ACKs success - even if an invalid mode is set. I need to do some more investigation because it should be returning denied
https://github.com/PX4/PX4-Autopilot/blob/5f06e861ec1474860f4fabfa51f57aceb2f5ba95/src/modules/commander/Commander.cpp#L911
