### PR TITLE
uavcan: statically allocate memory pool

### DIFF
--- a/src/drivers/uavcan/allocator.hpp
+++ b/src/drivers/uavcan/allocator.hpp
@@ -50,19 +50,19 @@ struct AllocatorSynchronizer {
 	~AllocatorSynchronizer() { ::leave_critical_section(state); }
 };
 
-struct Allocator : public uavcan::HeapBasedPoolAllocator<uavcan::MemPoolBlockSize, AllocatorSynchronizer> {
-	static constexpr unsigned CapacitySoftLimit = 250;
-	static constexpr unsigned CapacityHardLimit = 500;
+struct Allocator : public
+	uavcan::PoolAllocator<250 * uavcan::MemPoolBlockSize, uavcan::MemPoolBlockSize, AllocatorSynchronizer> {
+	static constexpr unsigned NumBlocks = 250;
 
 	Allocator() :
-		uavcan::HeapBasedPoolAllocator<uavcan::MemPoolBlockSize, AllocatorSynchronizer>(CapacitySoftLimit, CapacityHardLimit)
+		uavcan::PoolAllocator<250 * uavcan::MemPoolBlockSize, uavcan::MemPoolBlockSize, AllocatorSynchronizer>()
 	{ }
 
 	~Allocator()
 	{
-		if (getNumAllocatedBlocks() > 0) {
+		if (getNumUsedBlocks() > 0) {
 			PX4_ERR("UAVCAN LEAKS MEMORY: %u BLOCKS (%u BYTES) LOST",
-				getNumAllocatedBlocks(), getNumAllocatedBlocks() * uavcan::MemPoolBlockSize);
+				getNumUsedBlocks(), getNumUsedBlocks() * uavcan::MemPoolBlockSize);
 		}
 	}
 };

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -1132,11 +1132,7 @@ UavcanNode::print_info()
 {
 	// Memory status
 	printf("Pool allocator status:\n");
-	printf("\tCapacity hard/soft: %" PRIu16 "/%" PRIu16 " blocks\n",
-	       _pool_allocator.getBlockCapacityHardLimit(), _pool_allocator.getBlockCapacity());
-	printf("\tReserved:  %" PRIu16 " blocks\n", _pool_allocator.getNumReservedBlocks());
-	printf("\tAllocated: %" PRIu16 " blocks\n", _pool_allocator.getNumAllocatedBlocks());
-
+	printf("\tCapacity : %" PRIu16 " blocks\n", _pool_allocator.getBlockCapacity());
 	printf("\n");
 
 	// UAVCAN node perfcounters
@@ -1209,14 +1205,6 @@ UavcanNode::print_info()
 
 	perf_print_counter(_cycle_perf);
 	perf_print_counter(_interval_perf);
-}
-
-void
-UavcanNode::shrink()
-{
-	(void)pthread_mutex_lock(&_node_mutex);
-	_pool_allocator.shrink();
-	(void)pthread_mutex_unlock(&_node_mutex);
 }
 
 void
@@ -1435,7 +1423,7 @@ UavcanNode::get_next_dirty_node_id(uint8_t base)
 static void print_usage()
 {
 	PX4_INFO("usage: \n"
-		 "\tuavcan {start|status|stop|shrink|update}\n"
+		 "\tuavcan {start|status|stop|update}\n"
 		 "\t        param [set|get|list|save] <node-id> <name> <value>|reset <node-id>");
 }
 
@@ -1489,11 +1477,6 @@ extern "C" __EXPORT int uavcan_main(int argc, char *argv[])
 
 	if (!std::strcmp(argv[1], "status") || !std::strcmp(argv[1], "info")) {
 		inst->print_info();
-		::exit(0);
-	}
-
-	if (!std::strcmp(argv[1], "shrink")) {
-		inst->shrink();
 		::exit(0);
 	}
 

--- a/src/drivers/uavcan/uavcan_main.hpp
+++ b/src/drivers/uavcan/uavcan_main.hpp
@@ -215,8 +215,6 @@ public:
 
 	void		print_info();
 
-	void		shrink();
-
 	static UavcanNode	*instance() { return _instance; }
 	static int		 getHardwareVersion(uavcan::protocol::HardwareVersion &hwver);
 

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -692,11 +692,7 @@ void UavcanNode::PrintInfo()
 
 	// Memory status
 	printf("Pool allocator status:\n");
-	printf("\tCapacity hard/soft: %u/%u blocks\n",
-	       _pool_allocator.getBlockCapacityHardLimit(), _pool_allocator.getBlockCapacity());
-	printf("\tReserved:  %u blocks\n", _pool_allocator.getNumReservedBlocks());
-	printf("\tAllocated: %u blocks\n", _pool_allocator.getNumAllocatedBlocks());
-
+	printf("\tCapacity: %u blocks\n", _pool_allocator.getBlockCapacity());
 	printf("\n");
 
 	// UAVCAN node perfcounters
@@ -748,13 +744,6 @@ void UavcanNode::PrintInfo()
 	perf_print_counter(_interval_perf);
 
 	pthread_mutex_unlock(&_node_mutex);
-}
-
-void UavcanNode::shrink()
-{
-	(void)pthread_mutex_lock(&_node_mutex);
-	_pool_allocator.shrink();
-	(void)pthread_mutex_unlock(&_node_mutex);
 }
 
 } // namespace uavcannode

