### PR TITLE
rc_update: Add ability to use an R/C switch to enable/disable R/C manual inputs to the system.

### DIFF
--- a/docs/en/advanced_config/parameter_reference.md
+++ b/docs/en/advanced_config/parameter_reference.md
@@ -29187,41 +29187,6 @@ Reboot | minValue | maxValue | increment | default | unit
 --- | --- | --- | --- | --- | ---
 &nbsp; | 0 | 18 |  | 0 |
 
-### RC_MAP_RC_ENABLE (`INT32`) {#RC_MAP_RC_ENABLE}
-
-Single channel R/C enable switch.
-
-If this parameter is non-zero and this channel is asserted,
-then R/C controls are not passed to the Autopilot
-
-**Values:**
-
-- `0`: Unassigned
-- `1`: Channel 1
-- `2`: Channel 2
-- `3`: Channel 3
-- `4`: Channel 4
-- `5`: Channel 5
-- `6`: Channel 6
-- `7`: Channel 7
-- `8`: Channel 8
-- `9`: Channel 9
-- `10`: Channel 10
-- `11`: Channel 11
-- `12`: Channel 12
-- `13`: Channel 13
-- `14`: Channel 14
-- `15`: Channel 15
-- `16`: Channel 16
-- `17`: Channel 17
-- `18`: Channel 18
-
-
-Reboot | minValue | maxValue | increment | default | unit
---- | --- | --- | --- | --- | ---
-&nbsp; | 0 | 18 |  | 0 |
-
-
 ### RC_MAP_RETURN_SW (`INT32`) {#RC_MAP_RETURN_SW}
 
 Return switch channel.
@@ -29313,20 +29278,6 @@ negative : true when channel<th
 Reboot | minValue | maxValue | increment | default | unit
 --- | --- | --- | --- | --- | ---
 &nbsp; | -1 | 1 |  | 0.75 |
-
-### RC_ENABLESW_TH (`FLOAT`) {#RC_ENABLESW_TH}
-
-Threshold for selecting R/C enable switch
-0-1 indicate where in the full channel range the threshold sits
-		0 : min
-		1 : max
-sign indicates polarity of comparison
-		positive : true when channel>th
-		negative : true when channel<th
-
-Reboot | minValue | maxValue | increment | default | unit
---- | --- | --- | --- | ---
-@nbsp; | -1 | 1 | | 0.75 |
 
 ### RC_RETURN_TH (`FLOAT`) {#RC_RETURN_TH}
 

--- a/docs/en/advanced_config/parameter_reference.md
+++ b/docs/en/advanced_config/parameter_reference.md
@@ -29187,6 +29187,41 @@ Reboot | minValue | maxValue | increment | default | unit
 --- | --- | --- | --- | --- | ---
 &nbsp; | 0 | 18 |  | 0 |
 
+### RC_MAP_RC_ENABLE (`INT32`) {#RC_MAP_RC_ENABLE}
+
+Single channel R/C enable switch.
+
+If this parameter is non-zero and this channel is asserted,
+then R/C controls are not passed to the Autopilot
+
+**Values:**
+
+- `0`: Unassigned
+- `1`: Channel 1
+- `2`: Channel 2
+- `3`: Channel 3
+- `4`: Channel 4
+- `5`: Channel 5
+- `6`: Channel 6
+- `7`: Channel 7
+- `8`: Channel 8
+- `9`: Channel 9
+- `10`: Channel 10
+- `11`: Channel 11
+- `12`: Channel 12
+- `13`: Channel 13
+- `14`: Channel 14
+- `15`: Channel 15
+- `16`: Channel 16
+- `17`: Channel 17
+- `18`: Channel 18
+
+
+Reboot | minValue | maxValue | increment | default | unit
+--- | --- | --- | --- | --- | ---
+&nbsp; | 0 | 18 |  | 0 |
+
+
 ### RC_MAP_RETURN_SW (`INT32`) {#RC_MAP_RETURN_SW}
 
 Return switch channel.
@@ -29278,6 +29313,20 @@ negative : true when channel<th
 Reboot | minValue | maxValue | increment | default | unit
 --- | --- | --- | --- | --- | ---
 &nbsp; | -1 | 1 |  | 0.75 |
