### PR TITLE
ark boards: remove GPIO_FMU output init (default float)

### DIFF
--- a/boards/ark/fmu-v6x/src/board_config.h
+++ b/boards/ark/fmu-v6x/src/board_config.h
@@ -243,15 +243,6 @@
  */
 #define DIRECT_PWM_OUTPUT_CHANNELS   9
 
-#define GPIO_FMU_CH1                    /* PI0  */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTI|GPIO_PIN0)
-#define GPIO_FMU_CH2                    /* PH12 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTH|GPIO_PIN12)
-#define GPIO_FMU_CH3                    /* PH11 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTH|GPIO_PIN11)
-#define GPIO_FMU_CH4                    /* PH10 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTH|GPIO_PIN10)
-#define GPIO_FMU_CH5                    /* PD13 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTD|GPIO_PIN13)
-#define GPIO_FMU_CH6                    /* PD14 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTD|GPIO_PIN14)
-#define GPIO_FMU_CH7                    /* PH6  */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTH|GPIO_PIN6)
-#define GPIO_FMU_CH8                    /* PH9  */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTH|GPIO_PIN9)
-
 #define GPIO_FMU_CAP                    /* PE11 */ (GPIO_INPUT|GPIO_PULLDOWN|GPIO_PORTE|GPIO_PIN11)
 #define GPIO_SPIX_SYNC                  /* PE9  */ (GPIO_INPUT|GPIO_PULLDOWN|GPIO_PORTE|GPIO_PIN9)
 
@@ -465,14 +456,6 @@
 		GPIO_SAFETY_SWITCH_IN,            \
 		GPIO_PG6,                         \
 		GPIO_nARMED_INIT,                 \
-		GPIO_FMU_CH1,     	          \
-		GPIO_FMU_CH2,     	          \
-		GPIO_FMU_CH3,     	          \
-		GPIO_FMU_CH4,     	          \
-		GPIO_FMU_CH5,     	          \
-		GPIO_FMU_CH6,     	          \
-		GPIO_FMU_CH7,     	          \
-		GPIO_FMU_CH8,     	          \
 		GPIO_FMU_CAP,     	          \
 		GPIO_SPIX_SYNC                    \
 	}

--- a/boards/ark/fpv/src/board_config.h
+++ b/boards/ark/fpv/src/board_config.h
@@ -226,16 +226,6 @@
  */
 #define DIRECT_PWM_OUTPUT_CHANNELS   9
 
-#define GPIO_FMU_CH1                    /* PI0  */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTI|GPIO_PIN0)
-#define GPIO_FMU_CH2                    /* PH12 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTH|GPIO_PIN12)
-#define GPIO_FMU_CH3                    /* PH11 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTH|GPIO_PIN11)
-#define GPIO_FMU_CH4                    /* PH10 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTH|GPIO_PIN10)
-#define GPIO_FMU_CH5                    /* PI5  */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTI|GPIO_PIN5)
-#define GPIO_FMU_CH6                    /* PI6  */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTI|GPIO_PIN6)
-#define GPIO_FMU_CH7                    /* PI7  */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTI|GPIO_PIN7)
-#define GPIO_FMU_CH8                    /* PI2  */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTI|GPIO_PIN2)
-#define GPIO_FMU_CH9                    /* PD12 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTD|GPIO_PIN12)
-
 #define GPIO_SPIX_SYNC                  /* PE9  */ (GPIO_INPUT|GPIO_PULLDOWN|GPIO_PORTE|GPIO_PIN9)
 
 /* Power supply control and monitoring GPIOs */
@@ -339,15 +329,6 @@
 		GPIO_VDD_3V3_SD_CARD_EN,          \
 		GPIO_nARMED_INIT,                 \
 		SPI6_nRESET_EXTERNAL1,            \
-		GPIO_FMU_CH1,     	          \
-		GPIO_FMU_CH2,     	          \
-		GPIO_FMU_CH3,     	          \
-		GPIO_FMU_CH4,     	          \
-		GPIO_FMU_CH5,     	          \
-		GPIO_FMU_CH6,     	          \
-		GPIO_FMU_CH7,     	          \
-		GPIO_FMU_CH8,     	          \
-		GPIO_FMU_CH9,     	          \
 		GPIO_SPIX_SYNC                    \
 	}
 

--- a/boards/ark/pi6x/src/board_config.h
+++ b/boards/ark/pi6x/src/board_config.h
@@ -206,15 +206,6 @@
  */
 #define DIRECT_PWM_OUTPUT_CHANNELS   8
 
-#define GPIO_FMU_CH1                    /* PI0  */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTI|GPIO_PIN0)
-#define GPIO_FMU_CH2                    /* PH12 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTH|GPIO_PIN12)
-#define GPIO_FMU_CH3                    /* PH11 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTH|GPIO_PIN11)
-#define GPIO_FMU_CH4                    /* PH10 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTH|GPIO_PIN10)
-#define GPIO_FMU_CH5                    /* PD13 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTD|GPIO_PIN13)
-#define GPIO_FMU_CH6                    /* PD14 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTD|GPIO_PIN14)
-#define GPIO_FMU_CH7                    /* PH6  */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTH|GPIO_PIN6)
-#define GPIO_FMU_CH8                    /* PH9  */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTH|GPIO_PIN9)
-
 #define GPIO_FMU_CAP                    /* PE11 */ (GPIO_INPUT|GPIO_PULLDOWN|GPIO_PORTE|GPIO_PIN11)
 #define GPIO_SPIX_SYNC                  /* PE9  */ (GPIO_INPUT|GPIO_PULLDOWN|GPIO_PORTE|GPIO_PIN9)
 
@@ -341,14 +332,6 @@
 		GPIO_NFC_GPIO,                    \
 		GPIO_TONE_ALARM_IDLE,             \
 		GPIO_nARMED_INIT,                 \
-		GPIO_FMU_CH1,     	          \
-		GPIO_FMU_CH2,     	          \
-		GPIO_FMU_CH3,     	          \
-		GPIO_FMU_CH4,     	          \
-		GPIO_FMU_CH5,     	          \
-		GPIO_FMU_CH6,     	          \
-		GPIO_FMU_CH7,     	          \
-		GPIO_FMU_CH8,     	          \
 		GPIO_FMU_CAP,     	          \
 		GPIO_SPIX_SYNC                    \
 	}


### PR DESCRIPTION
While testing the DShot PR (#26263), I configured only the first output as DShot and ran a motor test in QGC. Sometimes 2 or 3 motors would spin despite only one being configured. With all 4 configured, each motor could be spun individually as expected.                                                                                                                                           
                                                                                                                                                                                                           
Scoping channels 1 and 2 revealed that channel 2 was floating with cross-talk from channel 1. AM32 ESC firmware configures its inputs as PULLUP, so the PULLDOWN on the PX4 side was leaving unconfigured channels at a mid-level voltage where cross-talk could be interpreted as a valid DShot signal.

Removing the explicit GPIO init for FMU outputs (matching all other boards in the tree) resolves the issue — unconfigured channels stay HIGH with minimal cross-talk and no spurious motor activation