### PR TITLE
commander: prevent setting nav_state to takeoff after disarming

### DIFF
--- a/src/modules/commander/UserModeIntention.cpp
+++ b/src/modules/commander/UserModeIntention.cpp
@@ -78,8 +78,7 @@ bool UserModeIntention::change(uint8_t user_intended_nav_state, ModeChangeSource
 		// Special case termination state: even though this mode prevents arming,
 		// still don't switch out of it after disarm and thus store it in _nav_state_after_disarming.
 		if ((!_health_and_arming_checks.modePreventsArming(user_intended_nav_state)
-		     && user_intended_nav_state != vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF
-		     && user_intended_nav_state != vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF)
+		     && !isTakeOffIntended(user_intended_nav_state))
 		    || user_intended_nav_state == vehicle_status_s::NAVIGATION_STATE_TERMINATION) {
 			_nav_state_after_disarming = user_intended_nav_state;
 		}

--- a/src/modules/commander/UserModeIntention.hpp
+++ b/src/modules/commander/UserModeIntention.hpp
@@ -91,6 +91,7 @@ public:
 
 private:
 	bool isArmed() const { return _vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED; }
+	bool isTakeOffIntended(uint8_t user_intented_nav_state) const {return user_intented_nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF || user_intented_nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF;}
 
 	const vehicle_status_s &_vehicle_status;
 	const HealthAndArmingChecks &_health_and_arming_checks;


### PR DESCRIPTION
### Solved Problem
When auto-landing while the current `nav_state` is set to a takeoff mode, the `nav_state` after disarming reverts to takeoff. On the next arming, the vehicle immediately initiates takeoff

### Solution
- Prevent _nav_state_after_disarming from being set to an auto-takeoff state by adding a check for takeoff modes.

### Changelog Entry
For release notes:
```
Feature/Bugfix Prevent nav_state_after_disarming from being set to a takeoff mode.
```

### Alternatives
Open to alternative solutions 

### Test coverage
- Tested in SITL: 

```
NAVIGATION_STATE_POSCTL = 2   
NAVIGATION_STATE_AUTO_TAKEOFF = 17        
NAVIGATION_STATE_AUTO_LAND = 18  
```

<img width="1579" height="624" alt="image" src="https://github.com/user-attachments/assets/091d8263-3ffc-4c69-9ec1-fc4220ed0241" />

