### PR TITLE
feat(mtd): add px4_at24c_set_npages API

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_mtd.h
+++ b/platforms/common/include/px4_platform_common/px4_mtd.h
@@ -80,6 +80,11 @@ __EXPORT ssize_t px4_mtd_get_partition_size(const mtd_instance_s *instance, cons
 int px4_at24c_initialize(FAR struct i2c_master_s *dev,
 			 uint8_t address, FAR struct mtd_dev_s **mtd_dev);
 
+/*
+  Update the page count of an already-initialised device.
+ */
+int px4_at24c_set_npages(FAR struct mtd_dev_s *dev, uint16_t npages);
+
 void px4_at24c_deinitialize(void);
 
 int flexspi_attach(mtd_instance_s *instance);

--- a/platforms/nuttx/src/px4/common/px4_24xxxx_mtd.c
+++ b/platforms/nuttx/src/px4/common/px4_24xxxx_mtd.c
@@ -618,6 +618,13 @@ int px4_at24c_initialize(FAR struct i2c_master_s *dev,
 	return 0;
 }
 
+int px4_at24c_set_npages(FAR struct mtd_dev_s *dev, uint16_t npages)
+{
+	FAR struct at24c_dev_s *priv = (FAR struct at24c_dev_s *)dev;
+	priv->npages = npages;
+	return 0;
+}
+
 /*
  * XXX: debug hackery
  */


### PR DESCRIPTION
### Solved Problem
- The `npages` var is set during compile-time and can not be changed during runtime
- We have different EEPROM sizes in an upcoming Skynode-S revision and want to avoid creating a new board just due to different EEPROM size
- This way it's possible to change the amount of pages after the revision is detected (which tells which EEPROM size to use)
- Can be used like this (will upstream Skynode-S change soon):
```
uint16_t eeprom_npages = fram_available ? 256 : 512;

/* instances[0] is always EEPROM on both board variants. */
if (mtd_count > 0 && instances[0]->mtd_dev != NULL) {
    px4_at24c_set_npages(instances[0]->mtd_dev, eeprom_npages);
}
```

### Solution
- Add a function to set the number of pages

### Test coverage
- Tested with a v6s on the bench