### PR TITLE
docs: Update user_guide.md To Fix Build Issue

### DIFF
--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -83,7 +83,7 @@ cd
 git clone https://github.com/PX4/PX4-Autopilot.git --recursive
 bash ./PX4-Autopilot/Tools/setup/ubuntu.sh
 cd PX4-Autopilot/
-make px4_sitl
+make px4_sitl gz_x500
 ```
 
 Note that the above commands will install the recommended simulator for your version of Ubuntu.


### PR DESCRIPTION
When running a command block provided, it gives an error on the "make px4_sitl" command because there is no make target specified. 

This pull request updates the ROS 2 user guide to specify the use of the `gz_x500` model when building the PX4 SITL simulator. 

Documentation update:

* [`docs/en/ros2/user_guide.md`](diffhunk://#diff-2bd47dc6baabf9bb23ac086186f961418e2f1ea55fb42ddfc87aaa5b328fe929L86-R86): Changed the `make px4_sitl` command to `make px4_sitl gz_x500` to clarify which simulator model to build.