### PR TITLE
Rover: Clean up velocity terminology and setpoints

### DIFF
--- a/msg/AckermannVelocitySetpoint.msg
+++ b/msg/AckermannVelocitySetpoint.msg
@@ -1,4 +1,0 @@
-uint64 timestamp # time since system start (microseconds)
-
-float32[2] velocity_ned # 2-dimensional velocity setpoint in NED frame [m/s]
-bool backwards	        # Flag for backwards driving

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -37,7 +37,6 @@ cmake_policy(SET CMP0057 NEW)
 include(px4_list_make_absolute)
 
 set(msg_files
-	AckermannVelocitySetpoint.msg
 	ActionRequest.msg
 	ActuatorArmed.msg
 	ActuatorControlsStatus.msg
@@ -64,7 +63,6 @@ set(msg_files
 	DebugValue.msg
 	DebugVect.msg
 	DifferentialPressure.msg
-	DifferentialVelocitySetpoint.msg
 	DistanceSensor.msg
 	DistanceSensorModeChangeRequest.msg
 	Ekf2Timestamps.msg
@@ -131,7 +129,6 @@ set(msg_files
 	ManualControlSwitches.msg
 	MavlinkLog.msg
 	MavlinkTunnel.msg
-	MecanumVelocitySetpoint.msg
 	MessageFormatRequest.msg
 	MessageFormatResponse.msg
 	Mission.msg
@@ -181,6 +178,7 @@ set(msg_files
 	RoverRateStatus.msg
 	RoverSteeringSetpoint.msg
 	RoverThrottleSetpoint.msg
+	RoverVelocitySetpoint.msg
 	RoverVelocityStatus.msg
 	Rpm.msg
 	RtlStatus.msg

--- a/msg/MecanumVelocitySetpoint.msg
+++ b/msg/MecanumVelocitySetpoint.msg
@@ -1,5 +1,0 @@
-uint64 timestamp # time since system start (microseconds)
-
-float32 speed # [m/s] [-inf, inf] Speed setpoint
-float32 bearing         # [rad] [-pi, pi] from North.
-float32 yaw 	        # [rad] [-pi, pi] (Optional, defaults to current vehicle yaw) Vehicle yaw setpoint in NED frame

--- a/msg/RoverThrottleSetpoint.msg
+++ b/msg/RoverThrottleSetpoint.msg
@@ -2,5 +2,4 @@
 uint64 timestamp        # time since system start (microseconds)
 
 float32 throttle_body_x # throttle setpoint along body X axis [-1, 1] (Positiv = forwards, Negativ = backwards)
-
 float32 throttle_body_y # throttle setpoint along body Y axis [-1, 1] (Mecanum only, Positiv = right, Negativ = left)

--- a/msg/RoverVelocitySetpoint.msg
+++ b/msg/RoverVelocitySetpoint.msg
@@ -2,3 +2,4 @@ uint64 timestamp # time since system start (microseconds)
 
 float32 speed   # [m/s] [-inf, inf] Speed setpoint (Backwards driving if negative)
 float32 bearing # [rad] [-pi,pi] from North.
+float32 yaw 	# [rad] [-pi, pi] (Mecanum only, Optional, defaults to current vehicle yaw) Vehicle yaw setpoint in NED frame

--- a/msg/RoverVelocitySetpoint.msg
+++ b/msg/RoverVelocitySetpoint.msg
@@ -1,5 +1,5 @@
 uint64 timestamp # time since system start (microseconds)
 
 float32 speed   # [m/s] [-inf, inf] Speed setpoint (Backwards driving if negative)
-float32 bearing # [rad] [-pi,pi] from North.
+float32 bearing # [rad] [-pi,pi] from North. [invalid: NAN, speed is defined in body x direction]
 float32 yaw 	# [rad] [-pi, pi] (Mecanum only, Optional, defaults to current vehicle yaw) Vehicle yaw setpoint in NED frame

--- a/msg/RoverVelocityStatus.msg
+++ b/msg/RoverVelocityStatus.msg
@@ -1,10 +1,8 @@
 uint64 timestamp # time since system start (microseconds)
 
 float32 measured_speed_body_x          # [m/s] Measured speed in body x direction. Positiv: forwards, Negativ: backwards
-float32 speed_body_x_setpoint          # [m/s] Speed setpoint in body x direction. Positiv: forwards, Negativ: backwards
 float32 adjusted_speed_body_x_setpoint # [m/s] Post slew rate speed setpoint in body x direction. Positiv: forwards, Negativ: backwards
-float32 measured_speed_body_y          # [m/s] Measured speed in body y direction. Positiv: right, Negativ: left
-float32 speed_body_y_setpoint          # [m/s] Speed setpoint in body y direction. Positiv: right, Negativ: left (Only for mecanum rovers)
-float32 adjusted_speed_body_y_setpoint # [m/s] Post slew rate speed setpoint in body y direction. Positiv: right, Negativ: left (Only for mecanum rovers)
 float32 pid_throttle_body_x_integral   # Integral of the PID for the closed loop controller of the speed in body x direction
-float32 pid_throttle_body_y_integral   # Integral of the PID for the closed loop controller of the speed in body y direction
+float32 measured_speed_body_y          # [m/s] Measured speed in body y direction. Positiv: right, Negativ: left (Mecanum only)
+float32 adjusted_speed_body_y_setpoint # [m/s] Post slew rate speed setpoint in body y direction. Positiv: right, Negativ: left (Mecanum only)
+float32 pid_throttle_body_y_integral   # Integral of the PID for the closed loop controller of the speed in body y direction (Mecanum only)

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -45,7 +45,6 @@ using namespace px4::logger;
 
 void LoggedTopics::add_default_topics()
 {
-	add_optional_topic("ackermann_velocity_setpoint", 100);
 	add_topic("action_request");
 	add_topic("actuator_armed");
 	add_optional_topic("actuator_controls_status_0", 300);
@@ -58,7 +57,6 @@ void LoggedTopics::add_default_topics()
 	add_topic("commander_state");
 	add_topic("config_overrides");
 	add_topic("cpuload");
-	add_optional_topic("differential_velocity_setpoint", 100);
 	add_topic("distance_sensor_mode_change_request");
 	add_optional_topic("external_ins_attitude");
 	add_optional_topic("external_ins_global_position");
@@ -93,7 +91,6 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("magnetometer_bias_estimate", 200);
 	add_topic("manual_control_setpoint", 200);
 	add_topic("manual_control_switches");
-	add_optional_topic("mecanum_velocity_setpoint", 100);
 	add_topic("mission_result");
 	add_topic("navigator_mission_item");
 	add_topic("navigator_status");
@@ -115,6 +112,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("rover_rate_status", 100);
 	add_optional_topic("rover_steering_setpoint", 100);
 	add_optional_topic("rover_throttle_setpoint", 100);
+	add_optional_topic("rover_velocity_setpoint", 100);
 	add_optional_topic("rover_velocity_status", 100);
 	add_topic("rtl_time_estimate", 1000);
 	add_topic("rtl_status", 2000);

--- a/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.hpp
+++ b/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.hpp
@@ -50,7 +50,7 @@
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/rover_position_setpoint.h>
-#include <uORB/topics/ackermann_velocity_setpoint.h>
+#include <uORB/topics/rover_velocity_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/trajectory_setpoint.h>
@@ -181,10 +181,10 @@ private:
 	rover_position_setpoint_s _rover_position_setpoint{};
 
 	// uORB publications
-	uORB::Publication<ackermann_velocity_setpoint_s> _ackermann_velocity_setpoint_pub{ORB_ID(ackermann_velocity_setpoint)};
-	uORB::Publication<position_controller_status_s>	 _position_controller_status_pub{ORB_ID(position_controller_status)};
-	uORB::Publication<pure_pursuit_status_s>	 _pure_pursuit_status_pub{ORB_ID(pure_pursuit_status)};
-	uORB::Publication<rover_position_setpoint_s>	 _rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
+	uORB::Publication<rover_velocity_setpoint_s>    _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
+	uORB::Publication<position_controller_status_s>	_position_controller_status_pub{ORB_ID(position_controller_status)};
+	uORB::Publication<pure_pursuit_status_s>	_pure_pursuit_status_pub{ORB_ID(pure_pursuit_status)};
+	uORB::Publication<rover_position_setpoint_s>	_rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
 
 	// Variables
 	hrt_abstime _timestamp{0};

--- a/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.cpp
+++ b/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.cpp
@@ -80,11 +80,11 @@ void AckermannVelControl::updateVelControl()
 	// Publish position controller status (logging only)
 	rover_velocity_status_s rover_velocity_status;
 	rover_velocity_status.timestamp = _timestamp;
-	rover_velocity_status.measured_speed_body_x = _vehicle_speed_body_x;
+	rover_velocity_status.measured_speed_body_x = _vehicle_speed;
 	rover_velocity_status.adjusted_speed_body_x_setpoint = _speed_setpoint.getState();
-	rover_velocity_status.measured_speed_body_y = _vehicle_speed_body_y;
-	rover_velocity_status.adjusted_speed_body_y_setpoint = NAN;
 	rover_velocity_status.pid_throttle_body_x_integral = _pid_speed.getIntegral();
+	rover_velocity_status.measured_speed_body_y = NAN;
+	rover_velocity_status.adjusted_speed_body_y_setpoint = NAN;
 	rover_velocity_status.pid_throttle_body_y_integral = NAN;
 	_rover_velocity_status_pub.publish(rover_velocity_status);
 }
@@ -106,10 +106,10 @@ void AckermannVelControl::updateSubscriptions()
 		vehicle_local_position_s vehicle_local_position{};
 		_vehicle_local_position_sub.copy(&vehicle_local_position);
 
-		Vector3f velocity_in_local_frame(vehicle_local_position.vx, vehicle_local_position.vy, vehicle_local_position.vz);
-		Vector3f velocity_in_body_frame = _vehicle_attitude_quaternion.rotateVectorInverse(velocity_in_local_frame);
-		_vehicle_speed_body_x = fabsf(velocity_in_body_frame(0)) > _param_ro_speed_th.get() ? velocity_in_body_frame(0) : 0.f;
-		_vehicle_speed_body_y = fabsf(velocity_in_body_frame(1)) > _param_ro_speed_th.get() ? velocity_in_body_frame(1) : 0.f;
+		Vector3f velocity_ned(vehicle_local_position.vx, vehicle_local_position.vy, vehicle_local_position.vz);
+		Vector3f velocity_xyz = _vehicle_attitude_quaternion.rotateVectorInverse(velocity_ned);
+		Vector2f velocity_2d = Vector2f(velocity_xyz(0), velocity_xyz(1));
+		_vehicle_speed = velocity_2d.norm() > _param_ro_speed_th.get() ? sign(velocity_2d(0)) * velocity_2d.norm() : 0.f;
 	}
 
 }
@@ -143,9 +143,16 @@ void AckermannVelControl::generateAttitudeAndThrottleSetpoint()
 		_ackermann_velocity_setpoint_sub.copy(&_ackermann_velocity_setpoint);
 	}
 
+	const Vector2f velocity_ned = Vector2f(_ackermann_velocity_setpoint.velocity_ned[0],
+					       _ackermann_velocity_setpoint.velocity_ned[1]);
+
+	// Santitize input
+	if (!velocity_ned.isAllFinite()) {
+		return;
+	}
+
 	// Attitude Setpoint
-	if (fabsf(_ackermann_velocity_setpoint.velocity_ned[1]) < FLT_EPSILON
-	    && fabsf(_ackermann_velocity_setpoint.velocity_ned[0]) < FLT_EPSILON) {
+	if (velocity_ned.norm() < FLT_EPSILON) {
 		rover_attitude_setpoint_s rover_attitude_setpoint{};
 		rover_attitude_setpoint.timestamp = _timestamp;
 		rover_attitude_setpoint.yaw_setpoint = _vehicle_yaw;
@@ -154,23 +161,21 @@ void AckermannVelControl::generateAttitudeAndThrottleSetpoint()
 	} else {
 		rover_attitude_setpoint_s rover_attitude_setpoint{};
 		rover_attitude_setpoint.timestamp = _timestamp;
-		const float yaw_setpoint = atan2f(_ackermann_velocity_setpoint.velocity_ned[1],
-						  _ackermann_velocity_setpoint.velocity_ned[0]);
+		const float yaw_setpoint = atan2f(velocity_ned(1), velocity_ned(0));
 		rover_attitude_setpoint.yaw_setpoint = _ackermann_velocity_setpoint.backwards ? matrix::wrap_pi(
 				yaw_setpoint + M_PI_F) : yaw_setpoint;
 		_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
 	}
 
 	// Throttle Setpoint
-	const float speed_magnitude = math::min(sqrtf(powf(_ackermann_velocity_setpoint.velocity_ned[0],
-						2) + powf(_ackermann_velocity_setpoint.velocity_ned[1], 2)), _param_ro_speed_limit.get());
-	const float speed_body_x_setpoint = _ackermann_velocity_setpoint.backwards ? -speed_magnitude : speed_magnitude;
+	const float speed_magnitude = math::min(velocity_ned.norm(), _param_ro_speed_limit.get());
+	const float speed_setpoint = _ackermann_velocity_setpoint.backwards ? -speed_magnitude : speed_magnitude;
 	rover_throttle_setpoint_s rover_throttle_setpoint{};
 	rover_throttle_setpoint.timestamp = _timestamp;
 	rover_throttle_setpoint.throttle_body_x = RoverControl::speedControl(_speed_setpoint, _pid_speed,
-			speed_body_x_setpoint, _vehicle_speed_body_x, _param_ro_accel_limit.get(), _param_ro_decel_limit.get(),
+			speed_setpoint, _vehicle_speed, _param_ro_accel_limit.get(), _param_ro_decel_limit.get(),
 			_param_ro_max_thr_speed.get(), _dt);
-	rover_throttle_setpoint.throttle_body_y = 0.f;
+	rover_throttle_setpoint.throttle_body_y = NAN;
 	_rover_throttle_setpoint_pub.publish(rover_throttle_setpoint);
 
 }

--- a/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.cpp
+++ b/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.cpp
@@ -149,7 +149,7 @@ void AckermannVelControl::generateAttitudeAndThrottleSetpoint()
 		rover_attitude_setpoint.yaw_setpoint = _vehicle_yaw;
 		_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
 
-	} else {
+	} else if (PX4_ISFINITE(_rover_velocity_setpoint.bearing)) {
 		rover_attitude_setpoint_s rover_attitude_setpoint{};
 		rover_attitude_setpoint.timestamp = _timestamp;
 		rover_attitude_setpoint.yaw_setpoint = _rover_velocity_setpoint.bearing;

--- a/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.hpp
+++ b/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.hpp
@@ -126,8 +126,7 @@ private:
 	// Variables
 	hrt_abstime _timestamp{0};
 	Quatf _vehicle_attitude_quaternion{};
-	float _vehicle_speed_body_x{0.f};
-	float _vehicle_speed_body_y{0.f};
+	float _vehicle_speed{0.f}; // [m/s] Positiv: Forwards, Negativ: Backwards
 	float _vehicle_yaw{0.f};
 	float _dt{0.f};
 	bool _prev_param_check_passed{true};

--- a/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.hpp
+++ b/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.hpp
@@ -48,7 +48,7 @@
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/rover_throttle_setpoint.h>
-#include <uORB/topics/ackermann_velocity_setpoint.h>
+#include <uORB/topics/rover_velocity_setpoint.h>
 #include <uORB/topics/rover_velocity_status.h>
 #include <uORB/topics/rover_attitude_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
@@ -112,7 +112,7 @@ private:
 	uORB::Subscription _offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
-	uORB::Subscription _ackermann_velocity_setpoint_sub{ORB_ID(ackermann_velocity_setpoint)};
+	uORB::Subscription _rover_velocity_setpoint_sub{ORB_ID(rover_velocity_setpoint)};
 	vehicle_control_mode_s _vehicle_control_mode{};
 	offboard_control_mode_s _offboard_control_mode{};
 
@@ -120,8 +120,8 @@ private:
 	uORB::Publication<rover_throttle_setpoint_s> _rover_throttle_setpoint_pub{ORB_ID(rover_throttle_setpoint)};
 	uORB::Publication<rover_attitude_setpoint_s> _rover_attitude_setpoint_pub{ORB_ID(rover_attitude_setpoint)};
 	uORB::Publication<rover_velocity_status_s>   _rover_velocity_status_pub{ORB_ID(rover_velocity_status)};
-	uORB::Publication<ackermann_velocity_setpoint_s> _ackermann_velocity_setpoint_pub{ORB_ID(ackermann_velocity_setpoint)};
-	ackermann_velocity_setpoint_s _ackermann_velocity_setpoint{};
+	uORB::Publication<rover_velocity_setpoint_s> _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
+	rover_velocity_setpoint_s _rover_velocity_setpoint{};
 
 	// Variables
 	hrt_abstime _timestamp{0};

--- a/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.cpp
+++ b/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.cpp
@@ -37,7 +37,7 @@ using namespace time_literals;
 
 DifferentialPosControl::DifferentialPosControl(ModuleParams *parent) : ModuleParams(parent)
 {
-	_differential_velocity_setpoint_pub.advertise();
+	_rover_velocity_setpoint_pub.advertise();
 	_rover_position_setpoint_pub.advertise();
 	_pure_pursuit_status_pub.advertise();
 
@@ -159,20 +159,20 @@ void DifferentialPosControl::manualPositionMode()
 	if (fabsf(speed_setpoint) < FLT_EPSILON) { // Turn on spot
 		_course_control = false;
 		const float bearing_setpoint = matrix::wrap_pi(_vehicle_yaw + bearing_delta);
-		differential_velocity_setpoint_s differential_velocity_setpoint{};
-		differential_velocity_setpoint.timestamp = _timestamp;
-		differential_velocity_setpoint.speed = 0.f;
-		differential_velocity_setpoint.bearing = bearing_setpoint;
-		_differential_velocity_setpoint_pub.publish(differential_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = 0.f;
+		rover_velocity_setpoint.bearing = bearing_setpoint;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else if (fabsf(bearing_delta) > FLT_EPSILON) { // Closed loop yaw rate control
 		_course_control = false;
 		const float bearing_setpoint = matrix::wrap_pi(_vehicle_yaw + bearing_delta);
-		differential_velocity_setpoint_s differential_velocity_setpoint{};
-		differential_velocity_setpoint.timestamp = _timestamp;
-		differential_velocity_setpoint.speed = speed_setpoint;
-		differential_velocity_setpoint.bearing = bearing_setpoint;
-		_differential_velocity_setpoint_pub.publish(differential_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = speed_setpoint;
+		rover_velocity_setpoint.bearing = bearing_setpoint;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else { // Course control if the steering input is zero (keep driving on a straight line)
 		if (!_course_control) {
@@ -192,12 +192,12 @@ void DifferentialPosControl::manualPositionMode()
 					       _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), target_waypoint_ned, _pos_ctl_start_position_ned,
 					       _curr_pos_ned, fabsf(speed_setpoint));
 		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		differential_velocity_setpoint_s differential_velocity_setpoint{};
-		differential_velocity_setpoint.timestamp = _timestamp;
-		differential_velocity_setpoint.speed = speed_setpoint;
-		differential_velocity_setpoint.bearing = speed_setpoint > -FLT_EPSILON ? bearing_setpoint : matrix::wrap_pi(
-					bearing_setpoint + M_PI_F);
-		_differential_velocity_setpoint_pub.publish(differential_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = speed_setpoint;
+		rover_velocity_setpoint.bearing = speed_setpoint > -FLT_EPSILON ? bearing_setpoint : matrix::wrap_pi(
+				bearing_setpoint + M_PI_F);
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 	}
 }
 
@@ -232,11 +232,11 @@ void DifferentialPosControl::autoPositionMode()
 	}
 
 	if (auto_stop) {
-		differential_velocity_setpoint_s differential_velocity_setpoint{};
-		differential_velocity_setpoint.timestamp = _timestamp;
-		differential_velocity_setpoint.speed = 0.f;
-		differential_velocity_setpoint.bearing = _vehicle_yaw;
-		_differential_velocity_setpoint_pub.publish(differential_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = 0.f;
+		rover_velocity_setpoint.bearing = _vehicle_yaw;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else {
 		const float speed_setpoint = calcSpeedSetpoint(_cruising_speed, distance_to_curr_wp, _param_ro_decel_limit.get(),
@@ -248,11 +248,11 @@ void DifferentialPosControl::autoPositionMode()
 					       _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), _curr_wp_ned, _prev_wp_ned, _curr_pos_ned,
 					       fabsf(speed_setpoint));
 		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		differential_velocity_setpoint_s differential_velocity_setpoint{};
-		differential_velocity_setpoint.timestamp = _timestamp;
-		differential_velocity_setpoint.speed = speed_setpoint;
-		differential_velocity_setpoint.bearing = bearing_setpoint;
-		_differential_velocity_setpoint_pub.publish(differential_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = speed_setpoint;
+		rover_velocity_setpoint.bearing = bearing_setpoint;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 	}
 
 }
@@ -302,18 +302,18 @@ void DifferentialPosControl::goToPositionMode()
 					       _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), target_waypoint_ned, _curr_pos_ned,
 					       _curr_pos_ned, fabsf(speed_setpoint));
 		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		differential_velocity_setpoint_s differential_velocity_setpoint{};
-		differential_velocity_setpoint.timestamp = _timestamp;
-		differential_velocity_setpoint.speed = speed_setpoint;
-		differential_velocity_setpoint.bearing = bearing_setpoint;
-		_differential_velocity_setpoint_pub.publish(differential_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = speed_setpoint;
+		rover_velocity_setpoint.bearing = bearing_setpoint;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else {
-		differential_velocity_setpoint_s differential_velocity_setpoint{};
-		differential_velocity_setpoint.timestamp = _timestamp;
-		differential_velocity_setpoint.speed = 0.f;
-		differential_velocity_setpoint.bearing = _vehicle_yaw;
-		_differential_velocity_setpoint_pub.publish(differential_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = 0.f;
+		rover_velocity_setpoint.bearing = _vehicle_yaw;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 	}
 }
 

--- a/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.hpp
+++ b/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.hpp
@@ -163,7 +163,7 @@ private:
 	uORB::Publication<rover_velocity_status_s>          _rover_velocity_status_pub{ORB_ID(rover_velocity_status)};
 	uORB::Publication<differential_velocity_setpoint_s> _differential_velocity_setpoint_pub{ORB_ID(differential_velocity_setpoint)};
 	uORB::Publication<pure_pursuit_status_s>	    _pure_pursuit_status_pub{ORB_ID(pure_pursuit_status)};
-	uORB::Publication<rover_position_setpoint_s>	 _rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
+	uORB::Publication<rover_position_setpoint_s>	    _rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
 
 	// Variables
 	hrt_abstime _timestamp{0};
@@ -171,7 +171,7 @@ private:
 	Vector2f _curr_pos_ned{};
 	Vector2f _pos_ctl_course_direction{};
 	Vector2f _pos_ctl_start_position_ned{};
-	float _vehicle_speed_body_x{0.f};
+	float _vehicle_speed{0.f}; // [m/s] Positiv: Forwards, Negativ: Backwards
 	float _vehicle_yaw{0.f};
 	float _max_yaw_rate{0.f};
 	float _dt{0.f};

--- a/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.hpp
+++ b/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.hpp
@@ -47,7 +47,7 @@
 // uORB includes
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
-#include <uORB/topics/differential_velocity_setpoint.h>
+#include <uORB/topics/rover_velocity_setpoint.h>
 #include <uORB/topics/pure_pursuit_status.h>
 #include <uORB/topics/rover_position_setpoint.h>
 #include <uORB/topics/rover_velocity_status.h>
@@ -152,7 +152,7 @@ private:
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _position_setpoint_triplet_sub{ORB_ID(position_setpoint_triplet)};
-	uORB::Subscription _differential_velocity_setpoint_sub{ORB_ID(differential_velocity_setpoint)};
+	uORB::Subscription _rover_velocity_setpoint_sub{ORB_ID(rover_velocity_setpoint)};
 	uORB::Subscription _rover_position_setpoint_sub{ORB_ID(rover_position_setpoint)};
 	vehicle_control_mode_s _vehicle_control_mode{};
 	offboard_control_mode_s _offboard_control_mode{};
@@ -160,10 +160,10 @@ private:
 
 
 	// uORB publications
-	uORB::Publication<rover_velocity_status_s>          _rover_velocity_status_pub{ORB_ID(rover_velocity_status)};
-	uORB::Publication<differential_velocity_setpoint_s> _differential_velocity_setpoint_pub{ORB_ID(differential_velocity_setpoint)};
-	uORB::Publication<pure_pursuit_status_s>	    _pure_pursuit_status_pub{ORB_ID(pure_pursuit_status)};
-	uORB::Publication<rover_position_setpoint_s>	    _rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
+	uORB::Publication<rover_velocity_status_s>   _rover_velocity_status_pub{ORB_ID(rover_velocity_status)};
+	uORB::Publication<rover_velocity_setpoint_s> _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
+	uORB::Publication<pure_pursuit_status_s>     _pure_pursuit_status_pub{ORB_ID(pure_pursuit_status)};
+	uORB::Publication<rover_position_setpoint_s> _rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
 
 	// Variables
 	hrt_abstime _timestamp{0};

--- a/src/modules/rover_differential/DifferentialVelControl/DifferentialVelControl.cpp
+++ b/src/modules/rover_differential/DifferentialVelControl/DifferentialVelControl.cpp
@@ -140,10 +140,12 @@ void DifferentialVelControl::generateAttitudeAndThrottleSetpoint()
 	}
 
 	// Attitude Setpoint
-	rover_attitude_setpoint_s rover_attitude_setpoint{};
-	rover_attitude_setpoint.timestamp = _timestamp;
-	rover_attitude_setpoint.yaw_setpoint = _rover_velocity_setpoint.bearing;
-	_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
+	if (PX4_ISFINITE(_rover_velocity_setpoint.bearing)) {
+		rover_attitude_setpoint_s rover_attitude_setpoint{};
+		rover_attitude_setpoint.timestamp = _timestamp;
+		rover_attitude_setpoint.yaw_setpoint = _rover_velocity_setpoint.bearing;
+		_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
+	}
 
 	// Throttle Setpoint
 	const float heading_error = matrix::wrap_pi(_rover_velocity_setpoint.bearing - _vehicle_yaw);

--- a/src/modules/rover_differential/DifferentialVelControl/DifferentialVelControl.hpp
+++ b/src/modules/rover_differential/DifferentialVelControl/DifferentialVelControl.hpp
@@ -50,7 +50,7 @@
 #include <uORB/topics/rover_steering_setpoint.h>
 #include <uORB/topics/rover_throttle_setpoint.h>
 #include <uORB/topics/rover_velocity_status.h>
-#include <uORB/topics/differential_velocity_setpoint.h>
+#include <uORB/topics/rover_velocity_setpoint.h>
 #include <uORB/topics/rover_attitude_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/trajectory_setpoint.h>
@@ -121,7 +121,7 @@ private:
 	uORB::Subscription _offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
-	uORB::Subscription _differential_velocity_setpoint_sub{ORB_ID(differential_velocity_setpoint)};
+	uORB::Subscription _rover_velocity_setpoint_sub{ORB_ID(rover_velocity_setpoint)};
 	uORB::Subscription _rover_steering_setpoint_sub{ORB_ID(rover_steering_setpoint)};
 	vehicle_control_mode_s _vehicle_control_mode{};
 	offboard_control_mode_s _offboard_control_mode{};
@@ -131,8 +131,8 @@ private:
 	uORB::Publication<rover_throttle_setpoint_s> _rover_throttle_setpoint_pub{ORB_ID(rover_throttle_setpoint)};
 	uORB::Publication<rover_attitude_setpoint_s> _rover_attitude_setpoint_pub{ORB_ID(rover_attitude_setpoint)};
 	uORB::Publication<rover_velocity_status_s> _rover_velocity_status_pub{ORB_ID(rover_velocity_status)};
-	uORB::Publication<differential_velocity_setpoint_s> _differential_velocity_setpoint_pub{ORB_ID(differential_velocity_setpoint)};
-	differential_velocity_setpoint_s _differential_velocity_setpoint{};
+	uORB::Publication<rover_velocity_setpoint_s> _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
+	rover_velocity_setpoint_s _rover_velocity_setpoint{};
 
 	// Variables
 	hrt_abstime _timestamp{0};

--- a/src/modules/rover_differential/DifferentialVelControl/DifferentialVelControl.hpp
+++ b/src/modules/rover_differential/DifferentialVelControl/DifferentialVelControl.hpp
@@ -137,8 +137,7 @@ private:
 	// Variables
 	hrt_abstime _timestamp{0};
 	Quatf _vehicle_attitude_quaternion{};
-	float _vehicle_speed_body_x{0.f};
-	float _vehicle_speed_body_y{0.f};
+	float _vehicle_speed{0.f}; // [m/s] Positiv: Forwards, Negativ: Backwards
 	float _vehicle_yaw{0.f};
 	float _dt{0.f};
 	bool _prev_param_check_passed{false};

--- a/src/modules/rover_mecanum/MecanumPosControl/MecanumPosControl.cpp
+++ b/src/modules/rover_mecanum/MecanumPosControl/MecanumPosControl.cpp
@@ -37,7 +37,7 @@ using namespace time_literals;
 
 MecanumPosControl::MecanumPosControl(ModuleParams *parent) : ModuleParams(parent)
 {
-	_mecanum_velocity_setpoint_pub.advertise();
+	_rover_velocity_setpoint_pub.advertise();
 	_rover_position_setpoint_pub.advertise();
 	_pure_pursuit_status_pub.advertise();
 
@@ -158,12 +158,12 @@ void MecanumPosControl::manualPositionMode()
 		_pos_ctl_yaw_setpoint = NAN;
 		const float yaw_setpoint = matrix::wrap_pi(_vehicle_yaw + yaw_delta);
 		const Vector3f velocity_setpoint_local = _vehicle_attitude_quaternion.rotateVector(velocity_setpoint_body);
-		mecanum_velocity_setpoint_s mecanum_velocity_setpoint{};
-		mecanum_velocity_setpoint.timestamp = _timestamp;
-		mecanum_velocity_setpoint.speed = velocity_setpoint_body.norm();
-		mecanum_velocity_setpoint.bearing = atan2f(velocity_setpoint_local(1), velocity_setpoint_local(0));
-		mecanum_velocity_setpoint.yaw = yaw_setpoint;
-		_mecanum_velocity_setpoint_pub.publish(mecanum_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = velocity_setpoint_body.norm();
+		rover_velocity_setpoint.bearing = atan2f(velocity_setpoint_local(1), velocity_setpoint_local(0));
+		rover_velocity_setpoint.yaw = yaw_setpoint;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else { // Course control if the steering input is zero (keep driving on a straight line)
 		const Vector3f velocity = Vector3f(velocity_setpoint_body(0), velocity_setpoint_body(1), 0.f);
@@ -194,12 +194,12 @@ void MecanumPosControl::manualPositionMode()
 					       _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), target_waypoint_ned, _pos_ctl_start_position_ned,
 					       _curr_pos_ned, velocity_magnitude_setpoint);
 		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		mecanum_velocity_setpoint_s mecanum_velocity_setpoint{};
-		mecanum_velocity_setpoint.timestamp = _timestamp;
-		mecanum_velocity_setpoint.speed = velocity_magnitude_setpoint;
-		mecanum_velocity_setpoint.bearing = bearing_setpoint;
-		mecanum_velocity_setpoint.yaw = _pos_ctl_yaw_setpoint;
-		_mecanum_velocity_setpoint_pub.publish(mecanum_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = velocity_magnitude_setpoint;
+		rover_velocity_setpoint.bearing = bearing_setpoint;
+		rover_velocity_setpoint.yaw = _pos_ctl_yaw_setpoint;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 	}
 }
 
@@ -241,12 +241,12 @@ void MecanumPosControl::autoPositionMode()
 	}
 
 	if (auto_stop) {
-		mecanum_velocity_setpoint_s mecanum_velocity_setpoint{};
-		mecanum_velocity_setpoint.timestamp = _timestamp;
-		mecanum_velocity_setpoint.speed = 0.f;
-		mecanum_velocity_setpoint.bearing = 0.f;
-		mecanum_velocity_setpoint.yaw = _vehicle_yaw;
-		_mecanum_velocity_setpoint_pub.publish(mecanum_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = 0.f;
+		rover_velocity_setpoint.bearing = 0.f;
+		rover_velocity_setpoint.yaw = _vehicle_yaw;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else { // Regular guidance algorithm
 		const float velocity_magnitude = calcVelocityMagnitude(_auto_speed, distance_to_curr_wp, _param_ro_decel_limit.get(),
@@ -258,12 +258,12 @@ void MecanumPosControl::autoPositionMode()
 					       _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), _curr_wp_ned, _prev_wp_ned, _curr_pos_ned,
 					       velocity_magnitude);
 		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		mecanum_velocity_setpoint_s mecanum_velocity_setpoint{};
-		mecanum_velocity_setpoint.timestamp = _timestamp;
-		mecanum_velocity_setpoint.speed = velocity_magnitude;
-		mecanum_velocity_setpoint.bearing = bearing_setpoint;
-		mecanum_velocity_setpoint.yaw = _auto_yaw;
-		_mecanum_velocity_setpoint_pub.publish(mecanum_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = velocity_magnitude;
+		rover_velocity_setpoint.bearing = bearing_setpoint;
+		rover_velocity_setpoint.yaw = _auto_yaw;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 	}
 }
 
@@ -313,20 +313,20 @@ void MecanumPosControl::goToPositionMode()
 					       _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), target_waypoint_ned, _curr_pos_ned,
 					       _curr_pos_ned, fabsf(speed_setpoint));
 		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		mecanum_velocity_setpoint_s mecanum_velocity_setpoint{};
-		mecanum_velocity_setpoint.timestamp = _timestamp;
-		mecanum_velocity_setpoint.speed = speed_setpoint;
-		mecanum_velocity_setpoint.bearing = bearing_setpoint;
-		mecanum_velocity_setpoint.yaw = _pos_ctl_yaw_setpoint;
-		_mecanum_velocity_setpoint_pub.publish(mecanum_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = speed_setpoint;
+		rover_velocity_setpoint.bearing = bearing_setpoint;
+		rover_velocity_setpoint.yaw = _pos_ctl_yaw_setpoint;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else {
-		mecanum_velocity_setpoint_s mecanum_velocity_setpoint{};
-		mecanum_velocity_setpoint.timestamp = _timestamp;
-		mecanum_velocity_setpoint.speed = 0.f;
-		mecanum_velocity_setpoint.bearing = 0.f;
-		mecanum_velocity_setpoint.yaw = _vehicle_yaw;
-		_mecanum_velocity_setpoint_pub.publish(mecanum_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = 0.f;
+		rover_velocity_setpoint.bearing = 0.f;
+		rover_velocity_setpoint.yaw = _vehicle_yaw;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 	}
 }
 

--- a/src/modules/rover_mecanum/MecanumPosControl/MecanumPosControl.hpp
+++ b/src/modules/rover_mecanum/MecanumPosControl/MecanumPosControl.hpp
@@ -49,7 +49,7 @@
 // uORB includes
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
-#include <uORB/topics/mecanum_velocity_setpoint.h>
+#include <uORB/topics/rover_velocity_setpoint.h>
 #include <uORB/topics/rover_position_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/manual_control_setpoint.h>
@@ -162,7 +162,7 @@ private:
 	rover_position_setpoint_s _rover_position_setpoint{};
 
 	// uORB publications
-	uORB::Publication<mecanum_velocity_setpoint_s> _mecanum_velocity_setpoint_pub{ORB_ID(mecanum_velocity_setpoint)};
+	uORB::Publication<rover_velocity_setpoint_s> _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
 	uORB::Publication<pure_pursuit_status_s>       _pure_pursuit_status_pub{ORB_ID(pure_pursuit_status)};
 	uORB::Publication<rover_position_setpoint_s>   _rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
 

--- a/src/modules/rover_mecanum/MecanumVelControl/MecanumVelControl.cpp
+++ b/src/modules/rover_mecanum/MecanumVelControl/MecanumVelControl.cpp
@@ -167,7 +167,7 @@ void MecanumVelControl::generateAttitudeAndThrottleSetpoint()
 	float speed_body_x_setpoint{0.f};
 	float speed_body_y_setpoint{0.f};
 
-	if (fabsf(_rover_velocity_setpoint.speed) > FLT_EPSILON) {
+	if (fabsf(_rover_velocity_setpoint.speed) > FLT_EPSILON && PX4_ISFINITE(_rover_velocity_setpoint.bearing)) {
 		const Vector3f velocity_in_local_frame(_rover_velocity_setpoint.speed * cosf(
 				_rover_velocity_setpoint.bearing),
 						       _rover_velocity_setpoint.speed * sinf(_rover_velocity_setpoint.bearing), 0.f);
@@ -175,6 +175,9 @@ void MecanumVelControl::generateAttitudeAndThrottleSetpoint()
 		speed_body_x_setpoint = velocity_in_body_frame(0);
 		speed_body_y_setpoint = velocity_in_body_frame(1);
 
+	} else {
+		speed_body_x_setpoint = _rover_velocity_setpoint.speed;
+		speed_body_y_setpoint = 0.f;
 	}
 
 	if (_param_ro_max_thr_speed.get() > FLT_EPSILON) { // Adjust speed setpoints if infeasible

--- a/src/modules/rover_mecanum/MecanumVelControl/MecanumVelControl.hpp
+++ b/src/modules/rover_mecanum/MecanumVelControl/MecanumVelControl.hpp
@@ -50,7 +50,7 @@
 #include <uORB/topics/rover_steering_setpoint.h>
 #include <uORB/topics/rover_throttle_setpoint.h>
 #include <uORB/topics/rover_velocity_status.h>
-#include <uORB/topics/mecanum_velocity_setpoint.h>
+#include <uORB/topics/rover_velocity_setpoint.h>
 #include <uORB/topics/rover_attitude_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/trajectory_setpoint.h>
@@ -113,7 +113,7 @@ private:
 	uORB::Subscription _offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
-	uORB::Subscription _mecanum_velocity_setpoint_sub{ORB_ID(mecanum_velocity_setpoint)};
+	uORB::Subscription _rover_velocity_setpoint_sub{ORB_ID(rover_velocity_setpoint)};
 	uORB::Subscription _rover_attitude_setpoint_sub{ORB_ID(rover_attitude_setpoint)};
 	uORB::Subscription _rover_steering_setpoint_sub{ORB_ID(rover_steering_setpoint)};
 	vehicle_control_mode_s _vehicle_control_mode{};
@@ -124,8 +124,8 @@ private:
 	uORB::Publication<rover_throttle_setpoint_s> _rover_throttle_setpoint_pub{ORB_ID(rover_throttle_setpoint)};
 	uORB::Publication<rover_attitude_setpoint_s> _rover_attitude_setpoint_pub{ORB_ID(rover_attitude_setpoint)};
 	uORB::Publication<rover_velocity_status_s> _rover_velocity_status_pub{ORB_ID(rover_velocity_status)};
-	uORB::Publication<mecanum_velocity_setpoint_s> _mecanum_velocity_setpoint_pub{ORB_ID(mecanum_velocity_setpoint)};
-	mecanum_velocity_setpoint_s _mecanum_velocity_setpoint{};
+	uORB::Publication<rover_velocity_setpoint_s> _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
+	rover_velocity_setpoint_s _rover_velocity_setpoint{};
 
 	// Variables
 	hrt_abstime _timestamp{0};


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This PR consist of 2 contributions:
1. Clean up the velocity/speed terminology for ackermann/differential rovers:
Defining the speed in body-x direction is tricky for these types of rovers, because during corning the velocity is not actually aligned with the body-x direction. Therefor, for control purposes we instead now use the absolute speed of the rover.
However, since the intend of `speed_body_x` is clear, we leave it for the `RoverThrottleSetpoint.msg` since this way it is easier to extend the message for mecanum rovers which actually require the differentiation in `body_x` and `body_y`.
Also removes some unused fields from `RoverVelocityStatus.msg`.
2. Clean up rover velocity setpoints:
Currently the 3 rover types have their own `[RoverType]VelocitySetpoint.msg`. This PR merges them into one single rover specific velocity message `RoverVelocitySetpoint.msg`.

Tested in SITL.
