### PR TITLE
[Docs] Airframe param reset on update

### DIFF
--- a/docs/en/dev_airframes/adding_a_new_frame.md
+++ b/docs/en/dev_airframes/adding_a_new_frame.md
@@ -26,7 +26,7 @@ The recommended process for developing a new frame configuration is:
 1. Configure the [geometry and actuator outputs](../config/actuators.md).
 1. Perform other [basic configuration](../config/index.md).
 1. Tune the vehicle.
-1. Run the [`param show-for-airframe`](../modules/modules_command.md#param) console command to list the parameter difference compared to the original generic airfame.
+1. Run the [`param show-for-airframe`](../modules/modules_command.md#param) console command to list the parameter difference compared to the original generic airframe.
 
 Once you have the parameters you can create a new frame configuration file by copying the configuration file for the generic configuration, and appending the new parameters.
 
@@ -64,6 +64,23 @@ These aspects are mostly independent, which means that many configurations share
 ::: info
 New frame configuration files are only automatically added to the build system after a clean build (run `make clean`).
 :::
+
+## Force Reset of Airframe Parameters on Update
+
+Sometimes airframe or PX4 changes are such that "system parameters" need to be reset when the airframe configuration is first loaded.
+
+This can be done by setting the value of `PARAM_DEFAULTS_VER` in your airframe configuration to a number greater than the default version number set in [ROMFS/px4fmu_common/init.d/rcS](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d/rcS#L40) (currently `1`).
+
+For example, at time of writing you would add the current line to your airframe file:
+
+```sh
+set PARAM_DEFAULTS_VER 2
+```
+
+This number is compared to the value in the (internal) [SYS_PARAM_VER](../advanced_config/parameter_reference.html#SYS_PARAM_VER) parameter when the airframe is updated, and if it is different the "system parameters" are all reset.
+
+Note that system parameters primarily include those related to the vehicle airframe configuration.
+Parameters such as accumulating flight hours, RC and sensor calibrations, are preserved.
 
 ### Example - Generic Quadcopter Frame Config
 

--- a/docs/en/dev_airframes/adding_a_new_frame.md
+++ b/docs/en/dev_airframes/adding_a_new_frame.md
@@ -77,7 +77,7 @@ For example, at time of writing you would add the current line to your airframe 
 set PARAM_DEFAULTS_VER 2
 ```
 
-This number is compared to the value in the (internal) [SYS_PARAM_VER](../advanced_config/parameter_reference.html#SYS_PARAM_VER) parameter when the airframe is updated, and if it is different the "system parameters" are all reset.
+This number is compared to the value in the (internal) [SYS_PARAM_VER](../advanced_config/parameter_reference.md#SYS_PARAM_VER) parameter when the airframe is updated, and if it is different the "system parameters" are all reset.
 
 Note that system parameters primarily include those related to the vehicle airframe configuration.
 Parameters such as accumulating flight hours, RC and sensor calibrations, are preserved.

--- a/docs/en/dev_airframes/adding_a_new_frame.md
+++ b/docs/en/dev_airframes/adding_a_new_frame.md
@@ -39,7 +39,7 @@ To add a frame configuration to firmware:
 1. Create a new config file in the [init.d/airframes](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d/airframes) folder.
    - Give it a short descriptive filename and prepend the filename with an unused autostart ID (for example, `1033092_superfast_vtol`).
    - Update the file with configuration parameters and apps (see section above).
-1. Add the name of the new frame config file to the [CMakeLists.txt](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt) in the relevant section for the type of vehicle
+1. Add the name of the new frame config file to the [CMakeLists.txt](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt) in the relevant section for the type of vehicle.
 1. [Build and upload](../dev_setup/building_px4.md) the software.
 
 ## How to add a Configuration to an SD Card
@@ -67,7 +67,9 @@ New frame configuration files are only automatically added to the build system a
 
 ## Force Reset of Airframe Parameters on Update
 
-To force a reset to the airframe defaults for all users of a specific airframe during update, increase the `PARAM_DEFAULTS_VER` variable in the airframe configuration. It starts at 1 in [rcS](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d/rcS#L40). Add `set PARAM_DEFAULTS_VER 2` in your airframe file, increasing the value with each future reset needed.
+To force a reset to the airframe defaults for all users of a specific airframe during update, increase the `PARAM_DEFAULTS_VER` variable in the airframe configuration.
+It starts at `1` in [rcS](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d/rcS#L40).
+Add `set PARAM_DEFAULTS_VER 2` in your airframe file, increasing the value with each future reset needed.
 
 This value is compared to [SYS_PARAM_VER](https://github.com/PX4/PX4-Autopilot/pull/advanced_config/parameter_reference.md#SYS_PARAM_VER) during PX4 updates.
 If different, user-customized parameters are reset to defaults.

--- a/docs/en/dev_airframes/adding_a_new_frame.md
+++ b/docs/en/dev_airframes/adding_a_new_frame.md
@@ -67,17 +67,11 @@ New frame configuration files are only automatically added to the build system a
 
 ## Force Reset of Airframe Parameters on Update
 
-Sometimes airframe or PX4 changes are such that "system parameters" need to be reset when the airframe configuration is first loaded.
+```suggestion
+To force a reset to the airframe defaults for all users of a specific airframe during update, increase the `PARAM_DEFAULTS_VER` variable in the airframe configuration. It starts at 1 in [rcS](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d/rcS#L40). Add `set PARAM_DEFAULTS_VER 2` in your airframe file, increasing the value with each future reset needed.
 
-This can be done by setting the value of `PARAM_DEFAULTS_VER` in your airframe configuration to a number greater than the default version number set in [ROMFS/px4fmu_common/init.d/rcS](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d/rcS#L40) (currently `1`).
-
-For example, at time of writing you would add the current line to your airframe file:
-
-```sh
-set PARAM_DEFAULTS_VER 2
-```
-
-This number is compared to the value in the (internal) [SYS_PARAM_VER](../advanced_config/parameter_reference.md#SYS_PARAM_VER) parameter when the airframe is updated, and if it is different the "system parameters" are all reset.
+This value is compared to [SYS_PARAM_VER](https://github.com/PX4/PX4-Autopilot/pull/advanced_config/parameter_reference.md#SYS_PARAM_VER) during PX4 updates.
+If different, user-customized parameters are reset to defaults.
 
 Note that system parameters primarily include those related to the vehicle airframe configuration.
 Parameters such as accumulating flight hours, RC and sensor calibrations, are preserved.

--- a/docs/en/dev_airframes/adding_a_new_frame.md
+++ b/docs/en/dev_airframes/adding_a_new_frame.md
@@ -67,7 +67,6 @@ New frame configuration files are only automatically added to the build system a
 
 ## Force Reset of Airframe Parameters on Update
 
-```suggestion
 To force a reset to the airframe defaults for all users of a specific airframe during update, increase the `PARAM_DEFAULTS_VER` variable in the airframe configuration. It starts at 1 in [rcS](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d/rcS#L40). Add `set PARAM_DEFAULTS_VER 2` in your airframe file, increasing the value with each future reset needed.
 
 This value is compared to [SYS_PARAM_VER](https://github.com/PX4/PX4-Autopilot/pull/advanced_config/parameter_reference.md#SYS_PARAM_VER) during PX4 updates.


### PR DESCRIPTION
THe PR #22813 added support for forcing parameter reset when an airframe is updated.
This attempts to capture the information.

