### PR TITLE
logging: log sensor_baro with add_topic_multi

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -195,7 +195,7 @@ void LoggedTopics::add_default_topics()
 	add_topic_multi("differential_pressure", 1000, 2);
 	add_topic_multi("distance_sensor", 1000, 2);
 	add_optional_topic_multi("sensor_accel", 1000, 4);
-	add_optional_topic_multi("sensor_baro", 1000, 4);
+	add_topic_multi("sensor_baro", 1000, 4);
 	add_topic_multi("sensor_gps", 1000, 2);
 	add_topic_multi("sensor_gnss_relative", 1000, 1);
 	add_optional_topic_multi("sensor_gyro", 1000, 4);


### PR DESCRIPTION
### Solved Problem
When connecting an external baro over UAVCAN, the `sensor_baro` topic was only logging the instance of the internal baro. 


### Solution
- Remove the `optional` from the `multi_topic` logging so all instances are logged. 

### Changelog Entry
For release notes:
```
Feature/Bugfix log all `sensor_baro` instances
```

### Alternatives

I don't know if this is the best way to do this. Happy to get feedback on this 

### Test coverage

Two instances shown in the MAVLink shell: 
```
nsh> listener sensor_baro
TOPIC: sensor_baro 2 instances

Instance 0:
 sensor_baro
    timestamp: 755793708 (0.010079 seconds ago)
    timestamp_sample: 755792762 (946 us before timestamp)
    device_id: 7239457 (Type: 0x6E, I2C:4 (0x77))
    pressure: 97468.40625
    temperature: 57.69000
    error_count: 0

Instance 1:
 sensor_baro
    timestamp: 755812747 (0.004100 seconds ago)
    timestamp_sample: 755812746 (1 us before timestamp)
    device_id: 8486147 (Type: 0x81, UAVCAN:0 (0x7D))
    pressure: 97536.33594
    temperature: 27.60001
    error_count: 0
```

1. On main: 


internal baro logged in `sensor_baro`, external baro used by `vehicle_air_data`. 
<img width="470" height="170" alt="image" src="https://github.com/user-attachments/assets/782b52b7-b1d8-44b5-98ec-6c6242a68f5a" />


2. On pr: 

two instances on the `sensor_baro` topic. 
<img width="473" height="259" alt="image" src="https://github.com/user-attachments/assets/78e28a25-7c91-4c32-bcfd-c04597da6edb" />

