### PR TITLE
Scferro/boat model

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4025_gz_boat
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4025_gz_boat
@@ -1,0 +1,55 @@
+#!/bin/sh
+#
+# @name Boat (GZ)
+#
+
+. ${R}etc/init.d/rc.boat_defaults
+
+PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
+PX4_GZ_WORLD=${PX4_GZ_WORLD:=boat}
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=boat}
+
+param set-default SIM_GZ_EN 1
+param set-default SENS_EN_ARSPDSIM 1
+param set-default FD_ESCS_EN 0
+
+param set-default GND_L1_DIST 5
+param set-default GND_L1_PERIOD 100
+param set-default GND_SP_CTRL_MODE 1
+param set-default GND_SPEED_D 0.001
+param set-default GND_SPEED_I 8
+param set-default GND_SPEED_IMAX 0.125
+param set-default GND_SPEED_P 2
+param set-default GND_SPEED_THR_SC 1
+param set-default GND_SPEED_TRIM 1
+param set-default GND_THR_CRUISE 0.85
+param set-default GND_THR_MAX 1
+param set-default GND_THR_MIN 0
+
+param set-default NAV_ACC_RAD 0.5
+param set-default NAV_LOITER_RAD 2
+
+param set-default GND_MAX_ANG 0.6
+param set-default GND_WHEEL_BASE 2
+
+param set-default CA_AIRFRAME 9
+
+param set-default CA_ROTOR_COUNT 2
+param set-default CA_ROTOR0_AX 1
+param set-default CA_ROTOR0_AZ 0
+param set-default CA_ROTOR0_KM 0
+param set-default CA_ROTOR0_PX -2
+param set-default CA_ROTOR0_PY -1
+param set-default CA_ROTOR1_AX 1
+param set-default CA_ROTOR1_AZ 0
+param set-default CA_ROTOR1_KM 0
+param set-default CA_ROTOR1_PX -2
+param set-default CA_ROTOR1_PY 1
+param set-default CA_R_REV 3
+
+param set-default SIM_GZ_EC_FUNC1 101
+param set-default SIM_GZ_EC_MIN1 0
+param set-default SIM_GZ_EC_MAX1 1000
+param set-default SIM_GZ_EC_FUNC2 102
+param set-default SIM_GZ_EC_MIN2 0
+param set-default SIM_GZ_EC_MAX2 1000

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -92,6 +92,7 @@ px4_add_romfs_files(
 	4019_gz_x500_gimbal
 	4020_gz_tiltrotor
 	4021_gz_x500_flow
+	4025_gz_boat
 
 	6011_gazebo-classic_typhoon_h480
 	6011_gazebo-classic_typhoon_h480.post

--- a/src/modules/simulation/gz_bridge/server.config
+++ b/src/modules/simulation/gz_bridge/server.config
@@ -15,6 +15,7 @@
     </plugin>
     <plugin entity_name="*" entity_type="world" filename="libOpticalFlowSystem.so" name="custom::OpticalFlowSystem"/>
     <plugin entity_name="*" entity_type="world" filename="libGstCameraSystem.so" name="custom::GstCameraSystem"/>
+    <plugin entity_name="*" entity_type="world" filename="libUsivDynamicsPlugin.so" name="custom::UsvDynamics"/>
     <!-- <plugin entity_name="*" entity_type="world" filename="libTemplatePlugin.so" name="custom::TemplateSystem"/> -->
   </plugins>
 </server_config>

--- a/src/modules/simulation/gz_plugins/usv_dynamics/CMakeLists.txt
+++ b/src/modules/simulation/gz_plugins/usv_dynamics/CMakeLists.txt
@@ -31,37 +31,26 @@
 #
 ############################################################################
 
-project(px4_gz_plugins)
+project(UsivDynamicsPlugin)
 
-if(NOT DEFINED ENV{GZ_DISTRO} OR NOT "$ENV{GZ_DISTRO}"  STREQUAL "harmonic")
-    find_package(gz-transport NAMES gz-transport14 gz-transport13)
-    find_package(gz-sim NAMES gz-sim9 gz-sim8)
-    find_package(gz-sensors NAMES gz-sensors9 gz-sensors8)
-    find_package(gz-plugin NAMES gz-plugin3 gz-plugin2 COMPONENTS register)
-else()
-    find_package(gz-transport NAMES gz-transport13)
-    find_package(gz-sim NAMES gz-sim8)
-    find_package(gz-sensors NAMES gz-sensors8)
-    find_package(gz-plugin NAMES gz-plugin2 COMPONENTS register)
-endif()
+# Find required packages
+find_package(Eigen3 REQUIRED)
 
-if (gz-transport_FOUND)
-    # Create a flat output directory for all plugin libraries
-    set(PX4_GZ_PLUGIN_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE PATH "Directory for all Gazebo plugin libraries")
-    file(MAKE_DIRECTORY ${PX4_GZ_PLUGIN_OUTPUT_DIR})
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PX4_GZ_PLUGIN_OUTPUT_DIR})
+add_library(${PROJECT_NAME} SHARED
+    UsvDynamics.cpp
+)
 
