### PR TITLE
FailureDetector: increase threshold for valid current to 1A

### DIFF
--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -394,7 +394,9 @@ void FailureDetector::updateMotorStatus(const vehicle_status_s &vehicle_status, 
 			}
 
 			// Check if ESC telemetry was available and valid at some point. This is a prerequisite for the failure detection.
-			if (!(_motor_failure_esc_valid_current_mask & (1 << i_esc)) && cur_esc_report.esc_current > 0.0f) {
+			static constexpr float kMinExpectedCurrent = 1.f; // we consider the current measurement valid if ever above this value
+
+			if (!(_motor_failure_esc_valid_current_mask & (1 << i_esc)) && cur_esc_report.esc_current > kMinExpectedCurrent) {
 				_motor_failure_esc_valid_current_mask |= (1 << i_esc);
 			}
 


### PR DESCRIPTION
### Solved Problem
We have false positive motor failure detection due to wrong, tiny current measurement. 
<img width="1389" height="495" alt="image" src="https://github.com/user-attachments/assets/f2f6c986-505e-4d46-86d9-e89d33e692a6" />

### Solution
Not declare the current measurement valid if never above 1A

### Changelog Entry
For release notes:
```
Improvement: Reduce chance of false-positive motor failure detection by discarding any current measurement below 1A
```

### Alternatives
The 1A threshold is very arbitrary, can be changed. We're also investigating the ESC side, where the wrong measurement comes from.

### Test coverage
Untested

