### PR TITLE
manifest: reserve ID for Skynode-N

### DIFF
--- a/platforms/common/pab_manifest.c
+++ b/platforms/common/pab_manifest.c
@@ -402,6 +402,52 @@ static const px4_hw_mft_item_t base_configuration_18[] = {
 	},
 };
 
+// BASE ID 19  Auterion Skynode N
+static const px4_hw_mft_item_t base_configuration_19[] = {
+	{
+		.id          = PX4_MFT_PX4IO,
+		.present     = 0,
+		.mandatory   = 0,
+		.connection  = px4_hw_con_unknown,
+	},
+	{
+		.id          = PX4_MFT_USB,
+		.present     = 0,
+		.mandatory   = 0,
+		.connection  = px4_hw_con_unknown,
+	},
+	{
+		.id          = PX4_MFT_CAN2,
+		.present     = 1,
+		.mandatory   = 1,
+		.connection  = px4_hw_con_onboard,
+	},
+	{
+		.id          = PX4_MFT_CAN3,
+		.present     = 0,
+		.mandatory   = 0,
+		.connection  = px4_hw_con_unknown,
+	},
+	{
+		.id          = PX4_MFT_PM2,
+		.present     = 0,
+		.mandatory   = 0,
+		.connection  = px4_hw_con_unknown,
+	},
+	{
+		.id          = PX4_MFT_ETHERNET,
+		.present     = 1,
+		.mandatory   = 1,
+		.connection  = px4_hw_con_onboard,
+	},
+	{
+		.id          = PX4_MFT_T100_ETH,
+		.present     = 1,
+		.mandatory   = 1,
+		.connection  = px4_hw_con_onboard,
+	},
+};
+
 // BASE ID 0x100 Holybro Pixhawk Jetson Baseboard Alaised to ID 0
 // BASE ID 0x150 ZeroOne Pixhawk Baseboard Alaised to ID 0
 // BASE ID 0x200 AmovLab Pixhawk Baseboard Alaised to ID 0
@@ -419,6 +465,7 @@ static px4_hw_mft_list_entry_t mft_lists[] = {
 	{HW_BASE_ID(16),     base_configuration_0, arraySize(base_configuration_0)},   // Auterion Skynode ver 16
 	{HW_BASE_ID(17),     base_configuration_17, arraySize(base_configuration_17)}, // Auterion Skynode ver 17
 	{HW_BASE_ID(18),     base_configuration_18, arraySize(base_configuration_18)}, // Auterion Skynode S ver 18
+	{HW_BASE_ID(19),     base_configuration_19, arraySize(base_configuration_19)}, // Auterion Skynode N
 	{HW_BASE_ID(0x100),  base_configuration_0, arraySize(base_configuration_0)},   // Holybro Pixhawk Jetson Baseboard ver 0x100 Alaised to ID 0
 	{HW_BASE_ID(0x150),  base_configuration_0, arraySize(base_configuration_0)},   // ZeroOne Pixhawk Baseboard ver 0x150
 	{HW_BASE_ID(0x200),  base_configuration_0, arraySize(base_configuration_0)},   // AmovLab Pixhawk Baseboard ver 0x150


### PR DESCRIPTION
### Solved Problem
- We are working on a new Auterion product and want to avoid duplication of IDs during parallel development that others maybe currently do

### Solution
- Reserve ID: 0x13

