### PR TITLE
Introduce battery_info uORB message for static data like the serial number

### DIFF
--- a/docs/en/msg_docs/BatteryStatus.md
+++ b/docs/en/msg_docs/BatteryStatus.md
@@ -27,7 +27,6 @@ uint8 priority					# Zero based priority is the connection on the Power Controll
 uint16 capacity					# actual capacity of the battery
 uint16 cycle_count				# number of discharge cycles the battery has experienced
 uint16 average_time_to_empty			# predicted remaining battery capacity based on the average rate of discharge in min
-uint16 serial_number				# serial number of the battery pack
 uint16 manufacture_date				# manufacture date, part of serial number of the battery pack. Formatted as: Day + Month×32 + (Year–1980)×512
 uint16 state_of_health				# state of health. FullChargeCapacity/DesignCapacity, 0-100%.
 uint16 max_error				# max error, expected margin of error in % in the state-of-charge calculation with a range of 1 to 100%

--- a/docs/ko/msg_docs/BatteryStatus.md
+++ b/docs/ko/msg_docs/BatteryStatus.md
@@ -25,7 +25,6 @@ uint8 priority					# Zero based priority is the connection on the Power Controll
 uint16 capacity					# actual capacity of the battery
 uint16 cycle_count				# number of discharge cycles the battery has experienced
 uint16 average_time_to_empty			# predicted remaining battery capacity based on the average rate of discharge in min
-uint16 serial_number				# serial number of the battery pack
 uint16 manufacture_date				# manufacture date, part of serial number of the battery pack. Formatted as: Day + Month×32 + (Year–1980)×512
 uint16 state_of_health				# state of health. FullChargeCapacity/DesignCapacity, 0-100%.
 uint16 max_error				# max error, expected margin of error in % in the state-of-charge calculation with a range of 1 to 100%

--- a/docs/uk/msg_docs/BatteryStatus.md
+++ b/docs/uk/msg_docs/BatteryStatus.md
@@ -25,7 +25,6 @@ uint8 priority					# Zero based priority is the connection on the Power Controll
 uint16 capacity					# actual capacity of the battery
 uint16 cycle_count				# number of discharge cycles the battery has experienced
 uint16 average_time_to_empty			# predicted remaining battery capacity based on the average rate of discharge in min
-uint16 serial_number				# serial number of the battery pack
 uint16 manufacture_date				# manufacture date, part of serial number of the battery pack. Formatted as: Day + Month×32 + (Year–1980)×512
 uint16 state_of_health				# state of health. FullChargeCapacity/DesignCapacity, 0-100%.
 uint16 max_error				# max error, expected margin of error in % in the state-of-charge calculation with a range of 1 to 100%

--- a/docs/zh/msg_docs/BatteryStatus.md
+++ b/docs/zh/msg_docs/BatteryStatus.md
@@ -25,7 +25,6 @@ uint8 priority					# Zero based priority is the connection on the Power Controll
 uint16 capacity					# actual capacity of the battery
 uint16 cycle_count				# number of discharge cycles the battery has experienced
 uint16 average_time_to_empty			# predicted remaining battery capacity based on the average rate of discharge in min
-uint16 serial_number				# serial number of the battery pack
 uint16 manufacture_date				# manufacture date, part of serial number of the battery pack. Formatted as: Day + Month×32 + (Year–1980)×512
 uint16 state_of_health				# state of health. FullChargeCapacity/DesignCapacity, 0-100%.
 uint16 max_error				# max error, expected margin of error in % in the state-of-charge calculation with a range of 1 to 100%

