### PR TITLE
voxl2-slpi: fix mavlink header dependency

### DIFF
--- a/boards/modalai/voxl2-slpi/src/drivers/dsp_hitl/CMakeLists.txt
+++ b/boards/modalai/voxl2-slpi/src/drivers/dsp_hitl/CMakeLists.txt
@@ -42,6 +42,7 @@ px4_add_module(
 	SRCS
 		dsp_hitl.cpp
 	DEPENDS
+		mavlink_c_generate
 		px4_work_queue
 		drivers_accelerometer
 		drivers_gyroscope


### PR DESCRIPTION
Attempt to fix CI failures
https://github.com/PX4/PX4-Autopilot/actions/runs/22462461760/job/65060218411?pr=26263