### PR TITLE
Lower default angular acceleration filter cutoff from 30Hz to 20Hz

### DIFF
--- a/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c
+++ b/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c
@@ -169,7 +169,7 @@ PARAM_DEFINE_INT32(IMU_GYRO_RATEMAX, 400);
 * @reboot_required false
 * @group Sensors
 */
-PARAM_DEFINE_FLOAT(IMU_DGYRO_CUTOFF, 30.0f);
+PARAM_DEFINE_FLOAT(IMU_DGYRO_CUTOFF, 20.0f);
 
 /**
 * IMU gyro dynamic notch filtering


### PR DESCRIPTION
### Solved Problem
Similar to https://github.com/PX4/PX4-Autopilot/pull/24968 we learned that on many lerger vehicles we had to slightly lower the angular acceleration cutoff which is the first order low pass filter applied to the state used for the derivative term of the PID rate controllers. It's there to avoid noise getting into the derivative term of the PID rate control loop on integration flights.

### Solution
I suggest to lower from 30Hz to 20Hz. In huge vehicles that have severe low frequency vibrations we had to go as low as 10Hz, for small vehicles where vibrations are either very low or at a much higher frequency it can sometimes be increased to 60 or even 90Hz and allow for quicker attenuation.

### Changelog Entry
```
Lower default angular acceleration filter cutoff from 30Hz to 20Hz
```

### Test coverage
This setting is flown daily on many e.g. 850mm diagonal sized multicopters.