### PR TITLE
Battery scaling: Move to control allocator (via ct scaling)

### DIFF
--- a/src/lib/control_allocation/actuator_effectiveness/ActuatorEffectiveness.hpp
+++ b/src/lib/control_allocation/actuator_effectiveness/ActuatorEffectiveness.hpp
@@ -61,7 +61,7 @@ enum class ActuatorType {
 };
 
 enum class EffectivenessUpdateReason {
-	NO_EXTERNAL_UPDATE = 0,
+	NO_EXTERNAL_UPDATE = 0, ///< Only update the effectiveness matrix if rotor tilt has changed significantly
 	CONFIGURATION_UPDATE = 1, ///< config changes (parameter)
 	MOTOR_ACTIVATION_UPDATE = 2, ///< motor failure detected or certain redundant motors are switched off to save energy
 	BATTERY_SCALE_UPDATE = 3, ///< Update with low rate to recalculate battery scale compensation

--- a/src/lib/control_allocation/actuator_effectiveness/ActuatorEffectiveness.hpp
+++ b/src/lib/control_allocation/actuator_effectiveness/ActuatorEffectiveness.hpp
@@ -64,6 +64,7 @@ enum class EffectivenessUpdateReason {
 	NO_EXTERNAL_UPDATE = 0,
 	CONFIGURATION_UPDATE = 1, ///< config changes (parameter)
 	MOTOR_ACTIVATION_UPDATE = 2, ///< motor failure detected or certain redundant motors are switched off to save energy
+	BATTERY_SCALE_UPDATE = 3, ///< Update with low rate to recalculate battery scale compensation
 };
 
 class ActuatorEffectiveness

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -397,24 +397,27 @@ ControlAllocator::Run()
 	if (do_update) {
 		_last_run = now;
 
-		check_for_motor_failures();
+		// Decide if and for what reasons the effectiveness matrix needs updating
+		{
+			check_for_motor_failures();
 
-		const hrt_abstime time_since_last_effectiveness_udpate = now - _last_effectiveness_update;
+			const hrt_abstime time_since_last_effectiveness_udpate = now - _last_effectiveness_update;
 
-		// If the above check_for_motor_failures has already triggered
-		// an effectiveness update, these timing checks all return false
-		// and no additional update is done. This is by design, because
-		// an effectiveness update due to MOTOR_ACTIVATION_UPDATE also
-		// updates the battery scale and directions of tiltable rotors.
+			// If the above check_for_motor_failures has already triggered
+			// an effectiveness update, these timing checks all return false
+			// and no additional update is done. This is by design, because
+			// an effectiveness update due to MOTOR_ACTIVATION_UPDATE also
+			// updates the battery scale and directions of tiltable rotors.
 
-		if (time_since_last_effectiveness_udpate > 1_s) {
-			// Update battery scaling at relatively low rate
-			update_effectiveness_matrix_if_needed(EffectivenessUpdateReason::BATTERY_SCALE_UPDATE);
+			if (time_since_last_effectiveness_udpate > 1_s) {
+				// Update battery scaling at relatively low rate
+				update_effectiveness_matrix_if_needed(EffectivenessUpdateReason::BATTERY_SCALE_UPDATE);
 
-		} else if (time_since_last_effectiveness_udpate > 100_ms) {
-			// Update periodically for "no external" reason,
-			// allowing tiltrotor directions to update.
-			update_effectiveness_matrix_if_needed(EffectivenessUpdateReason::NO_EXTERNAL_UPDATE);
+			} else if (time_since_last_effectiveness_udpate > 100_ms) {
+				// Update periodically for "no external" reason,
+				// allowing tiltrotor directions to update.
+				update_effectiveness_matrix_if_needed(EffectivenessUpdateReason::NO_EXTERNAL_UPDATE);
+			}
 		}
 
 		// Set control setpoint vector(s)

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessRotors.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessRotors.cpp
@@ -196,13 +196,11 @@ ActuatorEffectivenessRotors::computeEffectivenessMatrix(const Geometry &geometry
 		float ct = geometry.rotors[i].thrust_coef;
 		float km = geometry.rotors[i].moment_ratio;
 
-		// When battery depletes, scale rises above 1 (initially
-		// designed as a compensation factor to multiply thrust and
-		// torque commands with). Rather than that we model it here by a decreasing
-		// thrust coefficient (thrust = ct * u^2)
-		if (battery_scale > 1.f) {
-			ct /= battery_scale;
-		}
+		// When battery depletes, scale rises above 1, as it was
+		// initially designed as a compensation factor to multiply
+		// thrust and torque commands with. Rather than that we model it
+		// here by a decreasing thrust coefficient.
+		ct /= battery_scale;
 
 		if (geometry.propeller_torque_disabled) {
 			km = 0.f;

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessRotors.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessRotors.hpp
@@ -46,6 +46,7 @@
 #include <px4_platform_common/module_params.h>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
+#include <uORB/topics/battery_status.h>
 
 class ActuatorEffectivenessTilts;
 
@@ -96,7 +97,7 @@ public:
 	}
 
 	static int computeEffectivenessMatrix(const Geometry &geometry,
-					      EffectivenessMatrix &effectiveness, int actuator_start_index = 0);
+					      EffectivenessMatrix &effectiveness, int actuator_start_index = 0, float battery_scale = 1.f);
 
 	bool addActuators(Configuration &configuration);
 
@@ -135,6 +136,8 @@ private:
 	const AxisConfiguration _axis_config;
 	const bool _tilt_support; ///< if true, tilt servo assignment params are loaded
 
+	uORB::Subscription _battery_status_sub{ORB_ID(battery_status)};
+
 	struct ParamHandles {
 		param_t position_x;
 		param_t position_y;
@@ -149,8 +152,10 @@ private:
 	ParamHandles _param_handles[NUM_ROTORS_MAX];
 
 	Geometry _geometry{};
+	float _battery_scale{1.f};
 
 	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::CA_ROTOR_COUNT>) _param_ca_rotor_count
+		(ParamInt<px4::params::CA_ROTOR_COUNT>) _param_ca_rotor_count,
+		(ParamBool<px4::params::CA_BAT_SCALE_EN>) _param_ca_bat_scale_en
 	)
 };

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -48,6 +48,18 @@ parameters:
                 2: Automatic
             default: 2
 
+        CA_BAT_SCALE_EN:
+            description:
+                short: Enable battery scale compensation
+                long: |
+                  Battery scale compensation modifies the rotor effectiveness,
+                  modelling the weaker response with depleting battery. Results
+                  in consistent thrust and torque response despite depleting
+                  battery. This replaces MC_BAT_SCALE_EN, FW_BAT_SCALE_EN, and
+                  SC_BAT_SCALE_EN.
+            type: boolean
+            default: false
+
         # Motor parameters
         CA_R_REV:
             description:

--- a/src/modules/fw_rate_control/FixedwingRateControl.cpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.cpp
@@ -394,20 +394,6 @@ void FixedwingRateControl::Run()
 
 				/* throttle passed through if it is finite */
 				_vehicle_thrust_setpoint.xyz[0] = PX4_ISFINITE(_rates_sp.thrust_body[0]) ? _rates_sp.thrust_body[0] : 0.0f;
-
-				/* scale effort by battery status */
-				if (_param_fw_bat_scale_en.get() && _vehicle_thrust_setpoint.xyz[0] > 0.1f) {
-
-					if (_battery_status_sub.updated()) {
-						battery_status_s battery_status{};
-
-						if (_battery_status_sub.copy(&battery_status) && battery_status.connected && battery_status.scale > 0.f) {
-							_battery_scale = battery_status.scale;
-						}
-					}
-
-					_vehicle_thrust_setpoint.xyz[0] *= _battery_scale;
-				}
 			}
 
 			// publish rate controller status

