### PR TITLE
modify: remove xtensa-tarfile after installation

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -176,8 +176,10 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 
 		echo
 		echo "Fetching Xtensa compilers"
-		wget -q -P $DIR https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.xz
-		sudo tar -xf $DIR/xtensa-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.xz -C /opt
+		XTENSA_FILE_NAME=xtensa-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.xz
+		wget -q -P $DIR https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/$XTENSA_FILE_NAME
+		sudo tar -xf $DIR/$XTENSA_FILE_NAME -C /opt
+		rm $DIR/$XTENSA_FILE_NAME
 		echo 'export PATH=$PATH:/opt/xtensa-esp-elf/bin/' >> /home/$USER/.bashrc
 	fi
 


### PR DESCRIPTION
<!--

### Solved Problem
After calling Tools/setup/ubuntu.sh the xtensa.tar.xz - artifact does remain

### Solution
delete file after extraction to /opt

-->
