### PR TITLE
Fix up uorb message spacing to add whitespace

### DIFF
--- a/msg/ActionRequest.msg
+++ b/msg/ActionRequest.msg
@@ -4,23 +4,23 @@
 # It allows mapping triggers from various external interfaces like RC channels or MAVLink to cause an action.
 # Request are published by `manual_control` and subscribed by the `commander` and `vtol_att_control` modules.
 
-uint64 timestamp # [us] Time since system start
+uint64 timestamp  # [us] Time since system start
 
-uint8 action # [@enum ACTION] Requested action
-uint8 ACTION_DISARM = 0 # Disarm vehicle
-uint8 ACTION_ARM = 1 # Arm vehicle
-uint8 ACTION_TOGGLE_ARMING = 2 # Toggle arming
-uint8 ACTION_UNKILL = 3 # Revert a kill action
-uint8 ACTION_KILL = 4 # Kill vehicle (instantly stop the motors)
-uint8 ACTION_SWITCH_MODE = 5 # Switch mode. The target mode is set in the `mode` field.
-uint8 ACTION_VTOL_TRANSITION_TO_MULTICOPTER = 6 # Transition to hover flight
-uint8 ACTION_VTOL_TRANSITION_TO_FIXEDWING = 7 # Transition to fast forward flight
-uint8 ACTION_TERMINATION = 8 # Irreversably output failsafe values on all outputs, trigger parachute
+uint8 action                                     # [@enum ACTION] Requested action
+uint8 ACTION_DISARM = 0                          # Disarm vehicle
+uint8 ACTION_ARM = 1                             # Arm vehicle
+uint8 ACTION_TOGGLE_ARMING = 2                   # Toggle arming
+uint8 ACTION_UNKILL = 3                          # Revert a kill action
+uint8 ACTION_KILL = 4                            # Kill vehicle (instantly stop the motors)
+uint8 ACTION_SWITCH_MODE = 5                     # Switch mode. The target mode is set in the `mode` field.
+uint8 ACTION_VTOL_TRANSITION_TO_MULTICOPTER = 6  # Transition to hover flight
+uint8 ACTION_VTOL_TRANSITION_TO_FIXEDWING = 7    # Transition to fast forward flight
+uint8 ACTION_TERMINATION = 8                     # Irreversibly output failsafe values on all outputs, trigger parachute
 
-uint8 source # [@enum SOURCE] Request trigger type, such as a switch, button or gesture
-uint8 SOURCE_STICK_GESTURE = 0 # Triggered by holding the sticks in a certain position
-uint8 SOURCE_RC_SWITCH = 1 # Triggered by an RC switch moving into a certain position
-uint8 SOURCE_RC_BUTTON = 2 # Triggered by a momentary button on the RC being pressed or held
-uint8 SOURCE_RC_MODE_SLOT = 3 # Mode change through the RC mode selection mechanism
+uint8 source                    # [@enum SOURCE] Request trigger type, such as a switch, button or gesture
+uint8 SOURCE_STICK_GESTURE = 0  # Triggered by holding the sticks in a certain position
+uint8 SOURCE_RC_SWITCH = 1      # Triggered by an RC switch moving into a certain position
+uint8 SOURCE_RC_BUTTON = 2      # Triggered by a momentary button on the RC being pressed or held
+uint8 SOURCE_RC_MODE_SLOT = 3   # Mode change through the RC mode selection mechanism
 
-uint8 mode # Requested mode. Only applies when `action` is `ACTION_SWITCH_MODE`. Values for this field are defined by the `vehicle_status_s::NAVIGATION_STATE_*` enumeration.
+uint8 mode  # Requested mode. Only applies when `action` is `ACTION_SWITCH_MODE`. Values for this field are defined by the `vehicle_status_s::NAVIGATION_STATE_*` enumeration.

--- a/msg/Airspeed.msg
+++ b/msg/Airspeed.msg
@@ -3,8 +3,8 @@
 # This is published by airspeed sensor drivers, CAN airspeed sensors, simulators.
 # It is subscribed by the airspeed selector module, which validates the data from multiple sensors and passes on a single estimation to the EKF, controllers and telemetry providers.
 
-uint64 timestamp # [us] Time since system start
-uint64 timestamp_sample # [us] Timestamp of the raw data
-float32 indicated_airspeed_m_s # [m/s] Indicated airspeed
-float32 true_airspeed_m_s # [m/s] True airspeed
-float32 confidence # [@range 0,1] Confidence value for this sensor
+uint64 timestamp                 # [us] Time since system start
+uint64 timestamp_sample          # [us] Timestamp of the raw data
+float32 indicated_airspeed_m_s   # [m/s] Indicated airspeed
+float32 true_airspeed_m_s        # [m/s] True airspeed
+float32 confidence               # [@range 0,1] Confidence value for this sensor