--- a/src/modules/fw_rate_control/FixedwingRateControl.hpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.hpp
@@ -57,7 +57,6 @@
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/actuator_controls_status.h>
 #include <uORB/topics/airspeed_validated.h>
-#include <uORB/topics/battery_status.h>
 #include <uORB/topics/control_allocator_status.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/normalized_unsigned_setpoint.h>
@@ -103,7 +102,6 @@ private:
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
-	uORB::Subscription _battery_status_sub{ORB_ID(battery_status)};
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription _rates_sp_sub{ORB_ID(vehicle_rates_setpoint)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
@@ -141,8 +139,6 @@ private:
 
 	bool _landed{true};
 
-	float _battery_scale{1.0f};
-
 	float _energy_integration_time{0.0f};
 	float _control_energy[4] {};
 	float _control_prev[3] {};
@@ -172,8 +168,6 @@ private:
 		(ParamBool<px4::params::FW_USE_AIRSPD>) _param_fw_use_airspd,
 
 		(ParamInt<px4::params::FW_ARSP_SCALE_EN>) _param_fw_arsp_scale_en,
-
-		(ParamBool<px4::params::FW_BAT_SCALE_EN>) _param_fw_bat_scale_en,
 
 		(ParamFloat<px4::params::FW_DTRIM_P_VMAX>) _param_fw_dtrim_p_vmax,
 		(ParamFloat<px4::params::FW_DTRIM_P_VMIN>) _param_fw_dtrim_p_vmin,

--- a/src/modules/fw_rate_control/fw_rate_control_params.c
+++ b/src/modules/fw_rate_control/fw_rate_control_params.c
@@ -270,17 +270,6 @@ PARAM_DEFINE_FLOAT(FW_ACRO_Y_MAX, 90);
 PARAM_DEFINE_FLOAT(FW_ACRO_Z_MAX, 45);
 
 /**
- * Enable throttle scale by battery level
- *
- * This compensates for voltage drop of the battery over time by attempting to
- * normalize performance across the operating range of the battery.
- *
- * @boolean
- * @group FW Rate Control
- */
-PARAM_DEFINE_INT32(FW_BAT_SCALE_EN, 0);
-
-/**
  * Enable airspeed scaling
  *
  * This enables a logic that automatically adjusts the output of the rate controller to take

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -237,24 +237,6 @@ MulticopterRateControl::Run()
 			vehicle_torque_setpoint.xyz[1] = PX4_ISFINITE(torque_setpoint(1)) ? torque_setpoint(1) : 0.f;
 			vehicle_torque_setpoint.xyz[2] = PX4_ISFINITE(torque_setpoint(2)) ? torque_setpoint(2) : 0.f;
 
-			// scale setpoints by battery status if enabled
-			if (_param_mc_bat_scale_en.get()) {
-				if (_battery_status_sub.updated()) {
-					battery_status_s battery_status;
-
-					if (_battery_status_sub.copy(&battery_status) && battery_status.connected && battery_status.scale > 0.f) {
-						_battery_status_scale = battery_status.scale;
-					}
-				}
-
-				if (_battery_status_scale > 0.f) {
-					for (int i = 0; i < 3; i++) {
-						vehicle_thrust_setpoint.xyz[i] = math::constrain(vehicle_thrust_setpoint.xyz[i] * _battery_status_scale, -1.f, 1.f);
-						vehicle_torque_setpoint.xyz[i] = math::constrain(vehicle_torque_setpoint.xyz[i] * _battery_status_scale, -1.f, 1.f);
-					}
-				}
-			}
-
 			vehicle_thrust_setpoint.timestamp_sample = angular_velocity.timestamp_sample;
 			vehicle_thrust_setpoint.timestamp = hrt_absolute_time();
 			_vehicle_thrust_setpoint_pub.publish(vehicle_thrust_setpoint);

--- a/src/modules/mc_rate_control/MulticopterRateControl.hpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.hpp
@@ -92,7 +92,6 @@ private:
 
 	RateControl _rate_control; ///< class for rate control calculations
 
-	uORB::Subscription _battery_status_sub{ORB_ID(battery_status)};
 	uORB::Subscription _control_allocator_status_sub{ORB_ID(control_allocator_status)};
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
@@ -123,8 +122,6 @@ private:
 	// keep setpoint values between updates
 	matrix::Vector3f _acro_rate_max;		/**< max attitude rates in acro mode */
 	matrix::Vector3f _rates_setpoint{};
-
-	float _battery_status_scale{0.0f};
 	matrix::Vector3f _thrust_setpoint{};
 
 	float _energy_integration_time{0.0f};
@@ -161,8 +158,6 @@ private:
 		(ParamFloat<px4::params::MC_ACRO_EXPO>) _param_mc_acro_expo,			/**< expo stick curve shape (roll & pitch) */
 		(ParamFloat<px4::params::MC_ACRO_EXPO_Y>) _param_mc_acro_expo_y,				/**< expo stick curve shape (yaw) */
 		(ParamFloat<px4::params::MC_ACRO_SUPEXPO>) _param_mc_acro_supexpo,		/**< superexpo stick curve shape (roll & pitch) */
-		(ParamFloat<px4::params::MC_ACRO_SUPEXPOY>) _param_mc_acro_supexpoy,		/**< superexpo stick curve shape (yaw) */
-
-		(ParamBool<px4::params::MC_BAT_SCALE_EN>) _param_mc_bat_scale_en
+		(ParamFloat<px4::params::MC_ACRO_SUPEXPOY>) _param_mc_acro_supexpoy		/**< superexpo stick curve shape (yaw) */
 	)
 };

