### PR TITLE
Ackermann: Update control structure

### DIFF
--- a/msg/AckermannVelocitySetpoint.msg
+++ b/msg/AckermannVelocitySetpoint.msg
@@ -1,4 +1,0 @@
-uint64 timestamp # time since system start (microseconds)
-
-float32[2] velocity_ned # 2-dimensional velocity setpoint in NED frame [m/s]
-bool backwards	        # Flag for backwards driving

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -37,7 +37,6 @@ cmake_policy(SET CMP0057 NEW)
 include(px4_list_make_absolute)
 
 set(msg_files
-	AckermannVelocitySetpoint.msg
 	ActionRequest.msg
 	ActuatorArmed.msg
 	ActuatorControlsStatus.msg
@@ -64,7 +63,6 @@ set(msg_files
 	DebugValue.msg
 	DebugVect.msg
 	DifferentialPressure.msg
-	DifferentialVelocitySetpoint.msg
 	DistanceSensor.msg
 	DistanceSensorModeChangeRequest.msg
 	Ekf2Timestamps.msg
@@ -131,7 +129,6 @@ set(msg_files
 	ManualControlSwitches.msg
 	MavlinkLog.msg
 	MavlinkTunnel.msg
-	MecanumVelocitySetpoint.msg
 	MessageFormatRequest.msg
 	MessageFormatResponse.msg
 	Mission.msg
@@ -181,6 +178,7 @@ set(msg_files
 	RoverRateStatus.msg
 	RoverSteeringSetpoint.msg
 	RoverThrottleSetpoint.msg
+	RoverVelocitySetpoint.msg
 	RoverVelocityStatus.msg
 	Rpm.msg
 	RtlStatus.msg

--- a/msg/MecanumVelocitySetpoint.msg
+++ b/msg/MecanumVelocitySetpoint.msg
@@ -1,5 +1,0 @@
-uint64 timestamp # time since system start (microseconds)
-
-float32 speed # [m/s] [-inf, inf] Speed setpoint
-float32 bearing         # [rad] [-pi, pi] from North.
-float32 yaw 	        # [rad] [-pi, pi] (Optional, defaults to current vehicle yaw) Vehicle yaw setpoint in NED frame

--- a/msg/RoverPositionSetpoint.msg
+++ b/msg/RoverPositionSetpoint.msg
@@ -1,6 +1,8 @@
 uint64 timestamp # time since system start (microseconds)
 
 float32[2] position_ned # 2-dimensional position setpoint in NED frame [m]
-float32 cruising_speed  # (Optional) Specify rover speed (Defaults to maximum speed)
+float32[2] start_ned	# (Optional) 2-dimensional start position in NED frame [m] (Defaults to vehicle position)
+float32 cruising_speed  # (Optional) Specify rover speed [m/s] (Defaults to maximum speed)
+float32 arrival_speed   # (Optional) Specify arrival speed [m/s] (Defaults to zero)
 
-float32 yaw             # [rad] [-pi,pi] from North. Optional, NAN if not set. Mecanum only.
+float32 yaw             # [rad] [-pi,pi] from North. Optional, NAN if not set. Mecanum only. (Defaults to vehicle yaw)

--- a/msg/RoverThrottleSetpoint.msg
+++ b/msg/RoverThrottleSetpoint.msg
@@ -2,5 +2,4 @@
 uint64 timestamp        # time since system start (microseconds)
 
 float32 throttle_body_x # throttle setpoint along body X axis [-1, 1] (Positiv = forwards, Negativ = backwards)
-
 float32 throttle_body_y # throttle setpoint along body Y axis [-1, 1] (Mecanum only, Positiv = right, Negativ = left)

--- a/msg/RoverVelocitySetpoint.msg
+++ b/msg/RoverVelocitySetpoint.msg
@@ -2,3 +2,4 @@ uint64 timestamp # time since system start (microseconds)
 
 float32 speed   # [m/s] [-inf, inf] Speed setpoint (Backwards driving if negative)
 float32 bearing # [rad] [-pi,pi] from North.
+float32 yaw 	# [rad] [-pi, pi] (Mecanum only, Optional, defaults to current vehicle yaw) Vehicle yaw setpoint in NED frame

--- a/msg/RoverVelocitySetpoint.msg
+++ b/msg/RoverVelocitySetpoint.msg
@@ -1,5 +1,5 @@
 uint64 timestamp # time since system start (microseconds)
 
 float32 speed   # [m/s] [-inf, inf] Speed setpoint (Backwards driving if negative)
-float32 bearing # [rad] [-pi,pi] from North.
+float32 bearing # [rad] [-pi,pi] from North. [invalid: NAN, speed is defined in body x direction]
 float32 yaw 	# [rad] [-pi, pi] (Mecanum only, Optional, defaults to current vehicle yaw) Vehicle yaw setpoint in NED frame

--- a/msg/RoverVelocityStatus.msg
+++ b/msg/RoverVelocityStatus.msg
@@ -1,10 +1,8 @@
 uint64 timestamp # time since system start (microseconds)
 
 float32 measured_speed_body_x          # [m/s] Measured speed in body x direction. Positiv: forwards, Negativ: backwards
-float32 speed_body_x_setpoint          # [m/s] Speed setpoint in body x direction. Positiv: forwards, Negativ: backwards
 float32 adjusted_speed_body_x_setpoint # [m/s] Post slew rate speed setpoint in body x direction. Positiv: forwards, Negativ: backwards
-float32 measured_speed_body_y          # [m/s] Measured speed in body y direction. Positiv: right, Negativ: left
-float32 speed_body_y_setpoint          # [m/s] Speed setpoint in body y direction. Positiv: right, Negativ: left (Only for mecanum rovers)
-float32 adjusted_speed_body_y_setpoint # [m/s] Post slew rate speed setpoint in body y direction. Positiv: right, Negativ: left (Only for mecanum rovers)
 float32 pid_throttle_body_x_integral   # Integral of the PID for the closed loop controller of the speed in body x direction
-float32 pid_throttle_body_y_integral   # Integral of the PID for the closed loop controller of the speed in body y direction
+float32 measured_speed_body_y          # [m/s] Measured speed in body y direction. Positiv: right, Negativ: left (Mecanum only)
+float32 adjusted_speed_body_y_setpoint # [m/s] Post slew rate speed setpoint in body y direction. Positiv: right, Negativ: left (Mecanum only)
+float32 pid_throttle_body_y_integral   # Integral of the PID for the closed loop controller of the speed in body y direction (Mecanum only)

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -45,7 +45,6 @@ using namespace px4::logger;
 
 void LoggedTopics::add_default_topics()
 {
-	add_optional_topic("ackermann_velocity_setpoint", 100);
 	add_topic("action_request");
 	add_topic("actuator_armed");
 	add_optional_topic("actuator_controls_status_0", 300);
@@ -58,7 +57,6 @@ void LoggedTopics::add_default_topics()
 	add_topic("commander_state");
 	add_topic("config_overrides");
 	add_topic("cpuload");
-	add_optional_topic("differential_velocity_setpoint", 100);
 	add_topic("distance_sensor_mode_change_request");
 	add_optional_topic("external_ins_attitude");
 	add_optional_topic("external_ins_global_position");
@@ -93,7 +91,6 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("magnetometer_bias_estimate", 200);
 	add_topic("manual_control_setpoint", 200);
 	add_topic("manual_control_switches");
-	add_optional_topic("mecanum_velocity_setpoint", 100);
 	add_topic("mission_result");
 	add_topic("navigator_mission_item");
 	add_topic("navigator_status");
@@ -115,6 +112,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("rover_rate_status", 100);
 	add_optional_topic("rover_steering_setpoint", 100);
 	add_optional_topic("rover_throttle_setpoint", 100);
+	add_optional_topic("rover_velocity_setpoint", 100);
 	add_optional_topic("rover_velocity_status", 100);
 	add_topic("rtl_time_estimate", 1000);
 	add_topic("rtl_status", 2000);

--- a/src/modules/rover_ackermann/AckermannActControl/AckermannActControl.cpp
+++ b/src/modules/rover_ackermann/AckermannActControl/AckermannActControl.cpp
@@ -59,12 +59,6 @@ void AckermannActControl::updateActControl()
 	_timestamp = hrt_absolute_time();
 	_dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
 
-	generateActuatorSetpoint();
-
-}
-
-void AckermannActControl::generateActuatorSetpoint()
-{
 	// Motor control
 	rover_throttle_setpoint_s rover_throttle_setpoint{};
 	_rover_throttle_setpoint_sub.copy(&rover_throttle_setpoint);
@@ -102,4 +96,20 @@ void AckermannActControl::generateActuatorSetpoint()
 	actuator_servos.control[0] = _servo_setpoint.getState();
 	actuator_servos.timestamp = _timestamp;
 	_actuator_servos_pub.publish(actuator_servos);
+
+}
+
+void AckermannActControl::manualMode()
+{
+	manual_control_setpoint_s manual_control_setpoint{};
+	_manual_control_setpoint_sub.copy(&manual_control_setpoint);
+	rover_steering_setpoint_s rover_steering_setpoint{};
+	rover_steering_setpoint.timestamp = hrt_absolute_time();
+	rover_steering_setpoint.normalized_steering_angle = manual_control_setpoint.roll;
+	_rover_steering_setpoint_pub.publish(rover_steering_setpoint);
+	rover_throttle_setpoint_s rover_throttle_setpoint{};
+	rover_throttle_setpoint.timestamp = hrt_absolute_time();
+	rover_throttle_setpoint.throttle_body_x = manual_control_setpoint.throttle;
+	rover_throttle_setpoint.throttle_body_y = 0.f;
+	_rover_throttle_setpoint_pub.publish(rover_throttle_setpoint);
 }

--- a/src/modules/rover_ackermann/AckermannActControl/AckermannActControl.cpp
+++ b/src/modules/rover_ackermann/AckermannActControl/AckermannActControl.cpp
@@ -1,0 +1,105 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "AckermannActControl.hpp"
+
+using namespace time_literals;
+
+AckermannActControl::AckermannActControl(ModuleParams *parent) : ModuleParams(parent)
+{
+	updateParams();
+}
+
+void AckermannActControl::updateParams()
+{
+	ModuleParams::updateParams();
+
+	if (_param_ra_str_rate_limit.get() > FLT_EPSILON && _param_ra_max_str_ang.get() > FLT_EPSILON) {
+		_servo_setpoint.setSlewRate((M_DEG_TO_RAD_F * _param_ra_str_rate_limit.get()) / _param_ra_max_str_ang.get());
+	}
+
+	if (_param_ro_accel_limit.get() > FLT_EPSILON && _param_ro_max_thr_speed.get() > FLT_EPSILON) {
+		_motor_setpoint.setSlewRate(_param_ro_accel_limit.get() / _param_ro_max_thr_speed.get());
+	}
+}
+
+void AckermannActControl::updateActControl()
+{
+	const hrt_abstime timestamp_prev = _timestamp;
+	_timestamp = hrt_absolute_time();
+	_dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
+
+	generateActuatorSetpoint();
+
+}
+
+void AckermannActControl::generateActuatorSetpoint()
+{
+	// Motor control
+	rover_throttle_setpoint_s rover_throttle_setpoint{};
+	_rover_throttle_setpoint_sub.copy(&rover_throttle_setpoint);
+	actuator_motors_s actuator_motors_sub{};
+	_actuator_motors_sub.copy(&actuator_motors_sub);
+	actuator_motors_s actuator_motors{};
+	actuator_motors.reversible_flags = _param_r_rev.get();
+	actuator_motors.control[0] = RoverControl::throttleControl(_motor_setpoint,
+				     rover_throttle_setpoint.throttle_body_x, actuator_motors_sub.control[0], _param_ro_accel_limit.get(),
+				     _param_ro_decel_limit.get(), _param_ro_max_thr_speed.get(), _dt);
+	actuator_motors.timestamp = _timestamp;
+	_actuator_motors_pub.publish(actuator_motors);
+
+	// Servo control
+	rover_steering_setpoint_s rover_steering_setpoint{};
+	_rover_steering_setpoint_sub.copy(&rover_steering_setpoint);
+	actuator_servos_s actuator_servos_sub{};
+	_actuator_servos_sub.copy(&actuator_servos_sub);
+
+	if (_param_ra_str_rate_limit.get() > FLT_EPSILON
+	    && _param_ra_max_str_ang.get() > FLT_EPSILON) { // Apply slew rate if configured
+		if (fabsf(_servo_setpoint.getState() - actuator_servos_sub.control[0]) > fabsf(
+			    rover_steering_setpoint.normalized_steering_angle -
+			    actuator_servos_sub.control[0])) {
+			_servo_setpoint.setForcedValue(actuator_servos_sub.control[0]);
+		}
+
+		_servo_setpoint.update(rover_steering_setpoint.normalized_steering_angle, _dt);
+
+	} else {
+		_servo_setpoint.setForcedValue(rover_steering_setpoint.normalized_steering_angle);
+	}
+
+	actuator_servos_s actuator_servos{};
+	actuator_servos.control[0] = _servo_setpoint.getState();
+	actuator_servos.timestamp = _timestamp;
+	_actuator_servos_pub.publish(actuator_servos);
+}

--- a/src/modules/rover_ackermann/AckermannActControl/AckermannActControl.hpp
+++ b/src/modules/rover_ackermann/AckermannActControl/AckermannActControl.hpp
@@ -44,11 +44,11 @@
 // uORB includes
 #include <uORB/Subscription.hpp>
 #include <uORB/Publication.hpp>
-#include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/actuator_motors.h>
 #include <uORB/topics/actuator_servos.h>
 #include <uORB/topics/rover_steering_setpoint.h>
 #include <uORB/topics/rover_throttle_setpoint.h>
+#include <uORB/topics/manual_control_setpoint.h>
 
 /**
  * @brief Class for ackermann actuator control.
@@ -64,9 +64,14 @@ public:
 	~AckermannActControl() = default;
 
 	/**
-	 * @brief Update actuator controller.
+	 * @brief Generate and publish actuatorMotors/actuatorServos setpoints from roverThrottleSetpoint/roverSteeringSetpoint.
 	 */
 	void updateActControl();
+
+	/**
+	 * @brief Manual mode
+	 */
+	void manualMode();
 
 protected:
 	/**
@@ -76,20 +81,18 @@ protected:
 
 private:
 
-	/**
-	 * @brief Generate and publish actuatorMotors/actuatorServos setpoints from roverThrottleSetpoint/roverSteeringSetpoint.
-	 */
-	void generateActuatorSetpoint();
-
 	// uORB subscriptions
 	uORB::Subscription _actuator_servos_sub{ORB_ID(actuator_servos)};
 	uORB::Subscription _actuator_motors_sub{ORB_ID(actuator_motors)};
 	uORB::Subscription _rover_steering_setpoint_sub{ORB_ID(rover_steering_setpoint)};
 	uORB::Subscription _rover_throttle_setpoint_sub{ORB_ID(rover_throttle_setpoint)};
+	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 
 	// uORB publications
-	uORB::PublicationMulti<actuator_motors_s> _actuator_motors_pub{ORB_ID(actuator_motors)};
+	uORB::Publication<actuator_motors_s> _actuator_motors_pub{ORB_ID(actuator_motors)};
 	uORB::Publication<actuator_servos_s> _actuator_servos_pub{ORB_ID(actuator_servos)};
+	uORB::Publication<rover_steering_setpoint_s> _rover_steering_setpoint_pub{ORB_ID(rover_steering_setpoint)};
+	uORB::Publication<rover_throttle_setpoint_s> _rover_throttle_setpoint_pub{ORB_ID(rover_throttle_setpoint)};
 
 	// Variables
 	hrt_abstime _timestamp{0};

--- a/src/modules/rover_ackermann/AckermannActControl/AckermannActControl.hpp
+++ b/src/modules/rover_ackermann/AckermannActControl/AckermannActControl.hpp
@@ -34,48 +34,39 @@
 #pragma once
 
 // PX4 includes
-#include <px4_platform_common/px4_config.h>
-#include <px4_platform_common/defines.h>
-#include <px4_platform_common/module.h>
 #include <px4_platform_common/module_params.h>
-#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+
+// Libraries
+#include <lib/rover_control/RoverControl.hpp>
+#include <lib/slew_rate/SlewRate.hpp>
+#include <math.h>
 
 // uORB includes
 #include <uORB/Subscription.hpp>
 #include <uORB/Publication.hpp>
-#include <uORB/topics/parameter_update.h>
+#include <uORB/PublicationMulti.hpp>
+#include <uORB/topics/actuator_motors.h>
+#include <uORB/topics/actuator_servos.h>
 #include <uORB/topics/rover_steering_setpoint.h>
 #include <uORB/topics/rover_throttle_setpoint.h>
-#include <uORB/topics/vehicle_control_mode.h>
-#include <uORB/topics/manual_control_setpoint.h>
 
-// Local includes
-#include "AckermannActControl/AckermannActControl.hpp"
-#include "AckermannRateControl/AckermannRateControl.hpp"
-#include "AckermannAttControl/AckermannAttControl.hpp"
-#include "AckermannVelControl/AckermannVelControl.hpp"
-#include "AckermannPosControl/AckermannPosControl.hpp"
-
-class RoverAckermann : public ModuleBase<RoverAckermann>, public ModuleParams,
-	public px4::ScheduledWorkItem
+/**
+ * @brief Class for ackermann actuator control.
+ */
+class AckermannActControl : public ModuleParams
 {
 public:
 	/**
-	 * @brief Constructor for RoverAckermann
+	 * @brief Constructor for AckermannActControl.
+	 * @param parent The parent ModuleParams object.
 	 */
-	RoverAckermann();
-	~RoverAckermann() override = default;
+	AckermannActControl(ModuleParams *parent);
+	~AckermannActControl() = default;
 
-	/** @see ModuleBase */
-	static int task_spawn(int argc, char *argv[]);
-
-	/** @see ModuleBase */
-	static int custom_command(int argc, char *argv[]);
-
-	/** @see ModuleBase */
-	static int print_usage(const char *reason = nullptr);
-
-	bool init();
+	/**
+	 * @brief Update actuator controller.
+	 */
+	void updateActControl();
 
 protected:
 	/**
@@ -84,28 +75,37 @@ protected:
 	void updateParams() override;
 
 private:
-	void Run() override;
 
 	/**
-	 * @brief Generate and publish roverSteeringSetpoint and roverThrottleSetpoint from manualControlSetpoint (Manual Mode).
+	 * @brief Generate and publish actuatorMotors/actuatorServos setpoints from roverThrottleSetpoint/roverSteeringSetpoint.
 	 */
-	void generateSteeringAndThrottleSetpoint();
+	void generateActuatorSetpoint();
 
 	// uORB subscriptions
-	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
-	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
-	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
-	vehicle_control_mode_s _vehicle_control_mode{};
+	uORB::Subscription _actuator_servos_sub{ORB_ID(actuator_servos)};
+	uORB::Subscription _actuator_motors_sub{ORB_ID(actuator_motors)};
+	uORB::Subscription _rover_steering_setpoint_sub{ORB_ID(rover_steering_setpoint)};
+	uORB::Subscription _rover_throttle_setpoint_sub{ORB_ID(rover_throttle_setpoint)};
 
 	// uORB publications
-	uORB::Publication<rover_throttle_setpoint_s> _rover_throttle_setpoint_pub{ORB_ID(rover_throttle_setpoint)};
-	uORB::Publication<rover_steering_setpoint_s> _rover_steering_setpoint_pub{ORB_ID(rover_steering_setpoint)};
+	uORB::PublicationMulti<actuator_motors_s> _actuator_motors_pub{ORB_ID(actuator_motors)};
+	uORB::Publication<actuator_servos_s> _actuator_servos_pub{ORB_ID(actuator_servos)};
 
-	// Class instances
-	AckermannActControl  _ackermann_act_control{this};
-	AckermannRateControl _ackermann_rate_control{this};
-	AckermannAttControl  _ackermann_att_control{this};
-	AckermannVelControl  _ackermann_vel_control{this};
-	AckermannPosControl  _ackermann_pos_control{this};
+	// Variables
+	hrt_abstime _timestamp{0};
+	float _dt{0.f};
 
+	// Controllers
+	SlewRate<float> _servo_setpoint{0.f};
+	SlewRate<float> _motor_setpoint{0.f};
+
+	// Parameters
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::CA_R_REV>) _param_r_rev,
+		(ParamFloat<px4::params::RA_STR_RATE_LIM>) _param_ra_str_rate_limit,
+		(ParamFloat<px4::params::RA_MAX_STR_ANG>) _param_ra_max_str_ang,
+		(ParamFloat<px4::params::RO_ACCEL_LIM>) _param_ro_accel_limit,
+		(ParamFloat<px4::params::RO_DECEL_LIM>) _param_ro_decel_limit,
+		(ParamFloat<px4::params::RO_MAX_THR_SPEED>) _param_ro_max_thr_speed
+	)
 };

--- a/src/modules/rover_ackermann/AckermannActControl/AckermannActControl.hpp
+++ b/src/modules/rover_ackermann/AckermannActControl/AckermannActControl.hpp
@@ -69,9 +69,14 @@ public:
 	void updateActControl();
 
 	/**
-	 * @brief Manual mode
+	 * @brief Publish roverThrottleSetpoint and roverSteeringSetpoint from manualControlSetpoint.
 	 */
-	void manualMode();
+	void manualManualMode();
+
+	/**
+	 * @brief Stop the vehicle by sending 0 commands to motors and servos.
+	 */
+	void stopVehicle();
 
 protected:
 	/**
@@ -89,14 +94,15 @@ private:
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 
 	// uORB publications
-	uORB::Publication<actuator_motors_s> _actuator_motors_pub{ORB_ID(actuator_motors)};
-	uORB::Publication<actuator_servos_s> _actuator_servos_pub{ORB_ID(actuator_servos)};
+	uORB::Publication<actuator_motors_s> 	     _actuator_motors_pub{ORB_ID(actuator_motors)};
+	uORB::Publication<actuator_servos_s> 	     _actuator_servos_pub{ORB_ID(actuator_servos)};
 	uORB::Publication<rover_steering_setpoint_s> _rover_steering_setpoint_pub{ORB_ID(rover_steering_setpoint)};
 	uORB::Publication<rover_throttle_setpoint_s> _rover_throttle_setpoint_pub{ORB_ID(rover_throttle_setpoint)};
 
 	// Variables
 	hrt_abstime _timestamp{0};
-	float _dt{0.f};
+	float _throttle_setpoint{NAN};
+	float _steering_setpoint{NAN};
 
 	// Controllers
 	SlewRate<float> _servo_setpoint{0.f};
@@ -104,11 +110,11 @@ private:
 
 	// Parameters
 	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::CA_R_REV>) _param_r_rev,
-		(ParamFloat<px4::params::RA_STR_RATE_LIM>) _param_ra_str_rate_limit,
-		(ParamFloat<px4::params::RA_MAX_STR_ANG>) _param_ra_max_str_ang,
-		(ParamFloat<px4::params::RO_ACCEL_LIM>) _param_ro_accel_limit,
-		(ParamFloat<px4::params::RO_DECEL_LIM>) _param_ro_decel_limit,
+		(ParamInt<px4::params::CA_R_REV>) 	    _param_r_rev,
+		(ParamFloat<px4::params::RA_STR_RATE_LIM>)  _param_ra_str_rate_limit,
+		(ParamFloat<px4::params::RA_MAX_STR_ANG>)   _param_ra_max_str_ang,
+		(ParamFloat<px4::params::RO_ACCEL_LIM>)     _param_ro_accel_limit,
+		(ParamFloat<px4::params::RO_DECEL_LIM>)     _param_ro_decel_limit,
 		(ParamFloat<px4::params::RO_MAX_THR_SPEED>) _param_ro_max_thr_speed
 	)
 };

--- a/src/modules/rover_ackermann/AckermannActControl/CMakeLists.txt
+++ b/src/modules/rover_ackermann/AckermannActControl/CMakeLists.txt
@@ -31,27 +31,8 @@
 #
 ############################################################################
 
-add_subdirectory(AckermannActControl)
-add_subdirectory(AckermannRateControl)
-add_subdirectory(AckermannAttControl)
-add_subdirectory(AckermannVelControl)
-add_subdirectory(AckermannPosControl)
-
-px4_add_module(
-	MODULE modules__rover_ackermann
-	MAIN rover_ackermann
-	SRCS
-		RoverAckermann.cpp
-		RoverAckermann.hpp
-	DEPENDS
-		AckermannActControl
-		AckermannRateControl
-		AckermannAttControl
-		AckermannVelControl
-		AckermannPosControl
-		px4_work_queue
-		rover_control
-		pure_pursuit
-	MODULE_CONFIG
-		module.yaml
+px4_add_library(AckermannActControl
+	AckermannActControl.cpp
 )
+
+target_include_directories(AckermannActControl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/modules/rover_ackermann/AckermannAttControl/AckermannAttControl.cpp
+++ b/src/modules/rover_ackermann/AckermannAttControl/AckermannAttControl.cpp
@@ -64,10 +64,6 @@ void AckermannAttControl::updateAttControl()
 	_timestamp = hrt_absolute_time();
 	_dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
 
-	if (_vehicle_control_mode_sub.updated()) {
-		_vehicle_control_mode_sub.copy(&_vehicle_control_mode);
-	}
-
 	if (_vehicle_attitude_sub.updated()) {
 		vehicle_attitude_s vehicle_attitude{};
 		_vehicle_attitude_sub.copy(&vehicle_attitude);
@@ -75,25 +71,15 @@ void AckermannAttControl::updateAttControl()
 		_vehicle_yaw = matrix::Eulerf(vehicle_attitude_quaternion).psi();
 	}
 
-	if (_vehicle_control_mode.flag_control_attitude_enabled && _vehicle_control_mode.flag_armed && runSanityChecks()) {
-		// Estimate forward speed based on throttle
-		if (_actuator_motors_sub.updated()) {
-			actuator_motors_s actuator_motors;
-			_actuator_motors_sub.copy(&actuator_motors);
-			_estimated_speed_body_x = math::interpolate<float> (actuator_motors.control[0], -1.f, 1.f,
-						  -_param_ro_max_thr_speed.get(), _param_ro_max_thr_speed.get());
-		}
-
-		if (_vehicle_control_mode.flag_control_manual_enabled) {
-			generateAttitudeAndThrottleSetpoint();
-		}
-
-		generateRateSetpoint();
-
-	} else { // Reset pid and slew rate when attitude control is not active
-		_pid_yaw.resetIntegral();
-		_adjusted_yaw_setpoint.setForcedValue(0.f);
+	// Estimate forward speed based on throttle
+	if (_actuator_motors_sub.updated()) {
+		actuator_motors_s actuator_motors;
+		_actuator_motors_sub.copy(&actuator_motors);
+		_estimated_speed_body_x = math::interpolate<float> (actuator_motors.control[0], -1.f, 1.f,
+					  -_param_ro_max_thr_speed.get(), _param_ro_max_thr_speed.get());
 	}
+
+	generateRateSetpoint();
 
 	// Publish attitude controller status (logging only)
 	rover_attitude_status_s rover_attitude_status;
@@ -104,68 +90,52 @@ void AckermannAttControl::updateAttControl()
 
 }
 
-void AckermannAttControl::generateAttitudeAndThrottleSetpoint()
+void AckermannAttControl::stabMode()
 {
-	const bool stab_mode_enabled = _vehicle_control_mode.flag_control_manual_enabled
-				       && !_vehicle_control_mode.flag_control_position_enabled && _vehicle_control_mode.flag_control_attitude_enabled;
+	if (_vehicle_attitude_sub.updated()) {
+		vehicle_attitude_s vehicle_attitude{};
+		_vehicle_attitude_sub.copy(&vehicle_attitude);
+		matrix::Quatf vehicle_attitude_quaternion = matrix::Quatf(vehicle_attitude.q);
+		_vehicle_yaw = matrix::Eulerf(vehicle_attitude_quaternion).psi();
+	}
 
-	if (stab_mode_enabled && _manual_control_setpoint_sub.updated()) { // Stab Mode
-		manual_control_setpoint_s manual_control_setpoint{};
+	manual_control_setpoint_s manual_control_setpoint{};
+	_manual_control_setpoint_sub.copy(&manual_control_setpoint);
+	rover_throttle_setpoint_s rover_throttle_setpoint{};
+	rover_throttle_setpoint.timestamp = hrt_absolute_time();
+	rover_throttle_setpoint.throttle_body_x = manual_control_setpoint.throttle;
+	rover_throttle_setpoint.throttle_body_y = 0.f;
+	_rover_throttle_setpoint_pub.publish(rover_throttle_setpoint);
 
-		if (_manual_control_setpoint_sub.update(&manual_control_setpoint)) {
+	const float yaw_delta = math::interpolate<float>(math::deadzone(manual_control_setpoint.roll,
+				_param_ro_yaw_stick_dz.get()), -1.f, 1.f, -_max_yaw_rate / _param_ro_yaw_p.get(),
+				_max_yaw_rate / _param_ro_yaw_p.get());
 
-			rover_throttle_setpoint_s rover_throttle_setpoint{};
-			rover_throttle_setpoint.timestamp = _timestamp;
-			rover_throttle_setpoint.throttle_body_x = manual_control_setpoint.throttle;
-			rover_throttle_setpoint.throttle_body_y = 0.f;
-			_rover_throttle_setpoint_pub.publish(rover_throttle_setpoint);
+	if (fabsf(yaw_delta) > FLT_EPSILON
+	    || fabsf(rover_throttle_setpoint.throttle_body_x) < FLT_EPSILON) { // Closed loop yaw rate control
+		_stab_yaw_setpoint = NAN;
+		const float yaw_setpoint = matrix::wrap_pi(_vehicle_yaw + matrix::sign(manual_control_setpoint.throttle) * yaw_delta);
+		rover_attitude_setpoint_s rover_attitude_setpoint{};
+		rover_attitude_setpoint.timestamp = hrt_absolute_time();
+		rover_attitude_setpoint.yaw_setpoint = yaw_setpoint;
+		_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
 
-			const float yaw_delta = math::interpolate<float>(math::deadzone(manual_control_setpoint.roll,
-						_param_ro_yaw_stick_dz.get()), -1.f, 1.f, -_max_yaw_rate / _param_ro_yaw_p.get(),
-						_max_yaw_rate / _param_ro_yaw_p.get());
-
-			if (fabsf(yaw_delta) > FLT_EPSILON
-			    || fabsf(rover_throttle_setpoint.throttle_body_x) < FLT_EPSILON) { // Closed loop yaw rate control
-				_stab_yaw_ctl = false;
-				const float yaw_setpoint = matrix::wrap_pi(_vehicle_yaw + matrix::sign(manual_control_setpoint.throttle) * yaw_delta);
-				rover_attitude_setpoint_s rover_attitude_setpoint{};
-				rover_attitude_setpoint.timestamp = _timestamp;
-				rover_attitude_setpoint.yaw_setpoint = yaw_setpoint;
-				_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
-
-			} else { // Closed loop yaw control if the yaw rate input is zero (keep current yaw)
-				if (!_stab_yaw_ctl) {
-					_stab_yaw_setpoint = _vehicle_yaw;
-					_stab_yaw_ctl = true;
-				}
-
-				rover_attitude_setpoint_s rover_attitude_setpoint{};
-				rover_attitude_setpoint.timestamp = _timestamp;
-				rover_attitude_setpoint.yaw_setpoint = _stab_yaw_setpoint;
-				_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
-			}
-
-
+	} else { // Closed loop yaw control if the yaw rate input is zero (keep current yaw)
+		if (!PX4_ISFINITE(_stab_yaw_setpoint)) {
+			_stab_yaw_setpoint = _vehicle_yaw;
 		}
 
+		rover_attitude_setpoint_s rover_attitude_setpoint{};
+		rover_attitude_setpoint.timestamp = hrt_absolute_time();
+		rover_attitude_setpoint.yaw_setpoint = _stab_yaw_setpoint;
+		_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
 	}
 }
 
 void AckermannAttControl::generateRateSetpoint()
 {
-	if (_rover_attitude_setpoint_sub.updated()) {
-		_rover_attitude_setpoint_sub.copy(&_rover_attitude_setpoint);
-	}
-
-	if (_rover_rate_setpoint_sub.updated()) {
-		_rover_rate_setpoint_sub.copy(&_rover_rate_setpoint);
-	}
-
-	// Check if a new rate setpoint was already published from somewhere else
-	if (_rover_rate_setpoint.timestamp > _last_rate_setpoint_update
-	    && _rover_rate_setpoint.timestamp > _rover_attitude_setpoint.timestamp) {
-		return;
-	}
+	rover_attitude_setpoint_s rover_attitude_setpoint{};
+	_rover_attitude_setpoint_sub.copy(&rover_attitude_setpoint);
 
 	// Calculate yaw rate limit for slew rate
 	float max_possible_yaw_rate = fabsf(_estimated_speed_body_x) * tanf(_param_ra_max_str_ang.get()) /
@@ -173,9 +143,8 @@ void AckermannAttControl::generateRateSetpoint()
 	float yaw_slew_rate = math::min(max_possible_yaw_rate, _max_yaw_rate);
 
 	float yaw_rate_setpoint = RoverControl::attitudeControl(_adjusted_yaw_setpoint, _pid_yaw, yaw_slew_rate,
-				  _vehicle_yaw, _rover_attitude_setpoint.yaw_setpoint, _dt);
+				  _vehicle_yaw, rover_attitude_setpoint.yaw_setpoint, _dt);
 
-	_last_rate_setpoint_update = _timestamp;
 	rover_rate_setpoint_s rover_rate_setpoint{};
 	rover_rate_setpoint.timestamp = _timestamp;
 	rover_rate_setpoint.yaw_rate_setpoint = math::constrain(yaw_rate_setpoint, -_max_yaw_rate, _max_yaw_rate);

--- a/src/modules/rover_ackermann/AckermannAttControl/AckermannAttControl.hpp
+++ b/src/modules/rover_ackermann/AckermannAttControl/AckermannAttControl.hpp
@@ -68,19 +68,19 @@ public:
 	~AckermannAttControl() = default;
 
 	/**
-	 * @brief Update attitude controller.
+	 * @brief Generate and publish roverRateSetpoint from roverAttitudeSetpoint.
 	 */
 	void updateAttControl();
 
 	/**
-	 * @brief Stabilized mode
+	 * @brief Generate and publish roverThrottleSetpoint and RoverAttitudeSetpoint from manualControlSetpoint.
 	 */
-	void stabMode();
+	void manualStabMode();
 
 	/**
 	 * @brief Reset attitude controller.
 	 */
-	void reset() {_pid_yaw.resetIntegral(); _stab_yaw_setpoint = NAN;};
+	void reset() {_pid_yaw.resetIntegral(); _stab_yaw_setpoint = NAN; _yaw_setpoint = NAN;};
 
 	/**
 	 * @brief Check if the necessary parameters are set.
@@ -97,8 +97,9 @@ protected:
 private:
 	/**
 	 * @brief Generate and publish roverRateSetpoint from roverAttitudeSetpoint.
+	 * @param dt [s] Time since last update.
 	 */
-	void generateRateSetpoint();
+	void generateRateSetpoint(float dt);
 
 	// uORB subscriptions
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
@@ -107,19 +108,19 @@ private:
 	uORB::Subscription _rover_attitude_setpoint_sub{ORB_ID(rover_attitude_setpoint)};
 
 	// uORB publications
-	uORB::Publication<rover_rate_setpoint_s> _rover_rate_setpoint_pub{ORB_ID(rover_rate_setpoint)};
+	uORB::Publication<rover_rate_setpoint_s>     _rover_rate_setpoint_pub{ORB_ID(rover_rate_setpoint)};
 	uORB::Publication<rover_throttle_setpoint_s> _rover_throttle_setpoint_pub{ORB_ID(rover_throttle_setpoint)};
 	uORB::Publication<rover_attitude_setpoint_s> _rover_attitude_setpoint_pub{ORB_ID(rover_attitude_setpoint)};
-	uORB::Publication<rover_attitude_status_s> _rover_attitude_status_pub{ORB_ID(rover_attitude_status)};
+	uORB::Publication<rover_attitude_status_s>   _rover_attitude_status_pub{ORB_ID(rover_attitude_status)};
 
 	// Variables
 	float _vehicle_yaw{0.f};
 	hrt_abstime _timestamp{0};
-	float _dt{0.f};
 	float _max_yaw_rate{0.f};
 	float _estimated_speed_body_x{0.f}; /*Vehicle speed estimated by interpolating [actuatorMotorSetpoint,  _estimated_speed_body_x]
 					       between [0, 0] and [1, _param_ro_max_thr_speed].*/
-	float _stab_yaw_setpoint{0.f}; // Yaw setpoint for heading control stab mode (NAN heading not controlled)
+	float _stab_yaw_setpoint{0.f}; // Yaw setpoint for heading control stab mode (NAN: heading not controlled)
+	float _yaw_setpoint{NAN};
 
 	// Controllers
 	PID _pid_yaw;

--- a/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.cpp
+++ b/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.cpp
@@ -41,10 +41,6 @@ AckermannPosControl::AckermannPosControl(ModuleParams *parent) : ModuleParams(pa
 	_rover_position_setpoint_pub.advertise();
 	_rover_velocity_setpoint_pub.advertise();
 
-	// Initially set to NaN to indicate that the rover has no position setpoint
-	_rover_position_setpoint.position_ned[0] = NAN;
-	_rover_position_setpoint.position_ned[1] = NAN;
-
 	updateParams();
 }
 
@@ -61,21 +57,24 @@ void AckermannPosControl::updateParams()
 
 void AckermannPosControl::updatePosControl()
 {
-	const hrt_abstime timestamp_prev = _timestamp;
-	_timestamp = hrt_absolute_time();
-	_dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
-
 	updateSubscriptions();
 
 	if (_vehicle_control_mode.flag_control_position_enabled && _vehicle_control_mode.flag_armed && runSanityChecks()) {
+		// Generate Position Setpoint
 		if (_vehicle_control_mode.flag_control_offboard_enabled) {
 			generatePositionSetpoint();
+
+		} else if (_vehicle_control_mode.flag_control_manual_enabled) {
+			manualPositionMode();
+
+		} else if (_vehicle_control_mode.flag_control_auto_enabled) {
+			autoPositionMode();
 		}
 
+		// Generate Velocity Setpoint
 		generateVelocitySetpoint();
 
 	}
-
 }
 
 void AckermannPosControl::updateSubscriptions()
@@ -121,7 +120,7 @@ void AckermannPosControl::generatePositionSetpoint()
 
 	// Translate trajectory setpoint to rover position setpoint
 	rover_position_setpoint_s rover_position_setpoint{};
-	rover_position_setpoint.timestamp = _timestamp;
+	rover_position_setpoint.timestamp = hrt_absolute_time();
 	rover_position_setpoint.position_ned[0] = trajectory_setpoint.position[0];
 	rover_position_setpoint.position_ned[1] = trajectory_setpoint.position[1];
 	rover_position_setpoint.cruising_speed = _param_ro_speed_limit.get();
@@ -130,31 +129,10 @@ void AckermannPosControl::generatePositionSetpoint()
 
 }
 
-void AckermannPosControl::generateVelocitySetpoint()
-{
-	// Manual Position Mode
-	if (_vehicle_control_mode.flag_control_manual_enabled && _vehicle_control_mode.flag_control_position_enabled) {
-		manualPositionMode();
-		return;
-	}
-
-	// Auto Mode
-	if (_vehicle_control_mode.flag_control_auto_enabled) {
-		autoPositionMode();
-		return;
-	}
-
-	// Rover Position Setpoint
-	if (_rover_position_setpoint_sub.copy(&_rover_position_setpoint)
-	    && PX4_ISFINITE(_rover_position_setpoint.position_ned[0]) && PX4_ISFINITE(_rover_position_setpoint.position_ned[1])) {
-		goToPositionMode();
-		return;
-	}
-
-}
-
 void AckermannPosControl::manualPositionMode()
 {
+	updateSubscriptions();
+
 	manual_control_setpoint_s manual_control_setpoint{};
 	_manual_control_setpoint_sub.copy(&manual_control_setpoint);
 
@@ -167,12 +145,21 @@ void AckermannPosControl::manualPositionMode()
 	if (fabsf(yaw_delta) > FLT_EPSILON
 	    || fabsf(speed_setpoint) < FLT_EPSILON) { // Closed loop yaw rate control
 		_course_control = false;
+		// Construct a 'target waypoint' for course control s.t. it is never within the maximum lookahead of the rover
 		const float yaw_setpoint = matrix::wrap_pi(_vehicle_yaw + sign(speed_setpoint) * yaw_delta);
-		rover_velocity_setpoint_s rover_velocity_setpoint{};
-		rover_velocity_setpoint.timestamp = _timestamp;
-		rover_velocity_setpoint.speed = speed_setpoint;
-		rover_velocity_setpoint.bearing = yaw_setpoint;
-		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
+		const Vector2f pos_ctl_course_direction = Vector2f(cos(yaw_setpoint), sin(yaw_setpoint));
+		const Vector2f target_waypoint_ned = _curr_pos_ned + sign(speed_setpoint) * _param_pp_lookahd_max.get() *
+						     pos_ctl_course_direction;
+		rover_position_setpoint_s rover_position_setpoint{};
+		rover_position_setpoint.timestamp = hrt_absolute_time();
+		rover_position_setpoint.position_ned[0] = target_waypoint_ned(0);
+		rover_position_setpoint.position_ned[1] = target_waypoint_ned(1);
+		rover_position_setpoint.start_ned[0] = NAN;
+		rover_position_setpoint.start_ned[1] = NAN;
+		rover_position_setpoint.arrival_speed = NAN;
+		rover_position_setpoint.cruising_speed = speed_setpoint;
+		rover_position_setpoint.yaw = NAN;
+		_rover_position_setpoint_pub.publish(rover_position_setpoint);
 
 	} else { // Course control if the steering input is zero (keep driving on a straight line)
 		if (!_course_control) {
@@ -186,24 +173,23 @@ void AckermannPosControl::manualPositionMode()
 		const float vector_scaling = fabsf(start_to_curr_pos * _pos_ctl_course_direction) + _param_pp_lookahd_max.get();
 		const Vector2f target_waypoint_ned = _pos_ctl_start_position_ned + sign(speed_setpoint) *
 						     vector_scaling * _pos_ctl_course_direction;
-		pure_pursuit_status_s pure_pursuit_status{};
-		pure_pursuit_status.timestamp = _timestamp;
-		const float bearing_setpoint = PurePursuit::calcTargetBearing(pure_pursuit_status, _param_pp_lookahd_gain.get(),
-					       _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), target_waypoint_ned, _pos_ctl_start_position_ned,
-					       _curr_pos_ned, fabsf(speed_setpoint));
-		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		rover_velocity_setpoint_s rover_velocity_setpoint{};
-		rover_velocity_setpoint.timestamp = _timestamp;
-		rover_velocity_setpoint.speed = speed_setpoint;
-		rover_velocity_setpoint.bearing = speed_setpoint > -FLT_EPSILON ? bearing_setpoint : matrix::wrap_pi(
-				bearing_setpoint + M_PI_F);
-		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
-
+		rover_position_setpoint_s rover_position_setpoint{};
+		rover_position_setpoint.timestamp = hrt_absolute_time();
+		rover_position_setpoint.position_ned[0] = target_waypoint_ned(0);
+		rover_position_setpoint.position_ned[1] = target_waypoint_ned(1);
+		rover_position_setpoint.start_ned[0] = _pos_ctl_start_position_ned(0);
+		rover_position_setpoint.start_ned[1] = _pos_ctl_start_position_ned(1);
+		rover_position_setpoint.arrival_speed = NAN;
+		rover_position_setpoint.cruising_speed = speed_setpoint;
+		rover_position_setpoint.yaw = NAN;
+		_rover_position_setpoint_pub.publish(rover_position_setpoint);
 	}
 }
 
 void AckermannPosControl::autoPositionMode()
 {
+	updateSubscriptions();
+
 	if (_position_setpoint_triplet_sub.updated()) {
 		updateWaypointsAndAcceptanceRadius();
 	}
@@ -214,40 +200,19 @@ void AckermannPosControl::autoPositionMode()
 	const float distance_to_curr_wp = sqrt(powf(_curr_pos_ned(0) - _curr_wp_ned(0),
 					       2) + powf(_curr_pos_ned(1) - _curr_wp_ned(1), 2));
 
-	// Check stopping conditions
-	bool auto_stop{false};
-
-	if (_curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND
-	    || _curr_wp_type == position_setpoint_s::SETPOINT_TYPE_IDLE
-	    || !_next_wp_ned.isAllFinite()) {
-		auto_stop = distance_to_curr_wp < _param_nav_acc_rad.get();
-	}
-
-	if (auto_stop) {
-		rover_velocity_setpoint_s rover_velocity_setpoint{};
-		rover_velocity_setpoint.timestamp = _timestamp;
-		rover_velocity_setpoint.speed = 0.f;
-		rover_velocity_setpoint.bearing = _vehicle_yaw;
-		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
-
-	} else { // Regular guidance algorithm
-		const float speed_setpoint = calcSpeedSetpoint(_cruising_speed, _min_speed, distance_to_prev_wp,
-					     distance_to_curr_wp, _acceptance_radius, _prev_acceptance_radius, _param_ro_decel_limit.get(),
-					     _param_ro_jerk_limit.get(), _curr_wp_type, _waypoint_transition_angle, _prev_waypoint_transition_angle,
-					     _param_ro_speed_limit.get());
-		pure_pursuit_status_s pure_pursuit_status{};
-		pure_pursuit_status.timestamp = _timestamp;
-		const float yaw_setpoint = PurePursuit::calcTargetBearing(pure_pursuit_status, _param_pp_lookahd_gain.get(),
-					   _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), _curr_wp_ned, _prev_wp_ned, _curr_pos_ned,
-					   fabsf(speed_setpoint));
-		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		rover_velocity_setpoint_s rover_velocity_setpoint{};
-		rover_velocity_setpoint.timestamp = _timestamp;
-		rover_velocity_setpoint.speed = speed_setpoint;
-		rover_velocity_setpoint.bearing = yaw_setpoint;
-		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
-
-	}
+	rover_position_setpoint_s rover_position_setpoint{};
+	rover_position_setpoint.timestamp = hrt_absolute_time();
+	rover_position_setpoint.position_ned[0] = _curr_wp_ned(0);
+	rover_position_setpoint.position_ned[1] = _curr_wp_ned(1);
+	rover_position_setpoint.start_ned[0] = _prev_wp_ned(0);
+	rover_position_setpoint.start_ned[1] = _prev_wp_ned(1);
+	rover_position_setpoint.arrival_speed = autoArrivalSpeed(_cruising_speed, _min_speed, _acceptance_radius, _curr_wp_type,
+						_waypoint_transition_angle, _max_yaw_rate);
+	rover_position_setpoint.cruising_speed = autoCruisingSpeed(_cruising_speed, _min_speed, distance_to_prev_wp,
+			distance_to_curr_wp, _acceptance_radius, _prev_acceptance_radius, _waypoint_transition_angle,
+			_prev_waypoint_transition_angle, _max_yaw_rate);
+	rover_position_setpoint.yaw = NAN;
+	_rover_position_setpoint_pub.publish(rover_position_setpoint);
 }
 
 void AckermannPosControl::updateWaypointsAndAcceptanceRadius()
