### PR TITLE
ekf-agp: use same timeout value as other aid sources

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.cpp
@@ -137,7 +137,7 @@ void AuxGlobalPosition::update(Ekf &ekf, const estimator::imuSample &imu_delayed
 			if (continuing_conditions) {
 				ekf.fuseHorizontalPosition(aid_src);
 
-				if (isTimedOut(aid_src.time_last_fuse, imu_delayed.time_us, ekf._params.no_aid_timeout_max)
+				if (isTimedOut(aid_src.time_last_fuse, imu_delayed.time_us, ekf._params.reset_timeout_max)
 				    || (_reset_counters.lat_lon != sample.lat_lon_reset_counter)) {
 					if (ekf.isOnlyActiveSourceOfHorizontalPositionAiding(ekf.control_status_flags().aux_gpos)) {
 


### PR DESCRIPTION
### Solved Problem
Auxiliary Global Position (AGP) fusion control logic uses a different reset timeout than GNSS control, while being a really similar aid source. There is no reason for this.

Note that optical flow uses `no_aid_timeout_max` (1s) in case the EKF is doing inertial dead-reckoning.

### Solution
Use `reset_timeout_max` as in [GNSS control](https://github.com/PX4/PX4-Autopilot/blob/84cdc051959135ec5cbf25001be69d562c302ff5/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp#L366-L367)

### Test coverage
flight tested