### PR TITLE
PX4IO | only publish input_rc, if the IO RC status in ok

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1030,7 +1030,10 @@ int PX4IO::io_publish_raw_rc()
 	const bool rc_updated = (rc_valid_update_count != _rc_valid_update_count);
 	_rc_valid_update_count = rc_valid_update_count;
 
-	if (!rc_updated) {
+	// only publish if the IO status indicates that the RC is OK
+	const uint16_t status_rc_ok = _status & PX4IO_P_STATUS_FLAGS_RC_OK;
+
+	if (!rc_updated | !status_rc_ok) {
 		return 0;
 	}
 


### PR DESCRIPTION
### Solved Problem
I had two different flights where after loss of RC, and regain the vehicle switched from MISSION to HOLD, as there was some garbled data coming in on the SBUS.
Flight 1
<img width="1238" height="755" alt="image" src="https://github.com/user-attachments/assets/dc915b0c-a236-48fc-9add-7a7d1b40d85b" />
Flight 2
<img width="1238" height="755" alt="image" src="https://github.com/user-attachments/assets/1c7052c1-faf0-4249-815c-57701e8499a2" />


### Solution
I added a check in `io_publish_raw_rc` to only publish input_rc when on the io, the status flag for for the rc is set to OK


### Alternatives
Open for input / opinions

### Test coverage
As i'm unable to reliably reproduce the issue, i was currently unable to test it.


