### PR TITLE
HealthAndArmingChecks: yaw_align warning

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -589,6 +589,21 @@ void EstimatorChecks::checkEstimatorStatusFlags(const Context &context, Report &
 				mavlink_log_critical(reporter.mavlink_log_pub(), "GNSS heading not reliable - Land now!\t");
 			}
 		}
+
+		// If yaw alignment is not complete within 10s of boot something is wrong with the mag(s)
+		if ((hrt_absolute_time() > 10_s) && !estimator_status_flags.cs_yaw_align) {
+			/* EVENT
+			 * @description
+			 * Check mag cal
+			 */
+			reporter.armingCheckFailure(NavModes::All, health_component_t::local_position_estimate,
+						    events::ID("yaw_align_incomplete"),
+						    events::Log::Critical, "Yaw alignment incomplete - Check mag cal");
+
+			if (reporter.mavlink_log_pub()) {
+				mavlink_log_critical(reporter.mavlink_log_pub(), "Yaw alignment incomplete - Check mag cal\t");
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
I spent 3-4 hours today trying to figure out why my drone wouldn't arm. All of the data in the log indicated that the GPS was working and Commander was not giving me any reason for denying arming other than "Resolve system health failures". It was quite frustrating. I ended up tracking the logic down to `Ekf::controlGnssPosFusion` where it checks that `tilt_align` and `yaw_align` are true. I then discovered that in my case `yaw_align` was false. This occurred because I had unknowingly set SENS_MAG_MODE to 0 and for whatever reason this screwed up my calibration.