### PR TITLE
Support swapping RX/TX pins for ESC telemetry

### DIFF
--- a/boards/hkust/nxt-dual/init/rc.board_extras
+++ b/boards/hkust/nxt-dual/init/rc.board_extras
@@ -10,4 +10,4 @@
 # fi
 
 # DShot telemetry is always on UART7
-# dshot telemetry /dev/ttyS5
+# dshot telemetry -d /dev/ttyS5

--- a/boards/hkust/nxt-v1/init/rc.board_extras
+++ b/boards/hkust/nxt-v1/init/rc.board_extras
@@ -10,4 +10,4 @@
 # fi
 
 # DShot telemetry is always on UART7
-# dshot telemetry /dev/ttyS5
+# dshot telemetry -d /dev/ttyS5

--- a/boards/holybro/kakutef7/init/rc.board_extras
+++ b/boards/holybro/kakutef7/init/rc.board_extras
@@ -9,4 +9,4 @@ then
 fi
 
 # DShot telemetry is always on UART7
-dshot telemetry /dev/ttyS5
+dshot telemetry -d /dev/ttyS5

--- a/boards/holybro/kakuteh7/init/rc.board_extras
+++ b/boards/holybro/kakuteh7/init/rc.board_extras
@@ -9,4 +9,4 @@ then
 fi
 
 # DShot telemetry is always on UART7
-dshot telemetry /dev/ttyS5
+dshot telemetry -d /dev/ttyS5

--- a/boards/holybro/kakuteh7mini/init/rc.board_extras
+++ b/boards/holybro/kakuteh7mini/init/rc.board_extras
@@ -9,4 +9,4 @@ then
 fi
 
 # DShot telemetry is always on UART7
-dshot telemetry /dev/ttyS5
+dshot telemetry -d /dev/ttyS5

--- a/boards/holybro/kakuteh7v2/init/rc.board_extras
+++ b/boards/holybro/kakuteh7v2/init/rc.board_extras
@@ -9,4 +9,4 @@ then
 fi
 
 # DShot telemetry is always on UART7
-dshot telemetry /dev/ttyS5
+dshot telemetry -d /dev/ttyS5

--- a/boards/matek/h743-mini/init/rc.board_extras
+++ b/boards/matek/h743-mini/init/rc.board_extras
@@ -11,4 +11,4 @@
 atxxxx start -s
 
 # DShot telemetry is always on UART7
-# dshot telemetry /dev/ttyS5
+# dshot telemetry -d /dev/ttyS5

--- a/boards/matek/h743-slim/init/rc.board_extras
+++ b/boards/matek/h743-slim/init/rc.board_extras
@@ -12,4 +12,4 @@ atxxxx start -s
 
 
 # DShot telemetry is always on UART7
-# dshot telemetry /dev/ttyS5
+# dshot telemetry -d /dev/ttyS5

--- a/boards/matek/h743/init/rc.board_extras
+++ b/boards/matek/h743/init/rc.board_extras
@@ -12,4 +12,4 @@ atxxxx start -s
 
 
 # DShot telemetry is always on UART7
-# dshot telemetry /dev/ttyS5
+# dshot telemetry -d /dev/ttyS5

--- a/boards/x-mav/ap-h743v2/init/rc.board_extras
+++ b/boards/x-mav/ap-h743v2/init/rc.board_extras
@@ -10,4 +10,4 @@
 # fi
 
 # DShot telemetry is always on UART7
-# dshot telemetry /dev/ttyS5
+# dshot telemetry -d /dev/ttyS5

--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -38,6 +38,7 @@
 #include <px4_platform_common/sem.hpp>
 
 char DShot::_telemetry_device[] {};
+bool DShot::_telemetry_swap_rxtx{false};
 px4::atomic_bool DShot::_request_telemetry_init{false};
 
 DShot::DShot() :
@@ -189,7 +190,7 @@ void DShot::update_num_motors()
 	_num_motors = motor_count;
 }
 
