### PR TITLE
logging: allow logging backend config

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.logging
+++ b/ROMFS/px4fmu_common/init.d/rc.logging
@@ -8,6 +8,9 @@
 #                 End Setup for board specific configurations.                #
 ###############################################################################
 
+#
+# Set SD logging mode
+#
 if param compare SDLOG_MODE 1
 then
 	set LOGGER_ARGS "${LOGGER_ARGS} -e"
@@ -28,8 +31,28 @@ then
 	set LOGGER_ARGS "${LOGGER_ARGS} -a"
 fi
 
+#
+# Set logging backend
+#
+if param compare SDLOG_BACKEND 1
+then
+	set LOGGER_ARGS "${LOGGER_ARGS} -m file"
+fi
 
-if ! param compare SDLOG_MODE -1
+if param compare SDLOG_BACKEND 2
+then
+	set LOGGER_ARGS "${LOGGER_ARGS} -m mavlink"
+fi
+
+if param compare SDLOG_BACKEND 3
+then
+	set LOGGER_ARGS "${LOGGER_ARGS} -m all"
+fi
+
+#
+# Start logger if any logging backend is enabled
+#
+if ! param compare SDLOG_BACKEND 0
 then
 	logger start -b ${LOGGER_BUF} -t ${LOGGER_ARGS}
 fi

--- a/boards/auterion/fmu-v6s/init/rc.board_defaults
+++ b/boards/auterion/fmu-v6s/init/rc.board_defaults
@@ -14,7 +14,7 @@ param set-default SYS_DM_BACKEND 1
 # Set TELEM1 as default mavlink connection
 param set-default MAV_0_CONFIG 0
 # Disable logger writing to FRAM, only stream over MAVLINK
-set LOGGER_ARGS "-m mavlink"
+param set-default SDLOG_BACKEND 2
 
 # 200kOhm/10kOhm voltage divider on V_BAT
 param set-default BAT1_V_DIV 21

--- a/boards/holybro/kakuteh7mini/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7mini/init/rc.board_defaults
@@ -39,4 +39,4 @@ param set-default SYS_DM_BACKEND 1
 param set-default COM_ARM_SDCARD 0
 
 # Don't try to log onto SD card
-param set-default SDLOG_MODE -1
+param set-default SDLOG_BACKEND 0

--- a/boards/holybro/kakuteh7mini/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7mini/init/rc.board_defaults
@@ -38,5 +38,5 @@ param set-default SYS_DM_BACKEND 1
 # Ignore that there is no SD card
 param set-default COM_ARM_SDCARD 0
 
-# Don't try to log onto SD card
+# Disable logging
 param set-default SDLOG_BACKEND 0

--- a/boards/holybro/kakuteh7v2/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7v2/init/rc.board_defaults
@@ -39,4 +39,4 @@ param set-default SYS_DM_BACKEND 1
 param set-default COM_ARM_SDCARD 0
 
 # Don't try to log onto SD card
-param set-default SDLOG_MODE -1
+param set-default SDLOG_BACKEND 0

--- a/boards/holybro/kakuteh7v2/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7v2/init/rc.board_defaults
@@ -38,5 +38,5 @@ param set-default SYS_DM_BACKEND 1
 # Ignore that there is no SD card
 param set-default COM_ARM_SDCARD 0
 
-# Don't try to log onto SD card
+# Disable logging
 param set-default SDLOG_BACKEND 0

