### PR TITLE
ci: fix yarn not found in docs metadata-regen container

### DIFF
--- a/.github/workflows/docs-orchestrator.yml
+++ b/.github/workflows/docs-orchestrator.yml
@@ -178,12 +178,11 @@ jobs:
         env:
           CCACHE_DIR: ~/.ccache
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: ./docs/yarn.lock
+      - name: Install Node.js and Yarn
+        run: |
+          curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+          apt-get install -y nodejs
+          corepack enable
 
       - name: Format markdown with Prettier
         run: |


### PR DESCRIPTION
## Summary
- The `metadata-regen` job runs inside the `px4io/px4-dev:v1.17.0-beta1` Docker container, which has no Node.js/yarn
- `actions/setup-node@v4` only installs Node on the host runner, not inside the container, so `yarn` was never available
- Replace `actions/setup-node` with direct Node.js 20 installation via NodeSource + `corepack enable` for yarn

## Test plan
- [x] Verified locally: ran the container, installed Node+corepack, confirmed `yarn install --frozen-lockfile` and `yarn prettier` work against real docs files
- [x] CI should pass the `T2: Metadata Sync` job on push to main

Fixes the failure in https://github.com/PX4/PX4-Autopilot/actions/runs/21924306430/job/63312679514