### PR TITLE
docs(gz_bridge): magnetometer device address documentation

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -390,9 +390,10 @@ void GZBridge::magnetometerCallback(const gz::msgs::Magnetometer &msg)
 	id.devid_s.bus_type = device::Device::DeviceBusType::DeviceBusType_SIMULATION;
 	id.devid_s.devtype = DRV_MAG_DEVTYPE_MAGSIM;
 	id.devid_s.bus = 1;
-	id.devid_s.address =
-		3; // Parameters CAL_MAGx_ID set to 0x3030C and 0x3040C in init.d-posix so only address 3 and 4 are valid for sim magnetometers
+
+	// Parameters CAL_MAGx_ID set to 0x3030C and 0x3040C in init.d-posix so only address 3 and 4 are valid for sim magnetometers (unless overwritten)
 	// See: https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d-posix/rcS#L146-L149
+	id.devid_s.address = 3;
 
 	sensor_mag_s report{};
 	report.timestamp = timestamp;


### PR DESCRIPTION
### Solved Problem
Explains why device ID address can be 3 or 4 in gz simulation. Not really a significant change but hopefully the updated comment can make it easier for others to simulate with multiple compasses in gz sim

