### PR TITLE
airframes 4017, 4041: exclude from v6x targets to save flash

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4017_nxp_hovergames
+++ b/ROMFS/px4fmu_common/init.d/airframes/4017_nxp_hovergames
@@ -7,6 +7,9 @@
 #
 # @board px4_fmu-v2 exclude
 # @board px4_fmu-v5x exclude
+# @board auterion_fmu-v6s exclude
+# @board ark_fmu-v6x exclude
+# @board px4_fmu-v6x exclude
 # @board bitcraze_crazyflie exclude
 #
 # @maintainer Iain Galloway <iain.galloway@nxp.com>

--- a/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
@@ -13,6 +13,10 @@
 # @board px4_fmu-v4pro exclude
 # @board px4_fmu-v5 exclude
 # @board px4_fmu-v5x exclude
+# @board auterion_fmu-v6s exclude
+# @board ark_fmu-v6x exclude
+# @board px4_fmu-v6x exclude
+# @board px4_fmu-v6xrt exclude
 # @board bitcraze_crazyflie exclude
 #
 


### PR DESCRIPTION
### Solved Problem
- FLASH overflows on the v6x

### Solution
- Exclude some rarely used airframes from the v6x targets

