### PR TITLE
docs:hide non-functional search from home page

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -163,6 +163,15 @@
 
 
 /**
+ * Custom style to hide search on the ome page
+ * -------------------------------------------------------------------------- */
+
+.home #local-search {
+    display: none;
+  }
+
+
+/**
  * Custom styles for wide pages
  * -------------------------------------------------------------------------- */
 


### PR DESCRIPTION
The search doesn't work from the "hero" page, but it does from docs pages. It would be best to make it work, but hiding it on that page is a much easier solution.