### PR TITLE
MSP_OSD Update: Add original battery status msg.

### DIFF
--- a/src/drivers/osd/msp_osd/msp_osd.cpp
+++ b/src/drivers/osd/msp_osd/msp_osd.cpp
@@ -341,6 +341,9 @@ void MspOsd::Run()
 		battery_status_s battery_status{};
 		_battery_status_sub.copy(&battery_status);
 
+		const auto msg_original = msp_osd::construct_BATTERY_STATE(battery_status);
+		this->Send(MSP_BATTERY_STATE, &msg_original);
+
 		const auto msg = msp_osd::construct_rendor_BATTERY_STATE(battery_status);
 		this->Send(MSP_CMD_DISPLAYPORT, &msg, sizeof(msp_rendor_battery_state_t));
 


### PR DESCRIPTION
**MSP_OSD Update to support displaying battery status in DJI O3 OSD**

### Solved Problem
When running the MSP_OSD updates made in PR#24695, the battery status in the DJI OSD remains at 0V. This can be seen in the following image.

![IMG_4254](https://github.com/user-attachments/assets/a0578fb2-fa4f-48ff-befc-020bc9d32185)


### Solution
- Re-add the original battery status message to msp_osd.cpp to send the original battery status message while retaining the additions made in PR#24695 
- After re-adding the original battery status, the total battery status voltage displays correctly as seen in the following image:

![IMG_4253](https://github.com/user-attachments/assets/9acb4a9c-3e44-49a9-a52a-10657919d0ea)


* Note: The gps coordinates display correctly. At the time of these photos it was just disconnected.

### Changelog Entry
For release notes:
```

```

### Alternatives


### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
