### PR TITLE
WIP: per-GNSS antenna position offset plumbing for EKF2 (#21902)

### DIFF
--- a/msg/SensorGps.msg
+++ b/msg/SensorGps.msg
@@ -82,6 +82,13 @@ uint8 selected_rtcm_instance	# uorb instance that is being used for RTCM correct
 
 bool rtcm_crc_failed		# RTCM message CRC failure detected
 
+# Per-GNSS antenna position offset in body frame [m].
+# If position_offset_valid is false EKF2 should use legacy EKF2_GPS_POS_* params.
+float32 position_offset_x
+float32 position_offset_y
+float32 position_offset_z
+bool position_offset_valid
+
 uint8 RTCM_MSG_USED_UNKNOWN = 0
 uint8 RTCM_MSG_USED_NOT_USED = 1
 uint8 RTCM_MSG_USED_USED = 2

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2430,6 +2430,11 @@ void EKF2::UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps)
 				vehicle_gps_position.heading = matrix::wrap_pi(vehicle_gps_position.heading - yaw_offset);
 			}
 		}
+		if (vehicle_gps_position.position_offset_valid) {
+			_params->gps_pos_body(0) = vehicle_gps_position.position_offset_x;
+			_params->gps_pos_body(1) = vehicle_gps_position.position_offset_y;
+			_params->gps_pos_body(2) = vehicle_gps_position.position_offset_z;
+		}
 
 		const float altitude_amsl = static_cast<float>(vehicle_gps_position.altitude_msl_m);
 		const float altitude_ellipsoid = static_cast<float>(vehicle_gps_position.altitude_ellipsoid_m);

--- a/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.cpp
+++ b/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.cpp
@@ -37,6 +37,7 @@
 #include <lib/geo/geo.h>
 #include <lib/mathlib/mathlib.h>
 #include <lib/drivers/device/Device.hpp>
+#include <float.h>
 
 namespace sensors
 {
@@ -130,6 +131,15 @@ void VehicleGPSPosition::Run()
 			any_gps_updated = true;
 
 			_sensor_gps_sub[i].copy(&gps_data);
+
+			const bool gnss0 = (i == 0);
+			gps_data.position_offset_x = gnss0 ? _param_sens_gnss0_pos_x.get() : _param_sens_gnss1_pos_x.get();
+			gps_data.position_offset_y = gnss0 ? _param_sens_gnss0_pos_y.get() : _param_sens_gnss1_pos_y.get();
+			gps_data.position_offset_z = gnss0 ? _param_sens_gnss0_pos_z.get() : _param_sens_gnss1_pos_z.get();
+			gps_data.position_offset_valid = (fabsf(gps_data.position_offset_x) > FLT_EPSILON)
+							|| (fabsf(gps_data.position_offset_y) > FLT_EPSILON)
+							|| (fabsf(gps_data.position_offset_z) > FLT_EPSILON);
+
 			_gps_blending.setGpsData(gps_data, i);
 
 			if (math::isInRange(static_cast<int>(gps_prime), 2, 127)) {

--- a/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.hpp
+++ b/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.hpp
@@ -100,7 +100,13 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::SENS_GPS_MASK>) _param_sens_gps_mask,
 		(ParamFloat<px4::params::SENS_GPS_TAU>) _param_sens_gps_tau,
-		(ParamInt<px4::params::SENS_GPS_PRIME>) _param_sens_gps_prime
+		(ParamInt<px4::params::SENS_GPS_PRIME>) _param_sens_gps_prime,
+		(ParamFloat<px4::params::SENS_GNSS0_POS_X>) _param_sens_gnss0_pos_x,
+		(ParamFloat<px4::params::SENS_GNSS0_POS_Y>) _param_sens_gnss0_pos_y,
+		(ParamFloat<px4::params::SENS_GNSS0_POS_Z>) _param_sens_gnss0_pos_z,
+		(ParamFloat<px4::params::SENS_GNSS1_POS_X>) _param_sens_gnss1_pos_x,
+		(ParamFloat<px4::params::SENS_GNSS1_POS_Y>) _param_sens_gnss1_pos_y,
+		(ParamFloat<px4::params::SENS_GNSS1_POS_Z>) _param_sens_gnss1_pos_z
 	)
 };
 }; // namespace sensors

--- a/src/modules/sensors/vehicle_gps_position/params.c
+++ b/src/modules/sensors/vehicle_gps_position/params.c
@@ -83,3 +83,57 @@ PARAM_DEFINE_FLOAT(SENS_GPS_TAU, 10.0f);
  * @max 127
  */
 PARAM_DEFINE_INT32(SENS_GPS_PRIME, 0);
+
+/**
+ * GNSS instance 0 antenna offset X in body frame
+ *
+ * @group Sensors
+ * @unit m
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(SENS_GNSS0_POS_X, 0.0f);
+
+/**
+ * GNSS instance 0 antenna offset Y in body frame
+ *
+ * @group Sensors
+ * @unit m
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(SENS_GNSS0_POS_Y, 0.0f);
+
+/**
+ * GNSS instance 0 antenna offset Z in body frame
+ *
+ * @group Sensors
+ * @unit m
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(SENS_GNSS0_POS_Z, 0.0f);
+
+/**
+ * GNSS instance 1 antenna offset X in body frame
+ *
+ * @group Sensors
+ * @unit m
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(SENS_GNSS1_POS_X, 0.0f);
+
+/**
+ * GNSS instance 1 antenna offset Y in body frame
+ *
+ * @group Sensors
+ * @unit m
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(SENS_GNSS1_POS_Y, 0.0f);
+
+/**
+ * GNSS instance 1 antenna offset Z in body frame
+ *
+ * @group Sensors
+ * @unit m
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(SENS_GNSS1_POS_Z, 0.0f);


### PR DESCRIPTION
This is a first incremental PR for #21902.

What this patch does:
- adds per-GNSS offset fields to SensorGps message (position_offset_{x,y,z} + position_offset_valid)
- adds sensor params SENS_GNSS0_POS_{X,Y,Z} and SENS_GNSS1_POS_{X,Y,Z}
- injects per-instance offset into ehicle_gps_position path
- makes EKF2 use per-sample offset when position_offset_valid=true (fallback remains existing EKF2_GPS_POS_* params)

Next planned commits:
- explicit blending behavior for offsets
- tests + SITL validation + demo video