### PR TITLE
Upgrade ARM compiler in macOS CI

### DIFF
--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -28,7 +28,13 @@ jobs:
         token: ${{secrets.ACCESS_TOKEN}}
 
     - name: setup
-      run: ./Tools/setup/macos.sh; ./Tools/setup/macos.sh
+      run: |
+        ./Tools/setup/macos.sh
+        ./Tools/setup/macos.sh
+        brew unlink gcc-arm-none-eabi
+        brew tap osx-cross/arm
+        brew install arm-gcc-bin@13
+        brew link --force arm-gcc-bin@13
 
     - name: Prepare ccache timestamp
       id: ccache_cache_timestamp


### PR DESCRIPTION


### Solved Problem

macOS CI still runs on GCC9 which overflows flash. GCC13 is used in the Linux CI.
