### PR TITLE
Fix Takeoff mode to respect MIS_TAKEOFF_ALT

### DIFF
--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -204,6 +204,7 @@ Takeoff::set_takeoff_position()
 
 	if (!PX4_ISFINITE(_loiter_altitude_msl)) {
 		_loiter_altitude_msl = takeoff_altitude_amsl;
+
 		if (_navigator->get_loiter_min_alt() > FLT_EPSILON) {
 			_loiter_altitude_msl = math::max(_loiter_altitude_msl, takeoff_altitude_amsl + _navigator->get_loiter_min_alt());
 


### PR DESCRIPTION
Takeoff mode never transitions to hold after takeoff alt.

AKA: Fixed-wing takeoff mode fails to transition to Hold after reaching the clearance altitude. 

In set_takeoff_position(), the _loiter_altitude_msl is initialized to NAN and the assignment logic fails to set it to a finite value in all cases. When the loiter minimum altitude returns 0, the assignment is skipped entirely. When it returns a positive value, math::max() is called with the still-NAN _loiter_altitude_msl, propagating NAN to the result. This causes the CLIMBOUT state transition check (alt >= _loiter_altitude_msl) to always evaluate to false, trapping the takeoff state machine indefinitely. 

The fix ensures _loiter_altitude_msl is set to a finite value (takeoff_altitude_amsl) before any further logic.

Tested in SITL and linked to https://github.com/PX4/PX4-Autopilot/issues/26271#issuecomment-3750944671

@dirksavage88 