### PR TITLE
Add agp feedback

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/modules/mavlink/mavlink"]
 	path = src/modules/mavlink/mavlink
-	url = https://github.com/mavlink/mavlink.git
+	url = https://github.com/Auterion/mavlink.git
 	branch = master
 [submodule "Tools/simulation/jmavsim/jMAVSim"]
 	path = Tools/simulation/jmavsim/jMAVSim

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1766,6 +1766,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("CURRENT_MODE", 0.5f);
 		configure_stream_local("ESTIMATOR_STATUS", 1.0f);
 		configure_stream_local("EXTENDED_SYS_STATE", 1.0f);
+		configure_stream_local("GLOBAL_POSITION", unlimited_rate);
 		configure_stream_local("GLOBAL_POSITION_INT", 10.0f);
 		configure_stream_local("GPS_GLOBAL_ORIGIN", 1.0f);
 		configure_stream_local("GPS2_RAW", unlimited_rate);

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -74,6 +74,9 @@
 #include "streams/ESC_STATUS.hpp"
 #include "streams/ESTIMATOR_STATUS.hpp"
 #include "streams/EXTENDED_SYS_STATE.hpp"
+#if defined(MAVLINK_MSG_ID_GLOBAL_POSITION)
+#include "streams/GLOBAL_POSITION.hpp"
+#endif //MAVLINK_MSG_ID_GLOBAL_POSITION
 #include "streams/FLIGHT_INFORMATION.hpp"
 #include "streams/GLOBAL_POSITION_INT.hpp"
 #include "streams/GPS_GLOBAL_ORIGIN.hpp"
@@ -510,6 +513,9 @@ static const StreamListItem streams_list[] = {
 #if defined(CURRENT_MODE_HPP)
 	create_stream_list_item<MavlinkStreamCurrentMode>(),
 #endif // CURRENT_MODE_HPP
+#if defined(GLOBAL_POSITION_HPP)
+	create_stream_list_item<MavlinkStreamGLobalPosition>(),
+#endif // GLOBAL_POSITION_HPP
 };
 
 const char *get_stream_name(const uint16_t msg_id)

--- a/src/modules/mavlink/streams/GLOBAL_POSITION.hpp
+++ b/src/modules/mavlink/streams/GLOBAL_POSITION.hpp
@@ -1,0 +1,109 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef GLOBAL_POSITION_HPP
+#define GLOBAL_POSITION_HPP
+
+#include <stdint.h>
+
+#include <uORB/topics/vehicle_global_position.h>
+
+class MavlinkStreamGLobalPosition : public MavlinkStream
+{
+public:
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamGLobalPosition(mavlink); }
+
+	static constexpr const char *get_name_static() { return "GLOBAL_POSITION"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_GLOBAL_POSITION; }
+
+	const char *get_name() const override { return get_name_static(); }
+	uint16_t get_id() override { return get_id_static(); }
+
+	unsigned get_size() override
+	{
+		return _aux_global_position_sub.advertised() ? (MAVLINK_MSG_ID_GLOBAL_POSITION_LEN +
+				MAVLINK_NUM_NON_PAYLOAD_BYTES) : 0;
+	}
+
+private:
+	explicit MavlinkStreamGLobalPosition(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+
+	uORB::Subscription _aux_global_position_sub{ORB_ID(aux_global_position)};
+
+	bool send() override
+	{
+		vehicle_global_position_s pos{};
+
+		if (_aux_global_position_sub.update(&pos)) {
+			mavlink_global_position_t msg{};
+
+			msg.id = UINT8_C(1);
+			msg.time_usec = pos.timestamp;
+
+			if (PX4_ISFINITE(pos.lat)) {
+				msg.lat = static_cast<int32_t>(pos.lat * 1e7);
+
+			} else {
+				msg.lat = INT32_MAX;
+			}
+
+			if (PX4_ISFINITE(pos.lon)) {
+				msg.lon = static_cast<int32_t>(pos.lon * 1e7);
+
+			} else {
+				msg.lon = INT32_MAX;
+			}
+
+			msg.alt = pos.alt;
+			msg.alt_ellipsoid = NAN;
+			msg.eph = pos.eph;
+			msg.epv = pos.epv;
+			msg.vx = NAN;
+			msg.vy = NAN;
+			msg.vz = NAN;
+			msg.h_sacc = NAN;
+			msg.v_sacc = NAN;
+			msg.hdg = NAN;
+			msg.hdg_acc = NAN;
+
+
+			mavlink_msg_global_position_send_struct(_mavlink->get_channel(), &msg);
+
+			return true;
+		}
+
+		return false;
+	}
+};
+
+#endif // GLOBAL_POSITION_HPP


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
With the possibility of ading auxiliary position inputs into the EKF2 over the dds bridge, it is nice to also see the AGP raw value on the ground station. For this the AGP input from the dds must be streamed over mavlink.

### Solution
- Add a new MAVLINK stream to send the RAW AGP input values

### Changelog Entry
For release notes:
```
Feature: Stream the raw AGP input from DDS bridge over mavlink
```

### Context
This is a draft PR until the New message definition in https://github.com/mavlink/mavlink/pull/2256 is fixed and merged
