### PR TITLE
voxl2: added 32768 Hz external clock option for icm42688p driver start

### DIFF
--- a/boards/modalai/voxl2/target/voxl-px4-start
+++ b/boards/modalai/voxl2/target/voxl-px4-start
@@ -76,10 +76,10 @@ param load
 # IMU (accelerometer / gyroscope)
 if [ "$PLATFORM" == "M0104" ]; then
     /bin/echo "Starting IMU driver with rotation 12"
-    qshell icm42688p start -s -R 12
+    qshell icm42688p start -s -R 12 -C 32768
 else
     /bin/echo "Starting IMU driver with no rotation"
-    qshell icm42688p start -s
+    qshell icm42688p start -s -C 32768
 fi
 
 # Start Invensense ICP 101xx barometer built on to VOXL 2


### PR DESCRIPTION
The VOXL2 board has a 32768 Hz clock connected to the ICM42688P IMU. This PR adds the -C option to the driver start line to properly configure the driver to use that clock input.

