### PR TITLE
fix: allow RTL during mission

### DIFF
--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -384,7 +384,8 @@ MissionBase::on_active()
 bool
 MissionBase::isLanding()
 {
-	if (hasMissionLandStart() && (_mission.current_seq > _mission.land_start_index)) {
+	if (hasMissionLandStart() && (_mission.current_seq > _mission.land_start_index)
+	    && (_mission.current_seq <= _mission.land_index)) {
 		static constexpr size_t max_num_next_items{1u};
 		int32_t next_mission_items_index[max_num_next_items];
 		size_t num_found_items;


### PR DESCRIPTION



### Solved Problem

For missions with multiple land items: If an RTL is triggered after a landing, then `isLanding()` returns true and the vehicle continues with the mission instead of executing the RTL.

### Solution

The land index marks the actual landing. So, `isLanding()` should only be true for the items between `land_start_index` and `land_index`. If there are items after the land index, then they don't belong to the landing anymore.

### Changelog Entry
For release notes:
```
Feature/Bugfix isLanding() in MissionBase only return true during landing
```

### Test coverage
Tested in SITL: Mission with multiple landings. In between the 2nd and 3rd landing, triggered an RTL through the GS. 

Main: https://review.px4.io/plot_app?log=06418ae7-e01b-43be-9fc7-973f14638573
PR: https://review.px4.io/plot_app?log=504571b2-2aa5-4691-8443-e9c0b0ecaa9e

<img width="1544" height="619" alt="image" src="https://github.com/user-attachments/assets/1b1320dc-6757-44f5-a81a-55c4c03a82f9" />

