### PR TITLE
config: add dynamic init file

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -73,6 +73,11 @@ menu "Toolchain"
         help
             relative path to the ROMFS root directory
 
+    config BOARD_DYN_INIT
+        string "Dynamic init file"
+        help
+            additional configurable init file to include in the ROMFS
+
     config BOARD_IO
         string "IO board name"
         default "px4_io-v2_default"

--- a/Kconfig
+++ b/Kconfig
@@ -73,8 +73,8 @@ menu "Toolchain"
         help
             relative path to the ROMFS root directory
 
-    config BOARD_DYN_INIT
-        string "Dynamic init file"
+    config BOARD_ADDITIONAL_INIT
+        string "Additional init file"
         help
             additional configurable init file to include in the ROMFS
 

--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -202,6 +202,29 @@ foreach(board_rc_file ${OPTIONAL_BOARD_RC})
 
 endforeach()
 
+if(config_dyn_init)
+	if(EXISTS "${PX4_BOARD_DIR}/init/${config_dyn_init}")
+		file(RELATIVE_PATH rc_file_relative ${PX4_SOURCE_DIR} ${PX4_BOARD_DIR}/init/${config_dyn_init})
+		message(STATUS "ROMFS:  Adding ${rc_file_relative} -> /etc/init.d/rc.dyn_init")
+
+		add_custom_command(
+			OUTPUT
+				${romfs_gen_root_dir}/init.d/rc.dyn_init
+				${config_dyn_init}.stamp
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PX4_BOARD_DIR}/init/${config_dyn_init} ${romfs_gen_root_dir}/init.d/rc.dyn_init
+			COMMAND ${CMAKE_COMMAND} -E touch ${config_dyn_init}.stamp
+			DEPENDS
+				${PX4_BOARD_DIR}/init/${config_dyn_init}
+				romfs_copy.stamp
+			COMMENT "ROMFS: copying ${config_dyn_init}"
+		)
+
+		list(APPEND extras_dependencies
+			${config_dyn_init}.stamp
+			)
+	endif()
+endif()
+
 
 # board extras
 set(OPTIONAL_BOARD_EXTRAS)

--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -202,26 +202,28 @@ foreach(board_rc_file ${OPTIONAL_BOARD_RC})
 
 endforeach()
 
-if(config_dyn_init)
-	if(EXISTS "${PX4_BOARD_DIR}/init/${config_dyn_init}")
-		file(RELATIVE_PATH rc_file_relative ${PX4_SOURCE_DIR} ${PX4_BOARD_DIR}/init/${config_dyn_init})
-		message(STATUS "ROMFS:  Adding ${rc_file_relative} -> /etc/init.d/rc.dyn_init")
+if(config_additional_init)
+	if(EXISTS "${PX4_BOARD_DIR}/init/${config_additional_init}")
+		file(RELATIVE_PATH rc_file_relative ${PX4_SOURCE_DIR} ${PX4_BOARD_DIR}/init/${config_additional_init})
+		message(STATUS "ROMFS:  Adding ${rc_file_relative} -> /etc/init.d/rc.additional_init")
 
 		add_custom_command(
 			OUTPUT
-				${romfs_gen_root_dir}/init.d/rc.dyn_init
-				${config_dyn_init}.stamp
-			COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PX4_BOARD_DIR}/init/${config_dyn_init} ${romfs_gen_root_dir}/init.d/rc.dyn_init
-			COMMAND ${CMAKE_COMMAND} -E touch ${config_dyn_init}.stamp
+				${romfs_gen_root_dir}/init.d/rc.additional_init
+				${config_additional_init}.stamp
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PX4_BOARD_DIR}/init/${config_additional_init} ${romfs_gen_root_dir}/init.d/rc.additional_init
+			COMMAND ${CMAKE_COMMAND} -E touch ${config_additional_init}.stamp
 			DEPENDS
-				${PX4_BOARD_DIR}/init/${config_dyn_init}
+				${PX4_BOARD_DIR}/init/${config_additional_init}
 				romfs_copy.stamp
-			COMMENT "ROMFS: copying ${config_dyn_init}"
+			COMMENT "ROMFS: copying ${config_additional_init}"
 		)
 
 		list(APPEND extras_dependencies
-			${config_dyn_init}.stamp
+			${config_additional_init}.stamp
 			)