+
+### RC_ENABLESW_TH (`FLOAT`) {#RC_ENABLESW_TH}
+
+Threshold for selecting R/C enable switch
+0-1 indicate where in the full channel range the threshold sits
+		0 : min
+		1 : max
+sign indicates polarity of comparison
+		positive : true when channel>th
+		negative : true when channel<th
+
+Reboot | minValue | maxValue | increment | default | unit
+--- | --- | --- | --- | ---
+@nbsp; | -1 | 1 | | 0.75 |
 
 ### RC_RETURN_TH (`FLOAT`) {#RC_RETURN_TH}
 

--- a/docs/en/config/radio.md
+++ b/docs/en/config/radio.md
@@ -153,25 +153,27 @@ To map a PARAM tuning channel to a parameter:
 You can clear all parameter/tuning channel mappings by selecting menu **Tools > Clear RC to Param** at the top right of the _Parameters_ screen.
 :::
 
-## RC Input Enable/Disable Switch
+## RC-Input Enable/Disable Switch
 
-You can configure PX4 to use a switch channel on your transmitter to enable or disable R/C inputs to the rest of the PX4 system. This is convenient for flight testing companion software, as it allows a safety pilot to leave their R/C transmitter turned on, but without fear that bumping the sticks will override the companion software control. By default, this behavior is disabled.
+You can configure PX4 to use a switch channel on your transmitter to enable or disable RC inputs to the rest of the PX4 system.
+This is convenient for flight testing companion software, as it allows a safety pilot to leave their RC transmitter turned on, but without fear that bumping the sticks will override the companion software control.
 
