### PR TITLE
Fix fuzzing ci

### DIFF
--- a/.github/fuzzing_issue_template.md
+++ b/.github/fuzzing_issue_template.md
@@ -1,0 +1,6 @@
+---
+title: '[CI] Fuzzing Workflow Failed'
+labels: ['Fuzzing']
+---
+The automated fuzzing workflow has failed.
+See {{ env.WORKFLOW_RUN_URL }} for details.

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -36,3 +36,13 @@ jobs:
           for fuzz_binary in build/px4_sitl_test/*fuzz*; do
             ./Tools/ci/run_fuzz_tests.sh $fuzz_binary 15m
           done
+
+      # Create a github issue in case of a failure
+      - name: Create Issue
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/fuzzing_issue_template.md


### PR DESCRIPTION
The fuzzing CI failed due to a rebase with container version update: https://github.com/PX4/PX4-Autopilot/actions/runs/16235116238/job/45844179833.

Using a newer container fixes it.

In addition, the fuzzing workflow will now create a github issue in case it fails (scheduled workflow failures trigger notifications only to the author that [last made changes](https://docs.github.com/en/actions/concepts/workflows-and-actions/notifications-for-workflow-runs) to the workflow file).
Test issue: https://github.com/PX4/PX4-Autopilot/issues/25211