### PR TITLE
mavlink_main: add  profile handling

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2099,6 +2099,9 @@ Mavlink::task_main(int argc, char *argv[])
 					} else if (strcmp(myoptarg, "uavionix") == 0) {
 						_mode = MAVLINK_MODE_UAVIONIX;
 
+					} else if (strcmp(myoptarg, "low_bandwidth") == 0) {
+						_mode = MAVLINK_MODE_LOW_BANDWIDTH;
+
 					} else {
 						PX4_ERR("invalid mode");
 						err_flag = true;


### PR DESCRIPTION
### Solved Problem
Mavlink module is missing the logic for handling the `low_bandwidth` MAVLink mode introduced by https://github.com/PX4/PX4-Autopilot/pull/24328

### Test coverage
- SITL tested
