### PR TITLE
Loiter at the last mission waypoint on mission end

### DIFF
--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -556,7 +556,9 @@ void MissionBase::setEndOfMissionItems()
 		_mission_item.nav_cmd = NAV_CMD_IDLE;
 
 	} else {
-		if (pos_sp_triplet->current.valid && pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER) {
+		if (pos_sp_triplet->current.valid &&
+		    (pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER ||
+		     pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_POSITION)) {
 			setLoiterItemFromCurrentPositionSetpoint(&_mission_item);
 
 		} else {


### PR DESCRIPTION
### Solved Problem
When the final mission waypoint is reached, the navigator sets the loiter position setpoint to the current position instead of the mission’s intended waypoint.

As a result, the vehicle ends up loitering at the position where it entered the waypoint’s acceptance radius, instead at the waypoint itself.

### Solution

On mission end, call `setLoiterItemFromCurrentPositionSetpoint()` if current position setpoint is of type `SETPOINT_TYPE_POSITION`
