### PR TITLE
fix: use correct address passed with -a flag

### DIFF
--- a/src/lib/drivers/mcp_common/MCP.cpp
+++ b/src/lib/drivers/mcp_common/MCP.cpp
@@ -443,6 +443,7 @@ I2CSPIDriverBase *MCP230XX::instantiate(const I2CSPIDriverConfig &config, int ru
 	MCP230XX_config_t tmp_config = *static_cast<const MCP230XX_config_t *>(config.custom_data);
 	instance->mcp_config = tmp_config;
 	instance->mcp_config.i2c_bus = config.bus;
+	instance->mcp_config.i2c_addr = config.i2c_address;
 
 	if (OK != instance->init()) {
 		delete instance;


### PR DESCRIPTION


###Problem
The MCP23017 driver ignored the I2C address provided via the -a flag. When an address other than the default (0x27) was used, the driver initialized without error but did not respond to GPIO commands. This was caused by an incorrect device ID comparison.

###Solution
Store and use the correct I2C address in mcp_config so the device ID comparison reflects the address passed at startup.

###Testing
Manually verified functionality by configuring all pins as both inputs and outputs.
