### PR TITLE
ekf2: remove ev orientation variance comparison to ev position variance

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/external_vision/ev_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/external_vision/ev_height_control.cpp
@@ -67,10 +67,6 @@ void Ekf::controlEvHeightFusion(const imuSample &imu_sample, const extVisionSamp
 			pos = R_ev_to_ekf * ev_sample.pos;
 			pos_cov = R_ev_to_ekf * matrix::diag(ev_sample.position_var) * R_ev_to_ekf.transpose();
 
-			// increase minimum variance to include EV orientation variance
-			// TODO: do this properly
-			const float orientation_var_max = math::max(ev_sample.orientation_var(0), ev_sample.orientation_var(1));
-			pos_cov(2, 2) = math::max(pos_cov(2, 2), orientation_var_max);
 		}
 	}
 


### PR DESCRIPTION

### Solved Problem
- the observation variance of the external vision (ev) height is compared to that of the ev orientation variance. This comparison does not make sense, and inhibit the correct observation variance when EV is not supplying orientation measurements.

If there are some insight behind this comparison check, it would be awesome to understand and learn :smile: 