### PR TITLE
feat: configurable board pwm freq from Kconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -206,8 +206,8 @@ source "src/examples/Kconfig"
 endmenu
 
 menu "platforms"
-depends on PLATFORM_QURT || PLATFORM_POSIX
-source "platforms/common/Kconfig"
+depends on PLATFORM_QURT || PLATFORM_POSIX || PLATFORM_NUTTX
+source "platforms/Kconfig"
 endmenu
 
 source "src/lib/*/Kconfig"

--- a/platforms/Kconfig
+++ b/platforms/Kconfig
@@ -1,0 +1,1 @@
+rsource "*/Kconfig"

--- a/platforms/nuttx/Kconfig
+++ b/platforms/nuttx/Kconfig
@@ -1,0 +1,7 @@
+menu "nuttx"
+menuconfig BOARD_PWM_FREQ
+    int "Board default PWM frequency"
+    default 1000000
+    ---help---
+        Board default PWM frequency.
+endmenu

--- a/platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c
@@ -95,6 +95,12 @@ static int io_timer_handler7(int irq, void *context, void *arg);
 #define BOARD_PWM_FREQ 1000000
 #endif
 
+#if !defined(CONFIG_BOARD_PWM_FREQ) && !defined(BOARD_PWM_FREQ)
+#define BOARD_PWM_FREQ 1000000
+#elif defined(CONFIG_BOARD_PWM_FREQ) && !defined(BOARD_PWM_FREQ)
+#define BOARD_PWM_FREQ CONFIG_BOARD_PWM_FREQ
+#endif
+
 #if !defined(BOARD_ONESHOT_FREQ)
 #define BOARD_ONESHOT_FREQ 8000000
 #endif


### PR DESCRIPTION
### Solved Problem
Allows for configurable board PWM frequency from Kconfig. For slow PWMs (like 10Hz) this value needs to change due to timer overflow on a 16bit register.

### Solution
- Add options to Kconfig and proper setting on platforms/nuttx

### Changelog Entry
For release notes:
```
New parameter: CONFIG_BOARD_PWM_FREQUENCY
```

### Alternatives
None me and @dagar could think of.

### Test coverage
- Unit/integration test: -
- Simulation/hardware testing logs: -

### Context
Spacecraft solenoid valves requiring slow PWM.
