### PR TITLE
Add lark to python requirements for the rosidl parser

### DIFF
--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -27,3 +27,4 @@ six>=1.12.0
 toml>=0.9
 sympy>=1.10.1
 pycryptodome
+lark


### PR DESCRIPTION
Needed for #24476 so the IDL parser can generate RIHS01 hashes