### PR TITLE
map ROS_LOCALHOST_ONLY to UXRCE_DDS_PTCFG

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -311,6 +311,16 @@ then
 else
 	param set UXRCE_DDS_DOM_ID 0
 fi
+if [ -n "$ROS_LOCALHOST_ONLY" ]
+  then
+  	# Match UXRCE_DDS_PTCFG with ROS_LOCALHOST_ONLY, if defined.
+  	if [ "$ROS_LOCALHOST_ONLY" = "1" ]
+  	then
+  		param set UXRCE_DDS_PTCFG 1
+  	else
+  		param set UXRCE_DDS_PTCFG 0
+  	fi
+fi
 uxrce_dds_port=8888
 if [ -n "$PX4_UXRCE_DDS_PORT" ]
 then

--- a/docs/en/middleware/uxrce_dds.md
+++ b/docs/en/middleware/uxrce_dds.md
@@ -360,11 +360,12 @@ By default the client is started on localhost UDP port `8888` with no additional
 Environment variables are provided that override some [UXRCE-DDS parameters](../advanced_config/parameter_reference.md#uxrce-dds-client).
 These allow users to create custom startup files for their simulations:
 
-- `PX4_UXRCE_DDS_NS`: Use this to specify the topic [namespace](#customizing-the-namespace)).
+- `PX4_UXRCE_DDS_NS`: Use this to specify the topic [namespace](#customizing-the-namespace).
 - `ROS_DOMAIN_ID`: Use this to replace [UXRCE_DDS_DOM_ID](../advanced_config/parameter_reference.md#UXRCE_DDS_DOM_ID).
+- `ROS_LOCALHOST_ONLY`: Use this to replace [UXRCE_DDS_PTCFG](../advanced_config/parameter_reference.md#UXRCE_DDS_PTCFG) (valid values: `0` or `1`).
 - `PX4_UXRCE_DDS_PORT`: Use this to replace [UXRCE_DDS_PRT](../advanced_config/parameter_reference.md#UXRCE_DDS_PRT).
 
-For example, the following command can be used to start a Gazebo simulation with che client operating on the DDS domain `3`, port `9999` and topic namespace `drone`.
+For example, the following command can be used to start a Gazebo simulation with the client operating on the DDS domain `3`, port `9999` and topic namespace `drone`.
 
 ```sh
 ROS_DOMAIN_ID=3 PX4_UXRCE_DDS_PORT=9999 PX4_UXRCE_DDS_NS=drone make px4_sitl gz_x500


### PR DESCRIPTION
In SITL startup, mirror `ROS_LOCALHOST_ONLY` into `UXRCE_DDS_PTCFG` so PX4 and ROS middleware locality policy stay aligned with environment-based bringup.
    Also document `ROS_LOCALHOST_ONLY` as an env override for `UXRCE_DDS_PTCFG`.


### Solved Problem
  When running PX4 SITL with ROS 2, `ROS_LOCALHOST_ONLY` and PX4 `UXRCE_DDS_PTCFG` can become misaligned unless set manually.
  That mismatch causes DDS discovery/data flow failure from ROS 2 (e.g. missing `/fmu/out/*` topics).

  Fixes #N/A

  ### Solution
  - In `ROMFS/px4fmu_common/init.d-posix/rcS`, map `ROS_LOCALHOST_ONLY` to `UXRCE_DDS_PTCFG` during SITL startup:
    - if `ROS_LOCALHOST_ONLY` is set and equals `"1"`: `UXRCE_DDS_PTCFG=1`
    - if `ROS_LOCALHOST_ONLY` is set and is anything else: `UXRCE_DDS_PTCFG=0`
    - if `ROS_LOCALHOST_ONLY` is unset: leave parameter default behavior unchanged
  - Update `docs/en/middleware/uxrce_dds.md` to document `ROS_LOCALHOST_ONLY` override and update example command.

  ### Changelog Entry
  For release notes:
  ```text
  Bugfix: SITL startup now maps ROS_LOCALHOST_ONLY to UXRCE_DDS_PTCFG.
  Documentation: Added ROS_LOCALHOST_ONLY env override in uxrce_dds docs and updated example command.
```
  ### Alternatives

  - Keep manual param set UXRCE_DDS_PTCFG in scripts.

  ### Test coverage

  Tested with SITL (gz_x500, headless), MicroXRCEAgent UDP 8888, ROS_DOMAIN_ID=42.

  | Host ROS_LOCALHOST_ONLY | PX4 ROS_LOCALHOST_ONLY -> UXRCE_DDS_PTCFG | Result |
  |---|---|---|
  | 0 | 0 | PASS: /fmu/out/* visible and echo succeeds |
  | 1 | 1 | PASS: /fmu/out/* visible and echo succeeds |
  | 1 | 0 | FAIL (expected): ROS side only sees /parameter_events and /rosout |
  | 0 | 1 | FAIL (expected): ROS side only sees /parameter_events and /rosout |

  Echo command used:

  ros2 topic echo --once --no-daemon /fmu/out/vehicle_status_v1 \
    --qos-reliability best_effort --qos-durability transient_local

  ### Context

  This keeps env-based SITL bringup minimal and deterministic: setting ROS_LOCALHOST_ONLY directly drives PX4 uXRCE locality mode.