### PR TITLE
[board] Disable buzzer on Skynode base boards

### DIFF
--- a/boards/px4/fmu-v5x/init/rc.board_defaults
+++ b/boards/px4/fmu-v5x/init/rc.board_defaults
@@ -13,6 +13,9 @@ then
 	param set-default UXRCE_DDS_PTCFG 2
 	param set-default UXRCE_DDS_AG_IP 170461697
 	param set-default UXRCE_DDS_CFG 1000
+
+	# The buzzer draws too much power (0.2A) on the GPS power rail (limit 0.45A).
+	param set-default CBRK_BUZZER 782097
 else
 	# Mavlink ethernet (CFG 1000)
 	param set-default MAV_2_CONFIG 1000

--- a/boards/px4/fmu-v6x/init/rc.board_defaults
+++ b/boards/px4/fmu-v6x/init/rc.board_defaults
@@ -15,6 +15,9 @@ then
 	param set-default UXRCE_DDS_PTCFG 2
 	param set-default UXRCE_DDS_AG_IP 170461697
 	param set-default UXRCE_DDS_CFG 1000
+
+	# The buzzer draws too much power (0.2A) on the GPS power rail (limit 0.45A).
+	param set-default CBRK_BUZZER 782097
 else
 	# Mavlink ethernet (CFG 1000)
 	param set-default MAV_2_CONFIG 1000


### PR DESCRIPTION
### Solved Problem

We debugged an issue where the F9P GPS was connected to the Skynode primary breakout board together with an airspeed sensor. On arming the external mag and airspeed sensors would fail quite often. We checked the voltage rails for overcurrent conditions and found that the voltage rails collapse when the tone_alarm was running the speaker inside the F9P GPS. We reproduced it with three different F9P GPS modules, and could not reproduce it when `tone_alarm` was stopped.

1. The buzzer is connected directly to the 5V rail `VDD_5V_CAN1_GPS1` with a limit of only 0.45A.
2. The buzzer is actived using a FET on the baseboard that pulls to GND with ~0.2A (it's a 1W speaker!!!).
3. The e-fuse fails to restart only while the buzzer is still active due to inrush currents.
4. The e-fuse restart pattern matches the datasheet almost exactly. It disables the output after 13-15 retries.

### Solution

We have to disable the buzzer but only on the Skynode base boards by defaulting the buzzer circuit breaker to off.
If a customer is certain that the usage of the buzzer does not cause issues, they can reenable the circuit breaker.

### Changelog Entry
For release notes:
```
Bugfix Disable buzzer on Skynode base boards to prevent brown-outs on GPS power rail
```

### Alternatives

We could also *enable* the `tone_alarm` selectively per board, however, this is a discussion more about semantics, ie. how important is the buzzer (clearly important enough to have a circuit breaker). For us this solution is fine.

### Test coverage

- [x] Tested in Hardware on Skynode v5x/v6x

### Context

<img width="1209" src="https://github.com/user-attachments/assets/e9eda57b-cebf-4321-a37e-c9a95a045a78" />
<img width="1457" src="https://github.com/user-attachments/assets/ed32fd1d-39f1-4eb6-8e05-54df1cc31ffc" />