+	else()
+		message(FATAL_ERROR "BOARD_ADDITIONAL_INIT file not found at: ${PX4_BOARD_DIR}/init/${config_additional_init}")
 	endif()
 endif()
 

--- a/ROMFS/cannode/init.d/rcS
+++ b/ROMFS/cannode/init.d/rcS
@@ -57,6 +57,17 @@ fi
 unset BOARD_RC_DEFAULTS
 
 #
+# Optional dynamic init file: rc.dyn_init
+#
+set BOARD_RC_DYN_INIT ${R}etc/init.d/rc.dyn_init
+if [ -f $BOARD_RC_DYN_INIT ]
+then
+	echo "Board dynamic init: ${BOARD_RC_DYN_INIT}"
+	. $BOARD_RC_DYN_INIT
+fi
+unset BOARD_RC_DYN_INIT
+
+#
 # Start system state indicator.
 #
 rgbled start -X -q

--- a/ROMFS/cannode/init.d/rcS
+++ b/ROMFS/cannode/init.d/rcS
@@ -57,15 +57,15 @@ fi
 unset BOARD_RC_DEFAULTS
 
 #
-# Optional dynamic init file: rc.dyn_init
+# Optional additional init file: rc.additional_init
 #
-set BOARD_RC_DYN_INIT ${R}etc/init.d/rc.dyn_init
-if [ -f $BOARD_RC_DYN_INIT ]
+set BOARD_RC_ADDITIONAL_INIT ${R}etc/init.d/rc.additional_init
+if [ -f $BOARD_RC_ADDITIONAL_INIT ]
 then
-	echo "Board dynamic init: ${BOARD_RC_DYN_INIT}"
-	. $BOARD_RC_DYN_INIT
+	echo "Board additional init: ${BOARD_RC_ADDITIONAL_INIT}"
+	. $BOARD_RC_ADDITIONAL_INIT
 fi
-unset BOARD_RC_DYN_INIT
+unset BOARD_RC_ADDITIONAL_INIT
 
 #
 # Start system state indicator.

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -217,6 +217,17 @@ else
 	fi
 	unset BOARD_RC_DEFAULTS
 
+	#
+	# Optional dynamic init file: rc.dyn_init
+	#
+	set BOARD_RC_DYN_INIT ${R}etc/init.d/rc.dyn_init
+	if [ -f $BOARD_RC_DYN_INIT ]
+	then
+		echo "Board dynamic init: ${BOARD_RC_DYN_INIT}"
+		. $BOARD_RC_DYN_INIT
+	fi
+	unset BOARD_RC_DYN_INIT
+
 	# Load airframe configuration based on SYS_AUTOSTART parameter
 	if ! param compare SYS_AUTOSTART 0
 	then

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -218,15 +218,15 @@ else
 	unset BOARD_RC_DEFAULTS
 
 	#
-	# Optional dynamic init file: rc.dyn_init
+	# Optional additional init file: rc.additional_init
 	#
-	set BOARD_RC_DYN_INIT ${R}etc/init.d/rc.dyn_init
-	if [ -f $BOARD_RC_DYN_INIT ]
+	set BOARD_RC_ADDITIONAL_INIT ${R}etc/init.d/rc.additional_init
+	if [ -f $BOARD_RC_ADDITIONAL_INIT ]
 	then
-		echo "Board dynamic init: ${BOARD_RC_DYN_INIT}"
-		. $BOARD_RC_DYN_INIT
+		echo "Board additional init: ${BOARD_RC_ADDITIONAL_INIT}"
+		. $BOARD_RC_ADDITIONAL_INIT
 	fi
-	unset BOARD_RC_DYN_INIT
+	unset BOARD_RC_ADDITIONAL_INIT
 
 	# Load airframe configuration based on SYS_AUTOSTART parameter
 	if ! param compare SYS_AUTOSTART 0

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -339,6 +339,11 @@ if(EXISTS ${BOARD_DEFCONFIG})
 		endif()
 	endif()
 
