### PR TITLE
ci(stale): bump operations-per-run to 1500 and add manual trigger

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,6 +2,7 @@ name: 'Handle stale issues and PRs'
 on:
   schedule:
     - cron: '30 1 * * *'
+  workflow_dispatch:
 
 jobs:
   stale:
@@ -9,7 +10,7 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          operations-per-run: 250
+          operations-per-run: 1500
           days-before-stale: 90
           days-before-close: 30
           stale-issue-label: 'stale'


### PR DESCRIPTION
The stale workflow has been hitting its `operations-per-run: 250` cap on every daily run, logging `No more operations left! Exiting...` before it finishes processing the candidate queue. Today's run (24223026205) processed 393 items, marked 39 new stale, but only closed 1 issue before exiting. There are currently 178 items carrying the `stale` label waiting to be closed, and the backlog is growing faster than the workflow can drain it.

GitHub API headroom is not the constraint. After a full 250-op run the rate-remaining was 14,728/15,000, so 250 ops is about 1.6% of the hourly bucket. Bumping to 1500 uses ~10% and stays well under both the primary and secondary rate limits. The `actions/stale` maintainers explicitly recommend raising this when the `No more operations left` warning appears.

Also adds `workflow_dispatch` so maintainers can trigger the workflow manually from the Actions tab or via `gh workflow run stale.yml --repo PX4/PX4-Autopilot`, which is useful for draining the backlog and for testing config changes without waiting for the next cron.

Expect the first run after merge to be a catch-up run that closes more items than usual as it works through the accumulated stale-labeled backlog. Daily cadence should stabilize well under the new cap after that.