@@ -298,53 +263,47 @@ float AckermannPosControl::updateAcceptanceRadius(const float waypoint_transitio
 	// Publish updated acceptance radius
 	position_controller_status_s pos_ctrl_status{};
 	pos_ctrl_status.acceptance_radius = acceptance_radius;
-	pos_ctrl_status.timestamp = _timestamp;
+	pos_ctrl_status.timestamp = hrt_absolute_time();
 	_position_controller_status_pub.publish(pos_ctrl_status);
 	return acceptance_radius;
 }
 
-float AckermannPosControl::calcSpeedSetpoint(const float cruising_speed, const float miss_speed_min,
-		const float distance_to_prev_wp, const float distance_to_curr_wp, const float acc_rad,
-		const float prev_acc_rad, const float max_decel, const float max_jerk, const int curr_wp_type,
-		const float waypoint_transition_angle, const float prev_waypoint_transition_angle, const float max_speed)
+float AckermannPosControl::autoArrivalSpeed(const float cruising_speed, const float miss_speed_min, const float acc_rad,
+		const int curr_wp_type, const float waypoint_transition_angle, const float max_yaw_rate)
+{
+	if (!PX4_ISFINITE(waypoint_transition_angle)
+	    || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND
+	    || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_IDLE) {
+		return 0.f; // Stop at the waypoint
+
+	} else {
+		const float turning_circle = acc_rad * tanf(waypoint_transition_angle / 2.f);
+		const float cornering_speed = max_yaw_rate * turning_circle;
+		return math::constrain(cornering_speed, miss_speed_min, cruising_speed); // Slow down for cornering
+	}
+}
+
+float AckermannPosControl::autoCruisingSpeed(const float cruising_speed, const float miss_speed_min,
+		const float distance_to_prev_wp, const float distance_to_curr_wp, const float acc_rad, const float prev_acc_rad,
+		const float waypoint_transition_angle, const float prev_waypoint_transition_angle, const float max_yaw_rate)
 {
 	// Catch improper values
 	if (miss_speed_min < -FLT_EPSILON  || miss_speed_min > cruising_speed) {
 		return cruising_speed;
 	}
 
-	// Upcoming stop
-	if (max_decel > FLT_EPSILON && max_jerk > FLT_EPSILON && (!PX4_ISFINITE(waypoint_transition_angle)
-			|| curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND
-			|| curr_wp_type == position_setpoint_s::SETPOINT_TYPE_IDLE)) {
-		const float straight_line_speed = math::trajectory::computeMaxSpeedFromDistance(max_jerk,
-						  max_decel, distance_to_curr_wp, 0.f);
-		return math::min(straight_line_speed, cruising_speed);
-	}
-
 	// Cornering slow down effect
 	if (distance_to_prev_wp <= prev_acc_rad && prev_acc_rad > FLT_EPSILON && PX4_ISFINITE(prev_waypoint_transition_angle)) {
 		const float turning_circle = prev_acc_rad * tanf(prev_waypoint_transition_angle / 2.f);
-		const float cornering_speed = _max_yaw_rate * turning_circle;
+		const float cornering_speed = max_yaw_rate * turning_circle;
 		return math::constrain(cornering_speed, miss_speed_min, cruising_speed);
 
 	}
 
 	if (distance_to_curr_wp <= acc_rad && acc_rad > FLT_EPSILON && PX4_ISFINITE(waypoint_transition_angle)) {
 		const float turning_circle = acc_rad * tanf(waypoint_transition_angle / 2.f);
-		const float cornering_speed = _max_yaw_rate * turning_circle;
+		const float cornering_speed = max_yaw_rate * turning_circle;
 		return math::constrain(cornering_speed, miss_speed_min, cruising_speed);
-
-	}
-
-	// Straight line speed
-	if (max_decel > FLT_EPSILON && max_jerk > FLT_EPSILON && acc_rad > FLT_EPSILON) {
-		const float turning_circle = acc_rad * tanf(waypoint_transition_angle / 2.f);
-		float cornering_speed = _max_yaw_rate * turning_circle;
-		cornering_speed = math::constrain(cornering_speed, miss_speed_min, cruising_speed);
-		const float straight_line_speed = math::trajectory::computeMaxSpeedFromDistance(max_jerk,
-						  max_decel, distance_to_curr_wp - acc_rad, cornering_speed);
-		return math::min(straight_line_speed, cruising_speed);
 
 	}
 
@@ -352,33 +311,56 @@ float AckermannPosControl::calcSpeedSetpoint(const float cruising_speed, const f
 
 }
 
-void AckermannPosControl::goToPositionMode()
+void AckermannPosControl::generateVelocitySetpoint()
 {
+	hrt_abstime timestamp = hrt_absolute_time();
+
+	if (_rover_position_setpoint_sub.updated()) {
+		_rover_position_setpoint_sub.copy(&_rover_position_setpoint);
+		_start_ned = Vector2f(_rover_position_setpoint.start_ned[0], _rover_position_setpoint.start_ned[1]);
+		_start_ned = _start_ned.isAllFinite() ? _start_ned : _curr_pos_ned;
+	}
+
+	if (_position_controller_status_sub.updated()) {
+		position_controller_status_s position_controller_status{};
+		_position_controller_status_sub.copy(&position_controller_status);
+		_acceptance_radius = position_controller_status.acceptance_radius;
+	}
+
 	const Vector2f target_waypoint_ned(_rover_position_setpoint.position_ned[0], _rover_position_setpoint.position_ned[1]);
 	const float distance_to_target = (target_waypoint_ned - _curr_pos_ned).norm();
 
 	if (distance_to_target > _param_nav_acc_rad.get()) {
+
+		float arrival_speed = PX4_ISFINITE(_rover_position_setpoint.arrival_speed) ? _rover_position_setpoint.arrival_speed :
+				      0.f;
+		const float distance = arrival_speed > 0.f + FLT_EPSILON ? distance_to_target - _acceptance_radius : distance_to_target;
 		float speed_setpoint = math::trajectory::computeMaxSpeedFromDistance(_param_ro_jerk_limit.get(),
-				       _param_ro_decel_limit.get(), distance_to_target, 0.f);
-		const float max_speed = PX4_ISFINITE(_rover_position_setpoint.cruising_speed) ?
-					_rover_position_setpoint.cruising_speed :
-					_param_ro_speed_limit.get();
-		speed_setpoint = math::min(speed_setpoint, max_speed);
+				       _param_ro_decel_limit.get(), distance, fabsf(arrival_speed));
+		speed_setpoint = math::min(speed_setpoint, _param_ro_speed_limit.get());
+
+		if (PX4_ISFINITE(_rover_position_setpoint.cruising_speed)) {
+			speed_setpoint = sign(_rover_position_setpoint.cruising_speed) * math::min(speed_setpoint,
+					 fabsf(_rover_position_setpoint.cruising_speed));
+		}
+
 		pure_pursuit_status_s pure_pursuit_status{};
-		pure_pursuit_status.timestamp = _timestamp;
+		pure_pursuit_status.timestamp = timestamp;
+
 		const float yaw_setpoint = PurePursuit::calcTargetBearing(pure_pursuit_status, _param_pp_lookahd_gain.get(),
-					   _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), target_waypoint_ned, _curr_pos_ned,
+					   _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), target_waypoint_ned, _start_ned,
 					   _curr_pos_ned, fabsf(speed_setpoint));
 		_pure_pursuit_status_pub.publish(pure_pursuit_status);
 		rover_velocity_setpoint_s rover_velocity_setpoint{};
