### PR TITLE
feat(rcS): do not exclude RC* params from a reset

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -119,11 +119,11 @@ else
 	param set SYS_AUTOCONFIG 1
 fi
 
-# To trigger a parameter reset during boot SYS_AUTCONFIG was set to 1 before
+# To trigger a parameter reset during boot SYS_AUTOCONFIG was set to 1 before
 if param greater SYS_AUTOCONFIG 0
 then
-	# Reset parameters except airframe, parameter version, RC calibration, sensor calibration, total flight time, flight UUID
-	param reset_all SYS_AUTOSTART SYS_PARAM_VER RC* CAL_* LND_FLIGHT* TC_* COM_FLIGHT*
+	# Reset parameters except airframe, parameter version, sensor calibration, total flight time, flight UUID
+	param reset_all SYS_AUTOSTART SYS_PARAM_VER CAL_* LND_FLIGHT* TC_* COM_FLIGHT*
 	set AUTOCNF yes
 fi
 

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -188,11 +188,11 @@ else
 		netman update -i eth0
 	fi
 
-	# To trigger a parameter reset during boot SYS_AUTCONFIG was set to 1 before
+	# To trigger a parameter reset during boot SYS_AUTOCONFIG was set to 1 before
 	if param greater SYS_AUTOCONFIG 0
 	then
-		# Reset parameters except airframe, parameter version, RC calibration, sensor calibration, total flight time, flight UUID
-		param reset_all SYS_AUTOSTART SYS_PARAM_VER RC* CAL_* LND_FLIGHT* TC_* COM_FLIGHT*
+		# Reset parameters except airframe, parameter version, sensor calibration, total flight time, flight UUID
+		param reset_all SYS_AUTOSTART SYS_PARAM_VER CAL_* LND_FLIGHT* TC_* COM_FLIGHT*
 	fi
 
 	#


### PR DESCRIPTION
### Solved Problem
There are many settings falling into the RC_* category that definitely should be reset when e.g. placing the autopilot into a new airframe.
And even for RC calibration values: it's not the worst if those are newly calibrated after a reset. Or if they are not expected to change one can bake them into the airframe file.

### Solution
Remove the exclusion for `RC*`.

### Changelog Entry
For release notes:
```
Feature: do not exclude RC* params from a reset.
```

### Alternatives
Keep the exclusion for `RCx_MIN`, `RCx_TRIM`, `RCx_MAX`, `RCx_REV`.

### Context
Very similar to https://github.com/PX4/PX4-Autopilot/pull/26773
