### PR TITLE
serial: nuttx: revert tcdrain back to fsync

### DIFF
--- a/platforms/nuttx/src/px4/common/SerialImpl.cpp
+++ b/platforms/nuttx/src/px4/common/SerialImpl.cpp
@@ -355,11 +355,14 @@ ssize_t SerialImpl::write(const void *buffer, size_t buffer_size)
 	}
 
 	int written = ::write(_serial_fd, buffer, buffer_size);
-	::fsync(_serial_fd);
 
 	if (written < 0) {
-		PX4_ERR("%s write error %d", _port, written);
+		if (errno != EAGAIN) {
+			PX4_ERR("%s write error %d", _port, written);
+		}
 	}
+
+	::fsync(_serial_fd);
 
 	return written;
 }

--- a/platforms/posix/src/px4/common/SerialImpl.cpp
+++ b/platforms/posix/src/px4/common/SerialImpl.cpp
@@ -337,12 +337,14 @@ ssize_t SerialImpl::write(const void *buffer, size_t buffer_size)
 	}
 
 	int written = ::write(_serial_fd, buffer, buffer_size);
-	::fsync(_serial_fd);
 
 	if (written < 0) {
-		PX4_ERR("%s write error %d", _port, written);
-
+		if (errno != EAGAIN) {
+			PX4_ERR("%s write error %d", _port, written);
+		}
 	}
+
+	::fsync(_serial_fd);
 
 	return written;
 }

--- a/platforms/qurt/src/px4/SerialImpl.cpp
+++ b/platforms/qurt/src/px4/SerialImpl.cpp
@@ -268,8 +268,9 @@ ssize_t SerialImpl::write(const void *buffer, size_t buffer_size)
 	int ret_write = qurt_uart_write(_serial_fd, (const char *) buffer, buffer_size);
 
 	if (ret_write < 0) {
-		PX4_ERR("%s write error %d", _port, ret_write);
-
+		if (errno != EAGAIN) {
+			PX4_ERR("%s write error %d", _port, ret_write);
+		}
 	}
 
 	return ret_write;


### PR DESCRIPTION
Reverts https://github.com/PX4/PX4-Autopilot/pull/23686

Due to the bug described here
https://github.com/PX4/PX4-Autopilot/pull/23686#issuecomment-3268281777
> FYI this is a breaking change for a bunch of things, including bursts of RTCM traffic. We had a problem where a burst of RTCM data was taking down the GPS. This change made the GPS serial port effectively half-duplex, and was blocking the READ part of the code. If I reverted this change, I get a /dev/ttyS0 write error -1 on the write thread and the read loop continues to process correctly.

**Solutions**
GPS driver RTCM injection logic could be better
https://github.com/PX4/PX4-Autopilot/pull/25535

We need a blocking and non-blocking write method
https://github.com/PX4/PX4-Autopilot/pull/25537

But this should be reverted since the problem it solves is the minority case. The fix can be handled by instead adding a block write method OR by first polling (POLLOUT) to check if data can be written before calling write.