### PR TITLE
feat(gps): default DGNSS timeout to 3 seconds

### DIFF
--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -72,7 +72,10 @@ PARAM_DEFINE_INT32(GPS_UBX_DYNMODEL, 7);
 /**
  * u-blox GPS DGNSS timeout
  *
- * When set to 0 (default), default DGNSS timeout set by u-blox will be used.
+ * Sets the timeout for how long the receiver will use stale DGNSS/RTK
+ * corrections before falling back to standalone mode.
+ *
+ * When set to 0, the default DGNSS timeout set by u-blox will be used (60s).
  *
  * @min 0
  * @max 255
@@ -82,7 +85,7 @@ PARAM_DEFINE_INT32(GPS_UBX_DYNMODEL, 7);
  *
  * @group GPS
  */
-PARAM_DEFINE_INT32(GPS_UBX_DGNSS_TO, 0);
+PARAM_DEFINE_INT32(GPS_UBX_DGNSS_TO, 3);
 
 /**
  * u-blox GPS minimum satellite signal level for navigation


### PR DESCRIPTION
Change GPS_UBX_DGNSS_TO default from 0 (u-blox default of 60s) to 3s. This provides faster detection of lost RTK corrections, preventing the rover from navigating with stale correction data. The parameter remains user-adjustable for custom configurations.

Depends on PX4/PX4-GPSDrivers#201