### PR TITLE
Make payload power usable on all boards optionally as a 3-way switch

### DIFF
--- a/msg/ManualControlSwitches.msg
+++ b/msg/ManualControlSwitches.msg
@@ -29,8 +29,8 @@ uint8 transition_switch          # VTOL transition switch: _HOVER, FORWARD_FLIGH
 uint8 photo_switch               # Photo trigger switch
 uint8 video_switch               # Photo trigger switch
 
-uint8 payload_power_switch       # Payload power switch
-
 uint8 engage_main_motor_switch   # Engage the main motor (for helicopters)
+
+uint8 payload_power_switch       # Payload power switch
 
 uint32 switch_changes            # number of switch changes

--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -277,7 +277,8 @@ void ManualControl::processSwitches(hrt_abstime &now)
 					if (switches.payload_power_switch == manual_control_switches_s::SWITCH_POS_ON) {
 						PAYLOAD_POWER_EN(true);
 
-					} else if (switches.payload_power_switch == manual_control_switches_s::SWITCH_POS_OFF) {
+					} else if (switches.payload_power_switch == manual_control_switches_s::SWITCH_POS_OFF
+						   || switches.payload_power_switch == manual_control_switches_s::SWITCH_POS_MIDDLE) {
 						PAYLOAD_POWER_EN(false);
 					}
 				}

--- a/src/modules/rc_update/RCUpdateTest.cpp
+++ b/src/modules/rc_update/RCUpdateTest.cpp
@@ -128,16 +128,19 @@ public:
 		EXPECT_EQ(manual_control_switches_sub.get().return_switch, expected_position);
 	}
 
-	void checkPayloadPowerSwitch(float channel_value, float threshold, uint8_t expected_position)
+	void checkPayloadPowerSwitch(float channel_value, float on_threshold, float mid_threshold, uint8_t expected_position)
 	{
 		// GIVEN: First channel is configured as payload power switch
 		_param_rc_map_pay_sw.set(1);
 		_param_rc_map_pay_sw.commit();
-		_param_rc_payload_th.set(threshold);
+		_param_rc_payload_th.set(on_threshold);
 		_param_rc_payload_th.commit();
+		_param_rc_payload_midth.set(mid_threshold);
+		_param_rc_payload_midth.commit();
 		_rc_update.updateParams();
 		EXPECT_EQ(_param_rc_map_pay_sw.get(), 1);
-		EXPECT_FLOAT_EQ(_param_rc_payload_th.get(), threshold);
+		EXPECT_FLOAT_EQ(_param_rc_payload_th.get(), on_threshold);
+		EXPECT_FLOAT_EQ(_param_rc_payload_midth.get(), mid_threshold);
 		// GIVEN: First channel has some value
 		_rc_update.setChannel(0, channel_value);
 
@@ -160,7 +163,8 @@ public:
 		(ParamFloat<px4::params::RC_RETURN_TH>) _param_rc_return_th,
 
 		(ParamInt<px4::params::RC_MAP_PAY_SW>) _param_rc_map_pay_sw,
-		(ParamFloat<px4::params::RC_PAYLOAD_TH>) _param_rc_payload_th
+		(ParamFloat<px4::params::RC_PAYLOAD_TH>) _param_rc_payload_th,
+		(ParamFloat<px4::params::RC_PAYLOAD_MIDTH>) _param_rc_payload_midth
 	)
 };
 
@@ -260,43 +264,65 @@ TEST_F(RCUpdateTest, ReturnSwitchNegativeThresholds)
 	checkReturnSwitch(-1.f, -.001f, 1); // Slightly below minimum threshold -> SWITCH_POS_OFF
 }
 
