### PR TITLE
fix: adjusted probe function to new revision of TLA2528 (and add stat…

### DIFF
--- a/src/drivers/adc/tla2528/tla2528.cpp
+++ b/src/drivers/adc/tla2528/tla2528.cpp
@@ -142,7 +142,7 @@ int TLA2528::poll_reset()
 	uint8_t send_data[2];
 	uint8_t recv_data;
 	send_data[0] = READ;
-	send_data[0] = GENERAL_CFG;
+	send_data[1] = GENERAL_CFG;
 	int ret = transfer(&send_data[0], 2, nullptr, 0);
 	ret |= transfer(nullptr, 0, &recv_data, 1);
 
@@ -199,15 +199,27 @@ void TLA2528::adc_get()
 int TLA2528::probe()
 {
 	for (int i = 0; i < 3; i++) {
-		// Set device in debug mode (should respond with 0xA5AX to all reads)
-		uint8_t send_data[3] = {SET_BIT, DATA_CFG, 0x80};
+		// Select channel 0
+		uint8_t send_data[3];
+		send_data[0] = WRITE;
+		send_data[1] = CHANNEL_SEL;
+		send_data[2] = 0x00;            // Channel 0
 		int ret = transfer(&send_data[0], 3, nullptr, 0);
+
+		// Put device in in manual mode
+		send_data[0] = WRITE;
+		send_data[1] = OPMODE_CFG;
+		send_data[2] = 0x00;
+		ret |= transfer(&send_data[0], 3, nullptr, 0);
+
+		// Set device in debug mode (should respond with 0xA5AX to all reads)
+		send_data[0] = SET_BIT;
+		send_data[1] = DATA_CFG;
+		send_data[2] = 0x80;
+		ret |= transfer(&send_data[0], 3, nullptr, 0);
 
 		// Read
 		uint8_t recv_data[2];
-		send_data[0] = SET_BIT;
-		send_data[0] = DATA_CFG;
-		ret |= transfer(&send_data[0], 2, nullptr, 0);
 		ret |= transfer(nullptr, 0, &recv_data[0], 2);
 
 		// Turn debug mode off

--- a/src/drivers/adc/tla2528/tla2528.h
+++ b/src/drivers/adc/tla2528/tla2528.h
@@ -52,6 +52,7 @@ public:
 	int init() override;
 	void RunImpl();
 	int probe() override;
+	void print_status() override;
 
 private:
 	static const hrt_abstime SAMPLE_INTERVAL{10_ms};

--- a/src/drivers/adc/tla2528/tla2528_main.cpp
+++ b/src/drivers/adc/tla2528/tla2528_main.cpp
@@ -43,6 +43,13 @@ void TLA2528::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
+void TLA2528::print_status()
+{
+	I2CSPIDriverBase::print_status();
+	perf_print_counter(_cycle_perf);
+	perf_print_counter(_comms_errors);
+}
+
 extern "C" int tla2528_main(int argc, char *argv[])
 {
 	using ThisDriver = TLA2528;


### PR DESCRIPTION
### Solved Problem
The TLA2528 probe function failed on the new hardware revision, preventing proper device detection.

### Solution
On the new TLA2528 revision, enabling debug mode causes all register reads to return the fixed value 0xA5AX. Instead of relying on a register read during probing, the probe function now attempts an ADC data read, which works correctly across revisions.


### Changelog Entry
For release notes:
```
Bugfix: Fix TLA2528 probe for new hardware revision
```

### Test coverage
Verified successful probing and ADC reads.