-		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.timestamp = timestamp;
 		rover_velocity_setpoint.speed = speed_setpoint;
-		rover_velocity_setpoint.bearing = yaw_setpoint;
+		rover_velocity_setpoint.bearing = speed_setpoint > -FLT_EPSILON ? yaw_setpoint : matrix::wrap_pi(
+				yaw_setpoint + M_PI_F);
 		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else {
 		rover_velocity_setpoint_s rover_velocity_setpoint{};
-		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.timestamp = timestamp;
 		rover_velocity_setpoint.speed = 0.f;
 		rover_velocity_setpoint.bearing = _vehicle_yaw;
 		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);

--- a/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.cpp
+++ b/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.cpp
@@ -67,7 +67,6 @@ void AckermannPosControl::updatePosControl()
 		_start_ned = _start_ned.isAllFinite() ? _start_ned : _curr_pos_ned;
 	}
 
-
 	if (_position_controller_status_sub.updated()) {
 		position_controller_status_s position_controller_status{};
 		_position_controller_status_sub.copy(&position_controller_status);

--- a/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.cpp
+++ b/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.cpp
@@ -59,30 +59,63 @@ void AckermannPosControl::updatePosControl()
 {
 	updateSubscriptions();
 
-	if (_vehicle_control_mode.flag_control_position_enabled && _vehicle_control_mode.flag_armed && runSanityChecks()) {
-		// Generate Position Setpoint
-		if (_vehicle_control_mode.flag_control_offboard_enabled) {
-			generatePositionSetpoint();
+	hrt_abstime timestamp = hrt_absolute_time();
 
-		} else if (_vehicle_control_mode.flag_control_manual_enabled) {
-			manualPositionMode();
+	if (_rover_position_setpoint_sub.updated()) {
+		_rover_position_setpoint_sub.copy(&_rover_position_setpoint);
+		_start_ned = Vector2f(_rover_position_setpoint.start_ned[0], _rover_position_setpoint.start_ned[1]);
+		_start_ned = _start_ned.isAllFinite() ? _start_ned : _curr_pos_ned;
+	}
 
-		} else if (_vehicle_control_mode.flag_control_auto_enabled) {
-			autoPositionMode();
+
+	if (_position_controller_status_sub.updated()) {
+		position_controller_status_s position_controller_status{};
+		_position_controller_status_sub.copy(&position_controller_status);
+		_acceptance_radius = position_controller_status.acceptance_radius;
+	}
+
+	const Vector2f target_waypoint_ned(_rover_position_setpoint.position_ned[0], _rover_position_setpoint.position_ned[1]);
+	float distance_to_target = target_waypoint_ned.isAllFinite() ? (target_waypoint_ned - _curr_pos_ned).norm() : NAN;
+
+	if (PX4_ISFINITE(distance_to_target) && distance_to_target > _param_nav_acc_rad.get()) {
+
+		float arrival_speed = PX4_ISFINITE(_rover_position_setpoint.arrival_speed) ? _rover_position_setpoint.arrival_speed :
+				      0.f;
+		const float distance = arrival_speed > 0.f + FLT_EPSILON ? distance_to_target - _acceptance_radius : distance_to_target;
+		float speed_setpoint = math::trajectory::computeMaxSpeedFromDistance(_param_ro_jerk_limit.get(),
+				       _param_ro_decel_limit.get(), distance, fabsf(arrival_speed));
+		speed_setpoint = math::min(speed_setpoint, _param_ro_speed_limit.get());
+
+		if (PX4_ISFINITE(_rover_position_setpoint.cruising_speed)) {
+			speed_setpoint = sign(_rover_position_setpoint.cruising_speed) * math::min(speed_setpoint,
+					 fabsf(_rover_position_setpoint.cruising_speed));
 		}
 
-		// Generate Velocity Setpoint
-		generateVelocitySetpoint();
+		pure_pursuit_status_s pure_pursuit_status{};
+		pure_pursuit_status.timestamp = timestamp;
 
+		const float yaw_setpoint = PurePursuit::calcTargetBearing(pure_pursuit_status, _param_pp_lookahd_gain.get(),
+					   _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), target_waypoint_ned, _start_ned,
+					   _curr_pos_ned, fabsf(speed_setpoint));
+		_pure_pursuit_status_pub.publish(pure_pursuit_status);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = timestamp;
+		rover_velocity_setpoint.speed = speed_setpoint;
+		rover_velocity_setpoint.bearing = speed_setpoint > -FLT_EPSILON ? yaw_setpoint : matrix::wrap_pi(
+				yaw_setpoint + M_PI_F);
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
+
+	} else {
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = timestamp;
+		rover_velocity_setpoint.speed = 0.f;
+		rover_velocity_setpoint.bearing = _vehicle_yaw;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 	}
 }
 
 void AckermannPosControl::updateSubscriptions()
 {
-	if (_vehicle_control_mode_sub.updated()) {
-		_vehicle_control_mode_sub.copy(&_vehicle_control_mode);
-	}
-
 	if (_vehicle_attitude_sub.updated()) {
 		vehicle_attitude_s vehicle_attitude{};
 		_vehicle_attitude_sub.copy(&vehicle_attitude);
@@ -105,30 +138,6 @@ void AckermannPosControl::updateSubscriptions()
 
 }
 
-void AckermannPosControl::generatePositionSetpoint()
-{
-	if (_offboard_control_mode_sub.updated()) {
-		_offboard_control_mode_sub.copy(&_offboard_control_mode);
-	}
-
-	if (!_offboard_control_mode.position) {
-		return;
-	}
-
-	trajectory_setpoint_s trajectory_setpoint{};
-	_trajectory_setpoint_sub.copy(&trajectory_setpoint);
-
-	// Translate trajectory setpoint to rover position setpoint
-	rover_position_setpoint_s rover_position_setpoint{};
-	rover_position_setpoint.timestamp = hrt_absolute_time();
-	rover_position_setpoint.position_ned[0] = trajectory_setpoint.position[0];
-	rover_position_setpoint.position_ned[1] = trajectory_setpoint.position[1];
-	rover_position_setpoint.cruising_speed = _param_ro_speed_limit.get();
-	rover_position_setpoint.yaw = NAN;
-	_rover_position_setpoint_pub.publish(rover_position_setpoint);
-
-}
-
 void AckermannPosControl::manualPositionMode()
 {
 	updateSubscriptions();
@@ -144,7 +153,7 @@ void AckermannPosControl::manualPositionMode()
 
 	if (fabsf(yaw_delta) > FLT_EPSILON
 	    || fabsf(speed_setpoint) < FLT_EPSILON) { // Closed loop yaw rate control
-		_course_control = false;
+		_pos_ctl_course_direction = Vector2f(NAN, NAN);
 		// Construct a 'target waypoint' for course control s.t. it is never within the maximum lookahead of the rover
 		const float yaw_setpoint = matrix::wrap_pi(_vehicle_yaw + sign(speed_setpoint) * yaw_delta);
 		const Vector2f pos_ctl_course_direction = Vector2f(cos(yaw_setpoint), sin(yaw_setpoint));
@@ -162,10 +171,9 @@ void AckermannPosControl::manualPositionMode()
 		_rover_position_setpoint_pub.publish(rover_position_setpoint);
 
 	} else { // Course control if the steering input is zero (keep driving on a straight line)
-		if (!_course_control) {
+		if (!_pos_ctl_course_direction.isAllFinite()) {
 			_pos_ctl_course_direction = Vector2f(cos(_vehicle_yaw), sin(_vehicle_yaw));
 			_pos_ctl_start_position_ned = _curr_pos_ned;
-			_course_control = true;
 		}
 
 		// Construct a 'target waypoint' for course control s.t. it is never within the maximum lookahead of the rover
@@ -311,62 +319,6 @@ float AckermannPosControl::autoCruisingSpeed(const float cruising_speed, const f
 
 }
 
-void AckermannPosControl::generateVelocitySetpoint()
-{
-	hrt_abstime timestamp = hrt_absolute_time();
-
-	if (_rover_position_setpoint_sub.updated()) {
-		_rover_position_setpoint_sub.copy(&_rover_position_setpoint);
-		_start_ned = Vector2f(_rover_position_setpoint.start_ned[0], _rover_position_setpoint.start_ned[1]);
-		_start_ned = _start_ned.isAllFinite() ? _start_ned : _curr_pos_ned;
-	}
-
-	if (_position_controller_status_sub.updated()) {
-		position_controller_status_s position_controller_status{};
-		_position_controller_status_sub.copy(&position_controller_status);
-		_acceptance_radius = position_controller_status.acceptance_radius;
-	}
-
-	const Vector2f target_waypoint_ned(_rover_position_setpoint.position_ned[0], _rover_position_setpoint.position_ned[1]);
-	const float distance_to_target = (target_waypoint_ned - _curr_pos_ned).norm();
-
-	if (distance_to_target > _param_nav_acc_rad.get()) {
-
-		float arrival_speed = PX4_ISFINITE(_rover_position_setpoint.arrival_speed) ? _rover_position_setpoint.arrival_speed :
-				      0.f;
-		const float distance = arrival_speed > 0.f + FLT_EPSILON ? distance_to_target - _acceptance_radius : distance_to_target;
-		float speed_setpoint = math::trajectory::computeMaxSpeedFromDistance(_param_ro_jerk_limit.get(),
-				       _param_ro_decel_limit.get(), distance, fabsf(arrival_speed));
-		speed_setpoint = math::min(speed_setpoint, _param_ro_speed_limit.get());
-
-		if (PX4_ISFINITE(_rover_position_setpoint.cruising_speed)) {
-			speed_setpoint = sign(_rover_position_setpoint.cruising_speed) * math::min(speed_setpoint,
-					 fabsf(_rover_position_setpoint.cruising_speed));
-		}
-
-		pure_pursuit_status_s pure_pursuit_status{};
-		pure_pursuit_status.timestamp = timestamp;
-
-		const float yaw_setpoint = PurePursuit::calcTargetBearing(pure_pursuit_status, _param_pp_lookahd_gain.get(),
-					   _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), target_waypoint_ned, _start_ned,
-					   _curr_pos_ned, fabsf(speed_setpoint));
-		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		rover_velocity_setpoint_s rover_velocity_setpoint{};
-		rover_velocity_setpoint.timestamp = timestamp;
-		rover_velocity_setpoint.speed = speed_setpoint;
-		rover_velocity_setpoint.bearing = speed_setpoint > -FLT_EPSILON ? yaw_setpoint : matrix::wrap_pi(
-				yaw_setpoint + M_PI_F);
-		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
-
-	} else {
-		rover_velocity_setpoint_s rover_velocity_setpoint{};
-		rover_velocity_setpoint.timestamp = timestamp;
-		rover_velocity_setpoint.speed = 0.f;
-		rover_velocity_setpoint.bearing = _vehicle_yaw;
-		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
-	}
-}
-
 bool AckermannPosControl::runSanityChecks()
 {
 	bool ret = true;
@@ -391,6 +343,5 @@ bool AckermannPosControl::runSanityChecks()
 		ret = false;
 	}
 
-	_prev_param_check_passed = ret;
 	return ret;
 }

--- a/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.hpp
+++ b/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.hpp
@@ -50,7 +50,7 @@
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/rover_position_setpoint.h>
-#include <uORB/topics/ackermann_velocity_setpoint.h>
+#include <uORB/topics/rover_velocity_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/trajectory_setpoint.h>
@@ -181,10 +181,10 @@ private:
 	rover_position_setpoint_s _rover_position_setpoint{};
 
 	// uORB publications
-	uORB::Publication<ackermann_velocity_setpoint_s> _ackermann_velocity_setpoint_pub{ORB_ID(ackermann_velocity_setpoint)};
-	uORB::Publication<position_controller_status_s>	 _position_controller_status_pub{ORB_ID(position_controller_status)};
-	uORB::Publication<pure_pursuit_status_s>	 _pure_pursuit_status_pub{ORB_ID(pure_pursuit_status)};
-	uORB::Publication<rover_position_setpoint_s>	 _rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
+	uORB::Publication<rover_velocity_setpoint_s>    _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
+	uORB::Publication<position_controller_status_s>	_position_controller_status_pub{ORB_ID(position_controller_status)};
+	uORB::Publication<pure_pursuit_status_s>	_pure_pursuit_status_pub{ORB_ID(pure_pursuit_status)};
+	uORB::Publication<rover_position_setpoint_s>	_rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
 
 	// Variables
 	hrt_abstime _timestamp{0};

--- a/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.hpp
+++ b/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.hpp
@@ -78,9 +78,19 @@ public:
 	~AckermannPosControl() = default;
 
 	/**
-	 * @brief Update position controller.
+	 * @brief Update position control
 	 */
 	void updatePosControl();
+
+	/**
+	 * @brief Generate and publish roverVelocitySetpoint from manualControlSetpoint.
+	 */
+	void manualPositionMode();
+
+	/**
+	 * @brief Generate and publish roverVelocitySetpoint from positionSetpointTriplet.
+	 */
+	void autoPositionMode();
 
 protected:
 	/**
@@ -98,27 +108,6 @@ private:
 	 * @brief Generate and publish roverPositionSetpoint from position of trajectorySetpoint.
 	 */
 	void generatePositionSetpoint();
-
-	/**
-	 * @brief Generate and publish roverVelocitySetpoint from manualControlSetpoint (Position Mode) or
-	 * 	  positionSetpointTriplet (Auto Mode) or roverPositionSetpoint.
-	 */
-	void generateVelocitySetpoint();
-
-	/**
-	 * @brief Generate and publish roverVelocitySetpoint from manualControlSetpoint.
-	 */
-	void manualPositionMode();
-
-	/**
-	 * @brief Generate and publish roverVelocitySetpoint from positionSetpointTriplet.
-	 */
-	void autoPositionMode();
-
-	/**
-	 * @brief Generate and publish roverVelocitySetpoint from roverPositionSetpoint.
-	 */
-	void goToPositionMode();
 
 	/**
 	 * @brief Update global/NED waypoint coordinates and acceptance radius.
@@ -140,32 +129,45 @@ private:
 				     float acceptance_radius_gain, float acceptance_radius_max, float wheel_base, float max_steer_angle);
 
 	/**
-	 * @brief Calculate the speed setpoint. During cornering the speed is restricted based on the radius of the corner.
-	 * On straight lines it is based on a speed trajectory such that the rover will arrive at the next corner with the
-	 * desired cornering speed under consideration of the maximum deceleration and jerk.
+	 * @brief Calculate the speed at which the rover should arrive at the current waypoint based on the upcoming corner.
 	 * @param cruising_speed Cruising speed [m/s].
 	 * @param miss_speed_min Minimum speed setpoint [m/s].
-	 * @param distance_to_prev_wp Distance to the previous waypoint [m].
-	 * @param distance_to_curr_wp Distance to the current waypoint [m].
 	 * @param acc_rad Acceptance radius of the current waypoint [m].
-	 * @param prev_acc_rad Acceptance radius of the previous waypoint [m].
-	 * @param max_decel Maximum allowed deceleration [m/s^2].
-	 * @param max_jerk Maximum allowed jerk [m/s^3].
 	 * @param curr_wp_type Type of the current waypoint.
 	 * @param waypoint_transition_angle Angle between the prevWP-currWP and currWP-nextWP line segments [rad]
-	 * @param prev_waypoint_transition_angle Previous angle between the prevWP-currWP and currWP-nextWP line segments [rad]
-	 * @param max_speed Maximum speed setpoint [m/s]
+	 * @param max_yaw_rate Maximum yaw rate setpoint [rad/s]
 	 * @return Speed setpoint [m/s].
 	 */
-	float calcSpeedSetpoint(float cruising_speed, float miss_speed_min, float distance_to_prev_wp,
-				float distance_to_curr_wp, float acc_rad, float prev_acc_rad, float max_decel, float max_jerk, int curr_wp_type,
-				float waypoint_transition_angle, float prev_waypoint_transition_angle, float max_speed);
+	float autoArrivalSpeed(float cruising_speed, float miss_speed_min, float acc_rad, int curr_wp_type,
+			       float waypoint_transition_angle, float max_yaw_rate);
+
+	/**
+	* @brief Calculate the cruising speed setpoint. During cornering the speed is restricted based on the radius of the corner.
+	* @param cruising_speed Cruising speed [m/s].
+	* @param miss_speed_min Minimum speed setpoint [m/s].
+	* @param distance_to_prev_wp Distance to the previous waypoint [m].
+	* @param distance_to_curr_wp Distance to the current waypoint [m].
+	* @param acc_rad Acceptance radius of the current waypoint [m].
+	* @param prev_acc_rad Acceptance radius of the previous waypoint [m].
+	* @param waypoint_transition_angle Angle between the prevWP-currWP and currWP-nextWP line segments [rad]
+	* @param prev_waypoint_transition_angle Previous angle between the prevWP-currWP and currWP-nextWP line segments [rad]
+	*  @param max_yaw_rate Maximum yaw rate setpoint [rad/s]
+	* @return Speed setpoint [m/s].
+	*/
+	float autoCruisingSpeed(float cruising_speed, float miss_speed_min, float distance_to_prev_wp,
+				float distance_to_curr_wp, float acc_rad, float prev_acc_rad, float waypoint_transition_angle,
+				float prev_waypoint_transition_angle, float max_yaw_rate);
 
 	/**
 	 * @brief Check if the necessary parameters are set.
 	 * @return True if all checks pass.
 	 */
 	bool runSanityChecks();
+
+	/**
+	 * @brief Generate RoverVelocitySetpoint from RoverPositionSetpoint
+	 */
+	void generateVelocitySetpoint();
 
 	// uORB subscriptions
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
@@ -176,9 +178,10 @@ private:
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _position_setpoint_triplet_sub{ORB_ID(position_setpoint_triplet)};
 	uORB::Subscription _rover_position_setpoint_sub{ORB_ID(rover_position_setpoint)};
+	uORB::Subscription _position_controller_status_sub{ORB_ID(position_controller_status)};
+	rover_position_setpoint_s _rover_position_setpoint{};
 	vehicle_control_mode_s _vehicle_control_mode{};
 	offboard_control_mode_s _offboard_control_mode{};
-	rover_position_setpoint_s _rover_position_setpoint{};
 
 	// uORB publications
 	uORB::Publication<rover_velocity_setpoint_s>    _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
@@ -187,15 +190,14 @@ private:
 	uORB::Publication<rover_position_setpoint_s>	_rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
 
 	// Variables
-	hrt_abstime _timestamp{0};
 	Quatf _vehicle_attitude_quaternion{};
 	Vector2f _curr_pos_ned{};
 	Vector2f _pos_ctl_course_direction{};
 	Vector2f _pos_ctl_start_position_ned{};
+	Vector2f _start_ned{};
 	float _vehicle_yaw{0.f};
 	float _max_yaw_rate{0.f};
 	float _min_speed{0.f}; // Speed at which the maximum yaw rate limit is enforced given the maximum steer angle and wheel base.
-	float _dt{0.f};
 	int _curr_wp_type{position_setpoint_s::SETPOINT_TYPE_IDLE};
 	bool _course_control{false}; // Indicates if the rover is doing course control in manual position mode.
 	bool _prev_param_check_passed{true};

--- a/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.hpp
+++ b/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.hpp
@@ -51,11 +51,8 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/rover_position_setpoint.h>
 #include <uORB/topics/rover_velocity_setpoint.h>
-#include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/manual_control_setpoint.h>
-#include <uORB/topics/trajectory_setpoint.h>
 #include <uORB/topics/vehicle_attitude.h>
-#include <uORB/topics/offboard_control_mode.h>
 #include <uORB/topics/position_setpoint.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/vehicle_local_position.h>
@@ -92,6 +89,20 @@ public:
 	 */
 	void autoPositionMode();
 
+	/**
+	 * @brief Check if the necessary parameters are set.
+	 * @return True if all checks pass.
+	 */
+	bool runSanityChecks();
+
+	/**
+	 * @brief Reset position controller.
+	 */
+	void reset()
+	{
+		_pos_ctl_course_direction = Vector2f(NAN, NAN);
+	};
+
 protected:
 	/**
 	 * @brief Update the parameters of the module.
@@ -103,11 +114,6 @@ private:
 	 * @brief Update uORB subscriptions used in position controller.
 	 */
 	void updateSubscriptions();
-
-	/**
-	 * @brief Generate and publish roverPositionSetpoint from position of trajectorySetpoint.
-	 */
-	void generatePositionSetpoint();
 
 	/**
 	 * @brief Update global/NED waypoint coordinates and acceptance radius.
@@ -158,30 +164,14 @@ private:
 				float distance_to_curr_wp, float acc_rad, float prev_acc_rad, float waypoint_transition_angle,
 				float prev_waypoint_transition_angle, float max_yaw_rate);
 
-	/**
-	 * @brief Check if the necessary parameters are set.
-	 * @return True if all checks pass.
-	 */
-	bool runSanityChecks();
-
-	/**
-	 * @brief Generate RoverVelocitySetpoint from RoverPositionSetpoint
-	 */
-	void generateVelocitySetpoint();
-
 	// uORB subscriptions
-	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
-	uORB::Subscription _trajectory_setpoint_sub{ORB_ID(trajectory_setpoint)};
-	uORB::Subscription _offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _position_setpoint_triplet_sub{ORB_ID(position_setpoint_triplet)};
 	uORB::Subscription _rover_position_setpoint_sub{ORB_ID(rover_position_setpoint)};
 	uORB::Subscription _position_controller_status_sub{ORB_ID(position_controller_status)};
 	rover_position_setpoint_s _rover_position_setpoint{};
-	vehicle_control_mode_s _vehicle_control_mode{};
-	offboard_control_mode_s _offboard_control_mode{};
 
 	// uORB publications
 	uORB::Publication<rover_velocity_setpoint_s>    _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
@@ -199,8 +189,6 @@ private:
 	float _max_yaw_rate{0.f};
 	float _min_speed{0.f}; // Speed at which the maximum yaw rate limit is enforced given the maximum steer angle and wheel base.
 	int _curr_wp_type{position_setpoint_s::SETPOINT_TYPE_IDLE};
-	bool _course_control{false}; // Indicates if the rover is doing course control in manual position mode.
-	bool _prev_param_check_passed{true};
 
 	// Waypoint variables
 	Vector2f _curr_wp_ned{};

--- a/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.hpp
+++ b/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.hpp
@@ -75,7 +75,7 @@ public:
 	~AckermannPosControl() = default;
 
 	/**
-	 * @brief Update position control
+	 * @brief Generate and publish roverVelocitySetpoint from roverPositionSetpoint.
 	 */
 	void updatePosControl();
 
@@ -98,10 +98,7 @@ public:
 	/**
 	 * @brief Reset position controller.
 	 */
-	void reset()
-	{
-		_pos_ctl_course_direction = Vector2f(NAN, NAN);
-	};
+	void reset() {_pos_ctl_course_direction = Vector2f(NAN, NAN);};
 
 protected:
 	/**
@@ -148,18 +145,18 @@ private:
 			       float waypoint_transition_angle, float max_yaw_rate);
 
 	/**
-	* @brief Calculate the cruising speed setpoint. During cornering the speed is restricted based on the radius of the corner.
-	* @param cruising_speed Cruising speed [m/s].
-	* @param miss_speed_min Minimum speed setpoint [m/s].
-	* @param distance_to_prev_wp Distance to the previous waypoint [m].
-	* @param distance_to_curr_wp Distance to the current waypoint [m].
-	* @param acc_rad Acceptance radius of the current waypoint [m].
-	* @param prev_acc_rad Acceptance radius of the previous waypoint [m].
-	* @param waypoint_transition_angle Angle between the prevWP-currWP and currWP-nextWP line segments [rad]
-	* @param prev_waypoint_transition_angle Previous angle between the prevWP-currWP and currWP-nextWP line segments [rad]
-	*  @param max_yaw_rate Maximum yaw rate setpoint [rad/s]
-	* @return Speed setpoint [m/s].
-	*/
+	 * @brief Calculate the cruising speed setpoint. During cornering the speed is restricted based on the radius of the corner.
+	 * @param cruising_speed Cruising speed [m/s].
+	 * @param miss_speed_min Minimum speed setpoint [m/s].
+	 * @param distance_to_prev_wp Distance to the previous waypoint [m].
+	 * @param distance_to_curr_wp Distance to the current waypoint [m].
+	 * @param acc_rad Acceptance radius of the current waypoint [m].
+	 * @param prev_acc_rad Acceptance radius of the previous waypoint [m].
+	 * @param waypoint_transition_angle Angle between the prevWP-currWP and currWP-nextWP line segments [rad]
+	 * @param prev_waypoint_transition_angle Previous angle between the prevWP-currWP and currWP-nextWP line segments [rad]
+	 *  @param max_yaw_rate Maximum yaw rate setpoint [rad/s]
+	 * @return Speed setpoint [m/s].
+	 */
 	float autoCruisingSpeed(float cruising_speed, float miss_speed_min, float distance_to_prev_wp,
 				float distance_to_curr_wp, float acc_rad, float prev_acc_rad, float waypoint_transition_angle,
 				float prev_waypoint_transition_angle, float max_yaw_rate);
@@ -182,15 +179,17 @@ private:
 	// Variables
 	Quatf _vehicle_attitude_quaternion{};
 	Vector2f _curr_pos_ned{};
-	Vector2f _pos_ctl_course_direction{};
-	Vector2f _pos_ctl_start_position_ned{};
 	Vector2f _start_ned{};
 	float _vehicle_yaw{0.f};
 	float _max_yaw_rate{0.f};
 	float _min_speed{0.f}; // Speed at which the maximum yaw rate limit is enforced given the maximum steer angle and wheel base.
 	int _curr_wp_type{position_setpoint_s::SETPOINT_TYPE_IDLE};
 
-	// Waypoint variables
+	// Manual position mode variables
+	Vector2f _pos_ctl_course_direction{};
+	Vector2f _pos_ctl_start_position_ned{};
+
+	// Auto Mode Variables
 	Vector2f _curr_wp_ned{};
 	Vector2f _prev_wp_ned{};
 	Vector2f _next_wp_ned{};

--- a/src/modules/rover_ackermann/AckermannRateControl/AckermannRateControl.cpp
+++ b/src/modules/rover_ackermann/AckermannRateControl/AckermannRateControl.cpp
@@ -48,17 +48,21 @@ void AckermannRateControl::updateParams()
 {
 	ModuleParams::updateParams();
 	_max_yaw_rate = _param_ro_yaw_rate_limit.get() * M_DEG_TO_RAD_F;
+
+	// Set up PID controller
 	_pid_yaw_rate.setGains(_param_ro_yaw_rate_p.get(), _param_ro_yaw_rate_i.get(), 0.f);
 	_pid_yaw_rate.setIntegralLimit(1.f);
 	_pid_yaw_rate.setOutputLimit(1.f);
-	_yaw_rate_setpoint.setSlewRate(_param_ro_yaw_accel_limit.get() * M_DEG_TO_RAD_F);
+
+	// Set up slew rate
+	_adjusted_yaw_rate_setpoint.setSlewRate(_param_ro_yaw_accel_limit.get() * M_DEG_TO_RAD_F);
 }
 
 void AckermannRateControl::updateRateControl()
 {
 	hrt_abstime timestamp_prev = _timestamp;
 	_timestamp = hrt_absolute_time();
-	_dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
+	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
 
 	if (_vehicle_angular_velocity_sub.updated()) {
 		vehicle_angular_velocity_s vehicle_angular_velocity{};
@@ -71,24 +75,24 @@ void AckermannRateControl::updateRateControl()
 	if (_actuator_motors_sub.updated()) {
 		actuator_motors_s actuator_motors;
 		_actuator_motors_sub.copy(&actuator_motors);
-		_estimated_speed_body_x = math::interpolate<float>(actuator_motors.control[0], -1.f, 1.f,
-					  -_param_ro_max_thr_speed.get(), _param_ro_max_thr_speed.get());
-		_estimated_speed_body_x = fabsf(_estimated_speed_body_x) >  _param_ro_speed_th.get() ? _estimated_speed_body_x : 0.f;
+		_estimated_speed = math::interpolate<float>(actuator_motors.control[0], -1.f, 1.f,
+				   -_param_ro_max_thr_speed.get(), _param_ro_max_thr_speed.get());
+		_estimated_speed = fabsf(_estimated_speed) >  _param_ro_speed_th.get() ? _estimated_speed : 0.f;
 	}
 
-	generateSteeringSetpoint();
+	generateSteeringSetpoint(dt);
 
 	// Publish rate controller status (logging only)
 	rover_rate_status_s rover_rate_status;
 	rover_rate_status.timestamp = _timestamp;
 	rover_rate_status.measured_yaw_rate = _vehicle_yaw_rate;
-	rover_rate_status.adjusted_yaw_rate_setpoint = _yaw_rate_setpoint.getState();
+	rover_rate_status.adjusted_yaw_rate_setpoint = _adjusted_yaw_rate_setpoint.getState();
 	rover_rate_status.pid_yaw_rate_integral = _pid_yaw_rate.getIntegral();
 	_rover_rate_status_pub.publish(rover_rate_status);
 
 }
 
-void AckermannRateControl::acroMode()
+void AckermannRateControl::manualAcroMode()
 {
 	manual_control_setpoint_s manual_control_setpoint{};
 	_manual_control_setpoint_sub.copy(&manual_control_setpoint);
@@ -104,52 +108,57 @@ void AckermannRateControl::acroMode()
 	_rover_rate_setpoint_pub.publish(rover_rate_setpoint);
 }
 
-void AckermannRateControl::generateSteeringSetpoint()
+void AckermannRateControl::generateSteeringSetpoint(const float dt)
 {
 	if (_rover_rate_setpoint_sub.updated()) {
-		_rover_rate_setpoint_sub.copy(&_rover_rate_setpoint);
-
+		rover_rate_setpoint_s rover_rate_setpoint{};
+		_rover_rate_setpoint_sub.copy(&rover_rate_setpoint);
+		_yaw_rate_setpoint = rover_rate_setpoint.yaw_rate_setpoint;
 	}
 
-	float steering_setpoint{0.f};
-
-	if (fabsf(_estimated_speed_body_x) > FLT_EPSILON) {
+	if (fabsf(_estimated_speed) > FLT_EPSILON && PX4_ISFINITE(_yaw_rate_setpoint)) {
 		// Set up feasible yaw rate setpoint
-		float max_possible_yaw_rate = fabsf(_estimated_speed_body_x) * tanf(_param_ra_max_str_ang.get()) /
+		float steering_setpoint{0.f};
+		float max_possible_yaw_rate = fabsf(_estimated_speed) * tanf(_param_ra_max_str_ang.get()) /
 					      _param_ra_wheel_base.get(); // Maximum possible yaw rate at current velocity
 		float yaw_rate_limit = math::min(max_possible_yaw_rate, _max_yaw_rate);
-		float constrained_yaw_rate = math::constrain(_rover_rate_setpoint.yaw_rate_setpoint, -yaw_rate_limit, yaw_rate_limit);
+		float constrained_yaw_rate = math::constrain(_yaw_rate_setpoint, -yaw_rate_limit, yaw_rate_limit);
 
 		if (_param_ro_yaw_accel_limit.get() > FLT_EPSILON) { // Apply slew rate if configured
-			if (fabsf(_yaw_rate_setpoint.getState() - _vehicle_yaw_rate) > fabsf(constrained_yaw_rate -
+			if (fabsf(_adjusted_yaw_rate_setpoint.getState() - _vehicle_yaw_rate) > fabsf(constrained_yaw_rate -
 					_vehicle_yaw_rate)) {
-				_yaw_rate_setpoint.setForcedValue(_vehicle_yaw_rate);
+				_adjusted_yaw_rate_setpoint.setForcedValue(_vehicle_yaw_rate);
 			}
 
-			_yaw_rate_setpoint.update(constrained_yaw_rate, _dt);
+			_adjusted_yaw_rate_setpoint.update(constrained_yaw_rate, dt);
 
 		} else {
-			_yaw_rate_setpoint.setForcedValue(constrained_yaw_rate);
+			_adjusted_yaw_rate_setpoint.setForcedValue(constrained_yaw_rate);
 		}
 
 		// Feed forward
-		steering_setpoint = atanf(_yaw_rate_setpoint.getState() * _param_ra_wheel_base.get() / _estimated_speed_body_x);
+		steering_setpoint = atanf(_adjusted_yaw_rate_setpoint.getState() * _param_ra_wheel_base.get() / _estimated_speed);
 
 		// Feedback (Only when driving forwards because backwards driving is NMP and can introduce instability)
-		if (_estimated_speed_body_x > FLT_EPSILON) {
-			_pid_yaw_rate.setSetpoint(_yaw_rate_setpoint.getState());
-			steering_setpoint += _pid_yaw_rate.update(_vehicle_yaw_rate, _dt);
+		if (_estimated_speed > FLT_EPSILON) {
+			_pid_yaw_rate.setSetpoint(_adjusted_yaw_rate_setpoint.getState());
+			steering_setpoint += _pid_yaw_rate.update(_vehicle_yaw_rate, dt);
 		}
+
+		rover_steering_setpoint_s rover_steering_setpoint{};
+		rover_steering_setpoint.timestamp = _timestamp;
+		rover_steering_setpoint.normalized_steering_angle = math::interpolate<float>(steering_setpoint,
+				-_param_ra_max_str_ang.get(), _param_ra_max_str_ang.get(), -1.f, 1.f); // Normalize steering setpoint
+		_rover_steering_setpoint_pub.publish(rover_steering_setpoint);
 
 	} else {
 		_pid_yaw_rate.resetIntegral();
+		rover_steering_setpoint_s rover_steering_setpoint{};
+		rover_steering_setpoint.timestamp = _timestamp;
+		rover_steering_setpoint.normalized_steering_angle = 0.f;
+		_rover_steering_setpoint_pub.publish(rover_steering_setpoint);
 	}
 
-	rover_steering_setpoint_s rover_steering_setpoint{};
-	rover_steering_setpoint.timestamp = _timestamp;
-	rover_steering_setpoint.normalized_steering_angle = math::interpolate<float>(steering_setpoint,
-			-_param_ra_max_str_ang.get(), _param_ra_max_str_ang.get(), -1.f, 1.f); // Normalize steering setpoint
-	_rover_steering_setpoint_pub.publish(rover_steering_setpoint);
 }
 
 bool AckermannRateControl::runSanityChecks()

--- a/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.cpp
+++ b/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.cpp
@@ -80,11 +80,11 @@ void AckermannVelControl::updateVelControl()
 	// Publish position controller status (logging only)
 	rover_velocity_status_s rover_velocity_status;
 	rover_velocity_status.timestamp = _timestamp;
-	rover_velocity_status.measured_speed_body_x = _vehicle_speed_body_x;
+	rover_velocity_status.measured_speed_body_x = _vehicle_speed;
 	rover_velocity_status.adjusted_speed_body_x_setpoint = _speed_setpoint.getState();
-	rover_velocity_status.measured_speed_body_y = _vehicle_speed_body_y;
-	rover_velocity_status.adjusted_speed_body_y_setpoint = NAN;
 	rover_velocity_status.pid_throttle_body_x_integral = _pid_speed.getIntegral();
+	rover_velocity_status.measured_speed_body_y = NAN;
+	rover_velocity_status.adjusted_speed_body_y_setpoint = NAN;
 	rover_velocity_status.pid_throttle_body_y_integral = NAN;
 	_rover_velocity_status_pub.publish(rover_velocity_status);
 }
@@ -106,10 +106,10 @@ void AckermannVelControl::updateSubscriptions()
 		vehicle_local_position_s vehicle_local_position{};
 		_vehicle_local_position_sub.copy(&vehicle_local_position);
 
-		Vector3f velocity_in_local_frame(vehicle_local_position.vx, vehicle_local_position.vy, vehicle_local_position.vz);
-		Vector3f velocity_in_body_frame = _vehicle_attitude_quaternion.rotateVectorInverse(velocity_in_local_frame);
-		_vehicle_speed_body_x = fabsf(velocity_in_body_frame(0)) > _param_ro_speed_th.get() ? velocity_in_body_frame(0) : 0.f;
-		_vehicle_speed_body_y = fabsf(velocity_in_body_frame(1)) > _param_ro_speed_th.get() ? velocity_in_body_frame(1) : 0.f;
+		Vector3f velocity_ned(vehicle_local_position.vx, vehicle_local_position.vy, vehicle_local_position.vz);
+		Vector3f velocity_xyz = _vehicle_attitude_quaternion.rotateVectorInverse(velocity_ned);
+		Vector2f velocity_2d = Vector2f(velocity_xyz(0), velocity_xyz(1));
+		_vehicle_speed = velocity_2d.norm() > _param_ro_speed_th.get() ? sign(velocity_2d(0)) * velocity_2d.norm() : 0.f;
 	}
 
 }
@@ -143,9 +143,16 @@ void AckermannVelControl::generateAttitudeAndThrottleSetpoint()
 		_ackermann_velocity_setpoint_sub.copy(&_ackermann_velocity_setpoint);
 	}
 
+	const Vector2f velocity_ned = Vector2f(_ackermann_velocity_setpoint.velocity_ned[0],
+					       _ackermann_velocity_setpoint.velocity_ned[1]);
+
+	// Santitize input
+	if (!velocity_ned.isAllFinite()) {
+		return;
+	}
+
 	// Attitude Setpoint
-	if (fabsf(_ackermann_velocity_setpoint.velocity_ned[1]) < FLT_EPSILON
-	    && fabsf(_ackermann_velocity_setpoint.velocity_ned[0]) < FLT_EPSILON) {
+	if (velocity_ned.norm() < FLT_EPSILON) {
 		rover_attitude_setpoint_s rover_attitude_setpoint{};
 		rover_attitude_setpoint.timestamp = _timestamp;
 		rover_attitude_setpoint.yaw_setpoint = _vehicle_yaw;
@@ -154,23 +161,21 @@ void AckermannVelControl::generateAttitudeAndThrottleSetpoint()
 	} else {
 		rover_attitude_setpoint_s rover_attitude_setpoint{};
 		rover_attitude_setpoint.timestamp = _timestamp;
-		const float yaw_setpoint = atan2f(_ackermann_velocity_setpoint.velocity_ned[1],
-						  _ackermann_velocity_setpoint.velocity_ned[0]);
+		const float yaw_setpoint = atan2f(velocity_ned(1), velocity_ned(0));
 		rover_attitude_setpoint.yaw_setpoint = _ackermann_velocity_setpoint.backwards ? matrix::wrap_pi(
 				yaw_setpoint + M_PI_F) : yaw_setpoint;
 		_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
 	}
 
 	// Throttle Setpoint
-	const float speed_magnitude = math::min(sqrtf(powf(_ackermann_velocity_setpoint.velocity_ned[0],
-						2) + powf(_ackermann_velocity_setpoint.velocity_ned[1], 2)), _param_ro_speed_limit.get());
-	const float speed_body_x_setpoint = _ackermann_velocity_setpoint.backwards ? -speed_magnitude : speed_magnitude;
+	const float speed_magnitude = math::min(velocity_ned.norm(), _param_ro_speed_limit.get());
+	const float speed_setpoint = _ackermann_velocity_setpoint.backwards ? -speed_magnitude : speed_magnitude;
 	rover_throttle_setpoint_s rover_throttle_setpoint{};
 	rover_throttle_setpoint.timestamp = _timestamp;
 	rover_throttle_setpoint.throttle_body_x = RoverControl::speedControl(_speed_setpoint, _pid_speed,
-			speed_body_x_setpoint, _vehicle_speed_body_x, _param_ro_accel_limit.get(), _param_ro_decel_limit.get(),
+			speed_setpoint, _vehicle_speed, _param_ro_accel_limit.get(), _param_ro_decel_limit.get(),
 			_param_ro_max_thr_speed.get(), _dt);
-	rover_throttle_setpoint.throttle_body_y = 0.f;
+	rover_throttle_setpoint.throttle_body_y = NAN;
 	_rover_throttle_setpoint_pub.publish(rover_throttle_setpoint);
 
 }

--- a/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.cpp
+++ b/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.cpp
@@ -149,7 +149,7 @@ void AckermannVelControl::generateAttitudeAndThrottleSetpoint()
 		rover_attitude_setpoint.yaw_setpoint = _vehicle_yaw;
 		_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
 
-	} else {
+	} else if (PX4_ISFINITE(_rover_velocity_setpoint.bearing)) {
 		rover_attitude_setpoint_s rover_attitude_setpoint{};
 		rover_attitude_setpoint.timestamp = _timestamp;
 		rover_attitude_setpoint.yaw_setpoint = _rover_velocity_setpoint.bearing;

--- a/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.hpp
+++ b/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.hpp
@@ -51,10 +51,7 @@
 #include <uORB/topics/rover_velocity_setpoint.h>
 #include <uORB/topics/rover_velocity_status.h>
 #include <uORB/topics/rover_attitude_setpoint.h>
-#include <uORB/topics/vehicle_control_mode.h>
-#include <uORB/topics/trajectory_setpoint.h>
 #include <uORB/topics/vehicle_attitude.h>
-#include <uORB/topics/offboard_control_mode.h>
 #include <uORB/topics/vehicle_local_position.h>
 
 using namespace matrix;
@@ -77,6 +74,17 @@ public:
 	 */
 	void updateVelControl();
 
+	/**
+	 * @brief Check if the necessary parameters are set.
+	 * @return True if all checks pass.
+	 */
+	bool runSanityChecks();
+
+	/**
+	 * @brief Reset velocity controller.
+	 */
+	void reset() {_pid_speed.resetIntegral();};
+
 protected:
 	/**
 	 * @brief Update the parameters of the module.
@@ -90,31 +98,15 @@ private:
 	void updateSubscriptions();
 
 	/**
-	 * @brief Generate and publish roverVelocitySetpoint from velocity of trajectorySetpoint.
-	 */
-	void generateVelocitySetpoint();
-
-	/**
 	 * @brief Generate and publish roverAttitudeSetpoint and roverThrottleSetpoint
 	 *        from roverVelocitySetpoint.
 	 */
 	void generateAttitudeAndThrottleSetpoint();
 
-	/**
-	 * @brief Check if the necessary parameters are set.
-	 * @return True if all checks pass.
-	 */
-	bool runSanityChecks();
-
 	// uORB subscriptions
-	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
-	uORB::Subscription _trajectory_setpoint_sub{ORB_ID(trajectory_setpoint)};
-	uORB::Subscription _offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _rover_velocity_setpoint_sub{ORB_ID(rover_velocity_setpoint)};
-	vehicle_control_mode_s _vehicle_control_mode{};
-	offboard_control_mode_s _offboard_control_mode{};
 
 	// uORB publications
 	uORB::Publication<rover_throttle_setpoint_s> _rover_throttle_setpoint_pub{ORB_ID(rover_throttle_setpoint)};
@@ -129,7 +121,6 @@ private:
 	float _vehicle_speed{0.f}; // [m/s] Positiv: Forwards, Negativ: Backwards
 	float _vehicle_yaw{0.f};
 	float _dt{0.f};
-	bool _prev_param_check_passed{true};
 
 	// Controllers
 	PID _pid_speed;

--- a/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.hpp
+++ b/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.hpp
@@ -126,8 +126,7 @@ private:
 	// Variables
 	hrt_abstime _timestamp{0};
 	Quatf _vehicle_attitude_quaternion{};
-	float _vehicle_speed_body_x{0.f};
-	float _vehicle_speed_body_y{0.f};
+	float _vehicle_speed{0.f}; // [m/s] Positiv: Forwards, Negativ: Backwards
 	float _vehicle_yaw{0.f};
 	float _dt{0.f};
 	bool _prev_param_check_passed{true};

--- a/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.hpp
+++ b/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.hpp
@@ -48,7 +48,7 @@
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/rover_throttle_setpoint.h>
-#include <uORB/topics/ackermann_velocity_setpoint.h>
+#include <uORB/topics/rover_velocity_setpoint.h>
 #include <uORB/topics/rover_velocity_status.h>
 #include <uORB/topics/rover_attitude_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
@@ -112,7 +112,7 @@ private:
 	uORB::Subscription _offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
-	uORB::Subscription _ackermann_velocity_setpoint_sub{ORB_ID(ackermann_velocity_setpoint)};
+	uORB::Subscription _rover_velocity_setpoint_sub{ORB_ID(rover_velocity_setpoint)};
 	vehicle_control_mode_s _vehicle_control_mode{};
 	offboard_control_mode_s _offboard_control_mode{};
 
@@ -120,8 +120,8 @@ private:
 	uORB::Publication<rover_throttle_setpoint_s> _rover_throttle_setpoint_pub{ORB_ID(rover_throttle_setpoint)};
 	uORB::Publication<rover_attitude_setpoint_s> _rover_attitude_setpoint_pub{ORB_ID(rover_attitude_setpoint)};
 	uORB::Publication<rover_velocity_status_s>   _rover_velocity_status_pub{ORB_ID(rover_velocity_status)};
-	uORB::Publication<ackermann_velocity_setpoint_s> _ackermann_velocity_setpoint_pub{ORB_ID(ackermann_velocity_setpoint)};
-	ackermann_velocity_setpoint_s _ackermann_velocity_setpoint{};
+	uORB::Publication<rover_velocity_setpoint_s> _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
+	rover_velocity_setpoint_s _rover_velocity_setpoint{};
 
 	// Variables
 	hrt_abstime _timestamp{0};

--- a/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.hpp
+++ b/src/modules/rover_ackermann/AckermannVelControl/AckermannVelControl.hpp
@@ -70,7 +70,7 @@ public:
 	~AckermannVelControl() = default;
 
 	/**
-	 * @brief Update velocity controller.
+	 * @brief Generate and publish roverAttitudeSetpoint and RoverThrottleSetpoint from roverVelocitySetpoint.
 	 */
 	void updateVelControl();
 
@@ -83,7 +83,7 @@ public:
 	/**
 	 * @brief Reset velocity controller.
 	 */
-	void reset() {_pid_speed.resetIntegral();};
+	void reset() {_pid_speed.resetIntegral(); _speed_setpoint = NAN; _bearing_setpoint = NAN; _adjusted_speed_setpoint.setForcedValue(0.f);};
 
 protected:
 	/**
@@ -93,15 +93,11 @@ protected:
 
 private:
 	/**
-	 * @brief Update uORB subscriptions used in velocity controller.
-	 */
-	void updateSubscriptions();
-
-	/**
 	 * @brief Generate and publish roverAttitudeSetpoint and roverThrottleSetpoint
 	 *        from roverVelocitySetpoint.
+	 * @param dt [s] Time since last update.
 	 */
-	void generateAttitudeAndThrottleSetpoint();
+	void generateAttitudeAndThrottleSetpoint(float dt);
 
 	// uORB subscriptions
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
@@ -113,18 +109,18 @@ private:
 	uORB::Publication<rover_attitude_setpoint_s> _rover_attitude_setpoint_pub{ORB_ID(rover_attitude_setpoint)};
 	uORB::Publication<rover_velocity_status_s>   _rover_velocity_status_pub{ORB_ID(rover_velocity_status)};
 	uORB::Publication<rover_velocity_setpoint_s> _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
-	rover_velocity_setpoint_s _rover_velocity_setpoint{};
 
 	// Variables
 	hrt_abstime _timestamp{0};
 	Quatf _vehicle_attitude_quaternion{};
 	float _vehicle_speed{0.f}; // [m/s] Positiv: Forwards, Negativ: Backwards
 	float _vehicle_yaw{0.f};
-	float _dt{0.f};
+	float _speed_setpoint{NAN};
+	float _bearing_setpoint{NAN};
 
 	// Controllers
 	PID _pid_speed;
-	SlewRate<float> _speed_setpoint;
+	SlewRate<float> _adjusted_speed_setpoint;
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::RO_MAX_THR_SPEED>) _param_ro_max_thr_speed,

--- a/src/modules/rover_ackermann/RoverAckermann.cpp
+++ b/src/modules/rover_ackermann/RoverAckermann.cpp
@@ -53,14 +53,6 @@ bool RoverAckermann::init()
 void RoverAckermann::updateParams()
 {
 	ModuleParams::updateParams();
-
-	if (_param_ra_str_rate_limit.get() > FLT_EPSILON && _param_ra_max_str_ang.get() > FLT_EPSILON) {
-		_servo_setpoint.setSlewRate((M_DEG_TO_RAD_F * _param_ra_str_rate_limit.get()) / _param_ra_max_str_ang.get());
-	}
-
-	if (_param_ro_accel_limit.get() > FLT_EPSILON && _param_ro_max_thr_speed.get() > FLT_EPSILON) {
-		_motor_setpoint.setSlewRate(_param_ro_accel_limit.get() / _param_ro_max_thr_speed.get());
-	}
 }
 
 void RoverAckermann::Run()
@@ -68,15 +60,6 @@ void RoverAckermann::Run()
 	if (_parameter_update_sub.updated()) {
 		updateParams();
 	}
-
-	const hrt_abstime timestamp_prev = _timestamp;
-	_timestamp = hrt_absolute_time();
-	_dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
-
-	_ackermann_pos_control.updatePosControl();
-	_ackermann_vel_control.updateVelControl();
-	_ackermann_att_control.updateAttControl();
-	_ackermann_rate_control.updateRateControl();
 
 	if (_vehicle_control_mode_sub.updated()) {
 		_vehicle_control_mode_sub.copy(&_vehicle_control_mode);
@@ -90,8 +73,12 @@ void RoverAckermann::Run()
 		generateSteeringAndThrottleSetpoint();
 	}
 
-	generateActuatorSetpoint();
 
+	_ackermann_pos_control.updatePosControl();
+	_ackermann_vel_control.updateVelControl();
+	_ackermann_att_control.updateAttControl();
+	_ackermann_rate_control.updateRateControl();
+	_ackermann_act_control.updateActControl();
 }
 
 void RoverAckermann::generateSteeringAndThrottleSetpoint()
@@ -100,68 +87,15 @@ void RoverAckermann::generateSteeringAndThrottleSetpoint()
 
 	if (_manual_control_setpoint_sub.update(&manual_control_setpoint)) {
 		rover_steering_setpoint_s rover_steering_setpoint{};
-		rover_steering_setpoint.timestamp = _timestamp;
+		rover_steering_setpoint.timestamp = hrt_absolute_time();
 		rover_steering_setpoint.normalized_steering_angle = manual_control_setpoint.roll;
 		_rover_steering_setpoint_pub.publish(rover_steering_setpoint);
 		rover_throttle_setpoint_s rover_throttle_setpoint{};
-		rover_throttle_setpoint.timestamp = _timestamp;
+		rover_throttle_setpoint.timestamp = hrt_absolute_time();
 		rover_throttle_setpoint.throttle_body_x = manual_control_setpoint.throttle;
 		rover_throttle_setpoint.throttle_body_y = 0.f;
 		_rover_throttle_setpoint_pub.publish(rover_throttle_setpoint);
 	}
-}
-
-void RoverAckermann::generateActuatorSetpoint()
-{
-	if (_rover_throttle_setpoint_sub.updated()) {
-		_rover_throttle_setpoint_sub.copy(&_rover_throttle_setpoint);
-	}
-
-	if (_actuator_motors_sub.updated()) {
-		actuator_motors_s actuator_motors{};
-		_actuator_motors_sub.copy(&actuator_motors);
-		_current_motor_setpoint = actuator_motors.control[0];
-	}
-
-	if (_vehicle_control_mode.flag_armed) {
-		actuator_motors_s actuator_motors{};
-		actuator_motors.reversible_flags = _param_r_rev.get();
-		actuator_motors.control[0] = RoverControl::throttleControl(_motor_setpoint,
-					     _rover_throttle_setpoint.throttle_body_x, _current_motor_setpoint, _param_ro_accel_limit.get(),
-					     _param_ro_decel_limit.get(),
-					     _param_ro_max_thr_speed.get(), _dt);
-		actuator_motors.timestamp = _timestamp;
-		_actuator_motors_pub.publish(actuator_motors);
-	}
-
-	if (_rover_steering_setpoint_sub.updated()) {
-		_rover_steering_setpoint_sub.copy(&_rover_steering_setpoint);
-	}
-
-	if (_actuator_servos_sub.updated()) {
-		actuator_servos_s actuator_servos{};
-		_actuator_servos_sub.copy(&actuator_servos);
-		_current_servo_setpoint = actuator_servos.control[0];
-	}
-
-	if (_param_ra_str_rate_limit.get() > FLT_EPSILON
-	    && _param_ra_max_str_ang.get() > FLT_EPSILON) { // Apply slew rate if configured
-		if (fabsf(_servo_setpoint.getState() - _current_servo_setpoint) > fabsf(
-			    _rover_steering_setpoint.normalized_steering_angle -
-			    _current_servo_setpoint)) {
-			_servo_setpoint.setForcedValue(_current_servo_setpoint);
-		}
-
-		_servo_setpoint.update(_rover_steering_setpoint.normalized_steering_angle, _dt);
-
-	} else {
-		_servo_setpoint.setForcedValue(_rover_steering_setpoint.normalized_steering_angle);
-	}
-
-	actuator_servos_s actuator_servos{};
-	actuator_servos.control[0] = _servo_setpoint.getState();
-	actuator_servos.timestamp = _timestamp;
-	_actuator_servos_pub.publish(actuator_servos);
 }
 
 int RoverAckermann::task_spawn(int argc, char *argv[])

--- a/src/modules/rover_ackermann/RoverAckermann.hpp
+++ b/src/modules/rover_ackermann/RoverAckermann.hpp
@@ -40,14 +40,21 @@
 #include <px4_platform_common/module_params.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 
+// Library includes
+#include <math.h>
+
 // uORB includes
 #include <uORB/Subscription.hpp>
 #include <uORB/Publication.hpp>
+#include <uORB/topics/actuator_motors.h>
+#include <uORB/topics/actuator_servos.h>
 #include <uORB/topics/parameter_update.h>
-#include <uORB/topics/rover_steering_setpoint.h>
-#include <uORB/topics/rover_throttle_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
-#include <uORB/topics/manual_control_setpoint.h>
+#include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/rover_velocity_setpoint.h>
+#include <uORB/topics/rover_position_setpoint.h>
+#include <uORB/topics/offboard_control_mode.h>
+#include <uORB/topics/trajectory_setpoint.h>
 
 // Local includes
 #include "AckermannActControl/AckermannActControl.hpp"
@@ -87,19 +94,39 @@ private:
 	void Run() override;
 
 	/**
-	 * @brief Generate and publish roverSteeringSetpoint and roverThrottleSetpoint from manualControlSetpoint (Manual Mode).
+	 * @brief Handle manual control
 	 */
-	void generateSteeringAndThrottleSetpoint();
+	void manualControl();
+
+	/**
+	 * @brief Handle offboard control
+	 * @return True if actuator control needs to be handled by the module
+	 */
+	bool offboardControl();
+
+	/**
+	 * @brief Update the controllers
+	 */
+	void updateControllers();
+
+	/**
+	 * @brief Run sanity checks for the controllers
+	 */
+	void runSanityChecks();
 
 	// uORB subscriptions
 	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
-	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::Subscription _offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
+	uORB::Subscription _trajectory_setpoint_sub{ORB_ID(trajectory_setpoint)};
 	vehicle_control_mode_s _vehicle_control_mode{};
 
 	// uORB publications
-	uORB::Publication<rover_throttle_setpoint_s> _rover_throttle_setpoint_pub{ORB_ID(rover_throttle_setpoint)};
-	uORB::Publication<rover_steering_setpoint_s> _rover_steering_setpoint_pub{ORB_ID(rover_steering_setpoint)};
+	uORB::Publication<rover_velocity_setpoint_s> _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
+	uORB::Publication<rover_position_setpoint_s> _rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
+	uORB::Publication<actuator_motors_s> _actuator_motors_pub{ORB_ID(actuator_motors)};
+	uORB::Publication<actuator_servos_s> _actuator_servos_pub{ORB_ID(actuator_servos)};
 
 	// Class instances
 	AckermannActControl  _ackermann_act_control{this};
@@ -108,4 +135,14 @@ private:
 	AckermannVelControl  _ackermann_vel_control{this};
 	AckermannPosControl  _ackermann_pos_control{this};
 
+	// Variables
+	hrt_abstime _timestamp{0};
+	float _dt{0.f};
+	int _nav_state{0};
+	bool _sanity_checks_passed{true};
+
+	// Parameters
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::CA_R_REV>) _param_r_rev
+	)
 };

