### PR TITLE
Fetch metadata files from master not main

### DIFF
--- a/src/lib/version/px_update_git_header.py
+++ b/src/lib/version/px_update_git_header.py
@@ -97,9 +97,10 @@ except:
 if tag_or_branch is None:
     # replace / so it can be used as directory name
     tag_or_branch = git_branch_name.replace('/', '-')
-    # either a release or main branch (used for metadata)
+    # either a release or master branch (used for metadata)
+    # CI uploads to 'master/' on S3 for legacy QGC compatibility
     if not tag_or_branch.startswith('release-'):
-        tag_or_branch = 'main'
+        tag_or_branch = 'master'
 
 header += f"""
 #define PX4_GIT_VERSION_STR "{git_version}"
@@ -109,7 +110,7 @@ header += f"""
 
 #define PX4_GIT_OEM_VERSION_STR  "{oem_tag}"
 
-#define PX4_GIT_TAG_OR_BRANCH_NAME "{tag_or_branch}" // special variable: git tag, release or main branch
+#define PX4_GIT_TAG_OR_BRANCH_NAME "{tag_or_branch}" // special variable: git tag, release or master branch
 """
 
 


### PR DESCRIPTION
For flash constrained builds, the component metadata files are downloaded directly from s3. For the main branch, these files are currently still uploaded to master. Therefore, we also need to reference master and not main.

This fixes the actuators tab in QQC for KakuteH743-Wing which is one of the boards that did not exist in source when we briefly uploaded to main before reverting back to master, presumably for QGC compatibility.