### PR TITLE
docs: Numerous spelling and grammer fixes in flight controller section

### DIFF
--- a/docs/en/assembly/quick_start_cube.md
+++ b/docs/en/assembly/quick_start_cube.md
@@ -18,7 +18,7 @@ Further/updated information may be available in the [Cube User Manual](https://d
 
 ## Accessories
 
-Cube comes with most (or all) of the accessories you will need when [purchased](../flight_controller/pixhawk-2.md#stores).
+Cube comes with most (or all) of the accessories you will need when [purchased](../flight_controller/pixhawk-2.md#store).
 
 ![Cube Accessories](../../assets/flight_controller/cube/cube_accessories.jpg)
 

--- a/docs/en/complete_vehicles_mc/crazyflie2.md
+++ b/docs/en/complete_vehicles_mc/crazyflie2.md
@@ -2,12 +2,12 @@
 
 <Badge type="info" text="Discontinued" />
 
-:::warning
+::: warning
 _Crazyflie 2.0_ has been [discontinued/superseded](../flight_controller/autopilot_experimental.md).
 Try [Bitcraze Crazyflie 2.1](../complete_vehicles_mc/crazyflie21.md) instead!
 :::
 
-:::warning
+::: warning
 
 - PX4 does not manufacture this (or any) autopilot.
   Contact the [manufacturer](https://www.bitcraze.io/) for hardware support or compliance issues.
@@ -202,7 +202,7 @@ Next, launch the cfbridge by giving the same channel and address as the first an
 - After using _cfbridge_, you can deactivate the virtualenv if you activated it by pressing `CTRL+z`.
   Most of the time, launching _cfbridge_ again from the same terminal doesn't connect to crazyflie, this can be solved by closing the terminal and relaunching _cfbridge_ in a new terminal.
 
-:::tip
+::: tip
 If you change any driver in [crazyflie-lib-python](https://github.com/bitcraze/crazyflie-lib-python) or if launching _cfbridge_ in a new terminal does not find crazyflie, you can try navigating to the crazyflie-lib-python folder and run the script below to rebuild cflib.
 
 ```sh
@@ -251,7 +251,7 @@ Then, you need to stick the battery on top of the SD card deck using a double si
 Crazyflie is able to fly in _Altitude_ mode if you use a [Z-ranger deck](https://store.bitcraze.io/collections/decks/products/z-ranger-deck).
 According to the datasheet, the maximum height (above ground) the range finder can sense is 2 m. However, when tested on dark surfaces this value decreases to 0.5 m. On a light floor, it goes up to max 1.3 m. This means you cannot hold altitudes above this value in _Altitude_ or _Position_ flight modes.
 
-:::tip
+::: tip
 If the Crazyflie 2.0 height drifts at mid-throttle command in _Altitude mode_ or _Position mode_, first try rebooting the vehicle. If this does not fix the problem, recalibrate the accel and mag (compass).
 :::
 

--- a/docs/en/concept/system_startup.md
+++ b/docs/en/concept/system_startup.md
@@ -21,7 +21,7 @@ For that to work, a few things are required:
 - PX4 modules need to look like individual executables to the system.
   This is done via symbolic links.
   For each module a symbolic link `px4-<module> -> px4` is created in the `bin` directory of the build folder.
-  When executed, the binary path is checked (`argv[0]`), and if it is a module (starts with `px4-`), it sends the command to the main px4 instance (see below).
+  When executed, the binary path is checked (`argv[0]`), and if it is a module (starts with `px4-`), it sends the command to the main PX4 instance (see below).
 
   :::tip
   The `px4-` prefix is used to avoid conflicts with system commands (e.g. `shutdown`), and it also allows for simple tab completion by typing `px4-<TAB>`.
@@ -30,13 +30,13 @@ For that to work, a few things are required:
 - The shell needs to know where to find the symbolic links.
   For that the `bin` directory with the symbolic links is added to the `PATH` variable right before executing the startup scripts.
 - The shell starts each module as a new (client) process.
-  Each client process needs to communicate with the main instance of px4 (the server), where the actual modules are running as threads.
+  Each client process needs to communicate with the main instance of PX4 (the server), where the actual modules are running as threads.
   This is done through a [UNIX socket](https://man7.org/linux/man-pages/man7/unix.7.html).
   The server listens on a socket, to which clients can connect and send a command.
   The server then sends the output and return code back to the client.
 - The startup scripts call the module directly, e.g. `commander start`, rather than using the `px4-` prefix.
   This works via aliases: for each module an alias in the form of `alias <module>=px4-<module>` is created in the file `bin/px4-alias.sh`.
-- The `rcS` script is executed from the main px4 instance.
+- The `rcS` script is executed from the main PX4 instance.
   It does not start any modules, but first updates the `PATH` variable and then simply runs a shell with the `rcS` file as argument.
 - In addition to that, multiple server instances can be started for multi-vehicle simulations.
   A client selects the instance via `--instance`.

--- a/docs/en/config_vtol/vtol_quad_configuration.md
+++ b/docs/en/config_vtol/vtol_quad_configuration.md
@@ -95,7 +95,7 @@ It should be set to a value which ensures that the vehicle reaches a high enough
 [VT_TRANS_TIMEOUT](../advanced_config/parameter_reference.md#VT_TRANS_TIMEOUT)
 
 This specifies the upper limit for the duration of the front transition. If the vehicle has not reached the transition airspeed after this time, then the transition will be aborted and a [Quadchute](../config/safety.md#quad-chute-failsafe) event will be triggered.
-:::note
+::: info
 Additionally, if an airspeed sensor is present, the transition will also be aborted if the airspeed has not reached [VT_ARSP_BLEND](../advanced_config/parameter_reference.md#VT_ARSP_BLEND) after the openloop transition time [VT_F_TR_OL_TM](../advanced_config/parameter_reference.md#VT_F_TR_OL_TM) has elapsed. This checks is used to avoid a scenario where the vehicle gains excessive speed when the airspeed sensor is faulty.
 :::
 

--- a/docs/en/debug/simulation_debugging.md
+++ b/docs/en/debug/simulation_debugging.md
@@ -106,7 +106,7 @@ You can also start your simulation, and _then_ attach `gdb`:
    ```
 
    As the script runs, note the **SITL COMMAND:** output text located right above the large "PX4" text.
-   It will list the location of your px4 bin file for later use.
+   It will list the location of your PX4 bin file for later use.
 
    ```sh
    SITL COMMAND: "<px4 bin file>" "<build dir>"/etc

--- a/docs/en/flight_controller/accton-godwit_ga1.md
+++ b/docs/en/flight_controller/accton-godwit_ga1.md
@@ -1,6 +1,6 @@
 # Accton Godwit G-A1
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://cubepilot.org/#/home) for hardware support or compliance issues.
 :::
@@ -12,7 +12,7 @@ It also has independent buses and power supplies, and is designed for safety and
 
 With an integrated 10/100M Ethernet Physical Layer (PHY), the G-A1 can also communicate with a mission computer (airborne computer), high-end surveying and mapping cameras, and other UxV-mounted equipment for high-speed communications, meeting the needs of advanced UxV systems.
 
-:::tip
+::: tip
 Visit [Accton-IoT Godwit](https://www.accton-iot.com/godwit/) for more information.
 :::
 
@@ -65,7 +65,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - 92.2 (L) x 51.2 (W) x 28.3 (H) mm
 - 77.6g (carrier board with IMU)
 
-## Where to Buy
+## Where to Buy {#store}
 
 - [Accton-IoT Godwit](https://www.accton-iot.com/godwit/)
 - [sales@accton-iot.com](sales@accton-iot.com)

--- a/docs/en/flight_controller/accton-godwit_ga1.md
+++ b/docs/en/flight_controller/accton-godwit_ga1.md
@@ -5,7 +5,7 @@ PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://cubepilot.org/#/home) for hardware support or compliance issues.
 :::
 
-The G-A1 is a state-of-the-art flight controller developed derived from the [Pixhawk Autopilot v6X Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-012%20Pixhawk%20Autopilot%20v6X%20Standard.pdf).
+The G-A1 is a state-of-the-art flight controller derived from the [Pixhawk Autopilot v6X Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-012%20Pixhawk%20Autopilot%20v6X%20Standard.pdf).
 
 It includes an STM32H753 double-precision floating-point FMU processor and an STM32F103 IO coprocessor, multiple IMUs with 6-axis inertial sensors, two pressure/temperature sensors, and a geomagnetic sensor.
 It also has independent buses and power supplies, and is designed for safety and rich expansion capabilities.
@@ -115,7 +115,7 @@ PPM receivers should be connected to the PPM interface. And other RC systems can
 
 ## GPS/Compass
 
-The Godwit G-A1 has a built-in compass
+The Godwit G-A1 has a built-in compass.
 Due to potential interference, the autopilot is usually used with an external I2C compass as part of a GPS/Compass combination.
 
 ![G-A1 GPS](../../assets/flight_controller/accton-godwit/ga1/gps.png "G-A1 GPS")

--- a/docs/en/flight_controller/airlink.md
+++ b/docs/en/flight_controller/airlink.md
@@ -1,6 +1,6 @@
 # Sky-Drones AIRLink
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://sky-drones.com/) for hardware support or compliance issues.
 :::
@@ -71,7 +71,7 @@ AIRLink has two computers and integrated LTE Module:
   - Antenna, 4x4 MIMO
   - Bands: Worldwide
 
-## Where to Buy
+## Where to Buy {#store}
 
 Purchase from the original Sky-Drones Store (worldwide shipping with 1-2 days order processing time):
 
@@ -344,14 +344,14 @@ AIRLink has 16 PWM ouputs. Main outputs 1-8 and connected to IO MCU. AUX outputs
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make sky-drones_smartap-airlink
 ```
 

--- a/docs/en/flight_controller/airlink.md
+++ b/docs/en/flight_controller/airlink.md
@@ -26,7 +26,7 @@ AIRLink has two computers and integrated LTE Module:
 ## Specifications
 
 - **Sensors**
-  - 3x Accelerometers, 3x Gyroscopes, 3x Magnetometers, 3x Pressure sensorss
+  - 3x Accelerometers, 3x Gyroscopes, 3x Magnetometers, 3x Pressure sensors
   - GNSS, Rangefinders, Lidars, Optical Flow, Cameras
   - 3x-redundant IMU
   - Vibration dampening
@@ -92,7 +92,7 @@ The standard set contains:
 - 1x FPV camera with CSI cable
 - 1x WiFi antenna with MMCX connector
 - 2x/4x LTE/5G antenna with MMCX connector
-- 1x HDMI to mini HDMI cable1x set of cables (7 cables for all connectors)
+- 1x HDMI to mini HDMI cable, 1x set of cables (7 cables for all connectors)
 
 [AIRLink Telemetry](https://sky-drones.com/sets/airlink-telemetry-set.html) based on the Microhard LAN/IP-based RF micromodule is available as an add-on and is fully compatible with AIRLink.
 

--- a/docs/en/flight_controller/ark_fpv.md
+++ b/docs/en/flight_controller/ark_fpv.md
@@ -1,6 +1,6 @@
 # ARK FPV Flight Controller
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://arkelectron.com/contact-us/) for hardware support or compliance issues.
 :::
@@ -9,11 +9,11 @@ The USA-built ARK FPV flight controller is based on the [ARKV6X](https://arkelec
 
 ![ARK FPV Main Photo](../../assets/flight_controller/arkfpv/ark_fpv.jpg)
 
-:::info
+::: info
 This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
 :::
 
-## Where To Buy
+## Where To Buy {#store}
 
 Order from [Ark Electronics](https://arkelectron.com/product/arkv6x/) (US)
 

--- a/docs/en/flight_controller/ark_fpv.md
+++ b/docs/en/flight_controller/ark_fpv.md
@@ -76,7 +76,7 @@ See the documentation [Ark Electronics GitBook](https://arkelectron.gitbook.io/a
 
 ## Additional Information
 
-- Weight: 7.5 g g with MicroSD card
+- Weight: 7.5 g with MicroSD card
 - Dimensions: 3.6 x 3.6 x 0.8 cm
 - USA Built - NDAA compliant
 - Heater: 1W for warming sensors in extreme cold

--- a/docs/en/flight_controller/ark_pab.md
+++ b/docs/en/flight_controller/ark_pab.md
@@ -39,7 +39,7 @@ Order From [Ark Electronics](https://arkelectron.com/product/ark-pixhawk-autopil
   - 6 Pin JST-GH
 - Dual CAN Ports
   - 4 Pin JST-GH
-- Triple Telemetry Ports with Flow - Control
+- Triple Telemetry Ports with Flow Control
   - 6 Pin JST-GH
 - Eight PWM Outputs
   - 10 Pin JST-GH

--- a/docs/en/flight_controller/ark_pab.md
+++ b/docs/en/flight_controller/ark_pab.md
@@ -1,6 +1,6 @@
 # ARK Pixhawk Autopilot Bus Carrier
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://arkelectron.com/contact-us/) for hardware support or compliance issues.
 :::
@@ -11,7 +11,7 @@ The PAB form factor enables the ARK PAB Carrier to be used with any [PAB-compati
 
 ![ARKPAB Main Photo](../../assets/flight_controller/arkpab/ark_pab_main.jpg)
 
-### Where To Buy
+### Where To Buy {#store}
 
 Order From [Ark Electronics](https://arkelectron.com/product/ark-pixhawk-autopilot-bus-carrier/) (US)
 

--- a/docs/en/flight_controller/ark_pi6x.md
+++ b/docs/en/flight_controller/ark_pi6x.md
@@ -1,10 +1,19 @@
 # ARK Pi6X Flow
 
+::: warning
+PX4 does not manufacture this (or any) autopilot.
+Contact the [manufacturer](https://arkelectron.com/contact-us/) for hardware support or compliance issues.
+:::
+
 The [ARK Pi6X Flow](https://arkelectron.gitbook.io/ark-documentation/flight-controllers/ark-pi6x-flow) integrates a Raspberry Pi Compute Module 4 (CM4) Carrier, [ARKV6X Flight Controller](../flight_controller/ark_v6x.md), [ARK Flow sensors](../dronecan/ark_flow.md) , [ARK PAB Power Module](../power_module/ark_pab_power_module.md), and a 4-in-1 ESC, all mounted onto one compact board.
 
 ![ARK Pi6X Flow Flight Controller](../../assets/flight_controller/ark_pi6x_flow/ark_pi6xflow.jpg)
 
-## Where to Buy
+::: info
+This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
+:::
+
+## Where to Buy {#store}
 
 Order this module from:
 

--- a/docs/en/flight_controller/ark_v6x.md
+++ b/docs/en/flight_controller/ark_v6x.md
@@ -1,6 +1,6 @@
 # ARK Electronics ARKV6X
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://arkelectron.com/contact-us/) for hardware support or compliance issues.
 :::
@@ -16,7 +16,7 @@ The Pixhawk Autopilot Bus (PAB) form factor enables the ARKV6X to be used on any
 This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
 :::
 
-## Where To Buy
+## Where To Buy {#store}
 
 Order From [Ark Electronics](https://arkelectron.com/product/arkv6x/) (US)
 

--- a/docs/en/flight_controller/auav_x2.md
+++ b/docs/en/flight_controller/auav_x2.md
@@ -2,11 +2,11 @@
 
 <Badge type="info" text="Discontinued" />
 
-:::warning
+::: warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store.mrobotics.io/) for hardware support or compliance issues.
 :::

--- a/docs/en/flight_controller/autopilot_experimental.md
+++ b/docs/en/flight_controller/autopilot_experimental.md
@@ -1,6 +1,6 @@
 # Community Supported & Experimental Autopilots
 
-:::tip
+::: tip
 For more information about PX4 project autopilot board support levels see: [px4.io/autopilots/](https://px4.io/autopilots/).
 :::
 

--- a/docs/en/flight_controller/autopilot_manufacturer_supported.md
+++ b/docs/en/flight_controller/autopilot_manufacturer_supported.md
@@ -18,7 +18,7 @@ The boards in this category are:
 - [ARK Electronics ARKV6X](../flight_controller/ark_v6x.md) (and [ARK Electronics Pixhawk Autopilot Bus Carrier](../flight_controller/ark_pab.md))
 - [ARK FPV Flight Controller](../flight_controller/ark_fpv.md)
 - [ARK Pi6X Flow Flight Controller](../flight_controller/ark_pi6x.md)
-- [CUAV Nora](../flight_controller/cuav_nora.md)（CUAV X7 variant)
+- [CUAV Nora](../flight_controller/cuav_nora.md) (CUAV X7 variant)
 - [CUAV V5+](../flight_controller/cuav_v5_plus.md) (FMUv5)
 - [CUAV V5 nano](../flight_controller/cuav_v5_nano.md) (FMUv5)
 - [CUAV X25 EVO](../flight_controller/cuav_x25-evo.md)

--- a/docs/en/flight_controller/autopilot_manufacturer_supported.md
+++ b/docs/en/flight_controller/autopilot_manufacturer_supported.md
@@ -2,7 +2,7 @@
 
 Manufacturer-supported autopilots are maintained and supported by a board manufacturer (manufacturers commit to delivering compatibility with the current stable PX4 release within 4 months of the official release announcement).
 
-:::tip
+::: tip
 For more information about PX4 project autopilot board support levels see: [px4.io/autopilots/](https://px4.io/autopilots/).
 :::
 

--- a/docs/en/flight_controller/autopilot_pixhawk_standard.md
+++ b/docs/en/flight_controller/autopilot_pixhawk_standard.md
@@ -4,7 +4,7 @@
 
 These boards are maintained, updated, tested and otherwise supported by the PX4 project maintainers and Dronecode test team.
 
-:::tip
+::: tip
 For more information about PX4 project autopilot board support levels see: [px4.io/autopilots/](https://px4.io/autopilots/).
 :::
 

--- a/docs/en/flight_controller/beaglebone_blue.md
+++ b/docs/en/flight_controller/beaglebone_blue.md
@@ -209,7 +209,7 @@ Run the following commands on the BeagleBone Blue (i.e. via SSH):
 
 ## Changes in config
 
-All changes can be made in de px4.config file directly on beaglebone.
+All changes can be made in the px4.config file directly on beaglebone.
 For example, you can change the WIFI to wlan.
 
 ::: info

--- a/docs/en/flight_controller/beaglebone_blue.md
+++ b/docs/en/flight_controller/beaglebone_blue.md
@@ -2,7 +2,7 @@
 
 <LinkedBadge type="warning" text="Experimental" url="../flight_controller/autopilot_experimental.md"/>
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://beagleboard.org/blue) for hardware support or compliance issues.
 :::
@@ -23,7 +23,7 @@ _BeagleBone Blue_ images can be found here:
 Information about flashing OS images can be found on [this page](https://github.com/beagleboard/beaglebone-blue/wiki/Flashing-firmware).
 Other useful information can be found in the [FAQ](<https://github.com/beagleboard/beaglebone-blue/wiki/Frequently-Asked-Questions-(FAQ)>).
 
-:::tip
+::: tip
 Optionally you can update to a realtime kernel, and if you do, re-check if _librobotcontrol_ works properly with the realtime kernel.
 :::
 
@@ -33,7 +33,7 @@ The latest OS images at time of updating this document is [AM3358 Debian 10.3 20
 
 The recommended way to build PX4 for _BeagleBone Blue_ is to compile on a development computer and upload the PX4 executable binary directly to the BeagleBone Blue.
 
-:::tip
+::: tip
 This approach is recommended over [native build](#native_builds) due to speed of deployment and ease of use.
 :::
 
@@ -79,7 +79,7 @@ echo "PermitRootLogin yes" >>  /etc/ssh/sshd_config && systemctl restart sshd
    For _rsync_ over SSH with key authentication, follow the steps here (on the development machine):
    1. Generate an SSH key if you have not previously done so:
 
-      ```
+      ```sh
       ssh-keygen -t rsa
       ```
 
@@ -89,13 +89,13 @@ echo "PermitRootLogin yes" >>  /etc/ssh/sshd_config && systemctl restart sshd
 
    1. Define the BeagleBone Blue board as `beaglebone` in **/etc/hosts** and copy the public SSH key to the board for password-less SSH access:
 
-      ```
+      ```sh
       ssh-copy-id debian@beaglebone
       ```
 
    1. Alternatively you can use the beaglebone's IP directly:
 
-      ```
+      ```sh
       ssh-copy-id debian@<IP>
       ```
 
@@ -115,7 +115,7 @@ echo "PermitRootLogin yes" >>  /etc/ssh/sshd_config && systemctl restart sshd
 
          The ARM Cross Compiler for _BeagleBone Blue_ can be found at [Linaro Toolchain Binaries site](https://www.linaro.org/downloads/#gnu_and_llvm).
 
-         :::tip
+         ::: tip
          GCC in the toolchain should be compatible with kernel in _BeagleBone Blue_.
          General rule of thumb is to choose a toolchain where version of GCC is not higher than version of GCC which comes with the OS image on _BeagleBone Blue_.
          :::
@@ -129,7 +129,7 @@ echo "PermitRootLogin yes" >>  /etc/ssh/sshd_config && systemctl restart sshd
          tar -xf gcc-linaro-13.0.0-2022.06-x86_64_arm-linux-gnueabihf.tar.xz
          ```
 
-         :::tip
+         ::: tip
          The GCC version of the toolchain should be compatible with kernel in _BeagleBone Blue_.
          :::
 
@@ -147,7 +147,7 @@ echo "PermitRootLogin yes" >>  /etc/ssh/sshd_config && systemctl restart sshd
 
       1. Setup other dependencies by downloading the PX4 source code and then running the setup scripts:
 
-         ````
+         ````sh
          git clone https://github.com/PX4/PX4-Autopilot.git --recursive
          ols
          ```
@@ -166,7 +166,7 @@ echo "PermitRootLogin yes" >>  /etc/ssh/sshd_config && systemctl restart sshd
 
 Compile and Upload
 
-```
+```sh
 make beaglebone_blue_default upload
 ```
 
@@ -185,9 +185,7 @@ sudo ./bin/px4 -s px4.config
 Currently _librobotcontrol_ requires root access.
 :::
 
-<a id="native_builds"></a>
-
-## Native Builds (optional)
+## Native Builds (optional) {#native_builds}
 
 You can also natively build PX4 builds directly on the BeagleBone Blue.
 
@@ -290,8 +288,6 @@ For a quadcopter with GPS and an SBUS receiver, here are typical connections:
 
 1. Connect the ESC of motor 1, 2, 3 and 4 to channel 1, 2, 3 and 4 of servo outputs on BeagleBone Blue, respectively.
    If your ESC connector contains a power output pin, remove it and do not connect it to the power output pin of the servo channel on the BeagleBone Blue.
-
-1. Connect the above mentioned converted SBUS signal to the dsm2 port if you have the matching connector for dsm2, otherwise connect it to any other available UART port and change the corresponding port in **/home/debian/px4/px4.config** accordingly.
-
-1. Connect the signals of GPS module to GPS port on the BeagleBone Blue.
+2. Connect the above mentioned converted SBUS signal to the dsm2 port if you have the matching connector for dsm2, otherwise connect it to any other available UART port and change the corresponding port in **/home/debian/px4/px4.config** accordingly.
+3. Connect the signals of GPS module to GPS port on the BeagleBone Blue.
    Note that the signal pins of the GPS port on the BeagleBone Blue are only 3.3V tolerant, so choose your GPS module accordingly.

--- a/docs/en/flight_controller/cuav_nora.md
+++ b/docs/en/flight_controller/cuav_nora.md
@@ -1,6 +1,6 @@
 # CUAV Nora Flight Controller
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://www.cuav.net) for hardware support or compliance issues.
 :::
@@ -30,7 +30,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - Car-grade RM3100 compass
 - High performance processor
 
-:::tip
+::: tip
 The manufacturer [CUAV Docs](https://doc.cuav.net/flight-controller/x7/en/nora.html) are the canonical reference for Nora.
 They should be used by preference as they contain the most complete and up to date information.
 :::
@@ -72,7 +72,7 @@ When it runs PX4 firmware, only 8 PWM outputs work.
 The remaining 6 PWM ports are still being adapted (so it is not compatible with VOLT at time of writing).
 :::
 
-## Where to Buy
+## Where to Buy {#store}
 
 - [CUAV Store](https://store.cuav.net)<\br>
 - [CUAV Aliexpress](https://www.aliexpress.com/item/4001042501927.html?gps-id=8041884&scm=1007.14677.110221.0&scm_id=1007.14677.110221.0&scm-url=1007.14677.110221.0&pvid=3dc0a3ba-fa82-43d2-b0b3-6280e4329cef&spm=a2g0o.store_home.promoteRecommendProducts_7913969.58)
@@ -87,7 +87,7 @@ The remaining 6 PWM ports are still being adapted (so it is not compatible with 
 
 ![X7 pinouts](../../assets/flight_controller/cuav_nora/nora-pinouts.jpg)
 
-:::warning
+::: warning
 The `RCIN` port is limited to powering the rc receiver and cannot be connected to any power/load.
 :::
 
@@ -109,14 +109,14 @@ Under these conditions all power sources will be used in this order to power the
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make cuav_nora_default
 ```
 
@@ -125,7 +125,7 @@ make cuav_nora_default
 The _Nora_ has over-current protection on the 5 Volt Peripheral and 5 Volt high power, which limits the current to 2.5A.
 The _Nora_ has short circuit protection.
 
-:::warning
+::: warning
 Up to 2.5 A can be delivered to the connectors listed as pin 1 (although these are only rated at 1 A).
 :::
 
@@ -153,7 +153,7 @@ The provided debug cable does not connect to the SWD port `Vref` pin (1).
 
 ![CUAV Debug cable](../../assets/flight_controller/cuav_v5_plus/cuav_v5_debug_cable.jpg)
 
-:::warning
+::: warning
 The SWD Vref pin (1) uses 5V as Vref but the CPU is run at 3.3V!
 
 Some JTAG adapters (SEGGER J-Link) will use the Vref voltage to set the voltage on the SWD lines.

--- a/docs/en/flight_controller/cuav_pixhawk_v6x.md
+++ b/docs/en/flight_controller/cuav_pixhawk_v6x.md
@@ -1,6 +1,6 @@
 # CUAV Pixhawk V6X
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store.cuav.net/) for hardware support or compliance issues.
 :::
@@ -11,7 +11,7 @@ It is based on the [Pixhawk​​® Autopilot FMUv6X Standard](https://github.co
 
 ![Pixhawk V6X](../../assets/flight_controller/cuav_pixhawk_v6x/pixhawk_v6x.jpg)
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -104,7 +104,7 @@ The Pixhawk® V6X is ideal for corporate research labs, academic research and co
 
     ![Pixhawk V6X](../../assets/flight_controller/cuav_pixhawk_v6x/core.png)
 
-## Where to Buy
+## Where to Buy {#store}
 
 Order from [CUAV](https://store.cuav.net/).
 
@@ -166,20 +166,18 @@ Analog battery monitoring via an ADC is not supported on this particular board, 
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v6x_default
 ```
 
-<a id="debug_port"></a>
-
-## Debug Port
+## Debug Port {#debug_port}
 
 The [PX4 System Console](../debug/system_console.md) and [SWD interface](../debug/swd_debug.md) run on the **FMU Debug** port.
 

--- a/docs/en/flight_controller/cuav_pixhawk_v6x.md
+++ b/docs/en/flight_controller/cuav_pixhawk_v6x.md
@@ -61,7 +61,7 @@ The Pixhawk® V6X is ideal for corporate research labs, academic research and co
 - 16- PWM servo outputs
 - 1 Dedicated R/C input for Spektrum / DSM and S.Bus with analog / PWM RSSI input
 - 3 TELEM Ports（with full flow control）
-- 1 UART4(Seial and I2C)
+- 1 UART4(Serial and I2C)
 - 2 GPS ports
   - 1 full GPS plus Safety Switch Port(GPS1)
   - 1 basic GPS port(with I2C,GPS2)

--- a/docs/en/flight_controller/cuav_v5.md
+++ b/docs/en/flight_controller/cuav_v5.md
@@ -2,11 +2,11 @@
 
 <Badge type="info" text="Discontinued" /> <!-- 202507 / PX4v1.16 -->
 
-:::warning
+::: warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store.cuav.net/) for hardware support or compliance issues.
 :::
@@ -52,7 +52,7 @@ It is intended primarily for academic and commercial developers.
 - Other Characteristics:
   - Operating temperature: -20 ~ 80°C （Measured value）
 
-## Where to Buy
+## Where to Buy {#store}
 
 Order from [CUAV](https://cuav.taobao.com/index.htm?spm=2013.1.w5002-16371268426.2.411f26d9E18eAz).
 
@@ -60,7 +60,7 @@ Order from [CUAV](https://cuav.taobao.com/index.htm?spm=2013.1.w5002-16371268426
 
 ![CUAV v5](../../assets/flight_controller/cuav_v5/pixhack_v5_connector.jpg)
 
-:::warning
+::: warning
 The RCIN interface is limited to powering the rc receiver and cannot be connected to any power/load.
 :::
 
@@ -82,14 +82,14 @@ Under these conditions all power sources will be used in this order to power the
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v5_default
 ```
 

--- a/docs/en/flight_controller/cuav_v5_nano.md
+++ b/docs/en/flight_controller/cuav_v5_nano.md
@@ -1,6 +1,6 @@
 # CUAV V5 nano Autopilot
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store.cuav.net/) for hardware support or compliance issues.
 :::
@@ -58,7 +58,7 @@ Main FMU Processor: STM32F765◦32 Bit Arm® Cortex®-M7, 216MHz, 2MB memory, 51
 - Other Characteristics:
   - Operating temperature: -20 ~ 85°C （Measured value）
 
-## Where to Buy
+## Where to Buy {#store}
 
 [CUAV Store](https://store.cuav.net/shop/v5-nano/)
 
@@ -82,20 +82,18 @@ Download **V5 nano** pinouts from [here](http://manual.cuav.net/V5-Plus.pdf).
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v5_default
 ```
 
-<a id="debug_port"></a>
-
-## Debug Port
+## Debug Port {#debug_port}
 
 The [PX4 System Console](../debug/system_console.md) and [SWD interface](../debug/swd_debug.md) operate on the **FMU Debug** port (`DSU7`).
 The board does not have an I/O debug interface.
@@ -119,7 +117,7 @@ The provided debug cable does not connect to the SWD port `Vref` pin (1).
 
 ![CUAV Debug cable](../../assets/flight_controller/cuav_v5_nano/cuav_nano_debug_cable.jpg)
 
-:::warning
+::: warning
 The SWD Vref pin (1) uses 5V as Vref but the CPU is run at 3.3V!
 
 Some JTAG adapters (SEGGER J-Link) will use the Vref voltage to set the voltage on the SWD lines.
@@ -200,7 +198,7 @@ For direct connection to _Segger Jlink_ we recommended you use the 3.3 Volts of 
 
 `PM2` can only measure battery voltage and current, but **not** power the flight controller.
 
-:::warning
+::: warning
 PX4 does not support this interface.
 :::
 
@@ -214,7 +212,7 @@ For example, the serial number Batch V011904((V01 is the number of V5, 1904 is t
 
 #### SBUS / DSM / RSSI interface Pin1 unfused
 
-:::warning
+::: warning
 This is a safety issue.
 :::
 

--- a/docs/en/flight_controller/cuav_v5_plus.md
+++ b/docs/en/flight_controller/cuav_v5_plus.md
@@ -205,7 +205,7 @@ The UAVCAN [NEO V2 PRO GNSS receiver](https://doc.cuav.net/gps/neo-series-gnss/e
 
 `DSU7` FMU Debug Pin 1 is 5 volts - not the 3.3 volts of the CPU.
 
-Some JTAG use this voltage to set the IO levels when communicating to the target.
+Some JTAG adapters use this voltage to set the IO levels when communicating to the target.
 
 For direct connection to _Segger Jlink_ we recommended you use the 3.3 Volts of DSM/SBUS/RSSI pin 4 as Pin 1 on the debug connector (`Vtref`).
 

--- a/docs/en/flight_controller/cuav_v5_plus.md
+++ b/docs/en/flight_controller/cuav_v5_plus.md
@@ -1,6 +1,6 @@
 # CUAV V5+ Autopilot
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store.cuav.net/) for hardware support or compliance issues.
 :::
@@ -58,7 +58,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - Other Characteristics:
   - Operating temperature: -20 ~ 80°c（Measured value）
 
-## Where to Buy
+## Where to Buy {#store}
 
 [CUAV Aliexpress](https://www.aliexpress.com/item/32890380056.html?spm=a2g0o.detail.1000060.1.7a7233e7mLTlVl&gps-id=pcDetailBottomMoreThisSeller&scm=1007.13339.90158.0&scm_id=1007.13339.90158.0&scm-url=1007.13339.90158.0&pvid=d899bfab-a7ca-46e1-adf2-72ad1d649822) (International users)
 
@@ -101,20 +101,20 @@ Under these conditions all power sources will be used in this order to power the
 The _V5+_ has over current protection on the 5 Volt Peripheral and 5 Volt high power, which limits the current to 2.5A.
 The _V5+_ has short circuit protection.
 
-:::warning
+::: warning
 Up to 2.5 A can be delivered to the connectors listed as pin 1 (although these are only rated at 1 A).
 :::
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v5_default
 ```
 
@@ -142,7 +142,7 @@ The provided debug cable does not connect to the SWD port `Vref` pin (1).
 
 ![CUAV Debug cable](../../assets/flight_controller/cuav_v5_plus/cuav_v5_debug_cable.jpg)
 
-:::warning
+::: warning
 The SWD Vref pin (1) uses 5V as Vref but the CPU is run at 3.3V!
 
 Some JTAG adapters (SEGGER J-Link) will use the Vref voltage to set the voltage on the SWD lines.
@@ -219,7 +219,7 @@ For example, the serial number Batch V011904((V01 is the number of V5, 1904 is t
 
 #### SBUS / DSM / RSSI interface Pin1 unfused
 
-:::warning
+::: warning
 This is a safety issue.
 :::
 

--- a/docs/en/flight_controller/cuav_x25-evo.md
+++ b/docs/en/flight_controller/cuav_x25-evo.md
@@ -1,6 +1,6 @@
 # CUAV X25-EVO
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store.cuav.net/) for hardware support or compliance issues.
 :::
@@ -85,7 +85,7 @@ These flight controllers are [manufacturer supported](../flight_controller/autop
 
 - Not provided.
 
-## Purchase Channels
+## Purchase Channels {#store}
 
 Order from [CUAV](https://store.cuav.net/).
 
@@ -128,20 +128,18 @@ Digital DroneCAN/UAVCAN battery monitoring is enabled by default.
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users do not need to build this firmware!
 It is pre-built and installed automatically by _QGroundControl_ when the appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target, execute:
 
-```
+```sh
 make cuav_x25-evo_default
 ```
 
-<a id="debug_port"></a>
-
-## Debug Port
+## Debug Port {#debug_port}
 
 The [PX4 System Console](../debug/system_console.md) and [SWD Interface](../debug/swd_debug.md) operate on the **FMU Debug** port.
 

--- a/docs/en/flight_controller/cuav_x7.md
+++ b/docs/en/flight_controller/cuav_x7.md
@@ -2,12 +2,12 @@
 
 <Badge type="info" text="Discontinued" /> <!-- 202507 / PX4v1.16 -->
 
-:::warning
+::: warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 It has been superseded by the [CUAV X7+](https://doc.cuav.net/controller/x7/en/).
 :::
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://www.cuav.net) for hardware support or compliance issues.
 :::
@@ -38,7 +38,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - Car-grade RM3100 compass
 - High performance processor
 
-:::tip
+::: tip
 The manufacturer [CUAV Docs](https://doc.cuav.net/flight-controller/x7/en/) are the canonical reference for the X7.
 They should be used by preference as they contain the most complete and up to date information.
 :::
@@ -79,7 +79,7 @@ They should be used by preference as they contain the most complete and up to da
 When it runs PX4 firmware, only 8 pwm works, the remaining 6 pwm are still being adapted, so it is not compatible with VOLT now.
 :::
 
-## Where to Buy
+## Where to Buy {#store}
 
 [CUAV Store](https://store.cuav.net)
 
@@ -95,7 +95,7 @@ When it runs PX4 firmware, only 8 pwm works, the remaining 6 pwm are still being
 
 ![X7 pinouts](../../assets/flight_controller/cuav_x7/x7-pinouts.jpg)
 
-:::warning
+::: warning
 The `RCIN` port is limited to powering the RC receiver and cannot be connected to any power/load.
 :::
 
@@ -118,14 +118,14 @@ Under these conditions all power sources will be used in this order to power the
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make cuav_x7pro_default
 ```
 
@@ -134,7 +134,7 @@ make cuav_x7pro_default
 The _X7_ has over-current protection on the 5 Volt Peripheral and 5 Volt high power, which limits the current to 2.5A.
 The _X7_ has short circuit protection.
 
-:::warning
+::: warning
 Up to 2.5 A can be delivered to the connectors listed as pin 1 (although these are only rated at 1 A).
 :::
 
@@ -164,7 +164,7 @@ The provided debug cable does not connect to the SWD port `Vref` pin (1).
 
 ![CUAV Debug cable](../../assets/flight_controller/cuav_v5_plus/cuav_v5_debug_cable.jpg)
 
-:::warning
+::: warning
 The SWD Vref pin (1) uses 5V as Vref but the CPU is run at 3.3V!
 
 Some JTAG adapters (SEGGER J-Link) will use the Vref voltage to set the voltage on the SWD lines.

--- a/docs/en/flight_controller/cubepilot_cube_orange.md
+++ b/docs/en/flight_controller/cubepilot_cube_orange.md
@@ -10,7 +10,7 @@ The [Cube Orange](https://www.cubepilot.com/#/cube/features) flight controller i
 ![Cube Orange](../../assets/flight_controller/cube/orange/cube_orange_hero.jpg)
 
 The controller is designed to be used with a domain-specific carrier board in order to reduce the wiring, improve reliability, and ease of assembly.
-For example, a carrier board for a commercial inspection vehicle might include connections for a companion computer, while a carrier board for a racer could includes ESCs for the frame of the vehicle.
+For example, a carrier board for a commercial inspection vehicle might include connections for a companion computer, while a carrier board for a racer could include ESCs for the frame of the vehicle.
 
 The ADS-B carrier board includes a customized 1090MHz ADSB-In receiver from uAvionix.
 This provides attitude and location of commercial manned aircraft within the range of Cube.

--- a/docs/en/flight_controller/cubepilot_cube_orange.md
+++ b/docs/en/flight_controller/cubepilot_cube_orange.md
@@ -1,6 +1,6 @@
 # CubePilot Cube Orange Flight Controller
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://cubepilot.org/#/home) for hardware support or compliance issues.
 :::
@@ -18,8 +18,12 @@ This is automatically configured and enabled in the default PX4 firmware.
 
 Cube includes vibration isolation on two of the IMU's, with a third fixed IMU as a reference / backup.
 
-:::tip
+::: tip
 The manufacturer [Cube User Guide](https://docs.cubepilot.org/user-guides/autopilot/the-cube) contains detailed information, including an overview of the [Differences between Cube Colours](https://docs.cubepilot.org/user-guides/autopilot/the-cube/introduction/specifications).
+:::
+
+::: info
+This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
 :::
 
 ## Key Features
@@ -36,9 +40,7 @@ The manufacturer [Cube User Guide](https://docs.cubepilot.org/user-guides/autopi
 - High-power, multi-tone piezo audio indicator
 - microSD card for high-rate logging over extended periods of time
 
-<a id="stores"></a>
-
-## Where to Buy
+## Where to Buy {#store}
 
 - [Reseller list](https://www.cubepilot.com/#/reseller/list)
 
@@ -223,14 +225,14 @@ The manufacturer [Cube User Guide](https://docs.cubepilot.org/user-guides/autopi
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target, open up the terminal and enter:
 
-```
+```sh
 make cubepilot_cubeorange
 ```
 

--- a/docs/en/flight_controller/cubepilot_cube_orangeplus.md
+++ b/docs/en/flight_controller/cubepilot_cube_orangeplus.md
@@ -6,12 +6,12 @@ Contact the [manufacturer](https://cubepilot.org/#/home) for hardware support or
 :::
 
 The [Cube Orange+](https://www.cubepilot.com/#/cube/features) flight controller is a flexible autopilot intended primarily for manufacturers of commercial systems.
-Cube Orange+ is similar to Cube Orange, but has a more powerful dual-core processor (STM32H757, and some different sensors parts.
+Cube Orange+ is similar to Cube Orange, but has a more powerful dual-core processor (STM32H757), and some different sensor parts.
 
 ![Cube Orange](../../assets/flight_controller/cube/orangeplus/cubepilot_cube_orangeplus_standard_set.jpg)
 
 The controller is designed to be used with a domain-specific carrier board in order to reduce the wiring, improve reliability, and ease of assembly.
-For example, a carrier board for a commercial inspection vehicle might include connections for a companion computer, while a carrier board for a racer could includes ESCs for the frame of the vehicle.
+For example, a carrier board for a commercial inspection vehicle might include connections for a companion computer, while a carrier board for a racer could include ESCs for the frame of the vehicle.
 
 The ADS-B carrier board includes a customized 1090MHz ADSB-In receiver from uAvionix.
 This provides attitude and location of commercial manned aircraft within the range of Cube.

--- a/docs/en/flight_controller/cubepilot_cube_orangeplus.md
+++ b/docs/en/flight_controller/cubepilot_cube_orangeplus.md
@@ -1,6 +1,6 @@
 # CubePilot Cube Orange+ Flight Controller
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://cubepilot.org/#/home) for hardware support or compliance issues.
 :::
@@ -19,8 +19,12 @@ This is automatically configured and enabled in the default PX4 firmware.
 
 Cube includes vibration isolation on two of the IMU's, with a third fixed IMU as a reference / backup.
 
-:::tip
+::: tip
 The manufacturer [Cube User Guide](https://docs.cubepilot.org/user-guides/autopilot/the-cube) contains detailed information, including an overview of the [Differences between Cube Colours](https://docs.cubepilot.org/user-guides/autopilot/the-cube/introduction/specifications).
+:::
+
+::: info
+This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
 :::
 
 ## Key Features
@@ -37,9 +41,7 @@ The manufacturer [Cube User Guide](https://docs.cubepilot.org/user-guides/autopi
 - High-power, multi-tone piezo audio indicator
 - microSD card for high-rate logging over extended periods of time
 
-<a id="stores"></a>
-
-## Where to Buy
+## Where to Buy {#store}
 
 - [Reseller list](https://www.cubepilot.com/#/reseller/list)
 
@@ -224,13 +226,13 @@ The manufacturer [Cube User Guide](https://docs.cubepilot.org/user-guides/autopi
 
 ## Building Firmware
 
-:::warning
+::: warning
 The firmware for Orange+ will be present in releases from PX4 v1.14.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target, open up the terminal and enter:
 
-```
+```sh
 make cubepilot_cubeorangeplus
 ```
 

--- a/docs/en/flight_controller/cubepilot_cube_yellow.md
+++ b/docs/en/flight_controller/cubepilot_cube_yellow.md
@@ -1,6 +1,6 @@
 # CubePilot Cube Yellow Flight Controller
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://cubepilot.org/#/home) for hardware support or compliance issues.
 :::
@@ -14,8 +14,12 @@ For example, a carrier board for a commercial inspection vehicle might include c
 
 Cube includes vibration isolation on two of the IMU's, with a third fixed IMU as a reference / backup.
 
-:::tip
+::: tip
 The manufacturer [Cube User Guide](https://docs.cubepilot.org/user-guides/autopilot/the-cube) contains detailed information, including an overview of the [Differences between Cube Colours](https://docs.cubepilot.org/user-guides/autopilot/the-cube/introduction/specifications).
+:::
+
+::: info
+This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
 :::
 
 ## Key Features
@@ -32,9 +36,7 @@ The manufacturer [Cube User Guide](https://docs.cubepilot.org/user-guides/autopi
 - High-power, multi-tone piezo audio indicator
 - microSD card for high-rate logging over extended periods of time
 
-<a id="stores"></a>
-
-## Where to Buy
+## Where to Buy {#store}
 
 - [Reseller list](https://www.cubepilot.com/#/reseller/list)
 
@@ -121,14 +123,14 @@ Board schematics and other documentation can be found here: [The Cube Project](h
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make cubepilot_cubeyellow
 ```
 

--- a/docs/en/flight_controller/cubepilot_cube_yellow.md
+++ b/docs/en/flight_controller/cubepilot_cube_yellow.md
@@ -10,7 +10,7 @@ The Cube Yellow flight controller is a flexible autopilot intended primarily for
 ![Cube Yellow](../../assets/flight_controller/cube/yellow/cube_yellow_hero.jpg)
 
 The controller is designed to be used with a domain-specific carrier board in order to reduce the wiring, improve reliability, and ease of assembly.
-For example, a carrier board for a commercial inspection vehicle might include connections for a companion computer, while a carrier board for a racer could includes ESCs for the frame of the vehicle.
+For example, a carrier board for a commercial inspection vehicle might include connections for a companion computer, while a carrier board for a racer could include ESCs for the frame of the vehicle.
 
 Cube includes vibration isolation on two of the IMU's, with a third fixed IMU as a reference / backup.
 
@@ -49,7 +49,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - **Processor:**
   - STM32F777VI (32bit [ARM Cortex M7](https://en.wikipedia.org/wiki/ARM_Cortex-M#Cortex-M7))
   - 400 MHz
-  - 512 KB MB RAM
+  - 512 KB RAM
   - 2 MB Flash
 - **Failsafe co-processor:** <!-- inconsistent info on failsafe processor: 32 bit STM32F103 failsafe co-processor -->
   - STM32F100 (32bit _ARM Cortex-M3_)

--- a/docs/en/flight_controller/durandal.md
+++ b/docs/en/flight_controller/durandal.md
@@ -1,6 +1,6 @@
 # Holybro Durandal
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -19,7 +19,7 @@ At high level, some of the key features are:
 - Internal vibration isolation system.
 - Dual high-performance, low-noise IMUs on board are designed for demanding stabilization applications.
 
-A summary of the key features, [assembly](../assembly/quick_start_durandal.md), and [purchase](#purchase) links can be found below.
+A summary of the key features, [assembly](../assembly/quick_start_durandal.md), and [purchase](#store) links can be found below.
 
 ::: info
 This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
@@ -86,9 +86,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 
 For more information see: [Durandal Technical Data Sheet](https://cdn.shopify.com/s/files/1/0604/5905/7341/files/Durandal_technical_data_sheet_90f8875d-8035-4632-a936-a0d178062077.pdf).
 
-<a id="purchase"></a>
-
-## Where to Buy
+## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/durandal).
 
@@ -155,14 +153,14 @@ The [Durandal Wiring Quick Start](../assembly/quick_start_durandal.md) provides 
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make holybro_durandal-v1_default
 ```
 
@@ -372,7 +370,7 @@ These can also be downloaded from [here](https://cdn.shopifycdn.net/s/files/1/06
 
 <a id="warn_sensor"></a>
 
-:::warning
+::: warning
 \++ Sensors connected to pins 8, 9 must not send a signal exceeding the indicated voltage.
 :::
 

--- a/docs/en/flight_controller/gearup_airbrainh743.md
+++ b/docs/en/flight_controller/gearup_airbrainh743.md
@@ -1,6 +1,6 @@
 # Gear Up AirBrainH743
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://takeyourgear.com/) for hardware support.
 :::
@@ -31,7 +31,7 @@ For more information and pinout, check the [GitHub documentation](https://github
 
 ## Connectors and Pins
 
-:::warning
+::: warning
 The pin order is different from the Pixhawk standard (compatible to the Betaflight standard).
 :::
 
@@ -74,7 +74,7 @@ Download the [gearup_airbrainh743_bootloader.bin](https://github.com/PX4/PX4-Aut
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make gearup_airbrainh743_default
 ```
 
@@ -84,7 +84,7 @@ Firmware can be installed in any of the normal ways:
 
 - Build and upload the source:
 
-  ```
+  ```sh
   make gearup_airbrainh743_default upload
   ```
 

--- a/docs/en/flight_controller/holybro_pix32.md
+++ b/docs/en/flight_controller/holybro_pix32.md
@@ -2,7 +2,7 @@
 
 <Badge type="info" text="Discontinued" />
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -15,7 +15,7 @@ It runs the PX4 flight stack on the [NuttX](https://nuttx.apache.org/) OS.
 
 As a CC-BY-SA 3.0 licensed Open Hardware design, schematics and design files should be [available here](https://github.com/pixhawk/Hardware).
 
-:::tip
+::: tip
 The Holybro pix32 is software compatible with the [3DR Pixhawk 1](../flight_controller/pixhawk.md).
 It is not connector compatible, but is otherwise physically very similar to the 3DR Pixhawk or mRo Pixhawk.
 :::
@@ -56,7 +56,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - External microUSB port
 - Molex PicoBlade connectors
 
-## Where to Buy
+## Where to Buy {#store}
 
 [shop.holybro.com](https://holybro.com/products/pix32pixhawk-flight-controller)
 
@@ -67,14 +67,14 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v2_default
 ```
 

--- a/docs/en/flight_controller/holybro_pix32_v5.md
+++ b/docs/en/flight_controller/holybro_pix32_v5.md
@@ -1,6 +1,6 @@
 # Holybro Pix32 v5
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -71,7 +71,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 
 Additional information can be found in the [Pix32 V5 Technical Data Sheet](https://cdn.shopify.com/s/files/1/0604/5905/7341/files/Holybro_PIX32-V5_technical_data_sheet_v1.1.pdf).
 
-## Where to Buy
+## Where to Buy {#store}
 
 Order from [Holybro website](https://holybro.com/products/pix32-v5).
 
@@ -118,14 +118,14 @@ Under these conditions the system will not draw any power (will not be operation
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make holybro_pix32v5_default
 ```
 

--- a/docs/en/flight_controller/holybro_pix32_v6.md
+++ b/docs/en/flight_controller/holybro_pix32_v6.md
@@ -1,6 +1,6 @@
 # Holybro Pix32 v6
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -12,7 +12,7 @@ It is equipped with a high performance H7 Processor, and comes with IMU redundan
 <img src="../../assets/flight_controller/pix32v6/pix32v6_fc_only.png" width="550px" title="pix32v6 Upright Image" />
 
 <!--
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 -->
@@ -85,7 +85,7 @@ This flight controller is perfect for people that is looking for a affordable an
 - Other Characteristics:
   - Operating & storage temperature: -40 ~ 85°c
 
-## Where to Buy
+## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/pix32-v6).
 
@@ -141,20 +141,18 @@ Holybro makes various analog [power modules](../power_module/index.md) for diffe
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v6c_default
 ```
 
-<a id="debug_port"></a>
-
-## Debug Port
+## Debug Port {#debug_port}
 
 The [PX4 System Console](../debug/system_console.md) and [SWD interface](../debug/swd_debug.md) run on the **FMU Debug** port.
 

--- a/docs/en/flight_controller/kakutef7.md
+++ b/docs/en/flight_controller/kakutef7.md
@@ -2,11 +2,11 @@
 
 <Badge type="info" text="Discontinued" />
 
-:::warning
+::: warning
 This frame has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -34,13 +34,13 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - 6 PWM outputs
 - Built-in OSD chip (AB7456 via SPI)
 
-## Where to Buy
+## Where to Buy {#store}
 
 The board can be bought from one of the following shops (for example):
 
 - [getfpv](https://www.getfpv.com/holybro-kakute-f7-tekko32-f3-metal-65a-4-in-1-esc-combo.html)
 
-:::tip
+::: tip
 The _Kakute F7_ is designed to work with the _Tekko32_ 4-in-1 ESC and they can be bought in combination.
 :::
 
@@ -84,7 +84,7 @@ Download the [kakutef7_bl.hex](https://github.com/PX4/PX4-Autopilot/raw/main/doc
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make holybro_kakutef7_default
 ```
 
@@ -93,7 +93,7 @@ make holybro_kakutef7_default
 The firmware can be installed in any of the normal ways:
 
 - Build and upload the source
-  ```
+  ```sh
   make holybro_kakutef7_default upload
   ```
 - [Load the firmware](../config/firmware.md) using _QGroundControl_.

--- a/docs/en/flight_controller/kakuteh7-wing.md
+++ b/docs/en/flight_controller/kakuteh7-wing.md
@@ -2,7 +2,7 @@
 
 <Badge type="tip" text="PX4 v1.16" />
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -13,7 +13,7 @@ The [Holybro Kakute H743 Wing](https://holybro.com/products/kakute-h743-wing) is
 This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
 :::
 
-## Where to Buy
+## Where to Buy {#store}
 
 The board can be bought from one of the following shops (for example):
 
@@ -43,7 +43,7 @@ Download the [holybro_kakuteh7-wing.hex](https://github.com/PX4/PX4-Autopilot/ra
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make holybro_kakuteh7-wing_default
 ```
 
@@ -58,7 +58,7 @@ Firmware can be manually installed in any of the normal ways:
 
 - Build and upload the source:
 
-  ```
+  ```sh
   make holybro_kakuteh7-wing_default upload
   ```
 

--- a/docs/en/flight_controller/kakuteh7.md
+++ b/docs/en/flight_controller/kakuteh7.md
@@ -102,7 +102,7 @@ The firmware can be installed in any of the normal ways:
   You can use either pre-built firmware or your own custom firmware.
 
 ::: info
-If you are loading the pre-built firmware via QGroundcontrol, you must use QGC Daily or QGC version newer than 4.1.7.
+If you are loading the pre-built firmware via QGroundControl, you must use QGC Daily or QGC version newer than 4.1.7.
 :::
 
 ## PX4 Configuration

--- a/docs/en/flight_controller/kakuteh7.md
+++ b/docs/en/flight_controller/kakuteh7.md
@@ -2,7 +2,7 @@
 
 <Badge type="tip" text="PX4 v1.13" />
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -36,13 +36,13 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - Dimensions: 35x35mm
 - Weight: 8g
 
-## Where to Buy
+## Where to Buy {#store}
 
 The board can be bought from one of the following shops (for example):
 
 - [Holybro](https://holybro.com/products/kakute-h7)
 
-:::tip
+::: tip
 The _Kakute H7_ is designed to work with the _Tekko32_ 4-in-1 ESC and they can be bought in combination.
 :::
 

--- a/docs/en/flight_controller/kakuteh7mini.md
+++ b/docs/en/flight_controller/kakuteh7mini.md
@@ -2,7 +2,7 @@
 
 <Badge type="tip" text="PX4 v1.13" />
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -40,7 +40,7 @@ PX4 runs on the H7 mini v1.3 and later.
 - Dimensions: 30x31x6mm
 - Weight: 5.5g
 
-## Where to Buy
+## Where to Buy {#store}
 
 The board can be bought from one of the following shops (for example):
 
@@ -86,7 +86,7 @@ Download the [holybro_kakuteh7mini_bootloader.hex](https://github.com/PX4/PX4-Au
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make holybro_kakuteh7mini_default
 ```
 
@@ -101,7 +101,7 @@ Firmware can be manually installed in any of the normal ways:
 
 - Build and upload the source:
 
-  ```
+  ```sh
   make holybro_kakuteh7mini_default upload
   ```
 

--- a/docs/en/flight_controller/kakuteh7mini.md
+++ b/docs/en/flight_controller/kakuteh7mini.md
@@ -93,7 +93,7 @@ make holybro_kakuteh7mini_default
 ## Installing PX4 Firmware
 
 ::: info
-If you are loading the pre-built firmware via QGroundcontrol, you must use QGC Daily or QGC version newer than 4.1.7.
+If you are loading the pre-built firmware via QGroundControl, you must use QGC Daily or QGC version newer than 4.1.7.
 Prior to that release you will need to manually build and install the firmware.
 :::
 

--- a/docs/en/flight_controller/kakuteh7v2.md
+++ b/docs/en/flight_controller/kakuteh7v2.md
@@ -90,7 +90,7 @@ make holybro_kakuteh7v2_default
 ## Installing PX4 Firmware
 
 ::: info
-KakuteH7v2 is supported with PX4 master & PX4 v1.14 or newer. If you are loading the pre-built firmware via QGroundcontrol, you must use QGC Daily or QGC version newer than 4.1.7.
+KakuteH7v2 is supported with PX4 master & PX4 v1.14 or newer. If you are loading the pre-built firmware via QGroundControl, you must use QGC Daily or QGC version newer than 4.1.7.
 Prior to that release you will need to manually build and install the firmware.
 :::
 

--- a/docs/en/flight_controller/kakuteh7v2.md
+++ b/docs/en/flight_controller/kakuteh7v2.md
@@ -1,6 +1,6 @@
 # Holybro Kakute H7 V2
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -36,13 +36,13 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - Dimensions: 35x35mm
 - Weight: 8g
 
-## Where to Buy
+## Where to Buy {#store}
 
 The board can be bought from one of the following shops (for example):
 
 - [Holybro](https://holybro.com/products/kakute-h7-v2)
 
-:::tip
+::: tip
 The _Kakute H7v2_ is designed to work with the _Tekko32_ 4-in-1 ESC and they can be bought in combination.
 :::
 
@@ -83,7 +83,7 @@ Download the [holybro_kakuteh7v2_bootloader.hex](https://github.com/PX4/PX4-Auto
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make holybro_kakuteh7v2_default
 ```
 
@@ -98,7 +98,7 @@ Firmware can be manually installed in any of the normal ways:
 
 - Build and upload the source:
 
-  ```
+  ```sh
   make holybro_kakuteh7v2_default upload
   ```
 

--- a/docs/en/flight_controller/micoair743-lite.md
+++ b/docs/en/flight_controller/micoair743-lite.md
@@ -2,7 +2,7 @@
 
 <Badge type="tip" text="PX4 v1.17" />
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://micoair.com/) for hardware support or compliance issues.
 :::
@@ -67,7 +67,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 
 ![MicoAir743-Lite Size](../../assets/flight_controller/micoair743_lite/size.png)
 
-## Where to Buy
+## Where to Buy {#store}
 
 Order from [MicoAir Tech Store](https://store.micoair.com/product/micoair743-lite/).
 
@@ -90,7 +90,7 @@ Pinouts definition can be found in the [MicoAir743-Lite_pinout.xlsx](https://raw
 
 ## Interfaces Diagram
 
-::: note
+::: info
 All the connectors used on the board are SH1.0
 :::
 

--- a/docs/en/flight_controller/micoair743-lite.md
+++ b/docs/en/flight_controller/micoair743-lite.md
@@ -12,7 +12,7 @@ MicoAir743-Lite is an ultra-high performance H743 flight controller with an unbe
 ![MicoAir743-Lite Front View](../../assets/flight_controller/micoair743_lite/front_view.png)
 
 Equipped with a high-performance H7 processor, the MicoAir743-Lite features a compact form factor with SH1.0 connectors (which are more suitable than Pixhawk-standard GH1.25 for this board size).
-When paired with with Bluetooth telemetry, the board can be debugged with a phone or PC.
+When paired with Bluetooth telemetry, the board can be debugged with a phone or PC.
 
 ::: info
 This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
@@ -85,7 +85,7 @@ Pinouts definition can be found in the [MicoAir743-Lite_pinout.xlsx](https://raw
 | UART4  | /dev/ttyS3 | TELEM2 |
 | UART5  | /dev/ttyS4 | TELEM3 |
 | USART6 | /dev/ttyS5 | RC     |
-| UART7  | /dev/ttyS6 | URT6   |
+| UART7  | /dev/ttyS6 | UART6  |
 | UART8  | /dev/ttyS7 | TELEM4 |
 
 ## Interfaces Diagram

--- a/docs/en/flight_controller/mindpx.md
+++ b/docs/en/flight_controller/mindpx.md
@@ -19,7 +19,7 @@ These flight controllers are [manufacturer supported](../flight_controller/autop
 The main hardware documentation is [here](http://mindpx.net/assets/accessories/Specification9.18_3_pdf.pdf).
 :::
 
-MindPX is a new generation autopilot system branched from Pixhawk<sup>&reg;</sup>, been revised in schematic and structure, and been further enhanced with new features to make un-manned vehicle more smart and more friendly to use.
+MindPX is a new generation autopilot system branched from Pixhawk<sup>&reg;</sup>, has been revised in schematic and structure, and has been further enhanced with new features to make unmanned vehicle more smart and more friendly to use.
 
 MindPX increases total PWM output channels to 16 (8 main outputs + 8 aux outputs).
 This means that MindPX can support more complicated VTOL configurations and more fine control.
@@ -96,7 +96,7 @@ MindPX has a USB-TO-UART Bridge IC on the board.
 A micro-USB to USB type A cable is used for the connection.
 Connect micro-USB end to the 'OBC' port of MindPX and USB type A end to companion computer.
 
-And the max BAUD rate is the same with px4 family, which is up to 921600.
+And the max BAUD rate is the same as for the PX4 family, which is up to 921600.
 
 ## User Guide
 

--- a/docs/en/flight_controller/mindpx.md
+++ b/docs/en/flight_controller/mindpx.md
@@ -1,6 +1,6 @@
 # MindPX Hardware
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](http://mindpx.net) for hardware support or compliance issues.
 :::
@@ -79,14 +79,14 @@ For detailed Pin diagram, please refer to the [User Guide](http://mindpx.net/ass
 
 ### Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make airmind_mindpx-v2_default
 ```
 
@@ -104,7 +104,7 @@ And the max BAUD rate is the same with px4 family, which is up to 921600.
 The user guide is [here](http://mindpx.net/assets/accessories/UserGuide9.18_2_pdf.pdf).
 :::
 
-## Where to Buy
+## Where to Buy {#store}
 
 MindRacer is available at [AirMind Store](https://airmind.mindpx.net/catalog).
 You can also find MindRacer at Amazon<sup>&reg;</sup> or eBay<sup>&reg;</sup>.

--- a/docs/en/flight_controller/mindracer.md
+++ b/docs/en/flight_controller/mindracer.md
@@ -79,7 +79,7 @@ MindRacer has an attached Adapt IO board.
 MindRacer has a built-in UART-to-USB converter.
 To connect a companion computer, stack MindRacer on an interface board, and connect the companion computer to the USB port on the interface board.
 
-And the max BAUD rate is the same with px4 family, which is up to 921600.
+And the max BAUD rate is the same as for the PX4 family, which is up to 921600.
 
 ### User Guide
 

--- a/docs/en/flight_controller/mindracer.md
+++ b/docs/en/flight_controller/mindracer.md
@@ -1,6 +1,6 @@
 # MindRacer Hardware
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](http://mindpx.net) for hardware support or compliance issues.
 :::
@@ -59,14 +59,14 @@ The main hardware documentation is [here](http://mindpx.net/assets/accessories/m
 
 ### How to Build
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make airmind_mindpx-v2_default
 ```
 
@@ -87,7 +87,7 @@ And the max BAUD rate is the same with px4 family, which is up to 921600.
 The user guide is [here](http://mindpx.net/assets/accessories/mindracer_user_guide_v1.2.pdf)
 :::
 
-## Where to Buy
+## Where to Buy {#store}
 
 MindRacer is available at [AirMind Store](https://airmind.mindpx.net/catalog).
 You can also find MindRacer at Amazon<sup>&reg;</sup> or eBay<sup>&reg;</sup>.

--- a/docs/en/flight_controller/modalai_fc_v1.md
+++ b/docs/en/flight_controller/modalai_fc_v1.md
@@ -2,11 +2,11 @@
 
 <Badge type="info" text="Discontinued" /> <Badge type="tip" text="PX4 v1.11" />
 
-:::warning
+::: warning
 This frame has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://forum.modalai.com/) for hardware support or compliance issues.
 :::
@@ -122,7 +122,7 @@ The full user guide is available [here](https://docs.modalai.com/flight-core-man
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make modalai_fc-v1
 ```
 

--- a/docs/en/flight_controller/modalai_fc_v1.md
+++ b/docs/en/flight_controller/modalai_fc_v1.md
@@ -77,7 +77,7 @@ More information about the firmware can be found [here](https://docs.modalai.com
 
 ## QGroundControl Support
 
-This board supported in QGroundControl 4.0 and later.
+This board is supported in QGroundControl 4.0 and later.
 
 ## Availability
 

--- a/docs/en/flight_controller/modalai_voxl_2.md
+++ b/docs/en/flight_controller/modalai_voxl_2.md
@@ -70,7 +70,7 @@ PX4 mainline supports VOXL 2 (board documentation [here](https://github.com/PX4/
 
 ## QGroundControl Support
 
-This board supported in QGroundControl 4.0 and later.
+This board is supported in QGroundControl 4.0 and later.
 
 ## Availability
 

--- a/docs/en/flight_controller/modalai_voxl_2.md
+++ b/docs/en/flight_controller/modalai_voxl_2.md
@@ -1,6 +1,6 @@
 # ModalAI VOXL 2
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://forum.modalai.com/) for hardware support or compliance issues.
 :::

--- a/docs/en/flight_controller/modalai_voxl_flight.md
+++ b/docs/en/flight_controller/modalai_voxl_flight.md
@@ -2,11 +2,11 @@
 
 <Badge type="info" text="Discontinued" /> <Badge type="tip" text="PX4 v1.11" />
 
-:::warning
+::: warning
 This frame has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://forum.modalai.com/) for hardware support or compliance issues.
 :::
@@ -176,7 +176,7 @@ The full user guide is available [here](https://docs.modalai.com/voxl-flight-qui
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make modalai_fc-v1
 ```
 

--- a/docs/en/flight_controller/modalai_voxl_flight.md
+++ b/docs/en/flight_controller/modalai_voxl_flight.md
@@ -106,7 +106,7 @@ More information about the firmware can be found [here](https://docs.modalai.com
 
 ## QGroundControl Support
 
-This board supported in QGroundControl 4.0 and later.
+This board is supported in QGroundControl 4.0 and later.
 
 ## Availability
 

--- a/docs/en/flight_controller/mro_control_zero_f7.md
+++ b/docs/en/flight_controller/mro_control_zero_f7.md
@@ -1,6 +1,6 @@
 # mRo Control Zero F7 Flight Controller
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store.mrobotics.io/) for hardware support or compliance issues.
 :::
@@ -56,20 +56,20 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - Power System:
   - 3x Ultra low noise LDO voltage regulator
 
-## Where to Buy
+## Where to Buy {#store}
 
 - [mRo Control Zero](https://store.mrobotics.io/mRo-Control-Zero-F7-p/mro-ctrl-zero-f7.htm)
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make mro_ctrl-zero-f7
 ```
 

--- a/docs/en/flight_controller/mro_pixhawk.md
+++ b/docs/en/flight_controller/mro_pixhawk.md
@@ -1,13 +1,13 @@
 # mRo Pixhawk Flight Controller (Pixhawk 1)
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store.mrobotics.io/) for hardware support or compliance issues.
 :::
 
 The _mRo Pixhawk<sup>&reg;</sup>_ is a hardware compatible version of the original [Pixhawk 1](../flight_controller/pixhawk.md). It runs PX4 on the [NuttX](https://nuttx.apache.org/) OS.
 
-:::tip
+::: tip
 The controller can be used as a drop-in replacement for the 3DR<sup>&reg;</sup> [Pixhawk 1](../flight_controller/pixhawk.md).
 The main difference is that it is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv3** open hardware design, which corrects a bug that limited the original Pixhawk 1 to 1MB of flash.
 :::
@@ -16,7 +16,7 @@ The main difference is that it is based on the [Pixhawk-project](https://pixhawk
 
 Assembly/setup instructions for use with PX4 are provided here: [Pixhawk Wiring Quickstart](../assembly/quick_start_pixhawk.md)
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -62,14 +62,14 @@ This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v3_default
 ```
 

--- a/docs/en/flight_controller/mro_x2.1.md
+++ b/docs/en/flight_controller/mro_x2.1.md
@@ -2,11 +2,11 @@
 
 <Badge type="info" text="Discontinued" /> <!-- 202507 / PX4v1.16 -->
 
-:::warning
+::: warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store.mrobotics.io/) for hardware support or compliance issues.
 :::
@@ -92,14 +92,14 @@ This product can be ordered at the [mRobotics<sup>&reg;</sup> Store](https://sto
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make mro_x21_default
 ```
 

--- a/docs/en/flight_controller/nxp_mr_vmu_rt1176.md
+++ b/docs/en/flight_controller/nxp_mr_vmu_rt1176.md
@@ -2,7 +2,7 @@
 
 <Badge type="tip" text="PX4 v1.15" />
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://www.nxp.com) for hardware support (https://community.nxp.com/) or compliance issues.
 :::
@@ -23,7 +23,7 @@ It also removes the IO processor to enable 12 PWM ports, with 8 providing Dshot 
 This board takes advantage of multiple Pixhawk​​® open standards, such as the FMUv6X-RT Standard, [Autopilot Bus Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-010%20Pixhawk%20Autopilot%20Bus%20Standard.pdf), and [Connector Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-009%20Pixhawk%20Connector%20Standard.pdf).
 Equipped with a high performance NXP i.mx RT1176 dual core Processor, modular design, triple redundancy, temperature-controlled IMU board, isolated sensor domains, delivering incredible performance, reliability, and flexibility.
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -133,7 +133,7 @@ Similar variants will be available from our licensees.
 - Other Characteristics:
   - Operating & storage temperature: -40 ~ 85°c
 
-## Where to Buy
+## Where to Buy {#store}
 
 Order from [NXP](https://www.nxp.com).
 
@@ -214,7 +214,7 @@ Analog battery monitoring via an ADC is not supported on this particular board, 
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::

--- a/docs/en/flight_controller/nxp_rddrone_fmuk66.md
+++ b/docs/en/flight_controller/nxp_rddrone_fmuk66.md
@@ -2,11 +2,11 @@
 
 <Badge type="info" text="Discontinued" />
 
-:::warning
+::: warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://www.nxp.com/) for hardware support or compliance issues.
 :::
@@ -49,7 +49,7 @@ A "Lite" version RDDRONE-FMUK66L is also available which does not include the po
 
 Additional information can be found in the [Technical Data Sheet](https://www.nxp.com/design/design-center/development-boards-and-designs/px4-robotic-drone-vehicle-flight-management-unit-vmu-fmu-rddrone-fmuk66:RDDRONE-FMUK66). <!-- www.nxp.com/rddrone-fmuk66 -->
 
-## Where to Buy
+## Where to Buy {#store}
 
 **RDDRONE-FMUK66** reference design kit may be purchased direct from NXP or from any of NXP's authorised worldwide network of [electronics distributors](https://www.nxp.com/support/sample-and-buy/distributor-network:DISTRIBUTORS).
 
@@ -83,14 +83,14 @@ https://nxp.gitbook.io/hovergames
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make nxp_fmuk66-v3_default
 ```
 
@@ -117,7 +117,7 @@ The complete set of supported configurations can be seen in the [Airframes Refer
 
 ![HoverGames Drone Kit](../../assets/flight_controller/nxp_rddrone_fmuk66/hovergames_drone_14042019_xl001.jpg)
 
-:::tip
+::: tip
 The NXP [HoverGames Drone Kit](https://www.nxp.com/kit-hgdronek66) (shown above) is a complete drone development kit that includes everything needed to build a quadcopter.
 You only need to supply the 3S/4S LiPo battery.
 :::

--- a/docs/en/flight_controller/ocpoc_zynq.md
+++ b/docs/en/flight_controller/ocpoc_zynq.md
@@ -2,7 +2,7 @@
 
 <Badge type="info" text="Discontinued" />
 
-:::warning
+::: warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 
 PX4 v1.11 is the last release that has (experimental) support for this platform.

--- a/docs/en/flight_controller/omnibus_f4_sd.md
+++ b/docs/en/flight_controller/omnibus_f4_sd.md
@@ -193,7 +193,7 @@ On the handheld controller (e.g. Taranis) you will also need a [Transmitter Modu
 This can be plugged into the back of the RC controller.
 
 ::: info
-The referenced links above contains the documentation for the TX/RX modules.
+The referenced links above contain the documentation for the TX/RX modules.
 :::
 
 #### Setup

--- a/docs/en/flight_controller/omnibus_f4_sd.md
+++ b/docs/en/flight_controller/omnibus_f4_sd.md
@@ -1,10 +1,10 @@
 # Omnibus F4 SD
 
-:::warning
+::: warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the manufacturer for support or compliance issues.
 :::
@@ -23,7 +23,7 @@ These are the main differences compared to a [Pixracer](../flight_controller/pix
 - Same board dimensions as a _Pixracer_, but slightly smaller form factor (because it has less connectors)
 - Integrated OSD (not yet implemented in software)
 
-:::tip
+::: tip
 All the usual PX4 features can still be used for your racer!
 :::
 
@@ -46,15 +46,15 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - Built-in current sensor
 - Built-in OSD chip (AB7456 via SPI)
 
-## Where to Buy
+## Where to Buy {#store}
 
 The board is produced by different vendors, with some variations (e.g. with or without a barometer).
 
-:::tip
+::: tip
 PX4 is compatible with boards that support the Betaflight OMNIBUSF4SD target (if _OMNIBUSF4SD_ is present on the product page the board should work with PX4).
 :::
 
-:::tip
+::: tip
 Any Omnibus F4 labeled derivative (e.g. clone) should work as well. However, power distribution on these boards is of varying quality.
 :::
 
@@ -225,7 +225,7 @@ Download the [omnibusf4sd_bl.hex](https://github.com/PX4/PX4-Autopilot/raw/main/
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make omnibus_f4sd_default
 ```
 
@@ -233,7 +233,7 @@ make omnibus_f4sd_default
 
 You can use either pre-built firmware or your own custom firmware.
 
-:::warning  
+::: warning  
 If you use [CRSF Telemetry](../telemetry/crsf_telemetry.md#px4-configuration) in your radio system, as describe above, then you must use custom firmware.
 :::
 
@@ -241,7 +241,7 @@ The firmware can be installed in any of the normal ways:
 
 - Build and upload the source
 
-  ```
+  ```sh
   make omnibus_f4sd_default upload
   ```
 

--- a/docs/en/flight_controller/pixfalcon.md
+++ b/docs/en/flight_controller/pixfalcon.md
@@ -2,11 +2,11 @@
 
 <Badge type="info" text="Discontinued" px4_current="v1.15" year="2024"/>
 
-:::warning
+::: warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -47,14 +47,14 @@ Optional hardware:
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v2_default
 ```
 

--- a/docs/en/flight_controller/pixhack_v3.md
+++ b/docs/en/flight_controller/pixhack_v3.md
@@ -2,11 +2,11 @@
 
 <Badge type="info" text="Discontinued" />
 
-:::warning
+::: warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 :::
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store.cuav.net/) for hardware support or compliance issues.
 :::
@@ -63,7 +63,7 @@ The board can be purchased from:
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::

--- a/docs/en/flight_controller/pixhawk-2.md
+++ b/docs/en/flight_controller/pixhawk-2.md
@@ -1,11 +1,11 @@
 # Hex Cube Black Flight Controller
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://cubepilot.org/#/home) for hardware support or compliance issues.
 :::
 
-:::tip
+::: tip
 The [Cube Orange](cubepilot_cube_orange.md) is the successor to this product.
 We recommend however to consider products built on industry standards, such as the [Pixhawk Standards](autopilot_pixhawk_standard.md).
 This flight controller is not following the standard and uses a patented connector.
@@ -26,7 +26,7 @@ Cube includes vibration isolation on two of the IMU's, with a third fixed IMU as
 The manufacturer [Cube User Guide](https://docs.cubepilot.org/user-guides/autopilot/the-cube) contains detailed information, including an overview of the [Differences between Cube Colours](https://docs.cubepilot.org/user-guides/autopilot/the-cube/introduction/specifications).
 :::
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -47,9 +47,7 @@ This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md
 - High-power, multi-tone piezo audio indicator
 - microSD card for high-rate logging over extended periods of time
 
-<a id="stores"></a>
-
-## Where to Buy
+## Where to Buy {#store}
 
 [Cube Black](https://www.cubepilot.com/#/reseller/list) (Reseller list)
 
@@ -147,14 +145,14 @@ Board schematics and other documentation can be found here: [The Cube Project](h
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v3_default
 ```
 

--- a/docs/en/flight_controller/pixhawk.md
+++ b/docs/en/flight_controller/pixhawk.md
@@ -1,11 +1,11 @@
 # 3DR Pixhawk 1 Flight Controller (Discontinued)
 
-:::warning
+::: warning
 This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 You can use the [mRo Pixhawk](../flight_controller/mro_pixhawk.md) as a drop-in replacement.
 :::
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the manufacturer for support or compliance issues.
 :::
@@ -46,7 +46,7 @@ Connectivity
 - S.BUS / PPM / Spektrum input
 - S.BUS output
 
-# Where to Buy
+# Where to Buy {#store}
 
 Originally manufactured by 3DR&reg; this board was the original standard microcontroller platform for PX4&reg;. While the board is no longer manufactured by 3DR, you can use the [mRo Pixhawk](../flight_controller/mro_pixhawk.md) as a drop-in replacement.
 
@@ -127,14 +127,14 @@ As a CC-BY-SA 3.0 licensed Open Hardware design, all schematics and design files
 Pixhawk ports are shown below.
 These use Hirose DF13 connectors (predating the JST-GH connectors defined in the Pixhawk connector standard).
 
-:::warning
+::: warning
 Many 3DR Pixhawk clones use Molex picoblade connectors instead of DF13 connectors.
 They have rectangular instead of square pins, and cannot be assumed to be compatible.
 :::
 
 ![Pixhawk Connectors](../../assets/flight_controller/pixhawk1/pixhawk_connectors.png)
 
-:::tip
+::: tip
 The `RC IN` port is for RC receivers only and provides sufficient power for that purpose.
 **NEVER** connect any servos, power supplies or batteries to it or to the receiver connected to it.
 :::
@@ -262,7 +262,7 @@ Due to space constraints two ports are on one connector.
 
 The [PX4 System Console](../debug/system_console.md) runs on the port labeled [SERIAL4/5](#serial-4-5-port).
 
-:::tip
+::: tip
 A convenient way to connect to the console is to use a [Zubax BugFace BF1](https://github.com/Zubax/bugface_bf1), as it comes with connectors that can be used with several different Pixhawk devices.
 Simply connect the 6-pos DF13 1:1 cable on the [Zubax BugFace BF1](https://github.com/Zubax/bugface_bf1) to the Pixhawk `SERIAL4/5` port.
 
@@ -310,14 +310,14 @@ All Pixhawk FMUv2 boards have a similar SWD port.
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v2_default
 ```
 

--- a/docs/en/flight_controller/pixhawk3_pro.md
+++ b/docs/en/flight_controller/pixhawk3_pro.md
@@ -1,6 +1,6 @@
 # Pixhawk 3 Pro (Discontinued)
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store-drotek.com/) for hardware support or compliance issues.
 :::
@@ -14,7 +14,7 @@ The board was designed by [Drotek<sup>&reg;</sup>](https://drotek.com) and PX4.
 The main hardware documentation is here: https://drotek.gitbook.io/pixhawk-3-pro/hardware
 :::
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -40,14 +40,14 @@ No longer available.
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v4pro_default
 ```
 

--- a/docs/en/flight_controller/pixhawk4.md
+++ b/docs/en/flight_controller/pixhawk4.md
@@ -1,6 +1,6 @@
 # Holybro Pixhawk 4
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -12,7 +12,7 @@ It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv5** open hardwa
 
 <img src="../../assets/flight_controller/pixhawk4/pixhawk4_hero_upright.jpg" width="200px" title="Pixhawk4 Upright Image" /> <img src="../../assets/flight_controller/pixhawk4/pixhawk4_logo_view.jpg" width="420px" title="Pixhawk4 Image" />
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -51,7 +51,7 @@ This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md
 
 Additional information can be found in the [Pixhawk 4 Technical Data Sheet](https://github.com/PX4/PX4-Autopilot/blob/main/docs/assets/flight_controller/pixhawk4/pixhawk4_technical_data_sheet.pdf).
 
-## Where to Buy
+## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/pixhawk-4).
 
@@ -59,7 +59,7 @@ Order from [Holybro](https://holybro.com/products/pixhawk-4).
 
 ![Pixhawk 4 connectors](../../assets/flight_controller/pixhawk4/pixhawk4-connectors.jpg)
 
-:::warning
+::: warning
 The **DSM/SBUS RC** and **PPM RC** ports are for RC receivers only.
 These are powered! NEVER connect any servos, power supplies or batteries (or to any connected receiver).
 :::
@@ -119,20 +119,18 @@ The [Pixhawk 4 Wiring Quick Start](../assembly/quick_start_pixhawk4.md) provides
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v5_default
 ```
 
-<a id="debug_port"></a>
-
-## Debug Port
+## Debug Port {#debug_port}
 
 The [PX4 System Console](../debug/system_console.md) and [SWD interface](../debug/swd_debug.md) run on the **FMU Debug** port, while the I/O console and SWD interface can be accessed via **I/O Debug** port.
 In order to access these ports, the user must remove the _Pixhawk 4_ casing.

--- a/docs/en/flight_controller/pixhawk4_mini.md
+++ b/docs/en/flight_controller/pixhawk4_mini.md
@@ -2,7 +2,7 @@
 
 <Badge type="info" text="Discontinued" px4_current="v1.15" year="2024"/>
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -16,7 +16,7 @@ It is based on the [Pixhawk](https://pixhawk.org/) **FMUv5** design standard and
 
 ![Pixhawk4 mini](../../assets/flight_controller/pixhawk4mini/pixhawk4mini_iso_1.png)
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -54,7 +54,7 @@ This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md
 
 Additional information can be found in the [_Pixhawk 4 Mini_ Technical Data Sheet](https://github.com/PX4/PX4-Autopilot/raw/main/docs/assets/flight_controller/pixhawk4mini/pixhawk4mini_technical_data_sheet.pdf).
 
-## Where to Buy
+## Where to Buy {#store}
 
 No longer available.
 
@@ -62,7 +62,7 @@ No longer available.
 
 ![Pixhawk 4 Mini interfaces](../../assets/flight_controller/pixhawk4mini/pixhawk4mini_interfaces.png)
 
-:::warning
+::: warning
 The **RC IN** and **PPM** ports are for RC receivers only. These are powered! NEVER connect any servos, power supplies or batteries (or to any connected receiver).
 :::
 
@@ -104,14 +104,14 @@ The [_Pixhawk 4 Mini_ Wiring Quick Start](../assembly/quick_start_pixhawk4_mini.
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v5_default
 ```
 
@@ -148,7 +148,7 @@ The pinout uses the standard [Pixhawk debug connector](https://github.com/pixhaw
 Motors and servos are connected to the **MAIN OUT** ports in the order specified for your vehicle in the [Airframe Reference](../airframes/airframe_reference.md).
 This reference lists the output port to motor/servo mapping for all supported air and ground frames (if your frame is not listed in the reference then use a "generic" airframe of the correct type).
 
-:::warning
+::: warning
 _Pixhawk 4 Mini_ does not have AUX ports.
 The board cannot be used with frames that require more than 8 ports or which use AUX ports for motors or control surfaces.
 It can be used for airframes that use AUX for non-essential peripherals (e.g. "feed-through of RC AUX1 channel").

--- a/docs/en/flight_controller/pixhawk5x.md
+++ b/docs/en/flight_controller/pixhawk5x.md
@@ -129,7 +129,7 @@ The [Pixhawk 5X Wiring Quick Start](../assembly/quick_start_pixhawk5x.md) provid
 
 ::: info
 Connector pin assignments are left to right (i.e. Pin 1 is the left-most pin).
-::: infos:
+:::
 
 - The [camera capture pin](../camera/fc_connected_camera.md#camera-capture-configuration) (`PI0`) is pin 2 on the AD&IO port, marked above as `FMU_CAP1`.
 - _Pixhawk 5X_ pinouts can be downloaded in PDF from from [here](https://github.com/PX4/PX4-user_guide/blob/main/assets/flight_controller/pixhawk5x/pixhawk5x_pinout.pdf) or [here](https://cdn.shopify.com/s/files/1/0604/5905/7341/files/Holybro_Pixhawk5X_Pinout.pdf).

--- a/docs/en/flight_controller/pixhawk5x.md
+++ b/docs/en/flight_controller/pixhawk5x.md
@@ -1,6 +1,6 @@
 # Holybro Pixhawk 5X
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -12,7 +12,7 @@ It comes with the latest PX4 Autopilot​® pre-installed, triple redundancy, te
 
 <img src="../../assets/flight_controller/pixhawk5x/pixhawk5x_hero_upright.jpg" width="250px" title="Pixhawk5x Upright Image" /> <img src="../../assets/flight_controller/pixhawk5x/pixhawk5x_exploded_diagram.jpg" width="450px" title="Pixhawk5x Exploded Image" />
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -111,7 +111,7 @@ The Pixhawk® 5X is perfect for developers at corporate research labs, startups,
 - Other Characteristics:
   - Operating & storage temperature: -40 ~ 85°c
 
-## Where to Buy
+## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/pixhawk-5x).
 
@@ -181,20 +181,18 @@ Analog battery monitoring via an ADC is not supported on this particular board, 
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v5x_default
 ```
 
-<a id="debug_port"></a>
-
-## Debug Port
+## Debug Port {#debug_port}
 
 The [PX4 System Console](../debug/system_console.md) and [SWD interface](../debug/swd_debug.md) run on the **FMU Debug** port.
 

--- a/docs/en/flight_controller/pixhawk6c.md
+++ b/docs/en/flight_controller/pixhawk6c.md
@@ -1,6 +1,6 @@
 # Holybro Pixhawk 6C
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -12,7 +12,7 @@ It complies with the Pixhawk [Connector Standard](https://github.com/pixhawk/Pix
 
 <img src="../../assets/flight_controller/pixhawk6c/pixhawk6c_hero_upright.png" width="250px" title="Pixhawk6c Upright Image" />
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -88,7 +88,7 @@ The Pixhawk® 6C is perfect for developers at corporate research labs, startups,
 - Other Characteristics:
   - Operating & storage temperature: -40 ~ 85°c
 
-## Where to Buy
+## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/pixhawk-6c).
 
@@ -147,20 +147,18 @@ Holybro makes various analog [power modules](../power_module/index.md) for diffe
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v6c_default
 ```
 
-<a id="debug_port"></a>
-
-## Debug Port
+## Debug Port {#debug_port}
 
 The [PX4 System Console](../debug/system_console.md) and [SWD interface](../debug/swd_debug.md) run on the **FMU Debug** port.
 

--- a/docs/en/flight_controller/pixhawk6c_mini.md
+++ b/docs/en/flight_controller/pixhawk6c_mini.md
@@ -58,7 +58,7 @@ The Pixhawk® 6C Mini is perfect for developers at corporate research labs, star
   - USB Power Input: 4.75\~5.25V
   - Servo Rail Input: 0\~36V
 - Current Ratings:
-  - `TELEM1`` Max output current limiter: 1A
+  - `TELEM1` Max output current limiter: 1A
   - All other port combined output current limiter: 1A
 
 ### **Mechanical data**

--- a/docs/en/flight_controller/pixhawk6c_mini.md
+++ b/docs/en/flight_controller/pixhawk6c_mini.md
@@ -1,6 +1,6 @@
 # Holybro Pixhawk 6C Mini
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -12,7 +12,7 @@ It complies with the Pixhawk [Connector Standard](https://github.com/pixhawk/Pix
 
 ![Pixhawk6c mini A&B Image](../../assets/flight_controller/pixhawk6c_mini/HB_6C_MINI-A_B.jpg)
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -87,7 +87,7 @@ The Pixhawk® 6C Mini is perfect for developers at corporate research labs, star
 - Other Characteristics:
   - Operating & storage temperature: -40 ~ 85°c
 
-## Where to Buy
+## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/pixhawk-6c-mini).
 
@@ -151,20 +151,18 @@ Holybro makes various analog [power modules](../power_module/index.md) for diffe
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v6c_default
 ```
 
-<a id="debug_port"></a>
-
-## Debug Port
+## Debug Port {#debug_port}
 
 The [PX4 System Console](../debug/system_console.md) and [SWD interface](../debug/swd_debug.md) run on the **FMU Debug** port.
 

--- a/docs/en/flight_controller/pixhawk6x-rt.md
+++ b/docs/en/flight_controller/pixhawk6x-rt.md
@@ -1,6 +1,6 @@
 # Holybro Pixhawk 6X-RT
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -13,7 +13,7 @@ Equipped with a high performance NXP i.mx RT1176 dual core Processor, modular de
 
 <img src="../../assets/flight_controller/pixhawk6x-rt/pixhawk6x-rt.png" width="350px" title="Pixhawk6X-RT Upright Image" /> <img src="../../assets/flight_controller/pixhawk6x/pixhawk6x_exploded_diagram.png" width="300px" title="Pixhawk6X Exploded Image" />
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -120,7 +120,7 @@ The Pixhawk®​ 6X-RT is perfect for developers at corporate research labs, sta
 - Other Characteristics:
   - Operating & storage temperature: -40 ~ 85°c
 
-## Where to Buy
+## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/fmuv6x-rt-developer-edition).
 
@@ -190,20 +190,18 @@ Analog battery monitoring via an ADC is not supported on this particular board, 
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v6xrt_default
 ```
 
-<a id="debug_port"></a>
-
-## Debug Port
+## Debug Port {#debug_port}
 
 The [PX4 System Console](../debug/system_console.md) and [SWD interface](../debug/swd_debug.md) run on the **FMU Debug** port.
 

--- a/docs/en/flight_controller/pixhawk6x.md
+++ b/docs/en/flight_controller/pixhawk6x.md
@@ -1,6 +1,6 @@
 # Holybro Pixhawk 6X
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -51,7 +51,7 @@ Equipped with a high-performance H7 Processor, modular design, triple redundancy
 
 ::::
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -150,7 +150,7 @@ The Pixhawk®​ 6X is perfect for developers at corporate research labs, startu
 - Other Characteristics:
   - Operating & storage temperature: -40 ~ 85°c
 
-## Where to Buy
+## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/pixhawk-6x).
 
@@ -221,20 +221,18 @@ Analog battery monitoring via an ADC is not supported on this particular board b
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v6x_default
 ```
 
-<a id="debug_port"></a>
-
-## Debug Port
+## Debug Port {#debug_port}
 
 The [PX4 System Console](../debug/system_console.md) and [SWD interface](../debug/swd_debug.md) run on the **FMU Debug** port.
 

--- a/docs/en/flight_controller/pixhawk6x.md
+++ b/docs/en/flight_controller/pixhawk6x.md
@@ -205,7 +205,7 @@ Under these conditions, all power sources will be used in this order to power th
 
 **Absolute Maximum Ratings**
 
-Under these conditions, the system will not draw any power (will not be operational) but will remain intact.
+Under these conditions, the system will not draw any power (will not be operational), but will remain intact.
 
 1. **POWER1** and **POWER2** inputs (operational range 4.1V to 5.7V, 0V to 10V undamaged)
 1. **USB** input (operational range 4.1V to 5.7V, 0V to 6V undamaged)

--- a/docs/en/flight_controller/pixhawk6x_pro.md
+++ b/docs/en/flight_controller/pixhawk6x_pro.md
@@ -1,6 +1,6 @@
 # Holybro Pixhawk 6X Pro
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -111,7 +111,7 @@ It can also be used with any other Pixhawk Autopilot Bus (PAB) specification-com
 
 :::
 
-## Where to Buy
+## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/pixhawk-6x-pro).
 
@@ -188,14 +188,14 @@ Analog battery monitoring via an ADC is not supported on this particular board, 
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v6x_default
 ```
 

--- a/docs/en/flight_controller/pixhawk_mini.md
+++ b/docs/en/flight_controller/pixhawk_mini.md
@@ -42,7 +42,7 @@ This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md
 - **Power module output:** 4.1\~5.5V
 - **Max input voltage:** 45V (10S LiPo)
 - **Max current sensing:** 90A
-- **USB Power Input:** 4.1\`5.5V
+- **USB Power Input:** 4.1\~5.5V
 - **Servo Rail Input:** 0\~10V
 
 **Interfaces:**
@@ -287,7 +287,7 @@ Make sure to use the correct mapping for your vehicle.
 
 ::: tip
 If your frame is not listed in the reference then use a "generic" airframe of the correct type.
-::: infos:
+:::
 
 - The output rail must be separately powered, as discussed in the [Power](#power) section above.
 - Pixhawk Mini cannot be used for QuadPlane VTOL airframes. This is because QuadPlane requires 9 outputs (4 Main, 5 AUX) and the Pixhawk Mini only has 8 outputs (8 Main).

--- a/docs/en/flight_controller/pixhawk_mini.md
+++ b/docs/en/flight_controller/pixhawk_mini.md
@@ -1,6 +1,6 @@
 # Holybro Pixhawk Mini (Discontinued)
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://holybro.com/) for hardware support or compliance issues.
 :::
@@ -19,7 +19,7 @@ This flight controller was designed by 3DR in collaboration with HobbyKing<sup>&
 It was formerly known as the 3DR Pixhawk Mini.
 :::
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -67,7 +67,7 @@ This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md
 - **Weight:** 22.4g
 - **Dimensions:** 37x37x12mm
 
-## Where to Buy
+## Where to Buy {#store}
 
 Discontinued.
 
@@ -185,7 +185,7 @@ Pixhawk Mini features an advanced processor and sensor technology from ST Microe
 
 ## Wiring Quick Start
 
-:::warning
+::: warning
 The _Pixhawk Mini_ is no longer manufactured or available from 3DR.
 :::
 
@@ -280,12 +280,12 @@ If this switch is hard to access on a particular vehicle you can attach the (opt
 
 The mappings between MAIN/AUX output ports and motor/servos for all supported air and ground frames are listed in the [Airframe Reference](../airframes/airframe_reference.md).
 
-:::warning
+::: warning
 The mapping is not consistent across frames (e.g. you can't rely on the throttle being on the same output for all plane frames).
 Make sure to use the correct mapping for your vehicle.
 :::
 
-:::tip
+::: tip
 If your frame is not listed in the reference then use a "generic" airframe of the correct type.
 ::: infos:
 
@@ -306,14 +306,14 @@ QuadPlane specific configuration is covered here: [QuadPlane VTOL Configuration]
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v3_default
 ```
 

--- a/docs/en/flight_controller/pixhawk_series.md
+++ b/docs/en/flight_controller/pixhawk_series.md
@@ -6,7 +6,7 @@ Pixhawk is the reference hardware platform for PX4, and runs PX4 on the [NuttX](
 
 Manufacturers have created many different boards based on the open designs, with form factors that are optimised for applications from cargo carrying though to first person view (FPV) racers.
 
-:::tip
+::: tip
 For computationally intensive tasks (e.g. computer vision) you will need a separate companion computer (e.g. [Raspberry Pi 2/3 Navio2](../flight_controller/raspberry_pi_navio2.md)) or a platform with an integrated companion solution.
 :::
 
@@ -135,7 +135,7 @@ Products that are based on independently created schematics are considered origi
 Product names/brands can also be trademarked.
 Trademarked names may not be used without the permission of the owner.
 
-:::tip
+::: tip
 _Pixhawk_ is a trademark, and cannot be used in product names without permission.
 :::
 

--- a/docs/en/flight_controller/pixracer.md
+++ b/docs/en/flight_controller/pixracer.md
@@ -1,6 +1,6 @@
 # mRo Pixracer
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://store.mrobotics.io/) for hardware support or compliance issues.
 :::
@@ -10,7 +10,7 @@ In contrast to [Pixfalcon](../flight_controller/pixfalcon.md) and [Pixhawk](../f
 
 <img src="../../assets/flight_controller/pixracer/pixracer_hero_grey.jpg" width="300px" title="pixracer + 8266 grey" />
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -30,7 +30,7 @@ This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md
 - OneShot PWM out (configurable)
 - Optional: Safety switch and buzzer
 
-## Where to Buy
+## Where to Buy {#store}
 
 Pixracer Pro is available from the [store.3dr.com](https://store.3dr.com/pixracer-pro/).
 
@@ -210,14 +210,14 @@ The following PDF files are provided for _convenience only_:
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::
 
 To [build PX4](../dev_setup/building_px4.md) for this target:
 
-```
+```sh
 make px4_fmu-v4_default
 ```
 

--- a/docs/en/flight_controller/raccoonlab_fmu6x.md
+++ b/docs/en/flight_controller/raccoonlab_fmu6x.md
@@ -1,6 +1,6 @@
 # RaccoonLab FMUv6X Autopilot
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://raccoonlab.co) for hardware support or compliance issues.
 :::
@@ -18,7 +18,7 @@ The [Jetson Xavier NX HAT](https://docs.raccoonlab.co/guide/nx_hat/) is designed
 The [Raspberry Pi CM4 HAT](https://docs.raccoonlab.co/guide/rpi_hat/) provides robust features, including CAN bus connectivity, an LTE modem, internal voltage measurement, SWD debugging for other MCUs, and UART communication with PX4 over MAVLINK.
 These HATs expand the capabilities of devices, making them ideal for advanced robotics and UAV applications.
 
-:::tip
+::: tip
 This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 :::
 
@@ -125,12 +125,12 @@ Under these conditions all power sources will be used in this order to power the
 1. **POWER1** and **POWER2** inputs (4.9V to 5.5V)
 2. **USB** input (4.75V to 5.25V)
 
-:::tip
+::: tip
 The manufacturer [RaccoonLab Docs](https://docs.raccoonlab.co/guide/autopilot/RCLv6X.html) are the canonical reference for the RaccoonLab FMUv6X Autopilot.
 They should be used by preference as they contain the most complete and up to date information.
 :::
 
-## Where to Buy
+## Where to Buy {#store}
 
 [RaccoonLab Store](https://raccoonlab.co/store)
 
@@ -138,7 +138,7 @@ They should be used by preference as they contain the most complete and up to da
 
 ## Building Firmware
 
-:::tip
+::: tip
 Most users will not need to build this firmware!
 It is pre-built and automatically installed by _QGroundControl_ when appropriate hardware is connected.
 :::

--- a/docs/en/flight_controller/radiolink_pix6.md
+++ b/docs/en/flight_controller/radiolink_pix6.md
@@ -27,7 +27,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
   - 32KB FRAM - FM25V02A
   - AT7456E OSD
 - Sensors
-  - Bosh BMI088 IMU (accel, gyro)
+  - Bosch BMI088 IMU (accel, gyro)
   - InvenSense ICM-42688 IMU (accel, gyro)
   - SPA06 barometer
   - IST8310 magnetometer
@@ -277,7 +277,7 @@ In addition to the [basic configuration](../config/index.md), the following para
 ### Powering the PIX6
 
 The PIX6 has 2 dedicated power monitor ports, each with a 6 pin connector.
-One is the Analog power monitor (`POWER1`), and the others is the I2C power monitor (`POWER2`).
+One is the Analog power monitor (`POWER1`), and the other is the I2C power monitor (`POWER2`).
 
 The power module that comes with the flight controller with a wide voltage input range of 2-12S (7.4-50.4V), a maximum detection current of 90A (single ESC maximum detection current is 22.5A), a BEC output voltage of 5.3±0.2V, and a BEC output current of 2A.
 

--- a/docs/en/flight_controller/radiolink_pix6.md
+++ b/docs/en/flight_controller/radiolink_pix6.md
@@ -2,7 +2,7 @@
 
 <Badge type="tip" text="PX4 v1.17" />
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://radiolink.com.cn/) for hardware support or compliance issues.
 :::
@@ -48,7 +48,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
   - Weight 80g
   - Size 94mm x 51.5mm x 14.5mm
 
-## Where to Buy
+## Where to Buy {#store}
 
 [Radiolink Amazon](https://www.radiolink.com.cn/pix6_where_to_buy)（International users）
 

--- a/docs/en/flight_controller/raspberry_pi_navio2.md
+++ b/docs/en/flight_controller/raspberry_pi_navio2.md
@@ -2,7 +2,7 @@
 
 <LinkedBadge type="warning" text="Experimental" url="../flight_controller/autopilot_experimental.html"/>
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://emlid.com/) for hardware support or compliance issues.
 :::
@@ -17,7 +17,7 @@ It allows you to build PX4 and transfer to the RPi, or build natively.
 Use the preconfigured [Emlid Raspberry Pi OS image for Navio 2](https://docs.emlid.com/navio2/configuring-raspberry-pi/).
 The default image will have most of the setup procedures shown below already done.
 
-:::warning
+::: warning
 Make sure not to upgrade the system (more specifically the kernel).
 By upgrading, a new kernel can get installed which lacks the necessary HW support (you can check with `ls /sys/class/pwm`, the directory should not be empty).
 :::

--- a/docs/en/flight_controller/raspberry_pi_pilotpi.md
+++ b/docs/en/flight_controller/raspberry_pi_pilotpi.md
@@ -2,7 +2,7 @@
 
 <LinkedBadge type="warning" text="Experimental" url="../flight_controller/autopilot_experimental.html"/>
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](mailto:lhf2613@gmail.com) for hardware support or compliance issues.
 :::
@@ -62,7 +62,7 @@ Direct accessible from RPi:
 
 ## Pinout
 
-:::warning
+::: warning
 It still uses old GH1.25 connectors.
 Wiring is compatible with Pixhawk 2.4.8
 :::

--- a/docs/en/flight_controller/raspberry_pi_pilotpi.md
+++ b/docs/en/flight_controller/raspberry_pi_pilotpi.md
@@ -175,7 +175,7 @@ This switch is connected to Pin22(BCM25).
 System rc script will check its value and decide whether PX4 should start alongside with system booting or not.
 
 - On: start PX4 automatically
-- Off: don' t start PX4
+- Off: don't start PX4
 
 ## Developer Quick Start
 

--- a/docs/en/flight_controller/raspberry_pi_pilotpi_rpios.md
+++ b/docs/en/flight_controller/raspberry_pi_pilotpi_rpios.md
@@ -125,7 +125,7 @@ Don't forget to turn off the switch when it is not needed.
 #### CSI camera
 
 ::: info
-Enable CSI camera will stop anything works on I2C-0.
+Enabling CSI camera will stop anything that works on I2C-0.
 :::
 
 ```sh

--- a/docs/en/flight_controller/raspberry_pi_pilotpi_ubuntu_server.md
+++ b/docs/en/flight_controller/raspberry_pi_pilotpi_ubuntu_server.md
@@ -1,6 +1,6 @@
 # PilotPi with Ubuntu Server
 
-:::warning
+::: warning
 Ubuntu Server on RPi 4B consumes a lot of current and generates a lot of heat.
 Design for better heat dissipation and high power consumption when using this hardware.
 :::
@@ -205,7 +205,7 @@ Don't forget to turn off the switch when it is not needed!
 
 #### CSI camera
 
-:::warning
+::: warning
 Enable CSI camera will stop anything works on I2C-0.
 :::
 

--- a/docs/en/flight_controller/raspberry_pi_pilotpi_ubuntu_server.md
+++ b/docs/en/flight_controller/raspberry_pi_pilotpi_ubuntu_server.md
@@ -206,7 +206,7 @@ Don't forget to turn off the switch when it is not needed!
 #### CSI camera
 
 ::: warning
-Enable CSI camera will stop anything works on I2C-0.
+Enabling CSI camera will stop anything that works on I2C-0.
 :::
 
 ```sh

--- a/docs/en/flight_controller/silicon_errata.md
+++ b/docs/en/flight_controller/silicon_errata.md
@@ -11,7 +11,7 @@ Flash Bank 2 and full speed USB device exclusive.
 Silicon revisions up to rev 2 (revision 3 is the first not affected) can produce errors / data corruption when accessing the 2nd flash bank while there is activity on PA12, which is one of the USB data lines. There is no workaround / software fix for this, except to not use the flash bank #2.
 Since USB is needed to program the device, Pixhawk revisions built with silicon revisions < rev 3 can only use up to 1MB of the 2MB flash of the microprocessor.
 
-:::tip
+::: tip
 The errata is fixed in later versions, but this may not be detected if you are using an older bootloader.
 See [Firmware > FMUv2 Bootloader Update](../config/firmware.md#bootloader) for more information.
 :::

--- a/docs/en/flight_controller/spracingh7extreme.md
+++ b/docs/en/flight_controller/spracingh7extreme.md
@@ -1,6 +1,6 @@
 # SPRacingH7EXTREME (PX4 Edition)
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://shop.seriouslypro.com) for hardware support or compliance issues.
 :::
@@ -72,7 +72,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
   - 36x36mm with 30.5\*30.5 mouting pattern, M4 holes.
   - Soft-mount M4 to M3 grommets supplied.
 
-## Where to Buy
+## Where to Buy {#store}
 
 The SPRacingH7EXTREME is available from the [Seriously Pro shop](https://shop.seriouslypro.com/sp-racing-h7-extreme).
 

--- a/docs/en/flight_controller/svehicle_e2.md
+++ b/docs/en/flight_controller/svehicle_e2.md
@@ -1,6 +1,6 @@
 # S-Vehicle E2
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 :::
 
@@ -58,7 +58,7 @@ These flight controllers are [manufacturer supported](../flight_controller/autop
 - 1x Dedicated Debug Port
   - FMU Debug
 
-## Purchase Channels
+## Purchase Channels {#store}
 
 Order from [S-Vehicle](https://svehicle.cn/).
 

--- a/docs/en/flight_controller/thepeach_k1.md
+++ b/docs/en/flight_controller/thepeach_k1.md
@@ -1,6 +1,6 @@
 # ThePeach FCC-K1
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://thepeach.kr/) for hardware support or compliance issues.
 :::
@@ -10,6 +10,10 @@ Contact the [manufacturer](https://thepeach.kr/) for hardware support or complia
 It is based on the **Pixhawk-project FMUv3** open hardware design and runs **PX4** on **Nuttx OS**.
 
 ![ThePeach FCC-K1](../../assets/flight_controller/thepeach_k1/main.png)
+
+::: info
+This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
+:::
 
 ## Specifications
 

--- a/docs/en/flight_controller/thepeach_r1.md
+++ b/docs/en/flight_controller/thepeach_r1.md
@@ -1,6 +1,6 @@
 # ThePeach FCC-R1
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 Contact the [manufacturer](https://thepeach.kr/) for hardware support or compliance issues.
 :::
@@ -10,6 +10,10 @@ Contact the [manufacturer](https://thepeach.kr/) for hardware support or complia
 It is based on the **Pixhawk-project FMUv3** open hardware design and runs **PX4** on **Nuttx OS**.
 
 ![ThePeach_R1](../../assets/flight_controller/thepeach_r1/main.png)
+
+::: info
+This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
+:::
 
 ## Specifications
 

--- a/docs/en/flight_controller/x-mav_ap-h743r1.md
+++ b/docs/en/flight_controller/x-mav_ap-h743r1.md
@@ -2,7 +2,7 @@
 
 <Badge type="tip" text="PX4 v1.17" />
 
-:::warning
+::: warning
 PX4 does not manufacture this (or any) autopilot.
 :::
 
@@ -45,7 +45,7 @@ These flight controllers are [manufacturer supported](../flight_controller/autop
   - FMU Debug
   - IO Debug
 
-## Purchase Channels
+## Purchase Channels {#store}
 
 Order from [X-MAV](https://www.x-mav.cn/).
 

--- a/docs/en/flight_controller/x-mav_ap-h743r1.md
+++ b/docs/en/flight_controller/x-mav_ap-h743r1.md
@@ -91,7 +91,7 @@ The 7 FMU PWM outputs are in 3 groups:
 
 - A1 - A4 are in one group.
 - A5, A6 are in a 2nd group.
-- A7 is in a 3nd group.
+- A7 is in a 3rd group.
 
 Channels within the same group need to use the same output rate.
 If any channel in a group uses DShot then all channels in the group need to use DShot.

--- a/docs/en/frames_multicopter/holybro_x500_pixhawk4.md
+++ b/docs/en/frames_multicopter/holybro_x500_pixhawk4.md
@@ -118,7 +118,7 @@ Estimate time to assemble is 3.75 hours (180 minutes for frame, 45 minutes for a
    _Figure 7_: ESC power module and signal wiring
 
    The color on top of the motor indicate the spin direction (figure 7-1), black tip is clockwise, and white tip is counter-clockwise.
-   Make sure the follow the px4 quadrotor x airframe reference for motor direction (figure 7-2).
+   Make sure the follow the PX4 quadrotor x airframe reference for motor direction (figure 7-2).
 
    <img src="../../assets/airframes/multicopter/x500_holybro_pixhawk4/quadx.png" width="240">
 

--- a/docs/en/modules/modules_command.md
+++ b/docs/en/modules/modules_command.md
@@ -209,7 +209,7 @@ hardfault_log <command> [arguments...]
 
 Source: [systemcmds/hist](https://github.com/PX4/PX4-Autopilot/tree/main/src/systemcmds/hist)
 
-Command-line tool to show the px4 message history. There are no arguments.
+Command-line tool to show the PX4 message history. There are no arguments.
 
 ### Usage {#hist_usage}
 

--- a/docs/en/ros/external_position_estimation.md
+++ b/docs/en/ros/external_position_estimation.md
@@ -189,7 +189,7 @@ To use MoCap data with EKF2 you will have to [remap](https://wiki.ros.org/roslau
   The `geometry_msgs/PoseStamped` topic is most common as MoCap doesn't usually have associated covariances to the data.
 - If you get data through a `nav_msgs/Odometry` ROS message then you will need to remap it to `/mavros/odometry/out`, making sure to update the `frame_id` and `child_frame_id` accordingly.
 - The odometry frames `frame_id = odom`, `child_frame_id = base_link` can be changed by updating the file in `mavros/launch/px4_config.yaml`. However, the current version of mavros (`1.3.0`) needs to be able to use the tf tree to find a transform from `frame_id` to the hardcoded frame `odom_ned`. The same applies to the `child_frame_id`, which needs to be connected in the tf tree to the hardcoded frame `base_link_frd`. If you are using mavros `1.2.0` and you didn't update the file `mavros/launch/px4_config.yaml`, then you can safely use the odometry frames `frame_id = odom`, `child_frame_id = base_link` without much worry.
-- Note that if you are sending odometry data to px4 using `child_frame_id = base_link`, then you need to make sure that the `twist` portion of the `nav_msgs/Odometry` message is **expressed in body frame**, **not in inertial frame!!!!!**.
+- Note that if you are sending odometry data to PX4 using `child_frame_id = base_link`, then you need to make sure that the `twist` portion of the `nav_msgs/Odometry` message is **expressed in body frame**, **not in inertial frame!!!!!**.
 
 ### Reference Frames and ROS
 

--- a/docs/en/sim_gazebo_classic/index.md
+++ b/docs/en/sim_gazebo_classic/index.md
@@ -345,7 +345,7 @@ The video below shows that the location of the environment is aligned with the w
 
 For extended development sessions it might be more convenient to start Gazebo Classic and PX4 separately or even from within an IDE.
 
-In addition to the existing cmake targets that run `sitl_run.sh` with parameters for px4 to load the correct model it creates a launcher targets named `px4_<mode>` that is a thin wrapper around original sitl px4 app.
+In addition to the existing cmake targets that run `sitl_run.sh` with parameters for PX4 to load the correct model it creates a launcher targets named `px4_<mode>` that is a thin wrapper around original sitl PX4 app.
 This thin wrapper simply embeds app arguments like current working directories and the path to the model file.
 
 To start Gazebo Classic and PX4 separately:
@@ -365,7 +365,7 @@ To start Gazebo Classic and PX4 separately:
 - In your IDE select `px4_<mode>` target you want to debug (e.g. `px4_iris`)
 - Start the debug session directly from IDE
 
-This approach significantly reduces the debug cycle time because simulator is always running in background and you only re-run the px4 process which is very light.
+This approach significantly reduces the debug cycle time because simulator is always running in background and you only re-run the PX4 process which is very light.
 
 ## Simulated Survey Camera
 

--- a/docs/en/sim_sih/index.md
+++ b/docs/en/sim_sih/index.md
@@ -123,7 +123,7 @@ make px4_fmu-v6x boardconfig
 
 After uploading, check that the required modules are present.
 
-::: note
+::: info
 To use rover in SIH you must use the [rover build](../config_rover/index.md#flashing-the-rover-build) or add the rover modules to your board configuration.
 :::
 

--- a/docs/en/test_and_ci/integration_testing_mavsdk.md
+++ b/docs/en/test_and_ci/integration_testing_mavsdk.md
@@ -7,7 +7,7 @@ In future we plan to generalise them for any platform/hardware.
 
 The instructions below explain how to setup and run the tests locally.
 
-:::note
+::: info
 This is the recommended integration test framework for PX4.
 :::
 

--- a/docs/en/test_and_ci/integration_testing_ros1_mavros.md
+++ b/docs/en/test_and_ci/integration_testing_ros1_mavros.md
@@ -8,7 +8,7 @@ It should be used only for new test cases that _require_ ROS 1.
 [MAVSDK Integration Testing](../test_and_ci/integration_testing_mavsdk.md) is preferred when writing new tests.
 :::
 
-:::note
+::: info
 All PX4 integration tests are executed automatically by our [Continuous Integration](../test_and_ci/continous_integration.md) system.
 :::
 

--- a/docs/en/test_and_ci/unit_tests.md
+++ b/docs/en/test_and_ci/unit_tests.md
@@ -133,7 +133,7 @@ The steps to create new SITL unit tests are as follows:
    }
    ```
 
-   `OPTION` can be `OPT_NOALLTEST`,`OPT_NOJIGTEST` or `0` and is considered if within px4 shell one of the two commands are called:
+   `OPTION` can be `OPT_NOALLTEST`,`OPT_NOJIGTEST` or `0` and is considered if within PX4 shell one of the two commands are called:
 
    ```sh
    pxh> tests all


### PR DESCRIPTION
This fixes a number of spelling, gramatical issues. Also
- Consistent use of spacing on asides
- Adding `sh` for syntax highlighting of command blocks
- Add warnings for manufacturer provided FCs if missing
- Fixed up so that all docs have an anchor `#stores` for their buy page.
- Fixed up PX4 upper case issues.