### PR TITLE
EV height fusion only rotate ev sample coordinates if they are FRD

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/external_vision/ev_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/external_vision/ev_height_control.cpp
@@ -57,7 +57,7 @@ void Ekf::controlEvHeightFusion(const imuSample &imu_sample, const extVisionSamp
 	Matrix3f pos_cov{matrix::diag(ev_sample.position_var)};
 
 	// rotate EV to the EKF reference frame unless we're operating entirely in vision frame
-	if (!(_control_status.flags.ev_yaw && _control_status.flags.ev_pos)) {
+	if (!(_control_status.flags.ev_yaw && _control_status.flags.ev_pos) && ev_sample.pos_frame == PositionFrame::LOCAL_FRAME_FRD) {
 
 		const Quatf q_error(_ev_q_error_filt.getState());
 


### PR DESCRIPTION
Fixes issue where absolute NED coordinates would be rotated as if they were FRD coordinates if no heading is provided by the ev_sample. Now explicitly checks that a sample is FRD before applying frame rotation.