### PR TITLE
SIH Simulator: Add wind

### DIFF
--- a/docs/en/releases/main.md
+++ b/docs/en/releases/main.md
@@ -59,7 +59,7 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 ### Simulation
 
-- TBD
+- SIH: Add option to set wind velocity ([PX4-Autopilot#26467](https://github.com/PX4-Autopilot/pull/26467))
 
 <!-- MOVED THIS TO v1.17
 

--- a/docs/en/sim_sih/index.md
+++ b/docs/en/sim_sih/index.md
@@ -149,6 +149,12 @@ The airplane needs to takeoff in manual mode at full throttle.
 Also, if the airplane crashes the state estimator might lose its fix.
 :::
 
+## Simulation Configuration
+
+### Wind
+
+SIH supports setting a wind velocity with the PX4 parameters [`SIH_WIND_N`](../advanced_config/parameter_reference.md#SIH_WIND_E) and [`SIH_WIND_E`](../advanced_config/parameter_reference.md#SIH_WIND_E) [m/s]. The parameters can also be changed during flight to simulate changing wind.
+
 ## Display/Visualisation (optional)
 
 The SIH-simulated vehicle can be displayed using [jMAVSim](../sim_jmavsim/index.md) as a visualiser.

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -576,7 +576,7 @@ void Sih::ecefToNed()
 
 	// Transform velocity to NED frame
 	_v_N = C_SE * _v_E;
-	_v_N_apparent = _v_N - _v_wind;
+	_v_N_apparent = _v_N + _v_wind;
 
 	_q = Quatf(C_SE) * _q_E;
 	_q.normalize();

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -283,9 +283,7 @@ void Sih::parameters_updated()
 
 	_T_TAU = _sih_thrust_tau.get();
 
-	_v_wind(0) = _sih_wind_n.get();
-	_v_wind(1) = _sih_wind_e.get();
-	_v_wind(2) = 0.0f;
+	_v_wind = Vector3f(_sih_wind_n.get(), _sih_wind_e.get(), 0.f);
 }
 
 void Sih::read_motors(const float dt)
@@ -315,8 +313,8 @@ void Sih::generate_force_and_torques(const float dt)
 				 _L_PITCH * _T_MAX * (+_u[0] - _u[1] + _u[2] - _u[3]),
 				 _Q_MAX * (+_u[0] + _u[1] - _u[2] - _u[3]));
 
-		_Fa_E = -_KDV * _R_N2E * _v_N_apparent;  // first order drag to slow down the aircraft
-		_Ma_B = -_KDW * _w_B;                    // first order angular damper
+		_Fa_E = -_KDV * _R_N2E * _v_N_apparent; // first order drag to slow down the aircraft
+		_Ma_B = -_KDW * _w_B; // first order angular damper
 
 	} else if (_vehicle == VehicleType::Hexacopter) {
 		/*     m5    m0      ┬
@@ -331,8 +329,8 @@ void Sih::generate_force_and_torques(const float dt)
 				 _L_PITCH * _T_MAX * (M_SQRT3_F / 2.f) * (+_u[0] - _u[2] - _u[3] + _u[5]),
 				 _Q_MAX * (+_u[0] - _u[1] + _u[2] - _u[3] + _u[4] - _u[5]));
 
-		_Fa_E = -_KDV * _R_N2E * _v_N_apparent;  // first order drag to slow down the aircraft
-		_Ma_B = -_KDW * _w_B;                    // first order angular damper
+		_Fa_E = -_KDV * _R_N2E * _v_N_apparent; // first order drag to slow down the aircraft
+		_Ma_B = -_KDW * _w_B; // first order angular damper
 
 	} else if (_vehicle == VehicleType::FixedWing) {
 		_T_B = Vector3f(_T_MAX * _u[3], 0.0f, 0.0f); 	// forward thruster
@@ -345,8 +343,8 @@ void Sih::generate_force_and_torques(const float dt)
 		_Mt_B = Vector3f(_L_ROLL * _T_MAX * (_u[1] - _u[0]), 0.0f, _Q_MAX * (_u[1] - _u[0]));
 		generate_ts_aerodynamics();
 
-		// _Fa_E = -_KDV * _R_N2E * _v_N_apparent;  // first order drag to slow down the aircraft
-		// _Ma_B = -_KDW * _w_B;                    // first order angular damper
+		// _Fa_E = -_KDV * _R_N2E * _v_N_apparent; // first order drag to slow down the aircraft
+		// _Ma_B = -_KDW * _w_B; // first order angular damper
 
 	} else if (_vehicle == VehicleType::StandardVTOL) {
 
@@ -368,7 +366,6 @@ void Sih::generate_fw_aerodynamics(const float roll_cmd, const float pitch_cmd, 
 				   const float throttle_cmd)
 {
 	const Vector3f v_B = _q.rotateVectorInverse(_v_N_apparent);
-
 	const float &alt = _lla.altitude();
 
 	_wing_l.update_aero(v_B, _w_B, alt, roll_cmd * FLAP_MAX);
@@ -579,7 +576,6 @@ void Sih::ecefToNed()
 
 	// Transform velocity to NED frame
 	_v_N = C_SE * _v_E;
-
 	_v_N_apparent = _v_N - _v_wind;
 
 	_q = Quatf(C_SE) * _q_E;
@@ -640,8 +636,7 @@ void Sih::send_airspeed(const hrt_abstime &time_now_us)
 	airspeed_s airspeed{};
 	airspeed.timestamp_sample = time_now_us;
 
-	// Assume the pitot tube always points against the wind to not have
-	// tailsitter edge cases
+	// Assume the pitot tube always points against the wind to not have tailsitter edge cases
 	airspeed.true_airspeed_m_s = fmaxf(0.1f, _v_N_apparent.norm() + generate_wgn() * 0.2f);
 	airspeed.indicated_airspeed_m_s = airspeed.true_airspeed_m_s * sqrtf(_wing_l.get_rho() / RHO);
 	airspeed.confidence = 0.7f;

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -283,7 +283,7 @@ void Sih::parameters_updated()
 
 	_T_TAU = _sih_thrust_tau.get();
 
-	_v_wind = Vector3f(_sih_wind_n.get(), _sih_wind_e.get(), 0.f);
+	_v_wind_N = Vector3f(_sih_wind_n.get(), _sih_wind_e.get(), 0.f);
 }
 
 void Sih::read_motors(const float dt)
@@ -313,7 +313,7 @@ void Sih::generate_force_and_torques(const float dt)
 				 _L_PITCH * _T_MAX * (+_u[0] - _u[1] + _u[2] - _u[3]),
 				 _Q_MAX * (+_u[0] + _u[1] - _u[2] - _u[3]));
 
-		_Fa_E = -_KDV * _R_N2E * _v_N_apparent; // first order drag to slow down the aircraft
+		_Fa_E = -_KDV * _R_N2E * _v_apparent_N; // first order drag to slow down the aircraft
 		_Ma_B = -_KDW * _w_B; // first order angular damper
 
 	} else if (_vehicle == VehicleType::Hexacopter) {
@@ -329,7 +329,7 @@ void Sih::generate_force_and_torques(const float dt)
 				 _L_PITCH * _T_MAX * (M_SQRT3_F / 2.f) * (+_u[0] - _u[2] - _u[3] + _u[5]),
 				 _Q_MAX * (+_u[0] - _u[1] + _u[2] - _u[3] + _u[4] - _u[5]));
 
-		_Fa_E = -_KDV * _R_N2E * _v_N_apparent; // first order drag to slow down the aircraft
+		_Fa_E = -_KDV * _R_N2E * _v_apparent_N; // first order drag to slow down the aircraft
 		_Ma_B = -_KDW * _w_B; // first order angular damper
 
 	} else if (_vehicle == VehicleType::FixedWing) {
@@ -343,7 +343,7 @@ void Sih::generate_force_and_torques(const float dt)
 		_Mt_B = Vector3f(_L_ROLL * _T_MAX * (_u[1] - _u[0]), 0.0f, _Q_MAX * (_u[1] - _u[0]));
 		generate_ts_aerodynamics();
 
-		// _Fa_E = -_KDV * _R_N2E * _v_N_apparent; // first order drag to slow down the aircraft
+		// _Fa_E = -_KDV * _R_N2E * _v_apparent_N; // first order drag to slow down the aircraft
 		// _Ma_B = -_KDW * _w_B; // first order angular damper
 
 	} else if (_vehicle == VehicleType::StandardVTOL) {
@@ -365,7 +365,7 @@ void Sih::generate_force_and_torques(const float dt)
 void Sih::generate_fw_aerodynamics(const float roll_cmd, const float pitch_cmd, const float yaw_cmd,
 				   const float throttle_cmd)
 {
-	const Vector3f v_B = _q.rotateVectorInverse(_v_N_apparent);
+	const Vector3f v_B = _q.rotateVectorInverse(_v_apparent_N);
 	const float &alt = _lla.altitude();
 
 	_wing_l.update_aero(v_B, _w_B, alt, roll_cmd * FLAP_MAX);
@@ -387,7 +387,7 @@ void Sih::generate_fw_aerodynamics(const float roll_cmd, const float pitch_cmd, 
 void Sih::generate_ts_aerodynamics()
 {
 	// velocity in body frame [m/s]
-	const Vector3f v_B = _q.rotateVectorInverse(_v_N_apparent);
+	const Vector3f v_B = _q.rotateVectorInverse(_v_apparent_N);
 
 	// the aerodynamic is resolved in a frame like a standard aircraft (nose-right-belly)
 	Vector3f v_ts = _R_S2B.transpose() * v_B;
@@ -576,7 +576,7 @@ void Sih::ecefToNed()
 
 	// Transform velocity to NED frame
 	_v_N = C_SE * _v_E;
-	_v_N_apparent = _v_N + _v_wind;
+	_v_apparent_N = _v_N + _v_wind_N;
 
 	_q = Quatf(C_SE) * _q_E;
 	_q.normalize();
@@ -637,7 +637,7 @@ void Sih::send_airspeed(const hrt_abstime &time_now_us)
 	airspeed.timestamp_sample = time_now_us;
 
 	// Assume the pitot tube always points against the wind to not have tailsitter edge cases
-	airspeed.true_airspeed_m_s = fmaxf(0.1f, _v_N_apparent.norm() + generate_wgn() * 0.2f);
+	airspeed.true_airspeed_m_s = fmaxf(0.1f, _v_apparent_N.norm() + generate_wgn() * 0.2f);
 	airspeed.indicated_airspeed_m_s = airspeed.true_airspeed_m_s * sqrtf(_wing_l.get_rho() / RHO);
 	airspeed.confidence = 0.7f;
 	airspeed.timestamp = hrt_absolute_time();

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -282,6 +282,10 @@ void Sih::parameters_updated()
 	_distance_snsr_override = _sih_distance_snsr_override.get();
 
 	_T_TAU = _sih_thrust_tau.get();
+
+	_v_wind(0) = _sih_wind_n.get();
+	_v_wind(1) = _sih_wind_e.get();
+	_v_wind(2) = 0.0f;
 }
 
 void Sih::read_motors(const float dt)
@@ -363,6 +367,7 @@ void Sih::generate_fw_aerodynamics(const float roll_cmd, const float pitch_cmd, 
 				   const float throttle_cmd)
 {
 	const Vector3f v_B = _q.rotateVectorInverse(_v_N);
+
 	const float &alt = _lla.altitude();
 
 	_wing_l.update_aero(v_B, _w_B, alt, roll_cmd * FLAP_MAX);
@@ -573,6 +578,9 @@ void Sih::ecefToNed()
 
 	// Transform velocity to NED frame
 	_v_N = C_SE * _v_E;
+
+	_v_N_apparent = _v_N - _v_wind;
+
 	_q = Quatf(C_SE) * _q_E;
 	_q.normalize();
 }

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -310,8 +310,9 @@ void Sih::generate_force_and_torques(const float dt)
 		_Mt_B = Vector3f(_L_ROLL * _T_MAX * (-_u[0] + _u[1] + _u[2] - _u[3]),
 				 _L_PITCH * _T_MAX * (+_u[0] - _u[1] + _u[2] - _u[3]),
 				 _Q_MAX * (+_u[0] + _u[1] - _u[2] - _u[3]));
-		_Fa_E = -_KDV * _v_E;   // first order drag to slow down the aircraft
-		_Ma_B = -_KDW * _w_B;   // first order angular damper
+
+		_Fa_E = -_KDV * _R_N2E * _v_N;  // first order drag to slow down the aircraft
+		_Ma_B = -_KDW * _w_B;           // first order angular damper
 
 	} else if (_vehicle == VehicleType::Hexacopter) {
 		/*     m5    m0      ┬
@@ -325,8 +326,8 @@ void Sih::generate_force_and_torques(const float dt)
 		_Mt_B = Vector3f(_L_ROLL * _T_MAX * (-.5f * _u[0] - _u[1] - .5f * _u[2] + .5f * _u[3] + _u[4] + .5f * _u[5]),
 				 _L_PITCH * _T_MAX * (M_SQRT3_F / 2.f) * (+_u[0] - _u[2] - _u[3] + _u[5]),
 				 _Q_MAX * (+_u[0] - _u[1] + _u[2] - _u[3] + _u[4] - _u[5]));
-		_Fa_E = -_KDV * _v_E; // first order drag to slow down the aircraft
-		_Ma_B = -_KDW * _w_B; // first order angular damper
+		_Fa_E = -_KDV * _R_N2E * _v_N;  // first order drag to slow down the aircraft
+		_Ma_B = -_KDW * _w_B;           // first order angular damper
 
 	} else if (_vehicle == VehicleType::FixedWing) {
 		_T_B = Vector3f(_T_MAX * _u[3], 0.0f, 0.0f); 	// forward thruster
@@ -339,8 +340,8 @@ void Sih::generate_force_and_torques(const float dt)
 		_Mt_B = Vector3f(_L_ROLL * _T_MAX * (_u[1] - _u[0]), 0.0f, _Q_MAX * (_u[1] - _u[0]));
 		generate_ts_aerodynamics();
 
-		// _Fa_E = -_KDV * _v_E;   // first order drag to slow down the aircraft
-		// _Ma_B = -_KDW * _w_B;   // first order angular damper
+		// _Fa_E = -_KDV * _R_N2E * _v_N;  // first order drag to slow down the aircraft
+		// _Ma_B = -_KDW * _w_B;           // first order angular damper
 
 	} else if (_vehicle == VehicleType::StandardVTOL) {
 
@@ -361,7 +362,7 @@ void Sih::generate_force_and_torques(const float dt)
 void Sih::generate_fw_aerodynamics(const float roll_cmd, const float pitch_cmd, const float yaw_cmd,
 				   const float throttle_cmd)
 {
-	const Vector3f v_B = _q_E.rotateVectorInverse(_v_E);
+	const Vector3f v_B = _q.rotateVectorInverse(_v_N);
 	const float &alt = _lla.altitude();
 
 	_wing_l.update_aero(v_B, _w_B, alt, roll_cmd * FLAP_MAX);
@@ -383,7 +384,7 @@ void Sih::generate_fw_aerodynamics(const float roll_cmd, const float pitch_cmd, 
 void Sih::generate_ts_aerodynamics()
 {
 	// velocity in body frame [m/s]
-	const Vector3f v_B = _q_E.rotateVectorInverse(_v_E);
+	const Vector3f v_B = _q.rotateVectorInverse(_v_N);
 
 	// the aerodynamic is resolved in a frame like a standard aircraft (nose-right-belly)
 	Vector3f v_ts = _R_S2B.transpose() * v_B;

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -315,8 +315,8 @@ void Sih::generate_force_and_torques(const float dt)
 				 _L_PITCH * _T_MAX * (+_u[0] - _u[1] + _u[2] - _u[3]),
 				 _Q_MAX * (+_u[0] + _u[1] - _u[2] - _u[3]));
 
-		_Fa_E = -_KDV * _R_N2E * _v_N;  // first order drag to slow down the aircraft
-		_Ma_B = -_KDW * _w_B;           // first order angular damper
+		_Fa_E = -_KDV * _R_N2E * _v_N_apparent;  // first order drag to slow down the aircraft
+		_Ma_B = -_KDW * _w_B;                    // first order angular damper
 
 	} else if (_vehicle == VehicleType::Hexacopter) {
 		/*     m5    m0      ┬
@@ -330,8 +330,9 @@ void Sih::generate_force_and_torques(const float dt)
 		_Mt_B = Vector3f(_L_ROLL * _T_MAX * (-.5f * _u[0] - _u[1] - .5f * _u[2] + .5f * _u[3] + _u[4] + .5f * _u[5]),
 				 _L_PITCH * _T_MAX * (M_SQRT3_F / 2.f) * (+_u[0] - _u[2] - _u[3] + _u[5]),
 				 _Q_MAX * (+_u[0] - _u[1] + _u[2] - _u[3] + _u[4] - _u[5]));
-		_Fa_E = -_KDV * _R_N2E * _v_N;  // first order drag to slow down the aircraft
-		_Ma_B = -_KDW * _w_B;           // first order angular damper
+
+		_Fa_E = -_KDV * _R_N2E * _v_N_apparent;  // first order drag to slow down the aircraft
+		_Ma_B = -_KDW * _w_B;                    // first order angular damper
 
 	} else if (_vehicle == VehicleType::FixedWing) {
 		_T_B = Vector3f(_T_MAX * _u[3], 0.0f, 0.0f); 	// forward thruster
@@ -344,8 +345,8 @@ void Sih::generate_force_and_torques(const float dt)
 		_Mt_B = Vector3f(_L_ROLL * _T_MAX * (_u[1] - _u[0]), 0.0f, _Q_MAX * (_u[1] - _u[0]));
 		generate_ts_aerodynamics();
 
-		// _Fa_E = -_KDV * _R_N2E * _v_N;  // first order drag to slow down the aircraft
-		// _Ma_B = -_KDW * _w_B;           // first order angular damper
+		// _Fa_E = -_KDV * _R_N2E * _v_N_apparent;  // first order drag to slow down the aircraft
+		// _Ma_B = -_KDW * _w_B;                    // first order angular damper
 
 	} else if (_vehicle == VehicleType::StandardVTOL) {
 
@@ -366,7 +367,7 @@ void Sih::generate_force_and_torques(const float dt)
 void Sih::generate_fw_aerodynamics(const float roll_cmd, const float pitch_cmd, const float yaw_cmd,
 				   const float throttle_cmd)
 {
-	const Vector3f v_B = _q.rotateVectorInverse(_v_N);
+	const Vector3f v_B = _q.rotateVectorInverse(_v_N_apparent);
 
 	const float &alt = _lla.altitude();
 
@@ -389,7 +390,7 @@ void Sih::generate_fw_aerodynamics(const float roll_cmd, const float pitch_cmd, 
 void Sih::generate_ts_aerodynamics()
 {
 	// velocity in body frame [m/s]
-	const Vector3f v_B = _q.rotateVectorInverse(_v_N);
+	const Vector3f v_B = _q.rotateVectorInverse(_v_N_apparent);
 
 	// the aerodynamic is resolved in a frame like a standard aircraft (nose-right-belly)
 	Vector3f v_ts = _R_S2B.transpose() * v_B;
@@ -639,8 +640,9 @@ void Sih::send_airspeed(const hrt_abstime &time_now_us)
 	airspeed_s airspeed{};
 	airspeed.timestamp_sample = time_now_us;
 
-	// regardless of vehicle type, body frame, etc this holds as long as wind=0
-	airspeed.true_airspeed_m_s = fmaxf(0.1f, _v_E.norm() + generate_wgn() * 0.2f);
+	// Assume the pitot tube always points against the wind to not have
+	// tailsitter edge cases
+	airspeed.true_airspeed_m_s = fmaxf(0.1f, _v_N_apparent.norm() + generate_wgn() * 0.2f);
 	airspeed.indicated_airspeed_m_s = airspeed.true_airspeed_m_s * sqrtf(_wing_l.get_rho() / RHO);
 	airspeed.confidence = 0.7f;
 	airspeed.timestamp = hrt_absolute_time();

--- a/src/modules/simulation/simulator_sih/sih.hpp
+++ b/src/modules/simulation/simulator_sih/sih.hpp
@@ -211,8 +211,8 @@ private:
 	matrix::Quatf       _q{};             // quaternion attitude in local navigation frame
 	matrix::Vector3f    _w_B{};           // body rates in body frame [rad/s]
 
-	matrix::Vector3f    _v_wind{};        // velocity of the wind in local navigation frame [m/s]
-	matrix::Vector3f    _v_N_apparent{};  // velocity in local frame relative to the air, for aerodynamic calculations [m/s]
+	matrix::Vector3f _v_wind{}; // velocity of the wind in local navigation frame [m/s]
+	matrix::Vector3f _v_N_apparent{}; // velocity in local frame relative to the air, for aerodynamic calculations [m/s]
 
 	LatLonAlt _lla{};
 

--- a/src/modules/simulation/simulator_sih/sih.hpp
+++ b/src/modules/simulation/simulator_sih/sih.hpp
@@ -200,30 +200,34 @@ private:
 	hrt_abstime _airspeed_time{0};
 	hrt_abstime _dist_snsr_time{0};
 
-	bool        _grounded{true};// whether the vehicle is on the ground
+	bool _grounded{true}; // whether the vehicle is on the ground
 
-	matrix::Vector3f    _T_B{};           // thrust force in body frame [N]
-	matrix::Vector3f    _Mt_B{};          // thruster moments in the body frame [Nm]
-	matrix::Vector3f    _Ma_B{};          // aerodynamic moments in the body frame [Nm]
-	matrix::Vector3f    _lpos{};          // position in a local tangent-plane frame [m]
-	matrix::Vector3f    _v_N{};           // velocity in local navigation frame (NED, body-fixed) [m/s]
-	matrix::Vector3f    _v_N_dot{};       // time derivative of velocity in local navigation frame [m/s2]
-	matrix::Quatf       _q{};             // quaternion attitude in local navigation frame
-	matrix::Vector3f    _w_B{};           // body rates in body frame [rad/s]
+	// Quantities in body frame (FRD)
+	matrix::Vector3f _T_B{};  // thrust force [N]
+	matrix::Vector3f _Mt_B{}; // thruster moments [Nm]
+	matrix::Vector3f _Ma_B{}; // aerodynamic moments [Nm]
+	matrix::Vector3f _w_B{};  // body rates in body frame [rad/s]
 
-	matrix::Vector3f _v_wind{}; // velocity of the wind in local navigation frame [m/s]
-	matrix::Vector3f _v_N_apparent{}; // velocity in local frame relative to the air, for aerodynamic calculations [m/s]
-
-	LatLonAlt _lla{};
+	// Quantities in local navigation frame (NED, body-fixed)
+	matrix::Vector3f _v_N{};          // velocity [m/s]
+	matrix::Vector3f _v_N_dot{};      // time derivative of velocity [m/s^2]
+	matrix::Vector3f _v_wind{};       // wind velocity [m/s]
+	matrix::Vector3f _v_N_apparent{}; // vehicle velocity relative to the air [m/s]
 
 	// Quantities in Earth-centered-Earth-fixed coordinates
-	matrix::Vector3f    _Fa_E{};          // aerodynamic force in ECEF frame [N]
-	matrix::Vector3f    _specific_force_E{};
-	matrix::Quatf       _q_E{matrix::Eulerf(0.f, -M_PI_2_F, 0.f)};
-	matrix::Vector3d    _p_E{Wgs84::equatorial_radius, 0.0, 0.0};
-	matrix::Vector3f    _v_E{};
-	matrix::Vector3f    _v_E_dot{};
-	matrix::Dcmf        _R_N2E;           // local navigation to ECEF frame rotation matrix
+	matrix::Vector3f _Fa_E{};             // aerodynamic force [N]
+	matrix::Vector3d _p_E{};              // position [m]
+	matrix::Vector3f _v_E{};              // velocity [m/s]
+	matrix::Vector3f _v_E_dot{};          // time derivative of velocity [m/s^2]
+	matrix::Vector3f _specific_force_E{}; // acceleration except gravity (for IMU) [m/s^2]
+
+	// Frame conversion
+	matrix::Quatf _q_E{}; // Attitude quaternion (rotation from body to ECEF frame)
+	matrix::Quatf _q{};   // Attitude quaternion (rotation from body to local navigation frame)
+	matrix::Dcmf _R_N2E;  // Rotation matrix from local navigation to ECEF frame
+
+	LatLonAlt _lla{};
+	matrix::Vector3f _lpos{};  // position in a local tangent-plane frame [m]
 
 	float _u[NUM_ACTUATORS_MAX] {}; // thruster signals
 

--- a/src/modules/simulation/simulator_sih/sih.hpp
+++ b/src/modules/simulation/simulator_sih/sih.hpp
@@ -211,6 +211,9 @@ private:
 	matrix::Quatf       _q{};             // quaternion attitude in local navigation frame
 	matrix::Vector3f    _w_B{};           // body rates in body frame [rad/s]
 
+	matrix::Vector3f    _v_wind{};        // velocity of the wind in local navigation frame [m/s]
+	matrix::Vector3f    _v_N_apparent{};  // velocity in local frame relative to the air, for aerodynamic calculations [m/s]
+
 	LatLonAlt _lla{};
 
 	// Quantities in Earth-centered-Earth-fixed coordinates
@@ -292,6 +295,8 @@ private:
 		(ParamFloat<px4::params::SIH_DISTSNSR_MAX>) _sih_distance_snsr_max,
 		(ParamFloat<px4::params::SIH_DISTSNSR_OVR>) _sih_distance_snsr_override,
 		(ParamFloat<px4::params::SIH_T_TAU>) _sih_thrust_tau,
-		(ParamInt<px4::params::SIH_VEHICLE_TYPE>) _sih_vtype
+		(ParamInt<px4::params::SIH_VEHICLE_TYPE>) _sih_vtype,
+		(ParamFloat<px4::params::SIH_WIND_N>) _sih_wind_n,
+		(ParamFloat<px4::params::SIH_WIND_E>) _sih_wind_e
 	)
 };

--- a/src/modules/simulation/simulator_sih/sih.hpp
+++ b/src/modules/simulation/simulator_sih/sih.hpp
@@ -211,8 +211,8 @@ private:
 	// Quantities in local navigation frame (NED, body-fixed)
 	matrix::Vector3f _v_N{};          // velocity [m/s]
 	matrix::Vector3f _v_N_dot{};      // time derivative of velocity [m/s^2]
-	matrix::Vector3f _v_wind{};       // wind velocity [m/s]
-	matrix::Vector3f _v_N_apparent{}; // vehicle velocity relative to the air [m/s]
+	matrix::Vector3f _v_wind_N{};     // wind velocity [m/s]
+	matrix::Vector3f _v_apparent_N{}; // vehicle velocity relative to the air [m/s]
 
 	// Quantities in Earth-centered-Earth-fixed coordinates
 	matrix::Vector3f _Fa_E{};             // aerodynamic force [N]

--- a/src/modules/simulation/simulator_sih/sih_params.c
+++ b/src/modules/simulation/simulator_sih/sih_params.c
@@ -339,3 +339,20 @@ PARAM_DEFINE_FLOAT(SIH_T_TAU, 0.05f);
  * @group Simulation In Hardware
  */
 PARAM_DEFINE_INT32(SIH_VEHICLE_TYPE, 0);
+
+
+/**
+ * Wind velocity in north direction.
+ *
+ * @unit m/s
+ * @group Simulation In Hardware
+ */
+PARAM_DEFINE_FLOAT(SIH_WIND_N, 0.0f);
+
+/**
+ * Wind velocity in east direction.
+ *
+ * @unit m/s
+ * @group Simulation In Hardware
+ */
+PARAM_DEFINE_FLOAT(SIH_WIND_E, 0.0f);

--- a/src/modules/simulation/simulator_sih/sih_params.c
+++ b/src/modules/simulation/simulator_sih/sih_params.c
@@ -340,7 +340,6 @@ PARAM_DEFINE_FLOAT(SIH_T_TAU, 0.05f);
  */
 PARAM_DEFINE_INT32(SIH_VEHICLE_TYPE, 0);
 
-
 /**
  * Wind velocity in north direction.
  *

--- a/src/modules/simulation/simulator_sih/sih_params.c
+++ b/src/modules/simulation/simulator_sih/sih_params.c
@@ -341,7 +341,7 @@ PARAM_DEFINE_FLOAT(SIH_T_TAU, 0.05f);
 PARAM_DEFINE_INT32(SIH_VEHICLE_TYPE, 0);
 
 /**
- * Wind velocity in north direction.
+ * Wind velocity from north direction.
  *
  * @unit m/s
  * @group Simulation In Hardware
@@ -349,7 +349,7 @@ PARAM_DEFINE_INT32(SIH_VEHICLE_TYPE, 0);
 PARAM_DEFINE_FLOAT(SIH_WIND_N, 0.0f);
 
 /**
- * Wind velocity in east direction.
+ * Wind velocity from east direction.
  *
  * @unit m/s
  * @group Simulation In Hardware


### PR DESCRIPTION
### Solved Problem

Because wind is still [not supported in gazebo](https://github.com/PX4/PX4-Autopilot/issues/23602), and gazebo classic only supports Ubuntu <= 22, it is currently impossible to sanity check wind-related features and fixes in sim with Ubuntu > 22.

### Solution

Add it to SIH. We set the wind in (edit, FROM not in) north and east direction with parameters `SIH_WIND_N`/`SIH_WIND_E`, and replace all velocities entering aerodynamic calculations with apparent velocities (velocity relative to air). 

For the moment purely deterministic, if noise is wanted we can add it later. 

The resulting global wind field is impossible - it has nonzero divergence if there is a nonzero north-south component (infinite even at the poles). I think it's an acceptable limitation for SIH.

### Changelog Entry
```
SIH Simulator: Add wind set by parameters SIH_WIND_N, SIH_WIND_E
```


### Test coverage

1. flying `sihsim_standard_vtol` in hold mode, change the wind and watch the estimator pick it up. 

<img width="1587" height="1166" alt="image" src="https://github.com/user-attachments/assets/ee09608c-06fd-4ece-b422-9dc830c7e804" />

 Parameter changes:

```
414.260: SIH_WIND_N changed to 1.0
509.204: SIH_WIND_E changed to 2.0
683.828: SIH_WIND_E changed to -3.0
686.160: SIH_WIND_N changed to -3.0
```

2. flying `sihsim_quadx` in altitude mode, no input, change wind and watch the vehicle get pushed around 
<img width="652" height="588" alt="image" src="https://github.com/user-attachments/assets/232ff71f-ed29-4aa1-90a8-c4539147d68c" />



Parameter changes:
```
70.632: SIH_WIND_N changed to 3.0
90.696: SIH_WIND_N changed to 30.0
101.044: SIH_WIND_N changed to -30.0
110.152: SIH_WIND_N changed to -0.0
116.332: SIH_WIND_E changed to 10.0
128.996: SIH_WIND_E changed to 0.0
```