### PR TITLE
build(actions): Crowdin download to a conventional commit

### DIFF
--- a/.github/workflows/docs_crowdin_download.yml
+++ b/.github/workflows/docs_crowdin_download.yml
@@ -34,13 +34,13 @@ jobs:
           upload_sources: false
           upload_translations: false
           download_translations: true
-          commit_message: New Crowdin translations - ${{ matrix.lc }}
+          commit_message: 'docs(i18n): PX4 guide translations (Crowdin) - ${{ matrix.lc }}'
           localization_branch_name: l10n_crowdin_docs_translations_${{ matrix.lc }}
           crowdin_branch_name: main
           create_pull_request: true
           pull_request_base_branch_name: 'main'
-          pull_request_title: New PX4 guide translations (Crowdin) - ${{ matrix.lc }}
-          pull_request_body: 'New PX4 guide Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action) for ${{ matrix.lc }}'
+          pull_request_title: 'docs(i18n): PX4 guide translations (Crowdin) - ${{ matrix.lc }}'
+          pull_request_body: 'docs(i18n): PX4 guide Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action) for ${{ matrix.lc }}'
           pull_request_labels: 'Documentation 📑'
           pull_request_reviewers: hamishwillee
           download_language: ${{ matrix.lc }}


### PR DESCRIPTION
Crowdin is creating a commit that no longer matches PX4 conventions for naming. This updates the workflow to hopefully fix that