### PR TITLE
Navigator: delay neutral gimbal command 

### DIFF
--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -72,7 +72,7 @@ Land::on_activation()
 	// reset cruising speed to default
 	_navigator->reset_cruising_speed();
 
-	_navigator->set_gimbal_neutral_activation_time(hrt_absolute_time());
+	_navigator->activate_set_gimbal_neutral_timer(hrt_absolute_time());
 }
 
 void

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -182,7 +182,7 @@ MissionBase::on_inactivation()
 	_navigator->stop_capturing_images();
 
 	if (!_navigator->get_land_detected()->landed) {
-		_navigator->set_gimbal_neutral_activation_time(hrt_absolute_time());
+		_navigator->activate_set_gimbal_neutral_timer(hrt_absolute_time());
 	}
 
 	if (_navigator->get_precland()->is_activated()) {
@@ -700,7 +700,7 @@ void MissionBase::handleLanding(WorkItemType &new_work_item_type, mission_item_s
 			// if the vehicle drifted off the path during back-transition it should just go straight to the landing point
 			_navigator->reset_position_setpoint(pos_sp_triplet->previous);
 
-			_navigator->set_gimbal_neutral_activation_time(hrt_absolute_time());
+			_navigator->activate_set_gimbal_neutral_timer(hrt_absolute_time());
 
 		} else {
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -287,7 +287,7 @@ public:
 	void neutralize_gimbal_if_control_activated();
 	/* Accepts a new timestamp only if the current timestamp is UINT64_MAX, preventing the
 	timer from resetting during an ongoing neutral command. */
-	void set_gimbal_neutral_activation_time(const hrt_abstime timestamp);
+	void activate_set_gimbal_neutral_timer(const hrt_abstime timestamp);
 
 	void preproject_stop_point(double &lat, double &lon);
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1631,7 +1631,7 @@ void Navigator::set_gimbal_neutral()
 	publish_vehicle_command(vehicle_command);
 }
 
-void Navigator::set_gimbal_neutral_activation_time(const hrt_abstime timestamp)
+void Navigator::activate_set_gimbal_neutral_timer(const hrt_abstime timestamp)
 {
 	if (_gimbal_neutral_activation_time == UINT64_MAX) {
 		_gimbal_neutral_activation_time = timestamp;
@@ -1640,8 +1640,10 @@ void Navigator::set_gimbal_neutral_activation_time(const hrt_abstime timestamp)
 
 void Navigator::neutralize_gimbal_if_control_activated()
 {
-	hrt_abstime now{hrt_absolute_time()};
+	const hrt_abstime now{hrt_absolute_time()};
 
+	// The time delay must be sufficiently long to allow flight tasks to complete its
+	// destruction and release gimbal control before the navigator takes control of the gimbal.
 	if (_gimbal_neutral_activation_time != UINT64_MAX && now > _gimbal_neutral_activation_time + 250_ms) {
 		acquire_gimbal_control();
 		set_gimbal_neutral();

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -237,7 +237,7 @@ void RTL::on_activation()
 		break;
 	}
 
-	_navigator->set_gimbal_neutral_activation_time(hrt_absolute_time());
+	_navigator->activate_set_gimbal_neutral_timer(hrt_absolute_time());
 }
 
 void RTL::on_active()


### PR DESCRIPTION
### Solved Problem
When initiating RTL from postion slow mode, gimbal kept its pitch angle which possibly could damage the camera when landing. 
The issue was caused due to conflict between gimbal commands sent from FlightTaskManualAcceleration and the navigator. The navigator sent `VEHICLE_CMD_DO_GIMBAL_MANAGER_PITCHYAW` with `GIMBAL_MANAGER_FLAGS_NEUTRAL` which should level the gimbal and change control with respect to the vehicle frame. Immediately after, the exit of FlightTaskManualAcceleration send an attitude command with zero rates,  `GIMBAL_MANAGER_FLAGS_ROLL_LOCK` and `GIMBAL_MANAGER_FLAGS_PITCH_LOCK`.  Which meant that the gimbal had not enough time to reach the neutralized attitude.

### Solution
- Added a delay in the navigator to send neutral command after 250 ms.


### Context
Tested in SIH.

Here is a plot with the pitch angle of the gimbal that resets to 0 deg after 250 ms into the RTL state.
<img width="2028" height="1306" alt="image" src="https://github.com/user-attachments/assets/d9d21431-ca6a-4b80-bee6-624b43a4605e" />
