### PR TITLE
docs: Update supported Ubuntu versions in dev environment docs

### DIFF
--- a/docs/en/dev_setup/dev_env.md
+++ b/docs/en/dev_setup/dev_env.md
@@ -2,7 +2,7 @@
 
 The _supported platforms_ for PX4 development are:
 
-- [Ubuntu Linux (22.04/20.04/18.04)](../dev_setup/dev_env_linux_ubuntu.md) — Recommended
+- [Ubuntu Linux (24.04/22.04)](../dev_setup/dev_env_linux_ubuntu.md) — Recommended
 - [Windows (10/11)](../dev_setup/dev_env_windows_wsl.md) — via WSL2
 - [Mac OS](../dev_setup/dev_env_mac.md)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link
-->

### Solved Problem
Some documentation pages referenced deprecated Ubuntu LTS releases (e.g., 18.04, 20.04) that are no longer supported by PX4.  

### Solution
- Replaced outdated Ubuntu versions with currently supported LTS releases.  

### Changelog Entry
```
Documentation: Updated supported Ubuntu LTS versions to match official PX4 support policy.
```