### PR TITLE
msp_osd: Add VTX config, stick commands and arming status

### DIFF
--- a/src/drivers/osd/msp_osd/MspV1.cpp
+++ b/src/drivers/osd/msp_osd/MspV1.cpp
@@ -39,6 +39,7 @@
 #include <float.h>
 #include <string.h>
 #include <math.h>
+#include <stdio.h>
 
 #include <drivers/drv_pwm_output.h>
 #include <drivers/drv_hrt.h>
@@ -62,7 +63,7 @@ struct msp_message_descriptor_t {
 	uint8_t message_size;
 };
 
-#define MSP_DESCRIPTOR_COUNT 11
+#define MSP_DESCRIPTOR_COUNT 12
 const msp_message_descriptor_t msp_message_descriptors[MSP_DESCRIPTOR_COUNT] = {
 	{MSP_OSD_CONFIG, true, sizeof(msp_osd_config_t)},
 	{MSP_NAME, true, sizeof(msp_name_t)},
@@ -75,10 +76,9 @@ const msp_message_descriptor_t msp_message_descriptors[MSP_DESCRIPTOR_COUNT] = {
 	{MSP_COMP_GPS, true, sizeof(msp_comp_gps_t)},
 	{MSP_ESC_SENSOR_DATA, true, sizeof(msp_esc_sensor_data_dji_t)},
 	{MSP_MOTOR_TELEMETRY, true, sizeof(msp_motor_telemetry_t)},
+	{MSP_RC, true, sizeof(msp_rc_t)},
 };
 
-#define MSP_FRAME_START_SIZE 5
-#define MSP_CRC_SIZE 1
 bool MspV1::Send(const uint8_t message_id, const void *payload)
 {
 	uint32_t payload_size = 0;
@@ -148,4 +148,77 @@ bool MspV1::Send(const uint8_t message_id, const void *payload, uint32_t payload
 
 	int packet_size =  MSP_FRAME_START_SIZE + payload_size + MSP_CRC_SIZE;
 	return  write(_fd, packet, packet_size) == packet_size;
+}
+
+
+int MspV1::Receive(uint8_t *payload, uint8_t *message_id)
+{
+	uint8_t payload_size;
+	uint8_t crc;
+	uint8_t calc_crc;
+	int ret;
+
+	while (!has_header) {
+		int bytes_available = 0;
+
+		if (ioctl(_fd, FIONREAD, &bytes_available) < 0) {
+			return -EIO;
+		}
+
+		if (bytes_available < 5) {
+			return -EWOULDBLOCK;
+		}
+
+		while (bytes_available > 4) {
+			if ((ret = read(_fd, header, 1)) != 1) {
+				return ret;
+			}
+
+			bytes_available--;
+
+			if (header[0] == '$') {
+				break;
+			}
+
+		}
+
+		if (header[0] != '$') {
+			return -EWOULDBLOCK;
+		}
+
+		if ((ret = read(_fd, &header[1], 4)) != 4) {
+			return ret;
+		}
+
+		if (header[0] == '$' && header[1] == 'M' && header[2] == '<') {
+			has_header = true;
+		}
+	}
+
+	payload_size = header[3];
+	*message_id = header[4];
+
+	if ((ret = read(_fd, payload, payload_size + MSP_CRC_SIZE)) != payload_size + MSP_CRC_SIZE) {
+		if (ret != -EWOULDBLOCK) {
+			has_header = false;
+		}
+
+		return ret;
+	}
+
+	has_header = false;
+
+	crc = payload[payload_size];
+
+	calc_crc = payload_size ^ header[4];
+
+	for (int i = 0; i < payload_size; i++) {
+		calc_crc ^= payload[i];
+	}
+
+	if (calc_crc != crc) {
+		return -EINVAL;
+	}
+
+	return payload_size;
 }

--- a/src/drivers/osd/msp_osd/MspV1.hpp
+++ b/src/drivers/osd/msp_osd/MspV1.hpp
@@ -33,6 +33,9 @@
 
 #pragma once
 
+#define MSP_FRAME_START_SIZE 5
+#define MSP_CRC_SIZE 1
+
 class MspV1
 {
 public:
@@ -40,7 +43,10 @@ public:
 	int GetMessageSize(int message_type);
 	bool Send(const uint8_t message_id, const void *payload);
 	bool Send(const uint8_t message_id, const void *payload, uint32_t payload_size);
+	int Receive(uint8_t *payload, uint8_t *message_id);
 
 private:
 	int _fd{-1};
+	uint8_t header[MSP_FRAME_START_SIZE + MSP_CRC_SIZE];
+	bool has_header{false};
 };

--- a/src/drivers/osd/msp_osd/module.yaml
+++ b/src/drivers/osd/msp_osd/module.yaml
@@ -97,3 +97,14 @@ parameters:
             min: 100
             max: 10000
             default: 500
+
+        # RC Stick input
+        OSD_RC_STICK:
+            description:
+                short: OSD RC Stick commands
+                long: |
+                    Forward RC stick input to VTX when disarmed
+            type: int32
+            min: 0
+            max: 1
+            default: 1

--- a/src/drivers/osd/msp_osd/msp_defines.h
+++ b/src/drivers/osd/msp_osd/msp_defines.h
@@ -48,6 +48,8 @@
 #define MSP_ARMING_CONFIG         61
 #define MSP_RX_MAP                64 // get channel map (also returns number of channels total)
 #define MSP_LOOP_TIME             73 // FC cycle time i.e looptime parameter
+#define MSP_GET_VTX_CONFIG        88
+#define MSP_SET_VTX_CONFIG        89
 #define MSP_STATUS               101
 #define MSP_RAW_IMU              102
 #define MSP_SERVO                103
@@ -75,10 +77,12 @@
 #define MSP_SET_PID              202 // set P I D coeff
 
 // commands
-#define MSP_SET_HEAD             211 // define a new heading hold direction
-#define MSP_SET_RAW_RC           200 // 8 rc chan
-#define MSP_SET_RAW_GPS          201 // fix, numsat, lat, lon, alt, speed
-#define MSP_SET_WP               209 // sets a given WP (WP#, lat, lon, alt, flags)
+#define MSP_SET_HEAD                211 // define a new heading hold direction
+#define MSP_SET_RAW_RC              200 // 8 rc chan
+#define MSP_SET_RAW_GPS             201 // fix, numsat, lat, lon, alt, speed
+#define MSP_SET_WP                  209 // sets a given WP (WP#, lat, lon, alt, flags)
+#define MSP_SET_VTXTABLE_BAND       227
+#define MSP_SET_VTXTABLE_POWERLEVEL 228
 
 // bits of getActiveModes() return value
 #define MSP_MODE_ARM          0
@@ -894,6 +898,58 @@ struct msp_status_BF_t {
 	uint32_t arming_disable_flags;
 	uint8_t  extra_flags;
 } __attribute__((packed));
+
+struct msp_set_vtx_config_t {
+	uint16_t new_freq; //  if setting frequency then full uint16 is the frequency in MHz (ie. 5800)
+	//if setting band channel than band is high 8 bits and channel is low 8 bits
+	uint8_t power_level;
+	uint8_t pit_mode; // 0 = off, 1 = on
+	uint8_t low_power_disarm;
+	uint16_t pit_freq;
+	uint8_t user_band;
+	uint8_t user_channel;
+	uint16_t user_freq; // in MHz, 0 if using band & channel
+	uint8_t band_count;
+	uint8_t channel_count;
+	uint8_t power_count;
+	uint8_t clear_vtxtable; // Bool
+} __attribute__((packed));
+
+struct msp_get_vtx_config_t {
+	uint8_t vtx_type;
+	uint8_t band;
+	uint8_t channel;
+	uint8_t power_index;
+	uint8_t pit_mode; // 0 = off, 1 = on
+	uint16_t freq; // in MHz, 0 if using band & channel
+	uint8_t device_ready;
+	uint8_t low_power_disarm;
+} __attribute__((packed));
+
+struct msp_set_vtxtable_powerlevel_t {
+	uint8_t index;
+	uint16_t power_value;
+	uint8_t power_label_length;
+	uint8_t power_label_name[3];
+} __attribute__((packed));
+
+#define VTX_TABLE_BAND_NAME_LENGTH 8
+#define VTXDEV_MSP 5
+
+//29 bytes
+
+struct msp_set_vtxtable_band_t {
+	uint8_t band;
+	uint8_t band_name_length;
+	uint8_t band_label_name[VTX_TABLE_BAND_NAME_LENGTH];
+	uint8_t band_letter;
+	uint8_t is_factory_band;
+	uint8_t channel_count;
+	uint16_t frequency[8];
+} __attribute__((packed));
+
+
+
 
 ////ArduPlane
 enum arduPlaneModes_e {

--- a/src/drivers/osd/msp_osd/msp_osd.hpp
+++ b/src/drivers/osd/msp_osd/msp_osd.hpp
@@ -64,6 +64,9 @@ using namespace time_literals;
 // location to "hide" unused display elements
 #define LOCATION_HIDDEN 234;
 
+#define POWER_LEVEL_COUNT 5
+#define BAND_COUNT 7
+
 struct PerformanceData {
 	bool initialization_problems{false};
 	long unsigned int successful_sends{0};
@@ -118,12 +121,17 @@ public:
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
+	int set_channel(char *new_channel);
+
 private:
 	void Run() override;
 
 	// update a single display element in the display
 	void Send(const unsigned int message_type, const void *payload);
 	void Send(const unsigned int message_type, const void *payload, int32_t payload_size);
+
+	// receive vtx data
+	void Receive();
 
 	// send full configuration to MSP (triggers the actual update)
 	void SendConfig();
@@ -166,10 +174,19 @@ private:
 		(ParamInt<px4::params::OSD_CH_HEIGHT>) _param_osd_ch_height,
 		(ParamInt<px4::params::OSD_SCROLL_RATE>) _param_osd_scroll_rate,
 		(ParamInt<px4::params::OSD_DWELL_TIME>) _param_osd_dwell_time,
-		(ParamInt<px4::params::OSD_LOG_LEVEL>) _param_osd_log_level
+		(ParamInt<px4::params::OSD_LOG_LEVEL>) _param_osd_log_level,
+		(ParamInt<px4::params::OSD_RC_STICK>) _param_osd_rc_stick
 	)
 
 	// metadata
 	char _device[64] {};
 	PerformanceData _performance_data{};
+
+	msp_set_vtx_config_t vtx_config;
+	msp_set_vtxtable_powerlevel_t power_levels[POWER_LEVEL_COUNT];
+	msp_set_vtxtable_band_t vtx_bands[BAND_COUNT] {};
+	bool has_vtx_config {false};
+	bool has_power_config {false};
+	bool has_vtx_bands {false};
+	bool change_channel {false};
 };

--- a/src/drivers/osd/msp_osd/uorb_to_msp.cpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.cpp
@@ -214,14 +214,8 @@ msp_rendor_rssi_t construct_rendor_RSSI(const input_rc_s &input_rc)
 	rssi.screenYPosition = 0x02;
 	rssi.screenXPosition = 0x02;
 
-	int len = snprintf(&rssi.str[0], sizeof(rssi.str) - 1, "%d", input_rc.link_quality);
-
-	if (len >= 3) {
-		rssi.str[3] = '%';
-
-	} else {
-		rssi.str[len] = '%';
-	}
+	snprintf(&rssi.str[0], sizeof(rssi.str), "%3d", input_rc.link_quality);
+	rssi.str[3] = '%';
 
 	return rssi;
 }
@@ -568,5 +562,31 @@ msp_esc_sensor_data_dji_t construct_ESC_SENSOR_DATA()
 
 	return esc_sensor_data;
 }
