### PR TITLE
Handle external mode corner cases

### DIFF
--- a/msg/px4_msgs_old/msg/ArmingCheckRequestV0.msg
+++ b/msg/px4_msgs_old/msg/ArmingCheckRequestV0.msg
@@ -7,10 +7,8 @@
 # The reply will include the published request_id, allowing correlation of all arming check information for a particular request.
 # The reply will also include the registration_id for each external component, provided to it during the registration process (RegisterExtComponentReply).
 
-uint32 MESSAGE_VERSION = 1
+uint32 MESSAGE_VERSION = 0
 
 uint64 timestamp  # [us] Time since system start.
 
 uint8 request_id  # Id of this request. Allows correlation with associated ArmingCheckReply messages.
-
-uint32 valid_registrations_mask # Bitmask of valid registration ID's (the bit is also cleared if flagged as unresponsive)

--- a/msg/translation_node/translations/all_translations.h
+++ b/msg/translation_node/translations/all_translations.h
@@ -8,6 +8,7 @@
 
 #include "translation_airspeed_validated_v1.h"
 #include "translation_arming_check_reply_v1.h"
+#include "translation_arming_check_request_v1.h"
 #include "translation_battery_status_v1.h"
 #include "translation_event_v1.h"
 #include "translation_home_position_v1.h"

--- a/msg/translation_node/translations/translation_arming_check_request_v1.h
+++ b/msg/translation_node/translations/translation_arming_check_request_v1.h
@@ -1,0 +1,36 @@
+/****************************************************************************
+ * Copyright (c) 2025 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+#pragma once
+
+// Translate ArmingCheckRequest v0 <--> v1
+#include <px4_msgs_old/msg/arming_check_request_v0.hpp>
+#include <px4_msgs/msg/arming_check_request.hpp>
+
+class ArmingCheckRequestV1Translation {
+public:
+    using MessageOlder = px4_msgs_old::msg::ArmingCheckRequestV0;
+    static_assert(MessageOlder::MESSAGE_VERSION == 0);
+
+    using MessageNewer = px4_msgs::msg::ArmingCheckRequest;
+    static_assert(MessageNewer::MESSAGE_VERSION == 1);
+
+    static constexpr const char* kTopic = "/fmu/out/arming_check_request";
+
+    static void fromOlder(const MessageOlder &msg_older, MessageNewer &msg_newer) {
+	    msg_newer.timestamp = msg_older.timestamp;
+
+	    msg_newer.request_id = msg_older.request_id;
+
+	    msg_newer.valid_registrations_mask = 0xffffffff;
+    }
+
+    static void toOlder(const MessageNewer &msg_newer, MessageOlder &msg_older) {
+	    msg_older.timestamp = msg_newer.timestamp;
+
+	    msg_older.request_id = msg_newer.request_id;
+    }
+};
+
+REGISTER_TOPIC_TRANSLATION_DIRECT(ArmingCheckRequestV1Translation);

--- a/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.cpp
@@ -229,8 +229,10 @@ void ExternalChecks::update()
 	int max_num_updates = arming_check_reply_s::ORB_QUEUE_LENGTH;
 
 	while (_arming_check_reply_sub.update(&reply) && --max_num_updates >= 0) {
-		if (reply.registration_id < MAX_NUM_REGISTRATIONS && registrationValid(reply.registration_id)
-		    && _current_request_id == reply.request_id) {
+		const bool valid = reply.registration_id < MAX_NUM_REGISTRATIONS && registrationValid(reply.registration_id);
+		const bool timed_out = now > reply.timestamp + 300_ms;
+
+		if (!timed_out && valid && _current_request_id == reply.request_id) {
 			_reply_received_mask |= 1u << reply.registration_id;
 			_registrations[reply.registration_id].num_no_response = 0;
 			_registrations[reply.registration_id].waiting_for_first_response = false;

--- a/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.cpp
@@ -293,6 +293,15 @@ void ExternalChecks::update()
 		arming_check_request_s request{};
 		request.request_id = ++_current_request_id;
 		request.timestamp = hrt_absolute_time();
+		request.valid_registrations_mask = _active_registrations_mask;
+
+		// Clear unresponsive ones
+		for (int i = 0; i < MAX_NUM_REGISTRATIONS; ++i) {
+			if (_registrations[i].unresponsive) {
+				request.valid_registrations_mask &= ~(1u << i);
+			}
+		}
+
 		_arming_check_request_pub.publish(request);
 	}
 }


### PR DESCRIPTION
- check for stale arming_check_reply messages based on the message timestamp.
- add `valid_registrations_mask` to ArmingCheckRequest.msg
  This allows external modes to individually check if they are flagged as
invalid/unresponsive.
Previously this was done only based on whether or not ArmingCheckRequest
was received, which does not work when multiple modes are running.

See individual commits for details.