### PR TITLE
Battery scaling: Move to allocator (via mixing matrix scaling) 

### DIFF
--- a/src/lib/control_allocation/actuator_effectiveness/ActuatorEffectiveness.hpp
+++ b/src/lib/control_allocation/actuator_effectiveness/ActuatorEffectiveness.hpp
@@ -160,6 +160,16 @@ public:
 	}
 
 	/**
+	 * Query if the mixing matrix requires battery compensation
+	 */
+	virtual void getNeedsBatteryScaling(bool needs_scaling[MAX_NUM_MATRICES]) const
+	{
+		for (int i = 0; i < MAX_NUM_MATRICES; ++i) {
+			needs_scaling[i] = false;
+		}
+	}
+
+	/**
 	 * Get the control effectiveness matrix if updated
 	 *
 	 * @return true if updated and matrix is set

--- a/src/lib/control_allocation/control_allocation/ControlAllocation.hpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocation.hpp
@@ -70,6 +70,10 @@
 #pragma once
 
 #include <matrix/matrix/math.hpp>
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 
 #include "control_allocation/actuator_effectiveness/ActuatorEffectiveness.hpp"
 
@@ -228,6 +232,8 @@ public:
 
 	void setNormalizeRPY(bool normalize_rpy) { _normalize_rpy = normalize_rpy; }
 
+	virtual void setBatteryScaling(float new_battery_scaling) { _battery_scaling = new_battery_scaling; }
+
 protected:
 	friend class ControlAllocator; // for _actuator_sp
 
@@ -244,4 +250,5 @@ protected:
 	int _num_actuators{0};
 	bool _normalize_rpy{false};				///< if true, normalize roll, pitch and yaw columns
 	bool _had_actuator_failure{false};
+	float _battery_scaling{1.0f};
 };

--- a/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.cpp
@@ -73,6 +73,9 @@ ControlAllocationPseudoInverse::updatePseudoInverse()
 			normalizeControlAllocationMatrix();
 		}
 
+		// empty battery = scaling > 1 = larger mix matrix = smaller effectiveness
+		_mix *= _battery_scaling;
+
 		_mix_update_needed = false;
 	}
 }

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -72,6 +72,7 @@
 #include <uORB/topics/actuator_motors.h>
 #include <uORB/topics/actuator_servos.h>
 #include <uORB/topics/actuator_servos_trim.h>
+#include <uORB/topics/battery_status.h>
 #include <uORB/topics/control_allocator_status.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/vehicle_control_mode.h>
@@ -193,6 +194,7 @@ private:
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
 	uORB::Subscription _failure_detector_status_sub{ORB_ID(failure_detector_status)};
+	uORB::Subscription _battery_status_sub{ORB_ID(battery_status)};
 
 	matrix::Vector3f _torque_sp;
 	matrix::Vector3f _thrust_sp;
@@ -214,11 +216,15 @@ private:
 	Params _params{};
 	bool _has_slew_rate{false};
 
+	// For each allocation matrix, determine whether it needs battery scaling
+	bool _allocation_needs_battery_scaling[ActuatorEffectiveness::MAX_NUM_MATRICES] {};
+
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::CA_AIRFRAME>) _param_ca_airframe,
 		(ParamInt<px4::params::CA_METHOD>) _param_ca_method,
 		(ParamInt<px4::params::CA_FAILURE_MODE>) _param_ca_failure_mode,
-		(ParamInt<px4::params::CA_R_REV>) _param_r_rev
+		(ParamInt<px4::params::CA_R_REV>) _param_r_rev,
+		(ParamBool<px4::params::CA_BAT_SCALE_EN>) _param_ca_bat_scale_en
 	)
 
 };

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessMCTilt.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessMCTilt.hpp
@@ -55,6 +55,11 @@ public:
 		normalize[0] = true;
 	}
 
+	void getNeedsBatteryScaling(bool needs_scaling[MAX_NUM_MATRICES]) const override
+	{
+		needs_scaling[0] = true;
+	}
+
 	void updateSetpoint(const matrix::Vector<float, NUM_AXES> &control_sp, int matrix_index, ActuatorVector &actuator_sp,
 			    const ActuatorVector &actuator_min, const ActuatorVector &actuator_max) override;
 

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessMultirotor.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessMultirotor.hpp
@@ -54,6 +54,11 @@ public:
 		normalize[0] = true;
 	}
 
+	void getNeedsBatteryScaling(bool needs_scaling[MAX_NUM_MATRICES]) const override
+	{
+		needs_scaling[0] = true;
+	}
+
 	const char *name() const override { return "Multirotor"; }
 
 protected:

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessRotors.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessRotors.hpp
@@ -95,6 +95,11 @@ public:
 		normalize[0] = true;
 	}
 
+	void getNeedsBatteryScaling(bool needs_scaling[MAX_NUM_MATRICES]) const override
+	{
+		needs_scaling[0] = true;
+	}
+
 	static int computeEffectivenessMatrix(const Geometry &geometry,
 					      EffectivenessMatrix &effectiveness, int actuator_start_index = 0);
 

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessSpacecraft.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessSpacecraft.hpp
@@ -57,6 +57,13 @@ public:
 		normalize[0] = true;
 	}
 
+	void getNeedsBatteryScaling(bool needs_scaling[MAX_NUM_MATRICES]) const override
+	{
+		// Set to true if the spacecraft is using electric actuators
+		// that degrade as battery depletes
+		needs_scaling[0] = false;
+	}
+
 	void updateSetpoint(const matrix::Vector<float, NUM_AXES> &control_sp, int matrix_index,
 			    ActuatorVector &actuator_sp, const matrix::Vector<float, NUM_ACTUATORS> &actuator_min,
 			    const matrix::Vector<float, NUM_ACTUATORS> &actuator_max) override;

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.hpp
@@ -73,6 +73,12 @@ public:
 		normalize[1] = false;
 	}
 
+	void getNeedsBatteryScaling(bool needs_scaling[MAX_NUM_MATRICES]) const override
+	{
+		needs_scaling[0] = true;
+		needs_scaling[1] = false;
+	}
+
 	void allocateAuxilaryControls(const float dt, int matrix_index, ActuatorVector &actuator_sp) override;
 
 	void updateSetpoint(const matrix::Vector<float, NUM_AXES> &control_sp, int matrix_index, ActuatorVector &actuator_sp,

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTailsitterVTOL.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTailsitterVTOL.hpp
@@ -70,6 +70,12 @@ public:
 		normalize[1] = false;
 	}
 
+	void getNeedsBatteryScaling(bool needs_scaling[MAX_NUM_MATRICES]) const override
+	{
+		needs_scaling[0] = true;
+		needs_scaling[1] = true;  // Even in fixed wing we want to scale all thrusts and torques by battery because everything is a rotor
+	}
+
 	void allocateAuxilaryControls(const float dt, int matrix_index, ActuatorVector &actuator_sp) override;
 
 	void updateSetpoint(const matrix::Vector<float, NUM_AXES> &control_sp, int matrix_index, ActuatorVector &actuator_sp,

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
@@ -76,6 +76,12 @@ public:
 		normalize[1] = false;
 	}
 
+	void getNeedsBatteryScaling(bool needs_scaling[MAX_NUM_MATRICES]) const override
+	{
+		needs_scaling[0] = true;
+		needs_scaling[1] = false;
+	}
+
 	void setFlightPhase(const FlightPhase &flight_phase) override;
 
 	void allocateAuxilaryControls(const float dt, int matrix_index, ActuatorVector &actuator_sp) override;

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessUUV.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessUUV.hpp
@@ -54,6 +54,11 @@ public:
 		normalize[0] = true;
 	}
 
+	void getNeedsBatteryScaling(bool needs_scaling[MAX_NUM_MATRICES]) const override
+	{
+		needs_scaling[0] = true;
+	}
+
 	void updateSetpoint(const matrix::Vector<float, NUM_AXES> &control_sp, int matrix_index, ActuatorVector &actuator_sp,
 			    const ActuatorVector &actuator_min, const ActuatorVector &actuator_max) override;
 

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -48,6 +48,17 @@ parameters:
                 2: Automatic
             default: 2
 
+        CA_BAT_SCALE_EN:
+            description:
+                short: Enable battery scale compensation
+                long: |
+                  Battery scale compensation results in consistent thrust and
+                  torque response despite depleting battery. It applies to all
+                  rotors -- if they are gas powered disable it. This replaces
+                  MC_BAT_SCALE_EN, FW_BAT_SCALE_EN, and SC_BAT_SCALE_EN.
+            type: boolean
+            default: false
+
         # Motor parameters
         CA_R_REV:
             description:

--- a/src/modules/fw_rate_control/FixedwingRateControl.cpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.cpp
@@ -394,20 +394,6 @@ void FixedwingRateControl::Run()
 
 				/* throttle passed through if it is finite */
 				_vehicle_thrust_setpoint.xyz[0] = PX4_ISFINITE(_rates_sp.thrust_body[0]) ? _rates_sp.thrust_body[0] : 0.0f;
