### PR TITLE
fix(flight_mode_manager): fix terrain following position setpoint

### DIFF
--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -100,6 +100,9 @@ void FlightTaskManualAltitude::_updateAltitudeLock()
 	// Depending on stick inputs and velocity, position is locked.
 	// If not locked, altitude setpoint is set to NAN.
 
+	// Reset every iteration; _terrainFollowing() re-sets it true when it drives the setpoint
+	_z_setpoint_from_terrain = false;
+
 	// Check if user wants to break
 	const bool apply_brake = fabsf(_sticks.getThrottleZeroCenteredExpo()) <= FLT_EPSILON;
 
@@ -220,6 +223,8 @@ void FlightTaskManualAltitude::_terrainFollowing(bool apply_brake, bool stopped)
 		// user demands velocity change in D-direction
 		_dist_to_ground_lock = _position_setpoint(2) = NAN;
 	}
+
+	_z_setpoint_from_terrain = PX4_ISFINITE(_position_setpoint(2));
 }
 
 void FlightTaskManualAltitude::_respectMaxAltitude()

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -78,7 +78,8 @@ protected:
 	StickYaw _stick_yaw{this};
 
 	bool _sticks_data_required = true; ///< let inherited task-class define if it depends on stick data
-	bool _terrain_hold{false}; /**< true when vehicle is controlling height above a static ground position */
+	bool _terrain_hold{false}; /**< MPC_ALT_MODE=2 sub-state: true when latched onto ground distance while stationary. Input to the terrain-following gate. */
+	bool _z_setpoint_from_terrain{false}; /**< Output of _terrainFollowing() for this iteration: true iff it produced a finite _position_setpoint(2). */
 
 	float _velocity_constraint_up{INFINITY};
 	float _velocity_constraint_down{INFINITY};

--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
@@ -107,23 +107,19 @@ void FlightTaskManualAltitudeSmoothVel::_setOutputState()
 	_acceleration_setpoint(2) = _smoothing.getCurrentAcceleration();
 	_velocity_setpoint(2) = _smoothing.getCurrentVelocity();
 
-	const bool terrain_position = (_terrain_hold || _param_mpc_alt_mode.get() == 1)
-				      && PX4_ISFINITE(_dist_to_bottom)
-				      && PX4_ISFINITE(_position_setpoint(2));
-
-	if (terrain_position) {
-		// Terrain hold or terrain following: parent class set position from terrain.
+	if (_z_setpoint_from_terrain) {
+		// Parent class drove the position setpoint from terrain.
 		// Keep smoothing block synchronized to prevent divergence on transitions.
 		_smoothing.setCurrentPosition(_position_setpoint(2));
 
 	} else {
-		if (_terrain_position_previous) {
-			// Transitioning out of terrain mode: reset smoothing to current position
+		if (_z_setpoint_from_terrain_prev) {
+			// Transitioning off terrain-driven Z: reset smoothing to current position
 			_smoothing.setCurrentPosition(_position(2));
 		}
 
 		_position_setpoint(2) = _smoothing.getCurrentPosition();
 	}
 
-	_terrain_position_previous = terrain_position;
+	_z_setpoint_from_terrain_prev = _z_setpoint_from_terrain;
 }

--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
@@ -107,14 +107,23 @@ void FlightTaskManualAltitudeSmoothVel::_setOutputState()
 	_acceleration_setpoint(2) = _smoothing.getCurrentAcceleration();
 	_velocity_setpoint(2) = _smoothing.getCurrentVelocity();
 
-	if (!_terrain_hold) {
-		if (_terrain_hold_previous) {
-			// Reset position setpoint to current position when switching from terrain hold to non-terrain hold
+	const bool terrain_position = (_terrain_hold || _param_mpc_alt_mode.get() == 1)
+				      && PX4_ISFINITE(_dist_to_bottom)
+				      && PX4_ISFINITE(_position_setpoint(2));
+
+	if (terrain_position) {
+		// Terrain hold or terrain following: parent class set position from terrain.
+		// Keep smoothing block synchronized to prevent divergence on transitions.
+		_smoothing.setCurrentPosition(_position_setpoint(2));
+
+	} else {
+		if (_terrain_position_previous) {
+			// Transitioning out of terrain mode: reset smoothing to current position
 			_smoothing.setCurrentPosition(_position(2));
 		}
 
 		_position_setpoint(2) = _smoothing.getCurrentPosition();
 	}
 
-	_terrain_hold_previous = _terrain_hold;
+	_terrain_position_previous = terrain_position;
 }

--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
@@ -69,5 +69,5 @@ protected:
 				       )
 
 private:
-	bool _terrain_hold_previous{false}; /**< true when vehicle was controlling height above a static ground position in the previous iteration */
+	bool _terrain_position_previous{false}; /**< true when parent class was managing position setpoint from terrain data in the previous iteration */
 };

--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
@@ -69,5 +69,5 @@ protected:
 				       )
 
 private:
-	bool _terrain_position_previous{false}; /**< true when parent class was managing position setpoint from terrain data in the previous iteration */
+	bool _z_setpoint_from_terrain_prev{false}; /**< parent's _z_setpoint_from_terrain from the previous iteration; used to detect transitions out of terrain-driven Z */
 };


### PR DESCRIPTION
## Summary
- Fixes #24511
- In `MPC_ALT_MODE=1` (terrain following), the smoothing block in `_setOutputState()` was unconditionally overwriting the terrain-adjusted position setpoint computed by the parent class, effectively making terrain following non-functional when using acceleration-based position mode (`FlightTaskManualAltitudeSmoothVel`)
- Lift ownership of "is the Z setpoint coming from terrain this iteration?" into the base class `FlightTaskManualAltitude` via a `_z_setpoint_from_terrain` flag. Children that manage their own smoothing read the flag instead of re-deriving the terrain gate
- This also fixes a related case the original open-coded condition missed: the parent invokes `_terrainFollowing()` from the min-altitude safety branch (when braking below the distance sensor's minimum valid range — `vehicle_local_position.hagl_min`, populated by EKF2 — regardless of `MPC_ALT_MODE`). That setpoint is now also preserved through the smoothing block