### PR TITLE
[EKF2] Run simplified GNSS checks after initial fix

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.hpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.hpp
@@ -112,6 +112,7 @@ private:
 
 	bool isCheckEnabled(GnssChecksMask check) { return (_params.check_mask & static_cast<int32_t>(check)); }
 
+	bool runSimplifiedChecks(const gnssSample &gnss);
 	bool runInitialFixChecks(const gnssSample &gnss);
 	void runOnGroundGnssChecks(const gnssSample &gnss);
 

--- a/src/modules/ekf2/test/test_EKF_gps.cpp
+++ b/src/modules/ekf2/test/test_EKF_gps.cpp
@@ -84,12 +84,19 @@ TEST_F(EkfGpsTest, gpsTimeout)
 	// WHEN: the number of satellites drops below the minimum
 	_sensor_simulator._gps.setNumberOfSatellites(3);
 
+	// THEN: the GNSS fusion does not stop because other metrics are good enough
+	_sensor_simulator.runSeconds(8);
+	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsFusion());
+
+	// WHEN: the fix type drops
+	_sensor_simulator._gps.setFixType(0);
+
 	// THEN: the GNSS fusion stops after some time
 	_sensor_simulator.runSeconds(8);
 	EXPECT_FALSE(_ekf_wrapper.isIntendingGpsFusion());
 
-	// BUT WHEN: the number of satellites is good again
-	_sensor_simulator._gps.setNumberOfSatellites(16);
+	// BUT WHEN: the fix type is good again
+	_sensor_simulator._gps.setFixType(3);
 
 	// THEN: the GNSS fusion restarts
 	_sensor_simulator.runSeconds(6);


### PR DESCRIPTION
requires https://github.com/PX4/PX4-Autopilot/pull/24908

### Solved Problem
Thresholds of GNSS checks are supposed to be tight enough to make sure the drone starts with a good initial fix. However, currently, degradation of a single metric also stops the fusion (e.g.: high DOP) when other metrics are still good.

### Solution
Add a "simplified" list of checks with large (arbitrary) thresholds. Those values can be discussed, but hopefully we can agree on a common value to avoid additional parameters.

### Changelog Entry
For release notes:
```
Improvement: Simplified GNSS checks after initial fix 
```

### Test coverage
unit tests
@haumarco flight tested
