### PR TITLE
Define M_PI if not defined in math.h

### DIFF
--- a/platforms/common/include/px4_platform_common/defines.h
+++ b/platforms/common/include/px4_platform_common/defines.h
@@ -143,7 +143,9 @@ __END_DECLS
 
 /* The M_PI, as stated above, is not C standard. If you need it and
  * it isn't in your math.h file then you can use this instead. */
-#define M_PI_PRECISE	3.141592653589793238462643383279502884
+#ifndef M_PI
+#define M_PI			3.141592653589793238462643383279502884
+#endif
 
 #define M_DEG_TO_RAD 		0.017453292519943295
 #define M_RAD_TO_DEG 		57.295779513082323

--- a/src/lib/matrix/matrix/Euler.hpp
+++ b/src/lib/matrix/matrix/Euler.hpp
@@ -85,11 +85,11 @@ public:
 	{
 		theta() = std::asin(-dcm(2, 0));
 
-		if ((std::fabs(theta() - Type(M_PI_PRECISE / 2))) < Type(1.0e-3)) {
+		if ((std::fabs(theta() - Type(M_PI / 2))) < Type(1.0e-3)) {
 			phi() = 0;
 			psi() = std::atan2(dcm(1, 2), dcm(0, 2));
 
-		} else if ((std::fabs(theta() + Type(M_PI_PRECISE / 2))) < Type(1.0e-3)) {
+		} else if ((std::fabs(theta() + Type(M_PI / 2))) < Type(1.0e-3)) {
 			phi() = 0;
 			psi() = std::atan2(-dcm(1, 2), -dcm(0, 2));
 

--- a/src/lib/matrix/matrix/helper_functions.hpp
+++ b/src/lib/matrix/matrix/helper_functions.hpp
@@ -97,7 +97,7 @@ Integer wrap(Integer x, Integer low, Integer high)
 template<typename Type>
 Type wrap_pi(Type x)
 {
-	return wrap(x, Type(-M_PI_PRECISE), Type(M_PI_PRECISE));
+	return wrap(x, Type(-M_PI), Type(M_PI));
 }
 
 /**
@@ -106,7 +106,7 @@ Type wrap_pi(Type x)
 template<typename Type>
 Type wrap_2pi(Type x)
 {
-	return wrap(x, Type(0), Type((2 * M_PI_PRECISE)));
+	return wrap(x, Type(0), Type((2 * M_PI)));
 }
 
 /**
@@ -134,7 +134,7 @@ Type unwrap(const Type last_x, const Type new_x, const Type low, const Type high
 template<typename Type>
 Type unwrap_pi(const Type last_angle, const Type new_angle)
 {
-	return unwrap(last_angle, new_angle, Type(-M_PI_PRECISE), Type(M_PI_PRECISE));
+	return unwrap(last_angle, new_angle, Type(-M_PI), Type(M_PI));
 }
 
 /**

--- a/src/lib/matrix/test/MatrixAttitudeTest.cpp
+++ b/src/lib/matrix/test/MatrixAttitudeTest.cpp
@@ -200,8 +200,8 @@ TEST(MatrixAttitudeTest, Attitude)
 	}
 
 	// constants
-	double deg2rad = M_PI_PRECISE / 180.0;
-	double rad2deg = 180.0 / M_PI_PRECISE;
+	double deg2rad = M_PI / 180.0;
+	double rad2deg = 180.0 / M_PI;
 
 	// euler dcm round trip check
 	for (double roll = -90; roll <= 90; roll += 90) {

--- a/src/lib/matrix/test/MatrixHelperTest.cpp
+++ b/src/lib/matrix/test/MatrixHelperTest.cpp
@@ -81,20 +81,20 @@ TEST(MatrixHelperTest, Helper)
 
 	// wrap pi
 	EXPECT_FLOAT_EQ(wrap_pi(0.), 0.);
-	EXPECT_FLOAT_EQ(wrap_pi(4.), (4. - (2 * M_PI_PRECISE)));
-	EXPECT_FLOAT_EQ(wrap_pi(-4.), (-4. + (2 * M_PI_PRECISE)));
+	EXPECT_FLOAT_EQ(wrap_pi(4.), (4. - (2 * M_PI)));
+	EXPECT_FLOAT_EQ(wrap_pi(-4.), (-4. + (2 * M_PI)));
 	EXPECT_FLOAT_EQ(wrap_pi(3.), 3.);
-	EXPECT_FLOAT_EQ(wrap_pi(100.), (100. - 32. * M_PI_PRECISE));
-	EXPECT_FLOAT_EQ(wrap_pi(-100.), (-100. + 32. * M_PI_PRECISE));
-	EXPECT_FLOAT_EQ(wrap_pi(-101.), (-101. + 32. * M_PI_PRECISE));
+	EXPECT_FLOAT_EQ(wrap_pi(100.), (100. - 32. * M_PI));
+	EXPECT_FLOAT_EQ(wrap_pi(-100.), (-100. + 32. * M_PI));
+	EXPECT_FLOAT_EQ(wrap_pi(-101.), (-101. + 32. * M_PI));
 	EXPECT_FALSE(std::isfinite(wrap_pi(NAN)));
 
 	// wrap 2pi
 	EXPECT_FLOAT_EQ(wrap_2pi(0.), 0.);
-	EXPECT_FLOAT_EQ(wrap_2pi(-4.), (-4. + 2. * M_PI_PRECISE));
+	EXPECT_FLOAT_EQ(wrap_2pi(-4.), (-4. + 2. * M_PI));
 	EXPECT_FLOAT_EQ(wrap_2pi(3.), (3.));
-	EXPECT_FLOAT_EQ(wrap_2pi(200.), (200. - 31. * (2 * M_PI_PRECISE)));
-	EXPECT_FLOAT_EQ(wrap_2pi(-201.), (-201. + 32. * (2 * M_PI_PRECISE)));
+	EXPECT_FLOAT_EQ(wrap_2pi(200.), (200. - 31. * (2 * M_PI)));
+	EXPECT_FLOAT_EQ(wrap_2pi(-201.), (-201. + 32. * (2 * M_PI)));
 	EXPECT_FALSE(std::isfinite(wrap_2pi(NAN)));
 
 	// Equality checks

--- a/src/lib/matrix/test/MatrixUnwrapTest.cpp
+++ b/src/lib/matrix/test/MatrixUnwrapTest.cpp
@@ -34,7 +34,7 @@ TEST(MatrixUnwrapTest, UnwrapFloats)
 
 TEST(MatrixUnwrapTest, UnwrapDoubles)
 {
-	const double M_TWO_PI = M_PI_PRECISE * 2;
+	const double M_TWO_PI = M_PI * 2;
 
 	double unwrapped_angles[6] = {0.0, 0.25, 0.5, 0.75, 1.0, 1.25};
 	double wrapped_angles[6] = {0.0, 0.25, 0.5, -0.25, 0.0, 0.25};


### PR DESCRIPTION
A step towards sharing px4 libraries and reduce dependencies.

From [20458](https://github.com/PX4/PX4-Autopilot/pull/20458) it was known that not all math.h has math variables defined. However instead of defining a new variable name, one could just define `M_PI` if not defined. 

