### PR TITLE
Fix events interface docs

### DIFF
--- a/docs/en/concept/events_interface.md
+++ b/docs/en/concept/events_interface.md
@@ -92,12 +92,10 @@ Explanations and requirements:
     Disabled,
     ```
 
-  ```
   - Above we specify a separate external and internal log level, which are the levels displayed to GCS users and in the log file, respectively: `{events::Log::Error, events::LogInternal::Info}`.
     For the majority of cases you can pass a single log level, and this will be used for both exernal and internal cases.
   There are cases it makes sense to have two different log levels.
   For example an RTL failsafe action: the user should see it as Warning/Error, whereas in the log, it is an expected system response, so it can be set to `Info`.
-  ```
 
 - **Event Message**:
   - Single-line, short message of the event.


### PR DESCRIPTION
### Solved Problem
When reading the documentation I found that this formatting looks off:
![image](https://github.com/user-attachments/assets/1267f7cf-a9e8-4c7f-af2a-a149f5ed0688)

### Solution
I think this bullet point was accidentally declared as code and remove that part.

### Test coverage
In VS code markdown preview this fixes the problem:
![image](https://github.com/user-attachments/assets/30440d9a-4fd7-42ab-b3c4-a8f8e7451a37)

### Additional note which I could not address
@hamishwillee While making this pr I saw that translations "ko" and "zh" have this page as well and thought about adjusting them even though this is likely autogenerated at a lower rate. But then I saw that the entire indentation and hence markdown formating is screwed up for these translations 😱 

![image](https://github.com/user-attachments/assets/29277bd8-1fec-4d8e-926a-788b3bc23462)

This also shows in the real docs and makes it almost impossible to read because you can't follow the structure:
![image](https://github.com/user-attachments/assets/ec6dae83-e6a3-466e-a795-c20bbf53c209)