-void DShot::init_telemetry(const char *device)
+void DShot::init_telemetry(const char *device, bool swap_rxtx)
 {
 	if (!_telemetry) {
 		_telemetry = new DShotTelemetry{};
@@ -201,7 +202,7 @@ void DShot::init_telemetry(const char *device)
 	}
 
 	if (device != NULL) {
-		int ret = _telemetry->init(device);
+		int ret = _telemetry->init(device, swap_rxtx);
 
 		if (ret != 0) {
 			PX4_ERR("telemetry init failed (%i)", ret);
@@ -574,7 +575,7 @@ void DShot::Run()
 
 	// telemetry device update request?
 	if (_request_telemetry_init.load()) {
-		init_telemetry(_telemetry_device);
+		init_telemetry(_telemetry_device, _telemetry_swap_rxtx);
 		_request_telemetry_init.store(false);
 	}
 
@@ -703,31 +704,42 @@ int DShot::custom_command(int argc, char *argv[])
 {
 	const char *verb = argv[0];
 
-	if (!strcmp(verb, "telemetry")) {
-		if (argc > 1) {
-			// telemetry can be requested before the module is started
-			strncpy(_telemetry_device, argv[1], sizeof(_telemetry_device) - 1);
-			_telemetry_device[sizeof(_telemetry_device) - 1] = '\0';
-			_request_telemetry_init.store(true);
-		}
-
-		return 0;
-	}
-
 	int motor_index = -1; // select motor index, default: -1=all
 	int myoptind = 1;
+	bool swap_rxtx = false;
+	const char *device_name = nullptr;
 	int ch;
 	const char *myoptarg = nullptr;
 
-	while ((ch = px4_getopt(argc, argv, "m:", &myoptind, &myoptarg)) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "m:sd:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'm':
 			motor_index = strtol(myoptarg, nullptr, 10) - 1;
 			break;
 
+		case 's':
+			swap_rxtx = true;
+			break;
+
+		case 'd':
+			device_name = myoptarg;
+			break;
+
 		default:
 			return print_usage("unrecognized flag");
 		}
+	}
+
+	if (!strcmp(verb, "telemetry")) {
+		if (device_name) {
+			// telemetry can be requested before the module is started
+			strncpy(_telemetry_device, device_name, sizeof(_telemetry_device) - 1);
+			_telemetry_device[sizeof(_telemetry_device) - 1] = '\0';
+			_telemetry_swap_rxtx = swap_rxtx;
+			_request_telemetry_init.store(true);
+		}
+
+		return 0;
 	}
 
 	struct VerbCommand {
@@ -844,7 +856,8 @@ After saving, the reversed direction will be regarded as the normal one. So to r
 	PRINT_MODULE_USAGE_COMMAND("start");
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("telemetry", "Enable Telemetry on a UART");
-	PRINT_MODULE_USAGE_ARG("<device>", "UART device", false);
+	PRINT_MODULE_USAGE_PARAM_STRING('d', nullptr, "<device>", "UART device", true);
+	PRINT_MODULE_USAGE_PARAM_FLAG('s', "Swap RX/TX pins", false);
 
 	// DShot commands
 	PRINT_MODULE_USAGE_COMMAND_DESCR("reverse", "Reverse motor direction");

--- a/src/drivers/dshot/DShot.h
+++ b/src/drivers/dshot/DShot.h
@@ -123,7 +123,7 @@ private:
 
 	void enable_dshot_outputs(const bool enabled);
 
-	void init_telemetry(const char *device);
+	void init_telemetry(const char *device, bool swap_rxtx);
 
 	int handle_new_telemetry_data(const int telemetry_index, const DShotTelemetry::EscData &data, bool ignore_rpm);
 
@@ -149,6 +149,7 @@ private:
 	uORB::PublicationMultiData<esc_status_s> esc_status_pub{ORB_ID(esc_status)};
 
 	static char _telemetry_device[20];
+	static bool _telemetry_swap_rxtx;
 	static px4::atomic_bool _request_telemetry_init;
 
 	px4::atomic<Command *> _new_command{nullptr};

--- a/src/drivers/dshot/DShotTelemetry.cpp
+++ b/src/drivers/dshot/DShotTelemetry.cpp
@@ -49,7 +49,7 @@ DShotTelemetry::~DShotTelemetry()
 	deinit();
 }
 
-int DShotTelemetry::init(const char *uart_device)
+int DShotTelemetry::init(const char *uart_device, bool swap_rxtx)
 {
 	deinit();
 	_uart_fd = ::open(uart_device, O_RDONLY | O_NOCTTY);
@@ -59,6 +59,7 @@ int DShotTelemetry::init(const char *uart_device)
 		return -errno;
 	}
 
+	ioctl(_uart_fd, TIOCSSWAP, swap_rxtx ? SER_SWAP_ENABLED  : 0);
 	_num_timeouts = 0;
 	_num_successful_responses = 0;
 	_current_motor_index_request = -1;

--- a/src/drivers/dshot/DShotTelemetry.h
+++ b/src/drivers/dshot/DShotTelemetry.h
@@ -60,7 +60,7 @@ public:
 
 	~DShotTelemetry();
 
-	int init(const char *uart_device);
+	int init(const char *uart_device, bool swap_rxtx);
 
 	void deinit();
 

--- a/src/drivers/dshot/module.yaml
+++ b/src/drivers/dshot/module.yaml
@@ -1,6 +1,6 @@
 module_name: DShot Driver
 serial_config:
-    - command: dshot telemetry ${SERIAL_DEV}
+    - command: dshot telemetry -d ${SERIAL_DEV}
       port_config_param:
         name: DSHOT_TEL_CFG
         group: DShot


### PR DESCRIPTION

### Solved Problem

For the FMUv6s target, we only had one UART TX pin left, so we need to swap the pins internally to receive ESC telemetry data.

### Solution

Adds a `-s` command line flag to the `dshot telemetry` command. It is intended to be set in the board config, ie `dshot telemetry -d /dev/ttyS5 -s` in our case.

Unfortunately I couldn't quite get this to be backward compatible since the previous implementation did not use a command line argument for the device name. But I updated all calls for it in the repo.

### Changelog Entry
For release notes:
```
Feature Allow swapping of RX/TX pin of DShot Telemetry.
```

### Alternatives

We could also add a parameter for the inversion? However, I kinda doubt that a generic serial port will have their pins inverted. This setting is only useful for boards with hardwired ESC telemetry pins.

### Test coverage

- [ ] Tested in hardware.

