### PR TITLE
Ice shedding: fix docs rendering

### DIFF
--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -625,11 +625,9 @@ parameters:
             description:
                 short: Ice shedding cycle period
                 long: |
-                    Ice shedding prevents ice buildup in VTOL aircraft motors by
-                    periodically spinning inactive rotors. When enabled (period
-                    > 0), every cycle lasts for the defined period and includes
-                    a 2‑second spin at 0.01 motor output. If period <= 0, the
-                    feature is disabled.
+                    Ice shedding prevents ice buildup in VTOL aircraft motors by periodically spinning inactive rotors.
+                    When enabled (period > 0), every cycle lasts for the defined period and includes a 2-second spin at 0.01 motor output.
+                    If period <= 0, the feature is disabled.
             type: float
             decimal: 1
             unit: s


### PR DESCRIPTION
In the `CA_ICE_PERIOD` param description, a '>' is currently at the start of a line. This is interpredeted by the docs renderer as a markdown quote block which applies not only to that line, but also all following ones. 

Text in `docs/en/advanced_config/parameter_reference.md` currently:

```
### CA_ICE_PERIOD (`FLOAT`) {#CA_ICE_PERIOD}

Ice shedding cycle period.

Ice shedding prevents ice buildup in VTOL aircraft motors by
periodically spinning inactive rotors. When enabled (period

> 0), every cycle lasts for the defined period and includes
> a 2‑second spin at 0.01 motor output. If period <= 0, the
> feature is disabled.

| Reboot | minValue | maxValue | increment | default | unit |
| ------ | -------- | -------- | --------- | ------- | ---- |
| &nbsp; | 0.0      |          | 0.1       | 0.0     | s    |
```

Result in web param reference:
<img width="989" height="424" alt="Screenshot from 2026-03-02 11-14-03" src="https://github.com/user-attachments/assets/02edf19b-0ef1-429a-9497-9ee157d7de94" />

Changing the line breaks to only occur after full stops fixes it. This is a follow-up to https://github.com/PX4/PX4-Autopilot/pull/26322. 
