### PR TITLE
rangefinder: remove unused class member

### DIFF
--- a/src/lib/drivers/rangefinder/PX4Rangefinder.hpp
+++ b/src/lib/drivers/rangefinder/PX4Rangefinder.hpp
@@ -71,5 +71,4 @@ public:
 
 private:
 	uORB::PublicationMultiData<distance_sensor_s> _distance_sensor_pub{ORB_ID(distance_sensor)};
-	hrt_abstime _q_update_now {};
 };


### PR DESCRIPTION

### Solved Problem
[Failed CI check](https://github.com/Auterion/PX4_firmware_private/actions/runs/20712051593/job/59454619651?pr=3155) (clang tidy) on our internal repo - why did the CI checks in this repo not flag it?
<img width="1341" height="78" alt="image" src="https://github.com/user-attachments/assets/4d58573f-b83e-4e19-8e5b-b6e0267f6d6c" />
Came in [here](https://github.com/PX4/PX4-Autopilot/pull/26040/files).

### Solution
Remove the unused member. 

