### PR TITLE
Navigator: fix RTL_TYP=2 with NAV_CMD_CONDITION_GATE

### DIFF
--- a/src/modules/navigator/rtl_mission_fast.cpp
+++ b/src/modules/navigator/rtl_mission_fast.cpp
@@ -109,6 +109,20 @@ void RtlMissionFast::setActiveMissionItems()
 		}
 	}
 
+	// Skip CONDITION_GATEs
+	if (_mission_item.nav_cmd == NAV_CMD_CONDITION_GATE) {
+		if (setNextMissionItem()) {
+			if (!loadCurrentMissionItem()) {
+				setEndOfMissionItems();
+				return;
+			}
+
+		} else {
+			setEndOfMissionItems();
+			return;
+		}
+	}
+
 	// Transition to fixed wing if necessary.
 	if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
 	    _vehicle_status_sub.get().is_vtol &&

--- a/src/modules/navigator/rtl_mission_fast_reverse.cpp
+++ b/src/modules/navigator/rtl_mission_fast_reverse.cpp
@@ -104,6 +104,20 @@ void RtlMissionFastReverse::setActiveMissionItems()
 	WorkItemType new_work_item_type{WorkItemType::WORK_ITEM_TYPE_DEFAULT};
 	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
+	// Skip CONDITION_GATEs
+	if (_mission_item.nav_cmd == NAV_CMD_CONDITION_GATE) {
+		if (setNextMissionItem()) {
+			if (!loadCurrentMissionItem()) {
+				setEndOfMissionItems();
+				return;
+			}
+
+		} else {
+			setEndOfMissionItems();
+			return;
+		}
+	}
+
 	// Transition to fixed wing if necessary.
 	if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
 	    _vehicle_status_sub.get().is_vtol &&


### PR DESCRIPTION

### Solved Problem
The setpoint gets invalid (IDLE) during RTL with RTL_TYPE=2 and a mission containing NAV_CMD_CONDITION_GATE.

### Solution
Skip NAV_CMD_CONDITION_GATE.

### Changelog Entry
For release notes:
```
Bugfix: Navigator: fix RTL_TYP=2 with NAV_CMD_CONDITION_GATE
```

### Alternatives
I don't understand why the GATE is even considered, it should already not be considered as not being in the list of `MissionBlock::item_contains_position()`.

### Test coverage
SITL tested.