### PR TITLE
feat(commander): enable arming on boot

### DIFF
--- a/docs/en/advanced_config/prearm_arm_disarm.md
+++ b/docs/en/advanced_config/prearm_arm_disarm.md
@@ -91,6 +91,28 @@ The feature is configured using the following timeouts.
 | <a id="COM_DISARM_LAND"></a>[COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND)    | Time-out for auto disarm after landing. Default: 2s (-1 to disable).            |
 | <a id="COM_DISARM_PRFLT"></a>[COM_DISARM_PRFLT](../advanced_config/parameter_reference.md#COM_DISARM_PRFLT) | Time-out for auto disarm if too slow to takeoff. Default: 10s (<=0 to disable). |
 
+## Auto-Arming on Boot
+
+The vehicle can be configured to arm automatically on boot once all preflight checks pass,
+using the `COM_ARM_ON_BOOT` parameter. For safety, PX4 enforces a minimum 5-second delay after boot before attempting to arm.
+
+Once armed this way, the vehicle will not re-arm automatically after a manual disarm.
+
+::: info
+The parameter value is read once at boot.
+Changing it while the system is running has no effect until the next reboot.
+:::
+
+:::warning
+Use with caution.
+A vehicle that arms automatically can spin up motors and actuators without any operator gesture.
+Ensure the vehicle is in a safe state before powering on.
+:::
+
+| Parameter                                                                                                      | Description                                                                                    |
+| -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| <a id="COM_ARM_ON_BOOT"></a>[COM_ARM_ON_BOOT](../advanced_config/parameter_reference.md#COM_ARM_ON_BOOT) | Arm automatically once preflight checks pass after boot. Default: `0` (Disabled). |
+
 ## Pre-Arm Checks
 
 To reduce accidents, vehicles are only allowed to arm certain conditions are met (some of which are configurable).

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1870,6 +1870,7 @@ void Commander::run()
 #endif // BOARD_HAS_POWER_CONTROL
 
 	_boot_timestamp = hrt_absolute_time();
+	_arm_on_boot_requested = _param_com_arm_on_boot.get();
 
 	arm_auth_init(&_mavlink_log_pub, &_vehicle_status.system_id);
 
@@ -1949,6 +1950,20 @@ void Commander::run()
 
 			perf_end(_preflight_check_perf);
 			checkAndInformReadyForTakeoff();
+
+			// Arm automatically on boot once preflight checks pass
+			// _arm_on_boot_done prevents re-arming after disarming
+			const bool should_arm_on_boot = _arm_on_boot_requested
+							&& !_arm_on_boot_done
+							&& !isArmed()
+							&& hrt_elapsed_time(&_boot_timestamp) > 5_s
+							&& pre_flight_checks_pass;
+
+			if (should_arm_on_boot) {
+				if (arm(arm_disarm_reason_t::mission_start, false) != TRANSITION_DENIED) {
+					_arm_on_boot_done = true;
+				}
+			}
 		}
 
 		// handle commands last, as the system needs to be updated to handle them

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -258,6 +258,8 @@ private:
 
 	hrt_abstime _boot_timestamp{0};
 	hrt_abstime _last_disarmed_timestamp{0};
+	bool _arm_on_boot_done{false};    ///< true once arm-on-boot has been attempted
+	bool _arm_on_boot_requested{false};
 	hrt_abstime _overload_start{0};		///< time when CPU overload started
 
 #if !defined(CONFIG_ARCH_LEDS) && defined(BOARD_HAS_CONTROL_STATUS_LEDS)
@@ -347,6 +349,7 @@ private:
 		(ParamFloat<px4::params::COM_SPOOLUP_TIME>) _param_com_spoolup_time,
 		(ParamInt<px4::params::COM_FLIGHT_UUID>)    _param_com_flight_uuid,
 		(ParamInt<px4::params::COM_TAKEOFF_ACT>)    _param_com_takeoff_act,
-		(ParamFloat<px4::params::COM_CPU_MAX>)      _param_com_cpu_max
+		(ParamFloat<px4::params::COM_CPU_MAX>)      _param_com_cpu_max,
+		(ParamBool<px4::params::COM_ARM_ON_BOOT>)   _param_com_arm_on_boot
 	)
 };

--- a/src/modules/commander/commander_params.yaml
+++ b/src/modules/commander/commander_params.yaml
@@ -353,6 +353,16 @@ parameters:
         0: one arm
         1: two step arm
       default: 0
+    COM_ARM_ON_BOOT:
+      description:
+        short: Arm automatically on boot
+        long: |-
+          When enabled, the vehicle arms automatically once all preflight checks pass after boot.
+          The vehicle will not re-arm after a manual disarm.
+          Has no effect if COM_ARMABLE is 0.
+      type: boolean
+      default: 0
+      reboot_required: true
     COM_ARM_AUTH_TO:
       description:
         short: Arm authorization timeout


### PR DESCRIPTION
### Description 

Introduces a parameter `COM_ARM_ON_BOOT` that, when enabled, arms the vehicle on boot once pre-flight checks pass. Once disarmed, the vehicle doesn't arm again.

### Changelog Entry
For release notes:
```
New parameter: COM_ARM_ON_BOOT, arms on boot once pre-flight checks pass
```
### Test coverage
Bench tested and SITL tested 

### Context

Used for applications where it is not possible to arm through GCS / RC, for example, in RF restricted areas. 
