### PR TITLE
[crsf] Add support for link statistics message

### DIFF
--- a/docs/en/releases/main.md
+++ b/docs/en/releases/main.md
@@ -76,6 +76,10 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 - TBD
 
+### RC
+
+- Parse ELRS Status and Link Statistics TX messages in the CRSF parser.
+
 ### Multi-Rotor
 
 - Removed parameters `MPC_{XY/Z/YAW}_MAN_EXPO` and use default value instead, as they were not deemed necessary anymore. ([PX4-Autopilot#25435: Add new flight mode: Altitude Cruise](https://github.com/PX4/PX4-Autopilot/pull/25435)).

--- a/msg/InputRc.msg
+++ b/msg/InputRc.msg
@@ -32,9 +32,11 @@ bool rc_lost				# RC receiver connection status: True,if no frame has arrived in
 uint16 rc_lost_frame_count		# Number of lost RC frames. Note: intended purpose: observe the radio link quality if RSSI is not available. This value must not be used to trigger any failsafe-alike functionality.
 uint16 rc_total_frame_count		# Number of total RC frames. Note: intended purpose: observe the radio link quality if RSSI is not available. This value must not be used to trigger any failsafe-alike functionality.
 uint16 rc_ppm_frame_length		# Length of a single PPM frame. Zero for non-PPM systems
+uint16 rc_frame_rate			# RC frame rate in msg/second. 0 = invalid
 
 uint8 input_source			# Input source
 uint16[18] values			# measured pulse widths for each of the supported channels
 
 int8 link_quality			# link quality. Percentage 0-100%. -1 = invalid
 float32 rssi_dbm			# Actual rssi in units of dBm. NaN = invalid
+int8 link_snr				# link signal to noise ratio in units of dB. -1 = invalid

--- a/src/drivers/rc/crsf_rc/CrsfParser.hpp
+++ b/src/drivers/rc/crsf_rc/CrsfParser.hpp
@@ -43,6 +43,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <board_config.h>
 
 #define CRSF_CHANNEL_COUNT 16
 
@@ -108,5 +109,8 @@ typedef struct {
 
 void CrsfParser_Init(void);
 bool CrsfParser_LoadBuffer(const uint8_t *buffer, const uint32_t size);
+#ifdef DRIVERS_RC_CRSF_RC_INJECT
+bool CrsfParser_InjectBuffer(const uint8_t *buffer, const uint32_t size);
+#endif
 uint32_t CrsfParser_FreeQueueSize(void);
 bool CrsfParser_TryParseCrsfPacket(CrsfPacket_t *const new_packet, CrsfParserStatistics_t *const parser_statistics);

--- a/src/drivers/rc/crsf_rc/CrsfParser.hpp
+++ b/src/drivers/rc/crsf_rc/CrsfParser.hpp
@@ -63,6 +63,22 @@ struct CrsfLinkStatistics_t {
 	int8_t downlink_snr;
 };
 
+struct CrsfLinkStatisticsTx_t {
+	uint8_t uplink_rssi;
+	uint8_t uplink_rssi_pct;
+	uint8_t uplink_link_quality;
+	int8_t uplink_snr;
+	uint8_t downlink_power;
+	uint8_t uplink_fps;
+};
+
+struct CrsfElrsStatus_t {
+	uint8_t packets_bad;
+	uint16_t packets_good;
+	uint8_t flags;
+	char message[48];
+};
+
 struct CrsfParserStatistics_t {
 	uint32_t disposed_bytes;
 	uint32_t crcs_valid_known_packets;
@@ -75,6 +91,8 @@ struct CrsfParserStatistics_t {
 enum CRSF_MESSAGE_TYPE {
 	CRSF_MESSAGE_TYPE_RC_CHANNELS,
 	CRSF_MESSAGE_TYPE_LINK_STATISTICS,
+	CRSF_MESSAGE_TYPE_LINK_STATISTICS_TX,
+	CRSF_MESSAGE_TYPE_ELRS_STATUS,
 };
 
 typedef struct {
@@ -83,6 +101,8 @@ typedef struct {
 	union {
 		CrsfChannelData_t channel_data;
 		CrsfLinkStatistics_t link_statistics;
+		CrsfLinkStatisticsTx_t link_statistics_tx;
+		CrsfElrsStatus_t elrs_status;
 	};
 } CrsfPacket_t;
 

--- a/src/drivers/rc/crsf_rc/CrsfRc.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfRc.cpp
@@ -371,7 +371,7 @@ void CrsfRc::Run()
 	}
 
 	// If no communication
-	if (time_now_us - _last_packet_seen > 100_ms) {
+	if (time_now_us - _last_packet_seen > 500_ms) {
 		// Invalidate link statistics
 		_input_rc.rssi = -1;
 		_input_rc.rssi_dbm = NAN;
@@ -381,7 +381,7 @@ void CrsfRc::Run()
 	}
 
 	// If we have not gotten RC updates specifically
-	if (time_now_us - _input_rc.timestamp_last_signal > 50_ms) {
+	if (time_now_us - _input_rc.timestamp_last_signal > 500_ms) {
 		_input_rc.rc_lost = 1;
 		_input_rc.rc_failsafe = 1;
 

--- a/src/drivers/rc/crsf_rc/CrsfRc.hpp
+++ b/src/drivers/rc/crsf_rc/CrsfRc.hpp
@@ -100,6 +100,7 @@ private:
 	uint32_t _bytes_rx{0};
 
 	hrt_abstime _last_packet_seen{0};
+	hrt_abstime _last_stats_tx_seen{0};
 
 	CrsfParserStatistics_t _packet_parser_statistics{0};
 

--- a/src/drivers/rc/crsf_rc/CrsfRc.hpp
+++ b/src/drivers/rc/crsf_rc/CrsfRc.hpp
@@ -59,7 +59,7 @@ using namespace device;
 class CrsfRc : public ModuleBase<CrsfRc>, public ModuleParams, public px4::ScheduledWorkItem
 {
 public:
-	CrsfRc(const char *device);
+	CrsfRc(const char *device, uint32_t baudrate);
 	~CrsfRc() override;
 
 	/** @see ModuleBase */
@@ -94,6 +94,7 @@ private:
 
 	char _device[20] {}; ///< device / serial port path
 	bool _is_singlewire{false};
+	uint32_t _baudrate{0};
 
 	static constexpr size_t RC_MAX_BUFFER_SIZE{64};
 	uint8_t _rcs_buf[RC_MAX_BUFFER_SIZE] {};

--- a/src/drivers/rc/crsf_rc/Kconfig
+++ b/src/drivers/rc/crsf_rc/Kconfig
@@ -3,3 +3,9 @@ menuconfig DRIVERS_RC_CRSF_RC
 	default n
 	---help---
 		Enable support for crsf rc
+
+config DRIVERS_RC_CRSF_RC_INJECT
+	bool "Inject CRSF RC"
+	default n
+	---help---
+		Enable this to inject CRSF RC commands.

--- a/src/drivers/rc/crsf_rc/module.yaml
+++ b/src/drivers/rc/crsf_rc/module.yaml
@@ -1,6 +1,6 @@
 module_name: CRSF RC Input Driver
 serial_config:
-    - command: "crsf_rc start -d ${SERIAL_DEV}"
+    - command: "crsf_rc start -d ${SERIAL_DEV} -b ${BAUD_PARAM}"
       port_config_param:
         name: RC_CRSF_PRT_CFG
         group: Serial


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

- [x] Add support for ELRS and CRSF link statistics messages.
- [x] Allow setting CRSF baudrate via parameters, some receivers use slightly different baudrates than 420000
- [x] Extend the packet reception timeout to 0.5s.
- [x] Add ability to inject messages into the buffer (disabled by default via KConfig option)
- [x] Version the input_rc message and add it to the DDS bridge.

### Changelog Entry
For release notes:
```
Feature: Add CRSF and ELRS link statistics messages
```

### Alternatives

We could also split the input_rc message into just the control values and then a input_rc_link message with all the link quality metrics. But that involves probably quite a lot of refactoring.

### Test coverage

- [x] Tested in hardware with CRSF and ELRS receivers