--- a/src/modules/mc_rate_control/mc_rate_control_params.c
+++ b/src/modules/mc_rate_control/mc_rate_control_params.c
@@ -279,20 +279,6 @@ PARAM_DEFINE_FLOAT(MC_YAWRATE_FF, 0.0f);
 PARAM_DEFINE_FLOAT(MC_YAWRATE_K, 1.0f);
 
 /**
- * Battery power level scaler
- *
- * This compensates for voltage drop of the battery over time by attempting to
- * normalize performance across the operating range of the battery. The copter
- * should constantly behave as if it was fully charged with reduced max acceleration
- * at lower battery percentages. i.e. if hover is at 0.5 throttle at 100% battery,
- * it will still be 0.5 at 60% battery.
- *
- * @boolean
- * @group Multicopter Rate Control
- */
-PARAM_DEFINE_INT32(MC_BAT_SCALE_EN, 0);
-
-/**
  * Low pass filter cutoff frequency for yaw torque setpoint
  *
  * Reduces vibrations by lowering high frequency torque caused by rotor acceleration.

--- a/src/modules/spacecraft/SpacecraftRateControl/SpacecraftRateControl.cpp
+++ b/src/modules/spacecraft/SpacecraftRateControl/SpacecraftRateControl.cpp
@@ -204,26 +204,6 @@ void SpacecraftRateControl::updateRateControl()
 			vehicle_torque_setpoint.xyz[1] = PX4_ISFINITE(torque_sp(1)) ? torque_sp(1) : 0.f;
 			vehicle_torque_setpoint.xyz[2] = PX4_ISFINITE(torque_sp(2)) ? torque_sp(2) : 0.f;
 
-			// scale setpoints by battery status if enabled
-			if (_param_sc_bat_scale_en.get()) {
-				if (_battery_status_sub.updated()) {
-					battery_status_s battery_status;
-
-					if (_battery_status_sub.copy(&battery_status) && battery_status.connected && battery_status.scale > 0.f) {
-						_battery_status_scale = battery_status.scale;
-					}
-				}
-
-				if (_battery_status_scale > 0.f) {
-					for (int i = 0; i < 3; i++) {
-						vehicle_thrust_setpoint.xyz[i] =
-							math::constrain(vehicle_thrust_setpoint.xyz[i] * _battery_status_scale, -1.f, 1.f);
-						vehicle_torque_setpoint.xyz[i] =
-							math::constrain(vehicle_torque_setpoint.xyz[i] * _battery_status_scale, -1.f, 1.f);
-					}
-				}
-			}
-
 			vehicle_thrust_setpoint.timestamp_sample = angular_velocity.timestamp_sample;
 			vehicle_thrust_setpoint.timestamp = hrt_absolute_time();
 			_vehicle_thrust_setpoint_pub.publish(vehicle_thrust_setpoint);

--- a/src/modules/spacecraft/SpacecraftRateControl/SpacecraftRateControl.hpp
+++ b/src/modules/spacecraft/SpacecraftRateControl/SpacecraftRateControl.hpp
@@ -153,8 +153,6 @@ private:
 		(ParamFloat<px4::params::SC_ACRO_SUPEXPOY>) _param_sc_acro_supexpoy,		/**< superexpo stick curve shape (yaw) */
 
 		(ParamFloat<px4::params::SC_MAN_F_MAX>) _param_sc_manual_f_max,
