### PR TITLE
uavcan: more efficient calculation of esc.RawCommand.cmd array size

### DIFF
--- a/src/drivers/uavcan/actuators/esc.hpp
+++ b/src/drivers/uavcan/actuators/esc.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2014 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2014-2025 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,7 +71,7 @@ public:
 
 	bool initialized() { return _initialized; };
 
-	void update_outputs(uint16_t outputs[MAX_ACTUATORS], unsigned total_outputs);
+	void update_outputs(uint16_t outputs[MAX_ACTUATORS], uint8_t output_array_size);
 
 	/**
 	 * Sets the number of rotors and enable timer
@@ -114,7 +114,4 @@ private:
 	uavcan::INode								&_node;
 	uavcan::Publisher<uavcan::equipment::esc::RawCommand>			_uavcan_pub_raw_cmd;
 	uavcan::Subscriber<uavcan::equipment::esc::Status, StatusCbBinder>	_uavcan_sub_status;
-
-
-	param_t _param_handles[MAX_ACTUATORS] {PARAM_INVALID};
 };

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2014-2022 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2014-2025 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1082,7 +1082,19 @@ bool UavcanMixingInterfaceESC::updateOutputs(uint16_t outputs[MAX_ACTUATORS], un
 		unsigned num_control_groups_updated)
 {
 	if (_esc_controller.initialized()) {
-		_esc_controller.update_outputs(outputs, num_outputs);
+		// num_outputs is the maximum possible number of outputs (8)
+		// output_array_size adapts to the highest output index that is mapped (4 for a quad)
+		// this allows for sending less CAN frames depending on what output indices are mapped
+		uint8_t output_array_size = 0;
+
+		for (int i = MAX_ACTUATORS - 1; i >= 0; i--) {
+			if (mixingOutput().isFunctionSet(i)) {
+				output_array_size = i + 1;
+				break;
+			}
+		}
+
+		_esc_controller.update_outputs(outputs, output_array_size);
 	}
 
 	return true;


### PR DESCRIPTION
### Solved Problem
When facing the issue that the esc.RawCommand.cmd array size was either completely empty until arming the first time (problem with T-Motor DroneCAN ESCs) or if skipping the trimming always having an array size of 8 commands (currently a problem with Vertiq DroneCAN ESCs) I found that @dakejahl had already fixed this exact problem recently as part of this commit: https://github.com/PX4/PX4-Autopilot/commit/6a1cefd7a6e8b4a6273754f8ae82db3dde77d4c3#diff-ab37ceed09d81c098ac9e8d1ce89c3c5fb53fbb146bef6ed66c73837adcac408R114 from this pr: https://github.com/PX4/PX4-Autopilot/pull/25182/files#diff-ab37ceed09d81c098ac9e8d1ce89c3c5fb53fbb146bef6ed66c73837adcac408R112

But that solution holds a duplicate copy of all `UAVCAN_EC_FUNC{1-8}` parameters in RAM, even though the same module already has them. And it calls `param_get()` with 3.2kHz (400Hz * 8 parameters) which I haven't measured but certainly isn't for free.

### Solution
I quickly talked to @bkueng about a more efficient way and with his advice on using the already available interface
https://github.com/PX4/PX4-Autopilot/blob/73ee098a2571865757ecda0be6090d2a6477e17c/src/lib/mixer_module/mixer_module.hpp#L137-L140
I came up with a solution that iterates backwards through the actuator indexes, finding the highest index that's mapped to a function and that determines how many values should be filled to the array directly.

Notes:
- The `MixingOutput` is in scope of `uavcan_main` so I decided to do this calculation in that scope and pass the array size to the `UavcanEscController`.
- The calculation is done on every output update which could be further optimized to only happen upon a parameter change. I'm not sure if that's worth optimizing further. I assume the loop calling `isFunctionSet()` (a pointer check) is pretty cheap.
- It's not necessary to push all 8 values and then trim the array again so I directly only fill what should get sent.

### Changelog Entry
```
uavcan: more efficient calculation of esc.RawCommand.cmd array size
```

### Test coverage
I use this exact implementation on an older version not yet containing #25182 and did extensive bench testing on v5x hardware. The expected array size is sent out directly after boot, when changing the mapped UAVCAN function it immediately chages the array size correctly and when not mapping anything I can't see the empty array size because then sending out the messages correctly is not scheduled anymore.

### Context
We were also discussing that the mapped function could be checked to be a motor but I don't think that adds value. If someone wants to map a non-motor function to UAVCAN ESCs then it's his choice and it should still work.
