### PR TITLE
fix(uxrce_dds_client): use PX4 specific symbol __PX4 in Micro-XRCE-DDS-CLient and update submodule

### DIFF
--- a/src/modules/uxrce_dds_client/CMakeLists.txt
+++ b/src/modules/uxrce_dds_client/CMakeLists.txt
@@ -50,8 +50,8 @@ else()
 
 	# Include NuttX headers
 	get_property(include_dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
-	set(c_flags_with_includes "${CMAKE_C_FLAGS}")
-	set(cxx_flags_with_includes "${CMAKE_CXX_FLAGS}")
+	set(c_flags_with_includes "${CMAKE_C_FLAGS} -D__PX4")
+	set(cxx_flags_with_includes "${CMAKE_CXX_FLAGS} -D__PX4")
 	foreach(dir ${include_dirs})
 		set(c_flags_with_includes "${c_flags_with_includes} -I${dir}")
 		set(cxx_flags_with_includes "${cxx_flags_with_includes} -I${dir}")


### PR DESCRIPTION
<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->

Depends on:

- https://github.com/PX4/Micro-XRCE-DDS-Client/pull/3

### Solved Problem

The custom PX4 Micro-XRCE-DDS-Client submodule is currently forcing "PX4" mode even if you're not build the client inside PX4, see https://github.com/PX4/Micro-XRCE-DDS-Client/pull/3 for full details.

This PR:

- updates the submodule to use `__PX4` as symbol to detect if PX4 is being used
- Add `__PX4` symbol to Micro-XRCE-DDS-Client submodule during compilation.
