### PR TITLE
Fix photo triggering when using MAVLink camera on telem1

### DIFF
--- a/src/modules/mavlink/streams/CAMERA_TRIGGER.hpp
+++ b/src/modules/mavlink/streams/CAMERA_TRIGGER.hpp
@@ -65,6 +65,7 @@ private:
 
 	uORB::Subscription _camera_trigger_sub{ORB_ID(camera_trigger)};
 	uORB::Subscription _camera_status_sub{ORB_ID(camera_status)};
+	uORB::Publication<vehicle_command_s> _vehicle_cmd_pub{ORB_ID(vehicle_command)};
 	camera_status_s _camera_status = {
 		0,	//timestamp
 		0,	//target_sys_id
@@ -102,7 +103,7 @@ private:
 					vcmd.target_system = mavlink_system.sysid;
 					vcmd.target_component = i_camera + MAV_COMP_ID_CAMERA;
 
-					MavlinkCommandSender::instance().handle_vehicle_command(vcmd, _mavlink->get_channel());
+					_vehicle_cmd_pub.publish(vcmd);
 
 
 					// TODO: move this camera_trigger and publish as a vehicle_command


### PR DESCRIPTION
**Problem**
In some scenarios automated photo triggering during a survey would work (such as when using gazebo-classic_typhoon_h480) but in other siturations it would not (such as when using an external MAVLink camera attached to the telem1 MAV_0 port of a ModalAI voxl). This change makes so automated survey photo triggering works in both scenarios.

**Explanation of code change**
`MavlinkCommandSender` does not forward vehicle_command messages to external MAVLink components.  `uORB::Publication<vehicle_command_s>` does and handles camera message routing correctly.

**Before/After**
When testing with simulation (`make px4_sitl gazebo-classic_typhoon_h480`) nothing has changed. The difference is that when testing on hardware it now works for my setup (attaching a Mavlink Camera to telem1)

Here are some pictures of survey I used when testing with simulation and with my hardware setup. Notice how there are black circles along the light path indicating where photos were taken. This is the expected behavior when using a system with a camera with a survey item in its mission plan.
<img width="981" height="861" alt="Screenshot from 2025-10-31 10-31-49" src="https://github.com/user-attachments/assets/e638f578-8de7-4e83-90c1-c9e54207a086" />
<img width="981" height="861" alt="Screenshot from 2025-10-31 10-26-20" src="https://github.com/user-attachments/assets/0044a3cf-cd08-4af2-a50f-d2eb16073c08" />


**Environment**
Ubuntu 22
QGC 5.0.8
px4 software main (oct 31 2025)
px4 board: ModalAI voxl
MAVLink camera ((AirPixel ENTIRE R3 with Sony ILR LX1)) attached to telem1 of voxl 
