### PR TITLE
fix(docs): update translation image paths for cuav_x25-evo

### DIFF
--- a/docs/ko/flight_controller/cuav_x25-evo.md
+++ b/docs/ko/flight_controller/cuav_x25-evo.md
@@ -9,7 +9,7 @@ The _X25-EVO_ is an advanced autopilot manufactured by CUAV<sup>&reg;</sup>.
 
 The autopilot is recommended for commercial system integration but is also suitable for academic research and any other applications.
 
-![X25-EVO AutoPilot - hero image](../../assets/flight_controller/cuav_x25-evo/X25-EVO.jpg)
+![X25-EVO AutoPilot - hero image](../../assets/flight_controller/cuav_x25-evo/x25_evo.jpg)
 
 The X25-EVO brings you ultimate performance, stability, and reliability in every aspect.
 

--- a/docs/uk/flight_controller/cuav_x25-evo.md
+++ b/docs/uk/flight_controller/cuav_x25-evo.md
@@ -9,7 +9,7 @@ The _X25-EVO_ is an advanced autopilot manufactured by CUAV<sup>&reg;</sup>.
 
 The autopilot is recommended for commercial system integration but is also suitable for academic research and any other applications.
 
-![X25-EVO AutoPilot - hero image](../../assets/flight_controller/cuav_x25-evo/X25-EVO.jpg)
+![X25-EVO AutoPilot - hero image](../../assets/flight_controller/cuav_x25-evo/x25_evo.jpg)
 
 The X25-EVO brings you ultimate performance, stability, and reliability in every aspect.
 

--- a/docs/zh/flight_controller/cuav_x25-evo.md
+++ b/docs/zh/flight_controller/cuav_x25-evo.md
@@ -9,7 +9,7 @@ The _X25-EVO_ is an advanced autopilot manufactured by CUAV<sup>&reg;</sup>.
 
 The autopilot is recommended for commercial system integration but is also suitable for academic research and any other applications.
 
-![X25-EVO AutoPilot - hero image](../../assets/flight_controller/cuav_x25-evo/X25-EVO.jpg)
+![X25-EVO AutoPilot - hero image](../../assets/flight_controller/cuav_x25-evo/x25_evo.jpg)
 
 The X25-EVO brings you ultimate performance, stability, and reliability in every aspect.
 


### PR DESCRIPTION
PR #26882 (Update CUAV X25 Series Doc) renamed the hero image from `X25-EVO.jpg` to `x25_evo.jpg` and updated the English page, but the three Crowdin-managed translation files (ko, uk, zh) still reference the old filename. On Linux CI (case-sensitive FS), VitePress fails to resolve the deleted file. This has been breaking the T3 Build Site job on main since #26882 was merged.

Updates the image path in all three translation files to match.

Fixes #26958