### PR TITLE
Navigator: RTL reverse: when landing set next to invalid to fix horizontal oscillations

### DIFF
--- a/src/modules/navigator/rtl_mission_fast_reverse.cpp
+++ b/src/modules/navigator/rtl_mission_fast_reverse.cpp
@@ -251,6 +251,11 @@ void RtlMissionFastReverse::handleLanding(WorkItemType &new_work_item_type)
 			_mission_item.lon = _home_pos_sub.get().lon;
 			_mission_item.yaw = NAN;
 
+			// make previous and next setpoints invalid, such that there will be no line following.
+			// If the vehicle drifted off the path during back-transition it should just go straight to the landing point.
+			_navigator->reset_position_setpoint(pos_sp_triplet->previous);
+			_navigator->reset_position_setpoint(pos_sp_triplet->next);
+
 			if ((_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) &&
 			    do_need_move_to_item()) {
 				new_work_item_type = WorkItemType::WORK_ITEM_TYPE_MOVE_TO_LAND;
@@ -261,15 +266,9 @@ void RtlMissionFastReverse::handleLanding(WorkItemType &new_work_item_type)
 				_mission_item.autocontinue = true;
 				_mission_item.time_inside = 0.0f;
 
-				// make previous setpoint invalid, such that there will be no prev-current line following.
-				// if the vehicle drifted off the path during back-transition it should just go straight to the landing point
-				_navigator->reset_position_setpoint(pos_sp_triplet->previous);
-
 			} else {
 				_mission_item.altitude = _home_pos_sub.get().alt;
 				_mission_item.altitude_is_relative = false;
-				_navigator->reset_position_setpoint(pos_sp_triplet->previous);
-				_navigator->reset_position_setpoint(pos_sp_triplet->next);
 
 				_mission_item.land_precision = _param_rtl_pld_md.get();
 


### PR DESCRIPTION

### Solved Problem
Vehicle oscillates horizontally while in landing after a reverse RTL (RTL_TYPE=2 and no mission landing).
![image](https://github.com/user-attachments/assets/776871b1-d984-4c80-8a9f-8415a61c899a)
We were testing it without https://github.com/PX4/PX4-Autopilot/pull/24642, which would already have fixed this specific issue. Nevertheless, I think it's better to also set the next to invalid when in the `do_need_move_to_item()` phase.

### Solution
Extend what was done in https://github.com/PX4/PX4-Autopilot/pull/24642 by also reset next setpoint during the `do_need_move_to_item()` phase.

### Changelog Entry
For release notes:
```
Improvement: RTL reverse: reset next position triplet in `do_need_move_to_item()` phase
```

### Alternatives
The [position smoothing](https://github.com/PX4/PX4-Autopilot/blob/64989c3b8d062561523a71a68a999b446e50a91e/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp#L175) does something shady when the next waypoint is valid during a vertical decent for landing. Should be addressed as well later on.

### Test coverage
SITL tested.
