### PR TITLE
- Add parameters for mapping R/C autonomy consent switch

### DIFF
--- a/msg/RcChannels.msg
+++ b/msg/RcChannels.msg
@@ -29,13 +29,14 @@ uint8 FUNCTION_FLTBTN_SLOT_5 = 25
 uint8 FUNCTION_FLTBTN_SLOT_6 = 26
 uint8 FUNCTION_ENGAGE_MAIN_MOTOR = 27
 uint8 FUNCTION_PAYLOAD_POWER = 28
+uint8 FUNCTION_OFFBOARD_CONSENT = 29
 
 uint8 FUNCTION_FLTBTN_SLOT_COUNT = 6
 
 uint64 timestamp_last_valid					# Timestamp of last valid RC signal
 float32[18] channels						# Scaled to -1..1 (throttle: 0..1)
 uint8 channel_count						# Number of valid channels
-int8[29] function						# Functions mapping
+int8[30] function						# Functions mapping
 uint8 rssi							# Receive signal strength index
 bool signal_lost						# Control signal lost, should be checked together with topic timeout
 uint32 frame_drop_count						# Number of dropped frames

--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -1590,6 +1590,40 @@ PARAM_DEFINE_INT32(RC_MAP_GEAR_SW, 0);
 PARAM_DEFINE_INT32(RC_MAP_FLTM_BTN, 0);
 
 /**
+ * Offboard Autonomy Consent Switch
+ *
+ * Map an R/C switch that provides a signal to offboard autonomy systems that
+ * they can take control of the autopilot. NOTE: Engaging this switch does not
+ * switch to OFFBOARD mode, but rather indicates to companion autonomy systems that
+ * they can begin controlling the system. Use this in scenarios where the offboard
+ * autonomy may use flight modes besides OFFBOARD (i.e. takeoff, reposition, etc)
+ *
+ * @min 0
+ * @max 18
+ * @group Radio Switches
+ * @value 0 Unassigned
+ * @value 1 Channel 1
+ * @value 2 Channel 2
+ * @value 3 Channel 3
+ * @value 4 Channel 4
+ * @value 5 Channel 5
+ * @value 6 Channel 6
+ * @value 7 Channel 7
+ * @value 8 Channel 8
+ * @value 9 Channel 9
+ * @value 10 Channel 10
+ * @value 11 Channel 11
+ * @value 12 Channel 12
+ * @value 13 Channel 13
+ * @value 14 Channel 14
+ * @value 15 Channel 15
+ * @value 16 Channel 16
+ * @value 17 Channel 17
+ * @value 18 Channel 18
+ */
+ PARAM_DEFINE_INT32(RC_MAP_OFFBCNSNT, 0);
+
+/**
  * AUX1 Passthrough RC channel
  *
  * @min 0
@@ -2035,6 +2069,22 @@ PARAM_DEFINE_FLOAT(RC_TRANS_TH, 0.75f);
  * @group Radio Switches
  */
 PARAM_DEFINE_FLOAT(RC_GEAR_TH, 0.75f);
+
+/**
+ * Allow Offboard Autonomy Switch
+ *
+ * 0-1 indicate where in the full channel range the threshold sits
+ * 		0 : min
+ * 		1 : max
+ * sign indicates polarity of comparison
+ * 		positive : true when channel>th
+ * 		negative : true when channel<th
+ *
+ * @min -1
+ * @max 1
+ * @group Radio Switches
+ */
+PARAM_DEFINE_FLOAT(RC_OFFBCNSNT_TH, 0.75f);
 
 /**
  * Threshold for selecting main motor engage

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -53,6 +53,7 @@
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
+#include <uORB/topics/debug_key_value.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/manual_control_switches.h>
 #include <uORB/topics/input_rc.h>
@@ -168,9 +169,15 @@ protected:
 	uORB::Publication<rc_channels_s> _rc_channels_pub{ORB_ID(rc_channels)};
 	uORB::PublicationMulti<manual_control_setpoint_s> _manual_control_input_pub{ORB_ID(manual_control_input)};
 	uORB::Publication<manual_control_switches_s> _manual_control_switches_pub{ORB_ID(manual_control_switches)};
+	uORB::Publication<debug_key_value_s> _debug_kv_pub{ORB_ID(debug_key_value)};
 
 	manual_control_switches_s _manual_switches_previous{};
 	manual_control_switches_s _manual_switches_last_publish{};
+	switch_pos_t _offboard_consent_previous{false};
+	switch_pos_t _offboard_consent_last_publish{false};
+	uint64_t _offboard_consent_last_publish_ts{0};
+	uint64_t _offboard_consent_previous_ts{0};
+
 	rc_channels_s _rc{};
 	bool _rc_calibrated{false};
 
@@ -218,6 +225,7 @@ protected:
 		(ParamInt<px4::params::RC_MAP_TRANS_SW>) _param_rc_map_trans_sw,
 		(ParamInt<px4::params::RC_MAP_GEAR_SW>) _param_rc_map_gear_sw,
 		(ParamInt<px4::params::RC_MAP_FLTM_BTN>) _param_rc_map_fltm_btn,
+		(ParamInt<px4::params::RC_MAP_OFFBCNSNT>) _param_rc_map_offbcnsnt,
 
 		(ParamInt<px4::params::RC_MAP_AUX1>) _param_rc_map_aux1,
 		(ParamInt<px4::params::RC_MAP_AUX2>) _param_rc_map_aux2,
@@ -241,6 +249,7 @@ protected:
 		(ParamFloat<px4::params::RC_RETURN_TH>) _param_rc_return_th,
 		(ParamFloat<px4::params::RC_ENG_MOT_TH>) _param_rc_eng_mot_th,
 		(ParamFloat<px4::params::RC_PAYLOAD_TH>) _param_rc_payload_th,
+		(ParamFloat<px4::params::RC_OFFBCNSNT_TH>) _param_rc_offbcnsnt_th,
 
 		(ParamInt<px4::params::RC_CHAN_CNT>) _param_rc_chan_cnt
 	)


### PR DESCRIPTION
- Use R/C autonomy consent switch to trigger transmission of R/C consent debug Key/Value pair message

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When ... I found that ...

Fixes #{Github issue ID}

### Solution
- Add ... for ...
- Refactor ...

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
