### PR TITLE
MAV_CMD_DO_AUTOTUNE_ENABLE  reject invalid MAVLINK param1, param2

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -620,7 +620,7 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 
 		// Check command validity
 		if ((int)roundf(vehicle_command.param1) != 1 || (int)roundf(vehicle_command.param2) != 0) {
-			result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED;
+			result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_DENIED;
 			send_ack = true;
 
 		} else {


### PR DESCRIPTION
Autotuning allows you to specify the axes to use for tuning in fixed wing mode (only). This is currently done using parameters. The latest version of [MAV_CMD_DO_AUTOTUNE_ENABLE](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_AUTOTUNE_ENABLE) allows the GCS to specify the axes as a bitmask in param2. Zero indicates "do all" or "do default".

This rejects any other values than 1 for param 1 (enable) and 0 for param 2 (all axis) to allow for supporting axis and disabling in future.

We could actually support setting the axis. This is set in FW_AT_AXES parameter, which is read in places like https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp#L390-L395:

```
	case state::pitch_amp_detection: {
			if (!(_param_fw_at_axes.get() & Axes::pitch)) {
				// Should not tune this axis, skip
				_state = state::pitch_pause;
				break;
			}
```

@sfuhrer Would it be reasonable to simply overwrite the parameter with the data from the command on FW? This would be a permanent change to the value, which might be OK.

Note, this doesn't fix #18959 unless we actually accept setting the axes.