### PR TITLE
uavcan: add warning about CAN error counter reading issue

### DIFF
--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -1163,6 +1163,11 @@ UavcanNode::print_info()
 
 	printf("\n");
 
+	// See https://github.com/PX4/PX4-Autopilot/issues/22871
+	printf("WARNING: CAN error counter values below may increase during this function call due to internal counter reading implementation.\n");
+	printf("Do not fully trust these counters until this issue is fixed.\n");
+	printf("\n");
+
 	// UAVCAN node perfcounters
 	printf("UAVCAN node status:\n");
 	printf("\tInternal failures: %" PRIu64 "\n", _node.getInternalFailureCount());


### PR DESCRIPTION
### Solved Problem
Related to #22871 (temporary workaround/warning, not a fix)

### Solution
Added a warning message in `UavcanNode::print_info()` to inform users that the CAN error counter values displayed may be artificially inflated due to the function's internal implementation. The function holds a mutex lock while performing multiple printf calls, which blocks other UAVCAN operations and causes legitimate CAN errors to occur during status checking.

This warning helps prevent confusion when debugging CAN bus issues, as users may otherwise assume the displayed error counts are representative of actual bus problems.


### Changelog Entry
For release notes:
```
Bugfix: Added warning message to uavcan status output indicating that error counters may increase during status check
```

### Alternatives
See https://github.com/PX4/PX4-Autopilot/issues/22871 for proposed fix

### Test coverage

### Context
Related issue: https://github.com/PX4/PX4-Autopilot/issues/22871

The issue describes how `uavcan status` command causes actual CAN errors due to printf calls while the mutex is locked (~110ms lock duration on CubeOrange). This warning informs users that the error counter values should not be fully trusted until the underlying mutex/printf issue is resolved.
