### PR TITLE
docs(boards): Add PWM Outputs section

### DIFF
--- a/docs/en/flight_controller/accton-godwit_ga1.md
+++ b/docs/en/flight_controller/accton-godwit_ga1.md
@@ -91,24 +91,59 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 
 ![G-A1 Wiring](../../assets/flight_controller/accton-godwit/ga1/wiring.png "G-A1 Wiring")
 
+## PWM Output
+
+PWM M1-M8 (IO Main PWM), A1-A8(FMU PWM).
+All these 16 support normal PWM output formats.
+FMU PWM A1-A6 can support DShot and B-Directional DShot.
+A1-A8(FMU PWM) are grouped as:
+
+- Group 1: A1, A2, A3, A4
+- Group 2: A5, A6
+- Group 3: A7, A8
+
+The motor and servo system should be connected to these ports according to the order outlined in the fuselage reference for your carrier.
+
+![G-A1 PWM Motor Servo](../../assets/flight_controller/accton-godwit/ga1/motor_servo.png "G-A1 PWM Motor Servo")
+<!-- pwm_outputs-proposed
+<!-- pwm_outputs-proposed
 ## PWM Outputs {#pwm_outputs}
 
-This flight controller supports up to 9 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
 FMU Outputs:
 
 - Outputs 1-6 support [DShot](../peripherals/dshot.md).
-- Outputs 7-9 do not support DShot.
+- Outputs 7-8 do not support DShot.
 - Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
 
-The 9 outputs are in 4 groups:
+The 8 outputs are in 3 groups:
 
 - Outputs 1-4 in group1 (Timer5)
 - Outputs 5-6 in group2 (Timer4)
 - Outputs 7-8 in group3 (Timer12)
-- Output 9 in group4 (Timer1)
 
 All outputs within the same group must use the same output protocol and rate.
+-->
+
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+FMU Outputs:
+
+- Outputs 1-6 support [DShot](../peripherals/dshot.md).
+- Outputs 7-8 do not support DShot.
+- Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 8 outputs are in 3 groups:
+
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer12)
+
+All outputs within the same group must use the same output protocol and rate.
+-->
 
 ## RC Input
 

--- a/docs/en/flight_controller/accton-godwit_ga1.md
+++ b/docs/en/flight_controller/accton-godwit_ga1.md
@@ -91,20 +91,24 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 
 ![G-A1 Wiring](../../assets/flight_controller/accton-godwit/ga1/wiring.png "G-A1 Wiring")
 
-## PWM Output
+## PWM Outputs {#pwm_outputs}
 
-PWM M1-M8 (IO Main PWM), A1-A8(FMU PWM).
-All these 16 support normal PWM output formats.
-FMU PWM A1-A6 can support DShot and B-Directional DShot.
-A1-A8(FMU PWM) are grouped as:
+This flight controller supports up to 9 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
-- Group 1: A1, A2, A3, A4
-- Group 2: A5, A6
-- Group 3: A7, A8
+FMU Outputs:
 
-The motor and servo system should be connected to these ports according to the order outlined in the fuselage reference for your carrier.
+- Outputs 1-6 support [DShot](../peripherals/dshot.md).
+- Outputs 7-9 do not support DShot.
+- Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
 
-![G-A1 PWM Motor Servo](../../assets/flight_controller/accton-godwit/ga1/motor_servo.png "G-A1 PWM Motor Servo")
+The 9 outputs are in 4 groups:
+
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer12)
+- Output 9 in group4 (Timer1)
+
+All outputs within the same group must use the same output protocol and rate.
 
 ## RC Input
 

--- a/docs/en/flight_controller/airlink.md
+++ b/docs/en/flight_controller/airlink.md
@@ -325,22 +325,23 @@ For PPM receivers please use RC Connector PPM pin located on the left side of th
 
 ![RC Input](../../assets/flight_controller/airlink/airlink-rc-input.jpg)
 
-## Outputs
+## PWM Outputs {#pwm_outputs}
 
-AIRLink has 16 PWM outputs. Main outputs 1-8 and connected to IO MCU. AUX outputs 1-8 are connected to FMU.
+This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
-| Output | Timer    | Channel   |
-| ------ | -------- | --------- |
-| AUX 1  | Timer 1  | Channel 4 |
-| AUX 2  | Timer 1  | Channel 3 |
-| AUX 3  | Timer 1  | Channel 2 |
-| AUX 4  | Timer 1  | Channel 1 |
-| AUX 5  | Timer 4  | Channel 2 |
-| AUX 6  | Timer 4  | Channel 3 |
-| AUX 7  | Timer 12 | Channel 1 |
-| AUX 8  | Timer 12 | Channel 2 |
+FMU Outputs:
 
-[DShot](../peripherals/dshot.md) can be used on the first four AUX pins.
+- Outputs 1-6 support [DShot](../peripherals/dshot.md).
+- Outputs 7-8 do not support DShot.
+- Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 8 outputs are in 3 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer12)
+
+All outputs within the same group must use the same output protocol and rate.
 
 ## Building Firmware
 

--- a/docs/en/flight_controller/airlink.md
+++ b/docs/en/flight_controller/airlink.md
@@ -325,15 +325,28 @@ For PPM receivers please use RC Connector PPM pin located on the left side of th
 
 ![RC Input](../../assets/flight_controller/airlink/airlink-rc-input.jpg)
 
+## Outputs
+
+AIRLink has 16 PWM outputs. Main outputs 1-8 and connected to IO MCU. AUX outputs 1-8 are connected to FMU.
+
+| Output | Timer    | Channel   |
+| ------ | -------- | --------- |
+| AUX 1  | Timer 1  | Channel 4 |
+| AUX 2  | Timer 1  | Channel 3 |
+| AUX 3  | Timer 1  | Channel 2 |
+| AUX 4  | Timer 1  | Channel 1 |
+| AUX 5  | Timer 4  | Channel 2 |
+| AUX 6  | Timer 4  | Channel 3 |
+| AUX 7  | Timer 12 | Channel 1 |
+| AUX 8  | Timer 12 | Channel 2 |
+
+[DShot](../peripherals/dshot.md) can be used on the first four AUX pins.
+<!-- pwm_outputs-proposed
 ## PWM Outputs {#pwm_outputs}
 
 This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
-FMU Outputs:
-
-- Outputs 1-6 support [DShot](../peripherals/dshot.md).
-- Outputs 7-8 do not support DShot.
-- Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+[DShot](../peripherals/dshot.md) is not supported.
 
 The 8 outputs are in 3 groups:
 

