### PR TITLE
rover: constrain update steps

### DIFF
--- a/src/modules/rover_ackermann/AckermannActControl/AckermannActControl.cpp
+++ b/src/modules/rover_ackermann/AckermannActControl/AckermannActControl.cpp
@@ -57,7 +57,7 @@ void AckermannActControl::updateActControl()
 {
 	const hrt_abstime timestamp_prev = _timestamp;
 	_timestamp = hrt_absolute_time();
-	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
+	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 10_ms) * 1e-6f;
 
 	// Motor control
 	if (_rover_throttle_setpoint_sub.updated()) {

--- a/src/modules/rover_ackermann/AckermannAttControl/AckermannAttControl.cpp
+++ b/src/modules/rover_ackermann/AckermannAttControl/AckermannAttControl.cpp
@@ -65,7 +65,7 @@ void AckermannAttControl::updateAttControl()
 
 	hrt_abstime timestamp_prev = _timestamp;
 	_timestamp = hrt_absolute_time();
-	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
+	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 10_ms) * 1e-6f;
 
 	if (PX4_ISFINITE(_yaw_setpoint)) {
 		// Calculate yaw rate limit for slew rate

--- a/src/modules/rover_ackermann/AckermannRateControl/AckermannRateControl.cpp
+++ b/src/modules/rover_ackermann/AckermannRateControl/AckermannRateControl.cpp
@@ -62,7 +62,7 @@ void AckermannRateControl::updateRateControl()
 
 	hrt_abstime timestamp_prev = _timestamp;
 	_timestamp = hrt_absolute_time();
-	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
+	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 10_ms) * 1e-6f;
 
 	if (PX4_ISFINITE(_yaw_rate_setpoint)) {
 		if (fabsf(_estimated_speed) > FLT_EPSILON) {

--- a/src/modules/rover_ackermann/AckermannSpeedControl/AckermannSpeedControl.cpp
+++ b/src/modules/rover_ackermann/AckermannSpeedControl/AckermannSpeedControl.cpp
@@ -63,7 +63,7 @@ void AckermannSpeedControl::updateSpeedControl()
 
 	const hrt_abstime timestamp_prev = _timestamp;
 	_timestamp = hrt_absolute_time();
-	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
+	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 10_ms) * 1e-6f;
 
 	// Throttle Setpoint
 	if (PX4_ISFINITE(_speed_setpoint)) {

--- a/src/modules/rover_ackermann/AckermannSpeedControl/AckermannSpeedControl.hpp
+++ b/src/modules/rover_ackermann/AckermannSpeedControl/AckermannSpeedControl.hpp
@@ -113,7 +113,7 @@ private:
 
 	// Controllers
 	PID _pid_speed;
-	SlewRate<float> _adjusted_speed_setpoint;
+	SlewRate<float> _adjusted_speed_setpoint{0.f};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::RO_MAX_THR_SPEED>) _param_ro_max_thr_speed,

--- a/src/modules/rover_differential/DifferentialActControl/DifferentialActControl.cpp
+++ b/src/modules/rover_differential/DifferentialActControl/DifferentialActControl.cpp
@@ -53,7 +53,7 @@ void DifferentialActControl::updateActControl()
 {
 	const hrt_abstime timestamp_prev = _timestamp;
 	_timestamp = hrt_absolute_time();
-	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
+	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 10_ms) * 1e-6f;
 
 	// Motor control
 	if (_rover_throttle_setpoint_sub.updated()) {

--- a/src/modules/rover_differential/DifferentialAttControl/DifferentialAttControl.cpp
+++ b/src/modules/rover_differential/DifferentialAttControl/DifferentialAttControl.cpp
@@ -63,7 +63,7 @@ void DifferentialAttControl::updateAttControl()
 {
 	hrt_abstime timestamp_prev = _timestamp;
 	_timestamp = hrt_absolute_time();
-	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
+	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 10_ms) * 1e-6f;
 
 	if (_vehicle_attitude_sub.updated()) {
 		vehicle_attitude_s vehicle_attitude{};

--- a/src/modules/rover_differential/DifferentialRateControl/DifferentialRateControl.cpp
+++ b/src/modules/rover_differential/DifferentialRateControl/DifferentialRateControl.cpp
@@ -59,7 +59,7 @@ void DifferentialRateControl::updateRateControl()
 {
 	hrt_abstime timestamp_prev = _timestamp;
 	_timestamp = hrt_absolute_time();
-	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
+	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 10_ms) * 1e-6f;
 
 	if (_vehicle_angular_velocity_sub.updated()) {
 		vehicle_angular_velocity_s vehicle_angular_velocity{};

--- a/src/modules/rover_differential/DifferentialSpeedControl/DifferentialSpeedControl.cpp
+++ b/src/modules/rover_differential/DifferentialSpeedControl/DifferentialSpeedControl.cpp
@@ -63,7 +63,7 @@ void DifferentialSpeedControl::updateSpeedControl()
 
 	const hrt_abstime timestamp_prev = _timestamp;
 	_timestamp = hrt_absolute_time();
-	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
+	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 10_ms) * 1e-6f;
 
 	// Throttle Setpoint
 	if (PX4_ISFINITE(_speed_setpoint)) {

--- a/src/modules/rover_differential/DifferentialSpeedControl/DifferentialSpeedControl.hpp
+++ b/src/modules/rover_differential/DifferentialSpeedControl/DifferentialSpeedControl.hpp
@@ -122,7 +122,7 @@ private:
 
 	// Controllers
 	PID _pid_speed;
-	SlewRate<float> _adjusted_speed_setpoint;
+	SlewRate<float> _adjusted_speed_setpoint{0.f};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::RO_MAX_THR_SPEED>) _param_ro_max_thr_speed,

--- a/src/modules/rover_mecanum/MecanumActControl/MecanumActControl.cpp
+++ b/src/modules/rover_mecanum/MecanumActControl/MecanumActControl.cpp
@@ -54,7 +54,7 @@ void MecanumActControl::updateActControl()
 {
 	const hrt_abstime timestamp_prev = _timestamp;
 	_timestamp = hrt_absolute_time();
-	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
+	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 10_ms) * 1e-6f;
 
 	// Motor control
 	if (_rover_throttle_setpoint_sub.updated()) {

--- a/src/modules/rover_mecanum/MecanumAttControl/MecanumAttControl.cpp
+++ b/src/modules/rover_mecanum/MecanumAttControl/MecanumAttControl.cpp
@@ -63,7 +63,7 @@ void MecanumAttControl::updateAttControl()
 {
 	hrt_abstime timestamp_prev = _timestamp;
 	_timestamp = hrt_absolute_time();
-	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
+	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 10_ms) * 1e-6f;
 
 	if (_vehicle_attitude_sub.updated()) {
 		vehicle_attitude_s vehicle_attitude{};

--- a/src/modules/rover_mecanum/MecanumRateControl/MecanumRateControl.cpp
+++ b/src/modules/rover_mecanum/MecanumRateControl/MecanumRateControl.cpp
@@ -59,7 +59,7 @@ void MecanumRateControl::updateRateControl()
 {
 	hrt_abstime timestamp_prev = _timestamp;
 	_timestamp = hrt_absolute_time();
-	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
+	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 10_ms) * 1e-6f;
 
 	if (_vehicle_angular_velocity_sub.updated()) {
 		vehicle_angular_velocity_s vehicle_angular_velocity{};

--- a/src/modules/rover_mecanum/MecanumSpeedControl/MecanumSpeedControl.cpp
+++ b/src/modules/rover_mecanum/MecanumSpeedControl/MecanumSpeedControl.cpp
@@ -65,7 +65,7 @@ void MecanumSpeedControl::updateSpeedControl()
 {
 	const hrt_abstime timestamp_prev = _timestamp;
 	_timestamp = hrt_absolute_time();
-	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 5000_ms) * 1e-6f;
+	const float dt = math::constrain(_timestamp - timestamp_prev, 1_ms, 10_ms) * 1e-6f;
 
 	updateSubscriptions();
 

--- a/src/modules/rover_mecanum/MecanumSpeedControl/MecanumSpeedControl.hpp
+++ b/src/modules/rover_mecanum/MecanumSpeedControl/MecanumSpeedControl.hpp
@@ -126,8 +126,8 @@ private:
 	// Controllers
 	PID _pid_speed_x;
 	PID _pid_speed_y;
-	SlewRate<float> _adjusted_speed_x_setpoint;
-	SlewRate<float> _adjusted_speed_y_setpoint;
+	SlewRate<float> _adjusted_speed_x_setpoint{0.f};
+	SlewRate<float> _adjusted_speed_y_setpoint{0.f};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::RO_MAX_THR_SPEED>) _param_ro_max_thr_speed,


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When the rover is disarmed the controller timestamps are not updated. Once the rover is armed, the first update step will use the maximum value for `dt` which is currently set at `5s`. This leads to huge jumps in setpoints which winds up the integrator, leading to poor setpoint tracking.
This PR constrains the limit for the update step `dt` from `5s` to `0.1s` which is in line with the rover module update rate of `100Hz`.
<img width="4457" height="1344" alt="Untitled Diagram drawio" src="https://github.com/user-attachments/assets/88b99f04-706e-4a03-aa4b-bcd6e0ca4416" />

