### PR TITLE
Internal combustion engine control: disable module by default

### DIFF
--- a/src/modules/internal_combustion_engine_control/module.yaml
+++ b/src/modules/internal_combustion_engine_control/module.yaml
@@ -8,7 +8,7 @@ parameters:
         description:
           short: Enable internal combustion engine
         type: boolean
-        default: true
+        default: false
 
       ICE_ON_SOURCE:
         description:


### PR DESCRIPTION
### Solved Problem
If the PX4 build contains the ICE module, it gets automatically started. 

### Solution
We want to include the ICE module in PX4 binaries but not start it unless actively configured. 

### Changelog Entry
For release notes:
```
Improvement: Internal combustion engine control: disable module by default
```
