### PR TITLE
i2c_launcher: Dehardcode battery index

### DIFF
--- a/src/systemcmds/i2c_launcher/i2c_launcher.hpp
+++ b/src/systemcmds/i2c_launcher/i2c_launcher.hpp
@@ -51,7 +51,7 @@ using namespace time_literals;
 class I2CLauncher : public ModuleBase<I2CLauncher>, public ModuleParams, public px4::ScheduledWorkItem
 {
 public:
-	I2CLauncher(int bus);
+	I2CLauncher(int bus, int batt_index);
 
 	~I2CLauncher() override;
 
@@ -78,11 +78,12 @@ private:
 
 	void Run() override;
 
-	static void scan_i2c_bus(int bus);
+	static void scan_i2c_bus(int bus, int batt_index);
 
 	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};          // regular subscription for additional data
 
 	int _bus;
+	int _batt_index;
 	bool _armed {false};
 };


### PR DESCRIPTION
### Solved Problem
i2c_launcher launched the respective `inaxxx` driver with the harcoded value based on the bus_id. If you would only use i2c3 for example the battery id would be 3. This PR adds the `-t` argument allowing to specify which battery index gets used to launch the `inaxxx` driver.

### Test coverage
Tested on NXP mr-tropic board that has the PM on the `-b 3`
