### PR TITLE
TECS: fix: reset altitude reference model if we're using the height r…

### DIFF
--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -745,8 +745,8 @@ void TECS::update(float pitch, float altitude, float hgt_setpoint, float EAS_set
 		_airspeed_filter.update(dt, airspeed_input, _airspeed_filter_param, _control_flag.airspeed_enabled);
 
 		// Update Reference model submodule
-		if (1.f - _fast_descend < FLT_EPSILON) {
-			// Reset the altitude reference model, while we are in fast descend.
+		if (1.f - _fast_descend < FLT_EPSILON || !PX4_ISFINITE(hgt_rate_sp)) {
+			// Reset the altitude reference model while we are in fast descend or in height rate control mode
 			const TECSAltitudeReferenceModel::AltitudeReferenceState init_state{
 				.alt = altitude,
 				.alt_rate = hgt_rate};


### PR DESCRIPTION

### Solved Problem
The TECS altitude reference gets [initialized](https://github.com/PX4/PX4-Autopilot/blob/138427b3a8d4ffb62839322655bf49cc1ae162fa/src/lib/tecs/TECS.cpp#L733) as soon as the system is in a TECS-controlled flight mode. At least in sim that means almost instantly after boot. At this point in time, the local position estimate is not yet valid and not even published by EKF, resulting in the state being initialized as 0 [here](https://github.com/PX4/PX4-Autopilot/blob/138427b3a8d4ffb62839322655bf49cc1ae162fa/src/lib/tecs/TECS.cpp#L227C50-L227C53).
<img width="796" height="479" alt="image" src="https://github.com/user-attachments/assets/30517507-ced2-4290-b749-e33536d4917a" />


### Solution
TBD

### Changelog Entry
For release notes:
```
Feature/Bugfix TBD
```

### Alternatives
TBD

### Test coverage
SITL tested.
