### PR TITLE
Add support for manual heading reset

### DIFF
--- a/docs/zh/msg_docs/EstimatorStatusFlags.md
+++ b/docs/zh/msg_docs/EstimatorStatusFlags.md
@@ -54,6 +54,7 @@ bool cs_valid_fake_pos          # 41 - true if a valid constant position is bein
 bool cs_constant_pos            # 42 - true if the vehicle is at a constant position
 bool cs_baro_fault	        # 43 - true when the current baro has been declared faulty and is no longer being used
 bool cs_gnss_vel                # 44 - true if GNSS velocity measurement fusion is intended
+bool cs_yaw_manual              # 45 - true if yaw has been set manually
 
 # fault status
 uint32 fault_status_changes   # number of filter fault status (fs) changes

--- a/msg/EstimatorStatus.msg
+++ b/msg/EstimatorStatus.msg
@@ -47,7 +47,8 @@ uint8 CS_SYNTHETIC_MAG_Z = 25	# 25 - true when we are using a synthesized measur
 uint8 CS_VEHICLE_AT_REST = 26	# 26 - true when the vehicle is at rest
 uint8 CS_GPS_YAW_FAULT = 27	# 27 - true when the GNSS heading has been declared faulty and is no longer being used
 uint8 CS_RNG_FAULT = 28		# 28 - true when the range finder has been declared faulty and is no longer being used
-uint8 CS_GNSS_VEL = 44		# 44 - true if GNSS velocity measurements are being fused
+uint8 CS_GNSS_VEL = 44		# 44 - true if GNSS velocity measurement fusion is intended
+uint8 CS_GNSS_FAULT = 45        # 45 - true if GNSS measurements have been declared faulty and are no longer used
 
 uint32 filter_fault_flags	# Bitmask to indicate EKF internal faults
 # 0 - true if the fusion of the magnetometer X-axis has encountered a numerical error

--- a/msg/EstimatorStatus.msg
+++ b/msg/EstimatorStatus.msg
@@ -49,6 +49,7 @@ uint8 CS_GPS_YAW_FAULT = 27	# 27 - true when the GNSS heading has been declared 
 uint8 CS_RNG_FAULT = 28		# 28 - true when the range finder has been declared faulty and is no longer being used
 uint8 CS_GNSS_VEL = 44		# 44 - true if GNSS velocity measurement fusion is intended
 uint8 CS_GNSS_FAULT = 45        # 45 - true if GNSS measurements have been declared faulty and are no longer used
+uint8 CS_YAW_MANUAL = 46        # 46 - true if yaw has been set manually
 
 uint32 filter_fault_flags	# Bitmask to indicate EKF internal faults
 # 0 - true if the fusion of the magnetometer X-axis has encountered a numerical error

--- a/msg/EstimatorStatusFlags.msg
+++ b/msg/EstimatorStatusFlags.msg
@@ -49,6 +49,7 @@ bool cs_valid_fake_pos          # 41 - true if a valid constant position is bein
 bool cs_constant_pos            # 42 - true if the vehicle is at a constant position
 bool cs_baro_fault	        # 43 - true when the current baro has been declared faulty and is no longer being used
 bool cs_gnss_vel                # 44 - true if GNSS velocity measurement fusion is intended
+bool cs_gnss_fault              # 45 - true if GNSS measurements have been declared faulty and are no longer used
 
 # fault status
 uint32 fault_status_changes   # number of filter fault status (fs) changes

--- a/msg/EstimatorStatusFlags.msg
+++ b/msg/EstimatorStatusFlags.msg
@@ -50,6 +50,7 @@ bool cs_constant_pos            # 42 - true if the vehicle is at a constant posi
 bool cs_baro_fault	        # 43 - true when the current baro has been declared faulty and is no longer being used
 bool cs_gnss_vel                # 44 - true if GNSS velocity measurement fusion is intended
 bool cs_gnss_fault              # 45 - true if GNSS measurements have been declared faulty and are no longer used
