### PR TITLE
Navigator cleanup: remove IDLE setpoint type

### DIFF
--- a/msg/PositionSetpoint.msg
+++ b/msg/PositionSetpoint.msg
@@ -7,7 +7,6 @@ uint8 SETPOINT_TYPE_VELOCITY=1	# velocity setpoint
 uint8 SETPOINT_TYPE_LOITER=2	# loiter setpoint
 uint8 SETPOINT_TYPE_TAKEOFF=3	# takeoff setpoint
 uint8 SETPOINT_TYPE_LAND=4	# land setpoint, altitude must be ignored, descend until landing
-uint8 SETPOINT_TYPE_IDLE=5	# do nothing, switch off motors or keep at idle speed (MC)
 
 uint8 LOITER_TYPE_ORBIT=0 	# Circular pattern
 uint8 LOITER_TYPE_FIGUREEIGHT=1 # Pattern resembling an 8

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -108,13 +108,6 @@ bool FlightTaskAuto::update()
 	// always reset constraints because they might change depending on the type
 	_setDefaultConstraints();
 
-	// The only time a thrust set-point is sent out is during
-	// idle. Hence, reset thrust set-point to NAN in case the
-	// vehicle exits idle.
-	if (_type_previous == WaypointType::idle) {
-		_acceleration_setpoint.setNaN();
-	}
-
 	// during mission and reposition, raise the landing gears but only
 	// if altitude is high enough
 	if (_highEnoughForLandingGear()) {
@@ -122,13 +115,6 @@ bool FlightTaskAuto::update()
 	}
 
 	switch (_type) {
-	case WaypointType::idle:
-		// Send zero thrust setpoint
-		_position_setpoint.setNaN(); // Don't require any position/velocity setpoints
-		_velocity_setpoint.setNaN();
-		_acceleration_setpoint = Vector3f(0.f, 0.f, 100.f); // High downwards acceleration to make sure there's no thrust
-		break;
-
 	case WaypointType::land:
 		_prepareLandSetpoints();
 		break;

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -64,8 +64,7 @@ enum class WaypointType : int {
 	velocity = position_setpoint_s::SETPOINT_TYPE_VELOCITY,
 	loiter = position_setpoint_s::SETPOINT_TYPE_LOITER,
 	takeoff = position_setpoint_s::SETPOINT_TYPE_TAKEOFF,
-	land = position_setpoint_s::SETPOINT_TYPE_LAND,
-	idle = position_setpoint_s::SETPOINT_TYPE_IDLE
+	land = position_setpoint_s::SETPOINT_TYPE_LAND
 };
 
 enum class State {
@@ -129,7 +128,7 @@ protected:
 	matrix::Vector3f _next_wp{}; /**< The next waypoint after target (local frame). If no next setpoint is available, next is set to target. */
 	bool _next_was_valid{false};
 	float _mc_cruise_speed{NAN}; /**< Requested cruise speed. If not valid, default cruise speed is used. */
-	WaypointType _type{WaypointType::idle}; /**< Type of current target triplet. */
+	WaypointType _type{WaypointType::position}; /**< Type of current target triplet. */
 
 	uORB::SubscriptionData<home_position_s>			_sub_home_position{ORB_ID(home_position)};
 	uORB::SubscriptionData<vehicle_status_s>		_sub_vehicle_status{ORB_ID(vehicle_status)};
@@ -148,7 +147,7 @@ protected:
 	StickYaw _stick_yaw{this};
 	matrix::Vector3f _land_position;
 	float _land_heading;
-	WaypointType _type_previous{WaypointType::idle}; /**< Previous type of current target triplet. */
+	WaypointType _type_previous{WaypointType::position}; /**< Previous type of current target triplet. */
 	bool _is_emergency_braking_active{false};
 	bool _want_takeoff{false};
 

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -784,7 +784,10 @@ FixedWingModeManager::control_auto_position(const float control_interval, const 
 	float throttle_min = NAN;
 	float throttle_max = NAN;
 
-	if (pos_sp_curr.gliding_enabled) {
+	if (_landed) {
+		throttle_max = _param_fw_thr_idle.get();
+
+	} else if (pos_sp_curr.gliding_enabled) {
 		/* enable gliding with this waypoint */
 		throttle_min = 0.0;
 		throttle_max = 0.0;
@@ -844,7 +847,10 @@ FixedWingModeManager::control_auto_velocity(const float control_interval, const 
 
 	_longitudinal_ctrl_sp_pub.publish(fw_longitudinal_control_sp);
 
-	if (pos_sp_curr.gliding_enabled) {
+	if (_landed) {
+		_ctrl_configuration_handler.setThrottleMax(_param_fw_thr_idle.get());
+
+	} else if (pos_sp_curr.gliding_enabled) {
 		_ctrl_configuration_handler.setThrottleMin(0.0f);
 		_ctrl_configuration_handler.setThrottleMax(0.0f);
 		_ctrl_configuration_handler.setSpeedWeight(2.0f);
@@ -938,7 +944,10 @@ FixedWingModeManager::control_auto_loiter(const float control_interval, const Ve
 
 	_longitudinal_ctrl_sp_pub.publish(fw_longitudinal_control_sp);
 
-	if (pos_sp_curr.gliding_enabled) {
+	if (_landed) {
+		_ctrl_configuration_handler.setThrottleMax(_param_fw_thr_idle.get());
+
+	} else if (pos_sp_curr.gliding_enabled) {
 		_ctrl_configuration_handler.setThrottleMin(0.0f);
 		_ctrl_configuration_handler.setThrottleMax(0.0f);
 		_ctrl_configuration_handler.setSpeedWeight(2.0f);
@@ -986,7 +995,10 @@ FixedWingModeManager::controlAutoFigureEight(const float control_interval, const
 
 	_longitudinal_ctrl_sp_pub.publish(fw_longitudinal_control_sp);
 
-	if (pos_sp_curr.gliding_enabled) {
+	if (_landed) {
+		_ctrl_configuration_handler.setThrottleMax(_param_fw_thr_idle.get());
+
+	} else if (pos_sp_curr.gliding_enabled) {
 		_ctrl_configuration_handler.setThrottleMin(0.0f);
 		_ctrl_configuration_handler.setThrottleMax(0.0f);
 		_ctrl_configuration_handler.setSpeedWeight(2.0f);

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -431,17 +431,6 @@ FixedWingModeManager::set_control_mode_current(const hrt_abstime &now)
 		}
 
 	} else if (_control_mode.flag_control_auto_enabled && _control_mode.flag_control_position_enabled
-		   && (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_IDLE)) {
-
-		// A setpoint of type IDLE can be published by Navigator without a valid position, and is handled here in FW_POSCTRL_MODE_AUTO.
-		if (doing_backtransition) {
-			_control_mode_current = FW_POSCTRL_MODE_TRANSITION_TO_HOVER_HEADING_HOLD;
-
-		} else {
-			_control_mode_current = FW_POSCTRL_MODE_AUTO;
-		}
-
-	} else if (_control_mode.flag_control_auto_enabled && _control_mode.flag_control_position_enabled
 		   && (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LAND)) {
 
 		if (doing_backtransition) {

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -387,8 +387,7 @@ FixedWingModeManager::set_control_mode_current(const hrt_abstime &now)
 			return;
 		}
 
-	} else if ((_control_mode.flag_control_auto_enabled && _control_mode.flag_control_position_enabled)
-		   && _position_setpoint_current_valid) {
+	} else if (_control_mode.flag_control_auto_enabled && _control_mode.flag_control_position_enabled && _position_setpoint_current_valid) {
 
 		// Enter this mode only if the current waypoint has valid 3D position setpoints.
 
@@ -577,11 +576,6 @@ FixedWingModeManager::control_auto(const float control_interval, const Vector2d 
 	}
 
 	switch (position_sp_type) {
-	case position_setpoint_s::SETPOINT_TYPE_IDLE: {
-			control_idle();
-			break;
-		}
-
 	case position_setpoint_s::SETPOINT_TYPE_POSITION:
 		control_auto_position(control_interval, curr_pos, ground_speed, pos_sp_prev, current_sp);
 		break;
@@ -619,24 +613,6 @@ FixedWingModeManager::control_auto(const float control_interval, const Vector2d 
 	if (!_vehicle_status.in_transition_to_fw) {
 		publishLocalPositionSetpoint(current_sp);
 	}
-}
-
-void FixedWingModeManager::control_idle()
-{
-	const hrt_abstime  now = hrt_absolute_time();
-	fixed_wing_lateral_setpoint_s lateral_ctrl_sp {empty_lateral_control_setpoint};
-	lateral_ctrl_sp.timestamp = now;
-	lateral_ctrl_sp.lateral_acceleration = 0.0f;
-	_lateral_ctrl_sp_pub.publish(lateral_ctrl_sp);
-
-	fixed_wing_longitudinal_setpoint_s long_contrl_sp {empty_longitudinal_control_setpoint};
-	long_contrl_sp.timestamp = now;
-	long_contrl_sp.pitch_direct = 0.f;
-	long_contrl_sp.throttle_direct = 0.0f;
-	_longitudinal_ctrl_sp_pub.publish(long_contrl_sp);
-
-	_ctrl_configuration_handler.setThrottleMax(0.0f);
-	_ctrl_configuration_handler.setThrottleMin(0.0f);
 }
 
 void

--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
@@ -243,8 +243,7 @@ bool FeasibilityChecker::checkMissionItemValidity(mission_item_s &mission_item, 
 	}
 
 	// check if we find unsupported items and reject mission if so
-	if (mission_item.nav_cmd != NAV_CMD_IDLE &&
-	    mission_item.nav_cmd != NAV_CMD_WAYPOINT &&
+	if (mission_item.nav_cmd != NAV_CMD_WAYPOINT &&
 	    mission_item.nav_cmd != NAV_CMD_LOITER_UNLIMITED &&
 	    mission_item.nav_cmd != NAV_CMD_LOITER_TIME_LIMIT &&
 	    mission_item.nav_cmd != NAV_CMD_RETURN_TO_LAUNCH &&
@@ -344,8 +343,7 @@ bool FeasibilityChecker::checkTakeoff(mission_item_s &mission_item)
 	}
 
 	if (!_found_item_with_position) {
-		_found_item_with_position = (mission_item.nav_cmd != NAV_CMD_IDLE &&
-					     mission_item.nav_cmd != NAV_CMD_DELAY &&
+		_found_item_with_position = (mission_item.nav_cmd != NAV_CMD_DELAY &&
 					     mission_item.nav_cmd != NAV_CMD_DO_JUMP &&
 					     mission_item.nav_cmd != NAV_CMD_DO_CHANGE_SPEED &&
 					     mission_item.nav_cmd != NAV_CMD_DO_SET_HOME &&

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -94,7 +94,6 @@ Land::on_active()
 		_navigator->get_mission_result()->finished = true;
 		_navigator->set_mission_result_updated();
 		_navigator->mode_completed(getNavigatorStateId());
-		set_idle_item(&_mission_item);
 
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 		mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -76,45 +76,27 @@ Loiter::on_active()
 void
 Loiter::set_loiter_position()
 {
-	if (_navigator->get_vstatus()->arming_state != vehicle_status_s::ARMING_STATE_ARMED &&
-	    _navigator->get_land_detected()->landed) {
+	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-		// Not setting loiter position if disarmed and landed, instead mark the current
-		// setpoint as invalid and idle (both, just to be sure).
+	// Check if we already loiter on a circle and are on the loiter pattern.
+	bool on_loiter{false};
 
-		_navigator->get_position_setpoint_triplet()->current.type = position_setpoint_s::SETPOINT_TYPE_IDLE;
-		_navigator->set_position_setpoint_triplet_updated();
-		return;
+	if (pos_sp_triplet->current.valid && pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER
+	    && pos_sp_triplet->current.loiter_pattern == position_setpoint_s::LOITER_TYPE_ORBIT) {
+		const float d_current = get_distance_to_next_waypoint(pos_sp_triplet->current.lat, pos_sp_triplet->current.lon,
+					_navigator->get_global_position()->lat, _navigator->get_global_position()->lon);
+		on_loiter = d_current <= (_navigator->get_acceptance_radius() + pos_sp_triplet->current.loiter_radius);
 
 	}
 
-	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+	if (on_loiter) {
+		setLoiterItemFromCurrentPositionSetpoint(&_mission_item);
 
-	if (_navigator->get_land_detected()->landed) {
-		_mission_item.nav_cmd = NAV_CMD_IDLE;
+	} else if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+		setLoiterItemFromCurrentPositionWithBraking(&_mission_item);
 
 	} else {
-		// Check if we already loiter on a circle and are on the loiter pattern.
-		bool on_loiter{false};
-
-		if (pos_sp_triplet->current.valid && pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER
-		    && pos_sp_triplet->current.loiter_pattern == position_setpoint_s::LOITER_TYPE_ORBIT) {
-			const float d_current = get_distance_to_next_waypoint(pos_sp_triplet->current.lat, pos_sp_triplet->current.lon,
-						_navigator->get_global_position()->lat, _navigator->get_global_position()->lon);
-			on_loiter = d_current <= (_navigator->get_acceptance_radius() + pos_sp_triplet->current.loiter_radius);
-
-		}
-
-		if (on_loiter) {
-			setLoiterItemFromCurrentPositionSetpoint(&_mission_item);
-
-		} else if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
-			setLoiterItemFromCurrentPositionWithBraking(&_mission_item);
-
-		} else {
-			setLoiterItemFromCurrentPosition(&_mission_item);
-		}
-
+		setLoiterItemFromCurrentPosition(&_mission_item);
 	}
 
 	// convert mission item to current setpoint

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -552,10 +552,8 @@ void MissionBase::setEndOfMissionItems()
 {
 	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-	if (_land_detected_sub.get().landed) {
-		_mission_item.nav_cmd = NAV_CMD_IDLE;
-
-	} else {
+	// Set loiter item only if not landed
+	if (!_land_detected_sub.get().landed) {
 		if (pos_sp_triplet->current.valid &&
 		    (pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER ||
 		     pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_POSITION)) {

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -981,9 +981,7 @@ void MissionBlock::updateAltToAvoidTerrainCollisionAndRepublishTriplet(mission_i
 
 	if (_navigator->get_nav_min_gnd_dist_param() > FLT_EPSILON && _mission_item.nav_cmd != NAV_CMD_LAND
 	    && _mission_item.nav_cmd != NAV_CMD_VTOL_LAND && _mission_item.nav_cmd != NAV_CMD_DO_VTOL_TRANSITION
-	    // && _mission_item.nav_cmd != NAV_CMD_IDLE
-	    // this one was very specifically put here: https://github.com/PX4/PX4-Autopilot/pull/23674
-	    // do we need some other way to encode "mission finisihed"?
+	    && !_navigator->get_land_detected()->landed
 	    && _navigator->get_local_position()->dist_bottom_valid
 	    && _navigator->get_local_position()->dist_bottom < _navigator->get_nav_min_gnd_dist_param()
 	    && _navigator->get_local_position()->vz > FLT_EPSILON

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -106,7 +106,6 @@ MissionBlock::is_mission_item_reached_or_completed()
 	case NAV_CMD_VTOL_LAND:
 		return _navigator->get_land_detected()->landed;
 
-	case NAV_CMD_IDLE: /* fall through */
 	case NAV_CMD_LOITER_UNLIMITED:
 		return false;
 
@@ -650,10 +649,6 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 	sp->gliding_enabled = (_navigator->get_cruising_throttle() < FLT_EPSILON);
 
 	switch (item.nav_cmd) {
-	case NAV_CMD_IDLE:
-		sp->type = position_setpoint_s::SETPOINT_TYPE_IDLE;
-		break;
-
 	case NAV_CMD_TAKEOFF:
 	case NAV_CMD_VTOL_TAKEOFF:
 
@@ -809,22 +804,6 @@ MissionBlock::set_land_item(struct mission_item_s *item)
 
 	item->altitude = 0;
 	item->altitude_is_relative = false;
-	item->loiter_radius = _navigator->get_default_loiter_rad();
-	item->acceptance_radius = _navigator->get_acceptance_radius();
-	item->time_inside = 0.0f;
-	item->autocontinue = true;
-	item->origin = ORIGIN_ONBOARD;
-}
-
-void
-MissionBlock::set_idle_item(struct mission_item_s *item)
-{
-	item->nav_cmd = NAV_CMD_IDLE;
-	item->lat = _navigator->get_home_position()->lat;
-	item->lon = _navigator->get_home_position()->lon;
-	item->altitude_is_relative = false;
-	item->altitude = _navigator->get_home_position()->alt;
-	item->yaw = NAN;
 	item->loiter_radius = _navigator->get_default_loiter_rad();
 	item->acceptance_radius = _navigator->get_acceptance_radius();
 	item->time_inside = 0.0f;
@@ -1002,7 +981,9 @@ void MissionBlock::updateAltToAvoidTerrainCollisionAndRepublishTriplet(mission_i
 
 	if (_navigator->get_nav_min_gnd_dist_param() > FLT_EPSILON && _mission_item.nav_cmd != NAV_CMD_LAND
 	    && _mission_item.nav_cmd != NAV_CMD_VTOL_LAND && _mission_item.nav_cmd != NAV_CMD_DO_VTOL_TRANSITION
-	    && _mission_item.nav_cmd != NAV_CMD_IDLE
+	    // && _mission_item.nav_cmd != NAV_CMD_IDLE
+	    // this one was very specifically put here: https://github.com/PX4/PX4-Autopilot/pull/23674
+	    // do we need some other way to encode "mission finisihed"?
 	    && _navigator->get_local_position()->dist_bottom_valid
 	    && _navigator->get_local_position()->dist_bottom < _navigator->get_nav_min_gnd_dist_param()
 	    && _navigator->get_local_position()->vz > FLT_EPSILON

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -179,11 +179,6 @@ protected:
 	void set_land_item(struct mission_item_s *item);
 
 	/**
-	 * Set idle mission item
-	 */
-	void set_idle_item(struct mission_item_s *item);
-
-	/**
 	 * Set vtol transition item
 	 */
 	void set_vtol_transition_item(struct mission_item_s *item, const uint8_t new_mode);

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -48,7 +48,6 @@
 
 /* compatible to mavlink MAV_CMD */
 enum NAV_CMD {
-	NAV_CMD_IDLE = 0,
 	NAV_CMD_WAYPOINT = 16,
 	NAV_CMD_LOITER_UNLIMITED = 17,
 	NAV_CMD_LOITER_TIME_LIMIT = 19,

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1200,7 +1200,7 @@ void Navigator::reset_position_setpoint(position_setpoint_s &sp)
 	sp.cruising_speed = get_cruising_speed();
 	sp.cruising_throttle = get_cruising_throttle();
 	sp.valid = false;
-	sp.type = position_setpoint_s::SETPOINT_TYPE_IDLE;
+	sp.type = position_setpoint_s::SETPOINT_TYPE_POSITION;
 	sp.loiter_direction_counter_clockwise = false;
 }
 

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -379,7 +379,6 @@ void RtlDirect::set_rtl_item()
 		}
 
 	case RTLState::IDLE: {
-			set_idle_item(&_mission_item);
 			_navigator->mode_completed(getNavigatorStateId());
 			break;
 		}

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -157,11 +157,7 @@ Takeoff::on_active()
 
 			position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-			// set loiter item so position controllers stop doing takeoff logic
-			if (_navigator->get_land_detected()->landed) {
-				_mission_item.nav_cmd = NAV_CMD_IDLE;
-
-			} else {
+			if (!_navigator->get_land_detected()->landed) {
 				if (pos_sp_triplet->current.valid
 				    && _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
 					setLoiterItemFromCurrentPositionSetpoint(&_mission_item);

--- a/src/modules/rover_ackermann/AckermannDriveModes/AckermannAutoMode/AckermannAutoMode.cpp
+++ b/src/modules/rover_ackermann/AckermannDriveModes/AckermannAutoMode/AckermannAutoMode.cpp
@@ -139,8 +139,7 @@ float AckermannAutoMode::arrivalSpeed(const float cruising_speed, const float mi
 				      const int curr_wp_type, const float waypoint_transition_angle, const float max_yaw_rate)
 {
 	if (!PX4_ISFINITE(waypoint_transition_angle)
-	    || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND
-	    || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_IDLE) {
+	    || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND) {
 		return 0.f; // Stop at the waypoint
 
 	} else if (_param_ro_speed_red.get() > FLT_EPSILON) {

--- a/src/modules/rover_ackermann/AckermannDriveModes/AckermannAutoMode/AckermannAutoMode.cpp
+++ b/src/modules/rover_ackermann/AckermannDriveModes/AckermannAutoMode/AckermannAutoMode.cpp
@@ -76,7 +76,7 @@ void AckermannAutoMode::autoControl()
 		rover_position_setpoint.position_ned[1] = _curr_wp_ned(1);
 		rover_position_setpoint.start_ned[0] = _prev_wp_ned(0);
 		rover_position_setpoint.start_ned[1] = _prev_wp_ned(1);
-		rover_position_setpoint.arrival_speed = arrivalSpeed(_cruising_speed, _min_speed, _acceptance_radius, _curr_wp_type,
+		rover_position_setpoint.arrival_speed = arrivalSpeed(_cruising_speed, _min_speed, _acceptance_radius, _curr_wp_type, _curr_wp_valid,
 							_waypoint_transition_angle, _max_yaw_rate);
 		rover_position_setpoint.cruising_speed = _cruising_speed;
 		rover_position_setpoint.yaw = NAN;
@@ -90,6 +90,8 @@ void AckermannAutoMode::updateWaypointsAndAcceptanceRadius()
 	position_setpoint_triplet_s position_setpoint_triplet{};
 	_position_setpoint_triplet_sub.copy(&position_setpoint_triplet);
 	_curr_wp_type = position_setpoint_triplet.current.type;
+	_curr_wp_valid = position_setpoint_triplet.current.valid;
+
 
 	RoverControl::globalToLocalSetpointTriplet(_curr_wp_ned, _prev_wp_ned, _next_wp_ned, position_setpoint_triplet,
 			_curr_pos_ned, _global_ned_proj_ref);
@@ -136,10 +138,10 @@ float AckermannAutoMode::updateAcceptanceRadius(const float waypoint_transition_
 }
 
 float AckermannAutoMode::arrivalSpeed(const float cruising_speed, const float min_speed, const float acc_rad,
-				      const int curr_wp_type, const float waypoint_transition_angle, const float max_yaw_rate)
+				      const int curr_wp_type, const bool curr_wp_valid, const float waypoint_transition_angle, const float max_yaw_rate)
 {
 	if (!PX4_ISFINITE(waypoint_transition_angle)
-	    || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND) {
+	    || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND || !curr_wp_valid) {
 		return 0.f; // Stop at the waypoint
 
 	} else if (_param_ro_speed_red.get() > FLT_EPSILON) {

--- a/src/modules/rover_ackermann/AckermannDriveModes/AckermannAutoMode/AckermannAutoMode.hpp
+++ b/src/modules/rover_ackermann/AckermannDriveModes/AckermannAutoMode/AckermannAutoMode.hpp
@@ -98,12 +98,13 @@ private:
 	 * @param min_speed Minimum speed setpoint [m/s].
 	 * @param acc_rad Acceptance radius of the current waypoint [m].
 	 * @param curr_wp_type Type of the current waypoint.
+	 * @param curr_wp_valid Validity flag of the current waypoint.
 	 * @param waypoint_transition_angle Angle between the prevWP-currWP and currWP-nextWP line segments [rad]
 	 * @param max_yaw_rate Maximum yaw rate setpoint [rad/s]
 	 * @return Speed setpoint [m/s].
 	 */
-	float arrivalSpeed(float cruising_speed, float min_speed, float acc_rad, int curr_wp_type,
-			   float waypoint_transition_angle, float max_yaw_rate);
+	float arrivalSpeed(const float cruising_speed, const float min_speed, const float acc_rad, const int curr_wp_type, const bool curr_wp_valid,
+			   const float waypoint_transition_angle, const float max_yaw_rate);
 
 	// uORB subscriptions
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
@@ -125,6 +126,7 @@ private:
 	float _max_yaw_rate{NAN};
 	float _min_speed{NAN}; // Speed at which the maximum yaw rate limit is enforced given the maximum steer angle and wheel base.
 	int _curr_wp_type{position_setpoint_s::SETPOINT_TYPE_POSITION};
+	int _curr_wp_valid{false};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::RO_YAW_RATE_LIM>)  _param_ro_yaw_rate_limit,

--- a/src/modules/rover_ackermann/AckermannDriveModes/AckermannAutoMode/AckermannAutoMode.hpp
+++ b/src/modules/rover_ackermann/AckermannDriveModes/AckermannAutoMode/AckermannAutoMode.hpp
@@ -124,7 +124,7 @@ private:
 	float _waypoint_transition_angle{0.f}; // Angle between the prevWP-currWP and currWP-nextWP line segments [rad]
 	float _max_yaw_rate{NAN};
 	float _min_speed{NAN}; // Speed at which the maximum yaw rate limit is enforced given the maximum steer angle and wheel base.
-	int _curr_wp_type{position_setpoint_s::SETPOINT_TYPE_IDLE};
+	int _curr_wp_type{position_setpoint_s::SETPOINT_TYPE_POSITION};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::RO_YAW_RATE_LIM>)  _param_ro_yaw_rate_limit,

--- a/src/modules/rover_differential/DifferentialDriveModes/DifferentialAutoMode/DifferentialAutoMode.cpp
+++ b/src/modules/rover_differential/DifferentialDriveModes/DifferentialAutoMode/DifferentialAutoMode.cpp
@@ -51,7 +51,8 @@ void DifferentialAutoMode::autoControl()
 	if (_position_setpoint_triplet_sub.updated()) {
 		position_setpoint_triplet_s position_setpoint_triplet{};
 		_position_setpoint_triplet_sub.copy(&position_setpoint_triplet);
-		int curr_wp_type = position_setpoint_triplet.current.type;
+		const int curr_wp_type = position_setpoint_triplet.current.type;
+		const bool curr_wp_valid = position_setpoint_triplet.current.valid;
 
 		vehicle_local_position_s vehicle_local_position{};
 		_vehicle_local_position_sub.copy(&vehicle_local_position);
@@ -85,7 +86,7 @@ void DifferentialAutoMode::autoControl()
 		rover_position_setpoint.start_ned[0] = prev_wp_ned(0);
 		rover_position_setpoint.start_ned[1] = prev_wp_ned(1);
 		rover_position_setpoint.arrival_speed = arrivalSpeed(cruising_speed, waypoint_transition_angle,
-							_param_ro_speed_limit.get(), _param_rd_trans_drv_trn.get(), _param_ro_speed_red.get(), curr_wp_type);
+							_param_ro_speed_limit.get(), _param_rd_trans_drv_trn.get(), _param_ro_speed_red.get(), curr_wp_type, curr_wp_valid);
 		rover_position_setpoint.cruising_speed = cruising_speed;
 		rover_position_setpoint.yaw = NAN;
 		_rover_position_setpoint_pub.publish(rover_position_setpoint);
@@ -93,11 +94,11 @@ void DifferentialAutoMode::autoControl()
 }
 
 float DifferentialAutoMode::arrivalSpeed(const float cruising_speed, const float waypoint_transition_angle,
-		const float max_speed, const float trans_drv_trn, const float speed_red, int curr_wp_type)
+		const float max_speed, const float trans_drv_trn, const float speed_red, const int curr_wp_type, const bool curr_wp_valid)
 {
 	// Upcoming stop
 	if (!PX4_ISFINITE(waypoint_transition_angle) || waypoint_transition_angle < M_PI_F - trans_drv_trn
-	    || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND) {
+	    || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND || !curr_wp_valid) {
 		return 0.f;
 	}
 

--- a/src/modules/rover_differential/DifferentialDriveModes/DifferentialAutoMode/DifferentialAutoMode.cpp
+++ b/src/modules/rover_differential/DifferentialDriveModes/DifferentialAutoMode/DifferentialAutoMode.cpp
@@ -97,7 +97,7 @@ float DifferentialAutoMode::arrivalSpeed(const float cruising_speed, const float
 {
 	// Upcoming stop
 	if (!PX4_ISFINITE(waypoint_transition_angle) || waypoint_transition_angle < M_PI_F - trans_drv_trn
-	    || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_IDLE) {
+	    || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND) {
 		return 0.f;
 	}
 

--- a/src/modules/rover_differential/DifferentialDriveModes/DifferentialAutoMode/DifferentialAutoMode.hpp
+++ b/src/modules/rover_differential/DifferentialDriveModes/DifferentialAutoMode/DifferentialAutoMode.hpp
@@ -81,10 +81,11 @@ private:
 	 * @param trans_drv_trn Heading error threshold to switch from driving to turning [rad].
 	 * @param speed_red Tuning parameter for the speed reduction during waypoint transition.
 	 * @param curr_wp_type Type of the current waypoint.
+	 * @param curr_wp_valid Validity flag of the current waypoint.
 	 * @return Speed setpoint [m/s].
 	 */
 	float arrivalSpeed(const float cruising_speed, const float waypoint_transition_angle, const float max_speed,
-			   const float trans_drv_trn, const float speed_red, int curr_wp_type);
+			   const float trans_drv_trn, const float speed_red, const int curr_wp_type, const bool curr_wp_valid);
 
 	// uORB subscriptions
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};

--- a/src/modules/rover_mecanum/MecanumDriveModes/MecanumAutoMode/MecanumAutoMode.cpp
+++ b/src/modules/rover_mecanum/MecanumDriveModes/MecanumAutoMode/MecanumAutoMode.cpp
@@ -97,8 +97,7 @@ float MecanumAutoMode::arrivalSpeed(const float cruising_speed, const float wayp
 				    const float max_speed, const float speed_red, int curr_wp_type)
 {
 	// Upcoming stop
-	if (!PX4_ISFINITE(waypoint_transition_angle) || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND
-	    || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_IDLE) {
+	if (!PX4_ISFINITE(waypoint_transition_angle) || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND) {
 		return 0.f;
 	}
 

--- a/src/modules/rover_mecanum/MecanumDriveModes/MecanumAutoMode/MecanumAutoMode.cpp
+++ b/src/modules/rover_mecanum/MecanumDriveModes/MecanumAutoMode/MecanumAutoMode.cpp
@@ -51,7 +51,8 @@ void MecanumAutoMode::autoControl()
 	if (_position_setpoint_triplet_sub.updated()) {
 		position_setpoint_triplet_s position_setpoint_triplet{};
 		_position_setpoint_triplet_sub.copy(&position_setpoint_triplet);
-		int curr_wp_type = position_setpoint_triplet.current.type;
+		const int curr_wp_type = position_setpoint_triplet.current.type;
+		const bool curr_wp_valid = position_setpoint_triplet.current.valid;
 
 		vehicle_local_position_s vehicle_local_position{};
 		_vehicle_local_position_sub.copy(&vehicle_local_position);
@@ -85,7 +86,7 @@ void MecanumAutoMode::autoControl()
 		rover_position_setpoint.start_ned[0] = prev_wp_ned(0);
 		rover_position_setpoint.start_ned[1] = prev_wp_ned(1);
 		rover_position_setpoint.arrival_speed = arrivalSpeed(cruising_speed, waypoint_transition_angle,
-							_param_ro_speed_limit.get(), _param_ro_speed_red.get(), curr_wp_type);
+							_param_ro_speed_limit.get(), _param_ro_speed_red.get(), curr_wp_type, curr_wp_valid);
 		rover_position_setpoint.cruising_speed = cruising_speed;
 		rover_position_setpoint.yaw = PX4_ISFINITE(position_setpoint_triplet.current.yaw) ?
 					      position_setpoint_triplet.current.yaw : NAN;
@@ -94,10 +95,10 @@ void MecanumAutoMode::autoControl()
 }
 
 float MecanumAutoMode::arrivalSpeed(const float cruising_speed, const float waypoint_transition_angle,
-				    const float max_speed, const float speed_red, int curr_wp_type)
+				    const float max_speed, const float speed_red, const int curr_wp_type, const bool curr_wp_valid)
 {
 	// Upcoming stop
-	if (!PX4_ISFINITE(waypoint_transition_angle) || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND) {
+	if (!PX4_ISFINITE(waypoint_transition_angle) || curr_wp_type == position_setpoint_s::SETPOINT_TYPE_LAND || !curr_wp_valid) {
 		return 0.f;
 	}
 

--- a/src/modules/rover_mecanum/MecanumDriveModes/MecanumAutoMode/MecanumAutoMode.hpp
+++ b/src/modules/rover_mecanum/MecanumDriveModes/MecanumAutoMode/MecanumAutoMode.hpp
@@ -80,10 +80,11 @@ private:
 	 * @param max_speed Maximum speed setpoint [m/s]
 	 * @param speed_red Tuning parameter for the speed reduction during waypoint transition.
 	 * @param curr_wp_type Type of the current waypoint.
+	 * @param curr_wp_valid validity flag of the current waypoint.
 	 * @return Speed setpoint [m/s].
 	 */
 	float arrivalSpeed(const float cruising_speed, const float waypoint_transition_angle, const float max_speed,
-			   const float speed_red, int curr_wp_type);
+			   const float speed_red, const int curr_wp_type, const bool curr_wp_valid);
 
 	// uORB subscriptions
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};


### PR DESCRIPTION
Remake of https://github.com/PX4/PX4-Autopilot/pull/23704, removing `position_setpoint_s::SETPOINT_TYPE_IDLE` and close relatives, namely:
 - `NAV_CMD_IDLE`
 - `MissionBlock::set_idle_item`
 - `WaypointType::idle` from `FlightTaskAuto`, which mirrors the position setpoint types defined in `PositionSetpoint.msg`

### Why should we remove it? 

Idle position setpoints / mission items currently serve two functions, both of which are already provided elsewhere:
 1. When landed, in various places make the _current_ position setpoint idle or give an idle mission item. 
      - Even without the idle setpoint these landings work as expected.
 2. When using `reset_position_setpoint`, the setpoint is marked invalid and also given the idle type. This is often done to prevent line-following between previous-current setpoints.
      - The idle type is only checked explicitly in very few places, all of which allow alternatives which in my opinion are clearer:
         - in the rover modules we instead check for setpoint validity
         - in the terrain collision avoidance logic in `mission_block` we rely on the landed state directly, rather than the idle setpoint type which in that context is only a proxy of the landed state. 

Beyond this not very clearly defined functionality, they also present a simple path to a fatal mistake -- if the current position setpoint ever is of type `IDLE` in fixed-wing flight, then `FixedWingModeManager::set_control_mode_current` will switch to `FW_POSCTRL_MODE_AUTO`, which will then happily command level attitude and zero thrust, completely neglecting TECS. Depending on the airframe this will result in an uncontrolled descent or stall.

### Where is it currently used and why doesn't removing it break things? 

This is an exhaustive list of the ways in which an idle position setpoint currently enters the system, along with my reasoning why removing it should be unproblematic:

 - given exactly when the land detector says we have landed:                                                                                          
    - in `land.cpp` via `set_idle_item`                                                                                                 
    - in `rtl_direct.cpp` via `set_idle_item`                                                                              
    - in `mission_base.cpp` via mission item with `.nav_cmd = NAV_CMD_IDLE`
    - in `takeoff.cpp`, `on_active()`, via mission item with `.nav_cmd = NAV_CMD_IDLE` 
      - these four cases are SITL tested and work the same as previously
- as initial value                                                                                                                                                
    - Initialisation of _type and _type_previous in FlightTaskAuto.hpp with WaypointType::idle. Note this only concerns the mirrored version within `FlightTaskAuto` and does not come from a position setpoint itself.
 - Through `reset_position_setpoint` and `reset_triplets`, from which are used quite often (see search results below :mag:)
   - I have tested all of these cases in SITL, verifying basic functionality. 
   - I am also quite convinced this cleanup _should_ not break anything related to reset / invalidated setpoints, as there is currently not a single place where setpoint (in)validity is checked by comparing the type to idle -- rather, the `valid` flag or `PX4_ISFINITE` of the relevant entries are used.  

<details>
  <summary>:mag: Search results for  reset_position_setpoint and reset_triplets</summary>

```
$ grep -r reset_position_setpoint ./src                                                   
./src/modules/navigator/vtol_takeoff.cpp:				_navigator->reset_position_setpoint(reposition_triplet->previous);         
./src/modules/navigator/vtol_takeoff.cpp:				_navigator->reset_position_setpoint(reposition_triplet->current);          
./src/modules/navigator/vtol_takeoff.cpp:				_navigator->reset_position_setpoint(reposition_triplet->next);             
./src/modules/navigator/navigator_main.cpp:	reset_position_setpoint(_pos_sp_triplet.previous);                                     
./src/modules/navigator/navigator_main.cpp:	reset_position_setpoint(_pos_sp_triplet.current);                                      
./src/modules/navigator/navigator_main.cpp:	reset_position_setpoint(_pos_sp_triplet.next);                                         
./src/modules/navigator/navigator_main.cpp:void Navigator::reset_position_setpoint(position_setpoint_s &sp)                        
./src/modules/navigator/mission_base.cpp:			_navigator->reset_position_setpoint(pos_sp_triplet->previous);                 
./src/modules/navigator/mission_base.cpp:			_navigator->reset_position_setpoint(pos_sp_triplet->previous);                 
./src/modules/navigator/takeoff.cpp:					_navigator->reset_position_setpoint(reposition_triplet->previous);         
./src/modules/navigator/takeoff.cpp:					_navigator->reset_position_setpoint(reposition_triplet->current);          
./src/modules/navigator/takeoff.cpp:					_navigator->reset_position_setpoint(reposition_triplet->next);             
./src/modules/navigator/rtl_direct.cpp:			_navigator->reset_position_setpoint(pos_sp_triplet->previous);                     
./src/modules/navigator/navigator.h:	void reset_position_setpoint(position_setpoint_s &sp);                                     
./src/modules/navigator/rtl_mission_fast_reverse.cpp:				_navigator->reset_position_setpoint(pos_sp_triplet->previous); 
./src/modules/navigator/rtl_mission_fast_reverse.cpp:			_navigator->reset_position_setpoint(pos_sp_triplet->previous);     
./src/modules/navigator/rtl_mission_fast_reverse.cpp:			_navigator->reset_position_setpoint(pos_sp_triplet->next);         
$ grep -r reset_triplets ./src                                                             
./src/modules/navigator/navigator_main.cpp:	reset_triplets();                                                                      
./src/modules/navigator/navigator_main.cpp:				reset_triplets();                                                          
./src/modules/navigator/navigator_main.cpp:			reset_triplets();                                                              
./src/modules/navigator/navigator_main.cpp:void Navigator::reset_triplets()                                                        
./src/modules/navigator/mission.cpp:			_navigator->reset_triplets();                                                      
./src/modules/navigator/mission_base.cpp:		_navigator->reset_triplets();                                                      
./src/modules/navigator/navigator.h:	void reset_triplets();                                                                     
```
</details>


### Please review!

Despite sim testing everything, I cannot completely rule out changing the behaviour in a subtle, possibly detrimental way - I am looking forward to comments assessing this risk (maybe I requested reviews a bit too generously - only review if you feel like you can give a good review without wasting hours :) 

P.S. the diff in `loiter.cpp` looks less scary when viewed with `?w=1` (web) or `-w` (terminal)
