### PR TITLE
ekf: enable constant position fusion during engine warm-up

### DIFF
--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -489,7 +489,7 @@ private:
 		(ParamExtFloat<px4::params::EKF2_DELAY_MAX>) _param_ekf2_delay_max,
 		(ParamExtInt<px4::params::EKF2_IMU_CTRL>) _param_ekf2_imu_ctrl,
 		(ParamExtFloat<px4::params::EKF2_VEL_LIM>) _param_ekf2_vel_lim,
-		(ParamBool<px4::params::EKF2_EN_ICE_WRM>) _param_ekf2_en_ice_wrm,
+		(ParamBool<px4::params::EKF2_ENGINE_WRM>) _param_ekf2_engine_wrm,
 
 #if defined(CONFIG_EKF2_AUXVEL)
 		(ParamExtFloat<px4::params::EKF2_AVEL_DELAY>)

--- a/src/modules/ekf2/module.yaml
+++ b/src/modules/ekf2/module.yaml
@@ -184,7 +184,7 @@ parameters:
       unit: m/s
       decimal: 1
 
-    EKF2_EN_ICE_WRM:
+    EKF2_ENGINE_WRM:
       description:
         short: Enable constant position fusion during engine warmup
         long: When enabled, constant position fusion is enabled when the vehicle is landed and armed.


### PR DESCRIPTION
### Solved Problem

In cold weather, fuel engines need to be warmed up. Currently, this is done by switching to stabilized mode and throttle up. The issue is that when not using GNSS data, the vehicle is not detected as "at rest" due to vibrations and cannot switch into auto/takeoff modes.

### Solution

This PR introduces a parameter `EKF2_ENGINE_WRM`. If enabled, and if the vehicle is armed and landed, constant position fusion is enabled. 

### Changelog Entry
For release notes:
```
Feature/Bugfix enable constant position fusion during engine warm-up
New parameter: EKF2_ENGINE_WRM
```

### Alternatives

Other proposed ideas were: 

- Enabling warming up the engines directly in Auto/Mission mode --> being able to set the manual throttle is not hard to implement. But after discussing with @sfuhrer : It makes the actual takeoff part more complicated because usually you want to take off with a pre-set throttle (idle). So after you have warmed up the engine, which throttle should the system set for takeoff: manual or idle? 

- Add the launch detector into stabilized mode, as the EKF2 already enables the constant position fusion when it knows it's on a catapult. --> to me it feels wrong to bring an auto-mode feature into stabilized 

### Test coverage

SITL test: 
- armed 
- landed 
- high vibration (such that at_rest = 0)

1. `EKF2_ENGINE_WRM = 0`
<img width="1036" height="708" alt="image" src="https://github.com/user-attachments/assets/db16bd06-6987-461b-8a2f-6e3ad8821240" />

2. `EKF2_ENGINE_WRM = 1` 
<img width="1038" height="697" alt="Screenshot from 2025-12-04 16-21-00" src="https://github.com/user-attachments/assets/2fe7b89a-bfb3-4453-9482-fff53cfdd611" />
