### PR TITLE
Ark GNSS CAN - link to the DroneCAN docs for fixed base

### DIFF
--- a/docs/en/dronecan/ark_rtk_gps.md
+++ b/docs/en/dronecan/ark_rtk_gps.md
@@ -27,7 +27,7 @@ Order this module from:
 - Safety Button
 - Buzzer
 - Two Pixhawk Standard CAN Connectors (4 Pin JST GH)
-- F9P “UART 2” Connector
+- F9P `UART 2` Connector
   - 3 Pin JST GH
   - TX, RX, GND
 - Pixhawk Standard Debug Connector (6 Pin JST SH)
@@ -87,6 +87,25 @@ You need to set necessary [DroneCAN](index.md) parameters and define offsets if 
 - The parameters [EKF2_GPS_POS_X](../advanced_config/parameter_reference.md#EKF2_GPS_POS_X), [EKF2_GPS_POS_Y](../advanced_config/parameter_reference.md#EKF2_GPS_POS_Y) and [EKF2_GPS_POS_Z](../advanced_config/parameter_reference.md#EKF2_GPS_POS_Z) can be set to account for the offset of the ARK RTK GPS from the vehicles centre of gravity.
 - Set [CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM) to `1` on the GPS if this it that last node on the CAN bus.
 
+### Setting Up Rover and Fixed Base
+
+Position of the rover is established using RTCM messages from the RTK base module (the base module is connected to QGC, which sends the RTCM information to PX4 via MAVLink).
+
+PX4 DroneCAN parameters:
+
+- [UAVCAN_PUB_RTCM](../advanced_config/parameter_reference.md#UAVCAN_PUB_RTCM):
+  - Makes PX4 publish RTCM messages ([RTCMStream](https://dronecan.github.io/Specification/7._List_of_standard_data_types/#rtcmstream)) to the bus (which it gets from the RTK base module via QGC).
+
+Rover module parameters (also [set using QGC](#qgc-cannode-parameter-configuration)):
+
+- [CANNODE_SUB_RTCM](../advanced_config/parameter_reference.md#CANNODE_SUB_RTCM) tells the rover that it should subscribe to [RTCMStream](https://dronecan.github.io/Specification/7._List_of_standard_data_types/#rtcmstream) RTCM messages on the bus (from the moving base).
+
+::: info
+Use [UAVCAN_PUB_MBD](../advanced_config/parameter_reference.md#UAVCAN_PUB_MBD) and [CANNODE_SUB_MBD](../advanced_config/parameter_reference.md#CANNODE_SUB_MBD) instead if you want to implement moving base (see below) at the same time.
+:::
+
+For more information see [Rover and Fixed Base](../dronecan/index.md#rover-and-fixed-base) in the DroneCAN guide.
+
 ### Setting Up Moving Baseline & GPS Heading
 
 The simplest way to set up moving baseline and GPS heading with two ARK RTK GPS modules is via CAN, though it can be done via UART to reduce traffic on the CAN bus if desired.
@@ -127,10 +146,11 @@ Setup via UART:
 - On the _Moving Base_, set the following:
   - [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) to `2`.
 
+For more information see [Rover and Moving Base](../dronecan/index.md#rover-and-moving-base) in the DroneCAN guide.
+
 ## LED Meanings
 
 - The GPS status lights are located to the right of the connectors
-
   - Blinking green is GPS fix
   - Blinking blue is received corrections and RTK Float
   - Solid blue is RTK Fixed

--- a/docs/en/dronecan/ark_rtk_gps.md
+++ b/docs/en/dronecan/ark_rtk_gps.md
@@ -96,7 +96,7 @@ PX4 DroneCAN parameters:
 - [UAVCAN_PUB_RTCM](../advanced_config/parameter_reference.md#UAVCAN_PUB_RTCM):
   - Makes PX4 publish RTCM messages ([RTCMStream](https://dronecan.github.io/Specification/7._List_of_standard_data_types/#rtcmstream)) to the bus (which it gets from the RTK base module via QGC).
 
-Rover module parameters (also [set using QGC](#qgc-cannode-parameter-configuration)):
+Rover module parameters (also [set using QGC](../dronecan/index.md#qgc-cannode-parameter-configuration)):
 
 - [CANNODE_SUB_RTCM](../advanced_config/parameter_reference.md#CANNODE_SUB_RTCM) tells the rover that it should subscribe to [RTCMStream](https://dronecan.github.io/Specification/7._List_of_standard_data_types/#rtcmstream) RTCM messages on the bus (from the moving base).
 


### PR DESCRIPTION
ARK RTK GNSS (CAN) didn't mention the fixed base setup or link to the DroneCAN docs. This does that. Question in line.