### PR TITLE
fix(drivers): silence VTX_SER_CFG on boot

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -633,7 +633,7 @@ else
 	#
 	# Start the VTX services.
 	#
-	if ! param compare VTX_SER_CFG 0
+	if ! param compare -s VTX_SER_CFG 0
 	then
 		set RC_VTXTABLE ${R}etc/init.d/rc.vtxtable
 		if [ -f ${RC_VTXTABLE} ]


### PR DESCRIPTION
### Solved Problem
When booting a flight controller that does not include the VTX driver, a error message about VTX_SER_CFG not beeing found is shown. 

### Solution
Suppress this warning, as is done for all other modules in that category. 

### Changelog Entry
For release notes:
```
Bugfix: Suppress VTX driver param not found
```
### Test coverage
Tested in HW