### PR TITLE
[EKF2] Disable heading corrections performed to drag fusion

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/drag/drag_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/drag/drag_fusion.cpp
@@ -164,6 +164,10 @@ void Ekf::fuseDrag(const dragSample &drag_sample)
 
 			VectorState K = P * H / innovation_variance(axis_index);
 
+			// As drag fusion is often biased (due to approximate model or changing wind), using it to update the heading estimate
+			// can lead to unwanted heading corrections during acceleration and deceleration phases.
+			K(State::quat_nominal.idx + 2) = 0.f;
+
 			measurementUpdate(K, H, R_ACC, innovation(axis_index));
 		}
 	}


### PR DESCRIPTION
### Solved Problem
Drag fusion is mainly used to estimate wind when an position/velocity measurement is available, but it can also help to maintain a stable long term tilt estimate when other measurements are unavailable.
However, since the drag model is never perfect and since wind direction and speed can change over time, drag fusion can also induce heading deviations during acceleration phases. This can be significant, especially if no heading measurement is fused (e.g.: magless operation).

### Solution
Disable heading corrections during drag fusion.

Current behavior:
Taking "unaided heading" as short-term reference, we can see the heading estimate being over-corrected during the acceleration phase (starting at t=356).
<img width="406" height="388" alt="Screenshot from 2026-02-23 14-44-51" src="https://github.com/user-attachments/assets/0aedc216-20a0-4d57-911d-e4b44f140a96" />

PR:
By disabling heading corrections of the drag fusion we can remove those over-corrections and follow the reference
<img width="406" height="388" alt="Screenshot from 2026-02-23 14-45-21" src="https://github.com/user-attachments/assets/33b5a38a-86f4-42b8-9854-443ef8f4662b" />


### Changelog Entry
For release notes:
```
Remove heading corrections due to drag fusion
New parameter: -
Documentation: -
```

### Alternatives
We could only clear this Kalman gain in certain cases (e.g.: no heading measurement), but I don't think that heading corrections from drag fusion are ever useful.

### Test coverage
EKF replay

