### PR TITLE
EKF2: stop GNSS altittude and velocity aiding when gnss_fault is set

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
@@ -123,7 +123,8 @@ void Ekf::controlGnssVelFusion(estimator_aid_source3d_s &aid_src, const bool for
 {
 	const bool continuing_conditions_passing = (_params.ekf2_gps_ctrl & static_cast<int32_t>(GnssCtrl::VEL))
 			&& _control_status.flags.tilt_align
-			&& _control_status.flags.yaw_align;
+			&& _control_status.flags.yaw_align
+			&& !_control_status.flags.gnss_fault;
 	const bool starting_conditions_passing = continuing_conditions_passing && _gnss_checks.passed();
 
 	if (_control_status.flags.gnss_vel) {

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -120,6 +120,16 @@ bool EkfWrapper::isIntendingGpsFusion() const
 	return _ekf->control_status_flags().gnss_vel || _ekf->control_status_flags().gnss_pos;
 }
 
+bool EkfWrapper::isGnssFaultDetected() const
+{
+	return _ekf->control_status_flags().gnss_fault;
+}
+
+void EkfWrapper::setGnssDeadReckonMode()
+{
+	_ekf_params->ekf2_gps_mode = static_cast<int32_t>(GnssMode::kDeadReckoning);
+}
+
 void EkfWrapper::enableGpsHeadingFusion()
 {
 	_ekf_params->ekf2_gps_ctrl |= static_cast<int32_t>(GnssCtrl::YAW);

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
@@ -78,6 +78,8 @@ public:
 	void enableGpsFusion();
 	void disableGpsFusion();
 	bool isIntendingGpsFusion() const;
+	bool isGnssFaultDetected() const;
+	void setGnssDeadReckonMode();
 
 	void enableGpsHeadingFusion();
 	void disableGpsHeadingFusion();


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

follow up to https://github.com/PX4/PX4-Autopilot/pull/25297

### Solved Problem
In GNSS dead-reckoning mode, the velocity and height parts of the GNSS message are being fused even when `gnss_fault` is set.

### Solution
Stop the velocity and altitude fusion when `gnss_fault` is set (only GNSS lat/lon fusion is allowed to clear the fault by passing the test ratio again)

Note that the bias update was moved in the "continuing condition" section to avoid fusing incorrect data that would have failed this check (e.g.: `gnss_fault`)

### Test coverage
added unit test