--- a/msg/BatteryInfo.msg
+++ b/msg/BatteryInfo.msg
@@ -1,0 +1,4 @@
+uint64 timestamp # time since system start [us]
+
+uint8 id # Must match the id in the battery_status message for the same battery
+char[32] serial_number # Serial number of the battery pack in ASCII characters, 0 terminated [@invalid All bytes 0]

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -47,6 +47,7 @@ set(msg_files
 	Airspeed.msg
 	AirspeedWind.msg
 	AutotuneAttitudeControlStatus.msg
+	BatteryInfo.msg
 	ButtonEvent.msg
 	CameraCapture.msg
 	CameraStatus.msg

--- a/msg/versioned/BatteryStatus.msg
+++ b/msg/versioned/BatteryStatus.msg
@@ -1,4 +1,4 @@
-uint32 MESSAGE_VERSION = 0
+uint32 MESSAGE_VERSION = 1
 
 uint64 timestamp				# time since system start (microseconds)
 bool connected					# Whether or not a battery is connected, based on a voltage threshold
@@ -20,7 +20,6 @@ uint8 priority					# Zero based priority is the connection on the Power Controll
 uint16 capacity					# actual capacity of the battery
 uint16 cycle_count				# number of discharge cycles the battery has experienced
 uint16 average_time_to_empty			# predicted remaining battery capacity based on the average rate of discharge in min
-uint16 serial_number				# serial number of the battery pack
 uint16 manufacture_date				# manufacture date, part of serial number of the battery pack. Formatted as: Day + Month×32 + (Year–1980)×512
 uint16 state_of_health				# state of health. FullChargeCapacity/DesignCapacity, 0-100%.
 uint16 max_error				# max error, expected margin of error in % in the state-of-charge calculation with a range of 1 to 100%

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -52,6 +52,7 @@
 #include <px4_platform_common/param.h>
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/i2c_spi_buses.h>
+#include <uORB/topics/battery_info.h>
 #include <uORB/topics/battery_status.h>
 
 #include <board_config.h>
@@ -242,7 +243,7 @@ private:
 	/** @param _last_report Last published report, used for test(). */
 	battery_status_s _last_report{};
 
-	/** @param _batt_topic uORB battery topic. */
+	orb_advert_t _battery_info_topic{nullptr};
 	orb_advert_t _batt_topic{nullptr};
 
 	/** @param _cell_count Number of series cell. */

--- a/src/drivers/smart_battery/batmon/batmon.cpp
+++ b/src/drivers/smart_battery/batmon/batmon.cpp
@@ -191,7 +191,6 @@ void Batmon::RunImpl()
 	if (ret == PX4_OK) {
 		new_report.capacity = _batt_capacity;
 		new_report.cycle_count = _cycle_count;
-		new_report.serial_number = _serial_number;
 		new_report.max_cell_voltage_delta = _max_cell_voltage_delta;
 		new_report.cell_count = _cell_count;
 		new_report.state_of_health = _state_of_health;
@@ -220,6 +219,12 @@ void Batmon::RunImpl()
 		orb_publish_auto(ORB_ID(battery_status), &_batt_topic, &new_report, &instance);
 
 		_last_report = new_report;
+
+		battery_info_s battery_info{};
+		battery_info.timestamp = new_report.timestamp;
+		battery_info.id = new_report.id;
+		snprintf(battery_info.serial_number, sizeof(battery_info.serial_number), "%" PRIu16, _serial_number);
+		orb_publish_auto(ORB_ID(battery_info), &_battery_info_topic, &battery_info, &instance);
 	}
 }
 

--- a/src/drivers/uavcan/sensors/battery.hpp
+++ b/src/drivers/uavcan/sensors/battery.hpp
@@ -38,6 +38,7 @@
 #pragma once
 
 #include "sensor_bridge.hpp"
+#include <uORB/topics/battery_info.h>
 #include <uORB/topics/battery_status.h>
 #include <uavcan/equipment/power/BatteryInfo.hpp>
 #include <ardupilot/equipment/power/BatteryInfoAux.hpp>
@@ -95,6 +96,11 @@ private:
 	float _discharged_mah_loop = 0.f;
 	uint8_t _warning;
 	hrt_abstime _last_timestamp;
+
+	// Separate battery info publication because UavcanSensorBridgeBase only supports publishing one topic
+	uORB::PublicationMulti<battery_info_s> _battery_info_pub[battery_status_s::MAX_INSTANCES] {ORB_ID(battery_info), ORB_ID(battery_info), ORB_ID(battery_info), ORB_ID(battery_info)};
+
+	battery_info_s _battery_info[battery_status_s::MAX_INSTANCES] {};
 	battery_status_s _battery_status[battery_status_s::MAX_INSTANCES] {};
 	BatteryDataType _batt_update_mod[battery_status_s::MAX_INSTANCES] {};
 

--- a/src/lib/drivers/smbus_sbs/SBS.hpp
+++ b/src/lib/drivers/smbus_sbs/SBS.hpp
@@ -45,6 +45,7 @@
 
 #include <px4_platform_common/i2c_spi_buses.h>
 #include <lib/drivers/smbus/SMBus.hpp>
