### PR TITLE
CRSF_RC: Replace strlcpy with strncpy and null termination.

### DIFF
--- a/src/drivers/rc/crsf_rc/CrsfParser.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfParser.cpp
@@ -264,7 +264,8 @@ static bool ProcessElrsStatus(const uint8_t *data, const uint32_t size, CrsfPack
 	new_packet->elrs_status.packets_bad = data[2];
 	new_packet->elrs_status.packets_good = (data[3] << 8) | data[4];
 	new_packet->elrs_status.flags = data[5];
-	strlcpy(new_packet->elrs_status.message, (const char *)&data[6], sizeof(new_packet->elrs_status.message));
+	strncpy(new_packet->elrs_status.message, (const char *)&data[6], sizeof(new_packet->elrs_status.message) - 1);
+	new_packet->elrs_status.message[sizeof(new_packet->elrs_status.message) - 1] = '\0';
 
 	return true;
 }


### PR DESCRIPTION
Fix the voxl2 build on main branch. strlcpy is a BSD extension and is not part of standard C/C++. It's typically not available in glibc's <string.h> and isn't available in the voxl2 tool chain
