### PR TITLE
fix(navigator): correct mission resume waypoint with camera triggering

### DIFF
--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -224,7 +224,7 @@ MissionBase::on_activation()
 
 	if (_inactivation_index > 0 && cameraWasTriggering()) {
 		size_t num_found_items{0U};
-		getPreviousPositionItems(_inactivation_index - 1, &resume_index, num_found_items, 1U);
+		getPreviousPositionItems(_inactivation_index, &resume_index, num_found_items, 1U);
 
 		if (num_found_items == 1U) {
 			// The mission we are resuming had camera triggering enabled. In order to not lose any images


### PR DESCRIPTION
## Summary

Fixes #26795

Off-by-one in `MissionBase::on_activation()` causes the vehicle to resume at waypoint **n-2** instead of **n-1** when a mission with camera triggering is paused and resumed.

### Root cause

`getPreviousPositionItems()` already decrements the start index internally (line 1081: `next_mission_index--`) before searching backward. The call at line 227 passed `_inactivation_index - 1`, causing a **double-decrement**.

All 3 other call sites pass the index directly without pre-decrementing:

| Call site | Argument | Correct? |
|---|---|---|
| `rtl_mission_fast_reverse.cpp:81` | `_mission_index_prior_rtl` | Yes |
| `rtl_mission_fast_reverse.cpp:133` | `_mission.current_seq` | Yes |
| **`mission_base.cpp:227`** | **`_inactivation_index - 1`** | **No** |
| `mission_base.cpp:1149` | `_mission.current_seq` | Yes |

### Fix

```diff
- getPreviousPositionItems(_inactivation_index - 1, &resume_index, num_found_items, 1U);
+ getPreviousPositionItems(_inactivation_index, &resume_index, num_found_items, 1U);
```

Bug present since commit 007ed11bbe (June 2023). The identical bug in `RtlMissionFastReverse` was already fixed in PR #26380.

## Test plan

- [x] `make px4_sitl_default` — passes
- [x] `make tests` — 154/154 pass
- [x] `check_code_style_all.sh` — format checks passed