### PR TITLE
mavlink: add message spacing for AVAILABLE_MODES, for low bandwidth

### DIFF
--- a/src/modules/mavlink/streams/AVAILABLE_MODES.hpp
+++ b/src/modules/mavlink/streams/AVAILABLE_MODES.hpp
@@ -81,7 +81,7 @@ private:
 	uint32_t _last_can_set_nav_states_mask{0};
 
 	void send_single_mode(const vehicle_status_s &vehicle_status, int mode_index, int total_num_modes, uint8_t nav_state,
-			      uint32_t delay_us)
+			      uint32_t delay_us = 0)
 	{
 		if (delay_us > 0) {
 			px4_usleep(delay_us);
@@ -148,7 +148,8 @@ private:
 
 		int total_num_modes = math::countSetBits(vehicle_status.valid_nav_states_mask);
 
-		float mode_transmit_time = (float)sizeof(mavlink_available_modes_t) / _mavlink->get_data_rate();
+		float mode_transmit_time = (float)(MAVLINK_MSG_ID_AVAILABLE_MODES_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES) /
+					   _mavlink->get_data_rate();
 		uint32_t delay_us = (uint32_t)(mode_transmit_time * 1e6f);
 		delay_us = delay_us >= MIN_DELAY_THRESHOLD ? delay_us : 0;
 		delay_us = delay_us > MAX_DELAY_US ? MAX_DELAY_US : delay_us;
@@ -179,7 +180,7 @@ private:
 			}
 
 			if (nav_state < vehicle_status_s::NAVIGATION_STATE_MAX) {
-				send_single_mode(vehicle_status, mode_index, total_num_modes, nav_state, delay_us);
+				send_single_mode(vehicle_status, mode_index, total_num_modes, nav_state);
 			}
 
 			ret = true;


### PR DESCRIPTION
### Solved Problem
PX4 sends all of the available modes at once via mavlink, this can overflow the TX buffer of low bandwidth radios, causing the ground station to not receive most of them.

### Solution
- Add some spacing between the individual messages if the low bandwidth mode is used
- The spacing is calculated for the case of the maximum amount of modes being transmitted, this way it was able to test that it does work independent of the amount of modes
- The spacing does not add more than 2s delay overall to avoid ACK timeouts

### Test coverage
- Was tested with a low bandwidth radio and a ARK v6x

