### PR TITLE
Opposite macOS sim tools setup bash logic

### DIFF
--- a/Tools/setup/macos.sh
+++ b/Tools/setup/macos.sh
@@ -74,7 +74,7 @@ python3 -m pip install --user -r ${DIR}/requirements.txt
 
 # Optional, but recommended additional simulation tools:
 if [[ $INSTALL_SIM == "--sim-tools" ]]; then
-	if brew ls --versions px4-sim > /dev/null; then
+	if ! brew ls --versions px4-sim > /dev/null; then
 		brew install px4-sim
 	elif [[ $REINSTALL_FORMULAS == "--reinstall" ]]; then
 		brew reinstall px4-sim


### PR DESCRIPTION
The current bash file for macOS setup script always skips `--sim-tools' condition cause of the wrong logic. 

cc #25204 