### PR TITLE
Driver: fix mb12xx driver set address feature

### DIFF
--- a/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
+++ b/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
@@ -371,7 +371,9 @@ MB12XX::set_address(const uint8_t address)
 	    address == 80  ||
 	    address == 164 ||
 	    address == 170 ||
-	    address > 224) {
+	    address > 224 ||
+	    (address % 2) != 0 ||
+	    address < MB12XX_MIN_ADDR) {
 		PX4_ERR("incompatible address requested");
 		return PX4_ERROR;
 	}
@@ -386,6 +388,8 @@ MB12XX::set_address(const uint8_t address)
 	}
 
 	set_device_address(address);
+	_sensor_addresses[0] = address;
+
 	PX4_INFO("device address: %u", get_device_address());
 	return PX4_OK;
 }


### PR DESCRIPTION
### Solved Problem
fixed the mb12xx set_address module command

### Solution
BusCLIArguments::parseDefaultArguments doesnt accept the -p flag unless the i2c_address is set. So moved the line for setting the address up

Added more sanity checks on the set address error check. And fixed runtime state management when swapping addresses.
- If _sensor_addresses[0] = address; isnt set the main loop wont update to the new i2c address

### Changelog Entry
For release notes:
```
Bugfix set_address in mb12xx fixed
```