### PR TITLE
cuav_fmu-v6x: cuav-v6x_v2 iim42652 Sensor enable external clock

### DIFF
--- a/boards/cuav/fmu-v6x/init/rc.board_sensors
+++ b/boards/cuav/fmu-v6x/init/rc.board_sensors
@@ -68,7 +68,7 @@ fi
 
 bmi088 -A -R 4 -s start
 bmi088 -G -R 4 -s start
-iim42652 -R 6 -s start
+iim42652 -R 6 -s -C 32768 start
 icm45686 -R 2 -s start
 
 rm3100 -I -b 4 start


### PR DESCRIPTION
CUAV V6x V2 iim42652 Sensor enable external clock
