### PR TITLE
fix(boards/fmu-v6xrt): Enable usage of all three on-board IMUs on FMU-V6XRT by default

### DIFF
--- a/boards/px4/fmu-v6xrt/init/rc.board_defaults
+++ b/boards/px4/fmu-v6xrt/init/rc.board_defaults
@@ -12,10 +12,6 @@ param set-default MAV_2_RATE 100000
 param set-default MAV_2_REMOTE_PRT 14550
 param set-default MAV_2_UDP_PRT 14550
 
-# Make use of all 3 on-board IMUs on FMU-V6XRT
-param set-default SENS_IMU_MODE 0
-param set-default EKF2_MULTI_IMU 3
-
 safety_button start
 
 if param greater -s UAVCAN_ENABLE 0

--- a/boards/px4/fmu-v6xrt/init/rc.board_defaults
+++ b/boards/px4/fmu-v6xrt/init/rc.board_defaults
@@ -12,6 +12,10 @@ param set-default MAV_2_RATE 100000
 param set-default MAV_2_REMOTE_PRT 14550
 param set-default MAV_2_UDP_PRT 14550
 
+# Make use of all 3 on-board IMUs on FMU-V6XRT
+param set-default SENS_IMU_MODE 0
+param set-default EKF2_MULTI_IMU 3
+
 safety_button start
 
 if param greater -s UAVCAN_ENABLE 0

--- a/platforms/nuttx/init/imxrt/rc.board_arch_defaults
+++ b/platforms/nuttx/init/imxrt/rc.board_arch_defaults
@@ -5,4 +5,8 @@
 
 param set-default -s MC_AT_EN 1
 
+# Multi EKF
+param set-default -s EKF2_MULTI_IMU 3
+param set-default SENS_IMU_MODE 0
+
 set LOGGER_BUF 32

--- a/platforms/nuttx/init/imxrt/rc.board_arch_defaults
+++ b/platforms/nuttx/init/imxrt/rc.board_arch_defaults
@@ -3,10 +3,14 @@
 # imxrt specific defaults
 #------------------------------------------------------------------------------
 
-param set-default -s MC_AT_EN 1
-
-# Multi EKF
+# Multi-EKF
 param set-default -s EKF2_MULTI_IMU 3
 param set-default SENS_IMU_MODE 0
 
-set LOGGER_BUF 32
+param set-default -s IMU_GYRO_FFT_EN 1
+
+param set-default -s MC_AT_EN 1
+
+param set-default -s UAVCAN_ENABLE 2
+
+set LOGGER_BUF 64


### PR DESCRIPTION
fix(boards/px4_fmu-v6xrt): enables all on-board IMUs by default

FMU-V6XRT Pixhawk standard boards have 3 on-board IMUs. It is ideal behaviour for all 3 to be enabled by default. This is done with default parameters SENS_IMU_MODE set to 0, and EKF2_MULTI_IMU set to 3.