### PR TITLE
fix(mavlink): harden FTP path validation against symlink escape

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -37,12 +37,15 @@
 #include <crc32.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <errno.h>
-#include <limits.h>
 #include <cstring>
+
+#ifndef __PX4_NUTTX
+#include <stdlib.h>
+#include <limits.h>
+#endif
 
 #include "mavlink_ftp.h"
 #include "mavlink_main.h"
@@ -512,11 +515,13 @@ MavlinkFTP::_workOpen(PayloadHeader *payload, int oflag)
 	fileSize = st.st_size;
 
 	PX4_DEBUG("open: %s", _work_buffer1);
-	// Set mode to 666 incase oflag has O_CREAT. Use O_NOFOLLOW where available
-	// so a TOCTOU race cannot redirect the leaf through a symlink between
-	// validation and open(2).
+	// Set mode to 666 incase oflag has O_CREAT. On POSIX use O_NOFOLLOW so a
+	// TOCTOU race cannot redirect the leaf through a symlink between
+	// validation and open(2). NuttX has a flat VFS with no symlink support
+	// in the FAT driver and PSEUDOFS_SOFTLINKS off by default, so the flag
+	// is unnecessary there.
 	int leaf_oflag = oflag;
-#ifdef O_NOFOLLOW
+#if !defined(__PX4_NUTTX) && defined(O_NOFOLLOW)
 	leaf_oflag |= O_NOFOLLOW;
 #endif
 	int fd = ::open(_work_buffer1, leaf_oflag, PX4_O_MODE_666);
@@ -1207,19 +1212,18 @@ static bool canonicalize_path(const char *path, char *out, size_t out_len)
 }
 #endif // !__PX4_NUTTX
 
-/**
- * Resolve symlinks and verify the path is contained in PX4_STORAGEDIR.
- *
- * Defence against symlink-resolution bypasses where _validatePath() accepts a
- * string that does not contain ".." but the underlying open()/mkdir() follows
- * a symlink to a target outside the intended FTP root.
- *
- * On NuttX realpath() is not available; the simpler string-based check from
- * the previous implementation is used in that case.
- */
-bool MavlinkFTP::_validatePathIsInRoot(const char *path)
+bool MavlinkFTP::_validatePathIsWritable(const char *path)
 {
 #ifndef __PX4_NUTTX
+	// POSIX/SITL: resolve symlinks and verify the canonical path stays
+	// inside PX4_STORAGEDIR. Defence against symlink-resolution bypasses
+	// where _validatePath() accepts a string that does not contain ".."
+	// but the underlying open()/mkdir() follows a symlink to a target
+	// outside the intended FTP root (GHSA-93v7-287q-qx4g).
+	//
+	// NuttX is not affected: it has a flat VFS, the FAT driver used for
+	// /fs/microsd does not support symlinks, and CONFIG_PSEUDOFS_SOFTLINKS
+	// is off by default.
 	char canonical_root[PATH_MAX];
 
 	if (realpath(PX4_STORAGEDIR, canonical_root) == nullptr) {
@@ -1246,20 +1250,13 @@ bool MavlinkFTP::_validatePathIsInRoot(const char *path)
 
 	return true;
 #else
-
-	// NuttX: realpath() is not available. Fall back to a string-based prefix
-	// and traversal check; symlinks are not commonly used on NuttX targets.
+	// NuttX: simple string-based check. Original behavior, unchanged.
 	if (strncmp(path, CONFIG_BOARD_ROOT_PATH "/", strlen(CONFIG_BOARD_ROOT_PATH "/")) != 0
 	    || strstr(path, "/../") != nullptr) {
-		PX4_ERR("FTP: rejecting path outside FTP root: %s", path);
+		PX4_ERR("Disallowing write to %s", path);
 		return false;
 	}
 
 	return true;
 #endif
-}
-
-bool MavlinkFTP::_validatePathIsWritable(const char *path)
-{
-	return _validatePathIsInRoot(path);
 }

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -37,9 +37,11 @@
 #include <crc32.h>
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <limits.h>
 #include <cstring>
 
 #include "mavlink_ftp.h"
@@ -482,6 +484,12 @@ MavlinkFTP::_workOpen(PayloadHeader *payload, int oflag)
 		return kErrFailFileProtected;
 	}
 
