### PR TITLE
Concept: Separate GNSS position and heading topics

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -186,6 +186,7 @@ set(msg_files
 	vehicle_control_mode.msg
 	vehicle_global_position.msg
 	vehicle_gps_position.msg
+	vehicle_gnss_heading.msg
 	vehicle_imu.msg
 	vehicle_imu_status.msg
 	vehicle_land_detected.msg

--- a/msg/vehicle_gnss_heading.msg
+++ b/msg/vehicle_gnss_heading.msg
@@ -1,0 +1,5 @@
+uint64 timestamp                  # time since system start(microseconds)
+uint64 timestamp_sample           # time since system start(microseconds)
+
+float32 heading                   # Heading angle of XYZ body frame rel to NED.(radians)
+float32 heading_accuracy          # Accuracy of heading of the relative position vector(radians)

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -79,6 +79,12 @@ struct gps_message {
 	float pdop;		///< position dilution of precision
 };
 
+struct gnss_heading_message {
+	uint64_t time_usec{0};	///< timestamp of the measurement (uSec)
+	float heading;		///< heading angle in radians
+	float heading_accuracy;	///< heading accuracy in radians
+};
+
 struct outputSample {
 	uint64_t    time_us{0};	///< timestamp of the measurement (uSec)
 	Quatf  quat_nominal;	///< nominal quaternion describing vehicle attitude
@@ -111,6 +117,11 @@ struct gpsSample {
 	float	    hacc;	///< 1-std horizontal position error (m)
 	float	    vacc;	///< 1-std vertical position error (m)
 	float       sacc;	///< 1-std speed error (m/sec)
+};
+struct gnssHeadingSample {
+	uint64_t    time_us{0};	///< timestamp of the measurement (uSec)
+	float heading;		///< heading angle in radians
+	float heading_accuracy;	///< heading accuracy in radians
 };
 
 struct magSample {
@@ -202,10 +213,11 @@ enum TerrainFusionMask : int32_t {
 #define MAG_FUSE_TYPE_NONE	5	///< Do not use magnetometer under any circumstance. Other sources of yaw may be used if selected via the EKF2_AID_MASK parameter.
 
 // Maximum sensor intervals in usec
-#define GPS_MAX_INTERVAL  (uint64_t)5e5	///< Maximum allowable time interval between GPS measurements (uSec)
-#define BARO_MAX_INTERVAL (uint64_t)2e5	///< Maximum allowable time interval between pressure altitude measurements (uSec)
-#define RNG_MAX_INTERVAL  (uint64_t)2e5	///< Maximum allowable time interval between range finder  measurements (uSec)
-#define EV_MAX_INTERVAL   (uint64_t)2e5	///< Maximum allowable time interval between external vision system measurements (uSec)
+#define GPS_MAX_INTERVAL           (uint64_t)5e5	///< Maximum allowable time interval between GPS measurements (uSec)
+#define GNSS_HEADING_MAX_INTERVAL  (uint64_t)5e5	///< Maximum allowable time interval between GNSS heading measurements (uSec)
+#define BARO_MAX_INTERVAL          (uint64_t)2e5	///< Maximum allowable time interval between pressure altitude measurements (uSec)
+#define RNG_MAX_INTERVAL           (uint64_t)2e5	///< Maximum allowable time interval between range finder  measurements (uSec)
+#define EV_MAX_INTERVAL            (uint64_t)2e5	///< Maximum allowable time interval between external vision system measurements (uSec)
 
 // bad accelerometer detection and mitigation
 #define BADACC_PROBATION  (uint64_t)10e6	///< Period of time that accel data declared bad must continuously pass checks to be declared good again (uSec)

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -376,6 +376,7 @@ private:
 
 	// booleans true when fresh sensor data is available at the fusion time horizon
 	bool _gps_data_ready{false};	///< true when new GPS data has fallen behind the fusion time horizon and is available to be fused
+	bool _gnss_heading_data_ready{false};///< true when new GNSS heading data has fallen behind the fusion time horizon and is available to be fused
 	bool _baro_data_ready{false};	///< true when new baro height data has fallen behind the fusion time horizon and is available to be fused
 	bool _flow_data_ready{false};	///< true when the leading edge of the optical flow integration period has fallen behind the fusion time horizon
 	bool _ev_data_ready{false};	///< true when new external vision system data has fallen behind the fusion time horizon and is available to be fused
@@ -383,6 +384,7 @@ private:
 	bool _flow_for_terrain_data_ready{false}; /// same flag as "_flow_data_ready" but used for separate terrain estimator
 
 	uint64_t _time_prev_gps_us{0};	///< time stamp of previous GPS data retrieved from the buffer (uSec)
+	uint64_t _time_prev_gnss_heading_us{0}; ///< time stamp of previous GNSS heading data retrieved from the buffer (uSec)
 	uint64_t _time_last_aiding{0};	///< amount of time we have been doing inertial only deadreckoning (uSec)
 	bool _using_synthetic_position{false};	///< true if we are using a synthetic position to constrain drift
 
@@ -396,8 +398,8 @@ private:
 	uint64_t _time_last_beta_fuse{0};	///< time the last fusion of synthetic sideslip measurements were performed (uSec)
 	uint64_t _time_last_fake_pos_fuse{0};	///< last time we faked position measurements to constrain tilt errors during operation without external aiding (uSec)
 	uint64_t _time_last_zero_velocity_fuse{0}; ///< last time of zero velocity update (uSec)
-	uint64_t _time_last_gps_yaw_fuse{0};	///< time the last fusion of GPS yaw measurements were performed (uSec)
-	uint64_t _time_last_gps_yaw_data{0};	///< time the last GPS yaw measurement was available (uSec)
+	uint64_t _time_last_gnss_heading_fuse{0};	///< time the last fusion of GNSS heading measurements were performed (uSec)
+	uint64_t _time_last_gnss_heading_data{0};	///< time the last GNSS heading measurement was available (uSec)
 	uint64_t _time_last_healthy_rng_data{0};
 	uint8_t _nb_gps_yaw_reset_available{0}; ///< remaining number of resets allowed before switching to another aiding source
 
@@ -833,7 +835,7 @@ private:
 	bool hasHorizontalAidingTimedOut() const;
 	bool isYawFailure() const;
 
-	void controlGpsYawFusion(bool gps_checks_passing, bool gps_checks_failing);
+	void controlGNSSHeadingFusion();
 
 	// control fusion of magnetometer observations
 	void controlMagFusion();

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -1559,10 +1559,6 @@ void Ekf::stopGpsFusion()
 		stopGpsVelFusion();
 	}
 
-	if (_control_status.flags.gps_yaw) {
-		stopGpsYawFusion();
-	}
-
 	// We do not need to know the true North anymore
 	// EV yaw can start again
 	_inhibit_ev_yaw_use = false;

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -86,6 +86,8 @@ public:
 
 	void setGpsData(const gps_message &gps);
 
+	void setGnssHeadingData(const gnss_heading_message &gnss_heading_sample);
+
 	void setBaroData(const baroSample &baro_sample);
 
 	void setAirspeedData(const airspeedSample &airspeed_sample);
@@ -294,6 +296,7 @@ protected:
 	// measurement samples capturing measurements on the delayed time horizon
 	baroSample _baro_sample_delayed{};
 	gpsSample _gps_sample_delayed{};
+	gnssHeadingSample _gnss_heading_sample_delayed{};
 	sensor::SensorRangeFinder _range_sensor{};
 	airspeedSample _airspeed_sample_delayed{};
 	flowSample _flow_sample_delayed{};
@@ -363,6 +366,7 @@ protected:
 	RingBuffer<outputVert> _output_vert_buffer{12};
 
 	RingBuffer<gpsSample> *_gps_buffer{nullptr};
+	RingBuffer<gnssHeadingSample> *_gnss_heading_buffer{nullptr};
 	RingBuffer<magSample> *_mag_buffer{nullptr};
 	RingBuffer<baroSample> *_baro_buffer{nullptr};
 	RingBuffer<rangeSample> *_range_buffer{nullptr};
@@ -375,6 +379,7 @@ protected:
 	// timestamps of latest in buffer saved measurement in microseconds
 	uint64_t _time_last_imu{0};
 	uint64_t _time_last_gps{0};
+	uint64_t _time_last_gnss_heading{0};
 	uint64_t _time_last_mag{0}; ///< measurement time of last magnetomter sample (uSec)
 	uint64_t _time_last_baro{0};
 	uint64_t _time_last_range{0};

--- a/src/modules/ekf2/EKF/gps_control.cpp
+++ b/src/modules/ekf2/EKF/gps_control.cpp
@@ -51,8 +51,6 @@ void Ekf::controlGpsFusion()
 		const bool gps_checks_passing = isTimedOut(_last_gps_fail_us, (uint64_t)5e6);
 		const bool gps_checks_failing = isTimedOut(_last_gps_pass_us, (uint64_t)5e6);
 
-		controlGpsYawFusion(gps_checks_passing, gps_checks_failing);
-
 		// Determine if we should use GPS aiding for velocity and horizontal position
 		// To start using GPS we need angular alignment completed, the local NED origin set and GPS data that has not failed checks recently
 		const bool mandatory_conditions_passing = _control_status.flags.tilt_align

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -86,6 +86,7 @@
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_gps_position.h>
+#include <uORB/topics/vehicle_gnss_heading.h>
 #include <uORB/topics/vehicle_imu.h>
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_local_position.h>
@@ -160,6 +161,7 @@ private:
 	bool UpdateExtVisionSample(ekf2_timestamps_s &ekf2_timestamps, vehicle_odometry_s &ev_odom);
 	bool UpdateFlowSample(ekf2_timestamps_s &ekf2_timestamps);
 	void UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps);
+	void UpdateGNSSHeadingSample(ekf2_timestamps_s &ekf2_timestamps);
 	void UpdateMagSample(ekf2_timestamps_s &ekf2_timestamps);
 	void UpdateRangeSample(ekf2_timestamps_s &ekf2_timestamps);
 
@@ -194,6 +196,7 @@ private:
 	perf_counter_t _msg_missed_airspeed_validated_perf{nullptr};
 	perf_counter_t _msg_missed_distance_sensor_perf{nullptr};
 	perf_counter_t _msg_missed_gps_perf{nullptr};
+	perf_counter_t _msg_missed_gnss_heading_perf{nullptr};
 	perf_counter_t _msg_missed_landing_target_pose_perf{nullptr};
 	perf_counter_t _msg_missed_magnetometer_perf{nullptr};
 	perf_counter_t _msg_missed_odometry_perf{nullptr};
@@ -257,6 +260,7 @@ private:
 	uORB::Subscription _status_sub{ORB_ID(vehicle_status)};
 	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};
 	uORB::Subscription _vehicle_gps_position_sub{ORB_ID(vehicle_gps_position)};
+	uORB::Subscription _vehicle_gnss_heading_sub{ORB_ID(vehicle_gnss_heading)};
 	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
 
 	uORB::SubscriptionCallbackWorkItem _sensor_combined_sub{this, ORB_ID(sensor_combined)};

--- a/src/modules/ekf2/test/CMakeLists.txt
+++ b/src/modules/ekf2/test/CMakeLists.txt
@@ -42,7 +42,7 @@ px4_add_unit_gtest(SRC test_EKF_externalVision.cpp LINKLIBS ecl_EKF ecl_sensor_s
 px4_add_unit_gtest(SRC test_EKF_flow.cpp LINKLIBS ecl_EKF ecl_sensor_sim ecl_test_helper)
 px4_add_unit_gtest(SRC test_EKF_fusionLogic.cpp LINKLIBS ecl_EKF ecl_sensor_sim ecl_test_helper)
 px4_add_unit_gtest(SRC test_EKF_gps.cpp LINKLIBS ecl_EKF ecl_sensor_sim ecl_test_helper)
-px4_add_unit_gtest(SRC test_EKF_gps_yaw.cpp LINKLIBS ecl_EKF ecl_sensor_sim)
+px4_add_unit_gtest(SRC test_EKF_gnss_heading.cpp LINKLIBS ecl_EKF ecl_sensor_sim)
 px4_add_unit_gtest(SRC test_EKF_imuSampling.cpp LINKLIBS ecl_EKF ecl_sensor_sim)
 px4_add_unit_gtest(SRC test_EKF_initialization.cpp LINKLIBS ecl_EKF ecl_sensor_sim)
 px4_add_unit_gtest(SRC test_EKF_measurementSampling.cpp LINKLIBS ecl_EKF ecl_sensor_sim)

--- a/src/modules/ekf2/test/sensor_simulator/CMakeLists.txt
+++ b/src/modules/ekf2/test/sensor_simulator/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SRCS
 	mag.cpp
 	baro.cpp
 	gps.cpp
+	gnss_heading.cpp
 	flow.cpp
 	range_finder.cpp
 	vio.cpp

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -65,7 +65,7 @@ bool EkfWrapper::isIntendingGpsFusion() const
 	return _ekf->control_status_flags().gps;
 }
 
-void EkfWrapper::enableGpsHeadingFusion()
+void EkfWrapper::enableGnssHeadingFusion()
 {
 	_ekf_params->fusion_mode |= MASK_USE_GPSYAW;
 }

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
@@ -65,7 +65,7 @@ public:
 	void disableGpsFusion();
 	bool isIntendingGpsFusion() const;
 
-	void enableGpsHeadingFusion();
+	void enableGnssHeadingFusion();
 	void disableGpsHeadingFusion();
 	bool isIntendingGpsHeadingFusion() const;
 

--- a/src/modules/ekf2/test/sensor_simulator/gnss_heading.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/gnss_heading.cpp
@@ -1,0 +1,58 @@
+#include "gnss_heading.h"
+
+namespace sensor_simulator
+{
+namespace sensor
+{
+
+GnssHeading::GnssHeading(std::shared_ptr<Ekf> ekf) : Sensor(ekf)
+{
+}
+
+GnssHeading::~GnssHeading()
+{
+}
+
+void GnssHeading::send(const uint64_t time)
+{
+	if (!PX4_ISFINITE(_gnss_heading_data.heading)) {
+		// if heading is not set, don't send, as in reality, this data wouldn't be published to vehicle_gnss_heading
+		return;
+	}
+
+	// keep dt in case you want to evolve heading with a rate later
+	const float dt = static_cast<float>(time - _gnss_heading_data.time_usec) * 1e-6f;
+	(void)dt;
+
+	_gnss_heading_data.time_usec = time;
+
+	// hand the sample to the EKF
+	_ekf->setGnssHeadingData(_gnss_heading_data);
+}
+
+void GnssHeading::setData(const gnss_heading_message &gps_yaw)
+{
+	_gnss_heading_data = gps_yaw;
+}
+
+void GnssHeading::setHeading(const float heading)
+{
+	_gnss_heading_data.heading = heading;
+}
+
+void GnssHeading::setHeadingAccuracy(const float heading_accuracy)
+{
+	_gnss_heading_data.heading_accuracy = heading_accuracy;
+}
+
+gnss_heading_message GnssHeading::getDefaultGnssHeadingData()
+{
+	gnss_heading_message gps_yaw{};
+	gps_yaw.time_usec = 0;
+	gps_yaw.heading = NAN;
+	gps_yaw.heading_accuracy = 0.1f;
+	return gps_yaw;
+}
+
+} // namespace sensor
+} // namespace sensor_simulator

--- a/src/modules/ekf2/test/sensor_simulator/gnss_heading.h
+++ b/src/modules/ekf2/test/sensor_simulator/gnss_heading.h
@@ -1,0 +1,31 @@
+#ifndef EKF_GNSS_HEADING_H
+#define EKF_GNSS_HEADING_H
+
+#include "sensor.h"
+
+namespace sensor_simulator
+{
+namespace sensor
+{
+
+class GnssHeading: public Sensor
+{
+public:
+	GnssHeading(std::shared_ptr<Ekf> ekf);
+	~GnssHeading();
+
+	void setData(const gnss_heading_message &gps_yaw);
+	void setHeading(const float heading);
+	void setHeadingAccuracy(const float heading_accuracy);
+
+	gnss_heading_message getDefaultGnssHeadingData();
+
+private:
+	void send(uint64_t time) override;
+
+	gnss_heading_message _gnss_heading_data{};
+};
+
+} // namespace sensor
+} // namespace sensor_simulator
+#endif // EKF_GNSS_HEADING_H

--- a/src/modules/ekf2/test/sensor_simulator/sensor_simulator.h
+++ b/src/modules/ekf2/test/sensor_simulator/sensor_simulator.h
@@ -55,6 +55,7 @@
 #include "mag.h"
 #include "baro.h"
 #include "gps.h"
+#include "gnss_heading.h"
 #include "flow.h"
 #include "range_finder.h"
 #include "vio.h"
@@ -65,7 +66,7 @@ using namespace sensor_simulator::sensor;
 
 struct sensor_info {
 	uint64_t timestamp{};
-	enum measurement_t {IMU, MAG, BARO, GPS, AIRSPEED, RANGE, FLOW, VISION, LANDING_STATUS} sensor_type = IMU;
+	enum measurement_t {IMU, MAG, BARO, GPS, GPS_YAW, AIRSPEED, RANGE, FLOW, VISION, LANDING_STATUS} sensor_type = IMU;
 	std::array<double, 10> sensor_data{};
 };
 
@@ -93,6 +94,9 @@ public:
 
 	void startGps() { _gps.start(); }
 	void stopGps() { _gps.stop(); }
+
+	void startGnssHeading() { _gps_yaw.start(); }
+	void stopGnssHeading() { _gps_yaw.stop(); }
 
 	void startFlow() { _flow.start(); }
 	void stopFlow() { _flow.stop(); }
@@ -122,6 +126,7 @@ public:
 	Baro        _baro;
 	Flow        _flow;
 	Gps         _gps;
+	GnssHeading      _gps_yaw;
 	Imu         _imu;
 	Mag         _mag;
 	RangeFinder _rng;

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -107,6 +107,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("vehicle_control_mode");
 	add_topic("vehicle_global_position", 200);
 	add_topic("vehicle_gps_position", 500);
+	add_topic("vehicle_gnss_heading", 500);
 	add_topic("vehicle_land_detected");
 	add_topic("vehicle_local_position", 100);
 	add_topic("vehicle_local_position_setpoint", 100);
@@ -280,6 +281,7 @@ void LoggedTopics::add_estimator_replay_topics()
 	add_topic("sensor_selection");
 	add_topic("vehicle_air_data");
 	add_topic("vehicle_gps_position");
+	add_topic("vehicle_gnss_heading");
 	add_topic("vehicle_land_detected");
 	add_topic("vehicle_magnetometer");
 	add_topic("vehicle_status");

--- a/src/modules/sensors/CMakeLists.txt
+++ b/src/modules/sensors/CMakeLists.txt
@@ -38,6 +38,7 @@ add_subdirectory(vehicle_acceleration)
 add_subdirectory(vehicle_angular_velocity)
 add_subdirectory(vehicle_air_data)
 add_subdirectory(vehicle_gps_position)
+add_subdirectory(vehicle_gnss_heading)
 add_subdirectory(vehicle_imu)
 add_subdirectory(vehicle_magnetometer)
 
@@ -60,6 +61,7 @@ px4_add_module(
 		vehicle_angular_velocity
 		vehicle_air_data
 		vehicle_gps_position
+		vehicle_gnss_heading
 		vehicle_imu
 		vehicle_magnetometer
 	)

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -233,3 +233,39 @@ PARAM_DEFINE_INT32(SENS_IMU_MODE, 1);
  * @group Sensors
  */
 PARAM_DEFINE_INT32(SENS_INT_BARO_EN, 1);
+
+/**
+ * GPS Relative X offset
+ *
+ * The body-frame offset between the GPS moving baseline and the rover.
+ * A positive value means the rover antenna is in front of the moving baseline.
+ *
+ * @group Sensors
+ * @unit m
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(SENS_GNSSREL_PX, 0);
+
+/**
+ * GPS Relative Y offset
+ *
+ * The body-frame offset between the GPS moving baseline and the rover.
+ * A positive value means the rover antenna is to the right of the moving baseline.
+ *
+ * @group Sensors
+ * @unit m
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(SENS_GNSSREL_PY, 0);
+
+/**
+ * GPS Relative Z offset
+ *
+ * The body-frame offset between the GPS moving baseline and the rover.
+ * A positive value means the rover antenna is below the moving baseline.
+ *
+ * @group Sensors
+ * @unit m
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(SENS_GNSSREL_PZ, 0);

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -76,6 +76,7 @@
 #include "vehicle_angular_velocity/VehicleAngularVelocity.hpp"
 #include "vehicle_air_data/VehicleAirData.hpp"
 #include "vehicle_gps_position/VehicleGPSPosition.hpp"
+#include "vehicle_gnss_heading/VehicleGNSSHeading.hpp"
 #include "vehicle_imu/VehicleIMU.hpp"
 #include "vehicle_magnetometer/VehicleMagnetometer.hpp"
 
@@ -181,6 +182,7 @@ private:
 	VehicleAirData          *_vehicle_air_data{nullptr};
 	VehicleMagnetometer     *_vehicle_magnetometer{nullptr};
 	VehicleGPSPosition	*_vehicle_gps_position{nullptr};
+	VehicleGNSSHeading	   	*_vehicle_gnss_heading{nullptr};
 
 	VehicleIMU      *_vehicle_imu_list[MAX_SENSOR_COUNT] {};
 
@@ -218,6 +220,7 @@ private:
 
 	void		InitializeVehicleAirData();
 	void		InitializeVehicleGPSPosition();
+	void		InitializeVehicleGNSSHeading();
 	void		InitializeVehicleIMU();
 	void		InitializeVehicleMagnetometer();
 
@@ -267,6 +270,7 @@ Sensors::Sensors(bool hil_enabled) :
 
 	InitializeVehicleAirData();
 	InitializeVehicleGPSPosition();
+	InitializeVehicleGNSSHeading();
 	InitializeVehicleIMU();
 	InitializeVehicleMagnetometer();
 }
@@ -289,6 +293,11 @@ Sensors::~Sensors()
 	if (_vehicle_gps_position) {
 		_vehicle_gps_position->Stop();
 		delete _vehicle_gps_position;
+	}
+
+	if (_vehicle_gnss_heading) {
+		_vehicle_gnss_heading->Stop();
+		delete _vehicle_gnss_heading;
 	}
 
 	if (_vehicle_magnetometer) {
@@ -385,6 +394,7 @@ int Sensors::parameters_update()
 
 	InitializeVehicleAirData();
 	InitializeVehicleGPSPosition();
+	InitializeVehicleGNSSHeading();
 	InitializeVehicleMagnetometer();
 
 	return PX4_OK;
@@ -584,6 +594,19 @@ void Sensors::InitializeVehicleGPSPosition()
 
 			if (_vehicle_gps_position) {
 				_vehicle_gps_position->Start();
+			}
+		}
+	}
+}
+
+void Sensors::InitializeVehicleGNSSHeading()
+{
+	if (_param_sys_has_gps.get()) {
+		if (_vehicle_gnss_heading == nullptr) {
+			_vehicle_gnss_heading = new VehicleGNSSHeading();
+
+			if (_vehicle_gnss_heading) {
+				_vehicle_gnss_heading->Start();
 			}
 		}
 	}
@@ -789,6 +812,11 @@ int Sensors::print_status()
 	if (_vehicle_gps_position) {
 		PX4_INFO_RAW("\n");
 		_vehicle_gps_position->PrintStatus();
+	}
+
+	if (_vehicle_gnss_heading) {
+		PX4_INFO_RAW("\n");
+		_vehicle_gnss_heading->PrintStatus();
 	}
 
 	PX4_INFO_RAW("\n");

--- a/src/modules/sensors/vehicle_gnss_heading/CMakeLists.txt
+++ b/src/modules/sensors/vehicle_gnss_heading/CMakeLists.txt
@@ -1,0 +1,8 @@
+px4_add_library(vehicle_gnss_heading
+	VehicleGNSSHeading.cpp
+	VehicleGNSSHeading.hpp
+)
+target_link_libraries(vehicle_gnss_heading
+	PRIVATE
+		px4_work_queue
+)

--- a/src/modules/sensors/vehicle_gnss_heading/VehicleGNSSHeading.cpp
+++ b/src/modules/sensors/vehicle_gnss_heading/VehicleGNSSHeading.cpp
@@ -1,0 +1,169 @@
+#include "VehicleGNSSHeading.hpp"
+
+#include <px4_platform_common/log.h>
+#include <lib/geo/geo.h>
+#include <lib/mathlib/mathlib.h>
+#include <matrix/math.hpp>
+
+namespace sensors
+{
+VehicleGNSSHeading::VehicleGNSSHeading() :
+	ModuleParams(nullptr),
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers)
+{
+	_vehicle_gnss_heading_pub.advertise();
+}
+
+VehicleGNSSHeading::~VehicleGNSSHeading()
+{
+	Stop();
+	perf_free(_cycle_perf);
+}
+
+bool VehicleGNSSHeading::Start()
+{
+	// force initial updates
+	ParametersUpdate(true);
+
+	_sensor_gnss_relative_sub.registerCallback();
+
+	ScheduleNow();
+
+	return true;
+}
+
+void VehicleGNSSHeading::Stop()
+{
+	Deinit();
+	_sensor_gnss_relative_sub.unregisterCallback();
+}
+
+void VehicleGNSSHeading::ParametersUpdate(bool force)
+{
+	if (_parameter_update_sub.updated() || force) {
+		parameter_update_s param_update;
+		_parameter_update_sub.copy(&param_update);
+
+		updateParams();
+	}
+
+	const float bx = _params_gpsrel_px.get();
+	const float by = _params_gpsrel_py.get();
+	const float bz = _params_gpsrel_pz.get();
+
+	const float baseline_length = sqrtf(bx * bx + by * by + bz * bz);
+
+	if (baseline_length < 0.3f) {
+		PX4_ERR("[vehicle_gnss_heading]Expected baseline length is too small: %.2f m", (double)baseline_length);
+		_expected_baseline_length_m = NAN;
+		_baseline_body_angle = NAN;
+		return;
+	}
+
+	_expected_baseline_length_m = baseline_length;
+	_baseline_body_angle = atan2f(by, bx);
+}
+
+void VehicleGNSSHeading::Run()
+{
+	perf_begin(_cycle_perf);
+	ParametersUpdate();
+
+	if (PX4_ISFINITE(_expected_baseline_length_m) && PX4_ISFINITE(_baseline_body_angle)
+	    && _sensor_gnss_relative_sub.updated()) {
+		sensor_gnss_relative_s d{};
+		_sensor_gnss_relative_sub.copy(&d);
+
+		// Basic validity
+		if (!PX4_ISFINITE(d.heading) || !PX4_ISFINITE(d.heading_accuracy) ||
+		    !PX4_ISFINITE(d.position_length) || !d.heading_valid || !d.relative_position_valid) {
+			perf_end(_cycle_perf);
+			return;
+		}
+
+		if (_params_gpsyaw_crq.get() == 1 && (!d.carrier_solution_floating || !d.carrier_solution_fixed)) {
+			perf_end(_cycle_perf);
+			return;
+		}
+
+		if (_params_gpsyaw_crq.get() == 2 && !d.carrier_solution_fixed) {
+			perf_end(_cycle_perf);
+			return;
+		}
+
+		// The reported baseline length compared to expected is a good indication of accuracy.
+		// Additionally, it prevents potentially large errors if the wrong RTCM stream is sent to the receiver.
+		const float gate_len = _params_gpsyaw_lrq.get();
+
+		if (PX4_ISFINITE(gate_len) && gate_len >= 0.0f) {
+			const float len_diff = fabsf(d.position_length - _expected_baseline_length_m);
+
+			if (len_diff > gate_len) {
+				perf_end(_cycle_perf);
+				return;
+			}
+		}
+
+		const hrt_abstime prev_valid = _last_valid_timestamp;
+		_last_valid_timestamp = d.timestamp;
+
+		// Reject if the delta time to previous valid update is too large, ublox receivers can output stale data
+		// when in rover mode. F9P rovers publish every 125 ms, we accept up to 200 ms additional delay.
+		if (prev_valid == 0 || d.timestamp - prev_valid > 325_ms) {
+			perf_end(_cycle_perf);
+			return;
+		}
+
+		// Rotate into vehicle frame using configured antenna position
+		const float vehicle_yaw = matrix::wrap_pi(d.heading - _baseline_body_angle);
+
+		// publish
+		vehicle_gnss_heading_s out{
+			.timestamp = d.timestamp,
+			.timestamp_sample = d.timestamp_sample,
+			.heading = vehicle_yaw,
+			.heading_accuracy = d.heading_accuracy
+		};
+
+		_vehicle_gnss_heading_pub.publish(out);
+	}
+
+	perf_end(_cycle_perf);
+}
+
+void VehicleGNSSHeading::PrintStatus()
+{
+	PX4_INFO("VehicleGNSSHeading status:");
+
+	const float bx = _params_gpsrel_px.get();
+	const float by = _params_gpsrel_py.get();
+	const float bz = _params_gpsrel_pz.get();
+	const float gate_len = _params_gpsyaw_lrq.get();
+	const int32_t crq = _params_gpsyaw_crq.get();
+
+	PX4_INFO("  Antenna baseline (body) [m]: bx=%.2f by=%.2f bz=%.2f", (double)bx, (double)by, (double)bz);
+	PX4_INFO("  Expected baseline length [m]: %s%.2f",
+		 isfinite(_expected_baseline_length_m) ? "" : "(invalid) ",
+		 (double)_expected_baseline_length_m);
+
+	if (PX4_ISFINITE(gate_len) && gate_len >= 0.f) {
+		PX4_INFO("  Baseline length gate [m]: %.2f m", (double)gate_len);
+
+	} else {
+		PX4_INFO("  Baseline length gate: disabled");
+	}
+
+	PX4_INFO("  Required carrier solution: %d (0=None, 1=Floating or Fixed, 2=Fixed)", (int)crq);
+
+	if (_last_valid_timestamp != 0) {
+		const float since_last_valid_s = (hrt_absolute_time() - _last_valid_timestamp) * 1e-6f;
+		PX4_INFO("  Last valid GNSS-relative message: %.3f s ago", (double)since_last_valid_s);
+
+	} else {
+		PX4_INFO("  Last valid GNSS-relative message: none yet");
+	}
+
+	perf_print_counter(_cycle_perf);
+}
+
+}; // namespace sensors

--- a/src/modules/sensors/vehicle_gnss_heading/VehicleGNSSHeading.hpp
+++ b/src/modules/sensors/vehicle_gnss_heading/VehicleGNSSHeading.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/sensor_gnss_relative.h>
+#include <uORB/topics/vehicle_gnss_heading.h>
+
+using namespace time_literals;
+
+namespace sensors
+{
+class VehicleGNSSHeading : public ModuleParams, public px4::ScheduledWorkItem
+{
+public:
+
+	VehicleGNSSHeading();
+	~VehicleGNSSHeading() override;
+
+	bool Start();
+	void Stop();
+
+	void PrintStatus();
+
+private:
+	void Run() override;
+
+	void ParametersUpdate(bool force = false);
+
+	uORB::Publication<vehicle_gnss_heading_s> _vehicle_gnss_heading_pub{ORB_ID(vehicle_gnss_heading)};
+
+	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+
+	// Only one subscription callback for GNSS relative, since PX4 currently only supports two receivers,
+	// i.e. one base/rover pair.
+	uORB::SubscriptionCallbackWorkItem _sensor_gnss_relative_sub{this, ORB_ID(sensor_gnss_relative), 0};
+
+	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
+
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::SENS_GNSSREL_PX>) _params_gpsrel_px,
+		(ParamFloat<px4::params::SENS_GNSSREL_PY>) _params_gpsrel_py,
+		(ParamFloat<px4::params::SENS_GNSSREL_PZ>) _params_gpsrel_pz,
+		(ParamFloat<px4::params::SENS_GNSSHDG_LRQ>) _params_gpsyaw_lrq,
+		(ParamInt<px4::params::SENS_GNSSHDG_CRQ>) _params_gpsyaw_crq
+	)
+
+	float _expected_baseline_length_m{NAN};
+	float _baseline_body_angle{NAN};
+	hrt_abstime _last_valid_timestamp{0};
+};
+}; // namespace sensors

--- a/src/modules/sensors/vehicle_gnss_heading/params.c
+++ b/src/modules/sensors/vehicle_gnss_heading/params.c
@@ -1,0 +1,24 @@
+/**
+ * GPS Yaw Baseline Length Accuracy Requirement
+ *
+ * Discard any GPS yaw data if the baseline length deviates from the expected length by more than this value.
+ * Expected length is calculated from the SENS_GNSSREL_P{X,Y,Z} parameters.
+ * A value of 0 disables the gate. (This is not recommended.)
+ *
+ * @group Sensors
+ * @unit m
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(SENS_GNSSHDG_LRQ, 0.1f);
+
+/**
+ * Required carrier phase range solution for GPS Yaw
+ *
+ * @value 0 None
+ * @value 1 Floating or Fixed
+ * @value 2 Fixed
+ * @group Sensors
+ * @min 0
+ * @max 2
+ */
+PARAM_DEFINE_INT32(SENS_GNSSHDG_CRQ, 2);


### PR DESCRIPTION
**NB! Not for merge, just for discussing the approach, and to see what could be relevant for upstream master**

We are currently on PX4 v1.13, though in the process of upgrading to v1.15 (and potentially v1.16). Since our long-term goal is to keep our firmware as close as possible to upstream, we’d like to get your feedback on the approach. If you agree with the direction, we’re happy to continue working on it and adapt it to the current master branch.

> **Terminology note:** In this context I intentionally use GNSS and heading instead of GPS and yaw. “GPS” refers only to a single constellation, while “GNSS” is the broader and correct term. Similarly, the measurements in question provide a heading in the NED frame, which only coincides with yaw for certain Euler angle conventions (e.g. PX4’s roll–pitch–yaw sequence). That said, I sometimes slip into the older terminology when writing or talking, and you may still see “GPS” and “yaw” where interfacing with existing code requires it.

For reasons I elaborate below, we don’t want to use GPS blending in our setup, but we still need to make use of relative heading measurements from an MB/rover receiver pair. At the moment, this isn’t possible.

The current implementation in the GPS blending module feels both hacky and semantically incorrect for several reasons:
- GNSS heading is tied to blending, even though the two are conceptually unrelated.
- GNSS position and heading timestamps are forced to be identical, even though they may arrive at different rates.
- Because of the blending logic and timing, many `sensor_gps` messages end up without heading data—even when a heading was successfully computed. This complicates debugging.
- A heading measurement is fundamentally different from a position measurement: it comes from two body-frame receivers rather than a single one. (For self-contained dual-GPS units that act as a single receiver, this distinction is less relevant.)

To address these issues, we implemented a separate system where GNSS heading is decoupled from position. We added a new sensor bridge module that publishes `vehicle_gnss_heading`. This behaves analogously to `vehicle_gps_position`, but instead consumes `sensor_gnss_relative` (available since v1.13, [link](https://github.com/PX4/PX4-Autopilot/pull/19401))

This selector validates the baseline length and fix type, then converts the body-frame relative receiver positions into a NED-frame heading. Only validated results are published to `vehicle_gnss_heading`. Right now, it only supports one input topic instance (more than 2 receivers are not supported anyway). If we want do do something more with relative GNSS in the future, this could be expanded.

![GNSS Heading drawio](https://github.com/user-attachments/assets/4cc696ed-371f-4775-9384-013bf5d4f228)

_Topics below are not part of this PR, just explains the background of why we propose these changes._

----
 
### Background: Moving baseline navigation delay
 As described in the u-blox integration manual and detailed in [PX4-GPSDrivers#109](https://github.com/PX4/PX4-GPSDrivers/pull/109), a u-blox receiver operating in moving baseline mode can reduce its navigation rate to as low as 1 Hz. This occurs not only when communication between the moving base and rover is lost, but also during periods of poor signal quality where the rover cannot compute a valid navigation solution.

This reduced rate is already undesirable, but the real issue is that the navigation data itself is delayed by about one second. Our testing shows that the data within both `time_utc_usec` and the navigation fields in the GNSS message are approximately 900 ms older than normal when received by PX4. Even if compensated, using the time field as reference, these measurements fall outside the EKF’s valid time horizon.

If the moving base stops sending corrections entirely, the rover remains in this degraded mode for the duration of `CFG-NAVSPG-CONSTR_DGNSSTO`. [JonasPerolini](https://github.com/PX4/PX4-GPSDrivers/pull/109) suggested lowering this timeout, but this does not help in cases of intermittent connection or poor signal quality.

In practice, we have repeatedly observed the drone entering “toilet bowl” behavior and suffering position loss when the MB receiver dropped out, mainly because we had a unit which was vibration-sensitive and would occasionally go completely offline. Even though the rover continued reporting valid navigation data, the delay caused the EKF to accumulate large innovations, reject GNSS updates, and lose a reliable position estimate. (We can provide logs if anyone is interested.)

**Because of these issues, we avoid blending for GNSS heading fusion, since rover-mode data cannot be trusted in these conditions.**

### Side note: Rover reconfiguration for fallback use
To mitigate these problems, we use the MB unit as the primary GNSS source for position, and only fall back to the rover unit when necessary. To make the rover a reliable fallback, we added functionality in the GPS driver and module to dynamically reconfigure it.

When the rover is promoted to position source, it is reconfigured from rover mode to standard mode by disabling RTCM input and issuing a soft position reset command. This brings the unit back online within 1–2 seconds and avoids the delayed navigation problem.

This feature is somewhat specialized and may not be broadly useful, but if others are interested, we would be happy to contribute it upstream as well. Our internal PR (with a slightly outdated description) is here: https://github.com/aviant-tech/PX4-Autopilot/pull/104