### PR TITLE
[Bug] Fix TECS throttle integrator runaway

### DIFF
--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -590,7 +590,9 @@ void TECSControl::_calcThrottleControlUpdate(float dt, const STERateLimit &limit
 			if (_throttle_setpoint >= param.throttle_max) {
 				throttle_integ_input = math::min(0.f, throttle_integ_input);
 
-			} else if (_throttle_setpoint <= param.throttle_min) {
+			}
+
+			if (_throttle_setpoint <= param.throttle_min) {
 				throttle_integ_input = math::max(0.f, throttle_integ_input);
 			}
 


### PR DESCRIPTION
### Solved Problem
In case your throttle has very small authority (or for gliding, throttle is disabled), the throttle integrator can run away.

For example, in the following conditions the integrator will run away:
- if `params.max_throttle` is zero, and the `throttle_setpoint_` is zero, it will not reset the `throttle_integ_state_` if it is negative.

This results in the integrator running away during flight.

https://github.com/PX4/PX4-Autopilot/blob/f518f87d0f843d765ccaa6e2f8ece20fa45170fa/src/lib/tecs/TECS.cpp#L589-L595

The huge integrator build up resulted in the throttle not being recovered.

### Solution
Fix the throttle integrator reset condition by removing the else condition.

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context

