### PR TITLE
docs: Rover flashing update

### DIFF
--- a/docs/en/config_rover/index.md
+++ b/docs/en/config_rover/index.md
@@ -18,27 +18,37 @@ A drive mode will only work properly if all the configuration for the preceding 
 
 ## Flashing the Rover Build
 
-Rovers use a custom build that must be flashed onto your flight controller instead of the default PX4 build:
+Rover is built as a [firmware variant](../dev_setup/building_px4.md#px4-make-build-targets), and must be installed as "Custom Firmware" in QGC (other vehicles are present in the default variant).
 
-1. First build the rover firmware for your flight controller from the `main` branch (there is no release build, so you can't just select this build from QGroundControl).
+The release versions of Rover firmware for different boards are attached to the associated GitHub release tag.
+For example, you can find `px4_fmu-v5x_rover.px4` on [PX4-Autopilot/releases/tag/v1.16.1](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.16.1).
+For the `main` branch version of Rover you will need to [build the firmware](#building-rover).
 
-   To build for rover with the `make` command, replace the `_default` suffix with `_rover`.
-   For example, to build rover for px4_fmu-v6x boards, you would use the command:
+Load the firmware onto your flight controller as "Custom Firmware" (see [Loading Firmware > Installing PX4 Main, Beta or Custom Firmware](../config/firmware.md#installing-px4-main-beta-or-custom-firmware)).
 
-   ```sh
-   make px4_fmu-v6x_rover
-   ```
+## Building Rover
 
-   ::: info
-   You can also enable the modules in default builds by adding these lines to your [board configuration](../hardware/porting_guide_config.md) (e.g. for fmu-v6x you might add them to [`main/boards/px4/fmu-v6x/default.px4board`](https://github.com/PX4/PX4-Autopilot/blob/main/boards/px4/fmu-v6x/default.px4board)):
+Rover is built as the `rover` [firmware variant](h../dev_setup/building_px4.md#px4-make-build-targets).
+What this means is that when building the firmware with the `make` command, you replace the `_default` suffix in the configuration target with `_rover`.
 
-   ```sh
-   CONFIG_MODULES_ROVER_ACKERMANN=y
-   CONFIG_MODULES_ROVER_DIFFERENTIAL=y
-   CONFIG_MODULES_ROVER_MECANUM=y
-   ```
+For example, to build rover for `px4_fmu-v6x` boards, you would use the following command:
 
-   Note that adding the rover modules may lead to flash overflow, in which case you will need to disable modules that you do not plan to use (such as those related to multicopter or fixed wing).
-   :::
+```sh
+make px4_fmu-v6x_rover
+```
 
-2. Load the **custom firmware** that you just built onto your flight controller (see [Loading Firmware > Installing PX4 Main, Beta or Custom Firmware](../config/firmware.md#installing-px4-main-beta-or-custom-firmware)).
+Note that configuration targets are constructed with the format "VENDOR_MODEL_VARIANT".
+
+The built firmware can be installed as custom firmware, as shown above in in [Flashing the Rover Build](#flashing-the-rover-build).
+
+::: info
+You can also enable the modules in default builds by adding these lines to your [board configuration](../hardware/porting_guide_config.md) (e.g. for fmu-v6x you might add them to [`main/boards/px4/fmu-v6x/default.px4board`](https://github.com/PX4/PX4-Autopilot/blob/main/boards/px4/fmu-v6x/default.px4board)):
+
+```sh
+CONFIG_MODULES_ROVER_ACKERMANN=y
+CONFIG_MODULES_ROVER_DIFFERENTIAL=y
+CONFIG_MODULES_ROVER_MECANUM=y
+```
+
+Adding the rover modules may lead to flash overflow, in which case you will need to disable modules that you do not plan to use (such as those related to multicopter or fixed wing).
+:::

--- a/docs/en/config_rover/index.md
+++ b/docs/en/config_rover/index.md
@@ -28,7 +28,7 @@ Load the firmware onto your flight controller as "Custom Firmware" (see [Loading
 
 ## Building Rover
 
-Rover is built as the `rover` [firmware variant](h../dev_setup/building_px4.md#px4-make-build-targets).
+Rover is built as the `rover` [firmware variant](../dev_setup/building_px4.md#px4-make-build-targets).
 What this means is that when building the firmware with the `make` command, you replace the `_default` suffix in the configuration target with `_rover`.
 
 For example, to build rover for `px4_fmu-v6x` boards, you would use the following command:

--- a/docs/en/frames_rover/index.md
+++ b/docs/en/frames_rover/index.md
@@ -7,15 +7,20 @@ Support for rover is [experimental](../airframes/index.md#experimental-vehicles)
 Maintainer volunteers, [contribution](../contribute/index.md) of new features, new frame configurations, or other improvements would all be very welcome!
 :::
 
+::: tip
+Rover is not in the default PX4 firmware downloaded from QGC.
+Unlike for other vehicle types you will need to install it as custom firmware.
+For more information see [Flashing the Rover Build](../config_rover/index.md#flashing-the-rover-build).
+:::
+
 ![Rovers](../../assets/airframes/rover/rovers.png)
 
-
 PX4 provides support for the three most common types of rovers:
-| Rover Type                        | Steering                                                                                                                                                      |
+| Rover Type | Steering |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [**Ackermann**](#ackermann)       | Direction is controlled by pointing wheels in the direction of travel. This kind of steering is used on most commercial vehicles, including cars, trucks etc. |
-| [**Differential**](#differential) | Direction is controlled by moving the left- and right-side wheels at different speeds.                                                                        |
-| [**Mecanum**](#mecanum)           | Direction is controlled by moving each mecanum wheel individually at different speeds and in different directions.                                            |
+| [**Ackermann**](#ackermann) | Direction is controlled by pointing wheels in the direction of travel. This kind of steering is used on most commercial vehicles, including cars, trucks etc. |
+| [**Differential**](#differential) | Direction is controlled by moving the left- and right-side wheels at different speeds. |
+| [**Mecanum**](#mecanum) | Direction is controlled by moving each mecanum wheel individually at different speeds and in different directions. |
 
 The supported frames can be seen in [Airframes Reference > Rover](../airframes/airframe_reference.md#rover).
 


### PR DESCRIPTION
Rover is now built automatically in release tags as a variant so I have separated the configuraiton step into building and flashing.

Also in https://discord.com/channels/1022170275984457759/1466223145131311325 there was the comment that they did not see the need for specific hardware, so this makes it clear on the front page that you need custom firmware.