### PR TITLE
gz: airframes: standard_vtol: set VT_PITCH_MIN

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
@@ -101,6 +101,7 @@ param set-default NAV_ACC_RAD 5
 param set-default NAV_DLL_ACT 2
 
 param set-default VT_FWD_THRUST_EN 4
+param set-default VT_PITCH_MIN -5
 param set-default VT_F_TRANS_THR 1
 param set-default VT_TYPE 2
 param set-default FD_ESCS_EN 0


### PR DESCRIPTION
Attempt at fixing VTOL takeoff and hold test

---

## Summary                                                                                                                                                                                               
                                                                                                                                                                                                           
  - Fix flaky VTOL SITL "Takeoff and hold position" test (~70% failure rate for `standard_vtol`)                                                                                                           
                                                                                                                                                                                                           
  ## Problem                                                                                                                                                                                               
                                  
  The `4004_gz_standard_vtol` airframe sets `VT_FWD_THRUST_EN=4` (pusher assist always enabled) with the default `VT_PITCH_MIN=0.0°`. This means `pusher_assist()` intercepts **every** forward pitch  demand during hover — even sub-degree corrections from the MC position controller. It clamps pitch back to 0° and engages the pusher motor instead, but the position controller doesn't know this is  happening. The resulting control loop conflict (position controller increases pitch → pusher_assist removes it → repeat) creates sustained altitude oscillations that exceed the test's 0.3m tolerance.

  Copter passes the same test reliably because it has no `pusher_assist` layer.

  ## Fix

  Set `VT_PITCH_MIN=-5` in the SITL airframe config. This creates a 5° dead-band where normal hover pitch corrections pass through to the attitude controller unmodified. The pusher only engages for larger forward pitch demands (wind correction, waypoint tracking, etc.).