### PR TITLE
ci: no more uploads to flight review

### DIFF
--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -118,7 +118,7 @@ jobs:
           PX4_HOME_LON: ${{matrix.config.longitude}}
           PX4_HOME_ALT: ${{matrix.config.altitude}}
           PX4_CMAKE_BUILD_TYPE: ${{matrix.config.build_type}}
-        run: test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 10 --abort-early --model ${{matrix.config.model}} --upload test/mavsdk_tests/configs/sitl.json --verbose --force-color
+        run: test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 10 --abort-early --model ${{matrix.config.model}} test/mavsdk_tests/configs/sitl.json --verbose --force-color
         timeout-minutes: 45
 
       - name: Upload failed logs


### PR DESCRIPTION
CI is pushing most of the logs to flight review, and we end up hosting tons of not very useful logs, which increases costs drastically on our monthly bill, and on top of that, [uploads sometimes fail](https://github.com/PX4/PX4-Autopilot/actions/runs/19340081492/job/55325857067?pr=25912)