### PR TITLE
mavlink_receiver: fix "Upgrade to MAVLink v2 ..." message spamming bug

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -3229,7 +3229,8 @@ MavlinkReceiver::run()
 					if (mavlink_parse_char(_mavlink.get_channel(), buf[i], &msg, &_status)) {
 
 						// If we receive a complete MAVLink 2 packet, also switch the outgoing protocol version
-						if (!(_mavlink.get_status()->flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1)) {
+						if (!(_mavlink.get_status()->flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1)
+						    && (_mavlink.get_status()->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1)) {
 							PX4_INFO("Upgrade to MAVLink v2 because of incoming packet");
 							_mavlink.set_protocol_version(2);
 						}


### PR DESCRIPTION
### Solved Problem
<img width="394" height="307" alt="image" src="https://github.com/user-attachments/assets/6dbf74bc-e19b-4bcc-bae3-c982ce62cd8f" />

Because of the message I had added in the end here:
https://github.com/PX4/PX4-Autopilot/pull/25583#discussion_r2381555257

### Solution
Only enter the switch to MAVLink v2 case with the message if it was previously v1. Entering all the time wasn't expensive before we added the message and I kept the original design choice. But of course it makes sense to only switch to v2 (and output a message) if it was v1 before.

<img width="436" height="104" alt="image" src="https://github.com/user-attachments/assets/94987183-2402-4874-9c86-f7791aca3dc2" />

So now the message only appears once if MAVLink version was configured to v1 and QGC sending v2 is connected.

### Changelog Entry
```
mavlink_receiver: fix "Upgrade to MAVLink v2 ..." message spamming bug
```

### Test coverage
See screenshots, I ran into this using simulation (`make px4_sitl sihsim_quadx`) and also verified the change to fix the problem but still switch when expected in the same environment.