### PR TITLE
ekf: always publish baro and gnss bias even if zero

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
@@ -45,6 +45,11 @@ void Ekf::controlBaroHeightFusion(const imuSample &imu_sample)
 	auto &aid_src = _aid_src_baro_hgt;
 	HeightBiasEstimator &bias_est = _baro_b_est;
 
+	if (_params.ekf2_baro_ctrl == 0) {
+		stopBaroHgtFusion();
+		return;
+	}
+
 	bias_est.predict(_dt_ekf_avg);
 
 	baroSample baro_sample;

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1040,12 +1040,11 @@ void EKF2::PublishBaroBias(const hrt_abstime &timestamp)
 	if (_ekf.aid_src_baro_hgt().timestamp_sample != 0) {
 		const BiasEstimator::status &status = _ekf.getBaroBiasEstimatorStatus();
 
-		if (fabsf(status.bias - _last_baro_bias_published) > 0.001f || !_baro_bias_published) {
+		if (fabsf(status.bias - _last_baro_bias_published) > 1e-6f) {
 			_estimator_baro_bias_pub.publish(fillEstimatorBiasMsg(status, _ekf.aid_src_baro_hgt().timestamp_sample, timestamp,
 							 _device_id_baro));
 
 			_last_baro_bias_published = status.bias;
-			_baro_bias_published = true;
 		}
 	}
 }
@@ -1057,11 +1056,10 @@ void EKF2::PublishGnssHgtBias(const hrt_abstime &timestamp)
 	if (_ekf.get_gps_sample_delayed().time_us != 0) {
 		const BiasEstimator::status &status = _ekf.getGpsHgtBiasEstimatorStatus();
 
-		if (fabsf(status.bias - _last_gnss_hgt_bias_published) > 0.001f || !_gnss_hgt_bias_published) {
+		if (fabsf(status.bias - _last_gnss_hgt_bias_published) > 1e-6f) {
 			_estimator_gnss_hgt_bias_pub.publish(fillEstimatorBiasMsg(status, _ekf.get_gps_sample_delayed().time_us, timestamp));
 
 			_last_gnss_hgt_bias_published = status.bias;
-			_gnss_hgt_bias_published = true;
 		}
 	}
 }

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1040,11 +1040,12 @@ void EKF2::PublishBaroBias(const hrt_abstime &timestamp)
 	if (_ekf.aid_src_baro_hgt().timestamp_sample != 0) {
 		const BiasEstimator::status &status = _ekf.getBaroBiasEstimatorStatus();
 
-		if (fabsf(status.bias - _last_baro_bias_published) > 0.001f) {
+		if (fabsf(status.bias - _last_baro_bias_published) > 0.001f || !_baro_bias_published) {
 			_estimator_baro_bias_pub.publish(fillEstimatorBiasMsg(status, _ekf.aid_src_baro_hgt().timestamp_sample, timestamp,
 							 _device_id_baro));
 
 			_last_baro_bias_published = status.bias;
+			_baro_bias_published = true;
 		}
 	}
 }
@@ -1056,10 +1057,11 @@ void EKF2::PublishGnssHgtBias(const hrt_abstime &timestamp)
 	if (_ekf.get_gps_sample_delayed().time_us != 0) {
 		const BiasEstimator::status &status = _ekf.getGpsHgtBiasEstimatorStatus();
 
-		if (fabsf(status.bias - _last_gnss_hgt_bias_published) > 0.001f) {
+		if (fabsf(status.bias - _last_gnss_hgt_bias_published) > 0.001f || !_gnss_hgt_bias_published) {
 			_estimator_gnss_hgt_bias_pub.publish(fillEstimatorBiasMsg(status, _ekf.get_gps_sample_delayed().time_us, timestamp));
 
 			_last_gnss_hgt_bias_published = status.bias;
+			_gnss_hgt_bias_published = true;
 		}
 	}
 }

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -354,7 +354,6 @@ private:
 	hrt_abstime _status_baro_hgt_pub_last{0};
 
 	float _last_baro_bias_published{};
-	bool _baro_bias_published{};
 
 	uORB::Subscription _airdata_sub{ORB_ID(vehicle_air_data)};
 
@@ -458,7 +457,6 @@ private:
 	hrt_abstime _status_gnss_vel_pub_last{0};
 
 	float _last_gnss_hgt_bias_published{};
-	bool _gnss_hgt_bias_published{};
 
 	uORB::Subscription _vehicle_gps_position_sub{ORB_ID(vehicle_gps_position)};
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -354,6 +354,7 @@ private:
 	hrt_abstime _status_baro_hgt_pub_last{0};
 
 	float _last_baro_bias_published{};
+	bool _baro_bias_published{};
 
 	uORB::Subscription _airdata_sub{ORB_ID(vehicle_air_data)};
 
@@ -457,6 +458,7 @@ private:
 	hrt_abstime _status_gnss_vel_pub_last{0};
 
 	float _last_gnss_hgt_bias_published{};
+	bool _gnss_hgt_bias_published{};
 
 	uORB::Subscription _vehicle_gps_position_sub{ORB_ID(vehicle_gps_position)};
 


### PR DESCRIPTION
This helps with plotting in plot juggler. I have a custom function which relies on the baro bias topic. If the topic is not present in the log the plot breaks.