### PR TITLE
feat(px4io): Enable pwm center for PWM MAIN by IO processor

### DIFF
--- a/src/drivers/px4io/module.yaml
+++ b/src/drivers/px4io/module.yaml
@@ -9,6 +9,7 @@ actuator_output:
       standard_params:
         disarmed: { min: 800, max: 2200, default: 1000 }
         min: { min: 800, max: 1400, default: 1000 }
+        center: { min: 800, max: 2200}
         max: { min: 1600, max: 2200, default: 2000 }
         failsafe: { min: 800, max: 2200 }
       pwm_timer_param:


### PR DESCRIPTION
### Solved Problem
The PWM Center support introduced in https://github.com/PX4/PX4-Autopilot/pull/25897 was missing for all outputs powered by the px4io driver. 
This solves https://github.com/PX4/PX4-Autopilot/issues/26710, as the docs are generated from the px4_fmu_v5, which uses the px4io driver. 

### Changelog Entry
For release notes:
```
Feature/Bugfix: Enable PWM Center support on IO processor
Documentation: Fixes missing PWM_MAIN_CENTx params in reference list
```


### Test coverage
Tested on Pixhawk 4

### Context
<img width="633" height="256" alt="image" src="https://github.com/user-attachments/assets/a52602c8-a5c7-4eb7-8e34-087e15c95cfd" />
