### PR TITLE
Fix goto and orbit commands commanded by QGC 5

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -517,7 +517,7 @@ MavlinkReceiver::handle_message_command_int(mavlink_message_t *msg)
 		return;
 	}
 
-	if (cmd_mavlink.frame != MAV_FRAME_GLOBAL_INT) {
+	if (cmd_mavlink.frame != MAV_FRAME_GLOBAL && cmd_mavlink.frame != MAV_FRAME_GLOBAL_INT) {
 		// PX4 only supports global frame.
 		PX4_ERR("frame invalid for command %" PRIu16, cmd_mavlink.command);
 		acknowledge(msg->sysid, msg->compid, cmd_mavlink.command, vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED_MAV_FRAME);


### PR DESCRIPTION
### Solved Problem
https://github.com/PX4/PX4-Autopilot/pull/26408 breaks goto and orbit commands commanded by current QGC stable 5.0.8.

Report: https://github.com/PX4/PX4-Autopilot/pull/26408#discussion_r2853004264

<img width="553" height="73" alt="Image" src="https://github.com/user-attachments/assets/adad7197-3ccb-48d4-bebf-b9887eaa8186" />

### Solution
Allow `MAV_FRAME_GLOBAL` frame to be processed again. This seems to be the main frame QGC sends at least for goto and orbit commands.

<img width="1844" height="749" alt="image" src="https://github.com/user-attachments/assets/1072ed6f-218c-4340-934c-218bcbb2dd55" />

### Changelog Entry
```
Fix goto and orbit commands commanded by QGC 5
```

### Alternatives
I'm happy to discuss if that's the correct frame in terms of MAVLink and if it's processed correctly but if possible we should avoid braking compatibility for basic functionality even if we find it's all been used wrong all along.

### Test coverage
In SITL SIH (`make px4_sitl sihsim_hex`) both commands work again with this change.
