### PR TITLE
PCA9685: add PWM_CENTER to auto generated params

### DIFF
--- a/src/drivers/pca9685_pwm_out/module.yaml
+++ b/src/drivers/pca9685_pwm_out/module.yaml
@@ -7,6 +7,7 @@ actuator_output:
         disarmed: { min: 800, max: 2200, default: 1000 }
         min: { min: 800, max: 1400, default: 1100 }
         max: { min: 1600, max: 2200, default: 1900 }
+        center: { min: 800, max: 2200}
         failsafe: { min: 800, max: 2200 }
       custom_params:
         - name: 'DUTY_EN'


### PR DESCRIPTION


### Solved Problem
We so far don't generate the [PWM_CENTER](https://github.com/PX4/PX4-Autopilot/pull/25897) params for the PCA9685. 

### Solution
Just add the CENTER params.

### Changelog Entry
For release notes:
```
Feature: PCA9685: add PWM_CENTER to auto generated params
```