--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -2,37 +2,37 @@
 #
 # This is currently used only for logging cell status from MAVLink.
 
-uint64 timestamp # [us] Time since system start
+uint64 timestamp  # [us] Time since system start
 
-uint16 status # [@enum STATUS_FLAG] Status bitmap
-uint16 STATUS_FLAG_UNKNOWN = 1 # State unknown or not reportable
-uint16 STATUS_FLAG_FAILED = 2 # Modem is unusable
-uint16 STATUS_FLAG_INITIALIZING = 4 # Modem is being initialized
-uint16 STATUS_FLAG_LOCKED = 8 # Modem is locked
-uint16 STATUS_FLAG_DISABLED = 16 # Modem is not enabled and is powered down
-uint16 STATUS_FLAG_DISABLING = 32 # Modem is currently transitioning to the STATUS_FLAG_DISABLED state
-uint16 STATUS_FLAG_ENABLING = 64 # Modem is currently transitioning to the STATUS_FLAG_ENABLED state
-uint16 STATUS_FLAG_ENABLED = 128 # Modem is enabled and powered on but not registered with a network provider and not available for data connections
-uint16 STATUS_FLAG_SEARCHING = 256 # Modem is searching for a network provider to register
-uint16 STATUS_FLAG_REGISTERED = 512 # Modem is registered with a network provider, and data connections and messaging may be available for use
-uint16 STATUS_FLAG_DISCONNECTING = 1024 # Modem is disconnecting and deactivating the last active packet data bearer. This state will not be entered if more than one packet data bearer is active and one of the active bearers is deactivated
-uint16 STATUS_FLAG_CONNECTING = 2048 # Modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered
-uint16 STATUS_FLAG_CONNECTED = 4096 # One or more packet data bearers is active and connected
+uint16 status                            # [@enum STATUS_FLAG] Status bitmap
+uint16 STATUS_FLAG_UNKNOWN = 1           # State unknown or not reportable
+uint16 STATUS_FLAG_FAILED = 2            # Modem is unusable
+uint16 STATUS_FLAG_INITIALIZING = 4      # Modem is being initialized
+uint16 STATUS_FLAG_LOCKED = 8            # Modem is locked
+uint16 STATUS_FLAG_DISABLED = 16         # Modem is not enabled and is powered down
+uint16 STATUS_FLAG_DISABLING = 32        # Modem is currently transitioning to the STATUS_FLAG_DISABLED state
+uint16 STATUS_FLAG_ENABLING = 64         # Modem is currently transitioning to the STATUS_FLAG_ENABLED state
+uint16 STATUS_FLAG_ENABLED = 128         # Modem is enabled and powered on but not registered with a network provider and not available for data connections
+uint16 STATUS_FLAG_SEARCHING = 256       # Modem is searching for a network provider to register
+uint16 STATUS_FLAG_REGISTERED = 512      # Modem is registered with a network provider, and data connections and messaging may be available for use
+uint16 STATUS_FLAG_DISCONNECTING = 1024  # Modem is disconnecting and deactivating the last active packet data bearer. This state will not be entered if more than one packet data bearer is active and one of the active bearers is deactivated
+uint16 STATUS_FLAG_CONNECTING = 2048     # Modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered
+uint16 STATUS_FLAG_CONNECTED = 4096      # One or more packet data bearers is active and connected
 
-uint8 failure_reason # [@enum FAILURE_REASON] Failure reason
-uint8 FAILURE_REASON_NONE = 0 # No error
-uint8 FAILURE_REASON_UNKNOWN = 1 # Error state is unknown
-uint8 FAILURE_REASON_SIM_MISSING = 2 # SIM is required for the modem but missing
-uint8 FAILURE_REASON_SIM_ERROR = 3 # SIM is available, but not usable for connection
+uint8 failure_reason                  # [@enum FAILURE_REASON] Failure reason
+uint8 FAILURE_REASON_NONE = 0         # No error
+uint8 FAILURE_REASON_UNKNOWN = 1      # Error state is unknown
+uint8 FAILURE_REASON_SIM_MISSING = 2  # SIM is required for the modem but missing
+uint8 FAILURE_REASON_SIM_ERROR = 3    # SIM is available, but not usable for connection
 
