### PR TITLE
[WIP] Run the ROMFS through a CPP with the boardconfig

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -146,6 +146,11 @@ add_custom_command(
 		${romfs_copy_stamp}
 	COMMAND ${CMAKE_COMMAND} -E remove_directory ${romfs_gen_root_dir}/*
 	COMMAND ${CMAKE_COMMAND} -E tar xf ${romfs_tar_file}
+	# Preprocess ROMFS files with KConfig definitions
+	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_romfs_preprocess.py
+		--romfs-dir ${romfs_gen_root_dir}
+		--kconfig-header ${PX4_BINARY_DIR}/px4_boardconfig.h
+		--cpp ${CMAKE_C_COMPILER}
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_process_airframes.py
 		--airframes-path ${romfs_gen_root_dir}/init.d
 		--start-script ${romfs_gen_root_dir}/init.d/rc.autostart
@@ -159,8 +164,10 @@ add_custom_command(
 		--params-file ${CONFIG_BOARD_PARAM_FILE}
 	COMMAND ${CMAKE_COMMAND} -E touch ${romfs_copy_stamp}
 	WORKING_DIRECTORY ${romfs_gen_root_dir}
-	DEPENDS ${romfs_tar_file}
-	COMMENT "ROMFS: copying, generating airframes"
+	DEPENDS
+		${romfs_tar_file}
+		${PX4_BINARY_DIR}/px4_boardconfig.h
+	COMMENT "ROMFS: copying, preprocessing, generating airframes"
 	)
 
 # copy extras into ROMFS

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -8,17 +8,24 @@
 #                           Begin Optional drivers                            #
 ###############################################################################
 
+%ifdef CONFIG_DRIVERS_BATT_SMBUS
 if param compare -s SENS_EN_BATT 1
 then
 	batt_smbus start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_SMART_BATTERY_BATMON
 # Start batmon driver if enabled using BATMON_DRIVER_EN
 if param compare -s BATMON_DRIVER_EN 1
 then
 	batmon start -X  #start on external bus
 fi
+%endif
 
+
+%ifdef CONFIG_DRIVERS_PWM_INPUT
+%ifdef CONFIG_DRIVERS_DISTANCE_SENSOR_LL40LS
 # Sensors on the PWM interface bank
 if param compare -s SENS_EN_LL40LS 1
 then
@@ -27,92 +34,121 @@ then
 		ll40ls_pwm start
 	fi
 fi
+%endif
 
 # External automatic trigger system
 if param compare FD_EXT_ATS_EN 1
 then
 	pwm_input start
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DISTANCE_SENSOR_LL40LS
 # Lidar-Lite on I2C
 if param compare -s SENS_EN_LL40LS 2
 then
 	ll40ls start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DISTANCE_SENSOR_MAPPYDOT
 # mappydot lidar sensor
 if param compare -s SENS_EN_MPDT 1
 then
 	mappydot start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DISTANCE_SENSOR_MB12XX
 # mb12xx sonar sensor
 if param greater -s SENS_EN_MB12XX 0
 then
 	mb12xx start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DISTANCE_SENSOR_PGA460
 # pga460 sonar sensor
 if param greater -s SENS_EN_PGA460 0
 then
 	pga460 start
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DISTANCE_SENSOR_LIGHTWARE_LASER_I2C
 # Lightware i2c lidar sensor
 if param greater -s SENS_EN_SF1XX 0
 then
 	lightware_laser_i2c start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DISTANCE_SENSOR_SRF05
 # Sensor HY-SRF05 or HC-SR05 ultrasonic sensor
 if param compare -s SENS_EN_SR05 1
 then
 	srf05 start
 fi
+%endif
 
 
+%ifdef CONFIG_DRIVERS_DISTANCE_SENSOR_TERARANGER
 # Teraranger one tof sensor
 if param greater -s SENS_EN_TRANGER 0
 then
 	teraranger start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_OPTICAL_FLOW_PAA3905
 # paa3905 optical flow sensor (external SPI)
 if param greater -s SENS_EN_PAA3905 0
 then
 	paa3905 -S start
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_OPTICAL_FLOW_PAW3902
 # paw3902 optical flow sensor (external SPI)
 if param greater -s SENS_EN_PAW3902 0
 then
 	paw3902 -S start
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_OPTICAL_FLOW_PMW3901
 # pmw3901 optical flow sensor (external SPI)
 if param greater -s SENS_EN_PMW3901 0
 then
 	pmw3901 -S start
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DISTANCE_SENSOR_VL53L0X
 # vl53l0x i2c distance sensor
 if param compare -s SENS_EN_VL53L0X 1
 then
 	vl53l0x start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DISTANCE_SENSOR_VL53L1X
 # vl53l1x i2c distance sensor
 if param compare -s SENS_EN_VL53L1X 1
 then
 	vl53l1x start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DISTANCE_SENSOR_TF02PRO
 # tf02 pro i2c distance sensor
 if param compare -s SENS_EN_TF02PRO 1
 then
 	tf02pro start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_IMU_ANALOG_DEVICES_ADIS16448
 # ADIS16448 spi external IMU
 if param compare -s SENS_EN_ADIS164X 1
 then
@@ -125,25 +161,33 @@ then
 		adis16448 -S start -R 4
 	fi
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_IMU_ANALOG_DEVICES_ADIS16507
 # ADIS16507 spi external IMU
 if param greater -s SENS_EN_ADIS165X 0
 then
 	adis16507 -S start
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_IMU_MURATA_SCH16T
 # SCH16T spi external IMU
 if param compare -s SENS_EN_SCH16T 1
 then
 	sch16t -S start
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DIFFERENTIAL_PRESSURE_ETS
 # Eagle Tree airspeed sensor external I2C
 if param compare -s SENS_EN_ETSASPD 1
 then
 	ets_airspeed start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DIFFERENTIAL_PRESSURE_SDP3X
 # Sensirion SDP3X differential pressure sensor external I2C
 if param compare -s SENS_EN_SDP3X 1
 then
@@ -153,116 +197,171 @@ then
 		sdp3x start -X -a 0x22
 	fi
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_TEMPERATURE_SENSOR_MCP9808
 # Microchip MCP9808 temperature sensor external I2C
 if param compare -s SENS_EN_MCP9808 1
 then
 	mcp9808 start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DIFFERENTIAL_PRESSURE_MS4515
 # TE MS4515 differential pressure sensor external I2C
 if param compare -s SENS_EN_MS4515 1
 then
 	ms4515 start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DIFFERENTIAL_PRESSURE_MS4525DO
 # TE MS4525DO differential pressure sensor external I2C
 if param compare -s SENS_EN_MS4525DO 1
 then
 	ms4525do start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DIFFERENTIAL_PRESSURE_MS5525DSO
 # TE MS5525DSO differential pressure sensor external I2C
 if param compare -s SENS_EN_MS5525DS 1
 then
 	ms5525dso start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DIFFERENTIAL_PRESSURE_ASP5033
 # TE ASP5033 differential pressure sensor external I2C
 if param compare -s SENS_EN_ASP5033 1
 then
 	asp5033 start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_DIFFERENTIAL_PRESSURE_AUAV
 # AUAV absolute/differential pressure sensor external I2C
 if param greater -s SENS_EN_AUAVX 0
 then
 	auav start -D -X
 	auav start -A -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_HYGROMETER_SHT3X
 # SHT3x temperature and hygrometer sensor, external I2C
 if param compare -s SENS_EN_SHT3X 1
 then
 	sht3x start -X
 	sht3x start -X -a 0x45
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_IRLOCK
 # IR-LOCK sensor external I2C
 if param compare -s SENS_EN_IRLOCK 1
 then
 	irlock start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_BAROMETER_GOERTEK_SPL06
 # SPL06 sensor external I2C
 if param compare -s SENS_EN_SPL06 1
 then
 	spl06 -X start
 	spl06 -X -a 0x77 start
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_BAROMETER_GOERTEK_SPA06
 # SPA06 sensor external I2C
 if param compare -s SENS_EN_SPA06 1
 then
 	spa06 -X start
 	spa06 -X -a 0x77 start
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_RPM_PCF8583
 # PCF8583 counter (RPM sensor)
 if param compare -s SENS_EN_PCF8583 1
 then
 	pcf8583 start -X
 	pcf8583 start -X -a 0x51
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_ADC_ADS7953
 # ADC sensor ADS7953 external SPI
 if param compare -s ADC_ADS7953_EN 1
 then
 	ads7953 start -S
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_ADC_TLA2528
 # ADC sensor tla2528 external I2C
 if param compare -s ADC_TLA2528_EN 1
 then
 	tla2528 start -X
 fi
+%endif
 
+%ifdef CONFIG_DRIVERS_TEMPERATURE_SENSOR_TMP102
 # Start TMP102 temperature sensor
-if param compare SENS_EN_TMP102 1
+if param compare -s SENS_EN_TMP102 1
 then
 	tmp102 start -X
 fi
+%endif
 
+%ifdef COMMON_MAGNETOMETER
 # probe for optional external I2C devices
 if param compare SENS_EXT_I2C_PRB 1
 then
+%ifdef CONFIG_DRIVERS_IMU_INVENSENSE_ICM20948
 	icm20948_i2c_passthrough -X -q start
+%endif
 
 	# compasses
+%ifdef CONFIG_DRIVERS_MAGNETOMETER_HMC5883
 	hmc5883 -T -X -q start
+%endif
+%ifdef CONFIG_DRIVERS_MAGNETOMETER_ST_IIS2MDC
 	iis2mdc -X -q start
+%endif
+%ifdef CONFIG_DRIVERS_MAGNETOMETER_ISENTEK_IST8308
 	ist8308 -X -q start
+%endif
+%ifdef CONFIG_DRIVERS_MAGNETOMETER_ISENTEK_IST8310
 	ist8310 -X -q start
+%endif
+%ifdef CONFIG_DRIVERS_MAGNETOMETER_LIS3MDL
 	if ! lis3mdl -X -q start
 	then
 		lis3mdl -X -q -a 0x1c start
 	fi
+%endif
+%ifdef CONFIG_DRIVERS_MAGNETOMETER_QMC5883L
 	qmc5883l -X -q start
+%endif
+%ifdef CONFIG_DRIVERS_MAGNETOMETER_QMC5883P
 	qmc5883p -X -q start
+%endif
+%ifdef CONFIG_DRIVERS_MAGNETOMETER_RM3100
 	rm3100 -X -q start
+%endif
+%ifdef CONFIG_DRIVERS_MAGNETOMETER_BOSCH_BMM350
 	bmm350 -X -q start
+%endif
+%ifdef CONFIG_DRIVERS_MAGNETOMETER_ST_IIS2MDC
 	iis2mdc -X -q start
+%endif
 
 	# start last (wait for possible icm20948 passthrough mode)
+%ifdef CONFIG_DRIVERS_MAGNETOMETER_AKM_AK09916
 	ak09916 -X -q start
+%endif
 fi
+%endif

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -265,12 +265,15 @@ else
 	# Start the tone_alarm driver.
 	# Needs to be started after the parameters are loaded (for CBRK_BUZZER).
 	#
+%ifdef CONFIG_DRIVERS_TONE_ALARM
 	tone_alarm start
+%endif
 
 	#
 	# Waypoint storage.
 	# REBOOTWORK this needs to start in parallel.
 	#
+%ifdef CONFIG_MODULES_DATAMAN
 	if param compare -s SYS_DM_BACKEND 1
 	then
 		dataman start -r
@@ -281,11 +284,14 @@ else
 			dataman start
 		fi
 	fi
+%endif
 
 	#
 	# Start the socket communication send_event handler.
 	#
+%ifdef CONFIG_MODULES_SEND_EVENT
 	send_event start
+%endif
 
 	#
 	# Start the hardfault streamer.
@@ -298,15 +304,25 @@ else
 	#
 	# Start the resource load monitor.
 	#
+%ifdef CONFIG_MODULES_LOAD_MON
 	load_mon start
+%endif
 
 	#
 	# Start system state indicator.
 	#
+%ifdef CONFIG_DRIVERS_LIGHTS_RGBLED
 	rgbled start -X -q
+%endif
+%ifdef CONFIG_DRIVERS_LIGHTS_RGBLED_NCP5623C
 	rgbled_ncp5623c start -X -q
+%endif
+%ifdef CONFIG_DRIVERS_LIGHTS_RGBLED_LP5562
 	rgbled_lp5562 start -X -q
+%endif
+%ifdef CONFIG_DRIVERS_LIGHTS_RGBLED_IS31FL3195
 	rgbled_is31fl3195 start -X -q
+%endif
 
 	#
 	# Override parameters from user configuration file.
@@ -331,11 +347,21 @@ else
 		# start the simulator in hardware if needed
 		if param compare SYS_HITL 2
 		then
+%ifdef CONFIG_MODULES_SIMULATION_SIMULATOR_SIH
 			simulator_sih start
+%endif
+%ifdef CONFIG_MODULES_SIMULATION_SENSOR_BARO_SIM
 			sensor_baro_sim start
+%endif
+%ifdef CONFIG_MODULES_SIMULATION_SENSOR_MAG_SIM
 			sensor_mag_sim start
+%endif
+%ifdef CONFIG_MODULES_SIMULATION_SENSOR_GPS_SIM
 			sensor_gps_sim start
+%endif
+%ifdef CONFIG_MODULES_SIMULATION_SENSOR_AGP_SIM
 			sensor_agp_sim start
+%endif
 		fi
 
 	else
@@ -352,43 +378,58 @@ else
 
 		. ${R}etc/init.d/rc.sensors
 
+%ifdef CONFIG_MODULES_SENSORS
+%ifdef CONFIG_MODULES_ESC_BATTERY
 		if param compare -s BAT1_SOURCE 2
 		then
 			esc_battery start
 		fi
+%endif
 
+%ifdef CONFIG_MODULES_BATTERY_STATUS
 		if ! param compare BAT1_SOURCE 1
 		then
 			battery_status start
 		fi
+%endif
+%endif
 
+%ifdef CONFIG_MODULES_SENSORS
 		sensors start
+%endif
 	fi
 
 	#
 	# state estimator selection
 	#
+%ifdef CONFIG_MODULES_EKF2
 	if param compare -s EKF2_EN 1
 	then
 		ekf2 start &
 	fi
+%endif
 
+%ifdef CONFIG_MODULES_LOCAL_POSITION_ESTIMATOR
 	if param compare -s LPE_EN 1
 	then
 		local_position_estimator start
 	fi
+%endif
 
+%ifdef CONFIG_MODULES_ATTITUDE_ESTIMATOR_Q
 	if param compare -s ATT_EN 1
 	then
 		attitude_estimator_q start
 	fi
+%endif
 
+%ifdef CONFIG_DRIVERS_PX4IO
 	#
 	# px4io
 	#
 	if px4io supported
 	then
-	# Check if PX4IO present and update firmware if needed.
+		# Check if PX4IO present and update firmware if needed.
 		if [ -f $IOFW ]
 		then
 			if ! px4io checkcrc ${IOFW}
@@ -418,40 +459,56 @@ else
 			fi
 		fi
 	fi
+%endif
 
 	# Heater driver for temperature regulated IMUs.
 	# The heater needs to start after px4io.
+%ifdef CONFIG_DRIVERS_HEATER
 	if param compare -s SENS_EN_THERMAL 1
 	then
 		heater start
 	fi
+%endif
 
 
 	#
 	# RC update (map raw RC input to calibrate manual control)
 	#  start before commander
 	#
+%ifdef CONFIG_MODULES_RC_UPDATE
 	rc_update start
+%endif
+%ifdef CONFIG_MODULES_MANUAL_CONTROL
 	manual_control start
+%endif
 
 	# Start camera trigger, capture and PPS before pwm_out as they might access
 	# pwm pins
+%ifdef CONFIG_DRIVERS_CAMERA_TRIGGER
 	if param greater -s TRIG_MODE 0
 	then
 		camera_trigger start
+%ifdef CONFIG_MODULES_CAMERA_FEEDBACK
 		camera_feedback start
+%endif
 	fi
+%endif
 	# PPS capture driver
+%ifdef CONFIG_DRIVERS_PPS_CAPTURE
 	if param greater -s PPS_CAP_ENABLE 0
 	then
 		pps_capture start
 	fi
+%endif
 	# RPM capture driver
+%ifdef CONFIG_DRIVERS_RPM_CAPTURE
 	if param greater -s RPM_CAP_ENABLE 0
 	then
 		rpm_capture start
 	fi
+%endif
 	# Camera capture driver
+%ifdef CONFIG_DRIVERS_CAMERA_CAPTURE
 	if param greater -s CAM_CAP_FBACK 0
 	then
 		if camera_capture start
@@ -459,25 +516,34 @@ else
 			camera_capture on
 		fi
 	fi
+%endif
 
 	#
 	# Commander
 	#
+%ifdef CONFIG_MODULES_COMMANDER
 	if param greater SYS_HITL 0
 	then
 		commander start -h
 
+%ifdef CONFIG_MODULES_SIMULATION_PWM_OUT_SIM
 		if ! pwm_out_sim start -m hil
 		then
 			tune_control play error
 		fi
+%endif
 
 	else
 		commander start
 
+%ifdef CONFIG_DRIVERS_DSHOT
 		dshot start
+%endif
+%ifdef CONFIG_DRIVERS_PWM_OUT
 		pwm_out start
+%endif
 	fi
+%endif
 
 	#
 	# Configure vehicle type specific parameters.
@@ -485,10 +551,12 @@ else
 	. ${R}etc/init.d/rc.vehicle_setup
 
 	# Pre-takeoff continuous magnetometer calibration
+%ifdef CONFIG_MODULES_MAG_BIAS_ESTIMATOR
 	if param compare -s MBE_ENABLE 1
 	then
 		mag_bias_estimator start
 	fi
+%endif
 
 	#
 	# Optional board mavlink streams: rc.board_mavlink
@@ -533,54 +601,67 @@ else
 	#
 	# Start the navigator.
 	#
+%ifdef CONFIG_MODULES_NAVIGATOR
 	navigator start
+%endif
 
+%ifdef CONFIG_MODULES_TEMPERATURE_COMPENSATION
 	#
 	# Start a thermal calibration if required.
 	#
-	set RC_THERMAL_CAL ${R}etc/init.d/rc.thermal_cal
-	if [ -f ${RC_THERMAL_CAL} ]
-	then
-		. ${RC_THERMAL_CAL}
-	fi
-	unset RC_THERMAL_CAL
+	. ${R}etc/init.d/rc.thermal_cal
+%endif
 
 	#
 	# Start gimbal to control mounts such as gimbals, disabled by default.
 	#
+%ifdef CONFIG_MODULES_GIMBAL
 	if param greater -s MNT_MODE_IN -1
 	then
 		gimbal start
 	fi
+%endif
 
 	# Blacksheep telemetry
+%ifdef CONFIG_DRIVERS_TELEMETRY_BST
 	if param compare -s TEL_BST_EN 1
 	then
 		bst start -X
 	fi
+%endif
 
+%ifdef CONFIG_MODULES_GYRO_FFT
 	if param compare -s IMU_GYRO_FFT_EN 1
 	then
 		gyro_fft start
 	fi
+%endif
 
+%ifdef CONFIG_MODULES_GYRO_CALIBRATION
 	if param compare -s IMU_GYRO_CAL_EN 1
 	then
 		gyro_calibration start
 	fi
+%endif
 
 	# Check for px4flow sensor
+%ifdef CONFIG_DRIVERS_OPTICAL_FLOW_PX4FLOW
 	if param compare -s SENS_EN_PX4FLOW 1
 	then
 		px4flow start -X &
 	fi
+%endif
 
+%ifdef CONFIG_MODULES_PAYLOAD_DELIVERER
 	payload_deliverer start
+%endif
 
+%ifdef CONFIG_MODULES_INTERNAL_COMBUSTION_ENGINE_CONTROL
 	if param compare -s ICE_EN 1
 	then
 		internal_combustion_engine_control start
 	fi
+%endif
 
 	#
 	# Optional board supplied extras: rc.board_extras
@@ -602,15 +683,12 @@ else
 		. $FEXTRAS
 	fi
 
+%ifdef CONFIG_MODULES_LOGGER
 	#
 	# Start the logger.
 	#
-	set RC_LOGGING ${R}etc/init.d/rc.logging
-	if [ -f ${RC_LOGGING} ]
-	then
-		. ${RC_LOGGING}
-	fi
-	unset RC_LOGGING
+	. ${R}etc/init.d/rc.logging
+%endif
 
 	#
 	# Set additional parameters and env variables for selected AUTOSTART.
@@ -631,6 +709,7 @@ else
 	#
 	# Check if UAVCAN is enabled, default to it for ESCs.
 	#
+%ifdef CONFIG_DRIVERS_UAVCAN
 	if param greater -s UAVCAN_ENABLE 0
 	then
 		# Start core UAVCAN module.
@@ -639,15 +718,27 @@ else
 			tune_control play error
 		fi
 	else
+%ifdef CONFIG_DRIVERS_CYPHAL
 		if param greater -s CYPHAL_ENABLE 0
 		then
 			cyphal start
 		fi
+%endif
 	fi
+%else
+%ifdef CONFIG_DRIVERS_CYPHAL
+	if param greater -s CYPHAL_ENABLE 0
+	then
+		cyphal start
+	fi
+%endif
+%endif
+%ifdef CONFIG_MODULES_ZENOH
 	if param greater -s ZENOH_ENABLE 0
 	then
 		zenoh start
 	fi
+%endif
 
 #
 # End of autostart.

--- a/Tools/px_romfs_preprocess.py
+++ b/Tools/px_romfs_preprocess.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Preprocesses ROMFS files with C preprocessor to enable KConfig support.
+
+This script processes all rc* files in the ROMFS directory through the C preprocessor,
+allowing use of #ifdef, #ifndef, #if, #else, #endif directives with KConfig definitions.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def preprocess_file(file_path, kconfig_header, cpp_command):
+    """
+    Preprocess a single file through the C preprocessor.
+
+    Uses % as the preprocessor directive symbol (instead of #) to avoid conflicts
+    with shell comments. Converts %ifdef, %ifndef, %if, %else, %endif to
+    #ifdef, #ifndef, #if, #else, #endif before preprocessing.
+
+    Args:
+        file_path: Path to the file to preprocess
+        kconfig_header: Path to the px4_boardconfig.h header
+        cpp_command: C preprocessor command (usually the C compiler)
+    """
+    # Read original file
+    with open(file_path, 'r') as f:
+        original_content = f.read()
+
+    # Process the file line by line:
+    # 1. Remove shell comment lines (to avoid conflicts with CPP)
+    # 2. Convert % preprocessor directives to # directives
+    lines = original_content.split('\n')
+    converted_lines = []
+
+    for line in lines:
+        stripped = line.lstrip()
+
+        # Check if line starts with % followed by a preprocessor keyword
+        if stripped.startswith('%ifdef ') or stripped.startswith('%ifdef\t'):
+            # Preserve leading whitespace, convert %ifdef to #ifdef
+            converted_lines.append(line.replace('%ifdef', '#ifdef', 1))
+        elif stripped.startswith('%ifndef ') or stripped.startswith('%ifndef\t'):
+            converted_lines.append(line.replace('%ifndef', '#ifndef', 1))
+        elif stripped.startswith('%if '):
+            converted_lines.append(line.replace('%if', '#if', 1))
+        elif stripped.startswith('%elif '):
+            converted_lines.append(line.replace('%elif', '#elif', 1))
+        elif stripped.startswith('%else'):
+            converted_lines.append(line.replace('%else', '#else', 1))
+        elif stripped.startswith('%endif'):
+            converted_lines.append(line.replace('%endif', '#endif', 1))
+        elif stripped.startswith('#') and not stripped.startswith('#!'):
+            # Remove shell comment lines (but keep shebang)
+            # This prevents "# if ..." comments from being interpreted as "#if" by CPP
+            continue
+        else:
+            converted_lines.append(line)
+    converted_content = '\n'.join(converted_lines)
+
+    # Create temporary file with include directive and converted content
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.in', delete=False) as tmp:
+        tmp.write(f'#include "{kconfig_header}"\n')
+        tmp.write(converted_content)
+        tmp_path = tmp.name
+
+    try:
+        # Run C preprocessor
+        # -P: don't generate #line directives
+        # -E: preprocess only
+        # -undef: don't predefine any non-standard macros
+        # -nostdinc: don't search standard include directories
+        # -x assembler-with-cpp: treat input as assembly (allows # comments to pass through)
+        result = subprocess.run(
+            [cpp_command, '-P', '-E', '-undef', '-nostdinc', '-x', 'assembler-with-cpp', tmp_path],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+
+        preprocessed = result.stdout
+
+        # Clean up the output:
+        # 1. Remove empty lines at the beginning
+        # 2. Remove lines that are just whitespace
+        lines = preprocessed.split('\n')
+        cleaned_lines = []
+        started = False
+
+        for line in lines:
+            # Skip empty lines at the beginning
+            if not started and not line.strip():
+                continue
+            started = True
+            cleaned_lines.append(line)
+
+        # Remove trailing empty lines
+        while cleaned_lines and not cleaned_lines[-1].strip():
+            cleaned_lines.pop()
+
+        # Write preprocessed content back
+        with open(file_path, 'w') as f:
+            f.write('\n'.join(cleaned_lines))
+            if cleaned_lines:  # Add final newline if file is not empty
+                f.write('\n')
+
+        return True
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error preprocessing {file_path}: {e}")
+        print(f"stderr: {e.stderr}")
+        return False
+    finally:
+        # Clean up temporary file
+        try:
+            os.unlink(tmp_path)
+        except:
+            pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Preprocess ROMFS files with KConfig definitions')
+    parser.add_argument('--romfs-dir', required=True, help='ROMFS root directory')
+    parser.add_argument('--kconfig-header', required=True, help='Path to px4_boardconfig.h')
+    parser.add_argument('--cpp', required=True, help='C preprocessor command')
+    parser.add_argument('--pattern', default='rc*', help='File pattern to preprocess (default: rc*)')
+
+    args = parser.parse_args()
+
+    # Verify inputs
+    romfs_dir = Path(args.romfs_dir)
+    kconfig_header = Path(args.kconfig_header)
+
+    if not romfs_dir.exists():
+        print(f"Error: ROMFS directory not found: {romfs_dir}")
+        return 1
+
+    if not kconfig_header.exists():
+        print(f"Error: KConfig header not found: {kconfig_header}")
+        return 1
+
+    # Find all files to preprocess in init.d directory
+    init_d_dir = romfs_dir / 'init.d'
+    if not init_d_dir.exists():
+        print(f"Warning: init.d directory not found in {romfs_dir}")
+        return 0
+
+    # Find all rc* files (shell scripts)
+    files_to_process = []
+    for pattern in ['rc*', 'rcS']:
+        files_to_process.extend(init_d_dir.glob(pattern))
+
+    # Also check subdirectories like airframes
+    for subdir in init_d_dir.iterdir():
+        if subdir.is_dir():
+            for pattern in ['rc*']:
+                files_to_process.extend(subdir.glob(pattern))
+
+    # Remove duplicates and filter only files
+    files_to_process = list(set([f for f in files_to_process if f.is_file()]))
+
+    if not files_to_process:
+        print(f"Warning: No files matching pattern '{args.pattern}' found in {init_d_dir}")
+        return 0
+
+    print(f"Preprocessing {len(files_to_process)} ROMFS files with KConfig definitions...")
+
+    # Process each file
+    success_count = 0
+    for file_path in sorted(files_to_process):
+        rel_path = file_path.relative_to(romfs_dir)
+        print(f"  Processing: {rel_path}")
+        if preprocess_file(file_path, kconfig_header.absolute(), args.cpp):
+            success_count += 1
+        else:
+            print(f"  Warning: Failed to preprocess {rel_path}")
+
+    print(f"Successfully preprocessed {success_count}/{len(files_to_process)} files")
+
+    return 0 if success_count == len(files_to_process) else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This is a heavy WIP and vibe coded idea to start a discussion about putting the ROMFS through the CPP.
Please do not waste your time on reviewing the macro mapping, a lot of them are not thought through.

This started with me being annoyed at things like `px4io command not found` errors. Since we already use # for comments I switched to using % instead.

This has some advantages:
- saves flash by only including commands we have actually included.
- Does not need to check if files exist before calling them that we have added at compile time
- Does not silently fail paramter comparisons, since we can remove the `-s` flag for parameters we know at compile time must exists
- Better support for starting conflicting modules like uavcan vs cyphal