### PR TITLE
ci: use new container for checks workflow

### DIFF
--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -18,7 +18,7 @@ on:
       - 'docs/**'
   pull_request:
     branches:
-      - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -16,6 +16,7 @@ on:
       - 'release/**'
     paths-ignore:
       - 'docs/**'
+      - '.github/**'
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -16,7 +16,6 @@ on:
       - 'release/**'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,7 @@ on:
       - 'docs/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
 
@@ -39,7 +39,7 @@ jobs:
       - name: Building [${{ matrix.check }}]
         uses: addnab/docker-run-action@v3
         with:
-          image: px4io/px4-dev-nuttx-focal:2022-08-12
+          image: px4io/px4-dev:v1.16.0-rc1-258-g0369abd556
           options: -v ${{ github.workspace }}:/workspace
           run: |
             cd /workspace

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,6 +12,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -8,7 +8,7 @@ on:
       - 'docs/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
 jobs:

--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -8,7 +8,7 @@ on:
       - 'docs/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -12,6 +12,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-latest

--- a/.github/workflows/compile_ubuntu.yml
+++ b/.github/workflows/compile_ubuntu.yml
@@ -11,7 +11,7 @@ on:
       - 'docs/**'
   pull_request:
     branches:
-      - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/compile_ubuntu.yml
+++ b/.github/workflows/compile_ubuntu.yml
@@ -18,6 +18,10 @@ on:
 env:
   RUNS_IN_DOCKER: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_and_test:
     name: Build and Test

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -11,7 +11,7 @@ on:
       - 'v*'
   pull_request:
     branches:
-      - '*'
+      - '**'
     paths:
       - '.github/workflows/dev_container.yml'
       - 'Tools/setup/ubuntu.sh'

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -30,6 +30,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   setup:
     name: Set Tags and Variables

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -9,7 +9,7 @@ on:
       - 'docs/en/**'
   pull_request:
     branches:
-      - '*'
+      - '**'
     paths:
       - 'docs/en/**'
 
@@ -80,7 +80,7 @@ jobs:
       - name: Deploy
         run: |
           git clone --single-branch --branch main --depth 1 https://${{ secrets.PX4BUILTBOT_PERSONAL_ACCESS_TOKEN }}@github.com/PX4/docs.px4.io.git
-          # make it an orphan branch      
+          # make it an orphan branch
           cd docs.px4.io
           CURRENT_DATETIME=$(date +'%Y%m%d_%H_%M')
           git checkout --orphan "${CURRENT_DATETIME}_main"

--- a/.github/workflows/ekf_functional_change_indicator.yml
+++ b/.github/workflows/ekf_functional_change_indicator.yml
@@ -3,7 +3,7 @@ name: EKF Change Indicator
 on:
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/failsafe_sim.yml
+++ b/.github/workflows/failsafe_sim.yml
@@ -8,7 +8,7 @@ on:
       - 'docs/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/failsafe_sim.yml
+++ b/.github/workflows/failsafe_sim.yml
@@ -12,6 +12,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/flash_analysis.yml
+++ b/.github/workflows/flash_analysis.yml
@@ -13,7 +13,7 @@ on:
       - 'docs/**'
   pull_request:
     branches:
-      - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/itcm_check.yml
+++ b/.github/workflows/itcm_check.yml
@@ -15,6 +15,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_itcm:
     name: Checking ${{ matrix.target }}

--- a/.github/workflows/itcm_check.yml
+++ b/.github/workflows/itcm_check.yml
@@ -11,7 +11,7 @@ on:
       - 'docs/**'
   pull_request:
     branches:
-      - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -8,7 +8,7 @@ on:
       - 'docs/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -12,6 +12,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -8,7 +8,7 @@ on:
       - 'docs/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -12,6 +12,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/nuttx_env_config.yml
+++ b/.github/workflows/nuttx_env_config.yml
@@ -8,7 +8,7 @@ on:
       - 'docs/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/nuttx_env_config.yml
+++ b/.github/workflows/nuttx_env_config.yml
@@ -12,6 +12,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -8,7 +8,7 @@ on:
       - 'docs/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/ros_integration_tests.yml
+++ b/.github/workflows/ros_integration_tests.yml
@@ -17,6 +17,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: [runs-on,runner=16cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}",spot=false]

--- a/.github/workflows/ros_translation_node.yml
+++ b/.github/workflows/ros_translation_node.yml
@@ -7,7 +7,7 @@ on:
       - 'docs/**'
   pull_request:
     branches:
-    - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
 defaults:

--- a/.github/workflows/ros_translation_node.yml
+++ b/.github/workflows/ros_translation_node.yml
@@ -13,6 +13,11 @@ on:
 defaults:
   run:
     shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_and_test:
     name: Build and test

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -13,7 +13,7 @@ on:
       - 'docs/**'
   pull_request:
     branches:
-    - '*'
+    - '**'
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -17,6 +17,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Testing PX4 ${{ matrix.config.model }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,20 +240,6 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE ${PX4_BUILD_TYPE} CACHE STRING "Build type" FORCE)
 endif()
 
