### PR TITLE
FlightTaskAuto: disable MPC_LAND_RADIUS by default with value -1

### DIFF
--- a/src/modules/mc_pos_control/multicopter_nudging_params.c
+++ b/src/modules/mc_pos_control/multicopter_nudging_params.c
@@ -53,13 +53,19 @@ PARAM_DEFINE_INT32(MPC_LAND_RC_HELP, 0);
 /**
  * User assisted landing radius
  *
- * When nudging is enabled (see MPC_LAND_RC_HELP), this controls
- * the maximum allowed horizontal displacement from the original landing point.
+ * When nudging is enabled (see MPC_LAND_RC_HELP), this defines the maximum
+ * allowed horizontal displacement from the original landing point. Nudging in
+ * FlightTaskAuto is then restricted as follows:
+ *  - If the vehicle is inside of the allowed radius, only allow nudging inputs that do not move the vehicle outside of it.
+ *  - If the vehicle is outside of the allowed radius, only allow nudging inputs that move the vehicle back towards it.
+ *
+ * Setting the radius to -1 will disable this feature. Nudging is only limited
+ * while local position is valid.
  *
  * @unit m
- * @min 0
+ * @min -1
  * @decimal 0
  * @increment 1
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_LAND_RADIUS, 1000.f);
+PARAM_DEFINE_FLOAT(MPC_LAND_RADIUS, -1.0f);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This feature (for ensuring tethered drones do not go too far, see https://github.com/PX4/PX4-Autopilot/pull/23917) is currently not entirely disabled by default, but always on with a large radius of 1000m.


### Solution
 - Define a parameter value of -1 that entirely disables the check
 - Also bypass the check if local position is NaN, which would make the check nonsensical
 - Document parameter changes accordingly & clarify existing functionality in docstring

### Changelog Entry
For release notes:
```
FlightTaskAuto: disable MPC_LAND_RADIUS by default with value -1
```


### Test coverage

Verified in sim that:
 - The check skips with parameter value of -1
 - The check skips with invalid (= NaN within FlightTask) local position
 - Verified in sim that the feature still works (`MPC_LAND_RADIUS=30`):
 
<img width="732" height="686" alt="Screenshot from 2025-07-23 18-06-41" src="https://github.com/user-attachments/assets/2ec9899e-113b-4595-904b-d424d27a26cc" />

 