### PR TITLE
logger: clean up emission of events

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rc.replay
+++ b/ROMFS/px4fmu_common/init.d-posix/rc.replay
@@ -26,5 +26,5 @@ param set SDLOG_PROFILE 3
 # apply all params before ekf starts, as some params cannot be changed after startup
 replay tryapplyparams
 ekf2 start -r
-logger start -f -t -b 1000 -p vehicle_attitude
+logger start -f -b 1000 -p vehicle_attitude
 replay start

--- a/ROMFS/px4fmu_common/init.d/rc.logging
+++ b/ROMFS/px4fmu_common/init.d/rc.logging
@@ -31,5 +31,5 @@ fi
 
 if ! param compare SDLOG_MODE -1
 then
-	logger start -b ${LOGGER_BUF} -t ${LOGGER_ARGS}
+	logger start -b ${LOGGER_BUF} ${LOGGER_ARGS}
 fi

--- a/boards/modalai/voxl2/target/voxl-px4-hitl-start
+++ b/boards/modalai/voxl2/target/voxl-px4-hitl-start
@@ -91,7 +91,7 @@ mavlink stream -u 14556 -s GLOBAL_POSITION_INT -r 30
 mavlink start -x -u 14558 -o 14559 -r 100000 -n lo
 
 # Start logging and use timestamps for log files when possible.
-logger start -t -b 256
+logger start -b 256
 
 /bin/sleep 1
 

--- a/boards/modalai/voxl2/target/voxl-px4-start
+++ b/boards/modalai/voxl2/target/voxl-px4-start
@@ -240,7 +240,7 @@ mavlink start -x -u 14558 -o 14559 -r 100000 -n lo
 # because if power is removed without stopping the logger gracefully then
 # the log file may be corrupted. Rather than using "-e" option it's better
 # to use the SDLOG_MODE to do that.
-logger start -t -b 256
+logger start -b 256
 
 mavlink boot_complete
 

--- a/docs/en/modules/modules_system.md
+++ b/docs/en/modules/modules_system.md
@@ -467,7 +467,7 @@ the mission log). It should be large to avoid dropouts.
 ### Examples
 Typical usage to start logging immediately:
 ```
-logger start -e -t
+logger start -e
 ```
 
 Or if already running:

--- a/posix-configs/SITL/init/test/test_imu_filtering
+++ b/posix-configs/SITL/init/test/test_imu_filtering
@@ -43,7 +43,7 @@ fake_imu start
 sensors start
 gyro_fft start
 
-logger start -f -t -b 10000 -p sensor_gyro
+logger start -f -b 10000 -p sensor_gyro
 logger on
 
 echo "Running for 10 seconds"

--- a/posix-configs/SITL/init/test/test_shutdown
+++ b/posix-configs/SITL/init/test/test_shutdown
@@ -37,7 +37,7 @@ control_allocator start
 
 ver all
 
-logger start -e -t
+logger start -e
 
 mavlink boot_complete
 

--- a/posix-configs/bbblue/px4.config
+++ b/posix-configs/bbblue/px4.config
@@ -75,6 +75,6 @@ sleep 1
 control_allocator start
 linux_pwm_out start
 
-logger start -t -b 200
+logger start -b 200
 
 mavlink boot_complete

--- a/posix-configs/bbblue/px4_fw.config
+++ b/posix-configs/bbblue/px4_fw.config
@@ -70,6 +70,6 @@ rc_input start -d /dev/ttyS4
 control_allocator start
 linux_pwm_out start
 
-logger start -t -b 200
+logger start -b 200
 
 mavlink boot_complete

--- a/posix-configs/rpi/navigator/sub.config
+++ b/posix-configs/rpi/navigator/sub.config
@@ -44,6 +44,6 @@ uuv_att_control start
 uuv_pos_control start
 
 mavlink start -x -u 14556 -r 1000000 -p
-logger start -t -b 200
+logger start -b 200
 
 mavlink boot_complete

--- a/posix-configs/rpi/pilotpi_fw.config
+++ b/posix-configs/rpi/pilotpi_fw.config
@@ -70,6 +70,6 @@ mavlink start -x -u 14556 -r 1000000 -p
 # Telem
 mavlink start -x -Z -d /dev/ttySC1
 
-logger start -t -b 200
+logger start -b 200
 
 mavlink boot_complete

--- a/posix-configs/rpi/pilotpi_mc.config
+++ b/posix-configs/rpi/pilotpi_mc.config
@@ -68,6 +68,6 @@ mavlink start -x -u 14556 -r 1000000 -p
 # Telem
 mavlink start -x -Z -d /dev/ttySC1
 
-logger start -t -b 200
+logger start -b 200
 
 mavlink boot_complete

