### PR TITLE
Bugfix: Let user take over from a degraded failsafe

### DIFF
--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -499,9 +499,9 @@ void FailsafeBase::getSelectedAction(const State &state, const failsafe_flags_s 
 		allow_user_takeover = UserTakeoverAllowed::AlwaysModeSwitchOnly;
 	}
 
-	// User takeover is activated on user intented mode update (w/o action change, so takeover is not immediately
-	// requested when entering failsafe) or rc stick movements
-	bool want_user_takeover_mode_switch = user_intended_mode_updated && _selected_action == selected_action;
+	// User takeover interrupting a failsafe is triggered by a change of the user-intended mode
+	// (only if a failsafe action is already active otherwise there can be immediate takeover when entering a failsafe) or by stick movement
+	bool want_user_takeover_mode_switch = user_intended_mode_updated && (_selected_action > Action::Warn);
 	bool want_user_takeover = want_user_takeover_mode_switch || rc_sticks_takeover_request;
 	bool takeover_allowed =
 		(allow_user_takeover == UserTakeoverAllowed::Always && (_user_takeover_active || want_user_takeover))


### PR DESCRIPTION
### Solved Problem
User can **not** take over from a degraded failsafe e.g.
1. Configure an RTL failsafe e.g. ground station loss action: Return (`NAV_DLL_ACT = 2`)
2. Fly in manual mode (without position requirement)
3. No position estimates available
4. Lose ground station connection (but not RC connection)
5. RTL is desired but not possible -> failsafe is Land
6. Try to take over by changing the mode switch -> **Nothing happens**

<img width="500" alt="Untitled" src="https://github.com/user-attachments/assets/fa09ebde-9be5-460e-87d8-695584453679" />


### Solution
1. Add unit test cases for
   - the case above: Remaining battery time low -> RTL, no position -> Land, need to be able to take over
   - the case for which the condition `_selected_action == selected_action` was originally added: When a failsafe happens immediately on mode switch because a mode requirement is not met. Then the mode switch that caused it should not be interpreted as the user taking over immediately. Note that the context should avoid switching to modes that cannot run but the framework should still handle the case correctly.
2. Fix the condition `_selected_action == selected_action` to `(_selected_action > Action::Warn)`.
   - Remove `_selected_action == selected_action` because in the problem case `selected_action` is what we want to do: Return and `_selected_action` is what we end up doing after the fallbacks in the same function below: Land and the condition is never fulfilled while degraded.
   - Still have `(_selected_action > Action::Warn)` to avoid immediately flaging a user takeover if there was no failsafe before and it's triggered at the same time as/caused by a mode switch.
   
Big thanks to @bkueng who got me to understand the immediate takeover case and also was the one suggesting the fix 🙏 

### Changelog Entry
```
Bugfix: Let user take over from a degraded failsafe
```

### Test coverage
The [failsafe simulation](https://docs.px4.io/main/en/config/safety_simulation) shows the problem and it being resolved and we have automated unit tests for the cases we could think of such that we hopefully can't break it again.