### PR TITLE
Added Bypass Code for MC_RATE_CONTROLLER=n

### DIFF
--- a/ROMFS/px4fmu_common/init.d/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/CMakeLists.txt
@@ -67,6 +67,11 @@ if(CONFIG_MODULES_MC_RATE_CONTROL)
 		rc.mc_apps
 		rc.mc_defaults
 	)
+else()
+	px4_add_romfs_files(
+		rc.heli_defaults
+		rc.mc_defaults
+	)
 endif()
 
 if(CONFIG_MODULES_ROVER_DIFFERENTIAL)


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
rc_mc_defaults.sh was not being generated when MC_Rate_Controller=n, thus leading to an error 512

Fixes https://github.com/PX4/PX4-Autopilot/issues/21248

### Solution
- Refactored ROMFS/px4fmu_common/init.d/CMakeLists.txt to force file generation

### Changelog Entry
For release notes:
```
Feature/Bugfix #21248 
```
