### PR TITLE
increase battery max logging instances

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -191,7 +191,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic_multi("yaw_estimator_status", 1000);
 
 	// log all raw sensors at minimal rate (at least 1 Hz)
-	add_topic_multi("battery_status", 200, 2);
+	add_topic_multi("battery_status", 200, 3);
 	add_topic_multi("differential_pressure", 1000, 2);
 	add_topic_multi("distance_sensor", 1000, 2);
 	add_optional_topic_multi("sensor_accel", 1000, 4);


### PR DESCRIPTION
### Solved Problem
When working with drone setups that use 3 batteries, I found that the ulogs only list the data for 2 battery instances.

### Solution
- Bump the max_num_instances value for the "battery_status" message to 4 instead of 2 so far.
- This is in line with the MAX_INSTANCES listed in the BatteryStatus Message here: https://github.com/PX4/PX4-Autopilot/blob/c9206d6bd1d0ec8c5f487024e7b8c6e2593d274f/msg/versioned/BatteryStatus.msg#L8

### Changelog Entry
```
Improved logging: up to max. 4 battery status instead of 2
```

