### PR TITLE
add target check on MAVLINK_MSG_ID_SET_MODE

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -932,12 +932,11 @@ MavlinkReceiver::handle_message_set_mode(mavlink_message_t *msg)
 	mavlink_set_mode_t new_mode;
 	mavlink_msg_set_mode_decode(msg, &new_mode);
 
-	// Check target
 	if (new_mode.target_system != 0 && new_mode.target_system != _mavlink.get_system_id()) {
 		return;
 	}
 
-	union px4_custom_mode custom_mode;
+	px4_custom_mode custom_mode{};
 	custom_mode.data = new_mode.custom_mode;
 
 	vehicle_command_s vcmd{};


### PR DESCRIPTION
### Solved Problem

Messages were turned into VEHICLE_CMD_DO_SET_MODE for every PX4 on a shared link even when the packet targeted a different system ID. That caused unnecessary traffic and risked unintended mode changes in multi-vehicle setups.

### Solution

Adds a simple target system guard to handle_message_set_mode() so this instance only publishes VEHICLE_CMD_DO_SET_MODE either when the incoming packet is addressed to us or broadcast.

### Changelog Entry
For release notes:
```
Improvement: add target check on MAVLINK_MSG_ID_SET_MODE
```