### PR TITLE
fw_att_ctrl: zero-intialize member variables

### DIFF
--- a/src/modules/fw_att_control/fw_pitch_controller.h
+++ b/src/modules/fw_att_control/fw_pitch_controller.h
@@ -64,11 +64,11 @@ public:
 	float get_body_rate_setpoint() { return _body_rate_setpoint; }
 
 private:
-	float _tc;
-	float _max_rate_pos;
-	float _max_rate_neg;
-	float _euler_rate_setpoint;
-	float _body_rate_setpoint;
+	float _tc{};
+	float _max_rate_pos{};
+	float _max_rate_neg{};
+	float _euler_rate_setpoint{};
+	float _body_rate_setpoint{};
 };
 
 #endif // FW_PITCH_CONTROLLER_H

--- a/src/modules/fw_att_control/fw_roll_controller.h
+++ b/src/modules/fw_att_control/fw_roll_controller.h
@@ -63,10 +63,10 @@ public:
 	float get_body_rate_setpoint() { return _body_rate_setpoint; }
 
 private:
-	float _tc;
-	float _max_rate;
-	float _euler_rate_setpoint;
-	float _body_rate_setpoint;
+	float _tc{};
+	float _max_rate{};
+	float _euler_rate_setpoint{};
+	float _body_rate_setpoint{};
 };
 
 #endif // FW_ROLL_CONTROLLER_H

--- a/src/modules/fw_att_control/fw_yaw_controller.h
+++ b/src/modules/fw_att_control/fw_yaw_controller.h
@@ -71,9 +71,9 @@ public:
 	float get_body_rate_setpoint() { return _body_rate_setpoint; }
 
 private:
-	float _max_rate;
-	float _euler_rate_setpoint;
-	float _body_rate_setpoint;
+	float _max_rate{};
+	float _euler_rate_setpoint{};
+	float _body_rate_setpoint{};
 };
 
 #endif // FW_YAW_CONTROLLER_H


### PR DESCRIPTION
### Solved Problem

This PR fixes an issue where default-initialized member variables could contain uninitialized (garbage) values when controllers are activated after boot. For example, when the vehicle boots in Manual mode and later switches into a higher-level controller.

Because these variables are allocated on the heap and only initialized when first used, they may start out as NaN or Inf. In the attitude controller, this can cause the control loops to fail silently. 

In the FW Attitude controller we have: 

```
_roll_ctrl.control_roll(roll_sp, _yaw_ctrl.get_euler_rate_setpoint(), euler_angles.phi(),
								euler_angles.theta());
_pitch_ctrl.control_pitch(pitch_sp, _yaw_ctrl.get_euler_rate_setpoint(), euler_angles.phi(),
								  euler_angles.theta());
_yaw_ctrl.control_yaw(roll_sp, _pitch_ctrl.get_euler_rate_setpoint(), euler_angles.phi(),
							      euler_angles.theta(), get_airspeed_constrained());
```

If both the pitch and yaw `euler_rate_setpoint` are initialized with NaN/Inf, none of the three controllers will run properly. And they will return the default initialized `body_rate_setpoint` which can also be garbage/NaN/Inf. 

### Solution

Zero initialize all member variables 

### Changelog Entry
For release notes:
```
Feature/Bugfix zero initialize member variables of fw attitude controllers 
```
