### PR TITLE
Move NUM_MISSION_ITEMS_SUPPORTED to dataman

### DIFF
--- a/src/modules/dataman/Kconfig
+++ b/src/modules/dataman/Kconfig
@@ -19,3 +19,12 @@ menuconfig DATAMAN_PERSISTENT_STORAGE
 	depends on MODULES_DATAMAN
 	---help---
 		Dataman supports reading/writing to persistent storage
+
+menuconfig NUM_MISSION_ITMES_SUPPORTED
+	int "Maximum number of mission items"
+	default 500
+	depends on MODULES_DATAMAN
+	---help---
+		This limit always applies if mission items are stored on the SD card or in RAM. It should be set
+		adequately per boards such that if the items are stored in RAM they still fit the available memory.
+		The runtime parameter to configure the storage option is `SYS_DM_BACKEND`.

--- a/src/modules/navigator/Kconfig
+++ b/src/modules/navigator/Kconfig
@@ -27,12 +27,3 @@ menuconfig NAVIGATOR_ADSB
 	---help---
 		Add support for acting on ADSB transponder_report or ADSB_VEHICLE MAVLink messages.
 		Actions are warnings, Loiter, Land and RTL without climb.
-
-menuconfig NUM_MISSION_ITMES_SUPPORTED
-	int "Maximum number of mission items"
-	default 500
-	depends on MODULES_NAVIGATOR
-	---help---
-		This limit always applies if mission items are stored on the SD card or in RAM. It should be set
-		adequately per boards such that if the items are stored in RAM they still fit the available memory.
-		The runtime parameter to configure the storage option is `SYS_DM_BACKEND`.


### PR DESCRIPTION
The define CONFIG_NUM_MISSION_ITMES_SUPPORTED is used in dataman, not navigator, so this config variable needs to be moved to the dataman module, otherwise it breaks the build if navigator is not included in the build.

Follow up to https://github.com/PX4/PX4-Autopilot/pull/24252.