### PR TITLE
docs: src_parser.py keep empty lines in param desciption

### DIFF
--- a/src/lib/parameters/px4params/srcparser.py
+++ b/src/lib/parameters/px4params/srcparser.py
@@ -232,6 +232,9 @@ class SourceParser(object):
                         # start waiting for the next part - long comment.
                         if state == "wait-short-end":
                             state = "wait-long"
+                        if state == "wait-long-end":
+                            # Long description includes empty lines
+                            long_desc += "\n"
                     else:
                         m = self.re_comment_tag.match(comment_content)
                         if m:


### PR DESCRIPTION
Captures empty lines in parameter long descriptions so that formatting in the source is kept.

@dakejahl The line is now captured. Note that we also capture the line at the end, but since prettier is run afterwards, that gets deleted.

<img width="1070" height="657" alt="image" src="https://github.com/user-attachments/assets/a45b9969-e77b-4201-9ba3-0e9da3b7937b" />

NOTE, you can also much improve layout using bullets. So if I modify `SENS_GPS_PRIME` so that the accepted values section looks like this:

```
 * Accepted values:
 * - -1 : Auto (equal priority for all instances)
 * - 0 : Main serial GPS instance
 * - 1 : Secondary serial GPS instance
 * - 2-127 : UAVCAN module node ID
```

The rendering would be:

<img width="1066" height="840" alt="image" src="https://github.com/user-attachments/assets/70e09805-68c8-42c9-927d-7a60d8212b3b" />


Fixes #26636
