### PR TITLE
mission: add RTL to is_mission_item_reached_or_completed()

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -96,6 +96,7 @@ MissionBlock::is_mission_item_reached_or_completed()
 	case NAV_CMD_SET_CAMERA_FOCUS:
 	case NAV_CMD_DO_CHANGE_SPEED:
 	case NAV_CMD_DO_SET_HOME:
+	case NAV_CMD_RETURN_TO_LAUNCH:
 
 		return true;
 


### PR DESCRIPTION
This ensures that a mission is marked as completed when RTL is the last item. 

### Solved Problem
Mission not marked as complete when RTL is the last mission item. 

### Solution
- Add `NAV_CMD_RETURN_TO_LAUNCH` to `is_mission_item_reached_or_completed()`. 

Item was added to block of action commands that completes instantaneously. If it's grouped with the the other land actions `NAV_CMD_LAND` / `NAV_CMD_VTOL_LAND` the action never completes as (my understanding:) RTL executes outside of the mission framework. 
 
### Changelog Entry
For release notes:
```
Feature/Bugfix add RTL to is_mission_item_reached_or_completed()
```

### Test coverage

Tested in SITL: 

![image](https://github.com/user-attachments/assets/df581239-40f4-47ec-8f12-ed399708ad8a)
