### PR TITLE
50001_aion_robotics_r1_rover - discontinued

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/50001_aion_robotics_r1_rover
+++ b/ROMFS/px4fmu_common/init.d/airframes/50001_aion_robotics_r1_rover
@@ -2,7 +2,7 @@
 #
 # @name Aion Robotics R1 UGV
 #
-# @url https://www.aionrobotics.com/r1
+# @url https://docs.px4.io/main/en/complete_vehicles_rover/aion_r1.html
 #
 # @type Rover
 # @class Rover


### PR DESCRIPTION
The URL provided for Aion R1 is now discontinued - it doesn't appear on their site. Currently it is documented on our site, so one option is to do as I have done, and link to https://docs.px4.io/main/en/complete_vehicles_rover/aion_r1.html.
Another alternative is to remove the frame altogether. 

@chfriedrich98 @sfuhrer Thoughts?

Note, I will also mark the page in the docs as discontinued. But good to decide on the airframe too if we can.
We really need a reference platform for rover.