--- a/src/modules/rover_ackermann/RoverAckermann.hpp
+++ b/src/modules/rover_ackermann/RoverAckermann.hpp
@@ -46,8 +46,6 @@
 // uORB includes
 #include <uORB/Subscription.hpp>
 #include <uORB/Publication.hpp>
-#include <uORB/topics/actuator_motors.h>
-#include <uORB/topics/actuator_servos.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_status.h>
@@ -99,10 +97,9 @@ private:
 	void manualControl();
 
 	/**
-	 * @brief Handle offboard control
-	 * @return True if actuator control needs to be handled by the module
+	 * @brief Translate trajectorySetpoint to roverSetpoints and publish them
 	 */
-	bool offboardControl();
+	void offboardControl();
 
 	/**
 	 * @brief Update the controllers
@@ -110,7 +107,11 @@ private:
 	void updateControllers();
 
 	/**
-	 * @brief Run sanity checks for the controllers
+	 * @brief Check proper parameter setup for the controllers
+	 *
+	 * Modifies:
+	 *
+	 *   - _sanity_checks_passed: true if checks for all active controllers pass
 	 */
 	void runSanityChecks();
 
@@ -125,8 +126,6 @@ private:
 	// uORB publications
 	uORB::Publication<rover_velocity_setpoint_s> _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
 	uORB::Publication<rover_position_setpoint_s> _rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
