### PR TITLE
fix(mavlink): Fix gps raw int timestamp

### DIFF
--- a/src/modules/mavlink/streams/GPS2_RAW.hpp
+++ b/src/modules/mavlink/streams/GPS2_RAW.hpp
@@ -68,7 +68,7 @@ private:
 		hrt_abstime now{};
 
 		if (_sensor_gps_sub.update(&gps)) {
-			if (gps.time_utc_usec > 0) {
+			if (gps.time_utc_usec <= 0) {
 				msg.time_usec = gps.timestamp;
 
 			} else {

--- a/src/modules/mavlink/streams/GPS_RAW_INT.hpp
+++ b/src/modules/mavlink/streams/GPS_RAW_INT.hpp
@@ -68,7 +68,7 @@ private:
 		hrt_abstime now{};
 
 		if (_sensor_gps_sub.update(&gps)) {
-			if (gps.time_utc_usec > 0) {
+			if (gps.time_utc_usec <= 0) {
 				msg.time_usec = gps.timestamp;
 
 			} else {


### PR DESCRIPTION
### Solved Problem
The `GPS_RAW_INT` mavlink message shows a 0 _time_usec_ timestamp in SITL. This is due to a faulty `if()` statement. 

### Solution
fix `if()` statement

### Changelog Entry
For release notes:
```
Bugfix: use correct timestamp for GPS_RAW_INT
```

This is a regression Bug intoduced in https://github.com/PX4/PX4-Autopilot/pull/26127

### Test coverage
Tested in SITL

