### PR TITLE
[mavlink] Initialize the covariance matrix of odom to 0 

### DIFF
--- a/src/modules/mavlink/streams/ODOMETRY.hpp
+++ b/src/modules/mavlink/streams/ODOMETRY.hpp
@@ -112,7 +112,7 @@ private:
 			//  Row-major representation of a 6x6 pose cross-covariance matrix upper right triangle
 			//  (states: x, y, z, roll, pitch, yaw; first six entries are the first ROW, next five entries are the second ROW, etc.)
 			for (auto &pc : msg.pose_covariance) {
-				pc = NAN;
+				pc = 0.f;
 			}
 
 			msg.pose_covariance[0]  = odom.position_variance[0];  // X  row 0, col 0
@@ -127,7 +127,7 @@ private:
 			//  Row-major representation of a 6x6 velocity cross-covariance matrix upper right triangle
 			//  (states: vx, vy, vz, rollspeed, pitchspeed, yawspeed; first six entries are the first ROW, next five entries are the second ROW, etc.)
 			for (auto &vc : msg.velocity_covariance) {
-				vc = NAN;
+				vc = 0.f;
 			}
 
 			msg.velocity_covariance[0]  = odom.velocity_variance[0];   // X  row 0, col 0


### PR DESCRIPTION
Since mavros will convert the data from NED to ENU ([code](https://github.com/mavlink/mavros/blob/faef4e9abfcc045cd0b967ce10d05e4d0556b09c/mavros_extras/src/plugins/odom.cpp#L215-L226)), in order to prevent the entire matrix from becoming invalid after mavros performs coordinate transformation.

Some issues about this: https://github.com/PX4/PX4-Autopilot/pull/11081 , https://github.com/mavlink/mavros/pull/1142

Before:
```sh
parallels@ubuntu-linux-20-04-desktop:~/mavros_ws$ rostopic echo /mavros/odometry/in -n 1
header: 
  seq: 5042
  stamp: 
    secs: 1769000988
    nsecs: 158201359
  frame_id: "map"
child_frame_id: "base_link"
pose: 
  pose: 
    position: 
      x: -0.008909674361348131
      y: 0.015796979889273647
      z: -0.14644131064414978
    orientation: 
      x: -0.00550946911087481
      y: 0.00983806910590218
      z: -0.024188256534886928
      w: 0.9996438576168533
  covariance: [nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan]
twist: 
  twist: 
    linear: 
      x: 0.0034659551456570625
      y: 0.019803209230303754
      z: -0.09200948476791382
    angular: 
      x: -0.002516508335247636
      y: 0.0021886487957090135
      z: -0.0028962322976440196
  covariance: [nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan]
---
parallels@ubuntu-linux-20-04-desktop:~/mavros_ws$ 
```

After:
```sh
parallels@ubuntu-linux-20-04-desktop:~/mavros_ws$ rostopic echo /mavros/odometry/in -n 1
header: 
  seq: 330
  stamp: 
    secs: 1769001045
    nsecs: 135109476
  frame_id: "map"
child_frame_id: "base_link"
pose: 
  pose: 
    position: 
      x: 0.011775026097893708
      y: -0.007112141698598864
      z: 0.04631815478205681
    orientation: 
      x: -0.008098824108236164
      y: 0.01000432084006814
      z: -0.025055130869130308
      w: 0.9996032077423139
  covariance: [0.1378527581691742, 7.279189390466644e-23, 1.7110563470001938e-18, 0.0, 0.0, 0.0, 7.279189390466644e-23, 0.13785308599472046, -6.946773433696628e-34, 0.0, 0.0, 0.0, 1.7110563470001947e-18, -6.946773433696628e-34, 0.12388092279434204, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0005714378785341978, 1.806614156604097e-22, -2.3954883979139655e-19, 0.0, 0.0, 0.0, 1.806614156604097e-22, 0.0005722515052184463, 4.67688556884077e-35, 0.0, 0.0, 0.0, -2.395488397913965e-19, 4.67688556884077e-35, 0.0025275025982409716]
twist: 
  twist: 
    linear: 
      x: -0.00495776766911149
      y: -0.002971400273963812
      z: -0.023856859654188156
    angular: 
      x: 6.325972208287567e-05
      y: 0.00046744197607040416
      z: 0.0010904461378231645
  covariance: [0.026608560234308243, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.026607736945152283, -1.224007384372051e-18, 0.0, 0.0, 0.0, 0.0, -1.2240073843720513e-18, 0.016612958163022995, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
---
parallels@ubuntu-linux-20-04-desktop:~/mavros_ws$ 

```
