### PR TITLE
CI: remove .github paths-ignore in workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,13 +6,11 @@ on:
     - 'main'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -6,13 +6,11 @@ on:
     - 'main'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -6,13 +6,11 @@ on:
     - 'main'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/compile_ubuntu.yml
+++ b/.github/workflows/compile_ubuntu.yml
@@ -9,13 +9,11 @@ on:
       - 'release/**'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
       - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 env:
   RUNS_IN_DOCKER: true

--- a/.github/workflows/ekf_functional_change_indicator.yml
+++ b/.github/workflows/ekf_functional_change_indicator.yml
@@ -6,7 +6,6 @@ on:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 jobs:
   unit_tests:

--- a/.github/workflows/ekf_update_change_indicator.yml
+++ b/.github/workflows/ekf_update_change_indicator.yml
@@ -4,7 +4,6 @@ on:
   push:
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 jobs:
   unit_tests:

--- a/.github/workflows/failsafe_sim.yml
+++ b/.github/workflows/failsafe_sim.yml
@@ -6,13 +6,11 @@ on:
     - 'main'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/flash_analysis.yml
+++ b/.github/workflows/flash_analysis.yml
@@ -11,13 +11,11 @@ on:
       - 'main'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
       - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 env:
   MIN_FLASH_POS_DIFF_FOR_COMMENT: 50

--- a/.github/workflows/itcm_check.yml
+++ b/.github/workflows/itcm_check.yml
@@ -9,13 +9,11 @@ on:
       - 'main'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
       - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 jobs:
   check_itcm:

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -6,13 +6,11 @@ on:
     - 'main'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -6,13 +6,11 @@ on:
     - 'main'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/nuttx_env_config.yml
+++ b/.github/workflows/nuttx_env_config.yml
@@ -6,13 +6,11 @@ on:
     - 'main'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -6,13 +6,11 @@ on:
     - 'main'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/ros_translation_node.yml
+++ b/.github/workflows/ros_translation_node.yml
@@ -5,13 +5,11 @@ on:
     - 'main'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 defaults:
   run:
     shell: bash

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -11,13 +11,11 @@ on:
     - 'main'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/**'
 
 jobs:
   build:


### PR DESCRIPTION

### Solved Problem & Solution
When we open a PR or push a commit to main (protected branch) certain workflows are skipped because they have '.github/**' in their paths-ignore.
If we want to label certain checks as _required_ we still want those tests to be started...
