### PR TITLE
clean-up(SIH): remove confusing runtime uorb sub change

### DIFF
--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -79,8 +79,6 @@ void Sih::run()
 					    static_cast<int32_t>(VehicleType::First),
 					    static_cast<int32_t>(VehicleType::Last)));
 
-	_actuator_out_sub = uORB::Subscription{ORB_ID(actuator_outputs_sim)};
-
 #if defined(ENABLE_LOCKSTEP_SCHEDULER)
 	lockstep_loop();
 #else

--- a/src/modules/simulation/simulator_sih/sih.hpp
+++ b/src/modules/simulation/simulator_sih/sih.hpp
@@ -131,7 +131,7 @@ private:
 	uORB::Publication<vehicle_global_position_s>  _global_position_ground_truth_pub{ORB_ID(vehicle_global_position_groundtruth)};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
-	uORB::Subscription _actuator_out_sub{ORB_ID(actuator_outputs)};
+	uORB::Subscription _actuator_out_sub{ORB_ID(actuator_outputs_sim)};
 
 	// hard constants
 	static constexpr uint16_t NUM_ACTUATORS_MAX = 9;


### PR DESCRIPTION
The orb_id subscribed to is changed on runtime making things confusing for no reason. Fixes it by simply init to the correct uorb directly.