### PR TITLE
fix(flashfs32): pet watchdog between sector erases

### DIFF
--- a/src/lib/parameters/flashparams/flashfs32.c
+++ b/src/lib/parameters/flashparams/flashfs32.c
@@ -59,6 +59,9 @@
 #include <nuttx/compiler.h>
 #include <nuttx/progmem.h>
 #include <board_config.h>
+#ifdef CONFIG_WATCHDOG
+#include <drivers/drv_watchdog.h>
+#endif
 
 #if defined(CONFIG_ARCH_HAVE_PROGMEM)
 
@@ -1064,6 +1067,9 @@ int parameter_flashfs_erase(void)
 		rv = 0;
 
 		for (int s = 0; sector_map[s].address; s++) {
+#ifdef CONFIG_WATCHDOG
+			watchdog_pet();
+#endif
 			int sz = erase_sector(&sector_map[s], (flash_entry_header_t *)sector_map[s].address);
 
 			if (sz != 0) {


### PR DESCRIPTION
On boards with multiple flash-based parameter sectors, erasing them back-to-back during initialization can exceed the watchdog timeout, causing a reset. This was observed on STM32H7 with two 128KB sectors where each erase takes ~1-2 seconds.

Pet the watchdog before each sector erase to prevent the timeout.

Sponsored by CubePilot.