### PR TITLE
docs: update link for px4 ros2 interface lib python api docs

### DIFF
--- a/docs/en/ros2/px4_ros2_control_interface.md
+++ b/docs/en/ros2/px4_ros2_control_interface.md
@@ -27,7 +27,7 @@ Unless the mode is safety-critical, requires strict timing or very high update r
 
 ::: tip
 If you want to use Python, check out the [examples in the repository](https://github.com/Auterion/px4-ros2-interface-lib/tree/main/examples/python).
-Not all classes have Python bindings yet — the [supported bindings are here](https://github.com/Auterion/px4-ros2-interface-lib/tree/main/px4_ros2_py/src/px4_ros2).
+Not all classes have Python bindings yet — the [supported bindings are here](https://auterion.github.io/px4-ros2-interface-lib/python/index.html).
 You are welcome to add and contribute missing classes.
 :::
 


### PR DESCRIPTION
Follow-up to https://github.com/PX4/PX4-Autopilot/pull/26352, based on https://github.com/Auterion/px4-ros2-interface-lib/pull/179