### PR TITLE
fix(voxl2): Added explicit port identifier on gps start command

### DIFF
--- a/boards/modalai/voxl2/target/voxl-px4-start
+++ b/boards/modalai/voxl2/target/voxl-px4-start
@@ -143,7 +143,7 @@ if [ "$GPS" != "NONE" ]; then
     if [ "$PLATFORM" == "M0197" ]; then
 	gps start -d /dev/ttyHS7
     else
-	qshell gps start
+	qshell gps start -d 6
     fi
 fi
 


### PR DESCRIPTION
VOXL2 relied on a default UART port number being specified got the GPS driver but now that fails. This PR adds an explicit port name to prevent that failure.

Tested on VOXL2
