### PR TITLE
[auav] Robustify I2C transfers and guard against empty data

### DIFF
--- a/src/drivers/differential_pressure/auav/AUAV_Absolute.hpp
+++ b/src/drivers/differential_pressure/auav/AUAV_Absolute.hpp
@@ -51,6 +51,8 @@ static constexpr uint8_t EEPROM_ABS_ES		= 0x38;
 /* Measurement rate is 50Hz */
 static constexpr unsigned ABS_MEAS_RATE = 50;
 static constexpr int64_t ABS_CONVERSION_INTERVAL = (1000000 / ABS_MEAS_RATE); /* microseconds */
+/* reading too fast can yield all zero data -> incorrect sensor reading */
+static_assert(ABS_CONVERSION_INTERVAL >= 7000, "Conversion interval is too fast");
 
 /* Conversions */
 static constexpr float MBAR_TO_PA = 100.0f;

--- a/src/drivers/differential_pressure/auav/AUAV_Differential.hpp
+++ b/src/drivers/differential_pressure/auav/AUAV_Differential.hpp
@@ -51,6 +51,8 @@ static constexpr uint8_t EEPROM_DIFF_ES		= 0x34;
 /* Measurement rate is 100Hz */
 static constexpr unsigned DIFF_MEAS_RATE = 100;
 static constexpr int64_t DIFF_CONVERSION_INTERVAL = (1000000 / DIFF_MEAS_RATE); /* microseconds */
+/* reading too fast can yield all zero data -> incorrect sensor reading */
+static_assert(DIFF_CONVERSION_INTERVAL >= 7000, "Conversion interval is too fast");
 
 /* Conversions */
 static constexpr float INH_TO_PA = 249.08f;


### PR DESCRIPTION
### Solved Problem

1. Probing can fail.
2. Reading the data between 4.5-5.5ms after triggering can return a valid data ready flag, but an empty 

### Solution

1. Retry the probing of the AUAV sensor more often.
2. Enforce minimum sampling time of 7ms.

### Testing

- [x] Test in Hardware
