### PR TITLE
Tools: ci: package_build_artifact: Also copy bin folder if it exists

### DIFF
--- a/Tools/ci/package_build_artifacts.sh
+++ b/Tools/ci/package_build_artifacts.sh
@@ -8,6 +8,8 @@ for build_dir_path in build/*/ ; do
   build_dir=${build_dir_path#*/}
   mkdir artifacts/$build_dir
   find artifacts/ -maxdepth 1 -type f -name "*$build_dir*"
+  # Binaries
+  cp -r $build_dir_path/bin artifacts/$build_dir/
   # Airframe
   cp $build_dir_path/airframes.xml artifacts/$build_dir/
   # Parameters


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This should make SITL binaries available

"Should" Fix https://github.com/PX4/PX4-Autopilot/issues/23160

At the moment the px4_armhf-0_build_artifacts and px4_base-px4_build_artifacts only contain the non binary files.

### Solution
- Add bin folder to artifacts

### Changelog Entry
For release notes: Add bin folder to artifacts

### Alternatives
We could also ... build locally 😞 