### PR TITLE
Improve QMC5883P magnetometer stability by optimizing OSR and ODR setting

### DIFF
--- a/src/drivers/magnetometer/qmc5883p/QMC5883P.cpp
+++ b/src/drivers/magnetometer/qmc5883p/QMC5883P.cpp
@@ -244,6 +244,8 @@ void QMC5883P::RunImpl()
 
 bool QMC5883P::Configure()
 {
+	RegisterWrite(Register::REG_29, 0x06);
+
 	// first set and clear all configured register bits
 	for (const auto &reg_cfg : _register_cfg) {
 		RegisterSetAndClearBits(reg_cfg.reg, reg_cfg.set_bits, reg_cfg.clear_bits);

--- a/src/drivers/magnetometer/qmc5883p/QMC5883P.hpp
+++ b/src/drivers/magnetometer/qmc5883p/QMC5883P.hpp
@@ -107,7 +107,7 @@ private:
 	static constexpr uint8_t size_register_cfg{2};
 	register_config_t _register_cfg[size_register_cfg] {
 		// Register                   | Set bits, Clear bits
-		{ Register::CNTL1,            CNTL1_BIT::MODE_CONTINUOUS | CNTL1_BIT::OSR1_8 | CNTL1_BIT::ODR_50HZ,  CNTL1_BIT::OSR2_8},
+		{ Register::CNTL1,            CNTL1_BIT::MODE_CONTINUOUS | CNTL1_BIT::OSR2_4 | CNTL1_BIT::ODR_200HZ,  CNTL1_BIT::OSR1_8},
 		{ Register::CNTL2,            CNTL2_BIT::RNG_2G, CNTL2_BIT::SOFT_RST | CNTL2_BIT::SELF_TEST},
 	};
 };

--- a/src/drivers/magnetometer/qmc5883p/QST_QMC5883P_registers.hpp
+++ b/src/drivers/magnetometer/qmc5883p/QST_QMC5883P_registers.hpp
@@ -79,6 +79,8 @@ enum class Register : uint8_t {
 	CNTL2           = 0x0B, // Control Register 2
 
 	CHIP_ID         = 0x00,
+
+	REG_29 = 0x29,
 };
 
 // STATUS
@@ -90,11 +92,11 @@ enum STATUS_BIT : uint8_t {
 // CNTL1
 enum CNTL1_BIT : uint8_t {
 	// OSR2[7:6]
-	OSR2_8          =  Bit7 | Bit6, // 00
+	OSR2_4          =  Bit7, // 10
 	// OSR1[5:4]
 	OSR1_8          =  Bit5 | Bit4, // 11
 	// ODR[3:2]
-	ODR_50HZ        =  Bit2,        // 01
+	ODR_200HZ        =  Bit3 | Bit2, // 11
 	// MODE[1:0]
 	MODE_CONTINUOUS = Bit1 | Bit0,  // 11
 };


### PR DESCRIPTION
Description:
This PR addresses significant Z-axis noise observed in the QMC5883P magnetometer under PX4 (e.g., fluctuations >50 while stationary), which is not present when using ArduPilot on the same hardware.
The issue appears to stem from suboptimal sensor configuration in the current driver. This change updates the Control Register 1 (0x0A) settings to:

    ODR = 200 Hz (bits 3–2: 0b11)
    OSR1 = 8x oversampling (bits 5–4: 0b00) → reduces noise
    OSR2 = 4x downsampling (bits 7–6: 0b10) → further suppresses high-frequency noise

With this configuration, the effective output data rate is 50 Hz, but with significantly improved signal stability—especially on the Z-axis—making it more suitable for compass and attitude estimation.

**Before pr, fluctuations >50 while stationary, sometime almost 100, heading not stable:**
<img width="1691" height="644" alt="PX4_QMC5883P_ZMAG" src="https://github.com/user-attachments/assets/306f3b85-eca1-4bbd-a25a-fcecf485d0a7" />

**After pr, fluctuations ~20:**
<img width="1643" height="612" alt="PX4_QMC5883P_ZMAG2" src="https://github.com/user-attachments/assets/f366b227-d125-476c-a143-ade4d2bd6982" />