+	# DYN INIT
+	if(DYN_INIT)
+		set(config_dyn_init ${DYN_INIT} CACHE INTERNAL "dyn init" FORCE)
+	endif()
+
 	if(UAVCAN_INTERFACES)
 		set(config_uavcan_num_ifaces ${UAVCAN_INTERFACES} CACHE INTERNAL "UAVCAN interfaces" FORCE)
 	endif()

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -339,9 +339,9 @@ if(EXISTS ${BOARD_DEFCONFIG})
 		endif()
 	endif()
 
-	# DYN INIT
-	if(DYN_INIT)
-		set(config_dyn_init ${DYN_INIT} CACHE INTERNAL "dyn init" FORCE)
+	# ADDITIONAL INIT
+	if(ADDITIONAL_INIT)
+		set(config_additional_init ${ADDITIONAL_INIT} CACHE INTERNAL "additional init" FORCE)
 	endif()
 
 	if(UAVCAN_INTERFACES)

--- a/docs/en/concept/system_startup.md
+++ b/docs/en/concept/system_startup.md
@@ -90,6 +90,8 @@ This is documented below.
 The best way to customize the system startup is to introduce a [new frame configuration](../dev_airframes/adding_a_new_frame.md).
 The frame configuration file can be included in the firmware or on an SD Card.
 
+#### Dynamic customization
+
 If you only need to "tweak" the existing configuration, such as starting one more application or setting the value of a few parameters, you can specify these by creating two files in the `/etc/` directory of the SD Card:
 
 - [/etc/config.txt](#customizing-the-configuration-config-txt): modify parameter values
@@ -106,7 +108,7 @@ If editing on Windows use a suitable editor.
 These files are referenced in PX4 code as `/fs/microsd/etc/config.txt` and `/fs/microsd/etc/extras.txt`, where the root folder of the microsd card is identified by the path `/fs/microsd`.
 :::
 
-#### Customizing the Configuration (config.txt)
+##### Customizing the Configuration (config.txt)
 
 The `config.txt` file can be used to modify parameters.
 It is loaded after the main system has been configured and _before_ it is booted.
@@ -118,7 +120,7 @@ param set-default PWM_MAIN_DIS3 1000
 param set-default PWM_MAIN_MIN3 1120
 ```
 
-#### Starting Additional Applications (extras.txt)
+##### Starting Additional Applications (extras.txt)
 
 The `extras.txt` can be used to start additional applications after the main system boot.
 Typically these would be payload controllers or similar optional custom components.
@@ -144,4 +146,29 @@ The following example shows how to start custom applications:
   set -e
 
   mandatory_app start     # Will abort boot if mandatory_app is unknown or fails
+  ```
+
+#### Additional customization
+
+In rare cases where the desired setup cannot be achieved through frame configuration or dynamic customization,
+you can add a script that will be contained in the binary.
+
+**Note**: In almost all cases, you should use a frame configuration. This method should only be used for
+edge-cases such as customizing `cannode` based boards.
+
+- Add a new init script in `boards/<vendor>/<board>/init` that will run during board startup. For example:
+  ```sh
+  # File: boards/<vendor>/<board>/init/rc.additional
+  param set-default <param> <value>
+  ```
+
+- Add a new board variant in `boards/<vendor>/<board>/<variant>.px4board` that includes the additional script. For example:
+  ```sh
+  # File: boards/<vendor>/<board>/var.px4board
+  CONFIG_BOARD_ADDITIONAL_INIT="rc.additional"
+  ```
+
+- Compile the firmware with your new variant by appending the variant name to the compile target. For example:
+  ```sh
+  make <target>_var
   ```


### PR DESCRIPTION
### Solved Problem
When having some board (especially cannode based ones, which don't have airframes) you often would need to copy the whole board just to set for example different default parameters or change some small part in the init scripts. This duplicates code and is harder to maintain.

### Solution
- Adds the option to specify an additional dynamically selected init file by setting `CONFIG_BOARD_DYN_INIT`
  - For example: We use it in our GCS GPS. Add a new file `gcs.px4board` and enter `CONFIG_BOARD_DYN_INIT="rc.dyn_init_gcs"`. This way the file `rc.dyn_init_gcs` will be used when compiling this variant.

### Alternatives
- Duplicating the whole board is overkill
- Creating the concept of airframes for cannode based devices is also a bit overkill

### Test coverage
- Tested on a ARK RTK GPS where we set different default parameters via a `gcs.px4board`
