### PR TITLE
ark: UAVCAN_ESC_IFACE per board

### DIFF
--- a/boards/ark/fmu-v6x/init/rc.board_defaults
+++ b/boards/ark/fmu-v6x/init/rc.board_defaults
@@ -25,6 +25,8 @@ param set-default SENS_IMU_TEMP 10.0
 #param set-default SENS_IMU_TEMP_I 0.025
 #param set-default SENS_IMU_TEMP_P 1.0
 
+param set-default UAVCAN_ESC_IFACE 2
+
 if ver hwtypecmp ARKV6X000
 then
 	param set-default SENS_TEMP_ID 2818058

--- a/boards/ark/fpv/init/rc.board_defaults
+++ b/boards/ark/fpv/init/rc.board_defaults
@@ -30,6 +30,8 @@ param set-default BAT1_V_DIV 21.0
 param set-default RC_CRSF_PRT_CFG 300
 param set-default RC_SBUS_PRT_CFG 0
 
+param set-default UAVCAN_ESC_IFACE 1
+
 param set-default IMU_GYRO_DNF_EN 3
 
 # Single IMU

--- a/boards/ark/pi6x/init/rc.board_defaults
+++ b/boards/ark/pi6x/init/rc.board_defaults
@@ -26,6 +26,8 @@ param set-default SENS_IMU_TEMP 10.0
 #param set-default SENS_IMU_TEMP_I 0.025
 #param set-default SENS_IMU_TEMP_P 1.0
 
+param set-default UAVCAN_ESC_IFACE 1
+
 if ver hwtypecmp ARKPI6X000
 then
 	# TODO: Add the correct sensor ID


### PR DESCRIPTION
- v6x uses CAN2
- fpv uses CAN1
- pi6x uses CAN1