### PR TITLE
fix(ci): correct metadata artifact paths in package_build_artifacts.sh

### DIFF
--- a/Tools/ci/package_build_artifacts.sh
+++ b/Tools/ci/package_build_artifacts.sh
@@ -6,32 +6,42 @@ cp **/**/*.elf artifacts/ 2>/dev/null || true
 for build_dir_path in build/*/ ; do
   build_dir_path=${build_dir_path::${#build_dir_path}-1}
   build_dir=${build_dir_path#*/}
-  mkdir artifacts/$build_dir
+  mkdir -p artifacts/$build_dir
   find artifacts/ -maxdepth 1 -type f -name "*$build_dir*"
-  # Airframe
-  cp $build_dir_path/airframes.xml artifacts/$build_dir/
+  # Airframe (NuttX: build root, SITL: docs/ subdirectory)
+  airframes_src=""
+  if [ -f "$build_dir_path/airframes.xml" ]; then
+    airframes_src="$build_dir_path/airframes.xml"
+  elif [ -f "$build_dir_path/docs/airframes.xml" ]; then
+    airframes_src="$build_dir_path/docs/airframes.xml"
+  fi
+  if [ -n "$airframes_src" ]; then
+    cp "$airframes_src" "artifacts/$build_dir/"
+  fi
   # Parameters
-  cp $build_dir_path/parameters.xml artifacts/$build_dir/
-  cp $build_dir_path/parameters.json artifacts/$build_dir/
-  cp $build_dir_path/parameters.json.xz artifacts/$build_dir/
+  cp $build_dir_path/parameters.xml artifacts/$build_dir/ 2>/dev/null || true
+  cp $build_dir_path/parameters.json artifacts/$build_dir/ 2>/dev/null || true
+  cp $build_dir_path/parameters.json.xz artifacts/$build_dir/ 2>/dev/null || true
   # Actuators
-  cp $build_dir_path/actuators.json artifacts/$build_dir/
-  cp $build_dir_path/actuators.json.xz artifacts/$build_dir/
+  cp $build_dir_path/actuators.json artifacts/$build_dir/ 2>/dev/null || true
+  cp $build_dir_path/actuators.json.xz artifacts/$build_dir/ 2>/dev/null || true
   # Events
-  cp $build_dir_path/events/all_events.json.xz artifacts/$build_dir/
-  # ROS 2 msgs
-  cp $build_dir_path/events/all_events.json.xz artifacts/$build_dir/
-  # Module Docs
+  mkdir -p artifacts/$build_dir/events/
+  cp $build_dir_path/events/all_events.json.xz artifacts/$build_dir/events/ 2>/dev/null || true
   ls -la artifacts/$build_dir
   echo "----------"
 done
 
 if [ -d artifacts/px4_sitl_default ]; then
-  # general metadata
-  mkdir artifacts/_general/
-  cp artifacts/px4_sitl_default/airframes.xml artifacts/_general/
+  # general metadata (used by Flight Review and other downstream consumers)
+  mkdir -p artifacts/_general/
   # Airframe
-  cp artifacts/px4_sitl_default/airframes.xml artifacts/_general/
+  if [ -f artifacts/px4_sitl_default/airframes.xml ]; then
+    cp artifacts/px4_sitl_default/airframes.xml artifacts/_general/
+  else
+    echo "Error: expected 'artifacts/px4_sitl_default/airframes.xml' not found." >&2
+    exit 1
+  fi
   # Parameters
   cp artifacts/px4_sitl_default/parameters.xml artifacts/_general/
   cp artifacts/px4_sitl_default/parameters.json artifacts/_general/
@@ -40,9 +50,11 @@ if [ -d artifacts/px4_sitl_default ]; then
   cp artifacts/px4_sitl_default/actuators.json artifacts/_general/
   cp artifacts/px4_sitl_default/actuators.json.xz artifacts/_general/
   # Events
-  cp artifacts/px4_sitl_default/events/all_events.json.xz artifacts/_general/
-  # ROS 2 msgs
-  cp artifacts/px4_sitl_default/events/all_events.json.xz artifacts/_general/
-  # Module Docs
+  if [ -f artifacts/px4_sitl_default/events/all_events.json.xz ]; then
+    cp artifacts/px4_sitl_default/events/all_events.json.xz artifacts/_general/
+  else
+    echo "Error: expected 'artifacts/px4_sitl_default/events/all_events.json.xz' not found." >&2
+    exit 1
+  fi
   ls -la artifacts/_general/
 fi


### PR DESCRIPTION
Fixes #26713

`airframes.xml` and `all_events.json.xz` on the `px4-travis` S3 bucket have been stale since October 2025. Flight Review depends on these for airframe names and event descriptions.

The paths in `package_build_artifacts.sh` broke when the workflow moved from `metadata.yml` to `build_all_targets.yml`:

- **airframes.xml**: SITL builds put this under `docs/`, not at the build root (only NuttX does that). Added fallback to check both locations.
- **all_events.json.xz**: Was copied flat into `artifacts/$build_dir/` but the `_general` section expected it under `events/`. Now preserves the subdirectory so the copy actually finds the file.
- Removed duplicate `cp` lines that were misleadingly commented as "ROS 2 msgs".

Also manually uploaded fresh metadata to S3 to unblock Flight Review in the meantime.