### PR TITLE
logger: add new mask for high rate sensors

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -357,6 +357,14 @@ void LoggedTopics::add_system_identification_topics()
 	add_topic("actuator_motors");
 }
 
+void LoggedTopics::add_high_rate_sensors_topics()
+{
+	add_topic_multi("distance_sensor", 0, 4);
+	add_topic_multi("sensor_optical_flow", 0, 2);
+	add_topic_multi("sensor_gps", 0, 4);
+	add_topic_multi("sensor_mag", 0, 4);
+}
+
 void LoggedTopics::add_mavlink_tunnel()
 {
 	add_topic("mavlink_tunnel");
@@ -571,5 +579,9 @@ void LoggedTopics::initialize_configured_topics(SDLogProfileMask profile)
 
 	if (profile & SDLogProfileMask::MAVLINK_TUNNEL) {
 		add_mavlink_tunnel();
+	}
+
+	if (profile & SDLogProfileMask::HIGH_RATE_SENSORS) {
+		add_high_rate_sensors_topics();
 	}
 }

--- a/src/modules/logger/logged_topics.h
+++ b/src/modules/logger/logged_topics.h
@@ -54,7 +54,8 @@ enum class SDLogProfileMask : int32_t {
 	VISION_AND_AVOIDANCE =  1 << 7,
 	RAW_IMU_GYRO_FIFO =     1 << 8,
 	RAW_IMU_ACCEL_FIFO =    1 << 9,
-	MAVLINK_TUNNEL =        1 << 10
+	MAVLINK_TUNNEL =        1 << 10,
+	HIGH_RATE_SENSORS =     1 << 11
 };
 
 enum class MissionLogType : int32_t {
@@ -175,6 +176,7 @@ private:
 	void add_raw_imu_gyro_fifo();
 	void add_raw_imu_accel_fifo();
 	void add_mavlink_tunnel();
+	void add_high_rate_sensors_topics();
 
 	/**
 	 * add a logged topic (called by add_topic() above).

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -129,7 +129,7 @@ PARAM_DEFINE_INT32(SDLOG_MISSION, 0);
  * 10: Logging of mavlink tunnel message (useful for payload communication debugging)
  *
  * @min 0
- * @max 2047
+ * @max 4095
  * @bit 0 Default set (general log analysis)
  * @bit 1 Estimator replay (EKF2)
  * @bit 2 Thermal calibration
@@ -141,6 +141,7 @@ PARAM_DEFINE_INT32(SDLOG_MISSION, 0);
  * @bit 8 Raw FIFO high-rate IMU (Gyro)
  * @bit 9 Raw FIFO high-rate IMU (Accel)
  * @bit 10 Mavlink tunnel message logging
+ * @bit 11 High rate sensors
  * @reboot_required true
  * @group SD Logging
  */


### PR DESCRIPTION
I often find myself creating debug binaries that increases the logged rate of sensor data to unlimited for various sensors. Generally this is for debugging data loss or sensor error problems from external sensors.  A profile for "sensor debugging" to capture full rate data is very useful for me, perhaps for others too?