### PR TITLE
ekf: reduce EKF2_MIN_RNG to 0.01

### DIFF
--- a/src/modules/ekf2/params_terrain.yaml
+++ b/src/modules/ekf2/params_terrain.yaml
@@ -28,7 +28,7 @@ parameters:
           where the range finder may be inside its minimum measurements distance when
           on ground.
       type: float
-      default: 0.1
+      default: 0.01
       min: 0.01
       unit: m
       decimal: 2


### PR DESCRIPTION
**Problem**
The 0.1 default for rangefinder is too large and can lead to rangefinder fusion failing after takeoff if the rangefinder is not greater than this value.

**Solution**
Reduce the value to near 0

**Alternatives**
I think we should remove this parameter completely. Specifying a min range doesn't make a lot of sense since the validity of the rangefinder comes from the `quality` variable. Also the DistanceSensor.msg contains a min_distance and max_distance anyway which allows each rangefinder driver to set it's own min/max.