-TEST_F(RCUpdateTest, PayloadPowerSwitchPositiveThresholds)
+TEST_F(RCUpdateTest, PayloadPower2WaySwitchPositiveThresholds)
 {
-	checkPayloadPowerSwitch(-1.f, 0.5f, 3); // Below threshold -> SWITCH_POS_OFF
-	checkPayloadPowerSwitch(0.f, 0.5f, 3); // On threshold -> SWITCH_POS_OFF
-	checkPayloadPowerSwitch(.001f, 0.5f, 1); // Slightly above threshold -> SWITCH_POS_ON
-	checkPayloadPowerSwitch(1.f, 0.5f, 1); // Above threshold -> SWITCH_POS_ON
+	checkPayloadPowerSwitch(-1.f, 0.5f, 0.5f, 3); // Below threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(0.f, 0.5f, 0.5f, 3); // On threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(.001f, 0.5f, 0.5f, 1); // Slightly above threshold -> SWITCH_POS_ON
+	checkPayloadPowerSwitch(1.f, 0.5f, 0.5f, 1); // Above threshold -> SWITCH_POS_ON
 
-	checkPayloadPowerSwitch(-1.f, 0.75f, 3); // Below threshold -> SWITCH_POS_OFF
-	checkPayloadPowerSwitch(0.f, 0.75f, 3); // Below threshold -> SWITCH_POS_OFF
-	checkPayloadPowerSwitch(.5f, 0.75f, 3); // On threshold -> SWITCH_POS_OFF
-	checkPayloadPowerSwitch(.501f, 0.75f, 1); // Slightly above threshold -> SWITCH_POS_ON
-	checkPayloadPowerSwitch(1.f, 0.75f, 1); // Above threshold -> SWITCH_POS_ON
+	checkPayloadPowerSwitch(-1.f, 0.75f, 0.75f, 3); // Below threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(0.f, 0.75f, 0.75f, 3); // Below threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(.5f, 0.75f, 0.75f, 3); // On threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(.501f, 0.75f, 0.75f, 1); // Slightly above threshold -> SWITCH_POS_ON
+	checkPayloadPowerSwitch(1.f, 0.75f, 0.75f, 1); // Above threshold -> SWITCH_POS_ON
 
-	checkPayloadPowerSwitch(-1.f, 0.f, 3); // On minimum threshold -> SWITCH_POS_OFF
-	checkPayloadPowerSwitch(-.999f, 0.f, 1); // Slightly above minimum threshold -> SWITCH_POS_ON
-	checkPayloadPowerSwitch(1.f, 0.f, 1); // Above minimum threshold -> SWITCH_POS_ON
+	checkPayloadPowerSwitch(-1.f, 0.f, 0.f, 3); // On minimum threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(-.999f, 0.f, 0.f, 1); // Slightly above minimum threshold -> SWITCH_POS_ON
+	checkPayloadPowerSwitch(1.f, 0.f, 0.f, 1); // Above minimum threshold -> SWITCH_POS_ON
 
-	checkPayloadPowerSwitch(-1.f, 1.f, 3); // Below maximum threshold -> SWITCH_POS_OFF
-	checkPayloadPowerSwitch(1.f, 1.f, 3); // On maximum threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(-1.f, 1.f, 1.f, 3); // Below maximum threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(1.f, 1.f, 1.f, 3); // On maximum threshold -> SWITCH_POS_OFF
 }
 
-TEST_F(RCUpdateTest, PayloadPowerSwitchNegativeThresholds)
+TEST_F(RCUpdateTest, PayloadPower3WaySwitchPositiveThresholds)
 {
-	checkPayloadPowerSwitch(1.f, -0.5f, 3); // Above threshold -> SWITCH_POS_OFF
-	checkPayloadPowerSwitch(0.f, -0.5f, 3); // On threshold -> SWITCH_POS_OFF
-	checkPayloadPowerSwitch(-.001f, -0.5f, 1); // Slightly below threshold -> SWITCH_POS_ON
-	checkPayloadPowerSwitch(-1.f, -0.5f, 1); // Below threshold -> SWITCH_POS_ON
+	checkPayloadPowerSwitch(-1.f, 0.75f, 0.25f, 3); // Below mid_threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(-0.5f, 0.75f, 0.25f, 3); // On mid_threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(-0.449f, 0.75f, 0.25f, 2); // Slightly above mid_threshold -> SWITCH_POS_MIDDLE
+	checkPayloadPowerSwitch(0.f, 0.75f, 0.25f, 2); // Between mid_threshold and on_threshold -> SWITCH_POS_MIDDLE
+	checkPayloadPowerSwitch(0.5f, 0.75f, 0.25f, 2); // On on_threshold -> SWITCH_POS_MIDDLE
+	checkPayloadPowerSwitch(0.501f, 0.75f, 0.25f, 1); // Slightly above on_threshold -> SWITCH_POS_ON
+	checkPayloadPowerSwitch(1.f, 0.75f, 0.25f, 1); // Above on_threshold -> SWITCH_POS_ON
+}
 
