### PR TITLE
feat(allyes): Remove redundant filters from exception_list_sitl

### DIFF
--- a/Tools/kconfig/allyesconfig.py
+++ b/Tools/kconfig/allyesconfig.py
@@ -57,14 +57,47 @@ exception_list = [
 ]
 
 exception_list_sitl = [
-    'DRIVERS_BAROMETER', # Fails I2C dependencies
+    'DRIVERS_ADC', # Fails I2C dependencies
     'COMMON_BAROMETERS', # Fails I2C dependencies
+    'DRIVERS_BAROMETER', # Fails I2C dependencies
+    'DRIVERS_BATT_SMBUS', # Fails I2C dependencies in SMBus library
+    'COMMON_DIFFERENTIAL_PRESSURE', # Fails I2C dependencies
+    'DRIVERS_DIFFERENTIAL_PRESSURE', # Fails I2C dependencies
+    'COMMON_DISTANCE_SENSOR', # Fails I2C dependencies
+    'DRIVERS_DISTANCE_SENSOR', # Fails I2C dependencies
+    'COMMON_HYGROMETERS', # Fails I2C dependencies
+    'DRIVERS_HYGROMETER', # Fails I2C dependencies
+    'COMMON_IMU', # Fails I2C dependencies
+    'DRIVERS_IMU', # Fails I2C dependencies
+    'DRIVERS_IRLOCK', # Fails I2C dependencies
+    'COMMON_LIGHT', # Fails I2C dependencies
+    'DRIVERS_LIGHTS', # Fails I2C dependencies
+    'DRIVERS_MAGNETOMETER', # Fails I2C dependencies
+    'COMMON_MAGNETOMETER', # Fails I2C dependencies
+    'DRIVERS_OPTICAL_FLOW', # Fails I2C dependencies
+    'COMMON_OPTICAL_FLOW', # Fails I2C dependencies
+    'COMMON_OSD', # Fails I2C dependencies
+    'DRIVERS_OSD', # Fails I2C dependencies
+    'DRIVERS_PCA9685', # Fails I2C dependencies
+    'DRIVERS_POWER_MONITOR', # Fails I2C dependencies
+    'DRIVERS_RPM', # Fails I2C dependencies
+    'COMMON_RPM', # Fails I2C dependencies
+    'DRIVERS_SMART_BATTERY', # Fails I2C dependencies in SMBus library
+    'DRIVERS_TELEMETRY', # Fails I2C dependencies
+    'COMMON_TELEMETRY', # Fails I2C dependencies
+    'DRIVERS_TEMPERATURE', # Fails I2C dependencies
+    'COMMON_UWB', # Fail in UWB_PORT_CFG
+    'DRIVERS_UWB', # Fail in UWB_PORT_CFG
+    'DRIVERS_HEATER', # GPIO config failure
+    'DRIVERS_AUTERION_AUTOSTARTER', # Sitl doesn't provide a builtin lib
+    'DRIVERS_CYPHAL', # Sitl doesn't provide a memalign function
+    'DRIVERS_GPIO', # Sitl doesn't provide a mcp-common lib
     'DRIVERS_ADC_BOARD_ADC', # Fails HW dependencies, I think this only works on NuttX
     'DRIVERS_CAMERA_CAPTURE', # GPIO config failure
+    'DRIVERS_SAFETY_BUTTON', # GPIO config failure
+    'DRIVERS_TAP_ESC', # No nuttx/arch.h
     'DRIVERS_DSHOT', # No Posix driver, I think this only works on NuttX
     'DRIVERS_PWM_OUT', # No Posix driver, I think this only works on NuttX
-    'COMMON', # Fails I2C dependencies
-    'DRIVERS', # Fails I2C dependencies
     'SYSTEMCMDS_REBOOT', # Sitl can't reboot
     'MODULES_BATTERY_STATUS', # Sitl doesn't provide a power brick
     'SYSTEMCMDS_SERIAL_PASSTHRU', # Not supported in SITL

--- a/src/drivers/actuators/vertiq_io/vertiq_serial_interface.cpp
+++ b/src/drivers/actuators/vertiq_io/vertiq_serial_interface.cpp
@@ -189,12 +189,41 @@ bool VertiqSerialInterface::CheckForRx()
 
 uint8_t *VertiqSerialInterface::ReadAndSetRxBytes()
 {
-	//Read the bytes available for us
-	read(_uart_fd, _rx_buf, _bytes_available);
+	if (_uart_fd < 0 || _bytes_available == 0) {
+		return nullptr;
+	}
 
-	//Put the data into our IQUART handler
-	_iquart_interface.SetRxBytes(_rx_buf, _bytes_available);
-	return _rx_buf;
+	size_t total = 0;
+
+	while (total < _bytes_available) {
+		ssize_t n = read(_uart_fd, _rx_buf + total, _bytes_available - total);
+
+		if (n < 0) {
+			if (errno == EAGAIN) {
+				break; // no more data
+			}
+
+			if (errno == EINTR) {
+				continue; // interrupted. repeat again
+			}
+
+			PX4_ERR("Read failed: %s", strerror(errno));
+			return nullptr;
+		}
+
+		if (n == 0) {
+			break; // EOF or no data
+		}
+
+		total += static_cast<size_t>(n);
+	}
+
+	if (total > 0) {
+		_iquart_interface.SetRxBytes(_rx_buf, total);
+		return _rx_buf;
+	}
+
+	return nullptr;
 }
 
 void VertiqSerialInterface::ProcessSerialRx(ClientAbstract **client_array, uint8_t number_of_clients)
@@ -225,10 +254,41 @@ void VertiqSerialInterface::ProcessSerialTx()
 	//Make sure we can actually talk
 	ReOpenSerial();
 
+	if (_uart_fd < 0) {
+		return;
+	}
+
 	//while there's stuff to write, write it
 	//Clients are responsible for adding TX messages to the buffer through get/set/save commands
 	while (_iquart_interface.GetTxBytes(_tx_buf, _bytes_available)) {
-		write(_uart_fd, _tx_buf, _bytes_available);
+
+		size_t total = 0;
+
+		while (total < _bytes_available) {
+
+			ssize_t n = write(_uart_fd, _tx_buf + total, _bytes_available - total);
+
+			if (n < 0) {
+
+				if (errno == EAGAIN) {
+					// UART buffer full — try again later
+					break;
+				}
+
+				if (errno == EINTR) {
+					continue; // interrupted. try again
+				}
+
+				PX4_ERR("Write failed: %s", strerror(errno));
+				return;
+			}
+
+			if (n == 0) {
+				break;
+			}
+
+			total += static_cast<size_t>(n);
+		}
 	}
 }
 

--- a/src/drivers/cyphal/NodeManager.cpp
+++ b/src/drivers/cyphal/NodeManager.cpp
@@ -166,7 +166,9 @@ void NodeManager::HandleListResponse(const CanardRxTransfer &receive)
 			PX4_INFO("Set portID succesfull");
 
 		} else {
-			PX4_INFO("Register not found %.*s", msg.name.name.count, msg.name.name.elements);
+			PX4_INFO("Register not found %.*s",
+				 static_cast<int>(msg.name.name.count),
+				 msg.name.name.elements);
 		}
 	}
 }