-	uORB::Publication<actuator_motors_s> _actuator_motors_pub{ORB_ID(actuator_motors)};
-	uORB::Publication<actuator_servos_s> _actuator_servos_pub{ORB_ID(actuator_servos)};
 
 	// Class instances
 	AckermannActControl  _ackermann_act_control{this};
@@ -136,13 +135,7 @@ private:
 	AckermannPosControl  _ackermann_pos_control{this};
 
 	// Variables
-	hrt_abstime _timestamp{0};
-	float _dt{0.f};
-	int _nav_state{0};
-	bool _sanity_checks_passed{true};
-
-	// Parameters
-	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::CA_R_REV>) _param_r_rev
-	)
+	int _nav_state{0}; // Navigation state of the vehicle
+	bool _sanity_checks_passed{true}; // True if checks for all active controllers pass
+	bool _was_armed{false}; // True if the vehicle was armed before the last reset
 };

--- a/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.cpp
+++ b/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.cpp
@@ -37,7 +37,7 @@ using namespace time_literals;
 
 DifferentialPosControl::DifferentialPosControl(ModuleParams *parent) : ModuleParams(parent)
 {
-	_differential_velocity_setpoint_pub.advertise();
+	_rover_velocity_setpoint_pub.advertise();
 	_rover_position_setpoint_pub.advertise();
 	_pure_pursuit_status_pub.advertise();
 
@@ -159,20 +159,20 @@ void DifferentialPosControl::manualPositionMode()
 	if (fabsf(speed_setpoint) < FLT_EPSILON) { // Turn on spot
 		_course_control = false;
 		const float bearing_setpoint = matrix::wrap_pi(_vehicle_yaw + bearing_delta);
-		differential_velocity_setpoint_s differential_velocity_setpoint{};
-		differential_velocity_setpoint.timestamp = _timestamp;
-		differential_velocity_setpoint.speed = 0.f;
-		differential_velocity_setpoint.bearing = bearing_setpoint;
-		_differential_velocity_setpoint_pub.publish(differential_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = 0.f;
+		rover_velocity_setpoint.bearing = bearing_setpoint;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else if (fabsf(bearing_delta) > FLT_EPSILON) { // Closed loop yaw rate control
 		_course_control = false;
 		const float bearing_setpoint = matrix::wrap_pi(_vehicle_yaw + bearing_delta);
-		differential_velocity_setpoint_s differential_velocity_setpoint{};
-		differential_velocity_setpoint.timestamp = _timestamp;
-		differential_velocity_setpoint.speed = speed_setpoint;
-		differential_velocity_setpoint.bearing = bearing_setpoint;
-		_differential_velocity_setpoint_pub.publish(differential_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = speed_setpoint;
+		rover_velocity_setpoint.bearing = bearing_setpoint;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else { // Course control if the steering input is zero (keep driving on a straight line)
 		if (!_course_control) {
@@ -192,12 +192,12 @@ void DifferentialPosControl::manualPositionMode()
 					       _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), target_waypoint_ned, _pos_ctl_start_position_ned,
 					       _curr_pos_ned, fabsf(speed_setpoint));
 		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		differential_velocity_setpoint_s differential_velocity_setpoint{};
-		differential_velocity_setpoint.timestamp = _timestamp;
-		differential_velocity_setpoint.speed = speed_setpoint;
-		differential_velocity_setpoint.bearing = speed_setpoint > -FLT_EPSILON ? bearing_setpoint : matrix::wrap_pi(
-					bearing_setpoint + M_PI_F);
-		_differential_velocity_setpoint_pub.publish(differential_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = speed_setpoint;
+		rover_velocity_setpoint.bearing = speed_setpoint > -FLT_EPSILON ? bearing_setpoint : matrix::wrap_pi(
+				bearing_setpoint + M_PI_F);
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 	}
 }
 
@@ -232,11 +232,11 @@ void DifferentialPosControl::autoPositionMode()
 	}
 
 	if (auto_stop) {
-		differential_velocity_setpoint_s differential_velocity_setpoint{};
-		differential_velocity_setpoint.timestamp = _timestamp;
-		differential_velocity_setpoint.speed = 0.f;
-		differential_velocity_setpoint.bearing = _vehicle_yaw;
-		_differential_velocity_setpoint_pub.publish(differential_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = 0.f;
+		rover_velocity_setpoint.bearing = _vehicle_yaw;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else {
 		const float speed_setpoint = calcSpeedSetpoint(_cruising_speed, distance_to_curr_wp, _param_ro_decel_limit.get(),
@@ -248,11 +248,11 @@ void DifferentialPosControl::autoPositionMode()
 					       _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), _curr_wp_ned, _prev_wp_ned, _curr_pos_ned,
 					       fabsf(speed_setpoint));
 		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		differential_velocity_setpoint_s differential_velocity_setpoint{};
-		differential_velocity_setpoint.timestamp = _timestamp;
-		differential_velocity_setpoint.speed = speed_setpoint;
-		differential_velocity_setpoint.bearing = bearing_setpoint;
-		_differential_velocity_setpoint_pub.publish(differential_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = speed_setpoint;
+		rover_velocity_setpoint.bearing = bearing_setpoint;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 	}
 
 }
@@ -302,18 +302,18 @@ void DifferentialPosControl::goToPositionMode()
 					       _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), target_waypoint_ned, _curr_pos_ned,
 					       _curr_pos_ned, fabsf(speed_setpoint));
 		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		differential_velocity_setpoint_s differential_velocity_setpoint{};
-		differential_velocity_setpoint.timestamp = _timestamp;
-		differential_velocity_setpoint.speed = speed_setpoint;
-		differential_velocity_setpoint.bearing = bearing_setpoint;
-		_differential_velocity_setpoint_pub.publish(differential_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = speed_setpoint;
+		rover_velocity_setpoint.bearing = bearing_setpoint;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else {
-		differential_velocity_setpoint_s differential_velocity_setpoint{};
-		differential_velocity_setpoint.timestamp = _timestamp;
-		differential_velocity_setpoint.speed = 0.f;
-		differential_velocity_setpoint.bearing = _vehicle_yaw;
-		_differential_velocity_setpoint_pub.publish(differential_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = 0.f;
+		rover_velocity_setpoint.bearing = _vehicle_yaw;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 	}
 }
 

--- a/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.hpp
+++ b/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.hpp
@@ -163,7 +163,7 @@ private:
 	uORB::Publication<rover_velocity_status_s>          _rover_velocity_status_pub{ORB_ID(rover_velocity_status)};
 	uORB::Publication<differential_velocity_setpoint_s> _differential_velocity_setpoint_pub{ORB_ID(differential_velocity_setpoint)};
 	uORB::Publication<pure_pursuit_status_s>	    _pure_pursuit_status_pub{ORB_ID(pure_pursuit_status)};
-	uORB::Publication<rover_position_setpoint_s>	 _rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
+	uORB::Publication<rover_position_setpoint_s>	    _rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
 
 	// Variables
 	hrt_abstime _timestamp{0};
@@ -171,7 +171,7 @@ private:
 	Vector2f _curr_pos_ned{};
 	Vector2f _pos_ctl_course_direction{};
 	Vector2f _pos_ctl_start_position_ned{};
-	float _vehicle_speed_body_x{0.f};
+	float _vehicle_speed{0.f}; // [m/s] Positiv: Forwards, Negativ: Backwards
 	float _vehicle_yaw{0.f};
 	float _max_yaw_rate{0.f};
 	float _dt{0.f};

--- a/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.hpp
+++ b/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.hpp
@@ -47,7 +47,7 @@
 // uORB includes
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
-#include <uORB/topics/differential_velocity_setpoint.h>
+#include <uORB/topics/rover_velocity_setpoint.h>
 #include <uORB/topics/pure_pursuit_status.h>
 #include <uORB/topics/rover_position_setpoint.h>
 #include <uORB/topics/rover_velocity_status.h>
@@ -152,7 +152,7 @@ private:
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _position_setpoint_triplet_sub{ORB_ID(position_setpoint_triplet)};
-	uORB::Subscription _differential_velocity_setpoint_sub{ORB_ID(differential_velocity_setpoint)};
+	uORB::Subscription _rover_velocity_setpoint_sub{ORB_ID(rover_velocity_setpoint)};
 	uORB::Subscription _rover_position_setpoint_sub{ORB_ID(rover_position_setpoint)};
 	vehicle_control_mode_s _vehicle_control_mode{};
 	offboard_control_mode_s _offboard_control_mode{};
@@ -160,10 +160,10 @@ private:
 
 
 	// uORB publications
-	uORB::Publication<rover_velocity_status_s>          _rover_velocity_status_pub{ORB_ID(rover_velocity_status)};
-	uORB::Publication<differential_velocity_setpoint_s> _differential_velocity_setpoint_pub{ORB_ID(differential_velocity_setpoint)};
-	uORB::Publication<pure_pursuit_status_s>	    _pure_pursuit_status_pub{ORB_ID(pure_pursuit_status)};
-	uORB::Publication<rover_position_setpoint_s>	    _rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
+	uORB::Publication<rover_velocity_status_s>   _rover_velocity_status_pub{ORB_ID(rover_velocity_status)};
+	uORB::Publication<rover_velocity_setpoint_s> _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
+	uORB::Publication<pure_pursuit_status_s>     _pure_pursuit_status_pub{ORB_ID(pure_pursuit_status)};
+	uORB::Publication<rover_position_setpoint_s> _rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
 
 	// Variables
 	hrt_abstime _timestamp{0};

--- a/src/modules/rover_differential/DifferentialVelControl/DifferentialVelControl.cpp
+++ b/src/modules/rover_differential/DifferentialVelControl/DifferentialVelControl.cpp
@@ -140,10 +140,12 @@ void DifferentialVelControl::generateAttitudeAndThrottleSetpoint()
 	}
 
 	// Attitude Setpoint
-	rover_attitude_setpoint_s rover_attitude_setpoint{};
-	rover_attitude_setpoint.timestamp = _timestamp;
-	rover_attitude_setpoint.yaw_setpoint = _rover_velocity_setpoint.bearing;
-	_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
+	if (PX4_ISFINITE(_rover_velocity_setpoint.bearing)) {
+		rover_attitude_setpoint_s rover_attitude_setpoint{};
+		rover_attitude_setpoint.timestamp = _timestamp;
+		rover_attitude_setpoint.yaw_setpoint = _rover_velocity_setpoint.bearing;
+		_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
+	}
 
 	// Throttle Setpoint
 	const float heading_error = matrix::wrap_pi(_rover_velocity_setpoint.bearing - _vehicle_yaw);

--- a/src/modules/rover_differential/DifferentialVelControl/DifferentialVelControl.hpp
+++ b/src/modules/rover_differential/DifferentialVelControl/DifferentialVelControl.hpp
@@ -50,7 +50,7 @@
 #include <uORB/topics/rover_steering_setpoint.h>
 #include <uORB/topics/rover_throttle_setpoint.h>
 #include <uORB/topics/rover_velocity_status.h>
-#include <uORB/topics/differential_velocity_setpoint.h>
+#include <uORB/topics/rover_velocity_setpoint.h>
 #include <uORB/topics/rover_attitude_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/trajectory_setpoint.h>
@@ -121,7 +121,7 @@ private:
 	uORB::Subscription _offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
-	uORB::Subscription _differential_velocity_setpoint_sub{ORB_ID(differential_velocity_setpoint)};
+	uORB::Subscription _rover_velocity_setpoint_sub{ORB_ID(rover_velocity_setpoint)};
 	uORB::Subscription _rover_steering_setpoint_sub{ORB_ID(rover_steering_setpoint)};
 	vehicle_control_mode_s _vehicle_control_mode{};
 	offboard_control_mode_s _offboard_control_mode{};
@@ -131,8 +131,8 @@ private:
 	uORB::Publication<rover_throttle_setpoint_s> _rover_throttle_setpoint_pub{ORB_ID(rover_throttle_setpoint)};
 	uORB::Publication<rover_attitude_setpoint_s> _rover_attitude_setpoint_pub{ORB_ID(rover_attitude_setpoint)};
 	uORB::Publication<rover_velocity_status_s> _rover_velocity_status_pub{ORB_ID(rover_velocity_status)};
-	uORB::Publication<differential_velocity_setpoint_s> _differential_velocity_setpoint_pub{ORB_ID(differential_velocity_setpoint)};
-	differential_velocity_setpoint_s _differential_velocity_setpoint{};
+	uORB::Publication<rover_velocity_setpoint_s> _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
+	rover_velocity_setpoint_s _rover_velocity_setpoint{};
 
 	// Variables
 	hrt_abstime _timestamp{0};

--- a/src/modules/rover_differential/DifferentialVelControl/DifferentialVelControl.hpp
+++ b/src/modules/rover_differential/DifferentialVelControl/DifferentialVelControl.hpp
@@ -137,8 +137,7 @@ private:
 	// Variables
 	hrt_abstime _timestamp{0};
 	Quatf _vehicle_attitude_quaternion{};
-	float _vehicle_speed_body_x{0.f};
-	float _vehicle_speed_body_y{0.f};
+	float _vehicle_speed{0.f}; // [m/s] Positiv: Forwards, Negativ: Backwards
 	float _vehicle_yaw{0.f};
 	float _dt{0.f};
 	bool _prev_param_check_passed{false};

--- a/src/modules/rover_mecanum/MecanumPosControl/MecanumPosControl.cpp
+++ b/src/modules/rover_mecanum/MecanumPosControl/MecanumPosControl.cpp
@@ -37,7 +37,7 @@ using namespace time_literals;
 
 MecanumPosControl::MecanumPosControl(ModuleParams *parent) : ModuleParams(parent)
 {
-	_mecanum_velocity_setpoint_pub.advertise();
+	_rover_velocity_setpoint_pub.advertise();
 	_rover_position_setpoint_pub.advertise();
 	_pure_pursuit_status_pub.advertise();
 
@@ -158,12 +158,12 @@ void MecanumPosControl::manualPositionMode()
 		_pos_ctl_yaw_setpoint = NAN;
 		const float yaw_setpoint = matrix::wrap_pi(_vehicle_yaw + yaw_delta);
 		const Vector3f velocity_setpoint_local = _vehicle_attitude_quaternion.rotateVector(velocity_setpoint_body);
-		mecanum_velocity_setpoint_s mecanum_velocity_setpoint{};
-		mecanum_velocity_setpoint.timestamp = _timestamp;
-		mecanum_velocity_setpoint.speed = velocity_setpoint_body.norm();
-		mecanum_velocity_setpoint.bearing = atan2f(velocity_setpoint_local(1), velocity_setpoint_local(0));
-		mecanum_velocity_setpoint.yaw = yaw_setpoint;
-		_mecanum_velocity_setpoint_pub.publish(mecanum_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = velocity_setpoint_body.norm();
+		rover_velocity_setpoint.bearing = atan2f(velocity_setpoint_local(1), velocity_setpoint_local(0));
+		rover_velocity_setpoint.yaw = yaw_setpoint;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else { // Course control if the steering input is zero (keep driving on a straight line)
 		const Vector3f velocity = Vector3f(velocity_setpoint_body(0), velocity_setpoint_body(1), 0.f);
@@ -194,12 +194,12 @@ void MecanumPosControl::manualPositionMode()
 					       _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), target_waypoint_ned, _pos_ctl_start_position_ned,
 					       _curr_pos_ned, velocity_magnitude_setpoint);
 		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		mecanum_velocity_setpoint_s mecanum_velocity_setpoint{};
-		mecanum_velocity_setpoint.timestamp = _timestamp;
-		mecanum_velocity_setpoint.speed = velocity_magnitude_setpoint;
-		mecanum_velocity_setpoint.bearing = bearing_setpoint;
-		mecanum_velocity_setpoint.yaw = _pos_ctl_yaw_setpoint;
-		_mecanum_velocity_setpoint_pub.publish(mecanum_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = velocity_magnitude_setpoint;
+		rover_velocity_setpoint.bearing = bearing_setpoint;
+		rover_velocity_setpoint.yaw = _pos_ctl_yaw_setpoint;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 	}
 }
 
@@ -241,12 +241,12 @@ void MecanumPosControl::autoPositionMode()
 	}
 
 	if (auto_stop) {
-		mecanum_velocity_setpoint_s mecanum_velocity_setpoint{};
-		mecanum_velocity_setpoint.timestamp = _timestamp;
-		mecanum_velocity_setpoint.speed = 0.f;
-		mecanum_velocity_setpoint.bearing = 0.f;
-		mecanum_velocity_setpoint.yaw = _vehicle_yaw;
-		_mecanum_velocity_setpoint_pub.publish(mecanum_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = 0.f;
+		rover_velocity_setpoint.bearing = 0.f;
+		rover_velocity_setpoint.yaw = _vehicle_yaw;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else { // Regular guidance algorithm
 		const float velocity_magnitude = calcVelocityMagnitude(_auto_speed, distance_to_curr_wp, _param_ro_decel_limit.get(),
@@ -258,12 +258,12 @@ void MecanumPosControl::autoPositionMode()
 					       _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), _curr_wp_ned, _prev_wp_ned, _curr_pos_ned,
 					       velocity_magnitude);
 		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		mecanum_velocity_setpoint_s mecanum_velocity_setpoint{};
-		mecanum_velocity_setpoint.timestamp = _timestamp;
-		mecanum_velocity_setpoint.speed = velocity_magnitude;
-		mecanum_velocity_setpoint.bearing = bearing_setpoint;
-		mecanum_velocity_setpoint.yaw = _auto_yaw;
-		_mecanum_velocity_setpoint_pub.publish(mecanum_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = velocity_magnitude;
+		rover_velocity_setpoint.bearing = bearing_setpoint;
+		rover_velocity_setpoint.yaw = _auto_yaw;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 	}
 }
 
@@ -313,20 +313,20 @@ void MecanumPosControl::goToPositionMode()
 					       _param_pp_lookahd_max.get(), _param_pp_lookahd_min.get(), target_waypoint_ned, _curr_pos_ned,
 					       _curr_pos_ned, fabsf(speed_setpoint));
 		_pure_pursuit_status_pub.publish(pure_pursuit_status);
-		mecanum_velocity_setpoint_s mecanum_velocity_setpoint{};
-		mecanum_velocity_setpoint.timestamp = _timestamp;
-		mecanum_velocity_setpoint.speed = speed_setpoint;
-		mecanum_velocity_setpoint.bearing = bearing_setpoint;
-		mecanum_velocity_setpoint.yaw = _pos_ctl_yaw_setpoint;
-		_mecanum_velocity_setpoint_pub.publish(mecanum_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = speed_setpoint;
+		rover_velocity_setpoint.bearing = bearing_setpoint;
+		rover_velocity_setpoint.yaw = _pos_ctl_yaw_setpoint;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 
 	} else {
-		mecanum_velocity_setpoint_s mecanum_velocity_setpoint{};
-		mecanum_velocity_setpoint.timestamp = _timestamp;
-		mecanum_velocity_setpoint.speed = 0.f;
-		mecanum_velocity_setpoint.bearing = 0.f;
-		mecanum_velocity_setpoint.yaw = _vehicle_yaw;
-		_mecanum_velocity_setpoint_pub.publish(mecanum_velocity_setpoint);
+		rover_velocity_setpoint_s rover_velocity_setpoint{};
+		rover_velocity_setpoint.timestamp = _timestamp;
+		rover_velocity_setpoint.speed = 0.f;
+		rover_velocity_setpoint.bearing = 0.f;
+		rover_velocity_setpoint.yaw = _vehicle_yaw;
+		_rover_velocity_setpoint_pub.publish(rover_velocity_setpoint);
 	}
 }
 

