### PR TITLE
docs(update): ManualControlSetpoint uORB topic

### DIFF
--- a/msg/translation_node/translations/translation_manual_control_setpoint_v1.h
+++ b/msg/translation_node/translations/translation_manual_control_setpoint_v1.h
@@ -5,6 +5,8 @@
 #pragma once
 
 // Translate ManualControlSetpoint v0 <--> v1
+#include <cmath>
+
 #include <px4_msgs_old/msg/manual_control_setpoint_v0.hpp>
 #include <px4_msgs/msg/manual_control_setpoint.hpp>
 
@@ -50,15 +52,22 @@ public:
 		msg_older.yaw = msg_newer.yaw;
 		msg_older.throttle = msg_newer.throttle;
 		msg_older.flaps = msg_newer.flaps;
-		msg_older.aux1 = msg_newer.aux1;
-		msg_older.aux2 = msg_newer.aux2;
-		msg_older.aux3 = msg_newer.aux3;
-		msg_older.aux4 = msg_newer.aux4;
-		msg_older.aux5 = msg_newer.aux5;
-		msg_older.aux6 = msg_newer.aux6;
+		// v1 marks an unmapped aux channel as NaN, v0 has no invalid value and its
+		// consumers assume 0 for a channel that is not mapped: collapse it back.
+		msg_older.aux1 = auxToOlder(msg_newer.aux1);
+		msg_older.aux2 = auxToOlder(msg_newer.aux2);
+		msg_older.aux3 = auxToOlder(msg_newer.aux3);
+		msg_older.aux4 = auxToOlder(msg_newer.aux4);
+		msg_older.aux5 = auxToOlder(msg_newer.aux5);
+		msg_older.aux6 = auxToOlder(msg_newer.aux6);
 		msg_older.sticks_moving = msg_newer.sticks_moving;
 		msg_older.buttons = msg_newer.buttons;
 		// source_system_id / source_component_id dropped (not present in v0)
+	}
+
+private:
+	static float auxToOlder(float aux) {
+		return std::isfinite(aux) ? aux : 0.f;
 	}
 };
 

--- a/msg/versioned/ManualControlSetpoint.msg
+++ b/msg/versioned/ManualControlSetpoint.msg
@@ -1,45 +1,46 @@
+# Manual control setpoint message
+#
+# This message provides a representation of a manual control input, such as an RC controller or MAVLink controller (Joystick).
+# It defines the manual_control_input topic to represent configured inputs, and the manual_control_setpoint topic to represent the selected input.
+# The message includes fields for the roll, pitch, yaw, throttle and flaps, along with auxiliary channels and button states.
+#
+# Note: On a common RC mode 1/2/3/4 remote/joystick the stick deflection: -1 is down/left, 1 is up/right.
+# Note: QGC sends throttle/z in range [0,1000] - [0,1]. The MAVLink input conversion [0,1] to [-1,1] is at the moment kept backwards compatible.
+
 uint32 MESSAGE_VERSION = 0
 
-uint64 timestamp                        # time since system start (microseconds)
-uint64 timestamp_sample                 # the timestamp of the raw data (microseconds)
+uint64 timestamp # [us] Time since system start
+uint64 timestamp_sample # [us] Timestamp of the raw data
 
-bool valid
+bool valid # True if the current data is valid
 
-uint8 SOURCE_UNKNOWN   = 0
-uint8 SOURCE_RC        = 1		# radio control (input_rc)
-uint8 SOURCE_MAVLINK_0 = 2		# mavlink instance 0
-uint8 SOURCE_MAVLINK_1 = 3		# mavlink instance 1
-uint8 SOURCE_MAVLINK_2 = 4		# mavlink instance 2
-uint8 SOURCE_MAVLINK_3 = 5		# mavlink instance 3
-uint8 SOURCE_MAVLINK_4 = 6		# mavlink instance 4
-uint8 SOURCE_MAVLINK_5 = 7		# mavlink instance 5
+uint8 data_source # [@enum SOURCE] Source of the manual control setpoint
+uint8 SOURCE_UNKNOWN = 0 # Unknown source
+uint8 SOURCE_RC = 1 # Radio control (input_rc)
+uint8 SOURCE_MAVLINK_0 = 2 # MAVLink instance 0
+uint8 SOURCE_MAVLINK_1 = 3 # MAVLink instance 1
+uint8 SOURCE_MAVLINK_2 = 4 # MAVLink instance 2
+uint8 SOURCE_MAVLINK_3 = 5 # MAVLink instance 3
+uint8 SOURCE_MAVLINK_4 = 6 # MAVLink instance 4
+uint8 SOURCE_MAVLINK_5 = 7 # MAVLink instance 5
 
-uint8 data_source
+float32 roll # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: move right, positive roll rotation, right side down
+float32 pitch # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: move forward, negative pitch rotation, nose down
+float32 yaw # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: positive yaw rotation, clockwise when seen top down
+float32 throttle # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: move up, positive thrust, -1 is minimum available 0% or -100% +1 is 100% thrust
 
-# Any of the channels may not be available and be set to NaN
-# to indicate that it does not contain valid data.
+float32 flaps # [-] [@range -1,1] [@invalid NaN] Position of flaps switch/knob/lever
 
-# Stick positions [-1,1]
-# on a common RC mode 1/2/3/4 remote/joystick the stick deflection: -1 is down/left, 1 is up/right
-# Note: QGC sends throttle/z in range [0,1000] - [0,1]. The MAVLink input conversion [0,1] to [-1,1] is at the moment kept backwards compatible.
-# Positive values are generally used for:
-float32 roll     # move right,   positive roll rotation,  right side down
-float32 pitch    # move forward, negative pitch rotation, nose down
-float32 yaw      #               positive yaw rotation,   clockwise when seen top down
-float32 throttle # move up,      positive thrust,         -1 is minimum available 0% or -100% +1 is 100% thrust
+float32 aux1 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 1
+float32 aux2 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 2
+float32 aux3 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 3
+float32 aux4 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 4
+float32 aux5 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 5
+float32 aux6 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 6
 
-float32 flaps			 # position of flaps switch/knob/lever [-1, 1]
+bool sticks_moving # True once stick movement exceeds a velocity threshold (if feature is enabled). Used by Commander to trigger a manual override in auto/offboard modes.
 
-float32 aux1
-float32 aux2
-float32 aux3
-float32 aux4
-float32 aux5
-float32 aux6
-
-bool sticks_moving # manual control override request in an auto or offboard mode, only gets true if feature is enabled
-
-uint16 buttons		# From uint16 buttons field of Mavlink manual_control message
+uint16 buttons # From uint16 buttons field of MAVLink MANUAL_CONTROL message
 
 # TOPICS manual_control_setpoint manual_control_input
 # DEPRECATED: float32 x

--- a/msg/versioned/ManualControlSetpoint.msg
+++ b/msg/versioned/ManualControlSetpoint.msg
@@ -24,10 +24,10 @@ uint8 SOURCE_MAVLINK_3 = 5 # MAVLink instance 3
 uint8 SOURCE_MAVLINK_4 = 6 # MAVLink instance 4
 uint8 SOURCE_MAVLINK_5 = 7 # MAVLink instance 5
 
-float32 roll # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: move right, positive roll rotation, right side down
-float32 pitch # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: move forward, negative pitch rotation, nose down
-float32 yaw # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: positive yaw rotation, clockwise when seen top down
-float32 throttle # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: move up, positive thrust, -1 is minimum available 0% or -100% +1 is 100% thrust
+float32 roll # [-] [@range -1,1] [@invalid - NaN expected but not implemented] Positive values are generally used for: move right, positive roll rotation, right side down
+float32 pitch # [-] [@range -1,1] [@invalid - NaN expected but not implemented] Positive values are generally used for: move forward, negative pitch rotation, nose down
+float32 yaw # [-] [@range -1,1] [@invalid - NaN expected but not implemented] Positive values are generally used for: positive yaw rotation, clockwise when seen top down
+float32 throttle # [-] [@range -1,1] [@invalid - NaN expected but not implemented] Positive values are generally used for: move up, positive thrust, -1 is minimum available 0% or -100% +1 is 100% thrust
 
 float32 flaps # [-] [@range -1,1] [@invalid NaN] Position of flaps switch/knob/lever
 