--- a/src/drivers/ins/eulernav_bahrs/eulernav_driver.cpp
+++ b/src/drivers/ins/eulernav_bahrs/eulernav_driver.cpp
@@ -149,11 +149,15 @@ int EulerNavDriver::print_status()
 {
 	if (_is_initialized)
 	{
-		PX4_INFO("Elapsed time: %llu [us].\n", hrt_elapsed_time(&_statistics.start_time));
-		PX4_INFO("Total bytes received: %lu.\n", _statistics.total_bytes_received);
+		PX4_INFO("Elapsed time: %llu [us].\n",
+			 static_cast<unsigned long long>(hrt_elapsed_time(&_statistics.start_time)));
+		PX4_INFO("Total bytes received: %lu.\n",
+			 static_cast<unsigned long>(_statistics.total_bytes_received));
 		PX4_INFO("Inertial messages received: %lu. Navigation messages received: %lu.\n",
-			_statistics.inertial_message_counter, _statistics.navigation_message_counter);
-		PX4_INFO("Failed CRC count: %lu.\n", _statistics.crc_failures);
+			 static_cast<unsigned long>(_statistics.inertial_message_counter),
+			 static_cast<unsigned long>(_statistics.navigation_message_counter));
+		PX4_INFO("Failed CRC count: %lu.\n",
+			 static_cast<unsigned long>(_statistics.crc_failures));
 
 	}
 	else
