### PR TITLE
feat(logger): add high rate sensor topics at 100hz

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -371,12 +371,16 @@ void LoggedTopics::add_system_identification_topics()
 
 void LoggedTopics::add_high_rate_sensors_topics()
 {
-	add_topic_multi("distance_sensor", 0, 4);
-	add_topic_multi("sensor_baro", 0, 4);
-	add_topic_multi("sensor_optical_flow", 0, 2);
-	add_topic_multi("sensor_gps", 0, 4);
-	add_topic_multi("sensor_gnss_relative", 0, 1);
-	add_topic_multi("sensor_mag", 0, 4);
+	add_topic_multi("distance_sensor", 10, 4);
+	add_topic_multi("sensor_baro", 10, 4);
+	add_topic_multi("sensor_optical_flow", 10, 2);
+	add_topic_multi("sensor_gps", 10, 4);
+	add_topic_multi("sensor_gnss_relative", 10, 1);
+	add_topic_multi("sensor_mag", 10, 4);
+	add_topic("estimator_aid_src_baro_hgt", 10);
+	add_topic("vehicle_air_data", 10);
+	add_topic("vehicle_magnetometer", 10);
+	add_topic("vehicle_thrust_setpoint", 10);
 }
 
 void LoggedTopics::add_mavlink_tunnel()


### PR DESCRIPTION
## Summary
- Set all existing `add_high_rate_sensors_topics()` to 100Hz (10ms interval) instead of unlimited rate
- Add `vehicle_air_data`, `vehicle_thrust_setpoint`, `estimator_aid_src_baro_hgt`, and `vehicle_magnetometer` at 100Hz