### PR TITLE
feat(simulation): Bind Mavlink to specific interface via PX4_NET_INTERFACE

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
@@ -11,7 +11,9 @@ udp_onboard_gimbal_port_remote=$((13280+px4_instance))
 udp_gcs_port_local=$((18570+px4_instance))
 
 # GCS link
-mavlink start -x -u $udp_gcs_port_local -r 4000000 -f
+## Using -n $PX4_NET_INTERFACE to bind MAVLink to a specific interface.
+[ -z "$PX4_NET_INTERFACE" ] && PX4_NET_INTERFACE=""
+mavlink start -x -u $udp_gcs_port_local -r 4000000 -f -n $PX4_NET_INTERFACE
 mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u $udp_gcs_port_local
 mavlink stream -r 50 -s LOCAL_POSITION_NED -u $udp_gcs_port_local
 mavlink stream -r 50 -s GLOBAL_POSITION_INT -u $udp_gcs_port_local
@@ -23,19 +25,19 @@ mavlink stream -r 20 -s RC_CHANNELS -u $udp_gcs_port_local
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u $udp_gcs_port_local
 
 # API/Offboard link
-mavlink start -x -u $udp_offboard_port_local -r 4000000 -f -m onboard -o $udp_offboard_port_remote
+mavlink start -x -u $udp_offboard_port_local -r 4000000 -f -m onboard -o $udp_offboard_port_remote -n $PX4_NET_INTERFACE
 
 # Onboard link to camera
-mavlink start -x -u $udp_onboard_payload_port_local -r 4000 -f -m onboard -o $udp_onboard_payload_port_remote
+mavlink start -x -u $udp_onboard_payload_port_local -r 4000 -f -m onboard -o $udp_onboard_payload_port_remote -n $PX4_NET_INTERFACE
 
 # Onboard link to gimbal
-mavlink start -x -u $udp_onboard_gimbal_port_local -r 400000 -f -m gimbal -o $udp_onboard_gimbal_port_remote
+mavlink start -x -u $udp_onboard_gimbal_port_local -r 400000 -f -m gimbal -o $udp_onboard_gimbal_port_remote -n $PX4_NET_INTERFACE
 
 # To display for SIH sitl
 if [ "$PX4_SIMULATOR" = "sihsim" ]; then
 	udp_sihsim_port_local=$((19450+px4_instance))
 	udp_sihsim_port_remote=$((19410+px4_instance))
-	mavlink start -x -u $udp_sihsim_port_local -r 400000 -m custom -o $udp_sihsim_port_remote
+	mavlink start -x -u $udp_sihsim_port_local -r 400000 -m custom -o $udp_sihsim_port_remote -n $PX4_NET_INTERFACE
 	mavlink stream -r 200 -s HIL_ACTUATOR_CONTROLS -u  $udp_sihsim_port_local
 	mavlink stream -r 25 -s HIL_STATE_QUATERNION -u  $udp_sihsim_port_local
 fi

--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
@@ -11,9 +11,13 @@ udp_onboard_gimbal_port_remote=$((13280+px4_instance))
 udp_gcs_port_local=$((18570+px4_instance))
 
 # GCS link
-## Using -n $PX4_NET_INTERFACE to bind MAVLink to a specific interface.
-[ -z "$PX4_NET_INTERFACE" ] && PX4_NET_INTERFACE=""
-mavlink start -x -u $udp_gcs_port_local -r 4000000 -f -n $PX4_NET_INTERFACE
+mavlink_network_interface_arg=""
+if [ -n "$PX4_NET_INTERFACE" ]; then
+	# Adding  -n $PX4_NET_INTERFACE to bind MAVLink to a specific interface.
+	# And -p to enable broadcasting on that interface, and not be in localhost mode only.
+	mavlink_network_interface_arg="-n $PX4_NET_INTERFACE -p"
+fi
+mavlink start -x -u $udp_gcs_port_local -r 4000000 -f $mavlink_network_interface_arg
 mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u $udp_gcs_port_local
 mavlink stream -r 50 -s LOCAL_POSITION_NED -u $udp_gcs_port_local
 mavlink stream -r 50 -s GLOBAL_POSITION_INT -u $udp_gcs_port_local
