### PR TITLE
MavLinkShell: Corrected Backspace keystroke read

### DIFF
--- a/Tools/mavlink_shell.py
+++ b/Tools/mavlink_shell.py
@@ -191,7 +191,7 @@ def main():
                         cur_history_index = len(command_history)
                     mav_serialport.write(cur_line+'\n')
                     cur_line = ''
-                elif ord(ch) == 127: # backslash
+                elif ord(ch) == 8: # backspace
                     if len(cur_line) > 0:
                         erase_last_n_chars(1)
                         cur_line = cur_line[:-1]


### PR DESCRIPTION
Changed command ASCII used for backspace

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
ASCII used for backspace was actually the "Delete" key `ASCII Key 127`
Fixes #25601 

### Solution
- ASCII used for backspace was actually the "Delete" key `ASCII Key 127`  changed it to the "Backspace" Key ASCII Key 8` in Tools/mavlink_shell.py

### Changelog Entry
For release notes:
```
Feature/Bugfix  #25601 
New parameter: 
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
