### PR TITLE
Split out PX4 v1.17 release note

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -902,6 +902,7 @@
   - [Licenses](contribute/licenses.md)
 - [Releases](releases/index.md)
   - [main (alpha)](releases/main.md)
+  - [1.17 (alpha)](releases/1.17.md)
   - [1.16 (stable)](releases/1.16.md)
   - [1.15](releases/1.15.md)
   - [1.14](releases/1.14.md)

--- a/docs/en/advanced/neural_networks.md
+++ b/docs/en/advanced/neural_networks.md
@@ -1,6 +1,6 @@
 # Neural Networks
 
-<Badge type="tip" text="main (planned for: PX4 v1.17)" /> <Badge type="warning" text="Experimental" />
+<Badge type="tip" text="PX4 v1.17" /> <Badge type="warning" text="Experimental" />
 
 ::: warning
 This is an experimental module.

--- a/docs/en/features_fw/gain_compression.md
+++ b/docs/en/features_fw/gain_compression.md
@@ -1,6 +1,6 @@
 # Gain compression
 
-<Badge type="tip" text="main (planned for: PX4 v1.17)" />
+<Badge type="tip" text="PX4 v1.17" />
 
 Automatic gain compression reduces the gains of the angular-rate PID whenever oscillations are detected.
 It monitors the angular-rate controller output through a band-pass filter to identify these oscillations.

--- a/docs/en/flight_controller/micoair743-lite.md
+++ b/docs/en/flight_controller/micoair743-lite.md
@@ -1,6 +1,6 @@
 # MicoAir743-Lite
 
-<Badge type="tip" text="main (planned for: PX4 v1.17)" />
+<Badge type="tip" text="PX4 v1.17" />
 
 :::warning
 PX4 does not manufacture this (or any) autopilot.

--- a/docs/en/flight_controller/radiolink_pix6.md
+++ b/docs/en/flight_controller/radiolink_pix6.md
@@ -1,6 +1,6 @@
 # RadiolinkPIX6 Flight Controller
 
-<Badge type="tip" text="main (planned for: PX4 v1.17)" />
+<Badge type="tip" text="PX4 v1.17" />
 
 :::warning
 PX4 does not manufacture this (or any) autopilot.

--- a/docs/en/flight_controller/x-mav_ap-h743r1.md
+++ b/docs/en/flight_controller/x-mav_ap-h743r1.md
@@ -1,6 +1,6 @@
-# AP-H743-R1
+# AP-H743-R1 Flight Controller
 
-<Badge type="tip" text="main (planned for: PX4 v1.17)" />
+<Badge type="tip" text="PX4 v1.17" />
 
 :::warning
 PX4 does not manufacture this (or any) autopilot.