-if (CMAKE_BUILD_TYPE STREQUAL Coverage)
-	# Coverage instrumentation plus atomic updates
-	set(COVERAGE_FLAGS
-		--coverage
-		-fprofile-update=atomic
-	)
-
-	# Apply to every compile and link invocation
-	add_compile_options(${COVERAGE_FLAGS})
-	add_link_options(${COVERAGE_FLAGS})
-
-	message(STATUS "Coverage instrumentation enabled with flags: ${COVERAGE_FLAGS}")
-endif()
-
 if((CMAKE_BUILD_TYPE STREQUAL "Debug") OR (CMAKE_BUILD_TYPE STREQUAL "Coverage"))
 	set(MAX_CUSTOM_OPT_LEVEL -O0)
 elseif(CMAKE_BUILD_TYPE MATCHES "Sanitizer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,20 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE ${PX4_BUILD_TYPE} CACHE STRING "Build type" FORCE)
 endif()
 
+if (CMAKE_BUILD_TYPE STREQUAL Coverage)
+	# Coverage instrumentation plus atomic updates
+	set(COVERAGE_FLAGS
+		--coverage
+		-fprofile-update=atomic
+	)
+
+	# Apply to every compile and link invocation
+	add_compile_options(${COVERAGE_FLAGS})
+	add_link_options(${COVERAGE_FLAGS})
+
+	message(STATUS "Coverage instrumentation enabled with flags: ${COVERAGE_FLAGS}")
+endif()
+
 if((CMAKE_BUILD_TYPE STREQUAL "Debug") OR (CMAKE_BUILD_TYPE STREQUAL "Coverage"))
 	set(MAX_CUSTOM_OPT_LEVEL -O0)
 elseif(CMAKE_BUILD_TYPE MATCHES "Sanitizer")
@@ -425,7 +439,6 @@ if(BUILD_TESTING)
 			WORKING_DIRECTORY ${PX4_BINARY_DIR})
 	set_target_properties(test_results PROPERTIES EXCLUDE_FROM_ALL TRUE)
 endif()
-
 
 #=============================================================================
 # subdirectories

--- a/Makefile
+++ b/Makefile
@@ -410,11 +410,18 @@ tests:
 	$(eval UBSAN_OPTIONS += color=always)
 	$(call cmake-build,px4_sitl_test)
 
+# work around lcov bug #316; remove once lcov is fixed (see https://github.com/linux-test-project/lcov/issues/316)
+LCOBUG = --ignore-errors mismatch
 tests_coverage:
 	@$(MAKE) clean
 	@$(MAKE) --no-print-directory tests PX4_CMAKE_BUILD_TYPE=Coverage
 	@mkdir -p coverage
-	@lcov --directory build/px4_sitl_test --base-directory build/px4_sitl_test --gcov-tool gcov --capture -o coverage/lcov.info
+	@lcov --directory build/px4_sitl_test \
+		--base-directory build/px4_sitl_test \
+		--gcov-tool gcov \
+		--capture \
+		$(LCOBUG) \
+		-o coverage/lcov.info
 
 
 rostest: px4_sitl_default

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -224,7 +224,7 @@ else
 		# Look for airframe in ROMFS
 		. ${R}etc/init.d/rc.autostart
 
-		if [ ${VEHICLE_TYPE} == none ]
+		if [ ${VEHICLE_TYPE} = none ]
 		then
 			# Use external startup file
 			if [ $STORAGE_AVAILABLE = yes ]
@@ -235,7 +235,7 @@ else
 			fi
 		fi
 
-		if [ ${VEHICLE_TYPE} == none ]
+		if [ ${VEHICLE_TYPE} = none ]
 		then
 			echo "ERROR [init] No airframe file found for SYS_AUTOSTART value"
 			param set SYS_AUTOSTART 0

--- a/Tools/serial/rc.serial_port.jinja
+++ b/Tools/serial/rc.serial_port.jinja
@@ -5,7 +5,7 @@
 set SERIAL_DEV none
 {% for serial_device in serial_devices -%}
 if param compare "$PRT" {{ serial_device.index }}; then
-	if [ "x$PRT_{{ serial_device.tag }}_" = "x" ]; then
+	if [ "$PRT_{{ serial_device.tag }}_" = "" ]; then
 		set SERIAL_DEV {{ serial_device.device }}
 		set BAUD_PARAM SER_{{ serial_device.tag }}_BAUD
 		set PRT_{{ serial_device.tag }}_ 1

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -36,6 +36,20 @@ find_program(GENHTML_PATH genhtml)
 
 message(STATUS "Building for code coverage")
 
+if (CMAKE_BUILD_TYPE STREQUAL Coverage)
+	# Coverage instrumentation plus atomic updates
+	set(COVERAGE_FLAGS
+		--coverage
+		-fprofile-update=atomic
+	)
+
+	# Apply to every compile and link invocation
+	add_compile_options(${COVERAGE_FLAGS})
+	add_link_options(${COVERAGE_FLAGS})
+
+	message(STATUS "Coverage instrumentation enabled with flags: ${COVERAGE_FLAGS}")
+endif()
+
 # add code coverage build type
 if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang"))
 	set(CMAKE_C_FLAGS_COVERAGE "--coverage -ftest-coverage -fdiagnostics-absolute-paths -O0 -fprofile-arcs -fno-inline-functions"


### PR DESCRIPTION
few commits to update CI throughout

* Single asterisk ('*') won't work for '**release/v1.16**' branches, updating to double asterisk fixes this
* Cancel concurrent jobs to save on computing time
* Enable workflows on changes to **.github/workflows** directory, otherwise it's hard to test changes on those files. Keeps the ignore path to workflows for push events.
* shellcheck fixes with updated compiler
  * Fixes SC2268
  * Fixes SC3014
* ignore lcov mismatch errors
* enable atomic profile updates for coverage builds