### PR TITLE
UI: add advanced label to Altitude Cruise

### DIFF
--- a/src/lib/modes/ui.hpp
+++ b/src/lib/modes/ui.hpp
@@ -109,8 +109,6 @@ static inline bool isAdvanced(uint8_t nav_state)
 	switch (nav_state) {
 	case vehicle_status_s::NAVIGATION_STATE_ALTCTL: return false;
 
-	case vehicle_status_s::NAVIGATION_STATE_ALTITUDE_CRUISE: return false;
-
 	case vehicle_status_s::NAVIGATION_STATE_POSCTL: return false;
 
 	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL1: return false;


### PR DESCRIPTION

### Solved Problem
Normal UI showing the new flight mode "Altitude Cruise" (blend-over between Altitude and Acro), confusing some users.

### Solution
Remove the isAdvanced=false for Altitude Cruise. 

### Changelog Entry
For release notes:
```
Improvement: Label Altitude Cruise as advanced for the UI
```

### Alternatives
We can consider labeling it non-advanced once it has wider adoption. 
