### PR TITLE
fix(mtd): support for very small partition sizes of just 32B

### DIFF
--- a/src/systemcmds/mtd/mtd.cpp
+++ b/src/systemcmds/mtd/mtd.cpp
@@ -158,7 +158,7 @@ static void print_usage()
 
 int mtd_erase(mtd_instance_s &instance)
 {
-	uint8_t v[64];
+	uint8_t v[32];
 	memset(v, 0xFF, sizeof(v));
 
 	for (uint8_t i = 0; i < instance.n_partitions_current; i++) {
@@ -192,7 +192,7 @@ int mtd_erase(mtd_instance_s &instance)
  */
 int mtd_readtest(const mtd_instance_s &instance)
 {
-	uint8_t v[128];
+	uint8_t v[32];
 
 	for (uint8_t i = 0; i < instance.n_partitions_current; i++) {
 		ssize_t count = 0;
@@ -236,7 +236,7 @@ int mtd_readtest(const mtd_instance_s &instance)
  */
 int mtd_rwtest(const mtd_instance_s &instance)
 {
-	uint8_t v[128], v2[128];
+	uint8_t v[32], v2[32];
 
 	for (uint8_t i = 0; i < instance.n_partitions_current; i++) {
 		ssize_t count = 0;


### PR DESCRIPTION
### Solved Problem
- When you have small partitions, like using 1 block of an EEPROM only in an `px4_mtd_entry_t` a partition of size 32 byte is used.
- The `mtd` systemcmd can not handle those well as it works in chunks > 32 byte, which for example causes problems with `read(fd, v, sizeof(v)) == sizeof(v)` when `sizeof(v) > 32` (which it currently is)

### Solution
- Use chunks of 32 bytes

### Test coverage
- Tested with the v6s on the bench