### PR TITLE
chore(rcS posix): move env var param override after airframe selection

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -126,15 +126,6 @@ then
 	set AUTOCNF yes
 fi
 
-# Allow overriding parameters via env variables: export PX4_PARAM_{name}={value}
-env | while IFS='=' read -r line; do
-  value=${line#*=}
-  name=${line%%=*}
-  case $name in
-    "PX4_PARAM_"*) param set "${name#PX4_PARAM_}" "$value" ;;
-  esac
-done
-
 # multi-instance setup
 # shellcheck disable=SC2154
 param set MAV_SYS_ID $((px4_instance+1))
@@ -237,6 +228,15 @@ then
 	echo "Error: no autostart file found ($autostart_file)"
 	exit 1
 fi
+
+# Allow overriding parameters via env variables: export PX4_PARAM_{name}={value}
+env | while IFS='=' read -r line; do
+  value=${line#*=}
+  name=${line%%=*}
+  case $name in
+    "PX4_PARAM_"*) param set "${name#PX4_PARAM_}" "$value" ;;
+  esac
+done
 
 dataman start
 


### PR DESCRIPTION
The current poxix param override logic through env var is excecuter before the vehicle airframe is selected, therefore if the airframe defines custom parameter values, then the overrides will be ignored.

For example one cannot override `NAV_DLL_ACT` when running gz_x500 sim as that parameter is set in
https://github.com/PX4/PX4-Autopilot/blob/9df0ced9fa9720303c42870afc9f2e0728a7fbfe/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500#L51

This PR moves the override logic after the airframe selection so that you can override any parameter.
