### PR TITLE
FwModeManager:  don't skip takeoff detection if not yet in air

### DIFF
--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -1280,7 +1280,7 @@ FixedWingModeManager::control_auto_takeoff_no_nav(const hrt_abstime &now, const 
 			_launch_current_yaw = _yaw;
 		}
 
-		if (_skipping_takeoff_detection) {
+		if (_skipping_takeoff_detection && _runway_takeoff.getState() > RunwayTakeoffState::CLAMPED_TO_RUNWAY) {
 			_runway_takeoff.forceSetFlyState();
 		}
 


### PR DESCRIPTION
<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
