### PR TITLE
platform: serial: add bytesAvailable()

### DIFF
--- a/platforms/common/Serial.cpp
+++ b/platforms/common/Serial.cpp
@@ -69,6 +69,11 @@ bool Serial::close()
 	return _impl.close();
 }
 
+ssize_t Serial::bytesAvailable()
+{
+	return _impl.bytesAvailable();
+}
+
 ssize_t Serial::read(uint8_t *buffer, size_t buffer_size)
 {
 	return _impl.read(buffer, buffer_size);

--- a/platforms/common/include/px4_platform_common/Serial.hpp
+++ b/platforms/common/include/px4_platform_common/Serial.hpp
@@ -61,6 +61,7 @@ public:
 
 	bool close();
 
+	ssize_t bytesAvailable();
 	ssize_t read(uint8_t *buffer, size_t buffer_size);
 	ssize_t readAtLeast(uint8_t *buffer, size_t buffer_size, size_t character_count = 1, uint32_t timeout_ms = 0);
 

--- a/platforms/nuttx/src/px4/common/SerialImpl.cpp
+++ b/platforms/nuttx/src/px4/common/SerialImpl.cpp
@@ -259,6 +259,18 @@ bool SerialImpl::close()
 	return true;
 }
 
+ssize_t SerialImpl::bytesAvailable()
+{
+	if (!_open) {
+		PX4_ERR("Device not open!");
+		return -1;
+	}
+
+	ssize_t bytes_available = 0;
+	int ret = ioctl(_serial_fd, FIONREAD, &bytes_available);
+	return ret >= 0 ? bytes_available : 0;
+}
+
 ssize_t SerialImpl::read(uint8_t *buffer, size_t buffer_size)
 {
 	if (!_open) {

--- a/platforms/nuttx/src/px4/common/include/SerialImpl.hpp
+++ b/platforms/nuttx/src/px4/common/include/SerialImpl.hpp
@@ -59,6 +59,7 @@ public:
 
 	bool close();
 
+	ssize_t bytesAvailable();
 	ssize_t read(uint8_t *buffer, size_t buffer_size);
 	ssize_t readAtLeast(uint8_t *buffer, size_t buffer_size, size_t character_count = 1, uint32_t timeout_us = 0);
 

--- a/platforms/posix/include/SerialImpl.hpp
+++ b/platforms/posix/include/SerialImpl.hpp
@@ -59,6 +59,7 @@ public:
 
 	bool close();
 
+	ssize_t bytesAvailable();
 	ssize_t read(uint8_t *buffer, size_t buffer_size);
 	ssize_t readAtLeast(uint8_t *buffer, size_t buffer_size, size_t character_count = 1, uint32_t timeout_us = 0);
 

--- a/platforms/posix/src/px4/common/SerialImpl.cpp
+++ b/platforms/posix/src/px4/common/SerialImpl.cpp
@@ -251,6 +251,18 @@ bool SerialImpl::close()
 	return true;
 }
 
+ssize_t SerialImpl::bytesAvailable()
+{
+	if (!_open) {
+		PX4_ERR("Device not open!");
+		return -1;
+	}
+
+	ssize_t bytes_available = 0;
+	int ret = ioctl(_serial_fd, FIONREAD, &bytes_available);
+	return ret >= 0 ? bytes_available : 0;
+}
+
 ssize_t SerialImpl::read(uint8_t *buffer, size_t buffer_size)
 {
 	if (!_open) {

--- a/platforms/qurt/include/SerialImpl.hpp
+++ b/platforms/qurt/include/SerialImpl.hpp
@@ -58,6 +58,7 @@ public:
 
 	bool close();
 
+	ssize_t bytesAvailable();
 	ssize_t read(uint8_t *buffer, size_t buffer_size);
 	ssize_t readAtLeast(uint8_t *buffer, size_t buffer_size, size_t character_count = 1, uint32_t timeout_us = 0);
 

--- a/platforms/qurt/src/px4/SerialImpl.cpp
+++ b/platforms/qurt/src/px4/SerialImpl.cpp
@@ -158,6 +158,13 @@ bool SerialImpl::close()
 	return true;
 }
 
+ssize_t SerialImpl::bytesAvailable()
+{
+	// TODO:
+	PX4_WARN("bytesAvailable not implemented!");
+	return 0;
+}
+
 ssize_t SerialImpl::read(uint8_t *buffer, size_t buffer_size)
 {
 	if (!_open) {


### PR DESCRIPTION
@katzfey  Could you have a look please? Not sure what to do for qurt.

**Motivation**
I will be following this PR with another which refactors the DShotTelemetry class to use the `device::Serial` abstraction. It can't blocking read so needs to know that there are bytes available.