### PR TITLE
[Fix clang-tidy error] do not check pointer validity before deleting

### DIFF
--- a/src/lib/ringbuffer/TimestampedRingBuffer.hpp
+++ b/src/lib/ringbuffer/TimestampedRingBuffer.hpp
@@ -69,9 +69,7 @@ public:
 			return false;
 		}
 
-		if (_buffer != nullptr) {
-			delete[] _buffer;
-		}
+		delete[] _buffer;
 
 		_buffer = new data_type[size] {};
 


### PR DESCRIPTION
Deleting a nullptr has no effect
(this addresses a clang-tidy error `readability-delete-null-pointer`)