### PR TITLE
ekf2: range height skip "unhealthy" samples, but respect timeout

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/range_finder/range_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/range_finder/range_height_control.cpp
@@ -126,9 +126,9 @@ void Ekf::controlRangeHaglFusion(const imuSample &imu_sample)
 				stopRngHgtFusion();
 			}
 
-		} else {
+		} else if (starting_conditions_passing) {
 			if (_params.ekf2_hgt_ref == static_cast<int32_t>(HeightSensor::RANGE)) {
-				if (do_conditional_range_aid && starting_conditions_passing) {
+				if (do_conditional_range_aid) {
 					// Range finder is used while hovering to stabilize the height estimate. Don't reset but use it as height reference.
 					ECL_INFO("starting conditional %s height fusion", HGT_SRC_NAME);
 					_height_sensor_ref = HeightSensor::RANGE;
@@ -141,7 +141,7 @@ void Ekf::controlRangeHaglFusion(const imuSample &imu_sample)
 						resetAidSourceStatusZeroInnovation(aid_src);
 					}
 
-				} else if (do_range_aid && starting_conditions_passing) {
+				} else if (do_range_aid) {
 					// Range finder is the primary height source, the ground is now the datum used
 					// to compute the local vertical position
 					ECL_INFO("starting %s height fusion, resetting height", HGT_SRC_NAME);
@@ -158,7 +158,7 @@ void Ekf::controlRangeHaglFusion(const imuSample &imu_sample)
 				}
 
 			} else {
-				if ((do_conditional_range_aid || do_range_aid) && starting_conditions_passing) {
+				if ((do_conditional_range_aid || do_range_aid)) {
 					ECL_INFO("starting %s height fusion", HGT_SRC_NAME);
 					_control_status.flags.rng_hgt = true;
 


### PR DESCRIPTION
 - we should never directly use an "unhealthy" range finder sample for state corrections or reset, but we also shouldn't immediately abort active rng_hgt on a single sample until the timeout has passed

In this case "healthy" includes the sensor reported signal_quality (that most sensors don't even report) must acceptable for EKF2_RNG_QLTY_T seconds. For something like the Broadcom AFBRS50 intermittent signal_quality = 0 reports in and around takeoff/landing will wreak havoc if we're giving up all rng_hgt immediately.