### PR TITLE
Don't build translations on push (only PR)

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'main'
       - 'release/**'
-      - 'l10n_crowdin_docs_translations_*'
     paths:
       - 'docs/en/**'
       - 'docs/uk/**'


### PR DESCRIPTION
Avoids double build that isn't needed for translation branches