### PR TITLE
ci: sitl_tests: disable standard_vtol

### DIFF
--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -34,7 +34,7 @@ jobs:
         config:
           - {model: "iris",          latitude:  "59.617693", longitude: "-151.145316", altitude:  "48", build_type: "RelWithDebInfo" } # Alaska
           - {model: "tailsitter" ,   latitude:  "29.660316", longitude:  "-82.316658", altitude:  "30", build_type: "RelWithDebInfo" } # Florida
-          - {model: "standard_vtol", latitude:  "47.397742", longitude:    "8.545594", altitude: "488", build_type: "Coverage" } # Zurich
+          # - {model: "standard_vtol", latitude:  "47.397742", longitude:    "8.545594", altitude: "488", build_type: "Coverage" } # Zurich
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This SITL test always fails. I suggest we disable it in the meantime so we can at least get our CI passing and not spamming every PR with CI failures for this one test. Once we've fixed our CI SITL tests we can re-enable