### PR TITLE
Improve documentation for motor failure injection and detection

### DIFF
--- a/docs/en/config/safety.md
+++ b/docs/en/config/safety.md
@@ -207,7 +207,7 @@ The relevant parameters shown below.
 ### Position Loss Failsafe Action
 
 Multicopters will switch to [Altitude mode](../flight_modes_mc/altitude.md) if a height estimate is available, otherwise [Stabilized mode](../flight_modes_mc/manual_stabilized.md).
- 
+
 Fixed-wing planes, and VTOLs not configured to land in hover ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)), have a parameter ([FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT)) that defines how long they will loiter (circle with a constant roll angle ([FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)) at the current altitude) after losing position before attempting to land.
 If VTOLs have are configured to switch to hover for landing ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)) then they will first transition and then descend.
 
@@ -276,12 +276,12 @@ The relevant parameters are listed in the table below.
 
 ## Failure Detector
 
-The failure detector allows a vehicle to take protective action(s) if it unexpectedly flips, or if it is notified by an external failure detection system.
+The failure detector allows a vehicle to take protective actions if it unexpectedly flips, detects a motor failure, or if it is notified by an external failure detection system.
 
 During **flight**, the failure detector can be used to trigger [flight termination](../advanced_config/flight_termination.md) if failure conditions are met, which may then launch a [parachute](../peripherals/parachute.md) or perform some other action.
 
 ::: info
