### PR TITLE
docs: Max code line length 140 chars

### DIFF
--- a/docs/en/contribute/code.md
+++ b/docs/en/contribute/code.md
@@ -34,7 +34,7 @@ If you update an existing file you are not required to make the whole file compl
 
 ### Line Length
 
-- Maximum line length is 120 characters.
+- Maximum line length is 140 characters.
 
 ### File Extensions
 


### PR DESCRIPTION
Docs update to reflect astyle change of max line length:

- #25717