-
-				/* scale effort by battery status */
-				if (_param_fw_bat_scale_en.get() && _vehicle_thrust_setpoint.xyz[0] > 0.1f) {
-
-					if (_battery_status_sub.updated()) {
-						battery_status_s battery_status{};
-
-						if (_battery_status_sub.copy(&battery_status) && battery_status.connected && battery_status.scale > 0.f) {
-							_battery_scale = battery_status.scale;
-						}
-					}
-
-					_vehicle_thrust_setpoint.xyz[0] *= _battery_scale;
-				}
 			}
 
 			// publish rate controller status

--- a/src/modules/fw_rate_control/FixedwingRateControl.hpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.hpp
@@ -57,7 +57,6 @@
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/actuator_controls_status.h>
 #include <uORB/topics/airspeed_validated.h>
-#include <uORB/topics/battery_status.h>
 #include <uORB/topics/control_allocator_status.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/normalized_unsigned_setpoint.h>
@@ -103,7 +102,6 @@ private:
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
-	uORB::Subscription _battery_status_sub{ORB_ID(battery_status)};
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription _rates_sp_sub{ORB_ID(vehicle_rates_setpoint)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
@@ -141,8 +139,6 @@ private:
 
 	bool _landed{true};
 
-	float _battery_scale{1.0f};
-
 	float _energy_integration_time{0.0f};
 	float _control_energy[4] {};
 	float _control_prev[3] {};
@@ -172,8 +168,6 @@ private:
 		(ParamBool<px4::params::FW_USE_AIRSPD>) _param_fw_use_airspd,
 
 		(ParamInt<px4::params::FW_ARSP_SCALE_EN>) _param_fw_arsp_scale_en,
-
-		(ParamBool<px4::params::FW_BAT_SCALE_EN>) _param_fw_bat_scale_en,
 
 		(ParamFloat<px4::params::FW_DTRIM_P_VMAX>) _param_fw_dtrim_p_vmax,
 		(ParamFloat<px4::params::FW_DTRIM_P_VMIN>) _param_fw_dtrim_p_vmin,

--- a/src/modules/fw_rate_control/fw_rate_control_params.c
+++ b/src/modules/fw_rate_control/fw_rate_control_params.c
@@ -270,17 +270,6 @@ PARAM_DEFINE_FLOAT(FW_ACRO_Y_MAX, 90);
 PARAM_DEFINE_FLOAT(FW_ACRO_Z_MAX, 45);
 
 /**
- * Enable throttle scale by battery level
- *
- * This compensates for voltage drop of the battery over time by attempting to
- * normalize performance across the operating range of the battery.
- *
- * @boolean
- * @group FW Rate Control
- */
-PARAM_DEFINE_INT32(FW_BAT_SCALE_EN, 0);
-
-/**
  * Enable airspeed scaling
  *
  * This enables a logic that automatically adjusts the output of the rate controller to take

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -237,24 +237,6 @@ MulticopterRateControl::Run()
 			vehicle_torque_setpoint.xyz[1] = PX4_ISFINITE(torque_setpoint(1)) ? torque_setpoint(1) : 0.f;
 			vehicle_torque_setpoint.xyz[2] = PX4_ISFINITE(torque_setpoint(2)) ? torque_setpoint(2) : 0.f;
 
-			// scale setpoints by battery status if enabled
-			if (_param_mc_bat_scale_en.get()) {
-				if (_battery_status_sub.updated()) {
-					battery_status_s battery_status;
-
-					if (_battery_status_sub.copy(&battery_status) && battery_status.connected && battery_status.scale > 0.f) {
-						_battery_status_scale = battery_status.scale;
-					}
-				}
-
-				if (_battery_status_scale > 0.f) {
-					for (int i = 0; i < 3; i++) {
-						vehicle_thrust_setpoint.xyz[i] = math::constrain(vehicle_thrust_setpoint.xyz[i] * _battery_status_scale, -1.f, 1.f);
-						vehicle_torque_setpoint.xyz[i] = math::constrain(vehicle_torque_setpoint.xyz[i] * _battery_status_scale, -1.f, 1.f);
-					}
-				}
-			}
-
 			vehicle_thrust_setpoint.timestamp_sample = angular_velocity.timestamp_sample;
 			vehicle_thrust_setpoint.timestamp = hrt_absolute_time();
 			_vehicle_thrust_setpoint_pub.publish(vehicle_thrust_setpoint);

--- a/src/modules/mc_rate_control/MulticopterRateControl.hpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.hpp
@@ -48,7 +48,6 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/actuator_controls_status.h>
-#include <uORB/topics/battery_status.h>
 #include <uORB/topics/control_allocator_status.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/parameter_update.h>
@@ -92,7 +91,6 @@ private:
 
 	RateControl _rate_control; ///< class for rate control calculations
 
-	uORB::Subscription _battery_status_sub{ORB_ID(battery_status)};
 	uORB::Subscription _control_allocator_status_sub{ORB_ID(control_allocator_status)};
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
@@ -123,8 +121,6 @@ private:
 	// keep setpoint values between updates
 	matrix::Vector3f _acro_rate_max;		/**< max attitude rates in acro mode */
 	matrix::Vector3f _rates_setpoint{};
-
-	float _battery_status_scale{0.0f};
 	matrix::Vector3f _thrust_setpoint{};
 
 	float _energy_integration_time{0.0f};
@@ -161,8 +157,6 @@ private:
 		(ParamFloat<px4::params::MC_ACRO_EXPO>) _param_mc_acro_expo,			/**< expo stick curve shape (roll & pitch) */
 		(ParamFloat<px4::params::MC_ACRO_EXPO_Y>) _param_mc_acro_expo_y,				/**< expo stick curve shape (yaw) */
 		(ParamFloat<px4::params::MC_ACRO_SUPEXPO>) _param_mc_acro_supexpo,		/**< superexpo stick curve shape (roll & pitch) */
-		(ParamFloat<px4::params::MC_ACRO_SUPEXPOY>) _param_mc_acro_supexpoy,		/**< superexpo stick curve shape (yaw) */
-
-		(ParamBool<px4::params::MC_BAT_SCALE_EN>) _param_mc_bat_scale_en
+		(ParamFloat<px4::params::MC_ACRO_SUPEXPOY>) _param_mc_acro_supexpoy		/**< superexpo stick curve shape (yaw) */
 	)
 };

