### PR TITLE
gz_bridge: GZGimbal: fix frame flags

### DIFF
--- a/src/modules/simulation/gz_bridge/GZGimbal.cpp
+++ b/src/modules/simulation/gz_bridge/GZGimbal.cpp
@@ -214,7 +214,7 @@ void GZGimbal::publishDeviceAttitude()
 
 	gimbal_att.target_system = 0; // Broadcast
 	gimbal_att.target_component = 0; // Broadcast
-	gimbal_att.device_flags = gimbal_device_attitude_status_s::DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME;
+	gimbal_att.device_flags = gimbal_device_attitude_status_s::DEVICE_FLAGS_YAW_IN_EARTH_FRAME;
 	_q_gimbal.copyTo(gimbal_att.q);
 	gimbal_att.angular_velocity_x = _gimbal_rate[0];
 	gimbal_att.angular_velocity_y = _gimbal_rate[1];


### PR DESCRIPTION
Gimbal attitude is being reported in earth frame. 

Fixes https://github.com/PX4/PX4-Autopilot/issues/26166
Fixes https://github.com/mavlink/qgroundcontrol/issues/13804