### PR TITLE
fix(ekf2): fuse airspeed in both transition if above EKF2_ARSP_THR

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/airspeed/airspeed_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/airspeed/airspeed_fusion.cpp
@@ -94,7 +94,7 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 		updateAirspeed(airspeed_sample, _aid_src_airspeed);
 
 		const bool continuing_conditions_passing = _control_status.flags.in_air && (_control_status.flags.fixed_wing
-				|| _control_status.flags.in_transition_to_fw)
+				|| _control_status.flags.in_transition)
 				&& !_control_status.flags.fake_pos;
 
 		const bool is_airspeed_significant = airspeed_sample.true_airspeed > _params.ekf2_arsp_thr;

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -268,7 +268,7 @@ struct systemFlagUpdate {
 	bool is_fixed_wing{false};
 	bool gnd_effect{false};
 	bool constant_pos{false};
-	bool in_transition_to_fw{false};
+	bool in_transition{false};
 };
 
 struct parameters {
@@ -593,7 +593,7 @@ uint64_t gnss_fault              :
 		uint64_t yaw_manual              : 1; ///< 46 - true if yaw has been reset manually
 uint64_t gnss_hgt_fault              :
 		1; ///< 47 - true if GNSS measurements (alt) have been declared faulty and are no longer used
-		uint64_t in_transition_to_fw 	 : 1; ///< 48 - true if the vehicle is in transition to fw
+		uint64_t in_transition 	         : 1; ///< 48 - true if the vehicle is in vtol transition
 
 	} flags;
 	uint64_t value;

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -58,7 +58,7 @@ void Ekf::controlFusionModes(const imuSample &imu_delayed)
 			set_in_air_status(system_flags_delayed.in_air);
 
 			set_is_fixed_wing(system_flags_delayed.is_fixed_wing);
-			set_in_transition_to_fw(system_flags_delayed.in_transition_to_fw);
+			set_in_transition(system_flags_delayed.in_transition);
 
 			if (system_flags_delayed.gnd_effect) {
 				set_gnd_effect();

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -197,7 +197,7 @@ public:
 	// set vehicle is fixed wing status
 	void set_is_fixed_wing(bool is_fixed_wing) { _control_status.flags.fixed_wing = is_fixed_wing; }
 
-	void set_in_transition_to_fw(bool in_transition) { _control_status.flags.in_transition_to_fw = in_transition; }
+	void set_in_transition(bool in_transition) { _control_status.flags.in_transition = in_transition; }
 
 	// set flag if static pressure rise due to ground effect is expected
 	// use _params.ekf2_gnd_eff_dz to adjust for expected rise in static pressure

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2608,7 +2608,7 @@ void EKF2::UpdateSystemFlagsSample(ekf2_timestamps_s &ekf2_timestamps)
 
 			// let the EKF know if the vehicle motion is that of a fixed wing (forward flight only relative to wind)
 			flags.is_fixed_wing = (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING);
-			flags.in_transition_to_fw = vehicle_status.in_transition_to_fw;
+			flags.in_transition = vehicle_status.in_transition_mode;
 
 #if defined(CONFIG_EKF2_SIDESLIP)
 


### PR DESCRIPTION
### Solved Problem

In backtransitions, sometimes OF sensors still produce erratic data (combination of low light, low texture, high ground speed). Currently we stop fusing airspeed as soon as the backtransition is initiated - thus (if no GNSS) we immediately rely on the OF and have to reset to a potentially nonsensical velocity. 

Here is a log from a standard VTOL whose OF reported very noisy measurements averaging to about zero, so it did not slow down and crashed. We see the OF data becomes accurate about 5s after initiating backtransition, so initially relying more on airspeed would likely have saved the day. 

<img width="1288" height="1925" alt="image" src="https://github.com/user-attachments/assets/6a9fe29f-5669-421a-b4ae-a0956b98daf1" />


### Solution
Rather than only the front transition, fuse airspeed in either transition, if above `EKF2_ARSP_THR`. 

### Changelog entry

```
Fix: EKF2: fuse airspeed in both transition if above EKF2_ARSP_THR to gain robustness against inaccurate OF
```