@@ -50,6 +50,7 @@ These flight controllers are [manufacturer supported](../flight_controller/autop
 Order from [X-MAV](https://www.x-mav.cn/).
 
 ## Radio Control
+
 A Radio Control (RC) system is required if you want to manually control your vehicle (PX4 does not require a radio system for autonomous flight modes).
 
 You will need to select a compatible transmitter/receiver and then bind them so that they communicate (read the instructions that come with your specific transmitter/receiver).
@@ -59,14 +60,14 @@ CRSF receiver must be wired to a spare port (UART) on the Flight Controller. The
 
 ## Serial Port Mapping
 
-| UART   | Device     | Port          |
-| ------ | ---------- | ------------- |
-| USART1 | /dev/ttyS0 | GPS           |
-| USART2 | /dev/ttyS1 | GPS2          |
-| USART3 | /dev/ttyS2 | TELEM1        |
-| UART4  | /dev/ttyS3 | TELEM2        |
-| UART7  | /dev/ttyS4 | TELEM3        |
-| UART8  | /dev/ttyS5 | SERIAL4       |
+| UART   | Device     | Port    |
+| ------ | ---------- | ------- |
+| USART1 | /dev/ttyS0 | GPS     |
+| USART2 | /dev/ttyS1 | GPS2    |
+| USART3 | /dev/ttyS2 | TELEM1  |
+| UART4  | /dev/ttyS3 | TELEM2  |
+| UART7  | /dev/ttyS4 | TELEM3  |
+| UART8  | /dev/ttyS5 | SERIAL4 |
 
 ## PWM Output
 
@@ -133,13 +134,14 @@ The complete set of supported configurations can be found in the [Airframe Refer
 ## Debug Port
 
 ### SWD
+
 The [SWD interface](../debug/swd_debug.md) operate on the **FMU-DEBUG** port (`FMU-DEBUG`).
 
 The debug port (`FMU-DEBUG`) uses a [JST SM04B-GHS-TB](https://www.digikey.com/en/products/detail/jst-sales-america-inc/SM04B-GHS-TB/807788) connector and has the following pinout:
 
-| Pin     | Signal         | Volt  |
-| ------- | -------------- | ----- |
-| 1 (red) | 5V+            | +5V   |
-| 2 (blk) | FMU_SWDIO      | +3.3V |
-| 3 (blk) | FMU_SWCLK      | +3.3V |
-| 4 (blk) | GND            | GND   |
+| Pin     | Signal    | Volt  |
+| ------- | --------- | ----- |
+| 1 (red) | 5V+       | +5V   |
+| 2 (blk) | FMU_SWDIO | +3.3V |
+| 3 (blk) | FMU_SWCLK | +3.3V |
+| 4 (blk) | GND       | GND   |

--- a/docs/en/flight_modes_fw/takeoff.md
+++ b/docs/en/flight_modes_fw/takeoff.md
@@ -49,8 +49,8 @@ If the local position is invalid or becomes invalid while executing the takeoff,
 
 ::: info
 
-- Takeoff towards a target position was added in <Badge type="tip" text="main (planned for: PX4 v1.17)" />.
-- Holding wings level and ascending to clearance attitude when local position is invalid during takeoff was added in <Badge type="tip" text="main (planned for: PX4 v1.17)" />.
+- Takeoff towards a target position was added in <Badge type="tip" text="PX4 v1.17" />.
+- Holding wings level and ascending to clearance attitude when local position is invalid during takeoff was added in <Badge type="tip" text="PX4 v1.17" />.
 - QGroundControl does not support `MAV_CMD_NAV_TAKEOFF` (at time of writing).
 
 :::

--- a/docs/en/middleware/uxrce_dds.md
+++ b/docs/en/middleware/uxrce_dds.md
@@ -321,7 +321,7 @@ The configuration can be done using the [UXRCE-DDS parameters](../advanced_confi
   - [UXRCE_DDS_SYNCT](../advanced_config/parameter_reference.md#UXRCE_DDS_SYNCT): Bridge time synchronization enable.
     The uXRCE-DDS client module can synchronize the timestamp of the messages exchanged over the bridge.
     This is the default configuration. In certain situations, for example during [simulations](../ros2/user_guide.md#ros-gazebo-and-px4-time-synchronization), this feature may be disabled.
-  - <Badge type="tip" text="PX4 v1.17" /> [`UXRCE_DDS_NS_IDX`](../advanced_config/parameter_reference.md#UXRCE_DDS_NS_IDX): Index-based namespace definition
+  - [UXRCE_DDS_NS_IDX](../advanced_config/parameter_reference.md#UXRCE_DDS_NS_IDX) <Badge type="tip" text="PX4 v1.17" />: Index-based namespace definition
     Setting this parameter to any value other than `-1` creates a namespace with the prefix `uav_` and the specified value, e.g. `uav_0`, `uav_1`, etc.
     See [namespace](#customizing-the-namespace) for methods to define richer or arbitrary namespaces.
 
@@ -426,7 +426,7 @@ will generate topics under the namespaces:
 
 :::
 
-- A simple index-based namespace can be applied by setting the parameter [`UXRCE_DDS_NS_IDX`](../advanced_config/parameter_reference.md#UXRCE_DDS_NS_IDX) to a value between 0 and 9999.
+- A simple index-based namespace can be applied by setting the parameter [`UXRCE_DDS_NS_IDX`](../advanced_config/parameter_reference.md#UXRCE_DDS_NS_IDX) <Badge type="tip" text="PX4 v1.17" /> to a value between 0 and 9999.
   This will generate a namespace such as `/uav_0`, `/uav_1`, and so on.
   This technique is ideal if vehicles must be persistently associated with namespaces because their clients are automatically started through PX4.
 

--- a/docs/en/releases/1.16.md
+++ b/docs/en/releases/1.16.md
@@ -129,6 +129,7 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 ### uXRCE-DDS / ROS2
 
 - [PX4-Autopilot#24113](https://github.com/PX4/PX4-Autopilot/pull/24113): <Badge type="warning" text="Experimental"/> [ROS 2 Message Translation Node](../ros2/px4_ros2_msg_translation_node.md) to translate PX4 messages from one definition version to another dynamically
+- <Badge type="warning" text="Experimental"/>[PX4 ROS 2 Interface Library](../ros2/px4_ros2_control_interface.md) support for [ROS-based waypoint missions](../ros2/px4_ros2_waypoint_missions.md).
 - dds_topics: add vtol_vehicle_status ([PX4-Autopilot#24582](https://github.com/PX4/PX4-Autopilot/pull/24582))
 - dds_topics: add home_position ([PX4-Autopilot#24583](https://github.com/PX4/PX4-Autopilot/pull/24583))
 
@@ -138,6 +139,7 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 - Parameter to always start mavlink stream via USB. ([PX4-Autopilot#22234](https://github.com/PX4/PX4-Autopilot/pull/22234))
 - Refactor: MAVLink message handling in one function, reference instead of pointer to main instance ([PX4-Autopilo#23219](https://github.com/PX4/PX4-Autopilot/pull/22234))
 - mavlink log handler rewrite for improved effeciency ([PX4-Autopilo#23219](https://github.com/PX4/PX4-Autopilot/pull/22234))
+
 ### Multi-Rotor
 
 - [Multirotor] add yaw torque low pass filter ([PX4-Autopilot#24173](https://github.com/PX4/PX4-Autopilot/pull/24173))

--- a/docs/en/releases/1.17.md
+++ b/docs/en/releases/1.17.md
@@ -1,6 +1,6 @@
-# PX4-Autopilot Main Release Notes
+# PX4-Autopilot v1.17.0 Release Notes
 
-<Badge type="danger" text="Alpha" />
+<Badge type="danger" text="Alpha/Beta" />
 
 <script setup>
 import { useData } from 'vitepress'
@@ -13,16 +13,17 @@ const { site } = useData();
   </div>
 </div>
 
-This contains changes to PX4 `main` branch since the last major release ([PX v1.16](../releases/1.16.md)).
+This contains changes to PX4 planned for PX4 v1.17 (since the last major release [PX v1.16](../releases/1.16.md)).
 
 ::: warning
 PX4 v1.17 is in alpha/beta testing.
-Update these notes with features that are going to be in `main` (PX4 v1.18 or later) but not the PX4 v1.17 release.
+Update these notes with features that are going to be in PX4 v1.17 release.
+New features that are not expected to go into the v1.17 release are in [PX4-Autopilot `main` Release Notes](../releases/main.md).
 :::
 
 ## Read Before Upgrading
 
-- TBD …
+TBD …
 
 Please continue reading for [upgrade instructions](#upgrade-guide).
 
@@ -36,42 +37,55 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 ### Hardware Support
 
-- TBD
+- **[New Hardware]** boards: [MicoAir743-Lite FC](../flight_controller/micoair743-lite.md) <!-- CHECK is this version and add PR link (or fix up doc version tag and move this) -->
+- **[New Hardware]** boards: [RadiolinkPIX6 FC](../flight_controller/radiolink_pix6.md) <!-- CHECK is this version and add PR! -->
+- **[New Hardware]** boards: [AP-H743-R1 FC](../flight_controller/x-mav_ap-h743r1.md) <!-- CHECK is this version and add PR! -->
+
+<!--
 
 ### Common
 
 - [QGroundControl Bootloader Update](../advanced_config/bootloader_update.md#qgc-bootloader-update-sys-bl-update) via the [SYS_BL_UPDATE](../advanced_config/parameter_reference.md#SYS_BL_UPDATE) parameter has been re-enabled after being broken for a number of releases. ([PX4-Autopilot#25032: build: romf: fix generation of rc.board_bootloader_upgrade](https://github.com/PX4/PX4-Autopilot/pull/25032)).
+-->
 
 ### Control
+
+<!--
 
 - Added new flight mode(s): [Altitude Cruise (MC)](../flight_modes_mc/altitude_cruise.md), Altitude Cruise (FW).
   For fixed-wing the mode behaves the same as Altitude mode but you can disable the manual control loss failsafe. ([PX4-Autopilot#25435: Add new flight mode: Altitude Cruise](https://github.com/PX4/PX4-Autopilot/pull/25435)).
 
+-->
+
+- <Badge type="warning" text="Experimental" /> [MC Neural Network Module](../advanced/neural_networkss.md)
+
 ### Estimation
 
 - TBD
+
+<!--
 
 ### Sensors
 
 - Add [sbgECom INS driver](../sensor/sbgecom.md) ([PX4-Autopilot#24137](https://github.com/PX4/PX4-Autopilot/pull/24137))
 - Quick magnetometer calibration now supports specifying an arbitrary initial heading ([PX4-Autopilot#24637](https://github.com/PX4/PX4-Autopilot/pull/24637))
 
+-->
+
 ### Simulation
-
-- TBD
-
-<!-- MOVED THIS TO v1.17
 
 - Overhaul rover simulation:
   - Add synthetic differential rover model: [PX4-gazebo-models#107](https://github.com/PX4/PX4-gazebo-models/pull/107)
   - Add synthetic mecanum rover model: [PX4-gazebo-models#113](https://github.com/PX4/PX4-gazebo-models/pull/113)
   - Update synthetic ackermann rover model: [PX4-gazebo-models#117](https://github.com/PX4/PX4-gazebo-models/pull/117)
 
--->
+- [Simulation-in-Hardware (SIH)](../sim_sih/index.md#compatibility) <!-- Listed in https://docs.px4.io/main/en/sim_sih/#compatibility : Check the PRs -->
+  - New simulation: MC Hexacopter X
+  - New simulation: Ackermann Rover
 
 ### Debug & Logging
 
-- [Asset Tracking](../debug/asset_tracking.md): Automatic tracking and logging of external device information including vendor name, firmware and hardware version, serial numbers. Currently supports DroneCAN devices. ([PX4-Autopilot#25617](https://github.com/PX4/PX4-Autopilot/pull/25617))
+- TBD
 
 ### Ethernet
 
@@ -79,17 +93,15 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 ### uXRCE-DDS / Zenoh / ROS2
 
-- TBD
-
-<!-- MOVED THIS TO v1.17
-
 - [PX4 ROS 2 Interface Library](../ros2/px4_ros2_control_interface.md) support for [Fixed Wing lateral/longitudinal setpoint](../ros2/px4_ros2_control_interface.md#fixed-wing-lateral-and-longitudinal-setpoint-fwlaterallongitudinalsetpointtype) (`FwLateralLongitudinalSetpointType`) and [VTOL transitions](../ros2/px4_ros2_control_interface.md#controlling-a-vtol). ([PX4-Autopilot#24056](https://github.com/PX4/PX4-Autopilot/pull/24056)).
-- [PX4 ROS 2 Interface Library](../ros2/px4_ros2_control_interface.md) support for [ROS-based waypoint missions](../ros2/px4_ros2_waypoint_missions.md).
--->
+- [UXRCE_DDS: Simple index based namespace (UXRCE_DDS_NS_IDX)](../middleware/uxrce_dds.md#customizing-the-namespace)
+- [Zenoh (PX4 ROS 2 rmw_zenoh)](../middleware/zenoh.md)
 
 ### MAVLink
 
 - TBD
+
+<!--
 
 ### RC
 
@@ -99,6 +111,7 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 - Removed parameters `MPC_{XY/Z/YAW}_MAN_EXPO` and use default value instead, as they were not deemed necessary anymore. ([PX4-Autopilot#25435: Add new flight mode: Altitude Cruise](https://github.com/PX4/PX4-Autopilot/pull/25435)).
 - Renamed `MPC_HOLD_DZ` to `MAN_DEADZONE` to have it globally available in modes that allow for a dead zone. ([PX4-Autopilot#25435: Add new flight mode: Altitude Cruise](https://github.com/PX4/PX4-Autopilot/pull/25435)).
+-->
 
 ### VTOL
 
@@ -106,25 +119,15 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 ### Fixed-wing
 
-- TBD
-
-<!-- MOVED THIS TO v1.17
 - [Fixed Wing Takeoff mode](../flight_modes_fw/takeoff.md) will now keep climbing with level wings on position loss.
   A target takeoff waypoint can be set to control takeoff course and loiter altitude. ([PX4-Autopilot#25083](https://github.com/PX4/PX4-Autopilot/pull/25083)).
 - Automatically suppress angular rate oscillations using [Gain compression](../features_fw/gain_compression.md). ([PX4-Autopilot#25840: FW rate control: add gain compression algorithm](https://github.com/PX4/PX4-Autopilot/pull/25840))
--->
 
 ### Rover
 
-- TBD
-
-<!-- MOVED THIS TO v1.17
-
 - Removed deprecated rover module ([PX4-Autopilot#25054](https://github.com/PX4/PX4-Autopilot/pull/25054)).
-- Add support for [Apps & API](../flight_modes_rover/api.md) ([PX4-Autopilot#25074](https://github.com/PX4/PX4-Autopilot/pull/25074), [PX4-ROS2-Interface-Lib#140](https://github.com/Auterion/px4-ros2-interface-lib/pull/140)).
+- Add support for [Apps & API](../flight_modes_rover/api.md) including [Rover Setpoints](../ros2/px4_ros2_control_interface.md#rover-setpoints) ([PX4-Autopilot#25074](https://github.com/PX4/PX4-Autopilot/pull/25074), [PX4-ROS2-Interface-Lib#140](https://github.com/Auterion/px4-ros2-interface-lib/pull/140)).
 - Update [rover simulation](../frames_rover/index.md#simulation) ([PX4-Autopilot#25644](https://github.com/PX4/PX4-Autopilot/pull/25644)) (see [Simulation](#simulation) release note for details).
-
--->
 
 ### ROS 2
 

--- a/docs/en/releases/index.md
+++ b/docs/en/releases/index.md
@@ -2,7 +2,8 @@
 
 A list of PX4 release notes, they contain a list of the changes that went into each release, explaining the included features, bug fixes, deprecations and updates in detail.
 
-- [main](../releases/main.md) (changes since v1.16)
+- [main](../releases/main.md) (changes planned for v1.18 or later)
+- [v1.17](../releases/1.17.md) (changes planned for v1.17, since v1.16)
 - [v1.16](../releases/1.16.md)
 - [v1.15](../releases/1.15.md)
 - [v1.14](../releases/1.14.md)

--- a/docs/en/ros2/px4_ros2_control_interface.md
+++ b/docs/en/ros2/px4_ros2_control_interface.md
@@ -341,9 +341,9 @@ The used types also define the compatibility with different vehicle types.
 The following sections provide a list of supported setpoint types:
 
 - [MulticopterGotoSetpointType](#go-to-setpoint-multicoptergotosetpointtype): <Badge type="warning" text="MC only" /> Smooth position and (optionally) heading control
-- [FwLateralLongitudinalSetpointType](#fixed-wing-lateral-and-longitudinal-setpoint-fwlaterallongitudinalsetpointtype): <Badge type="warning" text="FW only" /> <Badge type="tip" text="main (planned for: PX4 v1.17)" /> Direct control of lateral and longitudinal fixed wing dynamics
+- [FwLateralLongitudinalSetpointType](#fixed-wing-lateral-and-longitudinal-setpoint-fwlaterallongitudinalsetpointtype): <Badge type="warning" text="FW only" /> <Badge type="tip" text="PX4 v1.17" /> Direct control of lateral and longitudinal fixed wing dynamics
 - [DirectActuatorsSetpointType](#direct-actuator-control-setpoint-directactuatorssetpointtype): Direct control of motors and flight surface servo setpoints
-- [Rover Setpoints](#rover-setpoints): <Badge type="tip" text="main (planned for: PX4 v1.17)" /> Direct access to rover control setpoints (Position, Speed, Attitude, Rate, Throttle and Steering).
+- [Rover Setpoints](#rover-setpoints): <Badge type="tip" text="PX4 v1.17" /> Direct access to rover control setpoints (Position, Speed, Attitude, Rate, Throttle and Steering).
 
 :::tip
 The other setpoint types are currently experimental, and can be found in: [px4_ros2/control/setpoint_types/experimental](https://github.com/Auterion/px4-ros2-interface-lib/tree/main/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental).
@@ -410,7 +410,7 @@ _goto_setpoint->update(
 
 #### Fixed-Wing Lateral and Longitudinal Setpoint (FwLateralLongitudinalSetpointType)
 
-<Badge type="warning" text="Fixed wing only" /> <Badge type="tip" text="main (planned for: PX4 v1.17)" />
+<Badge type="warning" text="Fixed wing only" /> <Badge type="tip" text="PX4 v1.17" />
 
 ::: info
 This setpoint type is supported for fixed-wing vehicles and for VTOLs in fixed-wing mode.
@@ -552,7 +552,7 @@ If you want to control an actuator that does not control the vehicle's motion, b
 
 #### Rover Setpoints
 
-<Badge type="tip" text="main (planned for: PX4 v1.17)" /> <Badge type="warning" text="Experimental" />
+<Badge type="tip" text="PX4 v1.17" /> <Badge type="warning" text="Experimental" />
 
 The rover modules use a hierarchical structure to propagate setpoints:
 
@@ -586,7 +586,7 @@ An example for a rover specific drive mode using the `RoverSpeedAttitudeSetpoint
 
 ### Controlling a VTOL
 
-<Badge type="tip" text="main (planned for: PX4 v1.17)" /> <Badge type="warning" text="Experimental" />
+<Badge type="tip" text="PX4 v1.17" /> <Badge type="warning" text="Experimental" />
 
 To control a VTOL in an external flight mode, ensure you're returning the correct setpoint type based on the current flight configuration:
 

--- a/docs/en/sim_sih/index.md
+++ b/docs/en/sim_sih/index.md
@@ -27,8 +27,8 @@ The Desktop computer is only used to display the virtual vehicle.
 - SIH for FW (airplane) and VTOL tailsitter are supported from PX4 v1.13.
 - SIH as SITL (without hardware) from PX4 v1.14.
 - SIH for Standard VTOL from PX4 v1.16.
-- SIH for MC Hexacopter X from `main` (expected to be PX4 v1.17).
-- SIH for Ackermann Rover from `main`.
+- SIH for MC Hexacopter X from PX4 v1.17.
+- SIH for Ackermann Rover from PX4 v1.17.
 
 ### Benefits
 
@@ -339,6 +339,7 @@ You can find a full list of available values for `PWM_MAIN_FUNCn` [here](../adva
 Alternatively, you can use the [`PWM_AUX_FUNCn`](../advanced_config/parameter_reference.md#PWM_AUX_FUNC1) parameters.
 
 You may also configure the output as desired:
+
 - Disarmed PWM: ([`PWM_MAIN_DISn`](../advanced_config/parameter_reference.md#PWM_MAIN_DIS1) / [`PWM_AUX_DIS1`](../advanced_config/parameter_reference.md#PWM_AUX_DIS1))
 - Minimum PWM ([`PWM_MAIN_MINn`](../advanced_config/parameter_reference.md#PWM_MAIN_MIN1) / [`PWM_AUX_MINn`](../advanced_config/parameter_reference.md#PWM_AUX_MIN1))
 - Maximum PWM ([`PWM_MAIN_MAXn`](../advanced_config/parameter_reference.md#PWM_MAIN_MAX1) / [`PWM_AUX_MAXn`](../advanced_config/parameter_reference.md#PWM_AUX_MAX1))


### PR DESCRIPTION
This creates a v1.17 release note page, and updates the docs that were saying  `main (planned for: PX4 v1.17)` to `v1.17` - and adds them to that page. 

This is needed so we can actually start building the v1.17 release note, and we don't mix up what is in each release.

@mrpollo
- Is there an easy way to generate the list of PRs that are v1.17 after v1.16 but not v1.18/main?  That way I can finish moving things between the two lists.
- No idea how I'll get the docs up to date for v1.17 on release. Do you have any kind of timeline for that going out?