### PR TITLE
fix(dshot): map MAVLink standard ACTUATOR_OUTPUT_FUNCTION to PX4 OutputFunction

### DIFF
--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -785,6 +785,11 @@ void DShot::handle_configure_actuator(const vehicle_command_s &command)
 	if (function > 1000) {
 		// NOTE: backwards compatibility for QGC - 1101=Motor1, 1102=Motor2, etc
 		function -= 1000;
+
+	} else if (function >= 1 && function <= 16) {
+		// MAVLink standard: ACTUATOR_OUTPUT_FUNCTION_MOTOR1=1 .. MOTOR16=16
+		// PX4 internal:     OutputFunction::Motor1=101 .. Motor12=112
+		function += 100;
 	}
 
 	int motor_index = -1;


### PR DESCRIPTION
## Summary
- The MAVLink standard defines `ACTUATOR_OUTPUT_FUNCTION_MOTOR1=1..MOTOR16=16`, but PX4 internally uses `OutputFunction::Motor1=101..Motor12=112`
- The DShot driver only handled PX4 internal values (101+) and QGC legacy values (1101+, via `-1000`), so any standards-compliant GCS sending the MAVLink enum values in `param5` of `MAV_CMD_CONFIGURE_ACTUATOR` would get `VEHICLE_CMD_RESULT_UNSUPPORTED`
- Adds a mapping from MAVLink standard values (1-16) to PX4 internal values (101-116) by adding 100

## Test plan
- [x] Send `MAV_CMD_CONFIGURE_ACTUATOR` with `param1=ACTUATOR_CONFIGURATION_BEEP` and `param5=1` (MAVLink standard Motor1) — should beep and ACK `ACCEPTED`
- [x] Send with `param5=101` (PX4 internal) — should still work (no regression)
- [x] Send with `param5=1101` (QGC legacy) — should still work (no regression)