### PR TITLE
Feature: Add option to prioritize either RC or MAVLink stick input with fallback

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -173,6 +173,8 @@ PARAM_DEFINE_INT32(COM_HOME_IN_AIR, 0);
  * A value of 2 allows either RC Transmitter or Joystick input. The first valid input is used, will fallback to other sources if the input stream becomes invalid.
  * A value of 3 allows either input from RC or joystick. The first available source is selected and used until reboot.
  * A value of 4 ignores any stick input.
+ * A value of 5 allows either RC Transmitter or Joystick input. But RC has priority and whenever avaiable is immedietely used.
+ * A value of 6 allows either RC Transmitter or Joystick input. But Joystick has priority and whenever avaiable is immedietely used.
  *
  * @group Commander
  * @min 0
@@ -182,6 +184,8 @@ PARAM_DEFINE_INT32(COM_HOME_IN_AIR, 0);
  * @value 2 RC and Joystick with fallback
  * @value 3 RC or Joystick keep first
  * @value 4 Stick input disabled
+ * @value 5 RC priority, Joystick fallback
+ * @value 6 Joystick priority, RC fallback
  */
 PARAM_DEFINE_INT32(COM_RC_IN_MODE, 3);
 

--- a/src/modules/manual_control/ManualControlSelector.cpp
+++ b/src/modules/manual_control/ManualControlSelector.cpp
@@ -67,7 +67,7 @@ bool ManualControlSelector::isInputValid(const manual_control_setpoint_s &input,
 {
 	// Check for timeout
 	const bool sample_from_the_past = now >= input.timestamp_sample;
-	const bool sample_newer_than_timeout = now - input.timestamp_sample < _timeout;
+	const bool sample_newer_than_timeout = now < input.timestamp_sample + _timeout;
 
 	// Check if source matches the configuration
 	const bool source_rc_matched = (_rc_in_mode == 0) && (input.data_source == manual_control_setpoint_s::SOURCE_RC);

--- a/src/modules/manual_control/ManualControlSelector.hpp
+++ b/src/modules/manual_control/ManualControlSelector.hpp
@@ -48,10 +48,14 @@ public:
 
 private:
 	bool isInputValid(const manual_control_setpoint_s &input, uint64_t now) const;
+	static bool isRc(uint8_t source);
+	static bool isMavlink(uint8_t source);
 
 	manual_control_setpoint_s _setpoint{};
 	uint64_t _timeout{0};
 	int32_t _rc_in_mode{0};
 	int _instance{-1};
 	uint8_t _first_valid_source{manual_control_setpoint_s::SOURCE_UNKNOWN};
+	uint64_t _timestamp_last_rc{0};
+	uint64_t _timestamp_last_mavlink{0};
 };


### PR DESCRIPTION
### Solved Problem
When discussing test secnario issues I got the feedback that having a fallback to RC (or Joystick) it would be really useful to be able to prioritize one over the other.

If `COM_RC_IN_MODE` is set to fallback (2) and the "main operator" with his ground station Joystick loses connection, the "safety pilot" with his RC link will take over after `COM_RC_LOSS_T` seconds (500ms by default). If the "main operator" regains connection he can only ever use his Joystick again if the "safety pilot" turns off his RC to lose connection. Also if the system is turned on with both RC and ground station Joystick available there's no guarantee for which one gets used, it's often the RC because of bootup timing and latency.

### Solution
With this pr I added two options for `COM_RC_LOSS_T`:
- 5 Accept both RC and Joystick and fall back but always prioritize RC immediately
- 6 {same} prioritize Joystick immediately

### Changelog Entry
```
Feature: Add option to prioritize either RC or MAVLink stick input with fallback
```

### Test coverage
I added unit tests for the new options where:
1. The prioritized input is available -> use it
2. The non-prioritized inputs gets available -> ignore that
3. The prioritized input is lost -> fall back to the non-prioritized
4. The prioritized input comes back -> use immediately again (different to the simple fallback option)

I also tested this on a pixracer with a Taranis and Crosfire receiver coming in through SBUS as "RC" and my laptop with QGC and a Logitech gamepad as MAVLink "Joystick". Testing both options turning on and off each source, the prioritized source is immediately used once available verified using `listener manual_control_setpoint` checking the `data_source`, `valid` fields and which device influences the stick data.

### Known gotchas
1. There's no unified UI in QGC to configure RC and Joystick holistically.
2. The user still has no visual feedback in QGC which source is currently in use.
3. If the prioritized source is very flaky the input could change a lot. The ways to escape this if unexpected is switching into an autonomous mode without RC override or changing `COM_RC_LOSS_T` mid operation which is supported.