--- a/msg/versioned/ManualControlSetpoint.msg
+++ b/msg/versioned/ManualControlSetpoint.msg
@@ -29,7 +29,7 @@ float32 pitch # [-] [@range -1,1] [@invalid - NaN expected but not implemented] 
 float32 yaw # [-] [@range -1,1] [@invalid - NaN expected but not implemented] Positive values are generally used for: positive yaw rotation, clockwise when seen top down
 float32 throttle # [-] [@range -1,1] [@invalid - NaN expected but not implemented] Positive values are generally used for: move up, positive thrust, -1 is minimum available 0% or -100% +1 is 100% thrust
 
-float32 flaps # [-] [@range -1,1] [@invalid NaN] Position of flaps switch/knob/lever
+float32 flaps # [-] [@range -1,1] [@invalid - NaN expected but not implemented] Position of flaps switch/knob/lever
 
 float32 aux1 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 1
 float32 aux2 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 2

--- a/msg/versioned/ManualControlSetpoint.msg
+++ b/msg/versioned/ManualControlSetpoint.msg
@@ -27,10 +27,10 @@ uint8 SOURCE_MAVLINK_5 = 7 # MAVLink instance 5
 uint8 source_system_id  # [@invalid 0] MAVLink system ID of the manual control source
 uint8 source_component_id # [@invalid 0] MAVLink component ID of the manual control source
 
-float32 roll # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: move right, positive roll rotation, right side down
-float32 pitch # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: move forward, negative pitch rotation, nose down
-float32 yaw # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: positive yaw rotation, clockwise when seen top down
-float32 throttle # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: move up, positive thrust, -1 is minimum available 0% or -100% +1 is 100% thrust
+float32 roll # [-] [@range -1,1] [@invalid - NaN expected but not implemented] Positive values are generally used for: move right, positive roll rotation, right side down
+float32 pitch # [-] [@range -1,1] [@invalid - NaN expected but not implemented] Positive values are generally used for: move forward, negative pitch rotation, nose down
+float32 yaw # [-] [@range -1,1] [@invalid - NaN expected but not implemented] Positive values are generally used for: positive yaw rotation, clockwise when seen top down
+float32 throttle # [-] [@range -1,1] [@invalid - NaN expected but not implemented] Positive values are generally used for: move up, positive thrust, -1 is minimum available 0% or -100% +1 is 100% thrust
 
 float32 flaps # [-] [@range -1,1] [@invalid NaN] Position of flaps switch/knob/lever
 

--- a/msg/versioned/ManualControlSetpoint.msg
+++ b/msg/versioned/ManualControlSetpoint.msg
@@ -1,59 +1,49 @@
-# Manual control input
+# Manual control setpoint message
 #
-# This message provides a representation of manual control input sources, 
-# such as RC controllers and MAVLink controller (Joystick).
-#
-# It defines the `manual_control_input` topic to represent each configured input, 
-# and the `manual_control_setpoint` topic to represent the input that is currently 
-# in charge of the vehicle (based on parameter COM_RC_IN_MODE).
-# `manual_control_setpoint` is the topic that is published to the controllers.
-#
+# This message provides a representation of a manual control input, such as an RC controller or MAVLink controller (Joystick).
+# It defines the manual_control_input topic to represent configured inputs, and the manual_control_setpoint topic to represent the selected input.
 # The message includes fields for the roll, pitch, yaw, throttle and flaps, along with auxiliary channels and button states.
+#
+# Note: On a common RC mode 1/2/3/4 remote/joystick the stick deflection: -1 is down/left, 1 is up/right.
+# Note: QGC sends throttle/z in range [0,1000] - [0,1]. The MAVLink input conversion [0,1] to [-1,1] is at the moment kept backwards compatible.
 
 uint32 MESSAGE_VERSION = 1
 
-uint64 timestamp                        # time since system start (microseconds)
-uint64 timestamp_sample                 # the timestamp of the raw data (microseconds)
+uint64 timestamp # [us] Time since system start
+uint64 timestamp_sample # [us] Timestamp of the raw data
 
-bool valid
+bool valid # True if the current data is valid
 
-uint8 SOURCE_UNKNOWN   = 0
-uint8 SOURCE_RC        = 1		# radio control (input_rc)
-uint8 SOURCE_MAVLINK_0 = 2		# mavlink instance 0
-uint8 SOURCE_MAVLINK_1 = 3		# mavlink instance 1
-uint8 SOURCE_MAVLINK_2 = 4		# mavlink instance 2
-uint8 SOURCE_MAVLINK_3 = 5		# mavlink instance 3
-uint8 SOURCE_MAVLINK_4 = 6		# mavlink instance 4
-uint8 SOURCE_MAVLINK_5 = 7		# mavlink instance 5
+uint8 data_source # [@enum SOURCE] Source of the manual control setpoint
+uint8 SOURCE_UNKNOWN = 0 # Unknown source
+uint8 SOURCE_RC = 1 # Radio control (input_rc)
+uint8 SOURCE_MAVLINK_0 = 2 # MAVLink instance 0
+uint8 SOURCE_MAVLINK_1 = 3 # MAVLink instance 1
+uint8 SOURCE_MAVLINK_2 = 4 # MAVLink instance 2
+uint8 SOURCE_MAVLINK_3 = 5 # MAVLink instance 3
+uint8 SOURCE_MAVLINK_4 = 6 # MAVLink instance 4
+uint8 SOURCE_MAVLINK_5 = 7 # MAVLink instance 5
 
-uint8 data_source
 uint8 source_system_id  # [@invalid 0] MAVLink system ID of the manual control source
 uint8 source_component_id # [@invalid 0] MAVLink component ID of the manual control source
 
-# Any of the channels may not be available and be set to NaN
-# to indicate that it does not contain valid data.
+float32 roll # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: move right, positive roll rotation, right side down
+float32 pitch # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: move forward, negative pitch rotation, nose down
+float32 yaw # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: positive yaw rotation, clockwise when seen top down
+float32 throttle # [-] [@range -1,1] [@invalid NaN] Positive values are generally used for: move up, positive thrust, -1 is minimum available 0% or -100% +1 is 100% thrust
 
-# Stick positions [-1,1]
-# on a common RC mode 1/2/3/4 remote/joystick the stick deflection: -1 is down/left, 1 is up/right
-# Note: QGC sends throttle/z in range [0,1000] - [0,1]. The MAVLink input conversion [0,1] to [-1,1] is at the moment kept backwards compatible.
-# Positive values are generally used for:
-float32 roll     # move right,   positive roll rotation,  right side down
-float32 pitch    # move forward, negative pitch rotation, nose down
-float32 yaw      #               positive yaw rotation,   clockwise when seen top down
-float32 throttle # move up,      positive thrust,         -1 is minimum available 0% or -100% +1 is 100% thrust
+float32 flaps # [-] [@range -1,1] [@invalid NaN] Position of flaps switch/knob/lever
 
-float32 flaps			 # position of flaps switch/knob/lever [-1, 1]
+float32 aux1 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 1
+float32 aux2 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 2
+float32 aux3 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 3
+float32 aux4 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 4
+float32 aux5 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 5
+float32 aux6 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 6
 
-float32 aux1
-float32 aux2
-float32 aux3
-float32 aux4
-float32 aux5
-float32 aux6
+bool sticks_moving # True once stick movement exceeds a velocity threshold (if feature is enabled). Used by Commander to trigger a manual override in auto/offboard modes.
 
