### PR TITLE
fix (msp_ods): clear buffers before writing and adjust sizes

### DIFF
--- a/src/drivers/osd/msp_osd/msp_defines.h
+++ b/src/drivers/osd/msp_osd/msp_defines.h
@@ -462,7 +462,7 @@ struct msp_rendor_satellites_used_t {
 	uint8_t iconIndex = 0x1E; //satellites icon
 	uint8_t iconIndex2 = 0x1F; //satellites icon
 
-	char str[2]; // 99
+	char str[3]; // 99
 } __attribute__((packed));
 
 

--- a/src/drivers/osd/msp_osd/uorb_to_msp.cpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.cpp
@@ -378,6 +378,7 @@ msp_rendor_satellites_used_t construct_rendor_GPS_NUM(const sensor_gps_s &vehicl
 	num.screenYPosition = 0x08;
 	num.screenXPosition = 0x29;
 
+	memset(&num.str[0], 0, sizeof(num.str));
 	snprintf(&num.str[0], sizeof(num.str), "%d", vehicle_gps_position.satellites_used);
 
 	return num;
@@ -485,6 +486,7 @@ msp_rendor_pitch_t  construct_rendor_PITCH(const vehicle_attitude_s &vehicle_att
 	double pitch_deg = (double)math::degrees(euler_attitude.theta());
 	// attitude.roll = math::degrees(euler_attitude.phi()) * 10;
 
+	memset(&pit.str[0], 0, sizeof(pit.str));
 	snprintf(&pit.str[0], sizeof(pit.str), "%.1f", pitch_deg);
 
 	return pit;
@@ -503,6 +505,7 @@ msp_rendor_roll_t  construct_rendor_ROLL(const vehicle_attitude_s &vehicle_attit
 	// double pitch = (double)math::degrees(euler_attitude.theta());
 	double roll_deg = (double)math::degrees(euler_attitude.phi());
 
+	memset(&roll.str[0], 0, sizeof(roll.str));
 	snprintf(&roll.str[0], sizeof(roll.str), "%.1f", roll_deg);
 
 	return roll;


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

- In `mps_ods` the string used to store the number of satellites only had two chars, therefore only one digit was printed (last char needs to be `\0`).
- In `mps_ods` the strings used to store the number of satellites and the roll/pitch values where not cleared before writing. Because the entire buffer is sent to the VTX and che logic does not stop at the `\0` added by the `snprintf` functions, trailing random values in the buffer end up being displayed.

Fixes #{Github issue ID}

### Solution

- Increase array size for number of satellites to 3.
- Clear the character buffers for number of satellites and the roll/pitch structures before writing them.

### Changelog Entry
For release notes:
```
NONE
```

### Alternatives

Instead of fixed lenght buffer structures, dynamic ones could be used across the entire driver

### Test coverage

- Tested on Walksnail vtx and googles hardware

### Context
Related links, screenshot before/after, video
