### PR TITLE
Fixed Wing Loiter Modes - Orbit and Figure 8

### DIFF
--- a/docs/en/flight_modes_fw/hold.md
+++ b/docs/en/flight_modes_fw/hold.md
@@ -49,14 +49,15 @@ This behaviour can be accessed in QGroundControl by clicking on the map in Fly v
 The behavior can be triggered using the MAVLink [MAV_CMD_DO_ORBIT](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_ORBIT) command.
 Note that PX4 respects the specified centre point (`param5`, `param6`, `param7`), and the radius and direction (`param1`).
 PX4 ignores `param3` (Yaw behaviour) and `param4` (Orbits).
-The value of `param2` (velocity) is also ignored, but the speed can be controlled using the [MAV_CMD_DO_CHANGE_SPEED](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED) command.
+The value of `param2` (velocity) is also ignored, but the speed can be controlled using the [MAV_CMD_DO_CHANGE_SPEED](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED) command (constrained between `FW_AIRSPD_MAX` and `FW_AIRSPD_MIN`).
 PX4 outputs orbit status using the [ORBIT_EXECUTION_STATUS](https://mavlink.io/en/messages/common.html#ORBIT_EXECUTION_STATUS) message.
 
 ### Figure 8 Loiter Mode
 
 <Badge type="tip" text="PX4 v1.15" /> <Badge type="warning" text="Experimental" />
 
-The aircraft flys towards a figure 8 centre position, then follows a figure 8 path as defined by the centre position, orientation, and radius of two circles.
+The aircraft flys towards the closest point on a specified figure 8 path and then follows it.
+The path is defined by the figure 8 centre position, orientation, and radius of two circles.
 
 The feature is experimental, and is not present in PX4 firmware by default (on most flight controller boards).
 It can be included by setting the `CONFIG_FIGURE_OF_EIGHT` key in the [PX4 board configuration](../hardware/porting_guide_config.md#px4-board-configuration-kconfig) for your board and rebuilding.

--- a/docs/en/flight_modes_fw/hold.md
+++ b/docs/en/flight_modes_fw/hold.md
@@ -4,6 +4,8 @@
 
 The _Hold_ flight mode causes the vehicle to loiter (circle) around its current GPS position and maintain its current altitude.
 
+There are also a number of [Loiter modes](#loiter-modes), such as figure 8 loiter, that can be run from within Hold mode.
+
 :::tip
 _Hold mode_ can be used to pause a mission or to help you regain control of a vehicle in an emergency.
 It is usually activated with a pre-programmed switch.
@@ -24,20 +26,65 @@ It is usually activated with a pre-programmed switch.
 
 :::
 
-## Technical Summary
+## Loiter modes
 
-The aircraft circles around the GPS hold position at the current altitude.
+### Default Loiter
+
+The default loiter mode is entered when you switch to Hold mode without explicitly specifying a loiter behaviour.
+
+The aircraft circles around the GPS hold position at the current altitude and with the radius [NAV_LOITER_RAD](#NAV_LOITER_RAD)
 The vehicle will first ascend to [NAV_MIN_LTR_ALT](#NAV_MIN_LTR_ALT) if the mode is engaged below this altitude.
 
 RC stick movement is ignored.
 
-### Parameters
+### Orbit Loiter Mode
+
+<Badge type="tip" text="PX4 v1.12)" />
+
+Orbit loiter mode allows you to set a position that the vehicle travels to, and then orbits following a circular path.
+Unlike the "default loiter" hold mode, the sticks can be used to control the radius and the velocity.
+
+This behaviour can be accessed in QGroundControl by clicking on the map in Fly mode, and selecting **Orbit at Location**.
+
+The behavior can be triggered using the MAVLink [MAV_CMD_DO_ORBIT](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_ORBIT) command and tracked using the [ORBIT_EXECUTION_STATUS](https://mavlink.io/en/messages/common.html#ORBIT_EXECUTION_STATUS) message.
+
+::: info
+Unlike MC vehicle, which have a distinct "Orbit Mode", Fixed-Wing vehicles orbit within the hold mode.
+:::
+
+### Figure 8 Loiter Mode
+
+<Badge type="tip" text="PX4 v1.15)" /> <Badge type="warning" text="Experimental" />
+
+Figure 8 loiter mode allows you to loiter the vehicle in a figure 8 path, as defined by the radius of two circles.
+
+The feature is experimental and can be enabled by setting the `CONFIG_FIGURE_OF_EIGHT` key in the [PX4 board configuration](../hardware/porting_guide_config.md#px4-board-configuration-kconfig) for your board and rebuilding.
+For example, this is enabled on the [default.px4board](https://github.com/PX4/PX4-Autopilot/blob/main/boards/auterion/fmu-v6s/default.px4board#L46) file for the `auterion/fmu-v6s` board.
+
+The mode can also be triggered using the MAVLink [MAV_CMD_DO_FIGURE_EIGHT](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_FIGURE_EIGHT) command.
+PX4 then outputs the [FIGURE_EIGHT_EXECUTION_STATUS](https://mavlink.io/en/messages/common.html#FIGURE_EIGHT_EXECUTION_STATUS) message.
+
+Figure 8 loitering is also available in the simulator.
+You can test it in [Gazebo](../sim_gazebo_gz/index.md) using a fixed wing frame:
+
+```sh
+make px4_sitl gz_rc_cessna
+```
+
+Note that at time of writing Figure8 loitering is not supported in QGC ([QGC##12778 Need Support Figure of eight (8 figure) loitering](https://github.com/mavlink/qgroundcontrol/issues/12778)) so you will need to trigger the operation directly via MAVLink.
+
+::: info
+Fixed-Wing vehicles fly figure 8 paths within the hold mode.
+There is no distinct "Figure 8" mode.
+:::
+
+## Parameters
 
 Hold mode behaviour can be configured using the parameters below.
 
 | Parameter                                                                                                | Description                                                                                                   |
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| [NAV_LOITER_RAD](../advanced_config/parameter_reference.md#NAV_LOITER_RAD)                               | The radius of the loiter circle.                                                                              |
+| <a id="NAV_LOITER_RAD"></a>[NAV_LOITER_RAD](../advanced_config/parameter_reference.md#NAV_LOITER_RAD)    | The radius of the loiter circle.                                                                              |
 | <a id="NAV_MIN_LTR_ALT"></a>[NAV_MIN_LTR_ALT](../advanced_config/parameter_reference.md#NAV_MIN_LTR_ALT) | Minimum height for loiter mode (vehicle will ascend to this altitude if mode is engaged at a lower altitude). |
 
 ## See Also

--- a/docs/en/flight_modes_fw/hold.md
+++ b/docs/en/flight_modes_fw/hold.md
@@ -2,13 +2,14 @@
 
 <img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />
 
-The _Hold_ flight mode causes the vehicle to loiter (circle) around its current GPS position and maintain its current altitude.
+The _Hold_ flight mode causes the vehicle to loiter around its current GPS position and maintain its current altitude.
 
-There are also a number of [Loiter modes](#loiter-modes), such as figure 8 loiter, that can be run from within Hold mode.
+The mode supports a [number of distinct loiter modes](#loiter-modes), which are triggered using different QGC controls or MAVLink commands.
+These allow loitering with circular and figure 8 flight paths.
 
 :::tip
 _Hold mode_ can be used to pause a mission or to help you regain control of a vehicle in an emergency.
-It is usually activated with a pre-programmed switch.
+It is usually activated with a pre-programmed RC switch.
 :::
 
 ::: info
@@ -30,39 +31,43 @@ It is usually activated with a pre-programmed switch.
 
 ### Default Loiter
 
-The default loiter mode is entered when you switch to Hold mode without explicitly specifying a loiter behaviour.
+The aircraft circles around the position at which the mode was triggered and maintain its current altitude.
+The loiter radius is set by the parameter [NAV_LOITER_RAD](#NAV_LOITER_RAD).
+Note that if the vehicle altitude is below [NAV_MIN_LTR_ALT](#NAV_MIN_LTR_ALT), it will ascend to that minimum altitude before circling.
 
-The aircraft circles around the GPS hold position at the current altitude and with the radius [NAV_LOITER_RAD](#NAV_LOITER_RAD)
-The vehicle will first ascend to [NAV_MIN_LTR_ALT](#NAV_MIN_LTR_ALT) if the mode is engaged below this altitude.
-
-RC stick movement is ignored.
+The default loiter mode is entered when you switch to Hold mode without explicitly specifying any loiter behaviour.
+For example, if you switch to Hold mode using an RC switch, select **Hold** on the QGC flight mode selector, or activate the mode using the MAVLink [MAV_CMD_DO_SET_MODE](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_MODE) command.
 
 ### Orbit Loiter Mode
 
-<Badge type="tip" text="PX4 v1.12)" />
+<Badge type="tip" text="PX4 v1.12" />
 
-Orbit loiter mode allows you to set a position that the vehicle travels to, and then orbits following a circular path.
-Unlike the "default loiter" hold mode, the sticks can be used to control the radius and the velocity.
+The aircraft travels towards a _specified_ orbit center position, then circles it with a given direction and radius.
 
-This behaviour can be accessed in QGroundControl by clicking on the map in Fly mode, and selecting **Orbit at Location**.
+This behaviour can be accessed in QGroundControl by clicking on the map in Fly view, selecting **Orbit at Location**, and configuring the radius.
 
-The behavior can be triggered using the MAVLink [MAV_CMD_DO_ORBIT](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_ORBIT) command and tracked using the [ORBIT_EXECUTION_STATUS](https://mavlink.io/en/messages/common.html#ORBIT_EXECUTION_STATUS) message.
-
-::: info
-Unlike MC vehicle, which have a distinct "Orbit Mode", Fixed-Wing vehicles orbit within the hold mode.
-:::
+The behavior can be triggered using the MAVLink [MAV_CMD_DO_ORBIT](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_ORBIT) command.
+Note that PX4 respects the specified centre point (`param5`, `param6`, `param7`), and the radius and direction (`param1`).
+PX4 ignores `param3` (Yaw behaviour) and `param4` (Orbits).
+The value of `param2` (velocity) is also ignored, but the speed can be controlled using the [MAV_CMD_DO_CHANGE_SPEED](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED) command.
+PX4 outputs orbit status using the [ORBIT_EXECUTION_STATUS](https://mavlink.io/en/messages/common.html#ORBIT_EXECUTION_STATUS) message.
 
 ### Figure 8 Loiter Mode
 
-<Badge type="tip" text="PX4 v1.15)" /> <Badge type="warning" text="Experimental" />
+<Badge type="tip" text="PX4 v1.15" /> <Badge type="warning" text="Experimental" />
 
-Figure 8 loiter mode allows you to loiter the vehicle in a figure 8 path, as defined by the radius of two circles.
+The aircraft flys towards a figure 8 centre position, then follows a figure 8 path as defined by the centre position, orientation, and radius of two circles.
 
-The feature is experimental and can be enabled by setting the `CONFIG_FIGURE_OF_EIGHT` key in the [PX4 board configuration](../hardware/porting_guide_config.md#px4-board-configuration-kconfig) for your board and rebuilding.
+The feature is experimental, and is not present in PX4 firmware by default (on most flight controller boards).
+It can be included by setting the `CONFIG_FIGURE_OF_EIGHT` key in the [PX4 board configuration](../hardware/porting_guide_config.md#px4-board-configuration-kconfig) for your board and rebuilding.
 For example, this is enabled on the [default.px4board](https://github.com/PX4/PX4-Autopilot/blob/main/boards/auterion/fmu-v6s/default.px4board#L46) file for the `auterion/fmu-v6s` board.
 
-The mode can also be triggered using the MAVLink [MAV_CMD_DO_FIGURE_EIGHT](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_FIGURE_EIGHT) command.
-PX4 then outputs the [FIGURE_EIGHT_EXECUTION_STATUS](https://mavlink.io/en/messages/common.html#FIGURE_EIGHT_EXECUTION_STATUS) message.
+The behavior can be triggered using the MAVLink [MAV_CMD_DO_FIGURE_EIGHT](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_FIGURE_EIGHT) command (PX4 respects all the parameters).
+PX4 outputs the figure 8 status using the [FIGURE_EIGHT_EXECUTION_STATUS](https://mavlink.io/en/messages/common.html#FIGURE_EIGHT_EXECUTION_STATUS) message.
+
+::: info
+Figure 8 loitering is not currently supported by QGC: [QGC#12778: Need Support Figure of eight (8 figure) loitering by QGC](https://github.com/mavlink/qgroundcontrol/issues/12778).
+:::
 
 Figure 8 loitering is also available in the simulator.
 You can test it in [Gazebo](../sim_gazebo_gz/index.md) using a fixed wing frame:
@@ -70,13 +75,6 @@ You can test it in [Gazebo](../sim_gazebo_gz/index.md) using a fixed wing frame:
 ```sh
 make px4_sitl gz_rc_cessna
 ```
-
-Note that at time of writing Figure8 loitering is not supported in QGC ([QGC##12778 Need Support Figure of eight (8 figure) loitering](https://github.com/mavlink/qgroundcontrol/issues/12778)) so you will need to trigger the operation directly via MAVLink.
-
-::: info
-Fixed-Wing vehicles fly figure 8 paths within the hold mode.
-There is no distinct "Figure 8" mode.
-:::
 
 ## Parameters
 
@@ -87,8 +85,21 @@ Hold mode behaviour can be configured using the parameters below.
 | <a id="NAV_LOITER_RAD"></a>[NAV_LOITER_RAD](../advanced_config/parameter_reference.md#NAV_LOITER_RAD)    | The radius of the loiter circle.                                                                              |
 | <a id="NAV_MIN_LTR_ALT"></a>[NAV_MIN_LTR_ALT](../advanced_config/parameter_reference.md#NAV_MIN_LTR_ALT) | Minimum height for loiter mode (vehicle will ascend to this altitude if mode is engaged at a lower altitude). |
 
+## MAVLink Commands
+
+The following commands are relevant to this mode:
+
+- [MAV_CMD_DO_ORBIT](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_ORBIT) - Switch to Hold mode and start the specified [Orbit loiter](#orbit-loiter-mode).
+  Params 2 (velocity), 3 (yaw), 4 (orbits) are ignored.
+  [ORBIT_EXECUTION_STATUS](https://mavlink.io/en/messages/common.html#ORBIT_EXECUTION_STATUS) is emitted.
+- [MAV_CMD_DO_FIGURE_EIGHT](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_FIGURE_EIGHT) - Switch to Hold mode and start the specified [Figure 8 loiter](#figure-8-loiter-mode).
+  All params are respected.
+  [FIGURE_EIGHT_EXECUTION_STATUS](https://mavlink.io/en/messages/common.html#FIGURE_EIGHT_EXECUTION_STATUS) is emitted.
+
+Note, other commands may be supported.
+
 ## See Also
 
-[Hold Mode (MC)](../flight_modes_mc/hold.md)
+- [Hold Mode (MC)](../flight_modes_mc/hold.md)
 
 <!-- this maps to AUTO_LOITER in flight mode state machine -->


### PR DESCRIPTION
Following question in https://discuss.px4.io/t/enabling-the-figure-of-eight-mode/48081/8 this adds docs for
-  #21852 

Testing shows that figure 8 and orbit loiter are implemented as loiter modes within hold mode on FW, and not as distinct modes such as Orbit mode in MC. 

As such, this is implemented as a "Loiter modes" section under the FW Hold mode doc.

There are questions about the implementation inline.

Note also that we need a QGC implementation. Issue for that is in https://github.com/mavlink/qgroundcontrol/issues/12778