-bool sticks_moving # manual control override request in an auto or offboard mode, only gets true if feature is enabled
-
-uint16 buttons		# From uint16 buttons field of Mavlink manual_control message
+uint16 buttons # From uint16 buttons field of MAVLink MANUAL_CONTROL message
 
 # TOPICS manual_control_setpoint manual_control_input
 # DEPRECATED: float32 x

--- a/msg/versioned/ManualControlSetpoint.msg
+++ b/msg/versioned/ManualControlSetpoint.msg
@@ -32,7 +32,7 @@ float32 pitch # [-] [@range -1,1] [@invalid - NaN expected but not implemented] 
 float32 yaw # [-] [@range -1,1] [@invalid - NaN expected but not implemented] Positive values are generally used for: positive yaw rotation, clockwise when seen top down
 float32 throttle # [-] [@range -1,1] [@invalid - NaN expected but not implemented] Positive values are generally used for: move up, positive thrust, -1 is minimum available 0% or -100% +1 is 100% thrust
 
-float32 flaps # [-] [@range -1,1] [@invalid NaN] Position of flaps switch/knob/lever
+float32 flaps # [-] [@range -1,1] [@invalid - NaN expected but not implemented] Position of flaps switch/knob/lever
 
 float32 aux1 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 1
 float32 aux2 # [-] [@range -1,1] [@invalid NaN] Auxiliary channel 2

--- a/src/drivers/actuators/voxl_esc/voxl_esc.cpp
+++ b/src/drivers/actuators/voxl_esc/voxl_esc.cpp
@@ -1514,7 +1514,7 @@ void VoxlEsc::Run()
 						setpoint = _manual_control_setpoint.aux2;
 					}
 
-					activate = (setpoint > VOXL_ESC_MODE_THRESHOLD);
+					activate = PX4_ISFINITE(setpoint) && (setpoint > VOXL_ESC_MODE_THRESHOLD);
 				}
 
 				_turtle_mode_en = activate;
@@ -1553,7 +1553,7 @@ void VoxlEsc::Run()
 				break;
 			}
 
