### PR TITLE
Fix error severity and failsafe activation when COM_LOW_BAT_ACT set to Warning

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
@@ -240,7 +240,7 @@ void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 						    log_level, "Critical battery");
 
 			if (reporter.mavlink_log_pub()) {
-				mavlink_log_warning(reporter.mavlink_log_pub(), "Critical battery\t");
+				mavlink_log_critical(reporter.mavlink_log_pub(), "Critical battery\t");
 			}
 
 			break;

--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
@@ -222,7 +222,7 @@ void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 						    log_level, "Low battery");
 
 			if (reporter.mavlink_log_pub()) {
-				mavlink_log_emergency(reporter.mavlink_log_pub(), "Low battery\t");
+				mavlink_log_warning(reporter.mavlink_log_pub(), "Low battery\t");
 			}
 
 			break;
@@ -240,7 +240,7 @@ void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 						    log_level, "Critical battery");
 
 			if (reporter.mavlink_log_pub()) {
-				mavlink_log_emergency(reporter.mavlink_log_pub(), "Critical battery\t");
+				mavlink_log_warning(reporter.mavlink_log_pub(), "Critical battery\t");
 			}
 
 			break;

--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
@@ -204,12 +204,12 @@ void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 		const bool critical_or_higher = reporter.failsafeFlags().battery_warning >= battery_status_s::WARNING_CRITICAL;
 		NavModes affected_modes = (!configured_arm_threshold_in_use && critical_or_higher)
 					  || (configured_arm_threshold_in_use && below_configured_arm_threshold) ? NavModes::All : NavModes::None;
-		events::LogLevel log_level = critical_or_higher || below_configured_arm_threshold
-					     ? events::Log::Critical : events::Log::Warning;
 
 		switch (reporter.failsafeFlags().battery_warning) {
 		default:
 		case battery_status_s::WARNING_LOW:
+			// This is declared critical so QGC displays a yellow box and reads "low battery" out loud making the user aware
+
 			/* EVENT
 			* @description
 			* The lowest battery state of charge is below the low threshold.
@@ -219,10 +219,10 @@ void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 			* </profile>
 			*/
 			reporter.armingCheckFailure(affected_modes, health_component_t::battery, events::ID("check_battery_low"),
-						    log_level, "Low battery");
+						    events::Log::Critical, "Low battery");
 
 			if (reporter.mavlink_log_pub()) {
-				mavlink_log_warning(reporter.mavlink_log_pub(), "Low battery\t");
+				mavlink_log_critical(reporter.mavlink_log_pub(), "Low battery\t");
 			}
 
 			break;
@@ -237,7 +237,7 @@ void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 			* </profile>
 			*/
 			reporter.armingCheckFailure(affected_modes, health_component_t::battery, events::ID("check_battery_critical"),
-						    log_level, "Critical battery");
+						    events::Log::Critical, "Critical battery");
 
 			if (reporter.mavlink_log_pub()) {
 				mavlink_log_critical(reporter.mavlink_log_pub(), "Critical battery\t");
@@ -255,7 +255,7 @@ void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 			* </profile>
 			*/
 			reporter.armingCheckFailure(affected_modes, health_component_t::battery, events::ID("check_battery_emergency"),
-						    log_level, "Emergency battery level");
+						    events::Log::Emergency, "Emergency battery level");
 
 			if (reporter.mavlink_log_pub()) {
 				mavlink_log_emergency(reporter.mavlink_log_pub(), "Emergency battery level\t");

--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -238,8 +238,6 @@ void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action 
 				{events::Log::Critical, events::LogInternal::Warning},
 				"Failsafe activated: Autopilot disengaged, switching to {2}", mavlink_mode, failsafe_action);
 
