### PR TITLE
fw_defaults: bump default EKF2_REQ_PDOP to 4

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.fw_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_defaults
@@ -26,6 +26,7 @@ param set-default EKF2_MAG_ACCLIM 0
 param set-default EKF2_REQ_EPH 10
 param set-default EKF2_REQ_EPV 10
 param set-default EKF2_REQ_HDRIFT 0.5
+param set-default EKF2_REQ_PDOP 4
 param set-default EKF2_REQ_SACC 1
 param set-default EKF2_REQ_VDRIFT 1
 param set-default EKF2_RNG_QLTY_T 3


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Default `EKF2_REQ_PDOP`  (=2.5) is very low for FW vehicles. 

### Solution
- Increase default to 4 for FW vehicles. 

### Changelog Entry
For release notes:
```
Feature/Bugfix Increase default `EKF2_REQ_PDOP` to 4 for fixed-wing vehicles
```

### Test coverage
- Tested in SITL