--- a/src/modules/mc_rate_control/mc_rate_control_params.c
+++ b/src/modules/mc_rate_control/mc_rate_control_params.c
@@ -279,20 +279,6 @@ PARAM_DEFINE_FLOAT(MC_YAWRATE_FF, 0.0f);
 PARAM_DEFINE_FLOAT(MC_YAWRATE_K, 1.0f);
 
 /**
- * Battery power level scaler
- *
- * This compensates for voltage drop of the battery over time by attempting to
- * normalize performance across the operating range of the battery. The copter
- * should constantly behave as if it was fully charged with reduced max acceleration
- * at lower battery percentages. i.e. if hover is at 0.5 throttle at 100% battery,
- * it will still be 0.5 at 60% battery.
- *
- * @boolean
- * @group Multicopter Rate Control
- */
-PARAM_DEFINE_INT32(MC_BAT_SCALE_EN, 0);
-
-/**
  * Low pass filter cutoff frequency for yaw torque setpoint
  *
  * Reduces vibrations by lowering high frequency torque caused by rotor acceleration.

--- a/src/modules/spacecraft/SpacecraftRateControl/SpacecraftRateControl.cpp
+++ b/src/modules/spacecraft/SpacecraftRateControl/SpacecraftRateControl.cpp
@@ -204,26 +204,6 @@ void SpacecraftRateControl::updateRateControl()
 			vehicle_torque_setpoint.xyz[1] = PX4_ISFINITE(torque_sp(1)) ? torque_sp(1) : 0.f;
 			vehicle_torque_setpoint.xyz[2] = PX4_ISFINITE(torque_sp(2)) ? torque_sp(2) : 0.f;
 
-			// scale setpoints by battery status if enabled
-			if (_param_sc_bat_scale_en.get()) {
-				if (_battery_status_sub.updated()) {
-					battery_status_s battery_status;
-
-					if (_battery_status_sub.copy(&battery_status) && battery_status.connected && battery_status.scale > 0.f) {
-						_battery_status_scale = battery_status.scale;
-					}
-				}
-
-				if (_battery_status_scale > 0.f) {
-					for (int i = 0; i < 3; i++) {
-						vehicle_thrust_setpoint.xyz[i] =
-							math::constrain(vehicle_thrust_setpoint.xyz[i] * _battery_status_scale, -1.f, 1.f);
-						vehicle_torque_setpoint.xyz[i] =
-							math::constrain(vehicle_torque_setpoint.xyz[i] * _battery_status_scale, -1.f, 1.f);
-					}
-				}
-			}
-
 			vehicle_thrust_setpoint.timestamp_sample = angular_velocity.timestamp_sample;
 			vehicle_thrust_setpoint.timestamp = hrt_absolute_time();
 			_vehicle_thrust_setpoint_pub.publish(vehicle_thrust_setpoint);

--- a/src/modules/spacecraft/SpacecraftRateControl/SpacecraftRateControl.hpp
+++ b/src/modules/spacecraft/SpacecraftRateControl/SpacecraftRateControl.hpp
@@ -81,7 +81,6 @@ private:
 
 	RateControl _rate_control; ///< class for rate control calculations
 
-	uORB::Subscription _battery_status_sub{ORB_ID(battery_status)};
 	uORB::Subscription _control_allocator_status_sub{ORB_ID(control_allocator_status)};
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
@@ -153,8 +152,6 @@ private:
 		(ParamFloat<px4::params::SC_ACRO_SUPEXPOY>) _param_sc_acro_supexpoy,		/**< superexpo stick curve shape (yaw) */
 
 		(ParamFloat<px4::params::SC_MAN_F_MAX>) _param_sc_manual_f_max,
