### PR TITLE
ci(fuzzing): migrate to RunsOn with ccache and bump container

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -12,19 +12,24 @@ env:
 
 jobs:
   Fuzzing:
-    runs-on: ubuntu-latest
+    runs-on: [runs-on,runner=4cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
     container:
-      image: px4io/px4-dev:v1.16.0-rc2-4-gb67c65bfe6
+      image: ghcr.io/px4/px4-dev:v1.17.0-rc2
     steps:
-      - name: Install Dependencies
-        run: |
-          apt update && apt install -y clang
-
-      - name: Fix git in Container
-        run: |
-          git config --global --add safe.directory $(realpath .)
+      - uses: runs-on/action@v2
 
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Configure Git Safe Directory
+        run: git config --system --add safe.directory '*'
+
+      - uses: ./.github/actions/setup-ccache
+        id: ccache
+        with:
+          cache-key-prefix: ccache-sitl
+          max-size: 300M
 
       - name: Build and Run Fuzz Tests
         run: |
@@ -38,7 +43,11 @@ jobs:
             ./Tools/ci/run_fuzz_tests.sh $fuzz_binary 15m
           done
 
-      # Create a github issue in case of a failure
+      - uses: ./.github/actions/save-ccache
+        if: always()
+        with:
+          cache-primary-key: ${{ steps.ccache.outputs.cache-primary-key }}
+
       - name: Create Issue
         if: ${{ failure() }}
         uses: JasonEtco/create-an-issue@v2


### PR DESCRIPTION
Migrates the fuzzing workflow from GitHub-hosted `ubuntu-latest` to RunsOn 4cpu with `extras=s3-cache` and `runs-on/action@v2`. Bumps the container from the stale `px4io/px4-dev:v1.16.0-rc2-4-gb67c65bfe6` to `ghcr.io/px4/px4-dev:v1.17.0-rc2`.

Wires `setup-ccache` / `save-ccache` with `cache-key-prefix: ccache-sitl` and `max-size: 300M`, sharing the SITL build cache with `checks.yml:tests`. Both targets build `px4_sitl_test` / `px4_sitl_default` so the ccache contents overlap. The build phase should be a near-instant cache hit on warm runs.

The `v1.17.0-rc2` container already ships clang, so the manual `apt install clang` step is dropped.

This workflow runs on a daily cron schedule, not on PRs, so it won't show up in the CI check list. It will run on the next scheduled trigger after merge.