### PR TITLE
[Backport 1.16] fix(ekf2): allow optical flow to start when range finder is height reference

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_control.cpp
@@ -153,7 +153,7 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 				&& is_magnitude_good
 				&& is_tilt_good
 				&& (_flow_counter > 10)
-				&& (isTerrainEstimateValid() || isHorizontalAidingActive())
+				&& (isTerrainEstimateValid() || isHorizontalAidingActive() || (_height_sensor_ref == HeightSensor::RANGE))
 				&& isTimedOut(_aid_src_optical_flow.time_last_fuse, (uint64_t)2e6); // Prevent rapid switching
 
 		// If the height is relative to the ground, terrain height cannot be observed.


### PR DESCRIPTION
Backport of #26960 to release/1.16.
