### PR TITLE
3DR Control Zero H7 OEM RevG: MTD driver fix

### DIFF
--- a/boards/3dr/ctrl-zero-h7-oem-revg/nuttx-config/scripts/script.ld
+++ b/boards/3dr/ctrl-zero-h7-oem-revg/nuttx-config/scripts/script.ld
@@ -132,6 +132,7 @@ ENTRY(_stext)
  */
 EXTERN(abort)
 EXTERN(_bootdelay_signature)
+EXTERN(board_get_manifest)
 
 SECTIONS
 {

--- a/boards/3dr/ctrl-zero-h7-oem-revg/src/CMakeLists.txt
+++ b/boards/3dr/ctrl-zero-h7-oem-revg/src/CMakeLists.txt
@@ -48,6 +48,7 @@ else()
 		i2c.cpp
 		init.c
 		led.c
+		mtd.cpp
 		spi.cpp
 		timer_config.cpp
 		usb.c

--- a/boards/3dr/ctrl-zero-h7-oem-revg/src/mtd.cpp
+++ b/boards/3dr/ctrl-zero-h7-oem-revg/src/mtd.cpp
@@ -1,0 +1,76 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <nuttx/spi/spi.h>
+#include <px4_platform_common/px4_manifest.h>
+//                                                              KiB BS    nB
+static const px4_mft_device_t spi2 = {             // FM25V01A on FMUM native: 32K X 8, emulated as (1024 Blocks of 32)
+	.bus_type = px4_mft_device_t::SPI,
+	.devid    = SPIDEV_FLASH(0)
+};
+
+static const px4_mtd_entry_t fmum_fram = {
+	.device = &spi2,
+	.npart = 1,
+	.partd = {
+		{
+			.type = MTD_PARAMETERS,
+			.path = "/fs/mtd_params",
+			.nblocks = (32768 / (1 << CONFIG_RAMTRON_EMULATE_PAGE_SHIFT))
+		},
+	},
+};
+
+static const px4_mtd_manifest_t board_mtd_config = {
+	.nconfigs = 1,
+	.entries  = {
+		&fmum_fram
+	}
+};
+
+static const px4_mft_entry_s mtd_mft = {
+	.type = MTD,
+	.pmft = (void *) &board_mtd_config,
+};
+
+static const px4_mft_s mft = {
+	.nmft = 1,
+	.mfts = {
+		&mtd_mft
+	}
+};
+
+const px4_mft_s *board_get_manifest(void)
+{
+	return &mft;
+}


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The MTD driver was unable to find the FRAM and mount the partition `/fs/mtd_params`, which prevented the user from saving and retrieving parameters. 

This PR solves issue #24925 

### Solution
- Add a definition for the MTD driver

### Changelog Entry
For release notes:
```
Fix: Adding MTD driver definition for 3DR Control Zero H7 OEM RevG
```

### Alternatives
To check the legacy option, where the FRAM alone is defined in the absence of an MTD definition for a board (which is intended for custom definitions).

### Test coverage
- Tested on hardware 

### Context
Related links, screenshot before/after, video
