### PR TITLE
drivers: auav, read sensor eeprom to get cal range

### DIFF
--- a/src/drivers/differential_pressure/auav/AUAV_Absolute.cpp
+++ b/src/drivers/differential_pressure/auav/AUAV_Absolute.cpp
@@ -32,7 +32,6 @@
  ****************************************************************************/
 
 #include "AUAV_Absolute.hpp"
-#include <cctype>
 
 AUAV_Absolute::AUAV_Absolute(const I2CSPIDriverConfig &config) :
 	AUAV(config)
@@ -81,32 +80,6 @@ float AUAV_Absolute::process_pressure_dig(const float pressure_dig) const
 
 int AUAV_Absolute::read_factory_data()
 {
-	uint16_t factory_data = 0;
-	int status = read_calibration_eeprom(EEPROM_ABS_CAL_RNG, factory_data);
-
-	if (status != PX4_OK) {
-		return status;
-	}
-
-	/* Decode the two bytes as ASCII characters */
-	uint8_t char_high = (factory_data >> 8) & 0xFF;
-	uint8_t char_low = factory_data & 0xFF;
-
-	/* Validate that both characters are ASCII digits (0-9) */
-	if (!isdigit(char_high) || !isdigit(char_low)) {
-		return PX4_ERROR;
-	}
-
-	int32_t sensor_type = ((char_high - '0') * 10) + (char_low - '0');
-
-	/* Check if the detected sensor type is valid */
-	if (sensor_type != AUAV_LD_05 && sensor_type != AUAV_LD_10 && sensor_type != AUAV_LD_30) {
-		return PX4_ERROR;
-	}
-
-	int32_t cal_range = sensor_type * 2;
-	PX4_INFO("Detected sensor type: %" PRId32 ", set cal range to: %" PRId32, sensor_type, cal_range);
-	_shared_cal_range_eeprom[_bus_num].store(cal_range);
-
+	/* Absolute sensor doesn't need to read factory data */
 	return PX4_OK;
 }

--- a/src/drivers/differential_pressure/auav/AUAV_Absolute.hpp
+++ b/src/drivers/differential_pressure/auav/AUAV_Absolute.hpp
@@ -37,7 +37,6 @@
 #include <uORB/topics/sensor_baro.h>
 
 /* AUAV EEPROM addresses for absolute channel */
-static constexpr uint8_t EEPROM_ABS_CAL_RNG	= 0x25;
 static constexpr uint8_t EEPROM_ABS_AHW 	= 0x2F;
 static constexpr uint8_t EEPROM_ABS_ALW 	= 0x30;
 static constexpr uint8_t EEPROM_ABS_BHW 	= 0x31;
