### PR TITLE
feat(sih): Add thrust model for hexacopter simulation

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10044_sihsim_hex
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10044_sihsim_hex
@@ -47,3 +47,5 @@ param set-default PWM_MAIN_FUNC6 106
 
 param set-default SENS_GPS0_DELAY 0
 param set-default SENS_GPS1_DELAY 0
+
+param set-default THR_MDL_FAC 1 # simulated quadratic motor thrust

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -366,15 +366,16 @@ void Sih::generate_force_and_torques(const float dt)
 		       m3    m2
 		          ├1/2┤
 		          ├  1  ┤    */
+		float u_sq[6];
+
 		for (int i = 0; i < 6; ++i) {
-			_u[i] *= _u[i]; // quadratic thrust model
+			u_sq[i] = _u[i] * _u[i]; // quadratic thrust model, keep _u[i] intact for the filter
 		}
 
-		_T_B = Vector3f(0.0f, 0.0f, -_T_MAX * (+_u[0] + _u[1] + _u[2] + _u[3] + _u[4] + _u[5]));
-		_Mt_B = Vector3f(_L_ROLL * _T_MAX * (-.5f * _u[0] - _u[1] - .5f * _u[2] + .5f * _u[3] + _u[4] + .5f * _u[5]),
-				 _L_PITCH * _T_MAX * (M_SQRT3_F / 2.f) * (+_u[0] - _u[2] - _u[3] + _u[5]),
-				 _Q_MAX * (+_u[0] - _u[1] + _u[2] - _u[3] + _u[4] - _u[5]));
-
+		_T_B = Vector3f(0.0f, 0.0f, -_T_MAX * (+u_sq[0] + u_sq[1] + u_sq[2] + u_sq[3] + u_sq[4] + u_sq[5]));
+		_Mt_B = Vector3f(_L_ROLL * _T_MAX * (-.5f * u_sq[0] - u_sq[1] - .5f * u_sq[2] + .5f * u_sq[3] + u_sq[4] + .5f * u_sq[5]),
+				 _L_PITCH * _T_MAX * (M_SQRT3_F / 2.f) * (+u_sq[0] - u_sq[2] - u_sq[3] + u_sq[5]),
+				 _Q_MAX * (+u_sq[0] - u_sq[1] + u_sq[2] - u_sq[3] + u_sq[4] - u_sq[5]));
 		_Fa_E = -_KDV * _R_N2E * _v_apparent_N; // first order drag to slow down the aircraft
 		_Ma_B = -_KDW * _w_B; // first order angular damper
 

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -366,6 +366,10 @@ void Sih::generate_force_and_torques(const float dt)
 		       m3    m2
 		          ├1/2┤
 		          ├  1  ┤    */
+		for (int i = 0; i < 6; ++i) {
+			_u[i] *= _u[i]; // quadratic thrust model
+		}
+
 		_T_B = Vector3f(0.0f, 0.0f, -_T_MAX * (+_u[0] + _u[1] + _u[2] + _u[3] + _u[4] + _u[5]));
 		_Mt_B = Vector3f(_L_ROLL * _T_MAX * (-.5f * _u[0] - _u[1] - .5f * _u[2] + .5f * _u[3] + _u[4] + .5f * _u[5]),
 				 _L_PITCH * _T_MAX * (M_SQRT3_F / 2.f) * (+_u[0] - _u[2] - _u[3] + _u[5]),


### PR DESCRIPTION
### Solution
Introduced a quadratic thrust model for the hexacopter SIH simulations

### Test coverage
Tested in SIH
