### PR TITLE
feat(logger): add sensor_baro to high rate sensors logging profile

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -372,6 +372,7 @@ void LoggedTopics::add_system_identification_topics()
 void LoggedTopics::add_high_rate_sensors_topics()
 {
 	add_topic_multi("distance_sensor", 0, 4);
+	add_topic_multi("sensor_baro", 0, 4);
 	add_topic_multi("sensor_optical_flow", 0, 2);
 	add_topic_multi("sensor_gps", 0, 4);
 	add_topic_multi("sensor_gnss_relative", 0, 1);


### PR DESCRIPTION
## Summary
- Add `sensor_baro` to the `HIGH_RATE_SENSORS` logging profile at full rate (max 4 instances)

## Test plan
- [ ] Verify `sensor_baro` appears in logs when `HIGH_RATE_SENSORS` profile is enabled