### PR TITLE
[1.16 backport] MAV_CMD_DO_SET_MODE - add support

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -606,6 +606,9 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 			send_ack = true;
 		}
 
+	} else if (cmd_mavlink.command == MAV_CMD_DO_SET_MODE) {
+		_cmd_pub.publish(vehicle_command);
+
 	} else if (cmd_mavlink.command == MAV_CMD_DO_AUTOTUNE_ENABLE) {
 
 		bool has_module = true;


### PR DESCRIPTION
This backports PR #24704 MAV_CMD_DO_SET_MODE - add support

It's a trivial modification that add support for `MAV_CMD_DO_SET_MODE` (SET_MODE as a command). Tested by sending the command for a number of different base/custom/customsub modes