### PR TITLE
feat(control_allocator): add tilting multirotor actuator effectiveness

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/8012_gz_omniquad
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/8012_gz_omniquad
@@ -1,0 +1,71 @@
+#!/bin/sh
+#
+# @name OmniQuad SITL
+#
+# @type Quadrotor
+#
+# @maintainer Andrea Berra <andrea.berra@outlook.com>
+#
+
+. ${R}etc/init.d/rc.mc_defaults
+
+PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
+PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=omniquad}
+
+param set-default CA_AIRFRAME 16
+
+param set-default CA_ROTOR_COUNT 4
+param set-default CA_SV_TL_COUNT 4
+
+param set-default CA_ROTOR0_PX 0.166170094
+param set-default CA_ROTOR0_PY 0.166170094
+param set-default CA_ROTOR0_KM 0.05
+
+param set-default CA_ROTOR1_PX -0.166170094
+param set-default CA_ROTOR1_PY -0.166170094
+param set-default CA_ROTOR1_KM 0.05
+
+param set-default CA_ROTOR2_PX 0.166170094
+param set-default CA_ROTOR2_PY -0.166170094
+param set-default CA_ROTOR2_KM -0.05
+
+param set-default CA_ROTOR3_PX -0.166170094
+param set-default CA_ROTOR3_PY 0.166170094
+param set-default CA_ROTOR3_KM -0.05
+
+param set-default CA_ROTOR0_TILT 1
+param set-default CA_ROTOR1_TILT 2
+param set-default CA_ROTOR2_TILT 3
+param set-default CA_ROTOR3_TILT 4
+
+param set-default SIM_GZ_EN 1
+
+param set-default SIM_GZ_EC_FUNC1 101
+param set-default SIM_GZ_EC_FUNC2 102
+param set-default SIM_GZ_EC_FUNC3 103
+param set-default SIM_GZ_EC_FUNC4 104
+
+param set-default SIM_GZ_SV_FUNC1 201
+param set-default SIM_GZ_SV_FUNC2 202
+param set-default SIM_GZ_SV_FUNC3 203
+param set-default SIM_GZ_SV_FUNC4 204
+
+param set-default CA_SV_TL0_MAXA 45
+param set-default CA_SV_TL0_MINA -45
+param set-default CA_SV_TL1_MAXA 45
+param set-default CA_SV_TL1_MINA -45
+param set-default CA_SV_TL2_MAXA 45
+param set-default CA_SV_TL2_MINA -45
+param set-default CA_SV_TL3_MAXA 45
+param set-default CA_SV_TL3_MINA -45
+
+param set-default SIM_GZ_EC_MIN1 0
+param set-default SIM_GZ_EC_MIN2 0
+param set-default SIM_GZ_EC_MIN3 0
+param set-default SIM_GZ_EC_MIN4 0
+
+param set-default SIM_GZ_EC_MAX1 1100
+param set-default SIM_GZ_EC_MAX2 1100
+param set-default SIM_GZ_EC_MAX3 1100
+param set-default SIM_GZ_EC_MAX4 1100

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -93,6 +93,7 @@ px4_add_romfs_files(
 	6011_gazebo-classic_typhoon_h480.post
 
 	8011_gz_omnicopter
+	8012_gz_omniquad
 
 	10015_gazebo-classic_iris
 	10016_none_iris

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -275,6 +275,10 @@ ControlAllocator::update_effectiveness_source()
 			tmp = new ActuatorEffectivenessSpacecraft(this);
 			break;
 
+		case EffectivenessSource::TILTING_MULTIROTOR:
+			tmp = new ActuatorEffectivenessTiltingMultirotor(this);
+			break;
+
 		default:
 			PX4_ERR("Unknown airframe");
 			break;

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -54,6 +54,7 @@
 #include <ActuatorEffectivenessHelicopter.hpp>
 #include <ActuatorEffectivenessHelicopterCoaxial.hpp>
 #include <ActuatorEffectivenessSpacecraft.hpp>
+#include <ActuatorEffectivenessTiltingMultirotor.hpp>
 
 #include <ControlAllocation.hpp>
 #include <ControlAllocationPseudoInverse.hpp>
@@ -172,6 +173,7 @@ private:
 		HELICOPTER_COAXIAL = 12,
 		SPACECRAFT_2D = 13,
 		SPACECRAFT_3D = 14,
+		TILTING_MULTIROTOR = 16,
 	};
 
 	enum class FailureMode {

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltingMultirotor.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltingMultirotor.cpp
@@ -1,0 +1,135 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file ActuatorEffectivenessTiltingMultirotor.hpp
+ *
+ * Actuator effectiveness for tilting multirotor
+ *
+ * @author Andrea Berra <andrea.berra@outlook.com>
+ */
+
+#include "ActuatorEffectivenessTiltingMultirotor.hpp"
+
+using namespace matrix;
+
+ActuatorEffectivenessTiltingMultirotor::ActuatorEffectivenessTiltingMultirotor(ModuleParams *parent)
+	: ModuleParams(parent),
+	  _mc_rotors(this, ActuatorEffectivenessRotors::AxisConfiguration::FixedUpwards, true),
+	  _tilts(this)
+{
+}
+
+bool
+ActuatorEffectivenessTiltingMultirotor::getEffectivenessMatrix(Configuration &configuration,
+		EffectivenessUpdateReason external_update)
+{
+	if (external_update == EffectivenessUpdateReason::NO_EXTERNAL_UPDATE) {
+		return false;
+	}
+
+	const auto &geometry = _mc_rotors.geometry();
+	const int num_rotors = geometry.num_rotors;
+
+	configuration.selected_matrix = 0;
+
+	Vector3f torque_vert, force_vert, torque_lat, force_lat;
+	const Vector3f axis_vert{0.0f, 0.0f, -1.0f};
+
+	for (int i = 0; i < num_rotors; ++i) {
+
+		const Vector3f &pos = geometry.rotors[i].position;
+		const float ct = geometry.rotors[i].thrust_coef;
+		const float km = geometry.rotors[i].moment_ratio;
+
+		if (fabsf(ct) < FLT_EPSILON) {
+			continue;
+		}
+
+		const float rotor_angle = atan2f(pos(1), pos(0));
+
+		const Vector3f axis_lat = ActuatorEffectivenessRotors::tiltedAxis(M_PI_2_F, rotor_angle + M_PI_2_F);
+
+		computeRotorWrench(pos, axis_vert, ct, km, torque_vert, force_vert);
+		computeRotorWrench(pos, axis_lat,  ct, km, torque_lat,  force_lat);
+
+		configuration.addActuator(ActuatorType::MOTORS, torque_vert, force_vert);
+		configuration.addActuator(ActuatorType::MOTORS, torque_lat, force_lat);
+	}
+
+	configuration.selected_matrix = 1;
+	configuration.actuatorsAdded(ActuatorType::SERVOS, num_rotors);
+
+	return true;
+}
+
+void
+ActuatorEffectivenessTiltingMultirotor::allocateAuxilaryControls(const float dt, int matrix_index,
+		ActuatorVector &actuator_sp)
+{
+	if (matrix_index == 0) {
+		const ActuatorVector force_sp = actuator_sp; // virtual force setpoint
+		actuator_sp.zero();
+
+		const int num_motors = _mc_rotors.geometry().num_rotors;
+
+		for (int i = 0; i < num_motors; ++i) {
+			const float f_vert = force_sp(2 * i);
+			const float f_lat  = force_sp(2 * i + 1);
+
+			actuator_sp(i) = hypotf(f_vert, f_lat);
+
+			const int servo_idx = _mc_rotors.geometry().rotors[i].tilt_index;
+
+			const float tilt_angle_rad = atan2f(f_lat, f_vert);
+
+			const auto &servo_param = _tilts.config(servo_idx);
+
+			_servo_sp(servo_idx) = math::interpolate(
+						       math::constrain(tilt_angle_rad, servo_param.min_angle, servo_param.max_angle),
+						       servo_param.min_angle, servo_param.max_angle, -1.f, 1.f);
+		}
+
+	} else if (matrix_index == 1) {
+		actuator_sp = _servo_sp;
+	}
+}
+
+void
+ActuatorEffectivenessTiltingMultirotor::computeRotorWrench(const Vector3f &pos, const Vector3f &axis,
+		float ct, float km,
+		Vector3f &torque, Vector3f &force)
+{
+	torque = pos.cross(axis) * ct - ct * km * axis;
+	force  = ct * axis;
+}

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltingMultirotor.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltingMultirotor.hpp
@@ -1,0 +1,89 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file ActuatorEffectivenessTiltingMultirotor.hpp
+ *
+ * Actuator effectiveness for tilting multirotor
+ *
+ * @author Andrea Berra <andrea.berra@outlook.com>
+ */
+
+#pragma once
+
+#include "control_allocation/actuator_effectiveness/ActuatorEffectiveness.hpp"
+#include "ActuatorEffectivenessRotors.hpp"
+#include "ActuatorEffectivenessTilts.hpp"
+
+#include <px4_platform_common/module_params.h>
+
+class ActuatorEffectivenessTiltingMultirotor : public ModuleParams, public ActuatorEffectiveness
+{
+public:
+	ActuatorEffectivenessTiltingMultirotor(ModuleParams *parent);
+	virtual ~ActuatorEffectivenessTiltingMultirotor() = default;
+
+	bool getEffectivenessMatrix(Configuration &configuration, EffectivenessUpdateReason external_update) override;
+
+	int numMatrices() const override { return 2; }
+
+	void getDesiredAllocationMethod(AllocationMethod allocation_method_out[MAX_NUM_MATRICES]) const override
+	{
+		allocation_method_out[0] = AllocationMethod::PSEUDO_INVERSE;
+		allocation_method_out[0] = AllocationMethod::PSEUDO_INVERSE;
+	}
+
+	void getNormalizeRPY(bool normalize[MAX_NUM_MATRICES]) const override
+	{
+		normalize[0] = true;
+		normalize[1] = false;
+	}
+
+	void allocateAuxilaryControls(const float dt, int matrix_index, ActuatorVector &actuator_sp) override;
+
+	const char *name() const override { return "Tilting Multirotor"; }
+
+protected:
+
+	ActuatorEffectivenessRotors _mc_rotors;
+	ActuatorEffectivenessTilts _tilts;
+
+
+private:
+
+	static void computeRotorWrench(const matrix::Vector3f &pos, const matrix::Vector3f &axis,
+				       float ct, float km,
+				       matrix::Vector3f &torque, matrix::Vector3f &force);
+
+	ActuatorVector _servo_sp{};
+};

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltingMultirotor.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltingMultirotor.hpp
@@ -60,13 +60,11 @@ public:
 	void getDesiredAllocationMethod(AllocationMethod allocation_method_out[MAX_NUM_MATRICES]) const override
 	{
 		allocation_method_out[0] = AllocationMethod::PSEUDO_INVERSE;
-		allocation_method_out[0] = AllocationMethod::PSEUDO_INVERSE;
 	}
 
 	void getNormalizeRPY(bool normalize[MAX_NUM_MATRICES]) const override
 	{
 		normalize[0] = true;
-		normalize[1] = false;
 	}
 
 	void allocateAuxilaryControls(const float dt, int matrix_index, ActuatorVector &actuator_sp) override;

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/CMakeLists.txt
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/CMakeLists.txt
@@ -17,6 +17,8 @@ px4_add_library(VehicleActuatorEffectiveness
 	ActuatorEffectivenessMultirotor.hpp
 	ActuatorEffectivenessTilts.cpp
 	ActuatorEffectivenessTilts.hpp
+	ActuatorEffectivenessTiltingMultirotor.cpp
+	ActuatorEffectivenessTiltingMultirotor.hpp
 	ActuatorEffectivenessRotors.cpp
 	ActuatorEffectivenessRotors.hpp
 	ActuatorEffectivenessSpacecraft.cpp

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -33,6 +33,7 @@ parameters:
                 13: Rover (Mecanum)
                 14: Spacecraft 2D
                 15: Spacecraft 3D
+                16: Tilting Multirotor
             default: 0
 
         CA_METHOD:
@@ -1315,3 +1316,34 @@ mixer:
                             function: 'axisz'
                           - name: 'CA_ROTOR${i}_CT'
                             label: "Thrust\nCoefficient"
+
+            16: #Tilting Multirotor
+                type: 'tilting_multirotor'
+                title: 'Tilting Multirotor'
+                actuators:
+                  - actuator_type: 'motor'
+                    group_label: 'Rotors'
+                    count: 'CA_ROTOR_COUNT'
+                    item_label_prefix: 'Rotor ${i}'
+                    per_item_parameters:
+                      standard:
+                        position: [ 'CA_ROTOR${i}_PX', 'CA_ROTOR${i}_PY', 'CA_ROTOR${i}_PZ' ]
+                      extra:
+                        - name: 'CA_ROTOR${i}_CT'
+                          label: "Thrust\nCoefficient"
+                        - name: 'CA_ROTOR${i}_KM'
+                          label: 'Direction CCW'
+                          function: 'spin-dir'
+                          show_as: 'true-if-positive'
+                        - name: 'CA_ROTOR${i}_TILT'
+                          label: 'Tilted by'
+                  - actuator_type: 'servo'
+                    group_label: 'Tilt Servos'
+                    count: 'CA_SV_TL_COUNT'
+                    item_label_prefix: 'Tilt ${i}'
+                    per_item_parameters:
+                      extra:
+                        - name: 'CA_SV_TL${i}_MINA'
+                          label: "Angle at Min\nTilt"
+                        - name: 'CA_SV_TL${i}_MAXA'
+                          label: "Angle at Max\nTilt"

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -1318,7 +1318,6 @@ mixer:
                             label: "Thrust\nCoefficient"
 
             16: #Tilting Multirotor
-                type: 'tilting_multirotor'
                 title: 'Tilting Multirotor'
                 actuators:
                   - actuator_type: 'motor'


### PR DESCRIPTION
## Tilting Multirotor Actuator Effectiveness

This PR is a split of [#26281](https://github.com/PX4/PX4-Autopilot/pull/26281), containing only the control allocation changes. 
It introduces the mixer to support tilting multirotor vehicles.


## Summary of Changes

- Adds `ActuatorEffectivenessTiltingMultirotor` to the Control Allocator
- Maps 6-DoF wrench setpoint to motor normalized speeds and servo angles
- Introduces new airframe type `CA_AIRFRAME = 16`
- Includes Gazebo model support for OmniQuad

The allocation method follows the approach in [Kamel et al. (2018)](https://arxiv.org/pdf/1801.04581).

## Test Coverage

Validated in SITL with OmniQuad. 
The full system in action can be seen in the flight videos from [#26281](https://github.com/PX4/PX4-Autopilot/pull/26281), where this allocation is already running.