### PR TITLE
Commander: adjust home position altitude after gnss altitude correction

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2110,6 +2110,7 @@ void Commander::landDetectorUpdate()
 				events::send(events::ID("commander_takeoff_detected"), events::Log::Info, "Takeoff detected");
 				_vehicle_status.takeoff_time = hrt_absolute_time();
 				_have_taken_off_since_arming = true;
+				_home_position.setTakeoffTime(_vehicle_status.takeoff_time);
 			}
 
 			// automatically set or update home position

--- a/src/modules/commander/HomePosition.cpp
+++ b/src/modules/commander/HomePosition.cpp
@@ -39,10 +39,8 @@
 #include <lib/geo/geo.h>
 #include "commander_helper.h"
 
-HomePosition::HomePosition(const failsafe_flags_s &failsafe_flags)
-	: _failsafe_flags(failsafe_flags)
-{
-}
+HomePosition::HomePosition(const failsafe_flags_s &failsafe_flags): ModuleParams(nullptr),
+	_failsafe_flags(failsafe_flags) {}
 
 bool HomePosition::hasMovedFromCurrentHomeLocation()
 {
@@ -341,7 +339,7 @@ void HomePosition::update(bool set_automatically, bool check_if_changed)
 
 		_gps_position_for_home_valid = time_valid && fix_valid && eph_valid && epv_valid && evh_valid;
 
-		if (_gps_position_for_home_valid && _last_gps_timestamp != 0 && _last_baro_timestamp != 0
+		if (_param_com_home_en.get() && _gps_position_for_home_valid && _last_gps_timestamp != 0 && _last_baro_timestamp != 0
 		    && _takeoff_time != 0 && now - _takeoff_time < kHomePositionCorrectionTimeWindow) {
 
 			const float gps_alt = static_cast<float>(_gps_alt);
@@ -355,10 +353,12 @@ void HomePosition::update(bool set_automatically, bool check_if_changed)
 
 			// correct baro_alt with offset from GPS alt from when the drift integral was initialized
 			const float baro_alt_corrected = _lpf_baro.getState() + _baro_gps_static_offset;
-			const float gps_alt_error = gps_alt + _baro_gps_home_offset;
+			const float gps_alt_with_home_offset = gps_alt + _baro_gps_home_offset;
 
-			if (fabsf(baro_alt_corrected - _gps_vel_integral) < fabsf(baro_alt_corrected - gps_alt_error) &&
-			    fabsf(baro_alt_corrected - _gps_vel_integral) < fabsf(_gps_vel_integral - gps_alt_error)) {
+			// Apply home altitude correction only if the GPS velocity-integrated altitude and baro altitude
+			// are more consistent with each other than either is with the GPS altitude (with home offset).
+			if (fabsf(baro_alt_corrected - _gps_vel_integral) < fabsf(baro_alt_corrected - gps_alt_with_home_offset) &&
+			    fabsf(baro_alt_corrected - _gps_vel_integral) < fabsf(_gps_vel_integral - gps_alt_with_home_offset)) {
 
 				home_position_s home = _home_position_pub.get();
 				const float home_new_alt = home.alt + baro_alt_corrected - gps_alt - _baro_gps_home_offset;
@@ -376,6 +376,9 @@ void HomePosition::update(bool set_automatically, bool check_if_changed)
 					_baro_gps_home_offset = baro_alt_corrected - gps_alt; // offset present when home position was last corrected
 				}
 			}
+
+		} else {
+			_gps_vel_integral = NAN;
 		}
 
 		_last_gps_timestamp = vehicle_gps_position.timestamp;

--- a/src/modules/commander/HomePosition.cpp
+++ b/src/modules/commander/HomePosition.cpp
@@ -315,7 +315,8 @@ void HomePosition::update(bool set_automatically, bool check_if_changed)
 
 		if (_last_baro_timestamp != 0) {
 			const float dt = baro_data.timestamp - _last_baro_timestamp;
-			lpf_baro.update(baro_alt, dt);
+			lpf_baro.setParameters(dt, kLpfBaroTimeConst);
+			lpf_baro.update(baro_alt);
 
 		} else {
 			lpf_baro.reset(baro_alt);
@@ -347,9 +348,10 @@ void HomePosition::update(bool set_automatically, bool check_if_changed)
 
 			const float gps_alt = static_cast<float>(_gps_alt);
 
-			if (_gps_vel_integral < FLT_EPSILON) {
+			if (!_gps_vel_integral_init) {
 				_gps_vel_integral = gps_alt;
 				_baro_gps_static_offset = gps_alt - lpf_baro.getState();
+				_gps_vel_integral_init = true;
 			}
 
 			_gps_vel_integral += 1e-6f * (vehicle_gps_position.timestamp - _last_gps_timestamp) * (-vehicle_gps_position.vel_d_m_s);

--- a/src/modules/commander/HomePosition.hpp
+++ b/src/modules/commander/HomePosition.hpp
@@ -91,7 +91,7 @@ private:
 	uint64_t _last_baro_timestamp{0};
 	AlphaFilter<float> _lpf_baro{kLpfBaroTimeConst};
 	float _gps_vel_integral{NAN};
-	float _baro_gps_home_offset{0.f};
+	float _home_altitude_offset_applied{0.f};
 	float _baro_gps_static_offset{0.f};
 	uint64_t _takeoff_time{0};
 

--- a/src/modules/commander/HomePosition.hpp
+++ b/src/modules/commander/HomePosition.hpp
@@ -43,6 +43,8 @@
 #include <uORB/topics/vehicle_air_data.h>
 #include <lib/mathlib/math/filter/AlphaFilter.hpp>
 
+using namespace time_literals;
+
 static constexpr int kHomePositionGPSRequiredFixType = 2;
 static constexpr float kHomePositionGPSRequiredEPH = 5.f;
 static constexpr float kHomePositionGPSRequiredEPV = 10.f;
@@ -50,6 +52,8 @@ static constexpr float kHomePositionGPSRequiredEVH = 1.f;
 static constexpr float kMinHomePositionChangeEPH = 1.f;
 static constexpr float kMinHomePositionChangeEPV = 1.5f;
 static constexpr float kLpfBaroTimeConst = 5.f;
+static constexpr float kAltitudeDifferenceThreshold = 1.f; // altitude difference after which home position gets updated
+static constexpr uint64_t kHomePositionCorrectionTimeWindow = 120_s;
 
 class HomePosition
 {
@@ -60,6 +64,7 @@ public:
 	bool setHomePosition(bool force = false);
 	void setInAirHomePosition();
 	bool setManually(double lat, double lon, float alt, float yaw);
+	void setTakeoffTime(uint64_t takeoff_time) { _takeoff_time = takeoff_time; }
 
 	void update(bool set_automatically, bool check_if_changed);
 
@@ -83,11 +88,11 @@ private:
 
 	uint64_t _last_gps_timestamp{0};
 	uint64_t _last_baro_timestamp{0};
-	AlphaFilter<float> lpf_baro{kLpfBaroTimeConst};
-	bool _gps_vel_integral_init{false};
-	float _gps_vel_integral{0.f};
+	AlphaFilter<float> _lpf_baro{kLpfBaroTimeConst};
+	float _gps_vel_integral{NAN};
 	float _baro_gps_home_offset{0.f};
 	float _baro_gps_static_offset{0.f};
+	uint64_t _takeoff_time{0};
 
 	uORB::PublicationData<home_position_s>			_home_position_pub{ORB_ID(home_position)};
 

--- a/src/modules/commander/HomePosition.hpp
+++ b/src/modules/commander/HomePosition.hpp
@@ -42,6 +42,7 @@
 #include <uORB/topics/failsafe_flags.h>
 #include <uORB/topics/vehicle_air_data.h>
 #include <lib/mathlib/math/filter/AlphaFilter.hpp>
+#include <px4_platform_common/module_params.h>
 
 using namespace time_literals;
 
@@ -55,7 +56,7 @@ static constexpr float kLpfBaroTimeConst = 5.f;
 static constexpr float kAltitudeDifferenceThreshold = 1.f; // altitude difference after which home position gets updated
 static constexpr uint64_t kHomePositionCorrectionTimeWindow = 120_s;
 
-class HomePosition
+class HomePosition: public ModuleParams
 {
 public:
 	HomePosition(const failsafe_flags_s &failsafe_flags);
@@ -105,4 +106,8 @@ private:
 	double							_gps_alt{0};
 	float							_gps_eph{0.f};
 	float							_gps_epv{0.f};
+
+	DEFINE_PARAMETERS(
+		(ParamBool<px4::params::COM_HOME_EN>) _param_com_home_en
+	)
 };

--- a/src/modules/commander/HomePosition.hpp
+++ b/src/modules/commander/HomePosition.hpp
@@ -40,6 +40,8 @@
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/failsafe_flags.h>
+#include <uORB/topics/vehicle_air_data.h>
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
 
 static constexpr int kHomePositionGPSRequiredFixType = 2;
 static constexpr float kHomePositionGPSRequiredEPH = 5.f;
@@ -76,6 +78,14 @@ private:
 
 	uORB::SubscriptionData<vehicle_global_position_s>	_global_position_sub{ORB_ID(vehicle_global_position)};
 	uORB::SubscriptionData<vehicle_local_position_s>	_local_position_sub{ORB_ID(vehicle_local_position)};
+	uORB::Subscription _vehicle_air_data_sub{ORB_ID(vehicle_air_data)};
+
+	uint64_t _last_gps_timestamp{0};
+	uint64_t _last_baro_timestamp{0};
+	AlphaFilter<float> lpf_baro{5.f};
+	float _gps_vel_integral{0.f};
+	float _baro_gps_home_offset{0.f};
+	float _baro_gps_static_offset{0.f};
 
 	uORB::PublicationData<home_position_s>			_home_position_pub{ORB_ID(home_position)};
 

--- a/src/modules/commander/HomePosition.hpp
+++ b/src/modules/commander/HomePosition.hpp
@@ -49,6 +49,7 @@ static constexpr float kHomePositionGPSRequiredEPV = 10.f;
 static constexpr float kHomePositionGPSRequiredEVH = 1.f;
 static constexpr float kMinHomePositionChangeEPH = 1.f;
 static constexpr float kMinHomePositionChangeEPV = 1.5f;
+static constexpr float kLpfBaroTimeConst = 5.f;
 
 class HomePosition
 {
@@ -82,7 +83,8 @@ private:
 
 	uint64_t _last_gps_timestamp{0};
 	uint64_t _last_baro_timestamp{0};
-	AlphaFilter<float> lpf_baro{5.f};
+	AlphaFilter<float> lpf_baro{kLpfBaroTimeConst};
+	bool _gps_vel_integral_init{false};
 	float _gps_vel_integral{0.f};
 	float _baro_gps_home_offset{0.f};
 	float _baro_gps_static_offset{0.f};

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -144,6 +144,7 @@ PARAM_DEFINE_FLOAT(COM_RC_LOSS_T, 0.5f);
  *
  * During missions, the home position is locked and will not reset during intermediate landings.
  * It will only update once the mission is complete or landed outside of a mission.
+ * However, the altitude of the home position can be updated if vertical drift in the GNSS-position is detected.
  *
  * @group Commander
  * @reboot_required true

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -142,9 +142,9 @@ PARAM_DEFINE_FLOAT(COM_RC_LOSS_T, 0.5f);
  *
  * Set home position automatically if possible.
  *
- * During missions, the home position is locked and will not reset during intermediate landings.
+ * During missions, the latitude/longitude of the home position is locked and will not reset during intermediate landings.
  * It will only update once the mission is complete or landed outside of a mission.
- * However, the altitude of the home position can be updated if vertical drift in the GNSS-position is detected.
+ * However, the altitude is still being adjusted to correct for GNSS vertical drift in the first 2 minutes after takeoff.
  *
  * @group Commander
  * @reboot_required true


### PR DESCRIPTION
### Solved Problem & Solution
When a drone takes off, its GNSS altitude might initially have a low uncertainty. However, as the drone ascends and can access more satellites, this position estimate often gets "corrected." This correction can cause the GNSS altitude reading to change significantly, even when the drone isn't physically moving vertically.

If the GNSS altitude is being used as the primary height reference, this sudden shift would incorrectly trigger the drone to move vertically in an attempt to maintain a constant GNSS altitude. This is problematic because the integrated GNSS velocity data does not exhibit the same behavior, indicating that the drone is not actually moving.

To address this, I've added a method that uses both the barometer and the integrated GNSS velocity to detect this GNSS "drift." We're not modifying the GNSS altitude measurement itself, as it's actually becoming more accurate. Instead, the issue lies with the distance above the home position, which is no longer correct after the GNSS altitude adjustment.

To ensure a proper landing procedure where the drone doesn't prematurely slow down at an incorrect altitude, we now adjust the home altitude with this new offset. This ensures that the drone's perceived height above home is accurate, allowing for a smooth and safe descent.

### Changelog Entry
For release notes:
```

Documentation: adjust home position after gnss altitude correction drift mid flight
```

### Test coverage
-- Tested in sim and hardware.

![image](https://github.com/user-attachments/assets/a6ffea6d-2d6c-4fc6-99a0-475533b42a22)


[log_37_2025-5-22-13-54-02.zip](https://github.com/user-attachments/files/20671840/log_37_2025-5-22-13-54-02.zip)
[log_29_2025-6-10-11-12-48.zip](https://github.com/user-attachments/files/20671845/log_29_2025-6-10-11-12-48.zip)


---

Edit:
To add some clarification behind the logic:
![Datei_000](https://github.com/user-attachments/assets/48ef411c-36fe-4868-838c-d69aabfe51cd)
![Datei_001](https://github.com/user-attachments/assets/d67c059c-b6a9-4ee9-b03d-092a3dc417e5)
