### PR TITLE
RoverAttitudeSetpoint et al - whitespace

### DIFF
--- a/msg/RoverAttitudeSetpoint.msg
+++ b/msg/RoverAttitudeSetpoint.msg
@@ -1,4 +1,4 @@
 # Rover Attitude Setpoint
 
-uint64 timestamp # [us] Time since system start
-float32 yaw_setpoint # [rad] [@range -inf, inf] [@frame NED] Yaw setpoint
+uint64 timestamp      # [us] Time since system start
+float32 yaw_setpoint  # [rad] [@range -inf, inf] [@frame NED] Yaw setpoint

--- a/msg/RoverAttitudeStatus.msg
+++ b/msg/RoverAttitudeStatus.msg
@@ -1,5 +1,5 @@
 # Rover Attitude Status
 
-uint64 timestamp # [us] Time since system start
-float32 measured_yaw # [rad] [@range -pi, pi] [@frame NED]Measured yaw
-float32 adjusted_yaw_setpoint # [rad] [@range -pi, pi] [@frame NED] Yaw setpoint that is being tracked (Applied slew rates)
+uint64 timestamp               # [us] Time since system start
+float32 measured_yaw           # [rad] [@range -pi, pi] [@frame NED]Measured yaw
+float32 adjusted_yaw_setpoint  # [rad] [@range -pi, pi] [@frame NED] Yaw setpoint that is being tracked (Applied slew rates)

--- a/msg/RoverPositionSetpoint.msg
+++ b/msg/RoverPositionSetpoint.msg
@@ -1,8 +1,8 @@
 # Rover Position Setpoint
 
-uint64 timestamp # [us] Time since system start
-float32[2] position_ned # [m] [@range -inf, inf] [@frame NED] Target position
-float32[2] start_ned # [m] [@range -inf, inf] [@frame NED] [@invalid NaN Defaults to vehicle position] Start position which specifies a line for the rover to track
-float32 cruising_speed # [m/s] [@range 0, inf] [@invalid NaN Defaults to maximum speed] Cruising speed
-float32 arrival_speed # [m/s] [@range 0, inf] [@invalid NaN Defaults to 0] Speed the rover should arrive at the target with
-float32 yaw # [rad] [@range -pi,pi] [@frame NED] [@invalid NaN Defaults to vehicle yaw] Mecanum only: Specify vehicle yaw during travel
+uint64 timestamp         # [us] Time since system start
+float32[2] position_ned  # [m] [@range -inf, inf] [@frame NED] Target position
+float32[2] start_ned     # [m] [@range -inf, inf] [@frame NED] [@invalid NaN Defaults to vehicle position] Start position which specifies a line for the rover to track
+float32 cruising_speed   # [m/s] [@range 0, inf] [@invalid NaN Defaults to maximum speed] Cruising speed
+float32 arrival_speed    # [m/s] [@range 0, inf] [@invalid NaN Defaults to 0] Speed the rover should arrive at the target with
+float32 yaw              # [rad] [@range -pi,pi] [@frame NED] [@invalid NaN Defaults to vehicle yaw] Mecanum only: Specify vehicle yaw during travel

--- a/msg/RoverRateSetpoint.msg
+++ b/msg/RoverRateSetpoint.msg
@@ -1,4 +1,4 @@
 # Rover Rate setpoint
 
-uint64 timestamp # [us] Time since system start
-float32 yaw_rate_setpoint # [rad/s] [@range -inf, inf] [@frame NED] Yaw rate setpoint
+uint64 timestamp           # [us] Time since system start
+float32 yaw_rate_setpoint  # [rad/s] [@range -inf, inf] [@frame NED] Yaw rate setpoint

--- a/msg/RoverRateStatus.msg
+++ b/msg/RoverRateStatus.msg
@@ -3,4 +3,4 @@
 uint64 timestamp                    # [us] Time since system start
 float32 measured_yaw_rate           # [rad/s] [@range -inf, inf] [@frame NED] Measured yaw rate
 float32 adjusted_yaw_rate_setpoint  # [rad/s] [@range -inf, inf] [@frame NED] Yaw rate setpoint that is being tracked (Applied slew rates)
-float32 pid_yaw_rate_integral       # [] [@range -1, 1] Integral of the PID for the closed loop yaw rate controller
+float32 pid_yaw_rate_integral       # [-] [@range -1, 1] Integral of the PID for the closed loop yaw rate controller

--- a/msg/RoverRateStatus.msg
+++ b/msg/RoverRateStatus.msg
@@ -1,6 +1,6 @@
 # Rover Rate Status
 
