### PR TITLE
uavcannode: fix compile error in BatteryInfo.hpp

### DIFF
--- a/src/drivers/uavcannode/Publishers/BatteryInfo.hpp
+++ b/src/drivers/uavcannode/Publishers/BatteryInfo.hpp
@@ -86,7 +86,7 @@ public:
 
 			battery_info_aux.timestamp.usec = battery.timestamp;
 
-			for (uint8_t i = 0; i < battery.cell_count && i < battery.voltage_cell_v.size(); i++) {
+			for (uint8_t i = 0; i < battery.cell_count && i < arraySize(battery_status_s::voltage_cell_v); i++) {
 				battery_info_aux.voltage_cell.push_back(battery.voltage_cell_v[i]);
 			}
 


### PR DESCRIPTION
### Solved Problem
The previous code did not compile due to:
```
 error: request for member 'size' in 'battery.battery_status_s::voltage_cell_v', which is of non-class type 'float [14]'
   89 |                         for (uint8_t i = 0; i < battery.cell_count && i < battery.voltage_cell_v.size(); i++) {
      |
```

### Solution
- Fixed the compile error

### Follow-up
- This was not detected as no board does use this publisher yet. We are currently working on one and will upstream as soon as we did more testing. Than this code is also compiled & tested

### Test coverage
- Tested with a local auterion board
