### PR TITLE
dshot: remove DSHOT_BIDIR_EN and extend PWM_MAIN_TIMx

### DIFF
--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -117,17 +117,21 @@ void DShot::enable_dshot_outputs(const bool enabled)
 			param_get(handle, &tim_config);
 			unsigned int dshot_frequency_request = 0;
 
-			if (tim_config == -5) {
+			if (tim_config == -5 || tim_config == -8) {
 				dshot_frequency_request = DSHOT150;
 
-			} else if (tim_config == -4) {
+			} else if (tim_config == -4 || tim_config == -7) {
 				dshot_frequency_request = DSHOT300;
 
-			} else if (tim_config == -3) {
+			} else if (tim_config == -3 || tim_config == -6) {
 				dshot_frequency_request = DSHOT600;
 
 			} else {
 				_output_mask &= ~channels; // don't use for dshot
+			}
+
+			if (tim_config < -5) {
+				_bidirectional_dshot_enabled = true;
 			}
 
 			if (dshot_frequency_request != 0) {
@@ -141,8 +145,6 @@ void DShot::enable_dshot_outputs(const bool enabled)
 				}
 			}
 		}
-
-		_bidirectional_dshot_enabled = _param_bidirectional_enable.get();
 
 		int ret = up_dshot_init(_output_mask, dshot_frequency, _bidirectional_dshot_enabled);
 

--- a/src/drivers/dshot/DShot.h
+++ b/src/drivers/dshot/DShot.h
@@ -180,7 +180,6 @@ private:
 		(ParamBool<px4::params::DSHOT_3D_ENABLE>) _param_dshot_3d_enable,
 		(ParamInt<px4::params::DSHOT_3D_DEAD_H>) _param_dshot_3d_dead_h,
 		(ParamInt<px4::params::DSHOT_3D_DEAD_L>) _param_dshot_3d_dead_l,
-		(ParamInt<px4::params::MOT_POLE_COUNT>) _param_mot_pole_count,
-		(ParamBool<px4::params::DSHOT_BIDIR_EN>) _param_bidirectional_enable
+		(ParamInt<px4::params::MOT_POLE_COUNT>) _param_mot_pole_count
 	)
 };

--- a/src/drivers/dshot/module.yaml
+++ b/src/drivers/dshot/module.yaml
@@ -33,16 +33,6 @@ parameters:
                     When mixer outputs 1000 or value inside DSHOT 3D deadband, DShot 0 is sent.
             type: boolean
             default: 0
-        DSHOT_BIDIR_EN:
-            description:
-                short: Enable bidirectional DShot
-                long: |
-                    This parameter enables bidirectional DShot which provides RPM feedback.
-                    Note that this requires ESCs that support bidirectional DSHot, e.g. BlHeli32.
-                    This is not the same as DShot telemetry which requires an additional serial connection.
-            type: boolean
-            default: 0
-            reboot_required: true
         DSHOT_3D_DEAD_H:
             description:
                 short: DSHOT 3D deadband high

--- a/src/drivers/pwm_out/module.yaml
+++ b/src/drivers/pwm_out/module.yaml
@@ -20,6 +20,9 @@ actuator_output:
         type: enum
         default: 400
         values:
+            -8: DShot150 Bidir
+            -7: DShot300 Bidir
+            -6: DShot600 Bidir
             -5: DShot150
             -4: DShot300
             -3: DShot600


### PR DESCRIPTION
Removes the DSHOT_BIDIR_EN parameter and instead extends the PWM_MAIN_TIMx pattern to include explicit bidirectional options. This improves the UX by making the option more obvious to users in QGC. 
![image](https://github.com/user-attachments/assets/616d7a97-05e0-4cf8-bf92-272004550690)
