### PR TITLE
PositionControlTest: Additional unit test case velocity setpoint with invalid states

### DIFF
--- a/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
@@ -316,23 +316,62 @@ TEST_F(PositionControlBasicTest, SetpointValidityAllCombinations)
 	}
 }
 
-TEST_F(PositionControlBasicTest, InvalidState)
+TEST_F(PositionControlBasicTest, PositionSetpointInvalidState)
 {
-	Vector3f(.1f, .2f, .3f).copyTo(_input_setpoint.position);
+	Vector3f(.1f, .2f, .3f).copyTo(_input_setpoint.position); // Position setpoint
 
+	// All states valid - ok
 	PositionControlStates states{};
+	_position_control.setState(states);
+	EXPECT_TRUE(runController());
+
+	// Position invalid
 	states.position(0) = NAN;
 	_position_control.setState(states);
 	EXPECT_FALSE(runController());
 
+	// Position and velocity invalid
 	states.velocity(0) = NAN;
 	_position_control.setState(states);
 	EXPECT_FALSE(runController());
 
+	// Velocity invalid
 	states.position(0) = 0.f;
 	_position_control.setState(states);
 	EXPECT_FALSE(runController());
 
+	// Velocity derivative invalid
+	states.velocity(0) = 0.f;
+	states.acceleration(1) = NAN;
+	_position_control.setState(states);
+	EXPECT_FALSE(runController());
+}
+
+TEST_F(PositionControlBasicTest, VelocitySetpointInvalidState)
+{
+	Vector3f(.1f, .2f, .3f).copyTo(_input_setpoint.velocity); // Velocity setpoint
+
+	// All states valid - ok
+	PositionControlStates states{};
+	_position_control.setState(states);
+	EXPECT_TRUE(runController());
+
+	// Position invalid - ok
+	states.position(0) = NAN;
+	_position_control.setState(states);
+	EXPECT_TRUE(runController());
+
+	// Position and velocity invalid
+	states.velocity(0) = NAN;
+	_position_control.setState(states);
+	EXPECT_FALSE(runController());
+
+	// Velocity invalid
+	states.position(0) = 0.f;
+	_position_control.setState(states);
+	EXPECT_FALSE(runController());
+
+	// Velocity derivative invalid
 	states.velocity(0) = 0.f;
 	states.acceleration(1) = NAN;
 	_position_control.setState(states);


### PR DESCRIPTION
### Solved Problem
When discussing with @mbjd while analyzing a problem, we went into the fact that the multicopter position controller checks for every setpoint to be a valid state otherwise it fails and you get a message that it had to fill in a setpoint to not crash in the unexpected emergency.

### Solution
I thought I'd improve the unit tests to be hopefully more clear and cover another case explicitly.

### Changelog Entry
```
PositionControlTest: Additional unit test case velocity setpoint with invalid states
```

### Test coverage
Still passes.