### PR TITLE
Add warning for known issue in FW RTL landings

### DIFF
--- a/docs/en/flight_modes_fw/return.md
+++ b/docs/en/flight_modes_fw/return.md
@@ -26,9 +26,9 @@ The default type is recommended.
 :::
 
 ::: warning
-
-There is a [known issue](https://github.com/PX4/PX4-Autopilot/issues/25436) with the approaches and landings of FW (not VTOL) mission landings while in RTL mode. Please review the issue there and verify in simulation that the behavior you get is acceptable for an RTL landing scenario, or consider using rally points to ensure safety of personnel.
-
+There is a known issue ([PX4-Autopilot#25436](https://github.com/PX4/PX4-Autopilot/issues/25436)) with fixed-wing approaches and landings while in RTL mode.
+Please review the issue and verify in simulation that the behavior you get is safe in an RTL landing scenario.
+If not, consider using rally points.
 :::
 
 ## Technical Summary

--- a/docs/en/flight_modes_fw/return.md
+++ b/docs/en/flight_modes_fw/return.md
@@ -25,6 +25,12 @@ The default type is recommended.
 
 :::
 
+::: warning
+
+There is a [known issue](https://github.com/PX4/PX4-Autopilot/issues/25436) with the approaches and landings of FW (not VTOL) mission landings while in RTL mode. Please review the issue there and verify in simulation that the behavior you get is acceptable for an RTL landing scenario, or consider using rally points to ensure safety of personnel.
+
+:::
+
 ## Technical Summary
 
 Fixed-wing vehicles use the _mission landing/rally point_ return type by default.

--- a/docs/en/flight_modes_fw/return.md
+++ b/docs/en/flight_modes_fw/return.md
@@ -27,8 +27,7 @@ The default type is recommended.
 
 ::: warning
 There is a known issue ([PX4-Autopilot#25436](https://github.com/PX4/PX4-Autopilot/issues/25436)) with fixed-wing approaches and landings while in RTL mode.
-Please review the issue and verify in simulation that the behavior you get is safe in an RTL landing scenario.
-If not, consider using rally points.
+Please review the issue and verify in simulation that the behavior you get is safe in an RTL landing scenario (if not, consider using rally points).
 :::
 
 ## Technical Summary


### PR DESCRIPTION
Currently there is an issue in 1.15.0...main which causes a FW aircraft to veer off course during the final approach on landing. This could cause a personnel safety risk and should be noted.

### Solved Problem
Documenting known bad landing behavior in RTL.

Fixes no issue, documents https://github.com/PX4/PX4-Autopilot/issues/25436
