### PR TITLE
fix(septentrio): bounds-check port name offset in detect_serial_port

### DIFF
--- a/src/drivers/gnss/septentrio/septentrio.cpp
+++ b/src/drivers/gnss/septentrio/septentrio.cpp
@@ -768,9 +768,11 @@ int SeptentrioDriver::detect_serial_port(char* const port_name) {
 
 		char* port_name_address = strstr(buf, ">");
 
-		// Check if we found a port candidate.
-		if (buffer_offset > 4 && port_name_address != nullptr) {
-			size_t port_name_offset = reinterpret_cast<size_t>(port_name_address) - reinterpret_cast<size_t>(buf) - 4;
+		// Check if we found a port candidate. The prompt must be preceded by at least
+		// four bytes of port name in the same buffer, otherwise the offset would
+		// underflow and read before buf.
+		if (port_name_address != nullptr && (port_name_address - buf) >= 4) {
+			size_t port_name_offset = static_cast<size_t>(port_name_address - buf) - 4;
 			for (size_t i = 0; i < 4; i++) {
 				port_name[i] = buf[port_name_offset + i];
 			}


### PR DESCRIPTION
The Septentrio GNSS serial port autodetect computed an offset relative to a `>` prompt without verifying that there were enough preceding bytes in the read buffer. When the prompt landed near the start of the buffer, the `size_t` offset arithmetic underflowed and the subsequent copy read before the buffer.

This patch replaces the `buffer_offset` heuristic with a direct check that the prompt sits at least four bytes into the read buffer before computing the port name offset, and uses signed pointer arithmetic on the address difference so the underflow is no longer reachable.

Refs: GHSA-v78g-fxg8-gv3j (CVE-2026-32744)