### PR TITLE
fix(simulation): GZ Sim Gimbal per-axis commands

### DIFF
--- a/src/modules/simulation/gz_bridge/GZGimbal.cpp
+++ b/src/modules/simulation/gz_bridge/GZGimbal.cpp
@@ -1,3 +1,4 @@
+
 // #define DEBUG_BUILD
 #include "GZGimbal.hpp"
 
@@ -73,6 +74,15 @@ void GZGimbal::Run()
 	const float dt = (now - _last_time_update) / 1e6f;
 	_last_time_update = now;
 
+	// Update vehicle attitude from groundtruth for frame transformations
+	if (_vehicle_attitude_sub.updated()) {
+		vehicle_attitude_s vehicle_att;
+
+		if (_vehicle_attitude_sub.copy(&vehicle_att)) {
+			_q_vehicle = matrix::Quatf(vehicle_att.q);
+		}
+	}
+
 	updateParameters();
 
 	if (pollSetpoint()) {
@@ -103,14 +113,16 @@ void GZGimbal::gimbalIMUCallback(const gz::msgs::IMU &IMU_data)
 	pthread_mutex_lock(&_node_mutex);
 
 	static const matrix::Quatf q_FLU_to_FRD = matrix::Quatf(0.0f, 1.0f, 0.0f, 0.0f);
-	static const matrix::Quatf q_ENU_to_NED = matrix::Quatf(0.0f, cosf(M_PI_4_F), cosf(M_PI_4_F), 0.0f);
+	static const matrix::Quatf q_ENU_to_NED = matrix::Quatf(0.0f, 0.707107, 0.707107, 0.0f);
 
-	// Get the gimbal orientation. Gimbal frame is FLU in Gazebo, reference frame is ENU in Gazebo
+	// Get the gimbal orientation in world frame. Gimbal frame is FLU in Gazebo, world frame is ENU.
+	// The IMU reports absolute orientation in world frame (ENU).
 	const matrix::Quatf q_gimbal_FLU = matrix::Quatf(IMU_data.orientation().w(),
 					   IMU_data.orientation().x(),
 					   IMU_data.orientation().y(),
 					   IMU_data.orientation().z());
 
+	// Convert from ENU/FLU (Gazebo) to NED/FRD (PX4) world frame
 	_q_gimbal = q_ENU_to_NED * q_gimbal_FLU * q_FLU_to_FRD.inversed();
 
 	matrix::Vector3f rate = q_FLU_to_FRD.rotateVector(matrix::Vector3f(IMU_data.angular_velocity().x(),
@@ -132,6 +144,7 @@ void GZGimbal::updateParameters()
 	param_get(_mnt_min_pitch_handle, &_mnt_min_pitch);
 	param_get(_mnt_range_yaw_handle, &_mnt_range_yaw);
 	param_get(_mnt_mode_out_handle, &_mnt_mode_out);
+
 }
 
 bool GZGimbal::pollSetpoint()
@@ -140,10 +153,29 @@ bool GZGimbal::pollSetpoint()
 		gimbal_device_set_attitude_s msg;
 
 		if (_gimbal_device_set_attitude_sub.copy(&msg)) {
-			const matrix::Eulerf gimbal_att_stp(matrix::Quatf(msg.q));
-			_roll_stp = gimbal_att_stp.phi();
-			_pitch_stp = gimbal_att_stp.theta();
-			_yaw_stp = gimbal_att_stp.psi();
+			// Extract Euler angles from setpoint quaternion (in earth/world frame if LOCK flags set)
+			const matrix::Quatf q_gimbal_setpoint(msg.q);
+			const matrix::Eulerf euler_setpoint(q_gimbal_setpoint);
+
+			// Get vehicle Euler angles for compensation
+			const matrix::Eulerf euler_vehicle(_q_vehicle);
+
+			// Check which axes are in absolute/earth frame (indicated by LOCK flags)
+			const bool roll_lock = msg.flags & gimbal_device_set_attitude_s::GIMBAL_DEVICE_FLAGS_ROLL_LOCK;
+			const bool pitch_lock = msg.flags & gimbal_device_set_attitude_s::GIMBAL_DEVICE_FLAGS_PITCH_LOCK;
+			const bool yaw_lock = msg.flags & gimbal_device_set_attitude_s::GIMBAL_DEVICE_FLAGS_YAW_LOCK;
+
+			// Per-axis compensation: if locked (earth frame), subtract vehicle attitude
+			// This follows the same logic as the gimbal manager in output.cpp
+			_roll_stp = roll_lock ? (euler_setpoint.phi() - euler_vehicle.phi()) : euler_setpoint.phi();
+			_pitch_stp = pitch_lock ? (euler_setpoint.theta() - euler_vehicle.theta()) : euler_setpoint.theta();
+			_yaw_stp = yaw_lock ? (euler_setpoint.psi() - euler_vehicle.psi()) : euler_setpoint.psi();
+
+			// To avoid gimbal lock constrain -90 degree
+			if (_pitch_stp < -1.569f) {
+				_pitch_stp = -1.5359f;
+			}
+
 			_roll_rate_stp = msg.angular_velocity_x;
 			_pitch_rate_stp = msg.angular_velocity_y;
 			_yaw_rate_stp = msg.angular_velocity_z;
@@ -223,12 +255,13 @@ void GZGimbal::publishDeviceAttitude()
 	gimbal_att.target_component = 0; // Broadcast
 	gimbal_att.device_flags = gimbal_device_attitude_status_s::DEVICE_FLAGS_YAW_IN_EARTH_FRAME;
 	_q_gimbal.copyTo(gimbal_att.q);
+
 	gimbal_att.angular_velocity_x = _gimbal_rate[0];
 	gimbal_att.angular_velocity_y = _gimbal_rate[1];
 	gimbal_att.angular_velocity_z = _gimbal_rate[2];
 	gimbal_att.failure_flags = 0;
 	gimbal_att.timestamp = hrt_absolute_time();
-
+	gimbal_att.gimbal_device_id = _gimbal_device_id;
 	_gimbal_device_attitude_status_pub.publish(gimbal_att);
 }
 

--- a/src/modules/simulation/gz_bridge/GZGimbal.hpp
+++ b/src/modules/simulation/gz_bridge/GZGimbal.hpp
@@ -10,6 +10,7 @@
 #include <uORB/topics/vehicle_command_ack.h>
 #include <uORB/topics/gimbal_controls.h>
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/vehicle_attitude.h>
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
@@ -42,6 +43,7 @@ private:
 	uORB::Subscription _gimbal_device_set_attitude_sub{ORB_ID(gimbal_device_set_attitude)};
 	uORB::Subscription _gimbal_controls_sub{ORB_ID(gimbal_controls)};
 	uORB::SubscriptionCallbackWorkItem _vehicle_command_sub{this, ORB_ID(vehicle_command)};
+	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude_groundtruth)};
 
 	uORB::Publication<gimbal_device_attitude_status_s> _gimbal_device_attitude_status_pub{ORB_ID(gimbal_device_attitude_status)};
 	uORB::Publication<gimbal_device_information_s> _gimbal_device_information_pub{ORB_ID(gimbal_device_information)};
@@ -78,6 +80,7 @@ private:
 	int32_t _mnt_mode_out = 0;
 
 	matrix::Quatf _q_gimbal = matrix::Quatf(1.0f, 0.0f, 0.0f, 0.0f);
+	matrix::Quatf _q_vehicle = matrix::Quatf(1.0f, 0.0f, 0.0f, 0.0f);
 	float _gimbal_rate[3] = {NAN};
 
 	// Device information attributes


### PR DESCRIPTION
### Solved Problem
Fixes https://github.com/PX4/PX4-Autopilot/issues/26600 and https://github.com/PX4/PX4-Autopilot/issues/26599
### Solution
Move to per-axis gimbal commands when one or more axis is not commanded

### Changelog Entry
For release notes:
```
Bugfix: GZ Sim gimbal per-axis commands

```

### Alternatives

### Test coverage
PX4 SITL
### Context



