### PR TITLE
Basic implementation of extended DSHOT telemetry.

### DIFF
--- a/platforms/nuttx/src/px4/nxp/imxrt/dshot/dshot.c
+++ b/platforms/nuttx/src/px4/nxp/imxrt/dshot/dshot.c
@@ -569,3 +569,8 @@ int up_dshot_arm(bool armed)
 {
 	return io_timer_set_enable(armed, IOTimerChanMode_Dshot, IO_TIMER_ALL_MODES_CHANNELS);
 }
+
+int up_bdshot_get_extended_telemetry(uint8_t channel, dshot_telemetry_field_t key, int32_t *value)
+{
+	return PX4_ERROR; // Not supported in this implementation
+}

--- a/src/drivers/drv_dshot.h
+++ b/src/drivers/drv_dshot.h
@@ -62,6 +62,8 @@ typedef enum {
 	DShot_cmd_3d_mode_on,
 	DShot_cmd_settings_request, // Currently not implemented
 	DShot_cmd_save_settings,
+	DShot_cmd_dshot_extended_telemetry_on = 13, // AM32 only
+	DShot_cmd_dshot_extended_telemetry_off = 14, // AM32 only
 	DShot_cmd_spin_direction_normal   = 20,
 	DShot_cmd_spin_direction_reversed = 21,
 	DShot_cmd_led0_on,      // BLHeli32 only
@@ -81,6 +83,28 @@ typedef enum {
 	DShot_cmd_MAX_throttle = 2047
 } dshot_command_t;
 
+
+typedef enum {
+	DShot_telemetry_ext_key_none = 0x0000, // Not extended telemetry, so it is a regular ERPM value
+	DShot_telemetry_ext_key_temperature = 0x0200, // Temperature in degrees Celsius
+	DShot_telemetry_ext_key_battery_voltage = 0x0400, // Battery voltage in 0.25V steps
+	DShot_telemetry_ext_key_current = 0x0600, // Current in 0.5A steps
+	DShot_telemetry_ext_key_debug_1 = 0x0800, // Debug value 1
+	DShot_telemetry_ext_key_debug_2 = 0x0A00, // Debug value 2
+	DShot_telemetry_ext_key_debug_3 = 0x0C00, // Debug value 3
+	DShot_telemetry_ext_key_evt = 0x0E00, // Event value
+} dshot_extended_telemetry_key_t;
+
+typedef enum {
+	DShot_telemetry_field_erpm = 0, // No extended telemetry
+	DShot_telemetry_field_temperature, // Temperature in degrees Celsius
+	DShot_telemetry_field_battery_voltage, // Battery voltage in 0.25V steps
+	DShot_telemetry_field_current, // Current in 0.5A steps
+	DShot_telemetry_field_debug_1, // Debug value 1
+	DShot_telemetry_field_debug_2, // Debug value 2
+	DShot_telemetry_field_debug_3, // Debug value 3
+	DShot_telemetry_field_evt, // Event value
+} dshot_telemetry_field_t;
 
 /**
  * Intialise the Dshot outputs using the specified configuration.
@@ -170,6 +194,16 @@ __EXPORT extern int up_bdshot_get_erpm(uint8_t channel, int *erpm);
  * @return <0 on error / not supported, 0 on offline, 1 on online
  */
 __EXPORT extern int up_bdshot_channel_status(uint8_t channel);
+
+
+/**
+ * Get the current bidirectional dshot telemetry data for a channel.
+ * @param channel	Dshot channel
+ * @param key		Extended telemetry key to get the value for.
+ * @param value		Pointer to write the value to.
+ * @return <0 on error, OK on success
+ */
+__EXPORT extern int up_bdshot_get_extended_telemetry(uint8_t channel, dshot_telemetry_field_t field, int32_t *value);
 
 
 __END_DECLS

--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -326,6 +326,37 @@ int DShot::handle_new_bdshot_erpm(void)
 				esc_status.esc[telemetry_index].actuator_function = _actuator_functions[telemetry_index];
 			}
 
