### PR TITLE
rover: fix setpoint generation

### DIFF
--- a/src/modules/rover_ackermann/RoverAckermann.cpp
+++ b/src/modules/rover_ackermann/RoverAckermann.cpp
@@ -97,7 +97,7 @@ void RoverAckermann::Run()
 void RoverAckermann::generateSetpoints()
 {
 	vehicle_status_s vehicle_status{};
-	_vehicle_status_sub.update(&vehicle_status);
+	_vehicle_status_sub.copy(&vehicle_status);
 
 	switch (vehicle_status.nav_state) {
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION:

--- a/src/modules/rover_differential/RoverDifferential.cpp
+++ b/src/modules/rover_differential/RoverDifferential.cpp
@@ -98,7 +98,7 @@ void RoverDifferential::Run()
 void RoverDifferential::generateSetpoints()
 {
 	vehicle_status_s vehicle_status{};
-	_vehicle_status_sub.update(&vehicle_status);
+	_vehicle_status_sub.copy(&vehicle_status);
 
 	switch (vehicle_status.nav_state) {
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION:

--- a/src/modules/rover_mecanum/RoverMecanum.cpp
+++ b/src/modules/rover_mecanum/RoverMecanum.cpp
@@ -98,7 +98,7 @@ void RoverMecanum::Run()
 void RoverMecanum::generateSetpoints()
 {
 	vehicle_status_s vehicle_status{};
-	_vehicle_status_sub.update(&vehicle_status);
+	_vehicle_status_sub.copy(&vehicle_status);
 
 	switch (vehicle_status.nav_state) {
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION:


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
While testing I encountered the following issue: In manual modes the rate control had a substantial delay in **acro, stab and position** mode.
Turns out this was caused by the fact, that during setpoint generation I used `update` instead of `copy` to get the current  **nav state**. If there was no update to `vehicle_status` (which is periodically updated every second even if there are no changes to it), this would write `0` to the nav state which lead the (full) manual mode to be executed instead of the actual **nav_state**. 
This was only noticable as a short delay in **acro, stab and position** because if a setpoint higher in the rover control hierarchy is published, it will override the unwanted **throttle** and **steering** setpoints published by the unintentionally executed code for full manual.

This is fixed by correctly calling `copy` instead of `update`.