### PR TITLE
docs: clean up outdated Ubuntu/GCC/container references

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -6,9 +6,9 @@ set -e
 ## Can also be used in docker.
 ##
 ## Installs:
-## - Common dependencies and tools for nuttx, jMAVSim, Gazebo
+## - Common dependencies and tools for nuttx, Gazebo
 ## - NuttX toolchain (omit with arg: --no-nuttx)
-## - jMAVSim and Gazebo9 simulator (omit with arg: --no-sim-tools)
+## - Gazebo Harmonic simulator (omit with arg: --no-sim-tools)
 ##
 
 INSTALL_NUTTX="true"
@@ -207,37 +207,18 @@ if [[ $INSTALL_SIM == "true" ]]; then
 		bc \
 		;
 
-	# Gazebo / Gazebo classic installation
-	if [[ "${UBUNTU_RELEASE}" == "18.04" || "${UBUNTU_RELEASE}" == "20.04" ]]; then
-		sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-		wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
-		# Update list, since new gazebo-stable.list has been added
-		sudo apt-get update -y --quiet
+	# Gazebo Harmonic installation (Ubuntu 22.04+)
+	echo "[ubuntu.sh] Gazebo (Harmonic) will be installed"
+	# Add Gazebo binary repository
+	sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+	echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+	sudo apt-get update -y --quiet
 
-		# Install Gazebo classic
-		if [[ "${UBUNTU_RELEASE}" == "18.04" ]]; then
-			gazebo_classic_version=9
-			gazebo_packages="gazebo$gazebo_classic_version libgazebo$gazebo_classic_version-dev"
-		else
-			# default and Ubuntu 20.04
-			gazebo_classic_version=11
-			gazebo_packages="gazebo$gazebo_classic_version libgazebo$gazebo_classic_version-dev"
-		fi
-	else
-		# Expects Ubuntu 22.04 > by default
-		echo "[ubuntu.sh] Gazebo (Harmonic) will be installed"
-		echo "[ubuntu.sh] Earlier versions will be removed"
-		# Add Gazebo binary repository
-		sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
-		echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
-		sudo apt-get update -y --quiet
+	# Install Gazebo
+	gazebo_packages="gz-harmonic libunwind-dev"
 
-		# Install Gazebo
-		gazebo_packages="gz-harmonic libunwind-dev"
-
-		if [[ "${UBUNTU_RELEASE}" == "24.04" ]]; then
-			gazebo_packages="$gazebo_packages cppzmq-dev"
-		fi
+	if [[ "${UBUNTU_RELEASE}" == "24.04" ]]; then
+		gazebo_packages="$gazebo_packages cppzmq-dev"
 	fi
 
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \

