### PR TITLE
MulticopterPositionControl: prevent velocity integrator filling up from stale acceleration setpoints

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -408,6 +408,7 @@ void MulticopterPositionControl::Run()
 				} else if (previous_position_control_enabled && !_vehicle_control_mode.flag_multicopter_position_control_enabled) {
 					// clear existing setpoint when controller is no longer active
 					_setpoint = PositionControl::empty_trajectory_setpoint;
+					_control.setInputSetpoint(_setpoint);
 				}
 			}
 		}

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -84,8 +84,11 @@ void PositionControl::updateHoverThrust(const float hover_thrust_new)
 	const float previous_hover_thrust = _hover_thrust;
 	setHoverThrust(hover_thrust_new);
 
-	_vel_int(2) += (_acc_sp(2) - CONSTANTS_ONE_G) * previous_hover_thrust / _hover_thrust
-		       + CONSTANTS_ONE_G - _acc_sp(2);
+	if (PX4_ISFINITE(_acc_sp(2))) {
+		_vel_int(2) += (_acc_sp(2) - CONSTANTS_ONE_G) * previous_hover_thrust / _hover_thrust
+			       + CONSTANTS_ONE_G - _acc_sp(2);
+	}
+
 }
 
 void PositionControl::setState(const PositionControlStates &states)


### PR DESCRIPTION
### Solved Problem

Sequence:

1. On ground in position mode: The z-axis acceleration setpoint is [set to 100 m/s²](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mc_pos_control/MulticopterPositionControl.cpp#L516) to ensure zero thrust.

2. Switch to manual mode and takeoff: The 100 m/s² acceleration setpoint is not cleared when exiting position control.

3. Hover thrust estimate updates while in manual mode OR during switch to position mode: The [hover thrust update function](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mc_pos_control/PositionControl/PositionControl.cpp#L87-L88) uses the stale _acc_sp(2) = 100 m/s². This can fill up the velocity integrator if the ratio `previous_hover_thrust / _hover_thrust` is not ≈ 1.0.  

Result: When the position controller runs with the saturated integrator, thrust output can hit minimum or maximum limits, causing the vehicle to drop or climb 

<img width="1832" height="325" alt="image" src="https://github.com/user-attachments/assets/3dc1ac92-8a41-48e1-9224-d87a579d3207" />

### Solution

Once position control is disabled, clear the setpoint properly to prevent stale values, and check that the `acc_sp` is finite before integrating. 

### Changelog Entry
For release notes:
```
Bugfix: prevent multicopter velocity integrator filling up from stale acceleration setpoints
```

### Test coverage

Tested in SITL. To simulate the conditions for this to occur , we need to:

- set an incorrect `MPC_THR_HOVER` (set to 0.2 in SITL, estimate is 0.4). 
- force the hover thrust estimate to update only when in position mode. That way we ensure that the ratio of `previous_hover_thrust / _hover_thrust` is high on the first run. 

Now the acceleration setpoint doesn't spike:  
<img width="2153" height="422" alt="image" src="https://github.com/user-attachments/assets/b1173068-82f2-403c-8787-e26b20ebac65" />


log:  https://review.px4.io/plot_app?log=8c9f1eca-66cd-4617-8ed8-d747289f7fec
