### PR TITLE
feat(commander): Remote ID in-flight failsafe via COM_ARM_ODID

### DIFF
--- a/docs/en/config/safety.md
+++ b/docs/en/config/safety.md
@@ -257,14 +257,11 @@ The relevant parameters are shown below:
 
 The Remote ID failsafe is triggered when the [Remote ID (Open Drone ID)](../peripherals/remote_id.md) module is missing or loses its heartbeat while the vehicle is armed and airborne.
 
-The failsafe action and arming behaviour are both configured by a single parameter:
+The failsafe action and arming behaviour are both configured by the `COM_ARM_ODID` parameter:
 
-| Parameter                                                                                       | Description                                                                                                                                                                                                                                                                                                                                                              |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| <a id="COM_ARM_ODID"></a>[COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID) | Remote ID arming check and in-flight failsafe. `0`: Disabled (default), `1`: Warning only, `2`: Error only, `3`: Return, `4`: Land, `5`: Terminate. |
-
-Values `2`–`5` prevent arming when the Remote ID system is not present and healthy.
-Values `3`–`5` also trigger the configured failsafe action if the Remote ID system is missing or unhealthy while airborne.
+| Parameter                                                                                       | Description                                                                                                                                                                                                                                                                                                                                    |
+| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <a id="COM_ARM_ODID"></a>[COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID) | Remote ID arming check and in-flight failsafe. `0`: Disabled (default), `1`: Warning only, `2`: Error only (prevents arming), `3`: Return, `4`: Land, `5`: Terminate.<br><br>On failsafe:<br>- `Error`, `Return`, `Land` and `Terminate` prevent arming.<br>- `Return`, `Land` and `Terminate` start the associated action/mode when airborne. |
 
 ## Quad-chute Failsafe
 

--- a/docs/en/config/safety.md
+++ b/docs/en/config/safety.md
@@ -255,7 +255,7 @@ The relevant parameters are shown below:
 
 <Badge type="tip" text="PX4 v1.18" />
 
-The Remote ID failsafe is triggered when the [Remote ID (Open Drone ID)](../peripherals/remote_id.md) module is missing or loses its heartbeat while the vehicle is armed and airborne.
+The Remote ID failsafe is triggered when the [Remote ID (Open Drone ID)](../peripherals/remote_id.md) module is not detected or reports as unhealthy while the vehicle is armed.
 
 The failsafe action and arming behaviour are both configured by the `COM_ARM_ODID` parameter:
 

