### PR TITLE
Fix displayed value in power check

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/powerCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/powerCheck.cpp
@@ -86,18 +86,19 @@ void PowerChecks::checkAndReport(const Context &context, Report &reporter)
 			const float high_error_threshold = 5.4f;
 
 			const auto now = hrt_absolute_time();
+
+			bool old_state_low = _voltage_low_hysteresis.get_state();
+			bool old_state_high = _voltage_high_hysteresis.get_state();
+
 			_voltage_low_hysteresis.set_state_and_update(avionics_power_rail_voltage < low_error_threshold, now);
 			_voltage_high_hysteresis.set_state_and_update(avionics_power_rail_voltage > high_error_threshold, now);
 
-			static float latest_low_failure_val = 0.0f;
-			static float latest_high_failure_val = 0.0f;
-
-			if (avionics_power_rail_voltage < low_error_threshold) {
-				latest_low_failure_val = avionics_power_rail_voltage;
+			if (_voltage_low_hysteresis.get_state() && !old_state_low) {
+				_latest_low_failure_val = avionics_power_rail_voltage;
 			}
 
-			if (avionics_power_rail_voltage > high_error_threshold) {
-				latest_high_failure_val = avionics_power_rail_voltage;
+			if (_voltage_high_hysteresis.get_state() && !old_state_high) {
+				_latest_high_failure_val = avionics_power_rail_voltage;
 			}
 
 			if (_voltage_low_hysteresis.get_state()) {
@@ -112,11 +113,11 @@ void PowerChecks::checkAndReport(const Context &context, Report &reporter)
 				 */
 				reporter.healthFailure<float, float>(NavModes::All, health_component_t::system,
 								     events::ID("check_avionics_power_low"),
-								     events::Log::Error, "Avionics Power low: {1:.2} Volt", latest_low_failure_val, low_error_threshold);
+								     events::Log::Error, "Avionics Power low: {1:.2} Volt", _latest_low_failure_val, low_error_threshold);
 
 				if (reporter.mavlink_log_pub()) {
 					mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Avionics Power low: %6.2f Volt",
-							     (double)latest_low_failure_val);
+							     (double)_latest_low_failure_val);
 				}
 
 			} else if (_voltage_high_hysteresis.get_state()) {
@@ -130,11 +131,11 @@ void PowerChecks::checkAndReport(const Context &context, Report &reporter)
 				 */
 				reporter.healthFailure<float, float>(NavModes::All, health_component_t::system,
 								     events::ID("check_avionics_power_high"),
-								     events::Log::Error, "Avionics Power high: {1:.2} Volt", latest_high_failure_val, high_error_threshold);
+								     events::Log::Error, "Avionics Power high: {1:.2} Volt", _latest_high_failure_val, high_error_threshold);
 
 				if (reporter.mavlink_log_pub()) {
 					mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Avionics Power high: %6.2f Volt",
-							     (double)latest_high_failure_val);
+							     (double)_latest_high_failure_val);
 				}
 			}
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/powerCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/powerCheck.hpp
@@ -57,4 +57,7 @@ private:
 					(ParamInt<px4::params::CBRK_SUPPLY_CHK>) _param_cbrk_supply_chk,
 					(ParamInt<px4::params::COM_POWER_COUNT>) _param_com_power_count
 				       )
+
+	float _latest_low_failure_val = 0.0f;
+	float _latest_high_failure_val = 0.0f;
 };


### PR DESCRIPTION

### Solved Problem
The displayed voltage in AMC was above the threshold, even though the warning indicated it was below. 

### Solution
Changed the displayed value to the last observed value that was below the threshold, instead of the current value 

### Test coverage
-Manually checked displayed value in AMC
