### PR TITLE
SagetechMXS: remove two unused subscriptions

### DIFF
--- a/src/drivers/transponder/sagetech_mxs/SagetechMXS.hpp
+++ b/src/drivers/transponder/sagetech_mxs/SagetechMXS.hpp
@@ -118,8 +118,6 @@ private:
 	// Subscriptions
 	uORB::Subscription                 _sensor_gps_sub{ORB_ID(sensor_gps)};
 	uORB::SubscriptionInterval         _parameter_update_sub{ORB_ID(parameter_update), 1_s}; // subscription limited to 1 Hz updates
-	uORB::Subscription                 _vehicle_status_sub{ORB_ID(vehicle_status)};          // regular subscription for additional data
-	uORB::Subscription                 _transponder_report_sub{ORB_ID(transponder_report)};
 	uORB::Subscription                 _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
 
 


### PR DESCRIPTION
### Solved Problem
Randomly saw that there's a publication and subscription for the same topic and it is in this case indeed useless.

### Test coverage
It still combiles `cubepilot_cubeorange_default` which includes this driver.