### PR TITLE
fix(simulation): use correlated gauss-markov noise for SIH-GPS

### DIFF
--- a/src/modules/simulation/sensor_gps_sim/SensorGpsSim.cpp
+++ b/src/modules/simulation/sensor_gps_sim/SensorGpsSim.cpp
@@ -116,11 +116,30 @@ void SensorGpsSim::Run()
 		vehicle_global_position_s gpos{};
 		_vehicle_global_position_sub.copy(&gpos);
 
-		double latitude = gpos.lat + math::degrees((double)generate_wgn() * 0.2 / CONSTANTS_RADIUS_OF_EARTH);
-		double longitude = gpos.lon + math::degrees((double)generate_wgn() * 0.2 / CONSTANTS_RADIUS_OF_EARTH);
-		double altitude = (double)(gpos.alt + (generate_wgn() * 0.5f));
+		// Correlated Markov process position noise (matching GZBridge model)
+		_gps_pos_noise_n = _pos_markov_time * _gps_pos_noise_n +
+				   _pos_random_walk * generate_wgn() * _pos_noise_amplitude;
 
-		Vector3f gps_vel = Vector3f{lpos.vx, lpos.vy, lpos.vz} + noiseGauss3f(0.06f, 0.077f, 0.158f);
+		_gps_pos_noise_e = _pos_markov_time * _gps_pos_noise_e +
+				   _pos_random_walk * generate_wgn() * _pos_noise_amplitude;
+
+		_gps_pos_noise_d = _pos_markov_time * _gps_pos_noise_d +
+				   _pos_random_walk * generate_wgn() * _pos_noise_amplitude * 1.5f;
+
+		const double latitude = gpos.lat + math::degrees((double)_gps_pos_noise_n / CONSTANTS_RADIUS_OF_EARTH);
+		const double longitude = gpos.lon + math::degrees((double)_gps_pos_noise_e / CONSTANTS_RADIUS_OF_EARTH);
+		const double altitude = (double)(gpos.alt + _gps_pos_noise_d);
+
+		_gps_vel_noise_n = _vel_markov_time * _gps_vel_noise_n +
+				   _vel_noise_density * generate_wgn() * _vel_noise_amplitude;
+
+		_gps_vel_noise_e = _vel_markov_time * _gps_vel_noise_e +
+				   _vel_noise_density * generate_wgn() * _vel_noise_amplitude;
+
+		_gps_vel_noise_d = _vel_markov_time * _gps_vel_noise_d +
+				   _vel_noise_density * generate_wgn() * _vel_noise_amplitude * 1.2f;
+
+		const Vector3f gps_vel = Vector3f{lpos.vx + _gps_vel_noise_n, lpos.vy + _gps_vel_noise_e, lpos.vz + _gps_vel_noise_d};
 
 		// device id
 		device::Device::DeviceId device_id;

--- a/src/modules/simulation/sensor_gps_sim/SensorGpsSim.hpp
+++ b/src/modules/simulation/sensor_gps_sim/SensorGpsSim.hpp
@@ -84,6 +84,22 @@ private:
 
 	perf_counter_t _loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
 
+	// GPS Markov process noise state
+	float _gps_pos_noise_n{0.0f};
+	float _gps_pos_noise_e{0.0f};
+	float _gps_pos_noise_d{0.0f};
+	float _gps_vel_noise_n{0.0f};
+	float _gps_vel_noise_e{0.0f};
+	float _gps_vel_noise_d{0.0f};
+
+	// Gauss-Markov noise parameters, rate-corrected from GZBridge (30 Hz) to SIH (8 Hz)
+	static constexpr float _pos_noise_amplitude{0.8f};
+	static constexpr float _pos_random_walk{0.02f};
+	static constexpr float _pos_markov_time{0.76f};
+	static constexpr float _vel_noise_amplitude{0.05f};
+	static constexpr float _vel_noise_density{0.4f};
+	static constexpr float _vel_markov_time{0.54f};
+
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::SIM_GPS_USED>) _sim_gps_used
 	)


### PR DESCRIPTION
### Solved Problem

Currently, the SIH GPS noise model used uncorrelated white noise for position and velocity. The white noise model produces sample-to-sample jumps that are huge compared to correlated Markov-Gauss process noise, which looks much more like slow drifts.

### Solution

Replace the white noise GPS error model in SensorGpsSim with a Gauss-Markov process matching the behavior of the GZBridge model used when simulated in GZ (new gazebo). Since GZBridge applies its Markov coefficients per-sample at 30 Hz and SensorGpsSim runs at 8 Hz, the coefficients are rate-corrected to produce the same continuous-time correlation. See https://github.com/PX4/PX4-Autopilot/pull/24421

**Adjust decay coefficients**
In GZBridge the effective position decay is 0.95 - 0.02 = 0.93 per step at 30 Hz.

To match this at 8 Hz:
`0.93 ^ (30/8) ≈ 0.76`

Same for velocity:
`0.85 ^ (30/8) ≈ 0.54`

**adjust variance (brownian bridge)**
```
scale = (30/8)^0.5 = 1.936
pos_random_walk: 0.01 × 1.936 ≈ 0.02
vel_noise_density: 0.2 × 1.936 ≈ 0.4
```

### Test coverage
Compared GZ output to SIH output.

left: GZ, right: SIH
<img width="3840" height="2160" alt="Screenshot from 2026-03-09 16-24-08" src="https://github.com/user-attachments/assets/6ff92337-5e5e-4161-92ba-fc9cd3341e78" />