@@ -57,11 +56,6 @@ static_assert(ABS_CONVERSION_INTERVAL >= 7000, "Conversion interval is too fast"
 
 /* Conversions */
 static constexpr float MBAR_TO_PA = 100.0f;
-
-/* Valid AUAV types */
-static constexpr int32_t AUAV_LD_05 = 5;
-static constexpr int32_t AUAV_LD_10 = 10;
-static constexpr int32_t AUAV_LD_30 = 30;
 
 class AUAV_Absolute : public AUAV
 {

--- a/src/drivers/differential_pressure/auav/AUAV_Differential.cpp
+++ b/src/drivers/differential_pressure/auav/AUAV_Differential.cpp
@@ -33,10 +33,38 @@
 
 #include "AUAV_Differential.hpp"
 #include <parameters/param.h>
+#include <cctype>
 
 AUAV_Differential::AUAV_Differential(const I2CSPIDriverConfig &config) :
 	AUAV(config)
 {
+	/* Initialize cal_range from parameter as fallback value */
+	int32_t hw_model = 0;
+	param_get(param_find("SENS_EN_AUAVX"), &hw_model);
+
+	switch (hw_model) {
+	case 1: /* AUAV L05D (+- 5 inH20) */
+		_cal_range = 10;
+		break;
+
+	case 2: /* AUAV L10D (+- 10 inH20) */
+		_cal_range = 20;
+		break;
+
+	case 3: /* AUAV L30D (+- 30 inH20) */
+		_cal_range = 60;
+		break;
+
+	default:
+		_cal_range = 10; /* Default fallback */
+		break;
+	}
+}
+
+void AUAV_Differential::print_status()
+{
+	AUAV::print_status();
+	PX4_INFO("cal range: %" PRId32, _cal_range);
 }
 
 void AUAV_Differential::publish_pressure(const float pressure_p, const float temperature_c,
@@ -89,6 +117,46 @@ float AUAV_Differential::process_pressure_dig(const float pressure_dig) const
 
 int AUAV_Differential::read_factory_data()
 {
-	/* Differential sensor doesn't need to read any additional factory data */
+	/* The differential sensor needs the cal_range from the absolute sensor's EEPROM.
+	 * Temporarily switch to the absolute sensor's I2C address to read it, then switch back. */
+
+	uint8_t original_address = get_device_address();
+	set_device_address(I2C_ADDRESS_ABSOLUTE);
+
+	/* Read the calibration range from the absolute sensor's EEPROM */
+	uint16_t factory_data = 0;
+	int status = read_calibration_eeprom(EEPROM_ABS_CAL_RNG, factory_data);
+
+	set_device_address(original_address);
+
+	if (status != PX4_OK) {
+		return status;
+	}
+
+	/* If EEPROM data is 0, stop trying (sensor does not have factory data) */
+	if (factory_data == 0) {
+		PX4_INFO("Differential: cal range data is 0, using fallback value");
+		return PX4_OK;
+	}
+
+	/* Decode the two bytes as ASCII characters */
+	uint8_t char_high = (factory_data >> 8) & 0xFF;
+	uint8_t char_low = factory_data & 0xFF;
+
+	/* Validate that both characters are ASCII digits (0-9) */
+	if (!isdigit(char_high) || !isdigit(char_low)) {
+		return PX4_ERROR;
+	}
+
+	int32_t sensor_type = ((char_high - '0') * 10) + (char_low - '0');
+
+	/* Check if the detected sensor type is valid */
+	if (sensor_type != AUAV_LD_05 && sensor_type != AUAV_LD_10 && sensor_type != AUAV_LD_30) {
+		return PX4_ERROR;
+	}
+
+	_cal_range = sensor_type * 2;
+	PX4_INFO("Differential: read cal range %" PRId32 " from absolute sensor EEPROM", _cal_range);
+
 	return PX4_OK;
 }

--- a/src/drivers/differential_pressure/auav/AUAV_Differential.hpp
+++ b/src/drivers/differential_pressure/auav/AUAV_Differential.hpp
@@ -37,6 +37,7 @@
 #include <uORB/topics/differential_pressure.h>
 
 /* AUAV EEPROM addresses for differential channel */
+static constexpr uint8_t EEPROM_ABS_CAL_RNG	= 0x25;
 static constexpr uint8_t EEPROM_DIFF_AHW 	= 0x2B;
 static constexpr uint8_t EEPROM_DIFF_ALW 	= 0x2C;
 static constexpr uint8_t EEPROM_DIFF_BHW 	= 0x2D;
@@ -57,11 +58,18 @@ static_assert(DIFF_CONVERSION_INTERVAL >= 7000, "Conversion interval is too fast
 /* Conversions */
 static constexpr float INH_TO_PA = 249.08f;
 
+/* Valid AUAV types */
+static constexpr int32_t AUAV_LD_05 = 5;
+static constexpr int32_t AUAV_LD_10 = 10;
+static constexpr int32_t AUAV_LD_30 = 30;
+
 class AUAV_Differential : public AUAV
 {
 public:
 	explicit AUAV_Differential(const I2CSPIDriverConfig &config);
 	~AUAV_Differential() = default;
+
+	void print_status() override;
 
 private:
 	void publish_pressure(const float pressure_p, const float temperature_c, const hrt_abstime timestamp_sample) override;
@@ -71,4 +79,5 @@ private:
 	int read_factory_data() override;
 
 	uORB::PublicationMulti<differential_pressure_s> _differential_pressure_pub{ORB_ID(differential_pressure)};
+	int32_t _cal_range{10};
 };


### PR DESCRIPTION
### Solved Problem
The AllSensors AUAV has an undocumented EEPROM feature that contains the pressure range. This is useful as it avoids user input error as the correct value can be used even when the user did select an incorrect pressure range.

The format was confirmed by the manufacturer and is valid for all sensors with revision greater than R24E06-13.
For older revisions the EEPROM contains 0 at this address.

### Solution
Read the EEPROM and try to get the pressure range. After a certain timeout or if the EEPROM does not contain valid data the range given in the user parameter will be used. In case valid data is found it will be used instead of the user provided one.

The solution sadly requires a shared var between the absolute/differential instances as only the absolute instance (with I2C address 0x27) can access the EEPROM address that contains the range.


### Test coverage
- Tested on a Auterion v6x