### PR TITLE
fix(ekf2): fix observation_variance unit mismatch in comparison

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
@@ -378,13 +378,14 @@ void Ekf::controlGnssYawEstimator(estimator_aid_source3d_s &aid_src_vel)
 {
 	// update yaw estimator velocity (basic sanity check on GNSS velocity data)
 	const float vel_var = aid_src_vel.observation_variance[0];
+	const float vel_accuracy = sqrtf(vel_var);
 	const Vector2f vel_xy(aid_src_vel.observation);
 
 	if ((vel_var > 0.f)
-	    && (vel_var < _params.ekf2_req_sacc)
+	    && (vel_accuracy < _params.ekf2_req_sacc)
 	    && vel_xy.isAllFinite()) {
 
-		_yawEstimator.fuseVelocity(vel_xy, vel_var, _control_status.flags.in_air);
+		_yawEstimator.fuseVelocity(vel_xy, vel_accuracy, _control_status.flags.in_air);
 
 		// Try to align yaw using estimate if available
 		if (((_params.ekf2_gps_ctrl & static_cast<int32_t>(GnssCtrl::VEL))


### PR DESCRIPTION
### Solved Problem
This PR fixes a units mismatch in `Ekf::controlGnssYawEstimator()`.
Previously, the code used `aid_src_vel.observation_variance[0]` (vel_var, in m^2/s^2) as if it were a 1-sigma speed accuracy (m/s):
* compared directly against `EKF2_REQ_SACC` (m/s)
* passed directly to `EKFGSF_yaw::fuseVelocity()`, which expects 1-sigma accuracy (m/s)
### Changelog Entry
For release notes:
```
Bugfix: fix observation_variance unit mismatch in comparison
```