-    # Add our plugins as subdirectories
-    add_subdirectory(optical_flow)
-    add_subdirectory(template_plugin)
-    add_subdirectory(gstreamer)
-    add_subdirectory(moving_platform_controller)
-    add_subdirectory(usv_dynamics)
+target_link_libraries(${PROJECT_NAME}
+    PUBLIC px4_gz_msgs
+    PUBLIC gz-sensors${gz-sensors_VERSION_MAJOR}::gz-sensors${gz-sensors_VERSION_MAJOR}
+    PUBLIC gz-plugin${gz-plugin_VERSION_MAJOR}::gz-plugin${gz-plugin_VERSION_MAJOR}
+    PUBLIC gz-sim${gz-sim_VERSION_MAJOR}::gz-sim${gz-sim_VERSION_MAJOR}
+    PUBLIC gz-transport${gz-transport_VERSION_MAJOR}::gz-transport${gz-transport_VERSION_MAJOR}
+    PUBLIC Eigen3::Eigen
+)
 
-    # Add an alias target for each plugin
-    if (TARGET GstCameraSystem)
-        add_custom_target(px4_gz_plugins ALL DEPENDS OpticalFlowSystem MovingPlatformController TemplatePlugin GstCameraSystem UsivDynamicsPlugin)
-    else()
-        add_custom_target(px4_gz_plugins ALL DEPENDS OpticalFlowSystem MovingPlatformController TemplatePlugin UsivDynamicsPlugin)
-    endif()
-endif()
+target_include_directories(${PROJECT_NAME}
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
+    PUBLIC px4_gz_msgs
+)

