### PR TITLE
ubuntu: help people running the install script on Ubuntu 25.10

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -196,6 +196,11 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 	fi
 fi
 
+if [[ "${UBUNTU_RELEASE}" == "25.10" ]]; then
+	echo "[ubuntu.sh] Gazebo binaries are not available for 25.10, skipping installation"
+	INSTALL_SIM="false"
+fi
+
 # Simulation tools
 if [[ $INSTALL_SIM == "true" ]]; then
 


### PR DESCRIPTION
### Solved Problem
OSRF provides no gazebo binary for 25.10, attempting to install leads to `apt update` errors and people get stuck with this without manually reverting the changes the setup script did.

### Solution
Skip sim tool installation on Ubuntu 25.10. Simulation with SIH still works perfectly fine. Gazebo can be installed from source if there's enough motivation.

### Changelog Entry
```
Toolchain: Skip Gazebo installation on Ubuntu 25.10
```

### Alternatives
I assume Gazebo gets full support on Ubuntu 26.04 again very soon. We'll jump on that train early. But for now if you need 25.10 because the laptop is too new you get stuck with apt update errors without this additional condition.

### Test coverage
@gguidone could you quickly run this and verify it skipps correctly? I currently don't have a 25.10 setup.