### PR TITLE
Update TransponderReport.msg - correct "heading" description

### DIFF
--- a/msg/TransponderReport.msg
+++ b/msg/TransponderReport.msg
@@ -4,7 +4,7 @@ float64 lat 		# Latitude, expressed as degrees
 float64 lon 		# Longitude, expressed as degrees
 uint8 altitude_type	# Type from ADSB_ALTITUDE_TYPE enum
 float32 altitude 	# Altitude(ASL) in meters
-float32 heading 	# Course over ground in radians, -pi to +pi, 0 is north
+float32 heading 	# Course over ground in radians, 0 to 2pi, 0 is north
 float32 hor_velocity	# The horizontal velocity in m/s
 float32 ver_velocity 	# The vertical velocity in m/s, positive is up
 char[9] callsign	# The callsign, 8+null


### PR DESCRIPTION
### Solved Problem
When *TransponderReport* message is published, the "heading" field must be filled with course over ground in aviation terms, 0..2PI radians (0 to 360 degrees). But the comment/description wrongly specifies -PI..PI range.

Fixes https://github.com/PX4/PX4-Autopilot/issues/24780

### Solution
- edit TransponderReport.msg to specify correct range in the comment to avoid confusion.

To fill "heading" field correctly, a wrap should be used - something like: `wrap_2pi(....gps_cog_rad)`

### Context

Please see discussion and example code in https://github.com/PX4/PX4-Autopilot/issues/24780