### PR TITLE
tools: update docker_run.sh to use px4-dev

### DIFF
--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -2,19 +2,7 @@
 
 if [ -z ${PX4_DOCKER_REPO+x} ]; then
 	echo "guessing PX4_DOCKER_REPO based on input";
-	if [[ $@ =~ .*px4_fmu.* ]]; then
-		# nuttx-px4fmu-v{1,2,3,4,5}
-		PX4_DOCKER_REPO="px4io/px4-dev-nuttx-focal:2022-08-12"
-	elif [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*beaglebone.* ]] || [[ $@ =~ .*pilotpi.default ]] || [[ $@ =~ .*navigator.* ]]; then
-		# beaglebone_blue_default, emlid_navio2_default, px4_raspberrypi_default, scumaker_pilotpi_default, bluerobotics_navigator_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2023-06-26"
-	elif [[ $@ =~ .*pilotpi.arm64 ]]; then
-		# scumaker_pilotpi_arm64
-		PX4_DOCKER_REPO="px4io/px4-dev-aarch64:2022-08-12"
-	elif [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*bebop.* ]]; then
-		# posix_rpi_cross, posix_bebop_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2023-06-26"
-	elif [[ $@ =~ .*clang.* ]] || [[ $@ =~ .*scan-build.* ]]; then
+	if [[ $@ =~ .*clang.* ]] || [[ $@ =~ .*scan-build.* ]]; then
 		# clang tools
 		PX4_DOCKER_REPO="px4io/px4-dev-clang:2021-02-04"
 	elif [[ $@ =~ .*tests* ]]; then
@@ -27,16 +15,8 @@ fi
 
 # otherwise default to nuttx
 if [ -z ${PX4_DOCKER_REPO+x} ]; then
-	PX4_DOCKER_REPO="px4io/px4-dev-nuttx-focal:2022-08-12"
+	PX4_DOCKER_REPO="px4io/px4-dev:v1.16.0-ondemand"
 fi
-
-# docker hygiene
-
-#Delete all stopped containers (including data-only containers)
-# docker container prune
-
-#Delete all 'untagged/dangling' (<none>) images
-# docker image prune
 
 echo "PX4_DOCKER_REPO: $PX4_DOCKER_REPO";
 


### PR DESCRIPTION
Updates the `docker_run.sh` script to use the latest `px4-dev` development container. This new image is multi-platform, and will work with arm64 and amd64 platforms.

😇 macOS users rejoice!