### PR TITLE
fix: use COM_POSCTL_NAVL failsafe action for Position Slow mode too

### DIFF
--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -661,8 +661,9 @@ FailsafeBase::Action Failsafe::checkModeFallback(const failsafe_flags_s &status_
 	switch (position_control_navigation_loss_response(_param_com_posctl_navl.get())) {
 	case position_control_navigation_loss_response::Altitude_Manual: // AltCtrl/Manual
 
-		// PosCtrl -> AltCtrl
-		if (user_intended_mode == vehicle_status_s::NAVIGATION_STATE_POSCTL
+		// PosCtrl/PositionSlow -> AltCtrl
+		if ((user_intended_mode == vehicle_status_s::NAVIGATION_STATE_POSCTL ||
+		     user_intended_mode == vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW)
 		    && !modeCanRun(status_flags, user_intended_mode)) {
 			action = Action::FallbackAltCtrl;
 			user_intended_mode = vehicle_status_s::NAVIGATION_STATE_ALTCTL;
@@ -679,8 +680,9 @@ FailsafeBase::Action Failsafe::checkModeFallback(const failsafe_flags_s &status_
 
 	case position_control_navigation_loss_response::Land_Descend: // Land/Terminate
 
-		// PosCtrl -> Land
-		if (user_intended_mode == vehicle_status_s::NAVIGATION_STATE_POSCTL
+		// PosCtrl/PositionSlow -> Land
+		if ((user_intended_mode == vehicle_status_s::NAVIGATION_STATE_POSCTL ||
+		     user_intended_mode == vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW)
 		    && !modeCanRun(status_flags, user_intended_mode)) {
 			action = Action::Land;
 			user_intended_mode = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;


### PR DESCRIPTION
### Solved problem

[COM_POSCTL_NAVL](https://docs.px4.io/main/en/advanced_config/parameter_reference.html#COM_POSCTL_NAVL) decides which mode to fall back to upon navigation loss. Navigation loss can be caused eg by stopping the gps module in the MAVLink console. The if statement only catches Position mode, so when flying in Position Slow mode, the fallback is not the mode specified by COM_POSCTL_NAVL (Altitude mode by default) but Descend.

### Solution
Also trigger the if statement when in Position Slow mode.

### Test coverage
Tested fix with SIH on Freefly Systems Astro. Triggered navigation loss by setting EKF2_GPS_CTRL to 0.