### PR TITLE
mavlink: don't send out GPS_GLOBAL_ORIGIN too early

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1283,8 +1283,6 @@ MavlinkReceiver::handle_message_set_gps_global_origin(mavlink_message_t *msg)
 		vcmd.timestamp = hrt_absolute_time();
 		_cmd_pub.publish(vcmd);
 	}
-
-	handle_request_message_command(MAVLINK_MSG_ID_GPS_GLOBAL_ORIGIN);
 }
 
 #if defined(MAVLINK_MSG_ID_SET_VELOCITY_LIMITS) // For now only defined if development.xml is used


### PR DESCRIPTION
This prevents PX4 from sending out the GPS_GLOBAL_ORIGIN message immediately when a SET_GPS_GLOBAL_ORIGIN message arrives.

Instead, we apply the new origin in the EKF, and only then send out the new origin, which is much more intuitive and doesn't confuse a user of the API.

This came up when testing https://github.com/mavlink/MAVSDK/pull/2738.