+bool cs_yaw_manual              # 46 - true if yaw has been set manually
 
 # fault status
 uint32 fault_status_changes   # number of filter fault status (fs) changes

--- a/msg/versioned/VehicleCommand.msg
+++ b/msg/versioned/VehicleCommand.msg
@@ -88,6 +88,7 @@ uint16 VEHICLE_CMD_REQUEST_CAMERA_INFORMATION = 521 # Request camera information
 uint16 VEHICLE_CMD_SET_CAMERA_MODE = 530 # Set camera capture mode (photo, video, etc.).
 uint16 VEHICLE_CMD_SET_CAMERA_ZOOM = 531 # Set camera zoom.
 uint16 VEHICLE_CMD_SET_CAMERA_FOCUS = 532
+uint16 VEHICLE_CMD_EXTERNAL_ATTITUDE_ESTIMATE = 620 # Set an external estimate of vehicle attitude in degrees.
 uint16 VEHICLE_CMD_DO_GIMBAL_MANAGER_PITCHYAW = 1000 # Setpoint to be sent to a gimbal manager to set a gimbal pitch and yaw.
 uint16 VEHICLE_CMD_DO_GIMBAL_MANAGER_CONFIGURE = 1001 # Gimbal configuration to set which sysid/compid is in primary and secondary control.
 uint16 VEHICLE_CMD_IMAGE_START_CAPTURE = 2000 # Start image capture sequence.

--- a/src/lib/motion_planning/HeadingSmoothing.cpp
+++ b/src/lib/motion_planning/HeadingSmoothing.cpp
@@ -42,7 +42,10 @@ void HeadingSmoothing::reset(const float heading, const float heading_rate)
 {
 	const float wrapped_heading = matrix::wrap_pi(heading);
 	_velocity_smoothing.setCurrentVelocity(wrapped_heading);
-	_velocity_smoothing.setCurrentAcceleration(heading_rate);
+
+	if (PX4_ISFINITE(heading_rate)) {
+		_velocity_smoothing.setCurrentAcceleration(heading_rate);
+	}
 }
 
 void HeadingSmoothing::update(const float heading_setpoint, const float time_elapsed)

--- a/src/lib/motion_planning/HeadingSmoothing.hpp
+++ b/src/lib/motion_planning/HeadingSmoothing.hpp
@@ -69,7 +69,7 @@ public:
 	 * @param heading [rad] [-pi,pi]
 	 * @param heading_rate [rad/s]
 	 */
-	void reset(const float heading, const float heading_rate);
+	void reset(const float heading, const float heading_rate = NAN);
 
 	/**
 	 * @brief updates the heading setpoint, re-calculates trajectory, and takes an integration step

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -462,6 +462,22 @@ int Commander::custom_command(int argc, char *argv[])
 		}
 	}
 
+	if (!strcmp(argv[0], "set_heading")) {
+		if (argc > 1) {
+			const float heading = atof(argv[1]);
+			const float heading_accuracy = NAN;
+
+			bool ret = send_vehicle_command(vehicle_command_s::VEHICLE_CMD_EXTERNAL_ATTITUDE_ESTIMATE,
+							0.f, 0.f, heading, 0.f, 0.f, 0.f, heading_accuracy);
+			return (ret ? 0 : 1);
+
+		} else {
+			PX4_ERR("missing argument");
+			return 0;
+		}
+	}
+
+
 	if (!strcmp(argv[0], "poweroff")) {
 
 		bool ret = send_vehicle_command(vehicle_command_s::VEHICLE_CMD_PREFLIGHT_REBOOT_SHUTDOWN,
@@ -1521,6 +1537,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 	case vehicle_command_s::VEHICLE_CMD_DO_GRIPPER:
 	case vehicle_command_s::VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE:
 	case vehicle_command_s::VEHICLE_CMD_REQUEST_CAMERA_INFORMATION:
+	case vehicle_command_s::VEHICLE_CMD_EXTERNAL_ATTITUDE_ESTIMATE:
 		/* ignore commands that are handled by other parts of the system */
 		break;
 
