### PR TITLE
chore: unify MC_RATE* param metadata

### DIFF
--- a/src/modules/mc_rate_control/mc_rate_control_params.c
+++ b/src/modules/mc_rate_control/mc_rate_control_params.c
@@ -205,7 +205,7 @@ PARAM_DEFINE_FLOAT(MC_PITCHRATE_K, 1.0f);
  *
  * @min 0.0
  * @max 0.6
- * @decimal 2
+ * @decimal 3
  * @increment 0.01
  * @group Multicopter Rate Control
  */
@@ -217,7 +217,7 @@ PARAM_DEFINE_FLOAT(MC_YAWRATE_P, 0.2f);
  * Yaw rate integral gain. Can be set to compensate static thrust difference or gravity center offset.
  *
  * @min 0.0
- * @decimal 2
+ * @decimal 3
  * @increment 0.01
  * @group Multicopter Rate Control
  */
@@ -241,8 +241,8 @@ PARAM_DEFINE_FLOAT(MC_YR_INT_LIM, 0.30f);
  * Yaw rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.
  *
  * @min 0.0
- * @decimal 2
- * @increment 0.01
+ * @decimal 4
+ * @increment 0.0005
  * @group Multicopter Rate Control
  */
 PARAM_DEFINE_FLOAT(MC_YAWRATE_D, 0.0f);
@@ -254,7 +254,6 @@ PARAM_DEFINE_FLOAT(MC_YAWRATE_D, 0.0f);
  *
  * @min 0.0
  * @decimal 4
- * @increment 0.01
  * @group Multicopter Rate Control
  */
 PARAM_DEFINE_FLOAT(MC_YAWRATE_FF, 0.0f);
@@ -271,7 +270,7 @@ PARAM_DEFINE_FLOAT(MC_YAWRATE_FF, 0.0f);
  * Set MC_YAWRATE_P=1 to implement a PID in the ideal form.
  * Set MC_YAWRATE_K=1 to implement a PID in the parallel form.
  *
- * @min 0.0
+ * @min 0.01
  * @max 5.0
  * @decimal 4
  * @increment 0.0005


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

The number of decimal points for the `MR_ROLLRATE_*`, `MR_PITCHRATE_*`, `MR_YAWRATE_*` is not consistent and it make tuning harder as small adjustments are not shown in QGC.

### Solution

- All `_P` with three decimals
- All `_I` with three decimals
- All `_D` with three decimals
- All `_FF` with three decimals

### Changelog Entry

N/A

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
