### PR TITLE
dshot: fix scaling

### DIFF
--- a/platforms/nuttx/src/px4/stm/stm32_common/dshot/dshot.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/dshot/dshot.c
@@ -553,7 +553,7 @@ void process_capture_results(uint8_t timer_index, uint8_t channel_index)
 
 	} else {
 		// Convert the period to eRPM
-		_erpms[output_channel] = (1000000 * 60) / period;
+		_erpms[output_channel] = (1000000 * 60 / 100 + period / 2) / period;
 	}
 
 	// We set it ready anyway, not to hold up other channels when used in round robin.


### PR DESCRIPTION
**Problem**
RPM is off by a factor of 100. The scaling was incorrect.

**Solution**
To match Ardupilot and Betaflight
https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp#L848
https://github.com/betaflight/betaflight/blob/master/src/main/drivers/dshot.c#L190