### PR TITLE
uORB docs parser

### DIFF
--- a/Tools/msg/generate_msg_docs.py
+++ b/Tools/msg/generate_msg_docs.py
@@ -240,8 +240,8 @@ class UORBMessage:
 
         # Generate field docs
         markdown += f"## Fields\n\n"
-        markdown += "Name (type) | Unit [Frame] | Values | Description\n"
-        markdown += "--- | --- | --- | ---\n"
+        markdown += "Name | Type | Unit [Frame] | Range/Enum | Description\n"
+        markdown += "--- | --- | --- | --- | ---\n"
         for field in self.fields:
             unit = f"{field.unit}" if field.unit else ""
             frame = f"[{field.frameValue}]" if field.frameValue else ""
@@ -256,16 +256,12 @@ class UORBMessage:
                     value += f"[{enum}](#{enum})"
                 value = value.strip()
                 value = f"{value}"
-            elif field.minValue and field.maxValue:
-                value = f"range: {field.minValue} to {field.maxValue}"
-            elif field.minValue:
-                value = f"min: {field.minValue}"
-            elif field.maxValue:
-                value = f"max: {field.maxValue}"
+            elif field.minValue or field.maxValue:
+                value = f"[{field.minValue if field.minValue else '-'} : {field.maxValue if field.maxValue else '-' }]"
 
             description = f" {field.description}" if field.description else ""
             invalid = f" (Invalid: {field.invalidValue}) " if field.invalidValue else ""
-            markdown += f"{field.name} (`{field.type}`) |{unit}|{value}|{description}{invalid}\n"
+            markdown += f"{field.name} | `{field.type}` |{unit}|{value}|{description}{invalid}\n"
 
         # Generate enum docs
         if len(self.enums) > 0:
@@ -274,21 +270,21 @@ class UORBMessage:
             for name, enum in self.enums.items():
                 markdown += f"\n### {name} {{#{name}}}\n\n"
 
-                markdown += "Name (type) | Value | Description\n"
-                markdown += "--- | --- | ---\n"
+                markdown += "Name | Type | Value | Description\n"
+                markdown += "--- | --- | --- | ---\n"
 
                 for enumValueName, enumValue in enum.enumValues.items():
                     description = f" {enumValue.comment} " if enumValue.comment else " "
-                    markdown += f'<a href="#{enumValueName}">{enumValueName}</a> (`{enumValue.type}`) | {enumValue.value} |{description}\n'
+                    markdown += f'<a href="#{enumValueName}"></a> {enumValueName} | `{enumValue.type}` | {enumValue.value} |{description}\n'
 
         # Generate table for constants docs
         if len(self.enumValues) > 0:
             markdown += f"\n## Constants\n\n"
-            markdown += "Name (type) | Value | Description\n"
-            markdown += "--- | --- | ---\n"
+            markdown += "Name | Type | Value | Description\n"
+            markdown += "--- | --- | --- |---\n"
             for name, enum in self.enumValues.items():
                 description = f" {enum.comment} " if enum.comment else " "
-                markdown += f'<a href="#{name}">{name}</a> (`{enum.type}`) | {enum.value} |{description}\n'
+                markdown += f'<a href="#{name}"></a> {name} | `{enum.type}` | {enum.value} |{description}\n'
 
         # Append msg contents to the end
         with open(self.msg_filename, 'r') as source_file:

--- a/Tools/msg/generate_msg_docs.py
+++ b/Tools/msg/generate_msg_docs.py
@@ -116,6 +116,11 @@ class ConstantValue:
 
 
 class CommandParam:
+    """
+    Represents an individual param in a command constant
+    Encapsulates parsing of the param to extract units etc.
+    """
+
     def __init__(self, num, paramText, line_number, parentCommand):
         self.paramNum = num
         self.paramText = paramText.strip()
@@ -221,6 +226,11 @@ class CommandParam:
 
         
 class CommandConstant:
