### PR TITLE
navigator: increase stack by 30 bytes

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1083,7 +1083,7 @@ int Navigator::task_spawn(int argc, char *argv[])
 	_task_id = px4_task_spawn_cmd("navigator",
 				      SCHED_DEFAULT,
 				      SCHED_PRIORITY_NAVIGATION,
-				      PX4_STACK_ADJUSTED(2200),
+				      PX4_STACK_ADJUSTED(2230),
 				      (px4_main_t)&run_trampoline,
 				      (char *const *)argv);
 


### PR DESCRIPTION
### Solved Problem
Report about one occurance of `[px4] [load_mon] navigator low on stack! (292 bytes left)` warnings with basically no customization in navigator but flying an extensive multirotor mission.

### Solution
Increase stack size by 30 bytes should give some minimal margin. Last such change was https://github.com/PX4/PX4-Autopilot/pull/23437

### Changelog Entry
```
Fix navigator low on stack warning
```

### Test coverage
Not specifically tested, given we only know of one instance where this warning occurred with the current stack size and it only consistently exceeded by 8 bytes, a 30 bytes bump should solve it.