### PR TITLE
QURT/SERIAL: Undo the breaking changes from commit 17f3db9231

### DIFF
--- a/platforms/qurt/src/px4/SerialImpl.cpp
+++ b/platforms/qurt/src/px4/SerialImpl.cpp
@@ -416,12 +416,8 @@ bool SerialImpl::getSingleWireMode() const
 
 bool SerialImpl::setSingleWireMode()
 {
-	if (enable) {
-		PX4_ERR("Qurt platform does not support single wire mode");
-		return false;
-	}
-
-	return true;
+	PX4_ERR("Qurt platform does not support single wire mode");
+	return false;
 }
 
 bool SerialImpl::getSwapRxTxMode() const
@@ -431,12 +427,8 @@ bool SerialImpl::getSwapRxTxMode() const
 
 bool SerialImpl::setSwapRxTxMode()
 {
-	if (enable) {
-		PX4_ERR("Qurt platform does not support swap rx tx mode");
-		return false;
-	}
-
-	return true;
+	PX4_ERR("Qurt platform does not support swap rx tx mode");
+	return false;
 }
 
 bool SerialImpl::setInvertedMode(bool enable)


### PR DESCRIPTION
Undo the breaking changes from commit 17f3db9231350caf86d9f0af6591f66044d9829c.
A check was added for a non-existent parameter. This commit removes those.
This killed the voxl2-slpi build.


