### PR TITLE
fix(drivers): Do not show warnings if no DShot is configured

### DIFF
--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -1032,7 +1032,7 @@ bool DShot::initialize_dshot()
 	}
 
 	if (dshot_timer_channels == 0) {
-		PX4_WARN("No channels configured");
+		PX4_INFO("No channels configured");
 		return false;
 	}
 
@@ -1238,6 +1238,7 @@ int DShot::custom_command(int argc, char *argv[])
 
 int DShot::task_spawn(int argc, char *argv[])
 {
+	int ret = PX4_ERROR;
 	DShot *instance = new DShot();
 
 	if (instance) {
@@ -1249,6 +1250,7 @@ int DShot::task_spawn(int argc, char *argv[])
 		}
 
 		PX4_INFO("Exiting");
+		ret = PX4_OK;
 
 	} else {
 		PX4_ERR("alloc failed");
@@ -1258,7 +1260,7 @@ int DShot::task_spawn(int argc, char *argv[])
 	desc.object.store(nullptr);
 	desc.task_id = -1;
 
-	return PX4_ERROR;
+	return ret;
 }
 
 int DShot::print_usage(const char *reason)


### PR DESCRIPTION
### Solved Problem
Currently, when no dshot actuator is configured this warning is shown:
```
WARN  [dshot] No channels configured
INFO  [dshot] Exiting
ERROR [module] Task start failed (-1)
```
The warning seems a bit extreme to me, as there are a lot of setups without any dshot. 
And the Error implies that something went wrong, even though everything is just fine. 

### Solution
Convert the `WARNING` to `INFO`
Do not return an error when the module stops after no channel is configured. 

### Changelog Entry
For release notes:
```
Bugfix: No warning when dshot voluntarily exits
```

### Alternatives
It would be better do only remove the warning, if no channel is found and not as generic as this solution, however I was not able to find a good solution for that. 

### Test coverage
Tested on HW. 
With this PR:
```
INFO  [dshot] No channels configured
INFO  [dshot] Exiting
```