### PR TITLE
Ignore max HAGL failsafe in front transition

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -1028,10 +1028,17 @@ void MissionBlock::updateMaxHaglFailsafe()
 {
 	const float target_alt = _navigator->get_position_setpoint_triplet()->current.alt;
 	const float max_alt = math::min(_navigator->get_local_position()->hagl_max_z, _navigator->get_local_position()->hagl_max_xy);
-	const float terrain_alt = _navigator->get_obal_position()->terrain_alt;
-	const bool terrain_alt_valid = _navigator->get_obal_position()->terrain_alt_valid;
+	const float terrain_alt = _navigator->get_global_position()->terrain_alt;
+	const bool terrain_alt_valid = _navigator->get_global_position()->terrain_alt_valid;
 
-	if (terrain_alt_valid && (target_alt - terrain_alt) > max_alt) {
+	// If the HAGL failsafe is declared during front transition, we enter a
+	// FW hold at the current low altitude while not having finished the
+	// transition. This is dangerous and worse than possibly fusing neither
+	// optical flow nor airspeed for a couple seconds, so we bypass the
+	// failsafe here.
+	const bool in_transition_to_fw = _navigator->get_vstatus()->in_transition_to_fw;
+
+	if (!in_transition_to_fw && terrain_alt_valid && (target_alt - terrain_alt) > max_alt) {
 		// Handle case where the altitude setpoint is above the maximum HAGL (height above ground level)
 		mavlink_log_info(_navigator->get_mavlink_log_pub(), "Target altitude higher than max HAGL\t");
 		events::send(events::ID("navigator_fail_max_hagl"), events::Log::Error, "Target altitude higher than max HAGL");


### PR DESCRIPTION
### Solved Problem
This addresses the following issue in GPS-denied front transitions: 
 - OF is the only horizontal aiding source, therefore here the max HAGL limit is set to OF max distance: https://github.com/PX4/PX4-Autopilot/blob/6901bc6a016a5cdcac2dfb90cd721aa29d5897d2/src/modules/ekf2/EKF/ekf_helper.cpp#L361-L385
 - We start the transition below that limit, but the terrain drops so the limit is violated _before_ airspeed fusion kicks in
 - This failsafe is declared, meaning we enter a _fixed wing_ hold at the altitude of the front transition. This can be dangerously low, and is also nonsensical as the fact we enter a fixed wing hold necessitates that we finish the front transition successfully, meaning the entire failsafe would not have been necessary

### Solution
We disable the failsafe during VTOL transition. In front transition, the risk of possibly spending a few seconds fusing neither OF nor airspeed is preferrable to this failsafe. 

In backtransition, the risk is lower, as in that case we enter a MC hold if the OF height is exceeded. 

### Changelog Entry
For release notes:
```
Disable max HAGL failsafe during fronttransition
```

### Alternatives

Alternatives could be: 
 - Change the failsafe to be a quad-chute / MC hold rather than FW hold
 - Lower `EKF2_ARSP_THR` to fuse airspeed earlier, or fuse it during the entire front transition (but questionable accuracy at low airspeeds) 

