### PR TITLE
Update 4011_gz_lawnmower to match recent changes in Rover controls

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
@@ -1,36 +1,53 @@
 #!/bin/sh
-# @name Gazebo lawnmower
+# @name Gazebo - Zero Turn Lawnmower
 # @type Rover
 # @class Rover
 
 . ${R}etc/init.d/rc.rover_differential_defaults
 
 PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
-PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
+PX4_GZ_WORLD=${PX4_GZ_WORLD:=lawn}
 PX4_SIM_MODEL=${PX4_SIM_MODEL:=lawnmower}
 
 param set-default SIM_GZ_EN 1 # Gazebo bridge
 
+param set-default NAV_ACC_RAD 0.5
+
 # We can arm and drive in manual mode when it slides and GPS check fails:
 param set-default COM_ARM_WO_GPS 1
 
-# Rover parameters
+# Differential Parameters
 param set-default RD_WHEEL_TRACK 0.9
-param set-default RD_YAW_RATE_I 0.1
-param set-default RD_YAW_RATE_P 5
-param set-default RD_MAX_ACCEL 1
-param set-default RD_MAX_JERK 3
-param set-default RD_MAX_SPEED 8
-param set-default RD_YAW_P 5
-param set-default RD_YAW_I 0.1
-param set-default RD_MAX_YAW_RATE 30
 param set-default RD_TRANS_DRV_TRN 0.349066
 param set-default RD_TRANS_TRN_DRV 0.174533
 
+# Rover Control Parameters
+param set-default RO_ACCEL_LIM 0.1
+param set-default RO_DECEL_LIM 0.8
+param set-default RO_JERK_LIM 10
+param set-default RO_MAX_THR_SPEED 2.1
+
+# Rover Rate Control Parameters
+param set-default RO_YAW_RATE_I 0.1
+param set-default RO_YAW_RATE_P 0.5
+param set-default RO_YAW_RATE_LIM 60
+param set-default RO_YAW_ACCEL_LIM 50
+param set-default RO_YAW_DECEL_LIM 1000
+param set-default RO_YAW_RATE_CORR 1.0
+
+# Rover Attitude Control Parameters
+param set-default RO_YAW_P 0.8
+
+# Rover Velocity Control Parameters
+param set-default RO_SPEED_LIM 0.5
+param set-default RO_SPEED_I 0.01
+param set-default RO_SPEED_P 0.05
+param set-defatul RO_SPEED_RED 1.0
+
 # Pure pursuit parameters
-param set-default PP_LOOKAHD_MAX 30
-param set-default PP_LOOKAHD_MIN 2
 param set-default PP_LOOKAHD_GAIN 1
+param set-default PP_LOOKAHD_MAX 10
+param set-default PP_LOOKAHD_MIN 1
 
 # Actuator mapping - set SITL motors/servos output parameters:
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
@@ -22,26 +22,26 @@ param set-default RD_TRANS_DRV_TRN 0.349066
 param set-default RD_TRANS_TRN_DRV 0.174533
 
 # Rover Control Parameters
-param set-default RO_ACCEL_LIM 0.1
-param set-default RO_DECEL_LIM 0.8
-param set-default RO_JERK_LIM 10
-param set-default RO_MAX_THR_SPEED 2.1
+param set-default RO_ACCEL_LIM 1.5
+param set-default RO_DECEL_LIM 5
+param set-default RO_JERK_LIM 15
+param set-default RO_MAX_THR_SPEED 2.7
 
 # Rover Rate Control Parameters
-param set-default RO_YAW_RATE_I 0.1
-param set-default RO_YAW_RATE_P 0.5
+param set-default RO_YAW_RATE_I 0.2
+param set-default RO_YAW_RATE_P 1.0
 param set-default RO_YAW_RATE_LIM 60
 param set-default RO_YAW_ACCEL_LIM 50
 param set-default RO_YAW_DECEL_LIM 1000
 param set-default RO_YAW_RATE_CORR 1.0
 
 # Rover Attitude Control Parameters
-param set-default RO_YAW_P 0.8
+param set-default RO_YAW_P 5
 
 # Rover Velocity Control Parameters
-param set-default RO_SPEED_LIM 0.5
+param set-default RO_SPEED_LIM 2.1
 param set-default RO_SPEED_I 0.01
-param set-default RO_SPEED_P 0.05
+param set-default RO_SPEED_P 0.1
 param set-defatul RO_SPEED_RED 1.0
 
 # Pure pursuit parameters
@@ -53,16 +53,16 @@ param set-default PP_LOOKAHD_MIN 1
 
 # "Motors" - motor channels 0 (Right) and 1 (Left) - via Wheels GZ bridge:
 param set-default SIM_GZ_WH_FUNC1 101 # right wheel
-#param set-default SIM_GZ_WH_MIN1 0
-#param set-default SIM_GZ_WH_MAX1 200
-#param set-default SIM_GZ_WH_DIS1 100
-#param set-default SIM_GZ_WH_FAIL1 100
+param set-default SIM_GZ_WH_MIN1 87
+param set-default SIM_GZ_WH_MAX1 113
+param set-default SIM_GZ_WH_DIS1 100
+param set-default SIM_GZ_WH_FAIL1 100
 
 param set-default SIM_GZ_WH_FUNC2 102 # left wheel
-#param set-default SIM_GZ_WH_MIN2 0
-#param set-default SIM_GZ_WH_MAX2 200
-#param set-default SIM_GZ_WH_DIS2 100
-#param set-default SIM_GZ_WH_FAIL2 100
+param set-default SIM_GZ_WH_MIN2 87
+param set-default SIM_GZ_WH_MAX2 113
+param set-default SIM_GZ_WH_DIS2 100
+param set-default SIM_GZ_WH_FAIL2 100
 
 param set-default SIM_GZ_WH_REV 0 # no need to reverse any wheels
 


### PR DESCRIPTION
### Solved Problem
As the Rover controls kept changing, Lawnmower stopped working in Gazebo due to obsolete parameters settings.

### Solution
I updated parameters and tested the rover in Gazebo (GZ)

### Test coverage
The simulation can be run as follows:
```
make px4_sitl gz_lawnmower_lawn
  or
make px4_sitl gz_lawnmower
```
In _QGroundControl_, upload any mission from this link and watch the rover execute missions:

https://github.com/slgrobotics/PX4-Autopilot/tree/dev/plans

**Note:** in my testing I observed that the velocity profile looks odd. The rover accelerates as it should to ~2.1 - 2.4 m/s, maintains that speed for about a third of the straight run, and then starts slowly decelerating for the rest 2/3rd of the leg.
I expected longer run with the set speed of 2.1 m/s, symmetrical deceleration. I couldn't find a combination of parameters to achieve that.

### Context
The Lawnmower model and _Lawn_ world, contributed earlier, provide an opportunity to test, debug and validate control algorithms with a heavy rover on a slippery surface - something much closer to a real life scenario than a light grippy R1 Aion model. Users who apply PX4 to agricultural robots and other larger vehicles might feel more confident knowing that the team provided a simulation more closely fitting their use case.

In my case I adopted PX4 codebase in 2020, and over time created a machine with acceptable characteristics. There's a lot of custom control code. With the latest changes in PX4 rover code I plan to get rid of most of my old code and use the new Rover architecture. So far, my main difficulty was achieving a maximum 20 cm deviation from the straight line, I made it work before and hope to make it work with the new code.

https://www.youtube.com/watch?v=lFeJqSS91A8

![Screenshot from 2025-06-17 19-40-21](https://github.com/user-attachments/assets/39084d0e-0be8-4b0b-a23b-ed6abc1ecd62)


