### PR TITLE
Correction of routing issue of mavlink parameter messages to CAN nodes.

### DIFF
--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -80,6 +80,7 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 #if defined(CONFIG_MAVLINK_UAVCAN_PARAMETERS)
 
 			if (req_list.target_system == mavlink_system.sysid && req_list.target_component < 127 &&
+			    !(req_list.target_component >= MAV_COMP_ID_CAMERA && req_list.target_component <= MAV_COMP_ID_CAMERA6) &&
 			    (req_list.target_component != mavlink_system.compid || req_list.target_component == MAV_COMP_ID_ALL)) {
 				// publish list request to UAVCAN driver via uORB.
 				uavcan_parameter_request_s req{};
@@ -139,6 +140,7 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 #if defined(CONFIG_MAVLINK_UAVCAN_PARAMETERS)
 
 			if (set.target_system == mavlink_system.sysid && set.target_component < 127 &&
+			    !(set.target_component >= MAV_COMP_ID_CAMERA && set.target_component <= MAV_COMP_ID_CAMERA6) &&
 			    (set.target_component != mavlink_system.compid || set.target_component == MAV_COMP_ID_ALL)) {
 				// publish set request to UAVCAN driver via uORB.
 				uavcan_parameter_request_s req{};
@@ -217,6 +219,7 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 #if defined(CONFIG_MAVLINK_UAVCAN_PARAMETERS)
 
 			if (req_read.target_system == mavlink_system.sysid && req_read.target_component < 127 &&
+			    !(req_read.target_component >= MAV_COMP_ID_CAMERA && req_read.target_component <= MAV_COMP_ID_CAMERA6) &&
 			    (req_read.target_component != mavlink_system.compid || req_read.target_component == MAV_COMP_ID_ALL)) {
 				// publish set request to UAVCAN driver via uORB.
 				uavcan_parameter_request_s req{};


### PR DESCRIPTION

### Solved Problem
When DRONECAN device as GPS / MAG / OpticalFlow device is connected to flight controller together with serial Mavlink camera (component ID 100-106 MAV_COMP_ID_CAMERA - MAV_COMP_ID_CAMERA6), routing of parameters for the camera is forwarded to CAN nodes and causes inability of parameters loading by QGC. CAN nodes stops responding to parameter requests and QGC times out in parameter loading.

### Solution
Correction stops forwarding range of messages with target component ID of MAV_COMP_ID_CAMERA to MAV_COMP_ID_CAMERA6 to CAN peripherals.

### Test coverage
Tested QGC 5.0.6, QGC 5.0.7, QGC 4.4.4
Hardware - CUAV v5 Nano and Cube Orange +, Here4 as CAN GPS, Here3 as CAN GPS, TAG-E as Serial camera controller, PhaseOne P3 as serial camera controller.
