### PR TITLE
Differential: separating planning and execution responsibilities

### DIFF
--- a/src/lib/rover_control/RoverControl.cpp
+++ b/src/lib/rover_control/RoverControl.cpp
@@ -112,30 +112,7 @@ float speedControl(SlewRate<float> &speed_with_rate_limit, PID &pid_speed, const
 		return NAN;
 	}
 
-	// Apply acceleration and deceleration limit
-	if (fabsf(speed_setpoint) >= fabsf(vehicle_speed) && max_accel > FLT_EPSILON) {
-		speed_with_rate_limit.setSlewRate(max_accel);
-		speed_with_rate_limit.update(speed_setpoint, dt);
-
-		// Reinitialize slew rate if current value is closer to setpoint than post slew rate value
-		if (fabsf(speed_with_rate_limit.getState() - vehicle_speed) > fabsf(
-			    speed_setpoint - vehicle_speed)) {
-			speed_with_rate_limit.setForcedValue(speed_setpoint);
-		}
-
-	} else if (fabsf(speed_setpoint) < fabsf(vehicle_speed) && max_decel > FLT_EPSILON) {
-		speed_with_rate_limit.setSlewRate(max_decel);
-		speed_with_rate_limit.update(speed_setpoint, dt);
-
-		// Reinitialize slew rate if current value is closer to setpoint than post slew rate value
-		if (fabsf(speed_with_rate_limit.getState() - vehicle_speed) > fabsf(
-			    speed_setpoint - vehicle_speed)) {
-			speed_with_rate_limit.setForcedValue(speed_setpoint);
-		}
-
-	} else { // Fallthrough if slew rate is not configured
-		speed_with_rate_limit.setForcedValue(speed_setpoint);
-	}
+	speed_with_rate_limit.setForcedValue(speed_setpoint);
 
 	// Calculate normalized forward speed setpoint
 	float forward_speed_normalized{0.f};

--- a/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.hpp
+++ b/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.hpp
@@ -55,6 +55,14 @@
 using namespace matrix;
 
 /**
+ * @brief Enum class for the different states of driving.
+ */
+enum class DrivingState {
+	SPOT_TURNING, // The vehicle is currently turning on the spot.
+	DRIVING      // The vehicle is currently driving.
+};
+
+/**
  * @brief Class for differential position control.
  */
 class DifferentialPosControl : public ModuleParams
@@ -71,6 +79,8 @@ public:
 	 * @brief Generate and publish roverVelocitySetpoint from roverPositionSetpoint.
 	 */
 	void updatePosControl();
+
+	DrivingState getCurrentState() const { return _current_state; };
 
 	/**
 	 * @brief Check if the necessary parameters are set.
@@ -104,8 +114,14 @@ private:
 	Vector2f _curr_pos_ned{};
 	Vector2f _start_ned{};
 	float _vehicle_yaw{0.f};
+	float _ground_speed_abs{0.f};
+	DrivingState _current_state{DrivingState::DRIVING};
+	float _speed_setpoint{0.f};
 
 	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::RD_TRANS_TRN_DRV>) _param_rd_trans_trn_drv,
+		(ParamFloat<px4::params::RD_TRANS_DRV_TRN>) _param_rd_trans_drv_trn,
+		(ParamFloat<px4::params::RO_ACCEL_LIM>)     _param_ro_accel_limit,
 		(ParamFloat<px4::params::RO_DECEL_LIM>)     _param_ro_decel_limit,
 		(ParamFloat<px4::params::RO_JERK_LIM>)      _param_ro_jerk_limit,
 		(ParamFloat<px4::params::RO_SPEED_LIM>)     _param_ro_speed_limit,

--- a/src/modules/rover_differential/DifferentialVelControl/DifferentialVelControl.hpp
+++ b/src/modules/rover_differential/DifferentialVelControl/DifferentialVelControl.hpp
@@ -58,14 +58,6 @@
 using namespace matrix;
 
 /**
- * @brief Enum class for the different states of driving.
- */
-enum class DrivingState {
-	SPOT_TURNING, // The vehicle is currently turning on the spot.
-	DRIVING      // The vehicle is currently driving.
-};
-
-/**
  * @brief Class for differential velocity control.
  */
 class DifferentialVelControl : public ModuleParams
@@ -129,18 +121,15 @@ private:
 	Quatf _vehicle_attitude_quaternion{};
 	float _vehicle_speed{0.f}; // [m/s] Positiv: Forwards, Negativ: Backwards
 	float _vehicle_yaw{0.f};
-	float _speed_setpoint{NAN};
-	float _bearing_setpoint{NAN};
+	float _speed_setpoint{NAN};	// marching orders from DifferentialPosControl
+	float _bearing_setpoint{NAN};	// marching orders from DifferentialPosControl
 	float _normalized_speed_diff{NAN};
-	DrivingState _current_state{DrivingState::DRIVING};
 
 	// Controllers
 	PID _pid_speed;
 	SlewRate<float> _adjusted_speed_setpoint;
 
 	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::RD_TRANS_TRN_DRV>) _param_rd_trans_trn_drv,
-		(ParamFloat<px4::params::RD_TRANS_DRV_TRN>) _param_rd_trans_drv_trn,
 		(ParamFloat<px4::params::RO_MAX_THR_SPEED>) _param_ro_max_thr_speed,
 		(ParamFloat<px4::params::RO_SPEED_P>) 	    _param_ro_speed_p,
 		(ParamFloat<px4::params::RO_SPEED_I>)       _param_ro_speed_i,


### PR DESCRIPTION
### Solved Problem

This is my "fast and dirty" attempt to have Pos control do speed planning, while the "downstream" Vel control just does what it is ordered, not trying to figure out those *SPOT_TURNING/DRIVING* states.

It is not intended to be a real polished PR, rather a quick way of illustrating what works for me best.

Kinda Fixes https://github.com/PX4/PX4-Autopilot/issues/25157

### Solution

I moved *SPOT_TURNING/DRIVING* states evaluation to Pos and ensured that the planned 
`rover_velocity_setpoint.speed` (a.k.a. "_speed_setpoint", or "*Vel marching orders*" ) stays zero in *SPOT_TURNING* state.

This is how speed profiles look like now:
![Screenshot from 2025-07-07 12-38-11](https://github.com/user-attachments/assets/e1fccf0d-d42d-4122-b276-fddf837dd789)

If I remove *SlewRate* application to speed in `src/lib/rover_control/RoverControl.cpp` - it is even better:

![Screenshot from 2025-07-07 12-42-37](https://github.com/user-attachments/assets/ca9bad60-db16-4de3-b8ca-9010a4130d46)

### Test coverage
- Simulation/hardware testing logs:

 https://review.px4.io/

### Context
Related links:
- https://github.com/PX4/PX4-Autopilot/issues/25157
- https://github.com/PX4/PX4-Autopilot/pull/25165
- https://github.com/PX4/PX4-Autopilot/pull/24640