### PR TITLE
fix(tools): prevent command injection in px_mkfw.py

### DIFF
--- a/Tools/px_mkfw.py
+++ b/Tools/px_mkfw.py
@@ -42,6 +42,7 @@
 import argparse
 import json
 import base64
+import os
 import zlib
 import time
 import subprocess
@@ -99,14 +100,13 @@ if args.summary != None:
 if args.description != None:
 	desc['description']	= str(args.description)
 if args.git_identity != None:
-	cmd = "git --git-dir '{:}/.git' describe --exclude ext/* --always --tags".format(args.git_identity)
-	p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout
-	desc['git_identity']	= p.read().strip().decode('utf-8')
-	p.close()
-	cmd = "git --git-dir '{:}/.git' rev-parse --verify HEAD".format(args.git_identity)
-	p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout
-	desc['git_hash']	= p.read().strip().decode('utf-8')
-	p.close()
+	git_dir = os.path.join(args.git_identity, '.git')
+	p = subprocess.run(["git", "--git-dir", git_dir, "describe", "--exclude", "ext/*", "--always", "--tags"],
+		capture_output=True, text=True)
+	desc['git_identity']	= p.stdout.strip()
+	p = subprocess.run(["git", "--git-dir", git_dir, "rev-parse", "--verify", "HEAD"],
+		capture_output=True, text=True)
+	desc['git_hash']	= p.stdout.strip()
 if args.parameter_xml != None:
 	f = open(args.parameter_xml, "rb")
 	bytes = f.read()


### PR DESCRIPTION
## Summary
- Fix command injection vulnerability (CWE-78) in `Tools/px_mkfw.py` where `--git_identity` argument was interpolated into shell commands via `subprocess.Popen(..., shell=True)`
- Replace with `subprocess.run()` using argument lists, eliminating shell interpretation of user input
- Defense-in-depth fix: while the argument is normally provided by CMake, manual invocation could allow arbitrary command execution

## Test plan
- [ ] Verify firmware packaging still works with a normal build (`make px4_fmu-v6x_default`)
- [ ] Confirm `git_identity` and `git_hash` fields are correctly populated in generated `.px4` firmware files
- [ ] Verify the PoC injection (`--git_identity "'; touch /tmp/pwned; echo '"`) no longer executes injected commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)