### PR TITLE
Fixed-wing autotune: fix immediate failure on first try

### DIFF
--- a/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
+++ b/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
@@ -98,15 +98,6 @@ void FwAutotuneAttitudeControl::Run()
 		updateStateMachine(hrt_absolute_time());
 	}
 
-	_aux_switch_en = isAuxEnableSwitchEnabled();
-
-	// new control data needed every iteration
-	if ((_state == state::idle && !_aux_switch_en)
-	    || !_vehicle_torque_setpoint_sub.updated()) {
-
-		return;
-	}
-
 	if (_vehicle_status_sub.updated()) {
 		vehicle_status_s vehicle_status;
 
@@ -114,6 +105,15 @@ void FwAutotuneAttitudeControl::Run()
 			_armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
 			_nav_state = vehicle_status.nav_state;
 		}
+	}
+
+	_aux_switch_en = isAuxEnableSwitchEnabled();
+
+	// new control data needed every iteration
+	if ((_state == state::idle && !_aux_switch_en)
+	    || !_vehicle_torque_setpoint_sub.updated()) {
+
+		return;
 	}
 
 	if (_actuator_controls_status_sub.updated()) {


### PR DESCRIPTION
### Solved Problem
Fixed-wing autotune directly aborts upon activation due to an apparent "mode switch".
<img width="1794" height="493" alt="image (11)" src="https://github.com/user-attachments/assets/473099a4-ea30-495c-979e-75817d64bcdd" />

This is because the `_nav_state` is only updated once autotune starts, so the [_start_flight_mode](https://github.com/PX4/PX4-Autopilot/blob/6de845e4f095a35239d34de0d813ca2be32490c4/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp#L304) is 0 (default value of `_nav_state`) and the [mode change abort](https://github.com/PX4/PX4-Autopilot/blob/6de845e4f095a35239d34de0d813ca2be32490c4/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp#L489) is triggered.

### Solution
update `_nav_state` even when autotune is not running

### Changelog Entry
For release notes:
```
Fixed-wing autotune: fix immediate failure on first try
New parameter: -
Documentation: -
```