### PR TITLE
rc: crsf: fix telem altitude units

### DIFF
--- a/src/drivers/rc/crsf_rc/CrsfRc.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfRc.cpp
@@ -241,7 +241,7 @@ void CrsfRc::Run()
 					int32_t longitude = static_cast<int32_t>(round(sensor_gps.longitude_deg * 1e7));
 					uint16_t groundspeed = sensor_gps.vel_d_m_s / 3.6f * 10.f;
 					uint16_t gps_heading = math::degrees(sensor_gps.cog_rad) * 100.f;
-					uint16_t altitude = static_cast<int16_t>(sensor_gps.altitude_msl_m) + 1000;
+					uint16_t altitude = static_cast<int16_t>(sensor_gps.altitude_msl_m);
 					uint8_t num_satellites = sensor_gps.satellites_used;
 					this->SendTelemetryGps(latitude, longitude, groundspeed, gps_heading, altitude, num_satellites);
 				}


### PR DESCRIPTION
A user reported 
> Newbee building first drone using ARK FPV.  Using ELRS RadioMaster Boxer, I am able to see all of the Telemetry data and it looks correct ... except for altitude which fluctuates widely (by thousands of meters, frequently negative).  In particular, the GPS LAT/LON displays perfectly.   I've managed to download and unpack an ulg log file from the SD card.  The altitude in the Sensors_GPS CSV file is spot on, so I've got good GPS data, but it is getting corrupted/lost somewhere on the way to the RC display.  I confirmed that the RC is instructed to extract ID:2 and Field:4, but the results are bogus.  Are there any known problems packing the Altitude data into the CRSF packets ?  I did notice in the Telemetry CSV file, that it is reporting Transmit Buffer overruns ... is that a clue to the problem ?  Any assistance in how to track this down would be greatly appreciated !  Thanks

It's hard to find documentation on the units in the CRSF Telem protocol but it sounds like it's in meters.
![image](https://github.com/user-attachments/assets/5f5c3d6c-3a8b-4c45-a472-c2d36beaf8c3)