-		(ParamFloat<px4::params::SC_MAN_T_MAX>) _param_sc_manual_t_max,
-
-		(ParamBool<px4::params::SC_BAT_SCALE_EN>) _param_sc_bat_scale_en
+		(ParamFloat<px4::params::SC_MAN_T_MAX>) _param_sc_manual_t_max
 	)
 };

--- a/src/modules/spacecraft/spacecraft_rate_params.c
+++ b/src/modules/spacecraft/spacecraft_rate_params.c
@@ -385,20 +385,6 @@ PARAM_DEFINE_FLOAT(SC_ACRO_SUPEXPO, 0.7f);
 PARAM_DEFINE_FLOAT(SC_ACRO_SUPEXPOY, 0.7f);
 
 /**
- * Battery power level scaler
- *
- * This compensates for voltage drop of the battery over time by attempting to
- * normalize performance across the operating range of the battery. The copter
- * should constantly behave as if it was fully charged with reduced max acceleration
- * at lower battery percentages. i.e. if hover is at 0.5 throttle at 100% battery,
- * it will still be 0.5 at 60% battery.
- *
- * @boolean
- * @group Spacecraft Rate Control
- */
-PARAM_DEFINE_INT32(SC_BAT_SCALE_EN, 0);
-
-/**
  * Manual mode maximum force.
  *
  * *


### PR DESCRIPTION
### Solved Problem
Same as #26235 
 
### Solution

Same basic idea as the other draft PR. That version fails due to the renormalization of the `_mix` matrix (snippet below) https://github.com/PX4/PX4-Autopilot/blob/ec8f34325e7b990250e7eee9eff1f9325f8e713a/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.cpp#L67-L74 which undoes all scaling we do to the effectiveness matrix. 

This solution instead scale the `_mix` matrix _after_ it has been renormalised. It's a bit less neat than the `ct` option -- we have to pass around the info about which matrix needs scaling quite far, maybe I can make this better still. But on the upside it actually works. 

Other option to improve: refactor the pinv update such that changing the battery scaling does not trigger recalculation of the original pinv, only the `_mix` matrix


### Alternatives
Current version (in rate control modules):
 - [+] simple
 - [-] Relies on FW/VTOL proxy to determine which directions of thrust/torque need battery scaling
 - [-] introduce battery scaled thrust / torque commands that are not physical thrust and torque -> confusion

Also modifying the torque / thrust setpoint like currently but inside of the allocator, right after receiving them (this one could actually reasonably work as well, consider it)
 - [+] minimal functional change w.r.t. before that still addresses the issue of confusing scaled and unscaled torque/thrust setpoints
 - [-] FW/VTOL distinction gets hairier.
	 - Currently we have separate scaling implementations for MC (-> scale all thrust and torque commands, reasonably assuming that all rotors are driven by the same battery) and FW (-> scale only forward thrust). 
	 - In the allocator we get either one torque sp (MC or FW, from the rate controllers) or two (VTOL, from VTOL attitude controller). In the VTOL case, we have 0 = MC and 1 = FW. To replicate the previous logic, we have to separate these setpoints again into clear MC and FW components.

Instead modifying the effectiveness matrix through `ActuatorEffectivenessRotors` (#26235)
 - [+] VERY clean and physically meaningful, the scale enters by modifying the thrust coefficient in one single place, 1:1 modelling the decreased effectiveness of the rotor in both thrust and torque
 - [+] automatically abstracted away from any FW/MC/VTOL differences
 - [-] Does not work because the `normalizeControlAllocationMatrix` reverts the scaling effect that entered through the effectivenss matrix. Getting it to work would require reworking this scaling from the ground up or removing it entirely

Modifying only the motor outputs after the allocator
 - [+] again very simple, does not care about FW/VTOL, we just do it for all the rotors
 - [-] Introduces wrong actuator limits: Allocator assumes that rotors saturate based on a model unaware of battery scale, but because after the allocator we scale (increase) the commands, the actual saturation happens earlier.

### Test coverage
small SITL sanity checks, more to come if we pursue this

