### PR TITLE
feat: allow PX4_UXRCE_DDS_NS override with empty sting

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -295,10 +295,15 @@ then
 	# for multi intances setup, add namespace prefix
 	uxrce_dds_ns="-n px4_$px4_instance"
 fi
-if [ -n "$PX4_UXRCE_DDS_NS" ]
-then
-	# Override namespace if environment variable is defined
-	uxrce_dds_ns="-n $PX4_UXRCE_DDS_NS"
+if [ "${PX4_UXRCE_DDS_NS+x}" ]; then
+	# Override, as variable is set (empty or not)
+	if [ -n "$PX4_UXRCE_DDS_NS" ]; then
+		# Override namespace if environment variable is non-empty
+		uxrce_dds_ns="-n $PX4_UXRCE_DDS_NS"
+	else
+		# Clear namespace if variable is empty
+		uxrce_dds_ns=""
+	fi
 fi
 if [ -n "$ROS_DOMAIN_ID" ]
 then


### PR DESCRIPTION
### Solved Problem
When working on DDS configuration I found that PX4_UXRCE_DDS_NS is only used to override the namespace when not empty. But there are cases where an empty override is required (when setting an instance id but still want an empty namespace, e.g.).

### Solution
- Add logic for PX4_UXRCE_DDS_NS being set but empty too.

### Changelog Entry
For release notes:
```
Feature: Allow DDS namespece override with empty/default namespace 
```

### Test coverage
- Simulation testing
