### PR TITLE
mixer: remove unused stop_motors variable and fix DShot updateOutputs()

### DIFF
--- a/platforms/nuttx/src/px4/stm/stm32_common/dshot/dshot.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/dshot/dshot.c
@@ -569,11 +569,11 @@ void process_capture_results(uint8_t timer_index, uint8_t channel_index)
 }
 
 /**
-* bits  1-11    - throttle value (0-47 are reserved, 48-2047 give 2000 steps of throttle resolution)
+* bits  1-11    - throttle value (0-47 are reserved for commands, 48-2047 give 2000 steps of throttle resolution)
 * bit   12      - dshot telemetry enable/disable
 * bits  13-16   - XOR checksum
 **/
-void dshot_motor_data_set(unsigned channel, uint16_t throttle, bool telemetry)
+void dshot_motor_data_set(unsigned channel, uint16_t data, bool telemetry)
 {
 	uint8_t timer_index = timer_io_channels[channel].timer_index;
 	uint8_t timer_channel_index = timer_io_channels[channel].timer_channel - 1;
@@ -586,7 +586,7 @@ void dshot_motor_data_set(unsigned channel, uint16_t throttle, bool telemetry)
 	uint16_t packet = 0;
 	uint16_t checksum = 0;
 
-	packet |= throttle << DSHOT_THROTTLE_POSITION;
+	packet |= data << DSHOT_THROTTLE_POSITION;
 	packet |= ((uint16_t)telemetry & 0x01) << DSHOT_TELEMETRY_POSITION;
 
 	uint16_t csum_data = packet;

--- a/src/drivers/actuators/vertiq_io/vertiq_io.cpp
+++ b/src/drivers/actuators/vertiq_io/vertiq_io.cpp
@@ -195,7 +195,7 @@ void VertiqIo::OutputControls(uint16_t outputs[MAX_ACTUATORS])
 	_serial_interface.ProcessSerialTx();
 }
 
