### PR TITLE
vtol: reduce schedule frequency, which causes DSHOT150 problems

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -94,26 +94,7 @@ VtolAttitudeControl::~VtolAttitudeControl()
 bool
 VtolAttitudeControl::init()
 {
-	if (!_vehicle_torque_setpoint_virtual_fw_sub.registerCallback()) {
-		PX4_ERR("callback registration failed");
-		return false;
-	}
-
-	if (!_vehicle_torque_setpoint_virtual_mc_sub.registerCallback()) {
-		PX4_ERR("callback registration failed");
-		return false;
-	}
-
-	if (!_vehicle_thrust_setpoint_virtual_fw_sub.registerCallback()) {
-		PX4_ERR("callback registration failed");
-		return false;
-	}
-
-	if (!_vehicle_thrust_setpoint_virtual_mc_sub.registerCallback()) {
-		PX4_ERR("callback registration failed");
-		return false;
-	}
-
+	ScheduleNow();
 	return true;
 }
 
@@ -273,13 +254,47 @@ VtolAttitudeControl::parameters_update()
 }
 
 void
+VtolAttitudeControl::update_registrations()
+{
+	mode current_vtol_mode = _vtol_type->get_mode();
+
+	switch (current_vtol_mode) {
+	case mode::TRANSITION_TO_FW:
+	case mode::TRANSITION_TO_MC:
+	case mode::ROTARY_WING:
+		register_mc_callbacks();
+		break;
+
+	case mode::FIXED_WING:
+		register_fw_callbacks();
+		break;
+	}
+
+	_previous_vtol_mode = current_vtol_mode;
+}
+
+void
+VtolAttitudeControl::register_mc_callbacks()
+{
+	if (_vehicle_torque_setpoint_virtual_mc_sub.registerCallback()) {
+		_vehicle_torque_setpoint_virtual_fw_sub.unregisterCallback();
+	}
+}
+
+void
+VtolAttitudeControl::register_fw_callbacks()
+{
+	if (_vehicle_torque_setpoint_virtual_fw_sub.registerCallback()) {
+		_vehicle_torque_setpoint_virtual_mc_sub.unregisterCallback();
+	}
+}
+
+void
 VtolAttitudeControl::Run()
 {
 	if (should_exit()) {
 		_vehicle_torque_setpoint_virtual_fw_sub.unregisterCallback();
 		_vehicle_torque_setpoint_virtual_mc_sub.unregisterCallback();
-		_vehicle_thrust_setpoint_virtual_fw_sub.unregisterCallback();
-		_vehicle_thrust_setpoint_virtual_mc_sub.unregisterCallback();
 		exit_and_cleanup();
 		return;
 	}
@@ -298,6 +313,7 @@ VtolAttitudeControl::Run()
 	if (!_initialized) {
 
 		if (_vtol_type->init()) {
+			update_registrations();
 			_initialized = true;
 
 		} else {
@@ -315,8 +331,13 @@ VtolAttitudeControl::Run()
 
 	// run on actuator publications corresponding to VTOL mode
 	bool should_run = false;
+	mode current_vtol_mode = _vtol_type->get_mode();
 
-	switch (_vtol_type->get_mode()) {
+	if (current_vtol_mode != _previous_vtol_mode) {
+		update_registrations();
+	}
+
+	switch (current_vtol_mode) {
 	case mode::TRANSITION_TO_FW:
 	case mode::TRANSITION_TO_MC:
 		should_run = updated_fw_in || updated_mc_in;

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -87,6 +87,7 @@
 #include "standard.h"
 #include "tailsitter.h"
 #include "tiltrotor.h"
+#include "vtol_type.h"
 
 using namespace time_literals;
 
@@ -149,8 +150,8 @@ private:
 	void Run() override;
 	uORB::SubscriptionCallbackWorkItem _vehicle_torque_setpoint_virtual_fw_sub{this, ORB_ID(vehicle_torque_setpoint_virtual_fw)};
 	uORB::SubscriptionCallbackWorkItem _vehicle_torque_setpoint_virtual_mc_sub{this, ORB_ID(vehicle_torque_setpoint_virtual_mc)};
-	uORB::SubscriptionCallbackWorkItem _vehicle_thrust_setpoint_virtual_fw_sub{this, ORB_ID(vehicle_thrust_setpoint_virtual_fw)};
-	uORB::SubscriptionCallbackWorkItem _vehicle_thrust_setpoint_virtual_mc_sub{this, ORB_ID(vehicle_thrust_setpoint_virtual_mc)};
+	uORB::Subscription _vehicle_thrust_setpoint_virtual_fw_sub{ORB_ID(vehicle_thrust_setpoint_virtual_fw)};
+	uORB::Subscription _vehicle_thrust_setpoint_virtual_mc_sub{ORB_ID(vehicle_thrust_setpoint_virtual_mc)};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
@@ -223,6 +224,7 @@ private:
 	uint8_t _nav_state_prev;
 
 	VtolType	*_vtol_type{nullptr};	// base class for different vtol types
+	mode		_previous_vtol_mode;
 
 	bool		_initialized{false};
 
@@ -235,6 +237,12 @@ private:
 	void		vehicle_cmd_poll();
 
 	void 		parameters_update();
+
+	void		update_registrations();
+
+	void		register_mc_callbacks();
+
+	void		register_fw_callbacks();
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::VT_TYPE>) _param_vt_type,

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -238,11 +238,7 @@ private:
 
 	void 		parameters_update();
 
-	void		update_registrations();
-
-	void		register_mc_callbacks();
-
-	void		register_fw_callbacks();
+	void		update_callbacks();
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::VT_TYPE>) _param_vt_type,


### PR DESCRIPTION
### Solved Problem
Specific ADP ESCs lost communication when switching from MC -> FW in case of using DSHOT150. When switching back from FW -> MC the motors would still not spin.

The communication loss is due to incorrect DSHOT messages on the wire. As can be seen multiple DSHOT frames got packed into one large stream:
![image](https://github.com/user-attachments/assets/9653a9ce-060e-4525-9dfe-d19b22a86193)

The cause of this is that a DSHOT transmission is started while an old one was still in progress. This occured only on DSHOT150 as the other ones are quick enough for this to not happen. The reason for this is a extremly fast scheduling of the DSHOT driver:
![image](https://github.com/user-attachments/assets/92d2310d-6101-4d13-97ab-84446c4d2412)

All this could be traced back to `vtol_att_control` being called too often due to it having configured 4 topic callbacks which are triggered by `MulticopterRateControl` and `FixedwingRateControl` which are triggered by an update of `vehicle_angular_velocity`. So one update of `vehicle_angular_velocity` causes a burst of 4 schedules of `vtol_att_control`.

### Solution
Depending on the VTOL mode only the relevant callbacks are registered. In addition only the `torque` topics are subscribed as they are published after the `thrust` topics.

### Changelog Entry
For release notes:
```
Bugfix: Reduce vtol schedule frequency to avoid DSHOT150 problems
```

### Test coverage
- On the bench with an ADP F3 80 and DSHOT
- Flight tested on a Loong VTOL with PWM output