### PR TITLE
dds_topics: accept landing_gear command from external modes

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -214,5 +214,8 @@ subscriptions:
   - topic: /fmu/in/rover_steering_setpoint
     type: px4_msgs::msg::RoverSteeringSetpoint
 
+  - topic: /fmu/in/landing_gear
+    type: px4_msgs::msg::LandingGear
+
 # Create uORB::PublicationMulti
 subscriptions_multi:


### PR DESCRIPTION
This allows controlling the landing gear from external ROS2 flight modes. 