### PR TITLE
mavlink_mission: Check mission_result.valid in mission_state handling

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1938,7 +1938,7 @@ MavlinkMissionManager::update_mission_state()
 	}
 
 	// Update mission state
-	if (_count[MAV_MISSION_TYPE_MISSION] == 0) {
+	if (_count[MAV_MISSION_TYPE_MISSION] == 0 || !mission_result.valid) {
 		_mission_state = MISSION_STATE_NO_MISSION;
 
 	} else if (mission_result.finished) {


### PR DESCRIPTION

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

Improve mission state determination by explicitly checking mission_result.valid
in addition to the mission count. This makes the state machine more robust
in cases where mission_result may be uninitialized or temporarily invalid.

### Changelog Entry
For release notes:
```
Feature/Bugfix Improve mission_state handling with mission_result validity check
```

