### PR TITLE
[uavcan] Fix safety state not getting published

### DIFF
--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -546,7 +546,7 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 
 #endif
 
-#if defined(CONFIG_UAVCAN_SAFETY_CONTROLLER)
+#if defined(CONFIG_UAVCAN_SAFETY_STATE_CONTROLLER)
 	ret = _safety_state_controller.init();
 
 	if (ret < 0) {


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

Connected a AP_Periph Cannode and couldn't enable the Servo output. Turns out the output is [guarded by the SafetyState message](https://github.com/ArduPilot/ardupilot/blob/9eed018bd77efc34cc48bb6c320170174ab88223/Tools/AP_Periph/rc_out.cpp#L139), which we didn't send.

### Solution

Fix the macro name 🙈.

### Changelog Entry
For release notes:
```
Bugfix Fix UAVCAN SafetyState not getting published
```

### Alternatives

I've also checked that the other macros are all correct. Yes they are.

```
$ rg "CONFIG_(UAVCAN_[^ \)]+)" -or \$1 -I | sort | uniq
UAVCAN_ARMING_CONTROLLER
UAVCAN_BEEP_CONTROLLER
UAVCAN_HARDPOINT_CONTROLLER
UAVCAN_OUTPUTS_CONTROLLER
UAVCAN_REMOTEID_CONTROLLER
UAVCAN_RGB_CONTROLLER
UAVCAN_SAFETY_STATE_CONTROLLER
UAVCAN_SENSOR_ACCEL
UAVCAN_SENSOR_AIRSPEED
UAVCAN_SENSOR_BARO
UAVCAN_SENSOR_BATTERY
UAVCAN_SENSOR_DIFFERENTIAL_PRESSURE
UAVCAN_SENSOR_FLOW
UAVCAN_SENSOR_FUEL_TANK_STATUS
UAVCAN_SENSOR_GNSS
UAVCAN_SENSOR_GNSS_RELATIVE
UAVCAN_SENSOR_HYGROMETER
UAVCAN_SENSOR_ICE_STATUS
UAVCAN_SENSOR_MAG
UAVCAN_SENSOR_RANGEFINDER
UAVCAN_SENSOR_SAFETY_BUTTON

$ rg "(UAVCAN_[^ \)]+)" -or \$1 -I Kconfig | sort | uniq
UAVCAN_ARMING_CONTROLLER
UAVCAN_BEEP_CONTROLLER
UAVCAN_HARDPOINT_CONTROLLER
UAVCAN_INTERFACES
UAVCAN_OUTPUTS_CONTROLLER
UAVCAN_PERIPHERALS
UAVCAN_REMOTEID_CONTROLLER
UAVCAN_RGB_CONTROLLER
UAVCAN_SAFETY_STATE_CONTROLLER
UAVCAN_SENSOR_ACCEL
UAVCAN_SENSOR_AIRSPEED
UAVCAN_SENSOR_BARO
UAVCAN_SENSOR_BATTERY
UAVCAN_SENSOR_DIFFERENTIAL_PRESSURE
UAVCAN_SENSOR_FLOW
UAVCAN_SENSOR_FUEL_TANK_STATUS
UAVCAN_SENSOR_GNSS
UAVCAN_SENSOR_GNSS_RELATIVE
UAVCAN_SENSOR_HYGROMETER
UAVCAN_SENSOR_ICE_STATUS
UAVCAN_SENSOR_MAG
UAVCAN_SENSOR_RANGEFINDER
UAVCAN_SENSOR_SAFETY_BUTTON
UAVCAN_TIMER_OVERRIDE
```

### Test coverage

Tested in hardware on a Skynode S connected to a Mateksys CanNode L431-PWM


