### PR TITLE
AirspeedSelector: increase default of ASPD_WERR_THR

### DIFF
--- a/src/modules/airspeed_selector/airspeed_selector_params.c
+++ b/src/modules/airspeed_selector/airspeed_selector_params.c
@@ -237,7 +237,7 @@ PARAM_DEFINE_FLOAT(ASPD_FS_T_START, -1.f);
  * @decimal 2
  * @group Airspeed Validator
  */
-PARAM_DEFINE_FLOAT(ASPD_WERR_THR, 0.55f);
+PARAM_DEFINE_FLOAT(ASPD_WERR_THR, 2.f);
 
 /**
  * First principle airspeed check time window

--- a/src/modules/airspeed_selector/airspeed_selector_params.c
+++ b/src/modules/airspeed_selector/airspeed_selector_params.c
@@ -226,15 +226,15 @@ PARAM_DEFINE_FLOAT(ASPD_FS_T_STOP, 1.f);
 PARAM_DEFINE_FLOAT(ASPD_FS_T_START, -1.f);
 
 /**
- * Horizontal wind uncertainty threshold for synthetic airspeed.
+ * Horizontal wind uncertainty threshold for valid ground-minus-wind
  *
- * The synthetic airspeed estimate (from groundspeed and heading) will be declared valid
+ * The airspeed alternative derived from groundspeed and heading will be declared valid
  * as soon and as long the horizontal wind uncertainty is below this value.
  *
  * @unit m/s
- * @min 0.001
+ * @min 0.01
  * @max 5
- * @decimal 3
+ * @decimal 2
  * @group Airspeed Validator
  */
 PARAM_DEFINE_FLOAT(ASPD_WERR_THR, 0.55f);


### PR DESCRIPTION
### Solved Problem
The default is very low, leading to the ground-minus-wind airspeed approximation being declared invalid all the time.

### Solution
Increase the default. And update the param meta data while on it.
I also consider removing the param and hard-code it. 

### Changelog Entry
For release notes:
```
Improvement: AirspeedSelector: increase default of ASPD_WERR_THR to have ground-minus-wind airspeed approximation valid most 
```

### Context
I got to the new default of 2m/s by looking at a bunch of logs from different vehicles and different conditions. Screenshots attached below. We generally want to not yet validate it right after init (the variance was around 6 there usually), and when on very long straight flight paths (see second screenshot). 
The check is [here](https://github.com/PX4/PX4-Autopilot/blob/b8dacf5ae4323667915ff5633d771f3884236d2b/src/modules/airspeed_selector/airspeed_selector_main.cpp#L614), sqrt(variance_north + variance_east).

<img width="1250" height="639" alt="image" src="https://github.com/user-attachments/assets/884648d1-3ef3-4a77-afef-6b31ac744266" />
<img width="1250" height="639" alt="image" src="https://github.com/user-attachments/assets/e116eb0f-0efb-43e3-8441-74144a38bc8e" />
<img width="1250" height="639" alt="image" src="https://github.com/user-attachments/assets/56ef6bac-bece-429c-8ef2-b147d1787fee" />

Note: since https://github.com/PX4/PX4-Autopilot/pull/24522 we have an alternative "synthetic" airspeed, based purely on the vehicle mode and the current thrust setpoint.