### PR TITLE
Adds ARKV6X to supported Ethernet controller list

### DIFF
--- a/docs/en/advanced_config/ethernet_setup.md
+++ b/docs/en/advanced_config/ethernet_setup.md
@@ -25,6 +25,7 @@ It may also be supported on other boards.
 
 Supported flight controllers include:
 
+- [ARK Electronics ARKV6X](../flight_controller/ark_v6x.md)
 - [CUAV Pixhawk V6X](../flight_controller/cuav_pixhawk_v6x.md)
 - [Holybro Pixhawk 5X](../flight_controller/pixhawk5x.md)
 - [Holybro Pixhawk 6X](../flight_controller/pixhawk6x.md)


### PR DESCRIPTION
Documents ARK Electronics ARKV6X as a supported flight controller for Ethernet setup, improving clarity for users seeking compatible hardware.
