### PR TITLE
docs_deploy.yml - update to create backup and always be single release

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -79,16 +79,21 @@ jobs:
 
       - name: Deploy
         run: |
-          git clone --single-branch --branch main https://${{ secrets.PX4BUILTBOT_PERSONAL_ACCESS_TOKEN }}@github.com/PX4/docs.px4.io.git
+          git clone --single-branch --branch main --depth 1 https://${{ secrets.PX4BUILTBOT_PERSONAL_ACCESS_TOKEN }}@github.com/PX4/docs.px4.io.git
+          CURRENT_DATETIME=$(date +'%Y%m%d_%H_%M')
+          # make it an orphan branch
+          git checkout --orphan "${CURRENT_DATETIME}_main"
           rm -rf docs.px4.io/${BRANCH_NAME}
           mkdir -p docs.px4.io/${BRANCH_NAME}
           cp -r ~/_book/* docs.px4.io/${BRANCH_NAME}/
           cd docs.px4.io
           git config --global user.name "${{ secrets.PX4BUILDBOT_USER }}"
           git config --global user.email "${{ secrets.PX4BUILDBOT_EMAIL }}"
-          git add ${BRANCH_NAME}
+          git add .
           git commit -a -m "PX4 docs build update (vitepress) `date`"
-          #git add .
-          #git commit --amend -m "PX4 docs build update (vitepress) `date`"
-          #git commit --allow-empty -m "Empty commit to force rebuild"
+          # push branch as backup
+          git push origin "${CURRENT_DATETIME}_main"
+          # Now make main from backup and push updated
+          git branch -D main
+          git checkout -b main
           git push origin main -f

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -37,6 +37,10 @@ export default {
     //Tabs: https://github.com/Red-Asuka/vitepress-plugin-tabs
     app.component("Tab", Tab);
     app.component("Tabs", Tabs);
+    // Global build time variable
+    app.config.globalProperties.$buildTime = JSON.stringify(
+      new Date().toISOString()
+    );
   },
 
   // to support medium zoom: https://github.com/vuejs/vitepress/issues/854

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -137,3 +137,5 @@ The PX4 flight stack is hosted under the governance of the [Dronecode Project](h
 <a href="https://www.linuxfoundation.org/projects" style="padding:20px;"><img src="https://mavlink.io/assets/site/logo_linux_foundation.png" alt="Linux Foundation Logo" width="80px" /></a>
 
 <div style="padding:10px">&nbsp;</div>
+
+Doc build time: {{ $buildTime }}


### PR DESCRIPTION
The docs are built and then previously the the rebuilt tree was added as a commit to the main branch of  https://github.com/PX4/docs.px4.io. This grows the main branch each time which makes the build longer. Further in several cases the build has failed and we've had to revert to significantly older builds.

What this does is 
- make the docs update always create a new deployment branch as a backup
- make the main branch only one commit deep.
- add a build date stamp at bottom of front page we can use to find actual last build time.

This should make build times more predictable, and easier to revert to a backup if needed.