### PR TITLE
CI: replace all usage of addnab/docker-run-action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,6 +19,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    container:
+      image: px4io/px4-dev:v1.16.0-rc1-258-g0369abd556
+
     strategy:
       fail-fast: false
       matrix:
@@ -35,20 +39,17 @@ jobs:
           "px4_sitl_allyes",
           "module_documentation",
         ]
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Building [${{ matrix.check }}]
-        uses: addnab/docker-run-action@v3
-        with:
-          image: px4io/px4-dev:v1.16.0-rc1-258-g0369abd556
-          options: -v ${{ github.workspace }}:/workspace
-          run: |
-            cd /workspace
-            git config --global --add safe.directory /workspace
-            make ${{ matrix.check }}
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          make ${{ matrix.check }}
 
       - name: Uploading Coverage to Codecov.io
         if: contains(matrix.check, 'coverage')

--- a/.github/workflows/ekf_functional_change_indicator.yml
+++ b/.github/workflows/ekf_functional_change_indicator.yml
@@ -15,21 +15,21 @@ concurrency:
 jobs:
   unit_tests:
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
-    - name: main test
-      uses: addnab/docker-run-action@v3
-      with:
-        image: px4io/px4-dev:v1.16.0-rc1-258-g0369abd556
-        options: -v ${{ github.workspace }}:/workspace
+    container:
+      image: px4io/px4-dev:v1.16.0-rc1-258-g0369abd556
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: main test
         run: |
-          cd /workspace
-          git config --global --add safe.directory /workspace
+          cd "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           make tests TESTFILTER=EKF
 
-    - name: Check if there is a functional change
-      run: git diff --exit-code
-      working-directory: src/modules/ekf2/test/change_indication
+      - name: Check if there is a functional change
+        run: git diff --exit-code
+        working-directory: src/modules/ekf2/test/change_indication

--- a/.github/workflows/ekf_update_change_indicator.yml
+++ b/.github/workflows/ekf_update_change_indicator.yml
@@ -8,40 +8,47 @@ on:
 jobs:
   unit_tests:
     runs-on: ubuntu-latest
+
+    container:
+      image: px4io/px4-dev:v1.16.0-rc1-258-g0369abd556
+
     env:
       GIT_COMMITTER_EMAIL: bot@px4.io
       GIT_COMMITTER_NAME: PX4BuildBot
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
-    - name: main test
-      uses: addnab/docker-run-action@v3
-      with:
-        image: px4io/px4-dev:v1.16.0-rc1-258-g0369abd556
-        options: -v ${{ github.workspace }}:/workspace
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: main test
         run: |
-          cd /workspace
-          git config --global --add safe.directory /workspace
+          cd "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           make tests TESTFILTER=EKF
 
-    - name: Check if there exists diff and save result in variable
-      id: diff-check
-      run: echo "CHANGE_INDICATED=$(git diff --exit-code --output=/dev/null || echo $?)" >> $GITHUB_OUTPUT
-      working-directory: src/modules/ekf2/test/change_indication
+      - name: Check if there exists diff and save result in variable
+        id: diff-check
+        working-directory: src/modules/ekf2/test/change_indication
+        run: |
+          if git diff --quiet; then
+            echo "CHANGE_INDICATED=false" >> $GITHUB_OUTPUT
+          else
+            echo "CHANGE_INDICATED=true" >> $GITHUB_OUTPUT
+          fi
 
-    - name: auto-commit any changes to change indication
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        file_pattern: 'src/modules/ekf2/test/change_indication/*.csv'
-        commit_user_name: ${GIT_COMMITTER_NAME}
-        commit_user_email: ${GIT_COMMITTER_EMAIL}
-        commit_message: |
-          '[AUTO COMMIT] update change indication'
+      - name: auto-commit any changes to change indication
+        if: steps.diff-check.outputs.CHANGE_INDICATED == 'true'
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          file_pattern: 'src/modules/ekf2/test/change_indication/*.csv'
+          commit_user_name: ${{ env.GIT_COMMITTER_NAME }}
+          commit_user_email: ${{ env.GIT_COMMITTER_EMAIL }}
+          commit_message: |
+            [AUTO COMMIT] update change indication
 
-          See .github/workflopws/ekf_update_change_indicator.yml for more details
+            See .github/workflows/ekf_update_change_indicator.yml for more details
 
-    - name: if there is a functional change, fail check
-      if: ${{ steps.diff-check.outputs.CHANGE_INDICATED }}
-      run: exit 1
+      - name: if there is a functional change, fail check
+        if: steps.diff-check.outputs.CHANGE_INDICATED == 'true'
+        run: exit 1

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -19,25 +19,27 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
-      matrix:
-        config:
-          - {vehicle: "iris",          mission: "MC_mission_box"}
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Build SITL and Run Tests
-      uses: addnab/docker-run-action@v3
-      with:
-        image: px4io/px4-dev-ros-melodic:2021-09-08
-        options: -v ${{ github.workspace }}:/workspace
+      - name: Build SITL and Run Tests (inside old ROS container)
         run: |
