### PR TITLE
[BACKPORT] failsafe: Prevent Offboard to Position without RC

### DIFF
--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -669,6 +669,15 @@ FailsafeBase::Action Failsafe::checkModeFallback(const failsafe_flags_s &status_
 		if (action == Action::Disarm) {
 			return action;
 		}
+
+		if (action == Action::FallbackPosCtrl || action == Action::FallbackAltCtrl || action == Action::FallbackStab) {
+			// Check if RC is available, if not use the mode specified in NAV_RCL_ACT
+			if (status_flags.manual_control_signal_lost) {
+				ActionOptions rc_loss_action = fromNavDllOrRclActParam(_param_nav_rcl_act.get());
+				action = rc_loss_action.action;
+			}
+
+		}
 	}
 
 	// PosCtrl/PositionSlow -> AltCtrl


### PR DESCRIPTION
## Backport
This is a Backport of this [PR](https://github.com/PX4/PX4-Autopilot/pull/26289), which fixed a dangerous failsafe condition in `OFFBOARD` mode. 

### Solved Problem
It was possible to failsafe from Offboard mode into Position mode by setting [COM_OBL_RC_ACT](https://docs.px4.io/main/en/advanced_config/parameter_reference#COM_OBL_RC_ACT)  to Position. If the offboard signal was lost and no RC was available (allowed by [COM_RCL_EXCEPT](https://docs.px4.io/main/en/advanced_config/parameter_reference#COM_RCL_EXCEPT) during Offboard mode), the vehicle would still switch to Position mode, creating a dangerous situation.

### Solution
Include a check in the offboard failsafe logic to prevent a switch to manual modes without RC.

### Changelog Entry
For release notes:
```
Bugfix: Fix Offboard mode failsafe allowed modes
```


### Test coverage
Failsafe State Machine Simulation

## Before:
<img width="1024" height="954" alt="image" src="https://github.com/user-attachments/assets/61a6a4ba-2a08-4643-8d0b-6d94c46aed20" />
## After: 
<img width="1835" height="1014" alt="image" src="https://github.com/user-attachments/assets/b1b70768-0d64-4eaa-9f12-f0f63fd80e99" />
