### PR TITLE
fix(qurt): Added i2c uninitialize

### DIFF
--- a/boards/modalai/voxl2/cmake/package.cmake
+++ b/boards/modalai/voxl2/cmake/package.cmake
@@ -47,7 +47,7 @@ set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
 set(CPACK_INSTALL_PREFIX "/usr")
 set(CPACK_SET_DESTDIR true)
 
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libfc-sensor (>=1.0.10), voxl-px4-params (>=0.3.10), voxl3-system-image(>=0.0.2) | voxl2-system-image(>=1.5.4) | rb5-system-image(>=1.6.2), modalai-slpi(>=1.1.16) | modalai-adsp(>=1.0.2)")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libfc-sensor (>=1.0.10), voxl-px4-params (>=0.3.10), voxl3-system-image(>=0.0.2) | voxl2-system-image(>=1.5.4) | rb5-system-image(>=1.6.2), modalai-slpi(>=1.2.2) | modalai-adsp(>=1.0.5)")
 set(CPACK_DEBIAN_PACKAGE_CONFLICTS "px4-rb5-flight")
 set(CPACK_DEBIAN_PACKAGE_REPLACES "px4-rb5-flight")
 set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "PX4 Autopilot for ModalAI VOXL2")

--- a/src/lib/drivers/device/qurt/I2C.cpp
+++ b/src/lib/drivers/device/qurt/I2C.cpp
@@ -48,6 +48,10 @@
 #include <px4_platform_common/px4_config.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
+extern "C" {
+	__EXPORT void fc_uninitialize_i2c_bus(int fd);
+}
+
 namespace device
 {
 
@@ -122,7 +126,7 @@ I2C::init()
 	_i2c_fd = _config_i2c_bus(get_device_bus(), get_device_address(), _frequency);
 	pthread_mutex_unlock(_mutex);
 
-	if (_i2c_fd == PX4_ERROR) {
+	if (_i2c_fd == -1) {
 		PX4_ERR("i2c init failed");
 		goto out;
 	}
@@ -132,6 +136,8 @@ I2C::init()
 
 	if (ret != OK) {
 		PX4_ERR("i2c probe failed");
+		fc_uninitialize_i2c_bus(_i2c_fd);
+		_i2c_fd = -1;
 		goto out;
 	}
 


### PR DESCRIPTION
In the Qurt platform i2c driver if the probe fails the port structure is not freed up and becomes a "zombie" port. This can prevent new i2c ports from being opened if free spots are taken up by these zombies. The PR fixes this and adds a proper i2c port uninitialize call when the probe fails.

The PR also updates the package dependencies to make sure that the i2c uninitialize function is available in the DSP.
