### PR TITLE
uavcan: don't init ESC if UAVCAN_ENABLE isn't set for ESC

### DIFF
--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -81,6 +81,8 @@ UavcanEscController::init()
 		_param_handles[i] = param_find(param_name);
 	}
 
+	_initialized = true;
+
 	return res;
 }
 

--- a/src/drivers/uavcan/actuators/esc.hpp
+++ b/src/drivers/uavcan/actuators/esc.hpp
@@ -69,6 +69,8 @@ public:
 
 	int init();
 
+	bool initialized() { return _initialized; };
+
 	void update_outputs(uint16_t outputs[MAX_ACTUATORS], unsigned total_outputs);
 
 	/**
@@ -96,6 +98,8 @@ private:
 
 	typedef uavcan::MethodBinder<UavcanEscController *,
 		void (UavcanEscController::*)(const uavcan::TimerEvent &)> TimerCbBinder;
+
+	bool _initialized{};
 
 	esc_status_s	_esc_status{};
 

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -1081,7 +1081,10 @@ void UavcanNode::publish_node_statuses()
 bool UavcanMixingInterfaceESC::updateOutputs(uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
-	_esc_controller.update_outputs(outputs, num_outputs);
+	if (_esc_controller.initialized()) {
+		_esc_controller.update_outputs(outputs, num_outputs);
+	}
+
 	return true;
 }
 

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -529,10 +529,16 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 
 	// Actuators
 #if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
-	ret = _esc_controller.init();
+	int32_t uavcan_enable = -1;
+	(void)param_get(param_find("UAVCAN_ENABLE"), &uavcan_enable);
 
-	if (ret < 0) {
-		return ret;
+	if (uavcan_enable > 2) {
+
+		ret = _esc_controller.init();
+
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 #endif
@@ -606,10 +612,6 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 	_param_getset_client.setCallback(GetSetCallback(this, &UavcanNode::cb_getset));
 	_param_opcode_client.setCallback(ExecuteOpcodeCallback(this, &UavcanNode::cb_opcode));
 	_param_restartnode_client.setCallback(RestartNodeCallback(this, &UavcanNode::cb_restart));
-
-
-	int32_t uavcan_enable = 1;
-	(void)param_get(param_find("UAVCAN_ENABLE"), &uavcan_enable);
 
 	if (uavcan_enable > 1) {
 		_servers = new UavcanServers(_node, _node_info_retriever);


### PR DESCRIPTION
There is a race condition between dshot and uavcan to claim the first uORB `esc_status`. The ESC controller should not be initialized and the callback should not be registered when ESC control is not enabled.