### PR TITLE
fix(navigator): fix bug in DO_CHANGE_ALTITUDE 

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -461,12 +461,6 @@ void Navigator::run()
 					// set the altitude corresponding to command
 					rep->current.alt = PX4_ISFINITE(cmd.param1) ? cmd.param1 : get_global_position()->alt;
 
-					if (_vstatus.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
-					    && (get_position_setpoint_triplet()->current.type != position_setpoint_s::SETPOINT_TYPE_TAKEOFF)) {
-
-						preproject_stop_point(rep->current.lat, rep->current.lon);
-					}
-
 					if (PX4_ISFINITE(curr->current.loiter_radius) && curr->current.loiter_radius > FLT_EPSILON) {
 						rep->current.loiter_radius = curr->current.loiter_radius;
 


### PR DESCRIPTION
Solved Problem
@Nathaniel-hl   We Fixes the issue:https://github.com/PX4/PX4-Autopilot/issues/26670

Bug Impact / Safety Hazards
1. Base Hazard: Unintended Horizontal Braking (Contradicting Design)
The code explicitly states its intention to maintain the current horizontal position: // Position is not changing, thus we keep the setpoint.
However, for rotary-wing vehicles, it immediately calls preproject_stop_point(rep->current.lat, rep->current.lon). This function calculates a stopping waypoint based on the vehicle's instantaneous velocity vector and forcibly overwrites the intended X/Y setpoint.
2. Escalated Hazard: Tangential Flyaway during Circular Motion (Orbit)
The safety risk becomes critical when the vehicle is executing a circular movement (e.g., Orbiting a point of interest).
Expected Behavior: The drone should purely adjust its altitude while seamlessly continuing its orbit around the original center point.
Safety Risk: The drone to violently break out of its intended curve. In confined spaces or near structures, this sudden and unpredictable tangential deviation will likely lead to catastrophic collisions or geofence breaches.

Solution
Remove the unconditional call to [preproject_stop_point()](https://github.com/PX4/PX4-Autopilot/blob/377bec1e8544ab11b1706026387c30b772e71616/src/modules/navigator/navigator_main.cpp#L464-L469) in the
VEHICLE_CMD_DO_CHANGE_ALTITUDE handler for multirotors.

The code comment at line 420 explicitly states [navigator_main.cpp:L420](https://github.com/PX4/PX4-Autopilot/blob/377bec1e8544ab11b1706026387c30b772e71616/src/modules/navigator/navigator_main.cpp#L420-L421):

A VEHICLE_CMD_DO_CHANGE_ALTITUDE has the exact same effect as a
VEHICLE_CMD_DO_REPOSITION with only the altitude field populated

However, the implementation unconditionally called [preproject_stop_point()](https://github.com/PX4/PX4-Autopilot/blob/377bec1e8544ab11b1706026387c30b772e71616/src/modules/navigator/navigator_main.cpp#L464-L469),
which overwrites the preserved horizontal setpoint (lat/lon) with a braking
point near the vehicle's current position. This causes the drone to abandon
any ongoing horizontal trajectory and hover in place before changing altitude.

In contrast, DO_REPOSITION with only the altitude field populated enters
the only_alt_change_requested branch and does not call
'preproject_stop_point()'— the horizontal setpoint is genuinely preserved.

The fix removes the 5-line 'preproject_stop_point()' block so that
DO_CHANGE_ALTITUDE now truly matches the behavior described in the comment
and the equivalent DO_REPOSITION code path.

Test Evidence
[test15_before.txt](https://github.com/user-attachments/files/25859319/test15_before.txt)

Final (concurrent cmds) -> north: 0.00 m, east: -0.02 m, alt: 19.83 m
Concurrent commands result classification: c_horizontal_overwritten

[test15_after.txt](https://github.com/user-attachments/files/25859442/test15_after.txt)

Final (concurrent cmds) -> north: 60.01 m, east: -0.02 m, alt: 19.95 m
Concurrent commands result classification: a_both_executed

Changelog Entry
Fixed: VEHICLE_CMD_DO_CHANGE_ALTITUDE no longer resets the horizontal position, allowing the vehicle to maintain its trajectory while changing altitude.