### PR TITLE
refactor(mavlink): Reword mission transfer timeout

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -567,9 +567,9 @@ MavlinkMissionManager::send()
 	} else if (_state != MAVLINK_WPM_STATE_IDLE && (_time_last_recv > 0)
 		   && hrt_elapsed_time(&_time_last_recv) > MAVLINK_MISSION_PROTOCOL_TIMEOUT_DEFAULT) {
 
-		_mavlink.send_statustext_critical("Operation timeout\t");
-		events::send(events::ID("mavlink_mission_op_timeout"), events::Log::Error,
-			     "Operation timeout, aborting transfer");
+		_mavlink.send_statustext_critical("Mission sync timeout\t");
+		events::send(events::ID("mavlink_mission_sync_timeout"), events::Log::Error,
+			     "Mission sync timeout, aborting transfer");
 
 		PX4_DEBUG("WPM: Last operation (state=%d) timed out, changing state to MAVLINK_WPM_STATE_IDLE", _state);
 


### PR DESCRIPTION
### Solved Problem
If the communicaiton link is lost, while the groundstation is trying to download the mission, and the link is not regained within 5 seconds, the transfer is aborted, and a “Operation timeout, aborting transfer” Message is displayed. This can also happen if no mission is present, as the request takes some time to process. 
Normally, this is not visible, as the link is only established AFTER that message is published - but with some exceptional timing it may be displayed in your groundstation, leading to confusion on what happend. 

### Solution
Solution: reworded “Operation timeout,aborting transfer” to “Mission sync timeout, aborting transfer"

### Changelog Entry
For release notes:
```
Bugfix: Reword Mission sync timeout

```

<img width="772" height="107" alt="image" src="https://github.com/user-attachments/assets/7351a84a-3495-4ab9-829a-f5e901470b89" />
