### PR TITLE
EKF2_GPS_POS_X/Y/Z have same long description

### DIFF
--- a/src/modules/ekf2/params_gnss.yaml
+++ b/src/modules/ekf2/params_gnss.yaml
@@ -77,7 +77,7 @@ parameters:
     EKF2_GPS_POS_X:
       description:
         short: X position of GPS antenna in body frame
-        long: Forward axis with origin relative to vehicle centre of gravity
+        long: Forward (roll) axis with origin relative to vehicle centre of gravity
       type: float
       default: 0.0
       unit: m
@@ -85,7 +85,7 @@ parameters:
     EKF2_GPS_POS_Y:
       description:
         short: Y position of GPS antenna in body frame
-        long: Forward axis with origin relative to vehicle centre of gravity
+        long: Right (pitch) axis with origin relative to vehicle centre of gravity
       type: float
       default: 0.0
       unit: m
@@ -93,7 +93,7 @@ parameters:
     EKF2_GPS_POS_Z:
       description:
         short: Z position of GPS antenna in body frame
-        long: Forward axis with origin relative to vehicle centre of gravity
+        long: Down (yaw) axis with origin relative to vehicle centre of gravity
       type: float
       default: 0.0
       unit: m


### PR DESCRIPTION
The description for EKF2_GPS_POS_X, Y, Z all refer to the Forward axis in the long description.

Note that I have referred to these as the Forward (roll), Right (pitch) and Down (yaw) axis. Not sure if this is correct - i.e. that you need roll/pitch/yaw.