### PR TITLE
auav: use correct sign during calib data reading

### DIFF
--- a/src/drivers/differential_pressure/auav/AUAV.cpp
+++ b/src/drivers/differential_pressure/auav/AUAV.cpp
@@ -240,14 +240,14 @@ int AUAV::read_calibration_eeprom(const uint8_t eeprom_address, uint16_t &data)
 void AUAV::process_calib_data_raw(const calib_data_raw_t calib_data_raw)
 {
 	/* Conversion of calib data as described in the datasheet */
-	_calib_data.a = (float)((calib_data_raw.a_hw << 16) | calib_data_raw.a_lw) / 0x7FFFFFFF;
-	_calib_data.b = (float)((calib_data_raw.b_hw << 16) | calib_data_raw.b_lw) / 0x7FFFFFFF;
-	_calib_data.c = (float)((calib_data_raw.c_hw << 16) | calib_data_raw.c_lw) / 0x7FFFFFFF;
-	_calib_data.d = (float)((calib_data_raw.d_hw << 16) | calib_data_raw.d_lw) / 0x7FFFFFFF;
+	_calib_data.a = (float)((int32_t)((calib_data_raw.a_hw << 16) | calib_data_raw.a_lw)) / 0x7FFFFFFF;
+	_calib_data.b = (float)((int32_t)((calib_data_raw.b_hw << 16) | calib_data_raw.b_lw)) / 0x7FFFFFFF;
+	_calib_data.c = (float)((int32_t)((calib_data_raw.c_hw << 16) | calib_data_raw.c_lw)) / 0x7FFFFFFF;
+	_calib_data.d = (float)((int32_t)((calib_data_raw.d_hw << 16) | calib_data_raw.d_lw)) / 0x7FFFFFFF;
 
-	_calib_data.tc50h = (float)(calib_data_raw.tc50 >> 8) / 0x7F;
-	_calib_data.tc50l = (float)(calib_data_raw.tc50 & 0xFF) / 0x7F;
-	_calib_data.es = (float)(calib_data_raw.es & 0xFF) / 0x7F;
+	_calib_data.tc50h = (float)((int8_t)(calib_data_raw.tc50 >> 8)) / 0x7F;
+	_calib_data.tc50l = (float)((int8_t)(calib_data_raw.tc50 & 0xFF)) / 0x7F;
+	_calib_data.es = (float)((int8_t)(calib_data_raw.es & 0xFF)) / 0x7F;
 }
 
 float AUAV::correct_pressure(const uint32_t pressure_raw, const uint32_t temperature_raw) const


### PR DESCRIPTION
### Solved Problem
- The measured values of the AUAV LD10 showed a slight offset, which was caused by the temperature correction not working as expected.

### Solution
- Read the calibration parameters correctly (by actually using their sign...)

See this section of the datasheet:
> As described more fully in the Extended Compensation section, these are referred to as A, B, C, D, Es, TC50H, TC50L. Values (A, B, C, and D) are 32-bit signed integers, stored in eight 16-bit registers in the EEPROM of each channel. Values Es, TC50H, TC50L are 8 bit signed integers, stored in two 16-bit EEPROM locations.

For release notes:
```
Feature/Bugfix Fix AUAV not using calibration params correctly
```

### Test coverage
- Tested on the bench with an AUAV LD10 and an ARK FMU v6x

