### PR TITLE
Add x500_lidar_2d_down airframe configuration

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4015_gz_x500_lidar_2d_down
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4015_gz_x500_lidar_2d_down
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# @name Gazebo x500 with dual LiDAR (horizontal + downward)
+#
+# @type Quadrotor
+#
+
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500_lidar_2d_down}
+
+. ${R}etc/init.d-posix/airframes/4001_gz_x500
+

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -82,6 +82,7 @@ px4_add_romfs_files(
 	4011_gz_lawnmower
 	4013_gz_x500_lidar_2d
 	4014_gz_x500_mono_cam_down
+	4015_gz_x500_lidar_2d_down
 	4016_gz_x500_lidar_down
 	4017_gz_x500_lidar_front
 	4018_gz_quadtailsitter


### PR DESCRIPTION
- New airframe 4015 for x500 with 2D LiDAR and downward rangefinder
- Configured for collision avoidance testing

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
