### PR TITLE
fix bidir dshot for NXP i.MXRT boards

### DIFF
--- a/platforms/nuttx/src/px4/nxp/imxrt/dshot/dshot.c
+++ b/platforms/nuttx/src/px4/nxp/imxrt/dshot/dshot.c
@@ -425,7 +425,7 @@ int up_bdshot_num_erpm_ready(void)
 	for (unsigned i = 0; i < DSHOT_TIMERS; ++i) {
 		// We only check that data has been received, rather than if it's valid.
 		// This ensures data is published even if one channel has bit errors.
-		if (bdshot_recv_mask & (1 << i)) {
+		if (bdshot_parsed_recv_mask & (1 << i)) {
 			++num_ready;
 		}
 	}


### PR DESCRIPTION
### Solved Problem
When attempting to use bidirectional dshot on a NXP MR-VMU-RT1176 Flight Controller (FMUv6X-RT) I found that the esc_status messages would never get published. This seems to be due to ``bdshot_recv_mask`` being used to check the number of ready erpms, while this mask seem to always be set to zero before this is done.

Fixes #25853

### Solution
- Check ``bdshot_parsed_recv_mask`` instead of ``bdshot_recv_mask`` when counting the number of ready erpms.

### Changelog Entry
For release notes:
```
Bugfix: esc_status never gets published for nxp xrt boards
```
