### PR TITLE
Tools: Support Setup for Linux Mint

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -54,6 +54,22 @@ if [[ ! -f "${DIR}/${REQUIREMENTS_FILE}" ]]; then
 	return 1
 fi
 
+# Linux Mint compatibility: use upstream Ubuntu values
+if [ -r /etc/upstream-release/lsb-release ]; then
+    . /etc/upstream-release/lsb-release
+    UBUNTU_CODENAME="${DISTRIB_CODENAME:-${UBUNTU_CODENAME:-}}"
+    UBUNTU_RELEASE="${DISTRIB_RELEASE:-${UBUNTU_RELEASE:-}}"
+
+    lsb_release() {
+        if [ "$1" = "-cs" ]; then
+            printf '%s' "$UBUNTU_CODENAME"
+        elif [ "$1" = "-rs" ]; then
+            printf '%s' "$UBUNTU_RELEASE"
+        else
+            command lsb_release "$@"
+        fi
+    }
+fi
 
 # check ubuntu version
 # otherwise warn and point to docker?


### PR DESCRIPTION
Pull Ubuntu version from upstream lsb-release file which contains
```
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=24.04
DISTRIB_CODENAME=noble
DISTRIB_DESCRIPTION="Ubuntu Noble Numbat"
```

Also noticed there is still support for < Ubuntu 22.04 version in this script which I can remove too if you guys want