### PR TITLE
ci: fix flash-analysis sporadic fail

### DIFF
--- a/.github/workflows/flash_analysis.yml
+++ b/.github/workflows/flash_analysis.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           make clean
           make distclean
+          make submodulesclean
 
       - name: If it's a PR checkout the base branch
         if: ${{ github.event.pull_request }}


### PR DESCRIPTION
### Solved Problem
Very sporadically the job fails to build the **previous** state. When trying to build locally everything works as expected. Debugging showed that this is caused by submodules not being cleaned up after the first build.

### Solution
Clean submodules after the first build.

### Test coverage
Tested on our PX4 fork with some testing PRs.
