### PR TITLE
Docs: uorb graph gen for 5x and 6x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,6 +300,8 @@ uorb_graphs:
 	@$(MAKE) --no-print-directory px4_fmu-v2_default uorb_graph
 	@$(MAKE) --no-print-directory px4_fmu-v4_default uorb_graph
 	@$(MAKE) --no-print-directory px4_fmu-v5_default uorb_graph
+	@$(MAKE) --no-print-directory px4_fmu-v5x_default uorb_graph
+	@$(MAKE) --no-print-directory px4_fmu-v6x_default uorb_graph
 	@$(MAKE) --no-print-directory px4_sitl_default uorb_graph
 
 px4io_update:

--- a/docs/public/middleware/index.html
+++ b/docs/public/middleware/index.html
@@ -15,6 +15,8 @@
       </option>
       <option value="graph_full.json">All Modules</option>
       <option value="graph_px4_sitl.json">SITL Modules</option>
+      <option value="graph_px4_fmu-v6x.json">FMUv6x Modules</option>
+      <option value="graph_px4_fmu-v5x.json">FMUv5x Modules</option>
       <option value="graph_px4_fmu-v5.json">FMUv5 Modules</option>
       <option value="graph_px4_fmu-v4.json">FMUv4 Modules</option>
       <option value="graph_px4_fmu-v2.json">FMUv2 Modules</option>


### PR DESCRIPTION
The uorb graph work for docs was done in FMU v5 timeframes and has not been updated. This adds generation of graphs for 5x and 6x.

@bkueng @julianoes There are other targets such as the 6c, and the RT variant. What are the considerations here for publishing? I mean we could add other build targets, but what is useful for developers?