### PR TITLE
Fix position setpoint update logic in Mission RTL

### DIFF
--- a/src/modules/navigator/rtl_direct_mission_land.cpp
+++ b/src/modules/navigator/rtl_direct_mission_land.cpp
@@ -203,9 +203,9 @@ void RtlDirectMissionLand::setActiveMissionItems()
 
 			_mission_item.autocontinue = true;
 			_mission_item.time_inside = 0.0f;
-
-			pos_sp_triplet->previous = pos_sp_triplet->current;
 		}
+
+		pos_sp_triplet->previous = pos_sp_triplet->current;
 
 		if (num_found_items > 0) {
 			mission_item_to_position_setpoint(next_mission_items[0u], &pos_sp_triplet->next);


### PR DESCRIPTION

### Solved Problem
Currently, when proceeding to the landing point the previous setpoint is not updated, which results in an unexpected and off course landing pattern in fixed wing. 

Fixes #25436

### Solution
Move position setpoint logic outside of conditional so it is applied even when it is a landing waypoint


### Changelog Entry
For release notes:
```
Bugfix: Fix RTL logic in fixed wing RTL Mission mode that caused landing patterns to veer off of expected course
```

### Test coverage
- See previous logs at #25436 for errant behavior
- See fixed log here: https://review.px4.io/plot_app?log=b9a09150-3c69-4c66-a643-0f3a491d4b14

### Context
#25436
