### PR TITLE
Sensors: remove some distance sensors from COMMON_DISTANCE_SENSOR again

### DIFF
--- a/src/drivers/distance_sensor/Kconfig
+++ b/src/drivers/distance_sensor/Kconfig
@@ -2,7 +2,6 @@ menu "Distance sensors"
     menuconfig COMMON_DISTANCE_SENSOR
         bool "Common distance sensor's"
         default n
-        select DRIVERS_DISTANCE_SENSOR_CM8JL65
         select DRIVERS_DISTANCE_SENSOR_LIGHTWARE_LASER_I2C
         select DRIVERS_DISTANCE_SENSOR_LIGHTWARE_LASER_SERIAL
         select DRIVERS_DISTANCE_SENSOR_LL40LS


### PR DESCRIPTION


### Solved Problem
We're low on flash again..

### Solution
Remove some distance sensors from the common list (which is included in most builds) that are EOL.
This is a follow up to https://github.com/PX4/PX4-Autopilot/pull/23993.

### Changelog Entry
For release notes:
```
Cleanup: Remove CM8JL65 and TERARANGER driver builds to save flash
```

### Alternatives
Many, e.g. https://github.com/PX4/PX4-Autopilot/pull/23993
