### PR TITLE
stylecheck script: improve bash condition to avoid error with newer terminal versions

### DIFF
--- a/Tools/astyle/check_code_style_all.sh
+++ b/Tools/astyle/check_code_style_all.sh
@@ -43,7 +43,7 @@ fi
 
 # install git pre-commit hook
 HOOK_FILE="$DIR/../../.git/hooks/pre-commit"
-if [ ! -f $HOOK_FILE ] && [ "$CI" != "true" ] && [ $- == *i* ]; then
+if [[ ! -f "$HOOK_FILE" && "$CI" != "true" && $- == *i* ]]; then
 	echo ""
 	echo -e "\033[31mNinja tip: add a git pre-commit hook to automatically check code style\033[0m"
 	echo -e "Would you like to install one now? (\033[94mcp ./Tools/astyle/pre-commit .git/hooks/pre-commit\033[0m): [y/\033[1mN\033[0m]"


### PR DESCRIPTION
### Solved Problem
On Ubuntu 25.04 `GNU bash, version 5.2.37(1)-release (x86_64-pc-linux-gnu)` when I run `make format` I get the following error: `PX4-Autopilot/Tools/astyle/check_code_style_all.sh: line 46: [: too many arguments`

### Solution
Honestly I asked GPT to fix the bash syntax based on the error and it suggested the structure in this pull request which I have tested to work. So a critical pair of reviewing eyes is welcome.

### Changelog Entry
```
stylecheck script: improve bash condition to avoid error with newer terminal versions
```

### Test coverage
I have no error anymore and the command fixes my style mistakes efficiently.
