### PR TITLE
EKF2: adjust min and max noise of OF-data

### DIFF
--- a/src/modules/ekf2/params_optical_flow.yaml
+++ b/src/modules/ekf2/params_optical_flow.yaml
@@ -35,8 +35,8 @@ parameters:
         long: Measurement noise for the optical flow sensor when it's reported quality
           metric is at the maximum
       type: float
-      default: 0.15
-      min: 0.05
+      default: 0.05
+      min: 0.01
       unit: rad/s
       decimal: 2
     EKF2_OF_N_MAX:
@@ -45,7 +45,7 @@ parameters:
         long: Measurement noise for the optical flow sensor when it's reported quality
           metric is at the minimum
       type: float
-      default: 0.5
+      default: 0.1
       min: 0.05
       unit: rad/s
       decimal: 2

--- a/src/modules/ekf2/params_optical_flow.yaml
+++ b/src/modules/ekf2/params_optical_flow.yaml
@@ -35,8 +35,8 @@ parameters:
         long: Measurement noise for the optical flow sensor when it's reported quality
           metric is at the maximum
       type: float
-      default: 0.05
-      min: 0.01
+      default: 0.1
+      min: 0.05
       unit: rad/s
       decimal: 2
     EKF2_OF_N_MAX:
@@ -45,7 +45,7 @@ parameters:
         long: Measurement noise for the optical flow sensor when it's reported quality
           metric is at the minimum
       type: float
-      default: 0.1
+      default: 0.2
       min: 0.05
       unit: rad/s
       decimal: 2


### PR DESCRIPTION

### Solved Problem
While analyzing different logs, we observed that most of the time the test ratio is really small. This is the result of the high noise level which is given to the OF-data. Combined with the high uncertainty the of the dist_to_bottom (alt-terrain) the measurements are sometimes getting fused but are barely adjusting the corresponding states.

### Solution
By replaying some logs and varying the minimum and maximum optical flow noise parameters, I realized that the default values are outdated and probably tuned according to the PX4Flow.


### Changelog Entry
For release notes: adjust EKF2_OF_N_MIN and EKF2_OF_N_MAX
```

Feature/Bugfix XYZ
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```


### Test coverage
- So far only in replays, we will test on various vehicles...