-	checkPayloadPowerSwitch(1.f, -0.75f, 3); // Above threshold -> SWITCH_POS_OFF
-	checkPayloadPowerSwitch(.5f, -0.75f, 3); // On threshold -> SWITCH_POS_OFF
-	checkPayloadPowerSwitch(.499f, -0.75f, 1); // Slightly below threshold -> SWITCH_POS_ON
-	checkPayloadPowerSwitch(-1.f, -0.75f, 1); // Below threshold -> SWITCH_POS_ON
+TEST_F(RCUpdateTest, PayloadPower2WaySwitchNegativeThresholds)
+{
+	checkPayloadPowerSwitch(1.f, -0.5f, -0.5f, 3); // Above threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(0.f, -0.5f, -0.5f, 3); // On threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(-.001f, -0.5f, -0.5f, 1); // Slightly below threshold -> SWITCH_POS_ON
+	checkPayloadPowerSwitch(-1.f, -0.5f, -0.5f, 1); // Below threshold -> SWITCH_POS_ON
 
-	checkPayloadPowerSwitch(1.f, -1.f, 3); // On maximum threshold -> SWITCH_POS_OFF
-	checkPayloadPowerSwitch(.999f, -1.f, 1); // Slighly below maximum threshold -> SWITCH_POS_ON
-	checkPayloadPowerSwitch(-1.f, -1.f, 1); // Below minimum threshold -> SWITCH_POS_ON
+	checkPayloadPowerSwitch(1.f, -0.75f, -0.75f, 3); // Above threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(.5f, -0.75f, -0.75f, 3); // On threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(.499f, -0.75f, -0.75f, 1); // Slightly below threshold -> SWITCH_POS_ON
+	checkPayloadPowerSwitch(-1.f, -0.75f, -0.75f, 1); // Below threshold -> SWITCH_POS_ON
 
-	checkPayloadPowerSwitch(1.f, -.001f, 3); // Above minimum threshold -> SWITCH_POS_OFF
-	checkPayloadPowerSwitch(-1.f, -.001f, 1); // Slightly below minimum threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(1.f, -1.f, -1.f, 3); // On maximum threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(.999f, -1.f, -1.f, 1); // Slighly below maximum threshold -> SWITCH_POS_ON
+	checkPayloadPowerSwitch(-1.f, -1.f, -1.f, 1); // Below minimum threshold -> SWITCH_POS_ON
+
+	checkPayloadPowerSwitch(1.f, -.001f, -.001f, 3); // Above minimum threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(-1.f, -.001f, -.001f, 1); // Slightly below minimum threshold -> SWITCH_POS_OFF
+}
+
+TEST_F(RCUpdateTest, PayloadPower3WaySwitchNegativeThresholds)
+{
+	checkPayloadPowerSwitch(1.f, -0.75f, -0.25f, 3); // Above on_threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(0.5f, -0.75f, -0.25f, 3); // On on_threshold -> SWITCH_POS_OFF
+	checkPayloadPowerSwitch(0.449f, -0.75f, -0.25f, 2); // Slightly below on_threshold -> SWITCH_POS_MIDDLE
+	checkPayloadPowerSwitch(0.f, -0.75f, -0.25f, 2); // Between on_threshold and mid_threshold -> SWITCH_POS_MIDDLE
+	checkPayloadPowerSwitch(-0.5f, -0.75f, -0.25f, 2); // On mid_threshold -> SWITCH_POS_MIDDLE
+	checkPayloadPowerSwitch(-0.501f, -0.75f, -0.25f, 1); // Slightly above on_threshold -> SWITCH_POS_ON
+	checkPayloadPowerSwitch(-1.f, -0.75f, -0.25f, 1); // Above on_threshold -> SWITCH_POS_ON
 }

