### PR TITLE
fix(commander): decouple heading preflight check from attitude mode-req

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -136,15 +136,23 @@ void EstimatorChecks::checkAndReport(const Context &context, Report &reporter)
 void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &reporter,
 		const estimator_status_s &estimator_status, NavModes required_groups)
 {
+	// Heading is required to arm for all modes that need any form of local position, plus FW AUTO_TAKEOFF
+	const NavModes heading_required_groups = (NavModes)(
+				reporter.failsafeFlags().mode_req_local_position |
+				reporter.failsafeFlags().mode_req_local_position_relaxed |
+				(1u << vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF));
+
 	if (!context.isArmed() && estimator_status.pre_flt_fail_innov_heading) {
 		/* EVENT
+		 * @description
+		 * Recalibrate compass or perform manual heading reset.
 		 */
-		reporter.armingCheckFailure(required_groups, health_component_t::local_position_estimate,
+		reporter.armingCheckFailure(heading_required_groups, health_component_t::local_position_estimate,
 					    events::ID("check_estimator_heading_not_stable"),
-					    events::Log::Error, "Heading estimate not stable");
+					    events::Log::Error, "Heading estimate invalid");
 
 		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: heading estimate not stable");
+			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: heading estimate invalid");
 		}
 
 	} else if (!context.isArmed() && estimator_status.pre_flt_fail_innov_vel_horiz) {


### PR DESCRIPTION
## Solved Problem

The heading preflight check (`pre_flt_fail_innov_heading`) was reported against `mode_req_attitude`, blocking arming in all attitude-requiring modes (including ALTCTL, STAB) when heading was unavailable or unstable. This prevented magless setups from arming even in altitude mode, where heading is not needed.

Context: #26596 correctly made the heading preflight check report the actual heading state (including `!yaw_align`), but the failure was scoped too broadly to all attitude modes.

## Solution

Report the heading preflight failure against only the modes that actually need heading for navigation, instead of all attitude-requiring modes.

Heading is kept as a **preflight arming check only** and not a runtime mode requirement. Using it as a full mode requirement would cause in-flight mode degradation based on `pre_flt_fail_innov_heading`, which uses a preflight innovation threshold that is too sensitive for in-flight use.

### Mode requirements matrix

Heading requirement (bold) compared against existing mode requirements:

| Mode | ang_vel | attitude | local_alt | local_pos | local_pos_rlx | global_pos | global_pos_rlx |
|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
| MANUAL | | | | | | | |
| ALTCTL | x | x | x | | | | |
| ALTITUDE_CRUISE | x | x | x | | | | |
| ACRO | x | | | | | | |
| DESCEND | x | x | | | | | |
| TERMINATION | | | | | | | |
| STAB | x | x | | | | | |
| OFFBOARD | x | x | | | | | |
| | | | | | | | |
| POSCTL | x | x | x | | x | | |
| POSITION_SLOW | x | x | x | | x | | |
| AUTO_MISSION | x | x | x | y | z | y | z |
| AUTO_LOITER | x | x | x | y | z | y | z |
| AUTO_RTL | x | x | x | y | z | y | z |
| AUTO_TAKEOFF | x | x | x | y | | | |
| AUTO_LAND | x | x | x | | x | | |
| AUTO_FOLLOW_TARGET | x | x | x | x | | | |
| AUTO_PRECLAND | x | x | x | x | | | |
| ORBIT | x | x | x | x | | | |
| AUTO_VTOL_TAKEOFF | x | x | x | y | z | | |

y = non-FW only, z = FW only

The set of modes that require heading maps almost exactly to the union of `mode_req_local_position | mode_req_local_position_relaxed` — every mode that needs any form of position also needs heading. The only exception is FW AUTO_TAKEOFF, which doesn't require local position (removed in #25083 to not degrade mode) but still needs heading for proper performance. This is handled by explicitly adding the `NAVIGATION_STATE_AUTO_TAKEOFF` bit.

### Alternatives considered

1. Full mode requirement: Overdoing it, `pre_flt_fail_innov_heading` uses a preflight threshold too sensitive for in-flight use, risking false mode degradation.
2. `mode_req_heading` field without `heading_invalid` (arming-only): Still requires a new field in `FailsafeFlags.msg` and per-mode entries in `mode_requirements.cpp`. This would act as a m`mode_requirement_on_arm` which is also unnecessary since the bitmask can be derived from existing position requirements.

## Changelog Entry

```
Bugfix: Commander: heading preflight check no longer blocks arming in altitude/stabilize modes on magless setups
```

## Test coverage
SITL:
- Verify magless setup can arm in ALTCTL/STAB but not in POSCTL or AUTO modes without heading.
- Verify that with a valid heading source, arming in POSCTL and AUTO modes works as before.
