### PR TITLE
Corrected max number of submodules displayed in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,7 +43,7 @@
         "files.watcherExclude": {
                 "**/build/**": true
         },
-        "git.detectSubmodulesLimit": 20,
+        "git.detectSubmodulesLimit": 25,
         "git.ignoreLimitWarning": true,
         "githubPullRequests.defaultMergeMethod": "squash",
         "githubPullRequests.telemetry.enabled": false,


### PR DESCRIPTION
### Solved Problem
In VSCode, not all submodules were being displayed. This was because "git.detectSubmodulesLimit" was set to 20, but there are currently 25 submodules. Increased value to 25.

### Solution
- Increased value of "git.detectSubmodulesLimit" from 20 to 25

### Changelog Entry
Fixed number of submodules VSCode displays

### Test coverage
Not applicable

### Context
Not applicable
