### PR TITLE
cmake: set CMAKE_CXX_STANDARD 17 to match code assumptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,7 @@ endif()
 
 set(package-contact "px4users@googlegroups.com")
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Usage of std::in_place_t implies C++17

Build on macOS 15.3.2 fails otherwise with:

```
/opt/homebrew/Cellar/abseil/20250127.1/include/absl/utility/utility.h:85:12: fatal error: no member named 'in_place_t' in namespace 'std'
   85 | using std::in_place_t;
      |       ~~~~~^
1 error generated.

```