### PR TITLE
Add SF1XX rotation parameter and update orientation in LightwareLaser…

### DIFF
--- a/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
+++ b/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
@@ -179,7 +179,7 @@ LightwareLaser::LightwareLaser(const I2CSPIDriverConfig &config) :
 	I2C(config),
 	I2CSPIDriver(config),
 	ModuleParams(nullptr),
-	_px4_rangefinder(get_device_id(), config.rotation)
+	_px4_rangefinder(get_device_id())
 {
 	_px4_rangefinder.set_device_type(DRV_DIST_DEVTYPE_LIGHTWARE_LASER);
 }
@@ -634,7 +634,7 @@ void LightwareLaser::print_usage()
 		R"DESCR_STR(
 ### Description
 
-I2C bus driver for Lightware SFxx series LIDAR rangefinders: SF10/a, SF10/b, SF10/c, SF11/c, SF/LW20, SF30/d.
+I2C bus driver for Lightware LIDAR rangefinders: SF10/a, SF10/b, SF10/c, SF11/c, SF/LW20, SF/LW30/d, GRF250, GRF500.
 
 Setup/usage information: https://docs.px4.io/main/en/sensor/sfxx_lidar.html
 )DESCR_STR");
@@ -644,28 +644,17 @@ Setup/usage information: https://docs.px4.io/main/en/sensor/sfxx_lidar.html
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
 	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x66);
-	PRINT_MODULE_USAGE_PARAM_INT('R', 25, 0, 25, "Sensor rotation - downward facing by default", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
 extern "C" __EXPORT int lightware_laser_i2c_main(int argc, char *argv[])
 {
-	int ch;
 	using ThisDriver = LightwareLaser;
 	BusCLIArguments cli{true, false};
-	cli.rotation = (Rotation)distance_sensor_s::ROTATION_DOWNWARD_FACING;
 	cli.default_i2c_frequency = 400000;
 	cli.i2c_address = LIGHTWARE_LASER_BASEADDR;
 
-	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
-		switch (ch) {
-		case 'R':
-			cli.rotation = (Rotation)atoi(cli.optArg());
-			break;
-		}
-	}
-
-	const char *verb = cli.optArg();
+	const char *verb = cli.parseDefaultArguments(argc, argv);
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/distance_sensor/lightware_laser_i2c/parameters.c
+++ b/src/drivers/distance_sensor/lightware_laser_i2c/parameters.c
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
- * Lightware SF1xx/SF20/LW20 laser rangefinder (i2c)
+ * Lightware laser rangefinder (i2c)
  *
  * @reboot_required true
  * @min 0
@@ -52,7 +52,7 @@
 PARAM_DEFINE_INT32(SENS_EN_SF1XX, 0);
 
 /**
- * Lightware SF1xx/SF20/LW20 Operation Mode
+ * Lightware laser rangefinder Operation Mode
  *
  * @value 0 Disabled
  * @value 1 Enabled
@@ -64,9 +64,10 @@ PARAM_DEFINE_INT32(SENS_EN_SF1XX, 0);
 PARAM_DEFINE_INT32(SF1XX_MODE, 1);
 
 /**
- * Lightware SF1xx/SF20/LW20 Rotation
+ * Lightware laser rangefinder Rotation
  *
  * Distance sensor orientation as MAV_SENSOR_ORIENTATION enum.
+ * Applies to all models supported by SENS_EN_SF1XX.
  *
  * @reboot_required true
  * @min 0


### PR DESCRIPTION
## Summary                                                                                                                                                                                               
                                                                                                                                                                                                           
  - Remove `-R` CLI rotation option; `SF1XX_ROT` param is now the single source of truth                                                                                                                   
  - Update param descriptions and module docs to cover all supported models (was missing SF30/d, GRF250, GRF500) 