-          cd /workspace
-          git config --global --add safe.directory /workspace
-          make px4_sitl_default
-          make px4_sitl_default sitl_gazebo-classic
-          ./test/rostest_px4_run.sh mavros_posix_test_mission.test mission:=${{matrix.config.mission}} vehicle:=${{matrix.config.vehicle}}
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -w /workspace \
+            px4io/px4-dev-ros-melodic:2021-09-08 \
+            bash -c '
+              git config --global --add safe.directory /workspace
+              make px4_sitl_default
+              make px4_sitl_default sitl_gazebo-classic
+              ./test/rostest_px4_run.sh \
+                mavros_posix_test_mission.test \
+                mission:=MC_mission_box \
+                vehicle:=iris
+            '

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -19,27 +19,26 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     strategy:
       fail-fast: false
-      matrix:
-        config:
-          - {test_file: "mavros_posix_tests_offboard_posctl.test",    vehicle: "iris"}
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Build PX4 and Run Tests
-      uses: addnab/docker-run-action@v3
-      with:
-        image: px4io/px4-dev-ros-melodic:2021-09-08
-        options: -v ${{ github.workspace }}:/workspace
+      - name: Build SITL and Run Tests (inside old ROS container)
         run: |
-          cd /workspace
-          git config --global --add safe.directory /workspace
-          make px4_sitl_default
-          make px4_sitl_default sitl_gazebo-classic
-          ./test/rostest_px4_run.sh ${{matrix.config.test_file}} vehicle:=${{matrix.config.vehicle}}
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -w /workspace \
+            px4io/px4-dev-ros-melodic:2021-09-08 \
+            bash -c '
+              git config --global --add safe.directory /workspace
+              make px4_sitl_default
+              make px4_sitl_default sitl_gazebo-classic
+              ./test/rostest_px4_run.sh \
+                mavros_posix_tests_offboard_posctl.test \
+                vehicle:=iris
+            '

--- a/.github/workflows/nuttx_env_config.yml
+++ b/.github/workflows/nuttx_env_config.yml
@@ -19,27 +19,28 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    container:
+      image: px4io/px4-dev:v1.16.0-rc1-258-g0369abd556
+
     strategy:
       matrix:
-        config: [
-          px4_fmu-v5_default,
-          ]
+        config:
+          - px4_fmu-v5_default
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Build PX4 and Run Test [${{ matrix.config }}]
-      uses: addnab/docker-run-action@v3
-      with:
-        image: px4io/px4-dev:v1.16.0-rc1-258-g0369abd556
-        options: -v ${{ github.workspace }}:/workspace
+      - name: Build PX4 and Run Test [${{ matrix.config }}]
         run: |
-          cd /workspace
-          git config --global --add safe.directory /workspace
-          export PX4_EXTRA_NUTTX_CONFIG="CONFIG_NSH_LOGIN_PASSWORD=\"test\";CONFIG_NSH_CONSOLE_LOGIN=y"
+          cd "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          export PX4_EXTRA_NUTTX_CONFIG='CONFIG_NSH_LOGIN_PASSWORD="test";CONFIG_NSH_CONSOLE_LOGIN=y'
           echo "PX4_EXTRA_NUTTX_CONFIG: $PX4_EXTRA_NUTTX_CONFIG"
+
           make ${{ matrix.config }} nuttx_context
+
           echo "Check that the config option is set"
           grep CONFIG_NSH_LOGIN_PASSWORD build/${{ matrix.config }}/NuttX/nuttx/.config


### PR DESCRIPTION
### Solved Problem

Since yesterday evening all prs fail most of the checks:
<img width="899" height="376" alt="image" src="https://github.com/user-attachments/assets/2bdf1ed1-ab8b-4005-b401-a35975b527f1" />
<img width="1669" height="364" alt="image" src="https://github.com/user-attachments/assets/a9cdb72c-2c74-4b42-ad99-e38175dea2cc" />

### Solution
Replace all usage of [addnab/docker-run-action](https://github.com/addnab/docker-run-action). It's unmaintained and the docker version it uses is not supported anymore.

1. All newer containers can be ran with the `container:` configuration of the CI workflow because checkoutv4 runs as expected inside these containers. I'm honestly not sure why the safe directory command is still needed because checkoutv4 should take care of that but it didn't work in my tests so I kept that.
2. The original reason to introduce `docker-run-action` was that in the old ROS melodic, mavros test container glibc is so old that checkoutv4 fails so we have to run only the build command using `docker run ...` but not depend on an additional actions plugin (also not [maintain it ourselveses](https://github.com/PX4/docker-run-action)).

### Changelog Entry
```
CI: replace all usage of addnab/docker-run-action
```

### Context
[addnab/docker-run-action](https://github.com/addnab/docker-run-action) was introduced in our CI with https://github.com/PX4/PX4-Autopilot/pull/24039 The reason was that certain tools which the workflow used outside of the main build were not available in very old containers. So I hope with the new containers there's no such issue and with the e.g. mavros very old containers we have to find another solution if it fails again 👀 But the container should according to what I read only be used for the `run:` part, let's see the first results.