### PR TITLE
fix(sensors): restrict baro calibrations to ground

### DIFF
--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -254,11 +254,15 @@ void VehicleAirData::Run()
 		}
 	}
 
-	if (!_relative_calibration_done) {
-		_relative_calibration_done = UpdateRelativeCalibrations(time_now_us);
+	estimator_status_flags_s latest_estimator_status_flags;
 
-	} else if (!_baro_gnss_calibration_done && _param_sens_baro_autocal.get()) {
-		_baro_gnss_calibration_done = BaroGNSSAltitudeOffset();
+	if (_estimator_status_flags_sub.copy(&latest_estimator_status_flags) && !latest_estimator_status_flags.cs_in_air) {
+		if (!_relative_calibration_done) {
+			_relative_calibration_done = UpdateRelativeCalibrations(time_now_us);
+
+		} else if (!_baro_gnss_calibration_done && _param_sens_baro_autocal.get() && latest_estimator_status_flags.cs_gps_hgt) {
+			_baro_gnss_calibration_done = BaroGNSSAltitudeOffset();
+		}
 	}
 
 	// Publish


### PR DESCRIPTION

### Solved Problem
Currently, both relative and absolute barometer calibration can be performed after takeoff, which may cause unwanted altitude jumps during flight. Additionally, users must be highly attentive when configuring the `CAL_BAR_AUTOCAL` parameter if they do not intend to use GNSS at all. It is not intuitive that GNSS altitude may still be used for calibration even when GNSS fusion is disabled.

### Solution
- Restrict baro relative and GNSS calibrations to ground only
- Gate GNSS-baro offset calibration on GPS height actually being fused