@@ -25,19 +29,19 @@ mavlink stream -r 20 -s RC_CHANNELS -u $udp_gcs_port_local
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u $udp_gcs_port_local
 
 # API/Offboard link
-mavlink start -x -u $udp_offboard_port_local -r 4000000 -f -m onboard -o $udp_offboard_port_remote -n $PX4_NET_INTERFACE
+mavlink start -x -u $udp_offboard_port_local -r 4000000 -f -m onboard -o $udp_offboard_port_remote $mavlink_network_interface_arg
 
 # Onboard link to camera
-mavlink start -x -u $udp_onboard_payload_port_local -r 4000 -f -m onboard -o $udp_onboard_payload_port_remote -n $PX4_NET_INTERFACE
+mavlink start -x -u $udp_onboard_payload_port_local -r 4000 -f -m onboard -o $udp_onboard_payload_port_remote $mavlink_network_interface_arg
 
 # Onboard link to gimbal
-mavlink start -x -u $udp_onboard_gimbal_port_local -r 400000 -f -m gimbal -o $udp_onboard_gimbal_port_remote -n $PX4_NET_INTERFACE
+mavlink start -x -u $udp_onboard_gimbal_port_local -r 400000 -f -m gimbal -o $udp_onboard_gimbal_port_remote $mavlink_network_interface_arg
 
 # To display for SIH sitl
 if [ "$PX4_SIMULATOR" = "sihsim" ]; then
 	udp_sihsim_port_local=$((19450+px4_instance))
 	udp_sihsim_port_remote=$((19410+px4_instance))
-	mavlink start -x -u $udp_sihsim_port_local -r 400000 -m custom -o $udp_sihsim_port_remote -n $PX4_NET_INTERFACE
+	mavlink start -x -u $udp_sihsim_port_local -r 400000 -m custom -o $udp_sihsim_port_remote $mavlink_network_interface_arg
 	mavlink stream -r 200 -s HIL_ACTUATOR_CONTROLS -u  $udp_sihsim_port_local
 	mavlink stream -r 25 -s HIL_STATE_QUATERNION -u  $udp_sihsim_port_local
 fi

--- a/docs/en/sim_gazebo_gz/index.md
+++ b/docs/en/sim_gazebo_gz/index.md
@@ -301,6 +301,11 @@ where `ARGS` is a list of environment variables including:
 - `PX4_GZ_FOLLOW_OFFSET_X`, `PX4_GZ_FOLLOW_OFFSET_Y`, `PX4_GZ_FOLLOW_OFFSET_Z`:
   Set the relative offset of the follow camera to the vehicle.
 
