### PR TITLE
FwModeManager: stabilize fixed-wing landing flare control

### DIFF
--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -170,6 +170,8 @@ FixedWingModeManager::airspeed_poll()
 
 			_airspeed_eas = airspeed_validated.calibrated_airspeed_m_s;
 		}
+
+		_time_airspeed_last_valid = airspeed_validated.timestamp;
 	}
 
 	// no airspeed updates for one second --> declare invalid
@@ -248,12 +250,22 @@ FixedWingModeManager::vehicle_attitude_poll()
 
 		const Eulerf euler_angles(R);
 		_yaw = euler_angles(2);
+		_pitch = euler_angles(1);
 
 		const Vector3f body_acceleration = R.transpose() * Vector3f{_local_pos.ax, _local_pos.ay, _local_pos.az};
 		_body_acceleration_x = body_acceleration(0);
 
 		const Vector3f body_velocity = R.transpose() * Vector3f{_local_pos.vx, _local_pos.vy, _local_pos.vz};
 		_body_velocity_x = body_velocity(0);
+	}
+}
+
+void FixedWingModeManager::vehicle_attitude_setpoint_poll()
+{
+	vehicle_attitude_setpoint_s vehicle_attitude_setpoint;
+
+	if (_vehicle_attitude_setpoint_sub.update(&vehicle_attitude_setpoint)) {
+		_throttle = vehicle_attitude_setpoint.thrust_body[0];
 	}
 }
 
@@ -1468,6 +1480,8 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 			_flare_states.flaring = true;
 			_flare_states.start_time = now;
 			_flare_states.initial_height_rate_setpoint = -_local_pos.vz;
+			_flare_states.initial_pitch = _pitch;
+			_flare_states.initial_throttle = math::min(_throttle, _param_fw_thr_max.get());
 			events::send(events::ID("fixedwing_position_control_landing_flaring"), events::Log::Info,
 				     "Landing, flaring");
 		}
@@ -1500,9 +1514,9 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 						   (1.0f - flare_ramp_interpolator_sqrt) * _flare_states.initial_height_rate_setpoint;
 
 		float pitch_min_rad = flare_ramp_interpolator_sqrt * radians(_param_fw_lnd_fl_pmin.get()) +
-				      (1.0f - flare_ramp_interpolator_sqrt) * radians(_param_fw_p_lim_min.get());
+				      (1.0f - flare_ramp_interpolator_sqrt) * _flare_states.initial_pitch;
 		float pitch_max_rad = flare_ramp_interpolator_sqrt * radians(_param_fw_lnd_fl_pmax.get()) +
