### PR TITLE
ekf2/gps: support per-instance position offsets from GPS driver

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
@@ -49,49 +49,58 @@ void Ekf::controlGnssHeightFusion(const gnssSample &gps_sample)
 
 	if (_gps_data_ready) {
 
-		// relax the upper observation noise limit which prevents bad GPS perturbing the position estimate
-		float noise = math::max(gps_sample.vacc, 1.5f * _params.ekf2_gps_p_noise); // use 1.5 as a typical ratio of vacc/hacc
+		// relax the upper observation noise limit which prevents bad GPS perturbing
+		// the position estimate
+		float noise =
+			math::max(gps_sample.vacc,
+				  1.5f * _params.ekf2_gps_p_noise); // use 1.5 as a typical
+		// ratio of vacc/hacc
 
-		if (!isOnlyActiveSourceOfVerticalPositionAiding(_control_status.flags.gps_hgt)) {
-			// if we are not using another source of aiding, then we are reliant on the GPS
-			// observations to constrain attitude errors and must limit the observation noise value.
+		if (!isOnlyActiveSourceOfVerticalPositionAiding(
+			    _control_status.flags.gps_hgt)) {
+			// if we are not using another source of aiding, then we are reliant on
+			// the GPS observations to constrain attitude errors and must limit the
+			// observation noise value.
 			if (noise > _params.ekf2_noaid_noise) {
 				noise = _params.ekf2_noaid_noise;
 			}
 		}
 
-		const Vector3f pos_offset_body = _params.gps_pos_body - _params.imu_pos_body;
+		const Vector3f pos_offset_body =
+			gps_sample.pos_offset_body - _params.imu_pos_body;
 		const Vector3f pos_offset_earth = _R_to_earth * pos_offset_body;
 		const float gnss_alt = gps_sample.alt + pos_offset_earth(2);
 
 		const float measurement = gnss_alt;
 		const float measurement_var = sq(noise);
 
-		const bool measurement_valid = PX4_ISFINITE(measurement) && PX4_ISFINITE(measurement_var);
+		const bool measurement_valid =
+			PX4_ISFINITE(measurement) && PX4_ISFINITE(measurement_var);
 
-		// GNSS position, vertical position GNSS measurement has opposite sign to earth z axis
-		updateVerticalPositionAidStatus(aid_src,
-						gps_sample.time_us,
+		// GNSS position, vertical position GNSS measurement has opposite sign to
+		// earth z axis
+		updateVerticalPositionAidStatus(aid_src, gps_sample.time_us,
 						-(measurement - bias_est.getBias()),
 						measurement_var + bias_est.getBiasVar(),
 						math::max(_params.ekf2_gps_p_gate, 1.f));
 
 		// determine if we should use height aiding
-		const bool common_conditions_passing = measurement_valid
-						       && _local_origin_lat_lon.isInitialized()
-						       && _gnss_checks.passed()
-						       && !_control_status.flags.gnss_fault;
+		const bool common_conditions_passing =
+			measurement_valid && _local_origin_lat_lon.isInitialized() &&
+			_gnss_checks.passed() && !_control_status.flags.gnss_fault;
 
-		const bool continuing_conditions_passing = (_params.ekf2_gps_ctrl & static_cast<int32_t>(GnssCtrl::VPOS))
-				&& common_conditions_passing;
+		const bool continuing_conditions_passing =
+			(_params.ekf2_gps_ctrl & static_cast<int32_t>(GnssCtrl::VPOS)) &&
+			common_conditions_passing;
 
-		const bool starting_conditions_passing = continuing_conditions_passing
-				&& isNewestSampleRecent(_time_last_gps_buffer_push, 2 * GNSS_MAX_INTERVAL);
+		const bool starting_conditions_passing =
+			continuing_conditions_passing &&
+			isNewestSampleRecent(_time_last_gps_buffer_push, 2 * GNSS_MAX_INTERVAL);
 
-		const bool altitude_initialisation_conditions_passing = common_conditions_passing
-				&& !PX4_ISFINITE(_local_origin_alt)
-				&& _params.ekf2_hgt_ref == static_cast<int32_t>(HeightSensor::GNSS)
-				&& isNewestSampleRecent(_time_last_gps_buffer_push, 2 * GNSS_MAX_INTERVAL);
+		const bool altitude_initialisation_conditions_passing =
+			common_conditions_passing && !PX4_ISFINITE(_local_origin_alt) &&
+			_params.ekf2_hgt_ref == static_cast<int32_t>(HeightSensor::GNSS) &&
+			isNewestSampleRecent(_time_last_gps_buffer_push, 2 * GNSS_MAX_INTERVAL);
 
 		if (_control_status.flags.gps_hgt) {
 			if (continuing_conditions_passing) {
@@ -100,15 +109,22 @@ void Ekf::controlGnssHeightFusion(const gnssSample &gps_sample)
 				// using its current state to compute the vertical position innovation
 				bias_est.setMaxStateNoise(sqrtf(measurement_var));
 				bias_est.setProcessNoiseSpectralDensity(_params.gps_hgt_bias_nsd);
-				bias_est.fuseBias(measurement - _gpos.altitude(), measurement_var + P(State::pos.idx + 2, State::pos.idx + 2));
+				bias_est.fuseBias(measurement - _gpos.altitude(),
+						  measurement_var +
+						  P(State::pos.idx + 2, State::pos.idx + 2));
 
 				fuseVerticalPosition(aid_src);
 
-				const bool is_fusion_failing = isTimedOut(aid_src.time_last_fuse, _params.hgt_fusion_timeout_max);
+				const bool is_fusion_failing =
+					isTimedOut(aid_src.time_last_fuse, _params.hgt_fusion_timeout_max);
 
-				if (isHeightResetRequired() && (_height_sensor_ref == HeightSensor::GNSS) && isGnssHgtResetAllowed()) {
+				if (isHeightResetRequired() &&
+				    (_height_sensor_ref == HeightSensor::GNSS) &&
+				    isGnssHgtResetAllowed()) {
 					// All height sources are failing
-					ECL_WARN("%s height fusion reset required, all height sources failing", HGT_SRC_NAME);
+					ECL_WARN(
+						"%s height fusion reset required, all height sources failing",
+						HGT_SRC_NAME);
 
 					_information_events.flags.reset_hgt_to_gps = true;
 					resetAltitudeTo(measurement, measurement_var);
@@ -129,7 +145,8 @@ void Ekf::controlGnssHeightFusion(const gnssSample &gps_sample)
 				}
 
 			} else {
-				ECL_WARN("stopping %s height fusion, continuing conditions failing", HGT_SRC_NAME);
+				ECL_WARN("stopping %s height fusion, continuing conditions failing",
+					 HGT_SRC_NAME);
 				stopGpsHgtFusion();
 			}
 
@@ -150,7 +167,8 @@ void Ekf::controlGnssHeightFusion(const gnssSample &gps_sample)
 				}
 
 			} else if (starting_conditions_passing) {
-				if (_params.ekf2_hgt_ref == static_cast<int32_t>(HeightSensor::GNSS) && isGnssHgtResetAllowed()) {
+				if (_params.ekf2_hgt_ref == static_cast<int32_t>(HeightSensor::GNSS) &&
+				    isGnssHgtResetAllowed()) {
 					_height_sensor_ref = HeightSensor::GNSS;
 					_information_events.flags.reset_hgt_to_gps = true;
 
@@ -171,11 +189,13 @@ void Ekf::controlGnssHeightFusion(const gnssSample &gps_sample)
 							_time_last_gnss_hgt_rejected = _time_delayed_us;
 						}
 
-						is_gnss_hgt_consistent = isTimedOut(_time_last_gnss_hgt_rejected, _params.hgt_fusion_timeout_max);
+						is_gnss_hgt_consistent = isTimedOut(_time_last_gnss_hgt_rejected,
+										    _params.hgt_fusion_timeout_max);
 					}
 
 					if (is_gnss_hgt_consistent) {
-						if (_params.ekf2_hgt_ref != static_cast<int32_t>(HeightSensor::GNSS)) {
+						if (_params.ekf2_hgt_ref !=
+						    static_cast<int32_t>(HeightSensor::GNSS)) {
 							bias_est.setBias(-_gpos.altitude() + measurement);
 						}
 
@@ -188,8 +208,9 @@ void Ekf::controlGnssHeightFusion(const gnssSample &gps_sample)
 			}
 		}
 
-	} else if (_control_status.flags.gps_hgt
-		   && !isNewestSampleRecent(_time_last_gps_buffer_push, 2 * GNSS_MAX_INTERVAL)) {
+	} else if (_control_status.flags.gps_hgt &&
+		   !isNewestSampleRecent(_time_last_gps_buffer_push,
+					 2 * GNSS_MAX_INTERVAL)) {
 		// No data anymore. Stop until it comes back.
 		ECL_WARN("stopping %s height fusion, no data", HGT_SRC_NAME);
 		stopGpsHgtFusion();
@@ -212,9 +233,11 @@ void Ekf::stopGpsHgtFusion()
 
 bool Ekf::isGnssHgtResetAllowed()
 {
-	const bool allowed = !(static_cast<GnssMode>(_params.ekf2_gps_mode) == GnssMode::kDeadReckoning
-			       && isOtherSourceOfVerticalPositionAidingThan(_control_status.flags.gps_hgt))
-			     || !PX4_ISFINITE(_local_origin_alt);
+	const bool allowed = !(static_cast<GnssMode>(_params.ekf2_gps_mode) ==
+			       GnssMode::kDeadReckoning &&
+			       isOtherSourceOfVerticalPositionAidingThan(
+				       _control_status.flags.gps_hgt)) ||
+			     !PX4_ISFINITE(_local_origin_alt);
 
 	return allowed;
 }

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -89,38 +89,38 @@
 #include <uORB/topics/yaw_estimator_status.h>
 
 #if defined(CONFIG_EKF2_AIRSPEED)
-# include <uORB/topics/airspeed.h>
-# include <uORB/topics/airspeed_validated.h>
+#include <uORB/topics/airspeed.h>
+#include <uORB/topics/airspeed_validated.h>
 #endif // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_AUXVEL)
-# include <uORB/topics/landing_target_pose.h>
+#include <uORB/topics/landing_target_pose.h>
 #endif // CONFIG_EKF2_AUXVEL
 
 #if defined(CONFIG_EKF2_BAROMETER)
-# include <uORB/topics/vehicle_air_data.h>
+#include <uORB/topics/vehicle_air_data.h>
 #endif // CONFIG_EKF2_BAROMETER
 
 #if defined(CONFIG_EKF2_GNSS)
-# include <uORB/topics/estimator_gps_status.h>
-# include <uORB/topics/sensor_gps.h>
+#include <uORB/topics/estimator_gps_status.h>
+#include <uORB/topics/sensor_gps.h>
 #endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_MAGNETOMETER)
-# include <uORB/topics/vehicle_magnetometer.h>
+#include <uORB/topics/vehicle_magnetometer.h>
 #endif // CONFIG_EKF2_MAGNETOMETER
 
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)
-# include <uORB/topics/vehicle_optical_flow.h>
-# include <uORB/topics/vehicle_optical_flow_vel.h>
+#include <uORB/topics/vehicle_optical_flow.h>
+#include <uORB/topics/vehicle_optical_flow_vel.h>
 #endif // CONFIG_EKF2_OPTICAL_FLOW
 
 #if defined(CONFIG_EKF2_RANGE_FINDER)
-# include <uORB/topics/distance_sensor.h>
+#include <uORB/topics/distance_sensor.h>
 #endif // CONFIG_EKF2_RANGE_FINDER
 
 #if defined(CONFIG_EKF2_WIND)
-# include <uORB/topics/wind.h>
+#include <uORB/topics/wind.h>
 #endif // CONFIG_EKF2_WIND
 
 extern pthread_mutex_t ekf2_module_mutex;
@@ -148,7 +148,10 @@ public:
 	void request_stop() { _task_should_exit.store(true); }
 
 	static void lock_module() { pthread_mutex_lock(&ekf2_module_mutex); }
-	static bool trylock_module() { return (pthread_mutex_trylock(&ekf2_module_mutex) == 0); }
+	static bool trylock_module()
+	{
+		return (pthread_mutex_trylock(&ekf2_module_mutex) == 0);
+	}
 	static void unlock_module() { pthread_mutex_unlock(&ekf2_module_mutex); }
 
 #if defined(CONFIG_EKF2_MULTI_INSTANCE)
@@ -158,7 +161,6 @@ public:
 	int instance() const { return _instance; }
 
 private:
-
 	static constexpr uint8_t MAX_NUM_IMUS = 4;
 	static constexpr uint8_t MAX_NUM_MAGS = 4;
 
@@ -181,15 +183,18 @@ private:
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
 	void PublishEvPosBias(const hrt_abstime &timestamp);
 #endif // CONFIG_EKF2_EXTERNAL_VISION
-	estimator_bias_s fillEstimatorBiasMsg(const BiasEstimator::status &status, uint64_t timestamp_sample_us,
-					      uint64_t timestamp, uint32_t device_id = 0);
+	estimator_bias_s fillEstimatorBiasMsg(const BiasEstimator::status &status,
+					      uint64_t timestamp_sample_us,
+					      uint64_t timestamp,
+					      uint32_t device_id = 0);
 	void PublishEventFlags(const hrt_abstime &timestamp);
 	void PublishGlobalPosition(const hrt_abstime &timestamp);
 	void PublishInnovations(const hrt_abstime &timestamp);
 	void PublishInnovationTestRatios(const hrt_abstime &timestamp);
 	void PublishInnovationVariances(const hrt_abstime &timestamp);
 	void PublishLocalPosition(const hrt_abstime &timestamp);
-	void PublishOdometry(const hrt_abstime &timestamp, const imuSample &imu_sample);
+	void PublishOdometry(const hrt_abstime &timestamp,
+			     const imuSample &imu_sample);
 	void PublishSensorBias(const hrt_abstime &timestamp);
 	void PublishStates(const hrt_abstime &timestamp);
 	void PublishStatus(const hrt_abstime &timestamp);
@@ -234,14 +239,20 @@ private:
 
 	// Used to check, save and use learned accel/gyro/mag biases
 	struct InFlightCalibration {
-		hrt_abstime last_us{0};         ///< last time the EKF was operating a mode that estimates accelerometer biases (uSec)
-		hrt_abstime total_time_us{0};   ///< accumulated calibration time since the last save
+		hrt_abstime last_us{0}; ///< last time the EKF was operating a mode that
+		///< estimates accelerometer biases (uSec)
+		hrt_abstime total_time_us{
+			0}; ///< accumulated calibration time since the last save
 		matrix::Vector3f bias{};
-		bool cal_available{false};      ///< true when an unsaved valid calibration for the XYZ accelerometer bias is available
+		bool cal_available{false}; ///< true when an unsaved valid calibration for
+		///< the XYZ accelerometer bias is available
 	};
 
-	void UpdateCalibration(const hrt_abstime &timestamp, InFlightCalibration &cal, const matrix::Vector3f &bias,
-			       const matrix::Vector3f &bias_variance, float bias_limit, bool bias_valid, bool learning_valid);
+	void UpdateCalibration(const hrt_abstime &timestamp, InFlightCalibration &cal,
+			       const matrix::Vector3f &bias,
+			       const matrix::Vector3f &bias_variance,
+			       float bias_limit, bool bias_valid,
+			       bool learning_valid);
 	void UpdateAccelCalibration(const hrt_abstime &timestamp);
 	void UpdateGyroCalibration(const hrt_abstime &timestamp);
 #if defined(CONFIG_EKF2_MAGNETOMETER)
@@ -250,7 +261,8 @@ private:
 
 	// publish helper for estimator_aid_source topics
 	template <typename T>
-	void PublishAidSourceStatus(const hrt_abstime &timestamp, const T &status, hrt_abstime &status_publish_last,
+	void PublishAidSourceStatus(const hrt_abstime &timestamp, const T &status,
+				    hrt_abstime &status_publish_last,
 				    uORB::PublicationMulti<T> &pub)
 	{
 		if (status.timestamp_sample > status_publish_last) {
@@ -267,19 +279,22 @@ private:
 
 	static constexpr float sq(float x) { return x * x; };
 
-	const bool _replay_mode{false};			///< true when we use replay data from a log
+	const bool _replay_mode{false}; ///< true when we use replay data from a log
 	const bool _multi_mode;
 	int _instance{0};
 
 	px4::atomic_bool _task_should_exit{false};
 
 	// time slip monitoring
-	uint64_t _integrated_time_us = 0;	///< integral of gyro delta time from start (uSec)
-	uint64_t _start_time_us = 0;		///< system time at EKF start (uSec)
-	int64_t _last_time_slip_us = 0;		///< Last time slip (uSec)
+	uint64_t _integrated_time_us =
+		0; ///< integral of gyro delta time from start (uSec)
+	uint64_t _start_time_us = 0;    ///< system time at EKF start (uSec)
+	int64_t _last_time_slip_us = 0; ///< Last time slip (uSec)
 
-	perf_counter_t _ekf_update_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": EKF update")};
-	perf_counter_t _msg_missed_imu_perf{perf_alloc(PC_COUNT, MODULE_NAME": IMU message missed")};
+	perf_counter_t _ekf_update_perf{
+		perf_alloc(PC_ELAPSED, MODULE_NAME ": EKF update")};
+	perf_counter_t _msg_missed_imu_perf{
+		perf_alloc(PC_COUNT, MODULE_NAME ": IMU message missed")};
 
 	InFlightCalibration _accel_cal{};
 	InFlightCalibration _gyro_cal{};
@@ -302,7 +317,8 @@ private:
 	uint32_t _device_id_mag {0};
 
 	// Used to control saving of mag declination to be used on next startup
-	bool _mag_decl_saved = false;	///< true when the magnetic declination has been saved
+	bool _mag_decl_saved =
+		false; ///< true when the magnetic declination has been saved
 
 	InFlightCalibration _mag_cal{};
 	uint8_t _mag_calibration_count{0};
@@ -312,14 +328,19 @@ private:
 
 	uORB::Subscription _magnetometer_sub{ORB_ID(vehicle_magnetometer)};
 
-	uORB::PublicationMulti<estimator_aid_source3d_s> _estimator_aid_src_mag_pub{ORB_ID(estimator_aid_src_mag)};
+	uORB::PublicationMulti<estimator_aid_source3d_s> _estimator_aid_src_mag_pub{
+		ORB_ID(estimator_aid_src_mag)};
 #endif // CONFIG_EKF2_MAGNETOMETER
 
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
-	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_ev_hgt_pub {ORB_ID(estimator_aid_src_ev_hgt)};
-	uORB::PublicationMulti<estimator_aid_source2d_s> _estimator_aid_src_ev_pos_pub{ORB_ID(estimator_aid_src_ev_pos)};
-	uORB::PublicationMulti<estimator_aid_source3d_s> _estimator_aid_src_ev_vel_pub{ORB_ID(estimator_aid_src_ev_vel)};
-	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_ev_yaw_pub{ORB_ID(estimator_aid_src_ev_yaw)};
+	uORB::PublicationMulti<estimator_aid_source1d_s>
+	_estimator_aid_src_ev_hgt_pub{ORB_ID(estimator_aid_src_ev_hgt)};
+	uORB::PublicationMulti<estimator_aid_source2d_s>
+	_estimator_aid_src_ev_pos_pub{ORB_ID(estimator_aid_src_ev_pos)};
+	uORB::PublicationMulti<estimator_aid_source3d_s>
+	_estimator_aid_src_ev_vel_pub{ORB_ID(estimator_aid_src_ev_vel)};
+	uORB::PublicationMulti<estimator_aid_source1d_s>
+	_estimator_aid_src_ev_yaw_pub{ORB_ID(estimator_aid_src_ev_yaw)};
 	hrt_abstime _status_ev_hgt_pub_last{0};
 	hrt_abstime _status_ev_pos_pub_last{0};
 	hrt_abstime _status_ev_vel_pub_last{0};
@@ -329,21 +350,26 @@ private:
 
 	uORB::Subscription _ev_odom_sub{ORB_ID(vehicle_visual_odometry)};
 
-	uORB::PublicationMulti<estimator_bias3d_s> _estimator_ev_pos_bias_pub{ORB_ID(estimator_ev_pos_bias)};
+	uORB::PublicationMulti<estimator_bias3d_s> _estimator_ev_pos_bias_pub{
+		ORB_ID(estimator_ev_pos_bias)};
 #endif // CONFIG_EKF2_EXTERNAL_VISION
 
 #if defined(CONFIG_EKF2_AUXVEL)
 	uORB::Subscription _landing_target_pose_sub {ORB_ID(landing_target_pose)};
 
-	uORB::PublicationMulti<estimator_aid_source2d_s> _estimator_aid_src_aux_vel_pub{ORB_ID(estimator_aid_src_aux_vel)};
+	uORB::PublicationMulti<estimator_aid_source2d_s>
+	_estimator_aid_src_aux_vel_pub{ORB_ID(estimator_aid_src_aux_vel)};
 	hrt_abstime _status_aux_vel_pub_last{0};
 #endif // CONFIG_EKF2_AUXVEL
 
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)
 	uORB::Subscription _vehicle_optical_flow_sub {ORB_ID(vehicle_optical_flow)};
-	uORB::PublicationMulti<vehicle_optical_flow_vel_s> _estimator_optical_flow_vel_pub{ORB_ID(estimator_optical_flow_vel)};
+	uORB::PublicationMulti<vehicle_optical_flow_vel_s>
+	_estimator_optical_flow_vel_pub{ORB_ID(estimator_optical_flow_vel)};
 
-	uORB::PublicationMulti<estimator_aid_source2d_s> _estimator_aid_src_optical_flow_pub{ORB_ID(estimator_aid_src_optical_flow)};
+	uORB::PublicationMulti<estimator_aid_source2d_s>
+	_estimator_aid_src_optical_flow_pub{
+		ORB_ID(estimator_aid_src_optical_flow)};
 	hrt_abstime _status_optical_flow_pub_last{0};
 	hrt_abstime _optical_flow_vel_pub_last{0};
 #endif // CONFIG_EKF2_OPTICAL_FLOW
@@ -357,12 +383,16 @@ private:
 
 	uORB::Subscription _airdata_sub{ORB_ID(vehicle_air_data)};
 
-	uORB::PublicationMulti<estimator_bias_s> _estimator_baro_bias_pub{ORB_ID(estimator_baro_bias)};
-	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_baro_hgt_pub {ORB_ID(estimator_aid_src_baro_hgt)};
+	uORB::PublicationMulti<estimator_bias_s> _estimator_baro_bias_pub{
+		ORB_ID(estimator_baro_bias)};
+	uORB::PublicationMulti<estimator_aid_source1d_s>
+	_estimator_aid_src_baro_hgt_pub{ORB_ID(estimator_aid_src_baro_hgt)};
 #endif // CONFIG_EKF2_BAROMETER
 
 #if defined(CONFIG_EKF2_DRAG_FUSION)
-	uORB::PublicationMulti<estimator_aid_source2d_s> _estimator_aid_src_drag_pub {ORB_ID(estimator_aid_src_drag)};
+	uORB::PublicationMulti<estimator_aid_source2d_s> _estimator_aid_src_drag_pub {
+		ORB_ID(estimator_aid_src_drag)
+	};
 	hrt_abstime _status_drag_pub_last{0};
 #endif // CONFIG_EKF2_DRAG_FUSION
 
@@ -370,42 +400,54 @@ private:
 	uORB::Subscription _airspeed_sub {ORB_ID(airspeed)};
 	uORB::Subscription _airspeed_validated_sub{ORB_ID(airspeed_validated)};
 
-	float _airspeed_scale_factor{1.0f}; ///< scale factor correction applied to airspeed measurements
+	float _airspeed_scale_factor{
+		1.0f}; ///< scale factor correction applied to airspeed measurements
 	hrt_abstime _airspeed_validated_timestamp_last{0};
 
-	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_airspeed_pub {ORB_ID(estimator_aid_src_airspeed)};
+	uORB::PublicationMulti<estimator_aid_source1d_s>
+	_estimator_aid_src_airspeed_pub{ORB_ID(estimator_aid_src_airspeed)};
 	hrt_abstime _status_airspeed_pub_last{0};
 #endif // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_SIDESLIP)
-	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_sideslip_pub {ORB_ID(estimator_aid_src_sideslip)};
-	hrt_abstime _status_sideslip_pub_last {0};
+	uORB::PublicationMulti<estimator_aid_source1d_s>
+	_estimator_aid_src_sideslip_pub{ORB_ID(estimator_aid_src_sideslip)};
+	hrt_abstime _status_sideslip_pub_last{0};
 #endif // CONFIG_EKF2_SIDESLIP
 
 	orb_advert_t _mavlink_log_pub{nullptr};
 
-	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update),
+		     1_s};
 
 	uORB::Subscription _sensor_selection_sub{ORB_ID(sensor_selection)};
 	uORB::Subscription _status_sub{ORB_ID(vehicle_status)};
 	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
-	uORB::Subscription _launch_detection_status_sub{ORB_ID(launch_detection_status)};
+	uORB::Subscription _launch_detection_status_sub{
+		ORB_ID(launch_detection_status)};
 
 	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};
