### PR TITLE
fix(navigator): fix alt setpoint after home-alt reset

### DIFF
--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -1459,12 +1459,11 @@ bool MissionBase::canRunMissionFeasibility()
 
 void MissionBase::updateMissionAltAfterHomeChanged()
 {
-	const float home_alt = _navigator->get_home_position()->alt;
-
 	if (_navigator->get_home_position()->update_count > _home_update_counter) {
 
-		if (PX4_ISFINITE(_last_home_alt)) {
-			const float altitude_diff = home_alt - _last_home_alt;
+		if (item_contains_position(_mission_item)) {
+			const float new_alt = get_absolute_altitude_for_item(_mission_item);
+			const float altitude_diff = new_alt - _navigator->get_position_setpoint_triplet()->current.alt;
 
 			if (_navigator->get_position_setpoint_triplet()->previous.valid
 			    && PX4_ISFINITE(_navigator->get_position_setpoint_triplet()->previous.alt)) {
@@ -1483,6 +1482,4 @@ void MissionBase::updateMissionAltAfterHomeChanged()
 
 		_home_update_counter = _navigator->get_home_position()->update_count;
 	}
-
-	_last_home_alt = home_alt;
 }

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -475,7 +475,6 @@ private:
 	bool canRunMissionFeasibility();
 
 	uint32_t _home_update_counter = 0; /**< Variable to store the previous value for home change detection.*/
-	float _last_home_alt{NAN};
 
 	bool _align_heading_necessary{false}; // if true, heading of vehicle needs to be aligned with heading of next waypoint. Used to create new mission items for heading alignment.
 


### PR DESCRIPTION
### Solved Problem

`updateMissionAltAfterHomeChanged()` in `mission_base.cpp` recomputes the altitude setpoint from `_mission_item` whenever the home position changes. If `_mission_item` is a non-position item (e.g. `NAV_CMD_DELAY`), the altitude field is 0 with `altitude_is_relative = false`, causing the altitude setpoint to be overwritten to 0.

#### Root Cause

The function `updateMissionAltAfterHomeChanged()` uses `get_absolute_altitude_for_item(_mission_item)` to recompute what the setpoint altitude should be after a home altitude change. This replaces `current.alt` rather than applying a delta:

This is correct when `_mission_item` is a position waypoint. But when it's a non-position item (DO command or DELAY), the altitude field is 0 because the ground station sends 0 for unused parameters. As a result, `new_alt = 0` and the setpoint gets overwritten to 0.

#### Trigger Conditions

1. The home position correction (PR #25003) fires during the first 120s after takeoff
2. At the same time, the mission-item holds a non-position item:
   - NAV_CMD_DELAY
   - Any DO command

#### Observed Symptoms

- altitude setpoint drops from actual setpoint to exactly 0.0
- Persists for multiple navigator updates, e.g. for X seconds when using delay-command, 1 cycle for do-command
- Recovers when a position waypoint is loaded
- Only occurs during the first 120s (home correction time window `kHomePositionCorrectionTimeWindow`)

This bug can be reproduced when running SIH, as it currently uses unusually high GPS noise (to be fixed). As a result, many home-position altitude resets are triggered, which then leads to the faulty adjustment during the DELAY command

### Solution

Skip the altitude recomputation when `_mission_item` is a non-position item using `item_contains_position()`. This keeps the existing recomputation logic intact for position waypoints while preventing non-position items (DELAY, DO commands) from overwriting the setpoint with their meaningless altitude field.

**Mission with takeoff, waypoint, delay 10s, RTL:**

current:
<img width="1865" height="1173" alt="Screenshot from 2026-03-05 08-54-45" src="https://github.com/user-attachments/assets/39c38930-12a9-4ff8-b380-085e179c443c" />

PR:
<img width="1865" height="1173" alt="Screenshot from 2026-03-05 08-54-18" src="https://github.com/user-attachments/assets/f9286f61-fd90-4f1d-992e-ca9fd5ec3387" />
