### PR TITLE
Add note on INS page about adding the driver modules

### DIFF
--- a/docs/en/sensor/inertial_navigation_systems.md
+++ b/docs/en/sensor/inertial_navigation_systems.md
@@ -2,12 +2,31 @@
 
 PX4 typically runs on flight controllers that include an IMU, such as the Pixhawk series, and fuse the sensor data along with GNSS information in the EKF2 estimator to determine vehicle attitude, heading, position, and velocity.
 
-However PX4 can also use some INS devices as either sources of raw data, or as an external estimator, replacing the EKF.
+However PX4 can also use some INS devices as either sources of raw data, or as an external estimator, replacing EKF2.
 
-Systems that can be used in this way include:
+## Supported INS Systems
+
+INS systems that can be used as a replacement for EKF2 in PX4:
 
 - [InertialLabs](../sensor/inertiallabs.md)
 - [VectorNav](../sensor/vectornav.md): IMU/AHRS, GNSS/INS, Dual GNSS/INS systems that can be used as an external INS or as a source of raw sensor data.
+
+## PX4 Firmware
+
+The driver module for your INS system may not be included in the PX4 firmware for your flight controller by default.
+
+You can check by searching the [default.px4board](https://github.com/PX4/PX4-Autopilot/blob/main/boards/px4/fmu-v6c/default.px4board#L25) configuration file for your target board for either:
+
+- `CONFIG_COMMON_INS`, which includes drivers for [all INS systems](https://github.com/PX4/PX4-Autopilot/blob/main/src/drivers/ins/Kconfig).
+- The key for the particular INS system you are using, such as:
+  - `CONFIG_DRIVERS_INS_ILABS`
+  - `CONFIG_DRIVERS_INS_MICROSTRAIN`
+  - `CONFIG_DRIVERS_INS_VECTORNAV`
+
+If the required key is not present you can include the module in firmware by adding the key to the `default.px4board` file, or using the [kconfig board configuration tool](../hardware/porting_guide_config.md#px4-board-configuration-kconfig) and then select the driver you want (`Drivers -> INS`).
+Note that if you're working on a flight controller where flash memory is limited, you're better off installing just the modules you need.
+
+You will then need to rebuild the firmware.
 
 ## Glossary
 


### PR DESCRIPTION
Many boards are omitting the INS modules. While individual docs may covers this, I've created a section in the INS page explaining how to check. 

It may be in future all the INS pages will link to this instead. Either way, does no harm to highlight the issue in the entry point.