-	uORB::Publication<vehicle_command_ack_s> _vehicle_command_ack_pub{ORB_ID(vehicle_command_ack)};
+	uORB::Publication<vehicle_command_ack_s> _vehicle_command_ack_pub{
+		ORB_ID(vehicle_command_ack)};
 
-	uORB::SubscriptionCallbackWorkItem _sensor_combined_sub{this, ORB_ID(sensor_combined)};
-	uORB::SubscriptionCallbackWorkItem _vehicle_imu_sub{this, ORB_ID(vehicle_imu)};
+	uORB::SubscriptionCallbackWorkItem _sensor_combined_sub{
+		this, ORB_ID(sensor_combined)};
+	uORB::SubscriptionCallbackWorkItem _vehicle_imu_sub{this,
+		     ORB_ID(vehicle_imu)};
 
 #if defined(CONFIG_EKF2_RANGE_FINDER)
 	hrt_abstime _status_rng_hgt_pub_last {0};
 
-	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_rng_hgt_pub{ORB_ID(estimator_aid_src_rng_hgt)};
+	uORB::PublicationMulti<estimator_aid_source1d_s>
+	_estimator_aid_src_rng_hgt_pub{ORB_ID(estimator_aid_src_rng_hgt)};
 
-	uORB::SubscriptionMultiArray<distance_sensor_s> _distance_sensor_subs{ORB_ID::distance_sensor};
+	uORB::SubscriptionMultiArray<distance_sensor_s> _distance_sensor_subs{
+		ORB_ID::distance_sensor};
 	hrt_abstime _last_range_sensor_update{0};
