### PR TITLE
EKF2: fix silent pass of preflt heading check if no heading src active

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -695,7 +695,7 @@ void EstimatorChecks::setModeRequirementFlags(const Context &context, bool pre_f
 	bool v_xy_valid = lpos.v_xy_valid;
 
 	if (!context.isArmed()) {
-		if (pre_flt_fail_innov_heading || pre_flt_fail_innov_pos_horiz) {
+		if (pre_flt_fail_innov_pos_horiz) {
 			xy_valid = false;
 		}
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1853,7 +1853,7 @@ void EKF2::PublishStatus(const hrt_abstime &timestamp)
 	status.time_slip = _last_time_slip_us * 1e-6f;
 
 	static constexpr float kMinTestRatioPreflight = 0.5f;
-	status.pre_flt_fail_innov_heading   = (kMinTestRatioPreflight < status.hdg_test_ratio);
+	status.pre_flt_fail_innov_heading   = (kMinTestRatioPreflight < status.hdg_test_ratio) || !_ekf.control_status_flags().yaw_align;
 	status.pre_flt_fail_innov_height    = (kMinTestRatioPreflight < status.hgt_test_ratio);
 	status.pre_flt_fail_innov_pos_horiz = (kMinTestRatioPreflight < status.pos_test_ratio);
 	status.pre_flt_fail_innov_vel_horiz = (kMinTestRatioPreflight < vel_xy_test_ratio);


### PR DESCRIPTION

### Solved Problem
Fix silent pass of preflight heading check when no heading source is active.

#### Setup
- No GPS
- High mag noise
- COM_ARM_MAG_STR=0 (ignore preflight mag strength check)
- EKF2_MAG_CHECK=3
- COM_ARM_MAG_ANG=100
- Flight mode: CRUISE

#### Observed behavior (on fixed-wing)
- Manual position reset performed
- local_position is valid (xy_valid=true), no horizontal dead-reckoning because airspeed-expected in air
- yaw_align is false → global_position never gets published → no chevron in AMC
- Commander does not complain — no warnings, no arming failures
- Workaround: apply manual heading reset in addition to position reset

####Root cause
- Mag checks are not displayed to the user (COM_ARM_MAG_STR=0)
- No information about yaw_align not being successful
- The heading test ratio does not trigger any preflight check when no heading sensor is active: `getHeadingInnovationTestRatio()` returns NAN when no source (mag, GNSS yaw, EV yaw) is fusing, and `(0.5 < NAN) = false` silently passes
- This can be a valid use case: if only GPS with no compass or other heading source, the heading can be estimated by introducing horizontal movements

### Solution
- Make `pre_flt_fail_innov_heading` also dependent on `yaw_align`. Now when no heading sensor is active, the heading must be aligned for it to pass the "heading unstable" check
- Local position `xy_valid` is now only dependent on the horizontal position preflight check, not the heading anymore
- Now one cannot arm without a valid heading in position mode. The mag has to be either fused or the user has to set the heading manually prior to takeoff

### Changelog Entry
For release notes:
```
Bugfix: preflight heading check now fails when yaw_align is false and no heading source is active
```

### Test coverage
Tested in SIH wihth above parameter settings, multiplied the mag-noise by a factor of 30 to make it fail the fusion.

### Context
current:
[man-pos-reset-old.webm](https://github.com/user-attachments/assets/8cbc4975-58a7-4db7-819c-233a8c5dfd56)
PR:
[man-pos-reset-new.webm](https://github.com/user-attachments/assets/14b4e6bc-e945-41e1-8b96-16c57cd4b701)

