### PR TITLE
AirspeedModule: Change to throttle without battery scaling

### DIFF
--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -66,7 +66,7 @@
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_status.h>
-#include <uORB/topics/vehicle_thrust_setpoint.h>
+#include <uORB/topics/vehicle_rates_setpoint.h>
 #include <uORB/topics/airspeed_wind.h>
 #include <uORB/topics/flight_phase_estimation.h>
 
@@ -127,7 +127,7 @@ private:
 	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
-	uORB::Subscription _vehicle_thrust_setpoint_0_sub{ORB_ID(vehicle_thrust_setpoint), 0};
+	uORB::Subscription _vehicle_rates_setpoint_sub{ORB_ID(vehicle_rates_setpoint)};
 	uORB::Subscription _position_setpoint_sub{ORB_ID(position_setpoint)};
 	uORB::Subscription _launch_detection_status_sub{ORB_ID(launch_detection_status)};
 	uORB::SubscriptionMultiArray<airspeed_s, MAX_NUM_AIRSPEED_SENSORS> _airspeed_subs{ORB_ID::airspeed};
@@ -841,16 +841,16 @@ float AirspeedModule::get_synthetic_airspeed(float throttle)
 void AirspeedModule::update_throttle_filter(hrt_abstime now)
 {
 	if (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
-		vehicle_thrust_setpoint_s vehicle_thrust_setpoint_0{};
-		_vehicle_thrust_setpoint_0_sub.copy(&vehicle_thrust_setpoint_0);
+		vehicle_rates_setpoint_s vehicle_rates_setpoint{};
+		_vehicle_rates_setpoint_sub.copy(&vehicle_rates_setpoint);
 
-		float forward_thrust = vehicle_thrust_setpoint_0.xyz[0];
+		float forward_thrust = vehicle_rates_setpoint.thrust_body[0];
 
 		// if VTOL, use the total thrust vector length (otherwise needs special handling for tailsitters and tiltrotors)
 		if (_vehicle_status.is_vtol) {
-			forward_thrust = sqrtf(vehicle_thrust_setpoint_0.xyz[0] * vehicle_thrust_setpoint_0.xyz[0] +
-					       vehicle_thrust_setpoint_0.xyz[1] * vehicle_thrust_setpoint_0.xyz[1] +
-					       vehicle_thrust_setpoint_0.xyz[2] * vehicle_thrust_setpoint_0.xyz[2]);
+			forward_thrust = sqrtf(vehicle_rates_setpoint.thrust_body[0] * vehicle_rates_setpoint.thrust_body[0] +
+					       vehicle_rates_setpoint.thrust_body[1] * vehicle_rates_setpoint.thrust_body[1] +
+					       vehicle_rates_setpoint.thrust_body[2] * vehicle_rates_setpoint.thrust_body[2]);
 		}
 
 		const float dt = static_cast<float>(now - _t_last_throttle_fw) * 1e-6f;


### PR DESCRIPTION
### Solved Problem
The first principles airspeed check was giving false positives, because #24522 changed the throttle value used from TECS throttle to `vehicle_thrust_setpoint`. The latter includes battery scaling and becomes high enough to trigger the check when the battery depletes. 

### Solution
Rather than thrust from the thrust setpoint (which is battery-scaled) we use the thrust from the rates setpoint, which is not battery scaled. 

Both synthetic airspeed and the first principles airspeed check only need throttle/thrust when TECS is running (snippets below), so we do not have to be concerned about cases in which e.g. the rates setpoint is created from sticks within rate controllers or similar as https://github.com/PX4/PX4-Autopilot/pull/26145#discussion_r2665803152) for not just always using TECS throttle. 

https://github.com/PX4/PX4-Autopilot/blob/c2490e01a53c5129e45c42474ddfa26a8f639fc9/src/modules/airspeed_selector/AirspeedValidator.cpp#L295-L299

https://github.com/PX4/PX4-Autopilot/blob/c2490e01a53c5129e45c42474ddfa26a8f639fc9/src/modules/airspeed_selector/airspeed_selector_main.cpp#L820-L823 (when TECS is not running the flight phase estimation is unknown)


### Changelog Entry
For release notes:
```
AirspeedModule: Fix first principles airspeed check false positives and overestimated synthetic airspeed with depleting battery
```

### Alternatives
(initially this PR contained another solution which uses TECS throttle for the airspeed check, and thrust setpoint for the synthetic airspeed, but this is much simpler without any obvious drawbacks so I changed it. Can change it back if you disagree)

### Test coverage
Short SITL sanity check, verifying:
 - the synthetic airspeed (and thus also the airspeed validator) is not affected by toggling FW battery scaling on and off
 - first principle airspeed check makes no false positives

Note that in this screenshot the changes in the synthetic airspeed are NOT due to the battery scaling toggling directly but due to the throttle changes commanded by the longitudinal controller. 
<img width="1629" height="1208" alt="image" src="https://github.com/user-attachments/assets/c70e512a-79a1-4c46-b7c3-3f340d47d76b" />


### Context

This is a superficial fix - the fundamental problem is that some thrust/torque topics are battery scaled and some aren't despite being named the same way. The long term fix will be to move battery scaling into the control allocator, cleaning up those uOrb topic inconsistencies. Some initial drafts on which we will iterate:
 - https://github.com/PX4/PX4-Autopilot/pull/26235
 - https://github.com/PX4/PX4-Autopilot/pull/26283
 - https://github.com/PX4/PX4-Autopilot/pull/26292