### PR TITLE
astyle: exclude tflite_micro

### DIFF
--- a/Tools/astyle/files_to_check_code_style.sh
+++ b/Tools/astyle/files_to_check_code_style.sh
@@ -37,4 +37,5 @@ exec find boards msg src platforms test \
     -path src/modules/zenoh/zenoh-pico -prune -o \
     -path boards/modalai/voxl2/libfc-sensor-api -prune -o \
     -path src/drivers/actuators/vertiq_io/iq-module-communication-cpp -prune -o \
+    -path src/lib/tensorflow_lite_micro/tflite_micro -prune -o \
     \( -type f \( -name "*.c" -o -name "*.h" -o -name "*.cpp" -o -name "*.hpp" \) -print \) | grep $PATTERN


### PR DESCRIPTION
Add tflite_micro to the blacklist for `make format`