### PR TITLE
uavcannode: Fix VCS Version Reporting in Node Info for UAVCAN Nodes

### DIFF
--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -468,7 +468,7 @@ UavcanNode::fill_node_info()
 	char fw_git_short[9] = {};
 	std::memmove(fw_git_short, px4_firmware_version_string(), 8);
 	char *end = nullptr;
-	swver.vcs_commit = std::strtol(fw_git_short, &end, 16);
+	swver.vcs_commit = std::strtoul(fw_git_short, &end, 16);
 	swver.optional_field_flags |= swver.OPTIONAL_FIELD_FLAG_VCS_COMMIT;
 
 	// Too verbose for normal operation

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -284,7 +284,7 @@ void UavcanNode::fill_node_info()
 	char fw_git_short[9] = {};
 	std::memmove(fw_git_short, px4_firmware_version_string(), 8);
 	char *end = nullptr;
-	swver.vcs_commit = std::strtol(fw_git_short, &end, 16);
+	swver.vcs_commit = std::strtoul(fw_git_short, &end, 16);
 	swver.optional_field_flags |= swver.OPTIONAL_FIELD_FLAG_VCS_COMMIT;
 	swver.major = AppDescriptor.major_version;
 	swver.minor = AppDescriptor.minor_version;


### PR DESCRIPTION
### Solved Problem
`long` is a 32-bit signed integer, which means the maximum it will hold is `0x7FFFFFFF`.

`strtol` is overflowing, resulting in clamping the value to `LONG_MAX` (or `0x7FFFFFFF`) and returns that instead.

### Solution
Fixes by using string to unsigned long (`strtoul`), which returns the correct expected value.

### Changelog Entry
For release notes: Fixes UAVCAN VCS Reporting a possible clamped version value

### Context
Can be tested by building a UAVCAN Node on the tag v1.16.1, flashing and checking the value displayed in dronecan_gui_tool. 

Screenshot added for convenience.

Before:
<img width="660" height="551" alt="image" src="https://github.com/user-attachments/assets/cb0881fe-4d26-41c2-9ba5-30d504095c1c" />


After:
<img width="660" height="551" alt="image" src="https://github.com/user-attachments/assets/9ec85a09-7f3b-45c8-b7ac-5b6c8f5665f2" />
