### PR TITLE
ci: fix VOXL2 build ordering in CI

### DIFF
--- a/Tools/ci/generate_board_targets_json.py
+++ b/Tools/ci/generate_board_targets_json.py
@@ -148,18 +148,18 @@ grouped_targets['base']['manufacturers'] = {}
 grouped_targets['base']['manufacturers']['px4'] = []
 grouped_targets['base']['manufacturers']['px4'] += metadata_targets
 
-for manufacturer in os.scandir(os.path.join(source_dir, '../boards')):
+for manufacturer in sorted(os.scandir(os.path.join(source_dir, '../boards')), key=lambda e: e.name):
     if not manufacturer.is_dir():
         continue
     if manufacturer.name in excluded_manufacturers:
         if verbose: print(f'excluding manufacturer {manufacturer.name}')
         continue
 
-    for board in os.scandir(manufacturer.path):
+    for board in sorted(os.scandir(manufacturer.path), key=lambda e: e.name):
         if not board.is_dir():
             continue
 
-        for files in os.scandir(board.path):
+        for files in sorted(os.scandir(board.path), key=lambda e: e.name):
             if files.is_file() and files.name.endswith('.px4board'):
 
                 board_name = manufacturer.name + '_' + board.name


### PR DESCRIPTION
## Summary
Sort `os.scandir()` calls lexicographically by name in `generate_board_targets_json.py` so `voxl2_default` always builds before `voxl2-slpi_default`, which depends on it.

## Problem
`os.scandir()` order is filesystem-dependent. When `voxl2-slpi` came first CI failed
https://github.com/PX4/PX4-Autopilot/actions/runs/22458863429/job/65047614207?pr=26590