### PR TITLE
ci: fix failsafe sim

### DIFF
--- a/.github/workflows/failsafe_sim.yml
+++ b/.github/workflows/failsafe_sim.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           git clone https://github.com/emscripten-core/emsdk.git _emscripten_sdk
           cd _emscripten_sdk
+          git checkout 4.0.15
           ./emsdk install latest
           ./emsdk activate latest
 


### PR DESCRIPTION
Pin emscripten to a previous version before they updated to c++ 17