### PR TITLE
ci: fix docs orchestrator docker image

### DIFF
--- a/.github/workflows/docs-orchestrator.yml
+++ b/.github/workflows/docs-orchestrator.yml
@@ -56,7 +56,7 @@ jobs:
       contents: read
     runs-on: [runs-on,runner=4cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
     container:
-      image: px4io/px4-dev-nuttx-focal:2024-11-07
+      image: px4io/px4-dev:v1.17.0-beta1
     steps:
       - uses: runs-on/action@v1
 
@@ -117,7 +117,7 @@ jobs:
       contents: write
     runs-on: [runs-on,runner=4cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
     container:
-      image: px4io/px4-dev-nuttx-focal:2024-11-07
+      image: px4io/px4-dev:v1.17.0-beta1
     steps:
       - uses: runs-on/action@v1
 


### PR DESCRIPTION
## Summary
- The docs-orchestrator workflow referenced `px4io/px4-dev-nuttx-focal:2024-11-07` which does not exist on Docker Hub
- This caused the `T2: Metadata Sync` job to fail on the merge push: https://github.com/PX4/PX4-Autopilot/actions/runs/21894661572
- Switches to `px4io/px4-dev:v1.17.0-beta1` which has all required toolchains

## Test plan
- [ ] CI passes with the new image (T2: Metadata Sync job succeeds)