### PR TITLE
Fix: `actuator_outputs` and `esc_status` topic not logged for UAVCAN

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -480,6 +480,19 @@ else
 	fi
 
 	#
+	# Optional UAVCAN/DroneCAN or Cyphal
+	#
+	if param greater -s UAVCAN_ENABLE 0
+	then
+		uavcan start
+	else
+		if param greater -s CYPHAL_ENABLE 0
+		then
+			cyphal start
+		fi
+	fi
+
+	#
 	# Configure vehicle type specific parameters.
 	# Note: rc.vehicle_setup is the entry point for all vehicle type specific setup.
 	. ${R}etc/init.d/rc.vehicle_setup
@@ -506,6 +519,11 @@ else
 	# Note: rc.serial is auto-generated from Tools/serial/generate_config.py
 	#
 	. ${R}etc/init.d/rc.serial
+
+	if param greater -s ZENOH_ENABLE 0
+	then
+		zenoh start
+	fi
 
 	# Must be started after the serial config is read
 	rc_input start $RC_INPUT_ARGS
@@ -627,27 +645,6 @@ else
 		sh $BOARD_BOOTLOADER_UPGRADE
 	fi
 	unset BOARD_BOOTLOADER_UPGRADE
-
-	#
-	# Check if UAVCAN is enabled, default to it for ESCs.
-	#
-	if param greater -s UAVCAN_ENABLE 0
-	then
-		# Start core UAVCAN module.
-		if ! uavcan start
-		then
-			tune_control play error
-		fi
-	else
-		if param greater -s CYPHAL_ENABLE 0
-		then
-			cyphal start
-		fi
-	fi
-	if param greater -s ZENOH_ENABLE 0
-	then
-		zenoh start
-	fi
 
 #
 # End of autostart.


### PR DESCRIPTION
### Solved Problem
`actuator_outputs` topic never logged for UAVCAN-powered vehicles.

Problem found here: https://github.com/PX4/PX4-Autopilot/pull/20597#issuecomment-3633248382
> `actuator_outputs` is an optional topic
> advertised before logger starts
> pr starts UAVCAN after logger nothing gets logged anymore

### Solution
Change order again to some extent reverting https://github.com/PX4/PX4-Autopilot/pull/20597
- UAVCAN is still started directly before logger and not early on like before.
- zenoh is also started before logger because it could publish potentially optional uORB topics from external components which should be logged. (FYI @PetervdPerk-NXP )

### Changelog Entry
```
Fix: `actuator_outputs` and `esc_status` topic not logged for UAVCAN
```

### Test coverage
I verified on fmu-v5x hardware (Skynode) that this indeed fixes the problem exactly because of the order.

### Context
Before: `actuator_outputs` only logged after manually restarting logger after every boot
<img width="400" alt="Untitled" src="https://github.com/user-attachments/assets/4071046b-0076-4dd5-9f30-bd300597f821" />

After: `actuator_outputs` logged as expected
<img width="400" alt="image" src="https://github.com/user-attachments/assets/3cbb4068-616e-420f-8a7c-fd44db15d04d" />

