### PR TITLE
feat(mavlink): Resend MISSION_COUNT when its dropped

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -564,6 +564,15 @@ MavlinkMissionManager::send()
 		// try to request item again after timeout
 		send_mission_request(_transfer_partner_sysid, _transfer_partner_compid, _transfer_seq);
 
+	} else if (_state == MAVLINK_WPM_STATE_SENDLIST && (_time_last_sent > 0)
+		   && hrt_elapsed_time(&_time_last_sent) > MAVLINK_MISSION_RETRY_TIMEOUT_DEFAULT
+		   && _transfer_seq == 0) {
+
+		// MISSION_COUNT may have been dropped
+		PX4_DEBUG("WPM: SENDLIST resending MISSION_COUNT (no MISSION_ACK received yet)");
+		send_mission_count(_transfer_partner_sysid, _transfer_partner_compid, _transfer_count, _mission_type,
+				   get_current_mission_type_crc());
+
 	} else if (_state != MAVLINK_WPM_STATE_IDLE && (_time_last_recv > 0)
 		   && hrt_elapsed_time(&_time_last_recv) > MAVLINK_MISSION_PROTOCOL_TIMEOUT_DEFAULT) {
 


### PR DESCRIPTION
### Solved Problem
MAVLink telemetry upon GCS connection, the `MISSION_COUNT` message can be dropped due to TX buffer overflow. This causes the mission protocol to stall, triggering a _"Mission sync timeout"_ warning after 5 seconds before retrying the transfer.

### Solution
Mirror the retry logic used when downloading missions from the GCS: resend `MISSION_COUNT` every 250ms until acknowledged, instead of waiting for the 5-second protocol timeout. This ensures rapid recovery from dropped packets without affecting successful transfers (the GCS typically acknowledges immediately). The timeout after 5 seconds still applies. 

### Changelog Entry
For release notes:
```
Bugfix: Prevent Mission sync from timeout when mavlink packets are dropped.
```

### Alternatives
The root cause is systemic packet loss due to buffer exhaustion during high telemetry load. A complete fix would require a larger refactor.