### PR TITLE
docs(sih): Enhance SIH and Flight Controller Hardware documentation

### DIFF
--- a/docs/en/sim_sih/hardware.md
+++ b/docs/en/sim_sih/hardware.md
@@ -1,7 +1,7 @@
 # SIH on Flight Controller Hardware
 
-SIH can run directly on flight controller hardware with `SYS_HITL=2`.
-This replaces real sensors with simulated data while running on the actual autopilot, useful for testing without propellers.
+[SIH](../sim_sih/index.md) can run directly on flight controller hardware with `SYS_AUTOSTART` set to the desired value for the frame.
+This replaces real sensors with simulated data while running on the actual autopilot.
 
 For a comparison of SIH and HITL on hardware, see [Hardware Simulation](../simulation/hardware.md).
 
@@ -16,16 +16,16 @@ For a comparison of SIH and HITL on hardware, see [Hardware Simulation](../simul
 To ensure there is no leftover parameter from previous setup, it is recommended to reset all the parameters to firmware's default before modifying `SYS_AUTOSTART`.
 :::
 
-The following airframes are supported
+The following airframes are supported.
 
-| SIH Airframe    | SYS_AUTOSTART | Status            |
-| --------------- | ------------- | ----------------- |
-| Quadrotor X     | 1100          | Stable            |
-| Airplane        | 1101          | Experimental      |
-| Tailsitter Duo  | 1102          | Experimental      |
-| Standard VTOL   | 1103          | Experimental      |
-| Ackermann Rover | 1104          | Experimental      |
-| Hexacopter X    | 1105          | Experimental      |
+| SIH Airframe    | SYS_AUTOSTART | Status       |
+| --------------- | ------------- | ------------ |
+| Quadrotor X     | 1100          | Stable       |
+| Airplane        | 1101          | Experimental |
+| Tailsitter Duo  | 1102          | Experimental |
+| Standard VTOL   | 1103          | Experimental |
+| Ackermann Rover | 1104          | Experimental |
+| Hexacopter X    | 1105          | Experimental |
 
 Once running, the vehicle can be controlled from QGroundControl or an RC controller.
 
@@ -37,7 +37,8 @@ Set `SIH_VEHICLE_TYPE` before building to limit included vehicle models.
 ## Firmware Builds with SIH
 
 The SIH module is included in many, but not all, default firmware builds.
-This list can change between PX4 releases. Always verify using the method in [Check if SIH is in Firmware](#check-if-sih-is-in-firmware).
+This list can change between PX4 releases.
+Always verify using the method in [Check if SIH is in Firmware](#check-if-sih-is-in-firmware).
 
 The table below lists build targets that include SIH at the time of writing:
 
@@ -102,13 +103,19 @@ You can add SIH to any board -- see [Check if SIH is in Firmware](#check-if-sih-
 
 ## Check if SIH is in Firmware
 
-SIH is included in most default firmware builds. To verify, search for `sih` in the parameter list in QGroundControl. If `SIH_*` parameters are available, the module is included.
+SIH is included in [most default firmware builds](#check-if-sih-is-in-firmware).
+To verify, search for `sih` in the parameter list in QGroundControl. If `SIH_*` parameters are available, the module is included.
 
 To add SIH to a custom build, enable it in the board configuration:
 
 ```txt
 CONFIG_MODULES_SIMULATION_SIMULATOR_SIH=y
 ```
+
+:::warning
+To save flash memory on boards with limited storage, SIH can be built with only quadrotor support.
+Set `SIH_VEHICLE_TYPE` before building to limit included vehicle models.
+:::
 
 ## Visualization (Optional) {#hardware-visualization}
 
@@ -132,7 +139,7 @@ On macOS, this is typically `/dev/tty.usbmodem*`.
 ## Controlling Actuators
 
 :::warning
-If you want to control throttling actuators in SIH, make sure to remove propellers for safety.
+If you want to control throttle actuators in SIH, make sure to remove propellers for safety.
 :::
 
 In some scenarios, it may be useful to control an actuator while running SIH on hardware. For example, you might want to verify that winches or grippers are functioning correctly by checking the servo responses.

--- a/docs/en/sim_sih/hardware.md
+++ b/docs/en/sim_sih/hardware.md
@@ -5,6 +5,35 @@ This replaces real sensors with simulated data while running on the actual autop
 
 For a comparison of SIH and HITL on hardware, see [Hardware Simulation](../simulation/hardware.md).
 
+## Starting SIH
+
+1. Connect the flight controller to QGroundControl via USB.
+2. Set `SYS_AUTOSTART` parameter to the desired airframe.
+3. Reboot the flight controller.
+4. The SIH module starts automatically and provides simulated sensor data.
+
+::: tip
+To ensure there is no leftover parameter from previous setup, it is recommended to reset all the parameters to firmware's default before modifying `SYS_AUTOSTART`.
+:::
+
+The following airframes are supported
+
+| SIH Airframe    | SYS_AUTOSTART | Status            |
+| --------------- | ------------- | ----------------- |
+| Quadrotor X     | 1100          | Stable            |
+| Airplane        | 1101          | Experimental      |
+| Tailsitter Duo  | 1102          | Experimental      |
+| Standard VTOL   | 1103          | Experimental      |
+| Ackermann Rover | 1104          | Experimental      |
+| Hexacopter X    | 1105          | Experimental      |
+
+Once running, the vehicle can be controlled from QGroundControl or an RC controller.
+
+:::warning
+To save flash memory on boards with limited storage, SIH can be built with only quadrotor support.
+Set `SIH_VEHICLE_TYPE` before building to limit included vehicle models.
+:::
+
 ## Firmware Builds with SIH
 
 The SIH module is included in many, but not all, default firmware builds.
@@ -80,20 +109,6 @@ To add SIH to a custom build, enable it in the board configuration:
 ```txt
 CONFIG_MODULES_SIMULATION_SIMULATOR_SIH=y
 ```
-
-## Starting SIH
-
-1. Connect the flight controller to QGroundControl via USB.
-2. Set `SYS_HITL` parameter to `2`.
-3. Reboot the flight controller.
-4. The SIH module starts automatically and provides simulated sensor data.
-
-Once running, the vehicle can be controlled from QGroundControl or an RC controller.
-
-:::warning
-To save flash memory on boards with limited storage, SIH can be built with only quadrotor support.
-Set `SIH_VEHICLE_TYPE` before building to limit included vehicle models.
-:::
 
 ## Visualization (Optional) {#hardware-visualization}
 

--- a/docs/en/sim_sih/hardware.md
+++ b/docs/en/sim_sih/hardware.md
@@ -29,11 +29,6 @@ The following airframes are supported.
 
 Once running, the vehicle can be controlled from QGroundControl or an RC controller.
 
-:::warning
-To save flash memory on boards with limited storage, SIH can be built with only quadrotor support.
-Set `SIH_VEHICLE_TYPE` before building to limit included vehicle models.
-:::
-
 ## Firmware Builds with SIH
 
 The SIH module is included in many, but not all, default firmware builds.

--- a/docs/en/sim_sih/hardware.md
+++ b/docs/en/sim_sih/hardware.md
@@ -107,11 +107,6 @@ To add SIH to a custom build, enable it in the board configuration:
 CONFIG_MODULES_SIMULATION_SIMULATOR_SIH=y
 ```
 
-:::warning
-To save flash memory on boards with limited storage, SIH can be built with only quadrotor support.
-Set `SIH_VEHICLE_TYPE` before building to limit included vehicle models.
-:::
-
 ## Visualization (Optional) {#hardware-visualization}
 
 If you need a visual aid to see what the simulated vehicle is doing on hardware:

--- a/docs/en/sim_sih/index.md
+++ b/docs/en/sim_sih/index.md
@@ -206,8 +206,25 @@ See [Port Reference](#port-reference) for the complete list of ports.
 
 ## SIH on Flight Controller Hardware {#sih-on-flight-controller-hardware}
 
-SIH can also run on flight controller hardware with `SYS_HITL=2`, replacing real sensors with simulated data while running on the actual autopilot.
-See [SIH on Flight Controller Hardware](hardware.md) for setup instructions.
+SIH can also run on flight controller hardware by replacing real sensors with simulated data while running on the actual autopilot. Setting it is a simple as selecting the appropriate SIH airframe. The easiest method to run the SIH Quadrotor X is to set the parameter `SYS_AUTOSTART=1100` then reboot the vehicle. 
+
+::: tip
+To ensure that the vehicles behaves well, it is recommended to reset all the parameters to firmware's default before modifying `SYS_AUTOSTART`.
+:::
+
+The following airframes are supported
+
+| SIH Airframe    | SYS_AUTOSTART | Status            |
+| --------------- | ------------- | ----------------- |
+| Quadrotor X     | 1100          | Stable            |
+| Airplane        | 1101          | Experimental      |
+| Tailsitter Duo  | 1102          | Experimental      |
+| Standard VTOL   | 1103          | Experimental      |
+| Ackermann Rover | 1104          | Experimental      |
+| Hexacopter X    | 1105          | Experimental      |
+
+
+See [SIH on Flight Controller Hardware](hardware.md) for more details and compilation instructions.
 
 ## Adding New Airframes
 

--- a/docs/en/sim_sih/index.md
+++ b/docs/en/sim_sih/index.md
@@ -204,7 +204,7 @@ Each instance allocates ports automatically (all offset by instance number):
 
 See [Port Reference](#port-reference) for the complete list of ports.
 
-## SIH on Flight Controller Hardware {#sih-on-flight-controller-hardware}
+## Running the SIH on Flight Controller Hardware {#sih-on-flight-controller-hardware}
 
 ::: info
 The SIH on flight controller is community supported.

--- a/docs/en/sim_sih/index.md
+++ b/docs/en/sim_sih/index.md
@@ -17,7 +17,7 @@ SIH runs as a PX4 module that replaces real sensor and actuator hardware with a 
 It provides simulated IMU, GPS, barometer, magnetometer, and airspeed sensor data via uORB, and reads actuator outputs to update the vehicle state at each timestep.
 
 The simulation runs in lockstep with PX4, ensuring deterministic and reproducible results.
-It also integrates seamlessly with ROS 2 via with no additional configuration (see [ROS 2 Integration](#ros-2-integration) below).
+It also integrates seamlessly with ROS 2 with no additional configuration (see [ROS 2 Integration](#ros-2-integration) below).
 
 Two modes are supported:
 
@@ -40,7 +40,7 @@ The following vehicle types are supported:
 | Ackermann Rover <Badge type="tip" text="PX4 v1.16" />           | `make px4_sitl_sih sihsim_rover`         | Experimental |
 
 ::: warning
-Only the quadrotor vehicle type is stable and recommended for development. All other vehicle types (hexarotor, fixed-wing, VTOL, rover) are experimental and may have aerodynamic model or controller interaction issues that produce unrealistic flight behavior.
+Only the quadrotor vehicle type is stable and recommended for development. All other vehicle types (hexarotor, fixed-wing, VTOL, rover) are experimental and may have aerodynamic model or controller interaction issues that produce unrealistic flight behaviour.
 :::
 
 ### How SIH Works
@@ -97,7 +97,7 @@ Flags:
 
 - `-a` for airplane model
 - `-t` for tailsitter model
-- `-o` enable display-only mode.
+- `-o` enables display-only mode.
 
 See [jMAVSim Display-Only Mode](../sim_jmavsim/index.md#display-only-mode) for details.
 
@@ -206,25 +206,12 @@ See [Port Reference](#port-reference) for the complete list of ports.
 
 ## SIH on Flight Controller Hardware {#sih-on-flight-controller-hardware}
 
-SIH can also run on flight controller hardware by replacing real sensors with simulated data while running on the actual autopilot. Setting it is a simple as selecting the appropriate SIH airframe. The easiest method to run the SIH Quadrotor X is to set the parameter `SYS_AUTOSTART=1100` then reboot the vehicle. 
-
-::: tip
-To ensure that the vehicles behaves well, it is recommended to reset all the parameters to firmware's default before modifying `SYS_AUTOSTART`.
+::: info
+The SIH on flight controller is community supported.
 :::
 
-The following airframes are supported
-
-| SIH Airframe    | SYS_AUTOSTART | Status            |
-| --------------- | ------------- | ----------------- |
-| Quadrotor X     | 1100          | Stable            |
-| Airplane        | 1101          | Experimental      |
-| Tailsitter Duo  | 1102          | Experimental      |
-| Standard VTOL   | 1103          | Experimental      |
-| Ackermann Rover | 1104          | Experimental      |
-| Hexacopter X    | 1105          | Experimental      |
-
-
-See [SIH on Flight Controller Hardware](hardware.md) for more details and compilation instructions.
+SIH can also run on flight controller hardware, replacing real sensors with simulated data while running on the actual autopilot.
+See [SIH on Flight Controller Hardware](hardware.md) for setup instructions.
 
 ## Adding New Airframes
 
@@ -259,11 +246,7 @@ The specific differences for SIH simulation airframes are listed in the sections
 
 ### SIH on Flight Controller
 
-::: warning
-The SIH on flight controller is community supported and might not work right away across different versions.
-:::
-
-SIH can also run on flight controller hardware by replacing real sensors with simulated data while running on the actual autopilot. Setting it is a simple as selecting the appropriate SIH airframe, refer to [SIH on Flight Controller](hardware.md).
+See [Adding New Airframes (FC)](../sim_sih/hardware.md#adding-new-airframes-fc) in _SIH on Flight Controller Hardware_.
 
 ### SIH as SITL
 
@@ -296,13 +279,16 @@ Since PX4 v1.17, the propeller model for fixed-wing, tailsitter, and VTOL pusher
 
 <img width="588" height="183" alt="UIUC_prop_equations" src="https://github.com/user-attachments/assets/55413486-b23b-4269-9ac5-dd630ec0849b" />
 
-This model includes the thrust coefficient CT(J) and power coefficient CP(J) as functions of the advance ratio J. As a result, the maximum thrust force is realistically reduced as the aircraft speed is increased. The SIH implements the thrust and power coeffients as second order polynomial fits
+This model includes the thrust coefficient CT(J) and power coefficient CP(J) as functions of the advance ratio J.
+As a result, the maximum thrust force is realistically reduced as the aircraft speed is increased.
+The SIH implements the thrust and power coefficients as second-order polynomial fits.
 
-CT = SIH_F_CT0 + SIH_F_CT1⋅J + SIH_F_CT2⋅J²
+$$C_T = \text{SIH\_F\_CT0} + \text{SIH\_F\_CT1} \cdot J + \text{SIH\_F\_CT2} \cdot J^2$$
 
-CP = SIH_F_CP0 + SIH_F_CP1⋅J + SIH_F_CP2⋅J²
+$$C_P = \text{SIH\_F\_CP0} + \text{SIH\_F\_CP1} \cdot J + \text{SIH\_F\_CP2} \cdot J^2$$
 
-If SIH_F_CT0 and SIH_F_CP0 and non zero positive, the SIH uses the model with advance ratio. If not, the SIH uses a simple model with maximum thrust force given by SIH_F_T_MAX and maximum torque given by SIH_F_Q_MAX.
+If `SIH_F_CT0` and `SIH_F_CP0` are non-zero and positive, the SIH uses the model with advance ratio.
+If not, the SIH uses a simple model with maximum thrust force given by `SIH_F_T_MAX` and maximum torque given by `SIH_F_Q_MAX`.
 
 **References:**
 

--- a/docs/en/sim_sih/index.md
+++ b/docs/en/sim_sih/index.md
@@ -259,7 +259,11 @@ The specific differences for SIH simulation airframes are listed in the sections
 
 ### SIH on Flight Controller
 
-For FC-specific airframe setup (file locations, `HIL_ACT_FUNC*` parameters), see [Adding New Airframes (FC)](hardware.md#adding-new-airframes-fc).
+::: warning
+The SIH on flight controller is community supported and might not work right away across different versions.
+:::
+
+SIH can also run on flight controller hardware by replacing real sensors with simulated data while running on the actual autopilot. Setting it is a simple as selecting the appropriate SIH airframe, refer to [SIH on Flight Controller](hardware.md).
 
 ### SIH as SITL
 
@@ -286,8 +290,19 @@ The dynamic models for the various vehicles are:
 - Tailsitter: based on Chiappinelli (2018), see references below
 - Rover: bicycle model with linear tire model
 
-Since PX4 v1.17, the propeller model for fixed-wing, tailsitter, and VTOL pusher vehicles is based on [UIUC propeller data](https://m-selig.ae.illinois.edu/props/propDB.html).
-The maximum thrust force is realistically reduced as aircraft speed increases.
+**Propeller model with advance ratio**
+
+Since PX4 v1.17, the propeller model for fixed-wing, tailsitter, and VTOL pusher vehicles is based on the equations from UIUC Propeller Database.
+
+<img width="588" height="183" alt="UIUC_prop_equations" src="https://github.com/user-attachments/assets/55413486-b23b-4269-9ac5-dd630ec0849b" />
+
+This model includes the thrust coefficient CT(J) and power coefficient CP(J) as functions of the advance ratio J. As a result, the maximum thrust force is realistically reduced as the aircraft speed is increased. The SIH implements the thrust and power coeffients as second order polynomial fits
+
+CT = SIH_F_CT0 + SIH_F_CT1⋅J + SIH_F_CT2⋅J²
+
+CP = SIH_F_CP0 + SIH_F_CP1⋅J + SIH_F_CP2⋅J²
+
+If SIH_F_CT0 and SIH_F_CP0 and non zero positive, the SIH uses the model with advance ratio. If not, the SIH uses a simple model with maximum thrust force given by SIH_F_T_MAX and maximum torque given by SIH_F_Q_MAX.
 
 **References:**
 
@@ -295,19 +310,20 @@ The maximum thrust force is realistically reduced as aircraft speed increases.
 2. W. Khan, "Dynamics modeling of agile fixed-wing unmanned aerial vehicles," Ph.D. thesis, Dept. of Mechanical Engineering, McGill University, Montreal, 2016.
 3. R. Chiappinelli, "Modeling and control of a flying wing tailsitter unmanned aerial vehicle," M.Sc. thesis, Dept. of Mechanical Engineering, McGill University, Montreal, 2018.
 4. S. Anumakonda, "Everything you need to know about Self-Driving Cars," 2021. [Link](https://srianumakonda.medium.com/everything-you-need-to-know-about-self-driving-in-30-minutes-b38d68bd3427)
+5. J.B. Brandt, R.W. Deters, G.K. Ananda, O.D. Dantsker, and M.S. Selig, UIUC Propeller Database, Vols 1-4, University of Illinois at Urbana-Champaign, Department of Aerospace Engineering, retrieved from https://m-selig.ae.illinois.edu/props/propDB.html.
 
 ## Video
 
-@[youtube](https://youtu.be/PzIpSCRD8Jo)
+SIH demo with a fixed-wing vehicle @[youtube](https://youtu.be/PzIpSCRD8Jo)  
+How to parametrize the thrust and power coefficients CT & CP @[youtube](https://www.youtube.com/watch?v=KNSd9ge0sSw)
 
 ## Credits
 
 SIH was originally developed by Coriolis g Corporation.
 The airplane model and tailsitter models were added by Altitude R&D inc.
-Both are Canadian companies:
 
 - Coriolis g developed a new type of Vertical Takeoff and Landing (VTOL) vehicles based on passive coupling systems;
-- [Altitude R&D](https://www.altitude-rd.com/) is specialized in dynamics, control, and real-time simulation (today relocated in Zurich).
+- [Altitude R&D](https://www.altitude-rd.com/) is specialized in dynamics, control, and real-time simulation (located in Zurich).
 
 The simulator is released for free under BSD license.
 

--- a/docs/en/sim_sih/index.md
+++ b/docs/en/sim_sih/index.md
@@ -283,9 +283,9 @@ This model includes the thrust coefficient CT(J) and power coefficient CP(J) as 
 As a result, the maximum thrust force is realistically reduced as the aircraft speed is increased.
 The SIH implements the thrust and power coefficients as second-order polynomial fits.
 
-$$C_T = \text{SIH\_F\_CT0} + \text{SIH\_F\_CT1} \cdot J + \text{SIH\_F\_CT2} \cdot J^2$$
+CT = SIH_F_CT0 + SIH_F_CT1⋅J + SIH_F_CT2⋅J²
 
-$$C_P = \text{SIH\_F\_CP0} + \text{SIH\_F\_CP1} \cdot J + \text{SIH\_F\_CP2} \cdot J^2$$
+CP = SIH_F_CP0 + SIH_F_CP1⋅J + SIH_F_CP2⋅J²
 
 If `SIH_F_CT0` and `SIH_F_CP0` are non-zero and positive, the SIH uses the model with advance ratio.
 If not, the SIH uses a simple model with maximum thrust force given by `SIH_F_T_MAX` and maximum torque given by `SIH_F_Q_MAX`.


### PR DESCRIPTION
Updated the section on running SIH on flight controller hardware, including setup instructions and supported airframes.

Adding documentation about the CT CP parameters.

<!--

### Solved Problem
The SIH Airframes were not listed

### Solution
listing them in a table


### Alternatives

### Test coverage

### Context
[PR26720](https://github.com/PX4/PX4-Autopilot/pull/26720#issuecomment-4217180421)

-->
