### PR TITLE
docs: Fix capitalization of macOS

### DIFF
--- a/docs/en/concept/system_startup.md
+++ b/docs/en/concept/system_startup.md
@@ -1,7 +1,7 @@
 # System Startup
 
 The PX4 startup is controlled by shell scripts.
-On NuttX they reside in the [ROMFS/px4fmu_common/init.d](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d) folder - some of these are also used on Posix (Linux/MacOS).
+On NuttX they reside in the [ROMFS/px4fmu_common/init.d](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d) folder - some of these are also used on Posix (Linux/macOS).
 The scripts that are only used on Posix are located in [ROMFS/px4fmu_common/init.d-posix](https://github.com/PX4/PX4-Autopilot/tree/main/ROMFS/px4fmu_common/init.d-posix).
 
 All files starting with a number and underscore (e.g. `10000_airplane`) are predefined airframe configurations.
@@ -13,7 +13,7 @@ The first executed file is the [init.d/rcS](https://github.com/PX4/PX4-Autopilot
 
 The following sections are split according to the operating system that PX4 runs on.
 
-## POSIX (Linux/MacOS)
+## POSIX (Linux/macOS)
 
 On POSIX, the system shell is used as script interpreter (e.g. /bin/sh, being symlinked to dash on Ubuntu).
 For that to work, a few things are required:

--- a/docs/en/dev_setup/dev_env.md
+++ b/docs/en/dev_setup/dev_env.md
@@ -4,13 +4,13 @@ The _supported platforms_ for PX4 development are:
 
 - [Ubuntu Linux (24.04/22.04)](../dev_setup/dev_env_linux_ubuntu.md) — Recommended
 - [Windows (10/11)](../dev_setup/dev_env_windows_wsl.md) — via WSL2
-- [Mac OS](../dev_setup/dev_env_mac.md)
+- [macOS](../dev_setup/dev_env_mac.md)
 
 ## Supported Targets
 
 The table below shows what PX4 targets you can build on each OS.
 
-| Target                                                                                                                                 | Linux (Ubuntu) | Mac | Windows |
+| Target                                                                                                                                 | Linux (Ubuntu) | macOS | Windows |
 | -------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :-: | :-----: |
 | **NuttX based hardware:** [Pixhawk Series](../flight_controller/pixhawk_series.md), [Crazyflie](../complete_vehicles_mc/crazyflie2.md) |       ✓        |  ✓  |    ✓    |
 | **Linux-based hardware:** [Raspberry Pi 2/3](../flight_controller/raspberry_pi_navio2.md)                                              |       ✓        |     |         |

--- a/docs/en/dev_setup/dev_env_mac.md
+++ b/docs/en/dev_setup/dev_env_mac.md
@@ -1,4 +1,4 @@
-# MacOS Development Environment
+# macOS Development Environment
 
 The following instructions set up a PX4 development environment for macOS.
 This environment can be used to build PX4 for:
@@ -21,8 +21,8 @@ The "base" macOS setup installs the tools needed for building firmware, and incl
 
 ### Environment Setup
 
-:::details Apple Silicon Macbook users!
-If you have an Apple M1, M2 etc. Macbook, make sure to run the terminal as x86 by setting up an x86 terminal:
+:::details Apple Silicon MacBook users!
+If you have an Apple M1, M2 etc. MacBook, make sure to run the terminal as x86 by setting up an x86 terminal:
 
 1. Locate the Terminal application within the Utilities folder (**Finder > Go menu > Utilities**)
 2. Select _Terminal.app_ and right-click on it, then choose **Duplicate**.
@@ -47,7 +47,7 @@ First set up the environment
 1. Enforce Python 3 by appending the following lines to `~/.zshenv`
 
    ```sh
-   # Point pip3 to MacOS system python 3 pip
+   # Point pip3 to macOS system python 3 pip
    alias pip3=/usr/bin/pip3
    ```
 


### PR DESCRIPTION
This pull request makes documentation updates to standardize the naming of Apple's operating system as "macOS" (instead of "Mac OS" or "MacOS") and to correct related terminology throughout the docs.