### PR TITLE
mavlink: accept broadcast commands

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -450,8 +450,8 @@ MavlinkReceiver::evaluate_target_ok(int command, int target_system, int target_c
 		break;
 
 	default:
-		target_ok = (target_system == mavlink_system.sysid) && ((target_component == mavlink_system.compid)
-				|| (target_component == MAV_COMP_ID_ALL));
+		target_ok = ((target_system == 0) || (target_system == mavlink_system.sysid))
+			    && ((target_component == mavlink_system.compid) || (target_component == MAV_COMP_ID_ALL));
 		break;
 	}
 


### PR DESCRIPTION
I think - per MAVLink spec - PX4 ought to accept broadcast commands which are aimed at system ID 0, so anyone/all.

This enables the uploader script to reboot the autopilot when the MAVLink sysid is different from 1.