### PR TITLE
CI: also allow filtering for build target names, instead of only entire boards

### DIFF
--- a/Tools/ci/generate_board_targets_json.py
+++ b/Tools/ci/generate_board_targets_json.py
@@ -25,15 +25,15 @@ parser.add_argument('-p', '--pretty', dest='pretty', action='store_true',
                     help='Pretty output instead of a single line')
 parser.add_argument('-g', '--groups', dest='group', action='store_true',
                     help='Groups targets')
-parser.add_argument('-f', '--filter', dest='filter', help='comma separated list of board names to use instead of all')
+parser.add_argument('-f', '--filter', dest='filter', help='comma separated list of build target name prefixes to include instead of all e.g. "px4_fmu-v5_"')
 
 args = parser.parse_args()
 verbose = args.verbose
 
-board_filter = []
+target_filter = []
 if args.filter:
-    for board in args.filter.split(','):
-        board_filter.append(board)
+    for target in args.filter.split(','):
+        target_filter.append(target)
 
 default_container = 'ghcr.io/px4/px4-dev:v1.16.0-rc1-258-g0369abd556'
 build_configs = []
@@ -144,7 +144,7 @@ for manufacturer in os.scandir(os.path.join(source_dir, '../boards')):
                 label = files.name[:-9]
                 target_name = manufacturer.name + '_' + board.name + '_' + label
 
-                if board_filter and not board_name in board_filter:
+                if target_filter and not any(target_name.startswith(f) for f in target_filter):
                     if verbose: print(f'excluding board {board_name} ({target_name})')
                     continue
 


### PR DESCRIPTION
### Solved Problem
Since https://github.com/PX4/PX4-Autopilot/pull/23885 it's possible to specify the boards you want to build in your downstream ci which works great but now I have the requirements to only build some targets of a certain board which is currently not possible.

### Solution
Instead of matching board strings to the filter entries provided by the CI workflow filter for any prefix of the target name e.g.
- `generate_board_targets_json.py --filter px4_fmu-v5x` matches `px4_fmu-v5x_default, px4_fmu-v5x_rover, px4_fmu-v5x_flash-analysis, px4_fmu-v5x_performance-test` just like before.
- `generate_board_targets_json.py --filter px4_fmu-v5x_default` newly matches `px4_fmu-v5x_default` which before was not supported.

<img width="2899" height="142" alt="image" src="https://github.com/user-attachments/assets/deb110c9-4d45-4fa0-98b0-b1dc8777708c" />

### Changelog Entry
```
CI: also allow filtering for build target names, instead of only entire boards
```

### Test coverage
I ran this test both locally to verify it filters according to the expectation based on string prefix and also in downstream CI to see it working end to end.