### PR TITLE
Recovering UTC timestamps from ULog without sensor_gps

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1990,6 +1990,11 @@ void Logger::write_info(LogType type, const char *name, uint32_t value)
 	write_info_template<uint32_t>(type, name, value, "uint32_t");
 }
 
+void Logger::write_info(LogType type, const char *name, double value)
+{
+	write_info_template<double>(type, name, value, "double");
+}
+
 
 template<typename T>
 void Logger::write_info_template(LogType type, const char *name, T value, const char *type_str)

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -2127,6 +2127,11 @@ void Logger::write_version(LogType type)
 
 	write_info(type, "time_ref_utc", _param_sdlog_utc_offset.get() * 60);
 
+	double boot_time_utc;
+	if (util::get_log_time(boot_time_utc, _param_sdlog_utc_offset.get() * 60, true)) {
+		write_info(type, "boot_time_utc", boot_time_utc);
+	}
+
 	if (_replay_file_name) {
 		write_info(type, "replay", _replay_file_name);
 	}

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1990,9 +1990,9 @@ void Logger::write_info(LogType type, const char *name, uint32_t value)
 	write_info_template<uint32_t>(type, name, value, "uint32_t");
 }
 
-void Logger::write_info(LogType type, const char *name, double value)
+void Logger::write_info(LogType type, const char *name, uint64_t value)
 {
-	write_info_template<double>(type, name, value, "double");
+	write_info_template<uint64_t>(type, name, value, "uint64_t");
 }
 
 
@@ -2127,9 +2127,10 @@ void Logger::write_version(LogType type)
 
 	write_info(type, "time_ref_utc", _param_sdlog_utc_offset.get() * 60);
 
