### PR TITLE
µxrce-dds: add parameter services to get and set parameters

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -255,6 +255,10 @@ set(msg_files
 	versioned/LongitudinalControlConfiguration.msg
 	versioned/ManualControlSetpoint.msg
 	versioned/ModeCompleted.msg
+	versioned/ParameterGetRequest.msg
+	versioned/ParameterGetReply.msg
+	versioned/ParameterSetRequest.msg
+	versioned/ParameterSetReply.msg
 	versioned/RegisterExtComponentReply.msg
 	versioned/RegisterExtComponentRequest.msg
 	versioned/TrajectorySetpoint.msg

--- a/msg/versioned/ParameterGetReply.msg
+++ b/msg/versioned/ParameterGetReply.msg
@@ -1,0 +1,19 @@
+uint32 MESSAGE_VERSION = 0
+
+uint64 timestamp
+
+uint8 TYPE_INT32 = 1
+uint8 TYPE_FLOAT = 2
+uint8 param_type
+
+int32 int_value
+float32 real_value
+
+uint16 param_count 		# total number of parameters
+int16 param_index		# index of the returned parameter
+char[16] param_id		# name of the returned parameter
+
+bool success			# false if the parameter doesn't exist
+
+uint8 ORB_QUEUE_LENGTH = 4
+

--- a/msg/versioned/ParameterGetRequest.msg
+++ b/msg/versioned/ParameterGetRequest.msg
@@ -1,0 +1,8 @@
+uint32 MESSAGE_VERSION = 0
+
+uint64 timestamp
+int16 param_index     # index of the parameter to get, -1 to use param_id
+char[16] param_id     # name of the parameter to get, used if param_index is -1
+
+uint8 ORB_QUEUE_LENGTH = 64
+

--- a/msg/versioned/ParameterSetReply.msg
+++ b/msg/versioned/ParameterSetReply.msg
@@ -1,0 +1,18 @@
+uint32 MESSAGE_VERSION = 0
+
+uint64 timestamp
+
+uint8 TYPE_INT32 = 1
+uint8 TYPE_FLOAT = 2
+uint8 param_type
+
+int32 int_value
+float32 real_value
+
+int16 param_index		# index of the returned parameter
+char[16] param_id		# name of the returned parameter
+
+bool success			# false if the parameter doesn't exist or couldn't be set
+
+uint8 ORB_QUEUE_LENGTH = 4
+

--- a/msg/versioned/ParameterSetRequest.msg
+++ b/msg/versioned/ParameterSetRequest.msg
@@ -1,0 +1,16 @@
+uint32 MESSAGE_VERSION = 0
+
+uint64 timestamp
+
+int16 param_index     		# index of the parameter to set, -1 to use param_id
+char[16] param_id		# name of the parameter to set, used if param_index is -1
+
+uint8 TYPE_INT32 = 1
+uint8 TYPE_FLOAT = 2
+uint8 param_type
+
+int32 int_value
+float32 real_value
+
+uint8 ORB_QUEUE_LENGTH = 32
+

--- a/src/modules/uxrce_dds_client/CMakeLists.txt
+++ b/src/modules/uxrce_dds_client/CMakeLists.txt
@@ -144,6 +144,8 @@ else()
 			vehicle_command_srv.h
 			srv_base.cpp
 			srv_base.h
+			parameter_srv.cpp
+			parameter_srv.h
 		DEPENDS
 			git_micro_xrce_dds_client
 			libmicroxrceddsclient_project

--- a/src/modules/uxrce_dds_client/parameter_srv.cpp
+++ b/src/modules/uxrce_dds_client/parameter_srv.cpp
@@ -1,0 +1,243 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "parameter_srv.h"
+#include <drivers/drv_hrt.h>
+#include <lib/mathlib/mathlib.h>
+#include <px4_platform_common/log.h>
+#include <uORB/ucdr/parameter_get_request.h>
+#include <uORB/ucdr/parameter_get_reply.h>
+#include <uORB/ucdr/parameter_set_request.h>
+#include <uORB/ucdr/parameter_set_reply.h>
+
+static param_t resolve_param(int16_t param_index, const char *param_id)
+{
+	param_t param = PARAM_INVALID;
+
+	if (param_index >= 0) {
+		// Get parameter by index
+		param = param_for_used_index((unsigned)param_index);
+	} else {
+		// Get parameter by name
+		param = param_find_no_notification(param_id);
+	}
+
+	return param;
+}
+
+template <typename ReplyType>
+static void populate_reply(ReplyType &reply, param_t param)
+{
+	reply.param_index = param_get_used_index(param);
+
+	// Copy name
+	const char *name = param_name(param);
+	strncpy(reply.param_id, name, sizeof(reply.param_id));
+
+	// Get type and value
+	param_type_t type = param_type(param);
+
+	if (type == PARAM_TYPE_INT32) {
+		reply.param_type = ReplyType::TYPE_INT32;
+		int32_t val;
+
+		if (param_get(param, &val) == 0) {
+			reply.int_value = val;
+			reply.success = true;
+		}
+
+	} else if (type == PARAM_TYPE_FLOAT) {
+		reply.param_type = ReplyType::TYPE_FLOAT;
+		float val;
+
+		if (param_get(param, &val) == 0) {
+			reply.real_value = val;
+			reply.success = true;
+		}
+	}
+}
+
+// ParameterGetSrv Implementation
+
+ParameterGetSrv::ParameterGetSrv(uxrSession *session, uxrStreamId reliable_out_stream_id,
+				 uxrStreamId input_stream_id, uxrObjectId participant_id, const char *client_namespace, const uint8_t index) :
+	SrvBase(session, reliable_out_stream_id, input_stream_id, participant_id)
+{
+	uint16_t queue_depth = orb_get_queue_size(ORB_ID(parameter_get_request));
+	create_replier(input_stream_id, participant_id, index, client_namespace, "param_get", "ParameterGet",
+		       queue_depth);
+};
+
+bool ParameterGetSrv::process_request(ucdrBuffer *ub, const int64_t time_offset_us)
+{
+	parameter_get_request_s req;
+
+	if (ucdr_deserialize_parameter_get_request(*ub, req, time_offset_us)) {
+
+		parameter_get_reply_s reply{};
+		reply.timestamp = hrt_absolute_time();
+		reply.success = false;
+		reply.param_count = param_count_used();
+
+		param_t param = resolve_param(req.param_index, req.param_id);
+
+		if (param != PARAM_INVALID) {
+			populate_reply(reply, param);
+
+		} else {
+			// Parameter not found
+			reply.success = false;
+
+			// Even if not found, we might want to populate param_id if it was a by-name lookup
+			// But if invalid name, we can't do much.
+			if (req.param_index < 0) {
+				strncpy(reply.param_id, req.param_id, sizeof(reply.param_id));
+			}
+		}
+
+		// Send reply
+		ucdrBuffer reply_ub;
+		const uint32_t topic_size = ucdr_topic_size_parameter_get_reply();
+		uint8_t reply_buffer[topic_size];
+		// Zero out buffer for safety
+		memset(reply_buffer, 0, sizeof(reply_buffer));
+
+		const int64_t reply_time_offset_us = session_->time_offset / 1000; // ns -> us
+		ucdr_init_buffer(&reply_ub, reply_buffer, sizeof(reply_buffer));
+
+		if (ucdr_serialize_parameter_get_reply(&reply, reply_ub, reply_time_offset_us)) {
+			uxr_buffer_reply(session_, reliable_out_stream_id_, replier_id_, &sample_id_, reply_buffer, sizeof(reply_buffer));
+		} else {
+			PX4_ERR("Param Get Reply serialization failed");
+		}
+	} else {
+		PX4_ERR("Param Get Request deserialization failed");
+	}
+
+	return true;
+}
+
+bool ParameterGetSrv::process_reply()
+{
+	return false;
+}
+
+// ParameterSetSrv Implementation
+
+ParameterSetSrv::ParameterSetSrv(uxrSession *session, uxrStreamId reliable_out_stream_id,
+				 uxrStreamId input_stream_id, uxrObjectId participant_id, const char *client_namespace, const uint8_t index) :
+	SrvBase(session, reliable_out_stream_id, input_stream_id, participant_id)
+{
+	uint16_t queue_depth = orb_get_queue_size(ORB_ID(parameter_set_request));
+	create_replier(input_stream_id, participant_id, index, client_namespace, "param_set", "ParameterSet",
+		       queue_depth);
+};
+
+bool ParameterSetSrv::process_request(ucdrBuffer *ub, const int64_t time_offset_us)
+{
+	parameter_set_request_s req;
+
+	if (ucdr_deserialize_parameter_set_request(*ub, req, time_offset_us)) {
+		parameter_set_reply_s reply{};
+		reply.timestamp = hrt_absolute_time();
+		reply.success = false;
+
+		param_t param = resolve_param(req.param_index, req.param_id);
+
+		if (param != PARAM_INVALID) {
+			param_type_t type = param_type(param);
+
+			bool set_success = false;
+			bool read_success = false;
+
+			if (type == PARAM_TYPE_INT32) {
+				if (req.param_type == parameter_set_request_s::TYPE_INT32) {
+					int32_t val = req.int_value;
+
+					if (param_set(param, &val) == 0) {
+						set_success = true;
+					}
+				}
+
+			} else if (type == PARAM_TYPE_FLOAT) {
+				if (req.param_type == parameter_set_request_s::TYPE_FLOAT) {
+					float val = req.real_value;
+
+					if (param_set(param, &val) == 0) {
+						set_success = true;
+					}
+				}
+			}
+
+			// Populate reply with current value (updated or not)
+			populate_reply(reply, param);
+			// populate_reply sets success=true only if it can READ the value.
+			read_success = reply.success;
+
+			// For a set request we only want success=true if the SET worked
+			// and we successfully read back the current value.
+			reply.success = set_success && read_success;
+
+		} else {
+			// Not found, fill ID from request for context
+			if (req.param_index < 0) {
+				strncpy(reply.param_id, req.param_id, sizeof(reply.param_id));
+			}
+		}
+
+		// Send reply
+		ucdrBuffer reply_ub;
+		const uint32_t topic_size = ucdr_topic_size_parameter_set_reply();
+		uint8_t reply_buffer[topic_size];
+		// Zero out buffer
+		memset(reply_buffer, 0, sizeof(reply_buffer));
+
+		const int64_t reply_time_offset_us = session_->time_offset / 1000; // ns -> us
+		ucdr_init_buffer(&reply_ub, reply_buffer, sizeof(reply_buffer));
+
+		if (ucdr_serialize_parameter_set_reply(&reply, reply_ub, reply_time_offset_us)) {
+			uxr_buffer_reply(session_, reliable_out_stream_id_, replier_id_, &sample_id_, reply_buffer, sizeof(reply_buffer));
+		} else {
+			PX4_ERR("Param Set Reply serialization failed");
+		}
+	} else {
+		PX4_ERR("Param Set Request deserialization failed");
+	}
+
+	return true;
+}
+
+bool ParameterSetSrv::process_reply()
+{
+	return false;
+}

--- a/src/modules/uxrce_dds_client/parameter_srv.h
+++ b/src/modules/uxrce_dds_client/parameter_srv.h
@@ -1,0 +1,89 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "srv_base.h"
+#include <lib/parameters/param.h>
+
+/**
+ * @see SrvBase
+ * @class ParameterGetSrv The ParameterGetSrv class implement the parameter get/list service server.
+ */
+class ParameterGetSrv : public SrvBase
+{
+public:
+	/**
+	 * @brief Constructor.
+	 * @see SrvBase.
+	 * @param client_namespace namespace for the client service.
+	 * @param index index used to create the replier id.
+	 * @return Returns false iff successful, otherwise false.
+	 */
+	ParameterGetSrv(uxrSession *session, uxrStreamId reliable_out_stream_id, uxrStreamId input_stream_id,
+		     uxrObjectId participant_id, const char *client_namespace, const uint8_t index);
+
+	~ParameterGetSrv() = default;
+
+	/** @see SrvBase */
+	bool process_request(ucdrBuffer *ub, const int64_t time_offset_us) override;
+
+	/** @see SrvBase */
+	bool process_reply() override;
+};
+
+/**
+ * @see SrvBase
+ * @class ParameterSetSrv The ParameterSetSrv class implement the parameter set service server.
+ */
+class ParameterSetSrv : public SrvBase
+{
+public:
+	/**
+	 * @brief Constructor.
+	 * @see SrvBase.
+	 * @param client_namespace namespace for the client service.
+	 * @param index index used to create the replier id.
+	 * @return Returns false iff successful, otherwise false.
+	 */
+	ParameterSetSrv(uxrSession *session, uxrStreamId reliable_out_stream_id, uxrStreamId input_stream_id,
+		     uxrObjectId participant_id, const char *client_namespace, const uint8_t index);
+
+	~ParameterSetSrv() = default;
+
+	/** @see SrvBase */
+	bool process_request(ucdrBuffer *ub, const int64_t time_offset_us) override;
+
+	/** @see SrvBase */
+	bool process_reply() override;
+};

--- a/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
+++ b/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
@@ -39,6 +39,7 @@
 
 // services
 #include "vehicle_command_srv.h"
+#include "parameter_srv.h"
 
 #include <uxr/client/client.h>
 #include <uxr/client/util/ping.h>
@@ -366,7 +367,24 @@ bool UxrceddsClient::setupSession(uxrSession *session)
 	if (_num_of_repliers < MAX_NUM_REPLIERS) {
 		if (add_replier(new VehicleCommandSrv(session, _reliable_out, reliable_in, _participant_id, _client_namespace,
 						      _num_of_repliers))) {
-			PX4_ERR("replier init failed");
+			PX4_ERR("vehicle command replier init failed");
+			return false;
+		}
+	}
+
+	// create Parameter repliers
+	if (_num_of_repliers < MAX_NUM_REPLIERS) {
+		if (add_replier(new ParameterGetSrv(session, _reliable_out, reliable_in, _participant_id, _client_namespace,
+						 _num_of_repliers))) {
+			PX4_ERR("param get replier init failed");
+			return false;
+		}
+	}
+
+	if (_num_of_repliers < MAX_NUM_REPLIERS) {
+		if (add_replier(new ParameterSetSrv(session, _reliable_out, reliable_in, _participant_id, _client_namespace,
+						 _num_of_repliers))) {
+			PX4_ERR("param set replier init failed");
 			return false;
 		}
 	}

--- a/srv/ParameterGet.srv
+++ b/srv/ParameterGet.srv
@@ -1,0 +1,4 @@
+ParameterGetRequest request
+---
+ParameterGetReply reply
+

--- a/srv/ParameterSet.srv
+++ b/srv/ParameterSet.srv
@@ -1,0 +1,4 @@
+ParameterSetRequest request
+---
+ParameterSetReply reply
+


### PR DESCRIPTION
### Solved Problem
At the moment if you want to get and set parameters from a companion computer the only real interface you have is MAVLink. There is no convenient way to change parameters over µXRCE-DDS from ROS 2.

### Solution
This PR adds two new services, one to get and one to set parameters over µXRCE-DDS either by name or by index.

To achieve this, 4 new versioned messages where created that are used in two service definitions. The µXRCE-DDS services follow the implementation of the Vehicle Command service closely but differ because they don't need to provide a response async.

One of the inconvenient parts is that we have to use `char[16]` for the name and can't use `string` as far as I know. We would need to add a wrapper around this on the ROS 2 side in e.g. [px4-ros2-interface-lib](https://github.com/Auterion/px4-ros2-interface-lib).

If you want to test this, I have a simple ROS 2 python package to test getting a parameter: [px4_parameter.zip](https://github.com/user-attachments/files/23968203/px4_parameter.zip)


### Alternatives
Instead of using services we could use topics directly with the messages added here. It is unclear to me if that would have a positive performance impact when getting or setting a lot of parameters at once. With the services from my Laptop with a Python test node, connected to a Pixhawk 6X over ethernet I'm seeing  about 15ms round-trip on average while a ping is 1.2 - 1.7ms and I've measured the µXRCE-DDS packet round-trip to be between 5 and 11ms in a wireshark capture. 

```
ros2 run px4_parameter px4_parameter_get
Starting benchmark for parameter 'MPC_XY_VEL_MAX' with 500 iterations...
Progress: 500/500

========================================
Benchmark Results (500 samples)
========================================
Average Time:        15.1521 ms
Standard Deviation:  5.4943 ms
Min Time:            5.3019 ms
Max Time:            36.4480 ms
========================================
```

### Open questions
- I haven't looked at how to implement this for Zenoh. I don't think Zenoh should block this PR but we should probably have a path to get feature parity in follow-up PRs.

@beniaminopozzan we discussed this feature at the PX4 dev summit, not sure if this is exactly what you had in mind. I'm open to feedback on how to improve this. 