### PR TITLE
feat(gimbal): reduced poll time in aux mode

### DIFF
--- a/src/modules/gimbal/gimbal.cpp
+++ b/src/modules/gimbal/gimbal.cpp
@@ -197,6 +197,8 @@ static int gimbal_thread_main(int argc, char *argv[])
 		thread_should_exit.store(true);
 	}
 
+	const unsigned int poll_timeout_ms = params.mnt_mode_out == MNT_MODE_OUT_AUX ? 10 : 20;
+
 	while (!thread_should_exit.load()) {
 
 		const bool updated = parameter_update_sub.updated();
@@ -219,7 +221,7 @@ static int gimbal_thread_main(int argc, char *argv[])
 				const bool already_active = (thread_data.last_input_active == i);
 				// poll only on active input to reduce latency, or on all if none is active
 				const unsigned int poll_timeout =
-					(already_active || thread_data.last_input_active == -1) ? 20 : 0;
+					(already_active || thread_data.last_input_active == -1) ? poll_timeout_ms : 0;
 
 				update_result = thread_data.input_objs[i]->update(poll_timeout, thread_data.control_data, already_active);
 


### PR DESCRIPTION

### Solved Problem
- Gimbal input objects blocks the output object from updating if no inputs arrive within 20 ms for each input object.
- Updating servo setpoint is too slow, that can be seen if rotating fmu, resulting in a lagging servo.

### Solution
Ideally update on every `vehicle_attitude`, but currently that kills the fmu, so short term solution that is not breaking anything is to reduce the poll time when using `MNT_AUX_OUT` = 0 (ie servo)

### Changelog Entry
```
Fix: Speed up gimbal control for direct actuator output mode
```

### Alternatives
- try to update on vehicle attitude, but still use `px4_task_spawn_cmd`
- upgrade gimbal module to use Work Queue Tasks `WorkItem`

### Test coverage
Skynode S + camera attached to servo. Control response gets much better.
