### PR TITLE
Commander: for VTOL_Takeoff only require relaxed position if fixed-wing phase

### DIFF
--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -194,8 +194,14 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	// NAVIGATION_STATE_AUTO_VTOL_TAKEOFF
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_attitude);
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_local_position);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_local_alt);
+
+	if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_local_position_relaxed);
+
+	} else {
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_local_position);
+	}
 
 	// NAVIGATION_STATE_EXTERNALx: handled outside
 


### PR DESCRIPTION
Noticed while working on https://github.com/PX4/PX4-Autopilot/pull/25083.

### Solved Problem
In https://github.com/PX4/PX4-Autopilot/pull/24280 we removed the dependency for FW vehicles on `vehicle_global_position` in Mission, Loiter and RTL, but seemed to have forgotten the takeoff modes. I'm handling the FW takeoff mode in https://github.com/PX4/PX4-Autopilot/pull/25083, and here just adapt the VTOL Takeoff separately.

### Solution
When in the fixed-wing phase of the VTOL Takeoff we do not want to failsafe due to position inaccuracy and thus only require `local_position_relaxed`.

### Changelog Entry
For release notes:
```
Improvement: Commander: for VTOL_Takeoff only require relaxed position if fixed-wing phase to not fail-safe due to position inaccuracy.
```

