### PR TITLE
MultiCopter: Created Bypass for MC_Rate_Controller=n

### DIFF
--- a/ROMFS/px4fmu_common/init.d/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/CMakeLists.txt
@@ -67,6 +67,11 @@ if(CONFIG_MODULES_MC_RATE_CONTROL)
 		rc.mc_apps
 		rc.mc_defaults
 	)
+else()
+	px4_add_romfs_files(
+		rc.heli_defaults
+		rc.mc_defaults
+	)
 endif()
 
 if(CONFIG_MODULES_ROVER_DIFFERENTIAL)


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
rc_mc_defaults.sh was not being generated when MC_Rate_Controller=n, thus leading to an error 512

Fixes #21248 

### Solution
Added an else condition to the CMakeLists.txt which allows the generation of rc.mc_defaults regardless of MC_Rate_Controller