### PR TITLE
vtxtable: fix KConfig type from string to bool

### DIFF
--- a/src/drivers/vtxtable/Kconfig
+++ b/src/drivers/vtxtable/Kconfig
@@ -19,7 +19,7 @@ if DRIVERS_VTXTABLE
 		default n if !(VTXTABLE_CONFIG_FILE != "")
 
 	config VTXTABLE_AUX_MAP
-		string "VTX Auxiliary Map"
+		bool "VTX Auxiliary Map"
 		default n
 		---help---
 			Enable the AUX map for mapping AUX channel ranges to VTX


### PR DESCRIPTION
### Problem
When you compile you get this warning
```
warning: DRIVERS_VTX (defined at src/drivers/vtx/Kconfig:1) selects the string symbol VTXTABLE_AUX_MAP (defined at src/drivers/vtxtable/Kconfig:21), which is not bool or tristate
warning: DRIVERS_VTX (defined at src/drivers/vtx/Kconfig:1) selects the string symbol VTXTABLE_AUX_MAP (defined at src/drivers/vtxtable/Kconfig:21), which is not bool or tristate
```

### Solution
The KConfig type was wrong, probably copy pasta 