### PR TITLE
Fix: cyclic roll and pitch input causes yaw drift on multicopters

### DIFF
--- a/src/modules/ekf2/EKF/output_predictor/output_predictor.cpp
+++ b/src/modules/ekf2/EKF/output_predictor/output_predictor.cpp
@@ -35,6 +35,7 @@
 
 using matrix::AxisAnglef;
 using matrix::Dcmf;
+using matrix::Eulerf;
 using matrix::Quatf;
 using matrix::Vector2f;
 using matrix::Vector3f;
@@ -196,6 +197,7 @@ void OutputPredictor::calculateOutputStates(const uint64_t time_us, const Vector
 	const Quatf dq(AxisAnglef{delta_angle_corrected});
 
 	// rotate the previous INS quaternion by the delta quaternions
+	const Quatf quat_nominal_before_update = _output_new.quat_nominal;
 	_output_new.quat_nominal = _output_new.quat_nominal * dq;
 
 	// the quaternions must always be normalised after modification
@@ -244,9 +246,14 @@ void OutputPredictor::calculateOutputStates(const uint64_t time_us, const Vector
 	}
 
 	// update auxiliary yaw estimate
-	const Vector3f unbiased_delta_angle = delta_angle - delta_angle_bias_scaled;
-	const float spin_del_ang_D = unbiased_delta_angle.dot(Vector3f(_R_to_earth_now.row(2)));
-	_unaided_yaw = matrix::wrap_pi(_unaided_yaw + spin_del_ang_D);
+	// rotate the state quternion by the delta quaternion only corrected for bias without EKF corrections
+	const Vector3f delta_angle_unaided = delta_angle - delta_angle_bias_scaled;
+	const float yaw_state = Eulerf(quat_nominal_before_update).psi();
+	const Quatf quat_unaided = quat_nominal_before_update * Quatf(AxisAnglef(delta_angle_unaided));
+	const float yaw_without_aiding = Eulerf(quat_unaided).psi();
+	// Yaw before delta quaternion applied and yaw after. The difference is the delta yaw. Accumulate it.
+	const float unaided_delta_yaw = yaw_without_aiding - yaw_state;
+	_unaided_yaw = matrix::wrap_pi(_unaided_yaw + unaided_delta_yaw);
 }
 
 void OutputPredictor::correctOutputStates(const uint64_t time_delayed_us,


### PR DESCRIPTION
### Solved Problem
I got the report that if you leave the yaw stick centered and hence absolute yaw locked but give cyclic roll, pitch input the vehicle drifts in yaw. And I verified this to be true e.g. you can fly in Position or Altitude mode with default settings and at the right rate of roll and pitch cyclic input you can turn the drone 360° in yaw relatively easily which is undesired.

### Solution
After a quick discussion with @bresch he already told me that it's likely because of the way the unaided yaw is not calculated accurately enough and hence the yaw lock is constantly reset because the high-pass filter of difference between yaw state and unaided yaw change quickly.

### Changelog Entry
```
Fix: cyclic roll and pitch input causes yaw drift on multicopters
```

### Test coverage
- Tested extensively in SITL SIH simulation to verify the improvement fixing the original issues. It is not impossible to get out of the yaw lock especially when going really hard at the right frequency in Stabilized/Manual mode but even then it will not rotate fast in yaw but you have to give very targeted input to achieve a yaw change. To solve this I suggest to switch to the level yaw definition of heading/yaw which I'm pushing for a long time. That should simplify calculations.
- Expecting this to have a performance impact since it's running in the high rate output predicotr I looked at `top` and `ekf2 status` metrics both on `fmu-v4` (pixracer) and `fmu-v5x` (Skynode) with and without change checking multiple reboots and I cannot tell the difference from looking at the numbers which means the performance impüact is not as significant as expected.
- I flew on a real vehicle and tried to have it yaw. Similar to in simulation I did not achieve any yaw change in Position and Altitude no matter what input and only small changes in Stabilized/Manual mode and only when going hard and wasn't able to really turn the vehicle around.

### Context
Mildly related to https://github.com/PX4/PX4-Autopilot/pull/24664 since that pr makes the same logic being used in Stabilized/manual mode.
