### PR TITLE
Revert "Add flash_analysis for auterion_v6s board"

### DIFF
--- a/boards/auterion/fmu-v6s/flash-analysis.px4board
+++ b/boards/auterion/fmu-v6s/flash-analysis.px4board
@@ -1,1 +1,0 @@
-CONFIG_BOARD_LINKER_PREFIX="flash-analysis"

--- a/boards/auterion/fmu-v6s/nuttx-config/scripts/flash-analysis-script.ld
+++ b/boards/auterion/fmu-v6s/nuttx-config/scripts/flash-analysis-script.ld
@@ -1,6 +1,0 @@
-INCLUDE "script.ld"
-
-MEMORY
-{
-    FLASH (rx) : ORIGIN = 0x08020000, LENGTH = 10080K
-}


### PR DESCRIPTION
Reverts PX4/PX4-Autopilot#24885

It was decided to keep it minimal and only keep the flash-analysis targets of the "basic" boards.