### PR TITLE
build(test): add proper gtest filtering

### DIFF
--- a/cmake/px4_add_gtest.cmake
+++ b/cmake/px4_add_gtest.cmake
@@ -31,6 +31,15 @@
 #
 ############################################################################
 
+# Attach only matching test binaries to `test_results` when TESTFILTER is set.
+# `ctest -R` filters execution only; without this helper the build still
+# compiles every gtest target before running the filtered subset.
+function(add_filtered_test_dependencies TESTNAME)
+	if(NOT TESTFILTER OR "${TESTNAME}" MATCHES "${TESTFILTER}")
+		add_dependencies(test_results ${TESTNAME})
+	endif()
+endfunction()
+
 #=============================================================================
 #
 #	px4_add_unit_gtest
@@ -74,7 +83,7 @@ function(px4_add_unit_gtest)
 		         WORKING_DIRECTORY ${PX4_BINARY_DIR})
 
 		# attach it to the unit test target
-		add_dependencies(test_results ${TESTNAME})
+		add_filtered_test_dependencies(${TESTNAME})
 	endif()
 endfunction()
 
@@ -133,6 +142,6 @@ function(px4_add_functional_gtest)
 		         COMMAND ${PX4_BINARY_DIR}/${TESTNAME})
 
 		# attach it to the unit test target
-		add_dependencies(test_results ${TESTNAME})
+		add_filtered_test_dependencies(${TESTNAME})
 	endif()
 endfunction()


### PR DESCRIPTION
Before this change, filtered test runs still built every gtest target because `test_results` depended on all unit and functional gtest targets.

This updates both `px4_add_unit_gtest()` and `px4_add_functional_gtest()` to use the filtered dependency helper so filtered runs only build the selected targets.

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
