### PR TITLE
fix(mavlink): GPS jamming only warning instead of critical

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -635,10 +635,10 @@ void EstimatorChecks::checkGps(const Context &context, Report &reporter, const s
 		 */
 		reporter.armingCheckFailure(NavModes::None, health_component_t::gps,
 					    events::ID("check_estimator_gps_jamming_critical"),
-					    events::Log::Critical, "GPS jamming detected");
+					    events::Log::Warning, "GPS jamming detected");
 
 		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "GPS jamming detected\t");
+			mavlink_log_warning(reporter.mavlink_log_pub(), "GPS jamming detected\t");
 		}
 	}
 }


### PR DESCRIPTION
### Solved Problem
GPS jamming is currently reported as a `CRITICAL` issue.

### Solution
This PR adjusts the severity level of GPS jamming detection in the estimator health checks.
Log messages and arming check failures related to GPS jamming are now reported as warnings instead of critical errors.

This change allows the operator to determine—based on their system knowledge—whether the detected jamming should be considered critical.

### Changelog Entry
For release notes:
```
Bugfix: GPS jamming shown as warning, instead of critical
```
