### PR TITLE
docs_flaw_checker.yml - attempt to fix the flaw safely

### DIFF
--- a/.github/workflows/docs_flaw_checker.yml
+++ b/.github/workflows/docs_flaw_checker.yml
@@ -43,7 +43,8 @@ jobs:
       - name: Save JSON file containing files to link check
         run: |
           echo "$ALL_CHANGED_FILES"
-          echo "$ALL_CHANGED_FILES" > ./logs/prFiles.json
+          # echo "$ALL_CHANGED_FILES" > ./logs/prFiles.json
+          echo "$ALL_CHANGED_FILES" | jq '.' > ./logs/prFiles.json
         env:
           ALL_CHANGED_FILES: ${{ steps.get_changed_markdown_english.outputs.all_changed_files }}
 


### PR DESCRIPTION
There is a flaw checker error because the update we did in #25419 results in invalid JSON (a forward slash in the generated file that is invalid JSON).

This attempts the suggestion of gemini AI to us the jq tool to clean up the json - replacing the direct echo with:

```js
echo "$ALL_CHANGED_FILES" | jq '.' > ./logs/prFiles.json
```