### PR TITLE
Make hover throttle more predictable in mc-stabilized mode

### DIFF
--- a/docs/en/advanced_config/parameter_reference.md
+++ b/docs/en/advanced_config/parameter_reference.md
@@ -24244,12 +24244,13 @@ Reboot | minValue | maxValue | increment | default | unit
 
 Thrust curve mapping in Stabilized Mode.
 
-Defines how the throttle stick is mapped to collective thrust in Stabilized mode. Rescale to hover thrust: Stick input is linearly rescaled, such that a centered stick corresponds to the hover throttle (see MPC_THR_HOVER). No Rescale: Directly map the stick 1:1 to the output. Can be useful with very low hover thrust which leads to much distortion and the upper half getting sensitive. With MPC_THR_HOVER 0.5 both modes are the same.
+Defines how the throttle stick is mapped to collective thrust in Stabilized mode. Rescale to hover thrust: Stick input is linearly rescaled, such that a centered stick corresponds to the hover throttle parameter value (see MPC_THR_HOVER). Rescale to HTE: Similar to rescaling to the hover thrust parameter value, but it uses the hover thrust estimator's output instead of a fixed parameter. No Rescale: Directly map the stick 1:1 to the output. Can be useful with very low hover thrust which leads to much distortion and the upper half getting sensitive. With MPC_THR_HOVER 0.5 both modes are the same.
 
 **Values:**
 
 - `0`: Rescale to hover thrust
-- `1`: No Rescale
+- `1`: Rescale to HTE
+- `2`: No rescale
 
 
 Reboot | minValue | maxValue | increment | default | unit
@@ -24338,7 +24339,7 @@ Reboot | minValue | maxValue | increment | default | unit
 
 Hover thrust estimator.
 
-Disable to use the fixed parameter MPC_THR_HOVER Enable to use the hover thrust estimator
+Disable to use the fixed parameter MPC_THR_HOVER. Enable to use the hover thrust estimator. This parameter does not influence Stabilized mode throttle curve (see MPC_THR_CURVE).
 
 Reboot | minValue | maxValue | increment | default | unit
 --- | --- | --- | --- | --- | ---

--- a/docs/en/advanced_config/parameter_reference.md
+++ b/docs/en/advanced_config/parameter_reference.md
@@ -24244,13 +24244,13 @@ Reboot | minValue | maxValue | increment | default | unit
 
 Thrust curve mapping in Stabilized Mode.
 
-Defines how the throttle stick is mapped to collective thrust in Stabilized mode. Rescale to hover thrust parameter: stick input is linearly rescaled, such that a centered stick corresponds to the hover throttle (see MPC_THR_HOVER). No rescale: directly map the stick 1:1 to the output. Can be useful with very low hover thrust which leads to much distortion and the upper half getting sensitive. Rescale to hover thrust estimate: similar to rescaling to the hover thrust parameter value, but it uses the hover thrust estimator's output instead of a fixed parameter.
+Defines how the throttle stick is mapped to collective thrust in Stabilized mode. Rescale to hover thrust estimate: Stick input is linearly rescaled, such that a centered throttle stick corresponds to the hover thrust estimator's output. No rescale: Directly map the stick 1:1 to the output. Can be useful with very low hover thrust which leads to much distortion and the upper half getting sensitive. Rescale to hover thrust parameter: Similar to rescaling to the hover thrust estimate, but it uses the hover thrust parameter value (see MPC_THR_HOVER) instead of estimated value. With MPC_THR_HOVER 0.5 it's equivalent to No rescale.
 
 **Values:**
 
-- `0`: Rescale to parameter
+- `0`: Rescale to estimate
 - `1`: No rescale
-- `2`: Rescale to estimate
+- `2`: Rescale to parameter
 
 
 Reboot | minValue | maxValue | increment | default | unit

--- a/docs/en/advanced_config/parameter_reference.md
+++ b/docs/en/advanced_config/parameter_reference.md
@@ -24244,13 +24244,13 @@ Reboot | minValue | maxValue | increment | default | unit
 
 Thrust curve mapping in Stabilized Mode.
 
