### PR TITLE
feat(commander): prevent terminate on arm from gcs loss

### DIFF
--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -510,7 +510,7 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 					   || state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND;
 
 	const bool dll_loss_ignored = isFailsafeIgnored(state.user_intended_mode, _param_com_dll_except.get())
-				      || ignore_any_link_loss_vtol_takeoff_fixedwing || dll_loss_ignored_land;
+				      || ignore_any_link_loss_vtol_takeoff_fixedwing || dll_loss_ignored_land || !state.armed;
 
 	if (_param_nav_dll_act.get() != int32_t(gcs_connection_loss_failsafe_mode::Disabled) && !dll_loss_ignored) {
 		CHECK_FAILSAFE(status_flags, gcs_connection_lost, fromNavDllOrRclActParam(_param_nav_dll_act.get()).causedBy(Cause::GCSConnectionLoss));


### PR DESCRIPTION
### Solved Problem
Setting `NAV_DLL_ACT` to `Terminate`, would lead to `Terminate` on arming, as the GCS loss flag is once set to true, very shortly after powering on, before the connection could be established. Because it is set to terminate, it would never clear, and cause the Terminate immediately when arming. 

### Solution
While not armed yet, the Failsafe check is not run to see if GCS was lost. 

### Changelog Entry
For release notes:
```
Bugfix: NAV_DLL_ACT set to Terminate now works as intended. 
```

