### PR TITLE
FwLateralLongitudinalControl: publish flight phase also if unknown, and with limited rate

### DIFF
--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
@@ -213,11 +213,12 @@ private:
 
 	void parameters_update();
 	void update_control_state(hrt_abstime now);
-	void tecs_update_pitch_throttle(const float control_interval, float alt_sp, float airspeed_sp,
-					float pitch_min_rad, float pitch_max_rad, float throttle_min,
-					float throttle_max, const float desired_max_sinkrate,
-					const float desired_max_climbrate,
-					bool disable_underspeed_detection, float hgt_rate_sp, hrt_abstime now);
+
+	uint8_t tecs_update_pitch_throttle(const float control_interval, float alt_sp, float airspeed_sp,
+					   float pitch_min_rad, float pitch_max_rad, float throttle_min,
+					   float throttle_max, const float desired_max_sinkrate,
+					   const float desired_max_climbrate,
+					   bool disable_underspeed_detection, float hgt_rate_sp, hrt_abstime now);
 
 	void tecs_status_publish(float alt_sp, float equivalent_airspeed_sp, float true_airspeed_derivative_raw,
 				 float throttle_trim, hrt_abstime now);


### PR DESCRIPTION
### Context / Problem

In this PR https://github.com/PX4/PX4-Autopilot/pull/26219 we re-added the publication of the flight phase in FwLateralLongitudinalControl, which has been dropped erroneously in a prior refactor. 

However, we did not quite replicate the correct behaviour (see [review comment](https://github.com/PX4/PX4-Autopilot/pull/26219#discussion_r2668459918)) -- we currently only publish a flight phase if TECS is running, whereas previously we would publish `flight_phase_estimation_s::FLIGHT_PHASE_UNKNOWN` if TECS is not running.

Also, the topic was previously and is now published at full rate, which is a bit lavish.


### Solution
 - we again initialise to unknown and publish unconditionally, in the main `if (_local_pos_sub.update(&_local_pos)) {` scope, so if TECS is not running we correctly publish the unknown flight phase (1st commit) 
 - we rate-limit the update to 1Hz, but publish immediately when it has changed. To detect the change we store the current flight phase in a local variable (which `tecs_update_pitch_throttle` returns now, rather than void) and compare against the one wihtin the `_flight_phase_estimation_pub` (2nd commit)

### Testing
Flying around in SITL (standard VTOL), verify that flight phase is always published in FW and updated immediately on change