### PR TITLE
mavlink: don't silently ignore mavlink dev streams

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1194,8 +1194,8 @@ Mavlink::configure_stream(const char *stream_name, const float rate)
 	}
 
 	// if we reach here, the stream list does not contain the stream.
-	// flash constrained target's don't include all streams, and some are only available for the development dialect
-#if defined(CONSTRAINED_FLASH) || !defined(MAVLINK_DEVELOPMENT_H)
+	// flash constrained target's don't include all streams
+#if defined(CONSTRAINED_FLASH)
 	return PX4_OK;
 #else
 	PX4_WARN("stream %s not found", stream_name);


### PR DESCRIPTION
I don't think it makes sense to ignore required streams that easily.

If we do use some streams that are only in the MAVLink development.xml dialect, then we will have to properly and explicitly ifdef them everywhere that we use them. Otherwise, this basically means that we will just swallow this warning on most (non mavlink-dev) platforms which can mask issues.