### PR TITLE
dronecan: esc: UAVCAN_ESC_IFACE default to CAN2 only

### DIFF
--- a/docs/en/dronecan/index.md
+++ b/docs/en/dronecan/index.md
@@ -270,6 +270,8 @@ PX4 DroneCAN parameters:
 
 [DroneCAN ESCs and servos](../dronecan/escs.md) require the [motor order and servo outputs](../config/actuators.md) to be configured.
 
+Select the CAN interface you want to output the ESC data on. By default CAN2 is selected. [UAVCAN_ESC_IFACE](../advanced_config/parameter_reference.md#UAVCAN_ESC_IFACE)
+
 ## QGC CANNODE Parameter Configuration
 
 QGroundControl can inspect and modify parameters belonging to CAN devices attached to the flight controller, provided the device are connected to the flight controller before QGC is started.
@@ -307,7 +309,7 @@ If successful, the firmware binary will be removed from the root directory and t
 
 **Q**: The motors aren't spinning when armed.
 
-**A**: Make sure `UAVCAN_ENABLE` is set to `3` to enable DroneCAN ESC output.
+**A**: Make sure `UAVCAN_ENABLE` is set to `3` to enable DroneCAN ESC output. Make sure `UAVCAN_ESC_IFACE` is set to the interface you're using.
 
 ---
 

--- a/docs/en/dronecan/index.md
+++ b/docs/en/dronecan/index.md
@@ -270,7 +270,7 @@ PX4 DroneCAN parameters:
 
 [DroneCAN ESCs and servos](../dronecan/escs.md) require the [motor order and servo outputs](../config/actuators.md) to be configured.
 
-Select the CAN interface you want to output the ESC data on. By default CAN2 is selected. [UAVCAN_ESC_IFACE](../advanced_config/parameter_reference.md#UAVCAN_ESC_IFACE)
+Select the CAN interface for ESC data output. All interfaces are selected by default. Avoid using the same interface as other nodes, as ESC messages can saturate the bus and starve other nodes of bandwidth. [UAVCAN_ESC_IFACE](../advanced_config/parameter_reference.md#UAVCAN_ESC_IFACE)
 
 ## QGC CANNODE Parameter Configuration
 

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -20,7 +20,7 @@ parameters:
         5: CAN6
         6: CAN7
         7: CAN8
-      default: 255
+      default: 2
       min: 1
       max: 255
       reboot_required: true

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -20,7 +20,7 @@ parameters:
         5: CAN6
         6: CAN7
         7: CAN8
-      default: 2
+      default: 255
       min: 1
       max: 255
       reboot_required: true


### PR DESCRIPTION
### Solved Problem
UAVCAN_ESC_IFACE parameter to select the CAN bus for outputting ESC data was added in https://github.com/PX4/PX4-Autopilot/pull/24922

### Solution
Default UAVCAN_ESC_IFACE to CAN2

### Changelog Entry
For release notes:
```
dronecan: esc: UAVCAN_ESC_IFACE default to CAN2 only
```