### PR TITLE
voxl2-slpi: generate MAVLink headers locally instead of cross-build dependency

### DIFF
--- a/boards/modalai/voxl2-slpi/src/CMakeLists.txt
+++ b/boards/modalai/voxl2-slpi/src/CMakeLists.txt
@@ -43,6 +43,37 @@ add_library(drivers_board
 	spi.cpp
     )
 
+# Generate MAVLink common headers for SLPI drivers (dsp_hitl, mavlink_rc_in)
+# Replicates the generation from src/modules/mavlink/CMakeLists.txt so the
+# SLPI build is self-contained and does not depend on voxl2-default.
+set(MAVLINK_GIT_DIR "${PX4_SOURCE_DIR}/src/modules/mavlink/mavlink")
+set(MAVLINK_LIBRARY_DIR "${CMAKE_BINARY_DIR}/mavlink")
+
+px4_add_git_submodule(TARGET git_mavlink_v2 PATH "${MAVLINK_GIT_DIR}")
+
+add_custom_command(
+	OUTPUT ${MAVLINK_LIBRARY_DIR}/common/common.h
+	COMMAND ${PYTHON_EXECUTABLE} ${MAVLINK_GIT_DIR}/pymavlink/tools/mavgen.py
+		--lang C --wire-protocol 2.0
+		--output ${MAVLINK_LIBRARY_DIR}
+		${MAVLINK_GIT_DIR}/message_definitions/v1.0/common.xml
+		> ${CMAKE_BINARY_DIR}/mavgen_common.log
+	DEPENDS
+		git_mavlink_v2
+		${MAVLINK_GIT_DIR}/pymavlink/tools/mavgen.py
+		${MAVLINK_GIT_DIR}/message_definitions/v1.0/common.xml
+	COMMENT "Generating MAVLink common headers for SLPI"
+)
+add_custom_target(mavlink_common_generate DEPENDS ${MAVLINK_LIBRARY_DIR}/common/common.h)
+
+add_library(mavlink_common_headers INTERFACE)
+add_dependencies(mavlink_common_headers mavlink_common_generate)
+target_compile_options(mavlink_common_headers INTERFACE -Wno-address-of-packed-member -Wno-cast-align)
+target_include_directories(mavlink_common_headers INTERFACE
+	${MAVLINK_LIBRARY_DIR}
+	${MAVLINK_LIBRARY_DIR}/common
+)
+
 # Add custom drivers for SLPI
 add_subdirectory(${PX4_BOARD_DIR}/src/drivers/rc_controller)
 add_subdirectory(${PX4_BOARD_DIR}/src/drivers/mavlink_rc_in)

--- a/boards/modalai/voxl2-slpi/src/drivers/dsp_hitl/CMakeLists.txt
+++ b/boards/modalai/voxl2-slpi/src/drivers/dsp_hitl/CMakeLists.txt
@@ -31,17 +31,15 @@
 #
 ############################################################################
 
-message(STATUS "Mavlink include directory: ${PX4_SOURCE_DIR}/../build/modalai_voxl2_default/mavlink/common")
-
 px4_add_module(
 	MODULE drivers__modalai__dsp_hitl
 	MAIN dsp_hitl
 	INCLUDES
 		${PX4_SOURCE_DIR}/src/drivers/dsp_hitl
-		${PX4_SOURCE_DIR}/build/modalai_voxl2_default/mavlink/common
 	SRCS
 		dsp_hitl.cpp
 	DEPENDS
+		mavlink_common_headers
 		px4_work_queue
 		drivers_accelerometer
 		drivers_gyroscope

--- a/boards/modalai/voxl2-slpi/src/drivers/mavlink_rc_in/CMakeLists.txt
+++ b/boards/modalai/voxl2-slpi/src/drivers/mavlink_rc_in/CMakeLists.txt
@@ -31,19 +31,17 @@
 #
 ############################################################################
 
-message(STATUS "Mavlink include directory: ${PX4_SOURCE_DIR}/../build/modalai_voxl2_default/mavlink/standard")
-
 px4_add_module(
 	MODULE drivers__modalai__mavlink_rc_in
 	MAIN mavlink_rc_in
 	COMPILE_FLAGS
-		-Wno-cast-align # TODO: fix and enable
-		-Wno-address-of-packed-member # TODO: fix in c_library_v2
+		-Wno-cast-align
+		-Wno-address-of-packed-member
 	INCLUDES
 		${PX4_SOURCE_DIR}/src/drivers/rc_input
-		${PX4_SOURCE_DIR}/build/modalai_voxl2_default/mavlink/common
 	SRCS
 		mavlink_rc_in.cpp
 	DEPENDS
+		mavlink_common_headers
 		px4_work_queue
 	)


### PR DESCRIPTION
The SLPI drivers `dsp_hitl` and `mavlink_rc_in` hardcoded an include path into the `voxl2-default` build output (`build/modalai_voxl2_default/mavlink/common`), creating an undeclared cross-target dependency. This meant `voxl2-default` had to be built before `voxl2-slpi`, and the CI fix in c424edd (sorting board scan order) was just a band-aid.

This PR makes the SLPI build self-contained by running `mavgen.py` to generate MAVLink common dialect headers directly into the SLPI build directory. An `mavlink_common_headers` INTERFACE library propagates the include paths and warning suppression flags to both drivers.