-Defines how the throttle stick is mapped to collective thrust in Stabilized mode. Rescale to hover thrust: Stick input is linearly rescaled, such that a centered stick corresponds to the hover throttle parameter value (see MPC_THR_HOVER). Rescale to HTE: Similar to rescaling to the hover thrust parameter value, but it uses the hover thrust estimator's output instead of a fixed parameter. No Rescale: Directly map the stick 1:1 to the output. Can be useful with very low hover thrust which leads to much distortion and the upper half getting sensitive. With MPC_THR_HOVER 0.5 both modes are the same.
+Defines how the throttle stick is mapped to collective thrust in Stabilized mode. Rescale to hover thrust parameter: stick input is linearly rescaled, such that a centered stick corresponds to the hover throttle (see MPC_THR_HOVER). No rescale: directly map the stick 1:1 to the output. Can be useful with very low hover thrust which leads to much distortion and the upper half getting sensitive. Rescale to hover thrust estimate: similar to rescaling to the hover thrust parameter value, but it uses the hover thrust estimator's output instead of a fixed parameter.
 
 **Values:**
 
-- `0`: Rescale to hover thrust
-- `1`: Rescale to HTE
-- `2`: No rescale
+- `0`: Rescale to parameter
+- `1`: No rescale
+- `2`: Rescale to estimate
 
 
 Reboot | minValue | maxValue | increment | default | unit

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -101,7 +101,7 @@ private:
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
-	uORB::Subscription _hover_thrust_slewrate_estimate_sub{ORB_ID(hover_thrust_estimate)};
+	uORB::Subscription _hover_thrust_estimate_sub{ORB_ID(hover_thrust_estimate)};
 	uORB::Subscription _vehicle_attitude_setpoint_sub{ORB_ID(vehicle_attitude_setpoint)};
 	uORB::Subscription _autotune_attitude_control_status_sub{ORB_ID(autotune_attitude_control_status)};
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -89,7 +89,7 @@ private:
 	 */
 	void parameters_updated();
 
-	float throttle_curve(float throttle_stick_input);
+	float throttle_curve(float throttle_stick_input, float dt);
 
 	/**
 	 * Generate & publish an attitude setpoint from stick inputs
@@ -121,7 +121,8 @@ private:
 	perf_counter_t  _loop_perf;             /**< loop duration performance counter */
 
 	matrix::Vector3f _thrust_setpoint_body; /**< body frame 3D thrust vector */
-	float _hover_thrust{NAN};
+
+	SlewRate<float> _hover_thrust_slew_rate{NAN};
 
 	float _yaw_setpoint_stabilized{0.f};
 	bool _heading_good_for_control{true}; // initialized true to have heading lock when local position never published

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -89,7 +89,7 @@ private:
 	 */
 	void parameters_updated();
 
-	float throttle_curve(float throttle_stick_input, float dt);
+	float throttle_curve(float throttle_stick_input);
 
 	/**
 	 * Generate & publish an attitude setpoint from stick inputs
@@ -101,7 +101,7 @@ private:
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
-	uORB::Subscription _hover_thrust_estimate_sub{ORB_ID(hover_thrust_estimate)};
+	uORB::Subscription _hover_thrust_slewrate_estimate_sub{ORB_ID(hover_thrust_estimate)};
 	uORB::Subscription _vehicle_attitude_setpoint_sub{ORB_ID(vehicle_attitude_setpoint)};
 	uORB::Subscription _autotune_attitude_control_status_sub{ORB_ID(autotune_attitude_control_status)};
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
@@ -122,7 +122,8 @@ private:
 
 	matrix::Vector3f _thrust_setpoint_body; /**< body frame 3D thrust vector */
 
-	SlewRate<float> _hover_thrust_slew_rate{NAN};
+	float _hover_thrust_estimate{NAN};
+	SlewRate<float> _hover_thrust_slew_rate{.5f};
 
 	float _yaw_setpoint_stabilized{0.f};
 	bool _heading_good_for_control{true}; // initialized true to have heading lock when local position never published

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -65,7 +65,8 @@ MulticopterAttitudeControl::MulticopterAttitudeControl(bool vtol) :
 	_manual_throttle_minimum.setSlewRate(0.05f);
 	// Rate of change 50% per second -> 2 seconds to ramp to 100%
 	_manual_throttle_maximum.setSlewRate(0.5f);
-	_hover_thrust_slew_rate.setSlewRate(0.5f);
+	// Rate of change 5% per second -> 6 seconds to ramp 30% if hover thrust parameter is off
+	_hover_thrust_slew_rate.setSlewRate(0.05f);
 }
 
 MulticopterAttitudeControl::~MulticopterAttitudeControl()
@@ -96,30 +97,18 @@ MulticopterAttitudeControl::parameters_updated()
 	_attitude_control.setRateLimit(Vector3f(radians(_param_mc_rollrate_max.get()), radians(_param_mc_pitchrate_max.get()),
 						radians(_param_mc_yawrate_max.get())));
 
