### PR TITLE
logger: add logger_status topic to default topics

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -91,6 +91,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("landing_gear_wheel", 100);
 	add_optional_topic("landing_target_pose", 1000);
 	add_optional_topic("launch_detection_status", 200);
+	add_topic("logger_status", 200);
 	add_optional_topic("magnetometer_bias_estimate", 200);
 	add_topic("manual_control_setpoint", 200);
 	add_topic("manual_control_switches");


### PR DESCRIPTION
This pull request makes a small addition to the default topics logged by the system. The most important change is the addition of the `logger_status` topic to the list of topics being logged.

Logging improvements:

* Added `logger_status` as a logged topic in `LoggedTopics::add_default_topics()` within `logged_topics.cpp`.

<img width="816" height="686" alt="image" src="https://github.com/user-attachments/assets/553f3799-ab5c-4cbb-bc20-8397602fe656" />
<img width="836" height="690" alt="image" src="https://github.com/user-attachments/assets/bde94d95-e417-4597-a0d8-84ed2366935b" />
