### PR TITLE
DSHOT: fix unit for DSHOT_MIN parameter

### DIFF
--- a/src/drivers/dshot/module.yaml
+++ b/src/drivers/dshot/module.yaml
@@ -16,7 +16,7 @@ parameters:
                     sure to set this high enough so that the motors are always spinning while
                     armed.
             type: float
-            unit: '%'
+            unit: norm
             min: 0
             max: 1
             decimal: 2


### PR DESCRIPTION

### Solved Problem
The unit of DSHOT_MIN gets correctly shown as %, but it doesn't scale the value by *100 as it should.

### Solution
Change the unit to norm - that is the correct way to have a parameter shown in %.
