### PR TITLE
mavlink: fix invalid param handle check in send_autopilot_capabilities

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1087,7 +1087,7 @@ Mavlink::send_autopilot_capabilities()
 			param_t param_handle = param_find_no_notification("MNT_MODE_IN");
 			int32_t mnt_mode_in = 0;
 
-			if (mnt_mode_in != PARAM_INVALID) {
+			if (param_handle != PARAM_INVALID) {
 				param_get(param_handle, &mnt_mode_in);
 
 				if (mnt_mode_in == 4) {


### PR DESCRIPTION
**Bug:** The code incorrectly checked the integer value mnt_mode_in instead of the param_handle against PARAM_INVALID. Since mnt_mode_in is initialized to 0, the check always passed, potentially causing param_get to run with an invalid handle.

**Fix:** Changed the condition to if (param_handle != PARAM_INVALID) to properly validate the parameter existence before accessing it.

**Impact:** Prevents undefined behavior when MNT_MODE_IN is not defined. No functional change for valid configurations.