### PR TITLE
SIH: Support sending PWM over SIH  

### DIFF
--- a/docs/en/sim_sih/index.md
+++ b/docs/en/sim_sih/index.md
@@ -316,6 +316,43 @@ For SIH as SITL (no FC):
 
 For specific examples see the `_sihsim_` airframes in [ROMFS/px4fmu_common/init.d-posix/airframes](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/airframes/) (SIH as SITL) and [ROMFS/px4fmu_common/init.d/airframes](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d/airframes) (SIH on FC).
 
+## Controlling Actuators in SIH
+
+:::warning
+If you want to control throttling actuators in SIH, make sure to remove propellers for safety.
+:::
+
+In some scenarios, it may be useful to control an actuator while running SIH. For example, you might want to verify that winches or grippers are functioning correctly by checking the servo responses.
+
+To enable actuator control in SIH:
+
+1. Configure PWM parameters in the airframe file:
+
+Ensure your airframe file includes the necessary parameters to map PWM outputs to the correct channels.
+
+For example, if a servo is connected to MAIN 3 and you want to map it to AUX1 on your RC, use the following command:
+
+`param set-default PWM_MAIN_FUNC3 407`
+
+You can find a full list of available values for `PWM_MAIN_FUNCn` [here](../advanced_config/parameter_reference.md#PWM_MAIN_FUNC1). In this case, `407` maps the MAIN 3 output to AUX1 on the RC.
+
+Alternatively, you can use the [`PWM_AUX_FUNCn`](../advanced_config/parameter_reference.md#PWM_AUX_FUNC1) parameters.
+
+You may also configure the output as desired:
+- Disarmed PWM: ([`PWM_MAIN_DISn`](../advanced_config/parameter_reference.md#PWM_MAIN_DIS1) / [`PWM_AUX_DIS1`](../advanced_config/parameter_reference.md#PWM_AUX_DIS1))
+- Minimum PWM ([`PWM_MAIN_MINn`](../advanced_config/parameter_reference.md#PWM_MAIN_MIN1) / [`PWM_AUX_MINn`](../advanced_config/parameter_reference.md#PWM_AUX_MIN1))
+- Maximum PWM ([`PWM_MAIN_MAXn`](../advanced_config/parameter_reference.md#PWM_MAIN_MAX1) / [`PWM_AUX_MAXn`](../advanced_config/parameter_reference.md#PWM_AUX_MAX1))
+
+2. Manually start the PWM output driver
+
+For safety, the PWM driver is not started automatically in SIH. To enable it, run the following command in the MAVLink shell:
+
+`pwm_out start`
+
+And to disable it again:
+
+`pwm_out stop`
+
 ## Dynamic Models
 
 The dynamic models for the various vehicles are:

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1895,8 +1895,7 @@ void Commander::run()
 		_actuator_armed.armed = isArmed();
 		_actuator_armed.prearmed = getPrearmState();
 		_actuator_armed.ready_to_arm = _vehicle_status.pre_flight_checks_pass || isArmed();
-		_actuator_armed.lockdown = ((_vehicle_status.hil_state == vehicle_status_s::HIL_STATE_ON)
-					    || _multicopter_throw_launch.isThrowLaunchInProgress());
+		_actuator_armed.lockdown = _multicopter_throw_launch.isThrowLaunchInProgress();
 		// _actuator_armed.kill // action_request_s::ACTION_KILL
 		_actuator_armed.termination = (_vehicle_status.nav_state == _vehicle_status.NAVIGATION_STATE_TERMINATION);
 		// _actuator_armed.in_esc_calibration_mode // VEHICLE_CMD_PREFLIGHT_CALIBRATION


### PR DESCRIPTION
### Solved Problem

It is currently not possible to send PWM while running in SIH (Software In Hardware) mode due to a boolean condition in the commander that blocks arming when SYS_HITL is set.

### Solution

This PR addresses the issue in two parts:

- PX4 Code Change:
Removed a check for SYS_HITL in  `_actuator_armed.lockdown` boolean. 

- Documentation Update: Added documentation outlining the necessary steps to enable actuator control in SIH. 
This enables workflows where developers want to test actuator behavior during SIH simulation by simply adding SIH parameters to their existing airframe file or enabling SIH via SYS_HITL, while maintaining existing PWM output mappings.

### Changelog Entry
For release notes:
```
Feature: Enable PWM output while running in SIH mode
Documentation: Added instructions for actuator control in SIH
```

### Test coverage

Tested on auterion_fmu_v6s with servo connected to main 3, mapped to AUX1 on the RC. 

From a safety perspective: the output driver (pwm_out) needs to be started manually on every reboot if you want to send PWM through SIH. In this regard, it's not that easy to accidentally or unintentionally send PWM. 

