### PR TITLE
SENS: DeviceInformation message support and implementation

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -63,6 +63,7 @@ set(msg_files
 	DebugKeyValue.msg
 	DebugValue.msg
 	DebugVect.msg
+	DeviceInformation.msg
 	DifferentialPressure.msg
 	DistanceSensor.msg
 	DistanceSensorModeChangeRequest.msg

--- a/msg/DeviceInformation.msg
+++ b/msg/DeviceInformation.msg
@@ -1,0 +1,16 @@
+uint64 timestamp		# time since system start (microseconds)
+
+uint8 device_type		# Type of the device (see DEVICE_TYPE enum)
+char[16] vendor_name		# Name of the device vendor
+char[16] model_name		# Name of the device model
+char[32] firmware_version	# Version of the firmware. If not available, set to "-1"
+char[32] hardware_version	# Version of the hardware. If not available, set to "-1"
+char[32] serial_number		# Device serial number or unique identifier. If not available, set to "-1"
+
+# Device type constants matching MAVLink DEVICE_TYPE enum
+uint8 DEVICE_TYPE_GENERIC = 0
+uint8 DEVICE_TYPE_GPS = 1
+uint8 DEVICE_TYPE_MAG = 2
+uint8 DEVICE_TYPE_AIRSPEED = 3
+uint8 DEVICE_TYPE_RANGEFINDER = 4
+uint8 DEVICE_TYPE_ESC = 5

--- a/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
+++ b/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
@@ -56,6 +56,8 @@
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/distance_sensor_mode_change_request.h>
+#include <uORB/topics/device_information.h>
+#include <uORB/Publication.hpp>
 
 using namespace time_literals;
 
@@ -85,6 +87,9 @@ private:
 	enum class Register : uint8_t {
 		// see http://support.lightware.co.za/sf20/#/commands
 		ProductName = 0,
+		HardwareVersion = 1,
+		FirmwareVersion = 2,
+		SerialNumber = 3,
 		DistanceOutput = 27,
 		DistanceData = 44,
 		LaserFiring = 50,
@@ -125,6 +130,7 @@ private:
 	int collect();
 
 	int updateRestriction();
+	void publishDeviceInformation();
 
 	PX4Rangefinder _px4_rangefinder;
 
@@ -149,6 +155,9 @@ private:
 	bool _restriction{false};
 	bool _auto_restriction{false};
 	bool _prev_restriction{false};
+
+	uORB::Publication<device_information_s> _device_information_pub{ORB_ID(device_information)};
+	bool _device_info_published{false};
 };
 
 LightwareLaser::LightwareLaser(const I2CSPIDriverConfig &config) :
@@ -271,6 +280,11 @@ int LightwareLaser::probe()
 
 		if (ret == 0 && (strncmp((const char *)product_name, "SF20", sizeof(product_name)) == 0 ||
 				 strncmp((const char *)product_name, "LW20", sizeof(product_name)) == 0)) {
+			if (!_device_info_published) {
+				publishDeviceInformation();
+				_device_info_published = true;
+			}
+
 			return 0;
 		}
 
@@ -487,6 +501,79 @@ int LightwareLaser::updateRestriction()
 	}
 
 	return 0;
+}
+
+void LightwareLaser::publishDeviceInformation()
+{
+	device_information_s device_info{};
+	device_info.timestamp = hrt_absolute_time();
+	device_info.device_type = device_information_s::DEVICE_TYPE_RANGEFINDER;
+
+	// Set vendor name to "Lightware"
+	strncpy(device_info.vendor_name, "Lightware", sizeof(device_info.vendor_name));
+	device_info.vendor_name[sizeof(device_info.vendor_name) - 1] = '\0';
+
+	// Read product name
+	uint8_t product_name[16];
+
+	if (readRegister(Register::ProductName, product_name, sizeof(product_name)) == 0) {
+		product_name[sizeof(product_name) - 1] = '\0';
+		strncpy(device_info.model_name, (const char *)product_name, sizeof(device_info.model_name));
+		device_info.model_name[sizeof(device_info.model_name) - 1] = '\0';
+	}
+
+	// Read hardware version
+	uint8_t hw_version[4];
+
+	if (readRegister(Register::HardwareVersion, hw_version, sizeof(hw_version)) == 0) {
+		uint32_t hw_ver_num = (hw_version[3] << 24) | (hw_version[2] << 16) |
+				      (hw_version[1] << 8) | hw_version[0];
+
+		snprintf(device_info.hardware_version, sizeof(device_info.hardware_version),
+			 "%lu", (unsigned long)hw_ver_num);
+
+	} else {
+		strncpy(device_info.hardware_version, "-1", sizeof(device_info.hardware_version));
+		device_info.hardware_version[sizeof(device_info.hardware_version) - 1] = '\0';
+	}
+
+	// Read firmware version
+	uint8_t fw_version[4];
+
+	if (readRegister(Register::FirmwareVersion, fw_version, sizeof(fw_version)) == 0) {
+		// According to Lightware spec:
+		uint8_t patch = fw_version[0];  // Byte 1 = Patch
+		uint8_t minor = fw_version[1];  // Byte 2 = Minor
+		uint8_t major = fw_version[2];  // Byte 3 = Major
+		// fw_version[3] is Byte 4 = Reserved
+
+		snprintf(device_info.firmware_version, sizeof(device_info.firmware_version),
+			 "%u.%u.%u", major, minor, patch);
+
+	} else {
+		strncpy(device_info.firmware_version, "-1", sizeof(device_info.firmware_version));
+		device_info.firmware_version[sizeof(device_info.firmware_version) - 1] = '\0';
+	}
+
+	// Read serial number
+	uint8_t serial_number[32];
+
+	if (readRegister(Register::SerialNumber, serial_number, sizeof(serial_number)) == 0) {
+		serial_number[sizeof(serial_number) - 1] = '\0';
+		strncpy(device_info.serial_number, (const char *)serial_number, sizeof(device_info.serial_number));
+		device_info.serial_number[sizeof(device_info.serial_number) - 1] = '\0';
+
+	} else {
+		strncpy(device_info.serial_number, "-1", sizeof(device_info.serial_number));
+		device_info.serial_number[sizeof(device_info.serial_number) - 1] = '\0';
+	}
+
+	_device_information_pub.publish(device_info);
+
+	PX4_DEBUG("Published device information: %s %s, HW: %s, FW: %s, SN: %s",
+		  device_info.vendor_name, device_info.model_name,
+		  device_info.hardware_version, device_info.firmware_version,
+		  device_info.serial_number);
 }
 
 void LightwareLaser::RunImpl()

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -141,6 +141,7 @@
 # include "streams/DEBUG.hpp"
 # include "streams/DEBUG_FLOAT_ARRAY.hpp"
 # include "streams/DEBUG_VECT.hpp"
