### PR TITLE
ist8310: unify startup

### DIFF
--- a/boards/auterion/fmu-v6s/init/rc.board_sensors
+++ b/boards/auterion/fmu-v6s/init/rc.board_sensors
@@ -23,8 +23,8 @@ else
 	bmm350 -I -R 8 start
 fi
 
-# External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
+# External compass: standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
+ist8310 -X -R 10 start
 
 # BARO on I2C4
 bmp388 -I -b 4 -a 0x77 start

--- a/boards/cuav/7-nano/init/rc.board_sensors
+++ b/boards/cuav/7-nano/init/rc.board_sensors
@@ -30,7 +30,7 @@ icp201xx -I start
 # CUAV pwm voltage 3.3V/5V switch
 pwm_voltage_apply
 
-# External compass on GPS1/I2C1: standard CUAV GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
+# External compass: standard CUAV GPS/compass puck (with lights, safety button, and buzzer)
+ist8310 -X -R 10 start
 
 netman update

--- a/boards/cuav/nora/init/rc.board_sensors
+++ b/boards/cuav/nora/init/rc.board_sensors
@@ -25,5 +25,5 @@ then
 fi
 ms5611 -s -b 6 start
 
-# External compass on GPS1/I2C1: standard CUAV GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
+# External compass: standard CUAV GPS/compass puck (with lights, safety button, and buzzer)
+ist8310 -X -R 10 start

--- a/boards/cuav/x7pro/init/rc.board_sensors
+++ b/boards/cuav/x7pro/init/rc.board_sensors
@@ -28,5 +28,5 @@ then
 fi
 ms5611 -s -b 6 start
 
-# External compass on GPS1/I2C1: standard CUAV GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
+# External compass: standard CUAV GPS/compass puck (with lights, safety button, and buzzer)
+ist8310 -X -R 10 start

--- a/boards/holybro/durandal-v1/init/rc.board_sensors
+++ b/boards/holybro/durandal-v1/init/rc.board_sensors
@@ -29,5 +29,5 @@ ist8310 -I -R 10 start
 # Baro on internal SPI
 ms5611 -s start
 
-# External compass on GPS1/I2C1: standard Holybro GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
+# External compass: standard Holybro GPS/compass puck (with lights, safety button, and buzzer)
+ist8310 -X -R 10 start

--- a/boards/holybro/pix32v5/init/rc.board_sensors
+++ b/boards/holybro/pix32v5/init/rc.board_sensors
@@ -21,5 +21,5 @@ ist8310 -I -R 10 start
 # Baro on internal SPI
 ms5611 -s start
 
-# External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
+# External compass: standard Holybro GPS/compass puck (with lights, safety button, and buzzer)
+ist8310 -X -R 10 start

--- a/boards/nxp/tropic-community/init/rc.board_sensors
+++ b/boards/nxp/tropic-community/init/rc.board_sensors
@@ -60,8 +60,8 @@ bmi088 -G -R 2 -b 4 -s start
 # Internal magnetometer on I2c
 bmm150 -I -b 4 -R 6 -a 18 start
 
-# External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
+# External compass: standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
+ist8310 -X -R 10 start
 
 # Possible internal Baro
 

--- a/boards/px4/fmu-v5/init/rc.board_sensors
+++ b/boards/px4/fmu-v5/init/rc.board_sensors
@@ -27,5 +27,5 @@ ms5611 -s start
 # internal compass
 ist8310 -I -R 10 start
 
-# External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
+# External compass: standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
+ist8310 -X -R 10 start

--- a/boards/px4/fmu-v5x/init/rc.board_sensors
+++ b/boards/px4/fmu-v5x/init/rc.board_sensors
@@ -100,8 +100,8 @@ else
 	bmm150 -I start
 fi
 
-# External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
+# External compass: standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
+ist8310 -X -R 10 start
 
 # Possible internal Baro
 

--- a/boards/px4/fmu-v6x/init/rc.board_sensors
+++ b/boards/px4/fmu-v6x/init/rc.board_sensors
@@ -149,8 +149,8 @@ else
 	bmm150 -I -R 0 start
 fi
 
-# External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
+# External compass: standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
+ist8310 -X -R 10 start
 
 # Possible internal Baro
 if param compare SENS_INT_BARO_EN 1

--- a/boards/px4/fmu-v6xrt/init/rc.board_sensors
+++ b/boards/px4/fmu-v6xrt/init/rc.board_sensors
@@ -99,8 +99,8 @@ icm42688p -R 6 -b 2 -s start
 bmm150 -I start
 
 
-# External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
+# External compass: standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
+ist8310 -X -R 10 start
 
 # Possible internal Baro
 

--- a/boards/zeroone/x6/init/rc.board_sensors
+++ b/boards/zeroone/x6/init/rc.board_sensors
@@ -146,8 +146,8 @@ rm3100 -I -b 4 start
 # 	bmm150 -I -R 0 start
 # fi
 
-# External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
+# External compass: standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
+ist8310 -X -R 10 start
 
 # Internal compass
 ist8310 start -I -a 0x0E -R 12


### PR DESCRIPTION
### Solved Problem
The IST8310 startup is currently a bit unexpected
- A lot of boards start it up with `-R 10` due to the way it is mounted in most GPS modules
- It is only started on one bus in the `rc.board_sensors`
- When connected to another bus it will fall-back to the start up in `rc.sensors` which does start on all buses, but with `-R 0`

### Solution
- Unified the startup by starting it up with `-R 10` on all buses in `rc.sensors`
- Kept it in `rc.board_sensors` for boards that start it with different rotation

### Changelog Entry
For release notes:
```
Feature/Bugfix unify ist8310 startup
```

### Alternatives
We could also start it up on all buses in `rc.board_sensors`, but as a lot of boards do start it up with `-R 10` it is easier to have a unified behavior.

### Test coverage
- Tested on v6x with a Holybro GPS
