### PR TITLE
fix(mavlink): reset mission sequence on platform restart

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -83,16 +83,6 @@ MavlinkMissionManager::MavlinkMissionManager(Mavlink &mavlink) :
 							sizeof(mission_s));
 
 		if (success) {
-			// Do not resume a previously persisted mission item after a platform restart.
-			if (mission_state.current_seq != 0) {
-				mission_state.current_seq = 0;
-
-				if (!_dataman_client.writeSync(DM_KEY_MISSION_STATE, 0, reinterpret_cast<uint8_t *>(&mission_state),
-							       sizeof(mission_s))) {
-					PX4_WARN("mission state seq reset failed");
-				}
-			}
-
 			init_offboard_mission(mission_state);
 			load_geofence_stats();
 			load_safepoint_stats();

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -83,6 +83,16 @@ MavlinkMissionManager::MavlinkMissionManager(Mavlink &mavlink) :
 							sizeof(mission_s));
 
 		if (success) {
+			// Do not resume a previously persisted mission item after a platform restart.
+			if (mission_state.current_seq != 0) {
+				mission_state.current_seq = 0;
+
+				if (!_dataman_client.writeSync(DM_KEY_MISSION_STATE, 0, reinterpret_cast<uint8_t *>(&mission_state),
+							       sizeof(mission_s))) {
+					PX4_WARN("mission state seq reset failed");
+				}
+			}
+
 			init_offboard_mission(mission_state);
 			load_geofence_stats();
 			load_safepoint_stats();

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -749,8 +749,8 @@ MissionBase::report_do_jump_mission_changed(int index, int do_jumps_remaining)
 void
 MissionBase::checkMissionRestart()
 {
-	if (_system_disarmed_while_inactive && _mission_has_been_activated && (_mission.count > 0U)
-	    && ((_mission.current_seq + 1) == _mission.count)) {
+	if (_system_disarmed_while_inactive && (_mission.count > 0U)
+	    && (!_mission_has_been_activated || (_mission.current_seq + 1) == _mission.count)) {
 		setMissionIndex(0);
 		_inactivation_index = -1; // reset
 		_is_current_planned_mission_item_valid = isMissionValid();


### PR DESCRIPTION
### Solved Problem
Fixes #14981

After a platform reboot, PX4 could restore the previously persisted `mission_state.current_seq` from Dataman and continue reporting the old active mission item. As a result, the vehicle could resume a stale waypoint from the previous run, for example a landing waypoint, instead of starting the mission again from the first waypoint.

### Solution
Reset the persisted `mission_state.current_seq` to `0` during `MavlinkMissionManager` initialization on startup, before the mission state is republished.

This keeps the uploaded mission itself intact:
- mission items remain stored in Dataman
- mission count and mission identifiers remain unchanged
- only the active mission sequence is reset

With this change, after a reboot the platform starts with the same mission, but with the current mission item reset to the first waypoint.

### Changelog Entry
For release notes:
```text
Bugfix: Reset persisted mission current waypoint to the first mission item after reboot