-				mavlink_log_critical(&_mavlink_log_pub, "Failsafe activated\t");
-
 			} else {
 				/* EVENT
 				* @type append_health_and_arming_messages
@@ -248,8 +246,6 @@ void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action 
 					events::ID("commander_failsafe_enter_generic"),
 				{events::Log::Critical, events::LogInternal::Warning},
 				"Failsafe activated: switching to {2}", mavlink_mode, failsafe_action);
-
-				mavlink_log_critical(&_mavlink_log_pub, "Failsafe activated\t");
 			}
 
 		} else {
@@ -291,12 +287,14 @@ void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action 
 					events::ID("commander_failsafe_enter"),
 				{events::Log::Critical, events::LogInternal::Warning},
 				"{3}: switching to {2}", mavlink_mode, failsafe_action, failsafe_cause);
-
-				mavlink_log_critical(&_mavlink_log_pub, "Failsafe activated\t");
 			}
 		}
 
+		if (action != Action::Warn) {
+			mavlink_log_critical(&_mavlink_log_pub, "Failsafe activated\t");
+		};
 	}
+
 
 #endif /* EMSCRIPTEN_BUILD */
 }

--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -238,6 +238,8 @@ void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action 
 				{events::Log::Critical, events::LogInternal::Warning},
 				"Failsafe activated: Autopilot disengaged, switching to {2}", mavlink_mode, failsafe_action);
 
+				mavlink_log_critical(&_mavlink_log_pub, "Failsafe activated\t");
+
 			} else {
 				/* EVENT
 				* @type append_health_and_arming_messages
@@ -246,6 +248,8 @@ void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action 
 					events::ID("commander_failsafe_enter_generic"),
 				{events::Log::Critical, events::LogInternal::Warning},
 				"Failsafe activated: switching to {2}", mavlink_mode, failsafe_action);
+
+				mavlink_log_critical(&_mavlink_log_pub, "Failsafe activated\t");
 			}
 
 		} else {
@@ -287,10 +291,11 @@ void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action 
 					events::ID("commander_failsafe_enter"),
 				{events::Log::Critical, events::LogInternal::Warning},
 				"{3}: switching to {2}", mavlink_mode, failsafe_action, failsafe_cause);
+
+				mavlink_log_critical(&_mavlink_log_pub, "Failsafe activated\t");
 			}
 		}
 
-		mavlink_log_critical(&_mavlink_log_pub, "Failsafe activated\t");
 	}
 
 #endif /* EMSCRIPTEN_BUILD */

--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -292,9 +292,8 @@ void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action 
 
 		if (action != Action::Warn) {
 			mavlink_log_critical(&_mavlink_log_pub, "Failsafe activated\t");
-		};
+		}
 	}
-
 
 #endif /* EMSCRIPTEN_BUILD */
 }


### PR DESCRIPTION
### Solved Problem
When setting [`COM_LOW_BAT_ACT`](https://docs.px4.io/main/en/advanced_config/parameter_reference.html#COM_LOW_BAT_ACT) to "Warning", low battery message is still reported as an `ERROR` and logs show failsafe is activated: 

![image](https://github.com/user-attachments/assets/5da7bf52-344c-4d6d-afa5-69ebfc36e526)

### Solution
Small fix in reporting logic: 

- For low and critical battery, set logging level to `WARN` instead of `ERROR`. (Regardless of failsafe action) 
- Only report "Failsafe activated" when the failsafe action =! Warn. 

### Changelog Entry
For release notes:
```
Bugfix: Fixed incorrect error severity and failsafe activation when COM_LOW_BAT_ACT is set to Warning.

```
### Test coverage
- Simulation testing logs: 

1. [SITL Test with main branch](https://review.px4.io/plot_app?log=fb04ab03-792e-4125-ab60-558b59695401): 

![image](https://github.com/user-attachments/assets/11160e6f-9d39-429d-bacb-58f38e806d13)

2. [SITL Test with PR branch](https://review.px4.io/plot_app?log=28250e11-b8bc-4afb-8ffb-7b40f8f10be3)

![image](https://github.com/user-attachments/assets/f2b8de5d-b32a-42ea-91fe-8c8071681bae)