-				      (1.0f - flare_ramp_interpolator_sqrt) * radians(_param_fw_p_lim_max.get());
+				      (1.0f - flare_ramp_interpolator_sqrt) * _flare_states.initial_pitch;
 
 		if (_param_fw_lnd_td_time.get() > FLT_EPSILON) {
 			const float touchdown_time = math::max(_param_fw_lnd_td_time.get(), _param_fw_lnd_fl_time.get());
@@ -1519,9 +1533,9 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 
 		// idle throttle may be >0 for internal combustion engines
 		// normally set to zero for electric motors
+		// Ramp throttle from current value to idle over flare duration
 		const float throttle_max = flare_ramp_interpolator_sqrt * _param_fw_thr_idle.get() +
-					   (1.0f - flare_ramp_interpolator_sqrt) *
-					   _param_fw_thr_max.get();
+					   (1.0f - flare_ramp_interpolator_sqrt) * _flare_states.initial_throttle;
 
 		const fixed_wing_longitudinal_setpoint_s fw_longitudinal_control_sp = {
 			.timestamp = now,
@@ -1651,6 +1665,8 @@ FixedWingModeManager::control_auto_landing_circular(const hrt_abstime &now, cons
 			_flare_states.flaring = true;
 			_flare_states.start_time = now;
 			_flare_states.initial_height_rate_setpoint = -_local_pos.vz;
+			_flare_states.initial_pitch = _pitch;
+			_flare_states.initial_throttle = math::min(_throttle, _param_fw_thr_max.get());
 			events::send(events::ID("fixedwing_position_control_landing_circle_flaring"), events::Log::Info,
 				     "Landing, flaring");
 		}
@@ -1678,9 +1694,9 @@ FixedWingModeManager::control_auto_landing_circular(const hrt_abstime &now, cons
 						   (1.0f - flare_ramp_interpolator_sqrt) * _flare_states.initial_height_rate_setpoint;
 
 		float pitch_min_rad = flare_ramp_interpolator_sqrt * radians(_param_fw_lnd_fl_pmin.get()) +
-				      (1.0f - flare_ramp_interpolator_sqrt) * radians(_param_fw_p_lim_min.get());
+				      (1.0f - flare_ramp_interpolator_sqrt) * _flare_states.initial_pitch;
 		float pitch_max_rad = flare_ramp_interpolator_sqrt * radians(_param_fw_lnd_fl_pmax.get()) +
-				      (1.0f - flare_ramp_interpolator_sqrt) * radians(_param_fw_p_lim_max.get());
+				      (1.0f - flare_ramp_interpolator_sqrt) * _flare_states.initial_pitch;
 
 		if (_param_fw_lnd_td_time.get() > FLT_EPSILON) {
 			const float touchdown_time = math::max(_param_fw_lnd_td_time.get(), _param_fw_lnd_fl_time.get());
@@ -1696,9 +1712,9 @@ FixedWingModeManager::control_auto_landing_circular(const hrt_abstime &now, cons
 
 		// idle throttle may be >0 for internal combustion engines
 		// normally set to zero for electric motors
+		// Ramp throttle from current value to idle over flare duration
 		const float throttle_max = flare_ramp_interpolator_sqrt * _param_fw_thr_idle.get() +
-					   (1.0f - flare_ramp_interpolator_sqrt) *
-					   _param_fw_thr_max.get();
+					   (1.0f - flare_ramp_interpolator_sqrt) * _flare_states.initial_throttle;
 		const fixed_wing_longitudinal_setpoint_s fw_longitudinal_control_sp = {
 			.timestamp = now,
 			.altitude = NAN,
@@ -2125,6 +2141,7 @@ FixedWingModeManager::Run()
 		airspeed_poll();
 		manual_control_setpoint_poll();
 		vehicle_attitude_poll();
+		vehicle_attitude_setpoint_poll();
 		vehicle_command_poll();
 		vehicle_control_mode_poll();
 		wind_poll(now);

--- a/src/modules/fw_mode_manager/FixedWingModeManager.hpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.hpp
@@ -184,6 +184,7 @@ private:
 	uORB::Subscription _trajectory_setpoint_sub{ORB_ID(trajectory_setpoint)};
 	uORB::Subscription _vehicle_angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
+	uORB::Subscription _vehicle_attitude_setpoint_sub{ORB_ID(vehicle_attitude_setpoint)};
 	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};
 	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
@@ -252,6 +253,8 @@ private:
 
 	float _yaw{0.0f};
 	float _yawrate{0.0f};
+	float _pitch{0.0f}; // [rad] current pitch angle from attitude
+	float _throttle{0.0f}; // [0-1] last set throttle
 
 	float _body_acceleration_x{0.f};
 	float _body_velocity_x{0.f};
@@ -336,6 +339,8 @@ private:
 		bool flaring{false};
 		hrt_abstime start_time{0}; // [us]
 		float initial_height_rate_setpoint{0.0f}; // [m/s]
+		float initial_pitch{0.0f}; // [rad]
+		float initial_throttle{0.0f}; // [0-1] throttle value when flare started
 	} _flare_states;
 
 	// [m] last terrain estimate which was valid
@@ -419,6 +424,7 @@ private:
 
 	void manual_control_setpoint_poll();
 	void vehicle_attitude_poll();
+	void vehicle_attitude_setpoint_poll();
 	void vehicle_command_poll();
 	void vehicle_control_mode_poll();
 


### PR DESCRIPTION
### Solved Problem

When flare begins, the height-rate (sink-rate) setpoint is initialized to the current measured height rate. This value is held during the initial flare phase and then ramped toward FW_LND_FL_SINK.

If the aircraft is already descending faster than the nominal flare sink-rate target, this higher sink rate is initially maintained. As a result, the vehicle may pitch down to track that sink rate.

Additionally, the minimum pitch constraint is ramped from FW_P_LIM_MIN rather than from the current pitch angle. So the aircraft’s pitch is not properly constrained during the initial flare phase.

<img width="1849" height="499" alt="image" src="https://github.com/user-attachments/assets/38b5735d-7f8d-43f2-8a71-d4468268e50f" />


### Solution

- Use single interpolator for height_rate, pitch, and throttle_max ramping
- Ramp pitch_min and pitch max from current pitch 
- Ramp throttle from current setpoint to idle

### Changelog Entry
For release notes:
```
Feature/Bugfix stabilize fixed-wing landing flare control
```

### Test coverage

1. SITL test: https://review.px4.io/plot_app?log=81443f93-5666-4358-b408-897fd21c6a59

<img width="1403" height="856" alt="Screenshot from 2026-01-06 17-13-10" src="https://github.com/user-attachments/assets/c0059d67-cfb9-44f0-ba35-4cc4622d5981" />


2. Flight tested: [log](https://review.px4.io/plot_app?log=5f558f8b-51ba-4fd3-8139-44a1cdc1f602)

