### PR TITLE
ManualControlSelector: check all input sources before selecting one

### DIFF
--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -104,14 +104,11 @@ void ManualControl::processInput(hrt_abstime now)
 	manual_control_setpoint_s inputs[MAX_MANUAL_INPUT_COUNT] {};
 
 	for (int i = 0; i < MAX_MANUAL_INPUT_COUNT; i++) {
-		if (_manual_control_input_subs[i].update(&inputs[i])) {
-
-			_selector.processInputSample(now, inputs[i], i);
-		}
+		_manual_control_input_subs[i].update(&inputs[i]);
 	}
 
-	// Decide on best input after collecting all samples
-	_selector.evaluateAndSetBestInput(now, inputs, MAX_MANUAL_INPUT_COUNT);
+	_selector.updateWithNewInputSamples(now, inputs, MAX_MANUAL_INPUT_COUNT);
+
 
 	if (_selector.setpoint().valid) {
 		_published_invalid_once = false;

--- a/src/modules/manual_control/ManualControlSelector.hpp
+++ b/src/modules/manual_control/ManualControlSelector.hpp
@@ -42,9 +42,7 @@ public:
 	void setRcInMode(int32_t rc_in_mode) { _rc_in_mode = rc_in_mode; }
 	void setTimeout(uint64_t timeout) { _timeout = timeout; }
 	void updateValidityOfChosenInput(uint64_t now);
-	void evaluateAndSetBestInput(uint64_t now, const manual_control_setpoint_s inputs[], int input_count);
-	void processInputSample(uint64_t now, const manual_control_setpoint_s &input, int instance);
-	void updateSetpoint(uint64_t now, const manual_control_setpoint_s &input, int instance);
+	void updateWithNewInputSamples(uint64_t now, const manual_control_setpoint_s inputs[], int count);
 	manual_control_setpoint_s &setpoint();
 	int instance() const { return _instance; };
 


### PR DESCRIPTION
### Solved Problem
When flying with a dual-link setup and controlling the vehicle via keyboard over the high-bandwidth link, a failsafe was incorrectly triggered if the low-bandwidth link went down. This was caused by an edge case in the manual input source selection logic: the timeout checking was not atomic across multiple input sources, resulting in valid inputs being overlooked and the system falsely declaring no valid manual input.

### Solution
1. Refactored the manual input selection logic in ManualControl.cpp to first iterate over all input sources and collect valid ones before switching.

2. The selector now evaluates all valid inputs after the loop and chooses the best available source (e.g., the one with the longest remaining timeout).

### Changelog Entry
For release notes: 
```
Bugfix Fix edge case in dual-link manual control input selection where failsafe could be triggered incorrectly due to non-atomic timeout checks.
```

To do: 

- [x] Rewrite unit tests for refactored code