### PR TITLE
ArmingCheckRequest/Reply UORB messages - update docs.

### DIFF
--- a/msg/versioned/ArmingCheckReply.msg
+++ b/msg/versioned/ArmingCheckReply.msg
@@ -1,34 +1,38 @@
+# Arming check reply.
+#
+# Response to an ArmingCheckRequest message.
+
 uint32 MESSAGE_VERSION = 0
 
-uint64 timestamp # time since system start (microseconds)
+uint64 timestamp # Time since system start [us]
 
-uint8 request_id
-uint8 registration_id
+uint8 request_id # Id of ArmingCheckRequest for which this is a response.
+uint8 registration_id # Id of component emitting this response.
 
-uint8 HEALTH_COMPONENT_INDEX_NONE = 0
+uint8 HEALTH_COMPONENT_INDEX_NONE = 0 # Index of health component for which this response applies.
 
-uint8 health_component_index      # HEALTH_COMPONENT_INDEX_*
-bool health_component_is_present
-bool health_component_warning
-bool health_component_error
+uint8 health_component_index # HEALTH_COMPONENT_INDEX_*
+bool health_component_is_present ?
+bool health_component_warning # ?
+bool health_component_error # ?
 
-bool can_arm_and_run              # whether arming is possible, and if it's a navigation mode, if it can run
+bool can_arm_and_run # True if arming is possible, and for a navigation mode, if it can run.
 
-uint8 num_events
+uint8 num_events # ?
 
-Event[5] events
+Event[5] events # ?
 
 # Mode requirements
-bool mode_req_angular_velocity
-bool mode_req_attitude
-bool mode_req_local_alt
-bool mode_req_local_position
-bool mode_req_local_position_relaxed
-bool mode_req_global_position
-bool mode_req_mission
-bool mode_req_home_position
-bool mode_req_prevent_arming
-bool mode_req_manual_control
+bool mode_req_angular_velocity # ?
+bool mode_req_attitude # Requires an attitude estimate.
+bool mode_req_local_alt # Requires a local altitude estimate
+bool mode_req_local_position # Requires a local position estimate
+bool mode_req_local_position_relaxed # ?
+bool mode_req_global_position # Requires a global position estimate
+bool mode_req_mission # Requires an uploaded mission
+bool mode_req_home_position # Requires a home position
+bool mode_req_prevent_arming # ?
+bool mode_req_manual_control # Requires a manual controller
 
 
-uint8 ORB_QUEUE_LENGTH = 4
+uint8 ORB_QUEUE_LENGTH = 4 #

--- a/msg/versioned/ArmingCheckRequest.msg
+++ b/msg/versioned/ArmingCheckRequest.msg
@@ -1,7 +1,11 @@
+# Arming check request
+#
+# Broadcast message to request arming checks be reported by all registered components, such as internal and external modes.
+# An ArmingCheckReply response should be published by all registered components.
+# The reply will include the published request_id, allowing correlation of all arming check information.
+
 uint32 MESSAGE_VERSION = 0
 
-uint64 timestamp # time since system start (microseconds)
+uint64 timestamp # Time since system start [us]
 
-# broadcast message to request all registered arming checks to be reported
-
-uint8 request_id
+uint8 request_id # Id of this request. Allows correlation with associated ArmingCheckReply messages.


### PR DESCRIPTION
We've been trying to standardize docs for  uorb message - by way of examples see #24818, #24842, #24662 , #24789).

This is an update of ArmingCheckRequest and ArmingCheckReply.

This is very draft (now) because I don't understand how it all works, even at high level, and even after reading https://github.com/PX4/PX4-Autopilot/pull/19708

@bkueng This is not urgent, but would appreciate your help filling in all the missing bits. I've put some questions in line. Many of the updates are `?` placeholders.


### Solution

- Single space for comments etc
- Sentence capitalize comments
- Enum values after the field that uses them
- Uses the following markup
  - `[<value>]` to mark units
  - ~`[@enum <value>]` to mark allowed values~
  - `[@range <minValue>,<maxValue>]` to mark ranges - inclusive
  - `[@invalid <value>]` to mark the invalid/not-supplied value

### Changelog Entry

For release notes:

```
Fix arming_check_request and arming_check_reply message definitions
```

### Other comments

See inline notes
