### PR TITLE
[uavcan] Fix unitless actuator range conversion

### DIFF
--- a/src/drivers/uavcan/actuators/servo.cpp
+++ b/src/drivers/uavcan/actuators/servo.cpp
@@ -53,7 +53,7 @@ UavcanServoController::update_outputs(bool stop_motors, uint16_t outputs[MAX_ACT
 		uavcan::equipment::actuator::Command cmd;
 		cmd.actuator_id = i;
 		cmd.command_type = uavcan::equipment::actuator::Command::COMMAND_TYPE_UNITLESS;
-		cmd.command_value = (float)outputs[i] / 500.f - 1.f; // [-1, 1]
+		cmd.command_value = (float)outputs[i] / 500.f - 3.f; // [1000, 2000] -> [-1, 1]
 
 		msg.commands.push_back(cmd);
 	}


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

When attaching [a UAVCAN servo](https://www.mateksys.com/?portfolio=can-l4-pwm), the output does not work.
The UAVCAN message that gets sent is `uavcan.equipment.actuator.ArrayCommand`, but all `command_values` are in the range [1, 3], while the `COMMAND_TYPE_UNITLESS` expects a range of [-1, +1].

### Solution

The formula for conversion was wrong, the input is [1000, 2000] and should map to [-1, +1]. The subtraction was -1, instead of -3.

### Changelog Entry

For release notes:
```
Bugfix: Fix UAVCAN actuator output conversion
```

### Test coverage

- [ ] Tested in hardware

