### PR TITLE
ci: fix deploy-aws skipped due to upstream always() propagation

### DIFF
--- a/.github/workflows/docs-orchestrator.yml
+++ b/.github/workflows/docs-orchestrator.yml
@@ -376,8 +376,12 @@ jobs:
   # =============================================================================
   deploy-aws:
     name: "T4: Deploy"
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs: [metadata-regen, build-site]
+    if: >-
+      always() &&
+      needs.metadata-regen.result == 'success' &&
+      needs.build-site.result == 'success' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     permissions:
       id-token: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `deploy-aws` was being skipped even when `metadata-regen` and `build-site` both succeeded
- Root cause: `build-site` uses `always()` in its `if:` condition to handle skipped upstream jobs (PR-only jobs). This causes GitHub Actions to propagate the "skipped" taint to downstream jobs that don't also use `always()`
- Fix: add `always()` to `deploy-aws` with explicit success checks on both dependencies

## Test plan
- [ ] Merge to main and verify `T4: Deploy` runs after `T2: Metadata Sync` and `T3: Build Site` succeed

Follow-up to #26457