### PR TITLE
HomePosition: only set home position using GNSS if bit 0 in EKF2_GPS_CTRL is active

### DIFF
--- a/src/modules/commander/HomePosition.hpp
+++ b/src/modules/commander/HomePosition.hpp
@@ -74,6 +74,7 @@ public:
 
 private:
 	bool hasMovedFromCurrentHomeLocation();
+	bool isGpsHorizontalFusionEnabled();
 	void setHomePosValid();
 	void updateHomePositionYaw(float yaw);
 
@@ -113,4 +114,5 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamBool<px4::params::COM_HOME_EN>) _param_com_home_en
 	)
+	param_t _param_ekf2_gps_ctrl_handle{PARAM_INVALID};
 };


### PR DESCRIPTION
### Solved Problem

The home position was being set using raw GNSS data even when the vehicle position estimate did not use GNSS. See video: 

[Screencast from 01-29-2026 02:29:37 PM.webm](https://github.com/user-attachments/assets/a04c144e-346e-4b41-a391-850586cc11c1)

### Solution

If the vehicle position is not set by GNSS, then the home position should not be either. The proposed solutions checks whether vehicle horizontal position is using GNSS by checking if bit 0 is enabled in `EKF2_GPS_CTRL`. 

### Changelog Entry
For release notes:
```
Feature/Bugfix only set home position using GNSS if vehicle position also uses GNSS
```

### Test coverage

Tested in SIH ([log](https://review.px4.io/plot_app?log=c451b203-b982-41c1-a1c2-e52c3526d888)).  

[Screencast from 01-29-2026 01:44:14 PM.webm](https://github.com/user-attachments/assets/e9e65e07-59ef-42b2-919c-cd695ac5c388)



