### PR TITLE
Remove usage of deprecated MISSION_REQUEST at initial flight plan message

### DIFF
--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -102,7 +102,7 @@ private:
 
 	uint8_t			_reached_sent_count{0};			///< last time when the vehicle reached a waypoint
 
-	bool			_int_mode{false};			///< Use accurate int32 instead of float
+	bool			_int_mode{true};			///< Use accurate int32 instead of float
 
 	unsigned		_filesystem_errcount{0};		///< File system error count
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Initial mission upload response with _MISSION_REQUEST_ which is deprecated according to docs: https://mavlink.io/en/services/mission.html#command_message_type.
It's happens only at first message after boot an autopilot. Second try response correctly with _MISSION_REQUEST_INT_. 

Used Wireshark to monitor message flow.

### Changelog Entry
For release notes:
```
Remove usage of deprecated MISSION_REQUEST as initial flight plan message.
```

### Context
```
MISSION_COUNT [255:190] {"target_system": "1", "target_component": "1", "count": "6", "mission_type": "MAV_MISSION_TYPE_FENCE (1)(MAV_MISSION_TYPE)", "opaque_id": "0"}
MISSION_REQUEST [1:1] {"target_system": "255", "target_component": "190", "seq": "0", "mission_type": 
```