### PR TITLE
fix(driver/auav): advanced status check for auav-airspeed-sensor

### DIFF
--- a/src/drivers/differential_pressure/auav/AUAV.hpp
+++ b/src/drivers/differential_pressure/auav/AUAV.hpp
@@ -49,7 +49,7 @@ static constexpr uint32_t I2C_SPEED = 100 * 1000; // 100 kHz I2C serial interfac
 class AUAV : public device::I2C, public I2CSPIDriver<AUAV>
 {
 public:
-	explicit AUAV(const I2CSPIDriverConfig &config);
+	explicit AUAV(const I2CSPIDriverConfig &config, const uint8_t status_byte_expected);
 	virtual ~AUAV();
 
 	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, const int runtime_instance);
@@ -125,6 +125,24 @@ protected:
 
 	perf_counter_t _sample_perf;
 	perf_counter_t _comms_errors;
+
+	/*
+	bit 0
+		alu_ok & 0x1 == 0,
+	bit 1 == 0
+	bit 2
+		memory_ok & 0x4 == 0,
+	bit 3 and 4
+		mode_abs & 0x10 != 0
+		mode_diff & 0x00 != 0
+	bit 5
+		sensor_data_ready & 0x20 == 0,
+	bit 6
+		power_on & 0x40 != 0
+	bit 7 == 0
+	 // diff_pressure or baro - expected status
+	*/
+	const uint8_t _status_byte;
 
 private:
 	int probe() override;

--- a/src/drivers/differential_pressure/auav/AUAV_Absolute.cpp
+++ b/src/drivers/differential_pressure/auav/AUAV_Absolute.cpp
@@ -34,9 +34,8 @@
 #include "AUAV_Absolute.hpp"
 
 AUAV_Absolute::AUAV_Absolute(const I2CSPIDriverConfig &config) :
-	AUAV(config)
-{
-}
+	AUAV(config, _status_byte_expected)
+{}
 
 void AUAV_Absolute::publish_pressure(const float pressure_p, const float temperature_c,
 				     const hrt_abstime timestamp_sample)

--- a/src/drivers/differential_pressure/auav/AUAV_Absolute.hpp
+++ b/src/drivers/differential_pressure/auav/AUAV_Absolute.hpp
@@ -71,4 +71,5 @@ private:
 	int read_factory_data() override;
 
 	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	static const uint8_t _status_byte_expected = 0x40;
 };

--- a/src/drivers/differential_pressure/auav/AUAV_Differential.cpp
+++ b/src/drivers/differential_pressure/auav/AUAV_Differential.cpp
@@ -36,7 +36,7 @@
 #include <cctype>
 
 AUAV_Differential::AUAV_Differential(const I2CSPIDriverConfig &config) :
-	AUAV(config)
+	AUAV(config, _status_byte_expected)
 {
 	/* Initialize cal_range from parameter as fallback value */
 	int32_t hw_model = 0;

--- a/src/drivers/differential_pressure/auav/AUAV_Differential.hpp
+++ b/src/drivers/differential_pressure/auav/AUAV_Differential.hpp
@@ -80,4 +80,6 @@ private:
 
 	uORB::PublicationMulti<differential_pressure_s> _differential_pressure_pub{ORB_ID(differential_pressure)};
 	int32_t _cal_range{10};
+
+	static const uint8_t _status_byte_expected = 0x50;
 };


### PR DESCRIPTION
<!--
Changed AUAV detection - status-Byte,
also differ between baro and diff-pressure sensor detection

Tested:
Sensor: DLVR-L10D NI3N on
Hardware: Auterion Skynode-X (fmu-v6x)
-->
