### PR TITLE
fix(sbom): fix false positives in monthly license audit

### DIFF
--- a/.github/workflows/sbom_monthly_audit.yml
+++ b/.github/workflows/sbom_monthly_audit.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Check for issues
         id: check
         run: |
-          if grep -q "NOASSERTION" /tmp/sbom-verify.txt; then
+          if grep -q "<-- UNRESOLVED" /tmp/sbom-verify.txt; then
             echo "has_issues=true" >> "$GITHUB_OUTPUT"
-            # Extract NOASSERTION lines
-            grep "NOASSERTION" /tmp/sbom-verify.txt | grep -v "skipped" > /tmp/sbom-issues.txt || true
+            # Extract only genuinely unresolved license lines
+            grep "<-- UNRESOLVED" /tmp/sbom-verify.txt > /tmp/sbom-issues.txt || true
             # Extract copyleft lines
             sed -n '/Copyleft licenses detected/,/^$/p' /tmp/sbom-verify.txt > /tmp/sbom-copyleft.txt || true
           else

--- a/Tools/ci/generate_sbom.py
+++ b/Tools/ci/generate_sbom.py
@@ -478,6 +478,7 @@ def verify_licenses(source_dir):
         sub_dir = source_dir / sub_path
 
         checked_out = sub_dir.is_dir() and any(sub_dir.iterdir())
+        has_explicit_override = sub_path in license_overrides
         if not checked_out:
             detected = "(not checked out)"
             override = license_overrides.get(sub_path, "")
@@ -487,9 +488,12 @@ def verify_licenses(source_dir):
             override = license_overrides.get(sub_path, "")
             final = override if override else detected
 
-        if final == "NOASSERTION" and checked_out:
+        if final == "NOASSERTION" and has_explicit_override:
+            # Explicitly acknowledged in overrides file — not a failure
+            marker = " (acknowledged)"
+        elif final == "NOASSERTION" and checked_out:
             has_noassertion = True
-            marker = " <-- NOASSERTION"
+            marker = " <-- UNRESOLVED"
         elif final == "NOASSERTION" and not checked_out:
             marker = " (skipped)"
         else:
@@ -521,7 +525,7 @@ def verify_licenses(source_dir):
         print()
 
     if has_noassertion:
-        print("FAIL: Some submodules resolved to NOASSERTION. "
+        print("FAIL: Some submodules have unresolved licenses. "
               "Add an entry to Tools/ci/license-overrides.yaml or check the LICENSE file.")
         return 1
 

--- a/Tools/ci/license-overrides.yaml
+++ b/Tools/ci/license-overrides.yaml
@@ -9,6 +9,12 @@ overrides:
     license: "LGPL-3.0-only AND MIT"
     comment: "Generator is LGPL-3.0; PX4 ships only MIT-licensed generated headers."
 
+  Tools/simulation/gazebo-classic/sitl_gazebo-classic:
+    license: "BSD-3-Clause"
+    comment: >-
+      PX4 org project. No LICENSE file in repo; source files carry
+      BSD-3-Clause headers consistent with the PX4 project license.
+
   src/lib/cdrstream/cyclonedds:
     license: "EPL-2.0 OR BSD-3-Clause"
     comment: >-


### PR DESCRIPTION
The monthly SBOM audit was creating issues for submodules that already had valid overrides in license-overrides.yaml. This happened because the workflow grepped for bare "NOASSERTION" anywhere in the verify output, which matched the Detected column even when the Final column was correctly resolved via override (e.g. libtomcrypt detected as NOASSERTION but overridden to Unlicense). Additionally, submodules with an intentional NOASSERTION override like libfc-sensor-api (proprietary, no LICENSE file) were still counted as failures despite being explicitly acknowledged.

This fixes three things: the workflow now greps for the specific "<-- UNRESOLVED" marker instead of bare "NOASSERTION", the verify logic treats explicit NOASSERTION overrides as acknowledged rather than failures, and adds the missing BSD-3-Clause override for sitl_gazebo-classic which has no LICENSE file in its repo.

Fixes #26932