### PR TITLE
Battery: Declare fault on overtemperature

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -330,6 +330,10 @@ uint16_t Battery::determineFaults()
 		faults |= (1 << battery_status_s::FAULT_SPIKES);
 	}
 
+	if (PX4_ISFINITE(_temperature_c) && _temperature_c > BAT_TEMP_MAX) {
+		faults |= (1 << battery_status_s::FAULT_OVER_TEMPERATURE);
+	}
+
 	return faults;
 }
 

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -217,4 +217,10 @@ private:
 	static constexpr float OCV_DEFAULT = 4.2f; // [V] Initial per cell estimate of the open circuit voltage
 	static constexpr float R_COVARIANCE = 0.1f; // Initial per cell covariance of the internal resistance
 	static constexpr float OCV_COVARIANCE = 1.5f; // Initial per cell covariance of the open circuit voltage
+
+	// Temperature [degC] above which an overtemperature fault is declared,
+	// leading to a failsafe warning recommending immediate landing. Note
+	// that depending on the setup this may be measured in/close to the
+	// battery (smart battery) or from a separate power monitor module.
+	static constexpr float BAT_TEMP_MAX = 100.0f;
 };


### PR DESCRIPTION
### Problem

In a flight we observed, a vehicle was lost because of a power module failure, causing it to slowly melt itself. The loss would have been prevented if we warned the user about this, allowing them to land in time.

### Solution

If the measured temperature exceeds a hardcoded threshold of 100 deg C, a fault is declared from the battery library. [`batteryCheck.cpp`](https://github.com/PX4/PX4-Autopilot/blob/c4535683a760033716abec776901331959258d7b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp#L157-L176) then warns the user like this: 
<img width="465" height="250" alt="Screenshot from 2026-02-09 14-11-27" src="https://github.com/user-attachments/assets/2ecbca1c-106d-4425-8cb1-66979175aaa9" />


### Alternative

Raise the warning from the power monitor driver. 
 - Advantage: We can tell the user it's the power module (not the battery). 
 - Disadvantage: We have to redo the implementation for different power monitors. 
 
 
 ### Context

The power module failure resulted in a power loss shortly after exceeding 135 deg C. With a warning at 100 deg C, there would have been 2 minutes of flight time to land and save the vehicle. In a large collection of other flights, the maximum battery_status temperature was 80 deg C.
<img width="654" height="646" alt="image" src="https://github.com/user-attachments/assets/9efc43d9-5ad8-4540-942c-47e21eb5511b" />
