### PR TITLE
Vehicle_odometry: protect angular_velocity field against aliasing

### DIFF
--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -243,6 +243,7 @@ public:
 	int getNumberOfActiveVerticalVelocityAidingSources() const;
 
 	const matrix::Quatf &getQuaternion() const { return _output_predictor.getQuaternion(); }
+	Vector3f getAngularVelocityAndResetAccumulator() { return _output_predictor.getAngularVelocityAndResetAccumulator(); }
 	float getUnaidedYaw() const { return _output_predictor.getUnaidedYaw(); }
 	Vector3f getVelocity() const { return _output_predictor.getVelocity(); }
 

--- a/src/modules/ekf2/EKF/output_predictor/output_predictor.h
+++ b/src/modules/ekf2/EKF/output_predictor/output_predictor.h
@@ -95,6 +95,8 @@ public:
 
 	const matrix::Quatf &getQuaternion() const { return _output_new.quat_nominal; }
 
+	matrix::Vector3f getAngularVelocityAndResetAccumulator();
+
 	// get a yaw value solely based on bias-removed gyro integration
 	float getUnaidedYaw() const { return _unaided_yaw; }
 
@@ -192,6 +194,8 @@ private:
 
 	matrix::Vector3f _imu_pos_body{};                ///< xyz position of IMU in body frame (m)
 
+	matrix::Quatf _delta_angle_sum{};
+	float _delta_angle_sum_dt{0.f};
 	float _unaided_yaw{};
 
 	// output complementary filter tuning

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1676,9 +1676,7 @@ void EKF2::PublishOdometry(const hrt_abstime &timestamp, const imuSample &imu_sa
 	_ekf.getVelocity().copyTo(odom.velocity);
 
 	// angular_velocity
-	const Vector3f rates{imu_sample.delta_ang / imu_sample.delta_ang_dt};
-	const Vector3f angular_velocity = rates - _ekf.getGyroBias();
-	angular_velocity.copyTo(odom.angular_velocity);
+	_ekf.getAngularVelocityAndResetAccumulator().copyTo(odom.angular_velocity);
 
 	// velocity covariances
 	_ekf.getVelocityVariance().copyTo(odom.velocity_variance);


### PR DESCRIPTION
### Solved Problem
External system using `vehicle_odometry` might want to use the `angular_velocity` field as a source of low-rate gyro data for another estimator. Currently, this signal is subject to aliasing as the last imu data is used to fill the message instead of properly down-sampling the gyro data.

### Solution
Accumulate delta-angles between each publication to get the correct angular velocity between two attitudes. 

The resulting angular velocity is not the average of the gyro measurements, but the time derivative of shortest rotation (delta_angle) between two unaided attitudes. The angular velocity is bias-corrected (using the bias estimate of the EKF) but otherwise not directly affected by other aiding sources.

### Changelog Entry
For release notes:
```
Bugfix: Avoid aliasing of angular vel in vehicle_odometry uORB topic
New parameter: -
Documentation: -
```

### Test coverage
Tested on hardware (sensor_combined @ 200Hz, vehicle_odometry @ 100Hz)
![image](https://github.com/user-attachments/assets/b19170ed-fef1-410c-9d5d-797ca7cca52e)