### PR TITLE
FixedWingModeManager: Fix configuration handler corner cases

### DIFF
--- a/src/modules/fw_mode_manager/ControllerConfigurationHandler.cpp
+++ b/src/modules/fw_mode_manager/ControllerConfigurationHandler.cpp
@@ -132,3 +132,8 @@ void CombinedControllerConfigurationHandler::setEnforceLowHeightCondition(bool l
 {
 	_longitudinal_configuration_current_cycle.enforce_low_height_condition = low_height_condition;
 }
+
+void CombinedControllerConfigurationHandler::resetLastPublishTime()
+{
+	_time_last_longitudinal_publish = _time_last_lateral_publish = 0;
+}

--- a/src/modules/fw_mode_manager/ControllerConfigurationHandler.hpp
+++ b/src/modules/fw_mode_manager/ControllerConfigurationHandler.hpp
@@ -75,6 +75,8 @@ public:
 
 	void setLateralAccelMax(float lateral_accel_max);
 
+	void resetLastPublishTime();
+
 private:
 	bool booleanValueChanged(bool new_value, bool current_value)
 	{


### PR DESCRIPTION
- after an external mode has been running, publish immediately after taking over
- don't publish when we are not in control, e.g. when in hover mode