-	int _distance_sensor_selected{-1}; // because we can have several distance sensor instances with different orientations
-#endif // CONFIG_EKF2_RANGE_FINDER
+	int _distance_sensor_selected{
+		-1}; // because we can have several distance sensor instances with
+	// different orientations
+#endif     // CONFIG_EKF2_RANGE_FINDER
 
 	bool _callback_registered{false};
 
@@ -419,34 +461,48 @@ private:
 	uint32_t _filter_fault_status_changes{0};
 	uint32_t _filter_information_event_changes{0};
 
-	uORB::PublicationMulti<ekf2_timestamps_s>            _ekf2_timestamps_pub{ORB_ID(ekf2_timestamps)};
-	uORB::PublicationMultiData<estimator_event_flags_s>  _estimator_event_flags_pub{ORB_ID(estimator_event_flags)};
-	uORB::PublicationMulti<estimator_innovations_s>      _estimator_innovation_test_ratios_pub{ORB_ID(estimator_innovation_test_ratios)};
-	uORB::PublicationMulti<estimator_innovations_s>      _estimator_innovation_variances_pub{ORB_ID(estimator_innovation_variances)};
-	uORB::PublicationMulti<estimator_innovations_s>      _estimator_innovations_pub{ORB_ID(estimator_innovations)};
-	uORB::PublicationMulti<estimator_sensor_bias_s>      _estimator_sensor_bias_pub{ORB_ID(estimator_sensor_bias)};
-	uORB::PublicationMulti<estimator_states_s>           _estimator_states_pub{ORB_ID(estimator_states)};
-	uORB::PublicationMulti<estimator_status_flags_s>     _estimator_status_flags_pub{ORB_ID(estimator_status_flags)};
-	uORB::PublicationMulti<estimator_status_s>           _estimator_status_pub{ORB_ID(estimator_status)};
+	uORB::PublicationMulti<ekf2_timestamps_s> _ekf2_timestamps_pub{
+		ORB_ID(ekf2_timestamps)};
+	uORB::PublicationMultiData<estimator_event_flags_s>
+	_estimator_event_flags_pub{ORB_ID(estimator_event_flags)};
+	uORB::PublicationMulti<estimator_innovations_s>
+	_estimator_innovation_test_ratios_pub{
+		ORB_ID(estimator_innovation_test_ratios)};
+	uORB::PublicationMulti<estimator_innovations_s>
+	_estimator_innovation_variances_pub{
+		ORB_ID(estimator_innovation_variances)};
+	uORB::PublicationMulti<estimator_innovations_s> _estimator_innovations_pub{
+		ORB_ID(estimator_innovations)};
+	uORB::PublicationMulti<estimator_sensor_bias_s> _estimator_sensor_bias_pub{
+		ORB_ID(estimator_sensor_bias)};
+	uORB::PublicationMulti<estimator_states_s> _estimator_states_pub{
+		ORB_ID(estimator_states)};
+	uORB::PublicationMulti<estimator_status_flags_s> _estimator_status_flags_pub{
+		ORB_ID(estimator_status_flags)};
+	uORB::PublicationMulti<estimator_status_s> _estimator_status_pub{
+		ORB_ID(estimator_status)};
 
-	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_fake_hgt_pub{ORB_ID(estimator_aid_src_fake_hgt)};
-	uORB::PublicationMulti<estimator_aid_source2d_s> _estimator_aid_src_fake_pos_pub{ORB_ID(estimator_aid_src_fake_pos)};
+	uORB::PublicationMulti<estimator_aid_source1d_s>
+	_estimator_aid_src_fake_hgt_pub{ORB_ID(estimator_aid_src_fake_hgt)};
+	uORB::PublicationMulti<estimator_aid_source2d_s>
+	_estimator_aid_src_fake_pos_pub{ORB_ID(estimator_aid_src_fake_pos)};
 
 	// publications with topic dependent on multi-mode
-	uORB::PublicationMulti<vehicle_attitude_s>           _attitude_pub;
-	uORB::PublicationMulti<vehicle_local_position_s>     _local_position_pub;
-	uORB::PublicationMulti<vehicle_global_position_s>    _global_position_pub;
-	uORB::PublicationMulti<vehicle_odometry_s>           _odometry_pub;
+	uORB::PublicationMulti<vehicle_attitude_s> _attitude_pub;
+	uORB::PublicationMulti<vehicle_local_position_s> _local_position_pub;
+	uORB::PublicationMulti<vehicle_global_position_s> _global_position_pub;
+	uORB::PublicationMulti<vehicle_odometry_s> _odometry_pub;
 
 #if defined(CONFIG_EKF2_WIND)
