### PR TITLE
fix: template_module update to best practise

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -210,6 +210,10 @@ menu "examples"
 source "src/examples/Kconfig"
 endmenu
 
+menu "templates"
+source "src/templates/Kconfig"
+endmenu
+
 menu "platforms"
 depends on PLATFORM_QURT || PLATFORM_POSIX || PLATFORM_NUTTX
 source "platforms/Kconfig"

--- a/src/templates/Kconfig
+++ b/src/templates/Kconfig
@@ -1,0 +1,1 @@
+rsource "*/Kconfig"

--- a/src/templates/template_module/Kconfig
+++ b/src/templates/template_module/Kconfig
@@ -1,0 +1,5 @@
+menuconfig TEMPLATES_TEMPLATE_MODULE
+	bool "template_module"
+	default n
+	---help---
+		Enable support for template_module

--- a/src/templates/template_module/template_module.cpp
+++ b/src/templates/template_module/template_module.cpp
@@ -38,7 +38,6 @@
 #include <px4_platform_common/posix.h>
 
 #include <uORB/topics/parameter_update.h>
-#include <uORB/topics/sensor_combined.h>
 
 ModuleBase::Descriptor TemplateModule::desc{task_spawn, custom_command, print_usage};
 
@@ -145,42 +144,20 @@ TemplateModule::TemplateModule(int example_param, bool example_flag)
 
 void TemplateModule::run()
 {
-	// Example: run the loop synchronized to the sensor_combined topic publication
-	int sensor_combined_sub = orb_subscribe(ORB_ID(sensor_combined));
-
-	px4_pollfd_struct_t fds[1];
-	fds[0].fd = sensor_combined_sub;
-	fds[0].events = POLLIN;
-
 	// initialize parameters
 	parameters_update(true);
 
 	while (!should_exit()) {
 
-		// wait for up to 1000ms for data
-		int pret = px4_poll(fds, (sizeof(fds) / sizeof(fds[0])), 1000);
-
-		if (pret == 0) {
-			// Timeout: let the loop run anyway, don't do `continue` here
-
-		} else if (pret < 0) {
-			// this is undesirable but not much we can do
-			PX4_ERR("poll error %d, %d", pret, errno);
-			px4_usleep(50000);
-			continue;
-
-		} else if (fds[0].revents & POLLIN) {
-
-			struct sensor_combined_s sensor_combined;
-			orb_copy(ORB_ID(sensor_combined), sensor_combined_sub, &sensor_combined);
+		if (_sensor_accel_sub.updated()) {
+			sensor_accel_s accel{};
+			_sensor_accel_sub.copy(&accel);
 			// TODO: do something with the data...
-
 		}
 
 		parameters_update();
+		px4_usleep(10_ms);
 	}
-
-	orb_unsubscribe(sensor_combined_sub);
 }
 
 void TemplateModule::parameters_update(bool force)

--- a/src/templates/template_module/template_module.h
+++ b/src/templates/template_module/template_module.h
@@ -35,8 +35,10 @@
 
 #include <px4_platform_common/module.h>
 #include <px4_platform_common/module_params.h>
+#include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/sensor_accel.h>
 
 using namespace time_literals;
 
@@ -89,5 +91,6 @@ private:
 
 	// Subscriptions
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+	uORB::Subscription _sensor_accel_sub{ORB_ID(sensor_accel)};
 
 };


### PR DESCRIPTION
This is proposed update to the template module, as generated by Claude when I asked for best practise.
- src/templates/template_module/Kconfig -  Created — follows work_item pattern with TEMPLATES_TEMPLATE_MODULE symbol                                                            - template_module.h - Added Subscription.hpp + sensor_accel.h includes; added _sensor_accel_sub member                                                     - template_module.cpp - Removed sensor_combined.h; replaced orb_subscribe/px4_poll/orb_copy/orb_unsubscribe with updated()+copy() loop and px4_usleep(10_ms)

I can see that the example is much simpler. However I'm not certain if the old method was done that way because the options here did not exist when it was written.

Note, I tested this. Had to make some further changes to cmake files get it into a build. I have kept the KConfig changes because they are an example of "how things are done", but not the other changes. Open to removing those.

