### PR TITLE
fix(commander): arm throttle check for all vehicle types

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -608,27 +608,29 @@ transition_result_t Commander::arm(arm_disarm_reason_t calling_reason, bool run_
 	if (run_preflight_checks) {
 		if (_vehicle_control_mode.flag_control_manual_enabled) {
 
-			if (_vehicle_control_mode.flag_control_climb_rate_enabled &&
-			    !_failsafe_flags.manual_control_signal_lost && _is_throttle_above_center) {
+			if (!_failsafe_flags.manual_control_signal_lost) {
+				bool throttle_safe;
 
-				mavlink_log_critical(&_mavlink_log_pub, "Arming denied: throttle above center\t");
-				events::send(events::ID("commander_arm_denied_throttle_center"), {events::Log::Critical, events::LogInternal::Info},
-					     "Arming denied: throttle above center");
-				tune_negative(true);
-				return TRANSITION_DENIED;
-			}
+				if (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROVER) {
+					// Rovers: center stick = stop, safe to arm near center
+					throttle_safe = (fabsf(_last_manual_throttle) < 0.2f);
 
-			if (!_vehicle_control_mode.flag_control_climb_rate_enabled &&
-			    !_failsafe_flags.manual_control_signal_lost && !_is_throttle_low
-			    && ((_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING)
-				|| (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING))
-			   ) {
+				} else if (_vehicle_control_mode.flag_control_climb_rate_enabled) {
+					// Climb-rate modes (AltCtl, PosCtl, etc.): center = hover, safe at or below center
+					throttle_safe = (_last_manual_throttle <= 0.2f);
 
-				mavlink_log_critical(&_mavlink_log_pub, "Arming denied: high throttle\t");
-				events::send(events::ID("commander_arm_denied_throttle_high"), {events::Log::Critical, events::LogInternal::Info},
-					     "Arming denied: high throttle");
-				tune_negative(true);
-				return TRANSITION_DENIED;
+				} else {
+					// Manual/Stab/Acro on MC/FW: bottom = no thrust, safe at bottom
+					throttle_safe = (_last_manual_throttle < -0.8f);
+				}
+
+				if (!throttle_safe) {
+					mavlink_log_critical(&_mavlink_log_pub, "Arming denied: throttle not in safe position\t");
+					events::send(events::ID("commander_arm_denied_throttle_unsafe"), {events::Log::Critical, events::LogInternal::Info},
+						     "Arming denied: throttle not in safe position");
+					tune_negative(true);
+					return TRANSITION_DENIED;
+				}
 			}
 
 		} else if (calling_reason == arm_disarm_reason_t::stick_gesture
@@ -3008,8 +3010,7 @@ void Commander::manualControlCheck()
 
 	if (manual_control_updated && manual_control_setpoint.valid) {
 
-		_is_throttle_above_center = (manual_control_setpoint.throttle > 0.2f);
-		_is_throttle_low = (manual_control_setpoint.throttle < -0.8f);
+		_last_manual_throttle = manual_control_setpoint.throttle;
 
 		if (isArmed()) {
 			// Abort autonomous mode and switch to position mode if sticks are moved significantly

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -279,8 +279,7 @@ private:
 	bool _last_overload{false};
 	bool _mode_switch_mapped{false};
 
-	bool _is_throttle_above_center{false};
-	bool _is_throttle_low{false};
+	float _last_manual_throttle{-1.f};
 
 	bool _arm_tune_played{false};
 	bool _have_taken_off_since_arming{false};


### PR DESCRIPTION
## Summary

Partially supersedes #25847 — this is just the Commander arm throttle fix. The DShot 3D deadzone fix is in #26685.

- **Extend arm throttle check to all vehicle types** — previously only applied to fixed-wing and rotary-wing, leaving rovers with no throttle safety check at arming
- **Unify two separate throttle checks** (`_is_throttle_above_center` / `_is_throttle_low`) into a single evaluation at arm-time using the cached throttle value against the current vehicle type and control mode:
  - Rovers: safe = stick centered (`|throttle| < 0.2`)
  - Climb-rate modes (AltCtl, PosCtl): safe = at or below center (`throttle <= 0.2`)
  - Manual/Stab/Acro on MC/FW: safe = stick at bottom (`throttle < -0.8`)

### Why not #25847

That PR subscribes Commander to `actuator_motors` (coupling command layer to actuator layer), adds a `COM_ARM_THR_DZ` parameter, and removes the climb-rate throttle safety check entirely.

This PR uses only information Commander already has (`vehicle_type`, `flag_control_climb_rate_enabled`) with no new subscriptions or parameters.

## Test plan

- [ ] Arm a rover in Manual mode with stick centered — should allow
- [ ] Arm a rover in Manual mode with stick not centered — should deny
- [ ] Arm a multicopter in PosCtl with throttle above center — should deny
- [ ] Arm a multicopter in Manual with throttle not at bottom — should deny
- [ ] Mode switch between PosCtl and Manual before arming uses correct throttle rule