### PR TITLE
Update 4004_gz_standard_vtol

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
@@ -101,6 +101,6 @@ param set-default NAV_ACC_RAD 5
 param set-default NAV_DLL_ACT 2
 
 param set-default VT_FWD_THRUST_EN 4
-param set-default VT_F_TRANS_THR 0.3
+param set-default VT_F_TRANS_THR 1
 param set-default VT_TYPE 2
 param set-default FD_ESCS_EN 0


### PR DESCRIPTION
VT_F_TRANS_THR at 0.3 always triggers front transition timeout in gazebo as the vehicle does not accaelerate quickly enough. With the param set to 1.0 it works.
