### PR TITLE
docs: build with clean URLs

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -31,6 +31,7 @@ export default defineConfig({
       tabsPlugin(md); //https://github.com/Red-Asuka/vitepress-plugin-tabs
     },
   },
+  cleanUrls: true,
 
   vite: {
     plugins: [


### PR DESCRIPTION
Enable clean urls for vitepress builds

cc @hamishwillee please verify this is actually building the files as we need them, suposedly creating directories with index files so the urls are clean