+
+			int32_t value = 0;
+			if(up_bdshot_get_extended_telemetry(i, DShot_telemetry_field_temperature, &value) == PX4_OK) {
+				esc_status.esc[telemetry_index].esc_temperature = static_cast<float>(value); // temperature is in Celsius
+			}
+			else
+			{
+				esc_status.esc[telemetry_index].esc_temperature = NAN; // No telemetry data available
+			}
+			value = 0;
+			if(up_bdshot_get_extended_telemetry(i, DShot_telemetry_field_battery_voltage, &value) == PX4_OK) {
+				esc_status.esc[telemetry_index].esc_voltage = static_cast<float>(value) * 0.25f; // voltage is 0.25V per unit
+			}
+			else
+			{
+				esc_status.esc[telemetry_index].esc_voltage = NAN; // No telemetry data available
+			}
+			value = 0;
+			if(up_bdshot_get_extended_telemetry(i, DShot_telemetry_field_current, &value) == PX4_OK) {
+				esc_status.esc[telemetry_index].esc_current = static_cast<float>(value) * 0.5f; // current is 0.5A per unit
+			}
+			else
+			{
+				esc_status.esc[telemetry_index].esc_current = NAN; // No telemetry data available
+			}
+
+			// esc_status.esc[telemetry_index].esc_current = 0.5; // These values show up exactly like this in QGroundControl, so it works
+			// esc_status.esc[telemetry_index].esc_voltage = 0.25; // These values show up exactly like this in QGroundControl, so it works
+
+			// No support for debug_1, debug_2, debug_3, evt telemetry keys yet
+
 			++telemetry_index;
 		}
 	}
@@ -694,6 +725,8 @@ int DShot::custom_command(int argc, char *argv[])
 		{"beep3", DShot_cmd_beacon3, 1},
 		{"beep4", DShot_cmd_beacon4, 1},
 		{"beep5", DShot_cmd_beacon5, 1},
+		{"dse_on", DShot_cmd_dshot_extended_telemetry_on, 10},
+		{"dse_off", DShot_cmd_dshot_extended_telemetry_off, 10}
 	};
 
 	for (unsigned i = 0; i < sizeof(commands) / sizeof(commands[0]); ++i) {
@@ -796,6 +829,10 @@ After saving, the reversed direction will be regarded as the normal one. So to r
 	PRINT_MODULE_USAGE_COMMAND_DESCR("beep4", "Send Beep pattern 4");
 	PRINT_MODULE_USAGE_PARAM_INT('m', -1, 0, 16, "Motor index (1-based, default=all)", true);
 	PRINT_MODULE_USAGE_COMMAND_DESCR("beep5", "Send Beep pattern 5");
+	PRINT_MODULE_USAGE_PARAM_INT('m', -1, 0, 16, "Motor index (1-based, default=all)", true);
+	PRINT_MODULE_USAGE_COMMAND_DESCR("dse_on", "Enable DShot Extended Telemetry (AM32 only)");
+	PRINT_MODULE_USAGE_PARAM_INT('m', -1, 0, 16, "Motor index (1-based, default=all)", true);
+	PRINT_MODULE_USAGE_COMMAND_DESCR("dse_off", "Disable DShot Extended Telemetry (AM32 only)");
 	PRINT_MODULE_USAGE_PARAM_INT('m', -1, 0, 16, "Motor index (1-based, default=all)", true);
 
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();


### PR DESCRIPTION
Added DSHOT commands 13 and 14 to the dshot CLI to enable and disable extended dshot telemetry on AM32 ESCs.

Added support for extended telemetry packets that transport values other than eRPM in bidirectional mode:
- ESC temperature
- battery voltage measured by ESC
- current measured by ESC
- debug fields 1, 2, 3
- event field.

Added code to publish the received values to ESC_INFO and ESC_STATUS in DShot::handle_new_bdshot_erpm().

The implementation uses the definitions from:
https://brushlesswhoop.com/dshot-and-bidirectional-dshot/#extended-dshot-telemetry-edt

In the AM32 firmware, these alternate messages are sent once per second, cycling through a few different fields. In the current 2.19 version of AM32, the fields ESC temperature, battery voltage, and current can be enabled in the EEPROM and then activated through DSHOT command 13.
Then the ESC sends one value per second, meaning that each value is received after three seconds.

With this update, PX4 can receive these parameters through the same DSHOT cable that is used to send motor commands and receive eRPM measurements without need for another UART cable.

### Test coverage
- I uploaded a log of a short test: https://review.px4.io/plot_app?log=d7800a68-10cd-4c61-bcb3-a3cf612aa93a
