### PR TITLE
Fixed Posix and Qurt platform build error introduced in earlier commit

### DIFF
--- a/platforms/Kconfig
+++ b/platforms/Kconfig
@@ -1,3 +1,7 @@
 if PLATFORM_NUTTX
 rsource "nuttx/Kconfig"
 endif
+
+if PLATFORM_POSIX || PLATFORM_QURT
+rsource "common/Kconfig"
+endif


### PR DESCRIPTION
An earlier commit (https://github.com/PX4/PX4-Autopilot/commit/6474e5d7c1a752fe9d910dbd55aae2e30f751357) broke the VOXL 2 Posix and Qurt platform builds. This PR fixes the build issue.
