### PR TITLE
Bugfix: revert blanket MAVLink command rejection by frame enum

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -521,13 +521,6 @@ MavlinkReceiver::handle_message_command_int(mavlink_message_t *msg)
 		return;
 	}
 
-	if (cmd_mavlink.frame != MAV_FRAME_GLOBAL_INT) {
-		// PX4 only supports global frame.
-		PX4_ERR("frame invalid for command %" PRIu16, cmd_mavlink.command);
-		acknowledge(msg->sysid, msg->compid, cmd_mavlink.command, vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED_MAV_FRAME);
-		return;
-	}
-
 	/* Copy the content of mavlink_command_int_t cmd_mavlink into command_t cmd */
 	vcmd.param1 = cmd_mavlink.param1;
 	vcmd.param2 = cmd_mavlink.param2;


### PR DESCRIPTION
### Solved Problem
Same as reported in https://github.com/PX4/PX4-Autopilot/pull/26577#issue-3989533482 here but completely removing the check again as discussed in the last dev call and described here:
https://github.com/PX4/PX4-Autopilot/pull/26408#issuecomment-3960727447

closes #26577

### Solution
Revert the check but leave in the message cleanup and translation required because of field order changes from:
https://github.com/PX4/PX4-Autopilot/pull/26408

### Changelog Entry
```
Bugfix: revert blanket MAVLink command rejection by frame enum
```

### Alternatives
We need to forward the frame in the vehicle command and consume it properly per consumer. Even better have an abstraction to not internally depend directly on MAVLink in the future.

### Test coverage
Tested the same way I found the issue:
- `make px4_sitl sihsim_hex`
- Run QGC 5.0.8
- Command a goto by pressing on the map after takeoff
- Command an Orbit
Both works again with this change.