### PR TITLE
fix(heater): don't turn heater on when controller time is zero

### DIFF
--- a/src/drivers/heater/heater.cpp
+++ b/src/drivers/heater/heater.cpp
@@ -417,9 +417,14 @@ void Heater::Run()
 			_temperature_target_met = false;
 		}
 
-		_heater_on = true;
-		heater_on();
-		ScheduleDelayed(_controller_time_on_usec);
+		if (_controller_time_on_usec > 0) {
+			_heater_on = true;
+			heater_on();
+			ScheduleDelayed(_controller_time_on_usec);
+
+		} else {
+			ScheduleDelayed(CONTROLLER_PERIOD_DEFAULT);
+		}
 	}
 
 	publish_status();


### PR DESCRIPTION
## Summary
- Fix bug where the heater GPIO was momentarily toggled on every control loop iteration even when the PI controller computed zero on-time (e.g. temperature already well above target)
- Skip the heater on/off cycle entirely when `_controller_time_on_usec` is 0, and just reschedule after the full controller period

<img width="1841" height="1049" alt="Screenshot from 2026-03-04 17-30-31" src="https://github.com/user-attachments/assets/2ef966bd-e179-4f33-a835-e669e5b1c6ef" />


## Test plan
- [ ] Verify with PlotJuggler that `heater_status/heater_on` stays 0 when temperature is above target
- [ ] Verify normal heating behavior (temperature below target) still works correctly
- [ ] Verify boundary case where on-time equals full period