### PR TITLE
MC PositionControl: Add timeout for invalid TrajectorySetpoint

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -574,13 +574,14 @@ void MulticopterPositionControl::Run()
 			if (_control.update(dt)) {
 
 				// Valid control update - store for fallback
-				_last_valid_setpoint_time = now;
+				_last_valid_setpoint_time = _setpoint.timestamp;
 				_last_valid_setpoint = _setpoint;
 
 			} else {
 
-				if ((now - _last_valid_setpoint_time) < 100_ms) {
+				if ((now - _last_valid_setpoint_time) < 200_ms) {
 					// Use last valid setpoint for the timeout period
+					adjustSetpointForEKFResets(vehicle_local_position, _last_valid_setpoint);
 					_control.setInputSetpoint(_last_valid_setpoint);
 
 				} else {
@@ -589,8 +590,9 @@ void MulticopterPositionControl::Run()
 
 					_control.setInputSetpoint(generateFailsafeSetpoint(vehicle_local_position.timestamp_sample, states, true));
 					_control.setVelocityLimits(_param_mpc_xy_vel_max.get(), _param_mpc_z_vel_max_up.get(), _param_mpc_z_vel_max_dn.get());
-					_control.update(dt);
 				}
+
+				_control.update(dt);
 			}
 
 			// Publish internal position control setpoints

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -578,10 +578,8 @@ void MulticopterPositionControl::Run()
 				_last_valid_setpoint = _setpoint;
 
 			} else {
-				const float invalid_setpoint_timeout_ms = 100;
-				const bool transient_invalid = (now - _last_valid_setpoint_time) < (invalid_setpoint_timeout_ms * 1e3f);
 
-				if (transient_invalid) {
+				if ((now - _last_valid_setpoint_time) < 100_ms) {
 					// Use last valid setpoint for the timeout period
 					_control.setInputSetpoint(_last_valid_setpoint);
 

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -207,7 +207,6 @@ private:
 	PositionControl _control; ///< class for core PID position control
 
 	hrt_abstime _last_warn{0}; /**< timer when the last warn message was sent out */
-	hrt_abstime _last_valid_setpoint_time{0}; /**< timer when the last valid setpoint was received */
 
 	bool _hover_thrust_initialized{false};
 

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -113,6 +113,7 @@ private:
 	hrt_abstime _time_position_control_enabled{0};
 
 	trajectory_setpoint_s _setpoint{PositionControl::empty_trajectory_setpoint};
+	trajectory_setpoint_s _last_valid_setpoint{PositionControl::empty_trajectory_setpoint};
 	vehicle_control_mode_s _vehicle_control_mode{};
 
 	vehicle_constraints_s _vehicle_constraints {
@@ -206,6 +207,7 @@ private:
 	PositionControl _control; ///< class for core PID position control
 
 	hrt_abstime _last_warn{0}; /**< timer when the last warn message was sent out */
+	hrt_abstime _last_valid_setpoint_time{0}; /**< timer when the last valid setpoint was received */
 
 	bool _hover_thrust_initialized{false};
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

There is a race condition in PX4 that can result in an invalid setpoint during a failsafe event. Specifically, the Flight Mode Manager (FMM) and multicopter position controller can run before the Commander updates the nav_state in response to a failsafe (e.g., loss of manual control signal). For example when you: 

1. Start in Manual Position mode (nav_state = 2).

2. Lose manual control signal (e.g., RC link loss).

3. Before the Commander updates nav_state, the FMM and position controller execute assuming nav_state = 2.

4. Since manual input is no longer valid, the position controller generates an emergency failsafe setpoint (vx = vy = 0), which is not ideal if you are flying fast. 

### Solution
- Add a timeout period in which the multicopter position controller that uses the last valid setpoint. After this period, the emergency failsafe setpoint is generated.  

(Note: I set this timeout to 100ms for now, but happy to get feedback on this) 

### Changelog Entry
For release notes:
```
Feature/Bugfix  Add timeout before triggering emergency setpoint on invalid TrajectorySetpoint in MulticopterPositionControl
```

### Test coverage
- Tested in SITL: 

<img width="1090" height="1011" alt="image" src="https://github.com/user-attachments/assets/db23c455-9695-4faa-9921-fb56a4fc6555" />


