### PR TITLE
Commander: don't reset home position if landed during a mission

### DIFF
--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -279,6 +279,7 @@ private:
 	bool _arm_tune_played{false};
 	bool _have_taken_off_since_arming{false};
 	bool _status_changed{true};
+	bool _mission_in_progress{false};
 
 	vehicle_land_detected_s	_vehicle_land_detected{};
 

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -142,6 +142,9 @@ PARAM_DEFINE_FLOAT(COM_RC_LOSS_T, 0.5f);
  *
  * Set home position automatically if possible.
  *
+ * During missions, the home position is locked and will not reset during intermediate landings.
+ * It will only update once the mission is complete or landed outside of a mission.
+ *
  * @group Commander
  * @reboot_required true
  * @boolean


### PR DESCRIPTION
### Solved Problem
If [`COM_HOME_EN`](https://docs.px4.io/main/en/advanced_config/parameter_reference.html#COM_HOME_EN) is enabled, the home position will reset when landed. 

However, during mission execution, we want to prevent the home position from resetting if an intermediate landing occurs. Instead, the home position should remain fixed at the one set at the beginning of the mission.

### Solution
- Check whether the vehicle is still executing a mission before updating home position

**To have multiple takeoff items in a mission:** I found [that this feasibility check](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp#L336-L341) fails and prevents you from uploading the mission. Commenting it out works for now, but is probably not a very robust solution. 

### Changelog Entry
For release notes:
```
Feature/Bugfix Don't reset home position until a mission is finished
```

### Alternatives

We briefly discussed whether this should be a configuration option. These are the alternative options: 

1. Extending `COM_HOME_EN` (or introducing a new parameter) that only sets the home_position once in a boot cycle (position where the vehicle was armed the very first time).  
    - Pros: more generalized, and gives everyone the option to enable this feature 
    - Cons: not explicitly linked to the mission. So the home_position won't update once the mission is finished. 
   
2. Creating a mission parameter that enables multiple takeoffs. If enabled, home_position doesn't update upon each landing. Something like: `MIS_MULTI_TKO_LND`? 

### Test coverage

Tested in SITL: 

![image](https://github.com/user-attachments/assets/5b5800a5-9af9-4f0c-a997-0b3b7802b983)

- Simulation testing logs: https://review.px4.io/plot_app?log=ed5fd532-f0c1-4e75-9b37-5fa25f4096de 


