### PR TITLE
ekf2: param name consistency

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.cpp
@@ -198,7 +198,7 @@ void GnssChecks::runOnGroundGnssChecks(const gnssSample &gnss)
 		}
 
 		// Calculate the horizontal and vertical drift velocity components and limit to 10x the threshold
-		const Vector3f vel_limit(_params.req_hdrift, _params.req_hdrift, _params.req_vdrift);
+		const Vector3f vel_limit(_params.ekf2_req_hdrift, _params.ekf2_req_hdrift, _params.ekf2_req_vdrift);
 		Vector3f delta_pos(delta_pos_n, delta_pos_e, (_alt_prev - gnss.alt));
 
 		// Apply a low pass filter
@@ -209,26 +209,26 @@ void GnssChecks::runOnGroundGnssChecks(const gnssSample &gnss)
 
 		// hdrift: calculate the horizontal drift speed and fail if too high
 		_horizontal_position_drift_rate_m_s = Vector2f(_lat_lon_alt_deriv_filt.xy()).norm();
-		_check_fail_status.flags.hdrift = (_horizontal_position_drift_rate_m_s > _params.req_hdrift);
+		_check_fail_status.flags.hdrift = (_horizontal_position_drift_rate_m_s > _params.ekf2_req_hdrift);
 
 		// vdrift: fail if the vertical drift speed is too high
 		_vertical_position_drift_rate_m_s = fabsf(_lat_lon_alt_deriv_filt(2));
-		_check_fail_status.flags.vdrift = (_vertical_position_drift_rate_m_s > _params.req_vdrift);
+		_check_fail_status.flags.vdrift = (_vertical_position_drift_rate_m_s > _params.ekf2_req_vdrift);
 
 		// hspeed: check the magnitude of the filtered horizontal GNSS velocity
 		const Vector2f vel_ne = matrix::constrain(Vector2f(gnss.vel.xy()),
-					-10.0f * _params.req_hdrift,
-					10.0f * _params.req_hdrift);
+					-10.0f * _params.ekf2_req_hdrift,
+					10.0f * _params.ekf2_req_hdrift);
 		_vel_ne_filt = vel_ne * filter_coef + _vel_ne_filt * (1.0f - filter_coef);
 		_filtered_horizontal_velocity_m_s = _vel_ne_filt.norm();
-		_check_fail_status.flags.hspeed = (_filtered_horizontal_velocity_m_s > _params.req_hdrift);
+		_check_fail_status.flags.hspeed = (_filtered_horizontal_velocity_m_s > _params.ekf2_req_hdrift);
 
 		// vspeed: check the magnitude of the filtered vertical GNSS velocity
-		const float gnss_vz_limit = 10.f * _params.req_vdrift;
+		const float gnss_vz_limit = 10.f * _params.ekf2_req_vdrift;
 		const float gnss_vz = math::constrain(gnss.vel(2), -gnss_vz_limit, gnss_vz_limit);
 		_vel_d_filt = gnss_vz * filter_coef + _vel_d_filt * (1.f - filter_coef);
 
