### PR TITLE
drivers/ins: InertialLabs INS driver bugfix

### DIFF
--- a/src/drivers/ins/ilabs/ILabs.h
+++ b/src/drivers/ins/ilabs/ILabs.h
@@ -80,6 +80,10 @@ private:
 	void        Run() override;
 	void        processData(InertialLabs::SensorsData *sensordata);
 	static void processDataProxy(void *context, InertialLabs::SensorsData *data) {
+		if (!context || !data) {
+			return;
+		}
+
 		ILabs *self = static_cast<ILabs *>(context);
 		self->processData(data);
 	}


### PR DESCRIPTION
### Solved Problem
Fixed driver crush when INS turned on/off.
Fixed device reinitialization.
Fixed resource use in different threads.
Comsetic changes (clang-format, improve warn/error messages)

### Solution
- Use correct waiting time
- Use atomic variables for work in threads
- Use memory checks

### Changelog Entry
For release notes:
```
Bugfix InertialLabs INS driver
```