### PR TITLE
UAVCAN: Add LED Addressing Mode with Vertiq Support

### DIFF
--- a/docs/en/peripherals/vertiq.md
+++ b/docs/en/peripherals/vertiq.md
@@ -38,6 +38,25 @@ Instructions for integrating the motor/ESC using with DroneCAN can be found in [
 
 These instructions walk you through setting the correct parameters for enabling the flight controller's DroneCAN drivers, setting the correct configuration parameters for communication with Vertiq modules on the DroneCAN bus, ESC configuration, and testing that your flight controller can properly control your modules over DroneCAN.
 
+#### LED Configuration for Vertiq Modules
+
+::: info
+This configuration is only required if you have the optional [Vertiq LED module add-on](https://www.vertiq.co/add-ons).
+Standard Vertiq ESC modules do not include LEDs.
+:::
+
+Vertiq modules with the LED add-on have two addressable LEDs per ESC: an RGB LED for status colours and a White LED for anti-collision lighting.
+The UAVCAN driver automatically calculates the correct `light_id` values using the formula: `light_id = esc_index * 3 + BASE_ID` (where RGB uses BASE_ID=1, White uses BASE_ID=2).
+
+To enable LED control for Vertiq modules:
+
+1. Set [UAVCAN_LGT_MODE](../advanced_config/parameter_reference.md#UAVCAN_LGT_MODE) to `1` (Vertiq).
+2. Reboot the flight controller.
+
+The driver will automatically detect the number of connected ESCs from the `esc_status` topic and send LED commands to all ESCs.
+RGB LEDs display the standard PX4 status colours (arming state, errors, etc.), while White LEDs are controlled by the anti-collision light settings.
+
+
 ### DShot/PWM Configuration
 
 Instructions for integrating the motor/ESC using PWM and DShot can be found in [PWM and DShot Control with a Flight Controller](https://iqmotion.readthedocs.io/en/latest/tutorials/pwm_control_flight_controller.html).

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -24,6 +24,22 @@ parameters:
       min: 1
       max: 255
       reboot_required: true
+    UAVCAN_LGT_MODE:
+      description:
+        short: UAVCAN LED addressing mode
+        long: |
+          Controls how light_id values are assigned in UAVCAN LightsCommand messages.
+
+          Generic (0): Uses standard DroneCAN lighting conventions.
+
+          Vertiq (1): Auto-calculates light_ids for Vertiq motor modules with LED Add-on.
+          Supports status and anti-collision lights on each motor.
+      type: enum
+      values:
+        0: Generic
+        1: Vertiq
+      default: 0
+      reboot_required: true
 actuator_output:
   show_subgroups_if: 'UAVCAN_ENABLE>=3'
   config_parameters:

--- a/src/drivers/uavcan/rgbled.hpp
+++ b/src/drivers/uavcan/rgbled.hpp
@@ -34,6 +34,7 @@
 #pragma once
 
 #include <uORB/topics/actuator_armed.h>
+#include <uORB/topics/esc_status.h>
 
 #include <uavcan/uavcan.hpp>
 #include <uavcan/equipment/indication/LightsCommand.hpp>
@@ -54,6 +55,10 @@ private:
 	// Max update rate to avoid excessive bus traffic
 	static constexpr unsigned MAX_RATE_HZ = 20;
 
+	// Vertiq LED addressing constants
+	static constexpr uint8_t VERTIQ_RGB_BASE_ID = 1;
+	static constexpr uint8_t VERTIQ_WHITE_BASE_ID = 2;
+
 	void periodic_update(const uavcan::TimerEvent &);
 
 	uavcan::equipment::indication::RGB565 brightness_to_rgb565(uint8_t brightness);
@@ -66,10 +71,14 @@ private:
 	uavcan::TimerEventForwarder<TimerCbBinder> _timer;
 
 	uORB::Subscription _armed_sub{ORB_ID(actuator_armed)};
+	uORB::Subscription _esc_status_sub{ORB_ID(esc_status)};
 
 	LedController _led_controller;
 
+	uint8_t _esc_count{0};
+
 	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::UAVCAN_LGT_MODE>) _param_lgt_mode,
 		(ParamInt<px4::params::UAVCAN_LGT_ANTCL>) _param_mode_anti_col,
 		(ParamInt<px4::params::UAVCAN_LGT_STROB>) _param_mode_strobe,
 		(ParamInt<px4::params::UAVCAN_LGT_NAV>) _param_mode_nav,

--- a/src/drivers/uavcan/rgbled.hpp
+++ b/src/drivers/uavcan/rgbled.hpp
@@ -75,13 +75,13 @@ private:
 
 	LedController _led_controller;
 
-	uint8_t _esc_count{0};
+	uint8_t _vertiq_esc_count{0};
 
 	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::UAVCAN_LGT_MODE>) _param_lgt_mode,
-		(ParamInt<px4::params::UAVCAN_LGT_ANTCL>) _param_mode_anti_col,
-		(ParamInt<px4::params::UAVCAN_LGT_STROB>) _param_mode_strobe,
-		(ParamInt<px4::params::UAVCAN_LGT_NAV>) _param_mode_nav,
-		(ParamInt<px4::params::UAVCAN_LGT_LAND>) _param_mode_land
+		(ParamInt<px4::params::UAVCAN_LGT_MODE>) _param_uavcan_lgt_mode,
+		(ParamInt<px4::params::UAVCAN_LGT_ANTCL>) _param_uavcan_lgt_antcl,
+		(ParamInt<px4::params::UAVCAN_LGT_STROB>) _param_uavcan_lgt_strob,
+		(ParamInt<px4::params::UAVCAN_LGT_NAV>) _param_uavcan_lgt_nav,
+		(ParamInt<px4::params::UAVCAN_LGT_LAND>) _param_uavcan_lgt_land
 	)
 };


### PR DESCRIPTION
### Summary

Adds a new `UAVCAN_LGT_MODE` parameter to configure LED addressing for UAVCAN LightsCommand messages. This enables automatic LED control for Vertiq motor modules with integrated LEDs.

### Changes

- **New parameter `UAVCAN_LGT_MODE`** with two modes:
  - `0` (Generic): Uses standard UAVCAN convention for led assignment
  - `1` (Vertiq): Auto-calculates `light_id` values for Vertiq ESC index

- **Vertiq mode features:**
  - RGB LED: `light_id = esc_index * 3 + 1` (displays PX4 status colours)
  - White LED: `light_id = esc_index * 3 + 2` (anti-collision lighting)
  - ESC count automatically detected from `esc_status` topic (no manual configuration required)

- **Documentation:** Added LED configuration section to Vertiq peripheral docs

### Motivation

Vertiq motor modules with the LED add-on require specific `light_id` addressing that doesn't match standard DroneCAN conventions. 

### Testing

- [x] Tested with 4 motors and LED Addons, status and anti-collision works as intended

