### PR TITLE
docs(maintainers): introduce Code Owner and Reviewer maintainer types

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,7 +3,7 @@ Maintainers
 
 PX4 is maintained by a group of contributors trusted to steward the project. All maintainers listed below are members of the @PX4/dev-team, have write access, and participate in maintainer decisions. We recognize two types: **Code Owners**, responsible for specific components, and **Reviewers**, who help across the project without a fixed component.
 
-See [the documentation on Maintainers](https://docs.px4.io/main/en/contribute/maintainers.html) to learn about the role of the maintainers and the process to become one.
+See [the documentation on Maintainers](https://docs.px4.io/main/en/contribute/maintainers) to learn about the role of the maintainers and the process to become one.
 
 **Code Owners**
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,9 +1,11 @@
 Maintainers
 ===========
 
+PX4 is maintained by a group of contributors trusted to steward the project. All maintainers listed below are members of the @PX4/dev-team, have write access, and participate in maintainer decisions. We recognize two types: **Code Owners**, responsible for specific components, and **Reviewers**, who help across the project without a fixed component.
+
 See [the documentation on Maintainers](https://docs.px4.io/main/en/contribute/maintainers.html) to learn about the role of the maintainers and the process to become one.
 
-**Active Maintainers**
+**Code Owners**
 
 | Name                    | Sector | GitHub | Chat | email
 |-------------------------|--------|--------|------|----------------
@@ -21,6 +23,15 @@ See [the documentation on Maintainers](https://docs.px4.io/main/en/contribute/ma
 | Christian Friedrich | Rover | [@chfriedrich98](https://github.com/chfriedrich98) | christian982564 |
 | Pedro Roque | Spacecraft | [@Pedro-Roque](https://github.com/Pedro-Roque) | .pedroroque | <roque@caltech.edu>
 | Jacob Dahl | Simulation | [@dakejahl](https://github.com/dakejahl) | dakejahl | <dahl.jakejacob@gmail.com>
+
+
+**Reviewers**
+
+Reviewers help maintain PX4 across the project without ownership of a specific component.
+
+| Name | GitHub | Chat | email
+|------|--------|------|----------------------
+| _No reviewers yet._ | | |
 
 
 **Documentation Maintainers**

--- a/docs/en/contribute/dev_call.md
+++ b/docs/en/contribute/dev_call.md
@@ -15,8 +15,8 @@ The PX4 dev team and community come together to discuss any topic of interest to
 
 ## Who should attend?
 
-- Core project maintainers
-- Component maintainers
+- Code Owners
+- Reviewers
 - Test team lead
 - Dronecode members
 - Community members (you!)

--- a/docs/en/contribute/dev_call.md
+++ b/docs/en/contribute/dev_call.md
@@ -7,7 +7,7 @@ const { site } = useData();
 
 <div v-if="site.title !== 'PX4 Guide (main)'">
   <div class="custom-block danger">
-    <p class="custom-block-title">This page may be out of date. <a href="https://docs.px4.io/main/en/contribute/dev_call">See the latest version</a>.</p>
+    <p class="custom-block-title">This page may be out of date. <a href="/en/contribute/dev_call.md">See the latest version</a>.</p>
   </div>
 </div>
 

--- a/docs/en/contribute/index.md
+++ b/docs/en/contribute/index.md
@@ -20,7 +20,7 @@ We pledge to adhere to the [PX4 code of conduct](https://github.com/PX4/PX4-Auto
 This section contains information about how you can meet with the community and contribute to PX4:
 
 - [Dev Call](../contribute/dev_call.md) - Discuss architecture, pull requests, impacting issues with the dev team
-- [Maintainers](./maintainers.md) - Maintainers of PX4 Subsystems and Ecosystem
+- [Maintainers](./maintainers.md) - Maintainer roles, types, and how to become one
 - [Support](../contribute/support.md) - Get help and raise issues
 - [Source Code Management](../contribute/code.md) - Work with PX4 code
 - [Documentation](../contribute/docs.md) - Improve the docs

--- a/docs/en/contribute/maintainers.md
+++ b/docs/en/contribute/maintainers.md
@@ -5,15 +5,26 @@ The maintainer role is defined by the community with help and supervision from t
 
 To find the most up-to-date maintainers list, visit [PX4-Autopilot README](https://github.com/PX4/PX4-Autopilot#maintenance-team).
 
+## Maintainer Types
+
+PX4 recognizes two types of maintainers. Both are full members of the maintainer team, have write access via the [`Dev Team`](https://github.com/orgs/PX4/teams/dev-team) GitHub team, and participate in maintainer decisions.
+
+- **Code Owners** are responsible for a specific category of the project (for example, State Estimation, Multirotor, or CI). They have final say on changes to their area, are the primary reviewers for that code, and help shape its roadmap. This is the role described in detail below.
+- **Reviewers** help maintain PX4 across the project without ownership of a specific category. They review, triage, and contribute wherever their interests and time allow. Reviewers have the same access and voting rights as Code Owners, but no on-call responsibility for any specific area of the codebase.
+
+The Reviewer role is a good fit for contributors who want to help steward the project without committing to a specific component up front. A Reviewer may later become a Code Owner for a category by mutual agreement with the existing Code Owners of that category and sign-off from the maintainer team.
+
 ## Recruitment Process
 
 If you would like to join the PX4 maintainers team or if you want to nominate someone else follow the steps below:
 
 1. Read the [role description](#dronecode-maintainer-role-description), and make sure you understand the responsibilities of the role.
 2. To nominate yourself, reach out to one of the maintainers (see the complete list in the [PX4-Autopilot README](https://github.com/PX4/PX4-Autopilot#maintenance-team)), and seek their sponsorship.
-3. Express your interest in becoming a maintainer, and specify which area you would like to maintain.
+3. Express your interest in becoming a maintainer, and specify whether you are applying as a **Code Owner** (for a specific category) or as a **Reviewer** (helping across the project without a fixed category).
 4. The sponsoring maintainer needs to bring this up for discussion in one of the [weekly developer calls](dev_call.md).
    The maintainer team will vote on the call to determine whether to accept you as a maintainer.
+
+A Reviewer may later transition to a Code Owner role for a specific category. This requires agreement from the existing Code Owners of that category and sign-off from the maintainer team, following the same discussion and vote on the weekly developer call.
 
 ## Onboarding Process
 
@@ -27,12 +38,14 @@ Once accepted every maintainers will go through the following process:
    2. Permission to trigger GitHub actions when a new contributor opens a PR.
    3. Permission to edit Issue/PR contents.
 3. **Add your info to official PX4 channels**:
-   1. Include your information on the PX4 [README](https://github.com/PX4/PX4-Autopilot/blob/main/README.md) next to the rest of the team
+   1. Include your information on the PX4 [README](https://github.com/PX4/PX4-Autopilot/blob/main/README.md) next to the rest of the team (under the **Code Owners** table with your category, or the **Reviewers** table if you are joining as a Reviewer)
    2. Listed on the [Maintainers section](https://px4.io/community/maintainers/) of the PX4 website.
    3. Add your information to the internal Dronecode database of maintainers to keep you in sync.
    4. Community introduction to the new maintainer in the form of a forum post, which is promoted through ever growing official channels
 
 ## Dronecode Maintainer Role Description
+
+The responsibilities and qualifications below describe the **Code Owner** role in detail. **Reviewers** share the same spirit of technical stewardship, community guidance, and participation in maintainer meetings, without being tied to a specific category. Reviewers are expected to review and triage across the project where their expertise and interest apply.
 
 ### Summary
 

--- a/docs/en/contribute/maintainers.md
+++ b/docs/en/contribute/maintainers.md
@@ -1,9 +1,9 @@
 # Maintainer Role
 
-Dronecode maintainers have technical leadership and responsibility for specific areas of PX4, and for other ecosystem components such as MAVLink, MAVSDK, QGroundControl, and others.
+Dronecode maintainers provide technical leadership for PX4 and for other ecosystem components such as MAVLink, MAVSDK, QGroundControl, and others. Some maintainers take responsibility for specific areas of the project, while others help across the project more broadly.
 The maintainer role is defined by the community with help and supervision from the [Dronecode Foundation](https://dronecode.org/).
 
-To find the most up-to-date maintainers list, visit [PX4-Autopilot README](https://github.com/PX4/PX4-Autopilot#maintenance-team).
+To find the most up-to-date maintainers list, see [`MAINTAINERS.md`](https://github.com/PX4/PX4-Autopilot/blob/main/MAINTAINERS.md) in the PX4-Autopilot repository.
 
 ## Maintainer Types
 
@@ -19,7 +19,7 @@ The Reviewer role is a good fit for contributors who want to help steward the pr
 If you would like to join the PX4 maintainers team or if you want to nominate someone else follow the steps below:
 
 1. Read the [role description](#dronecode-maintainer-role-description), and make sure you understand the responsibilities of the role.
-2. To nominate yourself, reach out to one of the maintainers (see the complete list in the [PX4-Autopilot README](https://github.com/PX4/PX4-Autopilot#maintenance-team)), and seek their sponsorship.
+2. To nominate yourself, reach out to one of the maintainers (see the complete list in [`MAINTAINERS.md`](https://github.com/PX4/PX4-Autopilot/blob/main/MAINTAINERS.md)), and seek their sponsorship.
 3. Express your interest in becoming a maintainer, and specify whether you are applying as a **Code Owner** (for a specific category) or as a **Reviewer** (helping across the project without a fixed category).
 4. The sponsoring maintainer needs to bring this up for discussion in one of the [weekly developer calls](dev_call.md).
    The maintainer team will vote on the call to determine whether to accept you as a maintainer.
@@ -48,7 +48,7 @@ Once accepted every maintainers will go through the following process:
    2. Permission to trigger GitHub actions when a new contributor opens a PR.
    3. Permission to edit Issue/PR contents.
 3. **Add your info to official PX4 channels**:
-   1. Include your information on the PX4 [README](https://github.com/PX4/PX4-Autopilot/blob/main/README.md) next to the rest of the team (under the **Code Owners** table with your category, or the **Reviewers** table if you are joining as a Reviewer)
+   1. Add your information to [`MAINTAINERS.md`](https://github.com/PX4/PX4-Autopilot/blob/main/MAINTAINERS.md) in the PX4-Autopilot repository (under the **Code Owners** table with your category, or the **Reviewers** table if you are joining as a Reviewer)
    2. Listed on the [Maintainers section](https://px4.io/community/maintainers/) of the PX4 website.
    3. Add your information to the internal Dronecode database of maintainers to keep you in sync.
    4. Community introduction to the new maintainer in the form of a forum post, which is promoted through ever growing official channels
@@ -61,20 +61,28 @@ The responsibilities and qualifications below describe the **Code Owner** role i
 
 Maintainers lead/manage the development of a **specific category (referred to as category below)** of any Open Source Projects hosted within the Dronecode Foundation, such as the PX4 Autopilot.
 
-### Responsibilities
+### Responsibilities (Code Owner)
 
 1. Take charge of overseeing the development in their category.
 2. Provide guidance/advice on community members in their category.
 3. Review relevant pull requests and issues from the community on GitHub.
 4. Coordinate with the maintainer group.
-5. Keep regular attendance on [weekly meetings ](dev_call.md).
+5. Keep regular attendance on [weekly meetings](dev_call.md).
 6. Help create and maintain a roadmap for the project your represent.
 7. Uphold the [Code of Conduct](https://github.com/Dronecode/foundation/blob/main/CODE-OF-CONDUCT.md) of our community.
+
+### Responsibilities (Reviewer)
+
+1. Review relevant pull requests and issues across the project where your expertise applies.
+2. Help triage issues and guide community contributors.
+3. Coordinate with the maintainer group.
+4. Keep regular attendance on [weekly meetings](dev_call.md).
+5. Uphold the [Code of Conduct](https://github.com/Dronecode/foundation/blob/main/CODE-OF-CONDUCT.md) of our community.
 
 ### Qualifications
 
 1. Proven track record of valuable contributions.
-2. Domain expertise in the category field.
+2. Domain expertise in the category field (for Code Owners) or broad working knowledge of the project (for Reviewers).
 3. Good overview of the project you are applying to.
 4. You need to manage approval from your employer when relevant.
 

--- a/docs/en/contribute/maintainers.md
+++ b/docs/en/contribute/maintainers.md
@@ -48,10 +48,8 @@ Once accepted every maintainers will go through the following process:
    2. Permission to trigger GitHub actions when a new contributor opens a PR.
    3. Permission to edit Issue/PR contents.
 3. **Add your info to official PX4 channels**:
-   1. Add your information to [`MAINTAINERS.md`](https://github.com/PX4/PX4-Autopilot/blob/main/MAINTAINERS.md) in the PX4-Autopilot repository (under the **Code Owners** table with your category, or the **Reviewers** table if you are joining as a Reviewer)
-   2. Listed on the [Maintainers section](https://px4.io/community/maintainers/) of the PX4 website.
-   3. Add your information to the internal Dronecode database of maintainers to keep you in sync.
-   4. Community introduction to the new maintainer in the form of a forum post, which is promoted through ever growing official channels
+   1. Add your information to the internal Dronecode database of maintainers to keep you in sync.
+   2. Community introduction to the new maintainer in the form of a forum post, which is promoted through ever growing official channels
 
 ## Dronecode Maintainer Role Description
 

--- a/docs/en/contribute/maintainers.md
+++ b/docs/en/contribute/maintainers.md
@@ -26,6 +26,16 @@ If you would like to join the PX4 maintainers team or if you want to nominate so
 
 A Reviewer may later transition to a Code Owner role for a specific category. This requires agreement from the existing Code Owners of that category and sign-off from the maintainer team, following the same discussion and vote on the weekly developer call.
 
+### Adding a new maintainer
+
+Once the maintainer team has agreed to add a new maintainer, the change is landed via a pull request to [`MAINTAINERS.md`](https://github.com/PX4/PX4-Autopilot/blob/main/MAINTAINERS.md). The process is intentionally simple:
+
+1. A current maintainer opens a PR adding the new maintainer to the appropriate table (**Code Owners** with a category, or **Reviewers**).
+2. The PR must be approved by at least one other current maintainer.
+3. If the new maintainer is being added as a Code Owner or sub-owner of a specific component, the existing Code Owner of that component must be among the approvers.
+
+Once the PR is merged, the new maintainer proceeds through the [Onboarding Process](#onboarding-process) below.
+
 ## Onboarding Process
 
 Once accepted every maintainers will go through the following process:

--- a/docs/en/contribute/maintainers.md
+++ b/docs/en/contribute/maintainers.md
@@ -42,7 +42,7 @@ Once accepted every maintainers will go through the following process:
 
 1. **Discord** server admin will grant you the `dev team` role, which gives you:
    1. Basic admin privileges on discord.
-   2. Access to the `#maintainers` channel.
+   2. Access to the private `#maintainers` channel for internal maintainer discussion.
 2. You will be given access to the GitHub team: "[`Dev Team`](https://github.com/orgs/PX4/teams/dev-team)" which grants you:
    1. Permission to merge the PR of any of PX4 workspace repositories after it's approved
    2. Permission to trigger GitHub actions when a new contributor opens a PR.


### PR DESCRIPTION
This introduces a second type of maintainer, **Reviewer**, alongside the existing scoped maintainers who are renamed to **Code Owners**. Both tiers are full members of the maintainer team, share the same `@PX4/dev-team` GitHub team, have write access, and participate in maintainer decisions. The difference is scope: Code Owners are responsible for a specific category of the project (State Estimation, Multirotor, CI, and so on) while Reviewers help across the project without ownership of any specific area.

The motivation is to make it easier to grow the maintainer bench without asking new contributors to commit to owning a component up front. A Reviewer can try out the role, review and triage where their interests and time allow, and later transition to a Code Owner for a specific category if a good fit emerges. Nothing about the current maintainer roster changes: everyone previously listed under Active Maintainers now sits under Code Owners with the same sector and the same responsibilities.

The `MAINTAINERS.md` change keeps the existing table format, renames the Active Maintainers section to Code Owners, and adds an empty Reviewers table so future nominations land as their own PRs. The companion docs update in `docs/en/contribute/maintainers.md` adds a Maintainer Types section, covers both tiers in the Recruitment and Onboarding flows, documents the promotion path from Reviewer to Code Owner, and splits the Responsibilities list into Code Owner and Reviewer variants so the Reviewer scope is explicit.

The recruitment process now also documents the mechanical flow for adding a new maintainer: a current maintainer opens a PR to `MAINTAINERS.md`, another current maintainer approves it, and if the addition is a Code Owner or sub-owner of a specific component the existing Code Owner of that component must be among the approvers. This codifies what has largely been implicit so far.

A few smaller cleanups ride along: the dev call attendee list in `docs/en/contribute/dev_call.md` is updated to use the new role names instead of the older core/component split, the contribute index entry for the maintainers page is reworded to cover both tiers, the docs link in `MAINTAINERS.md` drops the stale `.html` suffix, and three references in the maintainers docs that pointed at a non-existent `README#maintenance-team` anchor now link directly to `MAINTAINERS.md`.