### PR TITLE
fix(uavcan): silence DroneCAN DSDL compiler build warnings

### DIFF
--- a/src/drivers/uavcan/libdronecan/libuavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/libdronecan/libuavcan/CMakeLists.txt
@@ -21,7 +21,10 @@ endif ()
 
 project(libuavcan)
 
-find_package(PythonInterp)
+if(NOT PYTHON_EXECUTABLE)
+    find_package(Python3 COMPONENTS Interpreter)
+    set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(COMPILER_IS_GCC_COMPATIBLE 1)

--- a/src/drivers/uavcan/libdronecan/libuavcan/dsdl_compiler/libuavcan_dsdl_compiler/pyratemp.py
+++ b/src/drivers/uavcan/libdronecan/libuavcan/dsdl_compiler/libuavcan_dsdl_compiler/pyratemp.py
@@ -278,7 +278,7 @@ def escape(s, format=HTML):
 
           - `NONE`:  nothing is replaced
           - `HTML`:  replace &<>'" by &...;
-          - `LATEX`: replace \#$%&_{}~^
+          - `LATEX`: replace \\#$%&_{}~^
           - `MAIL_HEADER`: escape non-ASCII mail-header-contents
     :Returns:
         the escaped string in unicode


### PR DESCRIPTION
## Summary

Fixes two sources of build noise from the DroneCAN DSDL compiler that produce ~56 warnings per CI job.

### 1. Python `DeprecationWarning`: invalid escape sequence `\#`

`pyratemp.py` (the template engine used by the DSDL compiler) has a docstring on line 281 containing a literal `\#`. In Python 3.12+ this is a `DeprecationWarning` and will become a `SyntaxError` in a future Python release. Every invocation of the DSDL compiler prints:

```
pyratemp.py:273: DeprecationWarning: invalid escape sequence '\#'
```

Fix: escape the backslash in the docstring (`\\#`).

### 2. CMake `FindPythonInterp` deprecation (CMP0148)

`libuavcan/CMakeLists.txt` calls `find_package(PythonInterp)` which was deprecated in CMake 3.12 and removed by policy CMP0148. Every board target that builds DroneCAN emits:

```
CMake Warning (dev) ... FindPythonInterp ... has been removed by policy CMP0148
```

Fix: when building under PX4 (where the root CMakeLists.txt already sets `PYTHON_EXECUTABLE`), skip the find entirely. When building standalone, use the modern `find_package(Python3)` instead.

Closes #26500