### PR TITLE
RC driver config Kconfig -typo

### DIFF
--- a/src/drivers/rc/Kconfig
+++ b/src/drivers/rc/Kconfig
@@ -7,6 +7,6 @@ menu "RC"
         select DRIVERS_RC_GHST_RC
         select DRIVERS_RC_SBUS_RC
         ---help---
-            Enable default set of magnetometer drivers
+            Enable default set of radio control drivers
     rsource "*/Kconfig"
 endmenu


### PR DESCRIPTION
This is just a typo in a kconfig - it refers to magnetometers not RC.