-		(ParamFloat<px4::params::SC_MAN_T_MAX>) _param_sc_manual_t_max,
-
-		(ParamBool<px4::params::SC_BAT_SCALE_EN>) _param_sc_bat_scale_en
+		(ParamFloat<px4::params::SC_MAN_T_MAX>) _param_sc_manual_t_max
 	)
 };

--- a/src/modules/spacecraft/spacecraft_rate_params.c
+++ b/src/modules/spacecraft/spacecraft_rate_params.c
@@ -385,20 +385,6 @@ PARAM_DEFINE_FLOAT(SC_ACRO_SUPEXPO, 0.7f);
 PARAM_DEFINE_FLOAT(SC_ACRO_SUPEXPOY, 0.7f);
 
 /**
- * Battery power level scaler
- *
- * This compensates for voltage drop of the battery over time by attempting to
- * normalize performance across the operating range of the battery. The copter
- * should constantly behave as if it was fully charged with reduced max acceleration
- * at lower battery percentages. i.e. if hover is at 0.5 throttle at 100% battery,
- * it will still be 0.5 at 60% battery.
- *
- * @boolean
- * @group Spacecraft Rate Control
- */
-PARAM_DEFINE_INT32(SC_BAT_SCALE_EN, 0);
-
-/**
  * Manual mode maximum force.
  *
  * *


### PR DESCRIPTION
## Solved Problem

Currently, torque and thrust setpoints sometimes include battery scaling and sometimes do not, depending on where in the autopilot they show up. This is confusing, as we do not want higher torques and thrusts when the battery depletes, rather we have to give the motor a larger command to achieve the _same_ torques and thrusts. 

Some specific practical symptoms are:
 - First principle airspeed check giving false positives when battery depletes
 - Synthetic airspeed becoming higher and higher when battery depletes
 - Having to keep [one more thing](https://github.com/PX4/PX4-Autopilot/pull/26221#discussion_r2665730440) in mind while developing

## Solution

### High level
As suggested [here](https://github.com/PX4/PX4-Autopilot/pull/26145#discussion_r2665803152), we move the battery scaling from the rate control modules to the control allocator. This is an improvement in several aspects:
 - Greater encapsulation from rest of autopilot and less confusion - this implementation applies through the effectiveness matrix, and any torque / rate / thrust commands are now in "physical", non-battery-scaled units
 - Less repetition and incidental complexity - only one implementation handles both thrust and torque, and is completely decoupled from any FW/MC/VTOL distinction
 - The thrust and torque setpoints that we give during transition (e.g. [standard VTOL](https://github.com/PX4/PX4-Autopilot/blob/c71e2d41d6cd50c1aa884ea9ee659c4010a4ac57/src/modules/vtol_att_control/standard.cpp#L292-L363)) are now also battery-scaled, which before was not the case 

It is now controlled by a single parameter, `CA_BAT_SCALE_EN`, which replaces the previous three `MC_BAT_SCALE_EN`, `FW_BAT_SCALE_EN`, and `SC_BAT_SCALE_EN`. **We remove** the option of differently setting the MC and FW parameters for VTOL vehicles.

### Technicalities
 - We add a new `EffectivenessUpdateReason::BATTERY_SCALE_UPDATE` - within the effectiveness classes it is not really handled besides being different from `EffectivenessUpdateReason::NO_EXTERNAL_UPDATE`, causing the full update to occur. 
   - We could squeeze out some extra CPU cycles by only updating the rotor part of the effectiveness classes (the only one affected by battery scaling). 
   - We could also completely skip the effectiveness update if the parameter is off but that would require reading the parameter from two places
 - Included is a small refactor in the `ControlAllocator`, cleanly separating responsibilities:
   - the main loop decides when and for what reason we call `update_effectiveness_matrix_if_needed`
   - that function has no timing logic anymore, it only decides based on the given reason if and what kind of update it does.
 
## Changelog Entry

```
Battery scaling: Replace MC_BAT_SCALE_EN, FW_BAT_SCALE_EN, and SC_BAT_SCALE_EN by unified parameter CA_BAT_SCALE_EN
```

## Validation

Before and after SITL runs with `gazebo_standard_vtol` in FW. 
 - Before PR, `FW_BAT_SCALE_EN=1`: tecs throttle setpoint is unscaled, vehicle_thrust_setpoint and motor output are scaled, motor output / tecs throttle = battery scale
<img width="1140" height="645" alt="image" src="https://github.com/user-attachments/assets/87d7622f-8694-4948-bdd6-2c72aacf6e34" />

 - After PR, `CA_BAT_SCALE_EN=1`: tecs throttle setpoint as well as vehicle_thrust_setpoint unscaled, motor output is scaled, motor output / tecs throttle ratio = battery scale as before
   - Notice the staircase shape of the ratio - this is because we only update the effectiveness matrix at 1 Hz. In practice, the scale is probably going to move slowly enough for this to not be visible.  
<img width="1140" height="645" alt="image" src="https://github.com/user-attachments/assets/9fe1fe96-12fb-4691-8e2c-d366f0e0ca45" />

Because all rotors are handled equally, and by scaling `ct` we are scaling the two equations below uniformly, this automatically extends to torque (both lever arm and induced). https://github.com/PX4/PX4-Autopilot/blob/b1da6f760afe34d16d825669e361a8e592392f73/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessRotors.cpp#L223-L227
 - I realise sim results would be more satisfying but a good visualisation proved elusive even with high rate logging. 

## Known (and after further thought probably blocking and requiring a different implementation altogether) issue
It is not possible to turn the feature on in flight with `param set CA_BAT_SCALE_EN 1` - it fails in a very peculiar way where the scale entering `ActuatorEffectivenessRotors::computeEffectivenessMatrix` is correct but ultimately the ratio between motor output and throttle setpoint (standard vtol in FW, the pusher) is less than the battery scale. Turning it off works. The previous version had no problems doing this. 

New version, turning off works at 25.5s, turning on at 27.5s fails, the ratio (`actuator_motors/control.04` / `tecs_status/throttle_sp`) is lower than the scale but rises with the same shape???
<img width="1213" height="547" alt="image" src="https://github.com/user-attachments/assets/4bbbe755-0a69-42ec-8cf2-368204746151" />


Previous version, toggling works perfectly fine: 
<img width="1213" height="547" alt="image" src="https://github.com/user-attachments/assets/3f8d0235-f6c9-4203-accb-f2aed9ab136c" />

Debugging findings: 
 - the effectiveness matrix entry (from pusher output to forward thrust) does look absolutely correct when showing periodically with `print_status()` in the allocator
 - yet, the ratio between the actual motor output and throttle setpoint does not
 - The inconsistency appears here, and is fundamentally because mixing matrix is not precisely the pinv of the effectiveness, but a rescaled version of that. Whenever the scaling is updated (happens e.g. just after changing the param) then the overall ratio of motor output / throttle sp goes back to 1, and changes from there on if the battery scale changes further. I am not sure if it is fundamentally impossible but at least this severely complicates a working implementation in the current style... https://github.com/PX4/PX4-Autopilot/blob/ec8f34325e7b990250e7eee9eff1f9325f8e713a/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.cpp#L67-L74

## Other remarks
 - Airspeed scaling suffers from a similar issue - it applies in `FixedwingRateControl` and so the outgoing torque setpoint does not really deserve its name, rather it already corresponds more directly to "deflections for whichever control surfaces point in the corresponding direction". An obvious improvement in the same style is waiting here. 
 - The `EffectivenessUpdateReason` is currently an enum. This makes the situation where there are several reasons for the update a bit janky -- a bitfield would better reflect reality and enable better control of what we do in the various types of update.
 - TODO verify that slew rates in the allocator do not break it again