### PR TITLE
Update px4-rc.gzsim. Fix gz_world checking for PX4_GZ_STANDALONE=1

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim
@@ -28,11 +28,15 @@ else
     exit 1
 fi
 
+# Look for an already running world
+get_gz_world() {
+	gz_world=$( ${gz_command} topic -l | grep -m 1 -e "^/world/.*/clock" | sed 's/\/world\///g; s/\/clock//g' )
+}
+
 # If not standalone
 if [ -z "${PX4_GZ_STANDALONE}" ]; then
 
-	# Look for an already running world
-	gz_world=$( ${gz_command} topic -l | grep -m 1 -e "^/world/.*/clock" | sed 's/\/world\///g; s/\/clock//g' )
+	get_gz_world
 
 	# shellcheck disable=SC2153
 	if [ -z "${gz_world}" ] && [ -n "${PX4_GZ_WORLD}" ]; then
@@ -66,6 +70,13 @@ fi
 
 # Wait for Gazebo world to be ready before proceeding
 check_scene_info() {
+
+	get_gz_world
+
+	if [ -n "${PX4_GZ_STANDALONE}" ] && [ -n "${gz_world}" ]; then
+		PX4_GZ_WORLD=${gz_world}
+	fi
+
 	SERVICE_INFO=$(${gz_command} service -i --service "/world/${PX4_GZ_WORLD}/scene/info" 2>&1)
 	if echo "$SERVICE_INFO" | grep -q "Service providers"; then
 		return 0


### PR DESCRIPTION
Update px4-rc.gzsim. Fix gz_world checking for PX4_GZ_STANDALONE=1 mode.  Priority of gz_world (really running) over PX4_GZ_WORLD



### Solved Problem
Currently in PX4_GZ_STANDALONE=1 mode script uses PX4_GZ_WORLD as true and does not see what world is really  runned. It leads to needing to adding PX4_GZ_WORLD=${PX4_GZ_WORLD:=default} with correct world name you planed to run. It is ok for NOT STANDALONE mode. But in STANDALONE it leads to double place for world configuring (airframe and same world in gazebo launcher). And you cant use any other world in Gazebo launcher (only same as in airframe).

I belive in PX4_GZ_STANDALONE script should attach to any really runned world (as it was in  PX4 v1.14 ).

I fix that with using really runned world attach to.



