### PR TITLE
uavcan esc: initializers cosmetics

### DIFF
--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -89,7 +89,7 @@ UavcanEscController::update_outputs(uint16_t outputs[MAX_ACTUATORS], uint8_t out
 
 	_prev_cmd_pub = timestamp;
 
-	uavcan::equipment::esc::RawCommand msg = {};
+	uavcan::equipment::esc::RawCommand msg{};
 
 	for (unsigned i = 0; i < output_array_size; i++) {
 		msg.cmd.push_back(static_cast<int>(outputs[i]));

--- a/src/drivers/uavcan/actuators/esc.hpp
+++ b/src/drivers/uavcan/actuators/esc.hpp
@@ -97,7 +97,7 @@ private:
 	typedef uavcan::MethodBinder<UavcanEscController *,
 		void (UavcanEscController::*)(const uavcan::TimerEvent &)> TimerCbBinder;
 
-	bool _initialized{};
+	bool _initialized = false;
 
 	esc_status_s	_esc_status{};
 


### PR DESCRIPTION
### Solved Problem
I admit it's cosmetics but in my eyes this improves readability.

### Solution
- Use explicit assignment initializers for primitive types.
- Use directly appended empty initializers for zero initialization of larger structs.