### PR TITLE
SIH-plane: tune angular rate controllers

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
@@ -46,3 +46,22 @@ param set-default PWM_MAIN_FUNC3 203
 param set-default PWM_MAIN_FUNC4 101
 
 param set-default EKF2_GPS_DELAY 0
+
+# Rate controllers
+param set-default FW_RR_P 0.0500
+param set-default FW_RR_I 2.0000
+param set-default FW_RR_D 0.0000
+param set-default FW_RR_FF 0.0000
+param set-default FW_RR_IMAX 1.0000
+
+param set-default FW_PR_P 0.0800
+param set-default FW_PR_I 2.5000
+param set-default FW_PR_D 0.0000
+param set-default FW_PR_FF 0.0000
+param set-default FW_PR_IMAX 1.0000
+
+param set-default FW_YR_P 0.0500
+param set-default FW_YR_I 3.0000
+param set-default FW_YR_D 0.0000
+param set-default FW_YR_FF 0.0000
+param set-default FW_YR_IMAX 1.0000


### PR DESCRIPTION
### Solved Problem
When flying the plane in SIH I realized the angular rate tracking was not so great
![image](https://github.com/user-attachments/assets/2d68fef5-7bd8-43b6-8e9b-c41d7598c117)


### Solution
Tune the controllers (using https://github.com/Auterion/Flight_Control_Prototyping_Scripts/tree/master/autotune)
![Screenshot from 2025-07-04 11-57-26](https://github.com/user-attachments/assets/8ea42952-34c3-4532-a441-6d46cf3c0352)