### PR TITLE
Smooth yaw in auto mode by limiting acceleration

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -47,12 +47,12 @@
 #include <uORB/topics/vehicle_status.h>
 #include <lib/geo/geo.h>
 #include <lib/mathlib/math/filter/AlphaFilter.hpp>
+#include <lib/motion_planning/HeadingSmoothing.hpp>
 #include <lib/motion_planning/PositionSmoothing.hpp>
 #include <lib/stick_yaw/StickYaw.hpp>
 #include <lib/weather_vane/WeatherVane.hpp>
 #include "Sticks.hpp"
 #include "StickAccelerationXY.hpp"
-#include "HeadingSmoothing.hpp"
 
 /**
  * This enum has to agree with position_setpoint_s type definition
@@ -137,6 +137,7 @@ protected:
 	State _current_state{State::none};
 	float _target_acceptance_radius{0.0f}; /**< Acceptances radius of the target */
 
+	float _yaw_setpoint_previous{NAN}; /**< Used because _yaw_setpoint is overwritten in multiple places */
 	HeadingSmoothing _heading_smoothing;
 	bool _yaw_sp_aligned{false};
 

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -52,6 +52,7 @@
 #include <lib/weather_vane/WeatherVane.hpp>
 #include "Sticks.hpp"
 #include "StickAccelerationXY.hpp"
+#include "HeadingSmoothing.hpp"
 
 /**
  * This enum has to agree with position_setpoint_s type definition
@@ -136,8 +137,7 @@ protected:
 	State _current_state{State::none};
 	float _target_acceptance_radius{0.0f}; /**< Acceptances radius of the target */
 
-	float _yaw_sp_prev{NAN};
-	AlphaFilter<float> _yawspeed_filter;
+	HeadingSmoothing _heading_smoothing;
 	bool _yaw_sp_aligned{false};
 
 	PositionSmoothing _position_smoothing;
@@ -156,6 +156,7 @@ protected:
 					(ParamFloat<px4::params::NAV_MC_ALT_RAD>)
 					_param_nav_mc_alt_rad, //vertical acceptance radius at which waypoints are updated
 					(ParamInt<px4::params::MPC_YAW_MODE>) _param_mpc_yaw_mode, // defines how heading is executed,
+					(ParamFloat<px4::params::MPC_YAWRAUTO_ACC>) _param_mpc_yawrauto_acc,
 					(ParamFloat<px4::params::MPC_YAWRAUTO_MAX>) _param_mpc_yawrauto_max,
 					(ParamFloat<px4::params::MIS_YAW_ERR>) _param_mis_yaw_err, // yaw-error threshold
 					(ParamFloat<px4::params::MPC_ACC_HOR>) _param_mpc_acc_hor, // acceleration in flight
@@ -201,7 +202,7 @@ private:
 
 	matrix::Vector3f _initial_land_position;
 
-	void _limitYawRate(); /**< Limits the rate of change of the yaw setpoint. */
+	void _smoothYaw(); /**< Smoothen the yaw setpoint. */
 	bool _evaluateTriplets(); /**< Checks and sets triplets. */
 	bool _isFinite(const position_setpoint_s &sp); /**< Checks if all waypoint triplets are finite. */
 	bool _evaluateGlobalReference(); /**< Check is global reference is available. */

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
@@ -45,6 +45,7 @@
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/orbit_status.h>
 #include <lib/slew_rate/SlewRateYaw.hpp>
+#include <lib/motion_planning/HeadingSmoothing.hpp>
 #include <lib/motion_planning/PositionSmoothing.hpp>
 #include <lib/motion_planning/VelocitySmoothing.hpp>
 #include <lib/slew_rate/SlewRate.hpp>
@@ -127,7 +128,7 @@ private:
 	bool _started_clockwise{true};
 	bool _currently_orbiting{false};
 	float _initial_heading = 0.f; /**< the heading of the drone when the orbit command was issued */
-	SlewRateYaw<float> _slew_rate_yaw;
+	HeadingSmoothing _heading_smoothing;
 	SlewRate<float> _slew_rate_velocity;
 
 	orb_advert_t _mavlink_log_pub{nullptr};
@@ -138,6 +139,7 @@ private:
 		(ParamInt<px4::params::MC_ORBIT_YAW_MOD>) _param_mc_orbit_yaw_mod,
 		(ParamFloat<px4::params::MPC_XY_CRUISE>) _param_mpc_xy_cruise, /**< cruise speed for circle approach */
 		(ParamFloat<px4::params::MPC_YAWRAUTO_MAX>) _param_mpc_yawrauto_max,
+		(ParamFloat<px4::params::MPC_YAWRAUTO_ACC>) _param_mpc_yawrauto_acc,
 		(ParamFloat<px4::params::MPC_XY_TRAJ_P>) _param_mpc_xy_traj_p,
 		(ParamFloat<px4::params::NAV_MC_ALT_RAD>)
 		_param_nav_mc_alt_rad, //vertical acceptance radius at which waypoints are updated

--- a/src/modules/mc_pos_control/multicopter_autonomous_params.c
+++ b/src/modules/mc_pos_control/multicopter_autonomous_params.c
@@ -145,7 +145,7 @@ PARAM_DEFINE_FLOAT(MPC_XY_ERR_MAX, 2.f);
  * @increment 5
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MPC_YAWRAUTO_MAX, 45.f);
+PARAM_DEFINE_FLOAT(MPC_YAWRAUTO_MAX, 60.f);
 
 /**
  * Maximum yaw acceleration in autonomous modes
@@ -160,7 +160,7 @@ PARAM_DEFINE_FLOAT(MPC_YAWRAUTO_MAX, 45.f);
  * @increment 5
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MPC_YAWRAUTO_ACC, 60.f);
+PARAM_DEFINE_FLOAT(MPC_YAWRAUTO_ACC, 20.f);
 
 /**
  * Heading behavior in autonomous modes


### PR DESCRIPTION
### Solved Problem
Currently, only a slew rate is applied to the yaw setpoint, which causes issues on highly responsive platforms (e.g., helicopters) due to steep changes in the yaw setpoint.

![actual](https://github.com/user-attachments/assets/783fb8e4-a374-430c-8a39-138b96cd3ea9)

### Solution
Smooth the yaw setpoint by limiting the yaw acceleration.

### Results
Applying an acceleration limit leads to more realistic yaw and yaw rate setpoints, enabling improved yaw tracking performance.
![smoothed](https://github.com/user-attachments/assets/54f9acd8-2cfc-40e6-b5c0-914fba32b31b)
