### PR TITLE
params: COM_RC_LOSS_T: clarify safe adjustment of RC loss timeout

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -127,6 +127,7 @@ PARAM_DEFINE_INT32(COM_HLDL_REG_T, 0);
  *
  * The time in seconds without a new setpoint from RC or Joystick, after which the connection is considered lost.
  * This must be kept short as the vehicle will use the last supplied setpoint until the timeout triggers.
+ * **Note:** Setting this value too low may trigger an incorrect RC failsafe. This value can be longer on resource-constrained hardware or under high system load. It is recommended to carefully test and adjust this value based on the specific hardware performance.
  *
  * @group Commander
  * @unit s

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -127,7 +127,7 @@ PARAM_DEFINE_INT32(COM_HLDL_REG_T, 0);
  *
  * The time in seconds without a new setpoint from RC or Joystick, after which the connection is considered lost.
  * This must be kept short as the vehicle will use the last supplied setpoint until the timeout triggers.
- * **Note:** Setting this value too low may trigger an incorrect RC failsafe. This value can be longer on resource-constrained hardware or under high system load. It is recommended to carefully test and adjust this value based on the specific hardware performance.
+ * Ensure the value is not set lower than the update interval of the RC or Joystick.
  *
  * @group Commander
  * @unit s


### PR DESCRIPTION
Modified the description of the parameter COM_RC_LOSS_T to explicitly state that the timeout should not be set below the hardware capability. Otherwise, on limited hardware, a too low COM_RC_LOSS_T value may be smaller than the actual manual_control_setpoint update interval, thus triggering incorrect RC loss failsafe.

Fixes #25045
