### PR TITLE
Baro offset calibration based on GNSS height

### DIFF
--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -256,6 +256,9 @@ void VehicleAirData::Run()
 
 	if (!_relative_calibration_done) {
 		_relative_calibration_done = UpdateRelativeCalibrations(time_now_us);
+
+	} else if (!_baro_gnss_calibration_done && !estimator_status_flags.cs_in_air && estimator_status_flags.cs_gps_hgt) {
+		_baro_gnss_calibration_done = BaroGNSSAltitudeOffset();
 	}
 
 	// Publish
@@ -336,7 +339,7 @@ bool VehicleAirData::UpdateRelativeCalibrations(const hrt_abstime time_now_us)
 		_calibration_t_first = time_now_us;
 	}
 
-	if (time_now_us - _calibration_t_first > 1_s) {
+	if (time_now_us - _calibration_t_first > 1_s && _data_sum_count[_selected_sensor_sub_index] > 0) {
 		const float pressure_primary = _data_sum[_selected_sensor_sub_index] / _data_sum_count[_selected_sensor_sub_index];
 
 		for (int instance = 0; instance < MAX_SENSOR_COUNT; ++instance) {
@@ -467,6 +470,76 @@ void VehicleAirData::PrintStatus()
 			_calibration[i].PrintStatus();
 		}
 	}
+}
+
+bool VehicleAirData::BaroGNSSAltitudeOffset()
+{
+	param_t param_hgt_ref = param_find("EKF2_HGT_REF");
+	int32_t hgt_ref = 0;
+
+	if (param_hgt_ref != PARAM_INVALID) {
+		param_get(param_hgt_ref, &hgt_ref);
+	}
+
+	// not optimal to compare to , otherwise more overhead in msg or more dependencies
+	static constexpr int HeightSensor_GNSS = 1;
+
+	if (hgt_ref != HeightSensor_GNSS) {
+		return false;
+	}
+
+	param_t param_qnh = param_find("SENS_BARO_QNH");
+	float qnh = 1013.25f; // Default QNH value in hPa
+
+	if (param_qnh != PARAM_INVALID) {
+		param_get(param_qnh, &qnh);
+	}
+
+	const float pressure_sealevel = qnh * 100.0f;
+
+	sensor_gps_s gps_pos;
+
+	if (!_vehicle_gps_position_sub.copy(&gps_pos)) {
+		return false;
+	}
+
+	const float baro_pressure = _data_sum[_selected_sensor_sub_index] / _data_sum_count[_selected_sensor_sub_index];
+	const float target_altitude = static_cast<float>(gps_pos.altitude_msl_m);
+
+	// Binary search
+	float low = -10000.0f;
+	float high = 10000.0f;
+	float offset = NAN;
+	const float tolerance = 0.1f;
+	static constexpr int iterations = 100;
+
+	for (int i = 0; i < iterations; ++i) {
+		float mid = low + (high - low) / 2.0f;
+		float calibrated_altitude = getAltitudeFromPressure(baro_pressure - mid, pressure_sealevel);
+
+		if (calibrated_altitude > target_altitude + tolerance) {
+			high = mid;
+
+		} else if (calibrated_altitude < target_altitude - tolerance) {
+			low = mid;
+
+		} else {
+			offset = mid;
+			break;
+		}
+	}
+
+	// add new offset to existing relative offsets
+	for (int instance = 0; instance < MAX_SENSOR_COUNT; ++instance) {
+		if (_calibration[instance].device_id() != 0
+		    && _data_sum_count[instance] > 0) {
+			_calibration[instance].set_offset(_calibration[instance].offset() + offset);
+			_calibration[instance].ParametersSave(instance);
+			param_notify_changes();
+		}
+	}
+
+	return true;
 }
 
 }; // namespace sensors

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -477,6 +477,7 @@ bool VehicleAirData::BaroGNSSAltitudeOffset()
 	static constexpr float kEpvReq = 8.f;
 	static constexpr float kDeltaOffsetTolerance = 4.f;
 	static constexpr uint64_t kLpfWindow = 2_s;
+	static constexpr float kLpfTimeConstant = static_cast<float>(kLpfWindow) * 1.e-6f;
 
 	sensor_gps_s gps_pos;
 
