### PR TITLE
mc_att: remove dependency to heading_god_for_control

### DIFF
--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -126,7 +126,6 @@ private:
 	SlewRate<float> _hover_thrust_slew_rate{.5f};
 
 	float _yaw_setpoint_stabilized{0.f};
-	bool _heading_good_for_control{true}; // initialized true to have heading lock when local position never published
 	float _unaided_heading{NAN}; // initialized NAN to not distract heading lock when local position never published
 	float _man_tilt_max{0.f};			/**< maximum tilt allowed for manual flight [rad] */
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -141,7 +141,7 @@ MulticopterAttitudeControl::generate_attitude_setpoint(const Quatf &q, float dt)
 	// Avoid accumulating absolute yaw error with arming stick gesture
 	const bool arming_gesture = (_manual_control_setpoint.throttle < -.9f) && (_param_mc_airmode.get() != 2);
 
-	if (arming_gesture || !_heading_good_for_control) {
+	if (arming_gesture) {
 		_yaw_setpoint_stabilized = NAN;
 	}
 
@@ -278,7 +278,6 @@ MulticopterAttitudeControl::Run()
 			vehicle_local_position_s vehicle_local_position;
 
 			if (_vehicle_local_position_sub.copy(&vehicle_local_position)) {
-				_heading_good_for_control = vehicle_local_position.heading_good_for_control;
 				_unaided_heading = vehicle_local_position.unaided_heading;
 			}
 		}


### PR DESCRIPTION
follows https://github.com/PX4/PX4-Autopilot/pull/24664


### Solved Problem
Without yaw initialization, heading lock is working in altitude mode, but not in stabilized

### Solution
Absolute heading is not required in stabilized mode and a change in heading convergence is already handled by the StickYaw class using unaided_heading
