### PR TITLE
tools: add script to run clang-tidy to fix uninitialized variables

### DIFF
--- a/Tools/clang_tidy_fix_uninitialized.py
+++ b/Tools/clang_tidy_fix_uninitialized.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Fix uninitialized member variables using clang-tidy.
+Zero initialize and default construct variables using clang-tidy.
 Only modifies files within the specified directory.
 
 Usage: ./Tools/clang_tidy_fix_uninitialized.py <path>


### PR DESCRIPTION
**Dependencies**
```bash
  sudo apt install clang clang-tidy clang-tools
  sudo ln -s /usr/bin/clang-apply-replacements-14 /usr/bin/clang-apply-replacements
```
_Note: The version number (14) may vary depending on your Ubuntu version. The script will detect the installed version and provide the correct symlink command if needed_

**Usage**
```bash
make px4_sitl_default-clang
./Tools/clang_tidy_fix_uninitialized.py src/modules/fw_att_control
```