### PR TITLE
airspeed calibration: save offset only when full procedure succeed

### DIFF
--- a/src/modules/commander/airspeed_calibration.cpp
+++ b/src/modules/commander/airspeed_calibration.cpp
@@ -178,10 +178,7 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 						return PX4_ERROR;
 					}
 
-					/* save */
 					calibration_log_info(mavlink_log_pub, CAL_QGC_PROGRESS_MSG, 0);
-					param_save_default(true);
-
 					feedback_calibration_failed(mavlink_log_pub);
 					return PX4_ERROR;
 				}
@@ -209,8 +206,6 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 			}
 
 			calibration_log_info(mavlink_log_pub, CAL_QGC_PROGRESS_MSG, 0);
-			param_save_default(true);
-
 			feedback_calibration_failed(mavlink_log_pub);
 			return PX4_ERROR;
 		}
@@ -227,8 +222,6 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 		}
 
 		calibration_log_info(mavlink_log_pub, CAL_QGC_PROGRESS_MSG, 0);
-		param_save_default(true);
-
 		feedback_calibration_failed(mavlink_log_pub);
 		return PX4_ERROR;
 	}

--- a/src/modules/commander/airspeed_calibration.cpp
+++ b/src/modules/commander/airspeed_calibration.cpp
@@ -113,7 +113,29 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 
 	diff_pres_offset = diff_pres_offset / calibration_count;
 
+	if (PX4_ISFINITE(diff_pres_offset)) {
+		// Prevent a completely zero param
+		// since this is used to detect a missing calibration
+		// This value is numerically down in the noise and has
+		// no effect on the sensor performance.
+		if (fabsf(diff_pres_offset) < 0.00000001f) {
+			diff_pres_offset = 0.00000001f;
+		}
+
+		if (param_set(param_find("SENS_DPRES_OFF"), &diff_pres_offset)) {
+			calibration_log_critical(mavlink_log_pub, CAL_ERROR_SET_PARAMS_MSG);
+			return PX4_ERROR;
+		}
+
+	} else {
+		feedback_calibration_failed(mavlink_log_pub);
+		return PX4_ERROR;
+	}
+
 	calibration_log_info(mavlink_log_pub, "[cal] Offset of %d Pascal", (int)diff_pres_offset);
+
+	/* wait 500 ms to ensure parameter propagated through the system */
+	px4_usleep(500 * 1000);
 
 	calibration_log_critical(mavlink_log_pub, "[cal] Blow into front of pitot without touching");
 
@@ -148,7 +170,17 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 								 (int)differential_pressure_pa);
 					calibration_log_critical(mavlink_log_pub, "[cal] Swap static and dynamic ports or set SENS_DPRES_REV");
 
+					/* the user setup is wrong, wipe the calibration to force a proper re-calibration */
+					diff_pres_offset = 0.0f;
+
+					if (param_set(param_find("SENS_DPRES_OFF"), &(diff_pres_offset))) {
+						calibration_log_critical(mavlink_log_pub, CAL_ERROR_SET_PARAMS_MSG);
+						return PX4_ERROR;
+					}
+
+					/* save */
 					calibration_log_info(mavlink_log_pub, CAL_QGC_PROGRESS_MSG, 0);
+					param_save_default(true);
 
 					feedback_calibration_failed(mavlink_log_pub);
 					return PX4_ERROR;
@@ -169,6 +201,16 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 		}
 
 		if (hrt_elapsed_time(&calibration_started) > 90_s) {
+			diff_pres_offset = 0.0f;
+
+			if (param_set(param_find("SENS_DPRES_OFF"), &(diff_pres_offset))) {
+				calibration_log_critical(mavlink_log_pub, CAL_ERROR_SET_PARAMS_MSG);
+				return PX4_ERROR;
+			}
+
+			calibration_log_info(mavlink_log_pub, CAL_QGC_PROGRESS_MSG, 0);
+			param_save_default(true);
+
 			feedback_calibration_failed(mavlink_log_pub);
 			return PX4_ERROR;
 		}
@@ -177,25 +219,16 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 	}
 
 	if (calibration_counter == maxcount) {
-		feedback_calibration_failed(mavlink_log_pub);
-		return PX4_ERROR;
-	}
+		diff_pres_offset = 0.0f;
 
-	if (PX4_ISFINITE(diff_pres_offset)) {
-		// Prevent a completely zero param
-		// since this is used to detect a missing calibration
-		// This value is numerically down in the noise and has
-		// no effect on the sensor performance.
-		if (fabsf(diff_pres_offset) < 0.00000001f) {
-			diff_pres_offset = 0.00000001f;
-		}
-
-		if (param_set(param_find("SENS_DPRES_OFF"), &diff_pres_offset)) {
+		if (param_set(param_find("SENS_DPRES_OFF"), &(diff_pres_offset))) {
 			calibration_log_critical(mavlink_log_pub, CAL_ERROR_SET_PARAMS_MSG);
 			return PX4_ERROR;
 		}
 
-	} else {
+		calibration_log_info(mavlink_log_pub, CAL_QGC_PROGRESS_MSG, 0);
+		param_save_default(true);
+
 		feedback_calibration_failed(mavlink_log_pub);
 		return PX4_ERROR;
 	}


### PR DESCRIPTION
### Solved Problem
From the user's perspective, the sensor status indicator turns green even when calibration fails, creating confusion about whether the calibration was successful.

What happens: We [write the determined value](https://github.com/PX4/PX4-Autopilot/blob/f161a32c55b5a979a02100433eb7339749dc6a77/src/modules/commander/airspeed_calibration.cpp#L125) of differental pressure offset to [SENS_DPRES_OFF](https://docs.px4.io/main/en/advanced_config/parameter_reference.html#SENS_DPRES_OFF) before [the sensor reverse connection check](https://github.com/PX4/PX4-Autopilot/blob/f161a32c55b5a979a02100433eb7339749dc6a77/src/modules/commander/airspeed_calibration.cpp#L147) passes and don't wipe it out even when no positive pressure was read
My suggestion: is to make sure that we pass all the checks before we write the value or just wipe the value of SENS_DPRES_OFF if no positive pressure was read


### Solution
Write the value to the parameter only if the sensor check passes. 

### Changelog Entry
Moved param write after the sensor reverse connection check section.

### Alternatives
We could also eliminate the sensor connection check step, as it's unnecessary to perform it every time we calibrate the airspeed.