### PR TITLE
EstimatorCheck: fix reporting of low position accuracy failsafe

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -621,8 +621,7 @@ void EstimatorChecks::lowPositionAccuracy(const Context &context, Report &report
 		position_valid_but_low_accuracy = (_param_com_low_eph.get() > FLT_EPSILON && lpos.eph > _param_com_low_eph.get());
 	}
 
-	if (!reporter.failsafeFlags().position_accuracy_low && position_valid_but_low_accuracy
-	    && _param_com_pos_low_act.get()) {
+	if (position_valid_but_low_accuracy && _param_com_pos_low_act.get()) {
 
 		// only report if armed
 		if (context.isArmed()) {


### PR DESCRIPTION


### Solved Problem
For the low position accuracy failsafe (`COM_POS_LOW_ACT`) the reporting is not happening properly, see screenshot:
<img width="240" height="64" alt="image" src="https://github.com/user-attachments/assets/d80fe21a-4180-42e3-9242-d8b7628d25b5" />


### Solution
Remove condition to only send `reporter.armingCheckFailure()` once. As I understand it it must be sent continuously. 

### Changelog Entry
For release notes:
```
Bugfix EstimatorCheck: fix reporting of low position accuracy failsafe
```

### Alternatives
It's confusing that these checks are called `armingCheckFailure()`, but are actually active also (or here: exclusively) post arming.

### Test coverage
SITL tested.
