### PR TITLE
Remove multicopter autonomous flight offtrack logic

### DIFF
--- a/boards/nxp/mr-tropic/nuttx-config/scripts/itcm_functions_includes.ld
+++ b/boards/nxp/mr-tropic/nuttx-config/scripts/itcm_functions_includes.ld
@@ -432,7 +432,7 @@
 *(.text._ZN23MavlinkStreamStatustext8get_sizeEv)
 *(.text._ZN11calibration13Accelerometer13set_device_idEm)
 *(.text._ZN3px46logger6Logger18start_stop_loggingEv)
-*(.text._ZN14FlightTaskAuto17_evaluateTripletsEv)
+*(.text._ZN14FlightTaskAuto32_evaluatePositionSetpointTripletEv)
 *(.text._ZN11calibration9Gyroscope23SensorCorrectionsUpdateEb)
 *(.text._ZN25MavlinkStreamMagCalReport4sendEv)
 *(.text.imxrt_config_gpio)

--- a/boards/nxp/tropic-community/nuttx-config/scripts/itcm_functions_includes.ld
+++ b/boards/nxp/tropic-community/nuttx-config/scripts/itcm_functions_includes.ld
@@ -432,7 +432,7 @@
 *(.text._ZN23MavlinkStreamStatustext8get_sizeEv)
 *(.text._ZN11calibration13Accelerometer13set_device_idEm)
 *(.text._ZN3px46logger6Logger18start_stop_loggingEv)
-*(.text._ZN14FlightTaskAuto17_evaluateTripletsEv)
+*(.text._ZN14FlightTaskAuto32_evaluatePositionSetpointTripletEv)
 *(.text._ZN11calibration9Gyroscope23SensorCorrectionsUpdateEb)
 *(.text._ZN25MavlinkStreamMagCalReport4sendEv)
 *(.text.imxrt_config_gpio)

--- a/boards/px4/fmu-v6xrt/nuttx-config/scripts/itcm_functions_includes.ld
+++ b/boards/px4/fmu-v6xrt/nuttx-config/scripts/itcm_functions_includes.ld
@@ -440,7 +440,7 @@
 *(.text._ZN23MavlinkStreamStatustext8get_sizeEv)
 *(.text._ZN11calibration13Accelerometer13set_device_idEm)
 *(.text._ZN3px46logger6Logger18start_stop_loggingEv)
-*(.text._ZN14FlightTaskAuto17_evaluateTripletsEv)
+*(.text._ZN14FlightTaskAuto32_evaluatePositionSetpointTripletEv)
 *(.text._ZN11calibration9Gyroscope23SensorCorrectionsUpdateEb)
 *(.text._ZN25MavlinkStreamMagCalReport4sendEv)
 *(.text.imxrt_config_gpio)

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -119,6 +119,7 @@ protected:
 	float _mc_cruise_speed{NAN}; /**< Requested cruise speed. If not valid, default cruise speed is used. */
 	WaypointType _type{WaypointType::idle}; /**< Type of current target triplet. */
 
+	uORB::SubscriptionData<position_setpoint_triplet_s> _position_setpoint_triplet_sub{ORB_ID(position_setpoint_triplet)};
 	uORB::SubscriptionData<home_position_s>			_sub_home_position{ORB_ID(home_position)};
 	uORB::SubscriptionData<vehicle_status_s>		_sub_vehicle_status{ORB_ID(vehicle_status)};
 
@@ -170,8 +171,6 @@ private:
 	matrix::Vector2f _lock_position_xy{NAN, NAN}; /**< if no valid triplet is received, lock positition to current position */
 	bool _yaw_lock{false}; /**< if within acceptance radius, lock yaw to current yaw */
 
-	uORB::SubscriptionData<position_setpoint_triplet_s> _sub_triplet_setpoint{ORB_ID(position_setpoint_triplet)};
-
 	matrix::Vector3f _triplet_previous; ///< previous waypoint in triplet from navigator
 	matrix::Vector3f _triplet_current; ///< current waypoint in triplet from navigator
 	matrix::Vector3f _triplet_next; ///< next waypoint in triplet from navigator
@@ -187,7 +186,7 @@ private:
 	matrix::Vector3f _initial_land_position;
 
 	void _smoothYaw(); /**< Smoothen the yaw setpoint. */
-	bool _evaluateTriplets(); /**< Checks and sets triplets. */
+	bool _evaluatePositionSetpointTriplet();
 	bool _isFinite(const position_setpoint_s &sp); /**< Checks if all waypoint triplets are finite. */
 	bool _evaluateGlobalReference(); /**< Check is global reference is available. */
 	void _set_heading_from_mode(); /**< @see  MPC_YAW_MODE */


### PR DESCRIPTION
### Solved Problem
Since the beginning of FlightTaskAuto covering the navigator triplet interface for most autonomous multicopter flight there's the "offtrack" logic which made sure nothing too bad happens if the vehicle is too far away from the line between two waypoints or overshoots the goal waypoint.

See e.g. https://github.com/PX4/PX4-Autopilot/commit/6e62beb560b1e9f47ff4ee897617ff88af10b52f

This logic duplicates much of the position/velocity smoothing trajectory planner, which is a coarse path following logic. Now the offtrack logic can lead to unexpected behavior and regularly problems which are hard to debug. Last issue with hacky workaround for reference: https://github.com/PX4/PX4-Autopilot/pull/25725

### Solution
Remove the offtrack logic and test that the corner cases still work fine because the trajectory generation does better path tracking than the offtrack logic.

### Changelog Entry
```
Remove multicopter autonomous flight offtrack logic
```

### Test coverage
Testing the corner cases in SITL SIH:
- [x]  Bad velocity tracking leading to overshoots and not following the line exactly.

The vehicle slows down when it gets far from the line but no sudden jerky unexpected movements anymore.
<img width="670" height="624" alt="image" src="https://github.com/user-attachments/assets/26a91d39-5b56-4e15-aadc-da2ed081e877" />

- [ ] Stopping the mission between two waypoints, flying away in position and resuming the mission

The vehicle does not come back to the line but rather directly heads to the next waypoint. Remains to be fixed.
<img width="971" height="759" alt="image" src="https://github.com/user-attachments/assets/c83bde97-68a9-47b2-a938-6489a3b0fb39" />