--- a/src/modules/rover_mecanum/MecanumPosControl/MecanumPosControl.hpp
+++ b/src/modules/rover_mecanum/MecanumPosControl/MecanumPosControl.hpp
@@ -49,7 +49,7 @@
 // uORB includes
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
-#include <uORB/topics/mecanum_velocity_setpoint.h>
+#include <uORB/topics/rover_velocity_setpoint.h>
 #include <uORB/topics/rover_position_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/manual_control_setpoint.h>
@@ -162,7 +162,7 @@ private:
 	rover_position_setpoint_s _rover_position_setpoint{};
 
 	// uORB publications
-	uORB::Publication<mecanum_velocity_setpoint_s> _mecanum_velocity_setpoint_pub{ORB_ID(mecanum_velocity_setpoint)};
+	uORB::Publication<rover_velocity_setpoint_s> _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
 	uORB::Publication<pure_pursuit_status_s>       _pure_pursuit_status_pub{ORB_ID(pure_pursuit_status)};
 	uORB::Publication<rover_position_setpoint_s>   _rover_position_setpoint_pub{ORB_ID(rover_position_setpoint)};
 

--- a/src/modules/rover_mecanum/MecanumVelControl/MecanumVelControl.cpp
+++ b/src/modules/rover_mecanum/MecanumVelControl/MecanumVelControl.cpp
@@ -167,7 +167,7 @@ void MecanumVelControl::generateAttitudeAndThrottleSetpoint()
 	float speed_body_x_setpoint{0.f};
 	float speed_body_y_setpoint{0.f};
 
