### PR TITLE
Fix typo in SPI signal table

### DIFF
--- a/docs/en/assembly/cable_wiring.md
+++ b/docs/en/assembly/cable_wiring.md
@@ -89,7 +89,7 @@ This protocol is commonly use is for connecting [optical flow](../sensor/optical
 | SCK    | ![black][blkcircle] Black | ![yellow][ycircle] Yellow |
 | MISO   | ![black][blkcircle] Black | ![blue][bluecircle] Blue  |
 | MOSI   | ![black][blkcircle] Black | ![green][gcircle] Green   |
-| CS!    | ![black][blkcircle] Black | ![white][wcircle] White   |
+| CS1    | ![black][blkcircle] Black | ![white][wcircle] White   |
 | CS2    | ![black][blkcircle] Black | ![blue][bluecircle] Blue  |
 | GND    | ![black][blkcircle] Black | ![black][blkcircle] Black |
 


### PR DESCRIPTION
Change CS! to CS1 in cable_wiring

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Fixed a typo in cable wiring documentation 
