### PR TITLE
mc_att_control_main: fix check for hover thrust estimate update

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -224,7 +224,7 @@ MulticopterAttitudeControl::Run()
 	}
 
 	// Update hover thrust for stick scaling
-	if (_vehicle_status_sub.updated()) {
+	if (_hover_thrust_estimate_sub.updated()) {
 		hover_thrust_estimate_s hover_thrust_estimate;
 
 		if (_hover_thrust_estimate_sub.update(&hover_thrust_estimate)) {


### PR DESCRIPTION
### Solved Problem
When working on https://github.com/PX4/PX4-Autopilot/pull/24710 together with @dawr68 I added some suggestions and admittedly did this mistake which was apparently not found in review. It doesn't blow things up because the vehicle status is also regularly updated but it's of course completely wrong and hence worst a separate pr to fix.

See https://github.com/PX4/PX4-Autopilot/pull/24710/files#r2054448109

### Solution
Updating the hover thrust estimate should be dependent on the correct topic's update.

### Test coverage
I just found this while following up on reducing the parameter options like we discussed in the dev call. So it's purely based on reading the code again.