### PR TITLE
FW land detector: only use LNDFW_ROT_MAX if speeds are not valid

### DIFF
--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -121,7 +121,9 @@ bool FixedwingLandDetector::_get_landed_state()
 		const float vel_xy_max_threshold   = airspeed_invalid ? 0.7f * _param_lndfw_vel_xy_max.get() :
 						     _param_lndfw_vel_xy_max.get();
 
-		const float max_rotation_threshold = math::radians(_param_lndfw_rot_max.get()) ;
+		// only use the max rotational threshold if neither airspeed nor groundspeed can be used for landing detection
+		const float max_rotation_threshold = (!_vehicle_local_position.v_xy_valid
+						      && airspeed_invalid) ? math::radians(_param_lndfw_rot_max.get()) : INFINITY;
 
 		// Crude land detector for fixedwing.
 		landDetected = _airspeed_filtered         < _param_lndfw_airspd.get()

--- a/src/modules/land_detector/land_detector_params_fw.c
+++ b/src/modules/land_detector/land_detector_params_fw.c
@@ -107,6 +107,7 @@ PARAM_DEFINE_FLOAT(LNDFW_TRIG_TIME, 2.f);
  * Fixed-wing land detector: max rotational speed
  *
  * Maximum allowed norm of the angular velocity in the landed state.
+ * Only used if neither airspeed nor groundspeed can be used for landing detection.
  *
  * @unit deg/s
  * @decimal 1


### PR DESCRIPTION

### Solved Problem
Fixes [failed auto takeoff due to landed being false when started](https://discord.com/channels/1022170275984457759/1359063688958709862/1359473484555882506)
Takeoff is triggering easily if the plane is lifted prior to takeoff (hand-launch), and can cause issues for the auto takeoff state machine.

The rotational speed threshold on fixed-wing vehicles was added in https://github.com/PX4/PX4-Autopilot/pull/24133 with the intention to make it less error prone for airspeed-less vehicles to declare "land detected" due to invalid ground speed measurement (basically the land detector jumping to "landed" the instant you lose GPS e.g.).
What we didn't fully grasp in this moment was that a hand-launched vehicle will have a premature "takeoff detected" with that change, as when you hold the plane the rotational speed is similar to an in-flight condition, and thus not possible to use it robustly for land detection if one has to increase the threshold to account for the rotations during hand-launch.

### Solution
Only use LNDFW_ROT_MAX if neither airspeed nor groundspeed are valid. For the nominal setup/condition that means we have the same logic again as before https://github.com/PX4/PX4-Autopilot/pull/24133.

### Changelog Entry
For release notes:
```
Improvement:  FW land detector: only use LNDFW_ROT_MAX if speeds are not valid
```

### Alternatives
- always execute the takeoff, also when at moment of initialization landed=false
- rework FW launch/landing detection to have all in one place / combined state machine


We should port this fix also to release/1.16 after initial testing.
