### PR TITLE
mavlink_parameters: throttle MAVLink param transmission on low-bandwidth links

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -482,6 +482,8 @@ public:
 
 	unsigned		get_main_loop_delay() const { return _main_loop_delay; }
 
+	float			get_mav_prm_wait_s() const { return _mav_prm_wait_s; }
+
 	/** get the Mavlink shell. Create a new one if there isn't one. It is *always* created via MavlinkReceiver thread.
 	 *  Returns nullptr if shell cannot be created */
 	MavlinkShell		*get_shell();
@@ -657,6 +659,8 @@ private:
 
 	pthread_mutex_t		_send_mutex {};
 	pthread_mutex_t         _radio_status_mutex {};
+
+	const float 		_mav_prm_wait_s{0.125};	///< Time to wait (in seconds) before sending the next parameter message (only if MAVLINK_MODE_LOW_BANDWIDTH)
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::MAV_SYS_ID>) _param_mav_sys_id,

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -482,8 +482,6 @@ public:
 
 	unsigned		get_main_loop_delay() const { return _main_loop_delay; }
 
-	float			get_mav_prm_wait_s() const { return _mav_prm_wait_s; }
-
 	/** get the Mavlink shell. Create a new one if there isn't one. It is *always* created via MavlinkReceiver thread.
 	 *  Returns nullptr if shell cannot be created */
 	MavlinkShell		*get_shell();
@@ -659,8 +657,6 @@ private:
 
 	pthread_mutex_t		_send_mutex {};
 	pthread_mutex_t         _radio_status_mutex {};
-
-	const float 		_mav_prm_wait_s{0.125};	///< Time to wait (in seconds) before sending the next parameter message (only if MAVLINK_MODE_LOW_BANDWIDTH)
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::MAV_SYS_ID>) _param_mav_sys_id,

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -410,9 +410,9 @@ MavlinkParametersManager::send_one()
 {
 	const hrt_abstime now = hrt_absolute_time();
 
-	// If we are in low bandwidth mode, throttle parameter sending at 8Hz
+	// If in low-bandwidth mode, throttle parameter transmission to 8 Hz
 	if (_mavlink.get_mode() == Mavlink::MAVLINK_MODE_LOW_BANDWIDTH
-	    && now < _last_param_sent_timestamp + _mavlink.get_mav_prm_wait_s() * 1e6f) {
+	    && now < _last_param_sent_timestamp + 125_ms) {
 		return false;
 	}
 

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -408,6 +408,14 @@ MavlinkParametersManager::send_untransmitted()
 bool
 MavlinkParametersManager::send_one()
 {
+	const hrt_abstime now = hrt_absolute_time();
+
+	// If we are in low bandwidth mode, throttle parameter sending at 8Hz
+	if (_mavlink.get_mode() == Mavlink::MAVLINK_MODE_LOW_BANDWIDTH
+	    && now < _last_param_sent_timestamp + _mavlink.get_mav_prm_wait_s() * 1e6f) {
+		return false;
+	}
+
 	if (_send_all_index >= 0) {
 		/* send all parameters if requested, but only after the system has booted */
 
@@ -445,6 +453,7 @@ MavlinkParametersManager::send_one()
 
 		if (p != PARAM_INVALID) {
 			send_param(p);
+			_last_param_sent_timestamp = now;
 		}
 
 		if ((p == PARAM_INVALID) || (_send_all_index >= (int) param_count())) {

--- a/src/modules/mavlink/mavlink_parameters.h
+++ b/src/modules/mavlink/mavlink_parameters.h
@@ -162,5 +162,5 @@ protected:
 	Mavlink &_mavlink;
 
 	bool _first_send{false};
-	hrt_abstime _last_param_sent_timestamp{0};	// abstime at which the last parameter was sent
+	hrt_abstime _last_param_sent_timestamp{0}; // time at which the last parameter was sent
 };

--- a/src/modules/mavlink/mavlink_parameters.h
+++ b/src/modules/mavlink/mavlink_parameters.h
@@ -162,4 +162,5 @@ protected:
 	Mavlink &_mavlink;
 
 	bool _first_send{false};
+	hrt_abstime _last_param_sent_timestamp{0};	// abstime at which the last parameter was sent
 };


### PR DESCRIPTION
### Solved Problem
During complete parameter fetching, [PARAM_VALUE](https://mavlink.io/en/messages/common.html#PARAM_VALUE) messages are sent from PX4 to the GCS at an unlimited rate. In case of a low-bandwidth link, such traffic can completely clog it causing high delays for other messages and requiring retransmission of many packets (further worsening the link status).

### Solution
Add a new PX4 parameter `MAV_PRM_WAIT_S` that controls the delay between subsequent parameter transmissions. By default `MAV_PRM_WAIT_S=0` so that the default behaviour remains unchanged.

### Changelog Entry
For release notes:
```
Feature/Bugfix Introduced MAV_PRM_WAIT_S to throttle parameter transmission 
New parameter: MAV_PRM_WAIT_S
```
