### PR TITLE
astyle: remove max line length

### DIFF
--- a/Tools/astyle/astylerc
+++ b/Tools/astyle/astylerc
@@ -15,4 +15,4 @@ ignore-exclude-errors-x
 lineend=linux
 exclude=EASTL
 add-brackets
-max-code-length=120
+max-code-length=140


### PR DESCRIPTION
**Opinion**
Enforcing line length hurts readability by indenting logical one liners. IMO there isn't much point, I think most people have big monitors and would rather horizontally scroll than having broken up code scattered throughout.

**Alternative**
Bump to 140

**Example**
It's especially bad with one-liners that also contain a long comment on the same line
https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/ekf2/EKF2.hpp#L506-L507