--- a/docs/en/config/safety.md
+++ b/docs/en/config/safety.md
@@ -251,6 +251,21 @@ The relevant parameters are shown below:
 | ---------------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | [NAV_TRAFF_AVOID](../advanced_config/parameter_reference.md#NAV_TRAFF_AVOID) | Set the failsafe action: Disabled, Warn, Return mode, Land mode. |
 
+## Remote ID Failsafe
+
+<Badge type="tip" text="PX4 v1.18" />
+
+The Remote ID failsafe is triggered when the [Remote ID (Open Drone ID)](../peripherals/remote_id.md) module is missing or loses its heartbeat while the vehicle is armed and airborne.
+
+The failsafe action and arming behaviour are both configured by a single parameter:
+
+| Parameter                                                                                       | Description                                                                                                                                                                                                                                                                                                                                                              |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| <a id="COM_ARM_ODID"></a>[COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID) | Remote ID arming check and in-flight failsafe. `0`: Disabled (default), `1`: Warning only, `2`: Error only, `3`: Return, `4`: Land, `5`: Terminate. |
+
+Values `2`–`5` prevent arming when the Remote ID system is not present and healthy.
+Values `3`–`5` also trigger the configured failsafe action if the Remote ID system is missing or unhealthy while airborne.
+
 ## Quad-chute Failsafe
 
 Failsafe for when a VTOL vehicle can no longer fly in fixed-wing mode, perhaps due to the failure of a pusher motor, airspeed sensor, or control surface.
@@ -441,7 +456,7 @@ These parameters can be used to set conditions that prevent arming.
 | <a id="COM_ARM_MIS_REQ"></a>[COM_ARM_MIS_REQ](../advanced_config/parameter_reference.md#COM_ARM_MIS_REQ)    | Require valid mission to arm. `0`: Disabled (default), `1`: Enabled .                                                                                                                                      |
 | <a id="COM_ARM_SDCARD"></a>[COM_ARM_SDCARD](../advanced_config/parameter_reference.md#COM_ARM_SDCARD)       | Require SD card to arm. `0`: Disabled (default), `1`: Warning, `2`: Enabled.                                                                                                                               |
 | <a id="COM_ARM_AUTH_REQ"></a>[COM_ARM_AUTH_REQ](../advanced_config/parameter_reference.md#COM_ARM_AUTH_REQ) | Requires arm authorisation from an external (MAVLink) system. Flag to allow arming (at all). `1`: Enabled, `0`: Disabled (default). Associated configuration parameters are prefixed with `COM_ARM_AUTH_`. |
-| <a id="COM_ARM_ODID"></a>[COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID)             | Require healthy Remote ID system to arm. `0`: Disabled (default), `1`: Warning, `2`: Enabled.                                                                                                              |
+| <a id="COM_ARM_ODID"></a>[COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID)             | Remote ID arming check and in-flight failsafe. `0`: Disabled (default), `1`: Warning only, `2`: Error only, `3`: Return, `4`: Land, `5`: Terminate. See [Remote ID Failsafe](#remote-id-failsafe).         |
 
 In addition there are a number of parameters that configure system and sensor limits that make prevent arming if exceeded: [COM_CPU_MAX](../advanced_config/parameter_reference.md#COM_CPU_MAX), [COM_ARM_IMU_ACC](../advanced_config/parameter_reference.md#COM_ARM_IMU_ACC), [COM_ARM_IMU_GYR](../advanced_config/parameter_reference.md#COM_ARM_IMU_GYR), [COM_ARM_MAG_ANG](../advanced_config/parameter_reference.md#COM_ARM_MAG_ANG), [COM_ARM_MAG_STR](../advanced_config/parameter_reference.md#COM_ARM_MAG_STR).
 

--- a/docs/en/peripherals/remote_id.md
+++ b/docs/en/peripherals/remote_id.md
@@ -143,18 +143,12 @@ The [CAN Remote ID Not Working](../peripherals/remote_id.md#can-remote-id-not-wo
 
 There is no need to explicitly enable Remote ID (supported Remote ID messages are either streamed by default or must be requested in the current implementation, even if no remote ID is connected).
 
-### Remote ID Arming Check and In-Flight Failsafe
+### Remote ID Failsafe and Arming Check
 
 <Badge type="tip" text="PX4 v1.18" />
 
-The [COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID) parameter configures both the arming check and the in-flight failsafe action when the Remote ID system is missing or unhealthy:
-
-| Parameter                                                                                       | Description                                                                                                                                                                                                                                                                                                                                                                          |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| <a id="COM_ARM_ODID"></a>[COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID) | `0`: Disabled (default), `1`: Warning only, `2`: Error only, `3`: Return, `4`: Land, `5`: Terminate. |
-
-Values `2`–`5` prevent arming when the Remote ID system is not present and healthy.
-Values `3`–`5` also trigger the configured failsafe action if the Remote ID system is missing or unhealthy while airborne.
+The [COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID) parameter configures both the arming check and the in-flight failsafe action when the Remote ID system is missing or unhealthy.
+For more information see [Remote ID Failsafe](http://localhost:5173/px4_user_guide/en/config/safety#remote-id-failsafe) in _Safety Configuration_.
 
 ## Module Broadcast Testing
 

--- a/docs/en/peripherals/remote_id.md
+++ b/docs/en/peripherals/remote_id.md
@@ -143,13 +143,18 @@ The [CAN Remote ID Not Working](../peripherals/remote_id.md#can-remote-id-not-wo
 
 There is no need to explicitly enable Remote ID (supported Remote ID messages are either streamed by default or must be requested in the current implementation, even if no remote ID is connected).
 
-### Prevent Arming based on Remote ID
+### Remote ID Arming Check and In-Flight Failsafe
 
-To only allow arming when a Remote ID is ready, [set](../advanced_config/parameters.md#conditional-parameters) the parameter [COM_ARM_ODID](#COM_ARM_ODID) to `2` (it is disabled by default).
+<Badge type="tip" text="PX4 v1.18" />
 
-| Parameter                                                                                       | Description                                                                                                                                                                            |
-| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <a id="COM_ARM_ODID"></a>[COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID) | Enable Drone ID system detection and health check. `0`: Disable (default), `1`: Warn if Remote ID not detected but still allow arming, `2`: Only allow arming if Remote ID is present. |
+The [COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID) parameter configures both the arming check and the in-flight failsafe action when the Remote ID system is missing or unhealthy:
+
+| Parameter                                                                                       | Description                                                                                                                                                                                                                                                                                                                                                                          |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| <a id="COM_ARM_ODID"></a>[COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID) | `0`: Disabled (default), `1`: Warning only, `2`: Error only, `3`: Return, `4`: Land, `5`: Terminate. |
+
+Values `2`–`5` prevent arming when the Remote ID system is not present and healthy.
+Values `3`–`5` also trigger the configured failsafe action if the Remote ID system is missing or unhealthy while airborne.
 
 ## Module Broadcast Testing
 
@@ -173,7 +178,7 @@ The following message can be streamed on request (using [MAV_CMD_SET_MESSAGE_INT
 - [OPEN_DRONE_ID_BASIC_ID](https://mavlink.io/en/messages/common.html#OPEN_DRONE_ID_BASIC_ID) - UAV identity information (essentially a serial number)
   - PX4 v1.14 specifies a serial number ([MAV_ODID_ID_TYPE_SERIAL_NUMBER](https://mavlink.io/en/messages/common.html#MAV_ODID_ID_TYPE_SERIAL_NUMBER)) but does not use the required format (ANSI/CTA-2063 format).
 
-PX4 prevents arming based on Remote ID health if parameter [COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID) is set to `2`.
+PX4 can prevent arming and/or trigger an in-flight failsafe based on Remote ID health via the [COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID) parameter.
 The UAV will then require `HEARTBEAT` messages from the Remote ID as a precondition for arming the UAV.
 You can also set the parameter to `1` to warn but still allow arming when Remote ID `HEARTBEAT` messages are not detected.
 

--- a/docs/en/releases/main.md
+++ b/docs/en/releases/main.md
@@ -40,6 +40,7 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 ### Common
 
+- [Remote ID (Open Drone ID) in-flight failsafe](../peripherals/remote_id.md): extended [COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID) to also trigger a configurable failsafe action (Return, Land, or Terminate) if the Remote ID heartbeat is lost while airborne. Users previously on `COM_ARM_ODID=2` retain the same arming behaviour; set to `3` or higher to enable the in-flight action. ([PX4-Autopilot#27029](https://github.com/PX4/PX4-Autopilot/pull/27029))
 - [QGroundControl Bootloader Update](../advanced_config/bootloader_update.md#qgc-bootloader-update-sys-bl-update) via the [SYS_BL_UPDATE](../advanced_config/parameter_reference.md#SYS_BL_UPDATE) parameter has been re-enabled after being broken for a number of releases. ([PX4-Autopilot#25032: build: romf: fix generation of rc.board_bootloader_upgrade](https://github.com/PX4/PX4-Autopilot/pull/25032)).
 - [Feature: Allow prioritization of manual control inputs based on their instance number in ascending or descending order](../config/manual_control.md#px4-configuration). ([PX4-Autopilot#25602: Ascending and descending manual control input priorities](https://github.com/PX4/PX4-Autopilot/pull/25602)).
 

--- a/msg/FailsafeFlags.msg
+++ b/msg/FailsafeFlags.msg
@@ -60,3 +60,4 @@ bool flight_time_limit_exceeded       # Maximum flight time exceeded
 bool position_accuracy_low            # Position estimate has dropped below threshold, but is currently still declared valid
 bool navigator_failure        	      # Navigator failed to execute a mode
 bool parachute_unhealthy              # Parachute system missing or unhealthy
+bool remote_id_unhealthy              # Remote ID (Open Drone ID) system missing or unhealthy

--- a/src/modules/commander/HealthAndArmingChecks/checks/openDroneIDCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/openDroneIDCheck.cpp
@@ -36,17 +36,17 @@
 
 void OpenDroneIDChecks::checkAndReport(const Context &context, Report &reporter)
 {
-	// Check to see if the check has been disabled
+	reporter.failsafeFlags().remote_id_unhealthy =
+		!context.status().open_drone_id_system_present ||
+		!context.status().open_drone_id_system_healthy;
+
 	if (!_param_com_arm_odid.get()) {
 		return;
 	}
 
-	NavModes affected_modes{NavModes::None};
-
-	if (_param_com_arm_odid.get() == 2) {
-		// disallow arming without the Open Drone ID system
-		affected_modes = NavModes::All;
-	}
+	const bool is_error = _param_com_arm_odid.get() >= 2;
+	const NavModes affected_modes = is_error ? NavModes::All : NavModes::None;
+	const events::Log log_level = is_error ? events::Log::Error : events::Log::Warning;
 
 	if (!context.status().open_drone_id_system_present) {
 		/* EVENT
@@ -57,9 +57,9 @@ void OpenDroneIDChecks::checkAndReport(const Context &context, Report &reporter)
 		 * This check can be configured via <param>COM_ARM_ODID</param> parameter.
 		 * </profile>
 		 */
-		reporter.armingCheckFailure(affected_modes, health_component_t::open_drone_id,
-					    events::ID("check_open_drone_id_missing"),
-					    events::Log::Error, "Open Drone ID system missing");
+		reporter.healthFailure(affected_modes, health_component_t::open_drone_id,
+				       events::ID("check_open_drone_id_missing"),
+				       log_level, "Open Drone ID system missing");
 
 		if (reporter.mavlink_log_pub()) {
 			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Open Drone ID system missing");
@@ -74,9 +74,9 @@ void OpenDroneIDChecks::checkAndReport(const Context &context, Report &reporter)
 		 * This check can be configured via <param>COM_ARM_ODID</param> parameter.
 		 * </profile>
 		 */
-		reporter.armingCheckFailure(affected_modes, health_component_t::open_drone_id,
-					    events::ID("check_open_drone_id_unhealthy"),
-					    events::Log::Error, "Open Drone ID system not ready");
+		reporter.healthFailure(affected_modes, health_component_t::open_drone_id,
+				       events::ID("check_open_drone_id_unhealthy"),
+				       log_level, "Open Drone ID system not ready");
 
 		if (reporter.mavlink_log_pub()) {
 			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Open Drone ID system not ready");

--- a/src/modules/commander/commander_params.yaml
+++ b/src/modules/commander/commander_params.yaml
@@ -613,16 +613,7 @@ parameters:
     COM_ARM_ODID:
       description:
         short: Open Drone ID system check and in-flight failsafe
-        long: |-
-          Configures both the arming check and the in-flight failsafe for the
-          Open Drone ID (Remote ID) system.
-
-          Warning: warns at arming but does not block it, and takes no in-flight action.
-          Error only: blocks arming without the ODID system present and healthy, but
-          takes no automated action if the system is lost while airborne.
-          Return / Land / Terminate: block arming without the ODID system present and
-          healthy, and trigger the corresponding failsafe action if the system is lost
-          while airborne (heartbeat timeout > 3 s).
+        long: Actions other than warning also prevent arming.
       type: enum
       values:
         0: Disabled
@@ -632,7 +623,6 @@ parameters:
         4: Land
         5: Terminate
       default: 0
-      increment: 1
     COM_ARM_TRAFF:
       description:
         short: Enable Traffic Avoidance system detection check

--- a/src/modules/commander/commander_params.yaml
+++ b/src/modules/commander/commander_params.yaml
@@ -612,17 +612,27 @@ parameters:
       default: 1
     COM_ARM_ODID:
       description:
-        short: Enable Drone ID system detection and health check
+        short: Open Drone ID system check and in-flight failsafe
         long: |-
-          This check detects if the Open Drone ID system is missing.
-          Depending on the value of the parameter, the check can be
-          disabled, warn only or deny arming.
+          Configures both the arming check and the in-flight failsafe for the
+          Open Drone ID (Remote ID) system.
+
+          Warning: warns at arming but does not block it, and takes no in-flight action.
+          Error only: blocks arming without the ODID system present and healthy, but
+          takes no automated action if the system is lost while airborne.
+          Return / Land / Terminate: block arming without the ODID system present and
+          healthy, and trigger the corresponding failsafe action if the system is lost
+          while airborne (heartbeat timeout > 3 s).
       type: enum
       values:
         0: Disabled
         1: Warning only
-        2: Enforce Open Drone ID system presence
+        2: Error only
+        3: Return
+        4: Land
+        5: Terminate
       default: 0
+      increment: 1
     COM_ARM_TRAFF:
       description:
         short: Enable Traffic Avoidance system detection check

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -442,6 +442,38 @@ FailsafeBase::ActionOptions Failsafe::fromRemainingFlightTimeLowActParam(int par
 	return options;
 }
 
+FailsafeBase::ActionOptions Failsafe::fromOdidFailActParam(int param_value)
+{
+	ActionOptions options{};
+
+	switch (open_drone_id_failsafe_mode(param_value)) {
+	case open_drone_id_failsafe_mode::Return_mode:
+		options.action = Action::RTL;
+		options.clear_condition = ClearCondition::OnModeChangeOrDisarm;
+		break;
+
+	case open_drone_id_failsafe_mode::Land_mode:
+		options.action = Action::Land;
+		options.clear_condition = ClearCondition::OnModeChangeOrDisarm;
+		break;
+
+	case open_drone_id_failsafe_mode::Terminate:
+		options.allow_user_takeover = UserTakeoverAllowed::Never;
+		options.action = Action::Terminate;
+		options.clear_condition = ClearCondition::Never;
+		break;
+
+	case open_drone_id_failsafe_mode::None:
+	case open_drone_id_failsafe_mode::Warning:
+	case open_drone_id_failsafe_mode::Error:
+	default:
+		options.action = Action::None;
+		break;
+	}
+
+	return options;
+}
+
 bool Failsafe::isFailsafeIgnored(uint8_t user_intended_mode, int32_t exception_mask_parameter)
 {
 	switch (user_intended_mode) {
@@ -576,6 +608,11 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 
 	// Parachute system health failsafe
 	CHECK_FAILSAFE(status_flags, parachute_unhealthy, Action::RTL);
+
+	// Remote ID (Open Drone ID) loss failsafe
+	if (state.armed && _param_com_arm_odid.get() >= int32_t(open_drone_id_failsafe_mode::Return_mode)) {
+		CHECK_FAILSAFE(status_flags, remote_id_unhealthy, fromOdidFailActParam(_param_com_arm_odid.get()));
+	}
 
 	// Battery low failsafe
 	// If battery was low and arming was allowed through COM_ARM_BAT_MIN, don't failsafe immediately for the current low battery warning state

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -157,6 +157,15 @@ private:
 		Return_mode = 3
 	};
 
+	enum class open_drone_id_failsafe_mode : int32_t {
+		None = 0,
+		Warning = 1,
+		Error = 2,
+		Return_mode = 3,
+		Land_mode = 4,
+		Terminate = 5,
+	};
+
 	static ActionOptions fromNavDllOrRclActParam(int param_value);
 
 	static ActionOptions fromGfActParam(int param_value);
@@ -168,6 +177,7 @@ private:
 	static ActionOptions fromHighWindLimitActParam(int param_value);
 	static ActionOptions fromPosLowActParam(int param_value);
 	static ActionOptions fromRemainingFlightTimeLowActParam(int param_value);
+	static ActionOptions fromOdidFailActParam(int param_value);
 
 	static bool isFailsafeIgnored(uint8_t user_intended_mode, int32_t exception_mask_parameter);
 
@@ -209,7 +219,8 @@ private:
 					(ParamInt<px4::params::COM_QC_ACT>) _param_com_qc_act,
 					(ParamInt<px4::params::COM_WIND_MAX_ACT>) _param_com_wind_max_act,
 					(ParamInt<px4::params::COM_FLTT_LOW_ACT>) _param_com_fltt_low_act,
-					(ParamInt<px4::params::COM_POS_LOW_ACT>) _param_com_pos_low_act
+					(ParamInt<px4::params::COM_POS_LOW_ACT>) _param_com_pos_low_act,
+					(ParamInt<px4::params::COM_ARM_ODID>) _param_com_arm_odid
 				       );
 
 };


### PR DESCRIPTION
### Solved Problem
When a Remote ID (Open Drone ID) module is lost in flight, PX4 logged a critical message but took no automated action.

### Solution
COM_ARM_ODID previously accepted values 0 (Disabled), 1 (Warning), 2 (Enforce presence at arming). This PR extends it with new values and repurposes the existing ones, making it a unified arming + in-flight failsafe parameter:

0 = Disabled, 1 = Warning only, 2 = Error only (blocks arming, shows error in-flight but no automated action), 3 = Return, 4 = Land, 5 = Terminate

Values >= 2 block arming. Values >= 3 additionally trigger the configured failsafe action if the Remote ID system is lost while airborne (heartbeat timeout > 3 s).

Users who had COM_ARM_ODID=2 ("Enforce Open Drone ID system presence") retain the same behaviour, arming is blocked and no in-flight action is taken. To additionally trigger an automated failsafe on in-flight loss, update to 3 (Return), 4 (Land), or 5 (Terminate).

The health indicator now persists while airborne by switching from armingCheckFailure() to healthFailure(). A new failsafe_flags.remote_id_unhealthy flag is set every cycle and consumed by the failsafe state machine to trigger the configured action when armed.

### Changelog Entry
For release notes:
feat(commander): Remote ID loss in-flight failsafe configurable via COM_ARM_ODID
COM_ARM_ODID extended: 2 = Error only (same behaviour as previous "Enforce"), 3 = Return, 4 = Land, 5 = Terminate.


### Test coverage
Tested on SITL with a MAVLink script simulating a MAV_TYPE_ODID heartbeat:
- Arming blocked without ODID present (COM_ARM_ODID=2) 
- Arming succeeds with ODID present 
- In-flight RTL triggered on ODID loss 
- Warning mode allows arming, no failsafe in-flight 
- Land mode triggers AUTO_LAND on loss 