--- a/docs/en/flight_controller/ark_fpv.md
+++ b/docs/en/flight_controller/ark_fpv.md
@@ -13,6 +13,24 @@ The USA-built ARK FPV flight controller is based on the [ARKV6X](https://arkelec
 This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
 :::
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 9 FMU PWM outputs (MAIN).
+
+Outputs:
+
+- Outputs 1-8 support [DShot](../peripherals/dshot.md).
+- Output 9 does not support DShot.
+- Outputs 1-8 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 9 outputs are in 3 groups:
+
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-8 in group2 (Timer8)
+- Output 9 in group3 (Timer4)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where To Buy {#store}
 
 Order from [Ark Electronics](https://arkelectron.com/product/arkv6x/) (US)

--- a/docs/en/flight_controller/ark_pi6x.md
+++ b/docs/en/flight_controller/ark_pi6x.md
@@ -13,6 +13,24 @@ The [ARK Pi6X Flow](https://arkelectron.gitbook.io/ark-documentation/flight-cont
 This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
 :::
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 8 FMU PWM outputs (MAIN).
+
+Outputs:
+
+- Outputs 1-6 support [DShot](../peripherals/dshot.md).
+- Outputs 7-8 do not support DShot.
+- Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 8 outputs are in 3 groups:
+
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer12)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 Order this module from:

--- a/docs/en/flight_controller/ark_v6x.md
+++ b/docs/en/flight_controller/ark_v6x.md
@@ -18,20 +18,19 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 
 ## PWM Outputs {#pwm_outputs}
 
-This flight controller supports up to 9 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
 FMU Outputs:
 
 - Outputs 1-6 support [DShot](../peripherals/dshot.md).
-- Outputs 7-9 do not support DShot.
+- Outputs 7-8 do not support DShot.
 - Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
 
-The 9 outputs are in 4 groups:
+The 8 outputs are in 3 groups:
 
 - Outputs 1-4 in group1 (Timer5)
 - Outputs 5-6 in group2 (Timer4)
 - Outputs 7-8 in group3 (Timer12)
-- Output 9 in group4 (Timer1)
 
 All outputs within the same group must use the same output protocol and rate.
 

--- a/docs/en/flight_controller/ark_v6x.md
+++ b/docs/en/flight_controller/ark_v6x.md
@@ -16,6 +16,25 @@ The Pixhawk Autopilot Bus (PAB) form factor enables the ARKV6X to be used on any
 This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
 :::
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 9 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+FMU Outputs:
+
+- Outputs 1-6 support [DShot](../peripherals/dshot.md).
+- Outputs 7-9 do not support DShot.
+- Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 9 outputs are in 4 groups:
+
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer12)
+- Output 9 in group4 (Timer1)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where To Buy {#store}
 
 Order From [Ark Electronics](https://arkelectron.com/product/arkv6x/) (US)

--- a/docs/en/flight_controller/corvon_743v1.md
+++ b/docs/en/flight_controller/corvon_743v1.md
@@ -38,6 +38,24 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
   - 5V 3A BEC
   - ADC for battery voltage (up to 6S) and current monitoring
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 10 FMU PWM outputs (MAIN).
+
+Outputs:
+
+- Outputs 1-10 support [DShot](../peripherals/dshot.md).
+- Outputs 1-9 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+- Output 10 supports Bidirectional DShot output only (no eRPM capture).
+
+The 10 outputs are in 3 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer3)
+- Outputs 7-10 in group3 (Timer4)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy
 
 Order from [CORVON](https://corvon.tech).

--- a/docs/en/flight_controller/cuav_nora.md
+++ b/docs/en/flight_controller/cuav_nora.md
@@ -72,6 +72,26 @@ When it runs PX4 firmware, only 8 PWM outputs work.
 The remaining 6 PWM ports are still being adapted (so it is not compatible with VOLT at time of writing).
 :::
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 14 FMU PWM outputs (MAIN).
+
+Outputs:
+
+- Outputs 1-12 support [DShot](../peripherals/dshot.md).
+- Outputs 13-14 do not support DShot.
+- Outputs 1-7, 9-12 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+- Output 8 supports Bidirectional DShot output only (no eRPM capture).
+
+The 14 outputs are in 4 groups:
+
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-8 in group2 (Timer4)
+- Outputs 9-12 in group3 (Timer1)
+- Outputs 13-14 in group4 (Timer12)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 - [CUAV Store](https://store.cuav.net)<\br>

--- a/docs/en/flight_controller/cuav_pixhawk_v6x.md
+++ b/docs/en/flight_controller/cuav_pixhawk_v6x.md
@@ -104,6 +104,25 @@ The Pixhawk® V6X is ideal for corporate research labs, academic research and co
 
     ![Pixhawk V6X](../../assets/flight_controller/cuav_pixhawk_v6x/core.png)
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 9 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+FMU Outputs:
+
+- Outputs 1-6 support [DShot](../peripherals/dshot.md).
+- Outputs 7-9 do not support DShot.
+- Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 9 outputs are in 4 groups:
+
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer12)
+- Output 9 in group4 (Timer1)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 Order from [CUAV](https://store.cuav.net/).

--- a/docs/en/flight_controller/cuav_pixhawk_v6x.md
+++ b/docs/en/flight_controller/cuav_pixhawk_v6x.md
@@ -106,20 +106,19 @@ The Pixhawk® V6X is ideal for corporate research labs, academic research and co
 
 ## PWM Outputs {#pwm_outputs}
 
-This flight controller supports up to 9 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
 FMU Outputs:
 
 - Outputs 1-6 support [DShot](../peripherals/dshot.md).
-- Outputs 7-9 do not support DShot.
+- Outputs 7-8 do not support DShot.
 - Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
 
-The 9 outputs are in 4 groups:
+The 8 outputs are in 3 groups:
 
 - Outputs 1-4 in group1 (Timer5)
 - Outputs 5-6 in group2 (Timer4)
 - Outputs 7-8 in group3 (Timer12)
-- Output 9 in group4 (Timer1)
 
 All outputs within the same group must use the same output protocol and rate.
 

--- a/docs/en/flight_controller/cuav_x25-evo.md
+++ b/docs/en/flight_controller/cuav_x25-evo.md
@@ -109,22 +109,18 @@ The [X25 EVO Wiring Quick Start](../assembly/quick_start_cuav_x25_evo.md) provid
 
 ## PWM Outputs {#pwm_outputs}
 
-This flight controller supports up to 16 FMU PWM outputs (MAIN).
+This flight controller supports up to 8 FMU PWM outputs (MAIN).
 
 Outputs:
 
 - Outputs 1-8 support [DShot](../peripherals/dshot.md).
-- Outputs 9-16 do not support DShot.
 - Outputs 1-7 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
 - Output 8 supports Bidirectional DShot output only (no eRPM capture).
 
-The 16 outputs are in 5 groups:
+The 8 outputs are in 2 groups:
 
 - Outputs 1-4 in group1 (Timer5)
 - Outputs 5-8 in group2 (Timer4)
-- Outputs 9-11 in group3 (Timer1)
-- Outputs 12-14 in group4 (Timer8)
-- Outputs 15-16 in group5 (Timer12)
 
 All outputs within the same group must use the same output protocol and rate.
 
@@ -142,22 +138,18 @@ All outputs within the same group must use the same output protocol and rate.
 
 ## PWM Outputs {#pwm_outputs}
 
-This flight controller supports up to 16 FMU PWM outputs (MAIN).
+This flight controller supports up to 8 FMU PWM outputs (MAIN).
 
 Outputs:
 
 - Outputs 1-8 support [DShot](../peripherals/dshot.md).
-- Outputs 9-16 do not support DShot.
 - Outputs 1-7 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
 - Output 8 supports Bidirectional DShot output only (no eRPM capture).
 
-The 16 outputs are in 5 groups:
+The 8 outputs are in 2 groups:
 
 - Outputs 1-4 in group1 (Timer5)
 - Outputs 5-8 in group2 (Timer4)
-- Outputs 9-11 in group3 (Timer1)
-- Outputs 12-14 in group4 (Timer8)
-- Outputs 15-16 in group5 (Timer12)
 
 All outputs within the same group must use the same output protocol and rate.
 

--- a/docs/en/flight_controller/cuav_x25-evo.md
+++ b/docs/en/flight_controller/cuav_x25-evo.md
@@ -107,6 +107,27 @@ The [X25 EVO Wiring Quick Start](../assembly/quick_start_cuav_x25_evo.md) provid
 
 ![CUAV X25 EVO Pinout](../../assets/flight_controller/cuav_x25-evo/x25_evo_pinouts.jpg)
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 16 FMU PWM outputs (MAIN).
+
+Outputs:
+
+- Outputs 1-8 support [DShot](../peripherals/dshot.md).
+- Outputs 9-16 do not support DShot.
+- Outputs 1-7 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+- Output 8 supports Bidirectional DShot output only (no eRPM capture).
+
+The 16 outputs are in 5 groups:
+
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-8 in group2 (Timer4)
+- Outputs 9-11 in group3 (Timer1)
+- Outputs 12-14 in group4 (Timer8)
+- Outputs 15-16 in group5 (Timer12)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Serial Port Mapping
 
 | UART   | Device     | Port          |

--- a/docs/en/flight_controller/cuav_x25-super.md
+++ b/docs/en/flight_controller/cuav_x25-super.md
@@ -110,22 +110,18 @@ The [X25 SUPER Wiring Quick Start](../assembly/quick_start_cuav_x25_evo.md) prov
 
 ## PWM Outputs {#pwm_outputs}
 
-This flight controller supports up to 16 FMU PWM outputs (MAIN).
+This flight controller supports up to 8 FMU PWM outputs (MAIN).
 
 Outputs:
 
 - Outputs 1-8 support [DShot](../peripherals/dshot.md).
-- Outputs 9-16 do not support DShot.
 - Outputs 1-7 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
 - Output 8 supports Bidirectional DShot output only (no eRPM capture).
 
-The 16 outputs are in 5 groups:
+The 8 outputs are in 2 groups:
 
 - Outputs 1-4 in group1 (Timer5)
 - Outputs 5-8 in group2 (Timer4)
-- Outputs 9-11 in group3 (Timer1)
-- Outputs 12-14 in group4 (Timer8)
-- Outputs 15-16 in group5 (Timer12)
 
 All outputs within the same group must use the same output protocol and rate.
 

--- a/docs/en/flight_controller/cuav_x25-super.md
+++ b/docs/en/flight_controller/cuav_x25-super.md
@@ -108,6 +108,27 @@ The [X25 SUPER Wiring Quick Start](../assembly/quick_start_cuav_x25_evo.md) prov
 ![CUAV X25-SUPER Pinout_01](../../assets/flight_controller/cuav_x25-super/x25-super_pinouts_01.png)
 ![CUAV X25-SUPER Pinout_02](../../assets/flight_controller/cuav_x25-super/x25-super_pinouts_02.png)
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 16 FMU PWM outputs (MAIN).
+
+Outputs:
+
+- Outputs 1-8 support [DShot](../peripherals/dshot.md).
+- Outputs 9-16 do not support DShot.
+- Outputs 1-7 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+- Output 8 supports Bidirectional DShot output only (no eRPM capture).
+
+The 16 outputs are in 5 groups:
+
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-8 in group2 (Timer4)
+- Outputs 9-11 in group3 (Timer1)
+- Outputs 12-14 in group4 (Timer8)
+- Outputs 15-16 in group5 (Timer12)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Serial Port Mapping
 
 | UART   | Device     | Port          |

--- a/docs/en/flight_controller/cuav_x7.md
+++ b/docs/en/flight_controller/cuav_x7.md
@@ -5,3 +5,23 @@
 
 DOC REMOVED: 202603
 -->
+
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 14 FMU PWM outputs (MAIN).
+
+Outputs:
+
+- Outputs 1-12 support [DShot](../peripherals/dshot.md).
+- Outputs 13-14 do not support DShot.
+- Outputs 1-7, 9-12 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+- Output 8 supports Bidirectional DShot output only (no eRPM capture).
+
+The 14 outputs are in 4 groups:
+
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-8 in group2 (Timer4)
+- Outputs 9-12 in group3 (Timer1)
+- Outputs 13-14 in group4 (Timer12)
+
+All outputs within the same group must use the same output protocol and rate.

--- a/docs/en/flight_controller/cubepilot_cube_orange.md
+++ b/docs/en/flight_controller/cubepilot_cube_orange.md
@@ -40,6 +40,19 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - High-power, multi-tone piezo audio indicator
 - microSD card for high-rate logging over extended periods of time
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 6 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+All FMU outputs support [DShot](../peripherals/dshot.md) and [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 6 outputs are in 2 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 - [Reseller list](https://www.cubepilot.com/#/reseller/list)

--- a/docs/en/flight_controller/cubepilot_cube_orangeplus.md
+++ b/docs/en/flight_controller/cubepilot_cube_orangeplus.md
@@ -41,6 +41,19 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - High-power, multi-tone piezo audio indicator
 - microSD card for high-rate logging over extended periods of time
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 6 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+All FMU outputs support [DShot](../peripherals/dshot.md) and [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 6 outputs are in 2 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 - [Reseller list](https://www.cubepilot.com/#/reseller/list)

--- a/docs/en/flight_controller/cubepilot_cube_yellow.md
+++ b/docs/en/flight_controller/cubepilot_cube_yellow.md
@@ -36,6 +36,23 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - High-power, multi-tone piezo audio indicator
 - microSD card for high-rate logging over extended periods of time
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 6 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+FMU Outputs:
+
+- Outputs 1-4 support [DShot](../peripherals/dshot.md).
+- Outputs 5-6 do not support DShot.
+- Outputs 1-4 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 6 outputs are in 2 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 - [Reseller list](https://www.cubepilot.com/#/reseller/list)

--- a/docs/en/flight_controller/cubepilot_cube_yellow.md
+++ b/docs/en/flight_controller/cubepilot_cube_yellow.md
@@ -40,11 +40,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 
 This flight controller supports up to 6 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
-FMU Outputs:
-
-- Outputs 1-4 support [DShot](../peripherals/dshot.md).
-- Outputs 5-6 do not support DShot.
-- Outputs 1-4 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+[DShot](../peripherals/dshot.md) is not supported.
 
 The 6 outputs are in 2 groups:
 

--- a/docs/en/flight_controller/durandal.md
+++ b/docs/en/flight_controller/durandal.md
@@ -88,20 +88,14 @@ For more information see: [Durandal Technical Data Sheet](https://cdn.shopify.co
 
 ## PWM Outputs {#pwm_outputs}
 
-This flight controller supports up to 10 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+This flight controller supports up to 5 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
-FMU Outputs:
+All FMU outputs support [DShot](../peripherals/dshot.md) and [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
 
-- Outputs 1-5 support [DShot](../peripherals/dshot.md).
-- Outputs 6-10 do not support DShot.
-- Outputs 1-5 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
-
-The 10 outputs are in 4 groups:
+The 5 outputs are in 2 groups:
 
 - Outputs 1-4 in group1 (Timer1)
 - Output 5 in group2 (Timer4)
-- Outputs 6-8 in group3 (Timer2)
-- Outputs 9-10 in group4 (Timer12)
 
 All outputs within the same group must use the same output protocol and rate.
 

--- a/docs/en/flight_controller/durandal.md
+++ b/docs/en/flight_controller/durandal.md
@@ -86,6 +86,25 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 
 For more information see: [Durandal Technical Data Sheet](https://cdn.shopify.com/s/files/1/0604/5905/7341/files/Durandal_technical_data_sheet_90f8875d-8035-4632-a936-a0d178062077.pdf).
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 10 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+FMU Outputs:
+
+- Outputs 1-5 support [DShot](../peripherals/dshot.md).
+- Outputs 6-10 do not support DShot.
+- Outputs 1-5 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 10 outputs are in 4 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Output 5 in group2 (Timer4)
+- Outputs 6-8 in group3 (Timer2)
+- Outputs 9-10 in group4 (Timer12)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/durandal).

--- a/docs/en/flight_controller/gearup_airbrainh743.md
+++ b/docs/en/flight_controller/gearup_airbrainh743.md
@@ -70,6 +70,25 @@ Current UART configuration:
 Before PX4 firmware can be installed, the _PX4 bootloader_ must be flashed.
 Download the [gearup_airbrainh743_bootloader.bin](https://github.com/PX4/PX4-Autopilot/blob/main/boards/gearup/airbrainh743/extras/gearup_airbrainh743_bootloader.bin) bootloader binary and read [this page](../advanced_config/bootloader_update_from_betaflight.md) for flashing instructions.
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 9 FMU PWM outputs (MAIN).
+
+Outputs:
+
+- Outputs 1-8 support [DShot](../peripherals/dshot.md).
+- Output 9 does not support DShot.
+- Outputs 1-8 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 9 outputs are in 4 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer3)
+- Outputs 7-8 in group3 (Timer2)
+- Output 9 in group4 (Timer5)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Building Firmware
 
 To [build PX4](../dev_setup/building_px4.md) for this target:

--- a/docs/en/flight_controller/holybro_pix32_v5.md
+++ b/docs/en/flight_controller/holybro_pix32_v5.md
@@ -73,20 +73,15 @@ Additional information can be found in the [Pix32 V5 Technical Data Sheet](https
 
 ## PWM Outputs {#pwm_outputs}
 
-This flight controller supports up to 11 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
-FMU Outputs:
+[DShot](../peripherals/dshot.md) is not supported.
 
-- Outputs 1-4 support [DShot](../peripherals/dshot.md).
-- Outputs 5-11 do not support DShot.
-- Outputs 1-4 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
-
-The 11 outputs are in 4 groups:
+The 8 outputs are in 3 groups:
 
 - Outputs 1-4 in group1 (Timer1)
 - Outputs 5-6 in group2 (Timer4)
 - Outputs 7-8 in group3 (Timer12)
-- Outputs 9-11 in group4 (Timer2)
 
 All outputs within the same group must use the same output protocol and rate.
 

--- a/docs/en/flight_controller/holybro_pix32_v5.md
+++ b/docs/en/flight_controller/holybro_pix32_v5.md
@@ -71,6 +71,25 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 
 Additional information can be found in the [Pix32 V5 Technical Data Sheet](https://cdn.shopify.com/s/files/1/0604/5905/7341/files/Holybro_PIX32-V5_technical_data_sheet_v1.1.pdf).
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 11 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+FMU Outputs:
+
+- Outputs 1-4 support [DShot](../peripherals/dshot.md).
+- Outputs 5-11 do not support DShot.
+- Outputs 1-4 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 11 outputs are in 4 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer12)
+- Outputs 9-11 in group4 (Timer2)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 Order from [Holybro website](https://holybro.com/products/pix32-v5).

--- a/docs/en/flight_controller/kakutef7.md
+++ b/docs/en/flight_controller/kakutef7.md
@@ -5,3 +5,22 @@
 
 DOC REMOVED: 202603
 -->
+
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 6 FMU PWM outputs (MAIN).
+
+Outputs:
+
+- Outputs 1-6 support [DShot](../peripherals/dshot.md).
+- Outputs 3-4 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+- Outputs 1-2, 5-6 support Bidirectional DShot output only (no eRPM capture).
+
+The 6 outputs are in 4 groups:
+
+- Outputs 1-2 in group1 (Timer3)
+- Outputs 3-4 in group2 (Timer1)
+- Output 5 in group3 (Timer8)
+- Output 6 in group4 (Timer5)
+
+All outputs within the same group must use the same output protocol and rate.

--- a/docs/en/flight_controller/kakutef7.md
+++ b/docs/en/flight_controller/kakutef7.md
@@ -10,11 +10,7 @@ DOC REMOVED: 202603
 
 This flight controller supports up to 6 FMU PWM outputs (MAIN).
 
-Outputs:
-
-- Outputs 1-6 support [DShot](../peripherals/dshot.md).
-- Outputs 3-4 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
-- Outputs 1-2, 5-6 support Bidirectional DShot output only (no eRPM capture).
+[DShot](../peripherals/dshot.md) is not supported.
 
 The 6 outputs are in 4 groups:
 

--- a/docs/en/flight_controller/kakuteh7-wing.md
+++ b/docs/en/flight_controller/kakuteh7-wing.md
@@ -13,6 +13,28 @@ The [Holybro Kakute H743 Wing](https://holybro.com/products/kakute-h743-wing) is
 This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
 :::
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 14 FMU PWM outputs (MAIN).
+
+Outputs:
+
+- Outputs 1-8, 11-14 support [DShot](../peripherals/dshot.md).
+- Outputs 9-10 do not support DShot.
+- Outputs 1-5, 7-8, 11-14 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+- Output 6 supports Bidirectional DShot output only (no eRPM capture).
+
+The 14 outputs are in 6 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer5)
+- Outputs 9-10 in group4 (Timer15)
+- Outputs 11-13 in group5 (Timer3)
+- Output 14 in group6 (Timer2)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 The board can be bought from one of the following shops (for example):

--- a/docs/en/flight_controller/kakuteh7.md
+++ b/docs/en/flight_controller/kakuteh7.md
@@ -36,6 +36,21 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - Dimensions: 35x35mm
 - Weight: 8g
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 8 FMU PWM outputs (MAIN).
+
+All outputs support [DShot](../peripherals/dshot.md) and [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 8 outputs are in 4 groups:
+
+- Outputs 1-2 in group1 (Timer3)
+- Outputs 3-4 in group2 (Timer2)
+- Outputs 5-6 in group3 (Timer5)
+- Outputs 7-8 in group4 (Timer8)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 The board can be bought from one of the following shops (for example):

--- a/docs/en/flight_controller/kakuteh7mini.md
+++ b/docs/en/flight_controller/kakuteh7mini.md
@@ -40,6 +40,21 @@ PX4 runs on the H7 mini v1.3 and later.
 - Dimensions: 30x31x6mm
 - Weight: 5.5g
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 8 FMU PWM outputs (MAIN).
+
+All outputs support [DShot](../peripherals/dshot.md) and [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 8 outputs are in 4 groups:
+
+- Outputs 1-2 in group1 (Timer3)
+- Outputs 3-4 in group2 (Timer2)
+- Outputs 5-6 in group3 (Timer5)
+- Outputs 7-8 in group4 (Timer8)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 The board can be bought from one of the following shops (for example):

--- a/docs/en/flight_controller/kakuteh7v2.md
+++ b/docs/en/flight_controller/kakuteh7v2.md
@@ -36,6 +36,21 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - Dimensions: 35x35mm
 - Weight: 8g
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 8 FMU PWM outputs (MAIN).
+
+All outputs support [DShot](../peripherals/dshot.md) and [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 8 outputs are in 4 groups:
+
+- Outputs 1-2 in group1 (Timer3)
+- Outputs 3-4 in group2 (Timer2)
+- Outputs 5-6 in group3 (Timer5)
+- Outputs 7-8 in group4 (Timer8)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 The board can be bought from one of the following shops (for example):

--- a/docs/en/flight_controller/micoair743-lite.md
+++ b/docs/en/flight_controller/micoair743-lite.md
@@ -67,6 +67,26 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 
 ![MicoAir743-Lite Size](../../assets/flight_controller/micoair743_lite/size.png)
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 14 FMU PWM outputs (MAIN).
+
+Outputs:
+
+- Outputs 1-8, 11-12 support [DShot](../peripherals/dshot.md).
+- Outputs 9-10, 13-14 do not support DShot.
+- Outputs 1-8, 11-12 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 14 outputs are in 5 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-8 in group2 (Timer3)
+- Outputs 11-12 in group3 (Timer4)
+- Outputs 13-14 in group4 (Timer12)
+- Outputs 9-10 in group5 (Timer15)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 Order from [MicoAir Tech Store](https://store.micoair.com/product/micoair743-lite/).

--- a/docs/en/flight_controller/mindpx.md
+++ b/docs/en/flight_controller/mindpx.md
@@ -104,6 +104,19 @@ And the max BAUD rate is the same as for the PX4 family, which is up to 921600.
 The user guide is [here](http://mindpx.net/assets/accessories/UserGuide9.18_2_pdf.pdf).
 :::
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 8 FMU PWM outputs (MAIN).
+
+[DShot](../peripherals/dshot.md) is not supported.
+
+The 8 outputs are in 2 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-8 in group2 (Timer4)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 MindRacer is available at [AirMind Store](https://airmind.mindpx.net/catalog).

--- a/docs/en/flight_controller/modalai_fc_v1.md
+++ b/docs/en/flight_controller/modalai_fc_v1.md
@@ -10,11 +10,7 @@ DOC REMOVED: 202603
 
 This flight controller supports up to 8 FMU PWM outputs (MAIN).
 
-Outputs:
-
-- Outputs 1-8 support [DShot](../peripherals/dshot.md).
-- Outputs 1-7 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
-- Output 8 supports Bidirectional DShot output only (no eRPM capture).
+[DShot](../peripherals/dshot.md) is not supported.
 
 The 8 outputs are in 2 groups:
 

--- a/docs/en/flight_controller/modalai_fc_v1.md
+++ b/docs/en/flight_controller/modalai_fc_v1.md
@@ -5,3 +5,20 @@
 
 DOC REMOVED: 202603
 -->
+
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 8 FMU PWM outputs (MAIN).
+
+Outputs:
+
+- Outputs 1-8 support [DShot](../peripherals/dshot.md).
+- Outputs 1-7 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+- Output 8 supports Bidirectional DShot output only (no eRPM capture).
+
+The 8 outputs are in 2 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-8 in group2 (Timer4)
+
+All outputs within the same group must use the same output protocol and rate.

--- a/docs/en/flight_controller/mro_control_zero_f7.md
+++ b/docs/en/flight_controller/mro_control_zero_f7.md
@@ -56,6 +56,20 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 - Power System:
   - 3x Ultra low noise LDO voltage regulator
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 8 FMU PWM outputs (MAIN).
+
+[DShot](../peripherals/dshot.md) is not supported.
+
+The 8 outputs are in 3 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer8)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 - [mRo Control Zero](https://store.mrobotics.io/mRo-Control-Zero-F7-p/mro-ctrl-zero-f7.htm)

--- a/docs/en/flight_controller/mro_x2.1.md
+++ b/docs/en/flight_controller/mro_x2.1.md
@@ -8,3 +8,20 @@ Doc removed 202603
 
 Note: Got ports using https://github.com/PX4/PX4-user_guide/pull/672#issuecomment-598198434
 -->
+
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 6 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+FMU Outputs:
+
+- Outputs 1-4 support [DShot](../peripherals/dshot.md).
+- Outputs 5-6 do not support DShot.
+- Outputs 1-4 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 6 outputs are in 2 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+
+All outputs within the same group must use the same output protocol and rate.

--- a/docs/en/flight_controller/mro_x2.1.md
+++ b/docs/en/flight_controller/mro_x2.1.md
@@ -13,11 +13,7 @@ Note: Got ports using https://github.com/PX4/PX4-user_guide/pull/672#issuecommen
 
 This flight controller supports up to 6 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
-FMU Outputs:
-
-- Outputs 1-4 support [DShot](../peripherals/dshot.md).
-- Outputs 5-6 do not support DShot.
-- Outputs 1-4 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+[DShot](../peripherals/dshot.md) is not supported.
 
 The 6 outputs are in 2 groups:
 

--- a/docs/en/flight_controller/nxp_mr_vmu_rt1176.md
+++ b/docs/en/flight_controller/nxp_mr_vmu_rt1176.md
@@ -133,6 +133,23 @@ Similar variants will be available from our licensees.
 - Other Characteristics:
   - Operating & storage temperature: -40 ~ 85°c
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 6 FMU PWM outputs (MAIN).
+
+Outputs:
+
+- Outputs 1-3, 5-6 support [DShot](../peripherals/dshot.md).
+- Output 4 does not support DShot.
+- Outputs 1-3, 5-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 6 outputs are in 2 groups:
+
+- Outputs 1-4 in group1 (PWM2)
+- Outputs 5-6 in group2 (PWM4)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 Order from [NXP](https://www.nxp.com).

--- a/docs/en/flight_controller/nxp_rddrone_fmuk66.md
+++ b/docs/en/flight_controller/nxp_rddrone_fmuk66.md
@@ -5,3 +5,16 @@
 
 DOC REMOVED: 202603
 -->
+
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 6 FMU PWM outputs (MAIN).
+
+[DShot](../peripherals/dshot.md) is not supported.
+
+The 6 outputs are in 2 groups:
+
+- Outputs 1-4 in group1 (FTM0)
+- Outputs 5-6 in group2 (FTM3)
+
+All outputs within the same group must use the same output protocol and rate.

--- a/docs/en/flight_controller/omnibus_f4_sd.md
+++ b/docs/en/flight_controller/omnibus_f4_sd.md
@@ -5,3 +5,16 @@
 
 DOC REMOVED: 202603
 -->
+
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 4 FMU PWM outputs (MAIN).
+
+All outputs support [DShot](../peripherals/dshot.md) ([Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry) not supported).
+
+The 4 outputs are in 2 groups:
+
+- Outputs 1-2 in group1 (Timer3)
+- Outputs 3-4 in group2 (Timer2)
+
+All outputs within the same group must use the same output protocol and rate.

--- a/docs/en/flight_controller/omnibus_f4_sd.md
+++ b/docs/en/flight_controller/omnibus_f4_sd.md
@@ -10,7 +10,7 @@ DOC REMOVED: 202603
 
 This flight controller supports up to 4 FMU PWM outputs (MAIN).
 
-All outputs support [DShot](../peripherals/dshot.md) ([Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry) not supported).
+[DShot](../peripherals/dshot.md) is not supported.
 
 The 4 outputs are in 2 groups:
 

--- a/docs/en/flight_controller/pixhawk-2.md
+++ b/docs/en/flight_controller/pixhawk-2.md
@@ -47,6 +47,19 @@ This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md
 - High-power, multi-tone piezo audio indicator
 - microSD card for high-rate logging over extended periods of time
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 6 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+All FMU outputs support [DShot](../peripherals/dshot.md) ([Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry) not supported).
+
+The 6 outputs are in 2 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 [Cube Black](https://www.cubepilot.com/#/reseller/list) (Reseller list)

--- a/docs/en/flight_controller/pixhawk-2.md
+++ b/docs/en/flight_controller/pixhawk-2.md
@@ -51,7 +51,7 @@ This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md
 
 This flight controller supports up to 6 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
-All FMU outputs support [DShot](../peripherals/dshot.md) ([Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry) not supported).
+[DShot](../peripherals/dshot.md) is not supported.
 
 The 6 outputs are in 2 groups:
 

--- a/docs/en/flight_controller/pixhawk.md
+++ b/docs/en/flight_controller/pixhawk.md
@@ -9,7 +9,7 @@ Doc removed 202604
 
 This flight controller supports up to 6 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
-All FMU outputs support [DShot](../peripherals/dshot.md) ([Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry) not supported).
+[DShot](../peripherals/dshot.md) is not supported.
 
 The 6 outputs are in 2 groups:
 

--- a/docs/en/flight_controller/pixhawk.md
+++ b/docs/en/flight_controller/pixhawk.md
@@ -4,3 +4,16 @@
 # 3DR Pixhawk 1 Flight Controller (Discontinued)
 Doc removed 202604
 -->
+
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 6 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+All FMU outputs support [DShot](../peripherals/dshot.md) ([Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry) not supported).
+
+The 6 outputs are in 2 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+
+All outputs within the same group must use the same output protocol and rate.

--- a/docs/en/flight_controller/pixhawk3_pro.md
+++ b/docs/en/flight_controller/pixhawk3_pro.md
@@ -5,3 +5,16 @@
 
 DOC REMOVED: 202603
 -->
+
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 6 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+[DShot](../peripherals/dshot.md) is not supported.
+
+The 6 outputs are in 2 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+
+All outputs within the same group must use the same output protocol and rate.

--- a/docs/en/flight_controller/pixhawk4.md
+++ b/docs/en/flight_controller/pixhawk4.md
@@ -53,20 +53,15 @@ Additional information can be found in the [Pixhawk 4 Technical Data Sheet](http
 
 ## PWM Outputs {#pwm_outputs}
 
-This flight controller supports up to 11 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
-FMU Outputs:
+[DShot](../peripherals/dshot.md) is not supported.
 
-- Outputs 1-4 support [DShot](../peripherals/dshot.md).
-- Outputs 5-11 do not support DShot.
-- Outputs 1-4 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
-
-The 11 outputs are in 4 groups:
+The 8 outputs are in 3 groups:
 
 - Outputs 1-4 in group1 (Timer1)
 - Outputs 5-6 in group2 (Timer4)
 - Outputs 7-8 in group3 (Timer12)
-- Outputs 9-11 in group4 (Timer2)
 
 All outputs within the same group must use the same output protocol and rate.
 

--- a/docs/en/flight_controller/pixhawk4.md
+++ b/docs/en/flight_controller/pixhawk4.md
@@ -51,6 +51,25 @@ This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md
 
 Additional information can be found in the [Pixhawk 4 Technical Data Sheet](https://github.com/PX4/PX4-Autopilot/blob/main/docs/assets/flight_controller/pixhawk4/pixhawk4_technical_data_sheet.pdf).
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 11 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+FMU Outputs:
+
+- Outputs 1-4 support [DShot](../peripherals/dshot.md).
+- Outputs 5-11 do not support DShot.
+- Outputs 1-4 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 11 outputs are in 4 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer12)
+- Outputs 9-11 in group4 (Timer2)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/pixhawk-4).

--- a/docs/en/flight_controller/pixhawk5x.md
+++ b/docs/en/flight_controller/pixhawk5x.md
@@ -113,20 +113,15 @@ The Pixhawk® 5X is perfect for developers at corporate research labs, startups,
 
 ## PWM Outputs {#pwm_outputs}
 
-This flight controller supports up to 9 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
-FMU Outputs:
+[DShot](../peripherals/dshot.md) is not supported.
 
-- Outputs 1-6 support [DShot](../peripherals/dshot.md).
-- Outputs 7-9 do not support DShot.
-- Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
-
-The 9 outputs are in 4 groups:
+The 8 outputs are in 3 groups:
 
 - Outputs 1-4 in group1 (Timer1)
 - Outputs 5-6 in group2 (Timer4)
 - Outputs 7-8 in group3 (Timer12)
-- Output 9 in group4 (Timer5)
 
 All outputs within the same group must use the same output protocol and rate.
 

--- a/docs/en/flight_controller/pixhawk5x.md
+++ b/docs/en/flight_controller/pixhawk5x.md
@@ -111,6 +111,25 @@ The Pixhawk® 5X is perfect for developers at corporate research labs, startups,
 - Other Characteristics:
   - Operating & storage temperature: -40 ~ 85°c
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 9 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+FMU Outputs:
+
+- Outputs 1-6 support [DShot](../peripherals/dshot.md).
+- Outputs 7-9 do not support DShot.
+- Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 9 outputs are in 4 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer12)
+- Output 9 in group4 (Timer5)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/pixhawk-5x).

--- a/docs/en/flight_controller/pixhawk6c.md
+++ b/docs/en/flight_controller/pixhawk6c.md
@@ -88,6 +88,25 @@ The Pixhawk® 6C is perfect for developers at corporate research labs, startups,
 - Other Characteristics:
   - Operating & storage temperature: -40 ~ 85°c
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+FMU Outputs:
+
+- Outputs 1-6 support [DShot](../peripherals/dshot.md).
+- Outputs 7-8 do not support DShot.
+- Outputs 1-5 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+- Output 6 supports Bidirectional DShot output only (no eRPM capture).
+
+The 8 outputs are in 3 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer5)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/pixhawk-6c).

--- a/docs/en/flight_controller/pixhawk6x-rt.md
+++ b/docs/en/flight_controller/pixhawk6x-rt.md
@@ -120,6 +120,25 @@ The Pixhawk®​ 6X-RT is perfect for developers at corporate research labs, sta
 - Other Characteristics:
   - Operating & storage temperature: -40 ~ 85°c
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 12 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+FMU Outputs:
+
+- Outputs 1-8 support [DShot](../peripherals/dshot.md).
+- Outputs 9-12 do not support DShot.
+- Outputs 1-8 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 12 outputs are in 4 groups:
+
+- Outputs 1-3 in group1 (PWM1)
+- Outputs 4-7 in group2 (PWM2)
+- Outputs 8-10 in group3 (PWM3)
+- Outputs 11-12 in group4 (PWM4)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/pixhawk-6x-rt).

--- a/docs/en/flight_controller/pixhawk6x.md
+++ b/docs/en/flight_controller/pixhawk6x.md
@@ -150,6 +150,25 @@ The Pixhawk®​ 6X is perfect for developers at corporate research labs, startu
 - Other Characteristics:
   - Operating & storage temperature: -40 ~ 85°c
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 9 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+FMU Outputs:
+
+- Outputs 1-6 support [DShot](../peripherals/dshot.md).
+- Outputs 7-9 do not support DShot.
+- Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 9 outputs are in 4 groups:
+
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer12)
+- Output 9 in group4 (Timer1)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/pixhawk-6x).

--- a/docs/en/flight_controller/pixhawk6x.md
+++ b/docs/en/flight_controller/pixhawk6x.md
@@ -152,20 +152,19 @@ The Pixhawk®​ 6X is perfect for developers at corporate research labs, startu
 
 ## PWM Outputs {#pwm_outputs}
 
-This flight controller supports up to 9 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
 FMU Outputs:
 
 - Outputs 1-6 support [DShot](../peripherals/dshot.md).
-- Outputs 7-9 do not support DShot.
+- Outputs 7-8 do not support DShot.
 - Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
 
-The 9 outputs are in 4 groups:
+The 8 outputs are in 3 groups:
 
 - Outputs 1-4 in group1 (Timer5)
 - Outputs 5-6 in group2 (Timer4)
 - Outputs 7-8 in group3 (Timer12)
-- Output 9 in group4 (Timer1)
 
 All outputs within the same group must use the same output protocol and rate.
 

--- a/docs/en/flight_controller/pixhawk6x_pro.md
+++ b/docs/en/flight_controller/pixhawk6x_pro.md
@@ -113,20 +113,19 @@ It can also be used with any other Pixhawk Autopilot Bus (PAB) specification-com
 
 ## PWM Outputs {#pwm_outputs}
 
-This flight controller supports up to 9 FMU PWM outputs (MAIN).
+This flight controller supports up to 8 FMU PWM outputs (MAIN).
 
 Outputs:
 
 - Outputs 1-6 support [DShot](../peripherals/dshot.md).
-- Outputs 7-9 do not support DShot.
+- Outputs 7-8 do not support DShot.
 - Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
 
-The 9 outputs are in 4 groups:
+The 8 outputs are in 3 groups:
 
 - Outputs 1-4 in group1 (Timer5)
 - Outputs 5-6 in group2 (Timer4)
 - Outputs 7-8 in group3 (Timer12)
-- Output 9 in group4 (Timer1)
 
 All outputs within the same group must use the same output protocol and rate.
 

--- a/docs/en/flight_controller/pixhawk6x_pro.md
+++ b/docs/en/flight_controller/pixhawk6x_pro.md
@@ -111,6 +111,25 @@ It can also be used with any other Pixhawk Autopilot Bus (PAB) specification-com
 
 :::
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 9 FMU PWM outputs (MAIN).
+
+Outputs:
+
+- Outputs 1-6 support [DShot](../peripherals/dshot.md).
+- Outputs 7-9 do not support DShot.
+- Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 9 outputs are in 4 groups:
+
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer12)
+- Output 9 in group4 (Timer1)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 Order from [Holybro](https://holybro.com/products/pixhawk-6x-pro).

--- a/docs/en/flight_controller/pixracer.md
+++ b/docs/en/flight_controller/pixracer.md
@@ -30,6 +30,20 @@ This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md
 - OneShot PWM out (configurable)
 - Optional: Safety switch and buzzer
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 8 FMU PWM outputs (MAIN).
+
+All outputs support [DShot](../peripherals/dshot.md) and [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 8 outputs are in 3 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer8)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 Pixracer Pro is available from the [store.3dr.com](https://store.3dr.com/pixracer-pro/).

--- a/docs/en/flight_controller/radiolink_pix6.md
+++ b/docs/en/flight_controller/radiolink_pix6.md
@@ -52,11 +52,7 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
 
 This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
-FMU Outputs:
-
-- Outputs 1-8 support [DShot](../peripherals/dshot.md).
-- Outputs 1-4 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
-- Outputs 5-8 support Bidirectional DShot output only (no eRPM capture).
+[DShot](../peripherals/dshot.md) is not supported.
 
 The 8 outputs are in 3 groups:
 

--- a/docs/en/flight_controller/radiolink_pix6.md
+++ b/docs/en/flight_controller/radiolink_pix6.md
@@ -48,6 +48,24 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
   - Weight 80g
   - Size 94mm x 51.5mm x 14.5mm
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+FMU Outputs:
+
+- Outputs 1-8 support [DShot](../peripherals/dshot.md).
+- Outputs 1-4 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+- Outputs 5-8 support Bidirectional DShot output only (no eRPM capture).
+
+The 8 outputs are in 3 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer2)
+- Outputs 7-8 in group3 (Timer3)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 [Radiolink Amazon](https://www.radiolink.com.cn/pix6_where_to_buy)（International users）

--- a/docs/en/flight_controller/spracingh7extreme.md
+++ b/docs/en/flight_controller/spracingh7extreme.md
@@ -72,6 +72,20 @@ This flight controller is [manufacturer supported](../flight_controller/autopilo
   - 36x36mm with 30.5\*30.5 mouting pattern, M4 holes.
   - Soft-mount M4 to M3 grommets supplied.
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 8 FMU PWM outputs (MAIN).
+
+All outputs support [DShot](../peripherals/dshot.md) and [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 8 outputs are in 3 groups:
+
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer8)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to Buy {#store}
 
 The SPRacingH7EXTREME is available from the [Seriously Pro shop](https://shop.seriouslypro.com/sp-racing-h7-extreme).

--- a/docs/en/flight_controller/svehicle_e2.md
+++ b/docs/en/flight_controller/svehicle_e2.md
@@ -85,24 +85,80 @@ CRSF receiver must be wired to a spare port (UART) on the Flight Controller. The
 | UART7  | /dev/ttyS6 | TELEM1        |
 | UART8  | /dev/ttyS7 | GPS2          |
 
+## PWM Output
+
+The E2-Plus flight controller supports up to 14 PWM outputs.
+The first 8 outputs (labelled M1 to M8) are controlled by a dedicated STM32F103 IOMCU controller.
+The remaining 6 outputs (labelled 9 to 14) are the "auxiliary" outputs.
+These are directly attached to the STM32H753 FMU controller .
+
+The 14 PWM outputs are:
+
+M1 - M8 are connected to the IOMCU
+A1 - A6 are connected to the FMU
+
+M1 - M8 support DShot and are in 3 groups:
+
+- M1, M2 in group 1
+- M3, M4 in group 2
+- M5, M6, M7, M8 in group 3
+
+The 6 FMU PWM outputs are in 2 groups:
+
+A1 - A4 are in one group.
+A5, A6 are in a 2nd group.
+
+Channels within the same group need to use the same output rate.
+If any channel in a group uses DShot then all channels in the group need to use DShot.
+
+### Electrical data
+
+- Voltage Ratings:
+  - Max input voltage: 5.7V
+  - USB Power Input: 4.75\~5.25V
+  - Servo Rail Input: 0\~9.9V
+- Current Ratings:
+  - TELEM1 and GPS2 combined output current limiter: 1.5A
+  - All other port combined output current limiter: 1.5A
+<!-- pwm_outputs-proposed
+<!-- pwm_outputs-proposed
 ## PWM Outputs {#pwm_outputs}
 
-This flight controller supports up to 9 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
 FMU Outputs:
 
 - Outputs 1-6 support [DShot](../peripherals/dshot.md).
-- Outputs 7-9 do not support DShot.
+- Outputs 7-8 do not support DShot.
 - Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
 
-The 9 outputs are in 4 groups:
+The 8 outputs are in 3 groups:
 
 - Outputs 1-4 in group1 (Timer5)
 - Outputs 5-6 in group2 (Timer4)
 - Outputs 7-8 in group3 (Timer12)
-- Output 9 in group4 (Timer1)
 
 All outputs within the same group must use the same output protocol and rate.
+-->
+
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 8 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+FMU Outputs:
+
+- Outputs 1-6 support [DShot](../peripherals/dshot.md).
+- Outputs 7-8 do not support DShot.
+- Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 8 outputs are in 3 groups:
+
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer12)
+
+All outputs within the same group must use the same output protocol and rate.
+-->
 
 ## Battery Monitoring
 

--- a/docs/en/flight_controller/svehicle_e2.md
+++ b/docs/en/flight_controller/svehicle_e2.md
@@ -85,41 +85,24 @@ CRSF receiver must be wired to a spare port (UART) on the Flight Controller. The
 | UART7  | /dev/ttyS6 | TELEM1        |
 | UART8  | /dev/ttyS7 | GPS2          |
 
-## PWM Output
+## PWM Outputs {#pwm_outputs}
 
-The E2-Plus flight controller supports up to 14 PWM outputs.
-The first 8 outputs (labelled M1 to M8) are controlled by a dedicated STM32F103 IOMCU controller.
-The remaining 6 outputs (labelled 9 to 14) are the "auxiliary" outputs.
-These are directly attached to the STM32H753 FMU controller .
+This flight controller supports up to 9 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
-The 14 PWM outputs are:
+FMU Outputs:
 
-M1 - M8 are connected to the IOMCU
-A1 - A6 are connected to the FMU
+- Outputs 1-6 support [DShot](../peripherals/dshot.md).
+- Outputs 7-9 do not support DShot.
+- Outputs 1-6 support [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
 
-M1 - M8 support DShot and are in 3 groups:
+The 9 outputs are in 4 groups:
 
-- M1, M2 in group 1
-- M3, M4 in group 2
-- M5, M6, M7, M8 in group 3
+- Outputs 1-4 in group1 (Timer5)
+- Outputs 5-6 in group2 (Timer4)
+- Outputs 7-8 in group3 (Timer12)
+- Output 9 in group4 (Timer1)
 
-The 6 FMU PWM outputs are in 2 groups:
-
-A1 - A4 are in one group.
-A5, A6 are in a 2nd group.
-
-Channels within the same group need to use the same output rate.
-If any channel in a group uses DShot then all channels in the group need to use DShot.
-
-### Electrical data
-
-- Voltage Ratings:
-  - Max input voltage: 5.7V
-  - USB Power Input: 4.75\~5.25V
-  - Servo Rail Input: 0\~9.9V
-- Current Ratings:
-  - TELEM1 and GPS2 combined output current limiter: 1.5A
-  - All other port combined output current limiter: 1.5A
+All outputs within the same group must use the same output protocol and rate.
 
 ## Battery Monitoring
 

--- a/docs/en/flight_controller/thepeach_k1.md
+++ b/docs/en/flight_controller/thepeach_k1.md
@@ -96,6 +96,19 @@ To build PX4 for this target:
 make thepeach_k1_default
 ```
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 5 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+[DShot](../peripherals/dshot.md) is not supported.
+
+The 5 outputs are in 2 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Output 5 in group2 (Timer4)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to buy
 
 Order from [ThePeach](https://thepeach.shop/)

--- a/docs/en/flight_controller/thepeach_r1.md
+++ b/docs/en/flight_controller/thepeach_r1.md
@@ -100,6 +100,19 @@ To build PX4 for this target:
 make thepeach_r1_default
 ```
 
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 6 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+[DShot](../peripherals/dshot.md) is not supported.
+
+The 6 outputs are in 2 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Outputs 5-6 in group2 (Timer4)
+
+All outputs within the same group must use the same output protocol and rate.
+
 ## Where to buy
 
 Order from [ThePeach](https://thepeach.shop/)

--- a/docs/en/flight_controller/x-mav_ap-h743r1.md
+++ b/docs/en/flight_controller/x-mav_ap-h743r1.md
@@ -69,39 +69,19 @@ CRSF receiver must be wired to a spare port (UART) on the Flight Controller. The
 | UART7  | /dev/ttyS4 | TELEM3  |
 | UART8  | /dev/ttyS5 | SERIAL4 |
 
-## PWM Output
+## PWM Outputs {#pwm_outputs}
 
-The AP-H743-R1 flight controller supports up to 15 PWM outputs.
-The first 8 outputs (labelled M1 to M8) are controlled by a dedicated STM32F103 IOMCU controller.
-The remaining 7 outputs (labelled A1 to A7) are the "auxiliary" outputs.
-These are directly attached to the STM32H743 FMU controller .
+This flight controller supports up to 7 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
 
-The 15 PWM outputs are:
+All FMU outputs support [DShot](../peripherals/dshot.md) and [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
 
-M1 - M8 are connected to the IOMCU.
-A1 - A7 are connected to the FMU.
+The 7 outputs are in 3 groups:
 
-M1 - M8 support DShot and are in 3 groups:
+- Outputs 1-4 in group1 (Timer1)
+- Output 7 in group2 (Timer2)
+- Outputs 5-6 in group3 (Timer3)
 
-- M1, M2 in group 1
-- M3, M4 in group 2
-- M5, M6, M7, M8 in group 3
-
-The 7 FMU PWM outputs are in 3 groups:
-
-- A1 - A4 are in one group.
-- A5, A6 are in a 2nd group.
-- A7 is in a 3rd group.
-
-Channels within the same group need to use the same output rate.
-If any channel in a group uses DShot then all channels in the group need to use DShot.
-
-### Electrical data
-
-- Voltage Ratings:
-  - Max input voltage: 5.4V
-  - USB Power Input: 4.75\~5.25V
-  - Servo Rail Input: 0\~9.9V
+All outputs within the same group must use the same output protocol and rate.
 
 ## Battery Monitoring
 

--- a/docs/en/flight_controller/x-mav_ap-h743r1.md
+++ b/docs/en/flight_controller/x-mav_ap-h743r1.md
@@ -69,6 +69,41 @@ CRSF receiver must be wired to a spare port (UART) on the Flight Controller. The
 | UART7  | /dev/ttyS4 | TELEM3  |
 | UART8  | /dev/ttyS5 | SERIAL4 |
 
+## PWM Output
+
+The AP-H743-R1 flight controller supports up to 15 PWM outputs.
+The first 8 outputs (labelled M1 to M8) are controlled by a dedicated STM32F103 IOMCU controller.
+The remaining 7 outputs (labelled A1 to A7) are the "auxiliary" outputs.
+These are directly attached to the STM32H743 FMU controller .
+
+The 15 PWM outputs are:
+
+M1 - M8 are connected to the IOMCU.
+A1 - A7 are connected to the FMU.
+
+M1 - M8 support DShot and are in 3 groups:
+
+- M1, M2 in group 1
+- M3, M4 in group 2
+- M5, M6, M7, M8 in group 3
+
+The 7 FMU PWM outputs are in 3 groups:
+
+- A1 - A4 are in one group.
+- A5, A6 are in a 2nd group.
+- A7 is in a 3rd group.
+
+Channels within the same group need to use the same output rate.
+If any channel in a group uses DShot then all channels in the group need to use DShot.
+
+### Electrical data
+
+- Voltage Ratings:
+  - Max input voltage: 5.4V
+  - USB Power Input: 4.75\~5.25V
+  - Servo Rail Input: 0\~9.9V
+<!-- pwm_outputs-proposed
+<!-- pwm_outputs-proposed
 ## PWM Outputs {#pwm_outputs}
 
 This flight controller supports up to 7 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
@@ -82,6 +117,22 @@ The 7 outputs are in 3 groups:
 - Outputs 5-6 in group3 (Timer3)
 
 All outputs within the same group must use the same output protocol and rate.
+-->
+
+## PWM Outputs {#pwm_outputs}
+
+This flight controller supports up to 7 FMU PWM outputs (AUX) and 8 IO PWM outputs (MAIN).
+
+All FMU outputs support [DShot](../peripherals/dshot.md) and [Bidirectional DShot](../peripherals/dshot.md#bidirectional-dshot-telemetry).
+
+The 7 outputs are in 3 groups:
+
+- Outputs 1-4 in group1 (Timer1)
+- Output 7 in group2 (Timer2)
+- Outputs 5-6 in group3 (Timer3)
+
+All outputs within the same group must use the same output protocol and rate.
+-->
 
 ## Battery Monitoring
 


### PR DESCRIPTION
This adds a section `PWM Outputs` to all FC docs for which one can be generated - using #27103

This is generated from a Claude-created script. It looks at timers etc to determine the output. It generates some JSON in the file first.
[parse_pwm_outputs.py](https://github.com/user-attachments/files/26110504/parse_pwm_outputs.py)
[pwm_outputs_1.md](https://github.com/user-attachments/files/26110507/pwm_outputs_1.md)

@dakejahl This all looks pretty sensible and I've had happy results with Claude, but I am not sure how to verify that it hasn't gone off the rails. Could you spot check this - for example look at a few of the Ark and Pixhawk cases?
There are also 4 cases which already had entries, and these have changed. I am presuming as a resutl of your Dhot changes.