### PR TITLE
docs: Ease building metadata for docs locally

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,8 @@
     "docs:gen_alt_sidebar_ubuntu": "python3 ./scripts/gen_alt_sidebar.py",
     "docs:get_alt_sidebar_windows": "python ./scripts/gen_alt_sidebar.py",
     "start": "yarn docs:dev",
-    "linkcheck": "markdown_link_checker_sc -r .. -d docs -e en -i assets"
+    "linkcheck": "markdown_link_checker_sc -r .. -d docs -e en -i assets",
+    "build_docs_metadata_ubuntu": "(cd .. && Tools/ci/metadata_sync.sh --generate && Tools/ci/metadata_sync.sh --sync) && echo 'NOTE: These metadata changes are for local testing only and do not need to be merged.'"
   },
   "dependencies": {
     "@red-asuka/vitepress-plugin-tabs": "0.0.4",


### PR DESCRIPTION
This adds a command option for building the docs that allows you to build the metadata locally:
```
yarn build_docs_metadata_ubuntu
```

This makes testing of metadata changes in docs easier.

Note that metadata changes are automatically done on merge to main so if you were to add the changes from this they would be swamped on merging. However if you were to merge the changes it would complicate the review. That could be simplied by prettiering, so at least only changed files would appear - but I think overkill.

Upshot, people shouldn't merge the changes and I echo a note to that effect. But if they ignore that nothing will be broken except review would be harder.

Falls out of discussion here https://github.com/PX4/PX4-Autopilot/pull/26616#issuecomment-3993943155