### PR TITLE
workflows: remove stale comment to reduce notification spam

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
           remove-stale-when-updated: true
-          stale-issue-message: 'This issue has been marked as stale due to 90 days of inactivity. If no further activity occurs, it will be automatically closed in 30 days. Please leave a comment, add a reaction, make an update, or remove the stale label if you’d like to keep it open.'
-          close-issue-message: 'This issue has been closed due to prolonged inactivity after being marked as stale. If you believe this was closed in error or the topic is still relevant, please feel free to reopen it or create a new issue.'
-          stale-pr-message: 'This PR was identified as stale and it will be closed in 30 days unless any activity is detected.'
-          close-pr-message: 'This pull request has been closed after being marked as stale with no further activity. Thank you for the time and effort you put into this contribution. If you’d like to continue the discussion or update the work, please feel free to reopen it or submit a new PR.'
+          stale-issue-message: ''
+          close-issue-message: 'This issue has been automatically closed due to 120 days of inactivity. If you believe this is still relevant, please feel free to reopen it or create a new issue.'
+          stale-pr-message: ''
+          close-pr-message: 'This pull request has been automatically closed due to 120 days of inactivity. If you would like to continue, please feel free to reopen it or submit a new PR.'


### PR DESCRIPTION
The stale comments are spamming the inbox of everyone who watches the repo. This actively discourages people to watch the repo because these notifications frequently flood your inbox. It makes it much harder to parse the signal from the noise when skimming emails for relevant issues and PRs.