--- a/docs/en/dev_setup/building_px4.md
+++ b/docs/en/dev_setup/building_px4.md
@@ -127,7 +127,8 @@ The following list shows the build commands for the [Pixhawk standard](../flight
 - [Pixhawk 1 (FMUv2)](../flight_controller/pixhawk.md): `make px4_fmu-v2_default`
 
   :::warning
-  You **must** use a supported version of GCC to build this board (e.g. the `gcc-arm-none-eabi` package from the current Ubuntu LTS, which is the same toolchain used by CI) or remove modules from the build. Building with an unsupported GCC may fail, as PX4 is close to the board's 1MB flash limit.
+  You **must** use a supported version of GCC to build this board (e.g. the `gcc-arm-none-eabi` package from the current Ubuntu LTS, which is the same toolchain used by CI) or remove modules from the build.
+  Building with an unsupported GCC may fail, as PX4 is close to the board's 1MB flash limit.
   :::
 
 - Pixhawk 1 with 2 MB flash: `make px4_fmu-v3_default`
@@ -238,7 +239,7 @@ You may need to install it using:
     pip3 install --user jinja2
 ```
 
-If you have already installed these dependencies this may be because there is more than one Python version on the computer (e.g. Python 2.7.16 Python 3.8.3), and the module is not present in the version used by the build toolchain.
+If you have already installed these dependencies this may be because there is more than one Python version on the computer (e.g. Python 2.7.16 and Python 3.8.3), and the module is not present in the version used by the build toolchain.
 
 You should be able to fix this by explicitly installing the dependencies as shown:
 

--- a/docs/en/dev_setup/building_px4.md
+++ b/docs/en/dev_setup/building_px4.md
@@ -79,6 +79,16 @@ cd PX4-Autopilot
 make px4_fmu-v5_default
 ```
 
+:::tip
+You can also build using the [px4-dev Docker container](../test_and_ci/docker.md) without installing the toolchain locally.
+From the PX4-Autopilot directory:
+
+```sh
+./Tools/docker_run.sh 'make px4_fmu-v5_default'
+```
+
+:::
+
 A successful run will end with similar output to:
 
 ```sh

--- a/docs/en/dev_setup/building_px4.md
+++ b/docs/en/dev_setup/building_px4.md
@@ -231,7 +231,7 @@ sudo ln -s /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/* /us
 
 ### Failed to import Python packages
 
-"Failed to import" errors when running the `make px4_sitl jmavsim` command indicates that some Python packages are not installed (where expected).
+"Failed to import" errors when running the `make px4_sitl gz_x500` command indicates that some Python packages are not installed (where expected).
 
 ```sh
 Failed to import jinja2: No module named 'jinja2'
@@ -241,10 +241,10 @@ You may need to install it using:
 
 If you have already installed these dependencies this may be because there is more than one Python version on the computer (e.g. Python 2.7.16 and Python 3.8.3), and the module is not present in the version used by the build toolchain.
 
-You should be able to fix this by explicitly installing the dependencies as shown:
+You should be able to fix this by installing the dependencies from the repository's requirements file:
 
 ```sh
-pip3 install --user pyserial empty toml numpy pandas jinja2 pyyaml pyros-genmsg packaging
+pip3 install --user -r Tools/setup/requirements.txt
 ```
 
 ## PX4 Make Build Targets

--- a/docs/en/dev_setup/building_px4.md
+++ b/docs/en/dev_setup/building_px4.md
@@ -39,15 +39,6 @@ Navigate into the **PX4-Autopilot** directory and start [Gazebo SITL](../sim_gaz
 make px4_sitl gz_x500
 ```
 
-::: details If you installed Gazebo Classic
-Start [Gazebo Classic SITL](../sim_gazebo_classic/index.md) using the following command:
-
-```sh
-make px4_sitl gazebo-classic
-```
-
-:::
-
 This will bring up the PX4 console:
 
 ![PX4 Console](../../assets/toolchain/console_gazebo.png)
@@ -126,7 +117,7 @@ The following list shows the build commands for the [Pixhawk standard](../flight
 - [Pixhawk 1 (FMUv2)](../flight_controller/pixhawk.md): `make px4_fmu-v2_default`
 
   :::warning
-  You **must** use a supported version of GCC to build this board (e.g. the same as used by [CI/docker](../test_and_ci/docker.md)) or remove modules from the build. Building with an unsupported GCC may fail, as PX4 is close to the board's 1MB flash limit.
+  You **must** use a supported version of GCC to build this board (e.g. the `gcc-arm-none-eabi` package from the current Ubuntu LTS, which is the same toolchain used by CI) or remove modules from the build. Building with an unsupported GCC may fail, as PX4 is close to the board's 1MB flash limit.
   :::
 
 - Pixhawk 1 with 2 MB flash: `make px4_fmu-v3_default`
@@ -191,7 +182,7 @@ The `region 'flash' overflowed by XXXX bytes` error indicates that the firmware 
 This is common for `make px4_fmu-v2_default` builds, where the flash size is limited to 1MB.
 
 If you're building the _vanilla_ master branch, the most likely cause is using an unsupported version of GCC.
-In this case, install the version specified in the [Developer Toolchain](../dev_setup/dev_env.md) instructions.
+In this case, install the `gcc-arm-none-eabi` package from the current Ubuntu LTS as described in the [Developer Toolchain](../dev_setup/dev_env.md) instructions.
 
 If building your own branch, it is possible that you have increased the firmware size over the 1MB limit.
 In this case you will need to remove any drivers/modules that you don't need from the build.
@@ -204,7 +195,7 @@ The PX4 build system opens a large number of files, so you may exceed this numbe
 The build toolchain will then report `Too many open files` for many files, as shown below:
 
 ```sh
-/usr/local/Cellar/gcc-arm-none-eabi/20171218/bin/../lib/gcc/arm-none-eabi/7.2.1/../../../../arm-none-eabi/bin/ld: cannot find NuttX/nuttx/fs/libfs.a: Too many open files
+arm-none-eabi-ld: cannot find NuttX/nuttx/fs/libfs.a: Too many open files
 ```
 
 The solution is to increase the maximum allowed number of open files (e.g. to 300).
@@ -226,31 +217,6 @@ If you have build problems on this platform then try run the following command i
 xcode-select --install
 sudo ln -s /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/* /usr/local/include/
 ```
-
-### Ubuntu 18.04: Compile errors involving arm_none_eabi_gcc
-
-Build issues related to `arm_none_eabi_gcc`may be due to a broken g++ toolchain installation.
-You can verify that this is the case by checking for missing dependencies using:
-
-```sh
-arm-none-eabi-gcc --version
-arm-none-eabi-g++ --version
-arm-none-eabi-gdb --version
-arm-none-eabi-size --version
-```
-
-Example of bash output with missing dependencies:
-
-```sh
-arm-none-eabi-gdb --version
-arm-none-eabi-gdb: command not found
-```
-
-This can be resolved by removing and [reinstalling the compiler](https://askubuntu.com/questions/1243252/how-to-install-arm-none-eabi-gdb-on-ubuntu-20-04-lts-focal-fossa).
-
-### Ubuntu 18.04: Visual Studio Code is unable to watch for file changes in this large workspace
-
-See [Visual Studio Code IDE (VSCode) > Troubleshooting](../dev_setup/vscode.md#troubleshooting).
 
 ### Failed to import Python packages
 

--- a/docs/en/dev_setup/config_initial.md
+++ b/docs/en/dev_setup/config_initial.md
@@ -20,7 +20,7 @@ The equipment below is highly recommended:
   :::
   - Lenovo Thinkpad with i5-core running Windows 11
   - MacBook Pro (early 2015 and later) with macOS 10.15 or later
-  - Lenovo Thinkpad i5 with Ubuntu Linux 20.04 or later
+  - Lenovo Thinkpad i5 with Ubuntu Linux 22.04 or later
 
 - **Ground control station** (computer or tablet):
   - iPad (may require Wifi telemetry adapter)
@@ -39,9 +39,9 @@ Install the [QGroundControl Daily Build](../dev_setup/qgc_daily_build.md) for a 
 To configure the vehicle:
 
 1. [Install PX4 firmware](../config/firmware.md#installing-px4-main-beta-or-custom-firmware) (including "custom" firmware with your own changes).
-1. [Start with the airframe](../config/airframe.md) that best-matches your vehicle from the [airframe reference](../airframes/airframe_reference.md).
-1. [Basic Configuration](../config/index.md) explains how to perform basic configuration.
-1. [Parameter Configuration](../advanced_config/parameters.md) explains how you can find and modify individual parameters.
+2. [Start with the airframe](../config/airframe.md) that best-matches your vehicle from the [airframe reference](../airframes/airframe_reference.md).
+3. [Basic Configuration](../config/index.md) explains how to perform basic configuration.
+4. [Parameter Configuration](../advanced_config/parameters.md) explains how you can find and modify individual parameters.
 
 ::: info
 

--- a/docs/en/dev_setup/dev_env.md
+++ b/docs/en/dev_setup/dev_env.md
@@ -2,7 +2,7 @@
 
 The _supported platforms_ for PX4 development are:
 
-- [Ubuntu Linux (24.04/22.04)](../dev_setup/dev_env_linux_ubuntu.md) — Recommended
+- [Ubuntu Linux (24.04/22.04)](../dev_setup/dev_env_linux_ubuntu.md)
 - [Windows (10/11)](../dev_setup/dev_env_windows_wsl.md) — via WSL2
 - [macOS](../dev_setup/dev_env_mac.md)
 
@@ -15,9 +15,9 @@ The table below shows what PX4 targets you can build on each OS.
 | **NuttX based hardware:** [Pixhawk Series](../flight_controller/pixhawk_series.md), [Crazyflie](../complete_vehicles_mc/crazyflie2.md) |       ✓        |   ✓   |    ✓    |
 | **Linux-based hardware:** [Raspberry Pi 2/3](../flight_controller/raspberry_pi_navio2.md)                                              |       ✓        |       |         |
 | **Simulation:** [Gazebo SITL](../sim_gazebo_gz/index.md)                                                                               |       ✓        |   ✓   |    ✓    |
-| **Simulation:** [Gazebo Classic SITL](../sim_gazebo_classic/index.md)                                                                  |       ✓        |   ✓   |    ✓    |
-| **Simulation:** [ROS with Gazebo Classic](../simulation/ros_interface.md)                                                              |       ✓        |       |    ✓    |
 | **Simulation:** ROS 2 with Gazebo                                                                                                      |       ✓        |       |    ✓    |
+| **Simulation:** [Gazebo Classic SITL](../sim_gazebo_classic/index.md)                                                                  |                |   ✓   |    ✓    |
+| **Simulation:** [ROS with Gazebo Classic](../simulation/ros_interface.md)                                                              |                |       |    ✓    |
 
 Experienced Docker users can also build with the containers used by our continuous integration system: [Docker Containers](../test_and_ci/docker.md)
 

--- a/docs/en/dev_setup/dev_env_linux_centos.md
+++ b/docs/en/dev_setup/dev_env_linux_centos.md
@@ -39,8 +39,9 @@ You may want to also install `python-pip` and `screen`.
 Execute the script below to install GCC 7-2017-q4:
 
 :::warning
-This version of GCC is out of date.
-At time of writing the current version on Ubuntu is `9-2020-q2-update` (see [focal nuttx docker file](https://github.com/PX4/PX4-containers/blob/master/docker/Dockerfile_nuttx-focal#L28))
+This version of GCC is very outdated.
+PX4 now uses the `gcc-arm-none-eabi` package from the current Ubuntu LTS (GCC 13.2.1 on Ubuntu 24.04).
+This CentOS guide is community-maintained and may not produce working builds.
 :::
 
 ```sh

--- a/docs/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/docs/en/dev_setup/dev_env_linux_ubuntu.md
@@ -4,20 +4,14 @@ The following instructions use a bash script to set up the PX4 development envir
 
 The environment includes:
 
-- [Gazebo Simulator](../sim_gazebo_gz/index.md) ("Harmonic")
-- [Build toolchain for Pixhawk (and other NuttX-based hardware)](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards).
-
-On Ubuntu 22.04:
-
-- [Gazebo Classic Simulator](../sim_gazebo_classic/index.md) can be used instead of Gazebo.
-  Gazebo is nearing feature-parity with Gazebo-Classic on PX4, and will soon replace it for all use cases.
+- [Gazebo Simulator](../sim_gazebo_gz/index.md) (Gazebo Harmonic)
+- [Build toolchain for Pixhawk (and other NuttX-based hardware)](../dev_setup/building_px4.md#nuttx-pixhawk-based-boards) using the `gcc-arm-none-eabi` compiler from the Ubuntu package manager.
 
 The build toolchain for other flight controllers, simulators, and working with ROS are discussed in the [Other Targets](#other-targets) section below.
 
-::: details Can I use an older version of Ubuntu?
-PX4 supports the current and last Ubuntu LTS release where possible.
-Older releases are not supported (so you can't raise defects against them), but may still work.
-For example, Gazebo Classic setup is included in our standard build instructions for macOS, Ubuntu 18.04 and 20.04, and Windows on WSL2 for the same hosts.
+:::info
+PX4 targets the **current Ubuntu LTS** (24.04) for CI and release builds, with the **previous LTS** (22.04) also supported.
+Older Ubuntu versions are not supported and may not work.
 :::
 
 ## Simulation and NuttX (Pixhawk) Targets
@@ -50,19 +44,18 @@ To install the toolchain:
    - Acknowledge any prompts as the script progress.
    - You can use the `--no-nuttx` and `--no-sim-tools` options to omit the NuttX and/or simulation tools.
 
-3. If you need Gazebo Classic (Ubuntu 22.04 only) then you can manually remove Gazebo and install it by following the instructions in [Gazebo Classic > Installation](../sim_gazebo_classic/index.md#installation).
-
-4. Restart the computer on completion.
+3. Restart the computer on completion.
 
 :::details Additional notes
 These notes are provided "for information only":
 
 - This setup is supported by the PX4 Dev Team.
   The instructions may also work on other Debian Linux based systems.
-- You can verify the NuttX installation by confirming the `gcc` version as shown:
+- You can verify the NuttX installation by confirming `gcc` is available.
+  The version depends on your Ubuntu release (e.g. GCC 13.2.1 on Ubuntu 24.04):
 
   ```sh
-  $arm-none-eabi-gcc --version
+  $ arm-none-eabi-gcc --version
 
   arm-none-eabi-gcc (15:13.2.rel1-2) 13.2.1 20231009
   Copyright (C) 2023 Free Software Foundation, Inc.

--- a/docs/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/docs/en/dev_setup/dev_env_linux_ubuntu.md
@@ -9,7 +9,7 @@ The environment includes:
 
 The build toolchain for other flight controllers, simulators, and working with ROS are discussed in the [Other Targets](#other-targets) section below.
 
-:::info
+::: info
 PX4 targets the **current Ubuntu LTS** (24.04) for CI and release builds, with the **previous LTS** (22.04) also supported.
 Older Ubuntu versions are not supported and may not work.
 :::

--- a/docs/en/dev_setup/dev_env_windows_wsl.md
+++ b/docs/en/dev_setup/dev_env_windows_wsl.md
@@ -58,20 +58,20 @@ To install WSL2 with Ubuntu on a new installation of Windows 10 or 11:
      wsl --install
      ```
 
-   - Ubuntu 20.04 ([Gazebo-Classic Simulation](../sim_gazebo_classic/index.md))
-
-     ```sh
-     wsl --install -d Ubuntu-20.04
-     ```
-
    - Ubuntu 22.04 ([Gazebo Simulation](../sim_gazebo_gz/index.md))
 
      ```sh
      wsl --install -d Ubuntu-22.04
      ```
 
+   - Ubuntu 24.04 ([Gazebo Simulation](../sim_gazebo_gz/index.md))
+
+     ```sh
+     wsl --install -d Ubuntu-24.04
+     ```
+
    ::: info
-   You can also install[Ubuntu 20.04](https://www.microsoft.com/store/productId/9MTTCL66CPXJ) and [Ubuntu 22.04](https://www.microsoft.com/store/productId/9PN20MSR04DW) from the store, which allows you to delete the application using the normal Windows Add/Remove settings:
+   You can also [Ubuntu 24.04](https://www.microsoft.com/store/productId/9nz3klhxdjp5) or [Ubuntu 22.04](https://www.microsoft.com/store/productId/9PN20MSR04DW) from Microsoft Store, which allows you to delete the application using the normal Windows Add/Remove settings.
    :::
 
 1. WSL will prompt you for a user name and password for the Ubuntu installation.
@@ -106,7 +106,7 @@ To open a WSL shell using a command prompt:
    ```
 
    ```sh
-   wsl -d Ubuntu-20.04
+   wsl -d Ubuntu-24.04
    ```
 
    If you only have one version of Ubuntu, you can just use `wsl`.

--- a/docs/en/dev_setup/vscode.md
+++ b/docs/en/dev_setup/vscode.md
@@ -124,10 +124,10 @@ Once that is done you don't need to do anything else; the toolchain will automat
 
 This section includes guidance on setup and build errors.
 
-### Ubuntu 18.04: "Visual Studio Code is unable to watch for file changes in this large workspace"
+### "Visual Studio Code is unable to watch for file changes in this large workspace"
 
 This error surfaces on startup.
-On some systems, there is an upper-limit of 8192 file handles imposed on applications, which means that VSCode might not be able to detect file modifications in `/PX4-Autopilot`.
+On some systems, there is an upper-limit on file handles imposed on applications, which means that VSCode might not be able to detect file modifications in `/PX4-Autopilot`.
 
 You can increase this limit to avoid the error, at the expense of memory consumption.
 Follow the [instructions here](https://code.visualstudio.com/docs/setup/linux#_visual-studio-code-is-unable-to-watch-for-file-changes-in-this-large-workspace-error-enospc).

--- a/docs/en/ros/mavros_installation.md
+++ b/docs/en/ros/mavros_installation.md
@@ -26,7 +26,7 @@ They cover the _ROS Melodic and Noetic_ releases.
 
 ::: tab ROS Noetic (Ubuntu 20.04)
 
-If you're working with [ROS Noetic](https://wiki.ros.org/noetic) on Ubuntu 20.04:
+If you're working with [ROS "Noetic"](https://wiki.ros.org/noetic) on Ubuntu 20.04:
 
 1. Install PX4 without the simulator toolchain:
    1. [Download PX4 Source Code](../dev_setup/building_px4.md):
@@ -57,7 +57,7 @@ If you're working with [ROS Noetic](https://wiki.ros.org/noetic) on Ubuntu 20.04
 
 ::: tab ROS Melodic (Ubuntu 18.04)
 
-If you're working with ROS "Melodic on Ubuntu 18.04:
+If you're working with ROS "Melodic" on Ubuntu 18.04:
 
 1. Download the [ubuntu_sim_ros_melodic.sh](https://raw.githubusercontent.com/PX4/Devguide/master/build_scripts/ubuntu_sim_ros_melodic.sh) script in a bash shell:
 

--- a/docs/en/test_and_ci/docker.md
+++ b/docs/en/test_and_ci/docker.md
@@ -1,6 +1,6 @@
 # PX4 Docker Containers
 
-Docker containers are provided for the complete [PX4 development toolchain](../dev_setup/dev_env.md#supported-targets) including NuttX and Linux based hardware, [Gazebo Classic](../sim_gazebo_classic/index.md) simulation, and [ROS](../simulation/ros_interface.md).
+Docker containers are provided for the complete [PX4 development toolchain](../dev_setup/dev_env.md#supported-targets) including NuttX and Linux based hardware, [Gazebo](../sim_gazebo_gz/index.md) simulation, and [ROS 2](../ros2/user_guide.md).
 
 This topic shows how to use the [available docker containers](#px4_containers) to access the build environment in a local Linux computer.
 
@@ -41,22 +41,19 @@ The available containers are on [GitHub here](https://github.com/PX4/PX4-contain
 
 These allow testing of various build targets and configurations (the included tools can be inferred from their names).
 The containers are hierarchical, such that containers have the functionality of their parents.
-For example, the partial hierarchy below shows that the docker container with NuttX build tools (`px4-dev-nuttx-focal`) does not include ROS 2, while the simulation containers do:
+For example, the partial hierarchy below shows that the docker container with NuttX build tools (`px4-dev-nuttx-jammy`) does not include ROS 2, while the simulation containers do:
 
 ```plain
-- px4io/px4-dev-base-focal
-  - px4io/px4-dev-nuttx-focal
-  - px4io/px4-dev-simulation-focal
-    - px4io/px4-dev-ros-noetic
-      - px4io/px4-dev-ros2-foxy
-  - px4io/px4-dev-ros2-rolling
 - px4io/px4-dev-base-jammy
   - px4io/px4-dev-nuttx-jammy
+  - px4io/px4-dev-simulation-jammy
+    - px4io/px4-dev-ros2-humble
+  - px4io/px4-dev-ros2-rolling
 ```
 
-The most recent version can be accessed using the `latest` tag: `px4io/px4-dev-nuttx-focal:latest`
+The most recent version can be accessed using the `latest` tag: `px4io/px4-dev-nuttx-jammy:latest`
 (available tags are listed for each container on _hub.docker.com_.
-For example, the `px4io/px4-dev-nuttx-focal` tags can be found on [hub.docker.com here](https://hub.docker.com/r/px4io/px4-dev-nuttx-focal/tags?page=1&ordering=last_updated)).
+For example, the `px4io/px4-dev-nuttx-jammy` tags can be found on [hub.docker.com here](https://hub.docker.com/r/px4io/px4-dev-nuttx-jammy/tags?page=1&ordering=last_updated)).
 
 :::tip
 Typically you should use a recent container, but not necessarily the `latest` (as this changes too often).
@@ -137,7 +134,7 @@ docker run -it --privileged \
 -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
 -e DISPLAY=:0 \
 --network host \
---name=px4-ros px4io/px4-dev-ros2-foxy:2022-07-31 bash
+--name=px4-ros px4io/px4-dev-ros2-humble:latest bash
 ```
 
 ::: info
@@ -155,7 +152,7 @@ Verify if everything works by running, for example, SITL:
 
 ```sh
 cd src/PX4-Autopilot    #This is <container_src>
-make px4_sitl_default gazebo-classic
+make px4_sitl gz_x500
 ```
 
 ### Re-enter the Container
@@ -219,7 +216,7 @@ This ensures that all files created within the container will be accessible on t
 
 #### Graphics Driver Issues
 
-It's possible that running Gazebo Classic will result in a similar error message like the following:
+It's possible that running Gazebo will result in a similar error message like the following:
 
 ```sh
 libGL error: failed to load driver: swrast
@@ -239,7 +236,7 @@ Any recent Linux distribution should work.
 
 The following configuration is tested:
 
-- OS X with VMWare Fusion and Ubuntu 14.04 (Docker container with GUI support on Parallels make the X-Server crash).
+- OS X with VMWare Fusion and Ubuntu 22.04 (Docker container with GUI support on Parallels make the X-Server crash).
 
 **Memory**
 

--- a/docs/en/test_and_ci/docker.md
+++ b/docs/en/test_and_ci/docker.md
@@ -5,8 +5,7 @@ Docker containers are provided for the complete [PX4 development toolchain](../d
 This topic shows how to use the [available docker containers](#px4_containers) to access the build environment in a local Linux computer.
 
 ::: info
-Dockerfiles and README can be found on [Github here](https://github.com/PX4/PX4-containers/tree/master?tab=readme-ov-file#container-hierarchy).
-They are built automatically on [Docker Hub](https://hub.docker.com/u/px4io/).
+The recommended `px4-dev` container is built from the [Dockerfile in the PX4-Autopilot source tree](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/Dockerfile) by the [Container build workflow](https://github.com/PX4/PX4-Autopilot/actions/workflows/dev_container.yml).
 :::
 
 ## Prerequisites
@@ -35,29 +34,35 @@ sudo usermod -aG docker $USER
 # Log in/out again before using docker!
 ```
 
-## Container Hierarchy {#px4_containers}
+## px4-dev Container (Recommended) {#px4_containers}
 
-The available containers are on [GitHub here](https://github.com/PX4/PX4-containers/tree/master?tab=readme-ov-file#container-hierarchy).
+The **`px4-dev`** container is the recommended container for building PX4 firmware.
+It is a single, multi-architecture container (linux/amd64 and linux/arm64) based on Ubuntu 24.04 that includes everything needed to build PX4 for NuttX hardware targets.
 
-These allow testing of various build targets and configurations (the included tools can be inferred from their names).
-The containers are hierarchical, such that containers have the functionality of their parents.
-For example, the partial hierarchy below shows that the docker container with NuttX build tools (`px4-dev-nuttx-jammy`) does not include ROS 2, while the simulation containers do:
+It is published to both registries simultaneously:
 
-```plain
-- px4io/px4-dev-base-jammy
-  - px4io/px4-dev-nuttx-jammy
-  - px4io/px4-dev-simulation-jammy
-    - px4io/px4-dev-ros2-humble
-  - px4io/px4-dev-ros2-rolling
-```
+- **GitHub Container Registry:** [ghcr.io/px4/px4-dev](https://github.com/PX4/PX4-Autopilot/pkgs/container/px4-dev)
+- **Docker Hub:** [px4io/px4-dev](https://hub.docker.com/r/px4io/px4-dev)
 
-The most recent version can be accessed using the `latest` tag: `px4io/px4-dev-nuttx-jammy:latest`
-(available tags are listed for each container on _hub.docker.com_.
-For example, the `px4io/px4-dev-nuttx-jammy` tags can be found on [hub.docker.com here](https://hub.docker.com/r/px4io/px4-dev-nuttx-jammy/tags?page=1&ordering=last_updated)).
+The container includes:
+
+- Ubuntu 24.04 base
+- ARM cross-compiler (`gcc-arm-none-eabi`) and Xtensa compiler (for ESP32 targets)
+- Build tools: `cmake`, `ninja`, `ccache`, `make`
+- Python 3 with PX4 build dependencies
+- NuttX toolchain libraries (`libnewlib-arm-none-eabi`, etc.)
+
+The container is built from the [Dockerfile](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/Dockerfile) in the PX4 source tree using the [Container build workflow](https://github.com/PX4/PX4-Autopilot/actions/workflows/dev_container.yml).
+Images are tagged with the PX4 version (e.g. `px4io/px4-dev:v1.16.0`).
 
 :::tip
-Typically you should use a recent container, but not necessarily the `latest` (as this changes too often).
+A `px4-sim` container with simulation tools (Gazebo Harmonic) is planned to complement `px4-dev` for simulation workflows.
 :::
+
+### Legacy Containers
+
+The older per-distro containers from [PX4/PX4-containers](https://github.com/PX4/PX4-containers) (e.g. `px4-dev-nuttx-jammy`, `px4-dev-ros2-humble`, etc.) are no longer recommended.
+They will be replaced by `px4-dev` (for builds) and the upcoming `px4-sim` (for simulation).
 
 ## Use the Docker Container
 
@@ -118,7 +123,7 @@ Where,
 - `<host_src>`: The host computer directory to be mapped to `<container_src>` in the container. This should normally be the **PX4-Autopilot** directory.
 - `<container_src>`: The location of the shared (source) directory when inside the container.
 - `<local_container_name>`: A name for the docker container being created. This can later be used if we need to reference the container again.
-- `<container>:<tag>`: The container with version tag to start - e.g.: `px4io/px4-dev-ros:2017-10-23`.
+- `<container>:<tag>`: The container with version tag to start - e.g.: `px4io/px4-dev:v1.16.0`.
 - `<build_command>`: The command to invoke on the new container. E.g. `bash` is used to open a bash shell in the container.
 
 The concrete example below shows how to open a bash shell and share the directory **~/src/PX4-Autopilot** on the host computer.
@@ -134,7 +139,7 @@ docker run -it --privileged \
 -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
 -e DISPLAY=:0 \
 --network host \
---name=px4-ros px4io/px4-dev-ros2-humble:latest bash
+--name=px4-dev px4io/px4-dev:v1.16.0 bash
 ```
 
 ::: info


### PR DESCRIPTION
## Summary

- Drop Ubuntu 18.04/20.04 support from `ubuntu.sh` (Gazebo Classic branches removed, only 22.04/24.04 supported)
- Remove outdated Ubuntu 18.04 troubleshooting sections from build docs
- Update Ubuntu dev env docs to clearly state supported LTS versions (24.04 primary, 22.04 secondary)
- Remove Gazebo Classic references across docker, vscode, and centos docs
- Document `px4-dev` as the recommended container (multi-arch, Ubuntu 24.04, dual registry, version-tagged)
- Mark legacy per-distro containers as deprecated, note `px4-sim` is planned
- Add Docker build tip to the building guide

Closes #23963

## Test plan

- [x] Review each commit individually for correctness
- [x] Verify `ubuntu.sh` still works on Ubuntu 24.04 and 22.04
- [x] Verify docs render correctly (links, admonitions, code blocks)
- [x] Medium/low priority doc updates to follow in subsequent commits