### PR TITLE
Remove COM_POSCTL_NAVL

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/60002_gz_uuv_bluerov2_heavy
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/60002_gz_uuv_bluerov2_heavy
@@ -34,7 +34,6 @@ param set-default COM_LOW_BAT_ACT 0
 param set-default NAV_DLL_ACT 0
 param set-default GF_ACTION 1
 param set-default NAV_RCL_ACT 1
-param set-default COM_POSCTL_NAVL 2
 
 # disable attitude failure detection
 param set-default FD_FAIL_P 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/70000_gz_atmos
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/70000_gz_atmos
@@ -45,7 +45,6 @@ param set-default COM_LOW_BAT_ACT 0
 param set-default NAV_DLL_ACT 0
 param set-default GF_ACTION 1
 param set-default NAV_RCL_ACT 1
-param set-default COM_POSCTL_NAVL 2
 
 # disable attitude failure detection
 param set-default FD_FAIL_P 0

--- a/ROMFS/px4fmu_common/init.d/airframes/60002_uuv_bluerov2_heavy
+++ b/ROMFS/px4fmu_common/init.d/airframes/60002_uuv_bluerov2_heavy
@@ -45,7 +45,6 @@ param set-default COM_LOW_BAT_ACT 0
 param set-default NAV_DLL_ACT 0
 param set-default GF_ACTION 1
 param set-default NAV_RCL_ACT 1
-param set-default COM_POSCTL_NAVL 2
 
 # disable attitude failure detection
 param set-default FD_FAIL_P 0

--- a/ROMFS/px4fmu_common/init.d/airframes/70000_atmos
+++ b/ROMFS/px4fmu_common/init.d/airframes/70000_atmos
@@ -35,7 +35,6 @@ param set-default COM_LOW_BAT_ACT 0
 param set-default NAV_DLL_ACT 0
 param set-default GF_ACTION 1
 param set-default NAV_RCL_ACT 1
-param set-default COM_POSCTL_NAVL 2
 
 # Set Mocap Vision frame
 param set EKF2_EV_CTRL 15

--- a/docs/assets/airframes/multicopter/amovlab_f410/amovlabf410_drone_v1.15.4.params
+++ b/docs/assets/airframes/multicopter/amovlab_f410/amovlabf410_drone_v1.15.4.params
@@ -1,8 +1,8 @@
 # Onboard parameters for Vehicle 1
 #
 # Stack: PX4 Pro
-# Vehicle: ∂‡–˝“Ì
-# Version: 1.15.4 
+# Vehicle: Multi-Rotor
+# Version: 1.15.4
 # Git Revision: 99c40407ff000000
 #
 # Vehicle-Id Component-Id Name Value Type
@@ -318,7 +318,6 @@
 1	1	COM_OBS_AVOID	0	6
 1	1	COM_OF_LOSS_T	1.000000000000000000	9
 1	1	COM_PARACHUTE	0	6
-1	1	COM_POSCTL_NAVL	0	6
 1	1	COM_POS_FS_DELAY	1	6
 1	1	COM_POS_FS_EPH	5.000000000000000000	9
 1	1	COM_POS_LOW_EPH	-1.000000000000000000	9

--- a/docs/en/config/safety.md
+++ b/docs/en/config/safety.md
@@ -206,22 +206,10 @@ The relevant parameters shown below.
 
 ### Position Loss Failsafe Action
 
-The failure action is controlled by [COM_POSCTL_NAVL](../advanced_config/parameter_reference.md#COM_POSCTL_NAVL), based on whether RC control is assumed to be available (and altitude information):
-
-- `0`: Remote control available.
-  Switch to _Altitude mode_ if a height estimate is available, otherwise _Stabilized mode_.
-- `1`: Remote control _not_ available.
-  Switch to _Descend mode_ if a height estimate is available, otherwise enter flight termination.
-  _Descend mode_ is a landing mode that does not require a position estimate.
-
 Fixed-wing planes, and VTOLs not configured to land in hover ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)), have a parameter ([FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT)) that defines how long they will loiter (circle with a constant roll angle ([FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)) at the current altitude) after losing position before attempting to land.
 If VTOLs have are configured to switch to hover for landing ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)) then they will first transition and then descend.
 
 The relevant parameters for all vehicles shown below.
