### PR TITLE
perf(ekf2): replace std::pow(x, 2) with x * x in generated code

### DIFF
--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_airspeed_h.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_airspeed_h.h
@@ -32,8 +32,8 @@ matrix::Matrix<Scalar, 24, 1> ComputeAirspeedH(const matrix::Matrix<Scalar, 25, 
   // Intermediate terms (5)
   const Scalar _tmp0 = -state(23, 0) + state(5, 0);
   const Scalar _tmp1 = -state(22, 0) + state(4, 0);
-  const Scalar _tmp2 = std::pow(Scalar(std::pow(_tmp0, Scalar(2)) + std::pow(_tmp1, Scalar(2)) +
-                                       epsilon + std::pow(state(6, 0), Scalar(2))),
+  const Scalar _tmp2 = std::pow(Scalar((_tmp0) * (_tmp0) + (_tmp1) * (_tmp1) +
+                                       epsilon + (state(6, 0)) * (state(6, 0))),
                                 Scalar(Scalar(-1) / Scalar(2)));
   const Scalar _tmp3 = _tmp1 * _tmp2;
   const Scalar _tmp4 = _tmp0 * _tmp2;

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_airspeed_innov_and_innov_var.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_airspeed_innov_and_innov_var.h
@@ -39,8 +39,8 @@ void ComputeAirspeedInnovAndInnovVar(const matrix::Matrix<Scalar, 25, 1>& state,
   // Intermediate terms (7)
   const Scalar _tmp0 = -state(23, 0) + state(5, 0);
   const Scalar _tmp1 = -state(22, 0) + state(4, 0);
-  const Scalar _tmp2 = std::sqrt(Scalar(std::pow(_tmp0, Scalar(2)) + std::pow(_tmp1, Scalar(2)) +
-                                        epsilon + std::pow(state(6, 0), Scalar(2))));
+  const Scalar _tmp2 = std::sqrt(Scalar((_tmp0) * (_tmp0) + (_tmp1) * (_tmp1) +
+                                        epsilon + (state(6, 0)) * (state(6, 0))));
   const Scalar _tmp3 = Scalar(1.0) / (_tmp2);
   const Scalar _tmp4 = _tmp3 * state(6, 0);
   const Scalar _tmp5 = _tmp1 * _tmp3;

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_body_vel_innov_var_h.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_body_vel_innov_var_h.h
@@ -67,8 +67,8 @@ void ComputeBodyVelInnovVarH(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp25 = 2 * state(0, 0) * state(3, 0);
   const Scalar _tmp26 = _tmp12 * state(2, 0);
   const Scalar _tmp27 = _tmp25 + _tmp26;
-  const Scalar _tmp28 = -2 * std::pow(state(3, 0), Scalar(2));
-  const Scalar _tmp29 = 1 - 2 * std::pow(state(2, 0), Scalar(2));
+  const Scalar _tmp28 = -2 * (state(3, 0)) * (state(3, 0));
+  const Scalar _tmp29 = 1 - 2 * (state(2, 0)) * (state(2, 0));
   const Scalar _tmp30 = _tmp28 + _tmp29;
   const Scalar _tmp31 = _tmp14 * _tmp19 + _tmp15 * _tmp18 - _tmp4 * _tmp9 - _tmp5 * _tmp8;
   const Scalar _tmp32 = _tmp14 * _tmp5 - _tmp15 * _tmp4 - _tmp18 * _tmp9 + _tmp19 * _tmp8;
@@ -76,7 +76,7 @@ void ComputeBodyVelInnovVarH(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp34 = _tmp21 * state(3, 0);
   const Scalar _tmp35 = _tmp12 * state(0, 0);
   const Scalar _tmp36 = _tmp34 + _tmp35;
-  const Scalar _tmp37 = -2 * std::pow(state(1, 0), Scalar(2));
+  const Scalar _tmp37 = -2 * (state(1, 0)) * (state(1, 0));
   const Scalar _tmp38 = _tmp28 + _tmp37 + 1;
   const Scalar _tmp39 = 2 * state(4, 0);
   const Scalar _tmp40 = _tmp39 * state(3, 0);

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_body_vel_y_innov_var.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_body_vel_y_innov_var.h
@@ -37,7 +37,7 @@ void ComputeBodyVelYInnovVar(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp2 = -_tmp0 * state(0, 0) + _tmp1 * state(2, 0);
   const Scalar _tmp3 = _tmp0 * state(2, 0) + _tmp1 * state(0, 0);
   const Scalar _tmp4 =
-      -2 * std::pow(state(1, 0), Scalar(2)) - 2 * std::pow(state(3, 0), Scalar(2)) + 1;
+      -2 * (state(1, 0)) * (state(1, 0)) - 2 * (state(3, 0)) * (state(3, 0)) + 1;
   const Scalar _tmp5 = 2 * state(4, 0);
   const Scalar _tmp6 = _tmp1 * state(6, 0) - _tmp5 * state(3, 0);
   const Scalar _tmp7 = (Scalar(1) / Scalar(2)) * _tmp6;

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_body_vel_z_innov_var.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_body_vel_z_innov_var.h
@@ -52,7 +52,7 @@ void ComputeBodyVelZInnovVar(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp10 = -_tmp4 * state(1, 0) + _tmp9 * state(2, 0);
   const Scalar _tmp11 = _tmp4 * state(2, 0) + _tmp9 * state(1, 0);
   const Scalar _tmp12 =
-      -2 * std::pow(state(1, 0), Scalar(2)) - 2 * std::pow(state(2, 0), Scalar(2)) + 1;
+      -2 * (state(1, 0)) * (state(1, 0)) - 2 * (state(2, 0)) * (state(2, 0)) + 1;
   const Scalar _tmp13 =
       _tmp2 * state(0, 0) - _tmp3 * state(3, 0) + _tmp6 * state(1, 0) - _tmp7 * state(2, 0);
   const Scalar _tmp14 =

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_drag_x_innov_var_and_h.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_drag_x_innov_var_and_h.h
@@ -45,8 +45,8 @@ void ComputeDragXInnovVarAndH(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp3 = _tmp2 * state(2, 0);
   const Scalar _tmp4 = _tmp1 + _tmp3;
   const Scalar _tmp5 = _tmp4 * cm;
-  const Scalar _tmp6 = -2 * std::pow(state(3, 0), Scalar(2));
-  const Scalar _tmp7 = -2 * std::pow(state(2, 0), Scalar(2));
+  const Scalar _tmp6 = -2 * (state(3, 0)) * (state(3, 0));
+  const Scalar _tmp7 = -2 * (state(2, 0)) * (state(2, 0));
   const Scalar _tmp8 = _tmp6 + _tmp7 + 1;
   const Scalar _tmp9 = -state(22, 0) + state(4, 0);
   const Scalar _tmp10 = -state(23, 0) + state(5, 0);
@@ -61,7 +61,7 @@ void ComputeDragXInnovVarAndH(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp19 = _tmp2 * state(0, 0);
   const Scalar _tmp20 = _tmp18 - _tmp19;
   const Scalar _tmp21 = _tmp12 + _tmp13;
-  const Scalar _tmp22 = 1 - 2 * std::pow(state(1, 0), Scalar(2));
+  const Scalar _tmp22 = 1 - 2 * (state(1, 0)) * (state(1, 0));
   const Scalar _tmp23 = _tmp22 + _tmp7;
   const Scalar _tmp24 = _tmp10 * _tmp20 + _tmp21 * _tmp9 + _tmp23 * state(6, 0);
   const Scalar _tmp25 = 2 * _tmp24;
@@ -72,8 +72,8 @@ void ComputeDragXInnovVarAndH(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp30 = _tmp10 * _tmp27 + _tmp28 * _tmp9 + _tmp29 * state(6, 0);
   const Scalar _tmp31 = 2 * _tmp30;
   const Scalar _tmp32 = _tmp27 * _tmp31;
-  const Scalar _tmp33 = std::sqrt(Scalar(std::pow(_tmp15, Scalar(2)) + std::pow(_tmp24, Scalar(2)) +
-                                         std::pow(_tmp30, Scalar(2)) + epsilon));
+  const Scalar _tmp33 = std::sqrt(Scalar((_tmp15) * (_tmp15) + (_tmp24) * (_tmp24) +
+                                         (_tmp30) * (_tmp30) + epsilon));
   const Scalar _tmp34 = cd * rho;
   const Scalar _tmp35 = Scalar(0.25) * _tmp15 * _tmp34 / _tmp33;
   const Scalar _tmp36 = Scalar(0.5) * _tmp33 * _tmp34;

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_drag_y_innov_var_and_h.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_drag_y_innov_var_and_h.h
@@ -45,8 +45,8 @@ void ComputeDragYInnovVarAndH(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp3 = _tmp2 * state(2, 0);
   const Scalar _tmp4 = -_tmp1 + _tmp3;
   const Scalar _tmp5 = _tmp4 * cm;
-  const Scalar _tmp6 = -2 * std::pow(state(3, 0), Scalar(2));
-  const Scalar _tmp7 = -2 * std::pow(state(2, 0), Scalar(2));
+  const Scalar _tmp6 = -2 * (state(3, 0)) * (state(3, 0));
+  const Scalar _tmp7 = -2 * (state(2, 0)) * (state(2, 0));
   const Scalar _tmp8 = _tmp6 + _tmp7 + 1;
   const Scalar _tmp9 = -state(22, 0) + state(4, 0);
   const Scalar _tmp10 = _tmp1 + _tmp3;
@@ -60,14 +60,14 @@ void ComputeDragYInnovVarAndH(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp18 = _tmp2 * state(0, 0);
   const Scalar _tmp19 = _tmp17 - _tmp18;
   const Scalar _tmp20 = _tmp12 + _tmp13;
-  const Scalar _tmp21 = 1 - 2 * std::pow(state(1, 0), Scalar(2));
+  const Scalar _tmp21 = 1 - 2 * (state(1, 0)) * (state(1, 0));
   const Scalar _tmp22 = _tmp21 + _tmp7;
   const Scalar _tmp23 = _tmp11 * _tmp19 + _tmp20 * _tmp9 + _tmp22 * state(6, 0);
   const Scalar _tmp24 = _tmp21 + _tmp6;
   const Scalar _tmp25 = _tmp17 + _tmp18;
   const Scalar _tmp26 = _tmp11 * _tmp24 + _tmp25 * state(6, 0) + _tmp4 * _tmp9;
-  const Scalar _tmp27 = std::sqrt(Scalar(std::pow(_tmp15, Scalar(2)) + std::pow(_tmp23, Scalar(2)) +
-                                         std::pow(_tmp26, Scalar(2)) + epsilon));
+  const Scalar _tmp27 = std::sqrt(Scalar((_tmp15) * (_tmp15) + (_tmp23) * (_tmp23) +
+                                         (_tmp26) * (_tmp26) + epsilon));
   const Scalar _tmp28 = cd * rho;
   const Scalar _tmp29 = Scalar(0.5) * _tmp27 * _tmp28;
   const Scalar _tmp30 = _tmp29 * _tmp4;

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_flow_xy_innov_var_and_hx.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_flow_xy_innov_var_and_hx.h
@@ -42,18 +42,18 @@ void ComputeFlowXyInnovVarAndHx(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp3 = _tmp2 * state(1, 0);
   const Scalar _tmp4 = -_tmp1 + _tmp3;
   const Scalar _tmp5 = _tmp0 * state(1, 0) + _tmp2 * state(3, 0);
-  const Scalar _tmp6 = -2 * std::pow(state(3, 0), Scalar(2));
-  const Scalar _tmp7 = 1 - 2 * std::pow(state(1, 0), Scalar(2));
+  const Scalar _tmp6 = -2 * (state(3, 0)) * (state(3, 0));
+  const Scalar _tmp7 = 1 - 2 * (state(1, 0)) * (state(1, 0));
   const Scalar _tmp8 = _tmp6 + _tmp7;
   const Scalar _tmp9 = _tmp4 * state(4, 0) + _tmp5 * state(6, 0) + _tmp8 * state(5, 0);
-  const Scalar _tmp10 = -2 * std::pow(state(2, 0), Scalar(2));
+  const Scalar _tmp10 = -2 * (state(2, 0)) * (state(2, 0));
   const Scalar _tmp11 = _tmp10 + _tmp7;
   const Scalar _tmp12 = -epsilon * (2 * math::min<Scalar>(0, (((state(24, 0) - state(9, 0)) > 0) -
                                                              ((state(24, 0) - state(9, 0)) < 0))) +
                                     1) -
                         state(24, 0) + state(9, 0);
   const Scalar _tmp13 = std::fabs(_tmp12);
-  const Scalar _tmp14 = _tmp11 * (((_tmp12) > 0) - ((_tmp12) < 0)) / std::pow(_tmp13, Scalar(2));
+  const Scalar _tmp14 = _tmp11 * (((_tmp12) > 0) - ((_tmp12) < 0)) / (_tmp13) * (_tmp13);
   const Scalar _tmp15 = _tmp14 * _tmp9;
   const Scalar _tmp16 = Scalar(1.0) / (_tmp13);
   const Scalar _tmp17 = _tmp11 * _tmp16;

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_flow_y_innov_var_and_h.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_flow_y_innov_var_and_h.h
@@ -38,8 +38,8 @@ void ComputeFlowYInnovVarAndH(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp0 = 2 * state(0, 0);
   const Scalar _tmp1 = 2 * state(1, 0);
   const Scalar _tmp2 = -_tmp0 * state(2, 0) + _tmp1 * state(3, 0);
-  const Scalar _tmp3 = 1 - 2 * std::pow(state(2, 0), Scalar(2));
-  const Scalar _tmp4 = _tmp3 - 2 * std::pow(state(1, 0), Scalar(2));
+  const Scalar _tmp3 = 1 - 2 * (state(2, 0)) * (state(2, 0));
+  const Scalar _tmp4 = _tmp3 - 2 * (state(1, 0)) * (state(1, 0));
   const Scalar _tmp5 = -epsilon * (2 * math::min<Scalar>(0, (((state(24, 0) - state(9, 0)) > 0) -
                                                             ((state(24, 0) - state(9, 0)) < 0))) +
                                    1) -
@@ -50,10 +50,10 @@ void ComputeFlowYInnovVarAndH(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp9 = _tmp2 * _tmp8;
   const Scalar _tmp10 = _tmp0 * state(3, 0) + _tmp1 * state(2, 0);
   const Scalar _tmp11 = _tmp10 * _tmp8;
-  const Scalar _tmp12 = _tmp3 - 2 * std::pow(state(3, 0), Scalar(2));
+  const Scalar _tmp12 = _tmp3 - 2 * (state(3, 0)) * (state(3, 0));
   const Scalar _tmp13 = _tmp10 * state(5, 0) + _tmp12 * state(4, 0) + _tmp2 * state(6, 0);
   const Scalar _tmp14 =
-      _tmp13 * _tmp4 * (((_tmp5) > 0) - ((_tmp5) < 0)) / std::pow(_tmp6, Scalar(2));
+      _tmp13 * _tmp4 * (((_tmp5) > 0) - ((_tmp5) < 0)) / (_tmp6) * (_tmp6);
   const Scalar _tmp15 = 4 * state(4, 0);
   const Scalar _tmp16 = 2 * state(5, 0);
   const Scalar _tmp17 = 4 * _tmp13 * _tmp7;

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_gnss_yaw_pred_innov_var_and_h.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_gnss_yaw_pred_innov_var_and_h.h
@@ -39,18 +39,18 @@ void ComputeGnssYawPredInnovVarAndH(const matrix::Matrix<Scalar, 25, 1>& state,
   // Input arrays
 
   // Intermediate terms (29)
-  const Scalar _tmp0 = 1 - 2 * std::pow(state(3, 0), Scalar(2));
+  const Scalar _tmp0 = 1 - 2 * (state(3, 0)) * (state(3, 0));
   const Scalar _tmp1 = std::sin(antenna_yaw_offset);
   const Scalar _tmp2 = 2 * state(0, 0) * state(3, 0);
   const Scalar _tmp3 = 2 * state(1, 0) * state(2, 0);
   const Scalar _tmp4 = std::cos(antenna_yaw_offset);
   const Scalar _tmp5 =
-      _tmp1 * (_tmp0 - 2 * std::pow(state(1, 0), Scalar(2))) + _tmp4 * (_tmp2 + _tmp3);
+      _tmp1 * (_tmp0 - 2 * (state(1, 0)) * (state(1, 0))) + _tmp4 * (_tmp2 + _tmp3);
   const Scalar _tmp6 =
-      _tmp1 * (-_tmp2 + _tmp3) + _tmp4 * (_tmp0 - 2 * std::pow(state(2, 0), Scalar(2)));
+      _tmp1 * (-_tmp2 + _tmp3) + _tmp4 * (_tmp0 - 2 * (state(2, 0)) * (state(2, 0)));
   const Scalar _tmp7 = _tmp6 + epsilon * ((((_tmp6) > 0) - ((_tmp6) < 0)) + Scalar(0.5));
   const Scalar _tmp8 = 2 * _tmp1;
-  const Scalar _tmp9 = std::pow(_tmp7, Scalar(2));
+  const Scalar _tmp9 = (_tmp7) * (_tmp7);
   const Scalar _tmp10 = _tmp5 / _tmp9;
   const Scalar _tmp11 = _tmp10 * _tmp8;
   const Scalar _tmp12 = 4 * _tmp1;
@@ -58,7 +58,7 @@ void ComputeGnssYawPredInnovVarAndH(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp14 = Scalar(1.0) / (_tmp7);
   const Scalar _tmp15 =
       -_tmp11 * state(2, 0) + _tmp14 * (-_tmp12 * state(1, 0) + _tmp13 * state(2, 0));
-  const Scalar _tmp16 = (Scalar(1) / Scalar(2)) * _tmp9 / (std::pow(_tmp5, Scalar(2)) + _tmp9);
+  const Scalar _tmp16 = (Scalar(1) / Scalar(2)) * _tmp9 / ((_tmp5) * (_tmp5) + _tmp9);
   const Scalar _tmp17 = _tmp15 * _tmp16;
   const Scalar _tmp18 = _tmp13 * _tmp14;
   const Scalar _tmp19 = _tmp11 * state(3, 0) + _tmp18 * state(3, 0);

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_gravity_xyz_innov_var_and_hx.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_gravity_xyz_innov_var_and_hx.h
@@ -39,9 +39,9 @@ void ComputeGravityXyzInnovVarAndHx(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp2 = 2 * state(2, 0);
   const Scalar _tmp3 = _tmp2 * state(1, 0);
   const Scalar _tmp4 = _tmp1 - _tmp3;
-  const Scalar _tmp5 = std::pow(state(3, 0), Scalar(2));
-  const Scalar _tmp6 = std::pow(state(0, 0), Scalar(2));
-  const Scalar _tmp7 = std::pow(state(1, 0), Scalar(2)) - std::pow(state(2, 0), Scalar(2));
+  const Scalar _tmp5 = (state(3, 0)) * (state(3, 0));
+  const Scalar _tmp6 = (state(0, 0)) * (state(0, 0));
+  const Scalar _tmp7 = (state(1, 0)) * (state(1, 0)) - (state(2, 0)) * (state(2, 0));
   const Scalar _tmp8 = -_tmp5 + _tmp6 + _tmp7;
   const Scalar _tmp9 = _tmp1 + _tmp3;
   const Scalar _tmp10 = _tmp5 - _tmp6 + _tmp7;

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_gravity_y_innov_var_and_h.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_gravity_y_innov_var_and_h.h
@@ -35,8 +35,8 @@ void ComputeGravityYInnovVarAndH(const matrix::Matrix<Scalar, 25, 1>& state,
 
   // Intermediate terms (2)
   const Scalar _tmp0 = -2 * state(0, 0) * state(3, 0) + 2 * state(1, 0) * state(2, 0);
-  const Scalar _tmp1 = -std::pow(state(0, 0), Scalar(2)) + std::pow(state(1, 0), Scalar(2)) -
-                       std::pow(state(2, 0), Scalar(2)) + std::pow(state(3, 0), Scalar(2));
+  const Scalar _tmp1 = -(state(0, 0)) * (state(0, 0)) + (state(1, 0)) * (state(1, 0)) -
+                       (state(2, 0)) * (state(2, 0)) + (state(3, 0)) * (state(3, 0));
 
   // Output terms (2)
   if (innov_var != nullptr) {

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_mag_declination_pred_innov_var_and_h.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_mag_declination_pred_innov_var_and_h.h
@@ -40,7 +40,7 @@ void ComputeMagDeclinationPredInnovVarAndH(const matrix::Matrix<Scalar, 25, 1>& 
   const Scalar _tmp0 =
       epsilon * ((((state(16, 0)) > 0) - ((state(16, 0)) < 0)) + Scalar(0.5)) + state(16, 0);
   const Scalar _tmp1 =
-      Scalar(1.0) / (std::pow(_tmp0, Scalar(2)) + std::pow(state(17, 0), Scalar(2)));
+      Scalar(1.0) / ((_tmp0) * (_tmp0) + (state(17, 0)) * (state(17, 0)));
   const Scalar _tmp2 = _tmp1 * state(17, 0);
   const Scalar _tmp3 = _tmp0 * _tmp1;
 

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_mag_innov_innov_var_and_hx.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_mag_innov_innov_var_and_hx.h
@@ -43,8 +43,8 @@ void ComputeMagInnovInnovVarAndHx(const matrix::Matrix<Scalar, 25, 1>& state,
   // Input arrays
 
   // Intermediate terms (68)
-  const Scalar _tmp0 = -2 * std::pow(state(3, 0), Scalar(2));
-  const Scalar _tmp1 = 1 - 2 * std::pow(state(2, 0), Scalar(2));
+  const Scalar _tmp0 = -2 * (state(3, 0)) * (state(3, 0));
+  const Scalar _tmp1 = 1 - 2 * (state(2, 0)) * (state(2, 0));
   const Scalar _tmp2 = _tmp0 + _tmp1;
   const Scalar _tmp3 = 2 * state(3, 0);
   const Scalar _tmp4 = _tmp3 * state(0, 0);
@@ -55,7 +55,7 @@ void ComputeMagInnovInnovVarAndHx(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp9 = 2 * state(1, 0);
   const Scalar _tmp10 = _tmp9 * state(3, 0);
   const Scalar _tmp11 = _tmp10 - _tmp8;
-  const Scalar _tmp12 = -2 * std::pow(state(1, 0), Scalar(2));
+  const Scalar _tmp12 = -2 * (state(1, 0)) * (state(1, 0));
   const Scalar _tmp13 = _tmp0 + _tmp12 + 1;
   const Scalar _tmp14 = _tmp5 * state(3, 0);
   const Scalar _tmp15 = _tmp9 * state(0, 0);

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_mag_y_innov_var_and_h.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_mag_y_innov_var_and_h.h
@@ -44,7 +44,7 @@ void ComputeMagYInnovVarAndH(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp3 = 2 * state(3, 0);
   const Scalar _tmp4 = _tmp0 * state(1, 0) - _tmp3 * state(0, 0);
   const Scalar _tmp5 =
-      -2 * std::pow(state(1, 0), Scalar(2)) - 2 * std::pow(state(3, 0), Scalar(2)) + 1;
+      -2 * (state(1, 0)) * (state(1, 0)) - 2 * (state(3, 0)) * (state(3, 0)) + 1;
   const Scalar _tmp6 = _tmp1 * state(18, 0) - _tmp3 * state(16, 0);
   const Scalar _tmp7 = (Scalar(1) / Scalar(2)) * _tmp6;
   const Scalar _tmp8 = (Scalar(1) / Scalar(2)) * _tmp1 * state(16, 0) +

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_mag_z_innov_var_and_h.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_mag_z_innov_var_and_h.h
@@ -59,7 +59,7 @@ void ComputeMagZInnovVarAndH(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp10 =
       -_tmp2 * state(2, 0) - _tmp4 * state(1, 0) + _tmp6 * state(0, 0) + _tmp7 * state(3, 0);
   const Scalar _tmp11 =
-      -2 * std::pow(state(1, 0), Scalar(2)) - 2 * std::pow(state(2, 0), Scalar(2)) + 1;
+      -2 * (state(1, 0)) * (state(1, 0)) - 2 * (state(2, 0)) * (state(2, 0)) + 1;
   const Scalar _tmp12 = 2 * state(2, 0);
   const Scalar _tmp13 = _tmp12 * state(3, 0) - _tmp3 * state(0, 0);
   const Scalar _tmp14 = _tmp12 * state(0, 0) + _tmp3 * state(3, 0);

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_sideslip_h.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_sideslip_h.h
@@ -34,8 +34,8 @@ matrix::Matrix<Scalar, 24, 1> ComputeSideslipH(const matrix::Matrix<Scalar, 25, 
   const Scalar _tmp1 = 2 * state(1, 0);
   const Scalar _tmp2 = 2 * state(6, 0);
   const Scalar _tmp3 = _tmp2 * state(3, 0);
-  const Scalar _tmp4 = 1 - 2 * std::pow(state(3, 0), Scalar(2));
-  const Scalar _tmp5 = _tmp4 - 2 * std::pow(state(2, 0), Scalar(2));
+  const Scalar _tmp4 = 1 - 2 * (state(3, 0)) * (state(3, 0));
+  const Scalar _tmp5 = _tmp4 - 2 * (state(2, 0)) * (state(2, 0));
   const Scalar _tmp6 = 2 * state(0, 0);
   const Scalar _tmp7 = _tmp6 * state(3, 0);
   const Scalar _tmp8 = 2 * state(2, 0);
@@ -47,13 +47,13 @@ matrix::Matrix<Scalar, 24, 1> ComputeSideslipH(const matrix::Matrix<Scalar, 25, 
   const Scalar _tmp14 = _tmp13 + epsilon * ((((_tmp13) > 0) - ((_tmp13) < 0)) + Scalar(0.5));
   const Scalar _tmp15 = Scalar(1.0) / (_tmp14);
   const Scalar _tmp16 = _tmp2 * state(0, 0);
-  const Scalar _tmp17 = std::pow(_tmp14, Scalar(2));
-  const Scalar _tmp18 = _tmp4 - 2 * std::pow(state(1, 0), Scalar(2));
+  const Scalar _tmp17 = (_tmp14) * (_tmp14);
+  const Scalar _tmp18 = _tmp4 - 2 * (state(1, 0)) * (state(1, 0));
   const Scalar _tmp19 = -_tmp7 + _tmp9;
   const Scalar _tmp20 = _tmp6 * state(1, 0) + _tmp8 * state(3, 0);
   const Scalar _tmp21 = _tmp0 * _tmp19 + _tmp11 * _tmp18 + _tmp20 * state(6, 0);
   const Scalar _tmp22 = _tmp21 / _tmp17;
-  const Scalar _tmp23 = _tmp17 / (_tmp17 + std::pow(_tmp21, Scalar(2)));
+  const Scalar _tmp23 = _tmp17 / (_tmp17 + (_tmp21) * (_tmp21));
   const Scalar _tmp24 = (Scalar(1) / Scalar(2)) * _tmp23;
   const Scalar _tmp25 = _tmp24 * (_tmp15 * (_tmp0 * _tmp1 + _tmp3) -
                                   _tmp22 * (-4 * _tmp0 * state(2, 0) + _tmp1 * _tmp11 - _tmp16));

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_sideslip_innov_and_innov_var.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_sideslip_innov_and_innov_var.h
@@ -35,8 +35,8 @@ void ComputeSideslipInnovAndInnovVar(const matrix::Matrix<Scalar, 25, 1>& state,
   // Input arrays
 
   // Intermediate terms (49)
-  const Scalar _tmp0 = 1 - 2 * std::pow(state(3, 0), Scalar(2));
-  const Scalar _tmp1 = _tmp0 - 2 * std::pow(state(1, 0), Scalar(2));
+  const Scalar _tmp0 = 1 - 2 * (state(3, 0)) * (state(3, 0));
+  const Scalar _tmp1 = _tmp0 - 2 * (state(1, 0)) * (state(1, 0));
   const Scalar _tmp2 = -state(23, 0) + state(5, 0);
   const Scalar _tmp3 = 2 * state(3, 0);
   const Scalar _tmp4 = _tmp3 * state(0, 0);
@@ -47,17 +47,17 @@ void ComputeSideslipInnovAndInnovVar(const matrix::Matrix<Scalar, 25, 1>& state,
   const Scalar _tmp9 = 2 * state(2, 0);
   const Scalar _tmp10 = _tmp5 * state(0, 0) + _tmp9 * state(3, 0);
   const Scalar _tmp11 = _tmp1 * _tmp2 + _tmp10 * state(6, 0) + _tmp7 * _tmp8;
-  const Scalar _tmp12 = _tmp0 - 2 * std::pow(state(2, 0), Scalar(2));
+  const Scalar _tmp12 = _tmp0 - 2 * (state(2, 0)) * (state(2, 0));
   const Scalar _tmp13 = _tmp4 + _tmp6;
   const Scalar _tmp14 = _tmp5 * state(3, 0) - _tmp9 * state(0, 0);
   const Scalar _tmp15 = _tmp12 * _tmp8 + _tmp13 * _tmp2 + _tmp14 * state(6, 0);
   const Scalar _tmp16 = _tmp15 + epsilon * ((((_tmp15) > 0) - ((_tmp15) < 0)) + Scalar(0.5));
   const Scalar _tmp17 = Scalar(1.0) / (_tmp16);
   const Scalar _tmp18 = _tmp1 * _tmp17;
-  const Scalar _tmp19 = std::pow(_tmp16, Scalar(2));
+  const Scalar _tmp19 = (_tmp16) * (_tmp16);
   const Scalar _tmp20 = _tmp11 / _tmp19;
   const Scalar _tmp21 = _tmp13 * _tmp20;
-  const Scalar _tmp22 = _tmp19 / (std::pow(_tmp11, Scalar(2)) + _tmp19);
+  const Scalar _tmp22 = _tmp19 / ((_tmp11) * (_tmp11) + _tmp19);
   const Scalar _tmp23 = _tmp22 * (-_tmp18 + _tmp21);
   const Scalar _tmp24 = _tmp12 * _tmp20;
   const Scalar _tmp25 = _tmp17 * _tmp7;

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_wind_init_and_cov_from_airspeed.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_wind_init_and_cov_from_airspeed.h
@@ -43,11 +43,11 @@ void ComputeWindInitAndCovFromAirspeed(const matrix::Matrix<Scalar, 3, 1>& v_loc
   // Intermediate terms (9)
   const Scalar _tmp0 = std::cos(heading);
   const Scalar _tmp1 = std::sin(heading);
-  const Scalar _tmp2 = std::pow(_tmp1, Scalar(2));
-  const Scalar _tmp3 = std::pow(airspeed, Scalar(2));
+  const Scalar _tmp2 = (_tmp1) * (_tmp1);
+  const Scalar _tmp3 = (airspeed) * (airspeed);
   const Scalar _tmp4 = _tmp3 * sideslip_var;
   const Scalar _tmp5 = _tmp3 * heading_var;
-  const Scalar _tmp6 = std::pow(_tmp0, Scalar(2));
+  const Scalar _tmp6 = (_tmp0) * (_tmp0);
   const Scalar _tmp7 = _tmp0 * _tmp1;
   const Scalar _tmp8 = -_tmp4 * _tmp7 - _tmp5 * _tmp7 + _tmp7 * airspeed_var;
 

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_wind_init_and_cov_from_wind_speed_and_direction.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_wind_init_and_cov_from_wind_speed_and_direction.h
@@ -37,9 +37,9 @@ void ComputeWindInitAndCovFromWindSpeedAndDirection(
   // Intermediate terms (5)
   const Scalar _tmp0 = std::cos(wind_direction);
   const Scalar _tmp1 = std::sin(wind_direction);
-  const Scalar _tmp2 = std::pow(_tmp0, Scalar(2));
-  const Scalar _tmp3 = std::pow(_tmp1, Scalar(2));
-  const Scalar _tmp4 = wind_direction_var * std::pow(wind_speed, Scalar(2));
+  const Scalar _tmp2 = (_tmp0) * (_tmp0);
+  const Scalar _tmp3 = (_tmp1) * (_tmp1);
+  const Scalar _tmp4 = wind_direction_var * (wind_speed) * (wind_speed);
 
   // Output terms (2)
   if (wind != nullptr) {

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/predict_covariance.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/predict_covariance.h
@@ -49,13 +49,13 @@ matrix::Matrix<Scalar, 24, 24> PredictCovariance(const matrix::Matrix<Scalar, 25
   const Scalar _tmp4 = _tmp3 * state(2, 0);
   const Scalar _tmp5 = _tmp4 * dt;
   const Scalar _tmp6 = _tmp2 - _tmp5;
-  const Scalar _tmp7 = std::pow(state(3, 0), Scalar(2));
+  const Scalar _tmp7 = (state(3, 0)) * (state(3, 0));
   const Scalar _tmp8 = _tmp7 * dt;
-  const Scalar _tmp9 = std::pow(state(0, 0), Scalar(2));
+  const Scalar _tmp9 = (state(0, 0)) * (state(0, 0));
   const Scalar _tmp10 = -_tmp9 * dt;
-  const Scalar _tmp11 = std::pow(state(2, 0), Scalar(2));
+  const Scalar _tmp11 = (state(2, 0)) * (state(2, 0));
   const Scalar _tmp12 = _tmp11 * dt;
-  const Scalar _tmp13 = std::pow(state(1, 0), Scalar(2));
+  const Scalar _tmp13 = (state(1, 0)) * (state(1, 0));
   const Scalar _tmp14 = _tmp13 * dt;
   const Scalar _tmp15 = _tmp10 + _tmp12 - _tmp14 + _tmp8;
   const Scalar _tmp16 = _tmp13 + _tmp7;
@@ -158,7 +158,7 @@ matrix::Matrix<Scalar, 24, 24> PredictCovariance(const matrix::Matrix<Scalar, 25
                         P(14, 13) * _tmp64 + P(2, 13) * _tmp79 + P(3, 13);
   const Scalar _tmp94 = P(1, 14) * _tmp75 - P(12, 14) * _tmp57 - P(13, 14) * _tmp61 -
                         P(14, 14) * _tmp64 + P(2, 14) * _tmp79 + P(3, 14);
-  const Scalar _tmp95 = std::pow(dt, Scalar(2));
+  const Scalar _tmp95 = (dt) * (dt);
   const Scalar _tmp96 = _tmp95 * accel_var(0, 0);
   const Scalar _tmp97 = _tmp95 * accel_var(1, 0);
   const Scalar _tmp98 = _tmp95 * accel_var(2, 0);
@@ -236,30 +236,30 @@ matrix::Matrix<Scalar, 24, 24> PredictCovariance(const matrix::Matrix<Scalar, 25
 
   _res.setZero();
 
-  _res(0, 0) = std::pow(_tmp15, Scalar(2)) * gyro_var + _tmp15 * _tmp27 + _tmp18 * _tmp26 +
-               std::pow(_tmp23, Scalar(2)) * gyro_var + _tmp23 * _tmp25 + _tmp24 * _tmp6 +
-               std::pow(_tmp6, Scalar(2)) * gyro_var;
+  _res(0, 0) = (_tmp15) * (_tmp15) * gyro_var + _tmp15 * _tmp27 + _tmp18 * _tmp26 +
+               (_tmp23) * (_tmp23) * gyro_var + _tmp23 * _tmp25 + _tmp24 * _tmp6 +
+               (_tmp6) * (_tmp6) * gyro_var;
   _res(0, 1) = _tmp15 * _tmp38 + _tmp18 * _tmp35 + _tmp24 * _tmp34 + _tmp25 * _tmp29 +
                _tmp27 * _tmp36 + _tmp29 * _tmp37 + _tmp34 * _tmp39;
-  _res(1, 1) = _tmp18 * _tmp43 + std::pow(_tmp29, Scalar(2)) * gyro_var + _tmp29 * _tmp40 +
-               std::pow(_tmp34, Scalar(2)) * gyro_var + _tmp34 * _tmp41 +
-               std::pow(_tmp36, Scalar(2)) * gyro_var + _tmp36 * _tmp42;
+  _res(1, 1) = _tmp18 * _tmp43 + (_tmp29) * (_tmp29) * gyro_var + _tmp29 * _tmp40 +
+               (_tmp34) * (_tmp34) * gyro_var + _tmp34 * _tmp41 +
+               (_tmp36) * (_tmp36) * gyro_var + _tmp36 * _tmp42;
   _res(0, 2) = _tmp15 * _tmp47 * gyro_var + _tmp18 * _tmp46 + _tmp24 * _tmp44 + _tmp25 * _tmp45 +
                _tmp27 * _tmp47 + _tmp37 * _tmp45 + _tmp39 * _tmp44;
   _res(1, 2) = _tmp18 * _tmp48 + _tmp29 * _tmp45 * gyro_var + _tmp34 * _tmp44 * gyro_var +
                _tmp38 * _tmp47 + _tmp40 * _tmp45 + _tmp41 * _tmp44 + _tmp42 * _tmp47;
-  _res(2, 2) = _tmp18 * _tmp51 + std::pow(_tmp44, Scalar(2)) * gyro_var + _tmp44 * _tmp50 +
-               std::pow(_tmp45, Scalar(2)) * gyro_var + _tmp45 * _tmp49 +
-               std::pow(_tmp47, Scalar(2)) * gyro_var + _tmp47 * _tmp52;
+  _res(2, 2) = _tmp18 * _tmp51 + (_tmp44) * (_tmp44) * gyro_var + _tmp44 * _tmp50 +
+               (_tmp45) * (_tmp45) * gyro_var + _tmp45 * _tmp49 +
+               (_tmp47) * (_tmp47) * gyro_var + _tmp47 * _tmp52;
   _res(0, 3) = _tmp35 * _tmp75 + _tmp46 * _tmp79 - _tmp53 * _tmp57 - _tmp58 * _tmp61 -
                _tmp62 * _tmp64 + _tmp80;
   _res(1, 3) = _tmp43 * _tmp75 + _tmp48 * _tmp79 - _tmp57 * _tmp81 - _tmp61 * _tmp82 -
                _tmp64 * _tmp83 + _tmp84;
   _res(2, 3) = _tmp51 * _tmp79 - _tmp57 * _tmp85 - _tmp61 * _tmp87 - _tmp64 * _tmp88 +
                _tmp75 * _tmp86 + _tmp89;
-  _res(3, 3) = std::pow(_tmp56, Scalar(2)) * _tmp96 - _tmp57 * _tmp90 +
-               std::pow(_tmp60, Scalar(2)) * _tmp97 - _tmp61 * _tmp93 +
-               std::pow(_tmp63, Scalar(2)) * _tmp98 - _tmp64 * _tmp94 + _tmp75 * _tmp91 +
+  _res(3, 3) = (_tmp56) * (_tmp56) * _tmp96 - _tmp57 * _tmp90 +
+               (_tmp60) * (_tmp60) * _tmp97 - _tmp61 * _tmp93 +
+               (_tmp63) * (_tmp63) * _tmp98 - _tmp64 * _tmp94 + _tmp75 * _tmp91 +
                _tmp79 * _tmp92 + _tmp99;
   _res(0, 4) = -_tmp102 * _tmp58 + _tmp105 * _tmp46 - _tmp108 * _tmp62 - _tmp110 * _tmp53 +
                _tmp113 * _tmp26 + _tmp114;
@@ -270,11 +270,11 @@ matrix::Matrix<Scalar, 24, 24> PredictCovariance(const matrix::Matrix<Scalar, 25
   _res(3, 4) = _tmp101 * _tmp120 - _tmp102 * _tmp93 + _tmp105 * _tmp92 + _tmp107 * _tmp122 -
                _tmp108 * _tmp94 + _tmp109 * _tmp119 - _tmp110 * _tmp90 + _tmp113 * _tmp121 +
                _tmp123;
-  _res(4, 4) = std::pow(_tmp101, Scalar(2)) * _tmp97 - _tmp102 * _tmp125 +
+  _res(4, 4) = (_tmp101) * (_tmp101) * _tmp97 - _tmp102 * _tmp125 +
                _tmp105 * (P(0, 2) * _tmp113 - P(12, 2) * _tmp110 - P(13, 2) * _tmp102 -
                           P(14, 2) * _tmp108 + P(2, 2) * _tmp105 + P(4, 2)) +
-               std::pow(_tmp107, Scalar(2)) * _tmp98 - _tmp108 * _tmp126 +
-               std::pow(_tmp109, Scalar(2)) * _tmp96 - _tmp110 * _tmp127 + _tmp113 * _tmp124 +
+               (_tmp107) * (_tmp107) * _tmp98 - _tmp108 * _tmp126 +
+               (_tmp109) * (_tmp109) * _tmp96 - _tmp110 * _tmp127 + _tmp113 * _tmp124 +
                _tmp128;
   _res(0, 5) = -_tmp130 * _tmp62 + _tmp131 * _tmp35 - _tmp132 * _tmp58 - _tmp133 * _tmp53 +
                _tmp134 * _tmp26 + _tmp135;
@@ -289,14 +289,14 @@ matrix::Matrix<Scalar, 24, 24> PredictCovariance(const matrix::Matrix<Scalar, 25
                _tmp131 * (P(0, 1) * _tmp113 - P(12, 1) * _tmp110 - P(13, 1) * _tmp102 -
                           P(14, 1) * _tmp108 + P(2, 1) * _tmp105 + P(4, 1)) +
                _tmp139;
-  _res(5, 5) = std::pow(_tmp129, Scalar(2)) * _tmp98 - _tmp130 * _tmp140 +
+  _res(5, 5) = (_tmp129) * (_tmp129) * _tmp98 - _tmp130 * _tmp140 +
                _tmp131 * (P(0, 1) * _tmp134 + P(1, 1) * _tmp131 - P(12, 1) * _tmp133 -
                           P(13, 1) * _tmp132 - P(14, 1) * _tmp130 + P(5, 1)) -
                _tmp132 * _tmp141 - _tmp133 * _tmp142 +
                _tmp134 * (P(0, 0) * _tmp134 + P(1, 0) * _tmp131 - P(12, 0) * _tmp133 -
                           P(13, 0) * _tmp132 - P(14, 0) * _tmp130 + P(5, 0)) +
-               _tmp143 + std::pow(_tmp66, Scalar(2)) * _tmp96 +
-               std::pow(_tmp73, Scalar(2)) * _tmp97;
+               _tmp143 + (_tmp66) * (_tmp66) * _tmp96 +
+               (_tmp73) * (_tmp73) * _tmp97;
   _res(0, 6) =
       P(0, 6) * _tmp18 + P(10, 6) * _tmp23 + P(11, 6) * _tmp6 + P(9, 6) * _tmp15 + _tmp80 * dt;
   _res(1, 6) =

--- a/src/modules/ekf2/EKF/python/ekf_derivation/utils/derivation_utils.py
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/utils/derivation_utils.py
@@ -72,6 +72,9 @@ def generate_px4_function(function_name, output_names):
             line = line.replace("Eigen", "matrix")
             line = line.replace("matrix/Dense", "matrix/math.hpp")
 
+            # Replace std::pow(x, Scalar(2)) with (x) * (x) to avoid expensive library calls
+            line = re.sub(r'std::pow\(((?:[^()]*|\([^()]*\))*), Scalar\(2\)\)', r'(\1) * (\1)', line)
+
             # don't allow underscore + uppercase identifier naming (always reserved for any use)
             line = re.sub(r'_([A-Z])', lambda x: '_' + x.group(1).lower(), line)
 

--- a/src/modules/ekf2/EKF/yaw_estimator/derivation/generated/yaw_est_predict_covariance.h
+++ b/src/modules/ekf2/EKF/yaw_estimator/derivation/generated/yaw_est_predict_covariance.h
@@ -42,10 +42,10 @@ matrix::Matrix<Scalar, 3, 3> YawEstPredictCovariance(const matrix::Matrix<Scalar
   const Scalar _tmp2 = -_tmp0 * d_vel(1, 0) - _tmp1 * d_vel(0, 0);
   const Scalar _tmp3 = P(0, 2) + P(2, 2) * _tmp2;
   const Scalar _tmp4 =
-      std::pow(_tmp0, Scalar(2)) * d_vel_var + std::pow(_tmp1, Scalar(2)) * d_vel_var;
+      (_tmp0) * (_tmp0) * d_vel_var + (_tmp1) * (_tmp1) * d_vel_var;
   const Scalar _tmp5 = _tmp0 * d_vel(0, 0) - _tmp1 * d_vel(1, 0);
   const Scalar _tmp6 = P(1, 2) + P(2, 2) * _tmp5;
-  const Scalar _tmp7 = std::pow(d_ang, Scalar(2)) + 1;
+  const Scalar _tmp7 = (d_ang) * (d_ang) + 1;
 
   // Output terms (1)
   matrix::Matrix<Scalar, 3, 3> _res;
@@ -57,7 +57,7 @@ matrix::Matrix<Scalar, 3, 3> YawEstPredictCovariance(const matrix::Matrix<Scalar
   _res(1, 1) = P(1, 1) + P(2, 1) * _tmp5 + _tmp4 + _tmp5 * _tmp6;
   _res(0, 2) = _tmp3 * _tmp7;
   _res(1, 2) = _tmp6 * _tmp7;
-  _res(2, 2) = P(2, 2) * std::pow(_tmp7, Scalar(2)) + d_ang_var;
+  _res(2, 2) = P(2, 2) * (_tmp7) * (_tmp7) + d_ang_var;
 
   return _res;
 }  // NOLINT(readability/fn_size)


### PR DESCRIPTION
## Summary

- Adds a post-processing regex in `derivation_utils.py` to replace `std::pow(x, Scalar(2))` with `(x) * (x)` in SymForce-generated C++ code
- Applies the transformation to all 22 existing generated headers (98 replacements total)
- Heaviest impact in `predict_covariance.h` (23 replacements), which runs every EKF prediction step
- The one remaining `std::pow` call (exponent `-1/2` in `compute_airspeed_h.h`) is correctly left untouched

## Motivation

`std::pow(x, 2)` is a general-purpose exponentiation function. While some compilers optimize the constant-exponent-2 case to a multiply, this is not guaranteed across all toolchains and optimization levels. Replacing with direct multiplication ensures the fast path regardless of target.

## Test plan

- [ ] Verify build completes without errors
- [ ] Confirm no remaining `std::pow(x, Scalar(2))` in generated headers
- [ ] Re-run SymForce derivation to verify generator produces matching output