-uint8 type # [@enum CELLULAR_NETWORK_RADIO_TYPE] Cellular network radio type
-uint8 CELLULAR_NETWORK_RADIO_TYPE_NONE = 0 # None
-uint8 CELLULAR_NETWORK_RADIO_TYPE_GSM = 1 # GSM
-uint8 CELLULAR_NETWORK_RADIO_TYPE_CDMA = 2 # CDMA
-uint8 CELLULAR_NETWORK_RADIO_TYPE_WCDMA = 3 # WCDMA
-uint8 CELLULAR_NETWORK_RADIO_TYPE_LTE = 4 # LTE
+uint8 type                                   # [@enum CELLULAR_NETWORK_RADIO_TYPE] Cellular network radio type
+uint8 CELLULAR_NETWORK_RADIO_TYPE_NONE = 0   # None
+uint8 CELLULAR_NETWORK_RADIO_TYPE_GSM = 1    # GSM
+uint8 CELLULAR_NETWORK_RADIO_TYPE_CDMA = 2   # CDMA
+uint8 CELLULAR_NETWORK_RADIO_TYPE_WCDMA = 3  # WCDMA
+uint8 CELLULAR_NETWORK_RADIO_TYPE_LTE = 4    # LTE
 
-uint8 quality # [dBm] Cellular network RSSI/RSRP, absolute value
-uint16 mcc # [@invalid UINT16_MAX] Mobile country code
-uint16 mnc # [@invalid UINT16_MAX] Mobile network code
-uint16 lac # [@invalid 0] Location area code
+uint8 quality  # [dBm] Cellular network RSSI/RSRP, absolute value
+uint16 mcc     # [@invalid UINT16_MAX] Mobile country code
+uint16 mnc     # [@invalid UINT16_MAX] Mobile network code
+uint16 lac     # [@invalid 0] Location area code

--- a/msg/versioned/ActuatorMotors.msg
+++ b/msg/versioned/ActuatorMotors.msg
@@ -10,7 +10,7 @@ uint64 timestamp_sample  # [us] Sampling timestamp of the data this control resp
 
 uint16 reversible_flags  # Bitset indicating which motors are configured to be reversible
 
-uint8 ACTUATOR_FUNCTION_MOTOR1  #
+uint8 ACTUATOR_FUNCTION_MOTOR1 = 101 #
 
-uint8 NUM_CONTROLS   # 12
-float32[12] control  # [@range -1, 1] Normalized thrust. where 1 means maximum positive thrust, -1 maximum negative (if not supported by the output, <0 maps to NaN). NaN maps to disarmed (stop the motors)
+uint8 NUM_CONTROLS = 12  #
+float32[12] control                  # [@range -1, 1] Normalized thrust. where 1 means maximum positive thrust, -1 maximum negative (if not supported by the output, <0 maps to NaN). NaN maps to disarmed (stop the motors)

--- a/msg/versioned/ActuatorMotors.msg
+++ b/msg/versioned/ActuatorMotors.msg
@@ -5,12 +5,12 @@
 
 uint32 MESSAGE_VERSION = 0
 
-uint64 timestamp # [us] Time since system start
-uint64 timestamp_sample # [us] Sampling timestamp of the data this control response is based on
+uint64 timestamp         # [us] Time since system start
+uint64 timestamp_sample  # [us] Sampling timestamp of the data this control response is based on
 
-uint16 reversible_flags # Bitset indicating which motors are configured to be reversible
+uint16 reversible_flags  # Bitset indicating which motors are configured to be reversible
 
-uint8 ACTUATOR_FUNCTION_MOTOR1 = 101
+uint8 ACTUATOR_FUNCTION_MOTOR1  #
 
-uint8 NUM_CONTROLS = 12
-float32[12] control # [@range -1, 1] Normalized thrust. where 1 means maximum positive thrust, -1 maximum negative (if not supported by the output, <0 maps to NaN). NaN maps to disarmed (stop the motors)
+uint8 NUM_CONTROLS   # 12
+float32[12] control  # [@range -1, 1] Normalized thrust. where 1 means maximum positive thrust, -1 maximum negative (if not supported by the output, <0 maps to NaN). NaN maps to disarmed (stop the motors)

--- a/msg/versioned/ActuatorServos.msg
+++ b/msg/versioned/ActuatorServos.msg
@@ -5,8 +5,8 @@
 
 uint32 MESSAGE_VERSION = 0
 
-uint64 timestamp # [us] Time since system start
-uint64 timestamp_sample # [us] Sampling timestamp of the data this control response is based on
+uint64 timestamp         # [us] Time since system start
+uint64 timestamp_sample  # [us] Sampling timestamp of the data this control response is based on
 
-uint8 NUM_CONTROLS = 8
-float32[8] control # [@range -1, 1] Normalized output. 1 means maximum positive position. -1 maximum negative position (if not supported by the output, <0 maps to NaN). NaN maps to disarmed.
+uint8 NUM_CONTROLS = 8  #
+float32[8] control      # [@range -1, 1] Normalized output. 1 means maximum positive position. -1 maximum negative position (if not supported by the output, <0 maps to NaN). NaN maps to disarmed.

--- a/msg/versioned/ArmingCheckReply.msg
+++ b/msg/versioned/ArmingCheckReply.msg
@@ -7,37 +7,37 @@
 # Note that the external component is identified by its registration_id, which is allocated to the component during registration (arming_check_id in RegisterExtComponentReply).
 # The message is not used by internal/FMU components, as their mode requirements are known at compile time.
 
