### PR TITLE
ci: add geninfo negative error ignore to tests_coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,7 @@ tests:
 	$(call cmake-build,px4_sitl_test)
 
 # work around lcov bug #316; remove once lcov is fixed (see https://github.com/linux-test-project/lcov/issues/316)
-LCOBUG = --ignore-errors mismatch
+LCOBUG = --ignore-errors mismatch,negative
 tests_coverage:
 	@$(MAKE) clean
 	@$(MAKE) --no-print-directory tests PX4_CMAKE_BUILD_TYPE=Coverage


### PR DESCRIPTION
gcov can produce negative execution counts on multi-threaded code due to
.gcda counter race conditions. geninfo treats this as a fatal error since
lcov 2.x. The existing LCOBUG variable handles mismatch errors but not
negative ones.

Add negative to the ignore list so geninfo clips negative counts to zero
instead of failing the build.

Seen in https://github.com/PX4/PX4-Autopilot/actions/runs/22079949362/job/63803011622