### PR TITLE
chore(drivers): only start vtxtable when required

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -633,12 +633,15 @@ else
 	#
 	# Start the VTX services.
 	#
-	set RC_VTXTABLE ${R}etc/init.d/rc.vtxtable
-	if [ -f ${RC_VTXTABLE} ]
+	if ! param compare VTX_SER_CFG 0
 	then
-		. ${RC_VTXTABLE}
+		set RC_VTXTABLE ${R}etc/init.d/rc.vtxtable
+		if [ -f ${RC_VTXTABLE} ]
+		then
+			. ${RC_VTXTABLE}
+		fi
+		unset RC_VTXTABLE
 	fi
-	unset RC_VTXTABLE
 
 	#
 	# Set additional parameters and env variables for selected AUTOSTART.


### PR DESCRIPTION
### Solved Problem
`ERROR [vtxtable] /fs/microsd/vtx_config not found!` is shown on every boot, even if the `VTX_SER_CFG` is set to `Disabled`

### Solution
Only load the VTX table when `VTX_SER_CFG` is not diabled. 