+#include <uORB/topics/battery_info.h>
 #include <uORB/topics/battery_status.h>
 #include <px4_platform_common/param.h>
 #include <lib/atmosphere/atmosphere.h>
@@ -66,7 +67,7 @@ public:
 
 	friend SMBus;
 
-	int populate_smbus_data(battery_status_s &msg);
+	int populate_smbus_data(battery_status_s &msg, battery_info_s &battery_info);
 
 	virtual void RunImpl(); // Can be overridden by derived implimentation
 
@@ -136,7 +137,7 @@ protected:
 
 	perf_counter_t _cycle{perf_alloc(PC_ELAPSED, "batmon_cycle")}; // TODO
 
-	/** @param _batt_topic uORB battery topic. */
+	orb_advert_t _battery_info_topic{nullptr};
 	orb_advert_t _batt_topic{nullptr};
 
 	/** @param _cell_count Number of series cell (retrieved from cell_count PX4 params) */
@@ -173,8 +174,10 @@ SMBUS_SBS_BaseClass<T>::SMBUS_SBS_BaseClass(const I2CSPIDriverConfig &config, SM
 	I2CSPIDriver<T>(config),
 	_interface(interface)
 {
+	battery_info_s battery_info{};
 	battery_status_s new_report = {};
 	int SBS_instance_number = 0;
+	_battery_info_topic = orb_advertise_multi(ORB_ID(battery_info), &battery_info, &SBS_instance_number);
 	_batt_topic = orb_advertise_multi(ORB_ID(battery_status), &new_report, &SBS_instance_number);
 	_interface->init();
 }
@@ -251,7 +254,7 @@ int SMBUS_SBS_BaseClass<T>::get_startup_info()
 }
 
 template<class T>
-int SMBUS_SBS_BaseClass<T>::populate_smbus_data(battery_status_s &data)
+int SMBUS_SBS_BaseClass<T>::populate_smbus_data(battery_status_s &data, battery_info_s &battery_info)
 {
 
 	// Temporary variable for storing SMBUS reads.
@@ -285,7 +288,7 @@ int SMBUS_SBS_BaseClass<T>::populate_smbus_data(battery_status_s &data)
 
 	// Read serial number.
 	ret |= _interface->read_word(BATT_SMBUS_SERIAL_NUMBER, result);
-	data.serial_number = result;
+	snprintf(battery_info.serial_number, sizeof(battery_info.serial_number), "%" PRIu16, result);
 
 	// Read battery temperature and covert to Celsius.
 	ret |= _interface->read_word(BATT_SMBUS_TEMP, result);
@@ -312,12 +315,17 @@ void SMBUS_SBS_BaseClass<T>::RunImpl()
 
 	new_report.connected = true;
 
-	int ret = populate_smbus_data(new_report);
+	battery_info_s battery_info{};
+	battery_info.timestamp = now;
+	battery_info.id = new_report.id;
+
+	int ret = populate_smbus_data(new_report, battery_info);
 
 	new_report.cell_count = _cell_count;
 
 	// Only publish if no errors.
 	if (!ret) {
 		orb_publish(ORB_ID(battery_status), _batt_topic, &new_report);
+		orb_publish(ORB_ID(battery_info), _battery_info_topic, &battery_info);
 	}
 }

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -189,6 +189,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic_multi("yaw_estimator_status", 1000);
 
 	// log all raw sensors at minimal rate (at least 1 Hz)
+	add_topic_multi("battery_info", 5000, 2);
 	add_topic_multi("battery_status", 200, 2);
 	add_topic_multi("differential_pressure", 1000, 2);
 	add_topic_multi("distance_sensor", 1000, 2);

--- a/src/modules/mavlink/streams/BATTERY_INFO.hpp
+++ b/src/modules/mavlink/streams/BATTERY_INFO.hpp
@@ -34,6 +34,7 @@
 #ifndef BATTERY_INFO_HPP
 #define BATTERY_INFO_HPP
 
+#include <uORB/topics/battery_info.h>
 #include <uORB/topics/battery_status.h>
 
 class MavlinkStreamBatteryInfo : public MavlinkStream
@@ -57,21 +58,43 @@ private:
 	explicit MavlinkStreamBatteryInfo(Mavlink *mavlink) : MavlinkStream(mavlink) {}
 
 	uORB::SubscriptionMultiArray<battery_status_s, battery_status_s::MAX_INSTANCES> _battery_status_subs{ORB_ID::battery_status};
