### PR TITLE
flight task auto: fix offtrack mission landing bug

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -612,6 +612,7 @@ State FlightTaskAuto::_getCurrentState()
 	const Vector3f u_prev_to_target = (_triplet_target - _triplet_prev_wp).unit_or_zero();
 	const Vector3f prev_to_pos = _position - _triplet_prev_wp;
 	const Vector3f pos_to_target = _triplet_target - _position;
+
 	// Calculate the closest point to the vehicle position on the line prev_wp - target
 	_closest_pt = _triplet_prev_wp + u_prev_to_target * (prev_to_pos * u_prev_to_target);
 
@@ -629,10 +630,9 @@ State FlightTaskAuto::_getCurrentState()
 		// Previous is in front
 		return_state = State::previous_infront;
 
-	} else if ((_position - _closest_pt).longerThan(_target_acceptance_radius)) {
+	} else if (_type != WaypointType::land && (_position - _closest_pt).longerThan(_target_acceptance_radius)) {
 		// Vehicle too far from the track
 		return_state = State::offtrack;
-
 	}
 
 	return return_state;


### PR DESCRIPTION
During a mission the last waypoint is often a land waypoint. If the previous waypoint is not directly above the land waypoint the offtrack calculation is incorrect. Land is a special case and should not use the offtrack logic which is intended for line-following between waypoints.

Introduced in https://github.com/PX4/PX4-Autopilot/pull/23371 when the offtrack calculation switched from 2D to 3D.

Fixes https://github.com/PX4/PX4-Autopilot/issues/25723
