### PR TITLE
fix(dshot): 3D mode deadzone disarm + inclusive deadband

### DIFF
--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -741,7 +741,7 @@ uint16_t DShot::convert_output_to_3d_scaling(uint16_t output)
 	// This is in terms of DShot values, code below is in terms of actuator_output
 	// Direction 1) 48 is the slowest, 1047 is the fastest.
 	// Direction 2) 1049 is the slowest, 2047 is the fastest.
-	if (output >= _3d_dead_l && output < _3d_dead_h) {
+	if (output >= _3d_dead_l && output <= _3d_dead_h) {
 		return DSHOT_DISARM_VALUE;
 	}
 

--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -368,7 +368,15 @@ void DShot::update_motor_outputs(uint16_t outputs[MAX_ACTUATORS], int num_output
 			up_dshot_motor_command(i, DSHOT_CMD_MOTOR_STOP, set_telemetry_bit);
 
 		} else {
-			up_dshot_motor_data_set(i, calculate_output_value(outputs[i], i), set_telemetry_bit);
+			uint16_t output = calculate_output_value(outputs[i], i);
+
+			// 3D deadzone: send motor stop to avoid MIN_throttle offset in up_dshot_motor_data_set
+			if (output == DSHOT_DISARM_VALUE) {
+				up_dshot_motor_command(i, DSHOT_CMD_MOTOR_STOP, set_telemetry_bit);
+
+			} else {
+				up_dshot_motor_data_set(i, output, set_telemetry_bit);
+			}
 		}
 	}
 }

--- a/src/drivers/dshot/module.yaml
+++ b/src/drivers/dshot/module.yaml
@@ -56,7 +56,8 @@ parameters:
             description:
                 short: DSHOT 3D deadband high
                 long: |
-                    When the actuator_output is between DSHOT_3D_DEAD_L and DSHOT_3D_DEAD_H, motor will not spin.
+                    When the actuator_output is in the inclusive range [DSHOT_3D_DEAD_L, DSHOT_3D_DEAD_H], the motor will not spin.
+                    Setting DSHOT_3D_DEAD_L equal to DSHOT_3D_DEAD_H (e.g. the default 1000) produces a single-point deadband at that value.
                     This value is with respect to the mixer_module range (0-1999), not the DSHOT values.
             type: int32
             min: 1000
@@ -66,7 +67,8 @@ parameters:
             description:
                 short: DSHOT 3D deadband low
                 long: |
-                    When the actuator_output is between DSHOT_3D_DEAD_L and DSHOT_3D_DEAD_H, motor will not spin.
+                    When the actuator_output is in the inclusive range [DSHOT_3D_DEAD_L, DSHOT_3D_DEAD_H], the motor will not spin.
+                    Setting DSHOT_3D_DEAD_L equal to DSHOT_3D_DEAD_H (e.g. the default 1000) produces a single-point deadband at that value.
                     This value is with respect to the mixer_module range (0-1999), not the DSHOT values.
             type: int32
             min: 0


### PR DESCRIPTION
## Summary

Partially supersedes #25847 — this is just the DShot fix, separated from the Commander arm throttle changes.

Two related fixes for DShot 3D (reversible) mode:

**1. Motor stop for deadzone output**

In DShot 3D mode, `convert_output_to_3d_scaling()` returns `DSHOT_DISARM_VALUE` (0) for deadzone inputs. But `up_dshot_motor_data_set()` then adds the `DShot_cmd_MIN_throttle` offset (+48), causing motors to spin at minimum throttle instead of stopping.

Send an explicit motor stop command when 3D scaling produces a disarm value, bypassing the +48 offset. No API changes to `drv_dshot.h`.

**2. Inclusive deadband check**

The deadband check was `[DSHOT_3D_DEAD_L, DSHOT_3D_DEAD_H)` (exclusive upper). Both params default to 1000, which made the default deadband empty — an output of exactly 1000 fell into the positive-direction branch instead of disarming, producing unexpected "motors spinning when armed+idle" behavior (reported by @spiderkeys while testing).

Change the predicate to inclusive-inclusive `[L, H]` so that `L == H` produces a single-point deadband (e.g. the default 1000 → disarm at 1000), matching the natural reading of "between L and H". Clarified the `DSHOT_3D_DEAD_L/H` param descriptions accordingly.