### PR TITLE
fix(kakuteh7-wing): fix BOARD_FLASH_SECTORS to protect param sectors

### DIFF
--- a/boards/holybro/kakuteh7-wing/src/hw_config.h
+++ b/boards/holybro/kakuteh7-wing/src/hw_config.h
@@ -72,7 +72,7 @@
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
 #define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1105
-#define BOARD_FLASH_SECTORS            (14)
+#define BOARD_FLASH_SECTORS            (13)
 #define BOARD_FLASH_SIZE               (16 * 128 * 1024)
 #define APP_RESERVATION_SIZE           (2 * 128 * 1024)
 


### PR DESCRIPTION
Set BOARD_FLASH_SECTORS to 13 so the bootloader does not erase the parameter sectors (14 and 15) during firmware updates. Previously set to 14 which allowed the bootloader to erase sector 14, potentially wiping stored parameters.