### PR TITLE
fix(ekf2): update minimum values for required EPH and EPV parameters

### DIFF
--- a/src/modules/ekf2/params_gnss.yaml
+++ b/src/modules/ekf2/params_gnss.yaml
@@ -101,7 +101,7 @@ parameters:
         short: Required EPH to use GPS
       type: float
       default: 3.0
-      min: 2
+      min: 0.1
       max: 100
       unit: m
       decimal: 1
@@ -110,7 +110,7 @@ parameters:
         short: Required EPV to use GPS
       type: float
       default: 5.0
-      min: 2
+      min: 0.1
       max: 100
       unit: m
       decimal: 1


### PR DESCRIPTION


### Solved Problem
2m as a minimum value for EPH EPV doesnt really make sense for GPS's with RTK capability.
from my uderstanding this is only used in the GPS value as a check

### Solution
changed the value to 0.1