### PR TITLE
crsf_rc: fixed cmake directory conflict

### DIFF
--- a/src/drivers/rc/crsf_rc/CrsfParser.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfParser.cpp
@@ -143,7 +143,7 @@ static uint32_t working_segment_size = HEADER_SIZE;
 #define RX_QUEUE_BUFFER_SIZE 200
 static QueueBuffer_t rx_queue;
 static uint8_t rx_queue_buffer[RX_QUEUE_BUFFER_SIZE];
-#ifdef CONFIG_DRIVERS_RC_CRSF_RC_INJECT
+#ifdef CONFIG_RC_CRSF_INJECT
 static QueueBuffer_t inject_queue;
 static uint8_t inject_queue_buffer[RX_QUEUE_BUFFER_SIZE];
 static uint8_t temp_queue_buffer[RX_QUEUE_BUFFER_SIZE];
@@ -156,7 +156,7 @@ static CrsfPacketDescriptor_t *FindCrsfDescriptor(const enum CRSF_PACKET_TYPE pa
 void CrsfParser_Init(void)
 {
 	QueueBuffer_Init(&rx_queue, rx_queue_buffer, RX_QUEUE_BUFFER_SIZE);
-#ifdef CONFIG_DRIVERS_RC_CRSF_RC_INJECT
+#ifdef CONFIG_RC_CRSF_INJECT
 	QueueBuffer_Init(&inject_queue, inject_queue_buffer, RX_QUEUE_BUFFER_SIZE);
 #endif
 }
@@ -277,7 +277,7 @@ bool CrsfParser_LoadBuffer(const uint8_t *buffer, const uint32_t size)
 	return QueueBuffer_AppendBuffer(&rx_queue, buffer, size);
 }
 
-#ifdef CONFIG_DRIVERS_RC_CRSF_RC_INJECT
+#ifdef CONFIG_RC_CRSF_INJECT
 bool CrsfParser_InjectBuffer(const uint8_t *buffer, const uint32_t size)
 {
 	return QueueBuffer_AppendBuffer(&inject_queue, buffer, size);
@@ -406,7 +406,7 @@ bool CrsfParser_TryParseCrsfPacket(CrsfPacket_t *const new_packet, CrsfParserSta
 			parser_state = PARSER_STATE_HEADER;
 
 			if (valid_packet) {
-#ifdef CONFIG_DRIVERS_RC_CRSF_RC_INJECT
+#ifdef CONFIG_RC_CRSF_INJECT
 
 				if (!QueueBuffer_IsEmpty(&inject_queue)) {
 					// copy the remaining bytes from the rx queue to the temp buffer

--- a/src/drivers/rc/crsf_rc/CrsfParser.hpp
+++ b/src/drivers/rc/crsf_rc/CrsfParser.hpp
@@ -109,7 +109,7 @@ typedef struct {
 
 void CrsfParser_Init(void);
 bool CrsfParser_LoadBuffer(const uint8_t *buffer, const uint32_t size);
-#ifdef DRIVERS_RC_CRSF_RC_INJECT
+#ifdef CONFIG_RC_CRSF_INJECT
 bool CrsfParser_InjectBuffer(const uint8_t *buffer, const uint32_t size);
 #endif
 uint32_t CrsfParser_FreeQueueSize(void);

--- a/src/drivers/rc/crsf_rc/CrsfRc.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfRc.cpp
@@ -545,7 +545,7 @@ int CrsfRc::print_status()
 
 int CrsfRc::custom_command(int argc, char *argv[])
 {
-#ifdef CONFIG_DRIVERS_RC_CRSF_RC_INJECT
+#ifdef CONFIG_RC_CRSF_INJECT
 
 	if (!strcmp(argv[0], "start")) {
 		if (is_running()) {
@@ -602,7 +602,7 @@ This module parses the CRSF RC uplink protocol and generates CRSF downlink telem
 	PRINT_MODULE_USAGE_SUBCATEGORY("radio_control");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAM_STRING('d', "/dev/ttyS3", "<file:dev>", "RC device", true);
-#ifdef CONFIG_DRIVERS_RC_CRSF_RC_INJECT
+#ifdef CONFIG_RC_CRSF_INJECT
 	PRINT_MODULE_USAGE_COMMAND_DESCR("inject", "Inject frame data bytes (for testing)");
 #endif
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();

--- a/src/drivers/rc/crsf_rc/Kconfig
+++ b/src/drivers/rc/crsf_rc/Kconfig
@@ -4,8 +4,12 @@ menuconfig DRIVERS_RC_CRSF_RC
 	---help---
 		Enable support for crsf rc
 
-config DRIVERS_RC_CRSF_RC_INJECT
+if DRIVERS_RC_CRSF_RC
+
+config RC_CRSF_INJECT
 	bool "Inject CRSF RC"
 	default n
 	---help---
 		Enable this to inject CRSF RC commands.
+
+endif # DRIVERS_RC_CRSF_RC


### PR DESCRIPTION
### Solved Problem
Builds for `px4_fmu-v6xrt_allyes` started failing when crsf inject was enabled as seen in https://github.com/PX4/PX4-Autopilot/actions/runs/19669177723/job/56333675522 since https://github.com/PX4/PX4-Autopilot/commit/bb72088ff6cdc3b592ca642006d34dc1c7ad20e5 

```
  CMake Error at CMakeLists.txt:435 (add_subdirectory):
    The binary directory
  
      /__w/PX4-Autopilot/PX4-Autopilot/build/px4_fmu-v6xrt_allyes/src/drivers/rc/crsf_rc
  
    is already used to build a source directory.  It cannot be used to build
    source directory
  
      /__w/PX4-Autopilot/PX4-Autopilot/src/drivers/rc/crsf_rc
  
    Specify a unique binary directory name.
```

### Solution

Problem was caused by naming `config DRIVERS_RC_CRSF_RC_INJECT` option with `DRIVERS_` prefix causing https://github.com/PX4/PX4-Autopilot/blob/main/cmake/kconfig.cmake#L124 to treat it as another driver and generate a duplicate cmake folder reference duplicating the one created for the `DRIVERS_RC_CRSF_RC` config.

Fix is to simply avoid using the `DRIVERS_` prefix.