### PR TITLE
uavcan: fix driver init after stop/start

### DIFF
--- a/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/src/uc_stm32h7_can.cpp
+++ b/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/src/uc_stm32h7_can.cpp
@@ -644,7 +644,7 @@ uavcan::int16_t CanIface::configureFilters(const uavcan::CanFilterConfig *filter
 
 bool CanIface::waitCCCRBitStateChange(uint32_t mask, bool target_state)
 {
-#if UAVCAN_STM32_NUTTX
+#if UAVCAN_STM32H7_NUTTX
 	const unsigned Timeout = 1000;
 #else
 	const unsigned Timeout = 2000000;
@@ -657,7 +657,7 @@ bool CanIface::waitCCCRBitStateChange(uint32_t mask, bool target_state)
 			return true;
 		}
 
-#if UAVCAN_STM32_NUTTX
+#if UAVCAN_STM32H7_NUTTX
 		::usleep(1000);
 #endif
 	}

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -505,12 +505,16 @@ void UavcanNode::Run()
 
 			if (can_init_res < 0) {
 				PX4_ERR("CAN driver init failed %i", can_init_res);
+				ScheduleClear();
+				return;
 			}
 
 			int rv = _node.start();
 
 			if (rv < 0) {
 				PX4_ERR("Failed to start the node");
+				ScheduleClear();
+				return;
 			}
 
 			// If the node_id was not supplied by the bootloader do Dynamic Node ID allocation
@@ -528,6 +532,8 @@ void UavcanNode::Run()
 
 				if (client_start_res < 0) {
 					PX4_ERR("Failed to start the dynamic node ID client");
+					ScheduleClear();
+					return;
 				}
 			}
 		}


### PR DESCRIPTION
### Solved Problem
*Topic 1*
When stopping and starting uavcan using `uavcan stop` and `uavcan start`, the init sometimes fails due to timing here:
```
// Request Init mode, then wait for completion
can_->CCCR |= FDCAN_CCCR_INIT;

if (!waitCCCRBitStateChange(FDCAN_CCCR_INIT, true)) {
	UAVCAN_STM32H7_LOG("CCCR FDCAN_CCCR_INIT not set");
	return -ErrCCCrINITNotSet;
}
```

*Topic 2*
Similar to https://github.com/PX4/PX4-Autopilot/issues/24179 there is the chance of the driver init failing causing follow-up errors in `uavcannode` as the errors are not handled at all.

### Solution
*Topic 1*
The timeout function actually has a higher timeout implemented for NuttX targets, but this does not apply as the wrong macro is used. When using the correct one the init works.

*Topic 2*
Similar to https://github.com/PX4/PX4-Autopilot/issues/24179, the init  in `uavcannode` will not continue if errors occur to avoid follow-up errors when the init does not work.

### Test coverage
- Tested on the bench with a v6x
