### PR TITLE
fix: correct LED state read logic

### DIFF
--- a/boards/px4/fmu-v6xrt/src/led.c
+++ b/boards/px4/fmu-v6xrt/src/led.c
@@ -92,7 +92,7 @@ static bool phy_get_led(int led)
 {
 
 	if (g_ledmap[led] != 0) {
-		return imxrt_gpio_read(!g_ledmap[led]);
+		return !imxrt_gpio_read(g_ledmap[led]);
 	}
 
 	return false;


### PR DESCRIPTION
Move negation to return value instead of GPIO map argument for proper active-low handling.