-Set the [RC_MAP_RC_ENABLE](../advanced_config/parameter_reference.md#RC_MAP_RC_ENABLE) parameter to the channel index of the switch you want to use for this functionality. You can use [RC_ENABLESW_TH](../advanced_config/parameter_reference.md#RC_ENABLESW_TH) to configure the behavior of this switch.
+Set the [RC_MAP_RC_ENABLE](../advanced_config/parameter_reference.md#RC_MAP_RC_ENABLE) parameter to the channel index of the switch you want to use to control RC input.
+Optionally use [RC_ENABLESW_TH](../advanced_config/parameter_reference.md#RC_ENABLESW_TH) to configure the trigger level of the switch (this should not be necessary).
 
-When the switch is asserted, R/C stick inputs and switch interactions will have no effect on the autopilot. You can test this functionality prior to arming with the following procedure:
+When the RC-Input-Enable switch is engaged, RC stick inputs other switches will have no effect on the autopilot.
+You can test this functionality prior to arming with the following procedure:
 
-1. Assert the R/C enable switch
-2. Switch into a manual flight mode
-3. Deassert the R/C enable switch
-4. Observe in QGroundControl that manual control inputs have been lost
-5. Reassert the R/C enable switch
-6. Observe in QGroundControl that manual control inputs  have recovered
+1. Activate the RC-Input-Enable switch.
+2. Switch into a manual flight mode.
+3. Deactivate the RC-Input-Enable enable switch.
+4. Observe in QGroundControl that manual control inputs have been lost.
+5. Reactivate the RC enable switch.
+6. Observe in QGroundControl that manual control inputs have recovered.
 
 :::tip
-While the R/C enabled switch is deasserted, the autopilot will still report having a good R/C link in the Mavlink `RC_CHANNELS` message.
+While the _RC enabled_ switch is off, the autopilot will still report having a good RC link in the MAVLink `RC_CHANNELS` message.
 :::
-
 
 ## Further Information
 

--- a/docs/en/config/radio.md
+++ b/docs/en/config/radio.md
@@ -153,6 +153,26 @@ To map a PARAM tuning channel to a parameter:
 You can clear all parameter/tuning channel mappings by selecting menu **Tools > Clear RC to Param** at the top right of the _Parameters_ screen.
 :::
 
+## RC Input Enable/Disable Switch
+
+You can configure PX4 to use a switch channel on your transmitter to enable or disable R/C inputs to the rest of the PX4 system. This is convenient for flight testing companion software, as it allows a safety pilot to leave their R/C transmitter turned on, but without fear that bumping the sticks will override the companion software control. By default, this behavior is disabled.
+
+Set the [RC_MAP_RC_ENABLE](../advanced_config/parameter_reference.md#RC_MAP_RC_ENABLE) parameter to the channel index of the switch you want to use for this functionality. You can use [RC_ENABLESW_TH](../advanced_config/parameter_reference.md#RC_ENABLESW_TH) to configure the behavior of this switch.
+
+When the switch is asserted, R/C stick inputs and switch interactions will have no effect on the autopilot. You can test this functionality prior to arming with the following procedure:
+
+1. Assert the R/C enable switch
+2. Switch into a manual flight mode
+3. Deassert the R/C enable switch
+4. Observe in QGroundControl that manual control inputs have been lost
+5. Reassert the R/C enable switch
+6. Observe in QGroundControl that manual control inputs  have recovered
+
+:::tip
+While the R/C enabled switch is deasserted, the autopilot will still report having a good R/C link in the Mavlink `RC_CHANNELS` message.
+:::
+
+
 ## Further Information
 
 - [QGroundControl > Radio Control](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/radio.html)

--- a/src/modules/rc_update/RCUpdateTest.cpp
+++ b/src/modules/rc_update/RCUpdateTest.cpp
@@ -43,7 +43,7 @@ public:
 	void updateParams() { RCUpdate::updateParams(); }
 	void setChannel(size_t index, float channel_value) { _rc.channels[index] = channel_value; }
 	bool rc_inputs_enabled() const { return _rc_inputs_enabled; }
-	void run() {RCUpdate::Run();}
+	void run() { RCUpdate::Run(); }
 };
 
 class RCUpdateTest : public ::testing::Test, ModuleParams

--- a/src/modules/rc_update/RCUpdateTest.cpp
+++ b/src/modules/rc_update/RCUpdateTest.cpp
@@ -42,7 +42,7 @@ public:
 	void UpdateManualSwitches(const hrt_abstime &timestamp_sample) { RCUpdate::UpdateManualSwitches(timestamp_sample); }
 	void updateParams() { RCUpdate::updateParams(); }
 	void setChannel(size_t index, float channel_value) { _rc.channels[index] = channel_value; }
-	bool rc_inputs_enabled()const {return _rc_inputs_enabled;}
+	bool rc_inputs_enabled() const { return _rc_inputs_enabled; }
 	void run() {RCUpdate::Run();}
 };
 

--- a/src/modules/rc_update/RCUpdateTest.cpp
+++ b/src/modules/rc_update/RCUpdateTest.cpp
@@ -165,7 +165,6 @@ public:
 		(ParamInt<px4::params::RC_MAP_PAY_SW>) _param_rc_map_pay_sw,
 		(ParamFloat<px4::params::RC_PAYLOAD_TH>) _param_rc_payload_th,
 		(ParamFloat<px4::params::RC_PAYLOAD_MIDTH>) _param_rc_payload_midth,
-
 		(ParamInt<px4::params::RC_MAP_RC_ENABLE>) _param_rc_map_rc_enable,
 		(ParamFloat<px4::params::RC_ENABLESW_TH>) _param_rc_enable_th
 	)

--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -1330,6 +1330,38 @@ PARAM_DEFINE_INT32(RC_MAP_YAW, 0);
 PARAM_DEFINE_INT32(RC_MAP_FLTMODE, 0);
 
 /**
+ * Single channel R/C enable switch
+ *
+ * If this parameter is non-zero and this channel is asserted,
+ * then R/C controls are not passed to the Autopilot
+ *
+ * @min 0
+ * @max 18
+ * @group Radio Switches
+ * @value 0 Unassigned
+ * @value 1 Channel 1
+ * @value 2 Channel 2
+ * @value 3 Channel 3
+ * @value 4 Channel 4
+ * @value 5 Channel 5
+ * @value 6 Channel 6
+ * @value 7 Channel 7
+ * @value 8 Channel 8
+ * @value 9 Channel 9
+ * @value 10 Channel 10
+ * @value 11 Channel 11
+ * @value 12 Channel 12
+ * @value 13 Channel 13
+ * @value 14 Channel 14
+ * @value 15 Channel 15
+ * @value 16 Channel 16
+ * @value 17 Channel 17
+ * @value 18 Channel 18
+ *
+ */
+PARAM_DEFINE_INT32(RC_MAP_RC_ENABLE, 0);
+
+/**
  * Return switch channel
  *
  * @min 0
@@ -1923,6 +1955,23 @@ PARAM_DEFINE_INT32(RC_MAP_ENG_MOT, 0);
  * @group Radio Calibration
  */
 PARAM_DEFINE_INT32(RC_FAILS_THR, 0);
+
+/**
+ * Threshold for selecting R/C enable witch
+ *
+ * 0-1 indicate where in the full channel range the threshold sits
+ * 		0 : min
+ * 		1 : max
+ * sign indicates polarity of comparison
+ * 		positive : true when channel>th
+ * 		negative : true when channel<th
+ *
+ * @min -1
+ * @max 1
+ * @decimal 2
+ * @group Radio Switches
+ */
+PARAM_DEFINE_FLOAT(RC_ENABLESW_TH, 0.75f);
 
 /**
  * Threshold for selecting return to launch mode

--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -1957,7 +1957,7 @@ PARAM_DEFINE_INT32(RC_MAP_ENG_MOT, 0);
 PARAM_DEFINE_INT32(RC_FAILS_THR, 0);
 
 /**
- * Threshold for selecting R/C enable witch
+ * Threshold for selecting R/C enable switch
  *
  * 0-1 indicate where in the full channel range the threshold sits
  * 		0 : min

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -481,7 +481,7 @@ void RCUpdate::Run()
 		/* publish rc_channels topic even if signal is invalid, for debug */
 		_rc_channels_pub.publish(_rc);
 
-		/* check if the R/C enabled switch is set*/
+		// check if the R/C enabled switch is set
 		auto check_rc_enable_switch = [this]() {
 			bool rc_enabled = true;
 

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -486,8 +486,8 @@ void RCUpdate::Run()
 			bool rc_enabled = true;
 
 			if (_param_rc_map_rc_enable.get() > 0) {
-				int enable_channel = _param_rc_map_rc_enable.get() - 1;
-				const float value_raw = _rc.channels[enable_channel];
+				int channel_index = _param_rc_map_rc_enable.get() - 1;
+				const float value_raw = _rc.channels[channel_index];
 				const float value_scaled = (0.5f * value_raw) + 0.5f; //Scale value from [-1, 1] to [0,1]
 				const float threshold = _param_rc_enable_sw_th.get();
 				rc_enabled = (threshold > 0) ?

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -178,6 +178,8 @@ protected:
 	uORB::PublicationMulti<manual_control_setpoint_s> _manual_control_input_pub{ORB_ID(manual_control_input)};
 	uORB::Publication<manual_control_switches_s> _manual_control_switches_pub{ORB_ID(manual_control_switches)};
 
+	bool _rc_inputs_enabled{true};
+
 	manual_control_switches_s _manual_switches_previous{};
 	manual_control_switches_s _manual_switches_last_publish{};
 	rc_channels_s _rc{};
@@ -219,6 +221,7 @@ protected:
 
 		(ParamInt<px4::params::RC_MAP_FLAPS>) _param_rc_map_flaps,
 
+		(ParamInt<px4::params::RC_MAP_RC_ENABLE>) _param_rc_map_rc_enable,
 		(ParamInt<px4::params::RC_MAP_RETURN_SW>) _param_rc_map_return_sw,
 		(ParamInt<px4::params::RC_MAP_LOITER_SW>) _param_rc_map_loiter_sw,
 		(ParamInt<px4::params::RC_MAP_OFFB_SW>) _param_rc_map_offb_sw,
@@ -241,6 +244,7 @@ protected:
 
 		(ParamInt<px4::params::RC_MAP_PAY_SW>) _param_rc_map_pay_sw,
 
+		(ParamFloat<px4::params::RC_ENABLESW_TH>) _param_rc_enable_sw_th,
 		(ParamFloat<px4::params::RC_LOITER_TH>) _param_rc_loiter_th,
 		(ParamFloat<px4::params::RC_OFFB_TH>) _param_rc_offb_th,
 		(ParamFloat<px4::params::RC_KILLSWITCH_TH>) _param_rc_killswitch_th,


### PR DESCRIPTION
### Solved Problem

Adds an explicit signal to the system that R/C control is desired. This is useful in scenarios where the system is usually controlled from some companion computer, but a safety pilot link is desired via R/C. This prevents stick bumps or similar from wresting control from the companion computer. The companion computer software can also use the RC channels message to view the state of the RC enabled switch to indicate whether or not it should attempt to control the system.



### Solution

-  Add two new parameters `RC_MAP_RC_ENABLE` and `RC_ENABLESW_TH` to  configure the behavior. Default to no R/C Enable switch being mapped
- In rc_update, check the state of the RC Enable switch before publishing manual control request messages

### Changelog Entry
For release notes:
```
Feature: Add ability to specify an R/C switch that enables/disables R/C inputs to the system
New parameter: RC_MAP_RC_ENABLE Specify which R/C channel is mapped to the R/C Enable Switch
New parameter: RC_ENABLESW_TH Specify the threshold above/below which the R/C Enable Switch is asserted
```

### Test coverage
- Functional Test: Added `RCEnableSwitch` to `RCUpdateTest.cpp`
- Hardware: Tested on ArkV6X with Crossfire system in Mavlink mode

### Context
Related links, screenshot before/after, video