-bool VertiqIo::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool VertiqIo::updateOutputs(uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 			     unsigned num_control_groups_updated)
 {
 #ifdef CONFIG_USE_IFCI_CONFIGURATION

--- a/src/drivers/actuators/vertiq_io/vertiq_io.hpp
+++ b/src/drivers/actuators/vertiq_io/vertiq_io.hpp
@@ -94,7 +94,7 @@ public:
 	void print_info();
 
 	/** @see OutputModuleInterface */
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	/**

--- a/src/drivers/actuators/voxl_esc/voxl_esc.cpp
+++ b/src/drivers/actuators/voxl_esc/voxl_esc.cpp
@@ -1196,7 +1196,7 @@ void VoxlEsc::mix_turtle_mode(uint16_t outputs[MAX_ACTUATORS])
 }
 
 /* OutputModuleInterface */
-bool VoxlEsc::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+bool VoxlEsc::updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			    unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	//in Run() we call _mixing_output.update(), which calls MixingOutput::limitAndUpdateOutputs which calls _interface.updateOutputs (this function)
@@ -1212,7 +1212,7 @@ bool VoxlEsc::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
 	}
 
 	for (int i = 0; i < VOXL_ESC_OUTPUT_CHANNELS; i++) {
-		if (!_outputs_on || stop_motors) {
+		if (!_outputs_on) {
 			_esc_chans[i].rate_req = 0;
 
 		} else {

--- a/src/drivers/actuators/voxl_esc/voxl_esc.hpp
+++ b/src/drivers/actuators/voxl_esc/voxl_esc.hpp
@@ -81,7 +81,7 @@ public:
 	void print_params();
 
 	/** @see OutputModuleInterface */
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	virtual int	init();

--- a/src/drivers/cyphal/Actuators/EscClient.hpp
+++ b/src/drivers/cyphal/Actuators/EscClient.hpp
@@ -169,7 +169,7 @@ public:
 	{
 	}
 
-	void update_outputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
+	void update_outputs(uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
 	{
 		if (_port_id == 0 || _port_id == CANARD_PORT_ID_UNSET) {
 			return;

--- a/src/drivers/cyphal/Cyphal.cpp
+++ b/src/drivers/cyphal/Cyphal.cpp
@@ -435,7 +435,7 @@ void CyphalNode::sendPortList()
 	_uavcan_node_port_List_last = now;
 }
 
-bool UavcanMixingInterface::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool UavcanMixingInterface::updateOutputs(uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
 	// Note: This gets called from MixingOutput from within its update() function
@@ -445,7 +445,7 @@ bool UavcanMixingInterface::updateOutputs(bool stop_motors, uint16_t outputs[MAX
 	auto publisher = static_cast<UavcanEscController *>(_pub_manager.getPublisher("esc"));
 
 	if (publisher) {
-		publisher->update_outputs(stop_motors, outputs, num_outputs);
+		publisher->update_outputs(outputs, num_outputs);
 	}
 
 	return true;

--- a/src/drivers/cyphal/Cyphal.hpp
+++ b/src/drivers/cyphal/Cyphal.hpp
@@ -87,7 +87,7 @@ public:
 		  _node_mutex(node_mutex),
 		  _pub_manager(pub_manager) {}
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	void printInfo() { _mixing_output.printStatus(); }

--- a/src/drivers/dshot/DShot.h
+++ b/src/drivers/dshot/DShot.h
@@ -76,8 +76,6 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	void retrieve_and_print_esc_info_thread_safe(const int motor_index);
-
 	/**
 	 * Send a dshot command to one or all motors
 	 * This is expected to be called from another thread.
@@ -92,7 +90,7 @@ public:
 
 	bool telemetry_enabled() const { return _telemetry != nullptr; }
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:
@@ -131,8 +129,6 @@ private:
 
 	int handle_new_bdshot_erpm(void);
 
-	int request_esc_info();
-
 	void Run() override;
 
 	void update_params();
@@ -140,6 +136,8 @@ private:
 	void update_num_motors();
 
 	void handle_vehicle_commands();
+
+	uint16_t convert_output_to_3d_scaling(uint16_t output);
 
 	MixingOutput _mixing_output{PARAM_PREFIX, DIRECT_PWM_OUTPUT_CHANNELS, *this, MixingOutput::SchedulingPolicy::Auto, false, false};
 	uint32_t _reversible_outputs{};
@@ -154,11 +152,9 @@ private:
 
 	px4::atomic<Command *> _new_command{nullptr};
 
-	px4::atomic<DShotTelemetry::OutputBuffer *> _request_esc_info{nullptr};
 
 	bool _outputs_initialized{false};
 	bool _outputs_on{false};
-	bool _waiting_for_esc_info{false};
 	bool _bidirectional_dshot_enabled{false};
 
 	static constexpr unsigned _num_outputs{DIRECT_PWM_OUTPUT_CHANNELS};
@@ -167,6 +163,8 @@ private:
 	int _num_motors{0};
 
 	perf_counter_t	_cycle_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
+	perf_counter_t	_bdshot_rpm_perf{perf_alloc(PC_COUNT, MODULE_NAME": bdshot rpm")};
+	perf_counter_t	_dshot_telem_perf{perf_alloc(PC_COUNT, MODULE_NAME": dshot telem")};
 
 	Command _current_command{};
 

--- a/src/drivers/linux_pwm_out/linux_pwm_out.cpp
+++ b/src/drivers/linux_pwm_out/linux_pwm_out.cpp
@@ -95,7 +95,7 @@ int LinuxPWMOut::task_spawn(int argc, char *argv[])
 	return PX4_ERROR;
 }
 
-bool LinuxPWMOut::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+bool LinuxPWMOut::updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 				unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	_pwm_out->send_output_pwm(outputs, num_outputs);

--- a/src/drivers/linux_pwm_out/linux_pwm_out.hpp
+++ b/src/drivers/linux_pwm_out/linux_pwm_out.hpp
@@ -71,7 +71,7 @@ public:
 
 	int init();
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:

--- a/src/drivers/pca9685_pwm_out/main.cpp
+++ b/src/drivers/pca9685_pwm_out/main.cpp
@@ -70,7 +70,7 @@ public:
 	static int custom_command(int argc, char *argv[]);
 	static int print_usage(const char *reason = nullptr);
 
-	bool updateOutputs(bool stop_motors, uint16_t *outputs, unsigned num_outputs,
+	bool updateOutputs(uint16_t *outputs, unsigned num_outputs,
 			   unsigned num_control_groups_updated) override;
 
 	int print_status() override;
@@ -136,7 +136,7 @@ int PCA9685Wrapper::init()
 	return PX4_OK;
 }
 
-bool PCA9685Wrapper::updateOutputs(bool stop_motors, uint16_t *outputs, unsigned num_outputs,
+bool PCA9685Wrapper::updateOutputs(uint16_t *outputs, unsigned num_outputs,
 				   unsigned num_control_groups_updated)
 {
 	if (state != STATE::RUNNING) { return false; }

--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -125,7 +125,7 @@ bool PWMOut::update_pwm_out_state(bool on)
 	return true;
 }
 
-bool PWMOut::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+bool PWMOut::updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	/* output to the servos */

--- a/src/drivers/pwm_out/PWMOut.hpp
+++ b/src/drivers/pwm_out/PWMOut.hpp
@@ -71,7 +71,7 @@ public:
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -153,7 +153,7 @@ public:
 
 	uint16_t		system_status() const { return _status; }
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+	bool updateOutputs(uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 			   unsigned num_control_groups_updated) override;
 
 private:
@@ -360,7 +360,7 @@ PX4IO::~PX4IO()
 	perf_free(_interface_write_perf);
 }
 
-bool PX4IO::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+bool PX4IO::updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			  unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	for (size_t i = 0; i < num_outputs; i++) {

--- a/src/drivers/roboclaw/Roboclaw.cpp
+++ b/src/drivers/roboclaw/Roboclaw.cpp
@@ -154,20 +154,14 @@ int Roboclaw::initializeUART()
 	}
 }
 
-bool Roboclaw::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+bool Roboclaw::updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			     unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	float right_motor_output = ((float)outputs[0] - 128.0f) / 127.f;
 	float left_motor_output = ((float)outputs[1] - 128.0f) / 127.f;
 
-	if (stop_motors) {
-		setMotorSpeed(Motor::Right, 0.f);
-		setMotorSpeed(Motor::Left, 0.f);
-
-	} else {
-		setMotorSpeed(Motor::Right, right_motor_output);
-		setMotorSpeed(Motor::Left, left_motor_output);
-	}
+	setMotorSpeed(Motor::Right, right_motor_output);
+	setMotorSpeed(Motor::Left, left_motor_output);
 
 	return true;
 }

--- a/src/drivers/roboclaw/Roboclaw.hpp
+++ b/src/drivers/roboclaw/Roboclaw.hpp
@@ -77,7 +77,7 @@ public:
 	void Run() override;
 
 	/** @see OutputModuleInterface */
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	void setMotorSpeed(Motor motor, float value); ///< rev/sec

--- a/src/drivers/tap_esc/TAP_ESC.cpp
+++ b/src/drivers/tap_esc/TAP_ESC.cpp
@@ -241,7 +241,7 @@ void TAP_ESC::send_tune_packet(EscbusTunePacket &tune_packet)
 	tap_esc_common::send_packet(_uart_fd, buzzer_packet, -1);
 }
 
-bool TAP_ESC::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool TAP_ESC::updateOutputs(uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 			    unsigned num_control_groups_updated)
 {
 	if (_initialized) {

--- a/src/drivers/tap_esc/TAP_ESC.hpp
+++ b/src/drivers/tap_esc/TAP_ESC.hpp
@@ -99,7 +99,7 @@ public:
 
 	int init();
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:

--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -85,10 +85,8 @@ UavcanEscController::init()
 }
 
 void
-UavcanEscController::update_outputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned total_outputs)
+UavcanEscController::update_outputs(uint16_t outputs[MAX_ACTUATORS], unsigned total_outputs)
 {
-	// TODO: remove stop_motors as it's unnecessary and unused almost everywhere
-
 	// TODO: configurable rate limit
 	const auto timestamp = _node.getMonotonicTime();
 

--- a/src/drivers/uavcan/actuators/esc.hpp
+++ b/src/drivers/uavcan/actuators/esc.hpp
@@ -69,7 +69,7 @@ public:
 
 	int init();
 
-	void update_outputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned total_outputs);
+	void update_outputs(uint16_t outputs[MAX_ACTUATORS], unsigned total_outputs);
 
 	/**
 	 * Sets the number of rotors and enable timer

--- a/src/drivers/uavcan/actuators/servo.cpp
+++ b/src/drivers/uavcan/actuators/servo.cpp
@@ -45,7 +45,7 @@ UavcanServoController::UavcanServoController(uavcan::INode &node) :
 }
 
 void
-UavcanServoController::update_outputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
+UavcanServoController::update_outputs(uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
 {
 	uavcan::equipment::actuator::ArrayCommand msg;
 

--- a/src/drivers/uavcan/actuators/servo.hpp
+++ b/src/drivers/uavcan/actuators/servo.hpp
@@ -52,7 +52,7 @@ public:
 	UavcanServoController(uavcan::INode &node);
 	~UavcanServoController() = default;
 
-	void update_outputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs);
+	void update_outputs(uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs);
 
 private:
 	uavcan::INode								&_node;

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -1012,10 +1012,10 @@ UavcanNode::Run()
 }
 
 #if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
-bool UavcanMixingInterfaceESC::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool UavcanMixingInterfaceESC::updateOutputs(uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
-	_esc_controller.update_outputs(stop_motors, outputs, num_outputs);
+	_esc_controller.update_outputs(outputs, num_outputs);
 	return true;
 }
 
@@ -1042,10 +1042,10 @@ void UavcanMixingInterfaceESC::mixerChanged()
 	_esc_controller.set_rotor_count(rotor_count);
 }
 
-bool UavcanMixingInterfaceServo::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool UavcanMixingInterfaceServo::updateOutputs(uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
-	_servo_controller.update_outputs(stop_motors, outputs, num_outputs);
+	_servo_controller.update_outputs(outputs, num_outputs);
 	return true;
 }
 

--- a/src/drivers/uavcan/uavcan_main.hpp
+++ b/src/drivers/uavcan/uavcan_main.hpp
@@ -127,7 +127,7 @@ public:
 		  _node_mutex(node_mutex),
 		  _esc_controller(esc_controller) {}
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	void mixerChanged() override;
@@ -158,7 +158,7 @@ public:
 		  _node_mutex(node_mutex),
 		  _servo_controller(servo_controller) {}
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	MixingOutput &mixingOutput() { return _mixing_output; }

--- a/src/drivers/voxl2_io/voxl2_io.cpp
+++ b/src/drivers/voxl2_io/voxl2_io.cpp
@@ -276,7 +276,7 @@ int Voxl2IO::get_version_info()
 	return (got_response == true ? 0 : -1);
 }
 
-bool Voxl2IO::updateOutputs(bool stop_motors, uint16_t outputs[input_rc_s::RC_INPUT_MAX_CHANNELS],
+bool Voxl2IO::updateOutputs(uint16_t outputs[input_rc_s::RC_INPUT_MAX_CHANNELS],
 			    unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	// Stop Mixer while ESCs are being calibrated
@@ -305,13 +305,7 @@ bool Voxl2IO::updateOutputs(bool stop_motors, uint16_t outputs[input_rc_s::RC_IN
 			_pwm_on = true;
 		}
 
-		//Do we even need this condition? mixer should handle stopping motors anyway by sending the disable command, right?
-		if (0) { //(!_pwm_on || stop_motors) {
-			output_cmds[i] = _parameters.pwm_dis * MIXER_OUTPUT_TO_CMD_SCALE; //0; //convert to ns
-
-		} else {
-			output_cmds[i] = ((uint32_t)outputs[i]) * MIXER_OUTPUT_TO_CMD_SCALE;  //convert to ns
-		}
+		output_cmds[i] = ((uint32_t)outputs[i]) * MIXER_OUTPUT_TO_CMD_SCALE;  //convert to ns
 	}
 
 	Command cmd;

--- a/src/drivers/voxl2_io/voxl2_io.hpp
+++ b/src/drivers/voxl2_io/voxl2_io.hpp
@@ -82,7 +82,7 @@ public:
 	int print_status() override;
 
 	/** @see OutputModuleInterface */
-	bool updateOutputs(bool stop_motors, uint16_t outputs[input_rc_s::RC_INPUT_MAX_CHANNELS],
+	bool updateOutputs(uint16_t outputs[input_rc_s::RC_INPUT_MAX_CHANNELS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	virtual int	init();

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -473,15 +473,11 @@ bool MixingOutput::update()
 void
 MixingOutput::limitAndUpdateOutputs(float outputs[MAX_ACTUATORS], bool has_updates)
 {
-	bool stop_motors = !_throttle_armed && !_actuator_test.inTestMode();
-
 	if (_armed.lockdown || _armed.manual_lockdown) {
 		// overwrite outputs in case of lockdown with disarmed values
 		for (size_t i = 0; i < _max_num_outputs; i++) {
 			_current_output_value[i] = _disarmed_value[i];
 		}
-
-		stop_motors = true;
 
 	} else if (_armed.force_failsafe) {
 		// overwrite outputs in case of force_failsafe with _failsafe_value values
@@ -513,7 +509,7 @@ MixingOutput::limitAndUpdateOutputs(float outputs[MAX_ACTUATORS], bool has_updat
 	}
 
 	/* now return the outputs to the driver */
-	if (_interface.updateOutputs(stop_motors, _current_output_value, _max_num_outputs, has_updates)) {
+	if (_interface.updateOutputs(_current_output_value, _max_num_outputs, has_updates)) {
 		actuator_outputs_s actuator_outputs{};
 		setAndPublishActuatorOutputs(_max_num_outputs, actuator_outputs);
 

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -79,14 +79,12 @@ public:
 
 	/**
 	 * Callback to update the (physical) actuator outputs in the driver
-	 * @param stop_motors if true, all motors must be stopped (if false, individual motors
-	 *                    might still be stopped via outputs[i] == disarmed_value)
 	 * @param outputs individual actuator outputs in range [min, max] or failsafe/disarmed value
 	 * @param num_outputs number of outputs (<= max_num_outputs)
 	 * @param num_control_groups_updated number of actuator_control groups updated
 	 * @return if true, the update got handled, and actuator_outputs can be published
 	 */
-	virtual bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	virtual bool updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 				   unsigned num_outputs, unsigned num_control_groups_updated) = 0;
 
 	/** called whenever the mixer gets updated/reset */

--- a/src/lib/mixer_module/mixer_module_tests.cpp
+++ b/src/lib/mixer_module/mixer_module_tests.cpp
@@ -86,7 +86,7 @@ public:
 		was_scheduled = true;
 	}
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs_[MAX_ACTUATORS],
+	bool updateOutputs(uint16_t outputs_[MAX_ACTUATORS],
 			   unsigned num_outputs_, unsigned num_control_groups_updated) override
 	{
 		memcpy(outputs, outputs_, sizeof(outputs));

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -62,7 +62,7 @@ bool GZMixingInterfaceESC::init(const std::string &model_name)
 	return true;
 }
 
-bool GZMixingInterfaceESC::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool GZMixingInterfaceESC::updateOutputs(uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
 	unsigned active_output_count = 0;

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.hpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.hpp
@@ -55,7 +55,7 @@ public:
 		_node(node)
 	{}
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	MixingOutput &mixingOutput() { return _mixing_output; }

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.cpp
@@ -128,7 +128,7 @@ bool GZMixingInterfaceServo::init(const std::string &model_name)
 	return true;
 }
 
-bool GZMixingInterfaceServo::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool GZMixingInterfaceServo::updateOutputs(uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
 	bool updated = false;

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.hpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.hpp
@@ -49,7 +49,7 @@ public:
 		_node(node)
 	{}
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	MixingOutput &mixingOutput() { return _mixing_output; }

--- a/src/modules/simulation/pwm_out_sim/PWMSim.cpp
+++ b/src/modules/simulation/pwm_out_sim/PWMSim.cpp
@@ -58,7 +58,7 @@ PWMSim::~PWMSim()
 	perf_free(_interval_perf);
 }
 
-bool PWMSim::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool PWMSim::updateOutputs(uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 			   unsigned num_control_groups_updated)
 {
 	// Only publish once we receive actuator_controls (important for lock-step to work correctly)

--- a/src/modules/simulation/pwm_out_sim/PWMSim.hpp
+++ b/src/modules/simulation/pwm_out_sim/PWMSim.hpp
@@ -70,7 +70,7 @@ public:
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:


### PR DESCRIPTION
### Solved Problem
The `stop_motors` flag is unused almost everywhere and the places where it is used it has no effect. The mixer already has the logic to set the outputs to the correct value.

This is a continuation from https://github.com/PX4/PX4-Autopilot/pull/25171 and fixes Motor Test with DShot output on a CANnode acting as a PWM Expander. 

I've also removed the **esc info** command from the DShot driver. I discovered that it does not work on main anyway, at least with AM32 ESC firmware. It complicates the driver implementation and is not really useful as a shell command anyway. We can add it back in the future once we add support for more [DShot commands](https://brushlesswhoop.com/dshot-and-bidirectional-dshot/#special-commands) via `vehicle_command`.

### Changelog Entry
For release notes:
```
mixer: remove stop_motors flag
dshot: fix motor test on CANnode and remove esc info shell command
```

### Test coverage
Tested on an ARK FPV with DShot outputs.
Tested on an ARK CANnode with DShot outputs, conneced to an ARK FPV via CAN.