### PR TITLE
[fix] autotune: fix indentation on _state_start_time in abort logic

### DIFF
--- a/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
+++ b/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
@@ -562,6 +562,8 @@ void FwAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 			mavlink_log_critical(&mavlink_log_pub, "Autotune aborted before finishing");
 			_state = state::fail;
 
+			_state_start_time = now;
+
 		} else if (timeout) {
 			// Skip to next axis
 			mavlink_log_critical(&mavlink_log_pub, "Autotune axis timeout, skipping to next axis");
@@ -586,9 +588,11 @@ void FwAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 				_state = state::fail;         // safety fallback
 				break;
 			}
+
+			_state_start_time = now;
 		}
 
-		_state_start_time = now;
+
 	}
 }
 


### PR DESCRIPTION


### Solved Problem
Bug in FW autotune module where the time that a state was entered resets on every run 

### Solution

Fix indentation of when time is reset 

### Changelog Entry
For release notes:
```
Feature/Bugfix fix constant time reset in autotune module 
```


### Test coverage

Tested in SITL
