### PR TITLE
fix(driver): Do not integrate invalid current measurements

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -201,8 +201,9 @@ void Battery::updateDt(const hrt_abstime &timestamp)
 
 float Battery::sumDischarged(float current_a)
 {
-	if (_dt > FLT_EPSILON) {
+	if (_dt > FLT_EPSILON && fabsf(current_a + 1.f) > FLT_EPSILON) {
 		// mAh since last loop: (current[A] * 1000 = [mA]) * (dt[s] / 3600 = [h])
+		// current = -1 means invalid current measurement
 		_discharged_mah_loop = (current_a * 1e3f) * (_dt / 3600.f);
 		_discharged_mah += _discharged_mah_loop;
 	}


### PR DESCRIPTION
### Solved Problem
SITL publishes `-1.f` as the `current_a` value in `battery_status`, which is defined as invalid: 

https://mavlink.io/en/messages/common.html#BATTERY_STATUS
> current_battery	int16_t	cA	invalid:-1	Battery current, -1: autopilot does not measure the current


This current is then accumulated into the `discharged_mah`, which then becomes negative, which does not make sense. 

### Solution

Do not integrate the current when it is -1. 

### Changelog Entry
For release notes:
```
Bugfix: Do not integrate invalid current. 
```

### Test coverage
Tested in SITL
