### PR TITLE
ci: better container cache

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -130,8 +130,8 @@ jobs:
           load: false
           push: ${{ startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_to_registry) }}
           provenance: false
-          cache-from: type=gha,version=1
-          cache-to: type=gha,version=1,mode=max
+          cache-from: type=gha,version=1,scope=${{ matrix.arch }}
+          cache-to: type=gha,version=1,mode=max,scope=${{ matrix.arch }}
 
   deploy:
     name: Deploy To Registry


### PR DESCRIPTION
When building the dev container, we split into two servers one for each supported architecture (x64, arm64), caching is enabled, however they were both sharing the same scope and as a result only one of them ever hit the cache causing the other to build from scratch everytime. This fix makes it so each get their own cache everytime. Saving tons of minutes!

<img width="302" height="155" alt="Screenshot 2025-10-20 at 5 24 16 PM" src="https://github.com/user-attachments/assets/8d6b3315-43f8-4bd8-86f0-6eee08082664" />

Thanks to @beniaminopozzan for the tip (https://github.com/Dronecode/roscon-25-workshop/pull/30)