### PR TITLE
board:fixed ap-h743r1 bmi270 and mag rotation.

### DIFF
--- a/boards/x-mav/ap-h743r1/init/rc.board_sensors
+++ b/boards/x-mav/ap-h743r1/init/rc.board_sensors
@@ -8,12 +8,12 @@ board_adc start
 # IMU
 if ! icm42688p -s -b 1 -R 4 start
 then
-	bmi270 -s -b 1 -R 4 start
+	bmi270 -s -b 1 -R 2 start
 fi
 
 if ! icm42688p -s -b 4 -R 4 start
 then
-	bmi270 -s -b 4 -R 4 start
+	bmi270 -s -b 4 -R 2 start
 fi
 
 # baro
@@ -23,4 +23,4 @@ then
 fi
 
 # internal mag
-qmc5883p -I -R 2 start
+qmc5883p -I -R 4 start


### PR DESCRIPTION
Fix the BMI270 sensor rotation setting. On the same PCB, when replacing the ICM-42688P with the BMI270, the original ICM-42688P -R 4 corresponds to BMI270 -R 2.
