### PR TITLE
MAVLink streaming: report mission state with MISSION_CURRENT MAVLink message

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -499,9 +499,9 @@ MavlinkMissionManager::send()
 		return;
 	}
 
-	mission_result_s mission_result{};
 
-	if (_mission_result_sub.update(&mission_result)) {
+	if (_mission_result_sub.update()) {
+		const mission_result_s &mission_result = _mission_result_sub.get();
 
 		if (_current_seq != mission_result.seq_current) {
 
@@ -1925,11 +1925,7 @@ MavlinkMissionManager::update_mission_state()
 	}
 
 	// Get mission result
-	mission_result_s mission_result;
-
-	if (!_mission_result_sub.update(&mission_result)) {
-		return;
-	}
+	const mission_result_s &mission_result = _mission_result_sub.get();
 
 	// Update mission mode
 	if (vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION ||
@@ -1953,7 +1949,7 @@ MavlinkMissionManager::update_mission_state()
 		   && vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
 		_mission_state = MISSION_STATE_ACTIVE;
 
-	} else if (_mission_mode == MISSION_MODE_SUSPENDED && _last_reached >= 0) {
+	} else if (_mission_mode == MISSION_MODE_SUSPENDED && mission_result.seq_reached >= 0) {
 		// Only PAUSED if we were actually in the middle of a mission
 		_mission_state = MISSION_STATE_PAUSED;
 

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1945,15 +1945,14 @@ MavlinkMissionManager::update_mission_state()
 		// Mission is complete if the navigator says it's finished
 		_mission_state = MISSION_STATE_COMPLETE;
 
-	} else if (_mission_mode == MISSION_MODE_ACTIVE
-		   && vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
+	} else if (_mission_mode == MISSION_MODE_ACTIVE) {
 		_mission_state = MISSION_STATE_ACTIVE;
 
 	} else if (_mission_mode == MISSION_MODE_SUSPENDED && mission_result.seq_reached >= 0) {
 		// Only PAUSED if we were actually in the middle of a mission
 		_mission_state = MISSION_STATE_PAUSED;
 
-	} else {
+	} else if (mission_result.seq_reached < 0 && mission_result.seq_current < 1) {
 		_mission_state = MISSION_STATE_NOT_STARTED;
 	}
 }

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -148,7 +148,7 @@ private:
 
 	static bool		_transfer_in_progress;			///< Global variable checking for current transmission
 
-	uORB::Subscription	_mission_result_sub{ORB_ID(mission_result)};
+	uORB::SubscriptionData<mission_result_s>	_mission_result_sub{ORB_ID(mission_result)};
 	uORB::SubscriptionData<mission_s> 	_mission_sub{ORB_ID(mission)};
 	uORB::Subscription	_vehicle_status_sub{ORB_ID(vehicle_status)};	///< vehicle status subscription
 


### PR DESCRIPTION
### Solved Problem 

1. `mavlink_mission.cpp` checks for an updated `MissionResult` message twice in a row. As there is no new message on the second check, the `_mission_state` field isn't populated properly. 

2. `_mission_state` switches from `MISSION_STATE_ACTIVE` to `MISSION_STATE_NOT_STARTED` for cases in which the vehicle disarms mid mission (for example: delivery missions with multiple landings).  

### Solution 

1. Switch from Subscription to SubscriptionData so we can do a `.get()` operation on the latest message struct.   

2. Remove the armed requirement for a mission to be active, and robusity the conditional for `MISSION_STATE_NOT_STARTED` to be met. 

### Test coverage
- Tested in SITL

