### PR TITLE
Navigator: Use hysteresis for neutral gimbal command delay + some refactoring

### DIFF
--- a/src/modules/navigator/CMakeLists.txt
+++ b/src/modules/navigator/CMakeLists.txt
@@ -63,10 +63,11 @@ px4_add_module(
 	MAIN navigator
 	SRCS ${NAVIGATOR_SOURCES}
 	DEPENDS
+		adsb
 		dataman_client
 		geo
-		adsb
 		geofence_breach_avoidance
+		hysteresis
 		motion_planning
 		mission_feasibility_checker
 		rtl_time_estimator

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -72,7 +72,7 @@ Land::on_activation()
 	// reset cruising speed to default
 	_navigator->reset_cruising_speed();
 
-	_navigator->activate_set_gimbal_neutral_timer(hrt_absolute_time());
+	_navigator->gimbal_neutral_delayed();
 }
 
 void

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -182,7 +182,7 @@ MissionBase::on_inactivation()
 	_navigator->stop_capturing_images();
 
 	if (!_navigator->get_land_detected()->landed) {
-		_navigator->activate_set_gimbal_neutral_timer(hrt_absolute_time());
+		_navigator->gimbal_neutral_delayed();
 	}
 
 	if (_navigator->get_precland()->is_activated()) {
@@ -702,7 +702,7 @@ void MissionBase::handleLanding(WorkItemType &new_work_item_type, mission_item_s
 			// if the vehicle drifted off the path during back-transition it should just go straight to the landing point
 			_navigator->reset_position_setpoint(pos_sp_triplet->previous);
 
-			_navigator->activate_set_gimbal_neutral_timer(hrt_absolute_time());
+			_navigator->gimbal_neutral_delayed();
 
 		} else {
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -397,16 +397,6 @@ private:
 	// update subscriptions
 	void params_update();
 
-	/**
-	 * Publish a new position setpoint triplet for position controllers
-	 */
-	void publish_position_setpoint_triplet();
-
-	/**
-	 * Publish the mission result so commander and mavlink know what is going on
-	 */
-	void publish_mission_result();
-
 	void publish_navigator_status();
 
 	void publish_vehicle_command_ack(const vehicle_command_s &cmd, uint8_t result);

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -241,6 +241,8 @@ void Navigator::run()
 		_position_controller_status_sub.update();
 		_home_pos_sub.update(&_home_pos);
 
+		const hrt_abstime now = hrt_absolute_time();
+
 		// Handle Vehicle commands
 		int vehicle_command_updates = 0;
 
@@ -268,7 +270,7 @@ void Navigator::run()
 				// which can lead to dangerous and unexpected behaviors (see loiter.cpp, there is an if(armed) in there too)
 
 				// Wait for vehicle_status before handling the next command, otherwise the setpoint could be overwritten
-				_wait_for_vehicle_status_timestamp = hrt_absolute_time();
+				_wait_for_vehicle_status_timestamp = now;
 
 				vehicle_global_position_s position_setpoint{};
 
@@ -397,10 +399,10 @@ void Navigator::run()
 						rep->current.loiter_direction_counter_clockwise = curr->current.loiter_direction_counter_clockwise;
 					}
 
-					rep->previous.timestamp = hrt_absolute_time();
+					rep->previous.timestamp = now;
 
 					rep->current.valid = true;
-					rep->current.timestamp = hrt_absolute_time();
+					rep->current.timestamp = now;
 
 					rep->next.valid = false;
 
@@ -430,7 +432,7 @@ void Navigator::run()
 				position_setpoint.alt = PX4_ISFINITE(cmd.param1) ? cmd.param1 : get_global_position()->alt;
 
 				// Wait for vehicle_status before handling the next command, otherwise the setpoint could be overwritten
-				_wait_for_vehicle_status_timestamp = hrt_absolute_time();
+				_wait_for_vehicle_status_timestamp = now;
 
 				if (geofence_allows_position(position_setpoint)) {
 					position_setpoint_triplet_s *rep = get_reposition_triplet();
@@ -478,10 +480,10 @@ void Navigator::run()
 
 					rep->current.loiter_direction_counter_clockwise = curr->current.loiter_direction_counter_clockwise;
 
-					rep->previous.timestamp = hrt_absolute_time();
+					rep->previous.timestamp = now;
 
 					rep->current.valid = true;
-					rep->current.timestamp = hrt_absolute_time();
+					rep->current.timestamp = now;
 
 					rep->next.valid = false;
 
@@ -506,7 +508,7 @@ void Navigator::run()
 				position_setpoint.alt = PX4_ISFINITE(cmd.param7) ? cmd.param7 : get_global_position()->alt;
 
 				// Wait for vehicle_status before handling the next command, otherwise the setpoint could be overwritten
-				_wait_for_vehicle_status_timestamp = hrt_absolute_time();
+				_wait_for_vehicle_status_timestamp = now;
 
 				if (geofence_allows_position(position_setpoint)) {
 					position_setpoint_triplet_s *rep = get_reposition_triplet();
@@ -535,7 +537,7 @@ void Navigator::run()
 					rep->current.alt = position_setpoint.alt;
 
 					rep->current.valid = true;
-					rep->current.timestamp = hrt_absolute_time();
+					rep->current.timestamp = now;
 
 					_time_loitering_after_gf_breach = 0; // have to manually reset this in all LOITER cases
 
@@ -554,7 +556,7 @@ void Navigator::run()
 				position_setpoint.alt = PX4_ISFINITE(cmd.param7) ? cmd.param7 : get_global_position()->alt;
 
 				// Wait for vehicle_status before handling the next command, otherwise the setpoint could be overwritten
-				_wait_for_vehicle_status_timestamp = hrt_absolute_time();
+				_wait_for_vehicle_status_timestamp = now;
 
 				if (geofence_allows_position(position_setpoint)) {
 					position_setpoint_triplet_s *rep = get_reposition_triplet();
@@ -587,7 +589,7 @@ void Navigator::run()
 					rep->current.alt = position_setpoint.alt;
 
 					rep->current.valid = true;
-					rep->current.timestamp = hrt_absolute_time();
+					rep->current.timestamp = now;
 
 					_time_loitering_after_gf_breach = 0; // have to manually reset this in all LOITER cases
 
@@ -614,7 +616,7 @@ void Navigator::run()
 				if (home_global_position_valid()) {
 
 					rep->previous.valid = true;
-					rep->previous.timestamp = hrt_absolute_time();
+					rep->previous.timestamp = now;
 
 				} else {
 					rep->previous.valid = false;
@@ -638,7 +640,7 @@ void Navigator::run()
 				rep->current.alt = cmd.param7;
 
 				rep->current.valid = true;
-				rep->current.timestamp = hrt_absolute_time();
+				rep->current.timestamp = now;
 
 				rep->next.valid = false;
 
@@ -749,8 +751,7 @@ void Navigator::run()
 					break;
 				}
 
-				_vroi.timestamp = hrt_absolute_time();
-
+				_vroi.timestamp = now;
 				_vehicle_roi_pub.publish(_vroi);
 
 				publish_vehicle_command_ack(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED);
@@ -927,7 +928,6 @@ void Navigator::run()
 		}
 
 		// Set gimbal neutral if requested and delay is over
-		const hrt_abstime now = hrt_absolute_time();
 		_gimbal_neutral_hysteresis.update(now);
 
 		if (_gimbal_neutral_hysteresis.get_state()) {

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -920,11 +920,18 @@ void Navigator::run()
 		}
 
 		if (_pos_sp_triplet_updated) {
-			publish_position_setpoint_triplet();
+			_pos_sp_triplet.timestamp = hrt_absolute_time();
+			_pos_sp_triplet_pub.publish(_pos_sp_triplet);
+			_pos_sp_triplet_updated = false;
 		}
 
 		if (_mission_result_updated) {
-			publish_mission_result();
+			_mission_result.timestamp = hrt_absolute_time();
+			_mission_result_pub.publish(_mission_result);
+			_mission_result.item_do_jump_changed = false;
+			_mission_result.item_changed_index = 0;
+			_mission_result.item_do_jump_remaining = 0;
+			_mission_result_updated = false;
 		}
 
 		// Set gimbal neutral if requested and delay is over
@@ -1144,13 +1151,6 @@ int Navigator::print_status()
 	return 0;
 }
 
-void Navigator::publish_position_setpoint_triplet()
-{
-	_pos_sp_triplet.timestamp = hrt_absolute_time();
-	_pos_sp_triplet_pub.publish(_pos_sp_triplet);
-	_pos_sp_triplet_updated = false;
-}
-
 float Navigator::get_default_acceptance_radius()
 {
 	return _param_nav_acc_rad.get();
@@ -1367,21 +1367,6 @@ int Navigator::custom_command(int argc, char *argv[])
 	}
 
 	return print_usage("unknown command");
-}
-
-void Navigator::publish_mission_result()
-{
-	_mission_result.timestamp = hrt_absolute_time();
-
-	/* lazily publish the mission result only once available */
-	_mission_result_pub.publish(_mission_result);
-
-	/* reset some of the flags */
-	_mission_result.item_do_jump_changed = false;
-	_mission_result.item_changed_index = 0;
-	_mission_result.item_do_jump_remaining = 0;
-
-	_mission_result_updated = false;
 }
 
 void Navigator::set_mission_failure_heading_timeout()

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -237,7 +237,7 @@ void RTL::on_activation()
 		break;
 	}
 
-	_navigator->activate_set_gimbal_neutral_timer(hrt_absolute_time());
+	_navigator->gimbal_neutral_delayed();
 }
 
 void RTL::on_active()


### PR DESCRIPTION
### Solved Problem
I came across https://github.com/PX4/PX4-Autopilot/pull/25551 too late, but realized it's the implementation of a hysteresis/delay and there might be an opportunity to simplify the navigator for better readability, so I’m suggesting this follow-up.

### Solution
- Use the existing hysteresis library for the neutral gimbal command delay, it uses a bit more RAM but is well tested and has a simple interface.
- Unroll tiny functions that are only called once and for which the reader needs to jump to the end of the file and back.
- Reduce `hrt_absolute_time()` calls which all have an insignificantly different timestamp as a result and reuse a loop timestamp instead.

### Changelog Entry
```
Navigator: Use hysteresis for neutral gimbal command delay + some refactoring
```

### Test coverage
Not tested, it should be a pure refactor. The thing that would be nicest to verify is that I used the hysteresis correctly.