### PR TITLE
docs: battery: clarify BAT${i}_SOURCE parameter documentation

### DIFF
--- a/msg/px4_msgs_old/msg/BatteryStatusV0.msg
+++ b/msg/px4_msgs_old/msg/BatteryStatusV0.msg
@@ -22,7 +22,7 @@ uint8 cell_count # [@invalid 0] Number of cells
 
 uint8 source # [@enum SOURCE] Battery source
 uint8 SOURCE_POWER_MODULE = 0 # Power module (analog ADC or I2C power monitor)
-uint8 SOURCE_EXTERNAL = 1 # External (MAVLink or external driver)
+uint8 SOURCE_EXTERNAL = 1 # External (MAVLink, CAN, or external driver)
 uint8 SOURCE_ESCS = 2 # ESCs (via ESC telemetry)
 
 uint8 priority # Zero based priority is the connection on the Power Controller V1..Vn AKA BrickN-1

--- a/msg/px4_msgs_old/msg/BatteryStatusV0.msg
+++ b/msg/px4_msgs_old/msg/BatteryStatusV0.msg
@@ -21,9 +21,9 @@ uint8 cell_count # [@invalid 0] Number of cells
 
 
 uint8 source # [@enum SOURCE] Battery source
-uint8 SOURCE_POWER_MODULE = 0 # Power module
-uint8 SOURCE_EXTERNAL = 1 # External
-uint8 SOURCE_ESCS = 2 # ESCs
+uint8 SOURCE_POWER_MODULE = 0 # Power module (analog ADC or I2C power monitor)
+uint8 SOURCE_EXTERNAL = 1 # External (MAVLink or external driver)
+uint8 SOURCE_ESCS = 2 # ESCs (via ESC telemetry)
 
 uint8 priority # Zero based priority is the connection on the Power Controller V1..Vn AKA BrickN-1
 uint16 capacity # [mAh] Capacity of the battery when fully charged

--- a/msg/versioned/BatteryStatus.msg
+++ b/msg/versioned/BatteryStatus.msg
@@ -22,9 +22,9 @@ uint8 cell_count           # [-] [@invalid 0] Number of cells
 
 
 uint8 source                   # [@enum SOURCE] Battery source
-uint8 SOURCE_POWER_MODULE = 0  # Power module
-uint8 SOURCE_EXTERNAL = 1      # External
-uint8 SOURCE_ESCS = 2          # ESCs
+uint8 SOURCE_POWER_MODULE = 0  # Power module (analog ADC or I2C power monitor)
+uint8 SOURCE_EXTERNAL = 1      # External (MAVLink or external driver)
+uint8 SOURCE_ESCS = 2          # ESCs (via ESC telemetry)
 
 uint8 priority                # [-] Zero based priority is the connection on the Power Controller V1..Vn AKA BrickN-1
 uint16 capacity               # [mAh] Capacity of the battery when fully charged

--- a/msg/versioned/BatteryStatus.msg
+++ b/msg/versioned/BatteryStatus.msg
@@ -23,7 +23,7 @@ uint8 cell_count           # [-] [@invalid 0] Number of cells
 
 uint8 source                   # [@enum SOURCE] Battery source
 uint8 SOURCE_POWER_MODULE = 0  # Power module (analog ADC or I2C power monitor)
-uint8 SOURCE_EXTERNAL = 1      # External (MAVLink or external driver)
+uint8 SOURCE_EXTERNAL = 1      # External (MAVLink, CAN, or external driver)
 uint8 SOURCE_ESCS = 2          # ESCs (via ESC telemetry)
 
 uint8 priority                # [-] Zero based priority is the connection on the Power Controller V1..Vn AKA BrickN-1

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -112,7 +112,7 @@ parameters:
                     voltage divider and current shunt, or an external analog power module.
                     I2C power monitors are digital sensors on the I2C bus.
                     If the value is set to 'External' then the system expects to receive MAVLink
-                    battery status messages or the battery data is published by an external driver.
+                    or CAN battery status messages, or the battery data is published by an external driver.
                     If the value is set to 'ESCs', the battery information are taken from the esc_status message.
                     This requires the ESC to provide both voltage as well as current (via ESC telemetry).
             type: enum

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -105,7 +105,7 @@ parameters:
             description:
                 short: Battery ${i} monitoring source.
                 long: |
-                    This parameter controls the source of battery data. The value 'Power Module'
+                    This parameter controls the source of battery data. The value 'Power Module / Analog'
                     means that measurements are expected to come from either analog (ADC) inputs
                     or an I2C power monitor (e.g. INA226). Analog inputs are voltage and current
                     measurements read from the board's ADC channels, typically from an onboard

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -111,7 +111,7 @@ parameters:
                     measurements read from the board's ADC channels, typically from an onboard
                     voltage divider and current shunt, or an external analog power module.
                     I2C power monitors are digital sensors on the I2C bus.
-                    If the value is set to 'External' then the system expects to receive mavlink
+                    If the value is set to 'External' then the system expects to receive MAVLink
                     battery status messages or the battery data is published by an external driver.
                     If the value is set to 'ESCs', the battery information are taken from the esc_status message.
                     This requires the ESC to provide both voltage as well as current (via ESC telemetry).

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -106,14 +106,19 @@ parameters:
                 short: Battery ${i} monitoring source.
                 long: |
                     This parameter controls the source of battery data. The value 'Power Module'
-                    means that measurements are expected to come from a power module. If the value is set to
-                    'External' then the system expects to receive mavlink battery status messages.
+                    means that measurements are expected to come from either analog (ADC) inputs
+                    or an I2C power monitor (e.g. INA226). Analog inputs are voltage and current
+                    measurements read from the board's ADC channels, typically from an onboard
+                    voltage divider and current shunt, or an external analog power module.
+                    I2C power monitors are digital sensors on the I2C bus.
+                    If the value is set to 'External' then the system expects to receive mavlink
+                    battery status messages or the battery data is published by an external driver.
                     If the value is set to 'ESCs', the battery information are taken from the esc_status message.
-                    This requires the ESC to provide both voltage as well as current.
+                    This requires the ESC to provide both voltage as well as current (via ESC telemetry).
             type: enum
             values:
                 -1: Disabled
-                0: Power Module
+                0: Power Module / Analog
                 1: External
                 2: ESCs
             reboot_required: true


### PR DESCRIPTION
Clarify BAT${i}_SOURCE parameter documentation to explain that Power Module covers both analog ADC inputs and I2C power monitors.