### PR TITLE
gps: ubx: command line wipe config

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -1383,6 +1383,8 @@ $ gps reset warm
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 	PRINT_MODULE_USAGE_COMMAND_DESCR("reset", "Reset GPS device");
 	PRINT_MODULE_USAGE_ARG("cold|warm|hot", "Specify reset type", false);
+	PRINT_MODULE_USAGE_COMMAND_DESCR("wipe", "Wipe ublox configuration");
+
 
 	return 0;
 }


### PR DESCRIPTION
> [AlexKlimaj](https://github.com/AlexKlimaj) commented [2 hours ago](https://github.com/PX4/PX4-Autopilot/pull/25241#issuecomment-3114206988)
A command line function to just call "gps wipe" would be nice as well.

https://github.com/PX4/PX4-Autopilot/pull/25241#issuecomment-3114206988