### PR TITLE
[boards] Do not start Mavlink on external connector by default

### DIFF
--- a/boards/auterion/fmu-v6s/init/rc.board_mavlink
+++ b/boards/auterion/fmu-v6s/init/rc.board_mavlink
@@ -3,7 +3,6 @@
 # Auterion FMUv6s specific board MAVLink startup script.
 #------------------------------------------------------------------------------
 
-# If skynode base board is detected start Mavlink on Telem2
 if param compare MAV_S_FORWARD 1
 then
 	set S_FORWARD "-f"
@@ -13,9 +12,6 @@ fi
 
 # TELEM1 is mapped to USART1 with flow control
 mavlink start -d /dev/ttyS0 -b 3000000 -r 290000 -m onboard_low_bandwidth -x -z $S_FORWARD
-
-# External mavlink on EXTRAS connector
-mavlink start -d /dev/ttyS2 -b 57600 -r 5000 -x
 
 # Ensure nothing else starts on TEL1
 set PRT_TEL1_ 1


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

We accidentally started a mavlink connection on the external UART, which should instead be configurable by parameters.

### Test coverage
- Tested on FMUv6s

