### PR TITLE
ci: update rosdistro apt keys

### DIFF
--- a/.github/workflows/ros_integration_tests.yml
+++ b/.github/workflows/ros_integration_tests.yml
@@ -11,13 +11,11 @@ on:
     - 'main'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 jobs:
   build:
@@ -32,6 +30,12 @@ jobs:
 
     - name: Git Ownership Workaround
       run: git config --system --add safe.directory '*'
+
+    - name: Update ROS Keys
+      run: |
+        sudo rm /etc/apt/sources.list.d/ros2.list && \
+        sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg && \
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
     - name: Install gazebo
       run: |


### PR DESCRIPTION
This PR updates the rosdistro apt keys, and its a patch fix, the real fix is to update the container to include all of the dependencies, but that will have to come in a follow-up PR because its a lengthier process and will take more time