### PR TITLE
ICE: switch of engine if aux is negative instead of zero

### DIFF
--- a/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.hpp
+++ b/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.hpp
@@ -102,7 +102,7 @@ private:
 	enum class UserOnOffRequest {
 		Off,
 		On
-	};
+	} _user_request{UserOnOffRequest::Off};
 
 	enum class ICESource {
 		ArmingState,
@@ -126,7 +126,7 @@ private:
 	void controlEngineStartup(const hrt_abstime now);
 	void controlEngineFault();
 	bool maximumAttemptsReached();
-	void publishControl(const hrt_abstime now, const UserOnOffRequest user_request);
+	void publishControl(const hrt_abstime now);
 
 	// Starting state specifics
 	static constexpr float DELAY_BEFORE_RESTARTING{1.f};


### PR DESCRIPTION
### Solved Problem
It is possible to use `ICE_ON_SOURCE` AUX1, launch the vehicle, then if switching off the RC, ICE engine stops even if the RC input values are not updated.

### Solution
- Only update user request if the AUX channel is on -1 or 1

### Testing
TBD