-
-| Parameter                                                                                                | Description                                                                                                   |
-| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| <a id="COM_POSCTL_NAVL"></a>[COM_POSCTL_NAVL](../advanced_config/parameter_reference.md#COM_POSCTL_NAVL) | Position control navigation loss response during mission. Values: `0` - assume use of RC, `1` - Assume no RC. |
 
 Parameters that only affect Fixed-wing vehicles:
 

--- a/docs/en/config/safety.md
+++ b/docs/en/config/safety.md
@@ -206,6 +206,8 @@ The relevant parameters shown below.
 
 ### Position Loss Failsafe Action
 
+Multicopters will switch to [Altitude mode](../flight_modes_mc/altitude.md) if a height estimate is available, otherwise [Stabilized mode](../flight_modes_mc/manual_stabilized.md).
+ 
 Fixed-wing planes, and VTOLs not configured to land in hover ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)), have a parameter ([FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT)) that defines how long they will loiter (circle with a constant roll angle ([FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)) at the current altitude) after losing position before attempting to land.
 If VTOLs have are configured to switch to hover for landing ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)) then they will first transition and then descend.
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -230,7 +230,7 @@ private:
 		_health_and_arming_checks.externalChecks()
 #endif
 	};
-	UserModeIntention	_user_mode_intention {this, _vehicle_status, _health_and_arming_checks, &_mode_management};
+	UserModeIntention _user_mode_intention {_vehicle_status, _health_and_arming_checks, &_mode_management};
 
 	const failsafe_flags_s &_failsafe_flags{_health_and_arming_checks.failsafeFlags()};
 	HomePosition 		_home_position{_failsafe_flags};

--- a/src/modules/commander/UserModeIntention.cpp
+++ b/src/modules/commander/UserModeIntention.cpp
@@ -34,9 +34,9 @@
 
 #include "UserModeIntention.hpp"
 