-	uORB::PublicationMulti<wind_s>              _wind_pub;
+	uORB::PublicationMulti<wind_s> _wind_pub;
 #endif // CONFIG_EKF2_WIND
 
 #if defined(CONFIG_EKF2_GNSS)
 
 	uint64_t _last_geoid_height_update_us{0};
 	static constexpr float kGeoidHeightLpfTimeConstant = 10.f;
-	AlphaFilter<float> _geoid_height_lpf;  ///< height offset between AMSL and ellipsoid
+	AlphaFilter<float>
+	_geoid_height_lpf; ///< height offset between AMSL and ellipsoid
 
 	hrt_abstime _last_gps_status_published{0};
 
@@ -458,269 +514,337 @@ private:
 
 	uORB::Subscription _vehicle_gps_position_sub{ORB_ID(vehicle_gps_position)};
 
-	uORB::PublicationMulti<estimator_bias_s> _estimator_gnss_hgt_bias_pub{ORB_ID(estimator_gnss_hgt_bias)};
-	uORB::PublicationMulti<estimator_gps_status_s> _estimator_gps_status_pub{ORB_ID(estimator_gps_status)};
-	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_gnss_hgt_pub{ORB_ID(estimator_aid_src_gnss_hgt)};
-	uORB::PublicationMulti<estimator_aid_source2d_s> _estimator_aid_src_gnss_pos_pub{ORB_ID(estimator_aid_src_gnss_pos)};
-	uORB::PublicationMulti<estimator_aid_source3d_s> _estimator_aid_src_gnss_vel_pub{ORB_ID(estimator_aid_src_gnss_vel)};
+	uORB::PublicationMulti<estimator_bias_s> _estimator_gnss_hgt_bias_pub{
+		ORB_ID(estimator_gnss_hgt_bias)};
+	uORB::PublicationMulti<estimator_gps_status_s> _estimator_gps_status_pub{
+		ORB_ID(estimator_gps_status)};
+	uORB::PublicationMulti<estimator_aid_source1d_s>
+	_estimator_aid_src_gnss_hgt_pub{ORB_ID(estimator_aid_src_gnss_hgt)};
+	uORB::PublicationMulti<estimator_aid_source2d_s>
+	_estimator_aid_src_gnss_pos_pub{ORB_ID(estimator_aid_src_gnss_pos)};
+	uORB::PublicationMulti<estimator_aid_source3d_s>
+	_estimator_aid_src_gnss_vel_pub{ORB_ID(estimator_aid_src_gnss_vel)};
 
-	uORB::PublicationMulti<yaw_estimator_status_s> _yaw_est_pub{ORB_ID(yaw_estimator_status)};
+	uORB::PublicationMulti<yaw_estimator_status_s> _yaw_est_pub{
+		ORB_ID(yaw_estimator_status)};
 
-# if defined(CONFIG_EKF2_GNSS_YAW)
+#if defined(CONFIG_EKF2_GNSS_YAW)
 	hrt_abstime _status_gnss_yaw_pub_last {0};
-	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_gnss_yaw_pub {ORB_ID(estimator_aid_src_gnss_yaw)};
-# endif // CONFIG_EKF2_GNSS_YAW
+	uORB::PublicationMulti<estimator_aid_source1d_s>
+	_estimator_aid_src_gnss_yaw_pub{ORB_ID(estimator_aid_src_gnss_yaw)};
+#endif // CONFIG_EKF2_GNSS_YAW
 #endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_GRAVITY_FUSION)
 	hrt_abstime _status_gravity_pub_last {0};
-	uORB::PublicationMulti<estimator_aid_source3d_s> _estimator_aid_src_gravity_pub{ORB_ID(estimator_aid_src_gravity)};
+	uORB::PublicationMulti<estimator_aid_source3d_s>
+	_estimator_aid_src_gravity_pub{ORB_ID(estimator_aid_src_gravity)};
 #endif // CONFIG_EKF2_GRAVITY_FUSION
+
+	static constexpr int EKF2_GPS_MAX_INSTANCES = 4;
+	struct GpsOffsetParameters {
+		int32_t id;
+		matrix::Vector3f pos_body;
+	};
+	GpsOffsetParameters _params_gps_offset[EKF2_GPS_MAX_INSTANCES];
 
 	Ekf _ekf;
 
