### PR TITLE
Sensor params: improve board rotation parameter description and meta data

### DIFF
--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -168,10 +168,11 @@ PARAM_DEFINE_FLOAT(SENS_DPRES_ANSC, 0);
 PARAM_DEFINE_INT32(SENS_BOARD_ROT, 0);
 
 /**
- * Board rotation Y (Pitch) offset
+ * Board rotation Y (pitch) offset
  *
- * This parameter defines a rotational offset in degrees around the Y (Pitch) axis. It allows the user
- * to fine tune the board offset in the event of misalignment.
+ * Rotation from flight controller board to vehicle body frame.
+ * This parameter gets set during the "level horizon" calibration or can be
+ * set manually.
  *
  * @min -45.0
  * @max 45.0
@@ -182,10 +183,11 @@ PARAM_DEFINE_INT32(SENS_BOARD_ROT, 0);
 PARAM_DEFINE_FLOAT(SENS_BOARD_Y_OFF, 0.0f);
 
 /**
- * Board rotation X (Roll) offset
+ * Board rotation X (roll) offset
  *
- * This parameter defines a rotational offset in degrees around the X (Roll) axis It allows the user
- * to fine tune the board offset in the event of misalignment.
+ * Rotation from flight controller board to vehicle body frame.
+ * This parameter gets set during the "level horizon" calibration or can be
+ * set manually.
  *
  * @unit deg
  * @min -45.0
@@ -196,10 +198,10 @@ PARAM_DEFINE_FLOAT(SENS_BOARD_Y_OFF, 0.0f);
 PARAM_DEFINE_FLOAT(SENS_BOARD_X_OFF, 0.0f);
 
 /**
- * Board rotation Z (YAW) offset
+ * Board rotation Z (yaw) offset
  *
- * This parameter defines a rotational offset in degrees around the Z (Yaw) axis. It allows the user
- * to fine tune the board offset in the event of misalignment.
+ * Rotation from flight controller board to vehicle body frame.
+ * Has to be set manually (not set by any calibration).
  *
  * @min -45.0
  * @max 45.0

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -173,6 +173,9 @@ PARAM_DEFINE_INT32(SENS_BOARD_ROT, 0);
  * This parameter defines a rotational offset in degrees around the Y (Pitch) axis. It allows the user
  * to fine tune the board offset in the event of misalignment.
  *
+ * @min -45.0
+ * @max 45.0
+ * @decimal 1
  * @unit deg
  * @group Sensors
  */
@@ -185,6 +188,9 @@ PARAM_DEFINE_FLOAT(SENS_BOARD_Y_OFF, 0.0f);
  * to fine tune the board offset in the event of misalignment.
  *
  * @unit deg
+ * @min -45.0
+ * @max 45.0
+ * @decimal 1
  * @group Sensors
  */
 PARAM_DEFINE_FLOAT(SENS_BOARD_X_OFF, 0.0f);
@@ -195,6 +201,9 @@ PARAM_DEFINE_FLOAT(SENS_BOARD_X_OFF, 0.0f);
  * This parameter defines a rotational offset in degrees around the Z (Yaw) axis. It allows the user
  * to fine tune the board offset in the event of misalignment.
  *
+ * @min -45.0
+ * @max 45.0
+ * @decimal 1
  * @unit deg
  * @group Sensors
  */


### PR DESCRIPTION

### Solved Problem
The `SENS_BOARD_i_OFF` params currently don't have @decimals defined, and thus the GCS doesn't display any digits. Annoying if you want to setup half degrees.
Also noticed that the param description could be improved, as well as that adding a @min and @max would make sense.

### Solution
- add @decimals
- add @min, @max
- improve description

### Changelog Entry
For release notes:
```
Improvement: Sensor params: improve board rotation parameter description and meta data
```