### PR TITLE
crowdin_docs.yml - ignore the param reference

### DIFF
--- a/docs/crowdin_docs.yml
+++ b/docs/crowdin_docs.yml
@@ -7,7 +7,7 @@
 "files": [
   {
     "source": "docs/en/**/*.md",
-    "ignore": ["/docs/en/_sidebar.md"],
+    "ignore": ["/docs/en/_sidebar.md","docs/en/advanced_config/parameter_reference.md"],
     "translation": "docs/%two_letters_code%/**/%original_file_name%"
   }
 ]


### PR DESCRIPTION
This fixes upload errors in the crowdin upload workflow