@@ -3040,6 +3057,8 @@ The commander module contains the state machine for mode switching and failsafe 
 	PRINT_MODULE_USAGE_COMMAND("set_ekf_origin");
 	PRINT_MODULE_USAGE_ARG("lat, lon, alt", "Origin Latitude, Longitude, Altitude", false);
 	PRINT_MODULE_USAGE_COMMAND_DESCR("lat|lon|alt", "Origin latitude longitude altitude");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("set_heading", "Set current heading");
+	PRINT_MODULE_USAGE_ARG("heading", "degrees from True North [0 360]", false);
 	PRINT_MODULE_USAGE_COMMAND_DESCR("poweroff", "Power off board (if supported)");
 #endif
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
@@ -522,14 +522,6 @@ bool Ekf::resetYawToEKFGSF()
 		return false;
 	}
 
-	// don't allow reset if there's just been a yaw reset
-	const bool yaw_alignment_changed = (_control_status_prev.flags.yaw_align != _control_status.flags.yaw_align);
-	const bool quat_reset = (_state_reset_status.reset_count.quat != _state_reset_count_prev.quat);
-
-	if (yaw_alignment_changed || quat_reset) {
-		return false;
-	}
-
 	ECL_INFO("yaw estimator reset heading %.3f -> %.3f rad",
 		 (double)getEulerYaw(_R_to_earth), (double)_yawEstimator.getYaw());
 

--- a/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
@@ -593,8 +593,6 @@ void Ekf::resetMagHeading(const Vector3f &mag)
 	// update quaternion states and corresponding covarainces
 	resetQuatStateYaw(yaw_new, yaw_new_variance);
 
-	_time_last_heading_fuse = _time_delayed_us;
-
 	_mag_heading_innov_lpf.reset(0.f);
 	_control_status.flags.mag_heading_consistent = true;
 }

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -608,6 +608,7 @@ uint64_t mag_heading_consistent  :
 		uint64_t gnss_vel                : 1; ///< 44 - true if GNSS velocity measurement fusion is intended
 uint64_t gnss_fault              :
 		1; ///< 45 - true if GNSS measurements have been declared faulty and are no longer used
+		uint64_t yaw_manual              : 1; ///< 46 - true if yaw has been reset manually
 	} flags;
 	uint64_t value;
 };

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1935,6 +1935,7 @@ void EKF2::PublishStatusFlags(const hrt_abstime &timestamp)
 		status_flags.cs_constant_pos        = _ekf.control_status_flags().constant_pos;
 		status_flags.cs_baro_fault	    = _ekf.control_status_flags().baro_fault;
 		status_flags.cs_gnss_vel            = _ekf.control_status_flags().gnss_vel;
+		status_flags.cs_gnss_fault          = _ekf.control_status_flags().gnss_fault;
 
 		status_flags.fault_status_changes     = _filter_fault_status_changes;
 		status_flags.fs_bad_mag_x             = _ekf.fault_status_flags().bad_mag_x;

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -580,6 +580,24 @@ void EKF2::Run()
 				command_ack.timestamp = hrt_absolute_time();
 				_vehicle_command_ack_pub.publish(command_ack);
 			}