+	uORB::SubscriptionMultiArray<battery_info_s, battery_status_s::MAX_INSTANCES> _battery_info_subs{ORB_ID::battery_info};
+
+	uint8_t _serial_number_ids[battery_status_s::MAX_INSTANCES] {};
+	char _serial_numbers[battery_status_s::MAX_INSTANCES][32] {}; ///< keep track of serial numbers until all static battery info is split out
 
 	bool send() override
 	{
 		bool updated = false;
 
+		for (int i = 0; i < _battery_info_subs.size(); ++i) {
+			battery_info_s battery_info;
+
+			if (_battery_info_subs[i].update(&battery_info)) {
+				_serial_number_ids[i] = battery_info.id;
+				strncpy(_serial_numbers[i], battery_info.serial_number, sizeof(_serial_numbers[0]));
+			}
+		}
+
 		for (auto &battery_sub : _battery_status_subs) {
 			battery_status_s battery_status;
 
 			if (battery_sub.update(&battery_status)) {
-				if (battery_status.serial_number == 0) {
-					// Required to emit
-					continue;
+				mavlink_battery_info_t msg{};
+				bool battery_has_serial_number = false;
+
+				// load serial number from battery_info message until all static information fields were moved
+				for (int i = 0; i < battery_status_s::MAX_INSTANCES; ++i) {
+					if ((_serial_number_ids[i] != 0) && (_serial_number_ids[i] == battery_status.id)) {
+						strncpy(msg.serial_number, _serial_numbers[i], sizeof(msg.serial_number));
+						battery_has_serial_number = true;
+					}
 				}
 
-				mavlink_battery_info_t msg{};
+				if (!battery_has_serial_number) {
+					// Only publish BATTERY_INFO if the battery has a serial number
+					continue;
+				}
 
 				msg.id = battery_status.id - 1;
 				msg.design_capacity = (float)(battery_status.capacity * 1000);
@@ -82,17 +105,9 @@ private:
 					uint16_t day = battery_status.manufacture_date % 32;
 					uint16_t month = (battery_status.manufacture_date >> 5) % 16;
 					uint16_t year = (80 + (battery_status.manufacture_date >> 9));
-					uint16_t year2dig = year % 100;
 
 					//Formatted as 'ddmmyyyy' (maxed 9 chars)
 					snprintf(msg.manufacture_date, sizeof(msg.manufacture_date), "%d%d%d", day, month, year);
-					//Formatted as 'dd/mm/yy-123456' (maxed 15 + 1 chars)
-					snprintf(msg.serial_number, sizeof(msg.serial_number), "%d/%d/%d-%d", day, month, year2dig,
-						 battery_status.serial_number);
-
-				} else {
-
-					snprintf(msg.serial_number, sizeof(msg.serial_number), "%d", battery_status.serial_number);
 				}
 
 				// Not supported by PX4 (not in battery_status uorb topic)


### PR DESCRIPTION
### Solved Problem
When tracking battery use across multiple flights and vehicles using the serial number from flight logs I found that:
1. The serial number, that we currently have in battery status is a `uin16_t` which is too limiting for my use case and likely also others. I found that this [periodic battery DroneCAN message](https://github.com/dronecan/DSDL/blob/1b2118cf358027453830ef644838a3bedb9411ea/ardupilot/equipment/power/20011.BatteryPeriodic.uavcan#L6)
 and the [BATTERY_INFO MAVLink message](https://github.com/mavlink/mavlink/blame/067abb83cd2755f0e49491032d63438c64fd0aed/message_definitions/v1.0/common.xml#L7749) have settled on a `char[32]`. I asked in a thread about this here: https://github.com/mavlink/mavlink/pull/2070#discussion_r1819560607
2. The serial number of a battery doesn't change so it should not be logged at high rate. This gets more important with a `char[32]` type because of the wasted space. We need a low rate battery info message for all such static information.

### Solution
2. Add a battery info uORB message and have the `id` field match the value of `battery_status.id` to correctly keep track across topic instances.
1. Have a `char[32]` `battery_info.serial_number` field for the unique battery identifier and adjust the upstream drivers to use it.

Other static fields I plan to sort out and move to the `battery_info` message separately from this pull request.

### Changelog Entry
```
Introduce battery_info uORB message for static data like the serial number
```

### Test coverage
I tested an older version of this change, will do a hardware test to double-check the latest version on UAVCAN now.

### Context
Screenshots coming ⏳ 
