### PR TITLE
Cleanup: Navigator: Vehicle command refactor, FlightTaskAuto: parameter clarification

### DIFF
--- a/docs/en/camera/camera_architecture.md
+++ b/docs/en/camera/camera_architecture.md
@@ -88,9 +88,9 @@ Commands supported in missions, including camera commands, are shown in these me
   - Mission items are executed when set active.
   - `issue_command(_mission_item)` is called at the end of this to send the current non-waypoint command
     - [`MissionBlock::issue_command(const mission_item_s &item)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562)
-      - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(&vehicle_command);`)
-        - [`void Navigator::publish_vehicle_command(vehicle_command_s *vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
-          - For some camera commands it sets the component ID to the camera component id (`vehicle_command->target_component = 100; // MAV_COMP_ID_CAMERA`)
+      - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(vehicle_command);`)
+        - [`void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
+          - For some camera commands it sets the component ID to the camera component id (`vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA`)
           - All others just get published to default component ID.
           - The `VehicleCommand` UORB topic is published.
 

--- a/docs/en/camera/camera_architecture.md
+++ b/docs/en/camera/camera_architecture.md
@@ -88,9 +88,9 @@ Commands supported in missions, including camera commands, are shown in these me
   - Mission items are executed when set active.
   - `issue_command(_mission_item)` is called at the end of this to send the current non-waypoint command
     - [`MissionBlock::issue_command(const mission_item_s &item)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562)
-      - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(&vcmd);`)
-        - [`void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
-          - For some camera commands it sets the component ID to the camera component id (`vcmd->target_component = 100; // MAV_COMP_ID_CAMERA`)
+      - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(&vehicle_command);`)
+        - [`void Navigator::publish_vehicle_command(vehicle_command_s *vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
+          - For some camera commands it sets the component ID to the camera component id (`vehicle_command->target_component = 100; // MAV_COMP_ID_CAMERA`)
           - All others just get published to default component ID.
           - The `VehicleCommand` UORB topic is published.
 

--- a/docs/en/camera/camera_architecture.md
+++ b/docs/en/camera/camera_architecture.md
@@ -88,8 +88,8 @@ Commands supported in missions, including camera commands, are shown in these me
   - Mission items are executed when set active.
   - `issue_command(_mission_item)` is called at the end of this to send the current non-waypoint command
     - [`MissionBlock::issue_command(const mission_item_s &item)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562)
-      - Creates a vehicle command for the mission item then calls `publish_vehicle_cmd` to publish it (`_navigator->publish_vehicle_cmd(&vcmd);`)
-        - [`void Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
+      - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(&vcmd);`)
+        - [`void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
           - For some camera commands it sets the component ID to the camera component id (`vcmd->target_component = 100; // MAV_COMP_ID_CAMERA`)
           - All others just get published to default component ID.
           - The `VehicleCommand` UORB topic is published.

--- a/docs/en/camera/camera_architecture.md
+++ b/docs/en/camera/camera_architecture.md
@@ -89,7 +89,7 @@ Commands supported in missions, including camera commands, are shown in these me
   - `issue_command(_mission_item)` is called at the end of this to send the current non-waypoint command
     - [`MissionBlock::issue_command(const mission_item_s &item)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562)
       - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(vehicle_command);`)
-        - [`void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
+        - [`void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1395)
           - For some camera commands it sets the component ID to the camera component id (`vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA`)
           - All others just get published to default component ID.
           - The `VehicleCommand` UORB topic is published.

--- a/docs/en/camera/mavlink_v2_camera.md
+++ b/docs/en/camera/mavlink_v2_camera.md
@@ -83,11 +83,11 @@ void Mission::setActiveMissionItems() => https://github.com/PX4/PX4-Autopilot/bl
 Issuing command:
 MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562
   At end this publishes the current vehicle command
-  _navigator->publish_vehicle_command(&vcmd);
+  _navigator->publish_vehicle_command(&vehicle_command);
 
 Publishing command:
-void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
-  For camera commands set to vcmd->target_component = 100; // MAV_COMP_ID_CAMERA
+void Navigator::publish_vehicle_command(vehicle_command_s *vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+  For camera commands set to vehicle_command->target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->
 

--- a/docs/en/camera/mavlink_v2_camera.md
+++ b/docs/en/camera/mavlink_v2_camera.md
@@ -83,11 +83,11 @@ void Mission::setActiveMissionItems() => https://github.com/PX4/PX4-Autopilot/bl
 Issuing command:
 MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562
   At end this publishes the current vehicle command
-  _navigator->publish_vehicle_command(&vehicle_command);
+  _navigator.publish_vehicle_command(vehicle_command);
 
 Publishing command:
-void Navigator::publish_vehicle_command(vehicle_command_s *vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
-  For camera commands set to vehicle_command->target_component = 100; // MAV_COMP_ID_CAMERA
+void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+  For camera commands set to vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->
 

--- a/docs/en/camera/mavlink_v2_camera.md
+++ b/docs/en/camera/mavlink_v2_camera.md
@@ -86,7 +86,7 @@ MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/P
   _navigator.publish_vehicle_command(vehicle_command);
 
 Publishing command:
-void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1395
   For camera commands set to vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->

--- a/docs/en/camera/mavlink_v2_camera.md
+++ b/docs/en/camera/mavlink_v2_camera.md
@@ -83,10 +83,10 @@ void Mission::setActiveMissionItems() => https://github.com/PX4/PX4-Autopilot/bl
 Issuing command:
 MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562
   At end this publishes the current vehicle command
-  _navigator->publish_vehicle_cmd(&vcmd);
+  _navigator->publish_vehicle_command(&vcmd);
 
 Publishing command:
-void Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
   For camera commands set to vcmd->target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->

--- a/docs/ko/camera/camera_architecture.md
+++ b/docs/ko/camera/camera_architecture.md
@@ -88,9 +88,9 @@ Commands supported in missions, including camera commands, are shown in these me
   - Mission items are executed when set active.
   - `issue_command(_mission_item)` is called at the end of this to send the current non-waypoint command
     - [`MissionBlock::issue_command(const mission_item_s &item)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562)
-      - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(&vehicle_command);`)
-        - [`void Navigator::publish_vehicle_command(vehicle_command_s *vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
-          - For some camera commands it sets the component ID to the camera component id (`vehicle_command->target_component = 100; // MAV_COMP_ID_CAMERA`)
+      - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(vehicle_command);`)
+        - [`void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
+          - For some camera commands it sets the component ID to the camera component id (`vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA`)
           - All others just get published to default component ID.
           - The `VehicleCommand` UORB topic is published.
 

--- a/docs/ko/camera/camera_architecture.md
+++ b/docs/ko/camera/camera_architecture.md
@@ -88,9 +88,9 @@ Commands supported in missions, including camera commands, are shown in these me
   - Mission items are executed when set active.
   - `issue_command(_mission_item)` is called at the end of this to send the current non-waypoint command
     - [`MissionBlock::issue_command(const mission_item_s &item)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562)
-      - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(&vcmd);`)
-        - [`void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
-          - For some camera commands it sets the component ID to the camera component id (`vcmd->target_component = 100; // MAV_COMP_ID_CAMERA`)
+      - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(&vehicle_command);`)
+        - [`void Navigator::publish_vehicle_command(vehicle_command_s *vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
+          - For some camera commands it sets the component ID to the camera component id (`vehicle_command->target_component = 100; // MAV_COMP_ID_CAMERA`)
           - All others just get published to default component ID.
           - The `VehicleCommand` UORB topic is published.
 

--- a/docs/ko/camera/camera_architecture.md
+++ b/docs/ko/camera/camera_architecture.md
@@ -88,8 +88,8 @@ Commands supported in missions, including camera commands, are shown in these me
   - Mission items are executed when set active.
   - `issue_command(_mission_item)` is called at the end of this to send the current non-waypoint command
     - [`MissionBlock::issue_command(const mission_item_s &item)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562)
-      - Creates a vehicle command for the mission item then calls `publish_vehicle_cmd` to publish it (`_navigator->publish_vehicle_cmd(&vcmd);`)
-        - [`void Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
+      - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(&vcmd);`)
+        - [`void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
           - For some camera commands it sets the component ID to the camera component id (`vcmd->target_component = 100; // MAV_COMP_ID_CAMERA`)
           - All others just get published to default component ID.
           - The `VehicleCommand` UORB topic is published.

--- a/docs/ko/camera/camera_architecture.md
+++ b/docs/ko/camera/camera_architecture.md
@@ -89,7 +89,7 @@ Commands supported in missions, including camera commands, are shown in these me
   - `issue_command(_mission_item)` is called at the end of this to send the current non-waypoint command
     - [`MissionBlock::issue_command(const mission_item_s &item)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562)
       - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(vehicle_command);`)
-        - [`void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
+        - [`void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1395)
           - For some camera commands it sets the component ID to the camera component id (`vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA`)
           - All others just get published to default component ID.
           - The `VehicleCommand` UORB topic is published.

--- a/docs/ko/camera/mavlink_v2_camera.md
+++ b/docs/ko/camera/mavlink_v2_camera.md
@@ -83,11 +83,11 @@ void Mission::setActiveMissionItems() => https://github.com/PX4/PX4-Autopilot/bl
 Issuing command:
 MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562
   At end this publishes the current vehicle command
-  _navigator->publish_vehicle_command(&vcmd);
+  _navigator->publish_vehicle_command(vehicle_command);
 
 Publishing command:
-void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
-  For camera commands set to vcmd->target_component = 100; // MAV_COMP_ID_CAMERA
+void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+  For camera commands set to vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->
 

--- a/docs/ko/camera/mavlink_v2_camera.md
+++ b/docs/ko/camera/mavlink_v2_camera.md
@@ -86,7 +86,7 @@ MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/P
   _navigator->publish_vehicle_command(vehicle_command);
 
 Publishing command:
-void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1395
   For camera commands set to vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->

--- a/docs/ko/camera/mavlink_v2_camera.md
+++ b/docs/ko/camera/mavlink_v2_camera.md
@@ -83,10 +83,10 @@ void Mission::setActiveMissionItems() => https://github.com/PX4/PX4-Autopilot/bl
 Issuing command:
 MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562
   At end this publishes the current vehicle command
-  _navigator->publish_vehicle_cmd(&vcmd);
+  _navigator->publish_vehicle_command(&vcmd);
 
 Publishing command:
-void Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
   For camera commands set to vcmd->target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->

--- a/docs/uk/camera/camera_architecture.md
+++ b/docs/uk/camera/camera_architecture.md
@@ -88,8 +88,8 @@ PX4 повторно видає пункти камери, знайдені в �
   - Предмети місії виконуються, коли вони активовані.
   - `issue_command(_mission_item)` викликається в кінці цього, щоб відправити поточну непунктову команду
     - [`MissionBlock::видача_команди(const mission_item_s &item)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562)
-      - Створює команду для місії транспортного засобу, а потім викликає `publish_vehicle_cmd` для публікації її (`_navigator->publish_vehicle_cmd(&vcmd);`)
-        - [`void Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
+      - Створює команду для місії транспортного засобу, а потім викликає `publish_vehicle_command` для публікації її (`_navigator->publish_vehicle_command(&vcmd);`)
+        - [`void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
           - Для деяких команд камери це встановлює ідентифікатор компонента на ідентифікатор компонента камери (`vcmd->target_component = 100; // MAV_COMP_ID_CAMERA`)
           - Усі інші просто публікуються під стандартний компонент ID.
           - Тема UORB `VehicleCommand` публікується.

--- a/docs/uk/camera/camera_architecture.md
+++ b/docs/uk/camera/camera_architecture.md
@@ -89,7 +89,7 @@ PX4 повторно видає пункти камери, знайдені в �
   - `issue_command(_mission_item)` викликається в кінці цього, щоб відправити поточну непунктову команду
     - [`MissionBlock::видача_команди(const mission_item_s &item)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562)
       - Створює команду для місії транспортного засобу, а потім викликає `publish_vehicle_command` для публікації її (`_navigator->publish_vehicle_command(vehicle_command);`)
-        - [`void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
+        - [`void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1395)
           - Для деяких команд камери це встановлює ідентифікатор компонента на ідентифікатор компонента камери (`vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA`)
           - Усі інші просто публікуються під стандартний компонент ID.
           - Тема UORB `VehicleCommand` публікується.

--- a/docs/uk/camera/camera_architecture.md
+++ b/docs/uk/camera/camera_architecture.md
@@ -88,9 +88,9 @@ PX4 повторно видає пункти камери, знайдені в �
   - Предмети місії виконуються, коли вони активовані.
   - `issue_command(_mission_item)` викликається в кінці цього, щоб відправити поточну непунктову команду
     - [`MissionBlock::видача_команди(const mission_item_s &item)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562)
-      - Створює команду для місії транспортного засобу, а потім викликає `publish_vehicle_command` для публікації її (`_navigator->publish_vehicle_command(&vcmd);`)
-        - [`void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
-          - Для деяких команд камери це встановлює ідентифікатор компонента на ідентифікатор компонента камери (`vcmd->target_component = 100; // MAV_COMP_ID_CAMERA`)
+      - Створює команду для місії транспортного засобу, а потім викликає `publish_vehicle_command` для публікації її (`_navigator->publish_vehicle_command(vehicle_command);`)
+        - [`void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
+          - Для деяких команд камери це встановлює ідентифікатор компонента на ідентифікатор компонента камери (`vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA`)
           - Усі інші просто публікуються під стандартний компонент ID.
           - Тема UORB `VehicleCommand` публікується.
 

--- a/docs/uk/camera/mavlink_v2_camera.md
+++ b/docs/uk/camera/mavlink_v2_camera.md
@@ -83,11 +83,11 @@ void Mission::setActiveMissionItems() => https://github.com/PX4/PX4-Autopilot/bl
 Issuing command:
 MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562
   At end this publishes the current vehicle command
-  _navigator->publish_vehicle_command(&vcmd);
+  _navigator->publish_vehicle_command(&vehicle_command);
 
 Publishing command:
-void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
-  For camera commands set to vcmd->target_component = 100; // MAV_COMP_ID_CAMERA
+void Navigator::publish_vehicle_command(vehicle_command_s *vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+  For camera commands set to vehicle_command->target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->
 

--- a/docs/uk/camera/mavlink_v2_camera.md
+++ b/docs/uk/camera/mavlink_v2_camera.md
@@ -86,8 +86,8 @@ MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/P
   _navigator->publish_vehicle_command(&vehicle_command);
 
 Publishing command:
-void Navigator::publish_vehicle_command(vehicle_command_s *vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
-  For camera commands set to vehicle_command->target_component = 100; // MAV_COMP_ID_CAMERA
+void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+  For camera commands set to vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->
 

--- a/docs/uk/camera/mavlink_v2_camera.md
+++ b/docs/uk/camera/mavlink_v2_camera.md
@@ -83,10 +83,10 @@ void Mission::setActiveMissionItems() => https://github.com/PX4/PX4-Autopilot/bl
 Issuing command:
 MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562
   At end this publishes the current vehicle command
-  _navigator->publish_vehicle_cmd(&vcmd);
+  _navigator->publish_vehicle_command(&vcmd);
 
 Publishing command:
-void Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
   For camera commands set to vcmd->target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->

--- a/docs/uk/camera/mavlink_v2_camera.md
+++ b/docs/uk/camera/mavlink_v2_camera.md
@@ -86,7 +86,7 @@ MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/P
   _navigator->publish_vehicle_command(&vehicle_command);
 
 Publishing command:
-void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1395
   For camera commands set to vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->

--- a/docs/zh/camera/camera_architecture.md
+++ b/docs/zh/camera/camera_architecture.md
@@ -88,8 +88,8 @@ Commands supported in missions, including camera commands, are shown in these me
   - Mission items are executed when set active.
   - `issue_command(_mission_item)` is called at the end of this to send the current non-waypoint command
     - [`MissionBlock::issue_command(const mission_item_s &item)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562)
-      - Creates a vehicle command for the mission item then calls `publish_vehicle_cmd` to publish it (`_navigator->publish_vehicle_cmd(&vcmd);`)
-        - [`void Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
+      - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(&vcmd);`)
+        - [`void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
           - For some camera commands it sets the component ID to the camera component id (`vcmd->target_component = 100; // MAV_COMP_ID_CAMERA`)
           - All others just get published to default component ID.
           - The `VehicleCommand` UORB topic is published.

--- a/docs/zh/camera/camera_architecture.md
+++ b/docs/zh/camera/camera_architecture.md
@@ -88,9 +88,9 @@ Commands supported in missions, including camera commands, are shown in these me
   - Mission items are executed when set active.
   - `issue_command(_mission_item)` is called at the end of this to send the current non-waypoint command
     - [`MissionBlock::issue_command(const mission_item_s &item)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562)
-      - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(&vcmd);`)
-        - [`void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
-          - For some camera commands it sets the component ID to the camera component id (`vcmd->target_component = 100; // MAV_COMP_ID_CAMERA`)
+      - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(vehicle_command);`)
+        - [`void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
+          - For some camera commands it sets the component ID to the camera component id (`vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA`)
           - All others just get published to default component ID.
           - The `VehicleCommand` UORB topic is published.
 

--- a/docs/zh/camera/camera_architecture.md
+++ b/docs/zh/camera/camera_architecture.md
@@ -89,7 +89,7 @@ Commands supported in missions, including camera commands, are shown in these me
   - `issue_command(_mission_item)` is called at the end of this to send the current non-waypoint command
     - [`MissionBlock::issue_command(const mission_item_s &item)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562)
       - Creates a vehicle command for the mission item then calls `publish_vehicle_command` to publish it (`_navigator->publish_vehicle_command(vehicle_command);`)
-        - [`void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358)
+        - [`void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1395)
           - For some camera commands it sets the component ID to the camera component id (`vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA`)
           - All others just get published to default component ID.
           - The `VehicleCommand` UORB topic is published.

--- a/docs/zh/camera/mavlink_v2_camera.md
+++ b/docs/zh/camera/mavlink_v2_camera.md
@@ -83,11 +83,11 @@ void Mission::setActiveMissionItems() => https://github.com/PX4/PX4-Autopilot/bl
 Issuing command:
 MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562
   At end this publishes the current vehicle command
-  _navigator->publish_vehicle_command(&vcmd);
+  _navigator->publish_vehicle_command(&vehicle_command);
 
 Publishing command:
-void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
-  For camera commands set to vcmd->target_component = 100; // MAV_COMP_ID_CAMERA
+void Navigator::publish_vehicle_command(vehicle_command_s *vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+  For camera commands set to vehicle_command->target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->
 

--- a/docs/zh/camera/mavlink_v2_camera.md
+++ b/docs/zh/camera/mavlink_v2_camera.md
@@ -86,7 +86,7 @@ MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/P
   _navigator->publish_vehicle_command(vehicle_command);
 
 Publishing command:
-void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1395
   For camera commands set to vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->

--- a/docs/zh/camera/mavlink_v2_camera.md
+++ b/docs/zh/camera/mavlink_v2_camera.md
@@ -83,11 +83,11 @@ void Mission::setActiveMissionItems() => https://github.com/PX4/PX4-Autopilot/bl
 Issuing command:
 MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562
   At end this publishes the current vehicle command
-  _navigator->publish_vehicle_command(&vehicle_command);
+  _navigator->publish_vehicle_command(vehicle_command);
 
 Publishing command:
-void Navigator::publish_vehicle_command(vehicle_command_s *vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
-  For camera commands set to vehicle_command->target_component = 100; // MAV_COMP_ID_CAMERA
+void Navigator::publish_vehicle_command(vehicle_command_s &vehicle_command)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+  For camera commands set to vehicle_command.target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->
 

--- a/docs/zh/camera/mavlink_v2_camera.md
+++ b/docs/zh/camera/mavlink_v2_camera.md
@@ -83,10 +83,10 @@ void Mission::setActiveMissionItems() => https://github.com/PX4/PX4-Autopilot/bl
 Issuing command:
 MissionBlock::issue_command(const mission_item_s &item) =>  https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/mission_block.cpp#L543-L562
   At end this publishes the current vehicle command
-  _navigator->publish_vehicle_cmd(&vcmd);
+  _navigator->publish_vehicle_command(&vcmd);
 
 Publishing command:
-void Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
+void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)  => https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/navigator_main.cpp#L1358
   For camera commands set to vcmd->target_component = 100; // MAV_COMP_ID_CAMERA
   All others just get published as-is
 -->

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -235,7 +235,7 @@ void FlightTaskAuto::_prepareLandSetpoints()
 	bool range_dist_available = PX4_ISFINITE(_dist_to_bottom);
 
 	if (range_dist_available && _dist_to_bottom <= _param_mpc_land_alt3.get()) {
-		vertical_speed = _param_mpc_land_crawl_speed.get();
+		vertical_speed = _param_mpc_land_crwl.get();
 	}
 
 	if (_type_previous != WaypointType::land) {

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -165,20 +165,16 @@ protected:
 					(ParamFloat<px4::params::MPC_XY_TRAJ_P>) _param_mpc_xy_traj_p,
 					(ParamFloat<px4::params::MPC_XY_ERR_MAX>) _param_mpc_xy_err_max,
 					(ParamFloat<px4::params::MPC_LAND_SPEED>) _param_mpc_land_speed,
-					(ParamFloat<px4::params::MPC_LAND_CRWL>) _param_mpc_land_crawl_speed,
+					(ParamFloat<px4::params::MPC_LAND_CRWL>) _param_mpc_land_crwl,
 					(ParamInt<px4::params::MPC_LAND_RC_HELP>) _param_mpc_land_rc_help,
 					(ParamFloat<px4::params::MPC_LAND_RADIUS>) _param_mpc_land_radius,
-					(ParamFloat<px4::params::MPC_LAND_ALT1>)
-					_param_mpc_land_alt1, // altitude at which we start ramping down speed
-					(ParamFloat<px4::params::MPC_LAND_ALT2>)
-					_param_mpc_land_alt2, // altitude at which we descend at land speed
-					(ParamFloat<px4::params::MPC_LAND_ALT3>)
-					_param_mpc_land_alt3, // altitude where we switch to crawl speed, if LIDAR available
+					(ParamFloat<px4::params::MPC_LAND_ALT1>) _param_mpc_land_alt1,
+					(ParamFloat<px4::params::MPC_LAND_ALT2>) _param_mpc_land_alt2,
+					(ParamFloat<px4::params::MPC_LAND_ALT3>) _param_mpc_land_alt3,
 					(ParamFloat<px4::params::MPC_Z_V_AUTO_UP>) _param_mpc_z_v_auto_up,
 					(ParamFloat<px4::params::MPC_Z_V_AUTO_DN>) _param_mpc_z_v_auto_dn,
 					(ParamFloat<px4::params::MPC_TKO_SPEED>) _param_mpc_tko_speed,
-					(ParamFloat<px4::params::MPC_TKO_RAMP_T>)
-					_param_mpc_tko_ramp_t // time constant for smooth takeoff ramp
+					(ParamFloat<px4::params::MPC_TKO_RAMP_T>) _param_mpc_tko_ramp_t
 				       );
 
 private:

--- a/src/modules/mc_pos_control/multicopter_takeoff_land_params.c
+++ b/src/modules/mc_pos_control/multicopter_takeoff_land_params.c
@@ -89,9 +89,8 @@ PARAM_DEFINE_FLOAT(MPC_LAND_ALT2, 5.f);
 /**
  * Altitude for 3. step of slow landing
  *
- * Below this altitude descending velocity gets
- * limited to "MPC_LAND_CRWL", if LIDAR available.
- * No effect if LIDAR not available
+ * If a valid distance sensor measurement to the ground is available,
+ * limit descending velocity to "MPC_LAND_CRWL" below this altitude.
  *
  * @unit m
  * @min 0

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -111,8 +111,8 @@ Land::on_active()
 		// send reposition cmd to get out of land mode (will loiter at current position and altitude)
 		vehicle_command_s vehicle_command{};
 		vehicle_command.command = vehicle_command_s::VEHICLE_CMD_DO_REPOSITION;
-		vehicle_command.param1 = -1;
-		vehicle_command.param2 = 1;
+		vehicle_command.param1 = -1.f; // Default speed
+		vehicle_command.param2 = 1.f; // Modes should switch, not setting this is unsupported
 		vehicle_command.param5 = _navigator->get_global_position()->lat;
 		vehicle_command.param6 = _navigator->get_global_position()->lon;
 		// as we don't know the landing point altitude assume the worst case (abort at 0m above ground),

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -119,6 +119,6 @@ Land::on_active()
 		// and thus always climb MIS_LND_ABRT_ALT
 		vehicle_command.param7 = _navigator->get_global_position()->alt + _navigator->get_landing_abort_min_alt();
 
-		_navigator->publish_vehicle_command(&vehicle_command);
+		_navigator->publish_vehicle_command(vehicle_command);
 	}
 }

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -109,17 +109,16 @@ Land::on_active()
 	if (_navigator->abort_landing()) {
 
 		// send reposition cmd to get out of land mode (will loiter at current position and altitude)
-		vehicle_command_s vcmd = {};
-
-		vcmd.command = vehicle_command_s::VEHICLE_CMD_DO_REPOSITION;
-		vcmd.param1 = -1;
-		vcmd.param2 = 1;
-		vcmd.param5 = _navigator->get_global_position()->lat;
-		vcmd.param6 = _navigator->get_global_position()->lon;
+		vehicle_command_s vehicle_command{};
+		vehicle_command.command = vehicle_command_s::VEHICLE_CMD_DO_REPOSITION;
+		vehicle_command.param1 = -1;
+		vehicle_command.param2 = 1;
+		vehicle_command.param5 = _navigator->get_global_position()->lat;
+		vehicle_command.param6 = _navigator->get_global_position()->lon;
 		// as we don't know the landing point altitude assume the worst case (abort at 0m above ground),
 		// and thus always climb MIS_LND_ABRT_ALT
-		vcmd.param7 = _navigator->get_global_position()->alt + _navigator->get_landing_abort_min_alt();
+		vehicle_command.param7 = _navigator->get_global_position()->alt + _navigator->get_landing_abort_min_alt();
 
-		_navigator->publish_vehicle_command(&vcmd);
+		_navigator->publish_vehicle_command(&vehicle_command);
 	}
 }

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -120,6 +120,6 @@ Land::on_active()
 		// and thus always climb MIS_LND_ABRT_ALT
 		vcmd.param7 = _navigator->get_global_position()->alt + _navigator->get_landing_abort_min_alt();
 
-		_navigator->publish_vehicle_cmd(&vcmd);
+		_navigator->publish_vehicle_command(&vcmd);
 	}
 }

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -917,8 +917,8 @@ MissionBase::do_abort_landing()
 	// send reposition cmd to get out of mission
 	vehicle_command_s vehicle_command{};
 	vehicle_command.command = vehicle_command_s::VEHICLE_CMD_DO_REPOSITION;
-	vehicle_command.param1 = -1;
-	vehicle_command.param2 = 1;
+	vehicle_command.param1 = -1.f; // Default speed
+	vehicle_command.param2 = 1.f; // Modes should switch, not setting this is unsupported
 	vehicle_command.param5 = _mission_item.lat;
 	vehicle_command.param6 = _mission_item.lon;
 	vehicle_command.param7 = alt_sp;

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -922,7 +922,7 @@ MissionBase::do_abort_landing()
 	vehicle_command.param5 = _mission_item.lat;
 	vehicle_command.param6 = _mission_item.lon;
 	vehicle_command.param7 = alt_sp;
-	_navigator->publish_vehicle_command(&vehicle_command);
+	_navigator->publish_vehicle_command(vehicle_command);
 }
 
 void MissionBase::publish_navigator_mission_item()

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -924,7 +924,7 @@ MissionBase::do_abort_landing()
 	vcmd.param6 = _mission_item.lon;
 	vcmd.param7 = alt_sp;
 
-	_navigator->publish_vehicle_cmd(&vcmd);
+	_navigator->publish_vehicle_command(&vcmd);
 }
 
 void MissionBase::publish_navigator_mission_item()

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -915,16 +915,14 @@ MissionBase::do_abort_landing()
 	}
 
 	// send reposition cmd to get out of mission
-	vehicle_command_s vcmd = {};
-
-	vcmd.command = vehicle_command_s::VEHICLE_CMD_DO_REPOSITION;
-	vcmd.param1 = -1;
-	vcmd.param2 = 1;
-	vcmd.param5 = _mission_item.lat;
-	vcmd.param6 = _mission_item.lon;
-	vcmd.param7 = alt_sp;
-
-	_navigator->publish_vehicle_command(&vcmd);
+	vehicle_command_s vehicle_command{};
+	vehicle_command.command = vehicle_command_s::VEHICLE_CMD_DO_REPOSITION;
+	vehicle_command.param1 = -1;
+	vehicle_command.param2 = 1;
+	vehicle_command.param5 = _mission_item.lat;
+	vehicle_command.param6 = _mission_item.lon;
+	vehicle_command.param7 = alt_sp;
+	_navigator->publish_vehicle_command(&vehicle_command);
 }
 
 void MissionBase::publish_navigator_mission_item()

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -784,7 +784,7 @@ MissionBlock::set_land_item(struct mission_item_s *item)
 		vehicle_command_s vehicle_command{};
 		vehicle_command.command = NAV_CMD_DO_VTOL_TRANSITION;
 		vehicle_command.param1 = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
-		vehicle_command.param2 = 0.0f;
+		vehicle_command.param2 = 0.f; // normal unforced transition
 		_navigator->publish_vehicle_command(&vehicle_command);
 	}
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -529,27 +529,27 @@ MissionBlock::issue_command(const mission_item_s &item)
 
 	// Mission item's NAV_CMD enums directly map to the according vehicle command
 	// So set the raw value directly (MAV_FRAME_MISSION mission item)
-	vehicle_command_s vcmd = {};
-	vcmd.command = item.nav_cmd;
-	vcmd.param1 = item.params[0];
-	vcmd.param2 = item.params[1];
-	vcmd.param3 = item.params[2];
-	vcmd.param4 = item.params[3];
-	vcmd.param5 = static_cast<double>(item.params[4]);
-	vcmd.param6 = static_cast<double>(item.params[5]);
-	vcmd.param7 = item.params[6];
+	vehicle_command_s vehicle_command{};
+	vehicle_command.command = item.nav_cmd;
+	vehicle_command.param1 = item.params[0];
+	vehicle_command.param2 = item.params[1];
+	vehicle_command.param3 = item.params[2];
+	vehicle_command.param4 = item.params[3];
+	vehicle_command.param5 = static_cast<double>(item.params[4]);
+	vehicle_command.param6 = static_cast<double>(item.params[5]);
+	vehicle_command.param7 = item.params[6];
 
 	if (item.nav_cmd == NAV_CMD_DO_SET_ROI_LOCATION) {
 		// We need to send out the ROI location that was parsed potentially with double precision to lat/lon because mission item parameters 5 and 6 only have float precision
-		vcmd.param5 = item.lat;
-		vcmd.param6 = item.lon;
+		vehicle_command.param5 = item.lat;
+		vehicle_command.param6 = item.lon;
 
 		if (item.altitude_is_relative) {
-			vcmd.param7 = item.altitude + _navigator->get_home_position()->alt;
+			vehicle_command.param7 = item.altitude + _navigator->get_home_position()->alt;
 		}
 	}
 
-	_navigator->publish_vehicle_command(&vcmd);
+	_navigator->publish_vehicle_command(&vehicle_command);
 
 	if (item_has_timeout(item)) {
 		_timestamp_command_timeout = hrt_absolute_time();
@@ -781,11 +781,11 @@ MissionBlock::set_land_item(struct mission_item_s *item)
 	/* VTOL transition to RW before landing */
 	if (_navigator->force_vtol()) {
 
-		vehicle_command_s vcmd = {};
-		vcmd.command = NAV_CMD_DO_VTOL_TRANSITION;
-		vcmd.param1 = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
-		vcmd.param2 = 0.0f;
-		_navigator->publish_vehicle_command(&vcmd);
+		vehicle_command_s vehicle_command{};
+		vehicle_command.command = NAV_CMD_DO_VTOL_TRANSITION;
+		vehicle_command.param1 = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
+		vehicle_command.param2 = 0.0f;
+		_navigator->publish_vehicle_command(&vehicle_command);
 	}
 
 	/* set the land item */

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -549,7 +549,7 @@ MissionBlock::issue_command(const mission_item_s &item)
 		}
 	}
 
-	_navigator->publish_vehicle_cmd(&vcmd);
+	_navigator->publish_vehicle_command(&vcmd);
 
 	if (item_has_timeout(item)) {
 		_timestamp_command_timeout = hrt_absolute_time();
@@ -785,7 +785,7 @@ MissionBlock::set_land_item(struct mission_item_s *item)
 		vcmd.command = NAV_CMD_DO_VTOL_TRANSITION;
 		vcmd.param1 = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
 		vcmd.param2 = 0.0f;
-		_navigator->publish_vehicle_cmd(&vcmd);
+		_navigator->publish_vehicle_command(&vcmd);
 	}
 
 	/* set the land item */

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -549,7 +549,7 @@ MissionBlock::issue_command(const mission_item_s &item)
 		}
 	}
 
-	_navigator->publish_vehicle_command(&vehicle_command);
+	_navigator->publish_vehicle_command(vehicle_command);
 
 	if (item_has_timeout(item)) {
 		_timestamp_command_timeout = hrt_absolute_time();
@@ -785,7 +785,7 @@ MissionBlock::set_land_item(struct mission_item_s *item)
 		vehicle_command.command = NAV_CMD_DO_VTOL_TRANSITION;
 		vehicle_command.param1 = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
 		vehicle_command.param2 = 0.f; // normal unforced transition
-		_navigator->publish_vehicle_command(&vehicle_command);
+		_navigator->publish_vehicle_command(vehicle_command);
 	}
 
 	/* set the land item */

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -135,9 +135,9 @@ public:
 	 * Fill in timestamp, source and target IDs.
 	 * target_component special handling (e.g. For Camera control, set camera ID)
 	 *
-	 * @param vcmd Vehicle command to publish
+	 * @param vehicle_command Vehicle command to publish
 	 */
-	void publish_vehicle_command(vehicle_command_s *vcmd);
+	void publish_vehicle_command(vehicle_command_s *vehicle_command);
 
 #if CONFIG_NAVIGATOR_ADSB
 	/**

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -132,10 +132,10 @@ public:
 	/**
 	 * @brief Publish a given specified vehicle command
 	 *
-	 * Sets the target_component of the vehicle command accordingly depending on the
-	 * vehicle command value (e.g. For Camera control, sets target system component id)
+	 * Fill in timestamp, source and target IDs.
+	 * target_component special handling (e.g. For Camera control, set camera ID)
 	 *
-	 * @param vcmd Vehicle command to execute
+	 * @param vcmd Vehicle command to publish
 	 */
 	void publish_vehicle_command(vehicle_command_s *vcmd);
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -137,7 +137,7 @@ public:
 	 *
 	 * @param vcmd Vehicle command to execute
 	 */
-	void publish_vehicle_cmd(vehicle_command_s *vcmd);
+	void publish_vehicle_command(vehicle_command_s *vcmd);
 
 #if CONFIG_NAVIGATOR_ADSB
 	/**

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -137,7 +137,7 @@ public:
 	 *
 	 * @param vehicle_command Vehicle command to publish
 	 */
-	void publish_vehicle_command(vehicle_command_s *vehicle_command);
+	void publish_vehicle_command(vehicle_command_s &vehicle_command);
 
 #if CONFIG_NAVIGATOR_ADSB
 	/**

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1409,15 +1409,15 @@ void Navigator::publish_vehicle_command(vehicle_command_s *vehicle_command)
 	case NAV_CMD_IMAGE_START_CAPTURE:
 
 		if (static_cast<int>(vehicle_command->param3) == 1) {
-			// When sending a single capture we need to include the sequence number, thus camera_trigger needs to handle this cmd
-			vehicle_command->param1 = 0.0f;
-			vehicle_command->param2 = 0.0f;
-			vehicle_command->param3 = 0.0f;
-			vehicle_command->param4 = 0.0f;
-			vehicle_command->param5 = 1.0;
-			vehicle_command->param6 = 0.0;
-			vehicle_command->param7 = 0.0f;
+			// When sending a single capture we need to include the sequence number, thus camera_trigger needs to handle this command
 			vehicle_command->command = vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL;
+			vehicle_command->param1 = 0.f; // Session control hide lens
+			vehicle_command->param2 = 0.f; // Zoom absolute position
+			vehicle_command->param3 = 0.f; // Zoom step
+			vehicle_command->param4 = 0.f; // Focus lock
+			vehicle_command->param5 = 1.; // Shoot command
+			vehicle_command->param6 = 0.; // Command identity
+			vehicle_command->param7 = 0.f; // Shot identifier
 
 		} else {
 			// We are only capturing multiple if param3 is 0 or > 1.
@@ -1531,10 +1531,10 @@ void Navigator::acquire_gimbal_control()
 {
 	vehicle_command_s vehicle_command{};
 	vehicle_command.command = vehicle_command_s::VEHICLE_CMD_DO_GIMBAL_MANAGER_CONFIGURE;
-	vehicle_command.param1 = _vstatus.system_id;
+	vehicle_command.param1 = _vstatus.system_id; // Take primary control
 	vehicle_command.param2 = _vstatus.component_id;
-	vehicle_command.param3 = -1.0f; // Leave unchanged.
-	vehicle_command.param4 = -1.0f; // Leave unchanged.
+	vehicle_command.param3 = -1.f; // Leave secondary control unchanged
+	vehicle_command.param4 = -1.f;
 	publish_vehicle_command(&vehicle_command);
 }
 
@@ -1542,10 +1542,10 @@ void Navigator::release_gimbal_control()
 {
 	vehicle_command_s vehicle_command{};
 	vehicle_command.command = vehicle_command_s::VEHICLE_CMD_DO_GIMBAL_MANAGER_CONFIGURE;
-	vehicle_command.param1 = -3.0f; // Remove control if it had it.
-	vehicle_command.param2 = -3.0f; // Remove control if it had it.
-	vehicle_command.param3 = -1.0f; // Leave unchanged.
-	vehicle_command.param4 = -1.0f; // Leave unchanged.
+	vehicle_command.param1 = -3.f; // Remove primary control if it was taken
+	vehicle_command.param2 = -3.f;
+	vehicle_command.param3 = -1.f; // Leave secondary control unchanged
+	vehicle_command.param4 = -1.f;
 	publish_vehicle_command(&vehicle_command);
 }
 
@@ -1556,7 +1556,7 @@ Navigator::stop_capturing_images()
 	if (_is_capturing_images) {
 		vehicle_command_s vehicle_command{};
 		vehicle_command.command = NAV_CMD_IMAGE_STOP_CAPTURE;
-		vehicle_command.param1 = 0.0f;
+		vehicle_command.param1 = 0.f;
 		publish_vehicle_command(&vehicle_command);
 
 		// _is_capturing_images is reset inside publish_vehicle_command.
@@ -1608,8 +1608,8 @@ void Navigator::disable_camera_trigger()
 	vehicle_command_s vehicle_command{};
 	vehicle_command.command = vehicle_command_s::VEHICLE_CMD_DO_TRIGGER_CONTROL;
 	// Pause trigger
-	vehicle_command.param1 = -1.0f;
-	vehicle_command.param3 = 1.0f;
+	vehicle_command.param1 = -1.f;
+	vehicle_command.param3 = 1.f;
 	publish_vehicle_command(&vehicle_command);
 }
 
@@ -1617,9 +1617,9 @@ void Navigator::set_gimbal_neutral()
 {
 	vehicle_command_s vehicle_command{};
 	vehicle_command.command = vehicle_command_s::VEHICLE_CMD_DO_GIMBAL_MANAGER_PITCHYAW;
-	vehicle_command.param1 = NAN;
+	vehicle_command.param1 = NAN; // Don't set any angles
 	vehicle_command.param2 = NAN;
-	vehicle_command.param3 = NAN;
+	vehicle_command.param3 = NAN; // Don't set any angular velocities
 	vehicle_command.param4 = NAN;
 	vehicle_command.param5 = gimbal_manager_set_attitude_s::GIMBAL_MANAGER_FLAGS_NEUTRAL;
 	publish_vehicle_command(&vehicle_command);

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -665,7 +665,7 @@ void Navigator::run()
 					vehicle_command_s vcmd = {};
 					vcmd.command = vehicle_command_s::VEHICLE_CMD_MISSION_START;
 					vcmd.param1 = _mission.get_land_start_index();
-					publish_vehicle_cmd(&vcmd);
+					publish_vehicle_command(&vcmd);
 
 				} else {
 					PX4_WARN("planned mission landing not available");
@@ -867,7 +867,7 @@ void Navigator::run()
 			vehicle_command_s vcmd = {};
 			vcmd.command = NAV_CMD_DO_VTOL_TRANSITION;
 			vcmd.param1 = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
-			publish_vehicle_cmd(&vcmd);
+			publish_vehicle_command(&vcmd);
 			mavlink_log_info(&_mavlink_log_pub, "Transition to hover mode and descend.\t");
 			events::send(events::ID("navigator_transition_descend"), events::Log::Critical,
 				     "Transition to hover mode and descend");
@@ -1227,13 +1227,13 @@ void Navigator::take_traffic_conflict_action()
 	case 2: {
 			_rtl.set_return_alt_min(true);
 			vcmd.command = vehicle_command_s::VEHICLE_CMD_NAV_RETURN_TO_LAUNCH;
-			publish_vehicle_cmd(&vcmd);
+			publish_vehicle_command(&vcmd);
 			break;
 		}
 
 	case 3: {
 			vcmd.command = vehicle_command_s::VEHICLE_CMD_NAV_LAND;
-			publish_vehicle_cmd(&vcmd);
+			publish_vehicle_command(&vcmd);
 			break;
 
 		}
@@ -1241,7 +1241,7 @@ void Navigator::take_traffic_conflict_action()
 	case 4: {
 
 			vcmd.command = vehicle_command_s::VEHICLE_CMD_NAV_LOITER_UNLIM;
-			publish_vehicle_cmd(&vcmd);
+			publish_vehicle_command(&vcmd);
 			break;
 
 		}
@@ -1392,7 +1392,7 @@ void Navigator::publish_navigator_status()
 	}
 }
 
-void Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)
+void Navigator::publish_vehicle_command(vehicle_command_s *vcmd)
 {
 	vcmd->timestamp = hrt_absolute_time();
 	vcmd->source_system = _vstatus.system_id;
@@ -1537,7 +1537,7 @@ void Navigator::acquire_gimbal_control()
 	vcmd.param2 = _vstatus.component_id;
 	vcmd.param3 = -1.0f; // Leave unchanged.
 	vcmd.param4 = -1.0f; // Leave unchanged.
-	publish_vehicle_cmd(&vcmd);
+	publish_vehicle_command(&vcmd);
 }
 
 void Navigator::release_gimbal_control()
@@ -1548,7 +1548,7 @@ void Navigator::release_gimbal_control()
 	vcmd.param2 = -3.0f; // Remove control if it had it.
 	vcmd.param3 = -1.0f; // Leave unchanged.
 	vcmd.param4 = -1.0f; // Leave unchanged.
-	publish_vehicle_cmd(&vcmd);
+	publish_vehicle_command(&vcmd);
 }
 
 
@@ -1559,9 +1559,9 @@ Navigator::stop_capturing_images()
 		vehicle_command_s vcmd = {};
 		vcmd.command = NAV_CMD_IMAGE_STOP_CAPTURE;
 		vcmd.param1 = 0.0f;
-		publish_vehicle_cmd(&vcmd);
+		publish_vehicle_command(&vcmd);
 
-		// _is_capturing_images is reset inside publish_vehicle_cmd.
+		// _is_capturing_images is reset inside publish_vehicle_command.
 	}
 }
 
@@ -1612,7 +1612,7 @@ void Navigator::disable_camera_trigger()
 	// Pause trigger
 	cmd.param1 = -1.0f;
 	cmd.param3 = 1.0f;
-	publish_vehicle_cmd(&cmd);
+	publish_vehicle_command(&cmd);
 }
 
 void Navigator::set_gimbal_neutral()
@@ -1624,7 +1624,7 @@ void Navigator::set_gimbal_neutral()
 	vcmd.param3 = NAN;
 	vcmd.param4 = NAN;
 	vcmd.param5 = gimbal_manager_set_attitude_s::GIMBAL_MANAGER_FLAGS_NEUTRAL;
-	publish_vehicle_cmd(&vcmd);
+	publish_vehicle_command(&vcmd);
 }
 
 void Navigator::sendWarningDescentStoppedDueToTerrain()


### PR DESCRIPTION
### Solved Problem
While looking into what would be necessary to command the gimbal back to neutral automatically very close to ground I found that the internal interface for that is not as straight forward as I hoped and instead it's necessary to go through a complicated MAVLink protocol dance in every spot within PX4 that wants to do that.

As part of studying that I came across these pieces which I really at least want to refactor for clarity to enable further improvements.

### Solution
- Flight Task Auto crawl speed is not compliant with the parameter naming convention (1. commit)
- More clear `MPC_LAND_ALT3` parameter description
- Make navigator function `publish_vehicle_cmd` consume a reference instead of a pointer and rename it to `publish_vehicle_command`.
- Follow convention to name messages to publish according to the message name instead of some cryptic abbrevated version.
- Explicitly write float/double literals

Documentation I only adjusted the english version. There seem to be multiple different english versions in other language subdirectories, I still don't understand why such outdated non-translated versions exist.

### Changelog Entry
```
Cleanup: Navigator: Vehicle command refactor, FlightTaskAuto: parameter clarification
```

### Test coverage
It's refactoring except for the reference instead of pointer but if the previous version was ever called with a `nullptr` it would have hardfaulted.
