### PR TITLE
[Docs] flight_modes_fw/return.md: remove warning about now-fixed RTL bug

### DIFF
--- a/docs/en/flight_modes_fw/return.md
+++ b/docs/en/flight_modes_fw/return.md
@@ -25,11 +25,6 @@ The default type is recommended.
 
 :::
 
-::: warning
-There is a known issue ([PX4-Autopilot#25436](https://github.com/PX4/PX4-Autopilot/issues/25436)) with fixed-wing approaches and landings while in RTL mode.
-Please review the issue and verify in simulation that the behavior you get is safe in an RTL landing scenario (if not, consider using rally points).
-:::
-
 ## Technical Summary
 
 Fixed-wing vehicles use the _mission landing/rally point_ return type by default.


### PR DESCRIPTION
Remove warning now that bug has been fixed by https://github.com/PX4/PX4-Autopilot/pull/25600