### PR TITLE
Fixed the RTL return path error for multi-axis models when RTL_TYPE is 1

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -388,8 +388,8 @@ void RTL::findRtlDestination(DestinationType &destination_type, PositionYawSetpo
 
 	_home_has_land_approach = hasVtolLandApproach(rtl_position);
 
-	if (((_param_rtl_type.get() == 1) && !vtol_in_rw_mode) || (vtol_in_fw_mode && (_param_rtl_approach_force.get() == 1)
-			&& !_home_has_land_approach)) {
+	if (_vehicle_status_sub.get().is_vtol && (((_param_rtl_type.get() == 1) && !vtol_in_rw_mode) || (vtol_in_fw_mode && (_param_rtl_approach_force.get() == 1)
+			&& !_home_has_land_approach))) {
 		// Set minimum distance to maximum value when RTL_TYPE is set to 1 and we are not in RW mode or we forces approach landing for vtol in fw and it is not defined for home.
 		min_dist = FLT_MAX;
 


### PR DESCRIPTION
### Issue Description

**Problem Summary**  
In multi-axis vehicles with `RTL_TYPE` set to 1 (mission land on RTL), the RTL behavior during mid-mission return incorrectly prioritizes landing at the `mission_land` waypoint, even if the home position is closer. This results in the vehicle flying directly to `mission_land` for landing, potentially leading to inefficient or unsafe paths.

**Question**
Since I am a beginner, I don't know if this is the original design. If so, I'm sorry to bother you.
1. If this is a specific mode and mission_land exists, then all models will fly directly to mission_land after triggering return. However, the VEHICLE_TYPE_ROTARY_WING model of VTOL does not follow this design, but because it is almost similar to multi-axis, I submitted this PR.

**Expected Behavior**  
The RTL logic should evaluate the distance to both the home position and `mission_land`, then select the closer one for landing—similar to the `gz_standard_vto` model in Gazebo simulation. Fixed-wing models should continue to land at `mission_land` as per current design.

**Reproduction Steps**  
1. Configure a multi-axis vehicle model in PX4 SITL or hardware setup.  
3. Set `RTL_TYPE` to 1.  
4. Start a mission with a defined `mission_land` waypoint farther from home.  
5. Trigger RTL mid-mission 
6. Observe the vehicle path: It flies straight to `mission_land` regardless of proximity to home.

**Testing**  
- Verified in SITL with `gz_standard_vto` and 'gz_x500'
- Confirmed fixed-wing behavior unchanged.  
- Edge cases tested: RTL near home vs. far from both points.  

**Screenshot**
1. before the change
<img width="710" height="511" alt="图片" src="https://github.com/user-attachments/assets/df8087cb-2e9f-4383-ae4c-1d00f63a2b0b" />

2. adjusted
<img width="1647" height="924" alt="图片" src="https://github.com/user-attachments/assets/7f1e1794-92cd-4163-8e4f-9163ec8bbc67" />

<img width="782" height="490" alt="图片" src="https://github.com/user-attachments/assets/161ff791-6b21-4662-ae3c-7831d7954488" />
