### PR TITLE
ina228/ina238: correctly set ADC range, and a few fixes

### DIFF
--- a/src/drivers/power_monitor/ina226/ina226_params.c
+++ b/src/drivers/power_monitor/ina226/ina226_params.c
@@ -50,6 +50,7 @@ PARAM_DEFINE_INT32(SENS_EN_INA226, 0);
  * @max 65535
  * @decimal 1
  * @increment 1
+ * @reboot_required true
 */
 PARAM_DEFINE_INT32(INA226_CONFIG, 18139);
 
@@ -61,6 +62,7 @@ PARAM_DEFINE_INT32(INA226_CONFIG, 18139);
  * @max 200.0
  * @decimal 2
  * @increment 0.1
+ * @reboot_required true
  */
 PARAM_DEFINE_FLOAT(INA226_CURRENT, 164.0f);
 
@@ -72,5 +74,6 @@ PARAM_DEFINE_FLOAT(INA226_CURRENT, 164.0f);
  * @max 0.1
  * @decimal 10
  * @increment .000000001
+ * @reboot_required true
  */
 PARAM_DEFINE_FLOAT(INA226_SHUNT, 0.0005f);

--- a/src/drivers/power_monitor/ina228/ina228.h
+++ b/src/drivers/power_monitor/ina228/ina228.h
@@ -293,6 +293,8 @@ using namespace time_literals;
 #define INA228_VSCALE                        1.95e-04f  /* LSB of voltage is 195.3125 uV/LSB */
 #define INA228_TSCALE                        7.8125e-03f /* LSB of temperature is 7.8125 mDegC/LSB */
 
+#define INA228_ADCRANGE_LOW_V_SENSE          0.04096f // ± 40.96 mV
+
 #define swap16(w)                            __builtin_bswap16((w))
 #define swap32(d)                            __builtin_bswap32((d))
 #define swap64(q)                            __builtin_bswap64((q))

--- a/src/drivers/power_monitor/ina228/ina228_params.c
+++ b/src/drivers/power_monitor/ina228/ina228_params.c
@@ -50,6 +50,7 @@ PARAM_DEFINE_INT32(SENS_EN_INA228, 0);
  * @max 65535
  * @decimal 1
  * @increment 1
+ * @reboot_required true
 */
 PARAM_DEFINE_INT32(INA228_CONFIG, 63779);
 
@@ -61,6 +62,7 @@ PARAM_DEFINE_INT32(INA228_CONFIG, 63779);
  * @max 327.68
  * @decimal 2
  * @increment 0.1
+ * @reboot_required true
  */
 PARAM_DEFINE_FLOAT(INA228_CURRENT, 327.68f);
 
@@ -72,5 +74,6 @@ PARAM_DEFINE_FLOAT(INA228_CURRENT, 327.68f);
  * @max 0.1
  * @decimal 10
  * @increment .000000001
+ * @reboot_required true
  */
 PARAM_DEFINE_FLOAT(INA228_SHUNT, 0.0005f);

--- a/src/drivers/power_monitor/ina238/ina238.cpp
+++ b/src/drivers/power_monitor/ina238/ina238.cpp
@@ -55,14 +55,27 @@ INA238::INA238(const I2CSPIDriverConfig &config, int battery_index) :
 		_max_current = fvalue;
 	}
 
-	_range = _max_current > (DEFAULT_MAX_CURRENT - 1.0f) ? INA238_ADCRANGE_HIGH : INA238_ADCRANGE_LOW;
-
 	fvalue = DEFAULT_SHUNT;
 	_rshunt = fvalue;
 	ph = param_find("INA238_SHUNT");
 
 	if (ph != PARAM_INVALID && param_get(ph, &fvalue) == PX4_OK) {
 		_rshunt = fvalue;
+	}
+
+	// According to page 8.2.2.1, page 33/48 of the INA238 interface datasheet (Rev. A),
+	// the requirement is: R_SHUNT < V_SENSE_MAX / I_MAX
+	// therefore: R_SHUNT * I_MAX < V_SENSE_MAX
+	// and so if V_SENSE_MAX is bigger, we need to use the bigger ADC range to avoid
+	// the device from capping the measured current.
+
+	const float v_sense_max = _rshunt * _max_current;
+
+	if (v_sense_max > INA238_ADCRANGE_LOW_V_SENSE) {
+		_range = INA238_ADCRANGE_HIGH;
+
+	} else {
+		_range = INA238_ADCRANGE_LOW;
 	}
 
 	_current_lsb = _max_current / INA238_DN_MAX;

--- a/src/drivers/power_monitor/ina238/ina238.cpp
+++ b/src/drivers/power_monitor/ina238/ina238.cpp
@@ -137,7 +137,15 @@ int INA238::init()
 		return ret;
 	}
 
-	return Reset();
+	ret = Reset();
+
+	if (ret) {
+		return ret;
+	}
+
+	start();
+
+	return 0;
 }
 
 int INA238::force_init()

--- a/src/drivers/power_monitor/ina238/ina238.h
+++ b/src/drivers/power_monitor/ina238/ina238.h
@@ -75,6 +75,8 @@ using namespace ina238;
 #define INA238_VSCALE                        3.125e-03f  /* LSB of voltage is 3.1255 mV/LSB */
 #define INA238_TSCALE                        7.8125e-03f /* LSB of temperature is 7.8125 mDegC/LSB */
 
+#define INA238_ADCRANGE_LOW_V_SENSE          0.04096f // ± 40.96 mV
+
 #define DEFAULT_MAX_CURRENT                  327.68f    /* Amps */
 #define DEFAULT_SHUNT                        0.0003f   /* Shunt is 300 uOhm */
 

--- a/src/drivers/power_monitor/ina238/ina238_params.c
+++ b/src/drivers/power_monitor/ina238/ina238_params.c
@@ -50,6 +50,7 @@ PARAM_DEFINE_INT32(SENS_EN_INA238, 0);
  * @max 327.68
  * @decimal 2
  * @increment 0.1
+ * @reboot_required true
  */
 PARAM_DEFINE_FLOAT(INA238_CURRENT, 327.68f);
 
@@ -61,5 +62,6 @@ PARAM_DEFINE_FLOAT(INA238_CURRENT, 327.68f);
  * @max 0.1
  * @decimal 10
  * @increment .000000001
+ * @reboot_required true
  */
 PARAM_DEFINE_FLOAT(INA238_SHUNT, 0.0003f);


### PR DESCRIPTION
It turns out that we set the ADC range incorrectly leading to the measured current being capped at a certain level as the ADC on the sensor saturates.

Instead, we need to set the range according to the formula given in the interface datasheet.

![image](https://github.com/user-attachments/assets/38971f9d-f936-48f9-a71d-d60db7fe40e9)


https://www.ti.com/lit/ds/symlink/ina228.pdf
https://www.ti.com/lit/ds/symlink/ina238.pdf