### PR TITLE
nuttx: add nuttx_context dependency to jlink-nuttx build

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -598,6 +598,7 @@ if(NOT NUTTX_DIR MATCHES "external")
 		add_custom_target(jlink-nuttx ALL
 			DEPENDS ${NUTTX_DIR}/tools/jlink-nuttx.so
 		)
+		add_dependencies(jlink-nuttx nuttx_context)
 
 		# JLINK_RTOS_PATH used by launch.json.in
 		set(JLINK_RTOS_PATH ${NUTTX_DIR}/tools/jlink-nuttx.so)


### PR DESCRIPTION
The jlink-nuttx custom command has no dependency on nuttx_context so Ninja
can schedule it before .config is fully generated. Makefile.host includes
Make.defs which hard-includes .config, and reading it mid-write causes
"missing separator" errors.

Add add_dependencies(jlink-nuttx nuttx_context) so the .config and
Make.defs are guaranteed to exist before jlink-nuttx starts building.

Seen in https://github.com/PX4/PX4-Autopilot/actions/runs/22083321751/job/63812843075