### PR TITLE
Add reboot_required to RC_CRSF_PRT_CFG parameter

### DIFF
--- a/src/drivers/rc/crsf_rc/module.yaml
+++ b/src/drivers/rc/crsf_rc/module.yaml
@@ -6,6 +6,7 @@ serial_config:
         group: Serial
         #default: RC
         #depends_on_port: RC
+        reboot_required: true
         description_extended: |
             Crossfire RC (CRSF) driver.
 


### PR DESCRIPTION
### Solved Problem

GCS wouldn't prompt user to reboot vehicle when changing RC_CRSF_PRT_CFG parameter even though this is required 

### Solution
- Add `reboot_required: true` to the parameter 

### Changelog Entry
For release notes:
```
Feature/Bugfix Add reboot_required to RC_CRSF_PRT_CFG parameter
```

### Test coverage

Flashed onto v6s board and changed RC_CRSF_PRT_CFG:
<img width="542" height="171" alt="Screenshot from 2025-08-15 12-06-06" src="https://github.com/user-attachments/assets/25319d85-f62f-40a1-802b-fae7e5ba9ce5" />

