### PR TITLE
EKF2: relax gnss vel/pos soft start test-ratios

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
@@ -160,7 +160,7 @@ void Ekf::controlGnssVelFusion(estimator_aid_source3d_s &aid_src, const bool for
 			const bool do_reset = force_reset || !_control_status_prev.flags.yaw_align;
 
 			// Start fusing the data without reset if possible to avoid disturbing the filter
-			if (!do_reset && ((aid_src.test_ratio[0] + aid_src.test_ratio[1]) < sq(0.5f))) {
+			if (!do_reset && aid_src.test_ratio[0] < 1.f && aid_src.test_ratio[1] < 1.f) {
 				fused = fuseVelocity(aid_src);
 			}
 
@@ -221,7 +221,7 @@ void Ekf::controlGnssPosFusion(estimator_aid_source2d_s &aid_src, const bool for
 			// Start fusing the data without reset if possible to avoid disturbing the filter
 			if (_local_origin_lat_lon.isInitialized()
 			    && !do_reset
-			    && ((aid_src.test_ratio[0] + aid_src.test_ratio[1]) < sq(0.5f))) {
+			    && aid_src.test_ratio[0] < 1.f && aid_src.test_ratio[1] < 1.f) {
 				fused = fuseHorizontalPosition(aid_src);
 			}
 


### PR DESCRIPTION

### Solved Problem
After a GNSS fault, velocity and position fusion can only restart through a soft-start path that requires (test_ratio[0] + test_ratio[1]) < sq(0.5f) (= 0.25). This is significantly stricter than the normal innovation gate and can delay or prevent GNSS recovery, especially when the filter state has drifted during the outage.

### Solution
Solution: Check each axis individually against the standard innovation gate (test_ratio < 1.0) instead of requiring the sum to be below 0.25. This still ensures consistency on both axes before restarting fusion without a reset, but avoids unnecessarily blocking recovery.