--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -1936,6 +1936,7 @@ PARAM_DEFINE_INT32(RC_FAILS_THR, 0);
  *
  * @min -1
  * @max 1
+ * @decimal 2
  * @group Radio Switches
  */
 PARAM_DEFINE_FLOAT(RC_RETURN_TH, 0.75f);
@@ -1952,6 +1953,7 @@ PARAM_DEFINE_FLOAT(RC_RETURN_TH, 0.75f);
  *
  * @min -1
  * @max 1
+ * @decimal 2
  * @group Radio Switches
  */
 PARAM_DEFINE_FLOAT(RC_LOITER_TH, 0.75f);
@@ -1968,6 +1970,7 @@ PARAM_DEFINE_FLOAT(RC_LOITER_TH, 0.75f);
  *
  * @min -1
  * @max 1
+ * @decimal 2
  * @group Radio Switches
  */
 PARAM_DEFINE_FLOAT(RC_OFFB_TH, 0.75f);
@@ -1984,6 +1987,7 @@ PARAM_DEFINE_FLOAT(RC_OFFB_TH, 0.75f);
  *
  * @min -1
  * @max 1
+ * @decimal 2
  * @group Radio Switches
  */
 PARAM_DEFINE_FLOAT(RC_KILLSWITCH_TH, 0.75f);
@@ -2000,6 +2004,7 @@ PARAM_DEFINE_FLOAT(RC_KILLSWITCH_TH, 0.75f);
  *
  * @min -1
  * @max 1
+ * @decimal 2
  * @group Radio Switches
  */
 PARAM_DEFINE_FLOAT(RC_ARMSWITCH_TH, 0.75f);
@@ -2016,6 +2021,7 @@ PARAM_DEFINE_FLOAT(RC_ARMSWITCH_TH, 0.75f);
  *
  * @min -1
  * @max 1
+ * @decimal 2
  * @group Radio Switches
  */
 PARAM_DEFINE_FLOAT(RC_TRANS_TH, 0.75f);
@@ -2032,6 +2038,7 @@ PARAM_DEFINE_FLOAT(RC_TRANS_TH, 0.75f);
  *
  * @min -1
  * @max 1
+ * @decimal 2
  * @group Radio Switches
  */
 PARAM_DEFINE_FLOAT(RC_GEAR_TH, 0.75f);
@@ -2048,6 +2055,7 @@ PARAM_DEFINE_FLOAT(RC_GEAR_TH, 0.75f);
  *
  * @min -1
  * @max 1
+ * @decimal 2
  * @group Radio Switches
  */
 PARAM_DEFINE_FLOAT(RC_ENG_MOT_TH, 0.75f);
@@ -2064,6 +2072,7 @@ PARAM_DEFINE_FLOAT(RC_ENG_MOT_TH, 0.75f);
  *
  * @min -1
  * @max 1
+ * @decimal 2
  * @group Radio Switches
  */
 PARAM_DEFINE_FLOAT(RC_PAYLOAD_TH, 0.75f);

--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -2061,7 +2061,7 @@ PARAM_DEFINE_FLOAT(RC_GEAR_TH, 0.75f);
 PARAM_DEFINE_FLOAT(RC_ENG_MOT_TH, 0.75f);
 
 /**
- * Threshold for selecting payload power switch
+ * Threshold for on position of payload power switch
  *
  * 0-1 indicate where in the full channel range the threshold sits
  * 		0 : min
@@ -2076,6 +2076,23 @@ PARAM_DEFINE_FLOAT(RC_ENG_MOT_TH, 0.75f);
  * @group Radio Switches
  */
 PARAM_DEFINE_FLOAT(RC_PAYLOAD_TH, 0.75f);