+    """
+    Represents a constant that is a command definition.
+    Encapsulates parsing of the command format.
+    The individual params are further parsed in CommandParam
+    """
     def __init__(self, name, type, value, comment, line_number, parentMessage):
         self.name = name.strip()
         self.type = type.strip()
@@ -323,6 +333,10 @@ Param | Units | Range/Enum | Description
         print(f"   description: {self.description}\n  param1: {self.param1}\n  param2: {self.param2}\n  param3: {self.param3}\n  param4: {self.param4}\n  param5: {self.param5}\n  param6: {self.param6}\n  param7: {self.param7}")
 
 class MessageField:
+    """
+    Represents a field.
+    Encapsulates parsing of the field information.
+    """
     def __init__(self, name, type, comment, line_number, parentMessage):
         self.name = name
         self.type = type
@@ -406,6 +420,12 @@ class MessageField:
 
 
 class UORBMessage:
+    """
+    Represents a whole message, including fields, enums, commands, constants.
+    The parser function delegates the parsing of each part of the message to 
+    more appropriate classes, once the specific type of line has been identified.
+    """
+
     def __init__(self, filename):
 
         self.filename = filename
@@ -683,7 +703,7 @@ pageClass: is-wide-page
                     if isEmptyLine:
                         continue # empty line
                     if stripped_line.startswith("# TOPICS "):
-                        stripped_line =  stripped_line[9:]
+                        stripped_line = stripped_line[9:]
                         stripped_line = stripped_line.split(" ")
                         self.topics+= stripped_line
                         # Note, default topic and topic errors handled after all lines parsed
@@ -718,7 +738,6 @@ pageClass: is-wide-page
                 return re.sub('([A-Z]+)([A-Z][a-z]*)', r'\1_\2', s1).lower()
 
             defaultTopic = camel_to_snake(self.name)
-            #print(f"debug: defaultTopic: {defaultTopic}")
             if len(self.topics) == 0:
                 # We have no topic declared, so set the default topic
                 self.topics.append(defaultTopic)
@@ -769,9 +788,7 @@ pageClass: is-wide-page
             constantValuesToRemove = []
             #print(f"DEBUG: Self.enums: {self.enums}")
             for enumName, enumObject in self.enums.items():
-                #print(f"enum enumName key: {enumName}")
                 for enumValueName, enumValueObject in self.constantFields.items():
-                    #print(f"DEBUG: enumValueName key: {enumValueName}")
                     if enumValueName.startswith(enumName):
                         # Copy this value into the object (cant be duplicate because parent is dict)
                         enumObject.enumValues[enumValueName]=enumValueObject
@@ -791,7 +808,6 @@ pageClass: is-wide-page
                             self.errors["constant_not_in_assigned_enum"] = []
                         self.errors["constant_not_in_assigned_enum"].append(error)
                 # TODO Maybe present as list of possible enums.
-
 
 
 import yaml

--- a/Tools/msg/generate_msg_docs.py
+++ b/Tools/msg/generate_msg_docs.py
@@ -207,15 +207,12 @@ class CommandParam:
                         self.units.append(unit) 
 
                     if unit not in ALLOWED_UNITS:
-                        print(f"TODO: Command.param doesn't report errors in units: {unit}")
-                        """
                         invalid_units.add(unit)
-                        error = Error("unknown_unit", self.parent.filename, self.lineNumber, unit, self.name)
+                        error = Error("unknown_unit", self.parentMessage.filename, self.lineNumber, unit, self.parent.name)
                         #error.display_error()
-                        if not "unknown_unit" in self.parent.errors:
-                            self.parent.errors["unknown_unit"] = []
-                        self.parent.errors["unknown_unit"].append(error)
-                        """
+                        if not "unknown_unit" in self.parentMessage.errors:
+                            self.parentMessage.errors["unknown_unit"] = []
+                        self.parentMessage.errors["unknown_unit"].append(error)
 
 
     def display_info(self):