-	parameters *_params;	///< pointer to ekf parameter struct (located in _ekf class instance)
+	parameters *_params; ///< pointer to ekf parameter struct (located in _ekf
+	///< class instance)
 
 	DEFINE_PARAMETERS(
-		(ParamBool<px4::params::EKF2_LOG_VERBOSE>) _param_ekf2_log_verbose,
-		(ParamExtInt<px4::params::EKF2_PREDICT_US>) _param_ekf2_predict_us,
-		(ParamExtFloat<px4::params::EKF2_DELAY_MAX>) _param_ekf2_delay_max,
-		(ParamExtInt<px4::params::EKF2_IMU_CTRL>) _param_ekf2_imu_ctrl,
-		(ParamExtFloat<px4::params::EKF2_VEL_LIM>) _param_ekf2_vel_lim,
-		(ParamBool<px4::params::EKF2_ENGINE_WRM>) _param_ekf2_engine_wrm,
+		(ParamBool<px4::params::EKF2_LOG_VERBOSE>)_param_ekf2_log_verbose,
+		(ParamExtInt<px4::params::EKF2_PREDICT_US>)_param_ekf2_predict_us,
+		(ParamExtFloat<px4::params::EKF2_DELAY_MAX>)_param_ekf2_delay_max,
+		(ParamExtInt<px4::params::EKF2_IMU_CTRL>)_param_ekf2_imu_ctrl,
+		(ParamExtFloat<px4::params::EKF2_VEL_LIM>)_param_ekf2_vel_lim,
+		(ParamBool<px4::params::EKF2_ENGINE_WRM>)_param_ekf2_engine_wrm,
 
 #if defined(CONFIG_EKF2_AUXVEL)
 		(ParamExtFloat<px4::params::EKF2_AVEL_DELAY>)
-		_param_ekf2_avel_delay,	///< auxiliary velocity measurement delay relative to the IMU (mSec)
+		_param_ekf2_avel_delay, ///< auxiliary velocity measurement delay
+		///< relative to the IMU (mSec)
 #endif // CONFIG_EKF2_AUXVEL
 
 		(ParamExtFloat<px4::params::EKF2_GYR_NOISE>)
-		_param_ekf2_gyr_noise,	///< IMU angular rate noise used for covariance prediction (rad/sec)
+		_param_ekf2_gyr_noise, ///< IMU angular rate noise used for covariance
+		///< prediction (rad/sec)
 		(ParamExtFloat<px4::params::EKF2_ACC_NOISE>)
-		_param_ekf2_acc_noise,	///< IMU acceleration noise use for covariance prediction (m/sec**2)
+		_param_ekf2_acc_noise, ///< IMU acceleration noise use for covariance
+		///< prediction (m/sec**2)
 
 		// process noise
 		(ParamExtFloat<px4::params::EKF2_GYR_B_NOISE>)
-		_param_ekf2_gyr_b_noise,	///< process noise for IMU rate gyro bias prediction (rad/sec**2)
+		_param_ekf2_gyr_b_noise, ///< process noise for IMU rate gyro bias
+		///< prediction (rad/sec**2)
 		(ParamExtFloat<px4::params::EKF2_ACC_B_NOISE>)
-		_param_ekf2_acc_b_noise,///< process noise for IMU accelerometer bias prediction (m/sec**3)
+		_param_ekf2_acc_b_noise, ///< process noise for IMU accelerometer bias
+		///< prediction (m/sec**3)
 
 #if defined(CONFIG_EKF2_WIND)
-		(ParamExtFloat<px4::params::EKF2_WIND_NSD>) _param_ekf2_wind_nsd,
+		(ParamExtFloat<px4::params::EKF2_WIND_NSD>)_param_ekf2_wind_nsd,
 #endif // CONFIG_EKF2_WIND
 
-		(ParamExtFloat<px4::params::EKF2_NOAID_NOISE>) _param_ekf2_noaid_noise,
+		(ParamExtFloat<px4::params::EKF2_NOAID_NOISE>)_param_ekf2_noaid_noise,
 
 #if defined(CONFIG_EKF2_GNSS)
-		(ParamExtInt<px4::params::EKF2_GPS_CTRL>) _param_ekf2_gps_ctrl,
-		(ParamExtInt<px4::params::EKF2_GPS_MODE>) _param_ekf2_gps_mode,
-		(ParamExtFloat<px4::params::EKF2_GPS_DELAY>) _param_ekf2_gps_delay,
+		(ParamExtInt<px4::params::EKF2_GPS_CTRL>)_param_ekf2_gps_ctrl,
+		(ParamExtInt<px4::params::EKF2_GPS_MODE>)_param_ekf2_gps_mode,
+		(ParamExtFloat<px4::params::EKF2_GPS_DELAY>)_param_ekf2_gps_delay,
 
-		(ParamExtFloat<px4::params::EKF2_GPS_POS_X>) _param_ekf2_gps_pos_x,
-		(ParamExtFloat<px4::params::EKF2_GPS_POS_Y>) _param_ekf2_gps_pos_y,
-		(ParamExtFloat<px4::params::EKF2_GPS_POS_Z>) _param_ekf2_gps_pos_z,
+		(ParamExtFloat<px4::params::EKF2_GPS_V_NOISE>)_param_ekf2_gps_v_noise,
+		(ParamExtFloat<px4::params::EKF2_GPS_P_NOISE>)_param_ekf2_gps_p_noise,
 
-		(ParamExtFloat<px4::params::EKF2_GPS_V_NOISE>) _param_ekf2_gps_v_noise,
-		(ParamExtFloat<px4::params::EKF2_GPS_P_NOISE>) _param_ekf2_gps_p_noise,
+		(ParamExtFloat<px4::params::EKF2_GPS_P_GATE>)_param_ekf2_gps_p_gate,
+		(ParamExtFloat<px4::params::EKF2_GPS_V_GATE>)_param_ekf2_gps_v_gate,
 
-		(ParamExtFloat<px4::params::EKF2_GPS_P_GATE>) _param_ekf2_gps_p_gate,
-		(ParamExtFloat<px4::params::EKF2_GPS_V_GATE>) _param_ekf2_gps_v_gate,
-
-		(ParamExtInt<px4::params::EKF2_GPS_CHECK>) _param_ekf2_gps_check,
-		(ParamExtFloat<px4::params::EKF2_REQ_EPH>)    _param_ekf2_req_eph,
-		(ParamExtFloat<px4::params::EKF2_REQ_EPV>)    _param_ekf2_req_epv,
-		(ParamExtFloat<px4::params::EKF2_REQ_SACC>)   _param_ekf2_req_sacc,
-		(ParamExtInt<px4::params::EKF2_REQ_NSATS>)    _param_ekf2_req_nsats,
-		(ParamExtFloat<px4::params::EKF2_REQ_PDOP>)   _param_ekf2_req_pdop,
-		(ParamExtFloat<px4::params::EKF2_REQ_HDRIFT>) _param_ekf2_req_hdrift,
-		(ParamExtFloat<px4::params::EKF2_REQ_VDRIFT>) _param_ekf2_req_vdrift,
-		(ParamExtInt<px4::params::EKF2_REQ_FIX>)      _param_ekf2_req_fix,
-		(ParamFloat<px4::params::EKF2_REQ_GPS_H>)     _param_ekf2_req_gps_h,
+		(ParamExtInt<px4::params::EKF2_GPS_CHECK>)_param_ekf2_gps_check,
+		(ParamExtFloat<px4::params::EKF2_REQ_EPH>)_param_ekf2_req_eph,
+		(ParamExtFloat<px4::params::EKF2_REQ_EPV>)_param_ekf2_req_epv,
+		(ParamExtFloat<px4::params::EKF2_REQ_SACC>)_param_ekf2_req_sacc,
+		(ParamExtInt<px4::params::EKF2_REQ_NSATS>)_param_ekf2_req_nsats,
+		(ParamExtFloat<px4::params::EKF2_REQ_PDOP>)_param_ekf2_req_pdop,
+		(ParamExtFloat<px4::params::EKF2_REQ_HDRIFT>)_param_ekf2_req_hdrift,
+		(ParamExtFloat<px4::params::EKF2_REQ_VDRIFT>)_param_ekf2_req_vdrift,
+		(ParamExtInt<px4::params::EKF2_REQ_FIX>)_param_ekf2_req_fix,
+		(ParamFloat<px4::params::EKF2_REQ_GPS_H>)_param_ekf2_req_gps_h,
 
 		// Used by EKF-GSF experimental yaw estimator
-		(ParamExtFloat<px4::params::EKF2_GSF_TAS>) _param_ekf2_gsf_tas,
-		(ParamFloat<px4::params::EKF2_GPS_YAW_OFF>) _param_ekf2_gps_yaw_off,
+		(ParamExtFloat<px4::params::EKF2_GSF_TAS>)_param_ekf2_gsf_tas,
+		(ParamFloat<px4::params::EKF2_GPS_YAW_OFF>)_param_ekf2_gps_yaw_off,
 #endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_BAROMETER)
-		(ParamExtInt<px4::params::EKF2_BARO_CTRL>) _param_ekf2_baro_ctrl,///< barometer control selection
-		(ParamExtFloat<px4::params::EKF2_BARO_DELAY>) _param_ekf2_baro_delay,
-		(ParamExtFloat<px4::params::EKF2_BARO_NOISE>) _param_ekf2_baro_noise,
-		(ParamExtFloat<px4::params::EKF2_BARO_GATE>) _param_ekf2_baro_gate,
-		(ParamExtFloat<px4::params::EKF2_GND_EFF_DZ>) _param_ekf2_gnd_eff_dz,
-		(ParamExtFloat<px4::params::EKF2_GND_MAX_HGT>) _param_ekf2_gnd_max_hgt,
+		(ParamExtInt<px4::params::EKF2_BARO_CTRL>)
+		_param_ekf2_baro_ctrl, ///< barometer control selection
+		(ParamExtFloat<px4::params::EKF2_BARO_DELAY>)_param_ekf2_baro_delay,
+		(ParamExtFloat<px4::params::EKF2_BARO_NOISE>)_param_ekf2_baro_noise,
+		(ParamExtFloat<px4::params::EKF2_BARO_GATE>)_param_ekf2_baro_gate,
+		(ParamExtFloat<px4::params::EKF2_GND_EFF_DZ>)_param_ekf2_gnd_eff_dz,
+		(ParamExtFloat<px4::params::EKF2_GND_MAX_HGT>)_param_ekf2_gnd_max_hgt,
 
-# if defined(CONFIG_EKF2_BARO_COMPENSATION)
-		// Corrections for static pressure position error where Ps_error = Ps_meas - Ps_truth
-		(ParamExtFloat<px4::params::EKF2_ASPD_MAX>) _param_ekf2_aspd_max,
-		(ParamExtFloat<px4::params::EKF2_PCOEF_XP>) _param_ekf2_pcoef_xp,
-		(ParamExtFloat<px4::params::EKF2_PCOEF_XN>) _param_ekf2_pcoef_xn,
-		(ParamExtFloat<px4::params::EKF2_PCOEF_YP>) _param_ekf2_pcoef_yp,
-		(ParamExtFloat<px4::params::EKF2_PCOEF_YN>) _param_ekf2_pcoef_yn,
-		(ParamExtFloat<px4::params::EKF2_PCOEF_Z>) _param_ekf2_pcoef_z,
-# endif // CONFIG_EKF2_BARO_COMPENSATION
+#if defined(CONFIG_EKF2_BARO_COMPENSATION)
+		// Corrections for static pressure position error where Ps_error = Ps_meas
+		// - Ps_truth
+		(ParamExtFloat<px4::params::EKF2_ASPD_MAX>)_param_ekf2_aspd_max,
+		(ParamExtFloat<px4::params::EKF2_PCOEF_XP>)_param_ekf2_pcoef_xp,
+		(ParamExtFloat<px4::params::EKF2_PCOEF_XN>)_param_ekf2_pcoef_xn,
+		(ParamExtFloat<px4::params::EKF2_PCOEF_YP>)_param_ekf2_pcoef_yp,
+		(ParamExtFloat<px4::params::EKF2_PCOEF_YN>)_param_ekf2_pcoef_yn,
+		(ParamExtFloat<px4::params::EKF2_PCOEF_Z>)_param_ekf2_pcoef_z,
+#endif // CONFIG_EKF2_BARO_COMPENSATION
 #endif // CONFIG_EKF2_BAROMETER
 
 #if defined(CONFIG_EKF2_AIRSPEED)
 		(ParamExtFloat<px4::params::EKF2_ASP_DELAY>)
-		_param_ekf2_asp_delay, ///< airspeed measurement delay relative to the IMU (mSec)
+		_param_ekf2_asp_delay, ///< airspeed measurement delay relative to the
+		///< IMU (mSec)
 		(ParamExtFloat<px4::params::EKF2_TAS_GATE>)
-		_param_ekf2_tas_gate, ///< True Airspeed innovation consistency gate size (STD)
+		_param_ekf2_tas_gate, ///< True Airspeed innovation consistency gate
+		///< size (STD)
 		(ParamExtFloat<px4::params::EKF2_EAS_NOISE>)
-		_param_ekf2_eas_noise, ///< measurement noise used for airspeed fusion (m/sec)
+		_param_ekf2_eas_noise, ///< measurement noise used for airspeed fusion
+		///< (m/sec)
 
 		// control of airspeed fusion
 		(ParamExtFloat<px4::params::EKF2_ARSP_THR>)
-		_param_ekf2_arsp_thr, ///< A value of zero will disabled airspeed fusion. Any positive value sets the minimum airspeed which will be used (m/sec)
-#endif // CONFIG_EKF2_AIRSPEED
+		_param_ekf2_arsp_thr, ///< A value of zero will disabled airspeed
+		///< fusion. Any positive value sets the minimum
+		///< airspeed which will be used (m/sec)
+#endif                          // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_SIDESLIP)
-		(ParamExtFloat<px4::params::EKF2_BETA_GATE>) _param_ekf2_beta_gate,
-		(ParamExtFloat<px4::params::EKF2_BETA_NOISE>) _param_ekf2_beta_noise,
-		(ParamExtInt<px4::params::EKF2_FUSE_BETA>) _param_ekf2_fuse_beta,
+		(ParamExtFloat<px4::params::EKF2_BETA_GATE>)_param_ekf2_beta_gate,
+		(ParamExtFloat<px4::params::EKF2_BETA_NOISE>)_param_ekf2_beta_noise,
+		(ParamExtInt<px4::params::EKF2_FUSE_BETA>)_param_ekf2_fuse_beta,
 #endif // CONFIG_EKF2_SIDESLIP
 
 #if defined(CONFIG_EKF2_MAGNETOMETER)
-		(ParamExtFloat<px4::params::EKF2_MAG_DELAY>) _param_ekf2_mag_delay,
-		(ParamExtFloat<px4::params::EKF2_MAG_E_NOISE>) _param_ekf2_mag_e_noise,
-		(ParamExtFloat<px4::params::EKF2_MAG_B_NOISE>) _param_ekf2_mag_b_noise,
-		(ParamExtFloat<px4::params::EKF2_HEAD_NOISE>) _param_ekf2_head_noise,
-		(ParamExtFloat<px4::params::EKF2_MAG_NOISE>) _param_ekf2_mag_noise,
-		(ParamExtFloat<px4::params::EKF2_MAG_DECL>) _param_ekf2_mag_decl,
-		(ParamExtFloat<px4::params::EKF2_HDG_GATE>) _param_ekf2_hdg_gate,
-		(ParamExtFloat<px4::params::EKF2_MAG_GATE>) _param_ekf2_mag_gate,
-		(ParamExtInt<px4::params::EKF2_DECL_TYPE>) _param_ekf2_decl_type,
-		(ParamExtInt<px4::params::EKF2_MAG_TYPE>) _param_ekf2_mag_type,
-		(ParamExtFloat<px4::params::EKF2_MAG_ACCLIM>) _param_ekf2_mag_acclim,
-		(ParamExtInt<px4::params::EKF2_MAG_CHECK>) _param_ekf2_mag_check,
-		(ParamExtFloat<px4::params::EKF2_MAG_CHK_STR>) _param_ekf2_mag_chk_str,
-		(ParamExtFloat<px4::params::EKF2_MAG_CHK_INC>) _param_ekf2_mag_chk_inc,
-		(ParamExtInt<px4::params::EKF2_SYNT_MAG_Z>) _param_ekf2_synt_mag_z,
+		(ParamExtFloat<px4::params::EKF2_MAG_DELAY>)_param_ekf2_mag_delay,
+		(ParamExtFloat<px4::params::EKF2_MAG_E_NOISE>)_param_ekf2_mag_e_noise,
+		(ParamExtFloat<px4::params::EKF2_MAG_B_NOISE>)_param_ekf2_mag_b_noise,
+		(ParamExtFloat<px4::params::EKF2_HEAD_NOISE>)_param_ekf2_head_noise,
+		(ParamExtFloat<px4::params::EKF2_MAG_NOISE>)_param_ekf2_mag_noise,
+		(ParamExtFloat<px4::params::EKF2_MAG_DECL>)_param_ekf2_mag_decl,
+		(ParamExtFloat<px4::params::EKF2_HDG_GATE>)_param_ekf2_hdg_gate,
+		(ParamExtFloat<px4::params::EKF2_MAG_GATE>)_param_ekf2_mag_gate,
+		(ParamExtInt<px4::params::EKF2_DECL_TYPE>)_param_ekf2_decl_type,
+		(ParamExtInt<px4::params::EKF2_MAG_TYPE>)_param_ekf2_mag_type,
+		(ParamExtFloat<px4::params::EKF2_MAG_ACCLIM>)_param_ekf2_mag_acclim,
+		(ParamExtInt<px4::params::EKF2_MAG_CHECK>)_param_ekf2_mag_check,
+		(ParamExtFloat<px4::params::EKF2_MAG_CHK_STR>)_param_ekf2_mag_chk_str,
+		(ParamExtFloat<px4::params::EKF2_MAG_CHK_INC>)_param_ekf2_mag_chk_inc,
+		(ParamExtInt<px4::params::EKF2_SYNT_MAG_Z>)_param_ekf2_synt_mag_z,
 #endif // CONFIG_EKF2_MAGNETOMETER
 
-		(ParamExtInt<px4::params::EKF2_HGT_REF>) _param_ekf2_hgt_ref,    ///< selects the primary source for height data
+		(ParamExtInt<px4::params::EKF2_HGT_REF>)
+		_param_ekf2_hgt_ref, ///< selects the primary source for height data
 
 		(ParamExtInt<px4::params::EKF2_NOAID_TOUT>)
-		_param_ekf2_noaid_tout,	///< maximum lapsed time from last fusion of measurements that constrain drift before the EKF will report the horizontal nav solution invalid (uSec)
+		_param_ekf2_noaid_tout, ///< maximum lapsed time from last fusion of
+		///< measurements that constrain drift before
+		///< the EKF will report the horizontal nav
+		///< solution invalid (uSec)
 
-#if defined(CONFIG_EKF2_TERRAIN) || defined(CONFIG_EKF2_OPTICAL_FLOW) || defined(CONFIG_EKF2_RANGE_FINDER)
-		(ParamExtFloat<px4::params::EKF2_MIN_RNG>) _param_ekf2_min_rng,
-#endif // CONFIG_EKF2_TERRAIN || CONFIG_EKF2_OPTICAL_FLOW || CONFIG_EKF2_RANGE_FINDER
+#if defined(CONFIG_EKF2_TERRAIN) || defined(CONFIG_EKF2_OPTICAL_FLOW) ||       \
+    defined(CONFIG_EKF2_RANGE_FINDER)
+		(ParamExtFloat<px4::params::EKF2_MIN_RNG>)_param_ekf2_min_rng,
+#endif // CONFIG_EKF2_TERRAIN || CONFIG_EKF2_OPTICAL_FLOW ||
+		// CONFIG_EKF2_RANGE_FINDER
 #if defined(CONFIG_EKF2_TERRAIN)
-		(ParamExtFloat<px4::params::EKF2_TERR_NOISE>) _param_ekf2_terr_noise,
-		(ParamExtFloat<px4::params::EKF2_TERR_GRAD>) _param_ekf2_terr_grad,
+		(ParamExtFloat<px4::params::EKF2_TERR_NOISE>)_param_ekf2_terr_noise,
+		(ParamExtFloat<px4::params::EKF2_TERR_GRAD>)_param_ekf2_terr_grad,
 #endif // CONFIG_EKF2_TERRAIN
 #if defined(CONFIG_EKF2_RANGE_FINDER)
 		// range finder fusion
-		(ParamExtInt<px4::params::EKF2_RNG_CTRL>) _param_ekf2_rng_ctrl,
-		(ParamExtFloat<px4::params::EKF2_RNG_DELAY>) _param_ekf2_rng_delay,
-		(ParamExtFloat<px4::params::EKF2_RNG_NOISE>) _param_ekf2_rng_noise,
-		(ParamExtFloat<px4::params::EKF2_RNG_SFE>) _param_ekf2_rng_sfe,
-		(ParamExtFloat<px4::params::EKF2_RNG_GATE>) _param_ekf2_rng_gate,
-		(ParamExtFloat<px4::params::EKF2_RNG_PITCH>) _param_ekf2_rng_pitch,
-		(ParamExtFloat<px4::params::EKF2_RNG_A_VMAX>) _param_ekf2_rng_a_vmax,
-		(ParamExtFloat<px4::params::EKF2_RNG_A_HMAX>) _param_ekf2_rng_a_hmax,
-		(ParamExtFloat<px4::params::EKF2_RNG_QLTY_T>) _param_ekf2_rng_qlty_t,
-		(ParamExtFloat<px4::params::EKF2_RNG_K_GATE>) _param_ekf2_rng_k_gate,
-		(ParamExtFloat<px4::params::EKF2_RNG_FOG>) _param_ekf2_rng_fog,
-		(ParamExtFloat<px4::params::EKF2_RNG_POS_X>) _param_ekf2_rng_pos_x,
-		(ParamExtFloat<px4::params::EKF2_RNG_POS_Y>) _param_ekf2_rng_pos_y,
-		(ParamExtFloat<px4::params::EKF2_RNG_POS_Z>) _param_ekf2_rng_pos_z,
+		(ParamExtInt<px4::params::EKF2_RNG_CTRL>)_param_ekf2_rng_ctrl,
+		(ParamExtFloat<px4::params::EKF2_RNG_DELAY>)_param_ekf2_rng_delay,
+		(ParamExtFloat<px4::params::EKF2_RNG_NOISE>)_param_ekf2_rng_noise,
+		(ParamExtFloat<px4::params::EKF2_RNG_SFE>)_param_ekf2_rng_sfe,
+		(ParamExtFloat<px4::params::EKF2_RNG_GATE>)_param_ekf2_rng_gate,
+		(ParamExtFloat<px4::params::EKF2_RNG_PITCH>)_param_ekf2_rng_pitch,
+		(ParamExtFloat<px4::params::EKF2_RNG_A_VMAX>)_param_ekf2_rng_a_vmax,
+		(ParamExtFloat<px4::params::EKF2_RNG_A_HMAX>)_param_ekf2_rng_a_hmax,
+		(ParamExtFloat<px4::params::EKF2_RNG_QLTY_T>)_param_ekf2_rng_qlty_t,
+		(ParamExtFloat<px4::params::EKF2_RNG_K_GATE>)_param_ekf2_rng_k_gate,
+		(ParamExtFloat<px4::params::EKF2_RNG_FOG>)_param_ekf2_rng_fog,
+		(ParamExtFloat<px4::params::EKF2_RNG_POS_X>)_param_ekf2_rng_pos_x,
+		(ParamExtFloat<px4::params::EKF2_RNG_POS_Y>)_param_ekf2_rng_pos_y,
+		(ParamExtFloat<px4::params::EKF2_RNG_POS_Z>)_param_ekf2_rng_pos_z,
 #endif // CONFIG_EKF2_RANGE_FINDER
 
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
 		// vision estimate fusion
 		(ParamExtFloat<px4::params::EKF2_EV_DELAY>)
-		_param_ekf2_ev_delay, ///< off-board vision measurement delay relative to the IMU (mSec)
+		_param_ekf2_ev_delay, ///< off-board vision measurement delay relative
+		///< to the IMU (mSec)
 
-		(ParamExtInt<px4::params::EKF2_EV_CTRL>) _param_ekf2_ev_ctrl,	 ///< external vision (EV) control selection
-		(ParamInt<px4::params::EKF2_EV_NOISE_MD>) _param_ekf2_ev_noise_md, ///< determine source of vision observation noise
-		(ParamExtInt<px4::params::EKF2_EV_QMIN>) _param_ekf2_ev_qmin,
+		(ParamExtInt<px4::params::EKF2_EV_CTRL>)
+		_param_ekf2_ev_ctrl, ///< external vision (EV) control selection
+		(ParamInt<px4::params::EKF2_EV_NOISE_MD>)
+		_param_ekf2_ev_noise_md, ///< determine source of vision observation
+		///< noise
+		(ParamExtInt<px4::params::EKF2_EV_QMIN>)_param_ekf2_ev_qmin,
 		(ParamExtFloat<px4::params::EKF2_EVP_NOISE>)
-		_param_ekf2_evp_noise, ///< default position observation noise for exernal vision measurements (m)
+		_param_ekf2_evp_noise, ///< default position observation noise for
+		///< exernal vision measurements (m)
 		(ParamExtFloat<px4::params::EKF2_EVV_NOISE>)
-		_param_ekf2_evv_noise, ///< default velocity observation noise for exernal vision measurements (m/s)
+		_param_ekf2_evv_noise, ///< default velocity observation noise for
+		///< exernal vision measurements (m/s)
 		(ParamExtFloat<px4::params::EKF2_EVA_NOISE>)
-		_param_ekf2_eva_noise, ///< default angular observation noise for exernal vision measurements (rad)
+		_param_ekf2_eva_noise, ///< default angular observation noise for
+		///< exernal vision measurements (rad)
 		(ParamExtFloat<px4::params::EKF2_EVV_GATE>)
-		_param_ekf2_evv_gate, ///< external vision velocity innovation consistency gate size (STD)
+		_param_ekf2_evv_gate, ///< external vision velocity innovation
+		///< consistency gate size (STD)
 		(ParamExtFloat<px4::params::EKF2_EVP_GATE>)
-		_param_ekf2_evp_gate, ///< external vision position innovation consistency gate size (STD)
+		_param_ekf2_evp_gate, ///< external vision position innovation
+		///< consistency gate size (STD)
 
 		(ParamExtFloat<px4::params::EKF2_EV_POS_X>)
-		_param_ekf2_ev_pos_x, ///< X position of VI sensor focal point in body frame (m)
+		_param_ekf2_ev_pos_x, ///< X position of VI sensor focal point in body
+		///< frame (m)
 		(ParamExtFloat<px4::params::EKF2_EV_POS_Y>)
-		_param_ekf2_ev_pos_y, ///< Y position of VI sensor focal point in body frame (m)
+		_param_ekf2_ev_pos_y, ///< Y position of VI sensor focal point in body
+		///< frame (m)
 		(ParamExtFloat<px4::params::EKF2_EV_POS_Z>)
-		_param_ekf2_ev_pos_z, ///< Z position of VI sensor focal point in body frame (m)
-#endif // CONFIG_EKF2_EXTERNAL_VISION
+		_param_ekf2_ev_pos_z, ///< Z position of VI sensor focal point in body
+		///< frame (m)
+#endif                          // CONFIG_EKF2_EXTERNAL_VISION
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)
 		// optical flow fusion
 		(ParamExtInt<px4::params::EKF2_OF_CTRL>)
 		_param_ekf2_of_ctrl, ///< optical flow fusion selection
