### PR TITLE
[sitl] Implement gazbo-classic simulation of tailsitter with 2 rotors

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1046_gazebo-classic_advanced_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1046_gazebo-classic_advanced_tailsitter
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# @name Tailsitter
+# @name Advanced Tailsitter SITL
 #
 # @type VTOL Tailsitter
 #
@@ -39,7 +39,7 @@ param set-default PWM_MAIN_FUNC4 202
 param set-default EKF2_MULTI_IMU 0
 param set-default SENS_IMU_MODE 1
 
-param set-default FW_PR_FF 0.0
+param set-default FW_PR_FF 0
 param set-default FW_PSP_OFF 2
 param set-default MC_AIRMODE 1
 param set-default FW_THR_TRIM 0.6

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -62,6 +62,7 @@ px4_add_romfs_files(
 	1043_gazebo-classic_standard_vtol_drop
 	1044_gazebo-classic_plane_lidar
 	1045_gazebo-classic_quadtailsitter
+	1046_gazebo-classic_advanced_tailsitter
 	1062_flightgear_tf-r1
 	1070_gazebo-classic_boat
 

--- a/src/modules/simulation/simulator_mavlink/sitl_targets_gazebo-classic.cmake
+++ b/src/modules/simulation/simulator_mavlink/sitl_targets_gazebo-classic.cmake
@@ -79,6 +79,7 @@ if(gazebo_FOUND)
 	)
 
 	set(models
+		advanced_tailsitter
 		advanced_plane
 		believer
 		boat


### PR DESCRIPTION
- Update submodule sitl_gazebo-classic.

- Modified the 1041_gazebo-classic_tailsitter parameter to achieve stable flight.



### Solved Problem
For a long time, the tailsitter VTOL has used four rotors to simulate the torque effect of the tail control surface, which is actually a quadtailsitter. This PR will rework `1041_gazebo-classic_tailsitter` to achieve true tailsitter simulation in conjunction with https://github.com/PX4/PX4-SITL_gazebo-classic/pull/1083.
### Solution
By enabling the wind generated by the propeller, the control effect is achieved when hovering.

<img width="734" height="588" alt="截屏2026-01-05 21 28 39" src="https://github.com/user-attachments/assets/f74d02da-0925-4f64-86a6-0d04f902b936" />

