### PR TITLE
ActuatorMotors.msg - uORB docs

### DIFF
--- a/msg/versioned/ActuatorMotors.msg
+++ b/msg/versioned/ActuatorMotors.msg
@@ -6,7 +6,7 @@
 uint32 MESSAGE_VERSION = 0
 
 uint64 timestamp # Time since system start [us]
-uint64 timestamp_sample # Timestamp of the data this control response is based on was sampled [us]
+uint64 timestamp_sample # Sampling timestamp of the data this control response is based on [us]
 
 uint16 reversible_flags # Bitset indicating which motors are configured to be reversible
 

--- a/msg/versioned/ActuatorMotors.msg
+++ b/msg/versioned/ActuatorMotors.msg
@@ -1,15 +1,16 @@
 # Motor control message
+#
+# Normalised thrust setpoint for up to 12 motors.
+# This is scaled by output drivers to particular output, such as PWM or CAN.
 
 uint32 MESSAGE_VERSION = 0
 
-uint64 timestamp			# time since system start (microseconds)
-uint64 timestamp_sample	    # the timestamp the data this control response is based on was sampled
+uint64 timestamp # Time since system start [us]
+uint64 timestamp_sample # Timestamp of the data this control response is based on was sampled [us]
 
-uint16 reversible_flags     # bitset which motors are configured to be reversible
+uint16 reversible_flags # Bitset indicating which motors are configured to be reversible
 
 uint8 ACTUATOR_FUNCTION_MOTOR1 = 101
 
 uint8 NUM_CONTROLS = 12
-float32[12] control # range: [-1, 1], where 1 means maximum positive thrust,
-                    # -1 maximum negative (if not supported by the output, <0 maps to NaN),
-                    # and NaN maps to disarmed (stop the motors)
+float32[12] control # Normalized thrust. [@range -1, 1] where 1 means maximum positive thrust, -1 maximum negative (if not supported by the output, <0 maps to NaN). NaN maps to disarmed (stop the motors).

--- a/msg/versioned/ActuatorMotors.msg
+++ b/msg/versioned/ActuatorMotors.msg
@@ -13,4 +13,4 @@ uint16 reversible_flags # Bitset indicating which motors are configured to be re
 uint8 ACTUATOR_FUNCTION_MOTOR1 = 101
 
 uint8 NUM_CONTROLS = 12
-float32[12] control #  [@range -1, 1] Normalized thrust. where 1 means maximum positive thrust, -1 maximum negative (if not supported by the output, <0 maps to NaN). NaN maps to disarmed (stop the motors).
+float32[12] control # [@range -1, 1] Normalized thrust. where 1 means maximum positive thrust, -1 maximum negative (if not supported by the output, <0 maps to NaN). NaN maps to disarmed (stop the motors).

--- a/msg/versioned/ActuatorMotors.msg
+++ b/msg/versioned/ActuatorMotors.msg
@@ -1,7 +1,7 @@
 # Motor control message
 #
 # Normalised thrust setpoint for up to 12 motors.
-# This is scaled by output drivers to particular output, such as PWM or CAN.
+# Published by the vehicle's allocation and consumed by the ESC protocol drivers e.g. PWM, DSHOT, UAVCAN.
 
 uint32 MESSAGE_VERSION = 0
 

--- a/msg/versioned/ActuatorMotors.msg
+++ b/msg/versioned/ActuatorMotors.msg
@@ -5,8 +5,8 @@
 
 uint32 MESSAGE_VERSION = 0
 
-uint64 timestamp # Time since system start [us]
-uint64 timestamp_sample # Sampling timestamp of the data this control response is based on [us]
+uint64 timestamp # [us] Time since system start.
+uint64 timestamp_sample # [us] Sampling timestamp of the data this control response is based on.
 
 uint16 reversible_flags # Bitset indicating which motors are configured to be reversible
 

--- a/msg/versioned/ActuatorMotors.msg
+++ b/msg/versioned/ActuatorMotors.msg
@@ -13,4 +13,4 @@ uint16 reversible_flags # Bitset indicating which motors are configured to be re
 uint8 ACTUATOR_FUNCTION_MOTOR1 = 101
 
 uint8 NUM_CONTROLS = 12
-float32[12] control # Normalized thrust. [@range -1, 1] where 1 means maximum positive thrust, -1 maximum negative (if not supported by the output, <0 maps to NaN). NaN maps to disarmed (stop the motors).
+float32[12] control #  [@range -1, 1] Normalized thrust. where 1 means maximum positive thrust, -1 maximum negative (if not supported by the output, <0 maps to NaN). NaN maps to disarmed (stop the motors).

--- a/msg/versioned/ActuatorMotors.msg
+++ b/msg/versioned/ActuatorMotors.msg
@@ -5,12 +5,12 @@
 
 uint32 MESSAGE_VERSION = 0
 
-uint64 timestamp # [us] Time since system start.
-uint64 timestamp_sample # [us] Sampling timestamp of the data this control response is based on.
+uint64 timestamp # [us] Time since system start
+uint64 timestamp_sample # [us] Sampling timestamp of the data this control response is based on
 
 uint16 reversible_flags # Bitset indicating which motors are configured to be reversible
 
 uint8 ACTUATOR_FUNCTION_MOTOR1 = 101
 
 uint8 NUM_CONTROLS = 12
-float32[12] control # [@range -1, 1] Normalized thrust. where 1 means maximum positive thrust, -1 maximum negative (if not supported by the output, <0 maps to NaN). NaN maps to disarmed (stop the motors).
+float32[12] control # [@range -1, 1] Normalized thrust. where 1 means maximum positive thrust, -1 maximum negative (if not supported by the output, <0 maps to NaN). NaN maps to disarmed (stop the motors)


### PR DESCRIPTION
This fixes up the ActuatorMotors UORB topic to match the evolving doc standard (for similar, see #24662 , #24789).

### Solution
- Single space for comments etc
- Sentence capitalize comments
- ~Enum values after the field that uses them~
- Uses the following markup
  - `[<value>]` to mark units
  - ~`[@enum <value>]` to mark allowed values~
  - `[@range <minValue>,<maxValue>]` to mark ranges - inclusive
  - ~`[@invalid <value>]` to mark the invalid/not-supplied value~

### Changelog Entry

For release notes:
```
Fix actuator_motor message definition
```

### Other comments

See inline notes