### PR TITLE
ci: avoid multiple builds with concurrency checks

### DIFF
--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -24,6 +24,10 @@ on:
       - 'docs/**'
       - '.github/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   group_targets:
     name: Scan for Board Targets


### PR DESCRIPTION
This will make it so the big expensive "builds all" GitHub action won't allow multiple concurrent runs per pull request, it will cancel any prior runs if it detects that a new one was triggered. Saving us hundreds per month.