### PR TITLE
Add publication rate limits to odometry and attitude dds topics

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -62,6 +62,7 @@ publications:
 
   - topic: /fmu/out/vehicle_attitude
     type: px4_msgs::msg::VehicleAttitude
+    rate_limit: 50.
 
   - topic: /fmu/out/vehicle_control_mode
     type: px4_msgs::msg::VehicleControlMode
@@ -84,6 +85,7 @@ publications:
 
   - topic: /fmu/out/vehicle_odometry
     type: px4_msgs::msg::VehicleOdometry
+    rate_limit: 100.
 
   - topic: /fmu/out/vehicle_status
     type: px4_msgs::msg::VehicleStatus


### PR DESCRIPTION
### Solved Problem
Currently `/fmu/out/vehicle_attitude` and `/fmu/out/vehicle_odometry` publication rates are not limited, which can lead to additional CPU loads.

### Solution
Add rate limits to attitude and odometry topics.

Proposed rate limits are known to provide good results for real life scenarios.

### Changelog Entry
For release notes:
- Add 100Hz publication rate limit to /fmu/out/vehicle_odometry
- Add 50Hz publication rate limit to /fmu/out/vehicle_attitude

### Alternatives
We could also limit both publication rates to 50Hz by default, but that was proven to negatively impact the performance of external systems relaying on these messages.