### PR TITLE
fix(gz_bridge): add gimbal kconfig guard

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -136,11 +136,15 @@ int GZBridge::init()
 		return PX4_ERROR;
 	}
 
+#if defined(CONFIG_MODULES_GIMBAL)
+
 	// Gimbal mixing interface
 	if (!_gimbal.init(_world_name, _model_name)) {
 		PX4_ERR("failed to init gimbal");
 		return PX4_ERROR;
 	}
+
+#endif // CONFIG_MODULES_GIMBAL
 
 	ScheduleNow();
 	return OK;


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
To save flash usage on board without gimbal disabled gimbal module by:
`CONFIG_MODULES_GIMBAL=n`
However the building process of firmware fails because of missing gimbal for gz: 
`"failed to init gimbal"` - GZBridge.cpp:140

### Solution
Make the use of gimbal depends on availability of gimbal.

### Changelog Entry
For release notes:
```
The use of gimbal should depends on its module availability.
```