-			if (gpio_setpoint > VOXL_ESC_GPIO_CTL_THRESHOLD) {
+			if (PX4_ISFINITE(gpio_setpoint) && gpio_setpoint > VOXL_ESC_GPIO_CTL_THRESHOLD) {
 				_gpio_ctl_high = false;
 
 			} else {

--- a/src/drivers/actuators/voxl_esc/voxl_esc.cpp
+++ b/src/drivers/actuators/voxl_esc/voxl_esc.cpp
@@ -1491,8 +1491,10 @@ void VoxlEsc::Run()
 	if (_manual_control_setpoint_sub.updated()) {
 		_manual_control_setpoint_sub.copy(&_manual_control_setpoint);
 
+		// An invalid setpoint keeps the last received stick/aux values, so neither turtle mode
+		// nor GPIO control may be driven from it.
 		// if turtle mode enabled, we go straight to the sticks, no mix
-		if (_parameters.mode > 0) {
+		if (_parameters.mode > 0 && _manual_control_setpoint.valid) {
 
 			if (!_outputs_on) {
 
@@ -1522,7 +1524,7 @@ void VoxlEsc::Run()
 		}
 
 		// check if gpio control is enabled
-		if (_parameters.gpio_ctl_channel > 0) {
+		if (_parameters.gpio_ctl_channel > 0 && _manual_control_setpoint.valid) {
 
 			_gpio_ctl_en = true;
 			float gpio_setpoint = VOXL_ESC_GPIO_CTL_DISABLED_SETPOINT;

--- a/src/lib/sticks/Sticks.cpp
+++ b/src/lib/sticks/Sticks.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2026 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -86,6 +86,25 @@ bool Sticks::checkAndUpdateStickInputs()
 float Sticks::expoDeadzone(float value, float expo, float deadzone)
 {
 	return math::expo(math::deadzone(value, deadzone), expo);
+}
+
+float Sticks::getAuxValue(const manual_control_setpoint_s &manual_control_setpoint, int channel)
+{
+	switch (channel) {
+	case 1: return manual_control_setpoint.aux1;
+
+	case 2: return manual_control_setpoint.aux2;
+
+	case 3: return manual_control_setpoint.aux3;
+
+	case 4: return manual_control_setpoint.aux4;
+
+	case 5: return manual_control_setpoint.aux5;
+
+	case 6: return manual_control_setpoint.aux6;
+
+	default: return NAN;
+	}
 }
 
 void Sticks::limitStickUnitLengthXY(Vector2f &v)

--- a/src/lib/sticks/Sticks.cpp
+++ b/src/lib/sticks/Sticks.cpp
@@ -78,6 +78,7 @@ bool Sticks::checkAndUpdateStickInputs()
 	if (!_input_available) {
 		// Timeout: set all sticks to zero
 		_positions.zero();
+		_aux_positions.setNaN();	// invalidate aux positions
 	}
 
 	return _input_available;

--- a/src/lib/sticks/Sticks.hpp
+++ b/src/lib/sticks/Sticks.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2026 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +41,7 @@
 
 #pragma once
 
+#include <px4_platform_common/defines.h>
 #include <px4_platform_common/module_params.h>
 #include <matrix/matrix/math.hpp>
 #include <uORB/Subscription.hpp>
@@ -74,7 +75,19 @@ public:
 	const matrix::Vector2f getPitchRoll() { return {getPitch(), getRoll()}; }
 	const matrix::Vector2f getPitchRollExpo() { return {getPitchExpo(), getRollExpo()}; }
 
-	const matrix::Vector<float, 6> &getAux() const { return _aux_positions; }
+	// Raw aux channel values, may contain NaN for channels that are not mapped/present
+	const matrix::Vector<float, 6> &getAuxRaw() const { return _aux_positions; }
+
+	// Sanitized aux channel value (0-based index), NaN/non-finite is reported as 0.f
+	float getAux(int idx) const { return PX4_ISFINITE(_aux_positions(idx)) ? _aux_positions(idx) : 0.f; }
+
+	/**
+	 * Pick a single aux channel value directly out of a manual_control_setpoint message
+	 * @param manual_control_setpoint message to read from
+	 * @param channel 1-based aux channel number (1-6), matching RC_MAP_AUXn / .auxN naming
+	 * @return the raw (possibly NaN) field value, or NaN if channel is out of range
+	 */
+	static float getAuxValue(const manual_control_setpoint_s &manual_control_setpoint, int channel);
 
 	/**
 	 * Limit the the horizontal input from a square shaped joystick gimbal to a unit circle

--- a/src/lib/sticks/Sticks.hpp
+++ b/src/lib/sticks/Sticks.hpp
@@ -78,9 +78,6 @@ public:
 	// Raw aux channel values, may contain NaN for channels that are not mapped/present
 	const matrix::Vector<float, 6> &getAuxRaw() const { return _aux_positions; }
 
-	// Sanitized aux channel value (0-based index), NaN/non-finite is reported as 0.f
-	float getAux(int idx) const { return PX4_ISFINITE(_aux_positions(idx)) ? _aux_positions(idx) : 0.f; }
-
 	/**
 	 * Pick a single aux channel value directly out of a manual_control_setpoint message
 	 * @param manual_control_setpoint message to read from

--- a/src/lib/sticks/Sticks.hpp
+++ b/src/lib/sticks/Sticks.hpp
@@ -41,7 +41,6 @@
 
 #pragma once
 
-#include <px4_platform_common/defines.h>
 #include <px4_platform_common/module_params.h>
 #include <matrix/matrix/math.hpp>
 #include <uORB/Subscription.hpp>

--- a/src/modules/failure_injection_manager/CMakeLists.txt
+++ b/src/modules/failure_injection_manager/CMakeLists.txt
@@ -48,3 +48,4 @@ px4_add_module(
 
 px4_add_unit_gtest(SRC FailureInjectionManagerTest.cpp EXTRA_SRCS FailureTable.cpp LINKLIBS failure_injection)
 px4_add_functional_gtest(SRC FailureInjectionConfigTest.cpp LINKLIBS failure_injection)
+px4_add_functional_gtest(SRC FailureInjectionManagerRcInjectionTest.cpp EXTRA_SRCS FailureInjectionManager.cpp FailureTable.cpp LINKLIBS failure_injection)

--- a/src/modules/failure_injection_manager/CMakeLists.txt
+++ b/src/modules/failure_injection_manager/CMakeLists.txt
@@ -47,3 +47,4 @@ px4_add_module(
 
 px4_add_unit_gtest(SRC FailureInjectionManagerTest.cpp EXTRA_SRCS FailureTable.cpp LINKLIBS failure_injection)
 px4_add_functional_gtest(SRC FailureInjectionConfigTest.cpp LINKLIBS failure_injection)
+px4_add_functional_gtest(SRC FailureInjectionManagerRcInjectionTest.cpp EXTRA_SRCS FailureInjectionManager.cpp FailureTable.cpp LINKLIBS failure_injection)

--- a/src/modules/failure_injection_manager/FailureInjectionManager.cpp
+++ b/src/modules/failure_injection_manager/FailureInjectionManager.cpp
@@ -125,7 +125,7 @@ void FailureInjectionManager::evaluateRcInjection()
 			}
 		}
 
-		const bool triggered = value > 0.5f;
+		const bool triggered = PX4_ISFINITE(value) && value > 0.5f;
 
 		if (triggered && !_rc_active) {
 			const int32_t raw = _param_sys_fail_rc_inst.get();

--- a/src/modules/failure_injection_manager/FailureInjectionManager.cpp
+++ b/src/modules/failure_injection_manager/FailureInjectionManager.cpp
@@ -124,7 +124,7 @@ void FailureInjectionManager::evaluateRcInjection()
 			}
 		}
 
-		const bool triggered = value > 0.5f;
+		const bool triggered = PX4_ISFINITE(value) && value > 0.5f;
 
 		if (triggered && !_rc_active) {
 			_rc_active_unit = static_cast<uint8_t>(_param_sys_fail_rc_unit.get());

--- a/src/modules/failure_injection_manager/FailureInjectionManager.hpp
+++ b/src/modules/failure_injection_manager/FailureInjectionManager.hpp
@@ -74,7 +74,7 @@ public:
 
 	bool init();
 
-private:
+protected:
 	void Run() override;
 
 	void handleCommand(const vehicle_command_s &cmd);

--- a/src/modules/failure_injection_manager/FailureInjectionManager.hpp
+++ b/src/modules/failure_injection_manager/FailureInjectionManager.hpp
@@ -75,7 +75,7 @@ public:
 
 	bool init();
 
-private:
+protected:
 	void Run() override;
 
 	void handleCommand(const vehicle_command_s &cmd);

--- a/src/modules/failure_injection_manager/FailureInjectionManagerRcInjectionTest.cpp
+++ b/src/modules/failure_injection_manager/FailureInjectionManagerRcInjectionTest.cpp
@@ -1,0 +1,117 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+// Functional test for FailureInjectionManager::evaluateRcInjection(): an
+// unmapped aux channel now publishes NaN (see rc_update.cpp / mavlink_receiver.cpp)
+// instead of 0, so the RC-triggered failure injection source must explicitly
+// treat a non-finite aux value as "not triggered" rather than relying on
+// `NaN > threshold` evaluating false. This needs the uORB runtime to publish
+// manual_control_setpoint samples, so it runs as a functional gtest.
+
+#include <gtest/gtest.h>
+
+#include "FailureInjectionManager.hpp"
+
+#include <uORB/Publication.hpp>
+
+namespace
+{
+
+class TestFailureInjectionManager : public FailureInjectionManager
+{
+public:
+	// Sets the cached param value directly (no param_set()/commit): evaluateRcInjection()
+	// only ever reads the cached value via _param_sys_fail_rc_src.get(), so committing to
+	// the global param store (which would also trigger autosave scheduling on the work
+	// queue) is unnecessary here.
+	void configureRcSource(int32_t src) { _param_sys_fail_rc_src.set(src); }
+
+	void evaluate() { evaluateRcInjection(); }
+
+	bool rcActive() const { return _rc_active; }
+};
+
+void publishManualControlSetpoint(uORB::Publication<manual_control_setpoint_s> &pub, float aux1)
+{
+	manual_control_setpoint_s mc{};
+	mc.timestamp = mc.timestamp_sample = 1;
+	mc.valid = true;
+	mc.aux1 = aux1;
+	pub.publish(mc);
+}
+
+} // namespace
+
+TEST(FailureInjectionManagerRcInjection, UnmappedNaNAuxDoesNotTrigger)
+{
+	uORB::Publication<manual_control_setpoint_s> pub{ORB_ID(manual_control_setpoint)};
+	pub.advertise();
+
+	TestFailureInjectionManager manager;
+	manager.configureRcSource(1); // aux1
+
+	// Unmapped aux channel: producers (rc_update.cpp, mavlink_receiver.cpp) now
+	// publish NaN instead of 0 for this case.
+	publishManualControlSetpoint(pub, NAN);
+
+	manager.evaluate();
+	EXPECT_FALSE(manager.rcActive());
+}
+
+TEST(FailureInjectionManagerRcInjection, RealAuxAboveThresholdTriggers)
+{
+	uORB::Publication<manual_control_setpoint_s> pub{ORB_ID(manual_control_setpoint)};
+	pub.advertise();
+
+	TestFailureInjectionManager manager;
+	manager.configureRcSource(1); // aux1
+
+	publishManualControlSetpoint(pub, 0.8f);
+
+	manager.evaluate();
+	EXPECT_TRUE(manager.rcActive());
+}
+
+TEST(FailureInjectionManagerRcInjection, RealAuxBelowThresholdDoesNotTrigger)
+{
+	uORB::Publication<manual_control_setpoint_s> pub{ORB_ID(manual_control_setpoint)};
+	pub.advertise();
+
+	TestFailureInjectionManager manager;
+	manager.configureRcSource(1); // aux1
+
+	publishManualControlSetpoint(pub, 0.1f);
+
+	manager.evaluate();
+	EXPECT_FALSE(manager.rcActive());
+}

--- a/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/FlightTaskManualAccelerationSlow.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/FlightTaskManualAccelerationSlow.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2023-2026 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -157,8 +157,7 @@ bool FlightTaskManualAccelerationSlow::update()
 float FlightTaskManualAccelerationSlow::getInputFromSanitizedAuxParameterIndex(int parameter_value)
 {
 	const int sanitized_index = math::constrain(parameter_value - 1, 0, 5);
-	const float aux_value = _sticks.getAux()(sanitized_index);
-	return PX4_ISFINITE(aux_value) ? aux_value : 0.f;
+	return _sticks.getAux(sanitized_index);
 }
 
 bool FlightTaskManualAccelerationSlow::haveTakenOff()

--- a/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/FlightTaskManualAccelerationSlow.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/FlightTaskManualAccelerationSlow.cpp
@@ -157,7 +157,8 @@ bool FlightTaskManualAccelerationSlow::update()
 float FlightTaskManualAccelerationSlow::getInputFromSanitizedAuxParameterIndex(int parameter_value)
 {
 	const int sanitized_index = math::constrain(parameter_value - 1, 0, 5);
-	return _sticks.getAux()(sanitized_index);
+	const float aux_value = _sticks.getAux()(sanitized_index);
+	return PX4_ISFINITE(aux_value) ? aux_value : 0.f;
 }
 
 bool FlightTaskManualAccelerationSlow::haveTakenOff()

--- a/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/FlightTaskManualAccelerationSlow.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/FlightTaskManualAccelerationSlow.cpp
@@ -78,34 +78,39 @@ bool FlightTaskManualAccelerationSlow::update()
 		}
 	}
 
-	// Remote knob commanded limits
-	if (_param_mc_slow_map_hvel.get() != 0) {
+	// Remote knob commanded limits. An unmapped selection or an aux channel that carries no
+	// value reads as NaN and leaves the corresponding *_limited flag false, so the configured
+	// MC_SLOW_DEF_* fallback below applies instead of a neutral mid-range rescaling.
+	const float hvel_aux_input = getAuxInputFromParameterIndex(_param_mc_slow_map_hvel.get());
+
+	if (PX4_ISFINITE(hvel_aux_input)) {
 		const float min_horizontal_velocity_scale = _param_mc_slow_min_hvel.get() / fmaxf(velocity_horizontal, FLT_EPSILON);
-		const float aux_input = getInputFromSanitizedAuxParameterIndex(_param_mc_slow_map_hvel.get());
 		const float aux_based_scale =
-			math::interpolate(aux_input, -1.f, 1.f, min_horizontal_velocity_scale, 1.f);
+			math::interpolate(hvel_aux_input, -1.f, 1.f, min_horizontal_velocity_scale, 1.f);
 		velocity_horizontal *= aux_based_scale;
 		velocity_horizontal_limited = true;
 	}
 
-	if (_param_mc_slow_map_vvel.get() != 0) {
+	const float vvel_aux_input = getAuxInputFromParameterIndex(_param_mc_slow_map_vvel.get());
+
+	if (PX4_ISFINITE(vvel_aux_input)) {
 		const float min_up_speed_scale = _param_mc_slow_min_vvel.get() / fmaxf(velocity_up, FLT_EPSILON);
 		const float min_down_speed_scale = _param_mc_slow_min_vvel.get() / fmaxf(velocity_down, FLT_EPSILON);
-		const float aux_input = getInputFromSanitizedAuxParameterIndex(_param_mc_slow_map_vvel.get());
 		const float up_aux_based_scale =
-			math::interpolate(aux_input, -1.f, 1.f, min_up_speed_scale, 1.f);
+			math::interpolate(vvel_aux_input, -1.f, 1.f, min_up_speed_scale, 1.f);
 		const float down_aux_based_scale =
-			math::interpolate(aux_input, -1.f, 1.f, min_down_speed_scale, 1.f);
+			math::interpolate(vvel_aux_input, -1.f, 1.f, min_down_speed_scale, 1.f);
 		velocity_up *= up_aux_based_scale;
 		velocity_down *= down_aux_based_scale;
 		velocity_vertical_limited = true;
 	}
 
-	if (_param_mc_slow_map_yawr.get() != 0) {
+	const float yawr_aux_input = getAuxInputFromParameterIndex(_param_mc_slow_map_yawr.get());
+
+	if (PX4_ISFINITE(yawr_aux_input)) {
 		const float min_yaw_rate_scale = math::radians(_param_mc_slow_min_yawr.get()) / fmaxf(yaw_rate, FLT_EPSILON);
-		const float aux_input = getInputFromSanitizedAuxParameterIndex(_param_mc_slow_map_yawr.get());
 		const float aux_based_scale =
-			math::interpolate(aux_input, -1.f, 1.f, min_yaw_rate_scale, 1.f);
+			math::interpolate(yawr_aux_input, -1.f, 1.f, min_yaw_rate_scale, 1.f);
 		yaw_rate *= aux_based_scale;
 		yaw_rate_limited = true;
 	}
@@ -136,7 +141,9 @@ bool FlightTaskManualAccelerationSlow::update()
 		_gimbal.acquireGimbalControlIfNeeded();
 
 		// the exact same _yawspeed_setpoint is setpoint for the gimbal and vehicle feed-forward
-		const float pitchrate_setpoint = getInputFromSanitizedAuxParameterIndex(_param_mc_slow_map_pitch.get()) * yaw_rate;
+		// MC_SLOW_MAP_PTCH = 0 means no pitch rate input, as does an aux channel without a value
+		const float pitch_aux_input = getAuxInputFromParameterIndex(_param_mc_slow_map_pitch.get());
+		const float pitchrate_setpoint = PX4_ISFINITE(pitch_aux_input) ? pitch_aux_input * yaw_rate : 0.f;
 		_yawspeed_setpoint = _sticks.getYaw() * yaw_rate;
 
 		_gimbal.publishGimbalManagerSetAttitude(Gimbal::FLAGS_ALL_AXES_LOCKED, Quatf(NAN, NAN, NAN, NAN),
@@ -154,10 +161,16 @@ bool FlightTaskManualAccelerationSlow::update()
 	return ret;
 }
 
-float FlightTaskManualAccelerationSlow::getInputFromSanitizedAuxParameterIndex(int parameter_value)
+float FlightTaskManualAccelerationSlow::getAuxInputFromParameterIndex(int parameter_value)
 {
-	const int sanitized_index = math::constrain(parameter_value - 1, 0, 5);
-	return _sticks.getAux(sanitized_index);
+	// The MC_SLOW_MAP_* parameters use 0 for "not mapped" and 1-6 to select AUX1-AUX6.
+	// Return NaN rather than a neutral 0 for anything that carries no value, so that each
+	// caller applies its own fallback instead of acting on a value the pilot never commanded.
+	if (parameter_value < 1 || parameter_value > 6) {
+		return NAN;
+	}
+
+	return _sticks.getAuxRaw()(parameter_value - 1);
 }
 
 bool FlightTaskManualAccelerationSlow::haveTakenOff()

--- a/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/FlightTaskManualAccelerationSlow.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/FlightTaskManualAccelerationSlow.hpp
@@ -60,11 +60,11 @@ public:
 private:
 
 	/**
-	 * Get the input from a sanitized parameter aux index
-	 * @param parameter_value value of the parameter that specifies the AUX channel index to use
-	 * @return input from that AUX channel [-1,1]
+	 * Read the aux channel selected by an MC_SLOW_MAP_* parameter
+	 * @param parameter_value 0 for "not mapped", 1-6 to select AUX1-AUX6
+	 * @return the aux value, or NaN if unmapped or the channel carries no value
 	 */
-	float getInputFromSanitizedAuxParameterIndex(int parameter_value);
+	float getAuxInputFromParameterIndex(int parameter_value);
 
 	bool _velocity_limits_received_before{false};
 

--- a/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
+++ b/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
@@ -306,7 +306,7 @@ bool FwAutotuneAttitudeControl::isAuxEnableSwitchEnabled()
 		return false;
 	}
 
-	return aux_enable_channel > .5f;
+	return PX4_ISFINITE(aux_enable_channel) && aux_enable_channel > .5f;
 }
 
 void FwAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)

--- a/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
+++ b/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
@@ -272,6 +272,11 @@ bool FwAutotuneAttitudeControl::isAuxEnableSwitchEnabled()
 	manual_control_setpoint_s manual_control_setpoint{};
 	_manual_control_setpoint_sub.copy(&manual_control_setpoint);
 
+	if (!manual_control_setpoint.valid) {
+		// An invalid setpoint keeps the last received aux values, which must not keep autotune enabled
+		return false;
+	}
+
 	float aux_enable_channel = 0;
 
 	switch (_param_fw_at_man_aux.get()) {

--- a/src/modules/fw_rate_control/FixedwingRateControl.cpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.cpp
@@ -485,10 +485,16 @@ void FixedwingRateControl::Run()
 		// Manual flaps/spoilers control, also active in VTOL Hover. Is handled and published in FW Position controller/VTOL module if Auto.
 		if (_vcontrol_mode.flag_control_manual_enabled) {
 
+			// An invalid setpoint keeps the last received aux/flaps values. Fall through to the
+			// retracted default rather than holding a stale surface command, while still publishing
+			// the setpoints so the downstream stream does not stall.
+			const int32_t flaps_source = _manual_control_setpoint.valid ? _param_fw_flaps_man.get() : 0;
+			const int32_t spoilers_source = _manual_control_setpoint.valid ? _param_fw_spoilers_man.get() : 0;
+
 			// Flaps control
 			float flaps_control = 0.f; // default to no flaps
 
-			switch (_param_fw_flaps_man.get()) { 		// do not consider negative switch settings
+			switch (flaps_source) { 		// do not consider negative switch settings
 			case 0:
 				break;
 
@@ -527,7 +533,7 @@ void FixedwingRateControl::Run()
 			// Spoilers control
 			float spoilers_control = 0.f; // default to no spoilers
 
-			switch (_param_fw_spoilers_man.get()) {		// do not consider negative switch settings
+			switch (spoilers_source) {		// do not consider negative switch settings
 			case 0:
 				break;
 

--- a/src/modules/gimbal/CMakeLists.txt
+++ b/src/modules/gimbal/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2016-2026 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,4 +49,5 @@ px4_add_module(
 	DEPENDS
 		geo
 		output_functions_header
+		Sticks
 	)

--- a/src/modules/gimbal/input_rc.cpp
+++ b/src/modules/gimbal/input_rc.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *
-*   Copyright (c) 2016-2022 PX4 Development Team. All rights reserved.
+*   Copyright (c) 2016-2026 PX4 Development Team. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -41,6 +41,7 @@
 #include <px4_platform_common/posix.h>
 #include <px4_platform_common/defines.h>
 #include <px4_platform_common/log.h>
+#include <lib/sticks/Sticks.hpp>
 
 namespace gimbal
 {
@@ -194,38 +195,7 @@ float InputRC::_get_aux_value(const manual_control_setpoint_s &manual_control_se
 		}
 	}();
 
-	float value = 0.0f;
-
-	switch (aux_channel) {
-
-	case 1:
-		value = manual_control_setpoint.aux1;
-		break;
-
-	case 2:
-		value = manual_control_setpoint.aux2;
-		break;
-
-	case 3:
-		value = manual_control_setpoint.aux3;
-		break;
-
-	case 4:
-		value = manual_control_setpoint.aux4;
-		break;
-
-	case 5:
-		value = manual_control_setpoint.aux5;
-		break;
-
-	case 6:
-		value = manual_control_setpoint.aux6;
-		break;
-
-	default:
-		value = 0.0f;
-		break;
-	}
+	const float value = Sticks::getAuxValue(manual_control_setpoint, aux_channel);
 
 	return PX4_ISFINITE(value) ? value : 0.0f;
 }

--- a/src/modules/gimbal/input_rc.cpp
+++ b/src/modules/gimbal/input_rc.cpp
@@ -194,29 +194,40 @@ float InputRC::_get_aux_value(const manual_control_setpoint_s &manual_control_se
 		}
 	}();
 
+	float value = 0.0f;
+
 	switch (aux_channel) {
 
 	case 1:
-		return manual_control_setpoint.aux1;
+		value = manual_control_setpoint.aux1;
+		break;
 
 	case 2:
-		return manual_control_setpoint.aux2;
+		value = manual_control_setpoint.aux2;
+		break;
 
 	case 3:
-		return manual_control_setpoint.aux3;
+		value = manual_control_setpoint.aux3;
+		break;
 
 	case 4:
-		return manual_control_setpoint.aux4;
+		value = manual_control_setpoint.aux4;
+		break;
 
 	case 5:
-		return manual_control_setpoint.aux5;
+		value = manual_control_setpoint.aux5;
+		break;
 
 	case 6:
-		return manual_control_setpoint.aux6;
+		value = manual_control_setpoint.aux6;
+		break;
 
 	default:
-		return 0.0f;
+		value = 0.0f;
+		break;
 	}
+
+	return PX4_ISFINITE(value) ? value : 0.0f;
 }
 
 void InputRC::print_status() const

--- a/src/modules/gimbal/input_rc.cpp
+++ b/src/modules/gimbal/input_rc.cpp
@@ -99,6 +99,12 @@ InputRC::UpdateResult InputRC::_read_control_data_from_subscription(ControlData 
 {
 	manual_control_setpoint_s manual_control_setpoint{};
 	orb_copy(ORB_ID(manual_control_setpoint), _manual_control_setpoint_sub, &manual_control_setpoint);
+
+	if (!manual_control_setpoint.valid) {
+		// no valid date, nothing to update
+		return UpdateResult::NoUpdate;
+	}
+
 	control_data.type = ControlData::Type::Angle;
 	control_data.timestamp_last_update = manual_control_setpoint.timestamp;
 

--- a/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.cpp
+++ b/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.cpp
@@ -129,21 +129,25 @@ void InternalCombustionEngineControl::Run()
 		break;
 
 	case ICESource::Aux1: {
-			if (manual_control_setpoint.aux1 > 0.5f) {
-				_user_request = UserOnOffRequest::On;
+			if (PX4_ISFINITE(manual_control_setpoint.aux1)) {
+				if (manual_control_setpoint.aux1 > 0.5f) {
+					_user_request = UserOnOffRequest::On;
 
-			} else if (manual_control_setpoint.aux1 < -0.5f) {
-				_user_request = UserOnOffRequest::Off;
+				} else if (manual_control_setpoint.aux1 < -0.5f) {
+					_user_request = UserOnOffRequest::Off;
+				}
 			}
 		}
 		break;
 
 	case ICESource::Aux2: {
-			if (manual_control_setpoint.aux2 > 0.5f) {
-				_user_request = UserOnOffRequest::On;
+			if (PX4_ISFINITE(manual_control_setpoint.aux2)) {
+				if (manual_control_setpoint.aux2 > 0.5f) {
+					_user_request = UserOnOffRequest::On;
 
-			} else if (manual_control_setpoint.aux2 < -0.5f) {
-				_user_request = UserOnOffRequest::Off;
+				} else if (manual_control_setpoint.aux2 < -0.5f) {
+					_user_request = UserOnOffRequest::Off;
+				}
 			}
 		}
 		break;

--- a/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.cpp
+++ b/src/modules/internal_combustion_engine_control/InternalCombustionEngineControl.cpp
@@ -129,7 +129,7 @@ void InternalCombustionEngineControl::Run()
 		break;
 
 	case ICESource::Aux1: {
-			if (PX4_ISFINITE(manual_control_setpoint.aux1)) {
+			if (manual_control_setpoint.valid && PX4_ISFINITE(manual_control_setpoint.aux1)) {
 				if (manual_control_setpoint.aux1 > 0.5f) {
 					_user_request = UserOnOffRequest::On;
 
@@ -141,7 +141,7 @@ void InternalCombustionEngineControl::Run()
 		break;
 
 	case ICESource::Aux2: {
-			if (PX4_ISFINITE(manual_control_setpoint.aux2)) {
+			if (manual_control_setpoint.valid && PX4_ISFINITE(manual_control_setpoint.aux2)) {
 				if (manual_control_setpoint.aux2 > 0.5f) {
 					_user_request = UserOnOffRequest::On;
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1137,7 +1137,7 @@ bool Logger::start_stop_logging()
 
 		if (_manual_control_setpoint_sub.update(&manual_control_setpoint)) {
 
-			desired_state = (manual_control_setpoint.aux1 > 0.3f);
+			desired_state = PX4_ISFINITE(manual_control_setpoint.aux1) && (manual_control_setpoint.aux1 > 0.3f);
 			updated = true;
 		}
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1135,7 +1135,7 @@ bool Logger::start_stop_logging()
 		// aux1-based logging
 		manual_control_setpoint_s manual_control_setpoint;
 
-		if (_manual_control_setpoint_sub.update(&manual_control_setpoint)) {
+		if (_manual_control_setpoint_sub.update(&manual_control_setpoint) && manual_control_setpoint.valid) {
 
 			desired_state = PX4_ISFINITE(manual_control_setpoint.aux1) && (manual_control_setpoint.aux1 > 0.3f);
 			updated = true;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2319,6 +2319,15 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 
 	manual_control_setpoint_s manual_control_setpoint{};
 
+	// aux1-6 are only valid if the sender explicitly marks them as such via enabled_extensions;
+	// default to NaN so an unset channel is distinguishable from one centered at 0.
+	manual_control_setpoint.aux1 = NAN;
+	manual_control_setpoint.aux2 = NAN;
+	manual_control_setpoint.aux3 = NAN;
+	manual_control_setpoint.aux4 = NAN;
+	manual_control_setpoint.aux5 = NAN;
+	manual_control_setpoint.aux6 = NAN;
+
 	if (math::isInRange((int)mavlink_manual_control.x, -1000, 1000)) { manual_control_setpoint.pitch = mavlink_manual_control.x / 1000.f; }
 
 	if (math::isInRange((int)mavlink_manual_control.y, -1000, 1000)) { manual_control_setpoint.roll = mavlink_manual_control.y / 1000.f; }

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2369,6 +2369,15 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 
 	manual_control_setpoint_s manual_control_setpoint{};
 
+	// aux1-6 are only valid if the sender explicitly marks them as such via enabled_extensions;
+	// default to NaN so an unset channel is distinguishable from one centered at 0.
+	manual_control_setpoint.aux1 = NAN;
+	manual_control_setpoint.aux2 = NAN;
+	manual_control_setpoint.aux3 = NAN;
+	manual_control_setpoint.aux4 = NAN;
+	manual_control_setpoint.aux5 = NAN;
+	manual_control_setpoint.aux6 = NAN;
+
 	if (math::isInRange((int)mavlink_manual_control.x, -1000, 1000)) { manual_control_setpoint.pitch = mavlink_manual_control.x / 1000.f; }
 
 	if (math::isInRange((int)mavlink_manual_control.y, -1000, 1000)) { manual_control_setpoint.roll = mavlink_manual_control.y / 1000.f; }

--- a/src/modules/rc_update/RCUpdateTest.cpp
+++ b/src/modules/rc_update/RCUpdateTest.cpp
@@ -40,6 +40,7 @@ class TestRCUpdate : public RCUpdate
 {
 public:
 	void UpdateManualSwitches(const hrt_abstime &timestamp_sample) { RCUpdate::UpdateManualSwitches(timestamp_sample); }
+	void UpdateManualControlInput(const hrt_abstime &timestamp_sample) { RCUpdate::UpdateManualControlInput(timestamp_sample); }
 	void updateParams() { RCUpdate::updateParams(); }
 	void setChannel(size_t index, float channel_value) { _rc.channels[index] = channel_value; }
 };
@@ -162,7 +163,9 @@ public:
 
 		(ParamInt<px4::params::RC_MAP_PAY_SW>) _param_rc_map_pay_sw,
 		(ParamFloat<px4::params::RC_PAYLOAD_TH>) _param_rc_payload_th,
-		(ParamFloat<px4::params::RC_PAYLOAD_MIDTH>) _param_rc_payload_midth
+		(ParamFloat<px4::params::RC_PAYLOAD_MIDTH>) _param_rc_payload_midth,
+
+		(ParamInt<px4::params::RC_MAP_AUX1>) _param_rc_map_aux1
 	)
 };
 
@@ -323,4 +326,59 @@ TEST_F(RCUpdateTest, PayloadPower3WaySwitchNegativeThresholds)
 	checkPayloadPowerSwitch(-0.5f, -0.75f, -0.25f, 2); // On mid_threshold -> SWITCH_POS_MIDDLE
 	checkPayloadPowerSwitch(-0.501f, -0.75f, -0.25f, 1); // Slightly above on_threshold -> SWITCH_POS_ON
 	checkPayloadPowerSwitch(-1.f, -0.75f, -0.25f, 1); // Above on_threshold -> SWITCH_POS_ON
+}
+
+TEST_F(RCUpdateTest, UnmappedAuxChannelsAreNaN)
+{
+	// GIVEN: default configuration, no RC_MAP_AUX1..6 assigned
+	EXPECT_EQ(_param_rc_map_aux1.get(), 0);
+
+	// WHEN: we update the manual control input
+	_rc_update.UpdateManualControlInput(0);
+
+	// THEN: unmapped aux channels report NaN (invalid), not 0
+	uORB::SubscriptionData<manual_control_setpoint_s> manual_control_input_sub{ORB_ID(manual_control_input)};
+	manual_control_input_sub.update();
+	const manual_control_setpoint_s &manual_control_input = manual_control_input_sub.get();
+
+	EXPECT_FALSE(PX4_ISFINITE(manual_control_input.aux1));
+	EXPECT_FALSE(PX4_ISFINITE(manual_control_input.aux2));
+	EXPECT_FALSE(PX4_ISFINITE(manual_control_input.aux3));
+	EXPECT_FALSE(PX4_ISFINITE(manual_control_input.aux4));
+	EXPECT_FALSE(PX4_ISFINITE(manual_control_input.aux5));
+	EXPECT_FALSE(PX4_ISFINITE(manual_control_input.aux6));
+
+	// AND: unmapped roll/pitch/yaw/throttle still default to 0 (out of scope for this fix)
+	EXPECT_FLOAT_EQ(manual_control_input.roll, 0.f);
+	EXPECT_FLOAT_EQ(manual_control_input.pitch, 0.f);
+	EXPECT_FLOAT_EQ(manual_control_input.yaw, 0.f);
+	EXPECT_FLOAT_EQ(manual_control_input.throttle, 0.f);
+}
+
+TEST_F(RCUpdateTest, MappedAuxChannelReportsRealValue)
+{
+	// GIVEN: first channel is configured as aux1
+	_param_rc_map_aux1.set(1);
+	_param_rc_map_aux1.commit();
+	EXPECT_EQ(_param_rc_map_aux1.get(), 1);
+	_rc_update.updateParams();
+
+	// GIVEN: first channel has a real value
+	_rc_update.setChannel(0, 0.3f);
+
+	// WHEN: we update the manual control input
+	_rc_update.UpdateManualControlInput(0);
+
+	// THEN: aux1 reflects the mapped channel's value, not NaN
+	uORB::SubscriptionData<manual_control_setpoint_s> manual_control_input_sub{ORB_ID(manual_control_input)};
+	manual_control_input_sub.update();
+	const manual_control_setpoint_s &manual_control_input = manual_control_input_sub.get();
+
+	EXPECT_TRUE(PX4_ISFINITE(manual_control_input.aux1));
+	EXPECT_FLOAT_EQ(manual_control_input.aux1, 0.3f);
+
+	// Reset for other tests
+	_param_rc_map_aux1.set(0);
+	_param_rc_map_aux1.commit();
+	_rc_update.setChannel(0, 0.f);
 }

--- a/src/modules/rc_update/RCUpdateTest.cpp
+++ b/src/modules/rc_update/RCUpdateTest.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2022 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2022-2026 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
+
+#include <cmath>
 
 #include <gtest/gtest.h>
 #include "rc_update.h"
@@ -341,12 +343,12 @@ TEST_F(RCUpdateTest, UnmappedAuxChannelsAreNaN)
 	manual_control_input_sub.update();
 	const manual_control_setpoint_s &manual_control_input = manual_control_input_sub.get();
 
-	EXPECT_FALSE(PX4_ISFINITE(manual_control_input.aux1));
-	EXPECT_FALSE(PX4_ISFINITE(manual_control_input.aux2));
-	EXPECT_FALSE(PX4_ISFINITE(manual_control_input.aux3));
-	EXPECT_FALSE(PX4_ISFINITE(manual_control_input.aux4));
-	EXPECT_FALSE(PX4_ISFINITE(manual_control_input.aux5));
-	EXPECT_FALSE(PX4_ISFINITE(manual_control_input.aux6));
+	EXPECT_TRUE(std::isnan(manual_control_input.aux1));
+	EXPECT_TRUE(std::isnan(manual_control_input.aux2));
+	EXPECT_TRUE(std::isnan(manual_control_input.aux3));
+	EXPECT_TRUE(std::isnan(manual_control_input.aux4));
+	EXPECT_TRUE(std::isnan(manual_control_input.aux5));
+	EXPECT_TRUE(std::isnan(manual_control_input.aux6));
 
 	// AND: unmapped roll/pitch/yaw/throttle still default to 0 (out of scope for this fix)
 	EXPECT_FLOAT_EQ(manual_control_input.roll, 0.f);

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -264,13 +264,13 @@ void RCUpdate::rc_parameter_map_poll(bool forced)
 	}
 }
 
-float RCUpdate::get_rc_value(uint8_t func, float min_value, float max_value) const
+float RCUpdate::get_rc_value(uint8_t func, float min_value, float max_value, float default_value) const
 {
 	if (_rc.function[func] >= 0) {
 		return math::constrain(_rc.channels[_rc.function[func]], min_value, max_value);
 	}
 
-	return 0.f;
+	return default_value;
 }
 
 void RCUpdate::set_params_from_rc()
@@ -674,12 +674,12 @@ void RCUpdate::UpdateManualControlInput(const hrt_abstime &timestamp_sample)
 	manual_control_input.yaw = get_rc_value(rc_channels_s::FUNCTION_YAW,     -1.f, 1.f);
 	manual_control_input.throttle = get_rc_value(rc_channels_s::FUNCTION_THROTTLE, -1.f, 1.f);
 	manual_control_input.flaps = get_rc_value(rc_channels_s::FUNCTION_FLAPS,   -1.f, 1.f);
-	manual_control_input.aux1  = get_rc_value(rc_channels_s::FUNCTION_AUX_1,   -1.f, 1.f);
-	manual_control_input.aux2  = get_rc_value(rc_channels_s::FUNCTION_AUX_2,   -1.f, 1.f);
-	manual_control_input.aux3  = get_rc_value(rc_channels_s::FUNCTION_AUX_3,   -1.f, 1.f);
-	manual_control_input.aux4  = get_rc_value(rc_channels_s::FUNCTION_AUX_4,   -1.f, 1.f);
-	manual_control_input.aux5  = get_rc_value(rc_channels_s::FUNCTION_AUX_5,   -1.f, 1.f);
-	manual_control_input.aux6  = get_rc_value(rc_channels_s::FUNCTION_AUX_6,   -1.f, 1.f);
+	manual_control_input.aux1  = get_rc_value(rc_channels_s::FUNCTION_AUX_1,   -1.f, 1.f, NAN);
+	manual_control_input.aux2  = get_rc_value(rc_channels_s::FUNCTION_AUX_2,   -1.f, 1.f, NAN);
+	manual_control_input.aux3  = get_rc_value(rc_channels_s::FUNCTION_AUX_3,   -1.f, 1.f, NAN);
+	manual_control_input.aux4  = get_rc_value(rc_channels_s::FUNCTION_AUX_4,   -1.f, 1.f, NAN);
+	manual_control_input.aux5  = get_rc_value(rc_channels_s::FUNCTION_AUX_5,   -1.f, 1.f, NAN);
+	manual_control_input.aux6  = get_rc_value(rc_channels_s::FUNCTION_AUX_6,   -1.f, 1.f, NAN);
 	manual_control_input.valid = _rc_calibrated;
 
 	// publish manual_control_input topic

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -115,9 +115,9 @@ protected:
 	void updateParams() override;
 
 	/**
-	 * Get and limit value for specified RC function. Returns NAN if not mapped.
+	 * Get and limit value for specified RC function. Returns default_value if not mapped.
 	 */
-	float		get_rc_value(uint8_t func, float min_value, float max_value) const;
+	float		get_rc_value(uint8_t func, float min_value, float max_value, float default_value = 0.f) const;
 
 	/**
 	 * Get on/off switch position from the RC channel of the specified function


### PR DESCRIPTION
Updates ManualControlSetpoint topic to the current docs standard.

Following the update tests showed
- `aux1-6` didn't have NaN as invalid value, and there was no way to differentiate invalid vs 0 settings.
  
  This fixes that via claude and adds a few tests.
  I did NOT test this thorougly - just tested that connecting a joystick still works and you can fly.

  The behaviour is the same before-and-after except that previously an unmapped `RCAUX` output channel resolving to 0 value and now it resolves to the disarmed value. I'd say the previous behaviour was a bug: this maps the intent (see `lib/mixer_module/functions/FunctionManualRC`).

  It may be that some of the other cases should ALSO do something different than map the NaN setting to zero.
  I wasn't sure what though. I figure at least this is explicit and we can decide.
  
- `roll`, `pitch`, `yaw`, `throttle`, and `flaps` also default `0.0f`. They don't use NaN or have any way to differentiate specific invalid values from 0 values.
  This is wrong, but according to Claude is a bigger fix. 
  So what I have done is updated the topic to indicate `[@invalid - NaN expected but not implemented]` so the TBD is obvious.

Below is the Claude summary.

<details>

## Summary

Aligns `ManualControlSetpoint`'s `aux1`–`aux6` behavior with the `[@invalid NaN]` contract documented for these fields: an unmapped/unset aux channel now publishes `NAN` instead of `0.0f`, so consumers can distinguish "channel not present" from "channel intentionally centered at zero."

- `rc_update.cpp`/`.h`: `get_rc_value()` now takes an explicit `default_value` (defaults to `0.f`); aux1–6 pass `NAN` so unmapped RC aux channels publish `NAN` instead of `0.0f`.
- `mavlink_receiver.cpp`: `handle_message_manual_control()` pre-initializes aux1–6 to `NAN` before applying MAVLink `MANUAL_CONTROL` extension fields, so an aux channel not marked present via `enabled_extensions` publishes `NAN`.
- Updated consumers to explicitly guard against non-finite aux values instead of assuming `0`: `FlightTaskManualAccelerationSlow`, `fw_autotune_attitude_control`, `gimbal/input_rc`, `internal_combustion_engine_control`, `FailureInjectionManager`, `logger` (rc_aux1 log mode), and `voxl_esc` (turtle mode + GPIO control channel). These guards are behavior-preserving — each site already treated `NaN` the same as "below threshold" implicitly; the change just makes that explicit with `PX4_ISFINITE` instead of relying on float comparison semantics.
  - `lib/mixer_module/functions/FunctionManualRC` was reviewed and left as-is: an unmapped `RCAUX` output channel resolving to the disarmed value (via the generic NaN handling already in `mixer_module.cpp`) is the intended behavior.


## Tests

- `RCUpdateTest`: `UnmappedAuxChannelsAreNaN` and `MappedAuxChannelReportsRealValue` cover the RC producer path.
- `FailureInjectionManagerRcInjectionTest` (new functional gtest): covers the RC-triggered failure-injection NaN guard end-to-end via real uORB publish → `evaluateRcInjection()` → trigger state. `Run()` / `evaluateRcInjection()` made `protected` (was `private`) in `FailureInjectionManager.hpp` to allow this, matching the existing `RCUpdate` testability pattern.

## Known follow-ups (not addressed in this PR)

- `logger.cpp` (rc_aux1 log mode) and `voxl_esc.cpp` (turtle mode / GPIO control) don't have automated regression tests for their NaN guards — both would require extracting logic out of large `Run()`/`WorkItem` methods to be safely unit-testable. Verified manually via code inspection; a SITL check is recommended before relying on this in the field.
  - A MAVLink-receiver-side producer test for `handle_message_manual_control()` was attempted but dropped: constructing a real `Mavlink` object pulls in a dataman-client-backed mission manager that isn't available in a unit/functional gtest harness. Real test coverage for this path would need a lighter-weight construction path or test doubles.
  
</details>