### PR TITLE
uavcan: increase battery filter sample interval to 500ms

### DIFF
--- a/src/drivers/uavcan/sensors/battery.hpp
+++ b/src/drivers/uavcan/sensors/battery.hpp
@@ -118,7 +118,7 @@ private:
 	static constexpr int BATTERY_INDEX_2 = 2;
 	static constexpr int BATTERY_INDEX_3 = 3;
 	static constexpr int BATTERY_INDEX_4 = 4;
-	static constexpr int SAMPLE_INTERVAL_US = 20_ms; // assume higher frequency UAVCAN feedback than 50Hz
+	static constexpr int SAMPLE_INTERVAL_US = 500_ms; // Typical message rate for a CAN battery monitor should be 2-5Hz.
 
 	static_assert(battery_status_s::MAX_INSTANCES <= BATTERY_INDEX_4, "Battery array too big");
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When using CAN-based power monitors, I found that the battery filter sample interval was set to 20 ms, assuming ~50 Hz telemetry updates. As a result, when `UAVCAN_SUB_BAT = 2 `(filtering via the internal battery library), the reported battery current reacted very slowly to changes in actual current.

In reality, most CAN power monitors (e.g. Pomegranate Systems Power Monitor) provide updates at only 1–5 Hz.

Fixes #25430

### Solution
Increase `SAMPLE_INTERVAL_US` from 20 ms to 500 ms in _src/drivers/uavcan/sensors/battery.hpp_

This matches real-world CAN power monitor update rates and reduces slow averaging behavior

### Changelog Entry
```
Bugfix: Improve responsiveness of current averaging for CAN-based power monitors when UAVCAN_SUB_BAT=2
```
### Test coverage
Hardware tested with Pomegranate Systems Power Monitor at 2 Hz update rate. Battery monitoring worked fine. 
