### PR TITLE
[EKF2] Never skip post-takeoff mag yaw reset

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
@@ -210,9 +210,11 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 
 			if (continuing_conditions_passing && _control_status.flags.yaw_align) {
 
-				if (checkHaglYawResetReq() || (wmm_updated && no_ne_aiding_or_not_moving)) {
+				if ((checkHaglYawResetReq() && (_control_status.flags.mag_hdg || _control_status.flags.mag_3D))
+				    || (wmm_updated && no_ne_aiding_or_not_moving)) {
 					ECL_INFO("reset to %s", AID_SRC_NAME);
-					resetMagStates(_mag_lpf.getState(), _control_status.flags.mag_hdg || _control_status.flags.mag_3D);
+					const bool reset_heading = _control_status.flags.mag_hdg || _control_status.flags.mag_3D;
+					resetMagStates(_mag_lpf.getState(), reset_heading);
 					aid_src.time_last_fuse = imu_sample.time_us;
 
 				} else {
@@ -446,7 +448,7 @@ void Ekf::resetMagStates(const Vector3f &mag, bool reset_heading)
 	}
 
 	// record the start time for the magnetic field alignment
-	if (_control_status.flags.in_air) {
+	if (_control_status.flags.in_air && reset_heading) {
 		_control_status.flags.mag_aligned_in_flight = true;
 		_flt_mag_align_start_time = _time_delayed_us;
 	}


### PR DESCRIPTION
### Solved Problem
If the drone takes-off without mag aiding (i.e.: no mag_hdg nor mag_3D), the sanity reset at 1.5m after takeoff is skipped. It occurred that the checks are then passing because the error is pushed into the mag states and the heading is then not correctly reset, causing a large toilet bowl.

### Solution
Never skip the heading reset, even if mag (hdg or 3D) fusion only starts later in the flight.

Note that the logic starts to be a bit more complicated now and we might want to go through some cleanup again.

### Test coverage
SITL tested

