### PR TITLE
ActuatorServos.msg - uORB docs

### DIFF
--- a/msg/versioned/ActuatorServos.msg
+++ b/msg/versioned/ActuatorServos.msg
@@ -1,11 +1,12 @@
 # Servo control message
+#
+# Normalised output setpoint for up to 8 servos.
+# Published by the vehicle's allocation and consumed by the actuator output drivers.
 
 uint32 MESSAGE_VERSION = 0
 
-uint64 timestamp			# time since system start (microseconds)
-uint64 timestamp_sample	    # the timestamp the data this control response is based on was sampled
+uint64 timestamp # Time since system start [us]
+uint64 timestamp_sample # Sampling timestamp of the data this control response is based on [us]
 
 uint8 NUM_CONTROLS = 8
-float32[8] control # range: [-1, 1], where 1 means maximum positive position,
-                   # -1 maximum negative,
-                   # and NaN maps to disarmed
+float32[8] control # [@range -1, 1] Normalized output. 1 means maximum positive position. -1 maximum negative position (if not supported by the output, <0 maps to NaN). NaN maps to disarmed.


### PR DESCRIPTION
This fixes up the ActuatorServos UORB topic to match the evolving doc standard (for similar, see #24818, #24662 , #24789).

This particular version closely maps ActuatorMotors, which is being updated in #24818

### Solution
- Single space for comments etc
- Sentence capitalize comments
- ~Enum values after the field that uses them~
- Uses the following markup
  - `[<value>]` to mark units
  - ~`[@enum <value>]` to mark allowed values~
  - `[@range <minValue>,<maxValue>]` to mark ranges - inclusive
  - ~`[@invalid <value>]` to mark the invalid/not-supplied value~

### Changelog Entry

For release notes:
```
Fix actuator_servos message definition
```

### Other comments

See inline notes
