### PR TITLE
PPS: remove redundant boolean literal to silence clang-tidy

### DIFF
--- a/src/modules/sensors/vehicle_gps_position/PpsTimeSync.cpp
+++ b/src/modules/sensors/vehicle_gps_position/PpsTimeSync.cpp
@@ -96,9 +96,5 @@ bool PpsTimeSync::is_valid() const
 		now = UINT64_MAX;
 	}
 
-	if (now - _pps_hrt_timestamp > kPpsStaleTimeoutUs) {
-		return false;
-	}
-
-	return true;
+	return now - _pps_hrt_timestamp < kPpsStaleTimeoutUs;
 }


### PR DESCRIPTION
<img width="1466" height="169" alt="image" src="https://github.com/user-attachments/assets/995012ec-7366-4687-b822-28e12a7361e2" />
