### PR TITLE
fix(syslink): use signed int32 for SLNK_RADIO_ADDR2 default

### DIFF
--- a/boards/bitcraze/crazyflie/syslink/syslink_params.yaml
+++ b/boards/bitcraze/crazyflie/syslink/syslink_params.yaml
@@ -25,4 +25,4 @@ parameters:
       description:
         short: Operating address of the NRF51 (least significant 4 bytes)
       type: int32
-      default: 3890735079
+      default: -404232217


### PR DESCRIPTION
## Summary
- `SLNK_RADIO_ADDR2` default `3890735079` (0xE7E7E7E7) overflows signed int32. Use the signed equivalent `-404232217`.
- Follow-up to #26793

## Test plan
- [ ] Verify parameter metadata generates correctly