### PR TITLE
Multicopter Orbit: replace hardcoded 10m/s maximum speed with multicopter speed configuration

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -160,7 +160,7 @@ void FlightTaskOrbit::_sanitizeParams(float &radius, float &velocity) const
 {
 	// clip the radius to be within range
 	radius = math::constrain(radius, _radius_min, _param_mc_orbit_rad_max.get());
-	velocity = math::constrain(velocity, -fabsf(_velocity_max), fabsf(_velocity_max));
+	velocity = math::constrain(velocity, -fabsf(_param_mpc_xy_vel_max.get()), fabsf(_param_mpc_xy_vel_max.get()));
 
 	bool exceeds_maximum_acceleration = (velocity * velocity) >= _acceleration_max * radius;
 

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
@@ -72,7 +72,6 @@ protected:
 private:
 	/* TODO: Should be controlled by params */
 	static constexpr float _radius_min = 1.f;
-	static constexpr float _velocity_max = 10.f;
 	static constexpr float _acceleration_max = 2.f;
 	static constexpr float _horizontal_acceptance_radius = 2.f;
 
@@ -149,6 +148,7 @@ private:
 		(ParamFloat<px4::params::MPC_ACC_UP_MAX>) _param_mpc_acc_up_max,
 		(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max,
 		(ParamFloat<px4::params::MPC_Z_V_AUTO_UP>) _param_mpc_z_v_auto_up,
-		(ParamFloat<px4::params::MPC_Z_V_AUTO_DN>) _param_mpc_z_v_auto_dn
+		(ParamFloat<px4::params::MPC_Z_V_AUTO_DN>) _param_mpc_z_v_auto_dn,
+		(ParamFloat<px4::params::MPC_XY_VEL_MAX>) _param_mpc_xy_vel_max
 	)
 };


### PR DESCRIPTION
### Solved Problem
I got contacted that the 10m/s harcoded limit for orbit is too low for certain use cases e.g. one that requires 18m/s presumably for a larger circle. I followed the advice of @sfuhrer and made the limit dependent on the maximum velocity allowed by the multicopter configuration.

### Solution
Instead of hardcoded 10m/s limit the maximum velocity for multicopter orbit by `MPC_XY_VEL_MAX`.

### Changelog Entry
```
Multicopter Orbit: replace hardcoded 10m/s maximum speed with multicopter speed configuration
```

### Test coverage
I tested using SITL SIH (`make px4_sitl sihsim_quadx`) of which to my surprise the model maxes out at ~10m/s but lowering `MPC_XY_VEL_MAX` correctly limits the velocity so the implementation works.

### Context
Note that there is still a hardcoded limit for 2m/s² maximum centripetal acceleration which means with smaller radius the velocity will not get too high.
