### PR TITLE
fw_mode_manager: fixed altitude hold for auto fixed-bank loiter mode

### DIFF
--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -630,8 +630,8 @@ FixedWingModeManager::control_auto_fixed_bank_alt_hold()
 	const hrt_abstime now = hrt_absolute_time();
 	const fixed_wing_longitudinal_setpoint_s fw_longitudinal_control_sp = {
 		.timestamp = now,
-		.altitude = _current_altitude,
-		.height_rate = NAN,
+		.altitude = NAN,
+		.height_rate = 0.f,
 		.equivalent_airspeed = NAN,
 		.pitch_direct = NAN,
 		.throttle_direct = NAN


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When a FW vehicle was entering the fixed-bank altitude hold loiter mode (initial loiter when going into DESCEND) I found that it was not holding altitude.
<img width="1929" height="1208" alt="fixed-bank-loiter-before" src="https://github.com/user-attachments/assets/8ec1d5ba-9c97-4906-94fa-13e5b843b14d" />

### Solution
- Instead of having the current altitude as TECS altitude setpoint, set altitude setpoint to NAN and height rate setpoint to 0.0.
<img width="1442" height="998" alt="fixed-bank-loiter-after" src="https://github.com/user-attachments/assets/38431ffb-5eab-49a4-a923-10f8055feee4" />


### Changelog Entry
For release notes:
```
Bugfix - FixedWingModeManager: fixed altitude hold for auto fixed-bank loiter mode
```


