### PR TITLE
msg: add Wind.msg to versioned messages

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -237,7 +237,6 @@ set(msg_files
 	VehicleTorqueSetpoint.msg
 	VelocityLimits.msg
 	WheelEncoders.msg
-	Wind.msg
 	YawEstimatorStatus.msg
 	versioned/ActuatorMotors.msg
 	versioned/ActuatorServos.msg
@@ -271,6 +270,7 @@ set(msg_files
 	versioned/VehicleRatesSetpoint.msg
 	versioned/VehicleStatus.msg
 	versioned/VtolVehicleStatus.msg
+	versioned/Wind.msg
 )
 list(SORT msg_files)
 

--- a/msg/versioned/Wind.msg
+++ b/msg/versioned/Wind.msg
@@ -1,3 +1,5 @@
+uint32 MESSAGE_VERSION = 0
+
 uint64 timestamp		# time since system start (microseconds)
 uint64 timestamp_sample         # the timestamp of the raw data (microseconds)
 


### PR DESCRIPTION

### Solved Problem

Was added as a default DDS topic recently, but I forgot to transition WInd to a versioned message. 


### Solution

Add versioning to Wind.msg

### Changelog Entry
For release notes:
```
Feature/Bugfix Add versioning to Wind.msg
```

