### PR TITLE
Commander: avoid triggering obsolete failsafes after deferring & set failsafe action state immediately

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2341,6 +2341,7 @@ bool Commander::handleModeIntentionAndFailsafe()
 	}
 
 	// Handle failsafe action
+	_mode_management.setFailsafeState(_failsafe.selectedAction() > FailsafeBase::Action::Warn);
 	_vehicle_status.nav_state_user_intention = _mode_management.getNavStateReplacementIfValid(_user_mode_intention.get(),
 			false);
 	_vehicle_status.nav_state = _mode_management.getNavStateReplacementIfValid(FailsafeBase::modeFromAction(
@@ -2408,7 +2409,7 @@ void Commander::modeManagementUpdate()
 {
 	ModeManagement::UpdateRequest mode_management_update{};
 	_mode_management.update(isArmed(), _vehicle_status.nav_state_user_intention,
-				_failsafe.selectedAction() > FailsafeBase::Action::Warn, mode_management_update);
+				mode_management_update);
 
 	if (!isArmed() && mode_management_update.change_user_intended_nav_state) {
 		_user_mode_intention.change(mode_management_update.user_intended_nav_state);

--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -364,10 +364,8 @@ void ModeManagement::checkUnregistrations(uint8_t user_intended_nav_state, Updat
 	}
 }
 
-void ModeManagement::update(bool armed, uint8_t user_intended_nav_state, bool failsafe_action_active,
-			    UpdateRequest &update_request)
+void ModeManagement::update(bool armed, uint8_t user_intended_nav_state, UpdateRequest &update_request)
 {
-	_failsafe_action_active = failsafe_action_active;
 	_external_checks.update();
 
 	bool allow_update_while_armed = _external_checks.allowUpdateWhileArmed();

--- a/src/modules/commander/ModeManagement.hpp
+++ b/src/modules/commander/ModeManagement.hpp
@@ -138,7 +138,11 @@ public:
 		bool control_setpoint_update{false};
 	};
 
-	void update(bool armed, uint8_t user_intended_nav_state, bool failsafe_action_active, UpdateRequest &update_request);
+	void update(bool armed, uint8_t user_intended_nav_state, UpdateRequest &update_request);
+	void setFailsafeState(bool failsafe_action_active)
+	{
+		_failsafe_action_active = failsafe_action_active;
+	}
 
 	/**
 	 * Mode executor ID for who is currently in charge (and can send commands etc).

--- a/src/modules/commander/failsafe/failsafe_test.cpp
+++ b/src/modules/commander/failsafe/failsafe_test.cpp
@@ -370,6 +370,46 @@ TEST_F(FailsafeTest, defer)
 	ASSERT_FALSE(failsafe.failsafeDeferred());
 }
 
+TEST_F(FailsafeTest, defer_and_clear)
+{
+	FailsafeTester failsafe(nullptr);
+
+	failsafe_flags_s failsafe_flags{};
+	FailsafeBase::State state{};
+	state.armed = true;
+	state.user_intended_mode = vehicle_status_s::NAVIGATION_STATE_POSCTL;
+	state.vehicle_type = vehicle_status_s::VEHICLE_TYPE_ROTARY_WING;
+	hrt_abstime time = 3847124342;
+
+	uint8_t updated_user_intented_mode = failsafe.update(time, state, false, false, failsafe_flags);
+
+	failsafe.deferFailsafes(true, -1);
+	ASSERT_TRUE(failsafe.getDeferFailsafes());
+	ASSERT_FALSE(failsafe.failsafeDeferred());
+	// Manual control lost -> deferred
+	time += 10_ms;
+	failsafe_flags.manual_control_signal_lost = true;
+	updated_user_intented_mode = failsafe.update(time, state, false, false, failsafe_flags);
+	ASSERT_EQ(failsafe.selectedAction(), FailsafeBase::Action::None);
+	ASSERT_TRUE(failsafe.failsafeDeferred());
+
+	// Clear flag (the failsafe action only clears on mode switch, but we still expect it to clear as it's being deferred)
+	failsafe_flags.manual_control_signal_lost = false;
+	time += 5_s;
+	updated_user_intented_mode = failsafe.update(time, state, false, false, failsafe_flags);
+	ASSERT_EQ(failsafe.selectedAction(), FailsafeBase::Action::None);
+	ASSERT_FALSE(failsafe.failsafeDeferred());
+
+	// Wait a bit, don't defer anymore -> no failsafe triggered
+	time += 1_s;
+	failsafe.deferFailsafes(false, 0);
+	updated_user_intented_mode = failsafe.update(time, state, false, false, failsafe_flags);
+	ASSERT_EQ(updated_user_intented_mode, state.user_intended_mode);
+	ASSERT_EQ(failsafe.selectedAction(), FailsafeBase::Action::None);
+	ASSERT_FALSE(failsafe.getDeferFailsafes());
+	ASSERT_FALSE(failsafe.failsafeDeferred());
+}
+
 TEST_F(FailsafeTest, skip_failsafe)
 {
 	FailsafeTester failsafe(nullptr);


### PR DESCRIPTION
This brings two changes, relevant for external modes:

### do not trigger obsolete failsafe when deactivating failsafe deferring
Previously, when deferring was active and e.g. RC loss was triggered, and
RC regained, the action was not cleared, as the RC loss action only clears
on mode switch/disarm (when set to RTL for example).
When deferring was then disabled, the RC loss failsafe would still trigger.

This changes the behavior to immediately remove those actions when
deferring is active.

### set failsafe action state immediately after failsafe update
There was a race condition: for example when an external mode disabled
failsafe deferring, that then triggered a failsafe, while the mode executor
immediately sends a command (to e.g. switch modes).
In that case the failsafe got triggered but the mode switch was still
allowed.
This was because of the processing ordering:
- mode updates (and propagating the failsafe_action_active state)
- failsafe updates
- command handling

This patch makes sure failsafe_action_active is set immediately after
updating the failsafes.