-	if (fabsf(_rover_velocity_setpoint.speed) > FLT_EPSILON) {
+	if (fabsf(_rover_velocity_setpoint.speed) > FLT_EPSILON && PX4_ISFINITE(_rover_velocity_setpoint.bearing)) {
 		const Vector3f velocity_in_local_frame(_rover_velocity_setpoint.speed * cosf(
 				_rover_velocity_setpoint.bearing),
 						       _rover_velocity_setpoint.speed * sinf(_rover_velocity_setpoint.bearing), 0.f);
@@ -175,6 +175,9 @@ void MecanumVelControl::generateAttitudeAndThrottleSetpoint()
 		speed_body_x_setpoint = velocity_in_body_frame(0);
 		speed_body_y_setpoint = velocity_in_body_frame(1);
 
+	} else {
+		speed_body_x_setpoint = _rover_velocity_setpoint.speed;
+		speed_body_y_setpoint = 0.f;
 	}
 
 	if (_param_ro_max_thr_speed.get() > FLT_EPSILON) { // Adjust speed setpoints if infeasible

--- a/src/modules/rover_mecanum/MecanumVelControl/MecanumVelControl.hpp
+++ b/src/modules/rover_mecanum/MecanumVelControl/MecanumVelControl.hpp
@@ -50,7 +50,7 @@
 #include <uORB/topics/rover_steering_setpoint.h>
 #include <uORB/topics/rover_throttle_setpoint.h>
 #include <uORB/topics/rover_velocity_status.h>
-#include <uORB/topics/mecanum_velocity_setpoint.h>
+#include <uORB/topics/rover_velocity_setpoint.h>
 #include <uORB/topics/rover_attitude_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/trajectory_setpoint.h>
@@ -113,7 +113,7 @@ private:
 	uORB::Subscription _offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
-	uORB::Subscription _mecanum_velocity_setpoint_sub{ORB_ID(mecanum_velocity_setpoint)};
+	uORB::Subscription _rover_velocity_setpoint_sub{ORB_ID(rover_velocity_setpoint)};
 	uORB::Subscription _rover_attitude_setpoint_sub{ORB_ID(rover_attitude_setpoint)};
 	uORB::Subscription _rover_steering_setpoint_sub{ORB_ID(rover_steering_setpoint)};
 	vehicle_control_mode_s _vehicle_control_mode{};
@@ -124,8 +124,8 @@ private:
 	uORB::Publication<rover_throttle_setpoint_s> _rover_throttle_setpoint_pub{ORB_ID(rover_throttle_setpoint)};
 	uORB::Publication<rover_attitude_setpoint_s> _rover_attitude_setpoint_pub{ORB_ID(rover_attitude_setpoint)};
 	uORB::Publication<rover_velocity_status_s> _rover_velocity_status_pub{ORB_ID(rover_velocity_status)};
-	uORB::Publication<mecanum_velocity_setpoint_s> _mecanum_velocity_setpoint_pub{ORB_ID(mecanum_velocity_setpoint)};
-	mecanum_velocity_setpoint_s _mecanum_velocity_setpoint{};
+	uORB::Publication<rover_velocity_setpoint_s> _rover_velocity_setpoint_pub{ORB_ID(rover_velocity_setpoint)};
+	rover_velocity_setpoint_s _rover_velocity_setpoint{};
 
 	// Variables
 	hrt_abstime _timestamp{0};


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This PR updates the ackermann module to the following control structure:
![rover_graphics-rover_refactor_5](https://github.com/user-attachments/assets/c9fb7617-b990-46ff-aac8-42c9a8f59cea)

This is done to prepare the rover modules (and the RoverSpecificSetpoints) for access through API and is achieved through the following steps:
1. Seperate Actuator Control: This streamlines the Input/Output flow of the rover specific uORB messages.
2. Update Position Control: So far, in auto and manual position mode, position control directly published RoverVelocitySetpoints.
Position control now **always** turns a RoverPositionSetpoint into a RoverVelocitySetpoint which further streamlines the Input/Output flow of the rover specific uORB messages.
To achieve this, the RoverPositionSetpoint is extended with some optional fields.
3. Centralize mode management, resets and checks: All arming, control mode and nav state checks are now done in `RoverAckermann`. Based on the control mode, it will generate `RoverSetpoints` and udpate the necessary controllers . Further, sanity checks are now only performed on parameter or control mode changes.
4. Cleanup and NAN value handling: Align function/parameter names, comments and remove unused variables. Protect the controllers from NAN values in `RoverSetpoints`.

### Alternative
All functions that generate roverSetpoints (manual modes, offboard, auto, ...) could also be moved to `RoverAckermann`.
This way the controllers would only handle their setpoint and publish the setpoint that is one level lower in the hierarchy.
![rover_refactor6](https://github.com/user-attachments/assets/615eb055-6b00-4f27-af81-c6f60be6f454)

### Tests
Tested in SITL
Hardware tests:
- [Manual Mode](https://review.px4.io/plot_app?log=7c27510f-190a-4dc9-9dac-f10d53044a2a): 
![image](https://github.com/user-attachments/assets/6f3d66ab-7a48-4590-8488-7510419f5c0f)
- [Acro Mode](https://review.px4.io/plot_app?log=22cb8466-7b5b-4f2e-8bcc-91d76835f50a)
![image](https://github.com/user-attachments/assets/93411db7-da8d-4c7e-bab5-e01de3a6a2f6)
- [Stab Mode](https://review.px4.io/plot_app?log=c20cd96d-7c8b-4f64-a4da-457d80f1e9cc)
![image](https://github.com/user-attachments/assets/d4bf5415-63a3-465c-bab7-065783d85c5c)
- [Position Mode](https://review.px4.io/plot_app?log=50e305b6-1b0b-45e1-8404-cbc992283921)
![image](https://github.com/user-attachments/assets/216c4599-1954-4a86-8a76-18a123845898)
- [Auto Mode](https://review.px4.io/plot_app?log=df91f982-1332-4e64-bec5-4c9d20dc3545)
![image](https://github.com/user-attachments/assets/e144d6fb-bd88-4da7-a7ce-71bd3670c52b)