+	const bool is_write_open = (oflag & (O_WRONLY | O_RDWR)) != 0;
+
+	if (is_write_open && !_validatePathIsWritable(_work_buffer1)) {
+		return kErrFailFileProtected;
+	}
+
 	PX4_DEBUG("FTP: open '%s'", _work_buffer1);
 
 	uint32_t fileSize = 0;
@@ -504,8 +512,14 @@ MavlinkFTP::_workOpen(PayloadHeader *payload, int oflag)
 	fileSize = st.st_size;
 
 	PX4_DEBUG("open: %s", _work_buffer1);
-	// Set mode to 666 incase oflag has O_CREAT
-	int fd = ::open(_work_buffer1, oflag, PX4_O_MODE_666);
+	// Set mode to 666 incase oflag has O_CREAT. Use O_NOFOLLOW where available
+	// so a TOCTOU race cannot redirect the leaf through a symlink between
+	// validation and open(2).
+	int leaf_oflag = oflag;
+#ifdef O_NOFOLLOW
+	leaf_oflag |= O_NOFOLLOW;
+#endif
+	int fd = ::open(_work_buffer1, leaf_oflag, PX4_O_MODE_666);
 
 	if (fd < 0) {
 		_our_errno = errno;
@@ -592,7 +606,7 @@ MavlinkFTP::_workWrite(PayloadHeader *payload)
 		return kErrInvalidSession;
 	}
 
-	if (!_validatePathIsWritable(_work_buffer1)) {
+	if (!_validatePath(_work_buffer1) || !_validatePathIsWritable(_work_buffer1)) {
 		return kErrFailFileProtected;
 	}
 
@@ -1144,16 +1158,133 @@ bool MavlinkFTP::_validatePath(const char *path)
 	return true;
 }
 
