### PR TITLE
TemperatureCompensationModule: fix order of temp cal args

### DIFF
--- a/src/modules/temperature_compensation/TemperatureCompensationModule.cpp
+++ b/src/modules/temperature_compensation/TemperatureCompensationModule.cpp
@@ -306,7 +306,7 @@ void TemperatureCompensationModule::Run()
 				}
 
 				if (got_temperature_calibration_command) {
-					int ret = run_temperature_calibration(accel, baro, gyro, mag);
+					int ret = run_temperature_calibration(accel, gyro, mag, baro);
 
 					// publish ACK
 					vehicle_command_ack_s command_ack{};


### PR DESCRIPTION
### Solved Problem
Requesting barometer calibration starts gyro calibration. Requesting mag calibration starts barometer calibration. See below.

```
nsh> temperature_compensation calibrate -b
nsh> INFO [temperature_compensation] Starting temperature calibration task (accel=0, gyro=1, mag=0, baro=0)

nsh> temperature_compensation calibrate -m
nsh> INFO [temperature_compensation] Starting temperature calibration task (accel=0, gyro=0, mag=0, baro=1)
```

The function signature for running temperature calibration is: `int run_temperature_calibration(bool accel, bool gyro, bool mag, bool baro)`.

The order of the passed arguments in TemperatureCompensationModule.cpp doesn't match.

`int ret = run_temperature_calibration(accel, baro, gyro, mag);`

### Solution

Re-ordered sensor booleans.

### Changelog Entry
`Fix initiation of temperature compensation for gyro, mag, and baro.`
