### PR TITLE
mavlink_main.cpp - PROTOCOL_VERSION to 203

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1150,7 +1150,7 @@ Mavlink::send_protocol_version()
 
 	msg.version = _protocol_version * 100;
 	msg.min_version = 100;
-	msg.max_version = 200;
+	msg.max_version = 203;
 	uint64_t mavlink_lib_git_version_binary = px4_mavlink_lib_version_binary();
 	// TODO add when available
 	//memcpy(&msg.spec_version_hash, &mavlink_spec_git_version_binary, sizeof(msg.spec_version_hash));


### PR DESCRIPTION
The point of [PROTOCOL_VERSION](https://mavlink.io/en/messages/common.html#PROTOCOL_VERSION) is to indicate the maximum supported version of the protcol.

This is currently "3" in common.xml - https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/common.xml#L4
This updates the max to match.

Note
1. It is disturbing that this number is hard coded rather than coming from MAVLink library - it will inevitably get out of sync.
2. In theory then the GCS should use a version no greater than 200, which would be very old. Clearly this isn't actually checked by anything because if it was, we'd have broken lots of things added since that release many years ago.

See:
- [Determining Protocol/Message Version](https://mavlink.io/en/guide/mavlink_version.html#determining-protocol-message-version) 
- [Version handshaking](https://mavlink.io/en/guide/mavlink_version.html#version_handshaking) in Message versions protocol
