### PR TITLE
ekf2: add VehicleFullState publisher (pos, vel, accel, quat, body rates) for simplicity in ROS2-based control algorithms

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -263,6 +263,7 @@ set(msg_files
 	versioned/VehicleCommandAck.msg
 	versioned/VehicleCommand.msg
 	versioned/VehicleControlMode.msg
+	versioned/VehicleFullState.msg
 	versioned/VehicleGlobalPosition.msg
 	versioned/VehicleLandDetected.msg
 	versioned/VehicleLocalPosition.msg

--- a/msg/versioned/VehicleFullState.msg
+++ b/msg/versioned/VehicleFullState.msg
@@ -1,0 +1,12 @@
+# Vehicle full state information data for ROS2-based control loops
+uint32 MESSAGE_VERSION = 0
+
+uint64 timestamp              # hrt_absolute_time()
+uint64 timestamp_sample       # same timing as odometry: imu_sample.time_us
+
+# local frame is NED (same as vehicle_odometry/vehicle_local_position)
+float32[3] position           # (x,y,z) in meters, NED
+float32[3] velocity           # (vx,vy,vz) in m/s, NED
+float32[3] acceleration       # (ax,ay,az) in m/s^2, NED (linear accel)
+float32[4] q                  # quaternion (w,x,y,z): FRD body -> NED
+float32[3] angular_velocity   # (p,q,r) in rad/s, body frame (FRD)

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -40,7 +40,7 @@ using matrix::Eulerf;
 using matrix::Quatf;
 using matrix::Vector3f;
 
-static constexpr float kDefaultExternalPosAccuracy = 50.0f; // [m]
+static constexpr float kDefaultExternalPosAccuracy = 50.0f;			   // [m]
 static constexpr float kMaxDelaySecondsExternalPosMeasurement = 15.0f; // [s]
 
 pthread_mutex_t ekf2_module_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -49,8 +49,7 @@ static px4::atomic<EKF2 *> _objects[EKF2_MAX_INSTANCES] {};
 static px4::atomic<EKF2Selector *> _ekf2_selector {nullptr};
 #endif // CONFIG_EKF2_MULTI_INSTANCE
 
-EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
-	ModuleParams(nullptr),
+EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode) : ModuleParams(nullptr),
 	ScheduledWorkItem(MODULE_NAME, config),
 	_replay_mode(replay_mode && !multi_mode),
 	_multi_mode(multi_mode),
@@ -107,14 +106,14 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_baro_gate(_params->ekf2_baro_gate),
 	_param_ekf2_gnd_eff_dz(_params->ekf2_gnd_eff_dz),
 	_param_ekf2_gnd_max_hgt(_params->ekf2_gnd_max_hgt),
-# if defined(CONFIG_EKF2_BARO_COMPENSATION)
+#if defined(CONFIG_EKF2_BARO_COMPENSATION)
 	_param_ekf2_aspd_max(_params->ekf2_aspd_max),
 	_param_ekf2_pcoef_xp(_params->ekf2_pcoef_xp),
 	_param_ekf2_pcoef_xn(_params->ekf2_pcoef_xn),
 	_param_ekf2_pcoef_yp(_params->ekf2_pcoef_yp),
 	_param_ekf2_pcoef_yn(_params->ekf2_pcoef_yn),
 	_param_ekf2_pcoef_z(_params->ekf2_pcoef_z),
-# endif // CONFIG_EKF2_BARO_COMPENSATION
+#endif // CONFIG_EKF2_BARO_COMPENSATION
 #endif // CONFIG_EKF2_BAROMETER
 #if defined(CONFIG_EKF2_AIRSPEED)
 	_param_ekf2_asp_delay(_params->ekf2_asp_delay),
@@ -325,13 +324,13 @@ void EKF2::AdvertiseTopics()
 				_estimator_aid_src_gnss_vel_pub.advertise();
 			}
 
-# if defined(CONFIG_EKF2_GNSS_YAW)
+#if defined(CONFIG_EKF2_GNSS_YAW)
 
 			if (_param_ekf2_gps_ctrl.get() & static_cast<int32_t>(GnssCtrl::YAW)) {
 				_estimator_aid_src_gnss_yaw_pub.advertise();
 			}
 
-# endif // CONFIG_EKF2_GNSS_YAW
+#endif // CONFIG_EKF2_GNSS_YAW
 		}
 
 #endif // CONFIG_EKF2_GNSS
@@ -396,8 +395,7 @@ bool EKF2::multi_init(int imu, int mag)
 
 	const int status_instance = _estimator_states_pub.get_instance();
 
