### PR TITLE
Fully reset mean and M2 in perf_counter

### DIFF
--- a/src/lib/perf/perf_counter.cpp
+++ b/src/lib/perf/perf_counter.cpp
@@ -411,6 +411,8 @@ perf_reset(perf_counter_t handle)
 			pce->time_total = 0;
 			pce->time_least = 0;
 			pce->time_most = 0;
+			pce->mean = 0.0f;
+			pce->M2 = 0.0f;
 			break;
 		}
 
@@ -422,6 +424,8 @@ perf_reset(perf_counter_t handle)
 			pci->time_last = 0;
 			pci->time_least = 0;
 			pci->time_most = 0;
+			pci->mean = 0.0f;
+			pci->M2 = 0.0f;
 			break;
 		}
 	}


### PR DESCRIPTION
### Solved Problem

We never reset the running‐mean (`mean`) or the accumulated variance term (`M2`). That means as soon as we call perf_reset(handle) subsequent statistics (avg, rms) will still be tainted by whatever history `mean` and `M2` held before the reset.

### Solution

Reset `mean` and `M2` in `perf_reset`.
