### PR TITLE
io timer: fix input capture on various boards

### DIFF
--- a/platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c
@@ -889,6 +889,7 @@ int io_timer_channel_init(unsigned channel, io_timer_channel_mode_t mode,
 
 	case IOTimerChanMode_Capture:
 		setbits = CCMR_C1_CAPTURE_INIT;
+		gpio = timer_io_channels[channel].gpio_in | GPIO_PULLUP;
 		break;
 
 	case IOTimerChanMode_CaptureDMA:


### PR DESCRIPTION
### Solved Problem
The Camera Capture functionality does not work on boards like the fmu-v6x (general, auterion, rt, ...) but does work on other boards (ark v6x, general v5x).

What can be observed is that despite being configured correctly in the "Actuator" tab the FMU would configure the pin as output and drive it low.

Debugging showed that the difference is the following.
**Working boards (in init.c)**:
```
__EXPORT void board_on_reset(int status)
{
	for (int i = 0; i < DIRECT_PWM_OUTPUT_CHANNELS; ++i) {
		px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
	}
    [...]
```
**Non-working boards (in int.c)**
```
__EXPORT void board_on_reset(int status)
{
	for (int i = 0; i < DIRECT_PWM_OUTPUT_CHANNELS; ++i) {
		px4_arch_configgpio(io_timer_channel_get_gpio_output(i));
	}
    [...]
```

The diff is due to https://github.com/PX4/PX4-Autopilot/pull/19535 being applied to some boards but not all.

### Solution
When a timer is initialized with `IOTimerChanMode_Capture`, as for example done via `up_input_capture_set` set the corresponding GPIO to an input with `PULLUP`.

Regarding the `PULLUP`:
- This matches the behavior of `IOTimerChanMode_CaptureDMA`
- This matches how other *inputs* like `RPMCapture` and `PPMCapture` behave when they use `PX4_MAKE_GPIO_EXTI(io_timer_channel_get_as_pwm_input(_channel));`

### Changelog Entry
For release notes:
```
Bugfix Fix input capture on various boards
```

### Alternatives
- Could also align the v6x to the v5x, yet I think it is better to do it in the timer init and not rely on the general board init to set the GPIO state that a certain module needs

### Test coverage
- Tested on an Auterion v6x (I also tested with the v6x init being adapted to the other inits, still works)