-Failure detection during flight is deactivated by default (enable by setting the parameter: [CBRK_FLIGHTTERM=0](#CBRK_FLIGHTTERM)).
+Acting on a detected failure during flight is deactivated by default (enable by setting the parameter: [CBRK_FLIGHTTERM=0](#CBRK_FLIGHTTERM)).
 :::
 
 During **takeoff** the failure detector [attitude trigger](#attitude-trigger) invokes the [disarm action](#act_disarm) if the vehicle flips (disarm kills the motors but, unlike flight termination, will not launch a parachute or perform other failure actions).
@@ -302,6 +302,22 @@ The relevant parameters are shown below:
 | <a id="FD_FAIL_R"></a>[FD_FAIL_R](../advanced_config/parameter_reference.md#FD_FAIL_R)                   | Maximum allowed roll (in degrees).                                                                                               |
 | <a id="FD_FAIL_P_TTRI"></a>[FD_FAIL_P_TTRI](../advanced_config/parameter_reference.md#FD_FAIL_P_TTRI)    | Time to exceed [FD_FAIL_P](#FD_FAIL_P) for failure detection (default 0.3s).                                                     |
 | <a id="FD_FAIL_R_TTRI"></a>[FD_FAIL_R_TTRI](../advanced_config/parameter_reference.md#FD_FAIL_R_TTRI)    | Time to exceed [FD_FAIL_R](#FD_FAIL_R) for failure detection (default 0.3s).                                                     |
+
+### Motor Failure Trigger
+
+If while armed one of the following events happens a motor failure is declared for which an action can be configured.
+- A 300 milisecond timeout occurs in telemetry from an ESC that was previously available.
+- The input current in the telemetry of an ESC which was previously positive gets too low according to the condition
+   `{esc current} < {parameter FD_ACT_MOT_C2T} * {motor command between 0 and 1}`
+   for more than `FD_ACT_MOT_TOUT` miliseconds.
+
+| Parameter | Description |
+| - | - |
+| <a id="FD_ACT_EN"></a>[FD_ACT_EN](../advanced_config/parameter_reference.md#FD_ACT_EN) | Enable/disable the motor failure trigger completely. |
+| <a id="FD_ACT_MOT_THR"></a>[FD_ACT_MOT_THR](../advanced_config/parameter_reference.md#FD_ACT_MOT_THR) | Minimum normalized [0,1] motor command below which motor under current is ignored. |
+| <a id="FD_ACT_MOT_C2T"></a>[FD_ACT_MOT_C2T](../advanced_config/parameter_reference.md#FD_ACT_MOT_C2T) | Scale between normalized [0,1] motor command and expected minimally reported currrent when the rotor is healthy. |
+| <a id="FD_ACT_MOT_TOUT"></a>[FD_ACT_MOT_TOUT](../advanced_config/parameter_reference.md#FD_ACT_MOT_TOUT) | Time in miliseconds for which the under current detection condition needs to stay true. |
+| <a id="CA_FAILURE_MODE"></a>[CA_FAILURE_MODE](../advanced_config/parameter_reference.md#CA_FAILURE_MODE) | Configure to not only warn about a motor failure but remove the first motor that detects a failure from the allocation effectiveness which turns off the motor and tries to operate the vehicle without it until disarming the next time. |
 
 ### External Automatic Trigger System (ATS)
 

--- a/docs/en/config/safety.md
+++ b/docs/en/config/safety.md
@@ -305,18 +305,22 @@ The relevant parameters are shown below:
 
 ### Motor Failure Trigger
 
-If while armed one of the following events happens a motor failure is declared for which an action can be configured.
-- A 300 milisecond timeout occurs in telemetry from an ESC that was previously available.
-- The input current in the telemetry of an ESC which was previously positive gets too low according to the condition
-   `{esc current} < {parameter FD_ACT_MOT_C2T} * {motor command between 0 and 1}`
-   for more than `FD_ACT_MOT_TOUT` miliseconds.
+The failure detector can be configured to detect a motor failure while armed (and trigger an associated action) in the following conditions:
 
-| Parameter | Description |
-| - | - |
-| <a id="FD_ACT_EN"></a>[FD_ACT_EN](../advanced_config/parameter_reference.md#FD_ACT_EN) | Enable/disable the motor failure trigger completely. |
-| <a id="FD_ACT_MOT_THR"></a>[FD_ACT_MOT_THR](../advanced_config/parameter_reference.md#FD_ACT_MOT_THR) | Minimum normalized [0,1] motor command below which motor under current is ignored. |
-| <a id="FD_ACT_MOT_C2T"></a>[FD_ACT_MOT_C2T](../advanced_config/parameter_reference.md#FD_ACT_MOT_C2T) | Scale between normalized [0,1] motor command and expected minimally reported currrent when the rotor is healthy. |
-| <a id="FD_ACT_MOT_TOUT"></a>[FD_ACT_MOT_TOUT](../advanced_config/parameter_reference.md#FD_ACT_MOT_TOUT) | Time in miliseconds for which the under current detection condition needs to stay true. |
+- A 300 ms timeout occurs in telemetry from an ESC that was previously available.
+- The input current in the telemetry of an ESC which was previously positive gets too low for more than [`FD_ACT_MOT_TOUT`](FD_ACT_MOT_TOUT) ms.
+  The "too low" condition is defined by:
+
+  ```text
+  {esc current} < {parameter FD_ACT_MOT_C2T} * {motor command between 0 and 1}
+  ```
+
+| Parameter                                                                                                | Description                                                                                                                                                                                                                               |
+| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <a id="FD_ACT_EN"></a>[FD_ACT_EN](../advanced_config/parameter_reference.md#FD_ACT_EN)                   | Enable/disable the motor failure trigger completely.                                                                                                                                                                                      |
+| <a id="FD_ACT_MOT_THR"></a>[FD_ACT_MOT_THR](../advanced_config/parameter_reference.md#FD_ACT_MOT_THR)    | Minimum normalized [0,1] motor command below which motor under current is ignored.                                                                                                                                                        |
+| <a id="FD_ACT_MOT_C2T"></a>[FD_ACT_MOT_C2T](../advanced_config/parameter_reference.md#FD_ACT_MOT_C2T)    | Scale between normalized [0,1] motor command and expected minimally reported currrent when the rotor is healthy.                                                                                                                          |
+| <a id="FD_ACT_MOT_TOUT"></a>[FD_ACT_MOT_TOUT](../advanced_config/parameter_reference.md#FD_ACT_MOT_TOUT) | Time in miliseconds for which the under current detection condition needs to stay true.                                                                                                                                                   |
 | <a id="CA_FAILURE_MODE"></a>[CA_FAILURE_MODE](../advanced_config/parameter_reference.md#CA_FAILURE_MODE) | Configure to not only warn about a motor failure but remove the first motor that detects a failure from the allocation effectiveness which turns off the motor and tries to operate the vehicle without it until disarming the next time. |
 
 ### External Automatic Trigger System (ATS)

--- a/docs/en/debug/failure_injection.md
+++ b/docs/en/debug/failure_injection.md
@@ -61,11 +61,11 @@ where:
 - _instance number_ (optional): Instance number of affected sensor.
   0 (default) indicates all sensors of specified type.
 
-### Example
+### Example: RC signal
 
 To simulate losing RC signal without having to turn off your RC controller:
 
-1. Enable the parameter [SYS_FAILURE_EN](../advanced_config/parameter_reference.md#SYS_FAILURE_EN). And specifically to turn off motors also [CA_FAILURE_MODE](../advanced_config/parameter_reference.md#CA_FAILURE_MODE).
+1. Enable the parameter [SYS_FAILURE_EN](../advanced_config/parameter_reference.md#SYS_FAILURE_EN).
 1. Enter the following commands on the MAVLink console or SITL _pxh shell_:
 
    ```sh
@@ -74,6 +74,21 @@ To simulate losing RC signal without having to turn off your RC controller:
 
    # Restart RC publishing
    failure rc_signal ok
+   ```
+
+### Example: Motor
+
+To stop a motor mid-flight without the system anticipating it or excluding it from allocation effectiveness:
+
+1. Enable the parameter [SYS_FAILURE_EN](../advanced_config/parameter_reference.md#SYS_FAILURE_EN). And specifically to allow turning off motors also enable [CA_FAILURE_MODE](../advanced_config/parameter_reference.md#CA_FAILURE_MODE).
+1. Enter the following commands on the MAVLink console or SITL _pxh shell_:
+
+   ```sh
+   # Turn off first motor
+   failure motor off -i 1
+
+   # Turn it back on
+   failure motor ok -i 1
    ```
 
 ## MAVSDK Failure Plugin

--- a/docs/en/debug/failure_injection.md
+++ b/docs/en/debug/failure_injection.md
@@ -19,7 +19,7 @@ At time of writing (PX4 v1.14):
 
 ## Failure System Command
 
-Failures can be injected using the [failure system command](../modules/modules_command.md#failure) from any PX4 [console/shell](../debug/consoles.md) (such as the [QGC MAVLink Console](../debug/mavlink_shell.html#qgroundcontrol-mavlink-console) or SITL _pxh shell_), specifying both the target and type of the failure.
+Failures can be injected using the [failure system command](../modules/modules_command.md#failure) from any PX4 [console/shell](../debug/consoles.md) (such as the [QGC MAVLink Console](../debug/mavlink_shell.md#qgroundcontrol-mavlink-console) or SITL _pxh shell_), specifying both the target and type of the failure.
 
 ### Syntax
 

--- a/docs/en/debug/failure_injection.md
+++ b/docs/en/debug/failure_injection.md
@@ -19,7 +19,7 @@ At time of writing (PX4 v1.14):
 
 ## Failure System Command
 
-Failures can be injected using the [failure system command](../modules/modules_command.md#failure) from any PX4 console/shell, specifying both the target and type of the failure.
+Failures can be injected using the [failure system command](../modules/modules_command.md#failure) from any PX4 [console/shell](../debug/consoles.md) (such as the [QGC MAVLink Console](../debug/mavlink_shell.html#qgroundcontrol-mavlink-console) or SITL _pxh shell_), specifying both the target and type of the failure.
 
 ### Syntax
 
@@ -61,12 +61,19 @@ where:
 - _instance number_ (optional): Instance number of affected sensor.
   0 (default) indicates all sensors of specified type.
 
-### Example: RC signal
+## MAVSDK Failure Plugin
+
+The [MAVSDK failure plugin](https://mavsdk.mavlink.io/main/en/cpp/api_reference/classmavsdk_1_1_failure.html) can be used to programmatically inject failures.
+It is used in [PX4 Integration Testing](../test_and_ci/integration_testing_mavsdk.md) to simulate failure cases (for example, see [PX4-Autopilot/test/mavsdk_tests/autopilot_tester.cpp](https://github.com/PX4/PX4-Autopilot/blob/main/test/mavsdk_tests/autopilot_tester.cpp)).
+
+The plugin API is a direct mapping of the failure command shown above, with a few additional error signals related to the connection.
+
+## Example: RC signal
 
 To simulate losing RC signal without having to turn off your RC controller:
 
-1. Enable the parameter [SYS_FAILURE_EN](../advanced_config/parameter_reference.md#SYS_FAILURE_EN).
-1. Enter the following commands on the MAVLink console or SITL _pxh shell_:
+1. Enable the [SYS_FAILURE_EN](../advanced_config/parameter_reference.md#SYS_FAILURE_EN) parameter.
+2. Enter the following commands on the MAVLink console or SITL _pxh shell_:
 
    ```sh
    # Fail RC (turn publishing off)
@@ -76,12 +83,13 @@ To simulate losing RC signal without having to turn off your RC controller:
    failure rc_signal ok
    ```
 
-### Example: Motor
+## Example: Motor
 
 To stop a motor mid-flight without the system anticipating it or excluding it from allocation effectiveness:
 
-1. Enable the parameter [SYS_FAILURE_EN](../advanced_config/parameter_reference.md#SYS_FAILURE_EN). And specifically to allow turning off motors also enable [CA_FAILURE_MODE](../advanced_config/parameter_reference.md#CA_FAILURE_MODE).
-1. Enter the following commands on the MAVLink console or SITL _pxh shell_:
+1. Enable the [SYS_FAILURE_EN](../advanced_config/parameter_reference.md#SYS_FAILURE_EN) parameter.
+2. Enable [CA_FAILURE_MODE](../advanced_config/parameter_reference.md#CA_FAILURE_MODE) parameter to allow turning off motors.
+3. Enter the following commands on the MAVLink console or SITL _pxh shell_:
 
    ```sh
    # Turn off first motor
@@ -90,10 +98,3 @@ To stop a motor mid-flight without the system anticipating it or excluding it fr
    # Turn it back on
    failure motor ok -i 1
    ```
-
-## MAVSDK Failure Plugin
-
-The [MAVSDK failure plugin](https://mavsdk.mavlink.io/main/en/cpp/api_reference/classmavsdk_1_1_failure.html) can be used to programmatically inject failures.
-It is used in [PX4 Integration Testing](../test_and_ci/integration_testing_mavsdk.md) to simulate failure cases (for example, see [PX4-Autopilot/test/mavsdk_tests/autopilot_tester.cpp](https://github.com/PX4/PX4-Autopilot/blob/main/test/mavsdk_tests/autopilot_tester.cpp)).
-
-The plugin API is a direct mapping of the failure command shown above, with a few additional error signals related to the connection.


### PR DESCRIPTION
### Solved Problem
When answering questions about motor failure injection and motor failure detection, I found that there is next to no documentation. Even though I plan to change the implementation at some point it's worth documenting the current state.

Tagging @potaito to make sure the author gets to know about it.

### Solution
Add a full example to stop a single motor to make things very clear:
<img width="729" height="225" alt="image" src="https://github.com/user-attachments/assets/7b423be2-d909-4852-8404-84ab596d3fbb" />

Add a paragraph for failure detector covering motor failures:
<img width="617" height="348" alt="image" src="https://github.com/user-attachments/assets/ffb47987-d9b7-4ed4-a6df-0cdf93295f58" />

### Changelog Entry
```
Improve documentation for motor failure injection and detection
```