### PR TITLE
msg: GpsDump: queue 8->16 and instance->device_id

### DIFF
--- a/msg/GpsDump.msg
+++ b/msg/GpsDump.msg
@@ -2,6 +2,10 @@
 
 uint64 timestamp # time since system start (microseconds)
 
+uint8 INSTANCE_MAIN = 0
+uint8 INSTANCE_SECONDARY = 1
+
+uint8 instance   # Instance of GNSS receiver
 uint32 device_id
 uint8 len        # length of data, MSB bit set = message to the gps device,
                  # clear = message from the device

--- a/src/drivers/gnss/septentrio/septentrio.cpp
+++ b/src/drivers/gnss/septentrio/septentrio.cpp
@@ -1728,6 +1728,7 @@ void SeptentrioDriver::publish_rtcm_corrections(uint8_t *data, size_t len)
 void SeptentrioDriver::dump_gps_data(const uint8_t *data, size_t len, DataDirection data_direction)
 {
 	gps_dump_s *dump_data = data_direction == DataDirection::FromReceiver ? _message_data_from_receiver : _message_data_to_receiver;
+	dump_data->instance = _instance == Instance::Main ? gps_dump_s::INSTANCE_MAIN : gps_dump_s::INSTANCE_SECONDARY;
 	dump_data->device_id = get_device_id();
 
 	while (len > 0) {

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -695,6 +695,7 @@ void GPS::dumpGpsData(uint8_t *data, size_t len, gps_dump_comm_mode_t mode, bool
 		return;
 	}
 
+	dump_data->instance = (uint8_t)_instance;
 	dump_data->device_id = get_device_id();
 
 	while (len > 0) {


### PR DESCRIPTION
RTCM bursts are on average 462 bytes for MSM4 and 732 bytes for MSM7. With `uint8[79] data` and `ORB_QUEUE_LENGTH = 8` = 632, so data is lost.

Using `device_id` is superior to `instance` since the instance can change depending on the startup timing - on CAN this is a regular occurence.