### PR TITLE
EKF2: Allow airspeed & sideslip fusion only in front transition and fixed wing

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/airspeed/airspeed_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/airspeed/airspeed_fusion.cpp
@@ -96,7 +96,8 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 		_innov_check_fail_status.flags.reject_airspeed =
 			_aid_src_airspeed.innovation_rejected; // TODO: remove this redundant flag
 
-		const bool continuing_conditions_passing = _control_status.flags.in_air
+		const bool continuing_conditions_passing = _control_status.flags.in_air && (_control_status.flags.fixed_wing
+				|| _control_status.flags.in_transition_to_fw)
 				&& !_control_status.flags.fake_pos;
 
 		const bool is_airspeed_significant = airspeed_sample.true_airspeed > _params.ekf2_arsp_thr;

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -267,6 +267,7 @@ struct systemFlagUpdate {
 	bool is_fixed_wing{false};
 	bool gnd_effect{false};
 	bool constant_pos{false};
+	bool in_transition_to_fw{false};
 };
 
 struct parameters {
@@ -611,6 +612,8 @@ uint64_t gnss_fault              :
 		uint64_t yaw_manual              : 1; ///< 46 - true if yaw has been reset manually
 uint64_t gnss_hgt_fault              :
 		1; ///< 47 - true if GNSS measurements (alt) have been declared faulty and are no longer used
+		uint64_t in_transition_to_fw 	 : 1; ///< 48 - true if the vehicle is in transition to fw
+
 	} flags;
 	uint64_t value;
 };

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -58,6 +58,7 @@ void Ekf::controlFusionModes(const imuSample &imu_delayed)
 			set_in_air_status(system_flags_delayed.in_air);
 
 			set_is_fixed_wing(system_flags_delayed.is_fixed_wing);
+			set_in_transition_to_fw(system_flags_delayed.in_transition_to_fw);
 
 			if (system_flags_delayed.gnd_effect) {
 				set_gnd_effect();

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -200,6 +200,8 @@ public:
 	// set vehicle is fixed wing status
 	void set_is_fixed_wing(bool is_fixed_wing) { _control_status.flags.fixed_wing = is_fixed_wing; }
 
+	void set_in_transition_to_fw(bool in_transition) { _control_status.flags.in_transition_to_fw = in_transition; }
+
 	// set flag if static pressure rise due to ground effect is expected
 	// use _params.ekf2_gnd_eff_dz to adjust for expected rise in static pressure
 	// flag will clear after GNDEFFECT_TIMEOUT uSec

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2622,6 +2622,7 @@ void EKF2::UpdateSystemFlagsSample(ekf2_timestamps_s &ekf2_timestamps)
 
 			// let the EKF know if the vehicle motion is that of a fixed wing (forward flight only relative to wind)
 			flags.is_fixed_wing = (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING);
+			flags.in_transition_to_fw = vehicle_status.in_transition_to_fw;
 
 #if defined(CONFIG_EKF2_SIDESLIP)
 


### PR DESCRIPTION
### Solved Problem
In recent PX4 versions we have encountered the issue that a VTOL vehicle switches between `LAND` and `DESCEND` when hovering in strong headwinds and without GNSS. This is due to airspeed fusion purely depending on `EKF2_ARPS_THR`, even in MC. Because airspeed / beta fusion together represent a horizontal aiding source, they cause this mode switching. 

### Solution
Disable airspeed fusion in MC, but still make it possible in front transition, where it can be beneficial to have the additional aiding source in case optical flow goes out of range, and where at larger airspeed the zero sideslip assumption is warranted again.

### Changelog Entry
For release notes:
```
Allow airspeed and sideslip fusion only in front transition and fixed wing
```

### Alternatives

In principle we could make use of the airspeed sensor in MC mode, but there are many practical difficulties such as prop wash (made even worse by ground effect or backward movement), the fact that the sideslip assumption does not hold anymore, and the lower accuracy at small airspeeds due to airspeed ~ sqrt(differential pressure). At this moment we have no pressing need for it. 
