### PR TITLE
Update tools shebangs to python3

### DIFF
--- a/Tools/boot_now.py
+++ b/Tools/boot_now.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ############################################################################
 #
 #   Copyright (C) 2012-2015 PX4 Development Team. All rights reserved.

--- a/Tools/compress.py
+++ b/Tools/compress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import lzma

--- a/Tools/fetch_file.py
+++ b/Tools/fetch_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ############################################################################
 #
 #   Copyright (C) 2013-2014 PX4 Development Team. All rights reserved.
@@ -34,7 +34,7 @@
 
 """Fetch files via nsh console
 
-Usage: python fetch_file.py [-l] [-f] [-d device] [-s speed] [-o out_path] path
+Usage: python3 fetch_file.py [-l] [-f] [-d device] [-s speed] [-o out_path] path
 \t-l\tList files
 \t-f\tOverwrite existing files
 \t-d\tSerial device
@@ -134,7 +134,7 @@ def _get_files_in_dir(ser, path, path_out, force, timeout):
             _get_file(ser, path_fn, path_fn_out, force, timeout)
 
 def _usage():
-    print("""Usage: python fetch_file.py [-l] [-f] [-d device] [-s speed] [-o out_path] path
+    print("""Usage: python3 fetch_file.py [-l] [-f] [-d device] [-s speed] [-o out_path] path
 \t-l\tList files
 \t-f\tOverwrite existing files
 \t-d\tSerial device

--- a/Tools/geotag_images_ulog.py
+++ b/Tools/geotag_images_ulog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #######################################################################################
 #
 # DeltaTag: enhanced geo-referencing survey images
@@ -15,8 +15,8 @@
 # Note: DeltaTag does not make copies, it writes the Exif information directly to the images
 #
 # Install: pip install pyulog piexif Pillow numpy
-# Run: python geotag_images_ulog.py [logfile] [image dir] (optional offset)
-# eg: python geotag_images_ulog.py mylog.ulg ./images
+# Run: python3 geotag_images_ulog.py [logfile] [image dir] (optional offset)
+# eg: python3 geotag_images_ulog.py mylog.ulg ./images
 #
 # Parameters
 # logfile: a ulog formatted logfile containing camera_capture events (survey missions)
@@ -39,8 +39,8 @@ from fractions import Fraction
 
 
 if(len(sys.argv)) < 3:
-    print("Usage: python geotag_images_ulog.py [logfile] [image dir]")
-    print("Example: python geotag_images_ulog.py mylog.ulg ./images")
+    print("Usage: python3 geotag_images_ulog.py [logfile] [image dir]")
+    print("Example: python3 geotag_images_ulog.py mylog.ulg ./images")
     print(len(sys.argv))
     sys.exit()
 

--- a/Tools/package_firmware.py
+++ b/Tools/package_firmware.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import glob
 import zipfile

--- a/Tools/parameter_update.py
+++ b/Tools/parameter_update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 ############################################################################
@@ -55,7 +55,7 @@ Usage:
     The script needs a list of files as an input. To quickly find and feed all the file
     that it needs to inspect, one can simply pipe the result of a ripgrep -l command as follows:
 
-        rg -l '\.[gs]et\(|px4::params::' -tcpp | python parameter_update.py
+        rg -l '\.[gs]et\(|px4::params::' -tcpp | python3 parameter_update.py
 """
 
 import re

--- a/Tools/process_sensor_caldata.py
+++ b/Tools/process_sensor_caldata.py
@@ -23,7 +23,7 @@ Data can be gathered using the following sequence:
 5) Move to a warm dry, still air, constant pressure environment.
 6) Apply power for 45 minutes, keeping the board still.
 7) Remove power and extract the .ulog file
-8) Open a terminal window in the Firmware/Tools directory and run the python calibration script script file: 'python process_sensor_caldata.py <full path name to .ulog file>
+8) Open a terminal window in the Firmware/Tools directory and run the python calibration script script file: 'python3 process_sensor_caldata.py <full path name to .ulog file>
 9) Power the board, connect QGC and load the parameter from the generated .params file onto the board using QGC. Due to the number of parameters, loading them may take some time.
 10) TODO - we need a way for user to reliably tell when parameters have all been changed and saved.
 11) After parameters have finished loading, set SDLOG_MODE and SDLOG_PROFILE to their respective values prior to step 4) and remove power.

--- a/Tools/px4.py
+++ b/Tools/px4.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ############################################################################
 #
 #   Copyright (c) 2017-2020 PX4 Development Team. All rights reserved.

--- a/Tools/px_mkfw.py
+++ b/Tools/px_mkfw.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ############################################################################
 #
 #   Copyright (C) 2012, 2013 PX4 Development Team. All rights reserved.

--- a/Tools/px_process_airframes.py
+++ b/Tools/px_process_airframes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ############################################################################
 #
 #   Copyright (C) 2013-2017 PX4 Development Team. All rights reserved.

--- a/Tools/px_process_events.py
+++ b/Tools/px_process_events.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ############################################################################
 #
 #   Copyright (C) 2020 PX4 Development Team. All rights reserved.

--- a/Tools/px_process_module_doc.py
+++ b/Tools/px_process_module_doc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ############################################################################
 #
 #   Copyright (C) 2017 PX4 Development Team. All rights reserved.

--- a/Tools/px_romfs_pruner.py
+++ b/Tools/px_romfs_pruner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ############################################################################
 #
 #   Copyright (C) 2014-2018 PX4 Development Team. All rights reserved.

--- a/Tools/run-clang-tidy.py
+++ b/Tools/run-clang-tidy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #===- run-clang-tidy.py - Parallel clang-tidy runner ---------*- python -*--===#
 #

--- a/Tools/uorb_graph/create.py
+++ b/Tools/uorb_graph/create.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/Tools/validate_yaml.py
+++ b/Tools/validate_yaml.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 """ Script to validate YAML file(s) against a YAML schema file """
 
 from __future__ import print_function


### PR DESCRIPTION
### Solved Problem
There are a variety of different shebangs in the Tools python files. 

### Solution
- Update shebangs to python3

### Test coverage
- Tested running many of the python scripts. Many of the python scripts can now be run directly (i.e. `./Tools/px4.py` instead of `python3 Tools/px4.py`). There are no algorithmic changes to the scripts. 
