### PR TITLE
fix(fw_attitude_control): Correct turn coordination and rename variables

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -310,9 +310,6 @@ void FixedwingAttitudeControl::Run()
 					const float yawrate_ff = CONSTANTS_ONE_G * q1 / V;
 					const float pitchrate_ff = q1 * yawrate_ff / (1.f - 2.f * q_current(1) * q_current(1) - 2.f * q_current(2) * q_current(2));
 
-					body_rates_setpoint(1) += pitchrate_ff;
-					body_rates_setpoint(2) += yawrate_ff;
-
 					// Limit turn coordination to normal flight envelope
 					const float cos_tilt = 1.f - 2.f * (q_current(1) * q_current(1) + q_current(2) * q_current(2));
 					const float tilt = acosf(math::constrain((cos_tilt), -1.f, 1.f));


### PR DESCRIPTION
### Solved Problem
The feed-forward for the `yaw` and `pitch-rate` was added twice due to an error. 
The naming of the feedforward variables was inconsistent/wrong.

### Solution
Remove the duplicated feed-forward term.
Rename the feed-forward terms. 

### Changelog Entry
For release notes:
```
Bugfix: Correct turn coordination feed-forward
```

### Test coverage
Tested in SITL