+
+msp_rc_t construct_MSP_RC(const input_rc_s &input_rc)
+{
+	// initialize result
+	msp_rc_t rc;
+
+	rc.channelValue[0] = input_rc.values[0]; // roll
+	rc.channelValue[1] = input_rc.values[1]; // pitch
+	rc.channelValue[2] = input_rc.values[3]; // yaw
+	rc.channelValue[3] = input_rc.values[2]; // Throttle
+	return rc;
+}
+
+msp_status_t construct_MSP_STATUS(const vehicle_status_s &vehicle_status)
+{
+	// initialize result
+	msp_status_t status{0};
+
+	if (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
+		status.flightModeFlags |= (1 << MSP_MODE_ARM);
+	}
+
+	return status;
+}
+
+
 
 } // namespace msp_osd

--- a/src/drivers/osd/msp_osd/uorb_to_msp.hpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.hpp
@@ -126,4 +126,10 @@ msp_rendor_distanceToHome_t construct_rendor_distanceToHome(const home_position_
 // construct an MSP_ESC_SENSOR_DATA struct
 msp_esc_sensor_data_dji_t construct_ESC_SENSOR_DATA();
 
+// construct an MSP_RC struct
+msp_rc_t construct_MSP_RC(const input_rc_s &input_rc);
+
+// construct an MSP_STATUS struct
+msp_status_t construct_MSP_STATUS(const vehicle_status_s &vehicle_status);
+
 } // namespace msp_osd


