### PR TITLE
Jenkins: pin emscripten version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,6 +101,7 @@ pipeline {
             echo $0;
             git clone https://github.com/emscripten-core/emsdk.git _emscripten_sdk;
             cd _emscripten_sdk;
+            git checkout 4.0.15;
             ./emsdk install latest;
             ./emsdk activate latest;
             cd ..;


### PR DESCRIPTION
This would match GitHub action and hopefully fix CI.

See error: http://ci.px4.io/blue/organizations/jenkins/PX4%2FPX4-Autopilot/detail/main/2784/pipeline