### PR TITLE
feat(drivers): silence TMP102 driver startup

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -238,7 +238,7 @@ then
 fi
 
 # Start TMP102 temperature sensor
-if param compare SENS_EN_TMP102 1
+if param compare -s SENS_EN_TMP102 1
 then
 	tmp102 start -X
 fi


### PR DESCRIPTION
### Solved Problem
On every boot of NOT ark_jetson, you get this warning: 
ERROR [param] Parameter SENS_EN_TMP102 not found

### Solution
Silence the warnig, like it is done for most other startups. 

### Changelog Entry
For release notes:
```
Bugfix: Silence TMP102 driver

```

