### PR TITLE
fix(build): mark buildRawFrame noinline to avoid GCC false positive

### DIFF
--- a/src/lib/gnss/test/RtcmTestCommon.hpp
+++ b/src/lib/gnss/test/RtcmTestCommon.hpp
@@ -69,7 +69,11 @@ protected:
 	}
 
 	// Helper to build a frame with raw payload bytes (no message type encoding)
-	std::vector<uint8_t> buildRawFrame(const std::vector<uint8_t> &payload)
+	//
+	// Keep this helper out-of-line to avoid a GCC false positive on the
+	// inlined std::vector::push_back.
+	// See https://github.com/PX4/PX4-Autopilot/issues/26875 for details.
+	__attribute__((noinline)) std::vector<uint8_t> buildRawFrame(const std::vector<uint8_t> &payload)
 	{
 		std::vector<uint8_t> frame;
 		size_t payload_len = payload.size();


### PR DESCRIPTION
GCC 14.3.0 emits `-Wstringop-overflow` when `RtcmTest::buildRawFrame()` is optimized and inlined.

This change marks the helper `noinline` to keep it out of that optimization path.

Preserves the existing logic and only changes how the compiler emits the test helper.

Fixes https://github.com/PX4/PX4-Autopilot/issues/26875

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
