### PR TITLE
fix(ci): remove deprecated v1 cache API from container build

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -130,8 +130,8 @@ jobs:
           load: false
           push: ${{ startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_to_registry) }}
           provenance: false
-          cache-from: type=gha,version=1,scope=${{ matrix.arch }}
-          cache-to: type=gha,version=1,mode=max,scope=${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
   deploy:
     name: Deploy To Registry


### PR DESCRIPTION
## Summary

- Remove `version=1` from buildx GHA cache parameters in `dev_container.yml`
- Fixes container build failures on main since March 12

## Root Cause

RunsOn v2.12.0 (released March 6, 2026) removed v1 cache toolkit support:

> "Removed outdated v1 version of cache toolkit support. This is no longer used by GitHub anyway."

PX4's container build explicitly pinned `version=1` in the buildx cache config. The RunsOn Magic Cache proxy no longer serves v1 endpoints, returning 404 HTML pages that buildkit can't JSON-parse:

```
#4 importing cache manifest from gha:1461918403558416389
#4 ERROR: failed to parse error response 404: 404 page not found
: invalid character 'p' after top-level value
```

GitHub also sunset their own Cache API v1 in April 2025, so this parameter was outdated regardless.

## Fix

Remove `version=1` from both `cache-from` and `cache-to`. Without an explicit version, buildkit auto-detects v2.

First build after this change will have a cold cache (one-time slower build).

## Test plan

- [ ] Container build workflow passes on this PR
- [ ] Verify cache populates on subsequent main branch builds


🤖 Generated with [Claude Code](https://claude.com/claude-code)