### PR TITLE
Startup cleanup: skip setting INA default values again

### DIFF
--- a/boards/accton-godwit/ga1/init/rc.board_defaults
+++ b/boards/accton-godwit/ga1/init/rc.board_defaults
@@ -3,19 +3,13 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
-# By disabling all 3 INA modules, we use the
-# i2c_launcher instead.
-param set - default SENS_EN_INA238 0
-param set - default SENS_EN_INA228 0
-param set - default SENS_EN_INA226 0
-
 # Mavlink ethernet (CFG 1000)
-param set - default MAV_2_CONFIG 1000
-param set - default MAV_2_BROADCAST 1
-param set - default MAV_2_MODE 0
-param set - default MAV_2_RADIO_CTL 0
-param set - default MAV_2_RATE 100000
-param set - default MAV_2_REMOTE_PRT 14550
-param set - default MAV_2_UDP_PRT 14550
+param set-default MAV_2_CONFIG 1000
+param set-default MAV_2_BROADCAST 1
+param set-default MAV_2_MODE 0
+param set-default MAV_2_RADIO_CTL 0
+param set-default MAV_2_RATE 100000
+param set-default MAV_2_REMOTE_PRT 14550
+param set-default MAV_2_UDP_PRT 14550
 
 safety_button start

--- a/boards/ark/fmu-v6x/init/rc.board_defaults
+++ b/boards/ark/fmu-v6x/init/rc.board_defaults
@@ -14,10 +14,7 @@ param set-default MAV_2_RATE 100000
 param set-default MAV_2_REMOTE_PRT 14550
 param set-default MAV_2_UDP_PRT 14550
 
-param set-default SENS_EN_INA238 0
-param set-default SENS_EN_INA228 0
 param set-default SENS_EN_INA226 1
-
 param set-default SENS_EN_THERMAL 1
 param set-default SENS_IMU_MODE 1
 param set-default SENS_IMU_TEMP 10.0

--- a/boards/auterion/fmu-v6s/init/rc.board_defaults
+++ b/boards/auterion/fmu-v6s/init/rc.board_defaults
@@ -3,12 +3,6 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
-# By disabling INA modules, we use the
-# auterion launcher instead.
-param set-default SENS_EN_INA226 0
-param set-default SENS_EN_INA228 0
-param set-default SENS_EN_INA238 0
-
 # Set the backend of the dataman to SRAM
 param set-default SYS_DM_BACKEND 1
 # Set TELEM1 as default mavlink connection

--- a/boards/auterion/fmu-v6x/init/rc.board_defaults
+++ b/boards/auterion/fmu-v6x/init/rc.board_defaults
@@ -3,12 +3,6 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
-# By disabling all 3 INA modules, we use the
-# auterion launcher instead.
-param set-default SENS_EN_INA238 0
-param set-default SENS_EN_INA228 0
-param set-default SENS_EN_INA226 0
-
 # Skynode: use the "custom participant", IP=10.41.10.1 config for uxrce_dds_client
 param set-default UXRCE_DDS_PTCFG 2
 param set-default UXRCE_DDS_AG_IP 170461697

--- a/boards/cuav/fmu-v6x/init/rc.board_defaults
+++ b/boards/cuav/fmu-v6x/init/rc.board_defaults
@@ -3,13 +3,6 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
-# By disabling all 3 INA modules, we use the
-# i2c_launcher instead.
-param set-default SENS_EN_INA238 0
-param set-default SENS_EN_INA228 0
-param set-default SENS_EN_INA226 0
-
-
 # Mavlink ethernet (CFG 1000)
 param set-default MAV_2_CONFIG 1000
 param set-default MAV_2_BROADCAST 1

--- a/boards/cuav/x25-evo/init/rc.board_defaults
+++ b/boards/cuav/x25-evo/init/rc.board_defaults
@@ -15,10 +15,6 @@ param set-default MAV_2_UDP_PRT 14550
 param set-default BAT1_V_DIV 18
 param set-default BAT1_A_PER_V 24
 
-param set-default SENS_EN_INA238 0
-param set-default SENS_EN_INA228 0
-param set-default SENS_EN_INA226 0
-
 param set-default USB_MAV_MODE 5
 
 param set-default UAVCAN_SUB_GPS 1

--- a/boards/nxp/mr-tropic/init/rc.board_defaults
+++ b/boards/nxp/mr-tropic/init/rc.board_defaults
@@ -12,10 +12,6 @@ param set-default MAV_2_RATE 100000
 param set-default MAV_2_REMOTE_PRT 14550
 param set-default MAV_2_UDP_PRT 14550
 
