### PR TITLE
Added Qurt platform Serial implementations

### DIFF
--- a/platforms/qurt/src/px4/SerialImpl.cpp
+++ b/platforms/qurt/src/px4/SerialImpl.cpp
@@ -39,6 +39,11 @@
 
 #define MODULE_NAME "SerialImpl"
 
+extern "C" {
+	__EXPORT int fc_uart_rx_available(int fd, uint32_t *data);
+	__EXPORT int fc_uart_flush_rx(int fd);
+}
+
 namespace device
 {
 
@@ -160,9 +165,14 @@ bool SerialImpl::close()
 
 ssize_t SerialImpl::bytesAvailable()
 {
-	// TODO:
-	PX4_WARN("bytesAvailable not implemented!");
-	return 0;
+	if (!_open) {
+		PX4_ERR("Device not open!");
+		return -1;
+	}
+
+	uint32_t rx_bytes = 0;
+	(void) fc_uart_rx_available(_serial_fd, &rx_bytes);
+	return (ssize_t) rx_bytes;
 }
 
 ssize_t SerialImpl::read(uint8_t *buffer, size_t buffer_size)
@@ -267,7 +277,9 @@ ssize_t SerialImpl::write(const void *buffer, size_t buffer_size)
 
 void SerialImpl::flush()
 {
-	// TODO: Flush not implemented yet on Qurt
+	if (_open) {
+		(void) fc_uart_flush_rx(_serial_fd);
+	}
 }
 
 const char *SerialImpl::getPort() const


### PR DESCRIPTION
PR #25325 added a placeholder for the Qurt platform implementation of the SerialImpl::bytesAvailable() function. This PR fills in an implementation for that function and also fills in the missing flush function implementation. Some test code was added to the Qurt HITL implementation as well to make sure the functions work.