-uint64 timestamp # [us] Time since system start
-float32 measured_yaw_rate # [rad/s] [@range -inf, inf] [@frame NED] Measured yaw rate
-float32 adjusted_yaw_rate_setpoint # [rad/s] [@range -inf, inf] [@frame NED] Yaw rate setpoint that is being tracked (Applied slew rates)
-float32 pid_yaw_rate_integral #  [] [@range -1, 1] Integral of the PID for the closed loop yaw rate controller
+uint64 timestamp                    # [us] Time since system start
+float32 measured_yaw_rate           # [rad/s] [@range -inf, inf] [@frame NED] Measured yaw rate
+float32 adjusted_yaw_rate_setpoint  # [rad/s] [@range -inf, inf] [@frame NED] Yaw rate setpoint that is being tracked (Applied slew rates)
+float32 pid_yaw_rate_integral       #  [] [@range -1, 1] Integral of the PID for the closed loop yaw rate controller

--- a/msg/RoverRateStatus.msg
+++ b/msg/RoverRateStatus.msg
@@ -3,4 +3,4 @@
 uint64 timestamp                    # [us] Time since system start
 float32 measured_yaw_rate           # [rad/s] [@range -inf, inf] [@frame NED] Measured yaw rate
 float32 adjusted_yaw_rate_setpoint  # [rad/s] [@range -inf, inf] [@frame NED] Yaw rate setpoint that is being tracked (Applied slew rates)
-float32 pid_yaw_rate_integral       #  [] [@range -1, 1] Integral of the PID for the closed loop yaw rate controller
+float32 pid_yaw_rate_integral       # [] [@range -1, 1] Integral of the PID for the closed loop yaw rate controller

--- a/msg/RoverSpeedSetpoint.msg
+++ b/msg/RoverSpeedSetpoint.msg
@@ -1,5 +1,5 @@
 # Rover Speed Setpoint
 
-uint64 timestamp # [us] Time since system start
-float32 speed_body_x # [m/s] [@range -inf (Backwards), inf (Forwards)] [@frame Body] Speed setpoint in body x direction
-float32 speed_body_y # [m/s] [@range -inf (Left), inf (Right)] [@frame Body] [@invalid NaN If not mecanum] Mecanum only: Speed setpoint in body y direction
+uint64 timestamp      # [us] Time since system start
+float32 speed_body_x  # [m/s] [@range -inf (Backwards), inf (Forwards)] [@frame Body] Speed setpoint in body x direction
+float32 speed_body_y  # [m/s] [@range -inf (Left), inf (Right)] [@frame Body] [@invalid NaN If not mecanum] Mecanum only: Speed setpoint in body y direction

--- a/msg/RoverSpeedStatus.msg
+++ b/msg/RoverSpeedStatus.msg
@@ -1,9 +1,9 @@
 # Rover Velocity Status
 
-uint64 timestamp # [us] Time since system start
-float32 measured_speed_body_x # [m/s] [@range -inf (Backwards), inf (Forwards)] [@frame Body] Measured speed in body x direction
-float32 adjusted_speed_body_x_setpoint # [m/s] [@range -inf (Backwards), inf (Forwards)] [@frame Body] Speed setpoint in body x direction that is being tracked (Applied slew rates)
-float32 pid_throttle_body_x_integral # [] [@range -1, 1] Integral of the PID for the closed loop controller of the speed in body x direction
-float32 measured_speed_body_y # [m/s] [@range -inf (Left), inf (Right)] [@frame Body] [@invalid NaN If not mecanum] Mecanum only: Measured speed in body y direction
-float32 adjusted_speed_body_y_setpoint # [m/s] [@range -inf (Left), inf (Right)] [@frame Body] [@invalid NaN If not mecanum] Mecanum only: Speed setpoint in body y direction that is being tracked (Applied slew rates)
-float32 pid_throttle_body_y_integral # [] [@range -1, 1] [@invalid NaN If not mecanum] Mecanum only: Integral of the PID for the closed loop controller of the speed in body y direction
+uint64 timestamp                        # [us] Time since system start
+float32 measured_speed_body_x           # [m/s] [@range -inf (Backwards), inf (Forwards)] [@frame Body] Measured speed in body x direction
+float32 adjusted_speed_body_x_setpoint  # [m/s] [@range -inf (Backwards), inf (Forwards)] [@frame Body] Speed setpoint in body x direction that is being tracked (Applied slew rates)
+float32 pid_throttle_body_x_integral    # [] [@range -1, 1] Integral of the PID for the closed loop controller of the speed in body x direction
+float32 measured_speed_body_y           # [m/s] [@range -inf (Left), inf (Right)] [@frame Body] [@invalid NaN If not mecanum] Mecanum only: Measured speed in body y direction
+float32 adjusted_speed_body_y_setpoint  # [m/s] [@range -inf (Left), inf (Right)] [@frame Body] [@invalid NaN If not mecanum] Mecanum only: Speed setpoint in body y direction that is being tracked (Applied slew rates)
+float32 pid_throttle_body_y_integral    # [] [@range -1, 1] [@invalid NaN If not mecanum] Mecanum only: Integral of the PID for the closed loop controller of the speed in body y direction

