### PR TITLE
uavcannode: publisher: MovingBaseLine enhancements

### DIFF
--- a/src/drivers/uavcannode/Publishers/MovingBaselineData.hpp
+++ b/src/drivers/uavcannode/Publishers/MovingBaselineData.hpp
@@ -38,7 +38,6 @@
 #include <ardupilot/gnss/MovingBaselineData.hpp>
 
 #include <lib/drivers/device/Device.hpp>
-#include <drivers/drv_hrt.h>
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/gps_inject_data.h>
 


### PR DESCRIPTION
In the CANnode MovingBaseLine publisher:
- publish all GpsInjectData updates during the update cycle. 
- Check and report data loss via uorb generation counter. 
- Only registerCallback outside of the loop.

This is important to ensure minimal latency of RTCM epoch data.