### PR TITLE
CI: disable VTOL and tailsitter SITL tests

### DIFF
--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -33,8 +33,10 @@ jobs:
       matrix:
         config:
           - {model: "iris",          latitude:  "59.617693", longitude: "-151.145316", altitude:  "48", build_type: "RelWithDebInfo" } # Alaska
-          - {model: "tailsitter" ,   latitude:  "29.660316", longitude:  "-82.316658", altitude:  "30", build_type: "RelWithDebInfo" } # Florida
-          - {model: "standard_vtol", latitude:  "47.397742", longitude:    "8.545594", altitude: "488", build_type: "Coverage" } # Zurich
+          # VTOL/tailsitter disabled: persistent flaky CI failures (timeouts, erratic
+          # transitions). Re-enable once the test infrastructure is stabilized.
+          # - {model: "tailsitter" ,   latitude:  "29.660316", longitude:  "-82.316658", altitude:  "30", build_type: "RelWithDebInfo" } # Florida
+          # - {model: "standard_vtol", latitude:  "47.397742", longitude:    "8.545594", altitude: "488", build_type: "Coverage" } # Zurich
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Persistent flaky failures (timeouts, erratic transitions) make these tests unreliable in CI. Commented out from the workflow matrix so they can be re-enabled once the test infrastructure is stabilized. The test definitions in sitl.json are preserved for local use.

It's worth noting that there are currently two coordinated and parallel efforts to stabilize CI in the coming days.

1. Switching Gazebo for SIH as the simulation engine for the SITL tests https://github.com/PX4/PX4-Autopilot/pull/26032
2. Adopting a tier approach to our CI workflows/jobs, merging most CI workflow files into a single big job https://github.com/PX4/PX4-Autopilot/pull/26257

I'm planning to work with @julianoes to bring back the VTOL/Tailsitter tests ASAP. In the meantime, let's get everyone to adopt a "**CI must always pass**" mentality by eliminating flaky tests that have proven to be of no value.