### PR TITLE
SIH: write out vehicle type names for readability

### DIFF
--- a/src/modules/simulation/simulator_sih/sih.hpp
+++ b/src/modules/simulation/simulator_sih/sih.hpp
@@ -220,13 +220,9 @@ private:
 
 	float       _u[NUM_ACTUATORS_MAX] {};         // thruster signals
 
-	// MC = Multicopter
-	// FW = Fixed Wing
-	// TS = Tailsitter VTOL
-	// SVTOL = Standard VTOL
-	enum class VehicleType {MC, FW, TS, SVTOL};
+	enum class VehicleType {Multicopter, FixedWing, TailsitterVTOL, StandardVTOL};
 
-	VehicleType _vehicle = VehicleType::MC;
+	VehicleType _vehicle = VehicleType::Multicopter;
 
 	// aerodynamic segments for the fixedwing
 	AeroSeg _wing_l = AeroSeg(SPAN / 2.0f, MAC, -4.0f, matrix::Vector3f(0.0f, -SPAN / 4.0f, 0.0f), 3.0f,


### PR DESCRIPTION
### Solved Problem
When working on hexarotor things and checking how easy it would be to add such a vehicle to SIH I was wondering what `VehicleType::TS` is and after I found this:
https://github.com/PX4/PX4-Autopilot/blob/ff7c636065a26241766328562b33216ba737694e/src/modules/simulation/simulator_sih/sih.hpp#L223-L227
I couldn't help to just refactor the names for readability.

### Solution
I replaced all abbreviations with the name listed in the commit legend omitting spaces.

### Changelog Entry
```
Refactor: SIH simulator internal vehicle type naming
```

### Test coverage
Please review, no behavior change.