### PR TITLE
[issue: 26076] added config for prearm to be a toggle button

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2113,6 +2113,7 @@ bool Commander::getPrearmState() const
 		return hrt_elapsed_time(&_boot_timestamp) > 5_s;
 
 	case PrearmedMode::SAFETY_BUTTON:
+	case PrearmedMode::TOGGLE_BUTTON:
 		if (_safety.isButtonAvailable()) {
 			/* safety button is present, go into prearmed if safety is off */
 			return _safety.isSafetyOff();
@@ -2203,7 +2204,11 @@ void Commander::landDetectorUpdate()
 
 void Commander::safetyButtonUpdate()
 {
-	const bool safety_changed = _safety.safetyButtonHandler();
+	// use toggle button if configured and not armed
+	bool is_toggle = (PrearmedMode)_param_com_prearm_mode.get() == PrearmedMode::TOGGLE_BUTTON;
+	bool allow_toggle = is_toggle && !isArmed();
+
+	const bool safety_changed = _safety.safetyButtonHandler(allow_toggle);
 	_vehicle_status.safety_button_available = _safety.isButtonAvailable();
 	_vehicle_status.safety_off = _safety.isSafetyOff();
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -204,7 +204,8 @@ private:
 	enum class PrearmedMode {
 		DISABLED = 0,
 		SAFETY_BUTTON = 1,
-		ALWAYS = 2
+		TOGGLE_BUTTON = 2,
+		ALWAYS = 3
 	};
 
 	enum class RcOverrideBits : int32_t {

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -204,8 +204,8 @@ private:
 	enum class PrearmedMode {
 		DISABLED = 0,
 		SAFETY_BUTTON = 1,
-		TOGGLE_BUTTON = 2,
-		ALWAYS = 3
+		ALWAYS = 2,
+		TOGGLE_BUTTON = 3
 	};
 
 	enum class RcOverrideBits : int32_t {

--- a/src/modules/commander/Safety.cpp
+++ b/src/modules/commander/Safety.cpp
@@ -51,7 +51,7 @@ Safety::Safety()
 	}
 }
 
-bool Safety::safetyButtonHandler()
+bool Safety::safetyButtonHandler(bool is_toggle)
 {
 	if (!_safety_disabled) {
 		if (!_button_available && _safety_button_sub.advertised()) {
@@ -61,7 +61,10 @@ bool Safety::safetyButtonHandler()
 		button_event_s button_event;
 
 		while (_safety_button_sub.update(&button_event)) {
-			_safety_off |= button_event.triggered; // triggered safety button activates safety off
+			if (button_event.triggered) {
+				// triggered safety button either toggles value or activates safety off
+				_safety_off = (is_toggle) ? !_safety_off : true;
+			}
 		}
 	}
 

--- a/src/modules/commander/Safety.hpp
+++ b/src/modules/commander/Safety.hpp
@@ -47,7 +47,7 @@ public:
 	Safety();
 	~Safety() = default;
 
-	bool safetyButtonHandler();
+	bool safetyButtonHandler(bool is_toggle = false);
 	void activateSafety();
 	void deactivateSafety();
 	bool isButtonAvailable() const { return _button_available; }

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -695,8 +695,8 @@ PARAM_DEFINE_INT32(COM_ARM_CHK_ESCS, 0);
  *
  * @value 0 Disabled
  * @value 1 Safety button
- * @value 2 Toggle button
- * @value 3 Always
+ * @value 2 Always
+ * @value 3 Toggle button
  *
  * @group Commander
  */

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -695,7 +695,8 @@ PARAM_DEFINE_INT32(COM_ARM_CHK_ESCS, 0);
  *
  * @value 0 Disabled
  * @value 1 Safety button
- * @value 2 Always
+ * @value 2 Toggle button
+ * @value 3 Always
  *
  * @group Commander
  */


### PR DESCRIPTION
### Solved Problem
Fixes #26076

### Solution

To allow the rearm safety control (enabled or disabled servo outputs) I propose:

1. The COM_PREARM_MODE parameter should have a new option for Toggle Button
2. The safety_off should be toggled when the safety button is pressed (button triggered)
3. The toggle should be allowed if not armed and disabled if armed for safety
    - i.e. if the vehicle is armed, then any button press should be ignored


