### PR TITLE
fix(ina2xx): Reject exact zero readings

### DIFF
--- a/src/drivers/power_monitor/ina220/ina220.cpp
+++ b/src/drivers/power_monitor/ina220/ina220.cpp
@@ -247,8 +247,16 @@ INA220::collect()
 	switch (_ch_type) {
 	case PM_CH_TYPE_VBATT: {
 			_battery.setConnected(success);
-			_battery.updateVoltage(_voltage);
-			_battery.updateCurrent(_current);
+
+			// Sometimes the read operation "succeeds" but results in wrong
+			// zero readings. Given that with noise a true reading of
+			// exactly 0 is very improbable, we just ignore those readings.
+			// The battery library keeps the old value.
+
+			if (_bus_voltage) { _battery.updateVoltage(_voltage); }
+
+			if (_bus_current) { _battery.updateCurrent(_current); }
+
 			_battery.updateAndPublishBatteryStatus(hrt_absolute_time());
 		}
 		break;

--- a/src/drivers/power_monitor/ina220/ina220.cpp
+++ b/src/drivers/power_monitor/ina220/ina220.cpp
@@ -51,6 +51,7 @@ INA220::INA220(const I2CSPIDriverConfig &config, int battery_index) :
 	_comms_errors(perf_alloc(PC_COUNT, "ina220_com_err")),
 	_collection_errors(perf_alloc(PC_COUNT, "ina220_collection_err")),
 	_measure_errors(perf_alloc(PC_COUNT, "ina220_measurement_err")),
+	_zero_reading_perf(perf_alloc(PC_COUNT, "ina220_zero_reading")),
 	_ch_type((PM_CH_TYPE)config.custom2),
 	_battery(battery_index, this, INA220_SAMPLE_INTERVAL_US, battery_status_s::SOURCE_POWER_MODULE)
 {
@@ -105,6 +106,7 @@ INA220::~INA220()
 	perf_free(_comms_errors);
 	perf_free(_collection_errors);
 	perf_free(_measure_errors);
+	perf_free(_zero_reading_perf);
 }
 
 int INA220::read(uint8_t address, int16_t &data)
@@ -253,6 +255,8 @@ INA220::collect()
 			// exactly 0 is very improbable, we just ignore those readings.
 			// The battery library keeps the old value.
 
+			if (!_bus_voltage || !_bus_current) { perf_count(_zero_reading_perf); }
+
 			if (_bus_voltage) { _battery.updateVoltage(_voltage); }
 
 			if (_bus_current) { _battery.updateCurrent(_current); }
@@ -354,6 +358,7 @@ INA220::print_status()
 	if (_initialized) {
 		perf_print_counter(_sample_perf);
 		perf_print_counter(_comms_errors);
+		perf_print_counter(_zero_reading_perf);
 
 		switch (_ch_type) {
 		case PM_CH_TYPE_VBATT:

--- a/src/drivers/power_monitor/ina220/ina220.h
+++ b/src/drivers/power_monitor/ina220/ina220.h
@@ -180,6 +180,7 @@ private:
 	perf_counter_t		_comms_errors;
 	perf_counter_t 		_collection_errors;
 	perf_counter_t 		_measure_errors;
+	perf_counter_t		_zero_reading_perf;
 
 	int16_t           _bus_voltage{0};
 	int16_t           _bus_power{0};

--- a/src/drivers/power_monitor/ina226/ina226.cpp
+++ b/src/drivers/power_monitor/ina226/ina226.cpp
@@ -227,8 +227,15 @@ INA226::collect()
 	// success = success && (read(INA226_REG_SHUNTVOLTAGE, _shunt) == PX4_OK);
 
 	if (setConnected(success)) {
-		_battery.updateVoltage(static_cast<float>(_bus_voltage * INA226_VSCALE));
-		_battery.updateCurrent(static_cast<float>(_current * _current_lsb));
+
+		// Sometimes the read operation "succeeds" but results in wrong
+		// zero readings. Given that with noise a true reading of
+		// exactly 0 is very improbable, we just ignore those readings.
+		// The battery library keeps the old value.
+
+		if (_bus_voltage) { _battery.updateVoltage(static_cast<float>(_bus_voltage * INA226_VSCALE)); }
+
+		if (_current) { _battery.updateCurrent(static_cast<float>(_current * _current_lsb)); }
 	}
 
 	_battery.updateAndPublishBatteryStatus(hrt_absolute_time());

--- a/src/drivers/power_monitor/ina226/ina226.cpp
+++ b/src/drivers/power_monitor/ina226/ina226.cpp
@@ -49,6 +49,7 @@ INA226::INA226(const I2CSPIDriverConfig &config, int battery_index) :
 	_comms_errors(perf_alloc(PC_COUNT, "ina226_com_err")),
 	_collection_errors(perf_alloc(PC_COUNT, "ina226_collection_err")),
 	_measure_errors(perf_alloc(PC_COUNT, "ina226_measurement_err")),
+	_zero_reading_perf(perf_alloc(PC_COUNT, "ina226_zero_reading")),
 	_battery(battery_index, this, INA226_SAMPLE_INTERVAL_US, battery_status_s::SOURCE_POWER_MODULE)
 {
 	float fvalue = MAX_CURRENT;
@@ -96,6 +97,7 @@ INA226::~INA226()
 	perf_free(_comms_errors);
 	perf_free(_collection_errors);
 	perf_free(_measure_errors);
+	perf_free(_zero_reading_perf);
 }
 
 int INA226::read(uint8_t address, int16_t &data)
@@ -233,6 +235,8 @@ INA226::collect()
 		// exactly 0 is very improbable, we just ignore those readings.
 		// The battery library keeps the old value.
 
+		if (!_bus_voltage || !_current) { perf_count(_zero_reading_perf); }
+
 		if (_bus_voltage) { _battery.updateVoltage(static_cast<float>(_bus_voltage * INA226_VSCALE)); }
 
 		if (_current) { _battery.updateCurrent(static_cast<float>(_current * _current_lsb)); }
@@ -341,6 +345,7 @@ INA226::print_status()
 	if (_initialized) {
 		perf_print_counter(_sample_perf);
 		perf_print_counter(_comms_errors);
+		perf_print_counter(_zero_reading_perf);
 
 		printf("poll interval:  %u \n", _measure_interval);
 

--- a/src/drivers/power_monitor/ina226/ina226.h
+++ b/src/drivers/power_monitor/ina226/ina226.h
@@ -186,6 +186,7 @@ private:
 	perf_counter_t		_comms_errors;
 	perf_counter_t 		_collection_errors;
 	perf_counter_t 		_measure_errors;
+	perf_counter_t		_zero_reading_perf;
 
 	int16_t           _bus_voltage{0};
 	int16_t           _power{0};

--- a/src/drivers/power_monitor/ina228/ina228.cpp
+++ b/src/drivers/power_monitor/ina228/ina228.cpp
@@ -49,6 +49,7 @@ INA228::INA228(const I2CSPIDriverConfig &config, int battery_index) :
 	_comms_errors(perf_alloc(PC_COUNT, "ina228_com_err")),
 	_collection_errors(perf_alloc(PC_COUNT, "ina228_collection_err")),
 	_measure_errors(perf_alloc(PC_COUNT, "ina228_measurement_err")),
+	_zero_reading_perf(perf_alloc(PC_COUNT, "ina228_zero_reading")),
 	_battery(battery_index, this, INA228_SAMPLE_INTERVAL_US, battery_status_s::SOURCE_POWER_MODULE)
 {
 	float fvalue = MAX_CURRENT;
@@ -111,6 +112,7 @@ INA228::~INA228()
 	perf_free(_comms_errors);
 	perf_free(_collection_errors);
 	perf_free(_measure_errors);
+	perf_free(_zero_reading_perf);
 }
 
 int INA228::read(uint8_t address, int16_t &data)
@@ -328,6 +330,8 @@ INA228::collect()
 		// exactly 0 is very improbable, we just ignore those readings.
 		// The battery library keeps the old value.
 
+		if (!_bus_voltage || !_current || !_temperature) { perf_count(_zero_reading_perf); }
+
 		if (_bus_voltage) { _battery.updateVoltage(static_cast<float>(_bus_voltage * INA228_VSCALE)); }
 
 		if (_current) { _battery.updateCurrent(static_cast<float>(_current * _current_lsb)); }
@@ -438,6 +442,7 @@ INA228::print_status()
 	if (_initialized) {
 		perf_print_counter(_sample_perf);
 		perf_print_counter(_comms_errors);
+		perf_print_counter(_zero_reading_perf);
 
 		printf("poll interval:  %u \n", _measure_interval);
 

--- a/src/drivers/power_monitor/ina228/ina228.cpp
+++ b/src/drivers/power_monitor/ina228/ina228.cpp
@@ -322,8 +322,16 @@ INA228::collect()
 	success = success && (read(INA228_REG_DIETEMP, _temperature) == PX4_OK);
 
 	if (setConnected(success)) {
-		_battery.updateVoltage(static_cast<float>(_bus_voltage * INA228_VSCALE));
-		_battery.updateCurrent(static_cast<float>(_current * _current_lsb));
+
+		// Sometimes the read operation "succeeds" but results in wrong
+		// zero readings. Given that with noise a true reading of
+		// exactly 0 is very improbable, we just ignore those readings.
+		// The battery library keeps the old value.
+
+		if (_bus_voltage) { _battery.updateVoltage(static_cast<float>(_bus_voltage * INA228_VSCALE)); }
+
+		if (_current) { _battery.updateCurrent(static_cast<float>(_current * _current_lsb)); }
+
 		_battery.updateTemperature(static_cast<float>(_temperature * INA228_TSCALE));
 	}
 

--- a/src/drivers/power_monitor/ina228/ina228.cpp
+++ b/src/drivers/power_monitor/ina228/ina228.cpp
@@ -332,7 +332,7 @@ INA228::collect()
 
 		if (_current) { _battery.updateCurrent(static_cast<float>(_current * _current_lsb)); }
 
-		_battery.updateTemperature(static_cast<float>(_temperature * INA228_TSCALE));
+		if (_temperature) { _battery.updateTemperature(static_cast<float>(_temperature * INA228_TSCALE)); }
 	}
 
 	_battery.updateAndPublishBatteryStatus(hrt_absolute_time());

--- a/src/drivers/power_monitor/ina228/ina228.h
+++ b/src/drivers/power_monitor/ina228/ina228.h
@@ -338,6 +338,7 @@ private:
 	perf_counter_t		_comms_errors;
 	perf_counter_t 		_collection_errors;
 	perf_counter_t 		_measure_errors;
+	perf_counter_t		_zero_reading_perf;
 
 	int32_t           _bus_voltage{0};
 	int64_t           _power{0};

--- a/src/drivers/power_monitor/ina238/ina238.cpp
+++ b/src/drivers/power_monitor/ina238/ina238.cpp
@@ -251,9 +251,17 @@ int INA238::collect()
 	success = success && (RegisterRead(Register::DIETEMP, (uint16_t &)temperature) == PX4_OK);
 
 	if (setConnected(success)) {
-		_battery.updateVoltage(static_cast<float>(bus_voltage * INA238_VSCALE));
-		_battery.updateCurrent(static_cast<float>(current * _current_lsb));
-		_battery.updateTemperature(static_cast<float>(temperature * INA238_TSCALE));
+
+		// Sometimes the read operation "succeeds" but results in wrong
+		// zero readings. Given that with noise a true reading of
+		// exactly 0 is very improbable, we just ignore those readings.
+		// The battery library keeps the old value.
+
+		if (bus_voltage) { _battery.updateVoltage(static_cast<float>(bus_voltage * INA238_VSCALE)); }
+
+		if (current) { _battery.updateCurrent(static_cast<float>(current * _current_lsb)); }
+
+		if (temperature) { _battery.updateTemperature(static_cast<float>(temperature * INA238_TSCALE)); }
 
 		_battery.updateAndPublishBatteryStatus(hrt_absolute_time());
 	}

--- a/src/drivers/power_monitor/ina238/ina238.cpp
+++ b/src/drivers/power_monitor/ina238/ina238.cpp
@@ -102,6 +102,7 @@ INA238::~INA238()
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
 	perf_free(_collection_errors);
+	perf_free(_zero_reading_perf);
 }
 
 int INA238::read(uint8_t address, uint16_t &data)
@@ -257,6 +258,8 @@ int INA238::collect()
 		// exactly 0 is very improbable, we just ignore those readings.
 		// The battery library keeps the old value.
 
+		if (!bus_voltage || !current || !temperature) { perf_count(_zero_reading_perf); }
+
 		if (bus_voltage) { _battery.updateVoltage(static_cast<float>(bus_voltage * INA238_VSCALE)); }
 
 		if (current) { _battery.updateCurrent(static_cast<float>(current * _current_lsb)); }
@@ -382,6 +385,7 @@ void INA238::print_status()
 	if (_initialized) {
 		perf_print_counter(_sample_perf);
 		perf_print_counter(_comms_errors);
+		perf_print_counter(_zero_reading_perf);
 
 		printf("poll interval:  %u \n", _measure_interval);
 

--- a/src/drivers/power_monitor/ina238/ina238.h
+++ b/src/drivers/power_monitor/ina238/ina238.h
@@ -133,6 +133,7 @@ private:
 	perf_counter_t _comms_errors;
 	perf_counter_t _collection_errors;
 	perf_counter_t _bad_register_perf{perf_alloc(PC_COUNT, MODULE_NAME": bad register")};
+	perf_counter_t _zero_reading_perf{perf_alloc(PC_COUNT, MODULE_NAME": zero reading")};
 
 	// Configuration state, computed from params
 	float _max_current;


### PR DESCRIPTION
### Solved Problem

Even after https://github.com/PX4/PX4-Autopilot/pull/25786 we observe somewhat regular issues where the power monitor driver (INA238 in our case) gives a reading of zero volt which is obviously wrong. 

This causes the battery library to report an SoC of zero (which results in various failsafes) and declare the battery disconnected, which degrades the SoC estimation afterwards (e.g. through resetting the internal resistance estimate):

https://github.com/PX4/PX4-Autopilot/blob/c4abeed3a4d9f234f59b83992a44dac7ed8b0bd0/src/lib/battery/battery.cpp#L127-L130

The issue is often correlated with large currents, such as front-transition of a standard VTOL airframe. This suggests the explanation that EMI corrupts the payload but not the ACK/NACK, causing `transfer` to return `PX4_OK` despite zero data. 

I am not 100% sure that this is what happens (we have not managed to reproduce the failure reliably) but the proposed hardening would solve it if the explanation holds and is low-risk. 


### Solution

If the reading is exactly zero, ignore it and do not update the battery reading. 

Due to noise (but also the fact that an operating system requires some current and voltage) a true reading of zero is very unlikely, and even if it happens the consequences are very limited -- the battery library keeps the old value for all calculations and updates on the next nonzero sample. 

INA220 special case: only reject zero readings when output goes to battery library. When output goes to the `power_monitor` uOrb message, publish zero readings as before, as we do not have the option of publishing only a subset of readings.

### Changelog Entry
For release notes:
```
Fix: INA2XX power monitor: Ignore readings of exactly zero voltage, current, and temperature. Fixes false critical battery warnings on EMI.
```

### Test coverage

Sanity check on HW that it does not break basic functionality.

Will un-draft once we have more substantial evidence that this is what happens and that the fix is appropriate. 

### Alternatives 

(short of hardware changes: isolating EMI properly, switching to something differentially signalled)

 - double or triple-read
   - report only if readings agree up to sensible precision
   - maybe intentionally wait a tiny bit, to increase change that EMI pulse is over 
   - the "proper" solution but increased code and runtime, possibly even configuration 
 - variation of this fix that only ignores zeroes if they appear for a short time, if they persist they are reported normally again (INA238 only currently): https://github.com/PX4/PX4-Autopilot/tree/pr-better-ina238-fix
 - battery lib fix below

### Context

 - Previous battery-lib fix (rejected): https://github.com/PX4/PX4-Autopilot/pull/26819
 - Driver-level debouncing fix: https://github.com/PX4/PX4-Autopilot/pull/25786
 - Even earlier battery lib fix: https://github.com/PX4/PX4-Autopilot/pull/23513