-	if ((status_instance >= 0) && changed_instance
-	    && (_attitude_pub.get_instance() == status_instance)
+	if ((status_instance >= 0) && changed_instance && (_attitude_pub.get_instance() == status_instance)
 	    && (_local_position_pub.get_instance() == status_instance)
 	    && (_global_position_pub.get_instance() == status_instance)) {
 
@@ -514,7 +512,7 @@ void EKF2::Run()
 
 				if (_ekf.setEkfGlobalOrigin(latitude, longitude, altitude)) {
 					// Validate the ekf origin status.
-					uint64_t origin_time {};
+					uint64_t origin_time{};
 					_ekf.getEkfGlobalOrigin(origin_time, latitude, longitude, altitude);
 					PX4_INFO("%d - New NED origin (LLA): %3.10f, %3.10f, %4.3f\n",
 						 _instance, latitude, longitude, static_cast<double>(altitude));
@@ -533,10 +531,8 @@ void EKF2::Run()
 
 			} else if (vehicle_command.command == vehicle_command_s::VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE) {
 
-				if (PX4_ISFINITE(vehicle_command.param2)
-				    && PX4_ISFINITE(vehicle_command.param5)
-				    && PX4_ISFINITE(vehicle_command.param6)
-				   ) {
+				if (PX4_ISFINITE(vehicle_command.param2) && PX4_ISFINITE(vehicle_command.param5)
+				    && PX4_ISFINITE(vehicle_command.param6)) {
 
 					const float measurement_delay_seconds = math::constrain(vehicle_command.param2, 0.0f,
 										kMaxDelaySecondsExternalPosMeasurement);
@@ -549,8 +545,7 @@ void EKF2::Run()
 					}
 
 					if (_ekf.resetGlobalPosToExternalObservation(vehicle_command.param5, vehicle_command.param6, vehicle_command.param7,
-							accuracy, accuracy, timestamp_observation)
-					   ) {
+							accuracy, accuracy, timestamp_observation)) {
 						command_ack.result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED;
 
 					} else {
@@ -584,7 +579,7 @@ void EKF2::Run()
 	}
 
 	bool imu_updated = false;
-	imuSample imu_sample_new {};
+	imuSample imu_sample_new{};
 
 	hrt_abstime imu_dt = 0; // for tracking time slip later
 
@@ -621,8 +616,7 @@ void EKF2::Run()
 				_gyro_calibration_count = imu.gyro_calibration_count;
 
 			} else {
-				if ((imu.accel_calibration_count != _accel_calibration_count)
-				    || (imu.accel_device_id != _device_id_accel)) {
+				if ((imu.accel_calibration_count != _accel_calibration_count) || (imu.accel_device_id != _device_id_accel)) {
 
 					PX4_DEBUG("%d - resetting accelerometer bias", _instance);
 					_device_id_accel = imu.accel_device_id;
@@ -634,8 +628,7 @@ void EKF2::Run()
 					_accel_cal = {};
 				}
 
-				if ((imu.gyro_calibration_count != _gyro_calibration_count)
-				    || (imu.gyro_device_id != _device_id_gyro)) {
+				if ((imu.gyro_calibration_count != _gyro_calibration_count) || (imu.gyro_device_id != _device_id_gyro)) {
 
 					PX4_DEBUG("%d - resetting rate gyro bias", _instance);
 					_device_id_gyro = imu.gyro_device_id;
@@ -743,7 +736,7 @@ void EKF2::Run()
 		}
 
 		// ekf2_timestamps (using 0.1 ms relative timestamps)
-		ekf2_timestamps_s ekf2_timestamps {
+		ekf2_timestamps_s ekf2_timestamps{
 			.timestamp = now,
 			.airspeed_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID,
 			.airspeed_validated_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID,
@@ -788,6 +781,7 @@ void EKF2::Run()
 
 			PublishLocalPosition(now);
 			PublishOdometry(now, imu_sample_new);
+			PublishFullState(now, imu_sample_new);
 			PublishGlobalPosition(now);
 			PublishSensorBias(now);
 
@@ -818,7 +812,6 @@ void EKF2::Run()
 #if defined(CONFIG_EKF2_GNSS)
 				PublishGnssHgtBias(now);
 #endif // CONFIG_EKF2_GNSS
-
 			}
 
 #if defined(CONFIG_EKF2_GNSS)
@@ -850,11 +843,8 @@ void EKF2::VerifyParams()
 #if defined(CONFIG_EKF2_MAGNETOMETER)
 
 	// EKF2_MAG_TYPE obsolete options
-	if ((_param_ekf2_mag_type.get() != MagFuseType::AUTO)
-	    && (_param_ekf2_mag_type.get() != MagFuseType::HEADING)
-	    && (_param_ekf2_mag_type.get() != MagFuseType::NONE)
-	    && (_param_ekf2_mag_type.get() != MagFuseType::INIT)
-	   ) {
+	if ((_param_ekf2_mag_type.get() != MagFuseType::AUTO) && (_param_ekf2_mag_type.get() != MagFuseType::HEADING)
+	    && (_param_ekf2_mag_type.get() != MagFuseType::NONE) && (_param_ekf2_mag_type.get() != MagFuseType::INIT)) {
 
 		mavlink_log_critical(&_mavlink_log_pub, "EKF2_MAG_TYPE invalid, resetting to default");
 		/* EVENT
@@ -988,9 +978,9 @@ void EKF2::PublishAidSourceStatus(const hrt_abstime &timestamp)
 	PublishAidSourceStatus(timestamp, _ekf.aid_src_gnss_hgt(), _status_gnss_hgt_pub_last, _estimator_aid_src_gnss_hgt_pub);
 	PublishAidSourceStatus(timestamp, _ekf.aid_src_gnss_pos(), _status_gnss_pos_pub_last, _estimator_aid_src_gnss_pos_pub);
 	PublishAidSourceStatus(timestamp, _ekf.aid_src_gnss_vel(), _status_gnss_vel_pub_last, _estimator_aid_src_gnss_vel_pub);
-# if defined(CONFIG_EKF2_GNSS_YAW)
+#if defined(CONFIG_EKF2_GNSS_YAW)
 	PublishAidSourceStatus(timestamp, _ekf.aid_src_gnss_yaw(), _status_gnss_yaw_pub_last, _estimator_aid_src_gnss_yaw_pub);
-# endif // CONFIG_EKF2_GNSS_YAW
+#endif // CONFIG_EKF2_GNSS_YAW
 #endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_MAGNETOMETER)
@@ -1027,7 +1017,7 @@ void EKF2::PublishAttitude(const hrt_abstime &timestamp)
 		att.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 		_attitude_pub.publish(att);
 
-	}  else if (_replay_mode) {
+	} else if (_replay_mode) {
 		// in replay mode we have to tell the replay module not to wait for an update
 		// we do this by publishing an attitude with zero timestamp
 		vehicle_attitude_s att{};
@@ -1132,24 +1122,24 @@ void EKF2::PublishEventFlags(const hrt_abstime &timestamp)
 		estimator_event_flags_s event_flags{};
 		event_flags.timestamp_sample = _ekf.time_delayed_us();
 
-		event_flags.information_event_changes           = _filter_information_event_changes;
-		event_flags.gps_checks_passed                   = _ekf.information_event_flags().gps_checks_passed;
-		event_flags.reset_vel_to_gps                    = _ekf.information_event_flags().reset_vel_to_gps;
-		event_flags.reset_vel_to_flow                   = _ekf.information_event_flags().reset_vel_to_flow;
-		event_flags.reset_vel_to_vision                 = _ekf.information_event_flags().reset_vel_to_vision;
-		event_flags.reset_vel_to_zero                   = _ekf.information_event_flags().reset_vel_to_zero;
-		event_flags.reset_pos_to_last_known             = _ekf.information_event_flags().reset_pos_to_last_known;
-		event_flags.reset_pos_to_gps                    = _ekf.information_event_flags().reset_pos_to_gps;
-		event_flags.reset_pos_to_vision                 = _ekf.information_event_flags().reset_pos_to_vision;
-		event_flags.starting_gps_fusion                 = _ekf.information_event_flags().starting_gps_fusion;
-		event_flags.starting_vision_pos_fusion          = _ekf.information_event_flags().starting_vision_pos_fusion;
-		event_flags.starting_vision_vel_fusion          = _ekf.information_event_flags().starting_vision_vel_fusion;
-		event_flags.starting_vision_yaw_fusion          = _ekf.information_event_flags().starting_vision_yaw_fusion;
-		event_flags.yaw_aligned_to_imu_gps              = _ekf.information_event_flags().yaw_aligned_to_imu_gps;
-		event_flags.reset_hgt_to_baro                   = _ekf.information_event_flags().reset_hgt_to_baro;
-		event_flags.reset_hgt_to_gps                    = _ekf.information_event_flags().reset_hgt_to_gps;
-		event_flags.reset_hgt_to_rng                    = _ekf.information_event_flags().reset_hgt_to_rng;
-		event_flags.reset_hgt_to_ev                     = _ekf.information_event_flags().reset_hgt_to_ev;
+		event_flags.information_event_changes = _filter_information_event_changes;
+		event_flags.gps_checks_passed = _ekf.information_event_flags().gps_checks_passed;
+		event_flags.reset_vel_to_gps = _ekf.information_event_flags().reset_vel_to_gps;
+		event_flags.reset_vel_to_flow = _ekf.information_event_flags().reset_vel_to_flow;
+		event_flags.reset_vel_to_vision = _ekf.information_event_flags().reset_vel_to_vision;
+		event_flags.reset_vel_to_zero = _ekf.information_event_flags().reset_vel_to_zero;
+		event_flags.reset_pos_to_last_known = _ekf.information_event_flags().reset_pos_to_last_known;
+		event_flags.reset_pos_to_gps = _ekf.information_event_flags().reset_pos_to_gps;
+		event_flags.reset_pos_to_vision = _ekf.information_event_flags().reset_pos_to_vision;
+		event_flags.starting_gps_fusion = _ekf.information_event_flags().starting_gps_fusion;
+		event_flags.starting_vision_pos_fusion = _ekf.information_event_flags().starting_vision_pos_fusion;
+		event_flags.starting_vision_vel_fusion = _ekf.information_event_flags().starting_vision_vel_fusion;
+		event_flags.starting_vision_yaw_fusion = _ekf.information_event_flags().starting_vision_yaw_fusion;
+		event_flags.yaw_aligned_to_imu_gps = _ekf.information_event_flags().yaw_aligned_to_imu_gps;
+		event_flags.reset_hgt_to_baro = _ekf.information_event_flags().reset_hgt_to_baro;
+		event_flags.reset_hgt_to_gps = _ekf.information_event_flags().reset_hgt_to_gps;
+		event_flags.reset_hgt_to_rng = _ekf.information_event_flags().reset_hgt_to_rng;
+		event_flags.reset_hgt_to_ev = _ekf.information_event_flags().reset_hgt_to_ev;
 
 		event_flags.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 		_estimator_event_flags_pub.update(event_flags);
@@ -1232,26 +1222,25 @@ void EKF2::PublishGpsStatus(const hrt_abstime &timestamp)
 	estimator_gps_status.timestamp_sample = timestamp_sample;
 
 	estimator_gps_status.position_drift_rate_horizontal_m_s = _ekf.gps_horizontal_position_drift_rate_m_s();
-	estimator_gps_status.position_drift_rate_vertical_m_s   = _ekf.gps_vertical_position_drift_rate_m_s();
-	estimator_gps_status.filtered_horizontal_speed_m_s      = _ekf.gps_filtered_horizontal_velocity_m_s();
+	estimator_gps_status.position_drift_rate_vertical_m_s = _ekf.gps_vertical_position_drift_rate_m_s();
+	estimator_gps_status.filtered_horizontal_speed_m_s = _ekf.gps_filtered_horizontal_velocity_m_s();
 
 	estimator_gps_status.checks_passed = _ekf.gps_checks_passed();
 
-	estimator_gps_status.check_fail_gps_fix          = _ekf.gps_check_fail_status_flags().fix;
-	estimator_gps_status.check_fail_min_sat_count    = _ekf.gps_check_fail_status_flags().nsats;
-	estimator_gps_status.check_fail_max_pdop         = _ekf.gps_check_fail_status_flags().pdop;
-	estimator_gps_status.check_fail_max_horz_err     = _ekf.gps_check_fail_status_flags().hacc;
-	estimator_gps_status.check_fail_max_vert_err     = _ekf.gps_check_fail_status_flags().vacc;
-	estimator_gps_status.check_fail_max_spd_err      = _ekf.gps_check_fail_status_flags().sacc;
-	estimator_gps_status.check_fail_max_horz_drift   = _ekf.gps_check_fail_status_flags().hdrift;
-	estimator_gps_status.check_fail_max_vert_drift   = _ekf.gps_check_fail_status_flags().vdrift;
+	estimator_gps_status.check_fail_gps_fix = _ekf.gps_check_fail_status_flags().fix;
+	estimator_gps_status.check_fail_min_sat_count = _ekf.gps_check_fail_status_flags().nsats;
+	estimator_gps_status.check_fail_max_pdop = _ekf.gps_check_fail_status_flags().pdop;
+	estimator_gps_status.check_fail_max_horz_err = _ekf.gps_check_fail_status_flags().hacc;
+	estimator_gps_status.check_fail_max_vert_err = _ekf.gps_check_fail_status_flags().vacc;
+	estimator_gps_status.check_fail_max_spd_err = _ekf.gps_check_fail_status_flags().sacc;
+	estimator_gps_status.check_fail_max_horz_drift = _ekf.gps_check_fail_status_flags().hdrift;
+	estimator_gps_status.check_fail_max_vert_drift = _ekf.gps_check_fail_status_flags().vdrift;
 	estimator_gps_status.check_fail_max_horz_spd_err = _ekf.gps_check_fail_status_flags().hspeed;
 	estimator_gps_status.check_fail_max_vert_spd_err = _ekf.gps_check_fail_status_flags().vspeed;
-	estimator_gps_status.check_fail_spoofed_gps      = _ekf.gps_check_fail_status_flags().spoofed;
+	estimator_gps_status.check_fail_spoofed_gps = _ekf.gps_check_fail_status_flags().spoofed;
 
 	estimator_gps_status.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 	_estimator_gps_status_pub.publish(estimator_gps_status);
-
 
 	_last_gps_status_published = timestamp_sample;
 }
@@ -1267,20 +1256,20 @@ void EKF2::PublishInnovations(const hrt_abstime &timestamp)
 	// GPS
 	innovations.gps_hvel[0] = _ekf.aid_src_gnss_vel().innovation[0];
 	innovations.gps_hvel[1] = _ekf.aid_src_gnss_vel().innovation[1];
-	innovations.gps_vvel    = _ekf.aid_src_gnss_vel().innovation[2];
+	innovations.gps_vvel = _ekf.aid_src_gnss_vel().innovation[2];
 	innovations.gps_hpos[0] = _ekf.aid_src_gnss_pos().innovation[0];
 	innovations.gps_hpos[1] = _ekf.aid_src_gnss_pos().innovation[1];
-	innovations.gps_vpos    = _ekf.aid_src_gnss_hgt().innovation;
+	innovations.gps_vpos = _ekf.aid_src_gnss_hgt().innovation;
 #endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
 	// External Vision
 	innovations.ev_hvel[0] = _ekf.aid_src_ev_vel().innovation[0];
 	innovations.ev_hvel[1] = _ekf.aid_src_ev_vel().innovation[1];
-	innovations.ev_vvel    = _ekf.aid_src_ev_vel().innovation[2];
+	innovations.ev_vvel = _ekf.aid_src_ev_vel().innovation[2];
 	innovations.ev_hpos[0] = _ekf.aid_src_ev_pos().innovation[0];
 	innovations.ev_hpos[1] = _ekf.aid_src_ev_pos().innovation[1];
-	innovations.ev_vpos    = _ekf.aid_src_ev_hgt().innovation;
+	innovations.ev_vpos = _ekf.aid_src_ev_hgt().innovation;
 #endif // CONFIG_EKF2_EXTERNAL_VISION
 
 	// Height sensors
@@ -1360,20 +1349,20 @@ void EKF2::PublishInnovationTestRatios(const hrt_abstime &timestamp)
 	// GPS
 	test_ratios.gps_hvel[0] = _ekf.aid_src_gnss_vel().test_ratio[0];
 	test_ratios.gps_hvel[1] = _ekf.aid_src_gnss_vel().test_ratio[1];
-	test_ratios.gps_vvel    = _ekf.aid_src_gnss_vel().test_ratio[2];
+	test_ratios.gps_vvel = _ekf.aid_src_gnss_vel().test_ratio[2];
 	test_ratios.gps_hpos[0] = _ekf.aid_src_gnss_pos().test_ratio[0];
 	test_ratios.gps_hpos[1] = _ekf.aid_src_gnss_pos().test_ratio[1];
-	test_ratios.gps_vpos    = _ekf.aid_src_gnss_hgt().test_ratio;
+	test_ratios.gps_vpos = _ekf.aid_src_gnss_hgt().test_ratio;
 #endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
 	// External Vision
 	test_ratios.ev_hvel[0] = _ekf.aid_src_ev_vel().test_ratio[0];
 	test_ratios.ev_hvel[1] = _ekf.aid_src_ev_vel().test_ratio[1];
-	test_ratios.ev_vvel    = _ekf.aid_src_ev_vel().test_ratio[2];
+	test_ratios.ev_vvel = _ekf.aid_src_ev_vel().test_ratio[2];
 	test_ratios.ev_hpos[0] = _ekf.aid_src_ev_pos().test_ratio[0];
 	test_ratios.ev_hpos[1] = _ekf.aid_src_ev_pos().test_ratio[1];
-	test_ratios.ev_vpos    = _ekf.aid_src_ev_hgt().test_ratio;
+	test_ratios.ev_vpos = _ekf.aid_src_ev_hgt().test_ratio;
 #endif // CONFIG_EKF2_EXTERNAL_VISION
 
 	// Height sensors
@@ -1453,20 +1442,20 @@ void EKF2::PublishInnovationVariances(const hrt_abstime &timestamp)
 	// GPS
 	variances.gps_hvel[0] = _ekf.aid_src_gnss_vel().innovation_variance[0];
 	variances.gps_hvel[1] = _ekf.aid_src_gnss_vel().innovation_variance[1];
-	variances.gps_vvel    = _ekf.aid_src_gnss_vel().innovation_variance[2];
+	variances.gps_vvel = _ekf.aid_src_gnss_vel().innovation_variance[2];
 	variances.gps_hpos[0] = _ekf.aid_src_gnss_pos().innovation_variance[0];
 	variances.gps_hpos[1] = _ekf.aid_src_gnss_pos().innovation_variance[1];
-	variances.gps_vpos    = _ekf.aid_src_gnss_hgt().innovation_variance;
+	variances.gps_vpos = _ekf.aid_src_gnss_hgt().innovation_variance;
 #endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
 	// External Vision
 	variances.ev_hvel[0] = _ekf.aid_src_ev_vel().innovation_variance[0];
 	variances.ev_hvel[1] = _ekf.aid_src_ev_vel().innovation_variance[1];
-	variances.ev_vvel    = _ekf.aid_src_ev_vel().innovation_variance[2];
+	variances.ev_vvel = _ekf.aid_src_ev_vel().innovation_variance[2];
 	variances.ev_hpos[0] = _ekf.aid_src_ev_pos().innovation_variance[0];
 	variances.ev_hpos[1] = _ekf.aid_src_ev_pos().innovation_variance[1];
-	variances.ev_vpos    = _ekf.aid_src_ev_hgt().innovation_variance;
+	variances.ev_vpos = _ekf.aid_src_ev_hgt().innovation_variance;
 #endif // CONFIG_EKF2_EXTERNAL_VISION
 
 	// Height sensors
@@ -1576,7 +1565,7 @@ void EKF2::PublishLocalPosition(const hrt_abstime &timestamp)
 		lpos.ref_timestamp = _ekf.global_origin().getProjectionReferenceTimestamp();
 		lpos.ref_lat = _ekf.global_origin().getProjectionReferenceLat(); // Reference point latitude in degrees
 		lpos.ref_lon = _ekf.global_origin().getProjectionReferenceLon(); // Reference point longitude in degrees
-		lpos.ref_alt = _ekf.getEkfGlobalOriginAltitude();           // Reference point in MSL altitude meters
+		lpos.ref_alt = _ekf.getEkfGlobalOriginAltitude();				 // Reference point in MSL altitude meters
 		lpos.xy_global = true;
 		lpos.z_global = true;
 
@@ -1688,15 +1677,53 @@ void EKF2::PublishOdometry(const hrt_abstime &timestamp, const imuSample &imu_sa
 	// orientation covariance
 	_ekf.getRotVarBody().copyTo(odom.orientation_variance);
 
-	odom.reset_counter = _ekf.get_quat_reset_count()
-			     + _ekf.get_velNE_reset_count() + _ekf.get_velD_reset_count()
-			     + _ekf.get_posNE_reset_count() + _ekf.get_posD_reset_count();
+	odom.reset_counter = _ekf.get_quat_reset_count() + _ekf.get_velNE_reset_count() + _ekf.get_velD_reset_count() +
+			     _ekf.get_posNE_reset_count() + _ekf.get_posD_reset_count();
 
 	odom.quality = 0;
 
 	// publish vehicle odometry data
 	odom.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 	_odometry_pub.publish(odom);
+}
+
+void EKF2::PublishFullState(const hrt_abstime &timestamp, const imuSample &imu_sample)
+{
+	vehicle_full_state_s fs{};
+	fs.timestamp_sample = imu_sample.time_us;
+
+	// Position (local NED)
+	const Vector3f position{_ekf.getPosition()};
+	fs.position[0] = position(0);
+	fs.position[1] = position(1);
+	fs.position[2] = position(2);
+
+	// Velocity (local NED)
+	const Vector3f velocity{_ekf.getVelocity()};
+	fs.velocity[0] = velocity(0);
+	fs.velocity[1] = velocity(1);
+	fs.velocity[2] = velocity(2);
+
+	// Linear acceleration (local NED)
+	// EKF provides velocity derivative in local frame
+	const Vector3f vel_deriv{_ekf.getVelocityDerivative()};
+	fs.acceleration[0] = vel_deriv(0);
+	fs.acceleration[1] = vel_deriv(1);
+	fs.acceleration[2] = vel_deriv(2);
+
+	// Orientation quaternion (FRD -> NED), same convention as vehicle_odometry.q
+	_ekf.getQuaternion().copyTo(fs.q); // (w,x,y,z)
+
+	// Angular velocity (body FRD), same as vehicle_odometry angular_velocity
+	const Vector3f rates{imu_sample.delta_ang / imu_sample.delta_ang_dt};
+	const Vector3f angular_velocity = rates - _ekf.getGyroBias();
+	fs.angular_velocity[0] = angular_velocity(0);
+	fs.angular_velocity[1] = angular_velocity(1);
+	fs.angular_velocity[2] = angular_velocity(2);
+
+	// publish
+	fs.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
+	_vehicle_full_state_pub.publish(fs);
 }
 
 void EKF2::PublishSensorBias(const hrt_abstime &timestamp)
@@ -1834,11 +1861,11 @@ void EKF2::PublishStatus(const hrt_abstime &timestamp)
 	status.time_slip = _last_time_slip_us * 1e-6f;
 
 	static constexpr float kMinTestRatioPreflight = 0.5f;
-	status.pre_flt_fail_innov_heading   = (kMinTestRatioPreflight < status.hdg_test_ratio);
-	status.pre_flt_fail_innov_height    = (kMinTestRatioPreflight < status.hgt_test_ratio);
+	status.pre_flt_fail_innov_heading = (kMinTestRatioPreflight < status.hdg_test_ratio);
+	status.pre_flt_fail_innov_height = (kMinTestRatioPreflight < status.hgt_test_ratio);
 	status.pre_flt_fail_innov_pos_horiz = (kMinTestRatioPreflight < status.pos_test_ratio);
 	status.pre_flt_fail_innov_vel_horiz = (kMinTestRatioPreflight < vel_xy_test_ratio);
-	status.pre_flt_fail_innov_vel_vert  = (kMinTestRatioPreflight < vel_z_test_ratio);
+	status.pre_flt_fail_innov_vel_vert = (kMinTestRatioPreflight < vel_z_test_ratio);
 
 	status.pre_flt_fail_mag_field_disturbed = _ekf.control_status_flags().mag_field_disturbed;
 
@@ -1889,77 +1916,77 @@ void EKF2::PublishStatusFlags(const hrt_abstime &timestamp)
 		estimator_status_flags_s status_flags{};
 		status_flags.timestamp_sample = _ekf.time_delayed_us();
 
-		status_flags.control_status_changes   = _filter_control_status_changes;
-		status_flags.cs_tilt_align            = _ekf.control_status_flags().tilt_align;
-		status_flags.cs_yaw_align             = _ekf.control_status_flags().yaw_align;
-		status_flags.cs_gnss_pos              = _ekf.control_status_flags().gnss_pos;
-		status_flags.cs_opt_flow              = _ekf.control_status_flags().opt_flow;
-		status_flags.cs_mag_hdg               = _ekf.control_status_flags().mag_hdg;
-		status_flags.cs_mag_3d                = _ekf.control_status_flags().mag_3D;
-		status_flags.cs_mag_dec               = _ekf.control_status_flags().mag_dec;
-		status_flags.cs_in_air                = _ekf.control_status_flags().in_air;
-		status_flags.cs_wind                  = _ekf.control_status_flags().wind;
-		status_flags.cs_baro_hgt              = _ekf.control_status_flags().baro_hgt;
-		status_flags.cs_rng_hgt               = _ekf.control_status_flags().rng_hgt;
-		status_flags.cs_gps_hgt               = _ekf.control_status_flags().gps_hgt;
-		status_flags.cs_ev_pos                = _ekf.control_status_flags().ev_pos;
-		status_flags.cs_ev_yaw                = _ekf.control_status_flags().ev_yaw;
-		status_flags.cs_ev_hgt                = _ekf.control_status_flags().ev_hgt;
-		status_flags.cs_fuse_beta             = _ekf.control_status_flags().fuse_beta;
-		status_flags.cs_mag_field_disturbed   = _ekf.control_status_flags().mag_field_disturbed;
-		status_flags.cs_fixed_wing            = _ekf.control_status_flags().fixed_wing;
-		status_flags.cs_mag_fault             = _ekf.control_status_flags().mag_fault;
-		status_flags.cs_fuse_aspd             = _ekf.control_status_flags().fuse_aspd;
-		status_flags.cs_gnd_effect            = _ekf.control_status_flags().gnd_effect;
-		status_flags.cs_rng_stuck             = _ekf.control_status_flags().rng_stuck;
-		status_flags.cs_gnss_yaw               = _ekf.control_status_flags().gnss_yaw;
+		status_flags.control_status_changes = _filter_control_status_changes;
+		status_flags.cs_tilt_align = _ekf.control_status_flags().tilt_align;
+		status_flags.cs_yaw_align = _ekf.control_status_flags().yaw_align;
+		status_flags.cs_gnss_pos = _ekf.control_status_flags().gnss_pos;
+		status_flags.cs_opt_flow = _ekf.control_status_flags().opt_flow;
+		status_flags.cs_mag_hdg = _ekf.control_status_flags().mag_hdg;
+		status_flags.cs_mag_3d = _ekf.control_status_flags().mag_3D;
+		status_flags.cs_mag_dec = _ekf.control_status_flags().mag_dec;
+		status_flags.cs_in_air = _ekf.control_status_flags().in_air;
+		status_flags.cs_wind = _ekf.control_status_flags().wind;
+		status_flags.cs_baro_hgt = _ekf.control_status_flags().baro_hgt;
+		status_flags.cs_rng_hgt = _ekf.control_status_flags().rng_hgt;
+		status_flags.cs_gps_hgt = _ekf.control_status_flags().gps_hgt;
+		status_flags.cs_ev_pos = _ekf.control_status_flags().ev_pos;
+		status_flags.cs_ev_yaw = _ekf.control_status_flags().ev_yaw;
+		status_flags.cs_ev_hgt = _ekf.control_status_flags().ev_hgt;
+		status_flags.cs_fuse_beta = _ekf.control_status_flags().fuse_beta;
+		status_flags.cs_mag_field_disturbed = _ekf.control_status_flags().mag_field_disturbed;
+		status_flags.cs_fixed_wing = _ekf.control_status_flags().fixed_wing;
+		status_flags.cs_mag_fault = _ekf.control_status_flags().mag_fault;
+		status_flags.cs_fuse_aspd = _ekf.control_status_flags().fuse_aspd;
+		status_flags.cs_gnd_effect = _ekf.control_status_flags().gnd_effect;
+		status_flags.cs_rng_stuck = _ekf.control_status_flags().rng_stuck;
+		status_flags.cs_gnss_yaw = _ekf.control_status_flags().gnss_yaw;
 		status_flags.cs_mag_aligned_in_flight = _ekf.control_status_flags().mag_aligned_in_flight;
-		status_flags.cs_ev_vel                = _ekf.control_status_flags().ev_vel;
-		status_flags.cs_synthetic_mag_z       = _ekf.control_status_flags().synthetic_mag_z;
-		status_flags.cs_vehicle_at_rest       = _ekf.control_status_flags().vehicle_at_rest;
-		status_flags.cs_gnss_yaw_fault         = _ekf.control_status_flags().gnss_yaw_fault;
-		status_flags.cs_rng_fault             = _ekf.control_status_flags().rng_fault;
+		status_flags.cs_ev_vel = _ekf.control_status_flags().ev_vel;
+		status_flags.cs_synthetic_mag_z = _ekf.control_status_flags().synthetic_mag_z;
+		status_flags.cs_vehicle_at_rest = _ekf.control_status_flags().vehicle_at_rest;
+		status_flags.cs_gnss_yaw_fault = _ekf.control_status_flags().gnss_yaw_fault;
+		status_flags.cs_rng_fault = _ekf.control_status_flags().rng_fault;
 		status_flags.cs_inertial_dead_reckoning = _ekf.control_status_flags().inertial_dead_reckoning;
-		status_flags.cs_wind_dead_reckoning     = _ekf.control_status_flags().wind_dead_reckoning;
-		status_flags.cs_rng_kin_consistent      = _ekf.control_status_flags().rng_kin_consistent;
-		status_flags.cs_fake_pos                = _ekf.control_status_flags().fake_pos;
-		status_flags.cs_fake_hgt                = _ekf.control_status_flags().fake_hgt;
-		status_flags.cs_gravity_vector          = _ekf.control_status_flags().gravity_vector;
-		status_flags.cs_mag                     = _ekf.control_status_flags().mag;
-		status_flags.cs_ev_yaw_fault            = _ekf.control_status_flags().ev_yaw_fault;
-		status_flags.cs_mag_heading_consistent  = _ekf.control_status_flags().mag_heading_consistent;
-		status_flags.cs_aux_gpos                = _ekf.control_status_flags().aux_gpos;
-		status_flags.cs_rng_terrain    = _ekf.control_status_flags().rng_terrain;
-		status_flags.cs_opt_flow_terrain    = _ekf.control_status_flags().opt_flow_terrain;
-		status_flags.cs_valid_fake_pos      = _ekf.control_status_flags().valid_fake_pos;
-		status_flags.cs_constant_pos        = _ekf.control_status_flags().constant_pos;
-		status_flags.cs_baro_fault	    = _ekf.control_status_flags().baro_fault;
-		status_flags.cs_gnss_vel            = _ekf.control_status_flags().gnss_vel;
+		status_flags.cs_wind_dead_reckoning = _ekf.control_status_flags().wind_dead_reckoning;
+		status_flags.cs_rng_kin_consistent = _ekf.control_status_flags().rng_kin_consistent;
+		status_flags.cs_fake_pos = _ekf.control_status_flags().fake_pos;
+		status_flags.cs_fake_hgt = _ekf.control_status_flags().fake_hgt;
+		status_flags.cs_gravity_vector = _ekf.control_status_flags().gravity_vector;
+		status_flags.cs_mag = _ekf.control_status_flags().mag;
+		status_flags.cs_ev_yaw_fault = _ekf.control_status_flags().ev_yaw_fault;
+		status_flags.cs_mag_heading_consistent = _ekf.control_status_flags().mag_heading_consistent;
+		status_flags.cs_aux_gpos = _ekf.control_status_flags().aux_gpos;
+		status_flags.cs_rng_terrain = _ekf.control_status_flags().rng_terrain;
+		status_flags.cs_opt_flow_terrain = _ekf.control_status_flags().opt_flow_terrain;
+		status_flags.cs_valid_fake_pos = _ekf.control_status_flags().valid_fake_pos;
+		status_flags.cs_constant_pos = _ekf.control_status_flags().constant_pos;
+		status_flags.cs_baro_fault = _ekf.control_status_flags().baro_fault;
+		status_flags.cs_gnss_vel = _ekf.control_status_flags().gnss_vel;
 
-		status_flags.fault_status_changes     = _filter_fault_status_changes;
-		status_flags.fs_bad_mag_x             = _ekf.fault_status_flags().bad_mag_x;
-		status_flags.fs_bad_mag_y             = _ekf.fault_status_flags().bad_mag_y;
-		status_flags.fs_bad_mag_z             = _ekf.fault_status_flags().bad_mag_z;
-		status_flags.fs_bad_hdg               = _ekf.fault_status_flags().bad_hdg;
-		status_flags.fs_bad_mag_decl          = _ekf.fault_status_flags().bad_mag_decl;
-		status_flags.fs_bad_airspeed          = _ekf.fault_status_flags().bad_airspeed;
-		status_flags.fs_bad_sideslip          = _ekf.fault_status_flags().bad_sideslip;
-		status_flags.fs_bad_optflow_x         = _ekf.fault_status_flags().bad_optflow_X;
-		status_flags.fs_bad_optflow_y         = _ekf.fault_status_flags().bad_optflow_Y;
-		status_flags.fs_bad_acc_vertical      = _ekf.fault_status_flags().bad_acc_vertical;
-		status_flags.fs_bad_acc_clipping      = _ekf.fault_status_flags().bad_acc_clipping;
+		status_flags.fault_status_changes = _filter_fault_status_changes;
+		status_flags.fs_bad_mag_x = _ekf.fault_status_flags().bad_mag_x;
+		status_flags.fs_bad_mag_y = _ekf.fault_status_flags().bad_mag_y;
+		status_flags.fs_bad_mag_z = _ekf.fault_status_flags().bad_mag_z;
+		status_flags.fs_bad_hdg = _ekf.fault_status_flags().bad_hdg;
+		status_flags.fs_bad_mag_decl = _ekf.fault_status_flags().bad_mag_decl;
+		status_flags.fs_bad_airspeed = _ekf.fault_status_flags().bad_airspeed;
+		status_flags.fs_bad_sideslip = _ekf.fault_status_flags().bad_sideslip;
+		status_flags.fs_bad_optflow_x = _ekf.fault_status_flags().bad_optflow_X;
+		status_flags.fs_bad_optflow_y = _ekf.fault_status_flags().bad_optflow_Y;
+		status_flags.fs_bad_acc_vertical = _ekf.fault_status_flags().bad_acc_vertical;
+		status_flags.fs_bad_acc_clipping = _ekf.fault_status_flags().bad_acc_clipping;
 
 		status_flags.innovation_fault_status_changes = _innov_check_fail_status_changes;
-		status_flags.reject_hor_vel                  = _ekf.innov_check_fail_status_flags().reject_hor_vel;
-		status_flags.reject_ver_vel                  = _ekf.innov_check_fail_status_flags().reject_ver_vel;
-		status_flags.reject_hor_pos                  = _ekf.innov_check_fail_status_flags().reject_hor_pos;
-		status_flags.reject_ver_pos                  = _ekf.innov_check_fail_status_flags().reject_ver_pos;
-		status_flags.reject_yaw                      = _ekf.innov_check_fail_status_flags().reject_yaw;
-		status_flags.reject_airspeed                 = _ekf.innov_check_fail_status_flags().reject_airspeed;
-		status_flags.reject_sideslip                 = _ekf.innov_check_fail_status_flags().reject_sideslip;
-		status_flags.reject_hagl                     = _ekf.innov_check_fail_status_flags().reject_hagl;
-		status_flags.reject_optflow_x                = _ekf.innov_check_fail_status_flags().reject_optflow_X;
-		status_flags.reject_optflow_y                = _ekf.innov_check_fail_status_flags().reject_optflow_Y;
+		status_flags.reject_hor_vel = _ekf.innov_check_fail_status_flags().reject_hor_vel;
+		status_flags.reject_ver_vel = _ekf.innov_check_fail_status_flags().reject_ver_vel;
+		status_flags.reject_hor_pos = _ekf.innov_check_fail_status_flags().reject_hor_pos;
+		status_flags.reject_ver_pos = _ekf.innov_check_fail_status_flags().reject_ver_pos;
+		status_flags.reject_yaw = _ekf.innov_check_fail_status_flags().reject_yaw;
+		status_flags.reject_airspeed = _ekf.innov_check_fail_status_flags().reject_airspeed;
+		status_flags.reject_sideslip = _ekf.innov_check_fail_status_flags().reject_sideslip;
+		status_flags.reject_hagl = _ekf.innov_check_fail_status_flags().reject_hagl;
+		status_flags.reject_optflow_x = _ekf.innov_check_fail_status_flags().reject_optflow_X;
+		status_flags.reject_optflow_y = _ekf.innov_check_fail_status_flags().reject_optflow_Y;
 
 		status_flags.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 		_estimator_status_flags_pub.publish(status_flags);
@@ -2065,8 +2092,7 @@ void EKF2::UpdateAirspeedSample(ekf2_timestamps_s &ekf2_timestamps)
 		if (_airspeed_validated_sub.update(&airspeed_validated)) {
 
 			if (PX4_ISFINITE(airspeed_validated.true_airspeed_m_s)
-			    && (airspeed_validated.airspeed_source > airspeed_validated_s::GROUND_MINUS_WIND)
-			   ) {
+			    && (airspeed_validated.airspeed_source > airspeed_validated_s::GROUND_MINUS_WIND)) {
 
 				_ekf.setSyntheticAirspeed(airspeed_validated.airspeed_source == airspeed_validated_s::SYNTHETIC);
 
@@ -2077,7 +2103,7 @@ void EKF2::UpdateAirspeedSample(ekf2_timestamps_s &ekf2_timestamps)
 					cas2tas = airspeed_validated.true_airspeed_m_s / airspeed_validated.calibrated_airspeed_m_s;
 				}
 
-				airspeedSample airspeed_sample {
+				airspeedSample airspeed_sample{
 					.time_us = airspeed_validated.timestamp,
 					.true_airspeed = airspeed_validated.true_airspeed_m_s,
 					.eas2tas = cas2tas,
@@ -2100,11 +2126,9 @@ void EKF2::UpdateAirspeedSample(ekf2_timestamps_s &ekf2_timestamps)
 			// for scale factor errors and requires the ASPD_SCALE correction to be applied.
 			const float true_airspeed_m_s = airspeed.true_airspeed_m_s * _airspeed_scale_factor;
 
-			if (PX4_ISFINITE(airspeed.true_airspeed_m_s)
-			    && PX4_ISFINITE(airspeed.indicated_airspeed_m_s)
-			    && (airspeed.indicated_airspeed_m_s > 0.f)
-			   ) {
-				airspeedSample airspeed_sample {
+			if (PX4_ISFINITE(airspeed.true_airspeed_m_s) && PX4_ISFINITE(airspeed.indicated_airspeed_m_s)
+			    && (airspeed.indicated_airspeed_m_s > 0.f)) {
+				airspeedSample airspeed_sample{
 					.time_us = airspeed.timestamp_sample,
 					.true_airspeed = true_airspeed_m_s,
 					.eas2tas = airspeed.true_airspeed_m_s / airspeed.indicated_airspeed_m_s,
@@ -2281,13 +2305,11 @@ bool EKF2::UpdateExtVisionSample(ekf2_timestamps_s &ekf2_timestamps)
 		// check for valid orientation data
 		const Quatf ev_odom_q(ev_odom.q);
 		const Vector3f ev_odom_q_var(ev_odom.orientation_variance);
-		const bool non_zero = (fabsf(ev_odom_q(0)) > 0.f) || (fabsf(ev_odom_q(1)) > 0.f)
-				      || (fabsf(ev_odom_q(2)) > 0.f) || (fabsf(ev_odom_q(3)) > 0.f);
+		const bool non_zero = (fabsf(ev_odom_q(0)) > 0.f) || (fabsf(ev_odom_q(1)) > 0.f) || (fabsf(ev_odom_q(2)) > 0.f)
+				      || (fabsf(ev_odom_q(3)) > 0.f);
 		const float eps = 1e-5f;
-		const bool no_element_larger_than_one = (fabsf(ev_odom_q(0)) <= 1.f + eps)
-							&& (fabsf(ev_odom_q(1)) <= 1.f + eps)
-							&& (fabsf(ev_odom_q(2)) <= 1.f + eps)
-							&& (fabsf(ev_odom_q(3)) <= 1.f + eps);
+		const bool no_element_larger_than_one = (fabsf(ev_odom_q(0)) <= 1.f + eps) && (fabsf(ev_odom_q(1)) <= 1.f + eps)
+							&& (fabsf(ev_odom_q(2)) <= 1.f + eps) && (fabsf(ev_odom_q(3)) <= 1.f + eps);
 		const bool norm_in_tolerance = fabsf(1.f - ev_odom_q.norm()) <= eps;
 
 		const bool orientation_valid = ev_odom_q.isAllFinite() && non_zero && no_element_larger_than_one && norm_in_tolerance;
@@ -2317,7 +2339,7 @@ bool EKF2::UpdateExtVisionSample(ekf2_timestamps_s &ekf2_timestamps)
 		ev_data.reset_counter = ev_odom.reset_counter;
 		ev_data.quality = ev_odom.quality;
 
-		if (new_ev_odom)  {
+		if (new_ev_odom) {
 			_ekf.setExtVisionData(ev_data);
 		}
 
@@ -2354,12 +2376,11 @@ bool EKF2::UpdateFlowSample(ekf2_timestamps_s &ekf2_timestamps)
 			gyro_rate.zero();
 		}
 
-		flowSample flow {
+		flowSample flow{
 			.time_us = optical_flow.timestamp_sample - optical_flow.integration_timespan_us / 2, // correct timestamp to midpoint of integration interval as the data is converted to rates
 			.flow_rate = flow_rate,
 			.gyro_rate = gyro_rate,
-			.quality = optical_flow.quality
-		};
+			.quality = optical_flow.quality};
 
 		if (Vector2f(optical_flow.pixel_flow).isAllFinite() && optical_flow.integration_timespan_us < 1e6) {
 
@@ -2379,7 +2400,7 @@ bool EKF2::UpdateFlowSample(ekf2_timestamps_s &ekf2_timestamps)
 
 			int8_t quality = static_cast<float>(optical_flow.quality) / static_cast<float>(UINT8_MAX) * 100.f;
 
-			estimator::sensor::rangeSample range_sample {
+			estimator::sensor::rangeSample range_sample{
 				.time_us = optical_flow.timestamp_sample,
 				.rng = optical_flow.distance_m,
 				.quality = quality,
@@ -2416,7 +2437,7 @@ void EKF2::UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps)
 					   vehicle_gps_position.vel_d_m_s);
 
 		} else {
-			return; //TODO: change and set to NAN
+			return; // TODO: change and set to NAN
 		}
 
 		if (fabsf(_param_ekf2_gps_yaw_off.get()) > 0.f) {
@@ -2442,9 +2463,8 @@ void EKF2::UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps)
 			.sacc = vehicle_gps_position.s_variance_m_s,
 			.fix_type = vehicle_gps_position.fix_type,
 			.nsats = vehicle_gps_position.satellites_used,
-			.pdop = sqrtf(vehicle_gps_position.hdop *vehicle_gps_position.hdop
-				      + vehicle_gps_position.vdop * vehicle_gps_position.vdop),
-			.yaw = vehicle_gps_position.heading, //TODO: move to different message
+			.pdop = sqrtf(vehicle_gps_position.hdop * vehicle_gps_position.hdop + vehicle_gps_position.vdop * vehicle_gps_position.vdop),
+			.yaw = vehicle_gps_position.heading, // TODO: move to different message
 			.yaw_acc = vehicle_gps_position.heading_accuracy,
 			.yaw_offset = vehicle_gps_position.heading_offset,
 			.spoofed = vehicle_gps_position.spoofing_state == sensor_gps_s::SPOOFING_STATE_MULTIPLE,
@@ -2464,7 +2484,6 @@ void EKF2::UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps)
 			_geoid_height_lpf.update(geoid_height);
 			_last_geoid_height_update_us = gnss_sample.time_us;
 		}
-
 	}
 }
 
@@ -2554,7 +2573,7 @@ void EKF2::UpdateRangeSample(ekf2_timestamps_s &ekf2_timestamps)
 	if (_distance_sensor_selected >= 0 && _distance_sensor_subs[_distance_sensor_selected].update(&distance_sensor)) {
 		// EKF range sample
 		if (distance_sensor.orientation == distance_sensor_s::ROTATION_DOWNWARD_FACING) {
-			estimator::sensor::rangeSample range_sample {
+			estimator::sensor::rangeSample range_sample{
 				.time_us = distance_sensor.timestamp,
 				.rng = distance_sensor.current_distance,
 				.quality = distance_sensor.signal_quality,
@@ -2589,8 +2608,7 @@ void EKF2::UpdateSystemFlagsSample(ekf2_timestamps_s &ekf2_timestamps)
 		// vehicle_status
 		vehicle_status_s vehicle_status;
 
-		if (_status_sub.copy(&vehicle_status)
-		    && (ekf2_timestamps.timestamp < vehicle_status.timestamp + 3_s)) {
+		if (_status_sub.copy(&vehicle_status) && (ekf2_timestamps.timestamp < vehicle_status.timestamp + 3_s)) {
 
 			// initially set in_air from arming_state (will be overridden if land detector is available)
 			flags.in_air = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
@@ -2646,8 +2664,7 @@ void EKF2::UpdateCalibration(const hrt_abstime &timestamp, InFlightCalibration &
 	static constexpr float max_var_allowed = 1e-3f;
 	static constexpr float max_var_ratio = 1e2f;
 
-	const bool valid = bias_valid
-			   && (bias_variance.max() < max_var_allowed)
+	const bool valid = bias_valid && (bias_variance.max() < max_var_allowed)
 			   && (bias_variance.max() < max_var_ratio * bias_variance.min());
 
 	if (valid && learning_valid) {
@@ -2688,10 +2705,8 @@ void EKF2::UpdateAccelCalibration(const hrt_abstime &timestamp)
 {
 	// the EKF is operating in the correct mode and there are no filter faults
 	const bool bias_valid = (_param_ekf2_imu_ctrl.get() & static_cast<int32_t>(ImuCtrl::AccelBias))
-				&& _ekf.control_status_flags().tilt_align
-				&& (_ekf.fault_status().value == 0)
-				&& !_ekf.fault_status_flags().bad_acc_clipping
-				&& !_ekf.fault_status_flags().bad_acc_vertical;
+				&& _ekf.control_status_flags().tilt_align && (_ekf.fault_status().value == 0)
+				&& !_ekf.fault_status_flags().bad_acc_clipping && !_ekf.fault_status_flags().bad_acc_vertical;
 
 	const bool learning_valid = bias_valid && !_ekf.accel_bias_inhibited();
 
@@ -2703,8 +2718,7 @@ void EKF2::UpdateGyroCalibration(const hrt_abstime &timestamp)
 {
 	// the EKF is operating in the correct mode and there are no filter faults
 	const bool bias_valid = (_param_ekf2_imu_ctrl.get() & static_cast<int32_t>(ImuCtrl::GyroBias))
-				&& _ekf.control_status_flags().tilt_align
-				&& (_ekf.fault_status().value == 0);
+				&& _ekf.control_status_flags().tilt_align && (_ekf.fault_status().value == 0);
 
 	const bool learning_valid = bias_valid && !_ekf.gyro_bias_inhibited();
 
@@ -2718,8 +2732,7 @@ void EKF2::UpdateMagCalibration(const hrt_abstime &timestamp)
 	const Vector3f mag_bias = _ekf.getMagBias();
 	const Vector3f mag_bias_var = _ekf.getMagBiasVariance();
 
-	const bool bias_valid = (_ekf.fault_status().value == 0)
-				&& _ekf.control_status_flags().yaw_align
+	const bool bias_valid = (_ekf.fault_status().value == 0) && _ekf.control_status_flags().yaw_align
 				&& mag_bias_var.longerThan(0.f) && !mag_bias_var.longerThan(0.02f);
 
 	const bool learning_valid = bias_valid && _ekf.control_status_flags().mag;
@@ -2954,17 +2967,20 @@ timestamps from the sensor topics.
 
 extern "C" __EXPORT int ekf2_main(int argc, char *argv[])
 {
-	if (argc <= 1 || strcmp(argv[1], "-h") == 0) {
+	if (argc <= 1 || strcmp(argv[1], "-h") == 0)
+	{
 		return EKF2::print_usage();
 	}
 
-	if (strcmp(argv[1], "start") == 0) {
+	if (strcmp(argv[1], "start") == 0)
+	{
 		int ret = 0;
 		EKF2::lock_module();
 
 		ret = EKF2::task_spawn(argc - 1, argv + 1);
 
-		if (ret < 0) {
+		if (ret < 0)
+		{
 			PX4_ERR("start failed (%i)", ret);
 		}
 
@@ -2972,34 +2988,47 @@ extern "C" __EXPORT int ekf2_main(int argc, char *argv[])
 		return ret;
 
 #if defined(CONFIG_EKF2_MULTI_INSTANCE)
-	} else if (strcmp(argv[1], "select_instance") == 0) {
+	}
+	else if (strcmp(argv[1], "select_instance") == 0)
+	{
 
-		if (EKF2::trylock_module()) {
-			if (_ekf2_selector.load()) {
-				if (argc > 2) {
+		if (EKF2::trylock_module())
+		{
+			if (_ekf2_selector.load())
+			{
+				if (argc > 2)
+				{
 					int instance = atoi(argv[2]);
 					_ekf2_selector.load()->RequestInstance(instance);
-				} else {
+				}
+				else
+				{
 					EKF2::unlock_module();
 					return EKF2::print_usage("instance required");
 				}
-
-			} else {
+			}
+			else
+			{
 				PX4_ERR("multi-EKF not active, unable to select instance");
 			}
 
 			EKF2::unlock_module();
-
-		} else {
+		}
+		else
+		{
 			PX4_WARN("module locked, try again later");
 		}
 
 		return 0;
 #endif // CONFIG_EKF2_MULTI_INSTANCE
-	} else if (strcmp(argv[1], "status") == 0) {
-		if (EKF2::trylock_module()) {
+	}
+	else if (strcmp(argv[1], "status") == 0)
+	{
+		if (EKF2::trylock_module())
+		{
 #if defined(CONFIG_EKF2_MULTI_INSTANCE)
-			if (_ekf2_selector.load()) {
+			if (_ekf2_selector.load())
+			{
 				_ekf2_selector.load()->PrintStatus();
 			}
 #endif // CONFIG_EKF2_MULTI_INSTANCE
@@ -3007,52 +3036,64 @@ extern "C" __EXPORT int ekf2_main(int argc, char *argv[])
 			bool verbose_status = false;
 
 #if defined(CONFIG_EKF2_VERBOSE_STATUS)
-			if (argc > 2 && (strcmp(argv[2], "-v") == 0)) {
+			if (argc > 2 && (strcmp(argv[2], "-v") == 0))
+			{
 				verbose_status = true;
 			}
 #endif // CONFIG_EKF2_VERBOSE_STATUS
 
-			for (int i = 0; i < EKF2_MAX_INSTANCES; i++) {
-				if (_objects[i].load()) {
+			for (int i = 0; i < EKF2_MAX_INSTANCES; i++)
+			{
+				if (_objects[i].load())
+				{
 					PX4_INFO_RAW("\n");
 					_objects[i].load()->print_status(verbose_status);
 				}
 			}
 
 			EKF2::unlock_module();
-
-		} else {
+		}
+		else
+		{
 			PX4_WARN("module locked, try again later");
 		}
 
 		return 0;
-
-	} else if (strcmp(argv[1], "stop") == 0) {
+	}
+	else if (strcmp(argv[1], "stop") == 0)
+	{
 		EKF2::lock_module();
 
-		if (argc > 2) {
+		if (argc > 2)
+		{
 			int instance = atoi(argv[2]);
 
-			if (instance >= 0 && instance < EKF2_MAX_INSTANCES) {
+			if (instance >= 0 && instance < EKF2_MAX_INSTANCES)
+			{
 				PX4_INFO("stopping instance %d", instance);
 				EKF2 *inst = _objects[instance].load();
 
-				if (inst) {
+				if (inst)
+				{
 					inst->request_stop();
 					px4_usleep(20000); // 20 ms
 					delete inst;
 					_objects[instance].store(nullptr);
 				}
-			} else {
+			}
+			else
+			{
 				PX4_ERR("invalid instance %d", instance);
 			}
-
-		} else {
+		}
+		else
+		{
 			// otherwise stop everything
 			bool was_running = false;
 
 #if defined(CONFIG_EKF2_MULTI_INSTANCE)
-			if (_ekf2_selector.load()) {
+			if (_ekf2_selector.load())
+			{
 				PX4_INFO("stopping ekf2 selector");
 				_ekf2_selector.load()->Stop();
 				delete _ekf2_selector.load();
@@ -3061,10 +3102,12 @@ extern "C" __EXPORT int ekf2_main(int argc, char *argv[])
 			}
 #endif // CONFIG_EKF2_MULTI_INSTANCE
 
-			for (int i = 0; i < EKF2_MAX_INSTANCES; i++) {
+			for (int i = 0; i < EKF2_MAX_INSTANCES; i++)
+			{
 				EKF2 *inst = _objects[i].load();
 
-				if (inst) {
+				if (inst)
+				{
 					PX4_INFO("stopping ekf2 instance %d", i);
 					was_running = true;
 					inst->request_stop();
@@ -3074,7 +3117,8 @@ extern "C" __EXPORT int ekf2_main(int argc, char *argv[])
 				}
 			}
 
-			if (!was_running) {
+			if (!was_running)
+			{
 				PX4_WARN("not running");
 			}
 		}

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -87,40 +87,41 @@
 #include <uORB/topics/vehicle_odometry.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/yaw_estimator_status.h>
+#include <uORB/topics/vehicle_full_state.h>
 
 #if defined(CONFIG_EKF2_AIRSPEED)
-# include <uORB/topics/airspeed.h>
-# include <uORB/topics/airspeed_validated.h>
+#include <uORB/topics/airspeed.h>
+#include <uORB/topics/airspeed_validated.h>
 #endif // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_AUXVEL)
-# include <uORB/topics/landing_target_pose.h>
+#include <uORB/topics/landing_target_pose.h>
 #endif // CONFIG_EKF2_AUXVEL
 
 #if defined(CONFIG_EKF2_BAROMETER)
-# include <uORB/topics/vehicle_air_data.h>
+#include <uORB/topics/vehicle_air_data.h>
 #endif // CONFIG_EKF2_BAROMETER
 
 #if defined(CONFIG_EKF2_GNSS)
-# include <uORB/topics/estimator_gps_status.h>
-# include <uORB/topics/sensor_gps.h>
+#include <uORB/topics/estimator_gps_status.h>
+#include <uORB/topics/sensor_gps.h>
 #endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_MAGNETOMETER)
-# include <uORB/topics/vehicle_magnetometer.h>
+#include <uORB/topics/vehicle_magnetometer.h>
 #endif // CONFIG_EKF2_MAGNETOMETER
 
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)
-# include <uORB/topics/vehicle_optical_flow.h>
-# include <uORB/topics/vehicle_optical_flow_vel.h>
+#include <uORB/topics/vehicle_optical_flow.h>
+#include <uORB/topics/vehicle_optical_flow_vel.h>
 #endif // CONFIG_EKF2_OPTICAL_FLOW
 
 #if defined(CONFIG_EKF2_RANGE_FINDER)
-# include <uORB/topics/distance_sensor.h>
+#include <uORB/topics/distance_sensor.h>
 #endif // CONFIG_EKF2_RANGE_FINDER
 
 #if defined(CONFIG_EKF2_WIND)
-# include <uORB/topics/wind.h>
+#include <uORB/topics/wind.h>
 #endif // CONFIG_EKF2_WIND
 
 extern pthread_mutex_t ekf2_module_mutex;
@@ -158,7 +159,6 @@ public:
 	int instance() const { return _instance; }
 
 private:
-
 	static constexpr uint8_t MAX_NUM_IMUS = 4;
 	static constexpr uint8_t MAX_NUM_MAGS = 4;
 
@@ -190,6 +190,7 @@ private:
 	void PublishInnovationVariances(const hrt_abstime &timestamp);
 	void PublishLocalPosition(const hrt_abstime &timestamp);
 	void PublishOdometry(const hrt_abstime &timestamp, const imuSample &imu_sample);
+	void PublishFullState(const hrt_abstime &timestamp, const imuSample &imu_sample);
 	void PublishSensorBias(const hrt_abstime &timestamp);
 	void PublishStates(const hrt_abstime &timestamp);
 	void PublishStatus(const hrt_abstime &timestamp);
@@ -234,10 +235,10 @@ private:
 
 	// Used to check, save and use learned accel/gyro/mag biases
 	struct InFlightCalibration {
-		hrt_abstime last_us{0};         ///< last time the EKF was operating a mode that estimates accelerometer biases (uSec)
-		hrt_abstime total_time_us{0};   ///< accumulated calibration time since the last save
+		hrt_abstime last_us{0};		  ///< last time the EKF was operating a mode that estimates accelerometer biases (uSec)
+		hrt_abstime total_time_us{0}; ///< accumulated calibration time since the last save
 		matrix::Vector3f bias{};
-		bool cal_available{false};      ///< true when an unsaved valid calibration for the XYZ accelerometer bias is available
+		bool cal_available{false}; ///< true when an unsaved valid calibration for the XYZ accelerometer bias is available
 	};
 
 	void UpdateCalibration(const hrt_abstime &timestamp, InFlightCalibration &cal, const matrix::Vector3f &bias,
@@ -267,19 +268,19 @@ private:
 
 	static constexpr float sq(float x) { return x * x; };
 
-	const bool _replay_mode{false};			///< true when we use replay data from a log
+	const bool _replay_mode{false}; ///< true when we use replay data from a log
 	const bool _multi_mode;
 	int _instance{0};
 
 	px4::atomic_bool _task_should_exit{false};
 
 	// time slip monitoring
-	uint64_t _integrated_time_us = 0;	///< integral of gyro delta time from start (uSec)
-	uint64_t _start_time_us = 0;		///< system time at EKF start (uSec)
-	int64_t _last_time_slip_us = 0;		///< Last time slip (uSec)
+	uint64_t _integrated_time_us = 0; ///< integral of gyro delta time from start (uSec)
+	uint64_t _start_time_us = 0;	  ///< system time at EKF start (uSec)
+	int64_t _last_time_slip_us = 0;	  ///< Last time slip (uSec)
 
-	perf_counter_t _ekf_update_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": EKF update")};
-	perf_counter_t _msg_missed_imu_perf{perf_alloc(PC_COUNT, MODULE_NAME": IMU message missed")};
+	perf_counter_t _ekf_update_perf{perf_alloc(PC_ELAPSED, MODULE_NAME ": EKF update")};
+	perf_counter_t _msg_missed_imu_perf{perf_alloc(PC_COUNT, MODULE_NAME ": IMU message missed")};
 
 	InFlightCalibration _accel_cal{};
 	InFlightCalibration _gyro_cal{};
@@ -302,7 +303,7 @@ private:
 	uint32_t _device_id_mag {0};
 
 	// Used to control saving of mag declination to be used on next startup
-	bool _mag_decl_saved = false;	///< true when the magnetic declination has been saved
+	bool _mag_decl_saved = false; ///< true when the magnetic declination has been saved
 
 	InFlightCalibration _mag_cal{};
 	uint8_t _mag_calibration_count{0};
@@ -358,7 +359,7 @@ private:
 	uORB::Subscription _airdata_sub{ORB_ID(vehicle_air_data)};
 
 	uORB::PublicationMulti<estimator_bias_s> _estimator_baro_bias_pub{ORB_ID(estimator_baro_bias)};
-	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_baro_hgt_pub {ORB_ID(estimator_aid_src_baro_hgt)};
+	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_baro_hgt_pub{ORB_ID(estimator_aid_src_baro_hgt)};
 #endif // CONFIG_EKF2_BAROMETER
 
 #if defined(CONFIG_EKF2_DRAG_FUSION)
@@ -373,13 +374,13 @@ private:
 	float _airspeed_scale_factor{1.0f}; ///< scale factor correction applied to airspeed measurements
 	hrt_abstime _airspeed_validated_timestamp_last{0};
 
-	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_airspeed_pub {ORB_ID(estimator_aid_src_airspeed)};
+	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_airspeed_pub{ORB_ID(estimator_aid_src_airspeed)};
 	hrt_abstime _status_airspeed_pub_last{0};
 #endif // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_SIDESLIP)
 	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_sideslip_pub {ORB_ID(estimator_aid_src_sideslip)};
-	hrt_abstime _status_sideslip_pub_last {0};
+	hrt_abstime _status_sideslip_pub_last{0};
 #endif // CONFIG_EKF2_SIDESLIP
 
 	orb_advert_t _mavlink_log_pub{nullptr};
@@ -405,7 +406,7 @@ private:
 	uORB::SubscriptionMultiArray<distance_sensor_s> _distance_sensor_subs{ORB_ID::distance_sensor};
 	hrt_abstime _last_range_sensor_update{0};
 	int _distance_sensor_selected{-1}; // because we can have several distance sensor instances with different orientations
-#endif // CONFIG_EKF2_RANGE_FINDER
+#endif								   // CONFIG_EKF2_RANGE_FINDER
 
 	bool _callback_registered{false};
 
@@ -421,34 +422,36 @@ private:
 	uint32_t _innov_check_fail_status_changes{0};
 	uint32_t _filter_information_event_changes{0};
 
-	uORB::PublicationMulti<ekf2_timestamps_s>            _ekf2_timestamps_pub{ORB_ID(ekf2_timestamps)};
-	uORB::PublicationMultiData<estimator_event_flags_s>  _estimator_event_flags_pub{ORB_ID(estimator_event_flags)};
-	uORB::PublicationMulti<estimator_innovations_s>      _estimator_innovation_test_ratios_pub{ORB_ID(estimator_innovation_test_ratios)};
-	uORB::PublicationMulti<estimator_innovations_s>      _estimator_innovation_variances_pub{ORB_ID(estimator_innovation_variances)};
-	uORB::PublicationMulti<estimator_innovations_s>      _estimator_innovations_pub{ORB_ID(estimator_innovations)};
-	uORB::PublicationMulti<estimator_sensor_bias_s>      _estimator_sensor_bias_pub{ORB_ID(estimator_sensor_bias)};
-	uORB::PublicationMulti<estimator_states_s>           _estimator_states_pub{ORB_ID(estimator_states)};
-	uORB::PublicationMulti<estimator_status_flags_s>     _estimator_status_flags_pub{ORB_ID(estimator_status_flags)};
-	uORB::PublicationMulti<estimator_status_s>           _estimator_status_pub{ORB_ID(estimator_status)};
+	uORB::Publication<vehicle_full_state_s> _vehicle_full_state_pub{ORB_ID(vehicle_full_state)};
+
+	uORB::PublicationMulti<ekf2_timestamps_s> _ekf2_timestamps_pub{ORB_ID(ekf2_timestamps)};
+	uORB::PublicationMultiData<estimator_event_flags_s> _estimator_event_flags_pub{ORB_ID(estimator_event_flags)};
+	uORB::PublicationMulti<estimator_innovations_s> _estimator_innovation_test_ratios_pub{ORB_ID(estimator_innovation_test_ratios)};
+	uORB::PublicationMulti<estimator_innovations_s> _estimator_innovation_variances_pub{ORB_ID(estimator_innovation_variances)};
+	uORB::PublicationMulti<estimator_innovations_s> _estimator_innovations_pub{ORB_ID(estimator_innovations)};
+	uORB::PublicationMulti<estimator_sensor_bias_s> _estimator_sensor_bias_pub{ORB_ID(estimator_sensor_bias)};
+	uORB::PublicationMulti<estimator_states_s> _estimator_states_pub{ORB_ID(estimator_states)};
+	uORB::PublicationMulti<estimator_status_flags_s> _estimator_status_flags_pub{ORB_ID(estimator_status_flags)};
+	uORB::PublicationMulti<estimator_status_s> _estimator_status_pub{ORB_ID(estimator_status)};
 
 	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_fake_hgt_pub{ORB_ID(estimator_aid_src_fake_hgt)};
 	uORB::PublicationMulti<estimator_aid_source2d_s> _estimator_aid_src_fake_pos_pub{ORB_ID(estimator_aid_src_fake_pos)};
 
 	// publications with topic dependent on multi-mode
-	uORB::PublicationMulti<vehicle_attitude_s>           _attitude_pub;
-	uORB::PublicationMulti<vehicle_local_position_s>     _local_position_pub;
-	uORB::PublicationMulti<vehicle_global_position_s>    _global_position_pub;
-	uORB::PublicationMulti<vehicle_odometry_s>           _odometry_pub;
+	uORB::PublicationMulti<vehicle_attitude_s> _attitude_pub;
+	uORB::PublicationMulti<vehicle_local_position_s> _local_position_pub;
+	uORB::PublicationMulti<vehicle_global_position_s> _global_position_pub;
+	uORB::PublicationMulti<vehicle_odometry_s> _odometry_pub;
 
 #if defined(CONFIG_EKF2_WIND)
-	uORB::PublicationMulti<wind_s>              _wind_pub;
+	uORB::PublicationMulti<wind_s> _wind_pub;
 #endif // CONFIG_EKF2_WIND
 
 #if defined(CONFIG_EKF2_GNSS)
 
 	uint64_t _last_geoid_height_update_us{0};
 	static constexpr float kGeoidHeightLpfTimeConstant = 10.f;
-	AlphaFilter<float> _geoid_height_lpf;  ///< height offset between AMSL and ellipsoid
+	AlphaFilter<float> _geoid_height_lpf; ///< height offset between AMSL and ellipsoid
 
 	hrt_abstime _last_gps_status_published{0};
 
@@ -468,10 +471,10 @@ private:
 
 	uORB::PublicationMulti<yaw_estimator_status_s> _yaw_est_pub{ORB_ID(yaw_estimator_status)};
 
-# if defined(CONFIG_EKF2_GNSS_YAW)
+#if defined(CONFIG_EKF2_GNSS_YAW)
 	hrt_abstime _status_gnss_yaw_pub_last {0};
-	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_gnss_yaw_pub {ORB_ID(estimator_aid_src_gnss_yaw)};
-# endif // CONFIG_EKF2_GNSS_YAW
+	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_gnss_yaw_pub{ORB_ID(estimator_aid_src_gnss_yaw)};
+#endif // CONFIG_EKF2_GNSS_YAW
 #endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_GRAVITY_FUSION)
@@ -481,85 +484,85 @@ private:
 
 	Ekf _ekf;
 
-	parameters *_params;	///< pointer to ekf parameter struct (located in _ekf class instance)
+	parameters *_params; ///< pointer to ekf parameter struct (located in _ekf class instance)
 
 	DEFINE_PARAMETERS(
-		(ParamBool<px4::params::EKF2_LOG_VERBOSE>) _param_ekf2_log_verbose,
-		(ParamExtInt<px4::params::EKF2_PREDICT_US>) _param_ekf2_predict_us,
-		(ParamExtFloat<px4::params::EKF2_DELAY_MAX>) _param_ekf2_delay_max,
-		(ParamExtInt<px4::params::EKF2_IMU_CTRL>) _param_ekf2_imu_ctrl,
-		(ParamExtFloat<px4::params::EKF2_VEL_LIM>) _param_ekf2_vel_lim,
+		(ParamBool<px4::params::EKF2_LOG_VERBOSE>)_param_ekf2_log_verbose,
+		(ParamExtInt<px4::params::EKF2_PREDICT_US>)_param_ekf2_predict_us,
+		(ParamExtFloat<px4::params::EKF2_DELAY_MAX>)_param_ekf2_delay_max,
+		(ParamExtInt<px4::params::EKF2_IMU_CTRL>)_param_ekf2_imu_ctrl,
+		(ParamExtFloat<px4::params::EKF2_VEL_LIM>)_param_ekf2_vel_lim,
 
 #if defined(CONFIG_EKF2_AUXVEL)
 		(ParamExtFloat<px4::params::EKF2_AVEL_DELAY>)
-		_param_ekf2_avel_delay,	///< auxiliary velocity measurement delay relative to the IMU (mSec)
-#endif // CONFIG_EKF2_AUXVEL
+		_param_ekf2_avel_delay, ///< auxiliary velocity measurement delay relative to the IMU (mSec)
+#endif								// CONFIG_EKF2_AUXVEL
 
 		(ParamExtFloat<px4::params::EKF2_GYR_NOISE>)
-		_param_ekf2_gyr_noise,	///< IMU angular rate noise used for covariance prediction (rad/sec)
+		_param_ekf2_gyr_noise, ///< IMU angular rate noise used for covariance prediction (rad/sec)
 		(ParamExtFloat<px4::params::EKF2_ACC_NOISE>)
-		_param_ekf2_acc_noise,	///< IMU acceleration noise use for covariance prediction (m/sec**2)
+		_param_ekf2_acc_noise, ///< IMU acceleration noise use for covariance prediction (m/sec**2)
 
 		// process noise
 		(ParamExtFloat<px4::params::EKF2_GYR_B_NOISE>)
-		_param_ekf2_gyr_b_noise,	///< process noise for IMU rate gyro bias prediction (rad/sec**2)
+		_param_ekf2_gyr_b_noise, ///< process noise for IMU rate gyro bias prediction (rad/sec**2)
 		(ParamExtFloat<px4::params::EKF2_ACC_B_NOISE>)
-		_param_ekf2_acc_b_noise,///< process noise for IMU accelerometer bias prediction (m/sec**3)
+		_param_ekf2_acc_b_noise, ///< process noise for IMU accelerometer bias prediction (m/sec**3)
 
 #if defined(CONFIG_EKF2_WIND)
-		(ParamExtFloat<px4::params::EKF2_WIND_NSD>) _param_ekf2_wind_nsd,
+		(ParamExtFloat<px4::params::EKF2_WIND_NSD>)_param_ekf2_wind_nsd,
 #endif // CONFIG_EKF2_WIND
 
-		(ParamExtFloat<px4::params::EKF2_NOAID_NOISE>) _param_ekf2_noaid_noise,
+		(ParamExtFloat<px4::params::EKF2_NOAID_NOISE>)_param_ekf2_noaid_noise,
 
 #if defined(CONFIG_EKF2_GNSS)
-		(ParamExtInt<px4::params::EKF2_GPS_CTRL>) _param_ekf2_gps_ctrl,
-		(ParamExtInt<px4::params::EKF2_GPS_MODE>) _param_ekf2_gps_mode,
-		(ParamExtFloat<px4::params::EKF2_GPS_DELAY>) _param_ekf2_gps_delay,
+		(ParamExtInt<px4::params::EKF2_GPS_CTRL>)_param_ekf2_gps_ctrl,
+		(ParamExtInt<px4::params::EKF2_GPS_MODE>)_param_ekf2_gps_mode,
+		(ParamExtFloat<px4::params::EKF2_GPS_DELAY>)_param_ekf2_gps_delay,
 
-		(ParamExtFloat<px4::params::EKF2_GPS_POS_X>) _param_ekf2_gps_pos_x,
-		(ParamExtFloat<px4::params::EKF2_GPS_POS_Y>) _param_ekf2_gps_pos_y,
-		(ParamExtFloat<px4::params::EKF2_GPS_POS_Z>) _param_ekf2_gps_pos_z,
+		(ParamExtFloat<px4::params::EKF2_GPS_POS_X>)_param_ekf2_gps_pos_x,
+		(ParamExtFloat<px4::params::EKF2_GPS_POS_Y>)_param_ekf2_gps_pos_y,
+		(ParamExtFloat<px4::params::EKF2_GPS_POS_Z>)_param_ekf2_gps_pos_z,
 
-		(ParamExtFloat<px4::params::EKF2_GPS_V_NOISE>) _param_ekf2_gps_v_noise,
-		(ParamExtFloat<px4::params::EKF2_GPS_P_NOISE>) _param_ekf2_gps_p_noise,
+		(ParamExtFloat<px4::params::EKF2_GPS_V_NOISE>)_param_ekf2_gps_v_noise,
+		(ParamExtFloat<px4::params::EKF2_GPS_P_NOISE>)_param_ekf2_gps_p_noise,
 
-		(ParamExtFloat<px4::params::EKF2_GPS_P_GATE>) _param_ekf2_gps_p_gate,
-		(ParamExtFloat<px4::params::EKF2_GPS_V_GATE>) _param_ekf2_gps_v_gate,
+		(ParamExtFloat<px4::params::EKF2_GPS_P_GATE>)_param_ekf2_gps_p_gate,
+		(ParamExtFloat<px4::params::EKF2_GPS_V_GATE>)_param_ekf2_gps_v_gate,
 
-		(ParamExtInt<px4::params::EKF2_GPS_CHECK>) _param_ekf2_gps_check,
-		(ParamExtFloat<px4::params::EKF2_REQ_EPH>)    _param_ekf2_req_eph,
-		(ParamExtFloat<px4::params::EKF2_REQ_EPV>)    _param_ekf2_req_epv,
-		(ParamExtFloat<px4::params::EKF2_REQ_SACC>)   _param_ekf2_req_sacc,
-		(ParamExtInt<px4::params::EKF2_REQ_NSATS>)    _param_ekf2_req_nsats,
-		(ParamExtFloat<px4::params::EKF2_REQ_PDOP>)   _param_ekf2_req_pdop,
-		(ParamExtFloat<px4::params::EKF2_REQ_HDRIFT>) _param_ekf2_req_hdrift,
-		(ParamExtFloat<px4::params::EKF2_REQ_VDRIFT>) _param_ekf2_req_vdrift,
-		(ParamExtInt<px4::params::EKF2_REQ_FIX>)      _param_ekf2_req_fix,
-		(ParamFloat<px4::params::EKF2_REQ_GPS_H>)     _param_ekf2_req_gps_h,
+		(ParamExtInt<px4::params::EKF2_GPS_CHECK>)_param_ekf2_gps_check,
+		(ParamExtFloat<px4::params::EKF2_REQ_EPH>)_param_ekf2_req_eph,
+		(ParamExtFloat<px4::params::EKF2_REQ_EPV>)_param_ekf2_req_epv,
+		(ParamExtFloat<px4::params::EKF2_REQ_SACC>)_param_ekf2_req_sacc,
+		(ParamExtInt<px4::params::EKF2_REQ_NSATS>)_param_ekf2_req_nsats,
+		(ParamExtFloat<px4::params::EKF2_REQ_PDOP>)_param_ekf2_req_pdop,
+		(ParamExtFloat<px4::params::EKF2_REQ_HDRIFT>)_param_ekf2_req_hdrift,
+		(ParamExtFloat<px4::params::EKF2_REQ_VDRIFT>)_param_ekf2_req_vdrift,
+		(ParamExtInt<px4::params::EKF2_REQ_FIX>)_param_ekf2_req_fix,
+		(ParamFloat<px4::params::EKF2_REQ_GPS_H>)_param_ekf2_req_gps_h,
 
 		// Used by EKF-GSF experimental yaw estimator
-		(ParamExtFloat<px4::params::EKF2_GSF_TAS>) _param_ekf2_gsf_tas,
-		(ParamFloat<px4::params::EKF2_GPS_YAW_OFF>) _param_ekf2_gps_yaw_off,
+		(ParamExtFloat<px4::params::EKF2_GSF_TAS>)_param_ekf2_gsf_tas,
+		(ParamFloat<px4::params::EKF2_GPS_YAW_OFF>)_param_ekf2_gps_yaw_off,
 #endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_BAROMETER)
-		(ParamExtInt<px4::params::EKF2_BARO_CTRL>) _param_ekf2_baro_ctrl,///< barometer control selection
-		(ParamExtFloat<px4::params::EKF2_BARO_DELAY>) _param_ekf2_baro_delay,
-		(ParamExtFloat<px4::params::EKF2_BARO_NOISE>) _param_ekf2_baro_noise,
-		(ParamExtFloat<px4::params::EKF2_BARO_GATE>) _param_ekf2_baro_gate,
-		(ParamExtFloat<px4::params::EKF2_GND_EFF_DZ>) _param_ekf2_gnd_eff_dz,
-		(ParamExtFloat<px4::params::EKF2_GND_MAX_HGT>) _param_ekf2_gnd_max_hgt,
+		(ParamExtInt<px4::params::EKF2_BARO_CTRL>)_param_ekf2_baro_ctrl, ///< barometer control selection
+		(ParamExtFloat<px4::params::EKF2_BARO_DELAY>)_param_ekf2_baro_delay,
+		(ParamExtFloat<px4::params::EKF2_BARO_NOISE>)_param_ekf2_baro_noise,
+		(ParamExtFloat<px4::params::EKF2_BARO_GATE>)_param_ekf2_baro_gate,
+		(ParamExtFloat<px4::params::EKF2_GND_EFF_DZ>)_param_ekf2_gnd_eff_dz,
+		(ParamExtFloat<px4::params::EKF2_GND_MAX_HGT>)_param_ekf2_gnd_max_hgt,
 
-# if defined(CONFIG_EKF2_BARO_COMPENSATION)
+#if defined(CONFIG_EKF2_BARO_COMPENSATION)
 		// Corrections for static pressure position error where Ps_error = Ps_meas - Ps_truth
-		(ParamExtFloat<px4::params::EKF2_ASPD_MAX>) _param_ekf2_aspd_max,
-		(ParamExtFloat<px4::params::EKF2_PCOEF_XP>) _param_ekf2_pcoef_xp,
-		(ParamExtFloat<px4::params::EKF2_PCOEF_XN>) _param_ekf2_pcoef_xn,
-		(ParamExtFloat<px4::params::EKF2_PCOEF_YP>) _param_ekf2_pcoef_yp,
-		(ParamExtFloat<px4::params::EKF2_PCOEF_YN>) _param_ekf2_pcoef_yn,
-		(ParamExtFloat<px4::params::EKF2_PCOEF_Z>) _param_ekf2_pcoef_z,
-# endif // CONFIG_EKF2_BARO_COMPENSATION
+		(ParamExtFloat<px4::params::EKF2_ASPD_MAX>)_param_ekf2_aspd_max,
+		(ParamExtFloat<px4::params::EKF2_PCOEF_XP>)_param_ekf2_pcoef_xp,
+		(ParamExtFloat<px4::params::EKF2_PCOEF_XN>)_param_ekf2_pcoef_xn,
+		(ParamExtFloat<px4::params::EKF2_PCOEF_YP>)_param_ekf2_pcoef_yp,
+		(ParamExtFloat<px4::params::EKF2_PCOEF_YN>)_param_ekf2_pcoef_yn,
+		(ParamExtFloat<px4::params::EKF2_PCOEF_Z>)_param_ekf2_pcoef_z,
+#endif // CONFIG_EKF2_BARO_COMPENSATION
 #endif // CONFIG_EKF2_BAROMETER
 
 #if defined(CONFIG_EKF2_AIRSPEED)
@@ -573,60 +576,60 @@ private:
 		// control of airspeed fusion
 		(ParamExtFloat<px4::params::EKF2_ARSP_THR>)
 		_param_ekf2_arsp_thr, ///< A value of zero will disabled airspeed fusion. Any positive value sets the minimum airspeed which will be used (m/sec)
-#endif // CONFIG_EKF2_AIRSPEED
+#endif							  // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_SIDESLIP)
-		(ParamExtFloat<px4::params::EKF2_BETA_GATE>) _param_ekf2_beta_gate,
-		(ParamExtFloat<px4::params::EKF2_BETA_NOISE>) _param_ekf2_beta_noise,
-		(ParamExtInt<px4::params::EKF2_FUSE_BETA>) _param_ekf2_fuse_beta,
+		(ParamExtFloat<px4::params::EKF2_BETA_GATE>)_param_ekf2_beta_gate,
+		(ParamExtFloat<px4::params::EKF2_BETA_NOISE>)_param_ekf2_beta_noise,
+		(ParamExtInt<px4::params::EKF2_FUSE_BETA>)_param_ekf2_fuse_beta,
 #endif // CONFIG_EKF2_SIDESLIP
 
 #if defined(CONFIG_EKF2_MAGNETOMETER)
-		(ParamExtFloat<px4::params::EKF2_MAG_DELAY>) _param_ekf2_mag_delay,
-		(ParamExtFloat<px4::params::EKF2_MAG_E_NOISE>) _param_ekf2_mag_e_noise,
-		(ParamExtFloat<px4::params::EKF2_MAG_B_NOISE>) _param_ekf2_mag_b_noise,
-		(ParamExtFloat<px4::params::EKF2_HEAD_NOISE>) _param_ekf2_head_noise,
-		(ParamExtFloat<px4::params::EKF2_MAG_NOISE>) _param_ekf2_mag_noise,
-		(ParamExtFloat<px4::params::EKF2_MAG_DECL>) _param_ekf2_mag_decl,
-		(ParamExtFloat<px4::params::EKF2_HDG_GATE>) _param_ekf2_hdg_gate,
-		(ParamExtFloat<px4::params::EKF2_MAG_GATE>) _param_ekf2_mag_gate,
-		(ParamExtInt<px4::params::EKF2_DECL_TYPE>) _param_ekf2_decl_type,
-		(ParamExtInt<px4::params::EKF2_MAG_TYPE>) _param_ekf2_mag_type,
-		(ParamExtFloat<px4::params::EKF2_MAG_ACCLIM>) _param_ekf2_mag_acclim,
-		(ParamExtInt<px4::params::EKF2_MAG_CHECK>) _param_ekf2_mag_check,
-		(ParamExtFloat<px4::params::EKF2_MAG_CHK_STR>) _param_ekf2_mag_chk_str,
-		(ParamExtFloat<px4::params::EKF2_MAG_CHK_INC>) _param_ekf2_mag_chk_inc,
-		(ParamExtInt<px4::params::EKF2_SYNT_MAG_Z>) _param_ekf2_synt_mag_z,
+		(ParamExtFloat<px4::params::EKF2_MAG_DELAY>)_param_ekf2_mag_delay,
+		(ParamExtFloat<px4::params::EKF2_MAG_E_NOISE>)_param_ekf2_mag_e_noise,
+		(ParamExtFloat<px4::params::EKF2_MAG_B_NOISE>)_param_ekf2_mag_b_noise,
+		(ParamExtFloat<px4::params::EKF2_HEAD_NOISE>)_param_ekf2_head_noise,
+		(ParamExtFloat<px4::params::EKF2_MAG_NOISE>)_param_ekf2_mag_noise,
+		(ParamExtFloat<px4::params::EKF2_MAG_DECL>)_param_ekf2_mag_decl,
+		(ParamExtFloat<px4::params::EKF2_HDG_GATE>)_param_ekf2_hdg_gate,
+		(ParamExtFloat<px4::params::EKF2_MAG_GATE>)_param_ekf2_mag_gate,
+		(ParamExtInt<px4::params::EKF2_DECL_TYPE>)_param_ekf2_decl_type,
+		(ParamExtInt<px4::params::EKF2_MAG_TYPE>)_param_ekf2_mag_type,
+		(ParamExtFloat<px4::params::EKF2_MAG_ACCLIM>)_param_ekf2_mag_acclim,
+		(ParamExtInt<px4::params::EKF2_MAG_CHECK>)_param_ekf2_mag_check,
+		(ParamExtFloat<px4::params::EKF2_MAG_CHK_STR>)_param_ekf2_mag_chk_str,
+		(ParamExtFloat<px4::params::EKF2_MAG_CHK_INC>)_param_ekf2_mag_chk_inc,
+		(ParamExtInt<px4::params::EKF2_SYNT_MAG_Z>)_param_ekf2_synt_mag_z,
 #endif // CONFIG_EKF2_MAGNETOMETER
 
-		(ParamExtInt<px4::params::EKF2_HGT_REF>) _param_ekf2_hgt_ref,    ///< selects the primary source for height data
+		(ParamExtInt<px4::params::EKF2_HGT_REF>)_param_ekf2_hgt_ref, ///< selects the primary source for height data
 
 		(ParamExtInt<px4::params::EKF2_NOAID_TOUT>)
-		_param_ekf2_noaid_tout,	///< maximum lapsed time from last fusion of measurements that constrain drift before the EKF will report the horizontal nav solution invalid (uSec)
+		_param_ekf2_noaid_tout, ///< maximum lapsed time from last fusion of measurements that constrain drift before the EKF will report the horizontal nav solution invalid (uSec)
 
 #if defined(CONFIG_EKF2_TERRAIN) || defined(CONFIG_EKF2_OPTICAL_FLOW) || defined(CONFIG_EKF2_RANGE_FINDER)
-		(ParamExtFloat<px4::params::EKF2_MIN_RNG>) _param_ekf2_min_rng,
+		(ParamExtFloat<px4::params::EKF2_MIN_RNG>)_param_ekf2_min_rng,
 #endif // CONFIG_EKF2_TERRAIN || CONFIG_EKF2_OPTICAL_FLOW || CONFIG_EKF2_RANGE_FINDER
 #if defined(CONFIG_EKF2_TERRAIN)
-		(ParamExtFloat<px4::params::EKF2_TERR_NOISE>) _param_ekf2_terr_noise,
-		(ParamExtFloat<px4::params::EKF2_TERR_GRAD>) _param_ekf2_terr_grad,
+		(ParamExtFloat<px4::params::EKF2_TERR_NOISE>)_param_ekf2_terr_noise,
+		(ParamExtFloat<px4::params::EKF2_TERR_GRAD>)_param_ekf2_terr_grad,
 #endif // CONFIG_EKF2_TERRAIN
 #if defined(CONFIG_EKF2_RANGE_FINDER)
 		// range finder fusion
-		(ParamExtInt<px4::params::EKF2_RNG_CTRL>) _param_ekf2_rng_ctrl,
-		(ParamExtFloat<px4::params::EKF2_RNG_DELAY>) _param_ekf2_rng_delay,
-		(ParamExtFloat<px4::params::EKF2_RNG_NOISE>) _param_ekf2_rng_noise,
-		(ParamExtFloat<px4::params::EKF2_RNG_SFE>) _param_ekf2_rng_sfe,
-		(ParamExtFloat<px4::params::EKF2_RNG_GATE>) _param_ekf2_rng_gate,
-		(ParamExtFloat<px4::params::EKF2_RNG_PITCH>) _param_ekf2_rng_pitch,
-		(ParamExtFloat<px4::params::EKF2_RNG_A_VMAX>) _param_ekf2_rng_a_vmax,
-		(ParamExtFloat<px4::params::EKF2_RNG_A_HMAX>) _param_ekf2_rng_a_hmax,
-		(ParamExtFloat<px4::params::EKF2_RNG_QLTY_T>) _param_ekf2_rng_qlty_t,
-		(ParamExtFloat<px4::params::EKF2_RNG_K_GATE>) _param_ekf2_rng_k_gate,
-		(ParamExtFloat<px4::params::EKF2_RNG_FOG>) _param_ekf2_rng_fog,
-		(ParamExtFloat<px4::params::EKF2_RNG_POS_X>) _param_ekf2_rng_pos_x,
-		(ParamExtFloat<px4::params::EKF2_RNG_POS_Y>) _param_ekf2_rng_pos_y,
-		(ParamExtFloat<px4::params::EKF2_RNG_POS_Z>) _param_ekf2_rng_pos_z,
+		(ParamExtInt<px4::params::EKF2_RNG_CTRL>)_param_ekf2_rng_ctrl,
+		(ParamExtFloat<px4::params::EKF2_RNG_DELAY>)_param_ekf2_rng_delay,
+		(ParamExtFloat<px4::params::EKF2_RNG_NOISE>)_param_ekf2_rng_noise,
+		(ParamExtFloat<px4::params::EKF2_RNG_SFE>)_param_ekf2_rng_sfe,
+		(ParamExtFloat<px4::params::EKF2_RNG_GATE>)_param_ekf2_rng_gate,
+		(ParamExtFloat<px4::params::EKF2_RNG_PITCH>)_param_ekf2_rng_pitch,
+		(ParamExtFloat<px4::params::EKF2_RNG_A_VMAX>)_param_ekf2_rng_a_vmax,
+		(ParamExtFloat<px4::params::EKF2_RNG_A_HMAX>)_param_ekf2_rng_a_hmax,
+		(ParamExtFloat<px4::params::EKF2_RNG_QLTY_T>)_param_ekf2_rng_qlty_t,
+		(ParamExtFloat<px4::params::EKF2_RNG_K_GATE>)_param_ekf2_rng_k_gate,
+		(ParamExtFloat<px4::params::EKF2_RNG_FOG>)_param_ekf2_rng_fog,
+		(ParamExtFloat<px4::params::EKF2_RNG_POS_X>)_param_ekf2_rng_pos_x,
+		(ParamExtFloat<px4::params::EKF2_RNG_POS_Y>)_param_ekf2_rng_pos_y,
+		(ParamExtFloat<px4::params::EKF2_RNG_POS_Z>)_param_ekf2_rng_pos_z,
 #endif // CONFIG_EKF2_RANGE_FINDER
 
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
@@ -634,9 +637,9 @@ private:
 		(ParamExtFloat<px4::params::EKF2_EV_DELAY>)
 		_param_ekf2_ev_delay, ///< off-board vision measurement delay relative to the IMU (mSec)
 
-		(ParamExtInt<px4::params::EKF2_EV_CTRL>) _param_ekf2_ev_ctrl,	 ///< external vision (EV) control selection
-		(ParamInt<px4::params::EKF2_EV_NOISE_MD>) _param_ekf2_ev_noise_md, ///< determine source of vision observation noise
-		(ParamExtInt<px4::params::EKF2_EV_QMIN>) _param_ekf2_ev_qmin,
+		(ParamExtInt<px4::params::EKF2_EV_CTRL>)_param_ekf2_ev_ctrl,	  ///< external vision (EV) control selection
+		(ParamInt<px4::params::EKF2_EV_NOISE_MD>)_param_ekf2_ev_noise_md, ///< determine source of vision observation noise
+		(ParamExtInt<px4::params::EKF2_EV_QMIN>)_param_ekf2_ev_qmin,
 		(ParamExtFloat<px4::params::EKF2_EVP_NOISE>)
 		_param_ekf2_evp_noise, ///< default position observation noise for exernal vision measurements (m)
 		(ParamExtFloat<px4::params::EKF2_EVV_NOISE>)
@@ -654,7 +657,7 @@ private:
 		_param_ekf2_ev_pos_y, ///< Y position of VI sensor focal point in body frame (m)
 		(ParamExtFloat<px4::params::EKF2_EV_POS_Z>)
 		_param_ekf2_ev_pos_z, ///< Z position of VI sensor focal point in body frame (m)
-#endif // CONFIG_EKF2_EXTERNAL_VISION
+#endif							  // CONFIG_EKF2_EXTERNAL_VISION
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)
 		// optical flow fusion
 		(ParamExtInt<px4::params::EKF2_OF_CTRL>)
@@ -679,49 +682,48 @@ private:
 		_param_ekf2_of_pos_y, ///< Y position of optical flow sensor focal point in body frame (m)
 		(ParamExtFloat<px4::params::EKF2_OF_POS_Z>)
 		_param_ekf2_of_pos_z, ///< Z position of optical flow sensor focal point in body frame (m)
-#endif // CONFIG_EKF2_OPTICAL_FLOW
+#endif							  // CONFIG_EKF2_OPTICAL_FLOW
 
 #if defined(CONFIG_EKF2_DRAG_FUSION)
-		(ParamExtInt<px4::params::EKF2_DRAG_CTRL>) _param_ekf2_drag_ctrl,		///< drag fusion selection
+		(ParamExtInt<px4::params::EKF2_DRAG_CTRL>)_param_ekf2_drag_ctrl, ///< drag fusion selection
 		// Multi-rotor drag specific force fusion
 		(ParamExtFloat<px4::params::EKF2_DRAG_NOISE>)
-		_param_ekf2_drag_noise,	///< observation noise variance for drag specific force measurements (m/sec**2)**2
-		(ParamExtFloat<px4::params::EKF2_BCOEF_X>) _param_ekf2_bcoef_x,		///< ballistic coefficient along the X-axis (kg/m**2)
-		(ParamExtFloat<px4::params::EKF2_BCOEF_Y>) _param_ekf2_bcoef_y,		///< ballistic coefficient along the Y-axis (kg/m**2)
-		(ParamExtFloat<px4::params::EKF2_MCOEF>) _param_ekf2_mcoef,		///< propeller momentum drag coefficient (1/s)
-#endif // CONFIG_EKF2_DRAG_FUSION
+		_param_ekf2_drag_noise,									   ///< observation noise variance for drag specific force measurements (m/sec**2)**2
+		(ParamExtFloat<px4::params::EKF2_BCOEF_X>)_param_ekf2_bcoef_x, ///< ballistic coefficient along the X-axis (kg/m**2)
+		(ParamExtFloat<px4::params::EKF2_BCOEF_Y>)_param_ekf2_bcoef_y, ///< ballistic coefficient along the Y-axis (kg/m**2)
+		(ParamExtFloat<px4::params::EKF2_MCOEF>)_param_ekf2_mcoef,	   ///< propeller momentum drag coefficient (1/s)
+#endif																   // CONFIG_EKF2_DRAG_FUSION
 
 #if defined(CONFIG_EKF2_GRAVITY_FUSION)
-		(ParamExtFloat<px4::params::EKF2_GRAV_NOISE>) _param_ekf2_grav_noise,
+		(ParamExtFloat<px4::params::EKF2_GRAV_NOISE>)_param_ekf2_grav_noise,
 #endif // CONFIG_EKF2_GRAVITY_FUSION
 
 		// sensor positions in body frame
-		(ParamExtFloat<px4::params::EKF2_IMU_POS_X>) _param_ekf2_imu_pos_x,		///< X position of IMU in body frame (m)
-		(ParamExtFloat<px4::params::EKF2_IMU_POS_Y>) _param_ekf2_imu_pos_y,		///< Y position of IMU in body frame (m)
-		(ParamExtFloat<px4::params::EKF2_IMU_POS_Z>) _param_ekf2_imu_pos_z,		///< Z position of IMU in body frame (m)
+		(ParamExtFloat<px4::params::EKF2_IMU_POS_X>)_param_ekf2_imu_pos_x, ///< X position of IMU in body frame (m)
+		(ParamExtFloat<px4::params::EKF2_IMU_POS_Y>)_param_ekf2_imu_pos_y, ///< Y position of IMU in body frame (m)
+		(ParamExtFloat<px4::params::EKF2_IMU_POS_Z>)_param_ekf2_imu_pos_z, ///< Z position of IMU in body frame (m)
 
 		// IMU switch on bias parameters
 		(ParamExtFloat<px4::params::EKF2_GBIAS_INIT>)
-		_param_ekf2_gbias_init,	///< 1-sigma gyro bias uncertainty at switch on (rad/sec)
+		_param_ekf2_gbias_init, ///< 1-sigma gyro bias uncertainty at switch on (rad/sec)
 		(ParamExtFloat<px4::params::EKF2_ABIAS_INIT>)
-		_param_ekf2_abias_init,	///< 1-sigma accelerometer bias uncertainty at switch on (m/sec**2)
+		_param_ekf2_abias_init, ///< 1-sigma accelerometer bias uncertainty at switch on (m/sec**2)
 		(ParamExtFloat<px4::params::EKF2_ANGERR_INIT>)
-		_param_ekf2_angerr_init,	///< 1-sigma tilt error after initial alignment using gravity vector (rad)
+		_param_ekf2_angerr_init, ///< 1-sigma tilt error after initial alignment using gravity vector (rad)
 
 		// EKF accel bias learning control
-		(ParamExtFloat<px4::params::EKF2_ABL_LIM>) _param_ekf2_abl_lim,	///< Accelerometer bias learning limit (m/s**2)
+		(ParamExtFloat<px4::params::EKF2_ABL_LIM>)_param_ekf2_abl_lim, ///< Accelerometer bias learning limit (m/s**2)
 		(ParamExtFloat<px4::params::EKF2_ABL_ACCLIM>)
-		_param_ekf2_abl_acclim,	///< Maximum IMU accel magnitude that allows IMU bias learning (m/s**2)
+		_param_ekf2_abl_acclim, ///< Maximum IMU accel magnitude that allows IMU bias learning (m/s**2)
 		(ParamExtFloat<px4::params::EKF2_ABL_GYRLIM>)
-		_param_ekf2_abl_gyrlim,	///< Maximum IMU gyro angular rate magnitude that allows IMU bias learning (m/s**2)
+		_param_ekf2_abl_gyrlim, ///< Maximum IMU gyro angular rate magnitude that allows IMU bias learning (m/s**2)
 		(ParamExtFloat<px4::params::EKF2_ABL_TAU>)
-		_param_ekf2_abl_tau,	///< Time constant used to inhibit IMU delta velocity bias learning (sec)
+		_param_ekf2_abl_tau, ///< Time constant used to inhibit IMU delta velocity bias learning (sec)
 
-		(ParamExtFloat<px4::params::EKF2_GYR_B_LIM>) _param_ekf2_gyr_b_lim,	///< Gyro bias learning limit (rad/s)
+		(ParamExtFloat<px4::params::EKF2_GYR_B_LIM>)_param_ekf2_gyr_b_lim, ///< Gyro bias learning limit (rad/s)
 
 		// output predictor filter time constants
-		(ParamFloat<px4::params::EKF2_TAU_VEL>) _param_ekf2_tau_vel,
-		(ParamFloat<px4::params::EKF2_TAU_POS>) _param_ekf2_tau_pos
-	)
+		(ParamFloat<px4::params::EKF2_TAU_VEL>)_param_ekf2_tau_vel,
+		(ParamFloat<px4::params::EKF2_TAU_POS>)_param_ekf2_tau_pos)
 };
 #endif // !EKF2_HPP

--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -101,6 +101,10 @@ publications:
     type: px4_msgs::msg::Wind
     rate_limit: 1.
 
+  - topic: /fmu/out/vehicle_full_state
+    type: px4_msgs::msg::VehicleFullState
+    rate_limit: 50.
+
 # Create uORB::Publication
 subscriptions:
   - topic: /fmu/in/register_ext_component_request


### PR DESCRIPTION
- New uORB message VehicleFullState (versioned) with timestamp/timestamp_sample
- EKF2 publishes NED position/velocity/accel, FRD->NED quaternion, body rates
- Expose topic via uXRCE-DDS (/fmu/out/vehicle_full_state) at 50 Hz
- Verified in SITL: listener vehicle_full_state, compared to vehicle_odometry
- ROS2-based control algorithms now need only subscribe to /fmu/out/vehicle_full_state for full state information