### PR TITLE
fix(crsf_rc): guard against packet_size underflow in CRSF parser

### DIFF
--- a/src/drivers/rc/crsf_rc/CrsfParser.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfParser.cpp
@@ -393,6 +393,18 @@ bool CrsfParser_TryParseCrsfPacket(CrsfPacket_t *const new_packet, CrsfParserSta
 			QueueBuffer_Peek(&rx_queue, working_index++, &packet_size);
 			QueueBuffer_Peek(&rx_queue, working_index++, &packet_type);
 
+			// Discard packets with packet_size too small to contain type + CRC.
+			// Without this guard, (packet_size - PACKET_SIZE_TYPE_SIZE) underflows
+			// the uint32_t working_segment_size, permanently stalling the parser.
+			if (packet_size < PACKET_SIZE_TYPE_SIZE) {
+				parser_statistics->invalid_unknown_packet_sizes++;
+				parser_state = PARSER_STATE_HEADER;
+				working_segment_size = HEADER_SIZE;
+				working_index = 0;
+				buffer_count = QueueBuffer_Count(&rx_queue);
+				continue;
+			}
+
 			working_descriptor = FindCrsfDescriptor((enum CRSF_PACKET_TYPE)packet_type);
 
 			// If we know what this packet is...


### PR DESCRIPTION
## Summary

- Fixes integer underflow in `CrsfParser_TryParseCrsfPacket` when a CRSF frame arrives with `packet_size < 2`
- The subtraction `packet_size - PACKET_SIZE_TYPE_SIZE` wraps the `uint32_t working_segment_size` to `0xFFFFFFFF`, and the subsequent overflow guard also wraps, so the parser is **permanently stalled** until reboot
- Validates `packet_size >= PACKET_SIZE_TYPE_SIZE` once, early in `PARSER_STATE_SIZE_TYPE`, protecting both the known variable-length and unknown packet code paths

Supersedes #26782 which only guarded the unknown-packet branch — the same underflow also affects known variable-length packets (`LINK_STATISTICS_TX`, `MSP_WRITE`, `ELRS_STATUS`).

## Test plan

- [ ] Verify normal CRSF RC operation is unaffected
- [ ] Inject malformed frame `0xC8 0x01 0x13` and confirm the parser recovers and continues processing subsequent valid frames
- [ ] Inject malformed frame with `packet_size=0` (`0xC8 0x00 0x14`) for a known variable-length type and confirm recovery