### PR TITLE
FlightTaskManualAccelerationSlow: Acquire gimbal control until expected IDs are reported

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Utility/Gimbal.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Gimbal.cpp
@@ -68,8 +68,8 @@ void Gimbal::acquireGimbalControlIfNeeded()
 	if (_gimbal_manager_status_sub.updated()) {
 		_gimbal_manager_status_sub.copy(&gimbal_manager_status);
 
-		if(gimbal_manager_status.primary_control_compid != _param_mav_comp_id.get() ||
-		   gimbal_manager_status.primary_control_sysid != _param_mav_sys_id.get()) {
+		if (gimbal_manager_status.primary_control_compid != _param_mav_comp_id.get() ||
+		    gimbal_manager_status.primary_control_sysid != _param_mav_sys_id.get()) {
 			_tried_to_have_gimbal_control = true;
 			vehicle_command_s vehicle_command{};
 			vehicle_command.command = vehicle_command_s::VEHICLE_CMD_DO_GIMBAL_MANAGER_CONFIGURE;

--- a/src/modules/flight_mode_manager/tasks/Utility/Gimbal.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Gimbal.hpp
@@ -74,16 +74,7 @@ public:
 		| gimbal_manager_set_attitude_s::GIMBAL_MANAGER_FLAGS_PITCH_LOCK;
 
 private:
-
-	void updateAcquiringstateOnTelemetry();
-	enum class AcquiringState {
-		Unknown = 0,
-		Acquired,
-		Released,
-	};
-
-	AcquiringState _acquiring_state{AcquiringState::Unknown};
-
+	bool _tried_to_have_gimbal_control{false};
 	uORB::Subscription _gimbal_device_attitude_status_sub{ORB_ID(gimbal_device_attitude_status)};
 	uORB::Subscription _gimbal_manager_status_sub{ORB_ID(gimbal_manager_status)};
 	hrt_abstime _telemtry_timestamp{};

--- a/src/modules/flight_mode_manager/tasks/Utility/Gimbal.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Gimbal.hpp
@@ -74,10 +74,15 @@ public:
 		| gimbal_manager_set_attitude_s::GIMBAL_MANAGER_FLAGS_PITCH_LOCK;
 
 private:
-	bool gimbalHaveControl();
 
-	uint8_t _last_comp_id{UINT8_MAX};
-	uint8_t _last_sys_id{UINT8_MAX};
+	void updateAcquiringstateOnTelemetry();
+	enum class AcquiringState {
+		Unknown = 0,
+		Acquired,
+		Released,
+	};
+
+	AcquiringState _acquiring_state{AcquiringState::Unknown};
 
 	uORB::Subscription _gimbal_device_attitude_status_sub{ORB_ID(gimbal_device_attitude_status)};
 	uORB::Subscription _gimbal_manager_status_sub{ORB_ID(gimbal_manager_status)};

--- a/src/modules/flight_mode_manager/tasks/Utility/Gimbal.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Gimbal.hpp
@@ -45,6 +45,7 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/gimbal_manager_set_attitude.h>
 #include <uORB/topics/gimbal_device_attitude_status.h>
+#include <uORB/topics/gimbal_manager_status.h>
 #include <uORB/topics/vehicle_command.h>
 
 #include "Sticks.hpp"
@@ -73,9 +74,13 @@ public:
 		| gimbal_manager_set_attitude_s::GIMBAL_MANAGER_FLAGS_PITCH_LOCK;
 
 private:
-	bool _have_gimbal_control{false};
+	bool gimbalHaveControl();
+
+	uint8_t _last_comp_id{UINT8_MAX};
+	uint8_t _last_sys_id{UINT8_MAX};
 
 	uORB::Subscription _gimbal_device_attitude_status_sub{ORB_ID(gimbal_device_attitude_status)};
+	uORB::Subscription _gimbal_manager_status_sub{ORB_ID(gimbal_manager_status)};
 	hrt_abstime _telemtry_timestamp{};
 	uint16_t _telemetry_flags{};
 	float _telemetry_yaw{};


### PR DESCRIPTION
### Solved Problem
When switching between Position and Position Slow mode the gimbal does not behave as expected. Sometimes the  flag `GIMBAL_MANAGER_FLAGS_YAW_LOCK` remains in Position mode after switch.

### Solution

- [x] Continue acquire gimbal control until sys_id and comp_id are the expected values

### Alternative solutions
- Only send gimbal manager status on change as an event
- Configure stream rate to 5 Hz as [recommended](https://mavlink.io/en/messages/common.html#GIMBAL_MANAGER_STATUS). 
