### PR TITLE
fix Septentrio memory bugs (2)

### DIFF
--- a/src/drivers/gnss/septentrio/sbf/decoder.cpp
+++ b/src/drivers/gnss/septentrio/sbf/decoder.cpp
@@ -262,7 +262,7 @@ bool Decoder::done() const
 
 bool Decoder::can_parse() const
 {
-	return done() && _message.header.length <= sizeof(_message)
+	return done() && _message.header.length <= sizeof(_message) && _message.header.length > 4
 	       && _message.header.crc == buffer_crc16(reinterpret_cast<const uint8_t *>(&_message) + 4, _message.header.length - 4);
 }
 


### PR DESCRIPTION
Follow-up to #25011

_message.header.length - 4 is passed as unsigned to the CRC method, so if _message.header.length < 4, the length wraps and causes invalid memory access.

This was found with fuzzing.