### PR TITLE
docs(uxrce_dds): add missing closure for info section

### DIFF
--- a/docs/en/middleware/uxrce_dds.md
+++ b/docs/en/middleware/uxrce_dds.md
@@ -441,6 +441,7 @@ uxrce_dds_client start -n fancy_uav
 ```
 
 This can be included in `etc/extras.txt` as part of a custom [System Startup](../concept/system_startup.md).
+:::
 
 ## PX4 ROS 2 QoS Settings
 


### PR DESCRIPTION

An info section in the uxrce_dds docs was not properly closed which caused bad rendering of the page