### PR TITLE
feat(boards/fmu-v6xrt): add support for Agam GNSS v1.0 module with BMM350 on v6xrt devices

### DIFF
--- a/boards/px4/fmu-v6xrt/init/rc.board_sensors
+++ b/boards/px4/fmu-v6xrt/init/rc.board_sensors
@@ -117,8 +117,11 @@ then
 	bmm350 -I start
 fi
 
-# External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
+# External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer) or Agam GNSS v1.0
+if ! ist8310 -X -b 1 -R 10 start
+then
+    bmm350 -X -b 1 start
+fi
 
 # Possible internal Baro
 


### PR DESCRIPTION
FMU-V6XRT can now work plug-and-play with the Agam GNSS v1.0 on the GPS1 port.