+
+/**
+ * Threshold for mid position of payload power switch
+ *
+ * 0-1 indicate where in the full channel range the threshold sits
+ * 		0 : min
+ * 		1 : max
+ * sign indicates polarity of comparison
+ * 		positive : true when channel>th
+ * 		negative : true when channel<th
+ *
+ * @min -1
+ * @max 1
+ * @decimal 2
+ * @group Radio Switches
+ */
+PARAM_DEFINE_FLOAT(RC_PAYLOAD_MIDTH, 0.25f);
 
 /**
  * PWM input channel that provides RSSI.

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -220,7 +220,7 @@ void RCUpdate::update_rc_functions()
 	_rc.function[rc_channels_s::FUNCTION_AUX_5] = _param_rc_map_aux5.get() - 1;
 	_rc.function[rc_channels_s::FUNCTION_AUX_6] = _param_rc_map_aux6.get() - 1;
 
-	_rc.function[rc_channels_s::FUNCTION_PAYLOAD_POWER] = _param_rc_map_payload_sw.get() - 1;
+	_rc.function[rc_channels_s::FUNCTION_PAYLOAD_POWER] = _param_rc_map_pay_sw.get() - 1;
 
 	for (int i = 0; i < rc_parameter_map_s::RC_PARAM_MAP_NCHAN; i++) {
 		_rc.function[rc_channels_s::FUNCTION_PARAM_1 + i] = _parameters.rc_map_param[i] - 1;

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -544,6 +544,28 @@ switch_pos_t RCUpdate::getRCSwitchOnOffPosition(uint8_t function, float threshol
 	return manual_control_switches_s::SWITCH_POS_NONE;
 }
 
+switch_pos_t RCUpdate::getRCSwitch3WayPosition(uint8_t function, float on_threshold, float mid_threshold) const
+{
+	if (_rc.function[function] >= 0) {
+		const bool on_inverted = (on_threshold < 0.f);
+		const bool mid_inverted = (mid_threshold < 0.f);
+
+		const float value = 0.5f * _rc.channels[_rc.function[function]] + 0.5f;
+
+		if (on_inverted ? value < -mid_threshold : value > on_threshold) {
+			return manual_control_switches_s::SWITCH_POS_ON;
+
+		} else if (mid_inverted ? value < -on_threshold : value > mid_threshold) {
+			return manual_control_switches_s::SWITCH_POS_MIDDLE;
+
+		} else {
+			return manual_control_switches_s::SWITCH_POS_OFF;
+		}
+	}
+
+	return manual_control_switches_s::SWITCH_POS_NONE;
+}
+
 void RCUpdate::UpdateManualSwitches(const hrt_abstime &timestamp_sample)
 {
 	manual_control_switches_s switches{};
@@ -619,8 +641,8 @@ void RCUpdate::UpdateManualSwitches(const hrt_abstime &timestamp_sample)
 	switches.video_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_AUX_4, 0.5f);
 #endif
 
-	switches.payload_power_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_PAYLOAD_POWER,
-					_param_rc_payload_th.get());
+	switches.payload_power_switch = getRCSwitch3WayPosition(rc_channels_s::FUNCTION_PAYLOAD_POWER,
+					_param_rc_payload_th.get(), _param_rc_payload_midth.get());
 
 	// last 2 switch updates identical within 1 second (simple protection from bad RC data)
 	if ((switches == _manual_switches_previous)

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -619,10 +619,8 @@ void RCUpdate::UpdateManualSwitches(const hrt_abstime &timestamp_sample)
 	switches.video_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_AUX_4, 0.5f);
 #endif
 
-#if defined(PAYLOAD_POWER_EN)
 	switches.payload_power_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_PAYLOAD_POWER,
 					_param_rc_payload_th.get());
-#endif
 
 	// last 2 switch updates identical within 1 second (simple protection from bad RC data)
 	if ((switches == _manual_switches_previous)

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -126,6 +126,15 @@ protected:
 	switch_pos_t getRCSwitchOnOffPosition(uint8_t function, float threshold) const;
 
 	/**
+	 * Get 3-way switch position from the RC channel of the specified function
+	 *
+	 * @param function according to rc_channels_s::FUNCTION_XXX
+	 * @param on_threshold according to RC_XXX_TH parameters, negative means comparison is flipped
+	 * @param mid_threshold according to RC_XXX_MIDTH parameters, negative means comparison is flipped
+	 */
+	switch_pos_t getRCSwitch3WayPosition(uint8_t function, float on_threshold, float mid_threshold) const;
+
+	/**
 	 * Update parameters from RC channels if the functionality is activated and the
 	 * input has changed since the last update
 	 */