-UserModeIntention::UserModeIntention(ModuleParams *parent, const vehicle_status_s &vehicle_status,
+UserModeIntention::UserModeIntention(const vehicle_status_s &vehicle_status,
 				     const HealthAndArmingChecks &health_and_arming_checks, ModeChangeHandler *handler)
-	: ModuleParams(parent), _vehicle_status(vehicle_status), _health_and_arming_checks(health_and_arming_checks),
+	: _vehicle_status(vehicle_status), _health_and_arming_checks(health_and_arming_checks),
 	  _handler(handler)
 {
 }
@@ -59,7 +59,7 @@ bool UserModeIntention::change(uint8_t user_intended_nav_state, ModeChangeSource
 		allow_change = _health_and_arming_checks.canRun(user_intended_nav_state);
 
 		// Check fallback
-		if (!allow_change && allow_fallback && _param_com_posctl_navl.get() == 0) {
+		if (!allow_change && allow_fallback) {
 			if (user_intended_nav_state == vehicle_status_s::NAVIGATION_STATE_POSCTL) {
 				allow_change = _health_and_arming_checks.canRun(vehicle_status_s::NAVIGATION_STATE_ALTCTL);
 				// We still use the original user intended mode. The failsafe state machine will then set the

--- a/src/modules/commander/UserModeIntention.hpp
+++ b/src/modules/commander/UserModeIntention.hpp
@@ -35,7 +35,6 @@
 
 #include <uORB/topics/vehicle_status.h>
 #include "HealthAndArmingChecks/HealthAndArmingChecks.hpp"
-#include <px4_platform_common/module_params.h>
 
 enum class ModeChangeSource {
 	User,           ///< RC or MAVLink
@@ -58,10 +57,10 @@ public:
 };
 
 
-class UserModeIntention : ModuleParams
+class UserModeIntention
 {
 public:
-	UserModeIntention(ModuleParams *parent, const vehicle_status_s &vehicle_status,
+	UserModeIntention(const vehicle_status_s &vehicle_status,
 			  const HealthAndArmingChecks &health_and_arming_checks, ModeChangeHandler *handler);
 	~UserModeIntention() = default;
 
@@ -102,8 +101,4 @@ private:
 
 	bool _ever_had_mode_change{false}; ///< true if there was ever a mode change call (also if the same mode as already set)
 	bool _had_mode_change{false}; ///< true if there was a mode change call since the last getHadModeChangeAndClear()
-
-	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::COM_POSCTL_NAVL>) _param_com_posctl_navl
-	);
 };

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -462,18 +462,6 @@ PARAM_DEFINE_FLOAT(COM_RC_STICK_OV, 30.0f);
 PARAM_DEFINE_INT32(COM_ARM_MIS_REQ, 0);
 
 /**
- * Position mode navigation loss response
- *
- * This sets the flight mode that will be used if navigation accuracy is no longer adequate for position control in manual Position mode.
- *
- * @value 0 Altitude mode
- * @value 1 Land mode (descend)
- *
- * @group Commander
- */
-PARAM_DEFINE_INT32(COM_POSCTL_NAVL, 0);
-
-/**
  * Require arm authorization to arm
  *
  * By default off. The default allows to arm the vehicle without a arm authorization.

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -668,46 +668,20 @@ FailsafeBase::Action Failsafe::checkModeFallback(const failsafe_flags_s &status_
 		}
 	}
 
-	// posctrl
-	switch (position_control_navigation_loss_response(_param_com_posctl_navl.get())) {
-	case position_control_navigation_loss_response::Altitude_Manual: // AltCtrl/Manual
-
-		// PosCtrl/PositionSlow -> AltCtrl
-		if ((user_intended_mode == vehicle_status_s::NAVIGATION_STATE_POSCTL ||
-		     user_intended_mode == vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW)
-		    && !modeCanRun(status_flags, user_intended_mode)) {
-			action = Action::FallbackAltCtrl;
-			user_intended_mode = vehicle_status_s::NAVIGATION_STATE_ALTCTL;
-		}
-
-		// AltCtrl -> Stabilized
-		if (user_intended_mode == vehicle_status_s::NAVIGATION_STATE_ALTCTL
-		    && !modeCanRun(status_flags, user_intended_mode)) {
-			action = Action::FallbackStab;
-			user_intended_mode = vehicle_status_s::NAVIGATION_STATE_STAB;
-		}
-
-		break;
-
-	case position_control_navigation_loss_response::Land_Descend: // Land/Terminate
-
-		// PosCtrl/PositionSlow -> Land
-		if ((user_intended_mode == vehicle_status_s::NAVIGATION_STATE_POSCTL ||
-		     user_intended_mode == vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW)
-		    && !modeCanRun(status_flags, user_intended_mode)) {
-			action = Action::Land;
-			user_intended_mode = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
-
-			// Land -> Descend
-			if (!modeCanRun(status_flags, user_intended_mode)) {
-				action = Action::Descend;
-				user_intended_mode = vehicle_status_s::NAVIGATION_STATE_DESCEND;
-			}
-		}
-
-		break;
+	// PosCtrl/PositionSlow -> AltCtrl
+	if ((user_intended_mode == vehicle_status_s::NAVIGATION_STATE_POSCTL ||
+	     user_intended_mode == vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW)
+	    && !modeCanRun(status_flags, user_intended_mode)) {
+		action = Action::FallbackAltCtrl;
+		user_intended_mode = vehicle_status_s::NAVIGATION_STATE_ALTCTL;
 	}
 
+	// AltCtrl -> Stabilized
+	if (user_intended_mode == vehicle_status_s::NAVIGATION_STATE_ALTCTL
+	    && !modeCanRun(status_flags, user_intended_mode)) {
+		action = Action::FallbackStab;
+		user_intended_mode = vehicle_status_s::NAVIGATION_STATE_STAB;
+	}
 
 	// Last, check can_run for intended mode
 	if (!modeCanRun(status_flags, user_intended_mode)) {

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -85,11 +85,6 @@ private:
 		Disarm = 7,
 	};
 
-	enum class position_control_navigation_loss_response : int32_t {
-		Altitude_Manual = 0,
-		Land_Descend = 1,
-	};
-
 	enum class actuator_failure_failsafe_mode : int32_t {
 		Warning_only = 0,
 		Hold_mode = 1,
@@ -202,7 +197,6 @@ private:
 					(ParamInt<px4::params::COM_RCL_EXCEPT>) _param_com_rcl_except,
 					(ParamInt<px4::params::COM_DLL_EXCEPT>) _param_com_dll_except,
 					(ParamInt<px4::params::COM_RC_IN_MODE>) _param_com_rc_in_mode,
-					(ParamInt<px4::params::COM_POSCTL_NAVL>) _param_com_posctl_navl,
 					(ParamInt<px4::params::GF_ACTION>)  	_param_gf_action,
 					(ParamFloat<px4::params::COM_SPOOLUP_TIME>) _param_com_spoolup_time,
 					(ParamInt<px4::params::COM_IMB_PROP_ACT>) _param_com_imb_prop_act,


### PR DESCRIPTION
### Solved Problem
This parameter repeataddly confuses users who are looking for a way to influence position loss failsafe behavior. In an effort to reduce confusion and configuration space I suggest to remove this option which I've not seen use for. If a pilot flies manually in position mode we assume he has some visual reference of the vehicle and can do better than an autonomous mode without position reference. If that assumption wouldn't hold he was in Position mode by mistake and the static option here doesn't help. Also by now we have nudging in Descend mode so the pilot can still give input and the only difference is it automatically goes down instead of the pilot having to descend by stick to land.

### Solution
Remove COM_POSCTL_NAVL

### Changelog Entry
```
Remove COM_POSCTL_NAVL
```

### Alternatives
Someone posts a good reason to have this option and then we can document that case to make the correct assumptions.

### Test coverage
Compiles, and all use of the parameter was replaced with the default option (0). I haven't tested this though. Please review.