### PR TITLE
Fill TC_M0_ID in offboard thermal calibration script

### DIFF
--- a/Tools/process_sensor_caldata.py
+++ b/Tools/process_sensor_caldata.py
@@ -1138,6 +1138,8 @@ if num_mags >= 1:
 
     if not math.isnan(sensor_mag_0['temperature'][0]):
 
+        mag_0_params['TC_M0_ID'] = int(np.median(sensor_mag_0['device_id']))
+
         # find the min, max and reference temperature
         mag_0_params['TC_M0_TMIN'] = np.amin(sensor_mag_0['temperature'])
         mag_0_params['TC_M0_TMAX'] = np.amax(sensor_mag_0['temperature'])


### PR DESCRIPTION
### Solved Problem
Offboard thermal calibration with `Tools/process_sensor_caldata.py` was not filling `TC_M0_ID` paramater for mag 0 resulting in errors like `INFO  [temperature_compensation] No temperature calibration available for mag 0 (device id 15012889)`. This problem does not exist for other magnetometers.

### Solution
Fill `TC_M0_ID` the same way as is done for other magnetometers.