### PR TITLE
fix(mc_rate_control): remove redundant uORB copy in rate setpoint path

### DIFF
--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -179,12 +179,10 @@ MulticopterRateControl::Run()
 			}
 
 		} else if (_vehicle_rates_setpoint_sub.update(&vehicle_rates_setpoint)) {
-			if (_vehicle_rates_setpoint_sub.copy(&vehicle_rates_setpoint)) {
-				_rates_setpoint(0) = PX4_ISFINITE(vehicle_rates_setpoint.roll)  ? vehicle_rates_setpoint.roll  : rates(0);
-				_rates_setpoint(1) = PX4_ISFINITE(vehicle_rates_setpoint.pitch) ? vehicle_rates_setpoint.pitch : rates(1);
-				_rates_setpoint(2) = PX4_ISFINITE(vehicle_rates_setpoint.yaw)   ? vehicle_rates_setpoint.yaw   : rates(2);
-				_thrust_setpoint = Vector3f(vehicle_rates_setpoint.thrust_body);
-			}
+			_rates_setpoint(0) = PX4_ISFINITE(vehicle_rates_setpoint.roll)  ? vehicle_rates_setpoint.roll  : rates(0);
+			_rates_setpoint(1) = PX4_ISFINITE(vehicle_rates_setpoint.pitch) ? vehicle_rates_setpoint.pitch : rates(1);
+			_rates_setpoint(2) = PX4_ISFINITE(vehicle_rates_setpoint.yaw)   ? vehicle_rates_setpoint.yaw   : rates(2);
+			_thrust_setpoint = Vector3f(vehicle_rates_setpoint.thrust_body);
 		}
 
 		// run the rate controller


### PR DESCRIPTION
## Summary
- Remove redundant `Subscription::copy()` call immediately after `Subscription::update()` in the rate setpoint handling path
- `update(dst)` already copies data into the destination buffer via `orb_data_copy`, making the subsequent `copy()` an unnecessary duplicate memcpy every cycle on the rate control loop