+
+			if (vehicle_command.command == vehicle_command_s::VEHICLE_CMD_EXTERNAL_ATTITUDE_ESTIMATE) {
+				if (PX4_ISFINITE(vehicle_command.param3)) {
+					const float heading = wrap_pi(math::radians(vehicle_command.param3));
+					static constexpr float kDefaultHeadingAccuracyDeg = 20.f;
+					const float heading_accuracy = math::radians(PX4_ISFINITE(vehicle_command.param7)
+								       ? vehicle_command.param7
+								       : kDefaultHeadingAccuracyDeg);
+					_ekf.resetHeadingToExternalObservation(heading, heading_accuracy);
+					command_ack.result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED;
+
+				} else {
+					command_ack.result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;
+				}
+
+				command_ack.timestamp = hrt_absolute_time();
+				_vehicle_command_ack_pub.publish(command_ack);
+			}
 		}
 	}
 
@@ -1936,6 +1954,7 @@ void EKF2::PublishStatusFlags(const hrt_abstime &timestamp)
 		status_flags.cs_baro_fault	    = _ekf.control_status_flags().baro_fault;
 		status_flags.cs_gnss_vel            = _ekf.control_status_flags().gnss_vel;
 		status_flags.cs_gnss_fault          = _ekf.control_status_flags().gnss_fault;
+		status_flags.cs_yaw_manual          = _ekf.control_status_flags().yaw_manual;
 
 		status_flags.fault_status_changes     = _filter_fault_status_changes;
 		status_flags.fs_bad_mag_x             = _ekf.fault_status_flags().bad_mag_x;

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -707,19 +707,20 @@ void FlightTaskAuto::_ekfResetHandlerVelocityXY(const matrix::Vector2f &delta_vx
 	_position_smoothing.forceSetVelocity({_velocity(0), _velocity(1), NAN});
 }
 
-void FlightTaskAuto::_ekfResetHandlerPositionZ(float delta_z)
+void FlightTaskAuto::_ekfResetHandlerPositionZ(const float delta_z)
 {
 	_position_smoothing.forceSetPosition({NAN, NAN, _position(2)});
 }
 
-void FlightTaskAuto::_ekfResetHandlerVelocityZ(float delta_vz)
+void FlightTaskAuto::_ekfResetHandlerVelocityZ(const float delta_vz)
 {
 	_position_smoothing.forceSetVelocity({NAN, NAN, _velocity(2)});
 }
 
-void FlightTaskAuto::_ekfResetHandlerHeading(float delta_psi)
+void FlightTaskAuto::_ekfResetHandlerHeading(const float delta_psi)
 {
-	_yaw_setpoint_previous += delta_psi;
+	_yaw_setpoint_previous = wrap_pi(_yaw_setpoint_previous + delta_psi);
+	_heading_smoothing.reset(wrap_pi(_heading_smoothing.getSmoothedHeading() + delta_psi));
 }
 
 void FlightTaskAuto::_checkEmergencyBraking()


### PR DESCRIPTION
### Solved Problem
Heading can be initially incorrect due to local magnetic anomalies or not directly measurable by the drone (e.g.: mag type "none").

### Solution
Add support for the `heading/yaw` field of [MAV_CMD_EXTERNAL_ATTITUDE_ESTIMATE](https://mavlink.io/en/messages/development.html#MAV_CMD_EXTERNAL_ATTITUDE_ESTIMATE). Sending this command forces the EKF to reset its heading to this value. ~We don't use a "reset by fusion" here to keep it simple as the primary use case is heading initialization.~ Reset by fusion is used in case the heading is already aligned.
Also, mag heading/3D fusion is inhibited before it got aligned in air to avoid a fight between the operator and mag data before takeoff.

One can also send the command using `commander set_heading <0-360degrees>` in the shell.

### Changelog Entry
For release notes:
```
Add support for manual heading reset
New parameter: -
Documentation: command description done
```

### Test coverage
Tested in SITL: 
- add a bias of 0.1Gs to the Y mag, creates a heading error of 26 degrees
- reset the heading to -2 degrees (`commander set_heading 358`)
- takeoff, fly around and trigger again a couple of heading resets
<img width="2023" height="1227" alt="image" src="https://github.com/user-attachments/assets/04e50a0a-c035-4f88-9a29-e0a084ead6b9" />
