### PR TITLE
Update ll40ls.cpp - Fix module usage name to make unique 

### DIFF
--- a/src/drivers/distance_sensor/ll40ls_pwm/ll40ls.cpp
+++ b/src/drivers/distance_sensor/ll40ls_pwm/ll40ls.cpp
@@ -150,7 +150,7 @@ The sensor/driver must be enabled using the parameter SENS_EN_LL40LS.
 Setup/usage information: https://docs.px4.io/main/en/sensor/lidar_lite.html
 )DESCR_STR");
 
-	PRINT_MODULE_USAGE_NAME("ll40ls", "driver");
+	PRINT_MODULE_USAGE_NAME("ll40ls_pwm", "driver");
 	PRINT_MODULE_USAGE_SUBCATEGORY("distance_sensor");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("start","Start driver");
 	PRINT_MODULE_USAGE_PARAM_INT('R', 25, 0, 25, "Sensor rotation - downward facing by default", true);


### PR DESCRIPTION
There are two lightware sensor modules, one for I2C/SPI and one for PWM.

- https://github.com/PX4/PX4-Autopilot/blob/main/src/drivers/distance_sensor/ll40ls/ll40ls.cpp#L63 - this is the I2C/SPI variant
- https://github.com/PX4/PX4-Autopilot/blob/main/src/drivers/distance_sensor/ll40ls_pwm/ll40ls.cpp#L153 - this is the PWM variant

They both have exactly the same name and category:

```
PRINT_MODULE_USAGE_NAME("ll40ls", "driver");
PRINT_MODULE_USAGE_SUBCATEGORY("distance_sensor");
```

This fixes the PWM variant to use the actual name of the module. This fixes errors in the docs build where all the module docs get mixed together.

Falls out of #24795
