### PR TITLE
Disable remaining flight time based battery failsafe by default

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1031,7 +1031,7 @@ PARAM_DEFINE_FLOAT(COM_THROW_SPEED, 5);
  * @value 3 Return
  * @increment 1
  */
-PARAM_DEFINE_INT32(COM_FLTT_LOW_ACT, 3);
+PARAM_DEFINE_INT32(COM_FLTT_LOW_ACT, 0);
 
 /**
  * Allow external mode registration while armed.


### PR DESCRIPTION
### Solved Problem
A PX4 user was bringing up a drone and got surprised by a battery failsafe although he had reportedly disabled the failsafe. Currently as soon as you configure a battery capacity the remaining flight time gets calculated and you get an RTL when the flight time - return time is running out.

Since the state of charge threshold based battery failsafes `COM_LOW_BAT_ACT` are disabled by default I was asked to also disable the flight time based failsafe to be consistent.

### Solution
@sfuhrer I made up my mind, it makes sense to disable the failsafe by default for consistency. We can still follow up with making the battery configuration options more intuitive.

### Changelog Entry
```
Disable remaining flight time based battery failsafe by default
```

### Test coverage
This option was used multiple times before, I'm merely changing the default.