### PR TITLE
uavcan esc: translate temperature field from Kelvin to Celsius

### DIFF
--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -140,7 +140,7 @@ UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<uavca
 		ref.esc_address = msg.getSrcNodeID().get();
 		ref.esc_voltage     = msg.voltage;
 		ref.esc_current     = msg.current;
-		ref.esc_temperature = msg.temperature;
+		ref.esc_temperature = msg.temperature - 273.15f; // Kelvin to Celsius
 		ref.esc_rpm         = msg.rpm;
 		ref.esc_errorcount  = msg.error_count;
 


### PR DESCRIPTION
### Solved Problem
When looking at a log that was captured on a drone with [Holybro Kotleta20](https://holybro.com/products/kotleta20) ESCs attached through CAN I found that the reported temperatures are unreasonably high:
![image](https://github.com/user-attachments/assets/614e0fdd-54a9-40a2-8fe2-8be89d0fceed)

Then I realized the temperature field definitions of [UAVCAN](https://github.com/dronecan/DSDL/blob/1b2118cf358027453830ef644838a3bedb9411ea/uavcan/equipment/esc/1034.Status.uavcan#L10):
[`float16 temperature # Kelvin`]()
and uORB:
[`float32 esc_temperature # Temperature measured from current ESC [degC] - if supported`](https://github.com/PX4/PX4-Autopilot/blob/134ee7b64085c6e8bd0bdc22f59d0e0980c1c5f8/msg/EscReport.msg#L6)

but there's no conversion:
https://github.com/PX4/PX4-Autopilot/blob/134ee7b64085c6e8bd0bdc22f59d0e0980c1c5f8/src/drivers/uavcan/actuators/esc.cpp#L143

### Solution
Add a conversion from degree Kelvin to Celsius.

### Changelog Entry
```
Fix temperature conversion from UAVCAN to uORB ESC status
```

### Test coverage
I did not test this yet.