### PR TITLE
docs: clarify rover MAVLink offboard support

### DIFF
--- a/docs/en/flight_modes/offboard.md
+++ b/docs/en/flight_modes/offboard.md
@@ -285,7 +285,7 @@ These are converted into a [TrajectorySetpoint](../msg_docs/TrajectorySetpoint.m
 For rover-specific control setpoints and better behaviour we recommend using the [Rover Setpoints](#rover-setpoints) via ROS 2.
 
 ::: info
-Rover MAVLink setpoints are gated by the MAVLink parameter `MAV_FWDEXTSP` (Forward external setpoint messages).
+Rover MAVLink setpoints are gated by the MAVLink parameter [MAV_FWDEXTSP](../advanced_config/parameter_reference.md#MAV_FWDEXTSP) (Forward external setpoint messages).
 :::
 
 - [SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED)

--- a/docs/en/flight_modes/offboard.md
+++ b/docs/en/flight_modes/offboard.md
@@ -228,7 +228,7 @@ The following MAVLink messages and their particular fields and field values are 
 
     - Position setpoint **and** velocity setpoint (the velocity setpoint is used as feedforward; it is added to the output of the position controller and the result is used as the input to the velocity controller).
 
-  - PX4 supports the following `coordinate_frame` values (only): [MAV_FRAME_GLOBAL](https://mavlink.io/en/messages/common.html#MAV_FRAME_GLOBAL).
+  - PX4 supports the following `coordinate_frame` values (only): [MAV_FRAME_GLOBAL_INT](https://mavlink.io/en/messages/common.html#MAV_FRAME_GLOBAL_INT), [MAV_FRAME_GLOBAL_RELATIVE_ALT_INT](https://mavlink.io/en/messages/common.html#MAV_FRAME_GLOBAL_RELATIVE_ALT_INT), [MAV_FRAME_GLOBAL_TERRAIN_ALT_INT](https://mavlink.io/en/messages/common.html#MAV_FRAME_GLOBAL_TERRAIN_ALT_INT).
 
 - [SET_ATTITUDE_TARGET](https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET)
   - The following input combinations are supported:
@@ -271,7 +271,7 @@ The following MAVLink messages and their particular fields and field values are 
         - 12288: Loiter setpoint (fly a circle centred on setpoint).
         - 16384: Idle setpoint (zero throttle, zero roll / pitch).
 
-  - PX4 supports the following `coordinate_frame` values (only): [MAV_FRAME_GLOBAL](https://mavlink.io/en/messages/common.html#MAV_FRAME_GLOBAL).
+  - PX4 supports the following `coordinate_frame` values (only): [MAV_FRAME_GLOBAL_INT](https://mavlink.io/en/messages/common.html#MAV_FRAME_GLOBAL_INT), [MAV_FRAME_GLOBAL_RELATIVE_ALT_INT](https://mavlink.io/en/messages/common.html#MAV_FRAME_GLOBAL_RELATIVE_ALT_INT), [MAV_FRAME_GLOBAL_TERRAIN_ALT_INT](https://mavlink.io/en/messages/common.html#MAV_FRAME_GLOBAL_TERRAIN_ALT_INT).
 
 - [SET_ATTITUDE_TARGET](https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET)
   - The following input combinations are supported:
@@ -280,7 +280,29 @@ The following MAVLink messages and their particular fields and field values are 
 
 ### Rover
 
-Rover does not support a MAVLink offboard API (ROS2 is supported).
+Rover supports offboard control using the generic MAVLink position/velocity setpoint messages listed below.
+These are converted into a [TrajectorySetpoint](../msg_docs/TrajectorySetpoint.md) internally, and then into rover setpoints by the rover offboard modes.
+For rover-specific control setpoints and better behaviour we recommend using the [Rover Setpoints](#rover-setpoints) via ROS 2.
+
+::: info
+Rover MAVLink setpoints are gated by the MAVLink parameter `MAV_FWDEXTSP` (Forward external setpoint messages).
+:::
+
+- [SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED)
+  - Position setpoint: `x`, `y` in [MAV_FRAME_LOCAL_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_LOCAL_NED) (`z` is ignored by rover modules).
+  - Velocity setpoint: `vx`, `vy` in [MAV_FRAME_LOCAL_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_LOCAL_NED) or [MAV_FRAME_BODY_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_BODY_NED).
+  - `yaw`/`yaw_rate`:
+    - Ackermann/Differential: ignored (in velocity control the yaw setpoint is derived from the velocity direction).
+    - Mecanum: can be controlled independently (decoupled) using `yaw`/`yaw_rate`.
+  - Acceleration setpoints (`afx`, `afy`, `afz`) are ignored by rover modules.
+
+- [SET_POSITION_TARGET_GLOBAL_INT](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_GLOBAL_INT)
+  - Position setpoint: `lat_int`, `lon_int`, `alt` (converted into local NED internally; rover modules only use the horizontal components).
+  - Velocity setpoint: `vx`, `vy`, `vz` (rover modules use only the horizontal components).
+  - PX4 supports the following `coordinate_frame` values (only): [MAV_FRAME_GLOBAL_INT](https://mavlink.io/en/messages/common.html#MAV_FRAME_GLOBAL_INT), [MAV_FRAME_GLOBAL_RELATIVE_ALT_INT](https://mavlink.io/en/messages/common.html#MAV_FRAME_GLOBAL_RELATIVE_ALT_INT), [MAV_FRAME_GLOBAL_TERRAIN_ALT_INT](https://mavlink.io/en/messages/common.html#MAV_FRAME_GLOBAL_TERRAIN_ALT_INT).
+
+- [SET_ATTITUDE_TARGET](https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET)
+  - Not supported for rover offboard control.
 
 ## Offboard Parameters
 


### PR DESCRIPTION
### Solved Problem
Closes #26370 
The Offboard mode documentation incorrectly states that rovers do not support a MAVLink offboard API, which no longer matches the current PX4 implementation.

### Solution
- Update the rover section in `docs/en/flight_modes/offboard.md` to document MAVLink offboard support via:
  - `SET_POSITION_TARGET_LOCAL_NED`
  - `SET_POSITION_TARGET_GLOBAL_INT`
- Clarify behaviour differences across rover types:
  - Ackermann/Differential: yaw setpoint is derived from velocity direction (no independent yaw via these MAVLink setpoints).
  - Mecanum: supports body X/Y velocity and can decouple yaw/yaw_rate from position/velocity control.
- Note that `SET_ATTITUDE_TARGET` is not used for rover offboard control (rover offboard uses `TrajectorySetpoint` internally).
- Fix documented supported `coordinate_frame` values for `SET_POSITION_TARGET_GLOBAL_INT` to match the implementation (`*_INT` frames).

### Changelog Entry
For release notes:
```
Documentation: Clarify rover MAVLink offboard support and correct SET_POSITION_TARGET_GLOBAL_INT coordinate_frame values
```

### Alternatives
- N/A

### Test coverage
- SITL (Gazebo):
  - `make px4_sitl gz_rover_differential`
  - `make px4_sitl gz_rover_ackermann`
  - `make px4_sitl gz_rover_mecanum`
- Verified OFFBOARD engagement and vehicle response while streaming:
  - `SET_POSITION_TARGET_LOCAL_NED`
  - `SET_POSITION_TARGET_GLOBAL_INT`

### Context
- Updated file: `docs/en/flight_modes/offboard.md`