### PR TITLE
fix(uavcan): use node-published timestamps for CAN sensor bridges

### DIFF
--- a/src/drivers/uavcan/sensors/accel.cpp
+++ b/src/drivers/uavcan/sensors/accel.cpp
@@ -63,7 +63,7 @@ void UavcanAccelBridge::imu_sub_cb(const uavcan::ReceivedDataStructure<uavcan::e
 {
 	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getSrcNodeID().get(), msg.getIfaceIndex());
 
-	const hrt_abstime timestamp_sample = hrt_absolute_time();
+	const hrt_abstime timestamp_sample = (msg.timestamp.usec > 0) ? msg.timestamp.usec : hrt_absolute_time();
 
 	if (channel == nullptr) {
 		// Something went wrong - no channel to publish on; return

--- a/src/drivers/uavcan/sensors/gyro.cpp
+++ b/src/drivers/uavcan/sensors/gyro.cpp
@@ -75,7 +75,8 @@ void UavcanGyroBridge::imu_sub_cb(const uavcan::ReceivedDataStructure<uavcan::eq
 		return;
 	}
 
-	gyro->update(hrt_absolute_time(),
+	const hrt_abstime timestamp_sample = (msg.timestamp.usec > 0) ? msg.timestamp.usec : hrt_absolute_time();
+	gyro->update(timestamp_sample,
 		     msg.rate_gyro_latest[0],
 		     msg.rate_gyro_latest[1],
 		     msg.rate_gyro_latest[2]);

--- a/src/drivers/uavcan/sensors/rangefinder.cpp
+++ b/src/drivers/uavcan/sensors/rangefinder.cpp
@@ -116,7 +116,8 @@ void UavcanRangefinderBridge::range_sub_cb(const
 		quality = 100;
 	}
 
-	rangefinder->update(hrt_absolute_time(), msg.range, quality);
+	const hrt_abstime timestamp_sample = (msg.timestamp.usec > 0) ? msg.timestamp.usec : hrt_absolute_time();
+	rangefinder->update(timestamp_sample, msg.range, quality);
 
 	// Register device capability if not already done
 	if (_node_info_publisher != nullptr) {

--- a/src/drivers/uavcannode/Publishers/RangeSensorMeasurement.hpp
+++ b/src/drivers/uavcannode/Publishers/RangeSensorMeasurement.hpp
@@ -75,6 +75,7 @@ public:
 		if (uORB::SubscriptionCallbackWorkItem::update(&dist)) {
 			uavcan::equipment::range_sensor::Measurement range_sensor{};
 
+			range_sensor.timestamp.usec = getNode().getUtcTime().toUSec() - (hrt_absolute_time() - dist.timestamp);
 			range_sensor.sensor_id = get_instance();
 			range_sensor.range = dist.current_distance;
 			range_sensor.field_of_view = dist.h_fov;


### PR DESCRIPTION
## Summary
- Cannode range sensor publisher now sets `uavcan.Timestamp` using GlobalTimeSync UTC, matching the existing RawIMU pattern
- FC-side accel, gyro, and rangefinder bridges prefer the message timestamp when set (>0), falling back to `hrt_absolute_time()`
- Backwards compatible: old nodes that don't set the timestamp field (default 0) trigger the fallback