### PR TITLE
msg_docs: fix IndexError crash in generate_msg_docs.py

### DIFF
--- a/Tools/ci/metadata_sync.sh
+++ b/Tools/ci/metadata_sync.sh
@@ -123,7 +123,7 @@ generate_parameters() {
     if [[ "$VERBOSE" == "true" ]]; then
         make parameters_metadata
     else
-        make parameters_metadata >/dev/null 2>&1
+        make parameters_metadata >/dev/null
     fi
 }
 
@@ -132,7 +132,7 @@ generate_airframes() {
     if [[ "$VERBOSE" == "true" ]]; then
         make airframe_metadata
     else
-        make airframe_metadata >/dev/null 2>&1
+        make airframe_metadata >/dev/null
     fi
 }
 
@@ -141,7 +141,7 @@ generate_modules() {
     if [[ "$VERBOSE" == "true" ]]; then
         make module_documentation
     else
-        make module_documentation >/dev/null 2>&1
+        make module_documentation >/dev/null
     fi
 }
 
@@ -150,7 +150,7 @@ generate_msg_docs() {
     if [[ "$VERBOSE" == "true" ]]; then
         make msg_docs
     else
-        make msg_docs >/dev/null 2>&1
+        make msg_docs >/dev/null
     fi
 }
 
@@ -159,7 +159,7 @@ generate_uorb_graphs() {
     if [[ "$VERBOSE" == "true" ]]; then
         make uorb_graphs
     else
-        make uorb_graphs >/dev/null 2>&1
+        make uorb_graphs >/dev/null
     fi
 }
 
@@ -169,7 +169,7 @@ generate_failsafe_web() {
     if [[ "$VERBOSE" == "true" ]]; then
         make failsafe_web
     else
-        make failsafe_web >/dev/null 2>&1
+        make failsafe_web >/dev/null
     fi
 }
 

--- a/Tools/msg/generate_msg_docs.py
+++ b/Tools/msg/generate_msg_docs.py
@@ -729,10 +729,10 @@ pageClass: is-wide-page
 
             # Fix up topics if the topic is empty
             def camel_to_snake(name):
-                # Match upper case not at start of string
-                s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-                # Handle cases with multiple capital first letter
-                return re.sub('([A-Z]+)([A-Z][a-z]*)', r'\1_\2', s1).lower()
+                # Insert underscore between lowercase/digit and uppercase letter
+                s1 = re.sub('([a-z0-9])([A-Z])', r'\1_\2', name)
+                # Insert underscore between consecutive uppercase and uppercase+lowercase
+                return re.sub('([A-Z]+)([A-Z][a-z])', r'\1_\2', s1).lower()
 
             defaultTopic = camel_to_snake(self.name)
             if len(self.topics) == 0:
@@ -745,7 +745,7 @@ pageClass: is-wide-page
                     error = Error("topic_error", self.filename, "", f"WARNING: TOPIC {defaultTopic} unnecessarily declared for {self.name}")
                 else:
                     # Declared topic is not default topic
-                    error = Error("topic_error", self.filename, "", f"NOTE: TOPIC {self.topics[1]}: Only Declared topic is not default topic {defaultTopic} for {self.name}")
+                    error = Error("topic_error", self.filename, "", f"NOTE: TOPIC {self.topics[0]}: Only Declared topic is not default topic {defaultTopic} for {self.name}")
                 if not "topic_error" in self.errors:
                     self.errors["topic_error"] = []
                     self.errors["topic_error"].append(error)


### PR DESCRIPTION
Fix Docs - Orchestrator CI job failing on every branch since Feb 20.

`generate_msg_docs.py` crashes with an `IndexError` when a `.msg` file declares a single topic that doesn't match the `camel_to_snake` default. The `camel_to_snake()` regex was also broken for compound CamelCase names (`AuxGlobalPosition` produced `aux_globalposition` instead of `aux_global_position`). Additionally, `metadata_sync.sh` was redirecting stderr to `/dev/null` in non-verbose mode, hiding the actual error from CI logs.

PR #26306 added `AuxGlobalPosition.msg`, which exposed two latent bugs in `generate_msg_docs.py` from PR #24977.

Failed runs:
- https://github.com/PX4/PX4-Autopilot/actions/runs/22232656541 (main)
- https://github.com/PX4/PX4-Autopilot/actions/runs/22241400379 (dev-bluerov-hgt)
- https://github.com/PX4/PX4-Autopilot/actions/runs/22236627570 (pr-uavcan_esc_failures)
- https://github.com/PX4/PX4-Autopilot/actions/runs/22241117739 (mrpollo/ci_orchestration)