### PR TITLE
Fix workflow vulnerabilities in flaw checker and comments

### DIFF
--- a/.github/workflows/docs_flaw_checker.yml
+++ b/.github/workflows/docs_flaw_checker.yml
@@ -42,14 +42,23 @@ jobs:
 
       - name: Save JSON file containing files to link check
         run: |
-          echo "${{ steps.get_changed_markdown_english.outputs.all_changed_files }}"
-          echo "${{ steps.get_changed_markdown_english.outputs.all_changed_files }}" > ./logs/prFiles.json
+          echo "$ALL_CHANGED_FILES"
+          echo "$ALL_CHANGED_FILES" > ./logs/prFiles.json
+        env:
+          ALL_CHANGED_FILES: ${{ steps.get_changed_markdown_english.outputs.all_changed_files }}
 
       - name: Run link checker
         id: link-check
         run: |
           npm -g install markdown_link_checker_sc@0.0.138
-          markdown_link_checker_sc -r ${{ github.workspace }} -d docs -e en -f ./logs/prFiles.json -i assets -u docs.px4.io/main/ > ./logs/errorsFilteredByPrPages.md
+          markdown_link_checker_sc \
+            -r "$GITHUB_WORKSPACE" \
+            -d docs \
+            -e en \
+            -f ./logs/prFiles.json \
+            -i assets \
+            -u docs.px4.io/main/ \
+            > ./logs/errorsFilteredByPrPages.md
           mkdir -p ./pr
           cp ./logs/errorsFilteredByPrPages.md ./pr/errorsFilteredByPrPages.md
 
@@ -60,14 +69,15 @@ jobs:
           path: ./logs/errorsFilteredByPrPages.md
 
       - name: Echo Errors by Page
-        run: echo "${{ steps.read-errors-by-page.outputs.content }}"
+        run: echo "$ERRORS"
+        env:
+          ERRORS: ${{ steps.read-errors-by-page.outputs.content }}
 
       - name: Save PR number
+        run: echo "$PR_NUMBER" > ./pr/pr_number
         env:
           PR_NUMBER: ${{ github.event.number }}
-        run: |
-          #mkdir -p ./pr
-          echo $PR_NUMBER > ./pr/pr_number
+
       - uses: actions/upload-artifact@v4
         with:
           name: pr_number

--- a/.github/workflows/docs_pr_comment.yml
+++ b/.github/workflows/docs_pr_comment.yml
@@ -4,6 +4,7 @@ on:
     workflows: ["Docs - Check for flaws in PX4 Guide Source"]
     types:
       - completed
+
 jobs:
   comment:
     permissions:
@@ -56,8 +57,11 @@ jobs:
 
       - name: File detail info
         run: |
-          echo "${{ steps.read-errors-by-page.outputs.content }}"
-          echo "${{ steps.read-error-pr-number.outputs.content }}"
+          echo "$ERRORS"
+          echo "$PRNUM"
+        env:
+          ERRORS: ${{ steps.read-errors-by-page.outputs.content }}
+          PRNUM: ${{ steps.read-error-pr-number.outputs.content }}
 
       - name: Create or update comment
         id: comment_to_pr


### PR DESCRIPTION
The linked items below explain the problem - the workflows use echo to display untrusted content that might contain code that could be expanded to execute. The solution assigns the content to a variable before echoing. The variable is not expanded/executed, so this should be safe

Addresses
- https://github.com/PX4/PX4-Autopilot/security/advisories/GHSA-mq93-4g5w-w34h
- https://github.com/PX4/PX4-Autopilot/security/advisories/GHSA-rfc7-3pxc-c68p