### PR TITLE
[Docs] Incorrect URLS for dronecan/cyphal in params

### DIFF
--- a/src/drivers/cyphal/parameters.c
+++ b/src/drivers/cyphal/parameters.c
@@ -46,7 +46,7 @@ PARAM_DEFINE_INT32(CYPHAL_ENABLE, 1);
 /**
  * Cyphal Node ID.
  *
- * Read the specs at http://uavcan.org to learn more about Node ID.
+ * Read the specs at https://opencyphal.org/ to learn more about Node ID.
  *
  * @min -1
  * @max 125

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -57,7 +57,7 @@ PARAM_DEFINE_INT32(UAVCAN_ENABLE, 0);
 /**
  * UAVCAN Node ID.
  *
- * Read the specs at http://uavcan.org to learn more about Node ID.
+ * Read the specs at https://dronecan.github.io/ to learn more about Node ID.
  *
  * @min 1
  * @max 125


### PR DESCRIPTION
Updates links to http://uavcan.org in param docs to point at dronecan or opencyphal URLs.

This only changes documentation.