### PR TITLE
[Sponsored by CubePilot] airframes: don't mess with logging profile

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
+++ b/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
@@ -77,9 +77,6 @@ param set-default NAV_ACC_RAD 2
 param set-default RTL_DESCEND_ALT 5
 param set-default RTL_RETURN_ALT 5
 
-# Logging Parameters
-param set-default SDLOG_PROFILE 131
-
 # Sensors Parameters
 param set-default SENS_CM8JL65_CFG 104
 param set-default SENS_FLOW_MAXHGT 25

--- a/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
+++ b/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
@@ -78,9 +78,6 @@ param set-default NAV_ACC_RAD 2
 param set-default RTL_DESCEND_ALT 5
 param set-default RTL_RETURN_ALT 5
 
-# Logging Parameters
-param set-default SDLOG_PROFILE 131
-
 # Sensors Parameters
 param set-default SENS_CM8JL65_CFG 202
 param set-default SENS_FLOW_MAXHGT 25

--- a/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
@@ -29,9 +29,6 @@ param set-default MPC_MAN_TILT_MAX 60
 
 param set-default THR_MDL_FAC 0.3
 
-# enable high-rate logging profile (helps with tuning)
-param set-default SDLOG_PROFILE 19
-
 param set-default IMU_DGYRO_CUTOFF 50
 param set-default IMU_GYRO_CUTOFF 90
 


### PR DESCRIPTION
I don't think we should change the logging profile based on the type of airframe configured. Instead, this is an option you set based on the phase of development/testing you're in.

This came up because the KakuteH7v2 which is 4050 by default would log excessively which is not a good idea with only 128 MB flash storage.