### PR TITLE
fix(navigator): invalidate next setpoint when waypoint yaw is not aligned

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -221,7 +221,7 @@ void Mission::setActiveMissionItems()
 			pos_sp_triplet->current.alt_acceptance_radius = FLT_MAX;
 		}
 
-		// Allow a rotary wing vehicle to decelerate before reaching a wp with a hold time or a timeout
+		// Allow a rotary wing vehicle to decelerate before reaching a wp with a hold time or a timeout or a yaw requirement
 		// This is done by setting the position triplet's next position's valid flag to false,
 		// which makes the FlightTask disregard the next position
 		// TODO: Setting the next waypoint's validity flag to handle braking / correct waypoint behavior
@@ -229,11 +229,20 @@ void Mission::setActiveMissionItems()
 		const bool brake_for_hold = _vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
 					    && (get_time_inside(_mission_item) > FLT_EPSILON || item_has_timeout(_mission_item));
 
+		_next_sp_awaits_yaw = false;
+
 		if (_mission_item.autocontinue && !brake_for_hold) {
 			/* try to process next mission item */
 			if (num_found_items >= 1u) {
 				/* got next mission item, update setpoint triplet */
 				mission_item_to_position_setpoint(next_mission_items[0u], &pos_sp_triplet->next);
+
+				if (_navigator->get_yaw_to_be_accepted(_mission_item.yaw)) {
+					// If the next item requires a yaw alignment, wait until it's aligned
+					// before activating the next setpoint to prevent overshooting.
+					pos_sp_triplet->next.valid = false;
+					_next_sp_awaits_yaw = true;
+				}
 
 			} else {
 				/* next mission item is not available */

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -386,32 +386,41 @@ MissionBlock::is_mission_item_reached_or_completed()
 		}
 	}
 
-	// Update the 'waypoint position reached' status (only for rotary wing flight)
-	if (_waypoint_position_reached && !_waypoint_yaw_reached) {
+	// Evaluate yaw alignment independently of position, and continuously until
+	// both position and yaw are reached (after which it latches).
+	if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
+	    && _navigator->get_yaw_to_be_accepted(_mission_item.yaw)
+	    && _navigator->get_local_position()->heading_good_for_control) {
 
-		if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
-		    && _navigator->get_yaw_to_be_accepted(_mission_item.yaw)
-		    && _navigator->get_local_position()->heading_good_for_control) {
+		const float yaw_err = wrap_pi(_mission_item.yaw - _navigator->get_local_position()->heading);
 
-			const float yaw_err = wrap_pi(_mission_item.yaw - _navigator->get_local_position()->heading);
+		// accept yaw if reached or if timeout is set in which case we ignore not forced headings
+		// reevaluate until both position and yaw are reached
+		if (!_waypoint_yaw_reached || !_waypoint_position_reached) {
+			_waypoint_yaw_reached = fabsf(yaw_err) < _navigator->get_yaw_threshold()
+						|| (_navigator->get_yaw_timeout() >= FLT_EPSILON && !_mission_item.force_heading);
 
-			/* accept yaw if reached or if timeout is set in which case we ignore not forced headings */
-			if (fabsf(yaw_err) < _navigator->get_yaw_threshold()
-			    || (_navigator->get_yaw_timeout() >= FLT_EPSILON && !_mission_item.force_heading)) {
+		}
 
-				_waypoint_yaw_reached = true;
-			}
+		/* if heading needs to be reached, the timeout is enabled and we don't make it, abort mission */
+		if (_waypoint_position_reached && !_waypoint_yaw_reached && _mission_item.force_heading &&
+		    (_navigator->get_yaw_timeout() >= FLT_EPSILON) &&
+		    (now - _time_wp_reached >= (hrt_abstime)_navigator->get_yaw_timeout() * 1e6f)) {
 
-			/* if heading needs to be reached, the timeout is enabled and we don't make it, abort mission */
-			if (!_waypoint_yaw_reached && _mission_item.force_heading &&
-			    (_navigator->get_yaw_timeout() >= FLT_EPSILON) &&
-			    (now - _time_wp_reached >= (hrt_abstime)_navigator->get_yaw_timeout() * 1e6f)) {
+			_navigator->set_mission_failure_heading_timeout();
+		}
 
-				_navigator->set_mission_failure_heading_timeout();
-			}
+	} else {
+		_waypoint_yaw_reached = true;
+	}
 
-		} else {
-			_waypoint_yaw_reached = true;
+	// When yaw is the sole stop reason, drive next.valid from _waypoint_yaw_reached.
+	if (_next_sp_awaits_yaw) {
+		position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+
+		if (_waypoint_yaw_reached != pos_sp_triplet->next.valid) {
+			pos_sp_triplet->next.valid = _waypoint_yaw_reached;
+			_navigator->set_position_setpoint_triplet_updated();
 		}
 	}
 

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -226,6 +226,7 @@ protected:
 
 	bool _waypoint_position_reached{false};
 	bool _waypoint_yaw_reached{false};
+	bool _next_sp_awaits_yaw{false}; ///< next setpoint data is populated, validity driven by yaw alignment
 
 	hrt_abstime _time_wp_reached{0};
 


### PR DESCRIPTION
### Solved Problem

When a rotary wing waypoint requires yaw alignment, the next position setpoint
remains valid during approach. This causes FlightTaskAuto to plan a fly-through
trajectory instead of decelerating, so the vehicle overshoots the waypoint
before aligning yaw.

### Solution

- Invalidate `next.valid` when the current waypoint requires yaw acceptance,
  and re-enable it dynamically once yaw is aligned (`_next_sp_awaits_yaw`).
- Evaluate yaw alignment independently of position reached, so yaw can be
  checked during approach. Once both position and yaw are reached the state
  latches to avoid interfering with hold time. This keeps the existing logic unchanged.

### Changelog Entry
Bugfix: Multicopter missions now brake at waypoints requiring yaw alignment

### Alternatives

### Test coverage

TODO
