### PR TITLE
fix: Add dds client dependency when build generated_events_px4_file

### DIFF
--- a/src/lib/events/CMakeLists.txt
+++ b/src/lib/events/CMakeLists.txt
@@ -58,6 +58,7 @@ add_custom_command(OUTPUT ${generated_events_px4_file}
 		${PX4_SOURCE_DIR}/Tools/px4events/srcparser.py
 		${PX4_SOURCE_DIR}/Tools/px4events/srcscanner.py
 		prebuild_targets # ensure all generated source files exist
+		modules__uxrce_dds_client
 	COMMENT "Generating px4 event json file from source"
 )
 add_custom_target(events_px4_json DEPENDS ${generated_events_px4_file})


### PR DESCRIPTION
### Solved Problem
When building px4 with Ubuntu 22.04 and cmake, we got error. make[2]: *** No rule to make target 'src/modules/uxrce_dds_client/dds_topics.h', needed by 'events/px4.json'.  Stop. make[1]: *** [CMakeFiles/Makefile2:19164: src/lib/events/CMakeFiles/events_json.dir/all] Error 2

This is due to missing dependencies related to uxrce_dds_client, so we manually added them in CMakeLists.txt.

This Fixes #21788


### Test coverage
- Actually I tested with my machine (Ubuntu 22.04) only..