@@ -241,6 +250,7 @@ protected:
 		(ParamFloat<px4::params::RC_RETURN_TH>) _param_rc_return_th,
 		(ParamFloat<px4::params::RC_ENG_MOT_TH>) _param_rc_eng_mot_th,
 		(ParamFloat<px4::params::RC_PAYLOAD_TH>) _param_rc_payload_th,
+		(ParamFloat<px4::params::RC_PAYLOAD_MIDTH>) _param_rc_payload_midth,
 
 		(ParamInt<px4::params::RC_CHAN_CNT>) _param_rc_chan_cnt
 	)

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -230,7 +230,7 @@ protected:
 
 		(ParamInt<px4::params::RC_FAILS_THR>) _param_rc_fails_thr,
 
-		(ParamInt<px4::params::RC_MAP_PAY_SW>) _param_rc_map_payload_sw,
+		(ParamInt<px4::params::RC_MAP_PAY_SW>) _param_rc_map_pay_sw,
 
 		(ParamFloat<px4::params::RC_LOITER_TH>) _param_rc_loiter_th,
 		(ParamFloat<px4::params::RC_OFFB_TH>) _param_rc_offb_th,


### PR DESCRIPTION
### Solved Problem
When I got asked how to support an RC 3-way-switch controlling the output power of a video transmitter e.g. 25mW, 200mW, 500mW I found that we had removed support to detect 3 states for switches except the mode switch in
https://github.com/PX4/PX4-Autopilot/commit/089c962d9208b3616ba505ab927fa399554035d4#diff-bc65e8936281291b7e9801b185ee1740a6f2d4207e3b539c059469daa6cdfcc9L527-L547
and there was a "payload power switch" added in
https://github.com/PX4/PX4-Autopilot/pull/23830/files#diff-bc65e8936281291b7e9801b185ee1740a6f2d4207e3b539c059469daa6cdfcc9R622-R625

### Solution
I made the previously added payload power switch usable for other boards than ARK FPV, added the unit tests from
https://github.com/PX4/PX4-Autopilot/pull/21796/files#diff-d8e9502b8461830a414cb9f32098a0a7aaf5cb38e5f31dc37ea9e6bf43ae62c8R206-R245
for it to make sure none of the original 2-way functionality breaks and made it a 3-way switch with additional tests.

For the original 2-way operation the only thing that would change in case the mapped switch results in a value in the middle is that the GPIO call is ran unnecessarily again when switching from OFF to MIDDLE state. Otherwise, everything stays the same, the ON threshold is the same and on OpenTX or similar radios I used before any 2-way switch by default results in values that would correspond to OFF and ON.

This optional use with 3 states allows to map the 3 states of the "payload power switch" to 3 different transmit powers in a video transmitter protocol driver which I assume will be contributed shortly.

### Changelog Entry
```
Make payload power usable on all boards optionally as a 3-way switch
```

### Alternatives
It generally makes sense to support 3-way switches but we should have generic switches from which every position can be mapped to trigger actions in the system like switching to a mode or operating the landing gear or payload. It's a bigger overhaul but will vastly improve the usability of the pilots non-continuous inputs like switches and buttons.

### Test coverage
- Unit tests that I added
- We tested this using a three way switch on a Taranis X9D and the right OFF, MIDDLE, ON states are published also with both thresholds negative like in the unit test cases.