### PR TITLE
voxl2-slpi: directly bring in mavlink instead of relying on voxl2 build

### DIFF
--- a/boards/modalai/voxl2-slpi/src/CMakeLists.txt
+++ b/boards/modalai/voxl2-slpi/src/CMakeLists.txt
@@ -36,6 +36,38 @@
 # from other modules that are not running on the DSP.
 set(DISABLE_PARAMS_MODULE_SCOPING TRUE PARENT_SCOPE)
 
+# Generate mavlink headers for SLPI drivers that need them (dsp_hitl, mavlink_rc_in).
+# This eliminates the dependency on the voxl2 (apps proc) build having run first.
+set(MAVLINK_GIT_DIR "${PX4_SOURCE_DIR}/src/modules/mavlink/mavlink")
+set(MAVLINK_LIBRARY_DIR "${CMAKE_BINARY_DIR}/mavlink")
+file(RELATIVE_PATH MAVLINK_GIT_DIR_RELATIVE ${PX4_SOURCE_DIR} ${MAVLINK_GIT_DIR})
+
+px4_add_git_submodule(TARGET git_mavlink_v2 PATH "${MAVLINK_GIT_DIR}")
+
+add_custom_command(
+	OUTPUT ${MAVLINK_LIBRARY_DIR}/common/common.h
+	COMMAND
+		${PYTHON_EXECUTABLE} ${MAVLINK_GIT_DIR}/pymavlink/tools/mavgen.py
+			--lang C --wire-protocol 2.0
+			--output ${MAVLINK_LIBRARY_DIR}
+			${MAVLINK_GIT_DIR}/message_definitions/v1.0/common.xml > ${CMAKE_CURRENT_BINARY_DIR}/mavgen_common.log
+	DEPENDS
+		git_mavlink_v2
+		${MAVLINK_GIT_DIR}/pymavlink/tools/mavgen.py
+		${MAVLINK_GIT_DIR}/message_definitions/v1.0/common.xml
+	COMMENT "Generating Mavlink common headers for SLPI"
+)
+add_custom_target(mavlink_c_generate DEPENDS ${MAVLINK_LIBRARY_DIR}/common/common.h)
+
+add_library(mavlink_c INTERFACE)
+add_dependencies(mavlink_c mavlink_c_generate)
+target_compile_options(mavlink_c INTERFACE -Wno-address-of-packed-member -Wno-cast-align)
+target_include_directories(mavlink_c
+	INTERFACE
+		${MAVLINK_LIBRARY_DIR}
+		${MAVLINK_LIBRARY_DIR}/common
+)
+
 add_library(drivers_board
 	board_config.h
 	i2c.cpp

--- a/boards/modalai/voxl2-slpi/src/drivers/dsp_hitl/CMakeLists.txt
+++ b/boards/modalai/voxl2-slpi/src/drivers/dsp_hitl/CMakeLists.txt
@@ -31,14 +31,11 @@
 #
 ############################################################################
 
-message(STATUS "Mavlink include directory: ${PX4_SOURCE_DIR}/../build/modalai_voxl2_default/mavlink/common")
-
 px4_add_module(
 	MODULE drivers__modalai__dsp_hitl
 	MAIN dsp_hitl
 	INCLUDES
 		${PX4_SOURCE_DIR}/src/drivers/dsp_hitl
-		${PX4_SOURCE_DIR}/build/modalai_voxl2_default/mavlink/common
 	SRCS
 		dsp_hitl.cpp
 	DEPENDS
@@ -46,4 +43,5 @@ px4_add_module(
 		drivers_accelerometer
 		drivers_gyroscope
 		drivers_magnetometer
+		mavlink_c
 	)

--- a/boards/modalai/voxl2-slpi/src/drivers/mavlink_rc_in/CMakeLists.txt
+++ b/boards/modalai/voxl2-slpi/src/drivers/mavlink_rc_in/CMakeLists.txt
@@ -31,19 +31,14 @@
 #
 ############################################################################
 
-message(STATUS "Mavlink include directory: ${PX4_SOURCE_DIR}/../build/modalai_voxl2_default/mavlink/standard")
-
 px4_add_module(
 	MODULE drivers__modalai__mavlink_rc_in
 	MAIN mavlink_rc_in
-	COMPILE_FLAGS
-		-Wno-cast-align # TODO: fix and enable
-		-Wno-address-of-packed-member # TODO: fix in c_library_v2
 	INCLUDES
 		${PX4_SOURCE_DIR}/src/drivers/rc_input
-		${PX4_SOURCE_DIR}/build/modalai_voxl2_default/mavlink/common
 	SRCS
 		mavlink_rc_in.cpp
 	DEPENDS
 		px4_work_queue
+		mavlink_c
 	)


### PR DESCRIPTION
The voxl2-slpi build relies on the voxl2 build to get access to the mavlink headers. This means that if the voxl2-slpi image is built before the voxl2 image or they are built in different locations the build will fail. This PR fulfills the mavlink dependency directly in the voxl2-slpi build so that there is no longer a dependency on the voxl2 build happening first.
