### PR TITLE
[BACKPORT 1.16] ci: fix failsafe sim

### DIFF
--- a/.github/workflows/failsafe_sim.yml
+++ b/.github/workflows/failsafe_sim.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           git clone https://github.com/emscripten-core/emsdk.git _emscripten_sdk
           cd _emscripten_sdk
+          git checkout 4.0.15
           ./emsdk install latest
           ./emsdk activate latest
 


### PR DESCRIPTION
### Solved Problem
When checking 1.16 backport prs (https://github.com/PX4/PX4-Autopilot/pulls?q=is%3Apr+is%3Aopen+1.16) I found that ci is failing because https://github.com/PX4/PX4-Autopilot/pull/25739

### Solution
Backport it 1:1. It's very low risk, doesn't impact the PX4 build at all but will make ci pass on any prs to 1.16 based branches.

### Changelog Entry
```
ci: Pin emscripten to a version that doesn't warn -> error without C++ 17
```

### Test coverage
It works as expected on main and also on another internal branch where I had this problem and ci should then also pass on this pr.