### PR TITLE
Follow camera with gz topic

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim
@@ -171,7 +171,7 @@ if [ -n "${PX4_SIM_MODEL#*gz_}" ] && [ -z "${PX4_GZ_MODEL_NAME}" ]; then
 		# Set camera offset
 		${gz_command} topic -t /gui/track -m gz.msgs.CameraTrack \
 				-p "track_mode: FOLLOW, follow_target: {name: '${MODEL_NAME_INSTANCE}'},\
-				 follow_offset: {x: ${follow_x}, y: ${follow_y}, z: ${follow_z}}, track_pgain: 1.0"
+				 follow_offset: {x: ${follow_x}, y: ${follow_y}, z: ${follow_z}}, follow_pgain: 1.0, track_pgain: 1.0"
 
 		echo "INFO  [init] Camera follow offset set to ${follow_x}, ${follow_y}, ${follow_z}"
 	fi


### PR DESCRIPTION
### Solved Problem
Using Gz with drones have been quite inconvenient as the drones look generally tiny. This is especially true for fixed-wing vehicles, where viewing control surface deflections are helpful on debugging behaviors.

Fixes https://github.com/PX4/PX4-Autopilot/issues/26021

### Solution
This uses the `/gui/track` topic to lock the camera view on the vehicle.
- This replaces the deprecated service calls for `/gui/follow` and `/gui/follow/offset` to `/gui/track`
- This also enables camera following by default. This can be disabled by `GZ_NO_FOLLOW` instead of enabling it previously with `GZ_FOLLOW`

### Changelog Entry
For release notes:
```
Feature/Bugfix Enabling camera following by default for Gz Sim
New parameter: No new parameters
Documentation: Need to clarify environment variables for configuring follow mode.
```

### Test coverage
with 
```
make px4_sitl gz_advanced_plane
```
![Demo](https://github.com/user-attachments/assets/1a90c3bb-639d-4167-b74a-f9c9437d5e6f)



### Context
- The pgain for gz was added by @bperseghetti in https://github.com/gazebosim/gz-gui/pull/619 