--- a/docs/en/dev_log/logging.md
+++ b/docs/en/dev_log/logging.md
@@ -35,14 +35,15 @@ The parameters you are most likely to change are listed below.
 
 | Parameter                                                                | Description                                                                                                                                                                                                                                                                                                                                                                      |
 | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [SDLOG_MODE](../advanced_config/parameter_reference.md#SDLOG_MODE)       | Logging Mode. Defines when logging starts and stops.<br />- `-1`: Logging disabled.<br />- `0`: Log when armed until disarm (default).<br />- `1`: Log from boot until disarm.<br />- `2`: Log from boot until shutdown.<br />- `3`: Log based on the [AUX1 RC channel](../advanced_config/parameter_reference.md#RC_MAP_AUX1).<br />- `4`: Log from first armed until shutdown. |
+| [SDLOG_MODE](../advanced_config/parameter_reference.md#SDLOG_MODE)       | Logging Mode. Defines when logging starts and stops.<br />- `0`: Log when armed until disarm (default).<br />- `1`: Log from boot until disarm.<br />- `2`: Log from boot until shutdown.<br />- `3`: Log based on the [AUX1 RC channel](../advanced_config/parameter_reference.md#RC_MAP_AUX1).<br />- `4`: Log from first armed until shutdown. |
+| [SDLOG_BACKEND](../advanced_config/parameter_reference.md#SDLOG_BACKEND) | Logging Backend (bitmask). Setting a bit enables the corresponding backend. If no backend is selected, the logger is disabled.<br />- bit `0`: SD card logging.</br >- bit `1`: Mavlink logging.
 | [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) | Logging profile. Use this to enable less common logging/analysis (e.g. for EKF2 replay, high rate logging for PID & filter tuning, thermal temperature calibration).                                                                                                                                                                                                             |
 | [SDLOG_MISSION](../advanced_config/parameter_reference.md#SDLOG_MISSION) | Create very small additional "Mission Log".<br>This log can _not_ be used with [Flight Review](../log/flight_log_analysis.md#flight-review-online-tool), but is useful when you need a small log for geotagging or regulatory compliance.                                                                                                                                        |
 
 Useful settings for specific cases:
 
 - Raw sensor data for comparison: [SDLOG_MODE=1](../advanced_config/parameter_reference.md#SDLOG_MODE) and [SDLOG_PROFILE=64](../advanced_config/parameter_reference.md#SDLOG_PROFILE).
-- Disabling logging altogether: [SDLOG_MODE=`-1`](../advanced_config/parameter_reference.md#SDLOG_MODE)
+- Disabling logging altogether: [SDLOG_BACKEND=`0`](../advanced_config/parameter_reference.md#SDLOG_BACKEND)
 
 ### Logger module
 

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -150,5 +150,18 @@ param_modify_on_import_ret param_modify_on_import(bson_node_t node)
 		}
 	}
 
+	// 2025-08-22: translate SDLOG_MODE (disabled) to SDLOG_BACKEND (no logging backend)
+	{
+		if (strcmp("SDLOG_MODE", node->name) == 0) {
+			if (node->i32 == -1) {
+				node->i32 = 0;
+
+				int32_t sdlog_backend_val = 0;
+				param_set(param_find("SDLOG_BACKEND"), &sdlog_backend_val);
+				PX4_INFO("migrating %s -> %s", "SDLOG_MODE", "SDLOG_BACKEND");
+			}
+		}
+	}
+
 	return param_modify_on_import_ret::PARAM_NOT_MODIFIED;
 }

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -55,7 +55,10 @@ PARAM_DEFINE_INT32(SDLOG_UTC_OFFSET, 0);
  * Determines when to start and stop logging. By default, logging is started
  * when arming the system, and stopped when disarming.
  *
- * @value -1 disabled
+ * Note: The logging start/end points that can be configured here only apply to
+ * SD logging. The mavlink backend is started/stopped independently
+ * of these points.
+ *
  * @value 0 when armed until disarm (default)
  * @value 1 from boot until disarm
  * @value 2 from boot until shutdown
@@ -66,6 +69,25 @@ PARAM_DEFINE_INT32(SDLOG_UTC_OFFSET, 0);
  * @group SD Logging
  */
 PARAM_DEFINE_INT32(SDLOG_MODE, 0);
+
+/**
+ * Logging Backend (integer bitmask).
+ *
+ * If no logging is set the logger will not be started.
+ *
+ * Set bits true to enable:
+ * 0: SD card logging
+ * 1: Mavlink logging
+ *
+ * @min 0
+ * @max 3
+ * @bit 0 SD card logging
+ * @bit 1 Mavlink logging
+ *
+ * @reboot_required true
+ * @group SD Logging
+ */
+PARAM_DEFINE_INT32(SDLOG_BACKEND, 3);
 
 /**
  * Battery-only Logging


### PR DESCRIPTION
### Solved Problem
In some situations it is not desired to either log via the mavlink backend or the SD card backend.

### Solution
- Adds a new parameter `SDLOG_BACKEND` that allows to configure the backend

### Changelog Entry
For release notes:
```
New parameter: SDLOG_BACKEND
```

### Test coverage
- Tested on the bench with a v6x / v6s