+# include "streams/DEVICE_INFORMATION.hpp"
 # include "streams/GIMBAL_DEVICE_ATTITUDE_STATUS.hpp"
 # include "streams/GIMBAL_DEVICE_SET_ATTITUDE.hpp"
 # include "streams/GIMBAL_MANAGER_INFORMATION.hpp"
@@ -399,6 +400,9 @@ static const StreamListItem streams_list[] = {
 #if defined(DEBUG_FLOAT_ARRAY_HPP)
 	create_stream_list_item<MavlinkStreamDebugFloatArray>(),
 #endif // DEBUG_FLOAT_ARRAY_HPP
+#if defined(DEVICE_INFORMATION_HPP)
+	create_stream_list_item<MavlinkStreamDeviceInformation>(),
+#endif // DEVICE_INFORMATION_HPP
 #if defined(NAV_CONTROLLER_OUTPUT_HPP)
 	create_stream_list_item<MavlinkStreamNavControllerOutput>(),
 #endif // NAV_CONTROLLER_OUTPUT_HPP

--- a/src/modules/mavlink/streams/DEVICE_INFORMATION.hpp
+++ b/src/modules/mavlink/streams/DEVICE_INFORMATION.hpp
@@ -1,0 +1,88 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2024 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef DEVICE_INFORMATION_HPP
+#define DEVICE_INFORMATION_HPP
+
+#include <cstdlib>
+#include <uORB/topics/device_information.h>
+
+class MavlinkStreamDeviceInformation : public MavlinkStream
+{
+public:
+	static constexpr const char *get_name_static() { return "DEVICE_INFORMATION"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_DEVICE_INFORMATION; }
+
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamDeviceInformation(mavlink); }
+
+	const char *get_name() const override { return get_name_static(); }
+	uint16_t get_id() override { return get_id_static(); }
+
+	unsigned get_size() override
+	{
+		if (_device_information_sub.advertised()) {
+			return MAVLINK_MSG_ID_DEVICE_INFORMATION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+		}
+
+		return 0;
+	}
+
+private:
+	explicit MavlinkStreamDeviceInformation(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+
+	uORB::Subscription _device_information_sub{ORB_ID(device_information)};
+
+	bool send() override
+	{
+		device_information_s device_information;
+
+		if (_device_information_sub.advertised() && _device_information_sub.copy(&device_information)) {
+			mavlink_device_information_t msg{};
+
+			msg.device_type = device_information.device_type;
+			memcpy(msg.vendor_name, device_information.vendor_name, sizeof(msg.vendor_name));
+			memcpy(msg.model_name, device_information.model_name, sizeof(msg.model_name));
+			memcpy(msg.firmware_version, device_information.firmware_version, sizeof(msg.firmware_version));
+			memcpy(msg.hardware_version, device_information.hardware_version, sizeof(msg.hardware_version));
+			memcpy(msg.serial_number, device_information.serial_number, sizeof(msg.serial_number));
+
+			mavlink_msg_device_information_send_struct(_mavlink->get_channel(), &msg);
+
+			return true;
+		}
+
+		return false;
+	}
+};
+
+#endif // DEVICE_INFORMATION_HPP


### PR DESCRIPTION
### Solved Problem
When working with device diagnostics and system inventory, there was no standardized way to retrieve hardware and software information from connected devices through MAVLink.

### Solution

- Add DEVICE_INFORMATION MAVLink message support for device identification
- Add device information capability to the Lightware LW20 rangefinders
- Implement automatic device info publishing during device probe

### Alternatives
We could also implement this as:

- Device-specific commands instead of a generic message
- Manual request/response pattern instead of automatic publishing

### Test coverage
- [x] Simulation/hardware testing: Tested with Lightware SF20/LW20 rangefinders
### Context
- Related MAVLink PR: 
https://github.com/mavlink/mavlink/pull/2341

### Files changed:

Core: `DeviceInformation.msg`, `DEVICE_INFORMATION.hpp` MAVLink stream
Implementation: `lightware_laser_i2c.cpp` Added implementation to the LW20 driver
Updated mavlink submodule with new message definition