-		(ParamExtInt<px4::params::EKF2_OF_GYR_SRC>)
-		_param_ekf2_of_gyr_src,
+		(ParamExtInt<px4::params::EKF2_OF_GYR_SRC>)_param_ekf2_of_gyr_src,
 		(ParamExtFloat<px4::params::EKF2_OF_DELAY>)
-		_param_ekf2_of_delay, ///< optical flow measurement delay relative to the IMU (mSec) - this is to the middle of the optical flow integration interval
+		_param_ekf2_of_delay, ///< optical flow measurement delay relative to
+		///< the IMU (mSec) - this is to the middle of
+		///< the optical flow integration interval
 		(ParamExtFloat<px4::params::EKF2_OF_N_MIN>)
-		_param_ekf2_of_n_min, ///< best quality observation noise for optical flow LOS rate measurements (rad/sec)
+		_param_ekf2_of_n_min, ///< best quality observation noise for optical
+		///< flow LOS rate measurements (rad/sec)
 		(ParamExtFloat<px4::params::EKF2_OF_N_MAX>)
-		_param_ekf2_of_n_max, ///< worst quality observation noise for optical flow LOS rate measurements (rad/sec)
+		_param_ekf2_of_n_max, ///< worst quality observation noise for optical
+		///< flow LOS rate measurements (rad/sec)
 		(ParamExtInt<px4::params::EKF2_OF_QMIN>)
