### PR TITLE
fix(ekf2): remove heading corrections from gravity fusion

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gravity/gravity_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gravity/gravity_fusion.cpp
@@ -110,6 +110,9 @@ void Ekf::controlGravityFusion(const imuSample &imu)
 		const bool accel_clipping = imu.delta_vel_clipping[0] || imu.delta_vel_clipping[1] || imu.delta_vel_clipping[2];
 
 		if (_control_status.flags.gravity_vector && !_aid_src_gravity.innovation_rejected && !accel_clipping) {
+			// Prevent heading corrections through gravity fusion due to correlations between tilt and heading in P
+			K(State::quat_nominal.idx + 2) = 0.f;
+
 			fused[index] = measurementUpdate(K, H,
 							 _aid_src_gravity.observation_variance[index], _aid_src_gravity.innovation[index]);
 		}


### PR DESCRIPTION
### Solved Problem
Gravity vector fusion is used to correct tilt estimates when no velocity/position measurements are available. However, due to cross-correlations between heading and tilt in the state covariance matrix (created since the attitude is obtained from gyros), tilt corrections can also affect heading. Those spurious heading corrections can be noticed when the drone is in "magless" operation (`EKF2_MAG_TYPE` = none or init).

### Solution
Force the "heading" Kalman gain to 0 when fusing gravity measurements.

