### PR TITLE
Advertise attitude_sp_pub in attitude and FwLateralLongitudinal controller

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -48,6 +48,7 @@ FixedwingAttitudeControl::FixedwingAttitudeControl(bool vtol) :
 	/* fetch initial parameter values */
 	parameters_update();
 	_landing_gear_wheel_pub.advertise();
+	_attitude_sp_pub.advertise();
 }
 
 FixedwingAttitudeControl::~FixedwingAttitudeControl()

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -70,6 +70,7 @@ FwLateralLongitudinalControl::FwLateralLongitudinalControl(bool is_vtol) :
 	_attitude_sp_pub(is_vtol ? ORB_ID(fw_virtual_attitude_setpoint) : ORB_ID(vehicle_attitude_setpoint)),
 	_loop_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle"))
 {
+	_attitude_sp_pub.advertise();
 	_tecs_status_pub.advertise();
 	_flight_phase_estimation_pub.advertise();
 	_fixed_wing_lateral_status_pub.advertise();


### PR DESCRIPTION
When a vehicle was booted in manual mode, switching to loiter caused a ~0.3 s gap before attitude_setpoint messages appeared in the logs as the publisher wasn't advertised. 

### Changelog Entry
For release notes:
```
Feature/Bugfix advertise attitude_sp_pub in fw_attitude and fw_lateral_longitudinal controllers  
```


