### PR TITLE
Add option to disable RGB on cannode

### DIFF
--- a/ROMFS/cannode/init.d/rcS
+++ b/ROMFS/cannode/init.d/rcS
@@ -70,8 +70,11 @@ unset BOARD_RC_ADDITIONAL_INIT
 #
 # Start system state indicator.
 #
-rgbled start -X -q
-rgbled_ncp5623c start -X -q
+if [ -z "$NO_CANNODE_RGB" ]
+then
+	rgbled start -X -q
+	rgbled_ncp5623c start -X -q
+fi
 
 #
 # board sensors: rc.sensors


### PR DESCRIPTION
Not all cannodes contain RGB leds. 

```
OS: NuttXOS version: Release 11.0.0 (184549631)
OS git-hash: 886acbbdb4f061e5c0ce1a76afbcfa7cb7df9849
Build datetime: Jan 27 2026 16:13:24
Build uri: localhost
Build variant: default
Toolchain: GNU GCC, 13.2.1 20231009
PX4GUID: 0
MCU: STM32F???, rev. ?
Board architecture defaults: /etc/init.d/rc.board_arch_defaults
nsh: rgbled: command not found
nsh: rgbled_ncp5623c: command not found
Board sensors: /etc/init.d/rc.board_sensors
```

This change adds a `NO_CANNODE_RGB` parameter to `rc.board_defaults`

After setting the parameter:

```
NuttShell (NSH) NuttX-11.0.0
nsh> INFO  [afbrs50] switched to long range rate: 25
nsh: sysinit: fopen failed: 2
PX4 git-hash: bc0479f2375418bf650e792699068f7555abdc0f
PX4 version: 1.16.0 0 (17825792)
OS: NuttX
OS version: Release 11.0.0 (184549631)
OS git-hash: 886acbbdb4f061e5c0ce1a76afbcfa7cb7df9849
Build datetime: Jan 28 2026 11:03:26
Build uri: localhost
Build variant: default
Toolchain: GNU GCC, 9.3.1 20200408 (release)
PX4GUID: 0001
MCU: STM32F???, rev. ?
Board architecture defaults: /etc/init.d/rc.board_arch_defaults
Board defaults: /etc/init.d/rc.board_defaults
Board sensors: /etc/init.d/rc.board_sensors
```