--- a/Tools/msg/generate_msg_docs.py
+++ b/Tools/msg/generate_msg_docs.py
@@ -229,8 +229,14 @@ class UORBMessage:
     def markdown_out(self):
         #print(f"Debug: UORBMessage: markdown_out()")
 
-        markdown = f"# {self.name} (UORB message)\n\n"
+        # Add page header (forces wide pages)
+        markdown = f"""---
+pageClass: is-wide-page
+---
 
+# {self.name} (UORB message)
+
+"""
         ## Append description info if present
         markdown += f"{self.shortDescription}\n\n" if self.shortDescription else ""
         markdown += f"{self.longDescription}\n\n" if self.longDescription else ""
@@ -733,7 +739,7 @@ Graphs showing how these are used [can be found here](../middleware/uorb_graph.m
 {unversioned_msgs_list}
     """
     index_file = os.path.join(output_dir, 'index.md')
-    with open(index_file, 'w') as content_file:
+    with open(index_file, 'w', encoding='utf-8') as content_file:
             content_file.write(index_text)
 
     generate_dds_yaml_doc(msg_files)

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -160,3 +160,44 @@
  .vp-doc img {
   display: inline; /* block by default set by vitepress */
 }
+
+
+/**
+ * Custom styles for wide pages
+ * -------------------------------------------------------------------------- */
+
+.is-wide-page .content-container {
+  max-width: 100% !important;
+}
+@media (min-width: 1280px) {
+  .is-wide-page .content {
+    min-width: 940px !important;
+  }
+}
+
+/* Make page width larger  */
+@media (min-width: 1440px) {
+  .is-wide-page .VPSidebar {
+    padding-left: 32px !important;
+    width: var(--vp-sidebar-width) !important;
+  }
+  .is-wide-page .VPContent.has-sidebar {
+    padding-left: var(--vp-sidebar-width) !important;
+    padding-right: 0 !important;
+  }
+
+  .is-wide-page .VPNavBar.has-sidebar .title {
+    padding-left: 32px !important;
+  }
+
+  .is-wide-page .VPNavBar.has-sidebar .content {
+    padding-left: var(--vp-sidebar-width) !important;
+    padding-right: 32px !important;
+  }
+
+  /* Very hacky */
+  .is-wide-page .VPNavBar.has-sidebar #local-search {
+    z-index: 10;
+  }
+
+}


### PR DESCRIPTION
Now that we have a docs standard for UORB messages, it makes sense to generate better docs from them.

This parser splits out the fields, constants etc and generates docs that look like this: https://github.com/PX4/PX4-Autopilot/pull/24977#issuecomment-2943264626

It is relatively easy to run and test. In ubuntu from the root do the following to generate all the docs into a folder `msg_output2`:

```sh
python3 Tools/msg/generate_msg_docs.py -d msg_output2
```

If you are interested in getting logs you can append `-e -m ActuatorMotors Wind` to generate output that shows any problems with particular files - in this case `Wind` or `ActuatorMotors`. If you have `e` but omit `m` you get a log of all errors.
The logs show stuff like "multiple sequential spaces".
_Note though, nothing is an error. It will generate the docs it can from the data it has, and that is FINE._

You could then copy all the files form `msg_output2` into /docs/en/msg_docs/ to preview. 

Where are we at:
- Generation looks good EXCEPT for VehicleCommand. More work needed. My view is that even without VehicleCommand, this is pretty good. 
- Reporting probably could use more work - I'll have to go through the standard and check I have everything. BUT it is pretty good.



It will be tough to review because the code is non-trivial. 
Essentially it is a line parser 
- first detects the top comments section, if present, and finds the short and long descripton. Then goes to new state for parsing fields, constants, topics, internal comments.
- Splits up fields/constants and saves values to objects it can later render
- Also adds errors to an error variable by type. This is output if you specify `e` flag, and can be filtered by message using the `m` flag and a space separated name list.