### PR TITLE
fix(airspeed_selector): remove @volatile from ASPD_SCALE, add 3% save threshold

### DIFF
--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -444,8 +444,10 @@ AirspeedModule::Run()
 
 			// save estimated airspeed scale after disarm if airspeed is valid and scale has changed
 			if (!armed && _armed_prev) {
+				const float scale_change_threshold = _param_airspeed_scale[i] * 0.03f; // 3% relative change threshold
+
 				if (_param_aspd_scale_apply.get() > 0 && _airspeed_validator[i].get_airspeed_valid()
-				    && fabsf(_airspeed_validator[i].get_CAS_scale_validated() - _param_airspeed_scale[i]) > FLT_EPSILON) {
+				    && fabsf(_airspeed_validator[i].get_CAS_scale_validated() - _param_airspeed_scale[i]) > scale_change_threshold) {
 
 					mavlink_log_info(&_mavlink_log_pub, "Airspeed sensor Nr. %d ASPD_SCALE updated: %.4f --> %.4f", i + 1,
 							 (double)_param_airspeed_scale[i],

--- a/src/modules/airspeed_selector/airspeed_selector_params.c
+++ b/src/modules/airspeed_selector/airspeed_selector_params.c
@@ -96,7 +96,6 @@ PARAM_DEFINE_INT32(ASPD_SCALE_APPLY, 2);
  * @max 2.0
  * @decimal 2
  * @group Airspeed Validator
- * @volatile
  */
 PARAM_DEFINE_FLOAT(ASPD_SCALE_1, 1.0f);
 
@@ -109,7 +108,6 @@ PARAM_DEFINE_FLOAT(ASPD_SCALE_1, 1.0f);
  * @max 2.0
  * @decimal 2
  * @group Airspeed Validator
- * @volatile
  */
 PARAM_DEFINE_FLOAT(ASPD_SCALE_2, 1.0f);
 
@@ -122,7 +120,6 @@ PARAM_DEFINE_FLOAT(ASPD_SCALE_2, 1.0f);
  * @max 2.0
  * @decimal 2
  * @group Airspeed Validator
- * @volatile
  */
 PARAM_DEFINE_FLOAT(ASPD_SCALE_3, 1.0f);
 


### PR DESCRIPTION
## Summary
- Remove the `@volatile` flag from `ASPD_SCALE_1/2/3` params so the estimated airspeed scale persists across reboots and can be transferred between vehicles of the same airframe model. The scale is primarily determined by pitot position on the airframe, not the individual sensor.
- Raise the param save threshold from `FLT_EPSILON` to **3% relative change** to avoid corrupting the param transfer hash with negligible updates every flight.

Supersedes #22760, incorporating the dev-call feedback:
- @dagar: add a meaningful threshold to avoid saving negligible changes that screw up the param transfer hash
- @MaEtUgR (dev call): "Make a threshold for saving changes of 3-5% and then it shouldn't change every time -> not volatile"

## Test plan
- [ ] Build for a fixed-wing target (`make px4_fmu-v6x_default`)
- [ ] Verify `ASPD_SCALE_*` params persist across reboot (no longer `@volatile`)
- [ ] Verify scale is NOT saved on disarm when change is < 3%
- [ ] Verify scale IS saved on disarm when change is >= 3%
- [ ] Verify param transfer hash is stable across flights with negligible scale drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)