-param set-default SENS_EN_INA238 0
-param set-default SENS_EN_INA228 0
-param set-default SENS_EN_INA226 0
-
 param set-default RC_CRSF_PRT_CFG 300
 param set-default RC_CRSF_TEL_EN 1
 param set-default RC_SBUS_PRT_CFG 0

--- a/boards/nxp/tropic-community/init/rc.board_defaults
+++ b/boards/nxp/tropic-community/init/rc.board_defaults
@@ -12,10 +12,6 @@ param set-default MAV_2_RATE 100000
 param set-default MAV_2_REMOTE_PRT 14550
 param set-default MAV_2_UDP_PRT 14550
 
-param set-default SENS_EN_INA238 0
-param set-default SENS_EN_INA228 0
-param set-default SENS_EN_INA226 0
-
 param set-default BAT1_V_DIV 18.000000000
 param set-default BAT1_A_PER_V 38.462030303
 

--- a/boards/px4/fmu-v5x/init/rc.board_defaults
+++ b/boards/px4/fmu-v5x/init/rc.board_defaults
@@ -3,10 +3,6 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
-param set-default SENS_EN_INA238 0
-param set-default SENS_EN_INA228 0
-param set-default SENS_EN_INA226 0
-
 if ver hwbasecmp 008 009 00a 010 011
 then
 	# Skynode: use the "custom participant", IP=10.41.10.1 config for uxrce_dds_client

--- a/boards/px4/fmu-v6x/init/rc.board_defaults
+++ b/boards/px4/fmu-v6x/init/rc.board_defaults
@@ -3,12 +3,6 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
-# By disabling all 3 INA modules, we use the
-# i2c_launcher instead.
-param set-default SENS_EN_INA238 0
-param set-default SENS_EN_INA228 0
-param set-default SENS_EN_INA226 0
-
 # Mavlink ethernet (CFG 1000)
 param set-default MAV_2_CONFIG 1000
 param set-default MAV_2_BROADCAST 1

--- a/boards/px4/fmu-v6xrt/init/rc.board_defaults
+++ b/boards/px4/fmu-v6xrt/init/rc.board_defaults
@@ -12,12 +12,6 @@ param set-default MAV_2_RATE 100000
 param set-default MAV_2_REMOTE_PRT 14550
 param set-default MAV_2_UDP_PRT 14550
 
-# By disabling all 3 INA modules, we use the
-# i2c_launcher instead.
-param set-default SENS_EN_INA238 0
-param set-default SENS_EN_INA228 0
-param set-default SENS_EN_INA226 0
-
 safety_button start
 
 if param greater -s UAVCAN_ENABLE 0

--- a/boards/svehicle/e2/init/rc.board_defaults
+++ b/boards/svehicle/e2/init/rc.board_defaults
@@ -3,12 +3,6 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
-# By disabling all 3 INA modules, we use the
-# i2c_launcher instead.
-param set-default SENS_EN_INA238 0
-param set-default SENS_EN_INA228 0
-param set-default SENS_EN_INA226 0
-
 # Mavlink ethernet (CFG 1000)
 param set-default MAV_2_CONFIG 1000
 param set-default MAV_2_BROADCAST 1

--- a/boards/zeroone/x6/init/rc.board_defaults
+++ b/boards/zeroone/x6/init/rc.board_defaults
@@ -3,12 +3,6 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
-# By disabling all 3 INA modules, we use the
-# i2c_launcher instead.
-param set-default SENS_EN_INA238 0
-param set-default SENS_EN_INA228 0
-param set-default SENS_EN_INA226 0
-
 if ver hwbasecmp 009 010 011
 then
 	# Skynode: use the "custom participant", IP=10.41.10.1 config for uxrce_dds_client


### PR DESCRIPTION
### Solved Problem
When checking https://github.com/PX4/PX4-Autopilot/pull/25220/files#diff-d1d859b2b8ddefa3c53234379ae6595d97f3129409ada5e83b75655c77d9776dR6-R10 I found that a lot of these `param set-default` commands for the INA configuration set the default value 0 again.

### Solution
I leave the comment how these parameters are set but remove the `param set-default SENS_EN_X 0` commands because all these parameters are 0 by default. I also made the order consistent such that it's easy to follow.

### Changelog Entry
```
Startup cleanup: skip setting INA default values again
```

### Test coverage
I couldn't test this yet. Want to run on hardware just to make sure it doesn't break anything.