### PR TITLE
gps: use UTC timestamp when GPS fixed

### DIFF
--- a/src/modules/mavlink/streams/GPS2_RAW.hpp
+++ b/src/modules/mavlink/streams/GPS2_RAW.hpp
@@ -68,7 +68,13 @@ private:
 		hrt_abstime now{};
 
 		if (_sensor_gps_sub.update(&gps)) {
-			msg.time_usec = gps.timestamp;
+			if (gps.time_utc_usec > 0) {
+				msg.time_usec = gps.timestamp;
+
+			} else {
+				msg.time_usec = gps.time_utc_usec;
+			}
+
 			msg.fix_type = gps.fix_type;
 			msg.lat = static_cast<int32_t>(round(gps.latitude_deg * 1e7));
 			msg.lon = static_cast<int32_t>(round(gps.longitude_deg * 1e7));

--- a/src/modules/mavlink/streams/GPS_RAW_INT.hpp
+++ b/src/modules/mavlink/streams/GPS_RAW_INT.hpp
@@ -68,7 +68,13 @@ private:
 		hrt_abstime now{};
 
 		if (_sensor_gps_sub.update(&gps)) {
-			msg.time_usec = gps.timestamp;
+			if (gps.time_utc_usec > 0) {
+				msg.time_usec = gps.timestamp;
+
+			} else {
+				msg.time_usec = gps.time_utc_usec;
+			}
+
 			msg.fix_type = gps.fix_type;
 			msg.lat = static_cast<int32_t>(round(gps.latitude_deg * 1e7));
 			msg.lon = static_cast<int32_t>(round(gps.longitude_deg * 1e7));


### PR DESCRIPTION

### Solved Problem

According to MAVLINK GPS_RAW_INT's field description: "Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number."

But now this field only filled with boot time. After this PR, this field will be GPS time when GPS is fixed.


