### PR TITLE
fix(drvers/ins): InertialLabs INS driver fix name-collision

### DIFF
--- a/src/drivers/ins/ilabs/ILabs.cpp
+++ b/src/drivers/ins/ilabs/ILabs.cpp
@@ -485,7 +485,7 @@ void ILabs::processData(InertialLabs::SensorsData *data) {
 
 		sensor_gps.jamming_state = data->gps.jamStatus;
 		sensor_gps.jamming_indicator = (sensor_gps.jamming_state != InertialLabs::JammingStatus::UNKOWN_OR_DISABLED) &&
-					       (sensor_gps.jamming_state != InertialLabs::JammingStatus::OK);
+					       (sensor_gps.jamming_state != InertialLabs::JammingStatus::NO_SIGNIFICANT);
 		sensor_gps.spoofing_state = data->gps.spoofingStatus;
 
 		sensor_gps.vel_m_s =

--- a/src/drivers/ins/ilabs/libilabs/include/data.h
+++ b/src/drivers/ins/ilabs/libilabs/include/data.h
@@ -188,7 +188,7 @@ enum NewAidingData {
 
 enum JammingStatus : uint8_t {
 	UNKOWN_OR_DISABLED = 0,
-	OK                 = 1,  // No significant jamming
+	NO_SIGNIFICANT     = 1,  // No significant jamming
 	WARNING            = 2,  // Interference visible but fix ok
 	CRITICAL           = 3,  // Interference visible and no fix
 };


### PR DESCRIPTION
### Solved Problem
Macros `#define OK 0` from ./platforms/common/include/px4_platform_common/defines.h:111
affected
```
enum JammingStatus : uint8_t {
	OK                 = 1,  // No significant jamming
	...
};
```
from .src/drivers/ins/ilabs/libilabs/include/data.h:191

And build with InertialLabs INS driver get an error:
```
FAILED: Autopilot/platforms/common/include/px4_platform_common/defines.h:111:12: error: expected identifier before numeric constant
  111 | #define OK 0
      |            ^
/PX4-Autopilot/src/drivers/ins/ilabs/libilabs/include/data.h:191:9: note: in expansion of macro ‘OK’
  191 |         OK                 = 1,  // No significant jamming
      |         ^~
compilation terminated due to -Wfatal-errors.
ninja: build stopped: subcommand failed.
```

### Solution
Use the name "NO_SIGNIFICANT" instead of "OK" in the InertialLabs INS driver.

### Changelog Entry
For release notes:
```
Fixed name collision in the InertialLabs INS driver.
```