### PR TITLE
mavlink: set system clock from SYSTEM_TIME 

### DIFF
--- a/src/modules/mavlink/mavlink_timesync.cpp
+++ b/src/modules/mavlink/mavlink_timesync.cpp
@@ -86,11 +86,14 @@ MavlinkTimesync::handle_message(const mavlink_message_t *msg)
 			timespec tv = {};
 			px4_clock_gettime(CLOCK_REALTIME, &tv);
 
-			// date -d @1234567890: Sat Feb 14 02:31:30 MSK 2009
-			bool onb_unix_valid = (unsigned long long)tv.tv_sec > PX4_EPOCH_SECS;
-			bool ofb_unix_valid = time.time_unix_usec > PX4_EPOCH_SECS * 1000000ULL;
+			// Set the system time if we are lagging behind by more than a minute
+			hrt_abstime seconds_behind = 60;
+			hrt_abstime local_time = tv.tv_sec;
+			hrt_abstime remote_time = time.time_unix_usec / 1000000;
+			bool update = (remote_time > PX4_EPOCH_SECS) && (remote_time > local_time + seconds_behind);
 
-			if (!onb_unix_valid && ofb_unix_valid) {
+			if (update) {
+				PX4_INFO("Setting system clock");
 				tv.tv_sec = time.time_unix_usec / 1000000ULL;
 				tv.tv_nsec = (time.time_unix_usec % 1000000ULL) * 1000ULL;
 

--- a/src/modules/mavlink/mavlink_timesync.cpp
+++ b/src/modules/mavlink/mavlink_timesync.cpp
@@ -87,13 +87,13 @@ MavlinkTimesync::handle_message(const mavlink_message_t *msg)
 			px4_clock_gettime(CLOCK_REALTIME, &tv);
 
 			// Set the system time if we are lagging behind by more than a minute
-			hrt_abstime seconds_behind = 60;
-			hrt_abstime local_time = tv.tv_sec;
-			hrt_abstime remote_time = time.time_unix_usec / 1000000;
+			time_t seconds_behind = 60;
+			time_t local_time = tv.tv_sec;
+			time_t remote_time = time.time_unix_usec / 1000000;
 			bool update = (remote_time > PX4_EPOCH_SECS) && (remote_time > local_time + seconds_behind);
 
 			if (update) {
-				PX4_INFO("Setting system clock");
+				PX4_INFO("Setting system clock from SYSTEM_TIME sent by %d/%d", msg->sysid, msg->compid);
 				tv.tv_sec = time.time_unix_usec / 1000000ULL;
 				tv.tv_nsec = (time.time_unix_usec % 1000000ULL) * 1000ULL;
 


### PR DESCRIPTION
Previously the system clock was only set if the "offboard" timestamp was valid and the "onboard" timestamp was invalid. This usually is not the desired behavior, since your onboard time could be valid but just hours/days/weeks behind the actual time. A system that sends the SYSTEM_TIME message (eg companion computer application) will update the PX4 time if PX4 is behind by more than a minute. 