### PR TITLE
zenoh: fix default config topic type to use actual uORB topic name

### DIFF
--- a/src/modules/zenoh/default_topics.c.em
+++ b/src/modules/zenoh/default_topics.c.em
@@ -18,15 +18,15 @@ import os
 
 const char* default_pub_config =
 @[    for pub in publications]@
-	"@(pub['topic']);@(pub['simple_base_type']);0\n"
+	"@(pub['topic']);@(pub['topic_simple']);0\n"
 @[    end for]@
 ;
 
 const char* default_sub_config =
 @[    for sub in subscriptions]@
-	"@(sub['topic']);@(sub['simple_base_type']);0\n"
+	"@(sub['topic']);@(sub['topic_simple']);0\n"
 @[    end for]@
 @[    for sub in subscriptions_multi]@
-	"@(sub['topic']);@(sub['simple_base_type']);-1\n"
+	"@(sub['topic']);@(sub['topic_simple']);-1\n"
 @[    end for]@
 ;


### PR DESCRIPTION
### Solved Problem

The zenoh bridge maps incoming ROS2 data to the wrong uORB topics when the topic name differs from the message type name.

For example:
```
  - topic: /fmu/in/aux_global_position
    type: px4_msgs::msg::VehicleGlobalPosition
```
Will publish on topic `vehicle_global_position` instead of `aux_global_position`.

### Solution

In `default_topics.c.em`, use `topic_simple` (the actual uORB topic name) instead of `simple_base_type` (the message type name). Both are already computed by `generate_dds_topics.py`. For topics where the name matches the type, these are identical.