### PR TITLE
logger: gps_dump non-optional

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -76,7 +76,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("gain_compression", 100);
 	add_topic("gimbal_manager_set_attitude", 500);
 	add_optional_topic("generator_status");
-	add_optional_topic("gps_dump");
+	add_topic("gps_dump");
 	add_optional_topic("gimbal_controls", 200);
 	add_optional_topic("gripper");
 	add_optional_topic("heater_status");


### PR DESCRIPTION
The topic doesn't show up in the log because logger starts before data is received.