### PR TITLE
fix(ci): remove deprecated v1 cache API from container build

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -130,8 +130,8 @@ jobs:
           load: false
           push: ${{ startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_to_registry) }}
           provenance: false
-          cache-from: type=gha,version=1
-          cache-to: type=gha,version=1,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   deploy:
     name: Deploy To Registry


### PR DESCRIPTION
## Summary

- Backport of #26742 to `release/1.17`
- Remove `version=1` from buildx GHA cache parameters in `dev_container.yml`
- Fixes container build failure for `v1.17.0-rc2` tag

## Root Cause

RunsOn v2.12.0 (March 6, 2026) removed v1 cache toolkit support. The `v1.17.0-rc2` container build failed because of this.

Verified working on main via #26742.

## Test plan

- [x] Container build workflow passes on this PR


🤖 Generated with [Claude Code](https://claude.com/claude-code)