-		_param_ekf2_of_qmin, ///< minimum acceptable quality integer from  the flow sensor when in air
+		_param_ekf2_of_qmin, ///< minimum acceptable quality integer from  the
+		///< flow sensor when in air
 		(ParamExtInt<px4::params::EKF2_OF_QMIN_GND>)
-		_param_ekf2_of_qmin_gnd, ///< minimum acceptable quality integer from  the flow sensor when on ground
+		_param_ekf2_of_qmin_gnd, ///< minimum acceptable quality integer from
+		///< the flow sensor when on ground
 		(ParamExtFloat<px4::params::EKF2_OF_GATE>)
-		_param_ekf2_of_gate, ///< optical flow fusion innovation consistency gate size (STD)
+		_param_ekf2_of_gate, ///< optical flow fusion innovation consistency
+		///< gate size (STD)
 		(ParamExtFloat<px4::params::EKF2_OF_POS_X>)
-		_param_ekf2_of_pos_x, ///< X position of optical flow sensor focal point in body frame (m)
+		_param_ekf2_of_pos_x, ///< X position of optical flow sensor focal
+		///< point in body frame (m)
 		(ParamExtFloat<px4::params::EKF2_OF_POS_Y>)
-		_param_ekf2_of_pos_y, ///< Y position of optical flow sensor focal point in body frame (m)
+		_param_ekf2_of_pos_y, ///< Y position of optical flow sensor focal
+		///< point in body frame (m)
 		(ParamExtFloat<px4::params::EKF2_OF_POS_Z>)
-		_param_ekf2_of_pos_z, ///< Z position of optical flow sensor focal point in body frame (m)
-#endif // CONFIG_EKF2_OPTICAL_FLOW
+		_param_ekf2_of_pos_z, ///< Z position of optical flow sensor focal
+		///< point in body frame (m)
+#endif                          // CONFIG_EKF2_OPTICAL_FLOW
 
 #if defined(CONFIG_EKF2_DRAG_FUSION)
-		(ParamExtInt<px4::params::EKF2_DRAG_CTRL>) _param_ekf2_drag_ctrl,		///< drag fusion selection
+		(ParamExtInt<px4::params::EKF2_DRAG_CTRL>)
+		_param_ekf2_drag_ctrl, ///< drag fusion selection
 		// Multi-rotor drag specific force fusion
 		(ParamExtFloat<px4::params::EKF2_DRAG_NOISE>)
-		_param_ekf2_drag_noise,	///< observation noise variance for drag specific force measurements (m/sec**2)**2
-		(ParamExtFloat<px4::params::EKF2_BCOEF_X>) _param_ekf2_bcoef_x,		///< ballistic coefficient along the X-axis (kg/m**2)
-		(ParamExtFloat<px4::params::EKF2_BCOEF_Y>) _param_ekf2_bcoef_y,		///< ballistic coefficient along the Y-axis (kg/m**2)
-		(ParamExtFloat<px4::params::EKF2_MCOEF>) _param_ekf2_mcoef,		///< propeller momentum drag coefficient (1/s)
-#endif // CONFIG_EKF2_DRAG_FUSION
+		_param_ekf2_drag_noise, ///< observation noise variance for drag
+		///< specific force measurements (m/sec**2)**2
+		(ParamExtFloat<px4::params::EKF2_BCOEF_X>)
+		_param_ekf2_bcoef_x, ///< ballistic coefficient along the X-axis
+		///< (kg/m**2)
+		(ParamExtFloat<px4::params::EKF2_BCOEF_Y>)
+		_param_ekf2_bcoef_y, ///< ballistic coefficient along the Y-axis
+		///< (kg/m**2)
+		(ParamExtFloat<px4::params::EKF2_MCOEF>)
+		_param_ekf2_mcoef, ///< propeller momentum drag coefficient (1/s)
+#endif                       // CONFIG_EKF2_DRAG_FUSION
 
 #if defined(CONFIG_EKF2_GRAVITY_FUSION)
-		(ParamExtFloat<px4::params::EKF2_GRAV_NOISE>) _param_ekf2_grav_noise,
+		(ParamExtFloat<px4::params::EKF2_GRAV_NOISE>)_param_ekf2_grav_noise,
 #endif // CONFIG_EKF2_GRAVITY_FUSION
 
 		// sensor positions in body frame
-		(ParamExtFloat<px4::params::EKF2_IMU_POS_X>) _param_ekf2_imu_pos_x,		///< X position of IMU in body frame (m)
-		(ParamExtFloat<px4::params::EKF2_IMU_POS_Y>) _param_ekf2_imu_pos_y,		///< Y position of IMU in body frame (m)
-		(ParamExtFloat<px4::params::EKF2_IMU_POS_Z>) _param_ekf2_imu_pos_z,		///< Z position of IMU in body frame (m)
+		(ParamExtFloat<px4::params::EKF2_IMU_POS_X>)
+		_param_ekf2_imu_pos_x, ///< X position of IMU in body frame (m)
+		(ParamExtFloat<px4::params::EKF2_IMU_POS_Y>)
+		_param_ekf2_imu_pos_y, ///< Y position of IMU in body frame (m)
+		(ParamExtFloat<px4::params::EKF2_IMU_POS_Z>)
+		_param_ekf2_imu_pos_z, ///< Z position of IMU in body frame (m)
 
 		// IMU switch on bias parameters
 		(ParamExtFloat<px4::params::EKF2_GBIAS_INIT>)
-		_param_ekf2_gbias_init,	///< 1-sigma gyro bias uncertainty at switch on (rad/sec)
+		_param_ekf2_gbias_init, ///< 1-sigma gyro bias uncertainty at switch
+		///< on (rad/sec)
 		(ParamExtFloat<px4::params::EKF2_ABIAS_INIT>)
-		_param_ekf2_abias_init,	///< 1-sigma accelerometer bias uncertainty at switch on (m/sec**2)
+		_param_ekf2_abias_init, ///< 1-sigma accelerometer bias uncertainty at
+		///< switch on (m/sec**2)
 		(ParamExtFloat<px4::params::EKF2_ANGERR_INIT>)
-		_param_ekf2_angerr_init,	///< 1-sigma tilt error after initial alignment using gravity vector (rad)
+		_param_ekf2_angerr_init, ///< 1-sigma tilt error after initial
+		///< alignment using gravity vector (rad)
 
 		// EKF accel bias learning control
-		(ParamExtFloat<px4::params::EKF2_ABL_LIM>) _param_ekf2_abl_lim,	///< Accelerometer bias learning limit (m/s**2)
+		(ParamExtFloat<px4::params::EKF2_ABL_LIM>)
+		_param_ekf2_abl_lim, ///< Accelerometer bias learning limit (m/s**2)
 		(ParamExtFloat<px4::params::EKF2_ABL_ACCLIM>)
-		_param_ekf2_abl_acclim,	///< Maximum IMU accel magnitude that allows IMU bias learning (m/s**2)
+		_param_ekf2_abl_acclim, ///< Maximum IMU accel magnitude that allows
+		///< IMU bias learning (m/s**2)
 		(ParamExtFloat<px4::params::EKF2_ABL_GYRLIM>)
-		_param_ekf2_abl_gyrlim,	///< Maximum IMU gyro angular rate magnitude that allows IMU bias learning (m/s**2)
+		_param_ekf2_abl_gyrlim, ///< Maximum IMU gyro angular rate magnitude
+		///< that allows IMU bias learning (m/s**2)
 		(ParamExtFloat<px4::params::EKF2_ABL_TAU>)
-		_param_ekf2_abl_tau,	///< Time constant used to inhibit IMU delta velocity bias learning (sec)
+		_param_ekf2_abl_tau, ///< Time constant used to inhibit IMU delta
+		///< velocity bias learning (sec)
 
-		(ParamExtFloat<px4::params::EKF2_GYR_B_LIM>) _param_ekf2_gyr_b_lim,	///< Gyro bias learning limit (rad/s)
+		(ParamExtFloat<px4::params::EKF2_GYR_B_LIM>)
+		_param_ekf2_gyr_b_lim, ///< Gyro bias learning limit (rad/s)
 
 		// output predictor filter time constants
-		(ParamFloat<px4::params::EKF2_TAU_VEL>) _param_ekf2_tau_vel,
-		(ParamFloat<px4::params::EKF2_TAU_POS>) _param_ekf2_tau_pos
-	)
+		(ParamFloat<px4::params::EKF2_TAU_VEL>)_param_ekf2_tau_vel,
+		(ParamFloat<px4::params::EKF2_TAU_POS>)_param_ekf2_tau_pos)
 };
 #endif // !EKF2_HPP

