### PR TITLE
INA2xx: Debounce battery connection on comms errors

### DIFF
--- a/src/drivers/power_monitor/ina220/ina220.cpp
+++ b/src/drivers/power_monitor/ina220/ina220.cpp
@@ -329,8 +329,6 @@ INA220::RunImpl()
 
 		if (_ch_type == PM_CH_TYPE_VBATT) {
 			_battery.setConnected(false);
-			_battery.updateVoltage(0.f);
-			_battery.updateCurrent(0.f);
 			_battery.updateAndPublishBatteryStatus(hrt_absolute_time());
 		}
 

--- a/src/drivers/power_monitor/ina226/ina226.h
+++ b/src/drivers/power_monitor/ina226/ina226.h
@@ -206,6 +206,10 @@ private:
 	int read(uint8_t address, int16_t &data);
 	int write(uint8_t address, uint16_t data);
 
+	uint8_t _connected{0};
+	// returns state unchanged
+	bool setConnected(bool state);
+
 	/**
 	* Initialise the automatic measurement state machine and start it.
 	*

--- a/src/drivers/power_monitor/ina228/ina228.h
+++ b/src/drivers/power_monitor/ina228/ina228.h
@@ -356,6 +356,9 @@ private:
 
 	Battery 		  _battery;
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+	uint8_t _connected{0};
+	// returns state unchanged
+	bool setConnected(bool state);
 
 	int read(uint8_t address, int16_t &data);
 	int write(uint8_t address, int16_t data);

--- a/src/drivers/power_monitor/ina238/ina238.h
+++ b/src/drivers/power_monitor/ina238/ina238.h
@@ -154,6 +154,9 @@ private:
 
 	Battery _battery;
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+	uint8_t _connected{0};
+	// returns state unchanged
+	bool setConnected(bool state);
 
 	int read(uint8_t address, uint16_t &data);
 	int write(uint8_t address, uint16_t data);


### PR DESCRIPTION

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

We've had a lot of "critical low battery" warnings in vehicles with INA2xx based power monitors due to I2C communication errors, causing operator confusion. 

### Solution

Debounce the battery connection state so that a single I2C error does not show the battery as disconnected.
I've chosen a 2s count down, every good I2C communication resets the counter.

History of driver:
- INA226 was copied to create the INA238 driver: https://github.com/PX4/PX4-Autopilot/pull/18260
- INA226 driver was refactored and that behavior was introduced: https://github.com/PX4/PX4-Autopilot/pull/12673

So this bug was in there for over 6 years.

### Changelog Entry
For release notes:
```
INA2xx:  Debounce battery connection on comms errors
```

### Alternatives

Pretty sure this is just a bug.

### Test coverage

- [x] Hardware testing

### Context

![](https://github.com/user-attachments/assets/afffaf7f-6b01-494e-90c3-8d648ecca8dd)

