### PR TITLE
fix(iridiumsbd): harden TX buffer bounds check in write()

### DIFF
--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
@@ -666,17 +666,27 @@ ssize_t IridiumSBD::write(struct file *filp, const char *buffer, size_t buflen)
 		}
 	}
 
-	// check if there is enough space to write the message
-	if (SATCOM_TX_BUF_LEN - _tx_buf_write_idx - _packet_length < 0) {
+	// check if there is enough space to write the full pending message; reset only at packet boundaries
+	if ((int)SATCOM_TX_BUF_LEN - _tx_buf_write_idx - (int)_packet_length < 0) {
 		_tx_buf_write_idx = 0;
 		++_num_tx_buf_reset;
 	}
 
-	// keep track of the remaining packet length and if the full message is written
-	_packet_length -= buflen;
+	// hard bounds check on the actual buflen being copied to prevent overflow when the
+	// declared packet length is smaller than the chunk being written
+	if (buflen > (size_t)(SATCOM_TX_BUF_LEN - _tx_buf_write_idx)) {
+		++_num_tx_buf_reset;
+		pthread_mutex_unlock(&_tx_buf_mutex);
+		return PX4_ERROR;
+	}
 
-	if (_packet_length == 0) {
+	// keep track of the remaining packet length and if the full message is written
+	if (buflen >= _packet_length) {
+		_packet_length = 0;
 		_writing_mavlink_packet = false;
+
+	} else {
+		_packet_length -= buflen;
 	}
 
 	VERBOSE_INFO("WRITE: LEN %zu, TX WRITTEN: %d", buflen, _tx_buf_write_idx);


### PR DESCRIPTION
The IridiumSBD `write()` space check used the tracked packet length rather than the chunk being copied. When the running packet length had been driven below the size of an incoming write, the unsigned arithmetic let an oversized memcpy slip past the guard and overflow the 340 byte TX buffer.

Reset the write index only on a true overflow at packet boundaries and add an explicit bounds check on the actual `buflen` versus the remaining space in the TX buffer before the memcpy. The remaining length bookkeeping is updated to clamp at zero so the next write starts a fresh packet cleanly.

Refs: GHSA-7g5v-mxvr-g765