### PR TITLE
Lower default multicopter roll and pitch attitude gains

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -50,7 +50,7 @@
  * @increment 0.1
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_ROLL_P, 6.5f);
+PARAM_DEFINE_FLOAT(MC_ROLL_P, 4.0f);
 
 /**
  * Pitch P gain
@@ -63,7 +63,7 @@ PARAM_DEFINE_FLOAT(MC_ROLL_P, 6.5f);
  * @increment 0.1
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_PITCH_P, 6.5f);
+PARAM_DEFINE_FLOAT(MC_PITCH_P, 4.0f);
 
 /**
  * Yaw P gain


### PR DESCRIPTION
### Solved Problem
In larger vehicles, higher inertia typically requires lower attitude gains. The current defaults work well for smaller platforms but often cause issues on larger ones, so it's worth adjusting them to a compromise which should not impact smaller vehicles to much but be a better starting point for larger ones.

### Solution
The first gain I would find in PX4 was 6, see https://github.com/PX4/PX4-Autopilot/commit/282e0bb6703e6f013eee690bda97e09045837fd3
it was only once changed to 6.5 here https://github.com/PX4/PX4-Autopilot/commit/62b102d0b49f5cf47f5623761aed4db2a390ceaf
now after many changes to the control structure and many new use cases I suggest lowering the default gain to 4.
4 is a compromise between the lowest I ever had to set it on a big misbehaving vehicle with a lot of inertia 2.8, the well-behaving 850mm size tuning we use 3.2 and the normal gains for smaller vehicles. I'd suggest discussing values in the range 3.2 and 4.5 for the default.

### Changelog Entry
```
Lower default multicopter roll and pitch attitude gains
```

### Test coverage
I can pull up a list of vehicle sizes vs. gains we settled on to add some data.