--- a/src/drivers/uavcannode/UavcanNode.hpp
+++ b/src/drivers/uavcannode/UavcanNode.hpp
@@ -131,8 +131,6 @@ public:
 
 	void		PrintInfo();
 
-	void		shrink();
-
 	static UavcanNode	*instance() { return _instance; }
 	static int		 getHardwareVersion(uavcan::protocol::HardwareVersion &hwver);
 

--- a/src/drivers/uavcannode/allocator.hpp
+++ b/src/drivers/uavcannode/allocator.hpp
@@ -50,19 +50,19 @@ struct AllocatorSynchronizer {
 	~AllocatorSynchronizer() { ::leave_critical_section(state); }
 };
 
-struct Allocator : public uavcan::HeapBasedPoolAllocator<uavcan::MemPoolBlockSize, AllocatorSynchronizer> {
-	static constexpr unsigned CapacitySoftLimit = 250;
-	static constexpr unsigned CapacityHardLimit = 500;
+struct Allocator : public
+	uavcan::PoolAllocator<250 * uavcan::MemPoolBlockSize, uavcan::MemPoolBlockSize, AllocatorSynchronizer> {
+	static constexpr unsigned NumBlocks = 250;
 
 	Allocator() :
-		uavcan::HeapBasedPoolAllocator<uavcan::MemPoolBlockSize, AllocatorSynchronizer>(CapacitySoftLimit, CapacityHardLimit)
+		uavcan::PoolAllocator<250 * uavcan::MemPoolBlockSize, uavcan::MemPoolBlockSize, AllocatorSynchronizer>()
 	{ }
 
 	~Allocator()
 	{
-		if (getNumAllocatedBlocks() > 0) {
+		if (getNumUsedBlocks() > 0) {
 			PX4_ERR("UAVCAN LEAKS MEMORY: %u BLOCKS (%u BYTES) LOST",
-				getNumAllocatedBlocks(), getNumAllocatedBlocks() * uavcan::MemPoolBlockSize);
+				getNumUsedBlocks(), getNumUsedBlocks() * uavcan::MemPoolBlockSize);
 		}
 	}
 };


### PR DESCRIPTION
### Solved Problem
The uavcan drivers allocate memory from the heap. This can cause memory allocations during run time if the RX/TX queues are not serviced quickly enough. This can result in system jitter. In general we have a policy of not allocating memory after init.

### Solution
Statically allocate the uavcan memory pool. The HeapBasedPoolAllocator implementation seems to come from a time when RAM constraints were an ongoing battle (like flash is today). Modern flight controller designs use STM32H7 which has plenty of RAM (1MB).

### Changelog Entry
For release notes:
```
uavcan: statically allocate memory pool
```
### Test coverage
FC: ARK FPV
CANnode: ARK Mosaic GPS

### Context
I implemented high rate data streaming via uavcan.tunnel on the ARK Mosaic GPS and noticed the CAN bus appears to choke resulting in sporadic CAN frame loss. This was occuring in conjunction with memory allocations to increase the CAN TX queue size.
