### PR TITLE
Make Github docs-deploy workflow only run manually

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -1,23 +1,6 @@
-name: Docs - Deploy PX4 User Guide
+name: Docs - Deploy PX4 User Guide to Github pages (Manual)
 
 on:
-  push:
-    branches:
-      - 'main'
-      - 'release/**'
-    paths:
-      - 'docs/en/**'
-      - 'docs/uk/**'
-      - 'docs/zh/**'
-  pull_request:
-    branches:
-      - '**'
-    paths:
-      - 'docs/en/**'
-      - 'docs/uk/**'
-      - 'docs/zh/**'
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
We don't want to deploy to github pages any more, because we deploy to AWS.
But it might come in handy for backups or whatever, so in the short term making it only deploy on manual workflow trigger.