+- `PX4_NET_INTERFACE`:
+  Binds all MAVLink connections to a specific network interface (e.g., `eth0`).
+  Useful for containerized environments or multi-NIC systems.
+  See [Bind MAVLink to Specific Network Interface](../simulation/index.md#bind-mavlink-to-specific-network-interface) for more information.
+
 The PX4 Gazebo worlds and models databases [can be found on GitHub here](https://github.com/PX4/PX4-gazebo-models).
 
 ::: info

--- a/docs/en/sim_gazebo_gz/index.md
+++ b/docs/en/sim_gazebo_gz/index.md
@@ -304,7 +304,11 @@ where `ARGS` is a list of environment variables including:
 - `PX4_NET_INTERFACE`:
   Binds all MAVLink connections to a specific network interface (e.g., `eth0`).
   Useful for containerized environments or multi-NIC systems.
-  See [Bind MAVLink to Specific Network Interface](../simulation/index.md#bind-mavlink-to-specific-network-interface) for more information.
+  See [Environment Configuration](../simulation/index.md#environment-configuration) for more information.
+
+::: info
+For other general simulation environment variables (not Gazebo-specific), such as `PX4_SIM_SPEED_FACTOR` and `PX4_NET_INTERFACE`, see [Simulation > Environment Configuration](../simulation/index.md#environment-configuration).
+:::
 
 The PX4 Gazebo worlds and models databases [can be found on GitHub here](https://github.com/PX4/PX4-gazebo-models).
 

--- a/docs/en/sim_gazebo_gz/index.md
+++ b/docs/en/sim_gazebo_gz/index.md
@@ -307,7 +307,7 @@ where `ARGS` is a list of environment variables including:
   See [Environment Configuration](../simulation/index.md#environment-configuration) for more information.
 
 ::: info
-For other general simulation environment variables (not Gazebo-specific), such as `PX4_SIM_SPEED_FACTOR` and `PX4_NET_INTERFACE`, see [Simulation > Environment Configuration](../simulation/index.md#environment-configuration).
+See [Simulation > Environment Configuration](../simulation/index.md#environment-configuration) for simulation environment variables that are common to all simulators.
 :::
 
 The PX4 Gazebo worlds and models databases [can be found on GitHub here](https://github.com/PX4/PX4-gazebo-models).

--- a/docs/en/simulation/index.md
+++ b/docs/en/simulation/index.md
@@ -243,7 +243,7 @@ See [System Startup](../concept/system_startup.md) for more information.
 ### Environment Configuration
 
 SITL simulation behaviour can be configured using the following environment variables.
-Set them before the `make` command, either inline or via `export`.
+These can be specified inline, before the `make` command, or set for the environment using `export`.
 
 ::: info
 For Gazebo-specific environment variables (such as `PX4_GZ_WORLD`, `PX4_GZ_STANDALONE`, etc.), see [Gazebo > Usage/Configuration Options](../sim_gazebo_gz/index.md#usage-configuration-options).
@@ -251,6 +251,12 @@ For Gazebo-specific environment variables (such as `PX4_GZ_WORLD`, `PX4_GZ_STAND
 
 - `PX4_SIM_SPEED_FACTOR`:
   Sets the speed factor to run the simulation at faster or slower than realtime.
+  For example, to run Gazebo simulation at two times the speed factor:
+
+  ```sh
+  PX4_SIM_SPEED_FACTOR=2 make px4_sitl gz_x500
+  ```
+
   For more information see [Run Simulation Faster than Realtime](#simulation_speed).
 
 - `PX4_PARAM_{name}={value}`:

--- a/docs/en/simulation/index.md
+++ b/docs/en/simulation/index.md
@@ -345,6 +345,30 @@ The specified remote computer can then connect to the simulator by listening to 
 This should be done in various configuration files where `mavlink start` is called.
 For example: [/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink).
 
+### Bind MAVLink to Specific Network Interface
+
+The `PX4_NET_INTERFACE` environment variable allows binding all MAVLink connections to a specific network interface.
+This is useful when running simulations in containerized environments (e.g., Docker) or on systems with multiple network interfaces where you need MAVLink traffic to use a particular interface.
+
+Set the variable before launching the simulation:
+
+```sh
+export PX4_NET_INTERFACE=eth0
+make px4_sitl gz_x500
+```
+
+Or inline with the make command:
+
+```sh
+PX4_NET_INTERFACE=eth0 make px4_sitl gz_x500
+```
+
+This sets the `-n` flag on all `mavlink start` commands in [/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink), binding MAVLink to the specified interface.
+
+::: info
+When `PX4_NET_INTERFACE` is not set, MAVLink binds to all interfaces (default behavior).
+:::
+
 ### SSH Tunneling
 
 SSH tunneling is a flexible option because the simulation computer and the system using it need not be on the same network.

--- a/docs/en/simulation/index.md
+++ b/docs/en/simulation/index.md
@@ -240,6 +240,46 @@ See [System Startup](../concept/system_startup.md) for more information.
 
 [Simulate Failsafes](../simulation/failsafes.md) explains how to trigger safety failsafes like GPS failure and battery drain.
 
+### Environment Configuration
+
+SITL simulation behaviour can be configured using the following environment variables.
+Set them before the `make` command, either inline or via `export`.
+
+::: info
+For Gazebo-specific environment variables (such as `PX4_GZ_WORLD`, `PX4_GZ_STANDALONE`, etc.), see [Gazebo > Usage/Configuration Options](../sim_gazebo_gz/index.md#usage-configuration-options).
+:::
+
+- `PX4_SIM_SPEED_FACTOR`:
+  Sets the speed factor to run the simulation at faster or slower than realtime.
+  For more information see [Run Simulation Faster than Realtime](#simulation_speed).
+
+- `PX4_PARAM_{name}={value}`:
+  Overrides any [PX4 parameter](../advanced_config/parameter_reference.md) for the simulation session.
+  For example, to switch from EKF2 to the attitude estimator:
+
+  ```sh
+  export PX4_PARAM_EKF2_EN=0
+  export PX4_PARAM_ATT_EN=1
+  ```
+
+- `PX4_NET_INTERFACE`:
+  Binds all MAVLink connections to a specific network interface (e.g. `eth0`).
+  This is useful when running simulations in containerized environments (e.g. Docker) or on systems with multiple network interfaces where you need MAVLink traffic to use a particular interface.
+
+  ```sh
+  export PX4_NET_INTERFACE=eth0
+  make px4_sitl gz_x500
+  ```
+
+  Or inline with the make command:
+
+  ```sh
+  PX4_NET_INTERFACE=eth0 make px4_sitl gz_x500
+  ```
+
+  This sets the `-n` flag on all `mavlink start` commands in [/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink), binding MAVLink to the specified interface.
+  When `PX4_NET_INTERFACE` is not set, MAVLink binds to all interfaces (default behaviour).
+
 ## HITL Simulation Environment
 
 With Hardware-in-the-Loop (HITL) simulation the normal PX4 firmware is run on real hardware.
@@ -344,30 +384,6 @@ The specified remote computer can then connect to the simulator by listening to 
 
 This should be done in various configuration files where `mavlink start` is called.
 For example: [/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink).
-
-### Bind MAVLink to Specific Network Interface
-
-The `PX4_NET_INTERFACE` environment variable allows binding all MAVLink connections to a specific network interface.
-This is useful when running simulations in containerized environments (e.g., Docker) or on systems with multiple network interfaces where you need MAVLink traffic to use a particular interface.
-
-Set the variable before launching the simulation:
-
-```sh
-export PX4_NET_INTERFACE=eth0
-make px4_sitl gz_x500
-```
-
-Or inline with the make command:
-
-```sh
-PX4_NET_INTERFACE=eth0 make px4_sitl gz_x500
-```
-
-This sets the `-n` flag on all `mavlink start` commands in [/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink), binding MAVLink to the specified interface.
-
-::: info
-When `PX4_NET_INTERFACE` is not set, MAVLink binds to all interfaces (default behavior).
-:::
 
 ### SSH Tunneling
 


### PR DESCRIPTION
# SITL: Bind Mavlink to specific interface via PX4_NET_INTERFACE

This PR adds support for binding Mavlink instances to a specific network interface in simulation (SITL) using the PX4_NET_INTERFACE environment variable. Which closes #26384 .

## Changes:

- Modified `ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink` to check for PX4_NET_INTERFACE.
- If PX4_NET_INTERFACE is set, the -n <interface> flag is appended to mavlink start commands.
- If PX4_NET_INTERFACE is unset or empty, the default behavior (binding to all interfaces or default) is preserved.

## Motivation
This change allows for more flexible networking configurations, particularly in containerized environments (like Docker) or complex network setups where binding to a specific interface (e.g., a custom bridge or strict isolation) is required.

## Testing:

Verified that setting PX4_NET_INTERFACE correctly restricts Mavlink traffic to the specified interface.
Verified that leaving the variable unset maintains existing behavior.

<!--

### Solved Problem
Fixes #26384 

### Solution

This PR adds support for binding Mavlink instances to a specific network interface in simulation (SITL) using the PX4_NET_INTERFACE environment variable.

### Changelog Entry
For release notes:
```
Modified 
- `ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink` to check for PX4_NET_INTERFACE.
- If PX4_NET_INTERFACE is set, the -n <interface> flag is appended to mavlink start commands.
- If PX4_NET_INTERFACE is unset or empty, the default behavior (binding to all interfaces or default) is preserved.
- Added -p flag to the GCS link to explicitly enable multicast.

```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
