### PR TITLE
AUTO_LAND: Require fully valid local position again

### DIFF
--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -169,7 +169,7 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_attitude);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_local_alt);
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_local_position_relaxed);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_local_position);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_prevent_arming);
 
 	// NAVIGATION_STATE_AUTO_FOLLOW_TARGET


### PR DESCRIPTION
### Solved Problem

The current mode requirements allow `FlightTaskAuto` to start with invalid local position. But regardless of `failsafe_flags.local_position_invalid_relaxed`, FlightTask populates its `_position` with NaN when it is invalid in the proper sense. This then leads to various problems such as: 
 - erroneously disallowed nudging due to the `MPC_LAND_RADIUS` [check](https://github.com/PX4/PX4-Autopilot/blob/9c1a22e74eda968495555fca6d8f103308452fa1/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp#L269-L284) returning NaN
 - not even publishing a trajectory setpoint from `FlightModeManager::generateTrajectorySetpoint` due to another position validity check that does not know the concept of `local_position_invalid_relaxed` 

### Solution

This reverts the mode requirements to valid local position again. This causes the existing `FlightTaskDescend` to be engaged when position goes invalid, so that nudging inputs are still executed, even at the cost of losing any position stabilisation. 

This reverts commit 2f69f3fc2e1619f5864b212028f0c122b23ddee3, PR #23917.

Longer term, the functionality aimed at in #23917 should probably be made available with a separate `FlightTask` that works with invalid position, but valid velocity estimates. 
