### PR TITLE
IC Engine: allow motor to be stopped without disarming

### DIFF
--- a/msg/InternalCombustionEngineControl.msg
+++ b/msg/InternalCombustionEngineControl.msg
@@ -1,7 +1,7 @@
 uint64 timestamp        		# time since system start (microseconds)
 
 bool ignition_on          		# activate/deactivate ignition (spark plug)
-float32 throttle_control		# setpoint for throttle actuator, with slew rate if enabled, idles with 0 [norm] [@range 0,1]
+float32 throttle_control		# setpoint for throttle actuator, with slew rate if enabled, idles with 0 [norm] [@range 0,1] [@uncontrolled NAN to stop motor]
 float32 choke_control			# setpoint for choke actuator, 1: fully closed [norm] [@range 0,1]
 float32 starter_engine_control		# setpoint for (electric) starter motor [norm] [@range 0,1]
 

--- a/msg/InternalCombustionEngineControl.msg
+++ b/msg/InternalCombustionEngineControl.msg
@@ -1,8 +1,8 @@
 uint64 timestamp        		# time since system start (microseconds)
 
-bool ignition_on          		# activate/deactivate ignition (Spark Plug)
-float32 throttle_control		# [0,1] - Motor should idle with 0. Includes slew rate if enabled.
-float32 choke_control			# [0,1] - 1 fully closes the air inlet.
-float32 starter_engine_control		# [0,1] - control value for electric starter motor.
+bool ignition_on          		# activate/deactivate ignition (spark plug)
+float32 throttle_control		# setpoint for throttle actuator, with slew rate if enabled, idles with 0 [norm] [@range 0,1]
+float32 choke_control			# setpoint for choke actuator, 1: fully closed [norm] [@range 0,1]
+float32 starter_engine_control		# setpoint for (electric) starter motor [norm] [@range 0,1]
 
 uint8 user_request			# user intent for the ICE being on/off

--- a/src/lib/mixer_module/functions/FunctionICEngineControl.hpp
+++ b/src/lib/mixer_module/functions/FunctionICEngineControl.hpp
@@ -55,6 +55,7 @@ public:
 		internal_combustion_engine_control_s internal_combustion_engine_control;
 
 		// map [0, 1] to [-1, 1] which is the interface for non-motor PWM channels
+		// NAN is mapped to disarmed
 		if (_internal_combustion_engine_control_sub.update(&internal_combustion_engine_control)) {
 			_data[0] = internal_combustion_engine_control.ignition_on * 2.f - 1.f;
 			_data[1] = internal_combustion_engine_control.throttle_control * 2.f - 1.f;

--- a/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.cpp
+++ b/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.cpp
@@ -291,7 +291,7 @@ void InternalCombustionEngineControl::controlEngineStop()
 	_ignition_on = false;
 	_choke_control = _param_ice_stop_choke.get() ? 1.f : 0.f;
 	_starter_engine_control = 0.f;
-	_throttle_control = 0.f;
+	_throttle_control = NAN; // this will set it to the DISARMED value
 }
 
 void InternalCombustionEngineControl::controlEngineFault()
@@ -393,6 +393,9 @@ The state machine:
 - Allows for user inputs from:
   - Manual control AUX
   - Arming state in [VehicleStatus.msg](../msg_docs/VehicleStatus.md)
+- In the state "Stopped" the throttle is set to NAN, which by definition will set the
+  throttle output to the disarmed value configured for the specific output.
+
 
 The module publishes [InternalCombustionEngineControl.msg](../msg_docs/InternalCombustionEngineControl.md).
 

--- a/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.cpp
+++ b/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.cpp
@@ -217,7 +217,6 @@ void InternalCombustionEngineControl::Run()
 
 	case State::Fault: {
 
-			// do nothing
 			if (user_request == UserOnOffRequest::Off) {
 				_state = State::Stopped;
 				_starting_retry_cycle = 0;
@@ -355,7 +354,7 @@ int InternalCombustionEngineControl::print_usage(const char *reason)
 	PRINT_MODULE_DESCRIPTION(
 		R"DESCR_STR(
 ### Description
-		
+
 The module controls internal combustion engine (ICE) features including:
 ignition (on/off), throttle and choke level, starter engine delay, and user request.
 
@@ -389,18 +388,18 @@ The ICE is implemented with a (4) state machine:
 ![Architecture](../../assets/hardware/ice/ice_control_state_machine.png)
 
 The state machine:
-		
+
 - Checks if [Rpm.msg](../msg_docs/Rpm.md) is updated to know if the engine is running
 - Allows for user inputs from:
-  - AUX{N}
+  - Manual control AUX
   - Arming state in [VehicleStatus.msg](../msg_docs/VehicleStatus.md)
 
 The module publishes [InternalCombustionEngineControl.msg](../msg_docs/InternalCombustionEngineControl.md).
-		
+
 The architecture is as shown below:
 
 ![Architecture](../../assets/hardware/ice/ice_control_diagram.png)
-		
+
 <a id="internal_combustion_engine_control_usage"></a>
 )DESCR_STR");
 


### PR DESCRIPTION

### Solved Problem
The request is to stop the engine in flight without disarming the system.

### Solution
Set the throttle in the ICE module to NAN in the "Stopped" state, which is then mapped to PWM_DISARMED in the output module.

### Changelog Entry
For release notes:
```
Feature: Internal combustion engine: allow motor to be stopped without disarming
```

### Alternatives
This is partially related to https://github.com/PX4/PX4-Autopilot/pull/24684, though the implementations can be fully parallel. Just that generally we want to use NAN to command a motor to stop, while "0" should still spin.

### Test coverage
Bench test pending.
