### PR TITLE
feat(ekf2): generalize engine warmup mode

### DIFF
--- a/docs/en/advanced_config/tuning_the_ecl_ekf.md
+++ b/docs/en/advanced_config/tuning_the_ecl_ekf.md
@@ -406,6 +406,16 @@ With Valid GNSS Data:
 - **Alternative Sources**: Dead-reckoning mode provides enhanced protection by requiring absence of alternative navigation sources before allowing resets.
 - **Boot Vulnerability**: Initial faulty GNSS data cannot be detected automatically; requires operator intervention and manual position correction.
 
+#### Ground Position Lock
+
+When a vehicle equipped with dead-reckoning sensors (e.g. airspeed for fixed-wing, or optical flow) is sitting on the ground before takeoff, those sensors provide little to no aiding — airspeed and optical flow measurements are unreliable at rest. In this case, the EKF relies on _constant position fusion_ (fusing a synthetic position measurement at the last known position) to prevent the estimate from drifting. However, this is only active when the vehicle is detected as stationary, so handling the vehicle or starting the engine can interrupt it.
+
+To counter this, [EKF2_POS_LOCK](../advanced_config/parameter_reference.md#EKF2_POS_LOCK) can be enabled to force constant position fusion to run while landed and the global horizontal position has already been initialized.
+
+::: note
+`EKF2_POS_LOCK` has no effect in flight.
+:::
+
 ### Range Finder
 
 [Range finder](../sensor/rangefinders.md) distance to ground is used by a single state filter to estimate the vertical position of the terrain relative to the height datum.

--- a/docs/en/releases/main.md
+++ b/docs/en/releases/main.md
@@ -50,7 +50,7 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 ### Estimation
 
-- TBD
+- Added [EKF2_POS_LOCK](../advanced_config/parameter_reference.md#EKF2_POS_LOCK) to force constant position fusion while landed, useful for vehicles relying on dead-reckoning sensors (airspeed, optical flow) that provide no aiding on the ground.
 
 ### Sensors
 

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -223,5 +223,15 @@ param_modify_on_import_ret param_modify_on_import(bson_node_t node)
 		}
 	}
 
+	// 2026-03-19: translate EKF2_ENGINE_WRM to EKF2_POS_LOCK
+	{
+		if (strcmp("EKF2_ENGINE_WRM", node->name) == 0) {
+			int32_t delay_ms = static_cast<int32_t>(node->d);
+			param_set(param_find("EKF2_POS_LOCK"), &delay_ms);
+			PX4_INFO("migrating %s -> %s", "EKF2_ENGINE_WRM", "EKF2_POS_LOCK");
+			return param_modify_on_import_ret::PARAM_MODIFIED;
+		}
+	}
+
 	return param_modify_on_import_ret::PARAM_NOT_MODIFIED;
 }

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2638,8 +2638,7 @@ void EKF2::UpdateSystemFlagsSample(ekf2_timestamps_s &ekf2_timestamps)
 			flags.in_air = !vehicle_land_detected.landed;
 			flags.gnd_effect = vehicle_land_detected.in_ground_effect;
 
-			// Enable constant position fusion for engine warmup when landed and armed
-			flags.constant_pos = _param_ekf2_engine_wrm.get() && !flags.in_air && armed;
+			flags.constant_pos = _param_ekf2_pos_lock.get() && !flags.in_air && _ekf.isGlobalHorizontalPositionValid();
 		}
 
 		launch_detection_status_s launch_detection_status;
@@ -2647,8 +2646,8 @@ void EKF2::UpdateSystemFlagsSample(ekf2_timestamps_s &ekf2_timestamps)
 		if (_launch_detection_status_sub.copy(&launch_detection_status)
 		    && (ekf2_timestamps.timestamp < launch_detection_status.timestamp + 3_s)) {
 
-			flags.constant_pos = (launch_detection_status.launch_detection_state ==
-					      launch_detection_status_s::STATE_WAITING_FOR_LAUNCH);
+			flags.constant_pos |= (launch_detection_status.launch_detection_state ==
+					       launch_detection_status_s::STATE_WAITING_FOR_LAUNCH);
 		}
 
 		_ekf.setSystemFlagData(flags);

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -487,7 +487,7 @@ private:
 		(ParamExtFloat<px4::params::EKF2_DELAY_MAX>) _param_ekf2_delay_max,
 		(ParamExtInt<px4::params::EKF2_IMU_CTRL>) _param_ekf2_imu_ctrl,
 		(ParamExtFloat<px4::params::EKF2_VEL_LIM>) _param_ekf2_vel_lim,
-		(ParamBool<px4::params::EKF2_ENGINE_WRM>) _param_ekf2_engine_wrm,
+		(ParamBool<px4::params::EKF2_POS_LOCK>) _param_ekf2_pos_lock,
 
 #if defined(CONFIG_EKF2_AUXVEL)
 		(ParamExtFloat<px4::params::EKF2_AVEL_DELAY>)

--- a/src/modules/ekf2/module.yaml
+++ b/src/modules/ekf2/module.yaml
@@ -186,10 +186,9 @@ parameters:
       unit: m/s
       decimal: 1
 
-    EKF2_ENGINE_WRM:
+    EKF2_POS_LOCK:
       description:
-        short: Enable constant position fusion during engine warmup
-        long: When enabled, constant position fusion is enabled when the vehicle is landed and armed.
-         This is intended for IC engine warmup (e.g., fuel engines on catapult) to allow mode transitions to auto/takeoff despite vibrations from running engines.
+        short: Enable constant position fusion while on ground
+        long: When enabled, constant position fusion is enabled when the vehicle is landeded if position has been initialized but has currently no vel/pos aiding.
       type: boolean
       default: 0


### PR DESCRIPTION
### Solved Problem
A multirotor with optical flow or a fixedwing can dead-reckon while flying but those sensors don't work while on the ground. To solve this, fuse a constant position when at rest and assume the sensor will work while in air. The issue however, is that if something makes the "at_rest" flag fail (e.g.: engine starting, wind gust), the global position validity drops.

### Solution
Fuse a constant position if disarmed, the global position is currently valid, EKF2_POS_LOCK is set to true and if no horizontal aiding source is currently active (checked in the fake position control logic).

### Changelog Entry
For release notes:
```
Generalize EKF2 engine warmup mode
New parameter: rename EKF2_ENGINE_WRM -> EKF2_POS_LOCK
Documentation: yes, added to this PR
```