--- a/src/modules/ekf2/params_gnss.yaml
+++ b/src/modules/ekf2/params_gnss.yaml
@@ -1,7 +1,5 @@
 module_name: ekf2
 parameters:
-  num_instances: 4
-  instance_start: 1
 - group: EKF2
   definitions:
     EKF2_GPS_CTRL:
@@ -64,6 +62,8 @@ parameters:
       description:
         short: Heading/Yaw offset for dual antenna GPS
       type: float
+      num_instances: 4
+      instance_start: 1
       default: 0.0
       min: 0.0
       max: 360.0
@@ -93,12 +93,16 @@ parameters:
         short: Device ID of GPS ${i}
         long: Match this ID with the device ID of the GPS receiver (param STATUS_GPS${i}_DEV_ID)
       type: int32
+      num_instances: 4
+      instance_start: 1
       default: 0
     EKF2_GPS${i}_POS_X:
       description:
         short: X position of GPS ${i} antenna in body frame
         long: Forward (roll) axis with origin relative to vehicle centre of gravity
       type: float
+      num_instances: 4
+      instance_start: 1
       default: 0.0
       unit: m
       decimal: 3
@@ -107,6 +111,8 @@ parameters:
         short: Y position of GPS ${i} antenna in body frame
         long: Right (pitch) axis with origin relative to vehicle centre of gravity
       type: float
+      num_instances: 4
+      instance_start: 1
       default: 0.0
       unit: m
       decimal: 3
@@ -115,6 +121,8 @@ parameters:
         short: Z position of GPS ${i} antenna in body frame
         long: Down (yaw) axis with origin relative to vehicle centre of gravity
       type: float
+      num_instances: 4
+      instance_start: 1
       default: 0.0
       unit: m
       decimal: 3

--- a/src/modules/ekf2/params_gnss.yaml
+++ b/src/modules/ekf2/params_gnss.yaml
@@ -1,5 +1,7 @@
 module_name: ekf2
 parameters:
+  num_instances: 4
+  instance_start: 1
 - group: EKF2
   definitions:
     EKF2_GPS_CTRL:
@@ -86,25 +88,31 @@ parameters:
       max: 5.0
       unit: m/s
       decimal: 2
-    EKF2_GPS_POS_X:
+    EKF2_GPS${i}_ID:
       description:
-        short: X position of GPS antenna in body frame
+        short: Device ID of GPS ${i}
+        long: Match this ID with the device ID of the GPS receiver (param STATUS_GPS${i}_DEV_ID)
+      type: int32
+      default: 0
+    EKF2_GPS${i}_POS_X:
+      description:
+        short: X position of GPS ${i} antenna in body frame
         long: Forward (roll) axis with origin relative to vehicle centre of gravity
       type: float
       default: 0.0
       unit: m
       decimal: 3
-    EKF2_GPS_POS_Y:
+    EKF2_GPS${i}_POS_Y:
       description:
-        short: Y position of GPS antenna in body frame
+        short: Y position of GPS ${i} antenna in body frame
         long: Right (pitch) axis with origin relative to vehicle centre of gravity
       type: float
       default: 0.0
       unit: m
       decimal: 3
-    EKF2_GPS_POS_Z:
+    EKF2_GPS${i}_POS_Z:
       description:
-        short: Z position of GPS antenna in body frame
+        short: Z position of GPS ${i} antenna in body frame
         long: Down (yaw) axis with origin relative to vehicle centre of gravity
       type: float
       default: 0.0

--- a/src/modules/ekf2/test/sensor_simulator/gps.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/gps.cpp
@@ -5,13 +5,9 @@ namespace sensor_simulator
 namespace sensor
 {
 
-Gps::Gps(std::shared_ptr<Ekf> ekf): Sensor(ekf)
-{
-}
+Gps::Gps(std::shared_ptr<Ekf> ekf) : Sensor(ekf) {}
 
-Gps::~Gps()
-{
-}
+Gps::~Gps() {}
 
 void Gps::send(const uint64_t time)
 {
@@ -19,7 +15,8 @@ void Gps::send(const uint64_t time)
 
 	_gps_data.time_us = time;
 
-	if (fabsf(_gps_pos_rate(0)) > FLT_EPSILON || fabsf(_gps_pos_rate(1)) > FLT_EPSILON) {
+	if (fabsf(_gps_pos_rate(0)) > FLT_EPSILON ||
+	    fabsf(_gps_pos_rate(1)) > FLT_EPSILON) {
 		stepHorizontalPositionByMeters(Vector2f(_gps_pos_rate) * dt);
 	}
 
@@ -30,60 +27,38 @@ void Gps::send(const uint64_t time)
 	_ekf->setGpsData(_gps_data);
 }
 
-void Gps::setData(const gnssSample &gps)
-{
-	_gps_data = gps;
-}
+void Gps::setData(const gnssSample &gps) { _gps_data = gps; }
 
-void Gps::setAltitude(const float alt)
-{
-	_gps_data.alt = alt;
-}
+void Gps::setAltitude(const float alt) { _gps_data.alt = alt; }
 
-void Gps::setLatitude(const double lat)
-{
-	_gps_data.lat = lat;
-}
+void Gps::setLatitude(const double lat) { _gps_data.lat = lat; }
 
-void Gps::setLongitude(const double lon)
-{
-	_gps_data.lon = lon;
-}
+void Gps::setLongitude(const double lon) { _gps_data.lon = lon; }
 
-void Gps::setVelocity(const Vector3f &vel)
-{
-	_gps_data.vel = vel;
-}
+void Gps::setVelocity(const Vector3f &vel) { _gps_data.vel = vel; }
 
-void Gps::setYaw(const float yaw)
-{
-	_gps_data.yaw = yaw;
-}
+void Gps::setYaw(const float yaw) { _gps_data.yaw = yaw; }
 
 void Gps::setYawOffset(const float yaw_offset)
 {
 	_gps_data.yaw_offset = yaw_offset;
 }
 
-void Gps::setFixType(const int fix_type)
+void Gps::setPosOffsetBody(const Vector3f &pos_offset_body)
 {
-	_gps_data.fix_type = fix_type;
+	_gps_data.pos_offset_body = pos_offset_body;
 }
+
+void Gps::setFixType(const int fix_type) { _gps_data.fix_type = fix_type; }
 
 void Gps::setNumberOfSatellites(const int num_satellites)
 {
 	_gps_data.nsats = num_satellites;
 }
 
-void Gps::setPdop(const float pdop)
-{
-	_gps_data.pdop = pdop;
-}
+void Gps::setPdop(const float pdop) { _gps_data.pdop = pdop; }
 
-void Gps::setPositionRateNED(const Vector3f &rate)
-{
-	_gps_pos_rate = rate;
-}
+void Gps::setPositionRateNED(const Vector3f &rate) { _gps_pos_rate = rate; }
 
 void Gps::stepHeightByMeters(const float hgt_change)
 {
@@ -92,13 +67,14 @@ void Gps::stepHeightByMeters(const float hgt_change)
 
 void Gps::stepHorizontalPositionByMeters(const Vector2f hpos_change)
 {
-	float hposN_curr {0.f};
-	float hposE_curr {0.f};
+	float hposN_curr{0.f};
+	float hposE_curr{0.f};
 
-	double lat_new {0.0};
-	double lon_new {0.0};
+	double lat_new{0.0};
+	double lon_new{0.0};
 
-	_ekf->global_origin().project(_gps_data.lat, _gps_data.lon, hposN_curr, hposE_curr);
+	_ekf->global_origin().project(_gps_data.lat, _gps_data.lon, hposN_curr,
+				      hposE_curr);
 
 	Vector2f hpos_new = Vector2f{hposN_curr, hposE_curr} + hpos_change;
 

--- a/src/modules/ekf2/test/sensor_simulator/gps.h
+++ b/src/modules/ekf2/test/sensor_simulator/gps.h
@@ -45,7 +45,7 @@ namespace sensor_simulator
 namespace sensor
 {
 
-class Gps: public Sensor
+class Gps : public Sensor
 {
 public:
 	Gps(std::shared_ptr<Ekf> ekf);
@@ -61,6 +61,7 @@ public:
 	void setVelocity(const Vector3f &vel);
 	void setYaw(const float yaw);
 	void setYawOffset(const float yaw);
+	void setPosOffsetBody(const Vector3f &pos_offset_body);
 	void setFixType(const int fix_type);
 	void setNumberOfSatellites(const int num_satellites);
 	void setPdop(const float pdop);


### PR DESCRIPTION
/claim #21902

## Description
This PR moves the GPS antenna position offset configuration from the EKF2 module (global parameters) to the GPS driver (per-instance parameters).

## Motivation
Currently, `EKF2_GPS_POS_X/Y/Z` parameters define the GPS antenna offset globally. This works for single GPS setups, but for vehicles with multiple GPS units mounted at different locations (e.g., dual antenna setups for heading), applying a single global offset in the EKF is incorrect. The offset needs to be associated with the specific sensor instance producing the measurement.

## Changes
1. **GPS Driver:** Added `GPS_1_POS_X/Y/Z` and `GPS_2_POS_X/Y/Z` parameters. The driver now populates these values into the `SensorGps` message.
2. **uORB Message:** Added `device_pos_x/y/z` fields to [SensorGps.msg](cci:7://file:///d:/issue21902/PX4-Autopilot/msg/SensorGps.msg:0:0-0:0).
3. **EKF2:** Updated [EKF2.cpp](cci:7://file:///d:/issue21902/PX4-Autopilot/src/modules/ekf2/EKF2.cpp:0:0-0:0) and [common.h](cci:7://file:///d:/issue21902/PX4-Autopilot/src/modules/ekf2/EKF/common.h:0:0-0:0) to ingest the position offset from the sample. Modified fusion logic ([gps_control.cpp](cci:7://file:///d:/issue21902/PX4-Autopilot/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp:0:0-0:0), [gnss_height_control.cpp](cci:7://file:///d:/issue21902/PX4-Autopilot/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp:0:0-0:0)) to use the per-sample offset instead of the deprecated global parameter.
4. **Deprecation:** Marked `EKF2_GPS_POS_X/Y/Z` as deprecated in [params_gnss.yaml](cci:7://file:///d:/issue21902/PX4-Autopilot/src/modules/ekf2/params_gnss.yaml:0:0-0:0).

## Verification
- Added a new unit test `EkfGpsTest.gpsPositionOffset` in [test_EKF_gps.cpp](cci:7://file:///d:/issue21902/PX4-Autopilot/src/modules/ekf2/test/test_EKF_gps.cpp:0:0-0:0) which verifies that the EKF correctly subtracts the antenna offset from the reported position.