### PR TITLE
gz: Use pose specified by PX4_GZ_MODEL_POSE

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim
@@ -110,25 +110,33 @@ if [ -n "${PX4_SIM_MODEL#*gz_}" ] && [ -z "${PX4_GZ_MODEL_NAME}" ]; then
 	MODEL_NAME="${PX4_SIM_MODEL#*gz_}"
 	MODEL_NAME_INSTANCE="${MODEL_NAME}_${px4_instance}"
 
-	POSE_ARG=""
 	if [ -n "${PX4_GZ_MODEL_POSE}" ]; then
-		pos_x=$(echo "${PX4_GZ_MODEL_POSE}" | awk -F',' '{print $1}')
-		pos_y=$(echo "${PX4_GZ_MODEL_POSE}" | awk -F',' '{print $2}')
-		pos_z=$(echo "${PX4_GZ_MODEL_POSE}" | awk -F',' '{print $3}')
-		pos_x=${pos_x:-0}
-		pos_y=${pos_y:-0}
-		pos_z=${pos_z:-0}
+		pose_x=$(echo "${PX4_GZ_MODEL_POSE}" | awk -F',' '{print $1}')
+		pose_y=$(echo "${PX4_GZ_MODEL_POSE}" | awk -F',' '{print $2}')
+		pose_z=$(echo "${PX4_GZ_MODEL_POSE}" | awk -F',' '{print $3}')
+		pose_roll=$(echo "${PX4_GZ_MODEL_POSE}" | awk -F',' '{print $4}')
+		pose_pitch=$(echo "${PX4_GZ_MODEL_POSE}" | awk -F',' '{print $5}')
+		pose_yaw=$(echo "${PX4_GZ_MODEL_POSE}" | awk -F',' '{print $6}')
 
-		POSE_ARG=", pose: { position: { x: ${pos_x}, y: ${pos_y}, z: ${pos_z} } }"
-		echo "INFO  [init] Spawning model at position: ${pos_x} ${pos_y} ${pos_z}"
+		pose_x=${pose_x:-0}
+		pose_y=${pose_y:-0}
+		pose_z=${pose_z:-0}
+		pose_roll=${pose_roll:-0}
+		pose_pitch=${pose_pitch:-0}
+		pose_yaw=${pose_yaw:-0}
+
+		echo "INFO  [init] Gazebo model pose: ${pose_x} ${pose_y} ${pose_z} ${pose_roll} ${pose_pitch} ${pose_yaw}"
 	fi
 
 	echo "INFO  [init] Spawning model"
 
+	# include the actual SDF in this one containing the pose in x y z roll pitch yaw format
+	sdf_str="<sdf version=\"1.6\"> <include> <uri>file:///${PX4_GZ_MODELS}/${MODEL_NAME}/model.sdf</uri> <pose> ${pose_x} ${pose_y} ${pose_z} ${pose_roll} ${pose_pitch} ${pose_yaw} </pose> </include> </sdf>"
+
 	# Spawn model
 	${gz_command} service -s "/world/${PX4_GZ_WORLD}/create" --reqtype gz.msgs.EntityFactory \
 			--reptype gz.msgs.Boolean --timeout 5000 \
-			--req "sdf_filename: \"${PX4_GZ_MODELS}/${MODEL_NAME}/model.sdf\", name: \"${MODEL_NAME_INSTANCE}\", allow_renaming: false${POSE_ARG}" > /dev/null 2>&1
+			--req "name: \"${MODEL_NAME_INSTANCE}\", allow_renaming: false, sdf: '${sdf_str}'" > /dev/null 2>&1
 
 	# Wait for model to spawn
 	sleep 1


### PR DESCRIPTION
### Solved Problem

The `PX4_GZ_MODEL_POSE` environment variable is clearly described in the [docs](https://docs.px4.io/main/en/sim_gazebo_gz/#syntax) as a proper pose, i.e. position and orientation. However, the startup script as of now discards the orientation information (is this intentional? was it ever implemented and then dropped for a good reason?).


### Solution
We read the rest of the variables (roll, pitch and yaw) as well and initialise the model with the given pose. The reason I am constructing a new SDF string `<include>`ing the actual SDF file is that this allows us to neatly specify a pose in x, y, z, roll, pitch yaw format. In comparison, the json `POSE_ARG` used before would need (*) an orientation quaternion in the format `orientation: { w: ${quat_w}, x: ${quat_x}, y: ${quat_y}, z: ${quat_z} }`, and doing that conversion in bash is something I'd rather avoid if possible.

\* as far as I can tell  with the rather minimal documentation, happy to be corrected on this one

### Alternatives

To avoid the admittedly less than optimal SDF string wrapping, we could also: 
 - Only support yaw, which makes the quaternion simple enough -- the utility of pitch and roll is questionable anyway. But if we do, at least make the docs match the implemetation
 - bite the bullet and convert the full orientation to quaternion 

### Test coverage
roll, pitch and yaw :) 