+/**
+ * Resolve symlinks and verify the path is contained in PX4_STORAGEDIR.
+ *
+ * Used as a defence against symlink-resolution bypasses where _validatePath()
+ * accepts a string that does not contain ".." but the underlying open()/mkdir()
+ * follows a symlink to a target outside the intended FTP root.
+ *
+ * For files that do not yet exist (CreateFile, CreateDirectory) realpath() on
+ * the full path would fail, so we resolve the parent directory and reattach
+ * the leaf name. The result is a canonical absolute path (or a relative path
+ * starting with the canonicalized PX4_STORAGEDIR) that is then prefix-matched
+ * against the canonicalized root.
+ *
+ * On NuttX realpath() is not available; the simpler string-based check from
+ * the previous implementation is used in that case.
+ */
+bool MavlinkFTP::_validatePathIsInRoot(const char *path)
+{
+#ifndef __PX4_NUTTX
+	char canonical_root[PATH_MAX];
+
+	if (realpath(PX4_STORAGEDIR, canonical_root) == nullptr) {
+		PX4_ERR("FTP: realpath(root) failed: %s", strerror(errno));
+		return false;
+	}
+
+	const size_t canonical_root_len = strlen(canonical_root);
+
+	// Try to canonicalize the full path. If the leaf does not yet exist,
+	// fall back to resolving the parent directory and reattaching the leaf.
+	char canonical[PATH_MAX];
+
+	if (realpath(path, canonical) == nullptr) {
+		// Split into parent and leaf, resolve the parent, reattach the leaf.
+		char parent_buf[PATH_MAX];
+		strncpy(parent_buf, path, sizeof(parent_buf) - 1);
+		parent_buf[sizeof(parent_buf) - 1] = '\0';
+
+		char *slash = strrchr(parent_buf, '/');
+		const char *leaf = nullptr;
+
+		if (slash != nullptr) {
+			*slash = '\0';
+			leaf = slash + 1;
+
+		} else {
+			// No slash: parent is current directory, leaf is the whole path
+			parent_buf[0] = '.';
+			parent_buf[1] = '\0';
+			leaf = path;
+		}
+
+		char canonical_parent[PATH_MAX];
+
+		if (realpath(parent_buf, canonical_parent) == nullptr) {
+			PX4_ERR("FTP: realpath(parent of %s) failed: %s", path, strerror(errno));
+			return false;
+		}
+
+		const int n = snprintf(canonical, sizeof(canonical), "%s/%s", canonical_parent, leaf);
+
+		if (n < 0 || (size_t)n >= sizeof(canonical)) {
+			PX4_ERR("FTP: canonical path too long for %s", path);
+			return false;
+		}
+	}
+
+	// The canonical path must start with the canonical root and either
+	// equal it or be followed by a path separator.
+	if (strncmp(canonical, canonical_root, canonical_root_len) != 0
+	    || (canonical[canonical_root_len] != '\0' && canonical[canonical_root_len] != '/')) {
+		PX4_ERR("FTP: rejecting path outside FTP root: %s -> %s", path, canonical);
+		return false;
+	}
+
+	return true;
+#else
+	// NuttX: realpath() is not available. Fall back to a string-based prefix
+	// and traversal check; symlinks are not commonly used on NuttX targets.
+	if (strncmp(path, CONFIG_BOARD_ROOT_PATH "/", strlen(CONFIG_BOARD_ROOT_PATH "/")) != 0
+	    || strstr(path, "/../") != nullptr) {
+		PX4_ERR("FTP: rejecting path outside FTP root: %s", path);
+		return false;
+	}
+
+	return true;
+#endif
+}
+
 bool MavlinkFTP::_validatePathIsWritable(const char *path)
 {
-#ifdef __PX4_NUTTX
-
-	// Don't allow writes to system paths as they are in RAM
-	// Ideally we'd canonicalize the path (with 'realpath'), but it might not exist, so realpath() would fail.
-	// The next simpler thing is to check there's no reference to a parent dir.
-	if (strncmp(path, CONFIG_BOARD_ROOT_PATH "/", 12) != 0 || strstr(path, "/../") != nullptr) {
-		PX4_ERR("Disallowing write to %s", path);
+	if (!_validatePathIsInRoot(path)) {
 		return false;
+	}
+
+	// Reject writes to boot-executed startup hook files. The PX4 NuttX rcS
+	// sources $FRC, $FCONFIG, $FEXTRAS unconditionally during boot, so an
+	// attacker that can write to these paths gets persistent code execution
+	// at the next reboot. Reject the entire PX4_STORAGEDIR/etc/ subtree to
+	// keep future hooks safe by default.
+	static const char kBootHookPrefix[] = PX4_STORAGEDIR "/etc/";
+	const size_t kBootHookPrefixLen = sizeof(kBootHookPrefix) - 1;
+
+	if (strncmp(path, kBootHookPrefix, kBootHookPrefixLen) == 0) {
+		PX4_ERR("FTP: refusing to write protected path %s", path);
+		return false;
+	}
+
+#ifndef __PX4_NUTTX
+	// Also reject the canonical form, in case an in-root symlink redirects
+	// the leaf into the protected etc/ subtree.
+	char canonical[PATH_MAX];
+
+	if (realpath(path, canonical) != nullptr) {
+		char canonical_root[PATH_MAX];
+
+		if (realpath(PX4_STORAGEDIR, canonical_root) != nullptr) {
+			char canonical_boot_prefix[PATH_MAX];
+			const int n = snprintf(canonical_boot_prefix, sizeof(canonical_boot_prefix),
+					       "%s/etc/", canonical_root);
+
+			if (n > 0 && (size_t)n < sizeof(canonical_boot_prefix)
+			    && strncmp(canonical, canonical_boot_prefix, strlen(canonical_boot_prefix)) == 0) {
+				PX4_ERR("FTP: refusing to write protected path %s -> %s", path, canonical);
+				return false;
+			}
+		}
 	}
 
 #endif

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -1261,52 +1261,5 @@ bool MavlinkFTP::_validatePathIsInRoot(const char *path)
 
 bool MavlinkFTP::_validatePathIsWritable(const char *path)
 {
-	if (!_validatePathIsInRoot(path)) {
-		return false;
-	}
-
-	// Reject writes to boot-executed startup hook files. The PX4 NuttX rcS
-	// sources $FRC, $FCONFIG, $FEXTRAS unconditionally during boot, so an
-	// attacker that can write to these paths gets persistent code execution
-	// at the next reboot. Reject the entire PX4_STORAGEDIR/etc/ subtree to
-	// keep future hooks safe by default.
-
-#ifndef __PX4_NUTTX
-	// On POSIX, run the deny check on the same canonical path used by the
-	// in-root check (including the parent+leaf fallback for new files), so
-	// that prefix variations like ".//etc/x" or "./etc/x" cannot bypass the
-	// raw string match, and so symlinks redirecting through etc/ are caught.
-	char canonical_root[PATH_MAX];
-	char canonical[PATH_MAX];
-
-	if (realpath(PX4_STORAGEDIR, canonical_root) == nullptr
-	    || !canonicalize_path(path, canonical, sizeof(canonical))) {
-		PX4_ERR("FTP: cannot canonicalize for boot-hook check: %s", path);
-		return false;
-	}
-
-	char boot_hook_prefix[PATH_MAX];
-	const int n = snprintf(boot_hook_prefix, sizeof(boot_hook_prefix),
-			       "%s/etc/", canonical_root);
-
-	if (n <= 0 || (size_t)n >= sizeof(boot_hook_prefix)) {
-		return false;
-	}
-
-	if (strncmp(canonical, boot_hook_prefix, strlen(boot_hook_prefix)) == 0) {
-		PX4_ERR("FTP: refusing to write protected path %s -> %s", path, canonical);
-		return false;
-	}
-
-#else
-	// NuttX: simple literal prefix check.
-	static const char kBootHookPrefix[] = PX4_STORAGEDIR "/etc/";
-
-	if (strncmp(path, kBootHookPrefix, sizeof(kBootHookPrefix) - 1) == 0) {
-		PX4_ERR("FTP: refusing to write protected path %s", path);
-		return false;
-	}
-
-#endif
-	return true;
+	return _validatePathIsInRoot(path);
 }

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -1158,18 +1158,61 @@ bool MavlinkFTP::_validatePath(const char *path)
 	return true;
 }
 
+#ifndef __PX4_NUTTX
+/**
+ * Canonicalize `path` into `out` (an absolute, symlink-free path).
+ *
+ * For paths whose leaf does not yet exist (CreateFile, CreateDirectory)
+ * realpath() on the full path would fail, so the parent directory is
+ * resolved instead and the leaf name is reattached. The output is always
+ * an absolute path produced by realpath() on either the full path or
+ * its parent directory.
+ *
+ * Returns true on success, false on any error (caller should reject the
+ * request in that case).
+ */
+static bool canonicalize_path(const char *path, char *out, size_t out_len)
+{
+	if (realpath(path, out) != nullptr) {
+		return true;
+	}
+
+	// Split into parent and leaf, resolve the parent, reattach the leaf.
+	char parent_buf[PATH_MAX];
+	strncpy(parent_buf, path, sizeof(parent_buf) - 1);
+	parent_buf[sizeof(parent_buf) - 1] = '\0';
+
+	char *slash = strrchr(parent_buf, '/');
+	const char *leaf = nullptr;
+
+	if (slash != nullptr) {
+		*slash = '\0';
+		leaf = slash + 1;
+
+	} else {
+		// No slash: parent is current directory, leaf is the whole path.
+		parent_buf[0] = '.';
+		parent_buf[1] = '\0';
+		leaf = path;
+	}
+
+	char canonical_parent[PATH_MAX];
+
+	if (realpath(parent_buf, canonical_parent) == nullptr) {
+		return false;
+	}
+
+	const int n = snprintf(out, out_len, "%s/%s", canonical_parent, leaf);
+	return (n > 0) && ((size_t)n < out_len);
+}
+#endif // !__PX4_NUTTX
+
 /**
  * Resolve symlinks and verify the path is contained in PX4_STORAGEDIR.
  *
- * Used as a defence against symlink-resolution bypasses where _validatePath()
- * accepts a string that does not contain ".." but the underlying open()/mkdir()
- * follows a symlink to a target outside the intended FTP root.
- *
- * For files that do not yet exist (CreateFile, CreateDirectory) realpath() on
- * the full path would fail, so we resolve the parent directory and reattach
- * the leaf name. The result is a canonical absolute path (or a relative path
- * starting with the canonicalized PX4_STORAGEDIR) that is then prefix-matched
- * against the canonicalized root.
+ * Defence against symlink-resolution bypasses where _validatePath() accepts a
+ * string that does not contain ".." but the underlying open()/mkdir() follows
+ * a symlink to a target outside the intended FTP root.
  *
  * On NuttX realpath() is not available; the simpler string-based check from
  * the previous implementation is used in that case.
@@ -1184,49 +1227,17 @@ bool MavlinkFTP::_validatePathIsInRoot(const char *path)
 		return false;
 	}
 
-	const size_t canonical_root_len = strlen(canonical_root);
-
-	// Try to canonicalize the full path. If the leaf does not yet exist,
-	// fall back to resolving the parent directory and reattaching the leaf.
 	char canonical[PATH_MAX];
 
-	if (realpath(path, canonical) == nullptr) {
-		// Split into parent and leaf, resolve the parent, reattach the leaf.
-		char parent_buf[PATH_MAX];
-		strncpy(parent_buf, path, sizeof(parent_buf) - 1);
-		parent_buf[sizeof(parent_buf) - 1] = '\0';
-
-		char *slash = strrchr(parent_buf, '/');
-		const char *leaf = nullptr;
-
-		if (slash != nullptr) {
-			*slash = '\0';
-			leaf = slash + 1;
-
-		} else {
-			// No slash: parent is current directory, leaf is the whole path
-			parent_buf[0] = '.';
-			parent_buf[1] = '\0';
-			leaf = path;
-		}
-
-		char canonical_parent[PATH_MAX];
-
-		if (realpath(parent_buf, canonical_parent) == nullptr) {
-			PX4_ERR("FTP: realpath(parent of %s) failed: %s", path, strerror(errno));
-			return false;
-		}
-
-		const int n = snprintf(canonical, sizeof(canonical), "%s/%s", canonical_parent, leaf);
-
-		if (n < 0 || (size_t)n >= sizeof(canonical)) {
-			PX4_ERR("FTP: canonical path too long for %s", path);
-			return false;
-		}
+	if (!canonicalize_path(path, canonical, sizeof(canonical))) {
+		PX4_ERR("FTP: cannot canonicalize %s: %s", path, strerror(errno));
+		return false;
 	}
 
 	// The canonical path must start with the canonical root and either
 	// equal it or be followed by a path separator.
+	const size_t canonical_root_len = strlen(canonical_root);
+
 	if (strncmp(canonical, canonical_root, canonical_root_len) != 0
 	    || (canonical[canonical_root_len] != '\0' && canonical[canonical_root_len] != '/')) {
 		PX4_ERR("FTP: rejecting path outside FTP root: %s -> %s", path, canonical);
@@ -1235,6 +1246,7 @@ bool MavlinkFTP::_validatePathIsInRoot(const char *path)
 
 	return true;
 #else
+
 	// NuttX: realpath() is not available. Fall back to a string-based prefix
 	// and traversal check; symlinks are not commonly used on NuttX targets.
 	if (strncmp(path, CONFIG_BOARD_ROOT_PATH "/", strlen(CONFIG_BOARD_ROOT_PATH "/")) != 0
@@ -1258,33 +1270,41 @@ bool MavlinkFTP::_validatePathIsWritable(const char *path)
 	// attacker that can write to these paths gets persistent code execution
 	// at the next reboot. Reject the entire PX4_STORAGEDIR/etc/ subtree to
 	// keep future hooks safe by default.
-	static const char kBootHookPrefix[] = PX4_STORAGEDIR "/etc/";
-	const size_t kBootHookPrefixLen = sizeof(kBootHookPrefix) - 1;
 
-	if (strncmp(path, kBootHookPrefix, kBootHookPrefixLen) == 0) {
-		PX4_ERR("FTP: refusing to write protected path %s", path);
+#ifndef __PX4_NUTTX
+	// On POSIX, run the deny check on the same canonical path used by the
+	// in-root check (including the parent+leaf fallback for new files), so
+	// that prefix variations like ".//etc/x" or "./etc/x" cannot bypass the
+	// raw string match, and so symlinks redirecting through etc/ are caught.
+	char canonical_root[PATH_MAX];
+	char canonical[PATH_MAX];
+
+	if (realpath(PX4_STORAGEDIR, canonical_root) == nullptr
+	    || !canonicalize_path(path, canonical, sizeof(canonical))) {
+		PX4_ERR("FTP: cannot canonicalize for boot-hook check: %s", path);
 		return false;
 	}
 
-#ifndef __PX4_NUTTX
-	// Also reject the canonical form, in case an in-root symlink redirects
-	// the leaf into the protected etc/ subtree.
-	char canonical[PATH_MAX];
+	char boot_hook_prefix[PATH_MAX];
+	const int n = snprintf(boot_hook_prefix, sizeof(boot_hook_prefix),
+			       "%s/etc/", canonical_root);
 
-	if (realpath(path, canonical) != nullptr) {
-		char canonical_root[PATH_MAX];
+	if (n <= 0 || (size_t)n >= sizeof(boot_hook_prefix)) {
+		return false;
+	}
 
-		if (realpath(PX4_STORAGEDIR, canonical_root) != nullptr) {
-			char canonical_boot_prefix[PATH_MAX];
-			const int n = snprintf(canonical_boot_prefix, sizeof(canonical_boot_prefix),
-					       "%s/etc/", canonical_root);
+	if (strncmp(canonical, boot_hook_prefix, strlen(boot_hook_prefix)) == 0) {
+		PX4_ERR("FTP: refusing to write protected path %s -> %s", path, canonical);
+		return false;
+	}
 
-			if (n > 0 && (size_t)n < sizeof(canonical_boot_prefix)
-			    && strncmp(canonical, canonical_boot_prefix, strlen(canonical_boot_prefix)) == 0) {
-				PX4_ERR("FTP: refusing to write protected path %s -> %s", path, canonical);
-				return false;
-			}
-		}
+#else
+	// NuttX: simple literal prefix check.
+	static const char kBootHookPrefix[] = PX4_STORAGEDIR "/etc/";
+
+	if (strncmp(path, kBootHookPrefix, sizeof(kBootHookPrefix) - 1) == 0) {
+		PX4_ERR("FTP: refusing to write protected path %s", path);
+		return false;
 	}
 
 #endif

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -1250,6 +1250,7 @@ bool MavlinkFTP::_validatePathIsWritable(const char *path)
 
 	return true;
 #else
+
 	// NuttX: simple string-based check. Original behavior, unchanged.
 	if (strncmp(path, CONFIG_BOARD_ROOT_PATH "/", strlen(CONFIG_BOARD_ROOT_PATH "/")) != 0
 	    || strstr(path, "/../") != nullptr) {

--- a/src/modules/mavlink/mavlink_ftp.h
+++ b/src/modules/mavlink/mavlink_ftp.h
@@ -150,7 +150,6 @@ private:
 
 	bool _validatePath(const char *path);
 	bool _validatePathIsWritable(const char *path);
-	bool _validatePathIsInRoot(const char *path);
 
 	/**
 	 * make sure that the working buffers _work_buffer* are allocated

--- a/src/modules/mavlink/mavlink_ftp.h
+++ b/src/modules/mavlink/mavlink_ftp.h
@@ -150,6 +150,7 @@ private:
 
 	bool _validatePath(const char *path);
 	bool _validatePathIsWritable(const char *path);
+	bool _validatePathIsInRoot(const char *path);
 
 	/**
 	 * make sure that the working buffers _work_buffer* are allocated


### PR DESCRIPTION
Tighten path validation in MavlinkFTP on POSIX/SITL so that FTP write operations resolve symlinks before checking the result against the FTP root, closing GHSA-93v7-287q-qx4g.

NuttX is not affected by that report and is left functionally unchanged: it has a flat VFS, the FAT driver used for `/fs/microsd` does not support symlinks, and `CONFIG_PSEUDOFS_SOFTLINKS` is off by default, so there is no symlink primitive for an attacker to exploit. The new canonicalization helper, the `realpath()`-based in-root check, the extra `<stdlib.h>`/`<limits.h>` includes, and `O_NOFOLLOW` are all `#ifndef __PX4_NUTTX`. Flash impact on NuttX boards is negligible.

The previous revision of this branch also blocked all writes under `PX4_STORAGEDIR/etc/` as a defence-in-depth measure against attacker-controlled boot hook files. That has been dropped after feedback from @dakejahl: `etc/extras.txt`, `etc/config.txt`, and `etc/logging/logger_topics.txt` are documented user customization points and uploading them through QGC's MAVFTP file manager is a supported workflow. Blocking those writes on top of an already unauthenticated channel is a net loss; the real mitigation for unauthorized writes is MAVLink signing.

Changes:

- POSIX only: new internal `canonicalize_path()` helper resolves a path with `realpath()`, falling back to canonicalizing the parent directory and reattaching the leaf when the leaf does not yet exist (CreateFile, CreateDirectory).
- POSIX only: `_validatePathIsWritable()` now canonicalizes the requested path and verifies the result is contained inside `PX4_STORAGEDIR`. NuttX keeps its original simple string-based check.
- `_workOpen()` now applies `_validatePathIsWritable()` for write-mode opens (`O_WRONLY` or `O_RDWR`) on both platforms, matching the pattern already used by the other writable opcodes.
- `_workWrite()` now applies `_validatePath()` to match the same pattern.
- POSIX only: the leaf file is opened with `O_NOFOLLOW` so a TOCTOU race cannot redirect the leaf through a symlink between validation and `open(2)`.

### Testing

Ran a path probe matrix against `make px4_sitl_sih sihsim_quadx`. Representative cases:

Accepted:
- `root_file.txt` (plain filename)
- `log/regular.txt` (existing subdir)
- `file with spaces.txt`
- `..hidden.txt` (filename starting with two dots, not a `..` component)
- `etc/extras.txt`, `etc/config.txt` (user-editable boot hooks, intentionally allowed)

Rejected:
- `../escape.txt`, `log/../escape.txt`, `log/..` (literal `..` traversal)
- Symlinked paths that resolve outside `PX4_STORAGEDIR` (e.g. the default POSIX `rootfs/etc -> ../etc` escape from GHSA-93v7-287q-qx4g)

### Behavior change worth calling out

On POSIX, `CreateFile` for a path whose parent directory does not yet exist now returns `kErrFailFileProtected` instead of `kErrFailErrno`, because the canonicalization step needs the parent directory to resolve. Clients that relied on writing into a not-yet-created subtree will need to issue `CreateDirectory` first. NuttX behavior is unchanged.

Refs: GHSA-93v7-287q-qx4g