### PR TITLE
fix(airspeed_selector): fix invalid array access after airspeed failure

### DIFF
--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -751,11 +751,10 @@ void AirspeedModule::select_airspeed_and_publish()
 	airspeed_validated.indicated_airspeed_m_s = NAN;
 	airspeed_validated.calibrated_airspeed_m_s = NAN;
 	airspeed_validated.true_airspeed_m_s = NAN;
+	airspeed_validated.airspeed_derivative_filtered = NAN;
+	airspeed_validated.pitch_filtered = NAN;
 
-	airspeed_validated.airspeed_derivative_filtered = _airspeed_validator[valid_airspeed_index -
-					     1].get_airspeed_derivative();
 	airspeed_validated.throttle_filtered = _throttle_filtered.getState();
-	airspeed_validated.pitch_filtered = _airspeed_validator[valid_airspeed_index - 1].get_pitch_filtered();
 
 	airspeed_validated.airspeed_source = valid_airspeed_index;
 	_prev_airspeed_src = _valid_airspeed_src;
@@ -791,6 +790,8 @@ void AirspeedModule::select_airspeed_and_publish()
 		airspeed_validated.true_airspeed_m_s = _airspeed_validator[valid_airspeed_index - 1].get_TAS();
 		airspeed_validated.calibrated_ground_minus_wind_m_s = _ground_minus_wind_CAS;
 		airspeed_validated.calibraded_airspeed_synth_m_s = get_synthetic_airspeed(airspeed_validated.throttle_filtered);
+		airspeed_validated.airspeed_derivative_filtered = _airspeed_validator[valid_airspeed_index - 1].get_airspeed_derivative();
+		airspeed_validated.pitch_filtered = _airspeed_validator[valid_airspeed_index - 1].get_pitch_filtered();
 		break;
 	}
 


### PR DESCRIPTION
### Solved Problem

The array access

    _airspeed_validator[valid_airspeed_index - 1]

is only valid if `valid_airspeed_index > 0`. After an airspeed failure we have `valid_airspeed_index = -1` (invalid) or `0` (ground-minus-wind). (see [AirspeedSource enum definition](https://github.com/PX4/PX4-Autopilot/blob/44c128aade5984f4824225145ab8b58000fcd6dd/src/modules/airspeed_selector/airspeed_selector_main.cpp#L108-L115)) and are thus currently accessing array element -2 or -1. This is UB and pollutes the log (and potentially other modules) with garbage values.

### Solution

Like already done for other fields, we initialise the values with NaN and only populate (using the array access) when the airspeed source is a real sensor, and thus valid.

### Changelog Entry
Minor internal bugfix, not needed


### Context
Here is a log where the issue appears:
<img width="1083" height="1037" alt="image" src="https://github.com/user-attachments/assets/451a1483-8e2c-4db4-b261-50204cbc942f" />