-	double boot_time_utc;
-	if (util::get_log_time(boot_time_utc, _param_sdlog_utc_offset.get() * 60, true)) {
-		write_info(type, "boot_time_utc", boot_time_utc);
+	uint64_t boot_time_utc_us;
+
+	if (util::get_log_time(boot_time_utc_us, _param_sdlog_utc_offset.get() * 60, true)) {
+		write_info(type, "boot_time_utc_us", boot_time_utc_us);
 	}
 
 	if (_replay_file_name) {

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -267,7 +267,7 @@ private:
 	void write_info_multiple(LogType type, const char *name, int fd);
 	void write_info(LogType type, const char *name, int32_t value);
 	void write_info(LogType type, const char *name, uint32_t value);
-	void write_info(LogType type, const char *name, double value);
+	void write_info(LogType type, const char *name, uint64_t value);
 
 	/** generic common template method for write_info variants */
 	template<typename T>

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -267,6 +267,7 @@ private:
 	void write_info_multiple(LogType type, const char *name, int fd);
 	void write_info(LogType type, const char *name, int32_t value);
 	void write_info(LogType type, const char *name, uint32_t value);
+	void write_info(LogType type, const char *name, double value);
 
 	/** generic common template method for write_info variants */
 	template<typename T>

--- a/src/modules/logger/util.cpp
+++ b/src/modules/logger/util.cpp
@@ -72,7 +72,7 @@ bool file_exist(const char *filename)
 	return stat(filename, &buffer) == 0;
 }
 
-bool get_log_time(double &utc_time_sec, int utc_offset_sec, bool boot_time)
+bool get_log_time(uint64_t &utc_time_usec, int utc_offset_sec, bool boot_time)
 {
 	uORB::Subscription vehicle_gps_position_sub{ORB_ID(vehicle_gps_position)};
 
@@ -82,9 +82,9 @@ bool get_log_time(double &utc_time_sec, int utc_offset_sec, bool boot_time)
 	sensor_gps_s gps_pos;
 
 	if (vehicle_gps_position_sub.copy(&gps_pos)) {
-		utc_time_sec = gps_pos.time_utc_usec / 1e6;
+		utc_time_usec = gps_pos.time_utc_usec;
 
-		if (gps_pos.fix_type >= 2 && utc_time_sec >= GPS_EPOCH_SECS) {
+		if (gps_pos.fix_type >= 2 && utc_time_usec >= (uint64_t) GPS_EPOCH_SECS * 1000000ULL) {
 			use_clock_time = false;
 		}
 	}
@@ -93,30 +93,30 @@ bool get_log_time(double &utc_time_sec, int utc_offset_sec, bool boot_time)
 		/* take clock time if there's no fix (yet) */
 		struct timespec ts = {};
 		px4_clock_gettime(CLOCK_REALTIME, &ts);
-		utc_time_sec = ts.tv_sec + (ts.tv_nsec / 1e9);
+		utc_time_usec = ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000ULL;
 
-		if (utc_time_sec < GPS_EPOCH_SECS) {
+		if (utc_time_usec < (uint64_t) GPS_EPOCH_SECS * 1000000ULL) {
 			return false;
 		}
 	}
 
 	/* strip the time elapsed since boot */
 	if (boot_time) {
-		utc_time_sec -= hrt_absolute_time() / 1e6;
+		utc_time_usec -= hrt_absolute_time();
 	}
 
 	/* apply utc offset */
-	utc_time_sec += utc_offset_sec;
+	utc_time_usec += (int64_t) utc_offset_sec * 1000000LL;
 
 	return true;
 }
 
 bool get_log_time(struct tm *tt, int utc_offset_sec, bool boot_time)
 {
-	double utc_time_sec;
-	bool result = get_log_time(utc_time_sec, utc_offset_sec, boot_time);
-	time_t t = static_cast<time_t>(utc_time_sec);
-	return result && gmtime_r(&t, tt) != nullptr;
+	uint64_t utc_time_usec;
+	bool result = get_log_time(utc_time_usec, utc_offset_sec, boot_time);
+	time_t utc_time_sec = static_cast<time_t>(utc_time_usec / 1000000ULL);
+	return result && gmtime_r(&utc_time_sec, tt) != nullptr;
 }
 
 int check_free_space(const char *log_root_dir, int32_t max_log_dirs_to_keep, orb_advert_t &mavlink_log_pub,

--- a/src/modules/logger/util.cpp
+++ b/src/modules/logger/util.cpp
@@ -72,11 +72,10 @@ bool file_exist(const char *filename)
 	return stat(filename, &buffer) == 0;
 }
 
-bool get_log_time(struct tm *tt, int utc_offset_sec, bool boot_time)
+bool get_log_time(double &utc_time_sec, int utc_offset_sec, bool boot_time)
 {
 	uORB::Subscription vehicle_gps_position_sub{ORB_ID(vehicle_gps_position)};
 
-	time_t utc_time_sec;
 	bool use_clock_time = true;
 
 	/* Get the latest GPS publication */
@@ -109,7 +108,15 @@ bool get_log_time(struct tm *tt, int utc_offset_sec, bool boot_time)
 	/* apply utc offset */
 	utc_time_sec += utc_offset_sec;
 
-	return gmtime_r(&utc_time_sec, tt) != nullptr;
+	return true;
+}
+
+bool get_log_time(struct tm *tt, int utc_offset_sec, bool boot_time)
+{
+	double utc_time_sec;
+	bool result = get_log_time(utc_time_sec, utc_offset_sec, boot_time);
+	time_t t = static_cast<time_t>(utc_time_sec);
+	return result && gmtime_r(&t, tt) != nullptr;
 }
 
 int check_free_space(const char *log_root_dir, int32_t max_log_dirs_to_keep, orb_advert_t &mavlink_log_pub,

--- a/src/modules/logger/util.h
+++ b/src/modules/logger/util.h
@@ -77,13 +77,13 @@ int check_free_space(const char *log_root_dir, int32_t max_log_dirs_to_keep, orb
 
 
 /**
- * Utility for fetching UTC time in fractional seconds from sensor_gps or CLOCK_REALTIME
- * @param utc_time_sec returned fractional seconds
+ * Utility for fetching UTC time in microseconds from sensor_gps or CLOCK_REALTIME
+ * @param utc_time_usec returned microseconds
  * @param utc_offset_sec UTC time offset [s]
  * @param boot_time use time when booted instead of current time
  * @return true on success, false otherwise (eg. if no gps)
  */
-bool get_log_time(uint64_t &utc_time_sec, int utc_offset_sec, bool boot_time);
+bool get_log_time(uint64_t &utc_time_usec, int utc_offset_sec, bool boot_time);
 
 /**
  * Get the time for log file name

--- a/src/modules/logger/util.h
+++ b/src/modules/logger/util.h
@@ -83,7 +83,7 @@ int check_free_space(const char *log_root_dir, int32_t max_log_dirs_to_keep, orb
  * @param boot_time use time when booted instead of current time
  * @return true on success, false otherwise (eg. if no gps)
  */
-bool get_log_time(double &utc_time_sec, int utc_offset_sec, bool boot_time);
+bool get_log_time(uint64_t &utc_time_sec, int utc_offset_sec, bool boot_time);
 
 /**
  * Get the time for log file name

--- a/src/modules/logger/util.h
+++ b/src/modules/logger/util.h
@@ -75,6 +75,16 @@ bool file_exist(const char *filename);
 int check_free_space(const char *log_root_dir, int32_t max_log_dirs_to_keep, orb_advert_t &mavlink_log_pub,
 		     int &sess_dir_index);
 
+
+/**
+ * Utility for fetching UTC time in fractional seconds from sensor_gps or CLOCK_REALTIME
+ * @param utc_time_sec returned fractional seconds
+ * @param utc_offset_sec UTC time offset [s]
+ * @param boot_time use time when booted instead of current time
+ * @return true on success, false otherwise (eg. if no gps)
+ */
+bool get_log_time(double &utc_time_sec, int utc_offset_sec, bool boot_time);
+
 /**
  * Get the time for log file name
  * @param tt returned time


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When I opened my ULog files I found that there was no way to determine the UTC timestamp of the messages. My drone does not have a GPS sensor, and thus I could not use the `time_utc_usec` field of the https://docs.px4.io/main/en/msg_docs/SensorGps message to compute the offset between the message timestamps and UTC time. 

### Solution
This MR adds an Information Message to the ULog with the boot time in UTC microseconds from CLOCK_REALTIME which can be set by the GCS via Mavlink/DDS. To get the UTC timestamp of any message, just add the message's timestamp to the boot time saved in the ULog file. 

### Changelog Entry
New ULog Information Message: `boot_time_utc_us`. Only present if a >=2D GPS fix was acquired or CLOCK_REALTIME was set by the GCS before logging began. Value is system start time with respect to Unix time epoch, in microseconds (`uint64_t`). 

### Alternatives
We could also use the https://docs.px4.io/main/en/msg_docs/TimesyncStatus.html message, but I'm not sure how to recover the UTC timestamps of all other messages using that message. 

### Test coverage
[01_31_03.ulg.zip](https://github.com/user-attachments/files/22326164/01_31_03.ulg.zip)


Using:
```
ulog = ULog("01_31_03.ulg")
for msg in ulog.msg_info_dict:
    print(f"{msg}: {ulog.msg_info_dict[msg]}")
```

We recover the UTC boot time in microseconds
```
ver_sw: 5782c46a042d452c1805e020afaa0dfea4af34ee
ver_sw_release: 17825984
ver_vendor_sw_release: 192
ver_hw: PX4_SITL
sys_name: PX4
sys_os_name: Linux
ver_sw_branch: logger-info-boot-time
sys_os_ver_release: 101451263
sys_toolchain: GNU GCC
sys_toolchain_ver: 7.5.0
ver_data_format: 2
time_ref_utc: 0
boot_time_utc_us: 1757899862064610
metadata_events_sha256: 22d291af59dcc3b44fa778da1929ba8e8440b8fe16cf8be5bf4a5e6bcf209daf
```


### Context
The need for non-GPS ULogs to recover UTC time stamps is crucial to take full advantage of data analytics toolchains such as Flight Review, Foxglove, Roboto, etc. 
See https://discord.com/channels/1022170275984457759/1413437536981876860 for discussion with Roboto. 
