### PR TITLE
params: srcparser: don't strip newlines from long_desc

### DIFF
--- a/src/lib/parameters/px4params/srcparser.py
+++ b/src/lib/parameters/px4params/srcparser.py
@@ -311,7 +311,6 @@ class SourceParser(object):
                                 raise Exception('short description too long (150 max, is {:}, parameter: {:})'.format(len(short_desc), name))
                             param.SetField("short_desc", self.re_remove_dots.sub('', short_desc))
                         if long_desc is not None:
-                            long_desc = self.re_remove_carriage_return.sub(' ', long_desc)
                             param.SetField("long_desc", long_desc)
                         for tag in tags:
                             if tag == "group":


### PR DESCRIPTION
I'm not sure why the newlines are being stripped from the `long_desc`. 

Reported in QGC issue:
Fixes https://github.com/PX4/PX4-Autopilot/issues/25041