### PR TITLE
[Fix] Prevent yaw spikes on reset

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -748,7 +748,6 @@ void EKF2::Run()
 
 		// push imu data into estimator
 		_ekf.setIMUData(imu_sample_new);
-		PublishAttitude(now); // publish attitude immediately (uses quaternion from output predictor)
 
 		// integrate time to monitor time slippage
 		if (_start_time_us > 0) {
@@ -854,6 +853,9 @@ void EKF2::Run()
 			UpdateMagCalibration(now);
 #endif // CONFIG_EKF2_MAGNETOMETER
 		}
+
+		PublishAttitude(now); // publish attitude immediately (uses quaternion from output predictor)
+
 
 		// publish ekf2_timestamps
 		_ekf2_timestamps_pub.publish(ekf2_timestamps);


### PR DESCRIPTION
### Solved Problem
Fixes #25971

### Solution
Move the PublishAttitude after the EKF2 update, and consequently after the yaw reset. 

### Changelog Entry
For release notes:
```
Bugfix: Remove Quat reset yaw spikes
```


