### PR TITLE
[Fix] commander: only clear hold delay when failsafes are being deferred

### DIFF
--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -720,7 +720,7 @@ bool FailsafeBase::deferFailsafes(bool enabled, int timeout_s)
 		return false;
 	}
 
-	if (!enabled && _failsafe_defer_started == 0) {
+	if (!enabled && _defer_failsafes && _failsafe_defer_started == 0) {
 		_current_delay = 0;
 	}
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

The delay period (during which the vehicle is expected to hold/loiter before a failsafe action) is being unintentionally cleared, even when the failsafe is not deferred. As a result, the failsafe action is executed immediately, rather than after the intended delay.

### Solution

Only clear hold delay when failsafes are being deferred, so that the delay action is still executed. 

### Changelog Entry
For release notes:
```
Bugfix  Failsafe delay (hold/loiter) now works as expected before the failsafe action executes.
```

### Test coverage
Tested in SITL: 

<img width="1234" height="1095" alt="image" src="https://github.com/user-attachments/assets/24106299-1c38-43b6-8b10-0d0ee0ff02ce" />