+	// Update from hover thrust parameter if there's no valid estimate in use
+	if (!PX4_ISFINITE(_hover_thrust_estimate)) {
+		_hover_thrust_slew_rate.setForcedValue(_param_mpc_thr_hover.get());
+	}
+
 	_man_tilt_max = math::radians(_param_mpc_man_tilt_max.get());
 }
 
 float
-MulticopterAttitudeControl::throttle_curve(float throttle_stick_input, float dt)
+MulticopterAttitudeControl::throttle_curve(float throttle_stick_input)
 {
 	float thrust = 0.f;
-
-	{
-		hover_thrust_estimate_s hte;
-
-		if (_hover_thrust_estimate_sub.update(&hte)) {
-			if (hte.valid) {
-				_hover_thrust_slew_rate.update(hte.hover_thrust, dt);
-
-			} else { // fallback
-				_hover_thrust_slew_rate.update(_param_mpc_thr_hover.get(), dt);
-			}
-		}
-	}
-
-	if (!PX4_ISFINITE(_hover_thrust_slew_rate.getState())) {
-		_hover_thrust_slew_rate.setForcedValue(_param_mpc_thr_hover.get());
-	}
 
 	// throttle_stick_input is in range [-1, 1]
 	switch (_param_mpc_thr_curve.get()) {
@@ -207,7 +196,7 @@ MulticopterAttitudeControl::generate_attitude_setpoint(const Quatf &q, float dt)
 
 	q_sp.copyTo(attitude_setpoint.q_d);
 
-	attitude_setpoint.thrust_body[2] = -throttle_curve(_manual_control_setpoint.throttle, dt);
+	attitude_setpoint.thrust_body[2] = -throttle_curve(_manual_control_setpoint.throttle);
 
 	attitude_setpoint.timestamp = hrt_absolute_time();
 	_vehicle_attitude_setpoint_pub.publish(attitude_setpoint);
@@ -232,6 +221,21 @@ MulticopterAttitudeControl::Run()
 
 		updateParams();
 		parameters_updated();
+	}
+
+	// Update hover thrust for stick scaling
+	if (_vehicle_status_sub.updated()) {
+		hover_thrust_estimate_s hover_thrust_estimate;
+
+		if (_hover_thrust_slewrate_estimate_sub.update(&hover_thrust_estimate)) {
+			if (hover_thrust_estimate.valid) {
+				_hover_thrust_estimate = math::constrain(hover_thrust_estimate.hover_thrust, .05f, .9f);
+
+			} else {
+				// Possibly bad estimate before it got invalid, slew back to parameter
+				_hover_thrust_estimate = _param_mpc_thr_hover.get();
+			}
+		}
 	}
 
 	// run controller on attitude updates
@@ -380,6 +384,10 @@ MulticopterAttitudeControl::Run()
 
 		} else {
 			_manual_throttle_maximum.setForcedValue(0.f);
+		}
+
+		if (PX4_ISFINITE(_hover_thrust_estimate)) {
+			_hover_thrust_slew_rate.update(_hover_thrust_estimate, dt);
 		}
 	}
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -227,7 +227,7 @@ MulticopterAttitudeControl::Run()
 	if (_vehicle_status_sub.updated()) {
 		hover_thrust_estimate_s hover_thrust_estimate;
 
-		if (_hover_thrust_slewrate_estimate_sub.update(&hover_thrust_estimate)) {
+		if (_hover_thrust_estimate_sub.update(&hover_thrust_estimate)) {
 			if (hover_thrust_estimate.valid) {
 				_hover_thrust_estimate = math::constrain(hover_thrust_estimate.hover_thrust, .05f, .9f);
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -112,15 +112,15 @@ MulticopterAttitudeControl::throttle_curve(float throttle_stick_input)
 
 	// throttle_stick_input is in range [-1, 1]
 	switch (_param_mpc_thr_curve.get()) {
-	case 1: // rescale to HTE value
+	case 1: // no rescaling to hover throttle
+		thrust = math::interpolate(throttle_stick_input, -1.f, 1.f,
+					   _manual_throttle_minimum.getState(), _param_mpc_thr_max.get());
+		break;
+
+	case 2: // rescale to HTE value
 		thrust = math::interpolateNXY(throttle_stick_input,
 		{-1.f, 0.f, 1.f},
 		{_manual_throttle_minimum.getState(), _hover_thrust_slew_rate.getState(), _param_mpc_thr_max.get()});
-		break;
-
-	case 2: // no rescaling to hover throttle
-		thrust = math::interpolate(throttle_stick_input, -1.f, 1.f,
-					   _manual_throttle_minimum.getState(), _param_mpc_thr_max.get());
 		break;
 
 	default: // 0 or other: rescale to hover throttle at 0 stick input

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -110,6 +110,7 @@ MulticopterAttitudeControl::throttle_curve(float throttle_stick_input, float dt)
 		if (_hover_thrust_estimate_sub.update(&hte)) {
 			if (hte.valid) {
 				_hover_thrust_slew_rate.update(hte.hover_thrust, dt);
+
 			} else { // fallback
 				_hover_thrust_slew_rate.update(_param_mpc_thr_hover.get(), dt);
 			}

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -112,21 +112,21 @@ MulticopterAttitudeControl::throttle_curve(float throttle_stick_input)
 
 	// throttle_stick_input is in range [-1, 1]
 	switch (_param_mpc_thr_curve.get()) {
-	case 1: // no rescaling to hover throttle
+	case 1: // no rescaling
 		thrust = math::interpolate(throttle_stick_input, -1.f, 1.f,
 					   _manual_throttle_minimum.getState(), _param_mpc_thr_max.get());
 		break;
 
-	case 2: // rescale to HTE value
-		thrust = math::interpolateNXY(throttle_stick_input,
-		{-1.f, 0.f, 1.f},
-		{_manual_throttle_minimum.getState(), _hover_thrust_slew_rate.getState(), _param_mpc_thr_max.get()});
-		break;
-
-	default: // 0 or other: rescale to hover throttle at 0 stick input
+	case 2: // rescale to hover thrust param at 0 stick input
 		thrust = math::interpolateNXY(throttle_stick_input,
 		{-1.f, 0.f, 1.f},
 		{_manual_throttle_minimum.getState(), _param_mpc_thr_hover.get(), _param_mpc_thr_max.get()});
+		break;
+
+	default: // 0 or other: rescale to HTE value
+		thrust = math::interpolateNXY(throttle_stick_input,
+		{-1.f, 0.f, 1.f},
+		{_manual_throttle_minimum.getState(), _hover_thrust_slew_rate.getState(), _param_mpc_thr_max.get()});
 		break;
 	}
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -119,7 +119,13 @@ MulticopterAttitudeControl::throttle_curve(float throttle_stick_input)
 
 	// throttle_stick_input is in range [-1, 1]
 	switch (_param_mpc_thr_curve.get()) {
-	case 1: // no rescaling to hover throttle
+	case 1: // rescale to HTE value
+		thrust = math::interpolateNXY(throttle_stick_input,
+		{-1.f, 0.f, 1.f},
+		{_manual_throttle_minimum.getState(), _hover_thrust_slew_rate.getState(), _param_mpc_thr_max.get()});
+		break;
+
+	case 2: // no rescaling to hover throttle
 		thrust = math::interpolate(throttle_stick_input, -1.f, 1.f,
 					   _manual_throttle_minimum.getState(), _param_mpc_thr_max.get());
 		break;
@@ -127,7 +133,7 @@ MulticopterAttitudeControl::throttle_curve(float throttle_stick_input)
 	default: // 0 or other: rescale to hover throttle at 0 stick input
 		thrust = math::interpolateNXY(throttle_stick_input,
 		{-1.f, 0.f, 1.f},
-		{_manual_throttle_minimum.getState(), _hover_thrust, _param_mpc_thr_max.get()});
+		{_manual_throttle_minimum.getState(), _param_mpc_thr_hover.get(), _param_mpc_thr_max.get()});
 		break;
 	}
 

--- a/src/modules/mc_pos_control/multicopter_position_control_params.c
+++ b/src/modules/mc_pos_control/multicopter_position_control_params.c
@@ -49,10 +49,10 @@
 PARAM_DEFINE_FLOAT(MPC_THR_HOVER, 0.5f);
 
 /**
- * Hover thrust estimator
+ * Use hover thrust estimate for altitude control
  *
- * Disable to use the fixed parameter MPC_THR_HOVER
- * Enable to use the hover thrust estimator
+ * Disable to use the fixed parameter MPC_THR_HOVER but instead the hover thrust estimate in the position controller.
+ * This parameter does not influence Stabilized mode throttle curve (see MPC_THR_CURVE).
  *
  * @boolean
  * @group Multicopter Position Control

--- a/src/modules/mc_pos_control/multicopter_position_control_params.c
+++ b/src/modules/mc_pos_control/multicopter_position_control_params.c
@@ -51,7 +51,7 @@ PARAM_DEFINE_FLOAT(MPC_THR_HOVER, 0.5f);
 /**
  * Use hover thrust estimate for altitude control
  *
- * Disable to use the fixed parameter MPC_THR_HOVER but instead the hover thrust estimate in the position controller.
+ * Disable to use the fixed parameter MPC_THR_HOVER instead of the hover thrust estimate in the position controller.
  * This parameter does not influence Stabilized mode throttle curve (see MPC_THR_CURVE).
  *
  * @boolean

--- a/src/modules/mc_pos_control/multicopter_stabilized_mode_params.c
+++ b/src/modules/mc_pos_control/multicopter_stabilized_mode_params.c
@@ -77,17 +77,21 @@ PARAM_DEFINE_FLOAT(MPC_MANTHR_MIN, 0.08f);
  *
  * Defines how the throttle stick is mapped to collective thrust in Stabilized mode.
  *
- * Rescale to hover thrust:
+ * Rescale to hover thrust parameter:
  *   Stick input is linearly rescaled, such that a centered stick corresponds to the hover throttle (see MPC_THR_HOVER).
  *
  * No Rescale:
  *   Directly map the stick 1:1 to the output.
  *   Can be useful with very low hover thrust which leads to much distortion and the upper half getting sensitive.
  *
+ * Rescale to hover thrust estimate:
+ *   Similar to rescaling to the hover thrust parameter value, but it uses the hover thrust estimator's output instead of a fixed parameter.
+ *
  * With MPC_THR_HOVER 0.5 both modes are the same.
  *
- * @value 0 Rescale to hover thrust
+ * @value 0 Rescale to parameter
  * @value 1 No Rescale
+ * @value 2 Rescale to estimate
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_INT32(MPC_THR_CURVE, 0);

--- a/src/modules/mc_pos_control/multicopter_stabilized_mode_params.c
+++ b/src/modules/mc_pos_control/multicopter_stabilized_mode_params.c
@@ -94,4 +94,4 @@ PARAM_DEFINE_FLOAT(MPC_MANTHR_MIN, 0.08f);
  * @value 2 Rescale to estimate
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_INT32(MPC_THR_CURVE, 0);
+PARAM_DEFINE_INT32(MPC_THR_CURVE, 2);

--- a/src/modules/mc_pos_control/multicopter_stabilized_mode_params.c
+++ b/src/modules/mc_pos_control/multicopter_stabilized_mode_params.c
@@ -77,21 +77,20 @@ PARAM_DEFINE_FLOAT(MPC_MANTHR_MIN, 0.08f);
  *
  * Defines how the throttle stick is mapped to collective thrust in Stabilized mode.
  *
- * Rescale to hover thrust parameter:
- *   Stick input is linearly rescaled, such that a centered stick corresponds to the hover throttle (see MPC_THR_HOVER).
+ * Rescale to hover thrust estimate:
+ *   Stick input is linearly rescaled, such that a centered throttle stick corresponds to the hover thrust estimator's output.
  *
- * No Rescale:
+ * No rescale:
  *   Directly map the stick 1:1 to the output.
  *   Can be useful with very low hover thrust which leads to much distortion and the upper half getting sensitive.
  *
- * Rescale to hover thrust estimate:
- *   Similar to rescaling to the hover thrust parameter value, but it uses the hover thrust estimator's output instead of a fixed parameter.
+ * Rescale to hover thrust parameter:
+ *   Similar to rescaling to the hover thrust estimate, but it uses the hover thrust parameter value (see MPC_THR_HOVER) instead of estimated value.
+ *   With MPC_THR_HOVER 0.5 it's equivalent to No rescale.
  *
- * With MPC_THR_HOVER 0.5 both modes are the same.
- *
- * @value 0 Rescale to parameter
- * @value 1 No Rescale
- * @value 2 Rescale to estimate
+ * @value 0 Rescale to estimate
+ * @value 1 No rescale
+ * @value 2 Rescale to parameter
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_INT32(MPC_THR_CURVE, 2);
+PARAM_DEFINE_INT32(MPC_THR_CURVE, 0);


### PR DESCRIPTION
### Current behavior
Throttle curve rescaling using the Hover Thrust Estimator (HTE) causes throttle jumps, making the throttle response unpredictable for the pilot (see #24654).

### Proposed solution
A slew rate will be applied to the hover thrust used for throttle scaling. This will allow the hover throttle to gradually adjust towards the estimated value, improving predictability for the pilot.

### Changes
- [x] Clarify description of MPC_USE_HTE parameter
- [x] Add slew rate for hover thrust rescaling  

@bresch @MaEtUgR 