-uint32 MESSAGE_VERSION = 1
+uint32 MESSAGE_VERSION  = 1
 
 uint64 timestamp # [us] Time since system start.
 
-uint8 request_id # Id of ArmingCheckRequest for which this is a response.
-uint8 registration_id # Id of external component emitting this response.
+uint8 request_id       # Id of ArmingCheckRequest for which this is a response.
+uint8 registration_id  # Id of external component emitting this response.
 
-uint8 HEALTH_COMPONENT_INDEX_NONE = 0 # Index of health component for which this response applies.
+uint8 HEALTH_COMPONENT_INDEX_NONE = 0  # Index of health component for which this response applies.
 
-uint8 health_component_index # [@enum HEALTH_COMPONENT_INDEX]
-bool health_component_is_present # Unused. Intended for use with health events interface (health_component_t in events.json).
-bool health_component_warning # Unused. Intended for use with health events interface (health_component_t in events.json).
-bool health_component_error # Unused. Intended for use with health events interface (health_component_t in events.json).
+uint8 health_component_index      # [@enum HEALTH_COMPONENT_INDEX]
+bool health_component_is_present  # Unused. Intended for use with health events interface (health_component_t in events.json).
+bool health_component_warning     # Unused. Intended for use with health events interface (health_component_t in events.json).
+bool health_component_error       # Unused. Intended for use with health events interface (health_component_t in events.json).
 
-bool can_arm_and_run # True if the component can arm. For navigation mode components, true if the component can arm in the mode or switch to the mode when already armed.
+bool can_arm_and_run  # True if the component can arm. For navigation mode components, true if the component can arm in the mode or switch to the mode when already armed.
 
-uint8 num_events # Number of queued failure messages (Event) in the events field.
+uint8 num_events  # Number of queued failure messages (Event) in the events field.
 
-Event[5] events # Arming failure reasons (Queue of events to report to GCS).
+Event[5] events  # Arming failure reasons (Queue of events to report to GCS).
 
 # Mode requirements
-bool mode_req_angular_velocity # Requires angular velocity estimate (e.g. from gyroscope).
-bool mode_req_attitude # Requires an attitude estimate.
-bool mode_req_local_alt # Requires a local altitude estimate.
-bool mode_req_local_position # Requires a local position estimate.
-bool mode_req_local_position_relaxed # Requires a more relaxed global position estimate.
-bool mode_req_global_position # Requires a global position estimate.
-bool mode_req_global_position_relaxed # Requires a relaxed global position estimate.
-bool mode_req_mission # Requires an uploaded mission.
-bool mode_req_home_position # Requires a home position (such as RTL/Return mode).
-bool mode_req_prevent_arming # Prevent arming (such as in Land mode).
-bool mode_req_manual_control # Requires a manual controller
+bool mode_req_angular_velocity         # Requires angular velocity estimate (e.g. from gyroscope).
+bool mode_req_attitude                 # Requires an attitude estimate.
+bool mode_req_local_alt                # Requires a local altitude estimate.
+bool mode_req_local_position           # Requires a local position estimate.
+bool mode_req_local_position_relaxed   # Requires a more relaxed global position estimate.
+bool mode_req_global_position          # Requires a global position estimate.
+bool mode_req_global_position_relaxed  # Requires a relaxed global position estimate.
+bool mode_req_mission                  # Requires an uploaded mission.
+bool mode_req_home_position            # Requires a home position (such as RTL/Return mode).
+bool mode_req_prevent_arming           # Prevent arming (such as in Land mode).
+bool mode_req_manual_control           # Requires a manual controller
 
-uint8 ORB_QUEUE_LENGTH = 4 #
+uint8 ORB_QUEUE_LENGTH  = 4

--- a/msg/versioned/ArmingCheckRequest.msg
+++ b/msg/versioned/ArmingCheckRequest.msg
@@ -9,6 +9,6 @@
 
 uint32 MESSAGE_VERSION = 0
 
-uint64 timestamp # [us] Time since system start.
+uint64 timestamp  # [us] Time since system start.
 
-uint8 request_id # Id of this request. Allows correlation with associated ArmingCheckReply messages.
+uint8 request_id  # Id of this request. Allows correlation with associated ArmingCheckReply messages.


### PR DESCRIPTION
In https://github.com/PX4/PX4-Autopilot/pull/25228#discussion_r2272259726 we discussed that the alignment of comments should be either 

- longest field/constant in file - add two spaces before comment and then align all other comments.
- longest field/constant in block- add two spaces before comment and then align all other comments in block.

I decided on the second as closest match to what we do.

This fixes up the messages that we had already updated to the standard. Work for you @sfuhrer 


