### PR TITLE
[bug] AFBRS40: fix Range Mode switching

### DIFF
--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.cpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.cpp
@@ -370,6 +370,19 @@ status_t AFBRS50::setRateAndDfm(uint32_t rate_hz, argus_dfm_mode_t dfm_mode)
 		return status;
 	}
 
+	argus_dfm_mode_t result_mode;
+	status = Argus_GetConfigurationDFMMode(_hnd, &result_mode);
+
+	if (status != STATUS_OK) {
+		PX4_ERR("Argus_GetConfigurationDFMMode status not okay: %i", (int)status);
+		return status;
+	}
+
+	if (result_mode != dfm_mode) {
+		PX4_ERR("Argus_SetConfigurationDFMMode failed: %i", (int)status);
+		return status;
+	}
+
 	status = Argus_SetConfigurationFrameTime(_hnd, (1000000 / rate_hz));
 
 	if (status != STATUS_OK) {

--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.cpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.cpp
@@ -281,7 +281,6 @@ void AFBRS50::Run()
 			status_t status = Argus_TriggerMeasurement(_hnd, measurementReadyCallback);
 
 			if (status != STATUS_OK) {
-				// PX4_ERR("Argus_TriggerMeasurement status not okay: %i", (int)status);
 				perf_count(_not_ready_perf);
 				// Reschedule another trigger
 				_state = STATE::TRIGGER;
@@ -305,6 +304,7 @@ void AFBRS50::Run()
 
 			if (elapsed > _measurement_inverval) {
 				ScheduleNow();
+
 			} else {
 				ScheduleDelayed(_measurement_inverval - elapsed);
 			}

--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
@@ -74,7 +74,6 @@ private:
 		CONFIGURE,
 		TRIGGER,
 		COLLECT,
-		WATCHDOG
 	} _state{STATE::CONFIGURE};
 
 	PX4Rangefinder _px4_rangefinder;
@@ -89,6 +88,8 @@ private:
 	int8_t _current_quality{0};
 	float _max_distance{30.f};
 	uint32_t _current_rate{0};
+
+	hrt_abstime _trigger_time{0};
 
 	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 

--- a/src/drivers/distance_sensor/broadcom/afbrs50/API/Src/s2pi.cpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/API/Src/s2pi.cpp
@@ -70,6 +70,8 @@ private:
 };
 
 AFBRS50_SPI::AFBRS50_SPI():
+	// WARNING: SPI0 only exists for nxp and raspberry pi, so we hijack it here
+
 	// NOTE: we use SPI0 WQ since it is the 2nd highest priority thread (behind rate_ctrl).
 	// TODO: we should fix how SPI comms work. Async SPI comms is
 	// undesirable. We should use SPI TX DMA complete callback


### PR DESCRIPTION
### Solved Problem
The sensor will switch between Short and Long range modes depending on the distance. When I rewrote parts of this driver in https://github.com/PX4/PX4-Autopilot/pull/24837 I switched from manual triggering in the state machine to continuous triggering via an hrt. This can interfere with the range mode switching and cause it to fail

### Solution
Changed state machine to be trigger/collect and reschedule based on the max update interval. I did notice there is some jitter and sometimes the sensor isn't ready, or reports that it is ready and fails to trigger a measurement. I removed the PX4_WARN for this and instead we can track it with the perf counters. It doesn't seem to impact the sensors operation.

### Changelog Entry
For release notes:
```
afbr: fix Range Mode switching by switching to manually triggered state machine
```

### Test coverage
ARK Pi6X