### PR TITLE
fix(npfg): use NFPG_DAMPING and NPFG_PERIOD to calculate directional p gain

### DIFF
--- a/src/lib/npfg/AirspeedDirectionController.hpp
+++ b/src/lib/npfg/AirspeedDirectionController.hpp
@@ -59,13 +59,15 @@
 #ifndef PX4_AIRSPEEDDIRECTIONONTROLLER_HPP
 #define PX4_AIRSPEEDDIRECTIONONTROLLER_HPP
 
+#include <matrix/math.hpp>
+#include <lib/mathlib/mathlib.h>
+
 class AirspeedDirectionController
 {
 public:
-
 	AirspeedDirectionController();
 
-
+	void setPGainFromPeriodAndDamping(float damping, float period) {p_gain_ = 4.f * M_PI_F * damping / math::max(period, FLT_EPSILON);}
 	float controlHeading(const float heading_sp, const float heading, const float airspeed) const;
 
 private:

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -118,6 +118,8 @@ FwLateralLongitudinalControl::parameters_update()
 
 	_tecs_alt_time_const_slew_rate.setSlewRate(TECS_ALT_TIME_CONST_SLEW_RATE);
 	_tecs_alt_time_const_slew_rate.setForcedValue(_param_fw_t_h_error_tc.get() * _param_fw_thrtc_sc.get());
+
+	_airspeed_direction_control.setPGainFromPeriodAndDamping(_param_npfg_damping.get(), _param_npfg_period.get());
 }
 
 void FwLateralLongitudinalControl::Run()

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
@@ -171,7 +171,9 @@ private:
 		(ParamFloat<px4::params::FW_LND_THRTC_SC>) _param_fw_thrtc_sc,
 		(ParamFloat<px4::params::FW_T_THR_LOW_HGT>) _param_fw_t_thr_low_hgt,
 		(ParamFloat<px4::params::FW_WIND_ARSP_SC>) _param_fw_wind_arsp_sc,
-		(ParamFloat<px4::params::FW_GND_SPD_MIN>) _param_fw_gnd_spd_min
+		(ParamFloat<px4::params::FW_GND_SPD_MIN>) _param_fw_gnd_spd_min,
+		(ParamFloat<px4::params::NPFG_DAMPING>) _param_npfg_damping,
+		(ParamFloat<px4::params::NPFG_PERIOD>) _param_npfg_period
 	)
 
 	hrt_abstime _last_time_loop_ran{};


### PR DESCRIPTION

### Solved Problem
Regression from the [rework](https://github.com/PX4/PX4-Autopilot/pull/24056) last year: we didn't re-implement the calculation of the P gain from `NPFG_DAMPING` and `NPFG_PERIOD`, as it was previously done [here](https://github.com/PX4/PX4-Autopilot/blob/85df8c2281c2466b30a121b22b0bf33dc69bcfe4/src/lib/npfg/npfg.cpp#L278). This leads to us currently always using a gain of 0.8885 (which corresponds to the parameter defaults of `NPFG_DAMPING` and `NPFG_PERIOD`). 
`NPFG_PERIOD` is actually not used anywhere in the code base atm. It being the main tuning knob for FW guidance, this is obviously a big concern. Especially larger planes are currently flying with a too low `NPFG_PERIOD` (as if it would be set to 10).

### Solution
Add setter function.

### Changelog Entry
For release notes:
```
Bugfix: fix(npfg): use NFPG_DAMPING and NPFG_PERIOD to calculate directional p gain
```

### Test coverage
SITL tested.

### Context
Initializing variables with "reasonable" settings is dangerous, as it makes it easy to miss that the correct way of setting them (usually form PX4 params). This bug here is a perfect example. 

-->
