### PR TITLE
cdcacm_autostart: add low bandwidth profile

### DIFF
--- a/src/drivers/cdcacm_autostart/cdcacm_autostart_params.c
+++ b/src/drivers/cdcacm_autostart/cdcacm_autostart_params.c
@@ -60,6 +60,7 @@ PARAM_DEFINE_INT32(SYS_USB_AUTO, 2);
  * @value 10 gimbal
  * @value 11 onboard_low_bandwidth
  * @value 12 uavionix
+ * @value 13 Low Bandwidth
  *
  * @reboot_required true
  *


### PR DESCRIPTION
### Solved Problem
The low bandwdith mode is missing in the `cdcacm_autostart` params. This PR adds it.
