### PR TITLE
failsafe: prevent Hold when no action is taken

### DIFF
--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -565,7 +565,7 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 
 	// Battery flight time remaining failsafe
 	CHECK_FAILSAFE(status_flags, battery_low_remaining_time,
-		       fromRemainingFlightTimeLowActParam(_param_com_fltt_low_act.get()).cannotBeDeferred());
+		       ActionOptions(fromRemainingFlightTimeLowActParam(_param_com_fltt_low_act.get())));
 
 	if ((_armed_time != 0)
 	    && (time_us < _armed_time + static_cast<hrt_abstime>(_param_com_spoolup_time.get() * 1_s))


### PR DESCRIPTION
### Issue
When `Low battery based on remaining flight time` is triggered while the `LOW Battery` warning is active, the `COM_FLTT_LOW_ACT` `None` action triggers a `Hold` of `COM_FAIL_ACT_T` seconds before switching back to the mode. 

### SOLUTION
When `COM_FLTT_LOW_ACT` is set to `None`, the vehicle does not wait before initiating this action, effectively preventing the unneccessary hold. 

### Testing
- Issue appeared on a real vehicle
- Tested in the `Failsafe State Machine Simulation`


This is a regression, most likely from this [PR](https://github.com/PX4/PX4-Autopilot/pull/22863).