### PR TITLE
GNSS Spoofing Warning Sensitivity Adjustment

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -605,29 +605,6 @@ void EstimatorChecks::checkGps(const Context &context, Report &reporter, const s
 			mavlink_log_critical(reporter.mavlink_log_pub(), "GPS reports critical jamming state\t");
 		}
 	}
-
-	if (vehicle_gps_position.spoofing_state == sensor_gps_s::SPOOFING_STATE_INDICATED) {
-		/* EVENT
-		 */
-		reporter.armingCheckFailure(NavModes::None, health_component_t::gps,
-					    events::ID("check_estimator_gps_spoofing_indicated"),
-					    events::Log::Critical, "GPS reports spoofing indicated");
-
-		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "GPS reports spoofing indicated\t");
-		}
-
-	} else if (vehicle_gps_position.spoofing_state == sensor_gps_s::SPOOFING_STATE_MULTIPLE) {
-		/* EVENT
-		 */
-		reporter.armingCheckFailure(NavModes::None, health_component_t::gps,
-					    events::ID("check_estimator_gps_multiple_spoofing_indicated"),
-					    events::Log::Critical, "GPS reports multiple spoofing indicated");
-
-		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "GPS reports multiple spoofing indicated\t");
-		}
-	}
 }
 
 void EstimatorChecks::lowPositionAccuracy(const Context &context, Report &reporter,


### PR DESCRIPTION
### Solved Problem & Solution
The GNSS spoofing warning was previously too sensitive, as it relied solely on the GNSS message to trigger a warning—even though spoofing detection is also covered by the GNSS checks.


- Removed spoofing warnings based solely on the GNSS message (still gets logged per state change by driver)
https://github.com/PX4/PX4-Autopilot/blob/main/src/drivers/gps/gps.cpp#L1212

- Users receive a spoofing warning only once per state change, and only when the spoofing-check is enabled.
https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp#L259-L273

- The spoofing check triggers a failure only if the driver explicitly reports a critical spoofing case (SPOOFING_STATE_MULTIPLE).
https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/ekf2/EKF2.cpp#L2449

- GNSS jamming detection remains unchanged: if the driver reports jamming, repeated warnings are still sent to the user immediately.


### Test coverage
Tested in sim.


