### PR TITLE
ubx: add option to wipe flash

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -909,6 +909,15 @@ GPS::run()
 
 		gpsConfig.interface_protocols = static_cast<GPSHelper::InterfaceProtocolsMask>(gps_ubx_cfg_intf);
 
+		int32_t gps_cfg_wipe = 0;
+		handle = param_find("GPS_CFG_WIPE");
+
+		if (handle != PARAM_INVALID) {
+			param_get(handle, &gps_cfg_wipe);
+		}
+
+		gpsConfig.cfg_wipe = static_cast<bool>(gps_cfg_wipe);
+
 		if (_helper && _helper->configure(_baudrate, gpsConfig) == 0) {
 
 			/* reset report */

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -143,6 +143,22 @@ PARAM_DEFINE_INT32(GPS_UBX_BAUD2, 230400);
 PARAM_DEFINE_INT32(GPS_UBX_CFG_INTF, 0);
 
 /**
+ * Wipes the flash config of UBX modules.
+ *
+ * Some UBX modules have a FLASH that allows to store persistent configuration that will be loaded on start.
+ * PX4 does override all configuration parameters it needs in RAM, which takes precedence over the values in FLASH.
+ * However, configuration parameters that are not overriden by PX4 can still cause unexpected problems during flight.
+ * To avoid these kind of problems a clean config can be reached by wiping the FLASH on boot.
+ *
+ * Note: Currently only supported on UBX.
+ *
+ * @reboot_required true
+ * @group GPS
+ * @boolean
+ */
+PARAM_DEFINE_INT32(GPS_CFG_WIPE, 0);
+
+/**
  * Heading/Yaw offset for dual antenna GPS
  *
  * Heading offset angle for dual antenna GPS setups that support heading estimation.


### PR DESCRIPTION
### Solved Problem
 * Some UBX modules have a FLASH that allows to store persistent configuration that will be loaded on start.
 * PX4 does override all configuration parameters it needs in RAM, which takes precedence over the values in FLASH.
 * However, configuration parameters that are not overriden by PX4 can still cause unexpected problems during flight.

### Solution
- To avoid these kind of problems a clean config can be reached by wiping the FLASH on boot.
- The message CFG-CFG is not deprecated for this use-case, was confirmed by u-blox support
- Will rebase this as soon as https://github.com/PX4/PX4-GPSDrivers/pull/183 is merged

### Changelog Entry
For release notes:
```
Feature/Bugfix: add option to wipe flash on u-blox
```

### Alternatives
- Setting this to not always on has the disadvantage that users who forget to clean up their config will also forget to set the parameter
- There is no real option to clear the flash only once per GPS device as there is no good option to detect if it has already been cleaned. The u-blox support confirmed that the erase via CFG-CFG causes only 1 FLASH operation, so FLASH wearout will take many years

### Test coverage
- Tested on the bench with a F9P and a M8N