@@ -500,7 +501,7 @@ bool VehicleAirData::BaroGNSSAltitudeOffset()
 	if (_calibration_t_first == 0) {
 		_calibration_t_first = gps_pos.timestamp;
 		const float dt = (_calibration_t_first - _t_first_gnss_sample) * 1.e-6f;
-		_delta_baro_gnss_lpf.setParameters(dt, kLpfWindow * 1.e-6f);
+		_delta_baro_gnss_lpf.setParameters(dt, kLpfTimeConstant);
 		_delta_baro_gnss_lpf.reset(delta_alt);
 
 	} else {

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -257,8 +257,7 @@ void VehicleAirData::Run()
 	if (!_relative_calibration_done) {
 		_relative_calibration_done = UpdateRelativeCalibrations(time_now_us);
 
-	} else if (!_baro_gnss_calibration_done && _param_sens_baro_autocal.get()
-		   && !estimator_status_flags.cs_in_air && estimator_status_flags.cs_gps_hgt) {
+	} else if (!_baro_gnss_calibration_done && _param_sens_baro_autocal.get()) {
 		_baro_gnss_calibration_done = BaroGNSSAltitudeOffset();
 	}
 
@@ -475,9 +474,13 @@ void VehicleAirData::PrintStatus()
 
 bool VehicleAirData::BaroGNSSAltitudeOffset()
 {
+	static constexpr float kEpvReq = 8.f;
+	static constexpr float kDeltaOffsetTolerance = 4.f;
+	static constexpr uint64_t kLpfWindow = 2_s;
+
 	sensor_gps_s gps_pos;
 
-	if (!_vehicle_gps_position_sub.copy(&gps_pos)) {
+	if (!_vehicle_gps_position_sub.update(&gps_pos)) {
 		return false;
 	}
 
@@ -485,21 +488,57 @@ bool VehicleAirData::BaroGNSSAltitudeOffset()
 	const float baro_pressure = _data_sum[_selected_sensor_sub_index] / _data_sum_count[_selected_sensor_sub_index];
 	const float target_altitude = static_cast<float>(gps_pos.altitude_msl_m);
 
+	const float delta_alt =  getAltitudeFromPressure(baro_pressure, pressure_sealevel) - target_altitude;
+	bool gnss_baro_offset_stable = false;
+
+	if (gps_pos.epv > kEpvReq || _t_first_gnss_sample == 0) {
+		_calibration_t_first = 0;
+		_t_first_gnss_sample = gps_pos.timestamp;
+		return false;
+	}
+
+	_delta_baro_gnss_lpf.update(delta_alt);
+
+	if (_calibration_t_first == 0) {
+		_calibration_t_first = gps_pos.timestamp;
+		const float dt = (_calibration_t_first - _t_first_gnss_sample) * 1.e-6f;
+		_delta_baro_gnss_lpf.setParameters(dt, kLpfWindow * 1.e-6f);
+		_delta_baro_gnss_lpf.reset(delta_alt);
+	}
+
+	if (gps_pos.timestamp - _calibration_t_first > kLpfWindow && !PX4_ISFINITE(_baro_gnss_offset_t1)) {
+		_baro_gnss_offset_t1 = _delta_baro_gnss_lpf.getState();
+
+	} else if (gps_pos.timestamp - _calibration_t_first > 2 * kLpfWindow && PX4_ISFINITE(_baro_gnss_offset_t1)) {
+		if (fabsf(_delta_baro_gnss_lpf.getState() - _baro_gnss_offset_t1) > kDeltaOffsetTolerance) {
+			_baro_gnss_offset_t1 = NAN;
+			_calibration_t_first = 0;
+			_t_first_gnss_sample = 0;
+
+		} else {
+			gnss_baro_offset_stable = true;
+		}
+	}
+
+	if (!gnss_baro_offset_stable) {
+		return false;
+	}
+
 	// Binary search
 	float low = -10000.0f;
 	float high = 10000.0f;
 	float offset = NAN;
-	const float tolerance = 0.1f;
-	static constexpr int iterations = 100;
+	static constexpr float kTolerance = 0.1f;
+	static constexpr int kIterations = 100;
 
-	for (int i = 0; i < iterations; ++i) {
+	for (int i = 0; i < kIterations; ++i) {
 		float mid = low + (high - low) / 2.0f;
 		float calibrated_altitude = getAltitudeFromPressure(baro_pressure - mid, pressure_sealevel);
 
-		if (calibrated_altitude > target_altitude + tolerance) {
+		if (calibrated_altitude > target_altitude + kTolerance) {
 			high = mid;
 
-		} else if (calibrated_altitude < target_altitude - tolerance) {
+		} else if (calibrated_altitude < target_altitude - kTolerance) {
 			low = mid;
 
 		} else {

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -497,13 +497,14 @@ bool VehicleAirData::BaroGNSSAltitudeOffset()
 		return false;
 	}
 
-	_delta_baro_gnss_lpf.update(delta_alt);
-
 	if (_calibration_t_first == 0) {
 		_calibration_t_first = gps_pos.timestamp;
 		const float dt = (_calibration_t_first - _t_first_gnss_sample) * 1.e-6f;
 		_delta_baro_gnss_lpf.setParameters(dt, kLpfWindow * 1.e-6f);
 		_delta_baro_gnss_lpf.reset(delta_alt);
+
+	} else {
+		_delta_baro_gnss_lpf.update(delta_alt);
 	}
 
 	if (gps_pos.timestamp - _calibration_t_first > kLpfWindow && !PX4_ISFINITE(_baro_gnss_offset_t1)) {

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -55,6 +55,7 @@
 #include <uORB/topics/sensors_status.h>
 #include <uORB/topics/vehicle_air_data.h>
 #include <uORB/topics/estimator_status_flags.h>
+#include <uORB/topics/sensor_gps.h>
 
 using namespace time_literals;
 
@@ -86,6 +87,7 @@ private:
 	bool ParametersUpdate(bool force = false);
 	void UpdateStatus();
 	bool UpdateRelativeCalibrations(hrt_abstime time_now_us);
+	bool BaroGNSSAltitudeOffset();
 
 	static constexpr int MAX_SENSOR_COUNT = 4;
 
@@ -105,6 +107,8 @@ private:
 		{this, ORB_ID(sensor_baro), 2},
 		{this, ORB_ID(sensor_baro), 3},
 	};
+
+	uORB::Subscription _vehicle_gps_position_sub{ORB_ID(vehicle_gps_position)};
 
 	calibration::Barometer _calibration[MAX_SENSOR_COUNT];
 
@@ -134,6 +138,7 @@ private:
 	bool _last_status_baro_fault{false};
 
 	bool _relative_calibration_done{false};
+	bool _baro_gnss_calibration_done{false};
 	uint64_t _calibration_t_first{0};
 
 	DEFINE_PARAMETERS(

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -36,6 +36,7 @@
 #include "data_validator/DataValidatorGroup.hpp"
 
 #include <lib/sensor_calibration/Barometer.hpp>
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
 #include <lib/mathlib/math/Limits.hpp>
 #include <lib/matrix/matrix/math.hpp>
 #include <lib/perf/perf_counter.h>
@@ -140,6 +141,9 @@ private:
 	bool _relative_calibration_done{false};
 	bool _baro_gnss_calibration_done{false};
 	uint64_t _calibration_t_first{0};
+	AlphaFilter<float> _delta_baro_gnss_lpf{};
+	float _baro_gnss_offset_t1{NAN};
+	uint64_t _t_first_gnss_sample{0};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::SENS_BARO_QNH>) _param_sens_baro_qnh,

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -143,7 +143,8 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::SENS_BARO_QNH>) _param_sens_baro_qnh,
-		(ParamFloat<px4::params::SENS_BARO_RATE>) _param_sens_baro_rate
+		(ParamFloat<px4::params::SENS_BARO_RATE>) _param_sens_baro_rate,
+		(ParamBool<px4::params::SENS_BAR_AUTOCAL>) _param_sens_baro_autocal
 	)
 };
 }; // namespace sensors

--- a/src/modules/sensors/vehicle_air_data/params.c
+++ b/src/modules/sensors/vehicle_air_data/params.c
@@ -53,3 +53,15 @@ PARAM_DEFINE_FLOAT(SENS_BARO_QNH, 1013.25f);
  * @unit Hz
  */
 PARAM_DEFINE_FLOAT(SENS_BARO_RATE, 20.0f);
+
+/**
+ * Barometer auto calibration
+ *
+ * Automatically calibrate barometer based on the GNSS height
+ *
+ * @boolean
+ *
+ * @category system
+ * @group Sensors
+ */
+PARAM_DEFINE_INT32(SENS_BAR_AUTOCAL, 0);


### PR DESCRIPTION
### Solved Problem
Account for baro offset between GNSS heigth and baro height from very beginning. Store it as offset, since its not a bias but a "fixed" value from the start.

### Solution
When vehicle is still on the ground, GNSS-height gets fused and GNSS is selected as the height reference (EKF2_HGT_REF) then the baro pressure offset gets adjusted to match the GNSS height.

### Test coverage
Tested on hardware
