### PR TITLE
EKF2: Aux Globlal Pos (AGP) reset mode

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.cpp
@@ -69,7 +69,7 @@ void AuxGlobalPosition::update(Ekf &ekf, const estimator::imuSample &imu_delayed
 
 	if (_aux_global_position_buffer.pop_first_older_than(imu_delayed.time_us, &sample)) {
 
-		if (!(_param_ekf2_agp_ctrl.get() & static_cast<int32_t>(Ctrl::HPOS))) {
+		if (!(_param_ekf2_agp_ctrl.get() & static_cast<int32_t>(Ctrl::kHPos))) {
 			return;
 		}
 
@@ -96,12 +96,12 @@ void AuxGlobalPosition::update(Ekf &ekf, const estimator::imuSample &imu_delayed
 						   && ekf.global_origin_valid();
 
 		switch (_state) {
-		case State::stopped:
+		case State::kStopped:
 
 		/* FALLTHROUGH */
-		case State::starting:
+		case State::kStarting:
 			if (starting_conditions) {
-				_state = State::starting;
+				_state = State::kStarting;
 
 				if (ekf.global_origin_valid()) {
 					const bool fused = ekf.fuseHorizontalPosition(aid_src);
@@ -116,7 +116,7 @@ void AuxGlobalPosition::update(Ekf &ekf, const estimator::imuSample &imu_delayed
 					if (fused || reset) {
 						ekf.enableControlStatusAuxGpos();
 						_reset_counters.lat_lon = sample.lat_lon_reset_counter;
-						_state = State::active;
+						_state = State::kActive;
 					}
 
 				} else {
@@ -126,14 +126,14 @@ void AuxGlobalPosition::update(Ekf &ekf, const estimator::imuSample &imu_delayed
 						ekf.resetAidSourceStatusZeroInnovation(aid_src);
 						ekf.enableControlStatusAuxGpos();
 						_reset_counters.lat_lon = sample.lat_lon_reset_counter;
-						_state = State::active;
+						_state = State::kActive;
 					}
 				}
 			}
 
 			break;
 
-		case State::active:
+		case State::kActive:
 			if (continuing_conditions) {
 				ekf.fuseHorizontalPosition(aid_src);
 
@@ -149,13 +149,13 @@ void AuxGlobalPosition::update(Ekf &ekf, const estimator::imuSample &imu_delayed
 
 					} else {
 						ekf.disableControlStatusAuxGpos();
-						_state = State::stopped;
+						_state = State::kStopped;
 					}
 				}
 
 			} else {
 				ekf.disableControlStatusAuxGpos();
-				_state = State::stopped;
+				_state = State::kStopped;
 			}
 
 			break;
@@ -171,9 +171,9 @@ void AuxGlobalPosition::update(Ekf &ekf, const estimator::imuSample &imu_delayed
 		_test_ratio_filtered = math::max(fabsf(aid_src.test_ratio_filtered[0]), fabsf(aid_src.test_ratio_filtered[1]));
 #endif // MODULE_NAME
 
-	} else if ((_state != State::stopped) && isTimedOut(_time_last_buffer_push, imu_delayed.time_us, (uint64_t)5e6)) {
+	} else if ((_state != State::kStopped) && isTimedOut(_time_last_buffer_push, imu_delayed.time_us, (uint64_t)5e6)) {
 		ekf.disableControlStatusAuxGpos();
-		_state = State::stopped;
+		_state = State::kStopped;
 		ECL_WARN("Aux global position data stopped");
 	}
 }

--- a/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.hpp
+++ b/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.hpp
@@ -82,6 +82,8 @@ private:
 		return (last_sensor_timestamp == 0) || (last_sensor_timestamp + timeout_period < time_delayed_us);
 	}
 
+	bool isResetAllowed(const Ekf &ekf) const;
+
 	struct AuxGlobalPositionSample {
 		uint64_t time_us{};     ///< timestamp of the measurement (uSec)
 		double latitude{};
@@ -99,6 +101,11 @@ private:
 	enum class Ctrl : uint8_t {
 		HPOS  = (1 << 0),
 		VPOS  = (1 << 1)
+	};
+
+	enum class Mode : uint8_t {
+		kAuto           = 0,   	///< Reset on fusion timeout if no other source of position is available
+		kDeadReckoning = 1   	///< Reset on fusion timeout if no source of velocity is availabl
 	};
 
 	enum class State {
@@ -122,6 +129,7 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::EKF2_AGP_CTRL>) _param_ekf2_agp_ctrl,
+		(ParamInt<px4::params::EKF2_AGP_MODE>) _param_ekf2_agp_mode,
 		(ParamFloat<px4::params::EKF2_AGP_DELAY>) _param_ekf2_agp_delay,
 		(ParamFloat<px4::params::EKF2_AGP_NOISE>) _param_ekf2_agp_noise,
 		(ParamFloat<px4::params::EKF2_AGP_GATE>) _param_ekf2_agp_gate

--- a/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.hpp
+++ b/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.hpp
@@ -99,8 +99,8 @@ private:
 	uint64_t _time_last_buffer_push{0};
 
 	enum class Ctrl : uint8_t {
-		HPOS  = (1 << 0),
-		VPOS  = (1 << 1)
+		kHPos  = (1 << 0),
+		kVPos  = (1 << 1)
 	};
 
 	enum class Mode : uint8_t {
@@ -109,12 +109,12 @@ private:
 	};
 
 	enum class State {
-		stopped,
-		starting,
-		active,
+		kStopped,
+		kStarting,
+		kActive,
 	};
 
-	State _state{State::stopped};
+	State _state{State::kStopped};
 
 	float _test_ratio_filtered{INFINITY};
 

--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -336,7 +336,7 @@ bool Ekf::resetGlobalPosToExternalObservation(const double latitude, const doubl
 		const bool innov_rejected = (test_ratio > 1.f);
 
 		if (!_control_status.flags.in_air || (eph > 0.f && eph < 1.f) || innov_rejected) {
-			// when on ground or accuracy chosen to be very low, we hard reset position
+			// When on ground or accuracy chosen to be very low, we hard reset position
 			// this allows the user to still send hard resets at any time
 			ECL_INFO("reset position to external observation");
 			_information_events.flags.reset_pos_to_ext_obs = true;
@@ -346,13 +346,29 @@ bool Ekf::resetGlobalPosToExternalObservation(const double latitude, const doubl
 
 		} else {
 			ECL_INFO("fuse external observation as position measurement");
-			fuseDirectStateMeasurement(innov(0), innov_var(0), obs_var, State::pos.idx + 0);
-			fuseDirectStateMeasurement(innov(1), innov_var(1), obs_var, State::pos.idx + 1);
 
-			// Use the reset counters to inform the controllers about a potential large position jump
-			// TODO: compute the actual position change
-			_state_reset_status.reset_count.posNE++;
-			_state_reset_status.posNE_change.zero();
+			VectorState H;
+			VectorState K;
+
+			for (unsigned index = 0; index < 2; index++) {
+				K = VectorState(P.row(State::pos.idx + index)) / innov_var(index);
+				H(State::pos.idx + index) = 1.f;
+
+				// Artificially set the position Kalman gain to 1 in order to force a reset
+				// of the position through fusion. This allows the EKF to use part of the information
+				// to continue learning the correlated states (e.g.: velocity, heading, wind) while
+				// performing a position reset.
+				K(State::pos.idx + index) = 1.f;
+				measurementUpdate(K, H, obs_var, innov(index));
+				H(State::pos.idx + index) = 0.f; // Reset the whole vector to 0
+			}
+
+			// Use the reset counters to inform the controllers about a position jump
+			updateHorizontalPositionResetStatus(-innov);
+
+			// Reset the positon of the output predictor to avoid a transient that would disturb the
+			// position controller
+			_output_predictor.resetLatLonTo(_gpos.latitude_deg(), _gpos.longitude_deg());
 
 			_time_last_hor_pos_fuse = _time_delayed_us;
 			_last_known_gpos.setLatLon(gpos_corrected);

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -531,10 +531,9 @@ void EKF2::Run()
 
 			} else if (vehicle_command.command == vehicle_command_s::VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE) {
 
-				if ((_ekf.control_status_flags().wind_dead_reckoning || _ekf.control_status_flags().inertial_dead_reckoning
-				     || (!_ekf.control_status_flags().in_air && !_ekf.control_status_flags().gnss_pos))
-				    && PX4_ISFINITE(vehicle_command.param2)
-				    && PX4_ISFINITE(vehicle_command.param5) && PX4_ISFINITE(vehicle_command.param6)
+				if (PX4_ISFINITE(vehicle_command.param2)
+				    && PX4_ISFINITE(vehicle_command.param5)
+				    && PX4_ISFINITE(vehicle_command.param6)
 				   ) {
 
 					const float measurement_delay_seconds = math::constrain(vehicle_command.param2, 0.0f,

--- a/src/modules/ekf2/params_aux_global_position.yaml
+++ b/src/modules/ekf2/params_aux_global_position.yaml
@@ -14,6 +14,16 @@ parameters:
       default: 0
       min: 0
       max: 3
+    EKF2_AGP_MODE:
+      description:
+        short: Fusion reset mode
+        long: 'Automatic: reset on fusion timeout if no other source of position is available
+          Dead-reckoning: reset on fusion timeout if no source of velocity is available'
+      type: enum
+      values:
+        0: Automatic
+        1: Dead-reckoning
+      default: 0
     EKF2_AGP_DELAY:
       description:
         short: Aux global position estimator delay relative to IMU measurements

--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
@@ -106,7 +106,7 @@ bool FlightTaskManualAcceleration::update()
 
 void FlightTaskManualAcceleration::_ekfResetHandlerPositionXY(const matrix::Vector2f &delta_xy)
 {
-	_stick_acceleration_xy.resetPosition();
+	_stick_acceleration_xy.addToPositionSetpoint(delta_xy);
 }
 
 void FlightTaskManualAcceleration::_ekfResetHandlerVelocityXY(const matrix::Vector2f &delta_vxy)

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
@@ -55,6 +55,11 @@ void StickAccelerationXY::resetPosition(const matrix::Vector2f &position)
 	_position_setpoint = position;
 }
 
+void StickAccelerationXY::addToPositionSetpoint(const matrix::Vector2f &delta)
+{
+	_position_setpoint += delta;
+}
+
 void StickAccelerationXY::resetVelocity(const matrix::Vector2f &velocity)
 {
 	if (velocity.isAllFinite()) {

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
@@ -56,6 +56,7 @@ public:
 
 	void resetPosition();
 	void resetPosition(const matrix::Vector2f &position);
+	void addToPositionSetpoint(const matrix::Vector2f &delta);
 	void resetVelocity(const matrix::Vector2f &velocity);
 	void resetAcceleration(const matrix::Vector2f &acceleration);
 	void generateSetpoints(matrix::Vector2f stick_xy, const float yaw, const float yaw_sp, const matrix::Vector3f &pos,


### PR DESCRIPTION
### Solved Problem
The EKF performs statistical consistency checks using normalized innovation tests. However, when the AGP measurement starts to fail a test, we directly reset to the measurement after a timeout period.

### Solution
Add a "reset mode" parameter that tells the EKF whether it should always try to reset to the AGP position measurement when the statistical check fails or if the EKF is allowed to continue using solely velocity measurements.

New parameter: `EKF2_AGP_MODE`
- Automatic: reset on fusion timeout if no other source of position is available
- Dead-reckoning: reset on fusion timeout if no source of velocity is available

Additionally, the `VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE` is no longer filtered by the EKF2 front end. The command is sent and executed by the EKF as any other measurement. This allows the user to override the current position estimate.

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: EKF2_AGP_MODE
Documentation: -
```

### Test coverage
tested in SIH with simulated AGP failures
