### PR TITLE
extend COM_RCL_EXCEPT to support external modes

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -618,13 +618,14 @@ PARAM_DEFINE_INT32(NAV_RCL_ACT, 2);
 /**
  * RC loss exceptions
  *
- * Specify modes in which RC loss is ignored and the failsafe action not triggered.
+ * Specify modes in which the loss of non-essential stick input is ignored and no failsafe action is triggered.
  *
  * @min 0
  * @max 7
  * @bit 0 Mission
  * @bit 1 Hold
  * @bit 2 Offboard
+ * @bit 3 External Mode
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_RCL_EXCEPT, 0);

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -466,14 +466,24 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 					     && (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::Mission);
 	const bool rc_loss_ignored_loiter = state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER
 					    && (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::Hold);
-	const bool rc_loss_ignored_offboard = state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_OFFBOARD
-					      && (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::Offboard);
 	const bool rc_loss_ignored_takeoff = (state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF ||
 					      state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF)
 					     && (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::Hold);
+	const bool rc_loss_ignored_offboard = state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_OFFBOARD
+					      && (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::Offboard);
+	const bool rc_loss_ignored_external_mode =
+		(state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL1 ||
+		 state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL2 ||
+		 state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL3 ||
+		 state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL4 ||
+		 state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL5 ||
+		 state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL6 ||
+		 state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL7 ||
+		 state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL8)
+		&& (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::ExternalMode);
 
-	const bool rc_loss_ignored = rc_loss_ignored_mission || rc_loss_ignored_loiter || rc_loss_ignored_offboard ||
-				     rc_loss_ignored_takeoff || ignore_any_link_loss_vtol_takeoff_fixedwing
+	const bool rc_loss_ignored = rc_loss_ignored_mission || rc_loss_ignored_loiter || rc_loss_ignored_offboard
+				     || rc_loss_ignored_takeoff || rc_loss_ignored_external_mode || ignore_any_link_loss_vtol_takeoff_fixedwing
 				     || _manual_control_lost_at_arming;
 
 	if (_param_com_rc_in_mode.get() != int32_t(RcInMode::StickInputDisabled) && !rc_loss_ignored) {

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -56,7 +56,8 @@ private:
 	enum class ManualControlLossExceptionBits : int32_t {
 		Mission = (1 << 0),
 		Hold = (1 << 1),
-		Offboard = (1 << 2)
+		Offboard = (1 << 2),
+		ExternalMode = (1 << 3)
 	};
 
 	enum class DatalinkLossExceptionBits : int32_t {


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This PR extends the RC lost failsafe exception handling to support external modes. Specifically, it adds an additional bitmask for external modes in the RC lost failsafe exception parameter, `COM_RCL_EXCEPT`. Implementation is @MaEtUgR's work. 

todo: 
- [ ] testing

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

