### PR TITLE
docs(ekf2): clarify EKF2_HGT_REF param description

### DIFF
--- a/src/modules/ekf2/module.yaml
+++ b/src/modules/ekf2/module.yaml
@@ -92,6 +92,7 @@ parameters:
           by this parameter. The range sensor and vision options should only be used
           when for operation over a flat surface as the local NED origin will move
           up and down with ground level.
+
           If GPS is set as reference and EKF2_GPS_CTRL is not 0, the GPS altitude is
           still used to initiaize the bias of the other height sensors, regardless of
           the altitude fusion bit in EKF2_GPS_CTRL.


### PR DESCRIPTION
To me it was not obvious that with `EKF2_GPS_CTRL=0` this altitude initialisation based on GPS again does not apply.

Double newline to cause separate paragraph, should work as of https://github.com/PX4/PX4-Autopilot/pull/26656