### PR TITLE
Fix failsafe overriding user triggered termination

### DIFF
--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -443,7 +443,8 @@ void FailsafeBase::getSelectedAction(const State &state, const failsafe_flags_s 
 	returned_state.updated_user_intended_mode = state.user_intended_mode;
 	returned_state.cause = Cause::Generic;
 
-	if (_selected_action == Action::Terminate) { // Terminate never clears
+	if (state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_TERMINATION
+	    || _selected_action == Action::Terminate) { // Terminate never clears
 		returned_state.action = Action::Terminate;
 		return;
 	}


### PR DESCRIPTION
### Solved Problem
We had a case where a vehicle was intentionally terminated using the MAVLink command https://mavlink.io/en/messages/common.html#MAV_CMD_DO_FLIGHTTERMINATION and then the ground station was turned off which caused a data link loss and a failsafe RTL overriding termination. This must by definition not be possible.

<img width="937" height="1222" alt="image" src="https://github.com/user-attachments/assets/a84bac8f-5c0d-4fcd-b4ab-9b8aa30d4e6a" />

### Solution
This is a possible fix where it explicitly handles the case a user triggered termination and does not allow overriding it with a failsafe action triggered mode. I'm not sure if this is the right place to tackle it since the user messageing still contains the failsafe action but in the end it has no effect. Probably there's a better way.

<img width="1277" height="278" alt="image" src="https://github.com/user-attachments/assets/f192897f-fb20-4c41-bfc1-3651511ea498" />

### Changelog Entry
```
Fix failsafe overriding user triggered termination
```

### Test coverage
I did a STIL test and it does not override termination anymore but there's probably a better way.