### PR TITLE
Add copilot reviewer instructions for docs

### DIFF
--- a/.github/instructions/docs.en.instructions.md
+++ b/.github/instructions/docs.en.instructions.md
@@ -1,0 +1,31 @@
+---
+applyTo: "docs/en/**"
+---
+
+# Review Guidelines docs/en Tree
+
+## File System & Structure
+
+- **Naming:** Use `lowercase_with_underscores` for all filenames. No spaces.
+- **Hierarchy:** Markdown files must reside exactly in a first-level category folder. 
+  - Valid: `docs/en/category/file.md`
+  - Invalid: `docs/en/category/subcategory/file.md`
+- **Text Files:** Any `.txt` or `.text` files must start with an underscore (e.g., `_notes.txt`).
+- **Assets:** All images/non-docs must be in `/docs/assets/`. Deep nesting is permitted here.
+- **Formats:** Prefer **SVG** for diagrams and **PNG** for screenshots. Flag JPG files.
+
+## Markdown & Style
+
+- **Headings:** Use Title Case ("First Letter Capitalisation"). 
+  - The Page Title must be the only H1 (`#`). All others must be `##` or lower.
+  - Do not apply bold or italic styling inside a heading.
+- **Formatting:** 
+  - **Bold:** Only for UI elements (buttons, menu items).
+  - **Italics (Emphasis):** For tool names (e.g., *QGroundControl*).
+  - **Inline Code:** Use backticks for file paths, parameters, and CLI commands (e.g., `prettier`).
+- **Structure:** End every line at the end of a sentence (Semantic Line Breaks).
+
+## Quality Control
+
+- **Formatting:** Ensure Prettier rules have been applied.
+- **Language:** Enforce **UK English** spelling and grammar.


### PR DESCRIPTION
This adds some copilot review instructions for docs.

Note that this ONLY applies to reviews in the docs/en path.

These reflect the style guide, which in turn reflects the automatable part of my docs checks https://docs.px4.io/main/en/contribute/docs

Untested. I expect to iterate by running it on the next few docs PRs.