### PR TITLE
EKF: fix compilation error when CONFIG_EKF2_TERRAIN is not defined

### DIFF
--- a/src/modules/ekf2/EKF/position_fusion.cpp
+++ b/src/modules/ekf2/EKF/position_fusion.cpp
@@ -232,6 +232,7 @@ void Ekf::updateVerticalPositionResetStatus(const float delta_z)
 	_state_reset_status.reset_count.posD++;
 }
 
+#if defined(CONFIG_EKF2_TERRAIN)
 void Ekf::updateTerrainResetStatus(const float delta_z)
 {
 	if (_state_reset_status.reset_count.hagl == _state_reset_count_prev.hagl) {
@@ -244,6 +245,7 @@ void Ekf::updateTerrainResetStatus(const float delta_z)
 
 	_state_reset_status.reset_count.hagl++;
 }
+#endif // CONFIG_EKF2_TERRAIN
 
 void Ekf::resetHorizontalPositionToLastKnown()
 {


### PR DESCRIPTION
### Solved Problem
When CONFIG_EKF2_RANGE_FINDER is not set, compilation fails due to 
`error: no declaration matches 'void Ekf::updateTerrainResetStatus(float)'`

The issue is that the method is declared under `#if defined(CONFIG_EKF2_TERRAIN)` but the definition is always present.

### Solution
Add the `#if defined(CONFIG_EKF2_TERRAIN)` check for the method definition