### PR TITLE
fix(docs): fix Python 3.8 SyntaxError in generate_msg_docs.py

### DIFF
--- a/Tools/msg/generate_msg_docs.py
+++ b/Tools/msg/generate_msg_docs.py
@@ -316,7 +316,9 @@ Param | Units | Range/Enum | Description
                 if val.minValue or val.maxValue:
                     rangeVal = f"[{val.minValue if val.minValue else '-'} : {val.maxValue if val.maxValue else '-' }]"
 
-                output+=f"{i} | {", ".join(val.units)}|{', '.join(f"[{e}](#{e})" for e in val.enums)}{rangeVal} | {val.description}\n"
+                units_str = ", ".join(val.units)
+                enums_str = ', '.join("[{}](#{})".format(e, e) for e in val.enums)
+                output+=f"{i} | {units_str}|{enums_str}{rangeVal} | {val.description}\n"
             else:
                 output+=f"{i} | | | ?\n"
 


### PR DESCRIPTION
## Summary
- The `msg file docs` Jenkins stage has been failing on every main build since commit 6bf73d9d89 (Feb 19)
- Line 319 of `generate_msg_docs.py` used nested quotes inside f-strings, which requires Python 3.12+
- The CI Docker image (`px4-dev-base-focal:2021-08-18`) runs Python 3.8, causing a `SyntaxError`
- Fix extracts the join expressions into local variables, restoring compatibility with Python 3.8+

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('Tools/msg/generate_msg_docs.py').read())"` passes
- [x] `./Tools/msg/generate_msg_docs.py -d build/msg_docs` runs successfully, generates all 260 msg docs
- [ ] Jenkins `msg file docs` stage passes on CI