### PR TITLE
Revert "[crsf_rc] Allow setting the baudrate via parameter"

### DIFF
--- a/src/drivers/rc/crsf_rc/CrsfRc.hpp
+++ b/src/drivers/rc/crsf_rc/CrsfRc.hpp
@@ -59,7 +59,7 @@ using namespace device;
 class CrsfRc : public ModuleBase<CrsfRc>, public ModuleParams, public px4::ScheduledWorkItem
 {
 public:
-	CrsfRc(const char *device, uint32_t baudrate);
+	CrsfRc(const char *device);
 	~CrsfRc() override;
 
 	/** @see ModuleBase */
@@ -94,7 +94,6 @@ private:
 
 	char _device[20] {}; ///< device / serial port path
 	bool _is_singlewire{false};
-	uint32_t _baudrate{0};
 
 	static constexpr size_t RC_MAX_BUFFER_SIZE{64};
 	uint8_t _rcs_buf[RC_MAX_BUFFER_SIZE] {};

--- a/src/drivers/rc/crsf_rc/module.yaml
+++ b/src/drivers/rc/crsf_rc/module.yaml
@@ -1,6 +1,6 @@
 module_name: CRSF RC Input Driver
 serial_config:
-    - command: "crsf_rc start -d ${SERIAL_DEV} -b ${BAUD_PARAM}"
+    - command: "crsf_rc start -d ${SERIAL_DEV}"
       port_config_param:
         name: RC_CRSF_PRT_CFG
         group: Serial


### PR DESCRIPTION
This reverts commit 7a9b04c67c25e4b9eb2feef8a89a53a6c3e25b9c.

Unfortunately I forgot that the baudrate parameter is not set to the default 420000 needed for CRSF to work and so this commit simply breaks CRSF support for everyone. They would have to manually set the baudrate parameter which is completely unintuitive. I didn't catch this during testing, since my parameters were already set and I forgot about this.