### PR TITLE
feat(navigator): support MAV_FRAME_GLOBAL_INT and MAV_FRAME_GLOBAL_RELATIVE_ALT_INT for RTL safe points

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -558,23 +558,13 @@ void RTL::setSafepointAsDestination(PositionYawSetpoint &rtl_position, const mis
 	// TODO: handle all possible mission_safe_point.frame cases
 	switch (mission_safe_point.frame) {
 	case 0: // MAV_FRAME_GLOBAL
-		rtl_position.lat = mission_safe_point.lat;
-		rtl_position.lon = mission_safe_point.lon;
-		rtl_position.alt = mission_safe_point.altitude;	// alt of safe point is relative to MSL
-		break;
-
-	case 3: // MAV_FRAME_GLOBAL_RELATIVE_ALT
-		rtl_position.lat = mission_safe_point.lat;
-		rtl_position.lon = mission_safe_point.lon;
-		rtl_position.alt = mission_safe_point.altitude + _home_pos_sub.get().alt; // alt of safe point is rel to home
-		break;
-
 	case 5: // MAV_FRAME_GLOBAL_INT
 		rtl_position.lat = mission_safe_point.lat;
 		rtl_position.lon = mission_safe_point.lon;
 		rtl_position.alt = mission_safe_point.altitude;	// alt of safe point is relative to MSL
 		break;
 
+	case 3: // MAV_FRAME_GLOBAL_RELATIVE_ALT
 	case 6: // MAV_FRAME_GLOBAL_RELATIVE_ALT_INT
 		rtl_position.lat = mission_safe_point.lat;
 		rtl_position.lon = mission_safe_point.lon;


### PR DESCRIPTION
### Solved Problem
When rally/safe points are uploaded using `MISSION_ITEM_INT` with `MAV_FRAME_GLOBAL_INT` (5) or `MAV_FRAME_GLOBAL_RELATIVE_ALT_INT` (6), GCS logs `RTL: unsupported MAV_FRAME`. This happens because the frame switch in `rtl.cpp` only handled frames 0 and 3. the `_INT` suffix refers to how lat/lon are encoded on the wire in `MISSION_ITEM_INT`.

See [MAV_FRAME enum](https://mavlink.io/en/messages/common.html#MAV_FRAME) in common message set.

### Solution
Add `case 5` and `case 6` in the safe point frame switch in `RTL::findRtlDestination()`.

I left the `TODO` comment to handle all cases since there are more cases not handled.

### Test coverage
Tested on SITL (`gz_x500`, baylands world) by uploading rally points via MAVSDK `MissionRaw::upload_rally_points()` with `MAV_FRAME_GLOBAL_RELATIVE_ALT_INT` and verifying on GCS that rally points are created at correct positions, the unsupported MAV_FRAME warning no longer appears, and the vehicle navigates to the correct point on RTL.