### PR TITLE
Use PX4 default <2g ublox GNSS dynamic model also for multirotors

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -20,7 +20,5 @@ param set-default NAV_ACC_RAD 2
 param set-default RTL_RETURN_ALT 30
 param set-default RTL_DESCEND_ALT 10
 
-param set-default GPS_UBX_DYNMODEL 6
-
 # lower RNG_FOG since MC are expected to fly closer over obstacles
 param set-default EKF2_RNG_FOG 1.0


### PR DESCRIPTION
### Solved Problem
It currently defaults to 1g for multirotors, which works in most cases. However, during extended high-acceleration flight (e.g. in Stabilized mode), the limited dynamic model can upset the EKF, causing repeated resets due to data inconsistencies. Recovery is sometimes quick but can also be too slow to maintain position after high acceleration flight. This issue was observed on an 850mm vehicle with ublox F9P, not a small racer.

### Solution
Use <2g instead of <1g as default for multirotors. <2g is the PX4 default for this parameter.

### Changelog Entry
```
Use PX4 default <2g ublox GNSS dynamic model also for multirotors
```

### Test coverage
In testing so far the issue could not be reproduced with the <2g dynamic model.