### PR TITLE
fix: correct hex format for CRC output

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1230,8 +1230,8 @@ int PX4IO::io_reg_modify(uint8_t page, uint8_t offset, uint16_t clearbits, uint1
 int PX4IO::print_status()
 {
 	/* basic configuration */
-	printf("protocol %" PRIu32 " hardware %" PRIu32 " bootloader %" PRIu32 " buffer %" PRIu32 "B crc 0x%04" PRIu32 "%04"
-	       PRIu32 "\n",
+	printf("protocol %" PRIu32 " hardware %" PRIu32 " bootloader %" PRIu32 " buffer %" PRIu32 "B crc 0x%04" PRIx32 "%04"
+	       PRIx32 "\n",
 	       io_reg_get(PX4IO_PAGE_CONFIG, PX4IO_P_CONFIG_PROTOCOL_VERSION),
 	       io_reg_get(PX4IO_PAGE_CONFIG, PX4IO_P_CONFIG_HARDWARE_VERSION),
 	       io_reg_get(PX4IO_PAGE_CONFIG, PX4IO_P_CONFIG_BOOTLOADER_VERSION),


### PR DESCRIPTION
- switch to PRIx32 for proper hex formatting
- keep zero-padding and casing consistent
- ensure status prints CRC correctly

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When printing the CRC status, the output used PRIu32 (decimal format) instead of PRIx32 (hex format).
I found that this caused CRC values to be displayed incorrectly, making debugging harder and inconsistent with other PX4 CRC outputs.

### Solution
- Switch from PRIu32 to PRIx32 to ensure CRC values are formatted in hexadecimal.

### Changelog Entry
For release notes:
```
Bugfix: Correct CRC status print formatting
Documentation: CRC values are now displayed in proper hexadecimal format.
```