### PR TITLE
ci(px4_msgs): publishing stable tag triggers tag creation in px4_msgs

### DIFF
--- a/.github/workflows/tag_px4_msgs_from_px4_release_tag.yml
+++ b/.github/workflows/tag_px4_msgs_from_px4_release_tag.yml
@@ -1,0 +1,135 @@
+name: Tag px4_msgs from PX4 release tags
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'PX4 tag to propagate (example: v1.17.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  tag_px4_msgs:
+    if: github.repository == 'PX4/PX4-Autopilot'
+    runs-on: [runs-on,runner=4cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}",spot=false]
+    env:
+      TAG_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
+    steps:
+      - name: Checkout PX4 repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup git credentials
+        run: |
+          git config --global user.name "${{ secrets.PX4BUILDBOT_USER }}"
+          git config --global user.email "${{ secrets.PX4BUILDBOT_EMAIL }}"
+
+      - name: Resolve release branch from tag
+        id: tag_info
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${TAG_NAME}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Tag format is not stable vX.Y.Z, skipping: ${TAG_NAME}"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+
+          major="${BASH_REMATCH[1]}"
+          minor="${BASH_REMATCH[2]}"
+          release_branch="release/${major}.${minor}"
+
+          git show-ref --verify --quiet "refs/heads/${release_branch}" || {
+            echo "PX4 branch ${release_branch} not found"
+            exit 1
+          }
+
+          tag_date="$(git for-each-ref --format='%(creatordate:iso8601)' "refs/tags/${TAG_NAME}")"
+          if [[ -z "${tag_date}" ]]; then
+            echo "Unable to resolve tag date for ${TAG_NAME}"
+            exit 1
+          fi
+
+          echo "release_branch=${release_branch}" >> "$GITHUB_OUTPUT"
+          echo "tag_date=${tag_date}" >> "$GITHUB_OUTPUT"
+
+      - name: Clone px4_msgs repo
+        if: steps.tag_info.outputs.should_run == 'true'
+        run: |
+          git clone https://${{ secrets.PX4BUILTBOT_PERSONAL_ACCESS_TOKEN }}@github.com/PX4/px4_msgs.git
+
+      - name: Checkout matching px4_msgs release branch
+        if: steps.tag_info.outputs.should_run == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd px4_msgs
+
+          release_branch="${{ steps.tag_info.outputs.release_branch }}"
+          if git show-ref --verify --quiet "refs/remotes/origin/${release_branch}"; then
+            git checkout -B "${release_branch}" "origin/${release_branch}"
+          else
+            echo "px4_msgs branch ${release_branch} does not exist"
+            exit 1
+          fi
+
+      - name: Verify msg and srv trees are identical
+        if: steps.tag_info.outputs.should_run == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_branch="${{ steps.tag_info.outputs.release_branch }}"
+          git checkout "${release_branch}"
+
+          # Use the same synchronization logic as sync_to_px4_msgs.yml,
+          # then verify there are no changes in px4_msgs.
+          rm -f px4_msgs/msg/*.msg
+          rm -f px4_msgs/msg/versioned/*.msg
+          rm -f px4_msgs/srv/*.srv
+          rm -f px4_msgs/srv/versioned/*.srv
+          cp msg/*.msg px4_msgs/msg/
+          cp msg/versioned/*.msg px4_msgs/msg/ || true
+          cp srv/*.srv px4_msgs/srv/
+          cp srv/versioned/*.srv px4_msgs/srv/ || true
+
+          if ! git -C px4_msgs diff --exit-code -- msg srv; then
+            echo "Message/service definitions differ between PX4 ${release_branch} and px4_msgs ${release_branch}"
+            exit 1
+          fi
+
+      - name: Create and push tag in px4_msgs
+        if: steps.tag_info.outputs.should_run == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd px4_msgs
+
+          target="$(git rev-parse HEAD)"
+          existing_target="$(git rev-parse "refs/tags/${TAG_NAME}^{}" 2>/dev/null || true)"
+
+          if [[ -n "${existing_target}" ]]; then
+            if [[ "${existing_target}" == "${target}" ]]; then
+              echo "Tag ${TAG_NAME} already exists on ${target}; nothing to do"
+              exit 0
+            fi
+            echo "Tag ${TAG_NAME} already exists on ${existing_target}, expected ${target}"
+            exit 1
+          fi
+
+          GIT_COMMITTER_DATE="${{ steps.tag_info.outputs.tag_date }}" \
+            git tag -a "${TAG_NAME}" "${target}" \
+              -m "PX4 msgs and srvs definitions matching PX4 stable release ${TAG_NAME#v}"
+
+          git push origin "refs/tags/${TAG_NAME}"


### PR DESCRIPTION
CI already takes care of updating https://github.com/PX4/px4_msgs branches when message definitions change (https://github.com/PX4/PX4-Autopilot/blob/main/.github/workflows/sync_to_px4_msgs.yml).

This PR adds automatic tag generation so that if a stable PX4 tag is published like `v1.17.0`, then an homonymous tag is created on `PX4/px4_msgs`.

The new tag `vX.Y.Z` is created only if the branch `release/X.Y` exists on `PX4/px4_msgs` and its content (message and service definitions) matches the PX4 one.