### PR DESCRIPTION
I recently got my hands on HDZero VTX setup, to my surprise I wasn't able to change the configuration through PX4.
This PR solves that and some quality of life features:

 - Adds MSPv1 rx parsing to fetch VTX config
 - Allows to inspect and change VTX channel through CLI

```
nsh> msp_osd status
INFO  [msp_osd] Running on /dev/ttyS3
INFO  [msp_osd]         initialized: 1
INFO  [msp_osd]         initialization issues: 0
INFO  [msp_osd]         scroll rate: 125
INFO  [msp_osd]         successful sends: 13690
INFO  [msp_osd]         unsuccessful sends: 0
INFO  [msp_osd] Current message:
        HOL|DSRM|N
INFO  [msp_osd] === VTX Configuration ===
INFO  [msp_osd] Channel: R2
INFO  [msp_osd] Frequency: 5760 MHz
INFO  [msp_osd] Transmit power: 25  mW
INFO  [msp_osd] PIT Mode: Off
INFO  [msp_osd] Low Power Disarm: Off
INFO  [msp_osd] PIT Frequency: 0 MHz
```
```
msp_osd channel R2
```
 - Forward MSP_RC for stick commands osd
 - Forward MSP_STATUS for arming status for PIT and LP mode
 - Fix rendor_RSSI string formatting (sometimes you would get a corrupted character)

I also took quick a look at #24903 but this requires implementing MSPv2 format to parse and forward the CRSF MSPv2 payload.
https://github.com/crsf-wg/crsf/wiki/CRSF_FRAMETYPE_MSP_REQ
