### PR TITLE
Smooth acceleration planning for Rover Differential

### DIFF
--- a/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.hpp
+++ b/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.hpp
@@ -104,8 +104,10 @@ private:
 	Vector2f _curr_pos_ned{};
 	Vector2f _start_ned{};
 	float _vehicle_yaw{0.f};
+	float _ground_speed_abs{0.f};
 
 	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::RO_ACCEL_LIM>)     _param_ro_accel_limit,
 		(ParamFloat<px4::params::RO_DECEL_LIM>)     _param_ro_decel_limit,
 		(ParamFloat<px4::params::RO_JERK_LIM>)      _param_ro_jerk_limit,
 		(ParamFloat<px4::params::RO_SPEED_LIM>)     _param_ro_speed_limit,


### PR DESCRIPTION
### Solved Problem

Currently, *src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.cpp* calculates *rover_velocity_setpoint.speed* based on deceleration parameters, ignoring the important acceleration phase of the leg between waypoints:
```
const float distance = arrival_speed > 0.f + FLT_EPSILON ? distance_to_target - _param_nav_acc_rad.get() :
				       distance_to_target;
float speed_setpoint = math::trajectory::computeMaxSpeedFromDistance(_param_ro_jerk_limit.get(),
				       _param_ro_decel_limit.get(), distance, fabsf(arrival_speed));
```
Therefore, acceleration is defined by applying *SlewRate* - which seems to be a wrong idea overall.

Here is how it looks:
![src12-orig](https://github.com/user-attachments/assets/b1d45a6e-86b4-42bd-aede-9075e3a363f6)

Meanwhile, the *math::trajectory::computeMaxSpeedFromDistance()* is capable of computing both sides of the trapezoid speed profile, if given right arguments.

This PR fixes that, by supplying proper arguments, so that the profile looks like this (note the khaki *rover_velocity_setpoint/speed*):
![src12_smooth](https://github.com/user-attachments/assets/213b02b3-3b77-4063-901f-1c78a31d1b3b)

The plan looks like this:
![Screenshot from 2025-07-06 13-17-57](https://github.com/user-attachments/assets/1fc531d6-6af2-4b8d-a1c7-339ee93072b0)

Fixes (partially) #(https://github.com/PX4/PX4-Autopilot/issues/25157)

### Solution

Modified code detects "departure phase" and substitutes arguments for those related to acceleration.

### Test coverage
 Simulation testing logs:
- before:

- after:
