### PR TITLE
fix(flight_mode_manager): remove optical flow velocity constraint in manual modes

### DIFF
--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
@@ -63,24 +63,6 @@ bool FlightTaskManualAcceleration::update()
 	setMaxDistanceToGround(vehicle_local_pos.hagl_max_xy);
 	bool ret = FlightTaskManualAltitudeSmoothVel::update();
 
-	float max_hagl_ratio = 0.0f;
-
-	if (PX4_ISFINITE(vehicle_local_pos.hagl_max_xy) && vehicle_local_pos.hagl_max_xy > FLT_EPSILON) {
-		max_hagl_ratio = (vehicle_local_pos.dist_bottom) / vehicle_local_pos.hagl_max_xy;
-	}
-
-	// limit horizontal velocity near max hagl to decrease chance of larger gound distance jumps
-	static constexpr float factor_threshold = 0.8f; // threshold ratio of max_hagl
-	static constexpr float min_vel = 2.f; // minimum max-velocity near max_hagl
-
-	if (max_hagl_ratio > factor_threshold) {
-		const float vxy_max = math::min(vehicle_local_pos.vxy_max, _param_mpc_vel_manual.get());
-		_stick_acceleration_xy.setVelocityConstraint(interpolate(max_hagl_ratio, factor_threshold, 1.f, vxy_max, min_vel));
-
-	} else if (PX4_ISFINITE(vehicle_local_pos.vxy_max)) {
-		_stick_acceleration_xy.setVelocityConstraint(vehicle_local_pos.vxy_max);
-	}
-
 	_stick_acceleration_xy.generateSetpoints(_sticks.getPitchRollExpo(), _yaw, _yaw_setpoint, _position,
 			_velocity_setpoint_feedback.xy(), _deltatime);
 	_stick_acceleration_xy.getSetpoints(_position_setpoint, _velocity_setpoint, _acceleration_setpoint);

--- a/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -79,14 +79,7 @@ void FlightTaskManualPosition::_scaleSticks()
 		stick_xy(0) *= _param_mpc_vel_man_back.get() / _param_mpc_vel_manual.get();
 	}
 
-	const float max_speed_from_estimator = _sub_vehicle_local_position.get().vxy_max;
-
 	float velocity_scale = _param_mpc_vel_manual.get();
-
-	if (PX4_ISFINITE(max_speed_from_estimator)) {
-		// Constrain with optical flow limit but leave 0.3 m/s for repositioning
-		velocity_scale = math::constrain(velocity_scale, 0.3f, max_speed_from_estimator);
-	}
 
 	// scale velocity to its maximum limits
 	Vector2f vel_sp_xy = stick_xy * velocity_scale;


### PR DESCRIPTION
When relying exclusively on optical flow, the EKF publishes a `vxy_max` limit proportional to altitude (`0.5 * max_flow_rate * height`). Both `ManualPosition` and `ManualAcceleration` flight tasks used this to scale down stick sensitivity, compressing the stick-to-velocity mapping into a smaller range. This made the vehicle feel sluggish and difficult to control, particularly at low altitudes where the limit is most restrictive (e.g. at 0.3m with `SENS_FLOW_MAXR=8`, the velocity scale is only 1.2 m/s).

The `vxy_max` velocity limit is still enforced via `MulticopterPositionControl` for all flight modes, so the pilot cannot exceed the flow sensor envelope. These changes only remove the stick scaling that degraded control feel.

### Changes
- `FlightTaskManualPosition`: remove `vxy_max` clamping of velocity scale
- `FlightTaskManualAcceleration`: remove `vxy_max` velocity constraint and hagl-ratio velocity interpolation; altitude constraint (`setMaxDistanceToGround`) is preserved