--- a/posix-configs/rpi/px4.config
+++ b/posix-configs/rpi/px4.config
@@ -59,6 +59,6 @@ navio_sysfs_rc_in start
 linux_pwm_out start
 control_allocator start
 
-logger start -t -b 200
+logger start -b 200
 
 mavlink boot_complete

--- a/posix-configs/rpi/px4_fw.config
+++ b/posix-configs/rpi/px4_fw.config
@@ -57,6 +57,6 @@ navio_sysfs_rc_in start
 linux_pwm_out start
 control_allocator start
 
-logger start -t -b 200
+logger start -b 200
 
 mavlink boot_complete

--- a/posix-configs/rpi/px4_hil.config
+++ b/posix-configs/rpi/px4_hil.config
@@ -39,6 +39,6 @@ navio_sysfs_rc_in start
 pwm_out_sim start
 control_allocator start
 
-logger start -t -b 200
+logger start -b 200
 
 mavlink boot_complete

--- a/posix-configs/rpi/px4_test.config
+++ b/posix-configs/rpi/px4_test.config
@@ -56,7 +56,7 @@ navio_sysfs_rc_in start
 linux_pwm_out start
 control_allocator start
 
-logger start -t -f -b 200
+logger start -f -b 200
 
 mavlink boot_complete
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1293,11 +1293,8 @@ int Logger::get_log_file_name(LogType type, char *file_name, size_t file_name_si
 
 	time_t timestamp_utc = {};
 	struct timespec ts = {};
-	// px4_clock_gettime(CLOCK_REALTIME, &ts);
+	px4_clock_gettime(CLOCK_REALTIME, &ts);
 	timestamp_utc = ts.tv_sec + (ts.tv_nsec / 1e9);
-
-	tm tt = {};
-	gmtime_r(&timestamp_utc, &tt);
 
 	const char *replay_suffix = "";
 
@@ -1318,6 +1315,13 @@ int Logger::get_log_file_name(LogType type, char *file_name, size_t file_name_si
 
 	// Check if time is non-zero for valid UTC timestamp
 	if (timestamp_utc > 0) {
+		int offset = _param_sdlog_utc_offset.get() * 60;
+		if (timestamp_utc > abs(offset)) {
+			timestamp_utc += offset;
+		}
+
+		tm tt = {};
+		gmtime_r(&timestamp_utc, &tt);
 
 		// TODO: move create_log_dir outside of this...
 		int n = create_log_dir(type, &tt, file_name, file_name_size);

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1393,8 +1393,10 @@ void Logger::start_log_file(LogType type)
 	PX4_INFO("Start file log (type: %s)", log_type_str(type));
 	_statistics[(int) type].start_time_file = 0;
 
+	// TODO: might not need this since get_log_file_name sets a member variable _file_name
 	char file_name[LOG_DIR_LEN] = "";
 
+	// Populates the internal _file_name
 	if (get_log_file_name(type, file_name, sizeof(file_name)) != PX4_OK) {
 		PX4_ERR("failed to get log file name");
 		return;
@@ -1412,8 +1414,8 @@ void Logger::start_log_file(LogType type)
 	// Emit event when we're recording a full log type (TODO: rename "full" to "normal"?)
 	// TODO: do we really need separate events? If the intent is to convey the full log string
 	// it isn't quite right since the zeroes get dropped, see below:
-	// PX4: 	2025-04-05/14_27_49.ulg
-	// MAVSDK : 2025-4-5/14_27_49.ulg
+	// PX4:     2025-04-05/14_27_49.ulg
+	// MAVSDK:  2025-4-5/14_27_49.ulg
 	emit_log_start_event(type);
 
 	if (_writer.start_log_file(type, file_name)) {
@@ -1455,10 +1457,13 @@ void Logger::emit_log_start_event(LogType type)
 
 			// TODO: this way of populating the file_name is weird, especially since we already have it above
 			uint16_t year = 0;
-			uint8_t month = 0, day = 0;
+			uint8_t month = 0;
+			uint8_t day = 0;
 			sscanf(_file_name[(int)type].log_dir, "%hd-%hhd-%hhd", &year, &month, &day);
 
-			uint8_t hour = 0, minute = 0, second = 0;
+			uint8_t hour = 0;
+			uint8_t minute = 0;
+			uint8_t second = 0;
 			sscanf(_file_name[(int)type].log_file_name, "%hhd_%hhd_%hhd", &hour, &minute, &second);
 
 			events::send<uint16_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t>(

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1299,7 +1299,7 @@ int Logger::get_log_file_name(LogType type, char *file_name, size_t file_name_si
 	// Apply UTC offset parameter and handle potential underflow
 	int32_t utc_offset_seconds = _param_sdlog_utc_offset.get() * 60;
 
-	if (utc_offset_seconds < 0 && timestamp_utc < (uint32_t)abs(utc_offset_seconds)) {
+	if (utc_offset_seconds < 0 && timestamp_utc < (time_t)abs(utc_offset_seconds)) {
 		timestamp_utc = 0;
 
 	} else {

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1464,7 +1464,6 @@ void Logger::emit_log_start_event(LogType type)
 		// Check if we're using time-based format by checking for hyphen
 		if (strstr(_file_name[(int)type].log_dir, "-")) {
 
-			// TODO: this way of populating the file_name is weird, especially since we already have it above
 			uint16_t year = 0;
 			uint8_t month = 0;
 			uint8_t day = 0;

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1315,10 +1315,7 @@ int Logger::get_log_file_name(LogType type, char *file_name, size_t file_name_si
 
 	// Check if time is non-zero for valid UTC timestamp
 	if (timestamp_utc > 0) {
-		int offset = _param_sdlog_utc_offset.get() * 60;
-		if (timestamp_utc > abs(offset)) {
-			timestamp_utc += offset;
-		}
+		timestamp_utc += _param_sdlog_utc_offset.get() * 60;
 
 		tm tt = {};
 		gmtime_r(&timestamp_utc, &tt);

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -2476,7 +2476,7 @@ the mission log). It should be large to avoid dropouts.
 
 ### Examples
 Typical usage to start logging immediately:
-$ logger start -e -t
+$ logger start -e
 
 Or if already running:
 $ logger on

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -107,7 +107,7 @@ public:
 
 
 	Logger(LogWriter::Backend backend, size_t buffer_size, uint32_t log_interval, const char *poll_topic_name,
-	       LogMode log_mode, bool log_name_timestamp, float rate_factor);
+	       LogMode log_mode, float rate_factor);
 
 	~Logger();
 
@@ -211,7 +211,7 @@ private:
 	/**
 	 * Get log file name with directory (create it if necessary)
 	 */
-	int get_log_file_name(LogType type, char *file_name, size_t file_name_size, bool notify);
+	int get_log_file_name(LogType type, char *file_name, size_t file_name_size);
 
 	void start_log_file(LogType type);
 
@@ -350,7 +350,6 @@ private:
 	hrt_abstime					_last_sync_time{0}; ///< last time a sync msg was sent
 
 	LogMode						_log_mode;
-	const bool					_log_name_timestamp;
 
 	LoggerSubscription	 			*_subscriptions{nullptr}; ///< all subscriptions for full & mission log (in front)
 	int						_num_subscriptions{0};

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -213,6 +213,8 @@ private:
 	 */
 	int get_log_file_name(LogType type, char *file_name, size_t file_name_size);
 
+	void emit_log_start_event(LogType type);
+
 	void start_log_file(LogType type);
 
 	void stop_log_file(LogType type);

--- a/src/modules/logger/util.h
+++ b/src/modules/logger/util.h
@@ -75,15 +75,6 @@ bool file_exist(const char *filename);
 int check_free_space(const char *log_root_dir, int32_t max_log_dirs_to_keep, orb_advert_t &mavlink_log_pub,
 		     int &sess_dir_index);
 
-/**
- * Get the time for log file name
- * @param tt returned time
- * @param utc_offset_sec UTC time offset [s]
- * @param boot_time use time when booted instead of current time
- * @return true on success, false otherwise (eg. if no gps)
- */
-bool get_log_time(struct tm *tt, int utc_offset_sec = 0, bool boot_time = false);
-
 } //namespace util
 } //namespace logger
 } //namespace px4


### PR DESCRIPTION
I want to use the events interface in mavsdk to detect when the logger starts/stops. This was suggested to me in https://github.com/mavlink/MAVSDK/pull/2383#issuecomment-2738188317 by @julianoes and I agree the events interface seems like a better mechanism than the SYS_STATUS sensor flags. I looked through the code and saw some room for improvement, so I started cleaning up and consolidating logic. The question I have for reviewers: do we need to have different events depending on if the log file name is in timestamp format vs session format?

```
			events::send<uint16_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t>(
				events::ID("logger_open_file_time"),
				events::Log::Info,
				"logging: opening log file {1}-{2}-{3}/{4}_{5}_{6}.ulg",
				year, month, day, hour, minute, second);
```
vs
```
			events::send<uint16_t, uint16_t>(
				events::ID("logger_open_file_sess"),
				events::Log::Info,
				"logging: opening log file sess{1}/log{2}.ulg",
				sess, log_index);
```
If we use a single event ID it's one less thing to think about on the mavsdk side. On that note, on the mavsdk side we'd just string match on event IDs.
