### PR TITLE
fix(mavlink):  add send timeout to UDP socket to avoid infinite waiting on UDP IOB on NuttX

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -61,6 +61,10 @@
 #include "mavlink_receiver.h"
 #include "mavlink_main.h"
 
+#ifdef MAVLINK_UDP
+#include <sys/time.h>
+#endif
+
 // Guard against MAVLink misconfiguration
 #ifndef MAVLINK_CRC_EXTRA
 #error MAVLINK_CRC_EXTRA has to be defined on PX4 systems
@@ -1030,6 +1034,19 @@ void Mavlink::init_udp()
 	if ((_socket_fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
 		PX4_WARN("create socket failed: %s", strerror(errno));
 		return;
+	}
+
+	// Cap UDP send time to avoid blocking indefinitely if the NuttX net
+	// stack hasn't finished initializing the IOB write-buffer semaphore.
+	// 10ms is ~4x the worst-case send time measured on STM32H7.
+	constexpr long UDP_SEND_TIMEOUT_US = 10000;
+	struct timeval tv {
+		.tv_sec = 0,
+		.tv_usec = UDP_SEND_TIMEOUT_US
+	};
+
+	if (setsockopt(_socket_fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) < 0) {
+		PX4_WARN("setting socket timeout failed: %s", strerror(errno));
 	}
 
 	if (bind(_socket_fd, (struct sockaddr *)&_myaddr, sizeof(_myaddr)) < 0) {


### PR DESCRIPTION
Add send timeout to UDP socket to avoid infinite waiting on UDP IOB on NuttX

### Solved Problem  
When using the Mavlink together with UDP protocol and NuttX, it can happen that there is race condition between the initialization of the network interface and the sending of UDP packets over it. Namely, if the network interface is unreachable, the sendto() call on [mavlink_main.cpp#L812](https://github.com/PX4/PX4-Autopilot/blob/44c128aade5984f4824225145ab8b58000fcd6dd/src/modules/mavlink/mavlink_main.cpp#L812) will always return that error. On the network initialization, if the call of the same sendto() method is made during the execution of [net_initialize()](https://github.com/PX4/NuttX/blob/dcd640cdc86393b672b363273c64429d6aec4412/net/net_initialize.c#L76), but before the execution of [udp_wrbuffer_initialize()](https://github.com/PX4/NuttX/blob/dcd640cdc86393b672b363273c64429d6aec4412/net/net_initialize.c#L162) where the `g_wrbuffer.sem` structure is being initialized, the waiting on that semaphore that is invoked as part of the [psock_udp_sendto](https://github.com/PX4/NuttX/blob/dcd640cdc86393b672b363273c64429d6aec4412/net/udp/udp_sendto_buffered.c#L498) for the non-blocking socket (the one used by mavlink module) during the call of `udp_wrbuffer_timedalloc(timeout)` can cause the calling thread to block indefinitely (due to the default value of `conn->sconn.s_sndtimeo` being `UINT_MAX` and the semaphore not yet being set to initial value), leading to the loss of all outgoing network communication.

### Solution  
The implemented solution sets the `SO_SNDTIMEO` socket option to 10ms on socket creation. That time has been taken after investigating the maximum execution time of the `sendto()` function during the regular execution. With the maximum time of around 2.5ms on STM32 H7, the timeout was set to 10ms to give enough time for possible throttling, while preserving a low timeout to avoid the possible delays in the execution of the mavlink module main loop. The timeout time is only reached during a conflicting parallel execution of the network initialization and the attempts of sending UDP packets made by the mavlink module.

### Alternatives
Initializing the socket as non-blocking (or setting the `MSG_DONTWAIT` flag) was also examined as an option, but there has been a lot of `EAGAIN` errors during the bursts of messages caused by all IOB buffers being temporarily busy, causing the drops in the communication. The increase of `CONFIG_IOB_NBUFFERS` configuration to the value of 64 was also examined together with the use of non-blocking calls to `sendto()`, but it proved to still be unsuitable for some message bursts.

### Test coverage
All Unit tests passing.

### Context
[URL](https://drive.google.com/file/d/1V7cc1MWRZVtyAe2IsLTIazEij8G5G8nf/view?usp=sharing) to CSV file showing the execution time of the sendto() call of UDP packets on the STM32 H7.
