### PR TITLE
msg: VehicleCommandAck: bump queue length from 4 to 8

### DIFF
--- a/msg/versioned/VehicleCommandAck.msg
+++ b/msg/versioned/VehicleCommandAck.msg
@@ -23,7 +23,7 @@ uint16 ARM_AUTH_DENIED_REASON_TIMEOUT = 3
 uint16 ARM_AUTH_DENIED_REASON_AIRSPACE_IN_USE = 4
 uint16 ARM_AUTH_DENIED_REASON_BAD_WEATHER = 5
 
-uint8 ORB_QUEUE_LENGTH = 4
+uint8 ORB_QUEUE_LENGTH = 8
 
 uint32 command						# Command that is being acknowledged
 uint8 result						# Command result


### PR DESCRIPTION
Increase VehicleCommandAck ORB_QUEUE_LENGTH to match VehicleCommand
https://discord.com/channels/1022170275984457759/1022185721450213396/1456709818474828079
<img width="1257" height="516" alt="image" src="https://github.com/user-attachments/assets/e4d61897-3941-426e-81bb-386f8c306a9f" />
