### PR TITLE
dds: add Wind topic to dds bridge

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -97,6 +97,10 @@ publications:
     type: px4_msgs::msg::HomePosition
     rate_limit: 5.
 
+  - topic: /fmu/out/wind
+    type: px4_msgs::msg::Wind
+    rate_limit: 50.
+
 # Create uORB::Publication
 subscriptions:
   - topic: /fmu/in/register_ext_component_request


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Changelog Entry
For release notes:
```
Feature Add fmu/out/wind to dds_topics 
```

### Test coverage
- Tested in SITL with `make px4_sitl gazebo-classic_plane` while running the [UXRCE bridge](https://docs.px4.io/main/en/middleware/uxrce_dds.html) locally. 

Both `ros2 topic list` and `ros2 topic echo /fmu/out/wind` show the Wind.msg being streamed over ROS. 