--- a/msg/RoverSpeedStatus.msg
+++ b/msg/RoverSpeedStatus.msg
@@ -3,7 +3,7 @@
 uint64 timestamp                        # [us] Time since system start
 float32 measured_speed_body_x           # [m/s] [@range -inf (Backwards), inf (Forwards)] [@frame Body] Measured speed in body x direction
 float32 adjusted_speed_body_x_setpoint  # [m/s] [@range -inf (Backwards), inf (Forwards)] [@frame Body] Speed setpoint in body x direction that is being tracked (Applied slew rates)
-float32 pid_throttle_body_x_integral    # [] [@range -1, 1] Integral of the PID for the closed loop controller of the speed in body x direction
+float32 pid_throttle_body_x_integral    # [-] [@range -1, 1] Integral of the PID for the closed loop controller of the speed in body x direction
 float32 measured_speed_body_y           # [m/s] [@range -inf (Left), inf (Right)] [@frame Body] [@invalid NaN If not mecanum] Mecanum only: Measured speed in body y direction
 float32 adjusted_speed_body_y_setpoint  # [m/s] [@range -inf (Left), inf (Right)] [@frame Body] [@invalid NaN If not mecanum] Mecanum only: Speed setpoint in body y direction that is being tracked (Applied slew rates)
-float32 pid_throttle_body_y_integral    # [] [@range -1, 1] [@invalid NaN If not mecanum] Mecanum only: Integral of the PID for the closed loop controller of the speed in body y direction
+float32 pid_throttle_body_y_integral    # [-] [@range -1, 1] [@invalid NaN If not mecanum] Mecanum only: Integral of the PID for the closed loop controller of the speed in body y direction

--- a/msg/RoverSteeringSetpoint.msg
+++ b/msg/RoverSteeringSetpoint.msg
@@ -1,4 +1,4 @@
 # Rover Steering setpoint
 
 uint64 timestamp                      # [us] Time since system start
-float32 normalized_steering_setpoint  # [@range -1 (Left), 1 (Right)] [@frame Body] Ackermann: Normalized steering angle, Differential/Mecanum: Normalized speed difference between the left and right wheels
+float32 normalized_steering_setpoint  # [-] [@range -1 (Left), 1 (Right)] [@frame Body] Ackermann: Normalized steering angle, Differential/Mecanum: Normalized speed difference between the left and right wheels

--- a/msg/RoverSteeringSetpoint.msg
+++ b/msg/RoverSteeringSetpoint.msg
@@ -1,4 +1,4 @@
 # Rover Steering setpoint
 
-uint64 timestamp # [us] Time since system start
-float32 normalized_steering_setpoint # [@range -1 (Left), 1 (Right)] [@frame Body] Ackermann: Normalized steering angle, Differential/Mecanum: Normalized speed difference between the left and right wheels
+uint64 timestamp                      # [us] Time since system start
+float32 normalized_steering_setpoint  # [@range -1 (Left), 1 (Right)] [@frame Body] Ackermann: Normalized steering angle, Differential/Mecanum: Normalized speed difference between the left and right wheels

--- a/msg/RoverThrottleSetpoint.msg
+++ b/msg/RoverThrottleSetpoint.msg
@@ -1,5 +1,5 @@
 # Rover Throttle setpoint
 
 uint64 timestamp         # [us] Time since system start
-float32 throttle_body_x  # [] [@range -1 (Backwards), 1 (Forwards)] [@frame Body] Throttle setpoint along body X axis
-float32 throttle_body_y  # [] [@range -1 (Left), 1 (Right)] [@frame Body] [@invalid NaN If not mecanum] Mecanum only: Throttle setpoint along body Y axis
+float32 throttle_body_x  # [-] [@range -1 (Backwards), 1 (Forwards)] [@frame Body] Throttle setpoint along body X axis
+float32 throttle_body_y  # [-] [@range -1 (Left), 1 (Right)] [@frame Body] [@invalid NaN If not mecanum] Mecanum only: Throttle setpoint along body Y axis

--- a/msg/RoverThrottleSetpoint.msg
+++ b/msg/RoverThrottleSetpoint.msg
@@ -1,5 +1,5 @@
 # Rover Throttle setpoint
 
-uint64 timestamp # [us] Time since system start
-float32 throttle_body_x # [] [@range -1 (Backwards), 1 (Forwards)] [@frame Body] Throttle setpoint along body X axis
-float32 throttle_body_y # [] [@range -1 (Left), 1 (Right)] [@frame Body] [@invalid NaN If not mecanum] Mecanum only: Throttle setpoint along body Y axis
+uint64 timestamp         # [us] Time since system start
+float32 throttle_body_x  # [] [@range -1 (Backwards), 1 (Forwards)] [@frame Body] Throttle setpoint along body X axis
+float32 throttle_body_y  # [] [@range -1 (Left), 1 (Right)] [@frame Body] [@invalid NaN If not mecanum] Mecanum only: Throttle setpoint along body Y axis


### PR DESCRIPTION
Recently we agreed that whitespace indentation before a uorb comment should be 2 spaces after the longest field in a group for all fields/enum values in a group. This moves RoverAttitudeSetpoint and friends to match. Note, #25544 covers purePursuitSetup