### PR TITLE
Gimbal: fix CI failures

### DIFF
--- a/src/modules/gimbal/output.cpp
+++ b/src/modules/gimbal/output.cpp
@@ -305,7 +305,7 @@ void OutputBase::set_stabilize(bool roll_stabilize, bool pitch_stabilize, bool y
 	_stabilize[2] = yaw_stabilize;
 }
 
-void OutputBase::set_last_valid_setpoint(const bool compensate[3], const matrix::Eulerf euler_vehicle)
+void OutputBase::set_last_valid_setpoint(const bool compensate[3], const matrix::Eulerf &euler_vehicle)
 {
 	// No updates from angular velocity, hence no modification of last valid setpoint
 	if (!PX4_ISFINITE(_angle_velocity[0]) && !PX4_ISFINITE(_angle_velocity[1]) && !PX4_ISFINITE(_angle_velocity[2])) {

--- a/src/modules/gimbal/output.h
+++ b/src/modules/gimbal/output.h
@@ -106,9 +106,9 @@ protected:
 	 * the received MAVLink command, the last valid setpoint is updated to account for the vehicle attitude.
 	 *
 	 * @param compensate Boolean per axis (roll, pitch, yaw). If true, the vehicle attitude is taken into account.
-	 * @param euler_vehicle
+	 * @param euler_vehicle Reference to Euler float
 	 */
-	void set_last_valid_setpoint(const bool compensate[3], const matrix::Eulerf euler_vehicle);
+	void set_last_valid_setpoint(const bool compensate[3], const matrix::Eulerf &euler_vehicle);
 
 	float _angle_outputs[3] = { 0.f, 0.f, 0.f }; ///< calculated output angles (roll, pitch, yaw) [rad]
 

--- a/src/modules/gimbal/output_rc.cpp
+++ b/src/modules/gimbal/output_rc.cpp
@@ -38,8 +38,6 @@
 #include <px4_platform_common/defines.h>
 #include <matrix/matrix/math.hpp>
 
-using math::constrain;
-
 namespace gimbal
 {
 


### PR DESCRIPTION
### Solved Problem
Fixes clang formatting CI failure

### Solution
- Passing input by const reference instead to avoid the copy
- Remove unused using declaration

### Test coverage
TODO


