### PR TITLE
Bosch: BMM350: Fix self-test on high ODR rate

### DIFF
--- a/src/drivers/magnetometer/bosch/bmm350/BMM350.cpp
+++ b/src/drivers/magnetometer/bosch/bmm350/BMM350.cpp
@@ -34,6 +34,8 @@
 #include "BMM350.hpp"
 using namespace time_literals;
 
+#define MAX(a,b)          (a > b ? a : b)
+
 BMM350::BMM350(const I2CSPIDriverConfig &config) :
 	I2C(config),
 	I2CSPIDriver(config),
@@ -318,7 +320,7 @@ void BMM350::RunImpl()
 				_state = STATE::RESET;
 			}
 
-			ScheduleDelayed(OdrToUs(_mag_odr_mode));
+			ScheduleDelayed(MAX(6000_us, OdrToUs(_mag_odr_mode)));
 			break;
 		}
 


### PR DESCRIPTION
### Solved Problem
When changing BMM350_ODR to a faster rate, self-test would fail on startup.
Turns out you've to wait atleast 6000us before doing self-test

### Test coverage
NXP MR-Tropic board

@niklaut  I see that the FMU-V6S also has an BMM350, could you confirm if you've also have this issue? And that this fix solves it?