-		_check_fail_status.flags.vspeed = (fabsf(_vel_d_filt) > _params.req_vdrift);
+		_check_fail_status.flags.vspeed = (fabsf(_vel_d_filt) > _params.ekf2_req_vdrift);
 
 	} else {
 		// This is the case where the vehicle is on ground and IMU movement is blocking the drift calculation

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.cpp
@@ -113,17 +113,17 @@ bool GnssChecks::runInitialFixChecks(const gnssSample &gnss)
 	_check_fail_status.flags.fix = (gnss.fix_type < 3);
 
 	// Check the number of satellites
-	_check_fail_status.flags.nsats = (gnss.nsats < _params.req_nsats);
+	_check_fail_status.flags.nsats = (gnss.nsats < _params.ekf2_req_nsats);
 
 	// Check the position dilution of precision
-	_check_fail_status.flags.pdop = (gnss.pdop > _params.req_pdop);
+	_check_fail_status.flags.pdop = (gnss.pdop > _params.ekf2_req_pdop);
 
 	// Check the reported horizontal and vertical position accuracy
 	_check_fail_status.flags.hacc = (gnss.hacc > _params.req_hacc);
 	_check_fail_status.flags.vacc = (gnss.vacc > _params.req_vacc);
 
 	// Check the reported speed accuracy
-	_check_fail_status.flags.sacc = (gnss.sacc > _params.req_sacc);
+	_check_fail_status.flags.sacc = (gnss.sacc > _params.ekf2_req_sacc);
 
 	_check_fail_status.flags.spoofed = gnss.spoofed;
 

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.hpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.hpp
@@ -44,9 +44,9 @@ class GnssChecks final
 {
 public:
 	GnssChecks(int32_t &check_mask, int32_t &req_nsats, float &req_pdop, float &req_hacc, float &req_vacc, float &req_sacc,
-		   float &req_hdrift, float &req_vdrift, float &velocity_limit, uint32_t &min_health_time_us,
+		   float &ekf2_req_hdrift, float &ekf2_req_vdrift, float &velocity_limit, uint32_t &min_health_time_us,
 		   filter_control_status_u &control_status):
-		_params{check_mask, req_nsats, req_pdop, req_hacc, req_vacc, req_sacc, req_hdrift, req_vdrift, velocity_limit, min_health_time_us},
+		_params{check_mask, req_nsats, req_pdop, req_hacc, req_vacc, req_sacc, ekf2_req_hdrift, ekf2_req_vdrift, velocity_limit, min_health_time_us},
 		_control_status(control_status)
 	{};
 
@@ -148,8 +148,8 @@ private:
 		const float &req_hacc;
 		const float &req_vacc;
 		const float &req_sacc;
-		const float &req_hdrift;
-		const float &req_vdrift;
+		const float &ekf2_req_hdrift;
+		const float &ekf2_req_vdrift;
 		const float &velocity_limit;
 		const uint32_t &min_health_time_us;
 	};

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.hpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.hpp
@@ -43,10 +43,10 @@ namespace estimator
 class GnssChecks final
 {
 public:
-	GnssChecks(int32_t &check_mask, int32_t &req_nsats, float &req_pdop, float &req_hacc, float &req_vacc, float &req_sacc,
+	GnssChecks(int32_t &check_mask, int32_t &ekf2_req_nsats, float &ekf2_req_pdop, float &req_hacc, float &req_vacc, float &ekf2_req_sacc,
 		   float &ekf2_req_hdrift, float &ekf2_req_vdrift, float &velocity_limit, uint32_t &min_health_time_us,
 		   filter_control_status_u &control_status):
-		_params{check_mask, req_nsats, req_pdop, req_hacc, req_vacc, req_sacc, ekf2_req_hdrift, ekf2_req_vdrift, velocity_limit, min_health_time_us},
+		_params{check_mask, ekf2_req_nsats, ekf2_req_pdop, req_hacc, req_vacc, ekf2_req_sacc, ekf2_req_hdrift, ekf2_req_vdrift, velocity_limit, min_health_time_us},
 		_control_status(control_status)
 	{};
 
@@ -143,11 +143,11 @@ private:
 
 	struct Params {
 		const int32_t &check_mask;
-		const int32_t &req_nsats;
-		const float &req_pdop;
+		const int32_t &ekf2_req_nsats;
+		const float &ekf2_req_pdop;
 		const float &req_hacc;
 		const float &req_vacc;
-		const float &req_sacc;
+		const float &ekf2_req_sacc;
 		const float &ekf2_req_hdrift;
 		const float &ekf2_req_vdrift;
 		const float &velocity_limit;

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
@@ -235,7 +235,7 @@ void Ekf::updateGnssVel(const imuSample &imu_sample, const gnssSample &gnss_samp
 				   && (aid_src.test_ratio[0] < 1.f) && (aid_src.test_ratio[1] < 1.f); // vx & vy accepted
 
 	if (bad_acc_vz_rejected
-	    && (gnss_sample.sacc < _params.req_sacc)
+	    && (gnss_sample.sacc < _params.ekf2_req_sacc)
 	   ) {
 		const float innov_limit = innovation_gate * sqrtf(aid_src.innovation_variance[2]);
 		aid_src.innovation[2] = math::constrain(aid_src.innovation[2], -innov_limit, innov_limit);
@@ -283,7 +283,7 @@ void Ekf::controlGnssYawEstimator(estimator_aid_source3d_s &aid_src_vel)
 	const Vector2f vel_xy(aid_src_vel.observation);
 
 	if ((vel_var > 0.f)
-	    && (vel_var < _params.req_sacc)
+	    && (vel_var < _params.ekf2_req_sacc)
 	    && vel_xy.isAllFinite()) {
 
 		_yawEstimator.fuseVelocity(vel_xy, vel_var, _control_status.flags.in_air);

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -335,7 +335,7 @@ struct parameters {
 
 	// these parameters control the strictness of GPS quality checks used to determine if the GPS is
 	// good enough to set a local origin and commence aiding
-	int32_t gps_check_mask{21};             ///< bitmask used to control which GPS quality checks are used
+	int32_t ekf2_gps_check{21};             ///< bitmask used to control which GPS quality checks are used
 	float req_hacc{5.0f};                   ///< maximum acceptable horizontal position error (m)
 	float req_vacc{8.0f};                   ///< maximum acceptable vertical position error (m)
 	float req_sacc{1.0f};                   ///< maximum acceptable speed error (m/s)

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -341,8 +341,8 @@ struct parameters {
 	float req_sacc{1.0f};                   ///< maximum acceptable speed error (m/s)
 	int32_t req_nsats{6};                   ///< minimum acceptable satellite count
 	float req_pdop{2.0f};                   ///< maximum acceptable position dilution of precision
-	float req_hdrift{0.3f};                 ///< maximum acceptable horizontal drift speed (m/s)
-	float req_vdrift{0.5f};                 ///< maximum acceptable vertical drift speed (m/s)
+	float ekf2_req_hdrift{0.3f};            ///< maximum acceptable horizontal drift speed (m/s)
+	float ekf2_req_vdrift{0.5f};            ///< maximum acceptable vertical drift speed (m/s)
 
 # if defined(CONFIG_EKF2_GNSS_YAW)
 	// GNSS heading fusion

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -338,9 +338,9 @@ struct parameters {
 	int32_t ekf2_gps_check{21};             ///< bitmask used to control which GPS quality checks are used
 	float req_hacc{5.0f};                   ///< maximum acceptable horizontal position error (m)
 	float req_vacc{8.0f};                   ///< maximum acceptable vertical position error (m)
-	float req_sacc{1.0f};                   ///< maximum acceptable speed error (m/s)
-	int32_t req_nsats{6};                   ///< minimum acceptable satellite count
-	float req_pdop{2.0f};                   ///< maximum acceptable position dilution of precision
+	float ekf2_req_sacc{1.0f};              ///< maximum acceptable speed error (m/s)
+	int32_t ekf2_req_nsats{6};              ///< minimum acceptable satellite count
+	float ekf2_req_pdop{2.0f};              ///< maximum acceptable position dilution of precision
 	float ekf2_req_hdrift{0.3f};            ///< maximum acceptable horizontal drift speed (m/s)
 	float ekf2_req_vdrift{0.5f};            ///< maximum acceptable vertical drift speed (m/s)
 

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -404,7 +404,7 @@ protected:
 	gnssSample _gps_sample_delayed{};
 
 	uint32_t _min_gps_health_time_us{10000000}; ///< GPS is marked as healthy only after this amount of time
-	GnssChecks _gnss_checks{_params.gps_check_mask,
+	GnssChecks _gnss_checks{_params.ekf2_gps_check,
 			   _params.req_nsats,
 			   _params.req_pdop,
 			   _params.req_hacc,

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -410,8 +410,8 @@ protected:
 			   _params.req_hacc,
 			   _params.req_vacc,
 			   _params.req_sacc,
-			   _params.req_hdrift,
-			   _params.req_vdrift,
+			   _params.ekf2_req_hdrift,
+			   _params.ekf2_req_vdrift,
 			   _params.velocity_limit,
 			   _min_gps_health_time_us,
 			   _control_status};

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -405,11 +405,11 @@ protected:
 
 	uint32_t _min_gps_health_time_us{10000000}; ///< GPS is marked as healthy only after this amount of time
 	GnssChecks _gnss_checks{_params.ekf2_gps_check,
-			   _params.req_nsats,
-			   _params.req_pdop,
-			   _params.req_hacc,
-			   _params.req_vacc,
-			   _params.req_sacc,
+			   _params.ekf2_req_nsats,
+			   _params.ekf2_req_pdop,
+			   _params.req_hacc, // TODO: eph
+			   _params.req_vacc, // TODO: epv
+			   _params.ekf2_req_sacc,
 			   _params.ekf2_req_hdrift,
 			   _params.ekf2_req_vdrift,
 			   _params.velocity_limit,

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -88,7 +88,7 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_gps_p_noise(_params->gps_pos_noise),
 	_param_ekf2_gps_p_gate(_params->gps_pos_innov_gate),
 	_param_ekf2_gps_v_gate(_params->gps_vel_innov_gate),
-	_param_ekf2_gps_check(_params->gps_check_mask),
+	_param_ekf2_gps_check(_params->ekf2_gps_check),
 	_param_ekf2_req_eph(_params->req_hacc),
 	_param_ekf2_req_epv(_params->req_vacc),
 	_param_ekf2_req_sacc(_params->req_sacc),
@@ -1790,7 +1790,7 @@ void EKF2::PublishStatus(const hrt_abstime &timestamp)
 #if defined(CONFIG_EKF2_GNSS)
 	// only report enabled GPS check failures (the param indexes are shifted by 1 bit, because they don't include
 	// the GPS Fix bit, which is always checked)
-	status.gps_check_fail_flags = _ekf.gps_check_fail_status().value & (((uint16_t)_params->gps_check_mask << 1) | 1);
+	status.gps_check_fail_flags = _ekf.gps_check_fail_status().value & (((uint16_t)_params->ekf2_gps_check << 1) | 1);
 #endif // CONFIG_EKF2_GNSS
 
 	status.control_mode_flags = _ekf.control_status().value;

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -94,8 +94,8 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_req_sacc(_params->req_sacc),
 	_param_ekf2_req_nsats(_params->req_nsats),
 	_param_ekf2_req_pdop(_params->req_pdop),
-	_param_ekf2_req_hdrift(_params->req_hdrift),
-	_param_ekf2_req_vdrift(_params->req_vdrift),
+	_param_ekf2_req_hdrift(_params->ekf2_req_hdrift),
+	_param_ekf2_req_vdrift(_params->ekf2_req_vdrift),
 	_param_ekf2_gsf_tas_default(_params->EKFGSF_tas_default),
 #endif // CONFIG_EKF2_GNSS
 #if defined(CONFIG_EKF2_BAROMETER)

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -89,11 +89,11 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_gps_p_gate(_params->gps_pos_innov_gate),
 	_param_ekf2_gps_v_gate(_params->gps_vel_innov_gate),
 	_param_ekf2_gps_check(_params->ekf2_gps_check),
-	_param_ekf2_req_eph(_params->req_hacc),
-	_param_ekf2_req_epv(_params->req_vacc),
-	_param_ekf2_req_sacc(_params->req_sacc),
-	_param_ekf2_req_nsats(_params->req_nsats),
-	_param_ekf2_req_pdop(_params->req_pdop),
+	_param_ekf2_req_eph(_params->req_hacc), // TODO: eph
+	_param_ekf2_req_epv(_params->req_vacc), // TODO: epv
+	_param_ekf2_req_sacc(_params->ekf2_req_sacc),
+	_param_ekf2_req_nsats(_params->ekf2_req_nsats),
+	_param_ekf2_req_pdop(_params->ekf2_req_pdop),
 	_param_ekf2_req_hdrift(_params->ekf2_req_hdrift),
 	_param_ekf2_req_vdrift(_params->ekf2_req_vdrift),
 	_param_ekf2_gsf_tas_default(_params->EKFGSF_tas_default),


### PR DESCRIPTION
### Solved Problem
The EKF2 maps PX4 parameters to a parameter struct, but the names don't match making it difficult to grep by param name.

### Solution
Change EKF2 parameter names to match the PX4 parameter names.

### Changelog Entry
For release notes:
```
ekf2: update parameter names for consistency and easier search
```
