### PR TITLE
feat(navigator): Mission feasibility check: do not require takeoff waypoint if in-air

### DIFF
--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
@@ -540,7 +540,7 @@ bool FeasibilityChecker::checkTakeoffLandAvailable()
 		break;
 
 	case 1:
-		result = _has_takeoff;
+		result = _has_takeoff || !_is_landed;
 
 		if (!result) {
 			mavlink_log_critical(_mavlink_log_pub, "Mission rejected: Takeoff waypoint required.\t");
@@ -563,7 +563,7 @@ bool FeasibilityChecker::checkTakeoffLandAvailable()
 		break;
 
 	case 3:
-		result = _has_takeoff && _landing_valid;
+		result = (_has_takeoff || !_is_landed) && _landing_valid;
 
 		if (!result) {
 			mavlink_log_critical(_mavlink_log_pub, "Mission rejected: Takeoff or Landing item missing.\t");
@@ -574,7 +574,18 @@ bool FeasibilityChecker::checkTakeoffLandAvailable()
 		break;
 
 	case 4:
-		result = hasMissionBothOrNeitherTakeoffAndLanding();
+		if (_is_landed) {
+			result = hasMissionBothOrNeitherTakeoffAndLanding();
+
+		} else {
+			result = _landing_valid;
+
+			if (!result) {
+				mavlink_log_critical(_mavlink_log_pub, "Mission rejected: Landing waypoint/pattern required.");
+				events::send(events::ID("feasibility_mis_type_4_in_air"), {events::Log::Error, events::LogInternal::Info},
+					     "Mission rejected: Landing waypoint/pattern required");
+			}
+		}
 
 		break;
 

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -62,6 +62,7 @@ PARAM_DEFINE_FLOAT(MIS_TAKEOFF_ALT, 2.5f);
  *
  * Specifies if a mission has to contain a takeoff and/or mission landing.
  * Validity of configured takeoffs/landings is checked independently of the setting here.
+ * Takeoff requirement is dropped when in-air.
  *
  * @value 0 No requirements
  * @value 1 Require a takeoff


### PR DESCRIPTION

### Solved Problem
If `MIS_TKO_LAND_REQ` is configured to require a takeoff item, it will also request that when the mission is planned while the vehicle is flying. Even though that "takeoff" waypoint is then skipped in the actual execution, it's leading to a bad UX having to place a random takeoff point.

### Solution
Skip any "needs takeoff" requirement when currently in air. 

### Changelog Entry
For release notes:
```
Feature: Mission feasibility check: do not require takeoff waypoint if in-air
```

### Alternatives

### Test coverage
SITL tested. 
I keep this in draft because in my testing I was allowed to switch into Mission mode after landing with a mission that doesn't contain a takeoff (`MIS_TKO_LAND_REQ` set to 1). It then only complained when I armed, and switched to RTL. I expected it to reject the Mission mode without a valid mission.