### PR TITLE
Update px4-rc.gzsim - fix wrong check_scene_info() return

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim
@@ -68,9 +68,9 @@ fi
 check_scene_info() {
 	SERVICE_INFO=$(${gz_command} service -i --service "/world/${PX4_GZ_WORLD}/scene/info" 2>&1)
 	if echo "$SERVICE_INFO" | grep -q "Service providers"; then
-		return 0
-	else
 		return 1
+	else
+		return 0
 	fi
 }
 


### PR DESCRIPTION
Swaped up check_scene_info() return result. 

```
	if check_scene_info; then
		echo "INFO  [init] Gazebo world is ready"
		break
	fi
```
Therefore should return 1 in case of correct check.