### PR TITLE
Fix double-promotion warning in gz_msgs on macOS

### DIFF
--- a/src/modules/simulation/gz_msgs/CMakeLists.txt
+++ b/src/modules/simulation/gz_msgs/CMakeLists.txt
@@ -18,6 +18,9 @@ if (Protobuf_FOUND)
         ${PROTO_HDRS}
     )
 
+    # Disable double-promotion warning for protobuf-generated code
+    target_compile_options(px4_gz_msgs PRIVATE -Wno-double-promotion)
+
     target_include_directories(px4_gz_msgs
         PUBLIC
             ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
## Description
Fixes double-promotion warning when building gz_msgs on macOS with newer Protobuf/Abseil versions.

## Problem
When building on macOS with Protobuf 33.x and Abseil 20260107.1, the build fails with:

fatal error: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]

This error originates from Abseil library code included by Protobuf-generated files, not from PX4 code.

## Solution
Disable `-Wdouble-promotion` warning specifically for the `px4_gz_msgs` target, since we cannot modify the external Protobuf/Abseil code.

## Testing
- [x] Built successfully on macOS with Protobuf 33.4 and Abseil 20260107.1
- [x] Verified gz_msgs module compiles without errors

Closes #26533