### PR TITLE
dds: clean up timesync

### DIFF
--- a/src/lib/timesync/Timesync.cpp
+++ b/src/lib/timesync/Timesync.cpp
@@ -66,7 +66,7 @@ void Timesync::update(const uint64_t now_us, const int64_t remote_timestamp_ns, 
 				// We reset the filter if we received 5 consecutive samples which violate our present estimate.
 				// This is most likely due to a time jump on the offboard system.
 				if (_high_deviation_count > MAX_CONSECUTIVE_HIGH_DEVIATION) {
-					PX4_WARN("time jump detected. Resetting time synchroniser.");
+					PX4_DEBUG("time jump detected. Resetting time synchroniser.");
 					// Reset the filter
 					reset_filter();
 				}
@@ -104,7 +104,7 @@ void Timesync::update(const uint64_t now_us, const int64_t remote_timestamp_ns, 
 			_high_rtt_count++;
 
 			if (_high_rtt_count == MAX_CONSECUTIVE_HIGH_RTT) {
-				PX4_WARN("RTT too high for timesync: %llu ms", rtt_us / 1000ULL);
+				PX4_DEBUG("RTT too high for timesync: %llu ms", rtt_us / 1000ULL);
 			}
 		}
 

--- a/src/lib/timesync/Timesync.hpp
+++ b/src/lib/timesync/Timesync.hpp
@@ -78,7 +78,7 @@ static constexpr uint32_t CONVERGENCE_WINDOW = 500;
 // Outlier rejection and filter reset
 //
 // Samples with round-trip time higher than MAX_RTT_SAMPLE are not used to update the filter.
-// More than MAX_CONSECUTIVE_HIGH_RTT number of such events in a row will throw a warning
+// More than MAX_CONSECUTIVE_HIGH_RTT number of such events in a row will throw a debug message
 // but not reset the filter.
 // Samples whose calculated clock offset is more than MAX_DEVIATION_SAMPLE off from the current
 // estimate are not used to update the filter. More than MAX_CONSECUTIVE_HIGH_DEVIATION number

--- a/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
+++ b/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
@@ -54,29 +54,19 @@ static constexpr uint8_t TIMESYNC_MAX_TIMEOUTS = 10;
 
 using namespace time_literals;
 
-static void on_time(uxrSession *session, int64_t current_time, int64_t received_timestamp, int64_t transmit_timestamp,
-		    int64_t originate_timestamp, void *args)
+static void on_time(uxrSession *session, int64_t current_time, int64_t client_transmit_timestamp,
+		    int64_t agent_receive_timestamp, int64_t originate_timestamp, void *args)
 {
-	// latest round trip time (RTT)
-	int64_t rtt = current_time - originate_timestamp;
-
-	// HRT to AGENT
-	int64_t offset_1 = (received_timestamp - originate_timestamp) - (rtt / 2);
-	int64_t offset_2 = (transmit_timestamp - current_time) - (rtt / 2);
-
-	session->time_offset = (offset_1 + offset_2) / 2;
-
 	if (args) {
 		Timesync *timesync = static_cast<Timesync *>(args);
-		timesync->update(current_time / 1000, transmit_timestamp, originate_timestamp);
+		timesync->update(current_time / 1000, agent_receive_timestamp, originate_timestamp);
 
 		session->time_offset = -timesync->offset() * 1000; // us -> ns
 	}
 }
 
-static void on_time_no_sync(uxrSession *session, int64_t current_time, int64_t received_timestamp,
-			    int64_t transmit_timestamp,
-			    int64_t originate_timestamp, void *args)
+static void on_time_no_sync(uxrSession *session, int64_t current_time, int64_t client_transmit_timestamp,
+			    int64_t agent_receive_timestamp, int64_t originate_timestamp, void *args)
 {
 	session->time_offset = 0;
 }
@@ -693,7 +683,6 @@ void UxrceddsClient::run()
 			if (_synchronize_timestamps && hrt_elapsed_time(&last_sync_session) > 1_s) {
 
 				if (uxr_sync_session(&session, 10) && _timesync.sync_converged()) {
-					//PX4_INFO("synchronized with time offset %-5" PRId64 "ns", session.time_offset);
 					last_sync_session = hrt_absolute_time();
 
 					if (_param_uxrce_dds_syncc.get() > 0) {
@@ -702,10 +691,10 @@ void UxrceddsClient::run()
 				}
 
 				if (!_timesync_converged && _timesync.sync_converged()) {
-					PX4_INFO("time sync converged");
+					PX4_DEBUG("time sync converged");
 
 				} else if (_timesync_converged && !_timesync.sync_converged()) {
-					PX4_WARN("time sync no longer converged");
+					PX4_DEBUG("time sync no longer converged");
 				}
 
 				_timesync_converged = _timesync.sync_converged();


### PR DESCRIPTION
### Solved problem

#### Verbose timesync
When doing a timesync over DDS with a remote system under high load, the log gets spammed by timesync converge / RTT too high messages.

This primarily happens due to:
- The RTT gets calculated on the FMU as (`now() - originate_timestamp`)
  - When the load is high or a lot of packets are send, there can be a considerable delay until those packages leave the DDS agents queue and that time incorrectly gets calculated as high RTT
- The same applies to the offset calculation
- Using UART for DDS makes the situation even worse due to buffering / lower transmission speed

The timesync itself still works, it will only observe more high RTT messages and may converge / non coverge occasionally

#### Non used offset calculation
The function `on_time` will always receive an `args` argument due to the setup: `uxr_set_time_callback(session, on_time, &_timesync)`. Thus the calculation for the case of `args` not being present is redundant as it will always be overwritten.

#### Incorrect function parameters of `on_time`
The expected signature is:
```
typedef void (* uxrOnTimeFunc) (
        struct uxrSession* session,
        int64_t current_timestamp,
        int64_t transmit_timestamp,
        int64_t received_timestamp,
        int64_t originate_timestamp,
        void* args);
```
So transmit and receive are flipped.

### Solution

#### Verbose timesync
- Reduced the logging level, as the sync still works and the user can not change anything to "fix" the problem
- Long term I will try to implement the timestamps correctly on the DDS Agent side (at the actual receive / send). This way the RTT / offset can be calculated correctly

#### Non used offset calculation
- Removed the non used code

#### #### Incorrect function parameters of `on_time`
- Fixed the params and adapted the code