### PR TITLE
commander: use double literals to avoid implicit conversion

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  issues: write # for JasonEtco/create-an-issue
 
 env:
   RUNS_IN_DOCKER: true

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -468,7 +468,7 @@ int Commander::custom_command(int argc, char *argv[])
 			const float heading_accuracy = NAN;
 
 			bool ret = send_vehicle_command(vehicle_command_s::VEHICLE_CMD_EXTERNAL_ATTITUDE_ESTIMATE,
-							0.f, 0.f, heading, 0.f, 0.f, 0.f, heading_accuracy);
+							0.f, 0.f, heading, 0.f, 0.0, 0.0, heading_accuracy);
 			return (ret ? 0 : 1);
 
 		} else {


### PR DESCRIPTION
Fixes a CI failure for fuzzing and macos (from https://github.com/PX4/PX4-Autopilot/pull/25518):
https://github.com/PX4/PX4-Autopilot/actions/runs/17906277709/job/50907922642
```
/__w/PX4-Autopilot/PX4-Autopilot/src/modules/commander/Commander.cpp:471:37: fatal error: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
  470 |                         bool ret = send_vehicle_command(vehicle_command_s::VEHICLE_CMD_EXTERNAL_ATTITUDE_ESTIMATE,
      |                                    ~~~~~~~~~~~~~~~~~~~~
  471 |                                                         0.f, 0.f, heading, 0.f, 0.f, 0.f, heading_accuracy);
      |                                                                                      ^~~
1 error generated.
```

And add issue write permissions to ci for JasonEtco/create-an-issue.