### PR TITLE
septentrio: implement jamming/spoofing state

### DIFF
--- a/src/drivers/gnss/septentrio/sbf/decoder.cpp
+++ b/src/drivers/gnss/septentrio/sbf/decoder.cpp
@@ -163,7 +163,7 @@ int Decoder::parse(QualityInd *message) const
 
 int Decoder::parse(RFStatus *message) const
 {
-	if (can_parse() && id() == BlockID::PVTGeodetic) {
+	if (can_parse() && id() == BlockID::RFStatus) {
 		static_assert(sizeof(*message) <= sizeof(_message.payload), "Buffer too small");
 		memcpy(message, _message.payload, sizeof(RFStatus) - sizeof(RFStatus::rf_band));
 


### PR DESCRIPTION
### Solved Problem
The jamming/spoofing state is not yet implemented for septentrio modules.

### Solution
- Use the `Flags` of the `RFStatus`
- Bit1 directly indicates that message authentication failed, this is used for the spoofing state
- Bit 0 indicates that the signal may be jammed or spoofed, this is used for a jamming warning, as the description contains the word "may", which fits the semantic of a jamming warning, but not a spoofing indicated

### Changelog Entry
For release notes:
```
Feature/Bugfix implement jamming/spoofing state for septentrio
```

### Alternatives
- To even better differentiate we could also take values like AGC gain into consideration, but this is for a follow-up

### Test coverage
- Tested on the bench with a septentrio mosaic-go
