### PR TITLE
Adjust found_dix's judgment logic

### DIFF
--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -307,12 +307,12 @@ bool FailsafeBase::checkFailsafe(int caller_id, bool last_state_failure, bool cu
 		int found_idx = -1;
 
 		for (int i = 0; i < max_num_actions; ++i) {
-			if (!_actions[i].valid()) {
-				free_idx = i;
-
-			} else if (_actions[i].id == caller_id) {
+			if (_actions[i].id == caller_id) {
 				found_idx = i;
 				break;
+
+			} else if (!_actions[i].valid()) {
+				free_idx = i;
 			}
 		}
 


### PR DESCRIPTION
### Summary
This is my first PR, optimizing the condition check order in the `checkFailsafe` function of `FailsafeBase` to improve code readability. As a new contributor, I appreciate any feedback if I missed any community guidelines!

### Changes
- File: `src/lib/failsafe/FailsafeBase.cpp`

### Motivation
- **Readability**: The new order better reflects the function's intent (prioritizing `found_idx`), making the code easier to understand and maintain.
- **Functionality**: No change in behavior, as `free_idx` is only used when `found_idx` is `-1`, and any invalid slot is suitable.

### Notes
- Code formatted with `make format`.
- As my first PR, please let me know if additional tests or changes are needed!