### PR TITLE
FW land detector: only force to landed if launch detection is WAITING_FOR_LAUNCH

### DIFF
--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -64,9 +64,9 @@ bool FixedwingLandDetector::_get_landed_state()
 	_launch_detection_status_sub.copy(&launch_detection_status);
 
 	// force the landed state to stay landed if we're currently in the catapult/hand-launch launch process. Detect that we are in this state
-	// by checking if the last publication of launch_detection_status is less than 0.5s old, and we're not yet in the flying state.
+	// by checking if the last publication of launch_detection_status is less than 0.5s old, and we're still in the wait for launch state.
 	if (_landed_hysteresis.get_state() &&  hrt_elapsed_time(&launch_detection_status.timestamp) < 500_ms
-	    && launch_detection_status.launch_detection_state < launch_detection_status_s::STATE_FLYING) {
+	    && launch_detection_status.launch_detection_state == launch_detection_status_s::STATE_WAITING_FOR_LAUNCH) {
 		landDetected = true;
 
 	} else if (hrt_elapsed_time(&_vehicle_local_position.timestamp) < 1_s) {


### PR DESCRIPTION

### Solved Problem
For catapult launch vehicles: Vehicle stays landed until whole launch sequence is through, instead of when acceleration is measured.
![image](https://github.com/user-attachments/assets/811f860a-e9f4-48f2-8994-a61844692efc)
This has negative side effects:
- integrators stay locked while airborne
- Home position altitude gets updated to current altitude while already in-air

### Solution
Switch to landed=false the moment the acceleration threshold is passed (launch detection != `AITING_FOR_LAUNCH`).

### Changelog Entry
For release notes:
```
Bugfix: FW land detector: only force to landed if launch detection is WAITING_FOR_LAUNCH. Fixes: takeoff detection too late (which has effect on Home position altitude being set when already in air and integrators being locked when airborne).
```

