### PR TITLE
ci: explicitly set branches to test (release/1.16)

### DIFF
--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -16,13 +16,11 @@ on:
       - 'release/**'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
-      - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 jobs:
   group_targets:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -9,7 +9,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'

--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -9,7 +9,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'

--- a/.github/workflows/compile_ubuntu.yml
+++ b/.github/workflows/compile_ubuntu.yml
@@ -12,7 +12,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-      - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -15,7 +15,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-      - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -9,7 +9,7 @@ on:
       - 'docs/en/**'
   pull_request:
     branches:
-      - '*'
+      - '**'
     paths:
       - 'docs/en/**'
 
@@ -80,7 +80,7 @@ jobs:
       - name: Deploy
         run: |
           git clone --single-branch --branch main --depth 1 https://${{ secrets.PX4BUILTBOT_PERSONAL_ACCESS_TOKEN }}@github.com/PX4/docs.px4.io.git
-          # make it an orphan branch      
+          # make it an orphan branch
           cd docs.px4.io
           CURRENT_DATETIME=$(date +'%Y%m%d_%H_%M')
           git checkout --orphan "${CURRENT_DATETIME}_main"

--- a/.github/workflows/ekf_functional_change_indicator.yml
+++ b/.github/workflows/ekf_functional_change_indicator.yml
@@ -3,7 +3,7 @@ name: EKF Change Indicator
 on:
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'

--- a/.github/workflows/failsafe_sim.yml
+++ b/.github/workflows/failsafe_sim.yml
@@ -9,7 +9,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'

--- a/.github/workflows/flash_analysis.yml
+++ b/.github/workflows/flash_analysis.yml
@@ -14,7 +14,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-      - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -9,7 +9,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -9,7 +9,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-    - '*'
+    - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'

--- a/.github/workflows/nuttx_env_config.yml
+++ b/.github/workflows/nuttx_env_config.yml
@@ -9,7 +9,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -9,7 +9,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-    - '*'
+    - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'

--- a/.github/workflows/ros_integration_tests.yml
+++ b/.github/workflows/ros_integration_tests.yml
@@ -14,7 +14,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'

--- a/.github/workflows/ros_translation_node.yml
+++ b/.github/workflows/ros_translation_node.yml
@@ -8,7 +8,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -14,7 +14,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - '.github/**'


### PR DESCRIPTION
turns out the `'*'` single asterisk is not enough to do wildcard matching on `release/*` branches