--- a/src/modules/simulation/gz_plugins/usv_dynamics/README.md
+++ b/src/modules/simulation/gz_plugins/usv_dynamics/README.md
@@ -1,0 +1,134 @@
+# USV Dynamics Plugin
+
+This plugin implements comprehensive hydrodynamics simulation for Unmanned Surface Vehicles (USVs) in Gazebo. It provides realistic water-surface vehicle dynamics including hydrodynamic forces, buoyancy, drag, and added mass effects for boat/ship simulation.
+
+## Features
+
+- **Added Mass Effects**: Models virtual mass added by displaced water during acceleration
+- **Hydrodynamic Drag**: Linear and quadratic drag forces in all 6 degrees of freedom
+- **Coriolis Effects**: Cross-coupling between linear and angular motions for realistic turning behavior
+- **Buoyancy Simulation**: Grid-based buoyancy calculation using discrete hull points
+- **Twin-Hull Support**: Designed for catamaran-style vessels with configurable dimensions
+
+## Physics Model
+
+The plugin implements a 6-DOF hydrodynamic model with:
+
+### Added Mass Matrix (6x6)
+- Surge (X), Sway (Y), and Yaw (N) added mass coefficients
+- Models the virtual mass effect of water displaced during acceleration
+
+### Drag Forces
+- **Linear Drag**: Proportional to velocity in each DOF
+- **Quadratic Drag**: Proportional to velocity squared for surge, sway, and yaw
+- **Velocity-dependent**: Drag magnitude varies with speed
+
+### Buoyancy Forces
+- Grid-based calculation across hull length and width
+- Circular cross-section approximation for hull segments
+- Dynamic buoyancy based on water immersion depth
+
+## Configuration Parameters
+
+### Hull Geometry
+- `boatLength`: Overall vessel length [m] (default: 1.35)
+- `boatWidth`: Beam width between hulls [m] (default: 1.0)
+- `hullRadius`: Demi-hull radius [m] (default: 0.213)
+- `length_n`: Number of hull segments for buoyancy calculation (default: 10)
+
+### Environmental Parameters
+- `waterLevel`: Water surface height [m] (default: 0.5)
+- `waterDensity`: Water density [kg/m³] (default: 997.7735)
+
+### Hydrodynamic Coefficients
+
+#### Added Mass
+- `xDotU`: Added mass coefficient in surge (default: 5)
+- `yDotV`: Added mass coefficient in sway (default: 5)
+- `nDotR`: Added mass coefficient in yaw (default: 1)
+
+#### Linear Drag
+- `xU`: Linear drag coefficient in surge (default: 20)
+- `yV`: Linear drag coefficient in sway (default: 20)
+- `zW`: Linear drag coefficient in heave (default: 20)
+- `kP`: Linear drag coefficient in roll (default: 20)
+- `mQ`: Linear drag coefficient in pitch (default: 20)
+- `nR`: Linear drag coefficient in yaw (default: 20)
+
+#### Quadratic Drag
+- `xUU`: Quadratic drag coefficient in surge (default: 0)
+- `yVV`: Quadratic drag coefficient in sway (default: 0)
+- `nRR`: Quadratic drag coefficient in yaw (default: 0)
+
+## Usage
+
+### Basic Usage
+
+Add the plugin to your boat model SDF file:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<sdf version="1.9">
+  <model name="boat">
+
+    <!-- Your model links and joints -->
+
+    <link name="base_link">
+      <!-- Define the main hull link -->
+    </link>
+
+    <plugin
+      filename="libUsivDynamicsPlugin.so"
+      name="custom::UsvDynamics">
+      <bodyName>base_link</bodyName>
+
+      <!-- Hull geometry -->
+      <boatLength>1.35</boatLength>
+      <boatWidth>1.0</boatWidth>
+      <hullRadius>0.213</hullRadius>
+      <length_n>10</length_n>
+
+      <!-- Environmental parameters -->
+      <waterLevel>0.5</waterLevel>
+      <waterDensity>997.7735</waterDensity>
+
+      <!-- Added mass coefficients -->
+      <xDotU>5</xDotU>
+      <yDotV>5</yDotV>
+      <nDotR>1</nDotR>
+
+      <!-- Linear drag coefficients -->
+      <xU>20</xU>
+      <yV>20</yV>
+      <zW>20</zW>
+      <kP>20</kP>
+      <mQ>20</mQ>
+      <nR>20</nR>
+
+      <!-- Quadratic drag coefficients -->
+      <xUU>0</xUU>
+      <yVV>0</yVV>
+      <nRR>0</nRR>
+    </plugin>
+
+  </model>
+</sdf>
+```
+
+### Running with PX4
+
+To use the plugin with a boat model in PX4:
+
+```bash
+make px4_sitl gz_boat
+```
+
+## Dependencies
+
+- Eigen3: Matrix operations
+- Gazebo Garden/Harmonic: Simulation framework
+- PX4 simulation environment
+
+## Based On
+
+This plugin is a direct port of the USV dynamics plugin from Gazebo Classic, originally developed by Brian Bingham, adapted for modern Gazebo (Garden/Harmonic) and PX4 integration.

--- a/src/modules/simulation/gz_plugins/usv_dynamics/UsvDynamics.cpp
+++ b/src/modules/simulation/gz_plugins/usv_dynamics/UsvDynamics.cpp
@@ -1,0 +1,302 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *	notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *	notice, this list of conditions and the following disclaimer in
+ *	the documentation and/or other materials provided with the
+ *	distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *	used to endorse or promote products derived from this software
+ *	without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <cmath>
+#include <functional>
+#include <sstream>
+#include <algorithm>
+
+#include <gz/plugin/Register.hh>
+#include <gz/sim/Util.hh>
+#include <gz/sim/components/LinearAcceleration.hh>
+#include <gz/sim/components/AngularAcceleration.hh>
+#include <gz/sim/components/ExternalWorldWrenchCmd.hh>
+#include <gz/msgs/wrench.pb.h>
+
+#include "UsvDynamics.hpp"
+
+using namespace custom;
+
+#define GRAVITY 9.815
+
+//////////////////////////////////////////////////
+UsvDynamics::UsvDynamics() : _firstUpdate(true)
+{
+}
+
+//////////////////////////////////////////////////
+void UsvDynamics::Configure(const gz::sim::Entity &_modelEntity,
+			    const std::shared_ptr<const sdf::Element> &_sdf,
+			    gz::sim::EntityComponentManager &_ecm,
+			    gz::sim::EventManager &)
+{
+	gzdbg << "Loading USV Dynamics Model Plugin" << std::endl;
+
+	// Store the model entity
+	this->_usvData.modelEntity = _modelEntity;
+	this->_usvData.model = gz::sim::Model(_modelEntity);
+
+	// Get link name from plugin SDF
+	std::string linkName = _sdf->Get<std::string>("bodyName", "base_link").first;
+	this->_usvData.linkEntity = this->_usvData.model.LinkByName(_ecm, linkName);
+
+	if (this->_usvData.linkEntity == gz::sim::kNullEntity) {
+		gzerr << "USV dynamics plugin error: bodyName: " << linkName << " does not exist in model" << std::endl;
+		return;
+	}
+
+	this->_usvData.link = gz::sim::Link(this->_usvData.linkEntity);
+	this->_usvData.link.EnableVelocityChecks(_ecm, true);
+
+	// Load parameters from plugin configuration
+	this->_usvData.waterLevel = _sdf->Get<double>("waterLevel", 0.0).first;
+	this->_usvData.waterDensity = _sdf->Get<double>("waterDensity", 997.7735).first;
+	this->_usvData.paramXdotU = _sdf->Get<double>("xDotU", 50).first;
+	this->_usvData.paramYdotV = _sdf->Get<double>("yDotV", 50).first;
+	this->_usvData.paramNdotR = _sdf->Get<double>("nDotR", 15).first;
+	this->_usvData.paramXu = _sdf->Get<double>("xU", 30).first;
+	this->_usvData.paramXuu = _sdf->Get<double>("xUU", 10).first;
+	this->_usvData.paramYv = _sdf->Get<double>("yV", 40).first;
+	this->_usvData.paramYvv = _sdf->Get<double>("yVV", 20).first;
+	this->_usvData.paramZw = _sdf->Get<double>("zW", 50).first;
+	this->_usvData.paramKp = _sdf->Get<double>("kP", 25).first;
+	this->_usvData.paramMq = _sdf->Get<double>("mQ", 25).first;
+	this->_usvData.paramNr = _sdf->Get<double>("nR", 35).first;
+	this->_usvData.paramNrr = _sdf->Get<double>("nRR", 5).first;
+	this->_usvData.paramHullRadius = _sdf->Get<double>("hullRadius", 0.2).first;
+	this->_usvData.paramBoatWidth = _sdf->Get<double>("boatWidth", 2.06).first;
+	this->_usvData.paramBoatLength = _sdf->Get<double>("boatLength", 4.7).first;
+	this->_usvData.paramLengthN = _sdf->Get<int>("length_n", 15).first;
+
+	// Initialize Added Mass Matrix
+	this->_usvData.Ma = Eigen::MatrixXd(6, 6);
+	this->_usvData.Ma <<
+		this->_usvData.paramXdotU, 0,                0,   0,   0,   0,
+		0,                this->_usvData.paramYdotV, 0,   0,   0,   0,
+		0,                0,                0.1, 0,   0,   0,
+		0,                0,                0,   0.1, 0,   0,
+		0,                0,                0,   0,   0.1, 0,
+		0,                0,                0,   0,   0,   this->_usvData.paramNdotR;
+
+	gzdbg << "USV Dynamics configured for model with link: " << linkName << std::endl;
+}
+
+//////////////////////////////////////////////////
+double UsvDynamics::CircleSegment(double R, double h)
+{
+	return R * R * acos((R - h) / R) - (R - h) * sqrt(2 * R * h - h * h);
+}
+
+//////////////////////////////////////////////////
+void UsvDynamics::PreUpdate(const gz::sim::UpdateInfo &_info,
+			    gz::sim::EntityComponentManager &_ecm)
+{
+	if (_info.paused) {
+		return;
+	}
+
+	// Check if plugin was properly configured
+	if (this->_usvData.linkEntity == gz::sim::kNullEntity) {
+		return; // Plugin not properly configured, skip
+	}
+
+	// Initialize timing on first update
+	if (this->_firstUpdate) {
+		this->_prevUpdateTime = _info.simTime;
+		this->_firstUpdate = false;
+		return;
+	}
+
+	// Calculate time step
+	auto dt_duration = _info.simTime - this->_prevUpdateTime;
+	double dt = std::chrono::duration<double>(dt_duration).count();
+	this->_prevUpdateTime = _info.simTime;
+
+	if (dt <= 0.0) {
+		return; // Skip if no time has passed
+	}
+
+	// Handle first update for this model
+	if (this->_usvData.firstUpdate) {
+		this->_usvData.firstUpdate = false;
+		return;
+	}
+
+	// Get Pose/Orientation from Gazebo using the link's world pose
+	auto worldPose = this->_usvData.link.WorldPose(_ecm);
+	if (!worldPose) {
+		return; // Skip if pose not available
+	}
+	const gz::math::Pose3d kPose = worldPose.value();
+
+	// Get body-centered linear and angular velocities using Link methods
+	auto worldLinVel = this->_usvData.link.WorldLinearVelocity(_ecm);
+	auto worldAngVel = this->_usvData.link.WorldAngularVelocity(_ecm);
+
+	// Use zero velocity if not available yet (during startup)
+	gz::math::Vector3d kVelLinearWorld(0, 0, 0);
+	gz::math::Vector3d kVelAngularWorld(0, 0, 0);
+
+	if (worldLinVel) {
+		kVelLinearWorld = worldLinVel.value();
+	}
+	if (worldAngVel) {
+		kVelAngularWorld = worldAngVel.value();
+	}
+
+	// Transform to body frame
+	const gz::math::Vector3d kVelLinearBody = kPose.Rot().Inverse().RotateVector(kVelLinearWorld);
+	const gz::math::Vector3d kVelAngularBody = kPose.Rot().Inverse().RotateVector(kVelAngularWorld);
+
+	// Estimate the linear and angular accelerations
+	const gz::math::Vector3d kAccelLinearBody = (kVelLinearBody - this->_usvData.prevLinVel) / dt;
+	this->_usvData.prevLinVel = kVelLinearBody;
+
+	const gz::math::Vector3d kAccelAngularBody = (kVelAngularBody - this->_usvData.prevAngVel) / dt;
+	this->_usvData.prevAngVel = kVelAngularBody;
+
+	// Create state and derivative of state (accelerations)
+	Eigen::VectorXd stateDot = Eigen::VectorXd(6);
+	Eigen::VectorXd state = Eigen::VectorXd(6);
+	Eigen::MatrixXd Cmat = Eigen::MatrixXd::Zero(6, 6);
+	Eigen::MatrixXd Dmat = Eigen::MatrixXd::Zero(6, 6);
+
+	stateDot << kAccelLinearBody.X(), kAccelLinearBody.Y(), kAccelLinearBody.Z(),
+		kAccelAngularBody.X(), kAccelAngularBody.Y(), kAccelAngularBody.Z();
+
+	state << kVelLinearBody.X(), kVelLinearBody.Y(), kVelLinearBody.Z(),
+		kVelAngularBody.X(), kVelAngularBody.Y(), kVelAngularBody.Z();
+
+	// Added Mass
+	const Eigen::VectorXd kAmassVec = -1.0 * this->_usvData.Ma * stateDot;
+
+	// Coriolis - added mass components
+	Cmat(0, 5) = this->_usvData.paramYdotV * kVelLinearBody.Y();
+	Cmat(1, 5) = this->_usvData.paramXdotU * kVelLinearBody.X();
+	Cmat(5, 0) = this->_usvData.paramYdotV * kVelLinearBody.Y();
+	Cmat(5, 1) = this->_usvData.paramXdotU * kVelLinearBody.X();
+
+	// Drag
+	Dmat(0, 0) = this->_usvData.paramXu + this->_usvData.paramXuu * std::abs(kVelLinearBody.X());
+	Dmat(1, 1) = this->_usvData.paramYv + this->_usvData.paramYvv * std::abs(kVelLinearBody.Y());
+	Dmat(2, 2) = this->_usvData.paramZw;
+	Dmat(3, 3) = this->_usvData.paramKp;
+	Dmat(4, 4) = this->_usvData.paramMq;
+	Dmat(5, 5) = this->_usvData.paramNr + this->_usvData.paramNrr * std::abs(kVelAngularBody.Z());
+
+	const Eigen::VectorXd kDvec = -1.0 * Dmat * state;
+
+	// Sum all forces - in body frame
+	const Eigen::VectorXd kForceSum = kAmassVec + kDvec;
+
+	// Initialize total force and torque (in body frame like classic plugin)
+	gz::math::Vector3d totalForce(kForceSum(0), kForceSum(1), kForceSum(2));
+	gz::math::Vector3d totalTorque(kForceSum(3), kForceSum(4), kForceSum(5));
+
+	// Loop over boat grid points for buoyancy calculation
+	gz::math::Vector3d bpnt(0, 0, 0);
+	gz::math::Vector3d bpntW(0, 0, 0);
+
+	// For each hull
+	for (int ii = 0; ii < 2; ii++) {
+		// Grid point in boat frame
+		bpnt.Y((ii * 2.0 - 1.0) * this->_usvData.paramBoatWidth / 2.0);
+
+		// For each length segment
+		for (int jj = 1; jj <= this->_usvData.paramLengthN; jj++) {
+			bpnt.X(((jj - 0.5) / (static_cast<double>(this->_usvData.paramLengthN)) - 0.5) *
+			       this->_usvData.paramBoatLength);
+
+			// Transform from vessel to water/world frame
+			bpntW = kPose.Rot().RotateVector(bpnt);
+
+			// Vertical location of boat grid point in world frame
+			const double kDdz = kPose.Pos().Z() + bpntW.Z();
+
+			// Find vertical displacement of wave field
+			gz::math::Vector3d X;
+			X.X() = kPose.Pos().X() + bpntW.X();
+			X.Y() = kPose.Pos().Y() + bpntW.Y();
+
+			// Compute the depth at the grid point (no waves for now)
+			double depth = 0.0;
+
+			// Vertical wave displacement
+			double dz = depth + X.Z();
+
+			// Total z location of boat grid point relative to water surface
+			double deltaZ = (this->_usvData.waterLevel + dz) - kDdz;
+			deltaZ = std::max(deltaZ, 0.0);  // enforce only upward buoy force
+			deltaZ = std::min(deltaZ, this->_usvData.paramHullRadius);
+
+			// Buoyancy force at grid point
+			const double kBuoyForce = CircleSegment(this->_usvData.paramHullRadius, deltaZ) *
+						  this->_usvData.paramBoatLength / (static_cast<double>(this->_usvData.paramLengthN)) *
+						  GRAVITY * this->_usvData.waterDensity;
+
+			// Apply buoyancy force at grid point location (like classic plugin)
+			// Force is vertical (world frame), but we apply it at the grid point location
+			gz::math::Vector3d forceAtPoint(0, 0, kBuoyForce);
+			
+			// In classic plugin, forces are applied relative to link frame
+			// AddForceAtPosition effectively does: force + position.Cross(force) for torque
+			// We need to transform the vertical force to body frame and add torque manually
+			gz::math::Vector3d forceInBody = kPose.Rot().Inverse().RotateVector(forceAtPoint);
+			gz::math::Vector3d torqueFromForce = bpnt.Cross(forceInBody);
+			
+			totalForce += forceInBody;
+			totalTorque += torqueFromForce;
+		}
+	}
+
+	// Apply forces and torques in body frame (like classic plugin AddRelativeForce/Torque)
+	// Transform to world frame for modern Gazebo
+	gz::math::Vector3d forceWorld = kPose.Rot().RotateVector(totalForce);
+	gz::math::Vector3d torqueWorld = kPose.Rot().RotateVector(totalTorque);
+
+	// Apply forces and torques to the link
+	gz::msgs::Wrench wrenchMsg;
+	gz::msgs::Set(wrenchMsg.mutable_force(), forceWorld);
+	gz::msgs::Set(wrenchMsg.mutable_torque(), torqueWorld);
+
+	// Create or update the external wrench component
+	_ecm.SetComponentData<gz::sim::components::ExternalWorldWrenchCmd>(this->_usvData.linkEntity, {wrenchMsg});
+}
+
+// Register the plugin
+GZ_ADD_PLUGIN(UsvDynamics,
+	      gz::sim::System,
+	      UsvDynamics::ISystemConfigure,
+	      UsvDynamics::ISystemPreUpdate)
+
+GZ_ADD_PLUGIN_ALIAS(UsvDynamics, "custom::UsvDynamics")

--- a/src/modules/simulation/gz_plugins/usv_dynamics/UsvDynamics.cpp
+++ b/src/modules/simulation/gz_plugins/usv_dynamics/UsvDynamics.cpp
@@ -71,7 +71,6 @@ void UsvDynamics::Configure(const gz::sim::Entity &_modelEntity,
 	this->_usvData.linkEntity = this->_usvData.model.LinkByName(_ecm, linkName);
 
 	if (this->_usvData.linkEntity == gz::sim::kNullEntity) {
-		gzerr << "USV dynamics plugin error: bodyName: " << linkName << " does not exist in model" << std::endl;
 		return;
 	}
 
@@ -267,13 +266,13 @@ void UsvDynamics::PreUpdate(const gz::sim::UpdateInfo &_info,
 			// Apply buoyancy force at grid point location (like classic plugin)
 			// Force is vertical (world frame), but we apply it at the grid point location
 			gz::math::Vector3d forceAtPoint(0, 0, kBuoyForce);
-			
+
 			// In classic plugin, forces are applied relative to link frame
 			// AddForceAtPosition effectively does: force + position.Cross(force) for torque
 			// We need to transform the vertical force to body frame and add torque manually
 			gz::math::Vector3d forceInBody = kPose.Rot().Inverse().RotateVector(forceAtPoint);
 			gz::math::Vector3d torqueFromForce = bpnt.Cross(forceInBody);
-			
+
 			totalForce += forceInBody;
 			totalTorque += torqueFromForce;
 		}

--- a/src/modules/simulation/gz_plugins/usv_dynamics/UsvDynamics.hpp
+++ b/src/modules/simulation/gz_plugins/usv_dynamics/UsvDynamics.hpp
@@ -1,0 +1,143 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *	notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *	notice, this list of conditions and the following disclaimer in
+ *	the documentation and/or other materials provided with the
+ *	distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *	used to endorse or promote products derived from this software
+ *	without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <Eigen/Core>
+#include <string>
+#include <chrono>
+#include <unordered_map>
+
+#include <gz/sim/System.hh>
+#include <gz/sim/Model.hh>
+#include <gz/sim/Link.hh>
+#include <gz/sim/EntityComponentManager.hh>
+#include <gz/sim/components/Pose.hh>
+#include <gz/sim/components/LinearVelocity.hh>
+#include <gz/sim/components/AngularVelocity.hh>
+#include <gz/sim/components/Inertial.hh>
+#include <gz/sim/components/Link.hh>
+#include <gz/sim/components/Name.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/math/Quaternion.hh>
+#include <sdf/Element.hh>
+
+#define GRAVITY 9.815
+
+namespace custom
+{
+	/// \brief Plugin class to implement hydrodynamics and wave response for USV.
+	/// This plugin accepts the following SDF parameters:
+	///
+	/// <bodyName>: Name of base link for receiving pose and applying forces.
+	/// <boatLength>: Boat length [m]. Default value is 1.35.
+	/// <boatWidth>: Boat width [m]. Default value is 1.
+	/// <hullRadius>: Demi-hull radius [m]. Default value is 0.213.
+	/// <waterDensity>: Water density [kg/m^3]. Default value is 997.7735.
+	/// <waterLevel>: Water height [m]. Default value is 0.5.
+	/// <xDotU>: Added mass coeff, surge. Default value is 5.
+	/// <yDotV>: Added mass coeff, sway. Default value is 5.
+	/// <nDotR>: Added mass coeff, yaw. Default value is 1.
+	/// <xU>: Linear drag coeff surge. Default value is 20.
+	/// <xUU>: Quadratic drag coeff surge. Default value is 0.
+	/// <yV>: Linear drag coeff sway. Default value is 20.
+	/// <yVV>: Quadratic drag coeff sway. Default value is 0.
+	/// <zW>: Linear drag coeff heave. Default value is 20.
+	/// <kP>: Linear drag coeff roll. Default value is 20.
+	/// <mQ>: Linear drag coeff pitch. Default value is 20.
+	/// <nR>: Linear drag coeff yaw. Default value is 20.
+	/// <nRR>: Quadratic drag coeff yaw. Default value is 0.
+	/// <length_n>: Number of length segments for buoyancy calculation.
+	class UsvDynamics :
+		public gz::sim::System,
+		public gz::sim::ISystemConfigure,
+		public gz::sim::ISystemPreUpdate
+	{
+	public:
+		/// \brief Constructor.
+		UsvDynamics();
+
+		/// \brief Destructor.
+		virtual ~UsvDynamics() = default;
+
+		// Documentation inherited.
+		void Configure(const gz::sim::Entity &_modelEntity,
+			       const std::shared_ptr<const sdf::Element> &_sdf,
+			       gz::sim::EntityComponentManager &_ecm,
+			       gz::sim::EventManager &_eventMgr) override;
+
+		/// \brief Callback for Gazebo simulation engine.
+		void PreUpdate(const gz::sim::UpdateInfo &_info,
+			       gz::sim::EntityComponentManager &_ecm) override;
+
+	private:
+		/// \brief Structure to hold USV configuration for a model
+		struct UsvModelData {
+			gz::sim::Entity modelEntity;
+			gz::sim::Entity linkEntity;
+			gz::sim::Model model{gz::sim::kNullEntity};
+			gz::sim::Link link{gz::sim::kNullEntity};
+			
+			// USV parameters
+			double waterLevel;
+			double waterDensity;
+			double paramXdotU, paramYdotV, paramNdotR;
+			double paramXu, paramXuu, paramYv, paramYvv, paramZw;
+			double paramKp, paramMq, paramNr, paramNrr;
+			double paramBoatLength, paramBoatWidth, paramHullRadius;
+			int paramLengthN;
+			Eigen::MatrixXd Ma;
+			
+			// State tracking
+			gz::math::Vector3d prevLinVel{0, 0, 0};
+			gz::math::Vector3d prevAngVel{0, 0, 0};
+			bool firstUpdate{true};
+		};
+
+		/// \brief USV data for this model instance
+		UsvModelData _usvData;
+
+		/// \brief Convenience function for calculating the area of circle segment
+		/// \param[in] R Radius of circle
+		/// \param[in] h Height of the chord line
+		/// \return The area
+		double CircleSegment(double R, double h);
+
+		/// \brief Simulation time of the last update.
+		std::chrono::steady_clock::duration _prevUpdateTime{0};
+
+		/// \brief First update flag to initialize timing.
+		bool _firstUpdate{true};
+	};
+} // end namespace custom


### PR DESCRIPTION
###Solved Problem

Currently, there is no surface vehicle simulation in Ignition Gazebo, only in Gazebo Classic. This PR ports the USVDynamics plugin from Gazebo Classic and creates the sitl simulation for the boat. 

Fixes [PX4-gazebo-models Issue #110](https://github.com/PX4/PX4-gazebo-models/issues/110)
Associated [PX4-gazebo-models PR](https://github.com/PX4/PX4-gazebo-models/pull/112)

###Solution

- Add complete USV dynamics plugin for modern Gazebo with full 6-DOF hydrodynamics physics
- Port all physics calculations from Gazebo Classic including added mass matrix, linear/quadratic drag, grid-based buoyancy, and Coriolis effects
- Add boat airframe configuration (4025_gz_boat) with proper marine vehicle parameters
- Configure ESC failure detection bypass for marine vehicles
- Implement proper force application using modern Gazebo ExternalWorldWrenchCmd component

###Changelog Entry

Feature: Modern Gazebo USV/Boat Simulation Support
- Ported USV dynamics plugin from Gazebo Classic to Gazebo Ignition
- Boat airframe (4025_gz_boat) for marine surface vehicle simulation in Ignition 
- Proper buoyancy, drag, and added mass effects
Documentation: Requires boat model from PX4-gazebo-models repository

###Alternatives

We could also:
- Use Gazebo built in buoyancy plugin, however this does not support other surface dynamics such as the drag effects of water.

###Test coverage

- Integration test: Plugin loads and applies forces without errors in gz-sim
- Simulation testing: Boat maintains proper buoyancy, responds to propeller thrust, exhibits realistic marine vehicle dynamics
- Physics validation: Behavior matches Gazebo Classic USV plugin implementation
- Hardware testing logs: N/A (simulation-only feature)

###Context

This ports the existing boat simulation from Gazebo Classic to Gazebo Ignition, as Classic is now EOL. 