### PR TITLE
fix(setup): pin setuptools version to resolve pkg_resources ModuleNotFoundError

### DIFF
--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -23,7 +23,7 @@ pyserial
 pyulog>=0.5.0
 pyyaml
 requests
-setuptools>=39.2.0
+setuptools>=39.2.0,<=81.0.0
 six>=1.12.0
 sympy>=1.10.1
 toml>=0.9


### PR DESCRIPTION
### Solved Problem
Support for `pkg_resources` was removed in `setuptools` v82.0.0, which causes a ModuleNotFoundError when compiling uavcan drivers via `pydronecan`. `pydronecan` imports `pkg_resources` [here](https://github.com/dronecan/pydronecan/blob/19fdf2e5b383243ccdb1094edae0603cf11469e8/dronecan/__init__.py#L19).

Setuptools changelog: https://setuptools.pypa.io/en/stable/history.html#deprecations-and-removals

### Solution
Pinned `setuptools` upper version in the `requirements.txt`.

### Changelog Entry
For release notes:
```
Fix: pin setuptools<82.0.0 to restore pkg_resources availability for uavcan/dronecan build
```

