### PR TITLE
wind-estimator: learn airspeed scale faster at beginning of flight

### DIFF
--- a/docs/en/config_fw/airspeed_scale_handling.md
+++ b/docs/en/config_fw/airspeed_scale_handling.md
@@ -77,12 +77,17 @@ Follow these steps:
 
 1. **Set an Initial Scale**
 
-   Use a conservative starting point: set the CAS scale (`ASPD_SCALE_n`) slightly under 1.0 (for example 0.95).
-   This biases the system toward over-speed rather than under-speed, reducing stall risk.
+   Set the CAS scale (`ASPD_SCALE_n`) to 1.0 (the default value).
+   When the scale is at exactly 1.0, PX4 automatically accelerates the learning process during the first 5 minutes of flight, allowing faster convergence to the correct scale value.
 
 2. **Perform a Flight**
 
    After takeoff, place the vehicle in loiter for about 15 minutes to allow the scale estimation to converge.
+
+   ::: tip
+   Flying in circles (loiter/hold mode) is important as the scale-validation algorithm requires the aircraft to pass through multiple heading segments (12 segments covering all compass directions).
+   If these heading segments aren’t completed, PX4 cannot validate the estimated scale.
+   :::
 
 3. **Check Scale Convergence**
 

--- a/src/lib/wind_estimator/WindEstimator.hpp
+++ b/src/lib/wind_estimator/WindEstimator.hpp
@@ -139,6 +139,10 @@ private:
 	uint64_t _time_last_airspeed_fuse = 0;	///< timestamp of last airspeed fusion
 	uint64_t _time_last_beta_fuse = 0;	///< timestamp of last sideslip fusion
 	uint64_t _time_last_update = 0;		///< timestamp of last covariance prediction
+	uint64_t _time_initialised = 0;         ///< timestamp when estimator is initialised
+
+	static constexpr float kTASScalePSDMultiplier = 100;
+	static constexpr hrt_abstime kTASScaleFastLearnTime = 300_s;
 
 	bool _wind_estimator_reset = false; ///< wind estimator was reset in this cycle
 


### PR DESCRIPTION
### Solved Problem

Airspeed scale estimation can take 10+ minutes to converge during initial flights, especially when starting from inaccurate initial values. This long convergence time is problematic for:
- First flights of new airframes where the correct scale is unknown
- Testing after pitot-static system modifications
- Situations where the initial scale guess is significantly wrong

Slow convergence can lead to degraded controller performance, false airspeed validation failures and stalling/overspeeding

### Solution

Introduce accelerated learning for the first 5 minutes of flight by temporarily increasing the airspeed scale process noise by 10x (100x on the psd). This allows the wind estimator's EKF to adjust the scale estimate much more rapidly. 

This faster learning occurs only if the `ASPD_SCALE_n = 1.0` (default)  during the first 5 minutes of flight.

TO DO: 

- [x] Add documentation 
- [x] Flight test

### Changelog Entry
For release notes:
```
Feature/Bugfix Allow learning airspeed scale faster in first 5 minutes of flight 
```

### Alternatives

Rather than using a fixed 10x multiplier for 5 minutes, we could expose both the multiplier value and duration as tunable parameters. However, I don't love the idea of adding more parameters. 

Current hard-coded values: 

```
kTASScalePSDMultiplier = 100 
kTASScaleFastLearnTime = 300_s
```

### Test coverage

**SITL TEST  1** : `ASPD_SCALE_FAST = 1`, `ASPD_SCALE_1 = 0.8` (should be around 1) ([log](https://review.px4.io/plot_app?log=d1a0458e-7ca8-4f11-ae18-245d8f2074a7)) 

<img width="2122" height="584" alt="image" src="https://github.com/user-attachments/assets/6fa17855-e624-4576-abc6-c9e225c4c725" />


**SITL TEST 2**: `ASPD_SCALE_FAST = 0`, `ASPD_SCALE_1 = 0.8` (should be around 1) 

<img width="2122" height="584" alt="image" src="https://github.com/user-attachments/assets/686dcfd4-13c1-4c5d-95d2-9df385d10fca" />


**SITL TEST 3**: `ASPD_SCALE_FAST = 1`, `ASPD_SCALE_1 = 0.95` (should be around 1) ([log](https://review.px4.io/plot_app?log=7296bcde-05c2-48b1-9e2c-ca66b94849a0))

<img width="2122" height="584" alt="image" src="https://github.com/user-attachments/assets/c113e5d3-211b-42fa-9bfd-c2e832c9ead2" />