@@ -298,7 +302,7 @@ void EulerNavDriver::processDataBuffer()
 
 			if (static_cast<size_t>(bytes_to_retrieve) == _data_buffer.pop_front(bytes + sizeof(CSerialProtocol::SMessageHeader), bytes_to_retrieve))
 			{
-				const uint32_t message_length_in_words{message_length / sizeof(uint32_t)};
+				const uint32_t message_length_in_words{static_cast<uint32_t>(message_length / sizeof(uint32_t))};
 				const uint32_t actual_crc{crc32(_message_storage, message_length_in_words - 1)};
 				const uint32_t expected_crc = _message_storage[message_length_in_words - 1];
 

--- a/src/drivers/ins/ilabs/ILabs.cpp
+++ b/src/drivers/ins/ilabs/ILabs.cpp
@@ -67,13 +67,15 @@ enum ILabsMode {
 ILabs::ILabs(const char *serialDeviceName)
 	: ModuleParams(nullptr),
 	  ScheduledWorkItem(MODULE_NAME, px4::serial_port_to_wq(serialDeviceName)),
-	  _attitude_pub((_param_ilabs_mode.get() == ILabsMode::RAW_SENSORS_DATA) ? ORB_ID(external_ins_attitude)
-																			 : ORB_ID(vehicle_attitude)),
-	  _local_position_pub((_param_ilabs_mode.get() == ILabsMode::RAW_SENSORS_DATA) ? ORB_ID(external_ins_local_position)
-																				   : ORB_ID(vehicle_local_position)),
+	  _attitude_pub((_param_ilabs_mode.get() == ILabsMode::RAW_SENSORS_DATA)
+			    ? ORB_ID(external_ins_attitude)
+			    : ORB_ID(vehicle_attitude)),
+	  _local_position_pub((_param_ilabs_mode.get() == ILabsMode::RAW_SENSORS_DATA)
+				  ? ORB_ID(external_ins_local_position)
+				  : ORB_ID(vehicle_local_position)),
 	  _global_position_pub((_param_ilabs_mode.get() == ILabsMode::RAW_SENSORS_DATA)
-							   ? ORB_ID(external_ins_global_position)
-							   : ORB_ID(vehicle_global_position)) {
+				   ? ORB_ID(external_ins_global_position)
+				   : ORB_ID(vehicle_global_position)) {
 	// store port name
 	strncpy(_serialDeviceName, serialDeviceName, sizeof(_serialDeviceName) - 1);
 
@@ -470,8 +472,8 @@ void ILabs::processData(InertialLabs::SensorsData *data) {
 
 		sensor_gps.latitude_deg   = data->gps.latitude;
 		sensor_gps.longitude_deg  = data->gps.longitude;
-		sensor_gps.altitude_ellipsoid_m = data->gps.altitude;
-		sensor_gps.altitude_msl_m = data->gps.altitude;
+		sensor_gps.altitude_ellipsoid_m = static_cast<double>(data->gps.altitude);
+		sensor_gps.altitude_msl_m = static_cast<double>(data->gps.altitude);
 
 		sensor_gps.fix_type = data->gps.fixType + 1;
 

--- a/src/drivers/ins/ilabs/ILabs.h
+++ b/src/drivers/ins/ilabs/ILabs.h
@@ -90,6 +90,8 @@ private:
 		self->processData(data);
 	}
 
+private:
+	DEFINE_PARAMETERS((ParamInt<px4::params::ILABS_MODE>)_param_ilabs_mode)
 	InertialLabs::Sensor _sensor{};
 
 	char _serialDeviceName[20]{};
@@ -127,6 +129,4 @@ private:
 	    perf_alloc(PC_INTERVAL, MODULE_NAME ": local position publish interval")};
 	perf_counter_t _global_position_pub_interval_perf{
 	    perf_alloc(PC_INTERVAL, MODULE_NAME ": global position publish interval")};
-
-	DEFINE_PARAMETERS((ParamInt<px4::params::ILABS_MODE>)_param_ilabs_mode)
 };

--- a/src/drivers/ins/microstrain/MicroStrain.cpp
+++ b/src/drivers/ins/microstrain/MicroStrain.cpp
@@ -196,6 +196,7 @@ mip_cmd_result MicroStrain::forceIdle()
 
 	while (set_to_idle_tries++ < 3) {
 		res = mip_base_set_idle(&_device);
+
 		if (mip_cmd_result_is_ack(res)) {
 			break;
 
@@ -831,6 +832,7 @@ mip_cmd_result MicroStrain::configureGnssAiding()
 		// Sets up the GNSS aiding source
 		if (supportsDescriptor(MIP_FILTER_CMD_DESC_SET, MIP_CMD_DESC_FILTER_GNSS_SOURCE_CONTROL)) {
 			res = mip_filter_write_gnss_source(&_device, (uint8_t)_param_ms_gnss_aid_src_ctrl.get());
+
 			if (!mip_cmd_result_is_ack(res)) {
 				PX4_ERR("Could not write the gnss aiding source");
 				return res;
@@ -845,6 +847,7 @@ mip_cmd_result MicroStrain::configureGnssAiding()
 					res = mip_aiding_write_frame_config(&_device, 1,
 									    MIP_AIDING_FRAME_CONFIG_COMMAND_FORMAT_EULER, false,
 									    gnss_antenna_offset1, &rotation_gnss);
+
 					if (!mip_cmd_result_is_ack(res)) {
 						PX4_ERR("Could not write aiding frame config");
 						return res;
@@ -879,6 +882,7 @@ mip_cmd_result MicroStrain::configureGnssAiding()
 					 _param_ms_int_heading_en.get(),
 					 0, 0, nullptr, mip_aiding_frame_config_command_rotation{},
 					 0, _int_aiding, "dual antenna heading");
+
 		if (!mip_cmd_result_is_ack(res)) {
 			return res;
 		}
@@ -889,6 +893,7 @@ mip_cmd_result MicroStrain::configureGnssAiding()
 		res = mip_aiding_write_frame_config(&_device, 1,
 						    MIP_AIDING_FRAME_CONFIG_COMMAND_FORMAT_EULER, false,
 						    gnss_antenna_offset1, &rotation_gnss);
+
 		if (!mip_cmd_result_is_ack(res)) {
 			PX4_ERR("Could not write aiding frame config");
 			return res;
@@ -912,6 +917,7 @@ mip_cmd_result MicroStrain::configureAidingSources()
 				 _param_ms_int_mag_en.get(),
 				 0, 0, nullptr, mip_aiding_frame_config_command_rotation{},
 				 0, _int_aiding, "internal magnetometer");
+
 	if (!mip_cmd_result_is_ack(res)) {
 		return res;
 	}
@@ -924,6 +930,7 @@ mip_cmd_result MicroStrain::configureAidingSources()
 				 MIP_CMD_DESC_AIDING_MAGNETIC_FIELD,
 				 _ext_mag_aiding,
 				 "external magnetometer");
+
 	if (!mip_cmd_result_is_ack(res)) {
 		return res;
 	}
@@ -936,6 +943,7 @@ mip_cmd_result MicroStrain::configureAidingSources()
 				 MIP_CMD_DESC_AIDING_VEL_ODOM,
 				 _ext_optical_flow_aiding,
 				 "optical flow");
+
 	if (!mip_cmd_result_is_ack(res)) {
 		return res;
 	}
@@ -948,6 +956,7 @@ mip_cmd_result MicroStrain::configureAidingSources()
 				 MIP_CMD_DESC_AIDING_HEADING_TRUE,
 				 _ext_heading_aiding,
 				 "external heading");
+
 	if (!mip_cmd_result_is_ack(res)) {
 		return res;
 	}
@@ -1016,6 +1025,7 @@ bool MicroStrain::initializeIns()
 	PX4_INFO("Setting the baud to desired baud rate");
 
 	res = writeBaudRate(DESIRED_BAUDRATE, 1);
+
 	if (!mip_cmd_result_is_ack(res)) {
 		PX4_ERR("Could not set the baudrate!");
 		return false;
@@ -1031,6 +1041,7 @@ bool MicroStrain::initializeIns()
 
 	// Configure IMU ranges
 	res = configureImuRange();
+
 	if (!mip_cmd_result_is_ack(res)) {
 		MS_PX4_ERROR(res, "Could not configure IMU range");
 		return false;
@@ -1038,6 +1049,7 @@ bool MicroStrain::initializeIns()
 
 	// Configure the IMU message formt based on what descriptors are supported
 	res = configureImuMessageFormat();
+
 	if (!mip_cmd_result_is_ack(res)) {
 		MS_PX4_ERROR(res, "Could not write IMU message format");
 		return false;
@@ -1050,6 +1062,7 @@ bool MicroStrain::initializeIns()
 
 	// Configure the Filter message format based on what descriptors are supported
 	res = configureFilterMessageFormat();
+
 	if (!mip_cmd_result_is_ack(res)) {
 		MS_PX4_ERROR(res, "Could not write filter message format");
 		return false;
@@ -1062,6 +1075,7 @@ bool MicroStrain::initializeIns()
 
 	// Configure the GNSS1 message format based on what descriptors are supported
 	res = configureGnssMessageFormat(MIP_GNSS1_DATA_DESC_SET);
+
 	if (!mip_cmd_result_is_ack(res)) {
 		MS_PX4_ERROR(res, "Could not write GNSS1 message format");
 	}
@@ -1073,6 +1087,7 @@ bool MicroStrain::initializeIns()
 
 	// Configure the GNSS2 message format based on what descriptors are supported
 	res = configureGnssMessageFormat(MIP_GNSS2_DATA_DESC_SET);
+
 	if (!mip_cmd_result_is_ack(res)) {
 		MS_PX4_ERROR(res, "Could not write GNSS2 message format");
 	}
@@ -1084,6 +1099,7 @@ bool MicroStrain::initializeIns()
 
 	// Configure the aiding sources based on what the sensor supports
 	res = configureAidingSources();
+
 	if (!mip_cmd_result_is_ack(res)) {
 		MS_PX4_ERROR(res, "Could not configure aiding frames!");
 		return false;
@@ -1091,6 +1107,7 @@ bool MicroStrain::initializeIns()
 
 	// Initialize the filter
 	res = writeFilterInitConfig();
+
 	if (!mip_cmd_result_is_ack(res)) {
 		MS_PX4_ERROR(res, "Could not configure filter initialization!");
 		return false;
@@ -1101,9 +1118,10 @@ bool MicroStrain::initializeIns()
 		PX4_DEBUG("Writing SVT");
 
 		res = mip_3dm_write_sensor_2_vehicle_transform_euler(&_device,
-								     math::radians<float>(rotation_sens.euler[0]),
-								     math::radians<float>(rotation_sens.euler[1]),
-								     math::radians<float>(rotation_sens.euler[2]));
+				math::radians<float>(rotation_sens.euler[0]),
+				math::radians<float>(rotation_sens.euler[1]),
+				math::radians<float>(rotation_sens.euler[2]));
+
 		if (!mip_cmd_result_is_ack(res)) {
 			MS_PX4_ERROR(res, "Could not set sensor-to-vehicle transformation!");
 			return false;
@@ -1115,6 +1133,7 @@ bool MicroStrain::initializeIns()
 		PX4_DEBUG("Reseting filter");
 
 		res = mip_filter_reset(&_device);
+
 		if (!mip_cmd_result_is_ack(res)) {
 			MS_PX4_ERROR(res, "Could not reset the filter!");
 			return false;
@@ -1126,6 +1145,7 @@ bool MicroStrain::initializeIns()
 
 		res = mip_3dm_write_datastream_control(&_device,
 						       MIP_3DM_DATASTREAM_CONTROL_COMMAND_ALL_STREAMS, true);
+
 		if (!mip_cmd_result_is_ack(res)) {
 			MS_PX4_ERROR(res, "Could not enable the data stream");
 			return false;
@@ -1137,6 +1157,7 @@ bool MicroStrain::initializeIns()
 		PX4_DEBUG("Resuming device");
 
 		res = mip_base_resume(&_device);
+
 		if (!mip_cmd_result_is_ack(res)) {
 			MS_PX4_ERROR(res, "Could not resume the device!");
 			return false;

--- a/src/drivers/ins/microstrain/MicroStrain.cpp
+++ b/src/drivers/ins/microstrain/MicroStrain.cpp
@@ -195,7 +195,8 @@ mip_cmd_result MicroStrain::forceIdle()
 	uint8_t set_to_idle_tries = 0;
 
 	while (set_to_idle_tries++ < 3) {
-		if (mip_cmd_result_is_ack((res = mip_base_set_idle(&_device)))) {
+		res = mip_base_set_idle(&_device);
+		if (mip_cmd_result_is_ack(res)) {
 			break;
 
 		} else {
@@ -210,7 +211,7 @@ int MicroStrain::connectAtBaud(int32_t baud)
 {
 	if (device_uart.isOpen()) {
 		if (device_uart.setBaudrate(baud) == false) {
-			PX4_ERR("Failed to set UART %lu baud", baud);
+			PX4_ERR("Failed to set UART %lu baud", static_cast<unsigned long>(baud));
 		}
 
 	} else {
@@ -220,7 +221,7 @@ int MicroStrain::connectAtBaud(int32_t baud)
 		}
 
 		if (device_uart.setBaudrate(baud) == false) {
-			PX4_ERR("Failed to set UART %lu baud", baud);
+			PX4_ERR("Failed to set UART %lu baud", static_cast<unsigned long>(baud));
 			return PX4_ERROR;
 		}
 
@@ -230,11 +231,13 @@ int MicroStrain::connectAtBaud(int32_t baud)
 		}
 	}
 
-	PX4_INFO("Serial Port %s with baud of %lu baud", (device_uart.isOpen() ? "CONNECTED" : "NOT CONNECTED"), baud);
+	PX4_INFO("Serial Port %s with baud of %lu baud",
+		 (device_uart.isOpen() ? "CONNECTED" : "NOT CONNECTED"),
+		 static_cast<unsigned long>(baud));
 
 	// Re-init the interface with the correct timeouts
 	mip_interface_init(&_device, _parse_buffer, sizeof(_parse_buffer), mip_timeout_from_baudrate(baud) * 1_ms, 250_ms,
-			   &mipInterfaceUserSendToDevice, &mipInterfaceUserRecvFromDevice, &mip_interface_default_update, NULL);
+			   &mipInterfaceUserSendToDevice, &mipInterfaceUserRecvFromDevice, &mip_interface_default_update, nullptr);
 
 	if (!mip_cmd_result_is_ack(forceIdle())) {
 		PX4_ERR("Could not set device to idle");
@@ -827,7 +830,8 @@ mip_cmd_result MicroStrain::configureGnssAiding()
 
 		// Sets up the GNSS aiding source
 		if (supportsDescriptor(MIP_FILTER_CMD_DESC_SET, MIP_CMD_DESC_FILTER_GNSS_SOURCE_CONTROL)) {
-			if (!mip_cmd_result_is_ack(res = mip_filter_write_gnss_source(&_device, (uint8_t)_param_ms_gnss_aid_src_ctrl.get()))) {
+			res = mip_filter_write_gnss_source(&_device, (uint8_t)_param_ms_gnss_aid_src_ctrl.get());
+			if (!mip_cmd_result_is_ack(res)) {
 				PX4_ERR("Could not write the gnss aiding source");
 				return res;
 			}
@@ -838,9 +842,10 @@ mip_cmd_result MicroStrain::configureGnssAiding()
 
 				// Sets up the aiding frame for the external source
 				if (supportsDescriptor(MIP_AIDING_CMD_DESC_SET, MIP_CMD_DESC_AIDING_FRAME_CONFIG)) {
-					if (!mip_cmd_result_is_ack(res = mip_aiding_write_frame_config(&_device, 1,
-									 MIP_AIDING_FRAME_CONFIG_COMMAND_FORMAT_EULER, false,
-									 gnss_antenna_offset1, &rotation_gnss))) {
+					res = mip_aiding_write_frame_config(&_device, 1,
+									    MIP_AIDING_FRAME_CONFIG_COMMAND_FORMAT_EULER, false,
+									    gnss_antenna_offset1, &rotation_gnss);
+					if (!mip_cmd_result_is_ack(res)) {
 						PX4_ERR("Could not write aiding frame config");
 						return res;
 					}
@@ -870,20 +875,21 @@ mip_cmd_result MicroStrain::configureGnssAiding()
 		}
 
 		// Selectively enables dual antenna heading as an aiding measurement
-		if (!mip_cmd_result_is_ack(res = enableAidingSource(
-				MIP_FILTER_AIDING_MEASUREMENT_ENABLE_COMMAND_AIDING_SOURCE_GNSS_HEADING,
-				_param_ms_int_heading_en.get(),
-				0, 0, nullptr, mip_aiding_frame_config_command_rotation{0},
-				0, _int_aiding, "dual antenna heading"))) {
+		res = enableAidingSource(MIP_FILTER_AIDING_MEASUREMENT_ENABLE_COMMAND_AIDING_SOURCE_GNSS_HEADING,
+					 _param_ms_int_heading_en.get(),
+					 0, 0, nullptr, mip_aiding_frame_config_command_rotation{},
+					 0, _int_aiding, "dual antenna heading");
+		if (!mip_cmd_result_is_ack(res)) {
 			return res;
 		}
 	}
 
 	// Otherwise sets up the aiding frame
 	else if (supportsDescriptor(MIP_AIDING_CMD_DESC_SET, MIP_CMD_DESC_AIDING_FRAME_CONFIG)) {
-		if (!mip_cmd_result_is_ack(res = mip_aiding_write_frame_config(&_device, 1,
-						 MIP_AIDING_FRAME_CONFIG_COMMAND_FORMAT_EULER, false,
-						 gnss_antenna_offset1, &rotation_gnss))) {
+		res = mip_aiding_write_frame_config(&_device, 1,
+						    MIP_AIDING_FRAME_CONFIG_COMMAND_FORMAT_EULER, false,
+						    gnss_antenna_offset1, &rotation_gnss);
+		if (!mip_cmd_result_is_ack(res)) {
 			PX4_ERR("Could not write aiding frame config");
 			return res;
 		}
@@ -902,47 +908,47 @@ mip_cmd_result MicroStrain::configureAidingSources()
 	mip_cmd_result res;
 
 	// Selectively turn on internal magnetometer as an aiding source
-	if (!mip_cmd_result_is_ack(res = enableAidingSource(
-			MIP_FILTER_AIDING_MEASUREMENT_ENABLE_COMMAND_AIDING_SOURCE_MAGNETOMETER,
-			_param_ms_int_mag_en.get(),
-			0, 0, nullptr, mip_aiding_frame_config_command_rotation{0},
-			0, _int_aiding, "internal magnetometer"))) {
+	res = enableAidingSource(MIP_FILTER_AIDING_MEASUREMENT_ENABLE_COMMAND_AIDING_SOURCE_MAGNETOMETER,
+				 _param_ms_int_mag_en.get(),
+				 0, 0, nullptr, mip_aiding_frame_config_command_rotation{},
+				 0, _int_aiding, "internal magnetometer");
+	if (!mip_cmd_result_is_ack(res)) {
 		return res;
 	}
 
 	// Selectively turn on external magnetometer as an aiding source
-	if (!mip_cmd_result_is_ack(res = enableAidingSource(
-			MIP_FILTER_AIDING_MEASUREMENT_ENABLE_COMMAND_AIDING_SOURCE_EXTERNAL_MAGNETOMETER,
-			_param_ms_ext_mag_en.get(),
-			2, MIP_AIDING_FRAME_CONFIG_COMMAND_FORMAT_EULER,
-			ext_mag_offset, rotation_ext_mag,
-			MIP_CMD_DESC_AIDING_MAGNETIC_FIELD,
-			_ext_mag_aiding,
-			"external magnetometer"))) {
+	res = enableAidingSource(MIP_FILTER_AIDING_MEASUREMENT_ENABLE_COMMAND_AIDING_SOURCE_EXTERNAL_MAGNETOMETER,
+				 _param_ms_ext_mag_en.get(),
+				 2, MIP_AIDING_FRAME_CONFIG_COMMAND_FORMAT_EULER,
+				 ext_mag_offset, rotation_ext_mag,
+				 MIP_CMD_DESC_AIDING_MAGNETIC_FIELD,
+				 _ext_mag_aiding,
+				 "external magnetometer");
+	if (!mip_cmd_result_is_ack(res)) {
 		return res;
 	}
 
 	// Selectively turn on body frame velocity as an aiding source
-	if (!mip_cmd_result_is_ack(res = enableAidingSource(
-			MIP_FILTER_AIDING_MEASUREMENT_ENABLE_COMMAND_AIDING_SOURCE_VEHICLE_FRAME_VEL,
-			_param_ms_ext_opt_flow_en.get(),
-			3, MIP_AIDING_FRAME_CONFIG_COMMAND_FORMAT_EULER,
-			optical_flow_offset, rotation_oflow,
-			MIP_CMD_DESC_AIDING_VEL_ODOM,
-			_ext_optical_flow_aiding,
-			"optical flow"))) {
+	res = enableAidingSource(MIP_FILTER_AIDING_MEASUREMENT_ENABLE_COMMAND_AIDING_SOURCE_VEHICLE_FRAME_VEL,
+				 _param_ms_ext_opt_flow_en.get(),
+				 3, MIP_AIDING_FRAME_CONFIG_COMMAND_FORMAT_EULER,
+				 optical_flow_offset, rotation_oflow,
+				 MIP_CMD_DESC_AIDING_VEL_ODOM,
+				 _ext_optical_flow_aiding,
+				 "optical flow");
+	if (!mip_cmd_result_is_ack(res)) {
 		return res;
 	}
 
 	// Selectively turn on external heading as an aiding source
-	if (!mip_cmd_result_is_ack(res = enableAidingSource(
-			MIP_FILTER_AIDING_MEASUREMENT_ENABLE_COMMAND_AIDING_SOURCE_EXTERNAL_HEADING,
-			_param_ms_ext_heading_en.get(),
-			4, MIP_AIDING_FRAME_CONFIG_COMMAND_FORMAT_EULER,
-			ext_heading_offset, rotation_ext_heading,
-			MIP_CMD_DESC_AIDING_HEADING_TRUE,
-			_ext_heading_aiding,
-			"external heading"))) {
+	res = enableAidingSource(MIP_FILTER_AIDING_MEASUREMENT_ENABLE_COMMAND_AIDING_SOURCE_EXTERNAL_HEADING,
+				 _param_ms_ext_heading_en.get(),
+				 4, MIP_AIDING_FRAME_CONFIG_COMMAND_FORMAT_EULER,
+				 ext_heading_offset, rotation_ext_heading,
+				 MIP_CMD_DESC_AIDING_HEADING_TRUE,
+				 _ext_heading_aiding,
+				 "external heading");
+	if (!mip_cmd_result_is_ack(res)) {
 		return res;
 	}
 
@@ -989,7 +995,7 @@ bool MicroStrain::initializeIns()
 
 	for (auto &baudrate : BAUDRATES) {
 		if (connectAtBaud(baudrate) == PX4_OK) {
-			PX4_INFO("found baudrate %lu", baudrate);
+			PX4_INFO("found baudrate %lu", static_cast<unsigned long>(baudrate));
 			is_connected = true;
 			break;
 		}
@@ -1009,7 +1015,8 @@ bool MicroStrain::initializeIns()
 	// Setting the device baudrate to the desired value
 	PX4_INFO("Setting the baud to desired baud rate");
 
-	if (!mip_cmd_result_is_ack(res = writeBaudRate(DESIRED_BAUDRATE, 1))) {
+	res = writeBaudRate(DESIRED_BAUDRATE, 1);
+	if (!mip_cmd_result_is_ack(res)) {
 		PX4_ERR("Could not set the baudrate!");
 		return false;
 	}
@@ -1018,18 +1025,20 @@ bool MicroStrain::initializeIns()
 
 	// Connecting using the desired baudrate
 	if (connectAtBaud(DESIRED_BAUDRATE) != PX4_OK) {
-		PX4_ERR("Could not Connect at %lu", DESIRED_BAUDRATE);
+		PX4_ERR("Could not Connect at %lu", static_cast<unsigned long>(DESIRED_BAUDRATE));
 		return false;
 	}
 
 	// Configure IMU ranges
-	if (!mip_cmd_result_is_ack(res = configureImuRange())) {
+	res = configureImuRange();
+	if (!mip_cmd_result_is_ack(res)) {
 		MS_PX4_ERROR(res, "Could not configure IMU range");
 		return false;
 	}
 
 	// Configure the IMU message formt based on what descriptors are supported
-	if (!mip_cmd_result_is_ack(res = configureImuMessageFormat())) {
+	res = configureImuMessageFormat();
+	if (!mip_cmd_result_is_ack(res)) {
 		MS_PX4_ERROR(res, "Could not write IMU message format");
 		return false;
 	}
@@ -1040,7 +1049,8 @@ bool MicroStrain::initializeIns()
 					       this);
 
 	// Configure the Filter message format based on what descriptors are supported
-	if (!mip_cmd_result_is_ack(res = configureFilterMessageFormat())) {
+	res = configureFilterMessageFormat();
+	if (!mip_cmd_result_is_ack(res)) {
 		MS_PX4_ERROR(res, "Could not write filter message format");
 		return false;
 	}
@@ -1051,7 +1061,8 @@ bool MicroStrain::initializeIns()
 					       this);
 
 	// Configure the GNSS1 message format based on what descriptors are supported
-	if (!mip_cmd_result_is_ack(res = configureGnssMessageFormat(MIP_GNSS1_DATA_DESC_SET))) {
+	res = configureGnssMessageFormat(MIP_GNSS1_DATA_DESC_SET);
+	if (!mip_cmd_result_is_ack(res)) {
 		MS_PX4_ERROR(res, "Could not write GNSS1 message format");
 	}
 
@@ -1061,7 +1072,8 @@ bool MicroStrain::initializeIns()
 					       this);
 
 	// Configure the GNSS2 message format based on what descriptors are supported
-	if (!mip_cmd_result_is_ack(res = configureGnssMessageFormat(MIP_GNSS2_DATA_DESC_SET))) {
+	res = configureGnssMessageFormat(MIP_GNSS2_DATA_DESC_SET);
+	if (!mip_cmd_result_is_ack(res)) {
 		MS_PX4_ERROR(res, "Could not write GNSS2 message format");
 	}
 
@@ -1071,13 +1083,15 @@ bool MicroStrain::initializeIns()
 					       this);
 
 	// Configure the aiding sources based on what the sensor supports
-	if (!mip_cmd_result_is_ack(res = configureAidingSources())) {
+	res = configureAidingSources();
+	if (!mip_cmd_result_is_ack(res)) {
 		MS_PX4_ERROR(res, "Could not configure aiding frames!");
 		return false;
 	}
 
 	// Initialize the filter
-	if (!mip_cmd_result_is_ack(res = writeFilterInitConfig())) {
+	res = writeFilterInitConfig();
+	if (!mip_cmd_result_is_ack(res)) {
 		MS_PX4_ERROR(res, "Could not configure filter initialization!");
 		return false;
 	}
@@ -1086,9 +1100,11 @@ bool MicroStrain::initializeIns()
 	if (_param_ms_svt_en.get() && supportsDescriptor(MIP_3DM_CMD_DESC_SET, MIP_CMD_DESC_3DM_SENSOR2VEHICLE_TRANSFORM_EUL)) {
 		PX4_DEBUG("Writing SVT");
 
-		if (!mip_cmd_result_is_ack(res = mip_3dm_write_sensor_2_vehicle_transform_euler(&_device,
-						 math::radians<float>(rotation_sens.euler[0]),
-						 math::radians<float>(rotation_sens.euler[1]), math::radians<float>(rotation_sens.euler[2])))) {
+		res = mip_3dm_write_sensor_2_vehicle_transform_euler(&_device,
+								     math::radians<float>(rotation_sens.euler[0]),
+								     math::radians<float>(rotation_sens.euler[1]),
+								     math::radians<float>(rotation_sens.euler[2]));
+		if (!mip_cmd_result_is_ack(res)) {
 			MS_PX4_ERROR(res, "Could not set sensor-to-vehicle transformation!");
 			return false;
 		}
@@ -1098,7 +1114,8 @@ bool MicroStrain::initializeIns()
 	if (supportsDescriptor(MIP_FILTER_CMD_DESC_SET, MIP_CMD_DESC_FILTER_RESET_FILTER)) {
 		PX4_DEBUG("Reseting filter");
 
-		if (!mip_cmd_result_is_ack(res = mip_filter_reset(&_device))) {
+		res = mip_filter_reset(&_device);
+		if (!mip_cmd_result_is_ack(res)) {
 			MS_PX4_ERROR(res, "Could not reset the filter!");
 			return false;
 		}
@@ -1107,8 +1124,9 @@ bool MicroStrain::initializeIns()
 	if (supportsDescriptor(MIP_3DM_CMD_DESC_SET, MIP_CMD_DESC_3DM_CONTROL_DATA_STREAM)) {
 		PX4_DEBUG("Writing datastream control");
 
-		if (!mip_cmd_result_is_ack(res = mip_3dm_write_datastream_control(&_device,
-						 MIP_3DM_DATASTREAM_CONTROL_COMMAND_ALL_STREAMS, true))) {
+		res = mip_3dm_write_datastream_control(&_device,
+						       MIP_3DM_DATASTREAM_CONTROL_COMMAND_ALL_STREAMS, true);
+		if (!mip_cmd_result_is_ack(res)) {
 			MS_PX4_ERROR(res, "Could not enable the data stream");
 			return false;
 		}
@@ -1118,7 +1136,8 @@ bool MicroStrain::initializeIns()
 	if (supportsDescriptor(MIP_BASE_CMD_DESC_SET, MIP_CMD_DESC_BASE_RESUME)) {
 		PX4_DEBUG("Resuming device");
 
-		if (!mip_cmd_result_is_ack(res = mip_base_resume(&_device))) {
+		res = mip_base_resume(&_device);
+		if (!mip_cmd_result_is_ack(res)) {
 			MS_PX4_ERROR(res, "Could not resume the device!");
 			return false;
 		}

--- a/src/drivers/ins/microstrain/MicroStrain.hpp
+++ b/src/drivers/ins/microstrain/MicroStrain.hpp
@@ -201,11 +201,11 @@ private:
 	float ext_mag_offset[3] = {0};
 	float optical_flow_offset[3] = {0};
 	float ext_heading_offset[3] = {0};
-	mip_aiding_frame_config_command_rotation rotation_sens = {0};
-	mip_aiding_frame_config_command_rotation rotation_gnss = {0};
-	mip_aiding_frame_config_command_rotation rotation_ext_mag = {0};
-	mip_aiding_frame_config_command_rotation rotation_oflow = {0};
-	mip_aiding_frame_config_command_rotation rotation_ext_heading = {0};
+	mip_aiding_frame_config_command_rotation rotation_sens = {};
+	mip_aiding_frame_config_command_rotation rotation_gnss = {};
+	mip_aiding_frame_config_command_rotation rotation_ext_mag = {};
+	mip_aiding_frame_config_command_rotation rotation_oflow = {};
+	mip_aiding_frame_config_command_rotation rotation_ext_heading = {};
 
 	float ext_mag_uncert = 0.0;
 	float opt_flow_uncert = 0.0;

--- a/src/drivers/ins/sbgecom/CMakeLists.txt
+++ b/src/drivers/ins/sbgecom/CMakeLists.txt
@@ -40,6 +40,17 @@ add_subdirectory(sbgECom)
 
 add_dependencies(sbgECom prebuild_targets)
 
+# Vendor tree warning relaxations.
+#
+# sbgECom is a third-party submodule (PX4/sbgECom) we do not own.
+# These -Wno-* flags are scoped PRIVATE to the sbgECom target so they
+# apply only when compiling vendor .c files, not to the PX4 wrapper
+# (sbgecom.cpp/.hpp) which is built as a separate target via
+# px4_add_module() below and must remain under PX4's standard -Wall -Werror.
+#
+# If you add a flag here, it should address a warning emitted by vendor
+# code only. Warnings triggered in PX4-authored code must be fixed at
+# the source, not silenced here.
 target_compile_options(sbgECom
         PRIVATE
         -Wno-format
@@ -49,7 +60,14 @@ target_compile_options(sbgECom
         -Wno-type-limits
         -Wno-maybe-uninitialized
         -Wno-float-equal
+        -Wno-logical-op
 )
+
+# -Wno-typedef-redefinition is Clang-only. GCC rejects unrecognized
+# warning flags under -Werror, so guard this by compiler.
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+     target_compile_options(sbgECom PRIVATE -Wno-typedef-redefinition)
+endif()
 
 if("${PX4_PLATFORM}" MATCHES "nuttx")
     target_compile_definitions(sbgECom PUBLIC __NUTTX__)

--- a/src/drivers/ins/sbgecom/sbgecom.cpp
+++ b/src/drivers/ins/sbgecom/sbgecom.cpp
@@ -877,12 +877,26 @@ void SbgEcom::send_config_file(SbgEComHandle *pHandle, const char *file_path)
 		return;
 	}
 
-	ssize_t ret = read(fd, body, s.st_size);
+	ssize_t total_read = 0;
 
-	if (ret < 0) {
-		PX4_ERR("Read failed: %s", strerror(errno));
-		close(fd);
-		return;
+	while (total_read < s.st_size) {
+		const ssize_t ret = read(fd, body + total_read, s.st_size - total_read);
+
+		if (ret < 0) {
+			PX4_ERR("Read failed: %s", strerror(errno));
+			free(body);
+			close(fd);
+			return;
+		}
+
+		if (ret == 0) {
+			PX4_ERR("Read failed: unexpected end of file");
+			free(body);
+			close(fd);
+			return;
+		}
+
+		total_read += ret;
 	}
 
 	body[s.st_size] = '\0';

--- a/src/drivers/ins/sbgecom/sbgecom.cpp
+++ b/src/drivers/ins/sbgecom/sbgecom.cpp
@@ -43,6 +43,7 @@
 #include <lib/drivers/device/Device.hpp>
 #include <px4_platform_common/getopt.h>
 
+#include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <termios.h>
@@ -323,9 +324,9 @@ void SbgEcom::handleLogEkfNav(const SbgEComLogUnion *ref_sbg_data, void *user_ar
 	const double longitude = ref_sbg_data->ekfNavData.position[1];
 	const double altitude = ref_sbg_data->ekfNavData.position[2];
 
-	const double north_velocity = ref_sbg_data->ekfNavData.velocity[0];
-	const double east_velocity = ref_sbg_data->ekfNavData.velocity[1];
-	const double down_velocity = ref_sbg_data->ekfNavData.velocity[2];
+	const double north_velocity = static_cast<double>(ref_sbg_data->ekfNavData.velocity[0]);
+	const double east_velocity = static_cast<double>(ref_sbg_data->ekfNavData.velocity[1]);
+	const double down_velocity = static_cast<double>(ref_sbg_data->ekfNavData.velocity[2]);
 
 	if (!instance->_pos_ref.isInitialized()) {
 		instance->_pos_ref.initReference(latitude, longitude, time_now_us);
@@ -457,7 +458,7 @@ void SbgEcom::handleLogGnssPosVelHdt(SbgEComMsgId msg, const SbgEComLogUnion *re
 		sensor_gps.latitude_deg = gnss_data->gps_pos.latitude;
 		sensor_gps.longitude_deg = gnss_data->gps_pos.longitude;
 		sensor_gps.altitude_msl_m = gnss_data->gps_pos.altitude;
-		sensor_gps.altitude_ellipsoid_m = gnss_data->gps_pos.undulation;
+		sensor_gps.altitude_ellipsoid_m = static_cast<double>(gnss_data->gps_pos.undulation);
 
 		sensor_gps.s_variance_m_s = sqrt(pow(gnss_data->gps_vel.velocityAcc[0], 2) +
 						 pow(gnss_data->gps_vel.velocityAcc[1], 2) +
@@ -831,18 +832,18 @@ void SbgEcom::send_config(SbgEComHandle *pHandle, const char *config)
 
 	sbgEComCmdApiReplyConstruct(&reply);
 
-	sbgEComCmdApiPost(pHandle, "/api/v1/settings", NULL, config, &reply);
+	sbgEComCmdApiPost(pHandle, "/api/v1/settings", nullptr, config, &reply);
 
 	if (!sbgEComCmdApiReplySuccessful(&reply)) {
 		PX4_ERR("Fail to apply SBG configuration: %s", reply.pContent);
 
 	} else {
-		bool need_reboot = (strstr(reply.pContent, NEED_REBOOT_STR) != NULL);
-		sbgEComCmdApiPost(pHandle, "/api/v1/settings/save", NULL, NULL, &reply);
+		bool need_reboot = (strstr(reply.pContent, NEED_REBOOT_STR) != nullptr);
+		sbgEComCmdApiPost(pHandle, "/api/v1/settings/save", nullptr, nullptr, &reply);
 
 		if (need_reboot) {
 			PX4_INFO("Reboot SBG device");
-			sbgEComCmdApiPost(pHandle, "/api/v1/system/reboot", NULL, NULL, &reply);
+			sbgEComCmdApiPost(pHandle, "/api/v1/system/reboot", nullptr, nullptr, &reply);
 		}
 	}
 
@@ -852,7 +853,7 @@ void SbgEcom::send_config(SbgEComHandle *pHandle, const char *config)
 void SbgEcom::send_config_file(SbgEComHandle *pHandle, const char *file_path)
 {
 	int fd;
-	char *body = NULL;
+	char *body = nullptr;
 	struct stat s;
 
 	assert(pHandle);
@@ -869,12 +870,21 @@ void SbgEcom::send_config_file(SbgEComHandle *pHandle, const char *file_path)
 	body = (char *)malloc(s.st_size + 1);
 
 	if (!body) {
-		PX4_ERR("Failed to allocate memory (%ld) - %s", s.st_size + 1, strerror(get_errno()));
+		PX4_ERR("Failed to allocate memory (%lld) - %s",
+			static_cast<long long>(s.st_size + 1),
+			strerror(errno));
 		close(fd);
 		return;
 	}
 
-	read(fd, body, s.st_size);
+	ssize_t ret = read(fd, body, s.st_size);
+
+	if (ret < 0) {
+		PX4_ERR("Read failed: %s", strerror(errno));
+		close(fd);
+		return;
+	}
+
 	body[s.st_size] = '\0';
 
 	send_config(pHandle, body);
@@ -896,7 +906,9 @@ int SbgEcom::init()
 	error_code = sbgInterfaceSerialCreate(&_sbg_interface, _device_name, _baudrate);
 
 	if (error_code == SBG_NO_ERROR) {
-		PX4_INFO("Serial interface created successfully on port: %s, baudrate: %ld", _device_name, _baudrate);
+		PX4_INFO("Serial interface created successfully on port: %s, baudrate: %ld",
+			 _device_name,
+			 static_cast<long int>(_baudrate));
 	}
 
 	pSerialHandle = (int *)_sbg_interface.handle;

--- a/src/drivers/ins/sbgecom/sbgecom.hpp
+++ b/src/drivers/ins/sbgecom/sbgecom.hpp
@@ -218,7 +218,7 @@ private:
 	SbgErrorCode sendMagLog(SbgEComHandle *handle, SbgEcom *instance);
 
 	void set_device_id(uint32_t device_id);
-	uint32_t get_device_id(void);
+	uint32_t get_device_id();
 
 	// SBG interface and state variables
 	SbgInterface _sbg_interface;
@@ -241,7 +241,7 @@ private:
 	int init_result;
 
 	MapProjection _pos_ref{};
-	double _gps_alt_ref{NAN};
+	double _gps_alt_ref{static_cast<double>(NAN)};
 
 	struct GnssData {
 		bool pos_received = false;

--- a/src/drivers/ins/vectornav/VectorNav.cpp
+++ b/src/drivers/ins/vectornav/VectorNav.cpp
@@ -504,7 +504,9 @@ bool VectorNav::init()
 	VnError error = E_NONE;
 
 	// change baudrate to max
-	if ((error = VnSensor_changeBaudrate(&_vs, DESIRED_BAUDRATE)) != E_NONE) {
+	error = VnSensor_changeBaudrate(&_vs, DESIRED_BAUDRATE);
+
+	if (error != E_NONE) {
 		PX4_ERR("Error changing baud rate failed: %d", error);
 		VnSensor_disconnect(&_vs);
 		return false;
@@ -513,7 +515,9 @@ bool VectorNav::init()
 	// query the sensor's model number
 	char model_number[30] {};
 
-	if ((error = VnSensor_readModelNumber(&_vs, model_number, sizeof(model_number))) != E_NONE) {
+	error = VnSensor_readModelNumber(&_vs, model_number, sizeof(model_number));
+
+	if (error != E_NONE) {
 		PX4_ERR("Error reading model number %d", error);
 		VnSensor_disconnect(&_vs);
 		return false;
@@ -522,7 +526,9 @@ bool VectorNav::init()
 	// query the sensor's hardware revision
 	uint32_t hardware_revision = 0;
 
-	if ((error = VnSensor_readHardwareRevision(&_vs, &hardware_revision)) != E_NONE) {
+	error = VnSensor_readHardwareRevision(&_vs, &hardware_revision);
+
+	if (error != E_NONE) {
 		PX4_ERR("Error reading HW revision %d", error);
 		VnSensor_disconnect(&_vs);
 		return false;
@@ -531,7 +537,9 @@ bool VectorNav::init()
 	// query the sensor's serial number
 	uint32_t serial_number = 0;
 
-	if ((error = VnSensor_readSerialNumber(&_vs, &serial_number)) != E_NONE) {
+	error = VnSensor_readSerialNumber(&_vs, &serial_number);
+
+	if (error != E_NONE) {
 		PX4_ERR("Error reading serial number %d", error);
 		VnSensor_disconnect(&_vs);
 		return false;
@@ -540,7 +548,9 @@ bool VectorNav::init()
 	// query the sensor's firmware version
 	char firmware_version[30] {};
 
-	if ((error = VnSensor_readFirmwareVersion(&_vs, firmware_version, sizeof(firmware_version))) != E_NONE) {
+	error = VnSensor_readFirmwareVersion(&_vs, firmware_version, sizeof(firmware_version));
+
+	if (error != E_NONE) {
 		PX4_ERR("Error reading firmware version %d", error);
 		VnSensor_disconnect(&_vs);
 		return false;
@@ -623,7 +633,9 @@ bool VectorNav::configure()
 		GPSGROUP_NONE
 	);
 
-	if ((error = VnSensor_writeBinaryOutput1(&_vs, &_binary_output_group_1, true)) != E_NONE) {
+	error = VnSensor_writeBinaryOutput1(&_vs, &_binary_output_group_1, true);
+
+	if (error != E_NONE) {
 
 		// char buffer[128]{};
 		// strFromVnError((char*)buffer, error);
@@ -646,7 +658,9 @@ bool VectorNav::configure()
 		GPSGROUP_NONE
 	);
 
-	if ((error = VnSensor_writeBinaryOutput2(&_vs, &_binary_output_group_2, true)) != E_NONE) {
+	error = VnSensor_writeBinaryOutput2(&_vs, &_binary_output_group_2, true);
+
+	if (error != E_NONE) {
 		PX4_ERR("Error writing binary output 2 %d", error);
 		return false;
 	}
@@ -666,7 +680,9 @@ bool VectorNav::configure()
 		GPSGROUP_NONE
 	);
 
-	if ((error = VnSensor_writeBinaryOutput3(&_vs, &_binary_output_group_3, true)) != E_NONE) {
+	error = VnSensor_writeBinaryOutput3(&_vs, &_binary_output_group_3, true);
+
+	if (error != E_NONE) {
 		PX4_ERR("Error writing binary output 3 %d", error);
 		//return false;
 	}
@@ -719,7 +735,7 @@ void VectorNav::Run()
 		const hrt_abstime time_last_valid_imu_us = _time_last_valid_imu_us.load();
 
 		if (_param_vn_mode.get() == 1) {
-			if ((time_last_valid_imu_us != 0) && (hrt_elapsed_time(&time_last_valid_imu_us) < 3_s))
+			if ((time_last_valid_imu_us != 0) && (hrt_elapsed_time(&time_last_valid_imu_us) < 3_s)) {
 
 				// update sensor_selection if configured in INS mode
 				if ((_px4_accel.get_device_id() != 0) && (_px4_gyro.get_device_id() != 0)) {
@@ -729,6 +745,7 @@ void VectorNav::Run()
 					sensor_selection.timestamp = hrt_absolute_time();
 					_sensor_selection_pub.publish(sensor_selection);
 				}
+			}
 		}
 
 		if ((time_configured_us != 0) && (hrt_elapsed_time(&time_last_valid_imu_us) > 5_s)

--- a/src/drivers/ins/vectornav/VectorNav.hpp
+++ b/src/drivers/ins/vectornav/VectorNav.hpp
@@ -59,7 +59,6 @@ extern "C" {
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
 #include <px4_platform_common/px4_config.h>
-#include <px4_platform_common/module.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/Publication.hpp>
 #include <uORB/SubscriptionInterval.hpp>
@@ -96,7 +95,6 @@ public:
 	int print_status() override;
 
 private:
-
 	bool init();
 	bool configure();
 
@@ -109,6 +107,10 @@ private:
 
 	void sensorCallback(VnUartPacket *packet);
 
+private:
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::VN_MODE>) _param_vn_mode
+	)
 	char _port[20] {};
 
 	bool _initialized{false};
@@ -158,7 +160,6 @@ private:
 	perf_counter_t _local_position_pub_interval_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": local position publish interval")};
 	perf_counter_t _global_position_pub_interval_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": global position publish interval")};
 
-
 	// TODO: params for GNSS antenna offsets
 	// A
 	// B
@@ -180,8 +181,4 @@ private:
 	// VN_GNSS_ANTB_POS_X
 
 	// Uncertainty in the X-axis position measurement.
-
-	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::VN_MODE>) _param_vn_mode
-	)
 };

--- a/src/drivers/ins/vectornav/libvnc/.clang-tidy
+++ b/src/drivers/ins/vectornav/libvnc/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks: '-clang-analyzer-cplusplus.NewDeleteLeaks'
+WarningsAsErrors: ''
+...

--- a/src/drivers/roboclaw/Roboclaw.cpp
+++ b/src/drivers/roboclaw/Roboclaw.cpp
@@ -334,7 +334,7 @@ int Roboclaw::writeCommandWithPayload(Command command, uint8_t *wbuff, size_t by
 
 	// Not all bytes sent
 	if (bytes_written < packet_size) {
-		PX4_ERR("Only wrote %d out of %d bytes", bytes_written, bytes_to_write);
+		PX4_ERR("Only wrote %zu out of %zu bytes", bytes_written, bytes_to_write);
 		return ERROR;
 	}
 
@@ -381,7 +381,7 @@ int Roboclaw::writeCommand(Command command)
 	size_t bytes_written = write(_uart_fd, buffer, 2);
 
 	if (bytes_written < 2) {
-		PX4_ERR("Only wrote %d out of %d bytes", bytes_written, 2);
+		PX4_ERR("Only wrote %zu out of %d bytes", bytes_written, 2);
 		return ERROR;
 	}
 

--- a/src/drivers/vtxtable/VtxTable.cpp
+++ b/src/drivers/vtxtable/VtxTable.cpp
@@ -156,7 +156,7 @@ void vtxtable_print_status()
 		PX4_INFO("VTX table: <not configured>");
 
 	} else {
-		PX4_INFO("VTX table %ux%u: %s", vtxtable().bands(), vtxtable().channels(), vtxtable().name());
+		PX4_INFO("VTX table %zux%zu: %s", vtxtable().bands(), vtxtable().channels(), vtxtable().name());
 		vtxtable_print_frequencies();
 	}
 
@@ -306,7 +306,10 @@ int vtxtable_custom_command(int argc, char *argv[])
 void vtxtable_print_frequencies()
 {
 	for (uint8_t b = 0; b < vtxtable().bands(); b++) {
-		PX4_INFO_RAW("INFO  [vtxtable]  %c: %-*s=", vtxtable().band_letter(b), vtx::Config::NAME_LENGTH, vtxtable().band_name(b));
+		PX4_INFO_RAW("INFO  [vtxtable]  %c: %-*s=",
+			     vtxtable().band_letter(b),
+			     static_cast<int>(vtx::Config::NAME_LENGTH),
+			     vtxtable().band_name(b));
 
 		for (uint8_t c = 0; c < vtxtable().channels(); c++) {
 			PX4_INFO_RAW(" %4hu", vtxtable().frequency(b, c));

--- a/src/drivers/vtxtable/config.h
+++ b/src/drivers/vtxtable/config.h
@@ -404,7 +404,7 @@ public:
 	inline int store(const char *filename) const
 	{
 		LockGuard lg{_mutex};
-		int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC);
+		int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 
 		if (fd < 0) {
 			return errno;
@@ -432,7 +432,7 @@ public:
 		}
 
 		LockGuard lg{_mutex};
-		int fd = open(filename, O_RDONLY);
+		int fd = open(filename, O_RDONLY, 0666);
 
 		if (fd < 0) {
 			return errno;
@@ -489,8 +489,34 @@ public:
 		}
 
 		// now read into the data structure directly
-		lseek(fd, sizeof(magic), SEEK_SET);
-		read(fd, &_data, sizeof(Storage));
+		if (lseek(fd, sizeof(magic), SEEK_SET) < 0) {
+			close(fd);
+			return -errno;
+		}
+
+		size_t total = 0;
+		uint8_t *ptr = reinterpret_cast<uint8_t *>(&_data);
+
+		while (total < sizeof(Storage)) {
+			const int n = read(fd, ptr + total, sizeof(Storage) - total);
+
+			if (n < 0) {
+				if (errno == EINTR) {
+					continue;
+				}
+
+				close(fd);
+				return -errno;
+			}
+
+			if (n == 0) {
+				close(fd);
+				return -EIO;
+			}
+
+			total += static_cast<size_t>(n);
+		}
+
 		close(fd);
 
 		_change_value++;


### PR DESCRIPTION
### Solved Problem
INS-drivers had errors and can't build.

Currently, INS-drivers buildability isn't checked when merging pull-requests.
After these changes https://github.com/PX4/PX4-Autopilot/commit/b7c5ba17522db553a1838779b50e4b0725bc52d7 it was stopped.

Because of this, build-errors in this code-base go unnoticed.

### Solution
INS-drivers build fixed.
Clang-tidy errors fixed.
Code-style errors (astyle) fixed in the separate commits.

Build more targets in `px4_sitl_allyes`:
Exclude specific targets from build instead of redundant big filters `COMMON `and `DRIVERS` in `Tools/kconfig/allyesconfig.py`

### Changelog Entry
For release notes:
```
Restore driver build coverage in px4_sitl_allyes (previously silently skipped)
```