### PR TITLE
Differential: add parameter to adjust stick response for yaw control

### DIFF
--- a/src/lib/rover_control/rovercontrol_params.c
+++ b/src/lib/rover_control/rovercontrol_params.c
@@ -51,6 +51,19 @@
 PARAM_DEFINE_FLOAT(RO_YAW_STICK_DZ, 0.1f);
 
 /**
+ * Yaw stick gain in Manual mode
+ *
+ * Assign value <1.0 to decrease stick response for yaw control.
+ *
+ * @min 0
+ * @max 1
+ * @increment 0.01
+ * @decimal 2
+ * @group Rover Rate Control
+ */
+PARAM_DEFINE_FLOAT(RO_YAW_STIK_GAIN, 1.0f);
+
+/**
  * Yaw rate measurement threshold
  *
  * The minimum threshold for the yaw rate measurement not to be interpreted as zero.

--- a/src/modules/rover_differential/DifferentialDriveModes/DifferentialManualMode/DifferentialManualMode.cpp
+++ b/src/modules/rover_differential/DifferentialDriveModes/DifferentialManualMode/DifferentialManualMode.cpp
@@ -58,7 +58,7 @@ void DifferentialManualMode::manual()
 	_manual_control_setpoint_sub.copy(&manual_control_setpoint);
 	rover_steering_setpoint_s rover_steering_setpoint{};
 	rover_steering_setpoint.timestamp = hrt_absolute_time();
-	rover_steering_setpoint.normalized_steering_setpoint = manual_control_setpoint.roll;
+	rover_steering_setpoint.normalized_steering_setpoint = manual_control_setpoint.roll * _param_ro_yaw_stick_gain.get();
 	_rover_steering_setpoint_pub.publish(rover_steering_setpoint);
 	rover_throttle_setpoint_s rover_throttle_setpoint{};
 	rover_throttle_setpoint.timestamp = hrt_absolute_time();

--- a/src/modules/rover_differential/DifferentialDriveModes/DifferentialManualMode/DifferentialManualMode.hpp
+++ b/src/modules/rover_differential/DifferentialDriveModes/DifferentialManualMode/DifferentialManualMode.hpp
@@ -124,6 +124,7 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::RO_YAW_RATE_LIM>)  _param_ro_yaw_rate_limit,
 		(ParamFloat<px4::params::RO_YAW_STICK_DZ>)  _param_ro_yaw_stick_dz,
+		(ParamFloat<px4::params::RO_YAW_STIK_GAIN>)  _param_ro_yaw_stick_gain,
 		(ParamFloat<px4::params::PP_LOOKAHD_MAX>)   _param_pp_lookahd_max,
 		(ParamFloat<px4::params::RO_SPEED_LIM>)     _param_ro_speed_limit
 	)


### PR DESCRIPTION
### Solved Problem
In Manual mode *yaw stick* response can be uncomfortably sensitive.
This is especially noticeable on large heavy vehicles, and might be dangerous.

### Solution
Add a parameter `RO_YAW_STIK_GAIN` (next to `RO_YAW_STICK_DZ`) and code to `multiply manual_control_setpoint.roll` to its value.

**Note:** the "STIK" part is due to the parameters length limit; suggestions welcome.

### Changelog Entry
For release notes:
```
Feature: new parameter to adjust stick response for yaw control in Manual mode
New parameter: RO_YAW_STIK_GAIN
Documentation: ...
```
