### PR TITLE
fix(voxl2): Update to voxl-px4 service file

### DIFF
--- a/boards/modalai/voxl2/debian/voxl-px4.service
+++ b/boards/modalai/voxl2/debian/voxl-px4.service
@@ -4,11 +4,10 @@ After=sscrpcd.service
 Requires=sscrpcd.service
 
 [Service]
-Type=simple
+ExecStartPre=/bin/sleep 2
 ExecStart=/usr/bin/voxl-px4
 ExecStopPost=/usr/bin/voxl-reset-slpi
 Restart=on-failure
-RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Update to voxl-px4 service file that goes in the debian package. Current version does not start properly on board power up so added some fields to fix this.
