### PR TITLE
rc.sensors: add iis2mdc mag to list of probed for sensors

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -237,6 +237,7 @@ then
 	qmc5883p -X -q start
 	rm3100 -X -q start
 	bmm350 -X -q start
+	iis2mdc -X -q start
 
 	# start last (wait for possible icm20948 passthrough mode)
 	ak09916 -X -q start


### PR DESCRIPTION

### Solved Problem
The iis2mdc driver is only started on certain boards. I don't know how widely used this sensor is, but at least we are now using it on an airframe and not having it automatically probed for was quite confusing. 

### Solution
Probe for this mag like for most other mags we have driver for.

### Changelog Entry
For release notes: 
```
Feature: add iis2mdc mag to list of automatically probed for sensors
```

### Alternatives
Remove the iis2mdc startup in the boards (ark, cuav, nxp). It looks though as if it's there started with a certain rotation, so we likely want to keep it.
