### PR TITLE
navigator: RTL: fix idle setpoint on activation

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -220,6 +220,12 @@ void RTL::publishRemainingTimeEstimate()
 
 void RTL::on_activation()
 {
+	_global_pos_sub.update();
+	_vehicle_status_sub.update();
+	_mission_sub.update();
+	_home_pos_sub.update();
+	_wind_sub.update();
+
 	setRtlTypeAndDestination();
 
 	switch (_rtl_type) {
@@ -228,12 +234,21 @@ void RTL::on_activation()
 	case RtlType::RTL_MISSION_FAST_REVERSE:
 		if (_rtl_mission_type_handle) {
 			_rtl_mission_type_handle->setReturnAltMin(_enforce_rtl_alt);
+			_rtl_mission_type_handle->run(true);
 		}
+
+		_rtl_direct.run(false);
 
 		break;
 
 	case RtlType::RTL_DIRECT:
 		_rtl_direct.setReturnAltMin(_enforce_rtl_alt);
+		_rtl_direct.run(true);
+
+		if (_rtl_mission_type_handle) {
+			_rtl_mission_type_handle->run(false);
+		}
+
 		break;
 
 	default:


### PR DESCRIPTION
### Problem

When switching modes, navigator resets the position setpoint triplet to idle. In the case of entering RTL, it is not replaced immediately by the correct triplet, but published once and only corrected a split second later. This causes zero thrust to come from [here](https://github.com/PX4/PX4-Autopilot/blob/fd7edaa4fe3efc3a15381cceef5aa0dc1322a06b/src/modules/fw_mode_manager/FixedWingModeManager.cpp#L590-L594).


### Solution 

Fix by calling `run(true)` on the appropriate sub-mode at the end of `RTL::on_activation()`, same as in the `on_active` just below. 

The submode is in inactive at that point, but run(true) triggers:
 - `on_activation` of the submode
 - `set_rtl_item`, which calls:
     - `mission_item_to_position_setpoint` 
     - `_navigator->set_position_setpoint_triplet_updated`

and therefore the navigator publishes the position setpoint triplet immediately (which was already being correctly set).


### Changelog Entry
For release notes:
```
Fix short spike of zero throttle when entering RTL
```

### Test coverage
Simulating `gz_standard_vtol` in FW, print-debugging to see clearly when an idle setpoint ever appears in `FixedWingModeManager`:
```
diff --cc src/modules/fw_mode_manager/FixedWingModeManager.cpp
index 9cbcd2ea4c,9cbcd2ea4c..4c3951e0b7
--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@@ -634,6 -634,6 +634,8 @@@ FixedWingModeManager::control_auto(cons
  
  void FixedWingModeManager::control_idle()
  {
++      PX4_INFO("control_idle");
++
        const hrt_abstime  now = hrt_absolute_time();
        fixed_wing_lateral_setpoint_s lateral_ctrl_sp {empty_lateral_control_setpoint};
        lateral_ctrl_sp.timestamp = now;

```

**Before PR**
Issue appears reliably, regardless of whether the previous mode has a valid `position_setpoint_triplet/current`. Exactly on the mode switch, an IDLE position setpoint appears (type 5) but is very quickly replaced by the right one: 
<img width="654" height="530" alt="image" src="https://github.com/user-attachments/assets/c55ae61b-7c13-4c83-9bdc-f703140da7c0" />

Accordingly, the `FixedWingModeManager` gives zero throttle:
```
pxh> commander mode altctl
pxh> commander mode auto:rtl
pxh> INFO  [fw_mode_manager] control_idle
INFO  [fw_mode_manager] control_idle
INFO  [fw_mode_manager] control_idle
INFO  [navigator] RTL: start return at 78 m (78 m above destination)	
pxh> commander mode altctl
pxh> commander mode auto:rtl
pxh> INFO  [fw_mode_manager] control_idle
INFO  [fw_mode_manager] control_idle
INFO  [fw_mode_manager] control_idle
INFO  [navigator] RTL: start return at 78 m (78 m above destination)	
pxh> commander mode altctl
pxh> commander mode auto:rtl
pxh> INFO  [fw_mode_manager] control_idle
INFO  [fw_mode_manager] control_idle
INFO  [fw_mode_manager] control_idle
INFO  [navigator] RTL: start return at 75 m (75 m above destination)	
pxh> commander mode auto:loiter
pxh> commander mode auto:rtl
pxh> INFO  [fw_mode_manager] control_idle
INFO  [fw_mode_manager] control_idle
INFO  [fw_mode_manager] control_idle
INFO  [fw_mode_manager] control_idle
INFO  [navigator] RTL: start return at 74 m (73 m above destination)	
pxh> commander mode auto:loiter
pxh> commander mode auto:rtl
pxh> INFO  [fw_mode_manager] control_idle
INFO  [fw_mode_manager] control_idle
INFO  [fw_mode_manager] control_idle
INFO  [navigator] RTL: start return at 73 m (73 m above destination)	
pxh> commander mode auto:loiter
pxh> commander mode auto:rtl
pxh> INFO  [fw_mode_manager] control_idle
INFO  [fw_mode_manager] control_idle
INFO  [fw_mode_manager] control_idle
INFO  [fw_mode_manager] control_idle
INFO  [navigator] RTL: start return at 70 m (70 m above destination)	
```

**After PR**

we only have a valid (non-IDLE) position setpoint after the mode switch: 
<img width="654" height="530" alt="image" src="https://github.com/user-attachments/assets/9f8814e4-ed69-4c89-8c38-15a352b74fc9" />


No `control_idle` anymore:
```
pxh> param show RTL_TYPE
Symbols: x = used, + = saved, * = unsaved
x   RTL_TYPE [1016,1338] : 1

 1293/1974 parameters used.
pxh> commander mode auto:rtl
pxh> INFO  [navigator] RTL: start return at 61 m (60 m above destination)	
pxh> commander mode altctl
pxh> commander mode auto:rtl
pxh> INFO  [navigator] RTL: start return at 61 m (60 m above destination)	
pxh> commander mode altctl
pxh> commander mode auto:rtl
pxh> INFO  [navigator] RTL: start return at 61 m (60 m above destination)	
pxh> commander mode altctl
pxh> commander mode auto:rtl

```

Also not with mission RTL:
```
INFO  [commander] Armed by mission start	
INFO  [tone_alarm] arming warning
INFO  [navigator] Executing Mission	
INFO  [navigator] Climb to 100.1 meters above home	
INFO  [commander] Takeoff detected	
pxh> commander mode auto:rtl
pxh> INFO  [navigator] Executing Mission	
pxh> commander mode auto:mission
pxh> INFO  [navigator] Executing Mission	
INFO  [navigator] Climb to 581.1 meters above home	
```