### PR TITLE
fix(bmp388): correct timestamp_sample to integration midpoint

### DIFF
--- a/src/drivers/barometer/bmp388/bmp388.cpp
+++ b/src/drivers/barometer/bmp388/bmp388.cpp
@@ -171,8 +171,12 @@ BMP388::collect()
 
 	perf_begin(_sample_perf);
 
-	/* this should be fairly close to the end of the conversion, so the best approximation of the time */
-	const hrt_abstime timestamp_sample = hrt_absolute_time();
+	/* Correct for measurement integration delay: the pressure was
+	 * integrated over the preceding measurement_time window, so the
+	 * effective sample midpoint is half the measurement time before now. */
+	const hrt_abstime now = hrt_absolute_time();
+	const hrt_abstime half_meas = get_measurement_time() / 2;
+	const hrt_abstime timestamp_sample = (now > half_meas) ? (now - half_meas) : now;
 
 	if (!get_sensor_data(sensor_comp, &data)) {
 		perf_count(_comms_errors);


### PR DESCRIPTION
## Summary

The BMP388/BMP390 pressure measurement is integrated over a configurable window (e.g. 37ms at 16x oversampling). The current code uses the SPI read time as `timestamp_sample`, which corresponds to the **end** of the integration window. This introduces a systematic timing bias equal to half the measurement time (~18.5ms at 16x oversampling).

This PR corrects `timestamp_sample` to the integration midpoint by subtracting `measurement_time / 2`, with a guard against unsigned underflow.

This improves time alignment for all downstream consumers (EKF baro fusion, logging, etc.).

## Changes

- `src/drivers/barometer/bmp388/bmp388.cpp`: Replace `hrt_absolute_time()` with midpoint-corrected timestamp

## Test plan

- [ ] Before/after flight logs comparing baro timestamp alignment
- [ ] Verify EKF baro innovation statistics are equal or improved