### PR TITLE
rover: fix speed setpoint in position controller

### DIFF
--- a/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.hpp
+++ b/src/modules/rover_ackermann/AckermannPosControl/AckermannPosControl.hpp
@@ -106,6 +106,7 @@ private:
 	Quatf _vehicle_attitude_quaternion{};
 	Vector2f _curr_pos_ned{};
 	Vector2f _start_ned{};
+	float _arrival_speed{0.f};
 	float _vehicle_yaw{0.f};
 	float _max_yaw_rate{0.f};
 	float _acceptance_radius{0.f}; // Acceptance radius for the waypoint.

--- a/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.hpp
+++ b/src/modules/rover_differential/DifferentialPosControl/DifferentialPosControl.hpp
@@ -103,6 +103,7 @@ private:
 	// Variables
 	Vector2f _curr_pos_ned{};
 	Vector2f _start_ned{};
+	float _arrival_speed{0.f};
 	float _vehicle_yaw{0.f};
 
 	DEFINE_PARAMETERS(

--- a/src/modules/rover_mecanum/MecanumPosControl/MecanumPosControl.cpp
+++ b/src/modules/rover_mecanum/MecanumPosControl/MecanumPosControl.cpp
@@ -56,26 +56,21 @@ void MecanumPosControl::updatePosControl()
 
 	hrt_abstime timestamp = hrt_absolute_time();
 
-	if (_rover_position_setpoint_sub.updated()) {
-		_rover_position_setpoint_sub.copy(&_rover_position_setpoint);
-		_start_ned = Vector2f(_rover_position_setpoint.start_ned[0], _rover_position_setpoint.start_ned[1]);
-		_start_ned = _start_ned.isAllFinite() ? _start_ned : _curr_pos_ned;
-		_yaw_setpoint = PX4_ISFINITE(_rover_position_setpoint.yaw) ? _rover_position_setpoint.yaw : _vehicle_yaw;
-	}
-
 	const Vector2f target_waypoint_ned(_rover_position_setpoint.position_ned[0], _rover_position_setpoint.position_ned[1]);
 
 	if (target_waypoint_ned.isAllFinite()) {
 
 		float distance_to_target = (target_waypoint_ned - _curr_pos_ned).norm();
 
-		if (distance_to_target > _param_nav_acc_rad.get()) {
-			float arrival_speed = PX4_ISFINITE(_rover_position_setpoint.arrival_speed) ? _rover_position_setpoint.arrival_speed :
-					      0.f;
-			const float distance = arrival_speed > 0.f + FLT_EPSILON ? distance_to_target - _param_nav_acc_rad.get() :
-					       distance_to_target;
+		if (_arrival_speed > FLT_EPSILON) {
+			distance_to_target -=
+				_param_nav_acc_rad.get(); // shift target to the edge of the acceptance radius if arrival speed not zero
+		}
+
+		if (distance_to_target > _param_nav_acc_rad.get() || _arrival_speed > FLT_EPSILON) {
+
 			float speed_setpoint = math::trajectory::computeMaxSpeedFromDistance(_param_ro_jerk_limit.get(),
-					       _param_ro_decel_limit.get(), distance, fabsf(arrival_speed));
+					       _param_ro_decel_limit.get(), distance_to_target, fabsf(_arrival_speed));
 			speed_setpoint = math::min(speed_setpoint, _param_ro_speed_limit.get());
 
 			if (PX4_ISFINITE(_rover_position_setpoint.cruising_speed)) {
@@ -128,6 +123,14 @@ void MecanumPosControl::updateSubscriptions()
 		}
 
 		_curr_pos_ned = Vector2f(vehicle_local_position.x, vehicle_local_position.y);
+	}
+
+	if (_rover_position_setpoint_sub.updated()) {
+		_rover_position_setpoint_sub.copy(&_rover_position_setpoint);
+		_start_ned = Vector2f(_rover_position_setpoint.start_ned[0], _rover_position_setpoint.start_ned[1]);
+		_start_ned = _start_ned.isAllFinite() ? _start_ned : _curr_pos_ned;
+		_yaw_setpoint = PX4_ISFINITE(_rover_position_setpoint.yaw) ? _rover_position_setpoint.yaw : _vehicle_yaw;
+		_arrival_speed = PX4_ISFINITE(_rover_position_setpoint.arrival_speed) ? _rover_position_setpoint.arrival_speed : 0.f;
 	}
 
 }

--- a/src/modules/rover_mecanum/MecanumPosControl/MecanumPosControl.hpp
+++ b/src/modules/rover_mecanum/MecanumPosControl/MecanumPosControl.hpp
@@ -105,6 +105,7 @@ private:
 	Quatf _vehicle_attitude_quaternion{};
 	Vector2f _curr_pos_ned{};
 	Vector2f _start_ned{};
+	float _arrival_speed{0.f};
 	float _vehicle_yaw{0.f};
 	float _max_yaw_rate{0.f};
 	float _yaw_setpoint{NAN};


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Bug: When a rover approaches a waypoint with a non-zero arrival speed, the position controller will send zero speed setpoints when the rover is within the acceptance radius of the waypoint leading to a jerking motion:

<img width="6140" height="3472" alt="image" src="https://github.com/user-attachments/assets/4de8e41d-b9d3-413a-b725-23ef73c75f2f" />


### Solution
Don't send zero speed commands when the arrival speed is nonzero:
<img width="6088" height="3440" alt="image" src="https://github.com/user-attachments/assets/fb530e30-723e-4751-9c50-51e0c22509c7" />

### Test coverage
- Tested in SITL with all rover types
