### PR TITLE
docs(optical_flow): clarify that integrated flow values are angular, not translational

### DIFF
--- a/docs/en/sensor/optical_flow.md
+++ b/docs/en/sensor/optical_flow.md
@@ -34,6 +34,12 @@ The output of the flow when moving in different directions must be as follows:
 | Right            | - X             |
 | Left             | + X             |
 
+::: info
+The integrated flow values are **angular measurements** (radians) representing rotation of the image about the sensor's body axes using the right-hand convention.
+They are _not_ translational displacements along those axes, which is why forward vehicle movement (along X) appears in the Y flow axis, and rightward movement (along Y) appears in the X flow axis.
+Specifically, forward movement causes the ground image to rotate about the Y axis (+ Y), while rightward movement causes a negative rotation about the X axis (- X).
+:::
+
 Sensor data from the optical flow device is fused with other velocity data sources.
 The approach used for fusing sensor data and any offsets from the center of the vehicle must be configured in the [estimator](#estimators).
 


### PR DESCRIPTION
## Summary
- Adds an info note below the optical flow output table explaining that `integrated_x`/`integrated_y` are **angular measurements** (radians, right-hand convention), not translational displacements
- Clarifies why forward movement (along X) appears in Y flow and rightward movement (along Y) appears in X flow 