### PR TITLE
fix(ekf2): allow optical flow to start when range finder is height reference

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_control.cpp
@@ -155,7 +155,7 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 				&& is_magnitude_good
 				&& is_tilt_good
 				&& (_flow_counter > 10)
-				&& (isTerrainEstimateValid() || isHorizontalAidingActive())
+				&& (isTerrainEstimateValid() || isHorizontalAidingActive() || (_height_sensor_ref == HeightSensor::RANGE))
 				&& isTimedOut(_aid_src_optical_flow.time_last_fuse, (uint64_t)2e6); // Prevent rapid switching
 
 		// If the height is relative to the ground, terrain height cannot be observed.


### PR DESCRIPTION
## Summary

- When `EKF2_HGT_REF=2` (range sensor) with no GPS, optical flow can never start because the starting condition requires `isTerrainEstimateValid() || isHorizontalAidingActive()` — neither is true since terrain is not "estimated" when range is the height reference (ground is the datum, `_state.terrain` is fixed at 0), and there's no horizontal aiding without GPS
- HAGL is directly known from the range measurement, so flow has everything it needs — add `_height_sensor_ref == HeightSensor::RANGE` to the starting conditions, consistent with the check already present in the no-horizontal-aiding start path at line 206

Fixes https://github.com/PX4/PX4-Autopilot/issues/25248
Fixes https://github.com/PX4/PX4-Autopilot/issues/26911