### PR TITLE
boards: cuav_x25-super: fix core_heater build after ModuleBase CRTP removal

### DIFF
--- a/boards/cuav/x25-super/core_heater/core_heater.cpp
+++ b/boards/cuav/x25-super/core_heater/core_heater.cpp
@@ -47,6 +47,8 @@
 #  error "To use the heater driver, the board_config.h must define and initialize GPIO_CORE_HEATER_OUTPUT"
 #  endif
 
+ModuleBase::Descriptor Core_Heater::desc{task_spawn, custom_command, print_usage};
+
 Core_Heater::Core_Heater() :
 	ModuleParams(nullptr),
 	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::lp_default)
@@ -62,7 +64,7 @@ Core_Heater::~Core_Heater()
 int Core_Heater::custom_command(int argc, char *argv[])
 {
 	// Check if the driver is running.
-	if (!is_running()) {
+	if (!is_running(desc)) {
 		PX4_INFO("not running");
 		return PX4_ERROR;
 	}
@@ -117,7 +119,7 @@ bool Core_Heater::initialize_topics()
 void Core_Heater::Run()
 {
 	if (should_exit()) {
-		exit_and_cleanup();
+		exit_and_cleanup(desc);
 		return;
 	}
 
@@ -216,8 +218,8 @@ int Core_Heater::task_spawn(int argc, char *argv[])
 		return PX4_ERROR;
 	}
 
-	_object.store(core_heater);
-	_task_id = task_id_is_work_queue;
+	desc.object.store(core_heater);
+	desc.task_id = task_id_is_work_queue;
 
 	core_heater->start();
 	return 0;
@@ -257,5 +259,5 @@ Background process running periodically on the LP work queue to regulate IMU tem
 
 extern "C" __EXPORT int core_heater_main(int argc, char *argv[])
 {
-	return Core_Heater::main(argc, argv);
+	return ModuleBase::main(Core_Heater::desc, argc, argv);
 }

--- a/boards/cuav/x25-super/core_heater/core_heater.h
+++ b/boards/cuav/x25-super/core_heater/core_heater.h
@@ -56,9 +56,10 @@ using namespace time_literals;
 #define CONTROLLER_PERIOD_DEFAULT    10000
 #define TEMPERATURE_TARGET_THRESHOLD 2.5f
 
-class Core_Heater : public ModuleBase<Core_Heater>, public ModuleParams, public px4::ScheduledWorkItem
+class Core_Heater : public ModuleBase, public ModuleParams, public px4::ScheduledWorkItem
 {
 public:
+	static Descriptor desc;
 	Core_Heater();
 
 	virtual ~Core_Heater();


### PR DESCRIPTION
The CUAV X25-SUPER board (#26474) was merged after the ModuleBase CRTP template removal (#26476), so its core_heater driver still uses the old ModuleBase<Core_Heater> API and fails to build.

This migrates core_heater.h and core_heater.cpp to the new descriptor-based ModuleBase, same pattern as the canonical heater driver in src/drivers/heater/.

Fixes the cuav_x25-super_default and cuav_x25-super_bootloader build targets.