### PR TITLE
General Fixed-Wing Autotune Improvements

### DIFF
--- a/docs/en/config/_autotune.md
+++ b/docs/en/config/_autotune.md
@@ -98,8 +98,7 @@ The test steps are:
 
 </div><div v-else-if="$frontmatter.frame === 'Plane'">
 
-4. The drone will first start to perform quick roll motions followed by pitch and yaw motions. When [`FW_AT_SYSID_TYPE`](../advanced_config/parameter_reference.md#FW_AT_SYSID_TYPE) is set to linear/logarithmic sine sweep (recommended), the max rates are approximately 45 deg/s for roll and 30 deg/s for pitch and yaw.
-   The progress is shown in the progress bar, next to the _Autotune_ button.
+4. The drone will first start to perform quick roll motions followed by pitch and yaw motions. When [`FW_AT_SYSID_TYPE`](../advanced_config/parameter_reference.md#FW_AT_SYSID_TYPE) is set to linear/logarithmic sine sweep (recommended), the max rates reached during the maneuvers are 75% of the maximum configured roll (`FW_R_RMAX`), pitch (`FW_P_RMAX_NEG`, `FW_P_RMAX_POS`) and yaw (`FW_Y_RMAX`) rates. The progress is shown in the progress bar, next to the _Autotune_ button.
 
 </div>
 <div style="display: inline;" v-if="$frontmatter.frame === 'Multicopter'">
@@ -194,7 +193,7 @@ Increase the [MC_AT_SYSID_AMP](../advanced_config/parameter_reference.md#MC_AT_S
 </div>
 <div v-else-if="$frontmatter.frame === 'Plane'">
 
-By default, the autotune maneuvers ensure that a sufficient angular rate is reached for system identification. The target rates are approximately 45 deg/s for roll and 30 deg/s for pitch and yaw.
+By default, the autotune maneuvers ensure that a sufficient angular rate is reached for system identification, corresponding to 75% of the configured maximum roll (`FW_R_RMAX`), pitch (`FW_P_RMAX_NEG`, `FW_P_RMAX_POS`) and yaw (`FW_Y_RMAX`) rates.
 
 If the signal-to-noise ratio of the vehicle is low, the system identification algorithm might have issues finding the correct coefficients. Ensure that there is no excessive noise and/or platform vibration.
 

--- a/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
+++ b/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
@@ -345,7 +345,7 @@ void FwAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 			}
 
 			const float abs_roll_rate = fabsf(_angular_velocity(0));
-			const float target = min(kTargetRollRate, math::radians(_param_fw_r_rmax.get()));
+			const float target = 0.75f * math::radians(_param_fw_r_rmax.get());
 
 			updateAmplitudeDetectionState(now, abs_roll_rate, target);
 
@@ -396,7 +396,7 @@ void FwAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 
 			const float abs_pitch_rate = fabsf(_angular_velocity(1));
 			const float max_pitch_rate = min(_param_fw_p_rmax_pos.get(), _param_fw_p_rmax_neg.get());
-			const float target = min(kTargetPitchRate, math::radians(max_pitch_rate));
+			const float target = 0.75f * math::radians(max_pitch_rate);
 
 			updateAmplitudeDetectionState(now, abs_pitch_rate, target);
 
@@ -444,7 +444,7 @@ void FwAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 			}
 
 			const float abs_yaw_rate = fabsf(_angular_velocity(2));
-			const float target = min(kTargetYawRate, math::radians(_param_fw_y_rmax.get()));
+			const float target = 0.75f * math::radians(_param_fw_y_rmax.get());
 
 			updateAmplitudeDetectionState(now, abs_yaw_rate, target);
 

--- a/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
+++ b/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
@@ -550,7 +550,7 @@ void FwAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 	// In case of convergence timeout
 	// the identification sequence is aborted immediately
 	if (_state != state::wait_for_disarm && _state != state::idle && _state != state::fail && _state != state::complete) {
-		if (now - _state_start_time > 20_s
+		if (now - _state_start_time > 30_s
 		    || (_param_fw_at_man_aux.get() && !_aux_switch_en)
 		    || _start_flight_mode != _nav_state) {
 			orb_advert_t mavlink_log_pub = nullptr;

--- a/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.hpp
+++ b/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.hpp
@@ -243,6 +243,6 @@ private:
 		(ParamInt<px4::params::FW_AT_SYSID_TYPE>) _param_fw_sysid_signal_type
 	)
 
-	static constexpr float _publishing_dt_s = 100e-3f;
-	static constexpr hrt_abstime _publishing_dt_hrt = 100_ms;
+	static constexpr float _publishing_dt_s = 20e-3f;
+	static constexpr hrt_abstime _publishing_dt_hrt = 20_ms;
 };

--- a/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.hpp
+++ b/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.hpp
@@ -172,16 +172,6 @@ private:
 	static constexpr float kSignalAmpMax{5.0f};
 	static constexpr float kSignalAmpStep{0.1f};
 
-	// Target maximum angular rates for the system identification signal.
-	// ~45 deg/s for roll, ~30 deg/s for pitch and yaw. These values are:
-	// - High enough to provide good signal-to-noise ratio for identification.
-	// - Low enough to keep pitch and yaw responses within the linear range
-	//   for most vehicles.
-
-	static constexpr float kTargetRollRate{0.8f};
-	static constexpr float kTargetPitchRate{0.5f};
-	static constexpr float kTargetYawRate{0.5f};
-
 	matrix::Vector3f _angular_velocity{};
 
 	bool _armed{false};


### PR DESCRIPTION
### Solved Problems

1. Maneuvers not suitable for platforms with low angular rate limits 
2. Finite state machine running at 10Hz. This is not enough to capture the dynamics for system identification 
3. Heavily undertuned systems trigger abort during amplitude detection phase

### Solution

1. Limit amplitude of maneuver to `0.75 * max_rate`. Replaces previous hard coded target rates. 
2. Increased frequency to 50Hz. 
3. Increased timeout period. 

### Changelog Entry
For release notes:
```
Feature/Bugfix minor fixedwing autotune improvements 
```
### Test coverage
1. Limit amplitude of maneuver to `0.75 * max_rate`: Tested in SITL. 
2. Increased frequency to 50Hz: Tested in flight, no CPU issues observed 

