### PR TITLE
Takeoff: only use local position in execution logic and allow setting loiter point of fixed-wing takeoff

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2011,7 +2011,9 @@ void Commander::checkForMissionUpdate()
 					_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION);
 
 				} else {
-					_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER);
+					// Transition to loiter when the takeoff is completed (force into the Loiter, if mode is not executable then failsafe).
+					_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, ModeChangeSource::ModeExecutor, false,
+								    true);
 				}
 
 			} else if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION) {

--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -158,8 +158,14 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	// NAVIGATION_STATE_AUTO_TAKEOFF
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_attitude);
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_local_position);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_local_alt);
+
+	if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_local_position_relaxed);
+
+	} else {
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_local_position);
+	}
 
 	// NAVIGATION_STATE_AUTO_LAND
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_angular_velocity);
@@ -194,8 +200,14 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	// NAVIGATION_STATE_AUTO_VTOL_TAKEOFF
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_attitude);
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_local_position);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_local_alt);
+
+	if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_local_position_relaxed);
+
+	} else {
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_local_position);
+	}
 
 	// NAVIGATION_STATE_EXTERNALx: handled outside
 

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -1219,13 +1219,12 @@ FixedWingModeManager::control_auto_takeoff(const hrt_abstime &now, const float c
 							   _param_fw_thr_idle.get() : NAN;
 			const fixed_wing_longitudinal_setpoint_s fw_longitudinal_control_sp = {
 				.timestamp = now,
-				.altitude = altitude_setpoint_amsl,
-				.height_rate = NAN,
+				.altitude = NAN,
+				.height_rate = _param_fw_t_clmb_max.get(),
 				.equivalent_airspeed = takeoff_airspeed,
 				.pitch_direct = NAN,
 				.throttle_direct = NAN
 			};
-
 
 			_longitudinal_ctrl_sp_pub.publish(fw_longitudinal_control_sp);
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -640,6 +640,10 @@ void Navigator::run()
 
 				rep->next.valid = false;
 
+				// after the straight climbout the vehicle will establish on a loiter at this position
+				_takeoff.setLoiterPosition(matrix::Vector2d(cmd.param5, cmd.param6));
+				_takeoff.setLoiterAltitudeLocalZ(cmd.param7);
+
 				// CMD_NAV_TAKEOFF is acknowledged by commander
 
 #if CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF

--- a/src/modules/navigator/takeoff_params.c
+++ b/src/modules/navigator/takeoff_params.c
@@ -1,6 +1,6 @@
-/***************************************************************************
+/****************************************************************************
  *
- *   Copyright (c) 2014 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -17,7 +17,7 @@
  *    without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
  * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
  * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
@@ -30,47 +30,28 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
+
 /**
- * @file takeoff.h
+ * @file takeoff_params.c
  *
- * Helper class to take off
+ * Parameters for the takeoff navigation mode.
  *
- * @author Lorenz Meier <lorenz@px4.io>
  */
 
-#pragma once
-
-#include "navigator_mode.h"
-#include "mission_block.h"
-#include <lib/mathlib/mathlib.h>
-#include <px4_platform_common/module_params.h>
-
-class Takeoff : public MissionBlock,  public ModuleParams
-{
-public:
-	Takeoff(Navigator *navigator);
-	~Takeoff() = default;
-
-	void on_activation() override;
-	void on_active() override;
-
-	void setLoiterPosition(matrix::Vector2d loiter_location) { _loiter_position_lat_lon = loiter_location; }
-	void setLoiterAltitudeLocalZ(const float height_m);
-
-private:
-	void set_takeoff_position();
-
-	enum class fw_takeoff_state {
-		CLIMBOUT = 0,
-		GO_TO_LOITER
-	} _fw_takeoff_state;
-
-	float _takeoff_init_z{NAN};
-	float _climbout_alt_z{NAN};
-	matrix::Vector2d _loiter_position_lat_lon{static_cast<double>(NAN), static_cast<double>(NAN)};
-	float _loiter_height_z{NAN};
-
-	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::TKO_CLMB_OUT_ALT>) _param_tko_clmb_out_alt
-	)
-};
+/**
+ * Takeoff relative climbout altitude
+ *
+ * Altitude relative to home at which the vehicle will stop with the straight
+ * climbout and start heading in nominal configuration to the defined Hold position.
+ * Only applies to fixed-wing takeoff mode (excluding Mission takeoffs).
+ *
+ * Not used if set to negative value, in which case the climbout altitude
+ * is set equal to the Hold altitude.
+ *
+ * @unit m
+ * @min -1
+ * @decimal 1
+ * @increment 1
+ * @group Takeoff
+ */
+PARAM_DEFINE_FLOAT(TKO_CLMB_OUT_ALT, -1);


### PR DESCRIPTION
Partially replaces https://github.com/PX4/PX4-Autopilot/pull/25083 (without the takeoff without navigation part).

### Solved Problem
- It's currently not possible to define the position of the loiter that gets established upon climbing to the takeoff altitude, instead it will just loiter at the current position. Especially for large vehicles with big loiter radii it's desired to move this place further from away (and have it at pre-defined position).
- the Takeoff flight mode can be executed without global position, but was internally using global position
- in https://github.com/PX4/PX4-Autopilot/pull/24280 we removed the dependency for FW vehicles on vehicle_global_position in Mission, Loiter and RTL, but seemed to have forgotten the takeoff modes

### Solution
- use the lat/long fields [MAV_CMD_NAV_TAKEOFF](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_TAKEOFF) to define where to loiter
- only use local position in Takeoff flight mode. That should make it more robust against 
- only require vehicle_local_position_relaxed for Takeoff and VTOL_Takeoff

In more detail:
- split up the takeoff phase into "climbout" and "go to loiter" states.
- during climbout the course setpoint is fixed to the heading the vehicle had on launch and the height rate setpoint set to `FW_CLMB_MAX`
- climbout altitude can be configured with new parameter (`TKO_CLMB_OUT_ALT`). We can hopefully expose this setting also to the users through a field in [NAV_TAKEOFF](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_TAKEOFF).
after reaching the climbout altitude, the vehicle starts going to the loiter point

### Changelog Entry
For release notes:
```
Feature: FW Takeoff: and add option to define loiter position
```

### Alternatives
- Add a "climbout altitude" field to  [MAV_CMD_NAV_TAKEOFF](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_TAKEOFF) to replace the added param `TKO_CLMB_OUT_ALT`. 
- can we remove the absolute altitude dependency of TECS as a next step?

### Test coverage
SITL tested, partially flight tested.




