### PR TITLE
fix(boards): remove default SYS_AUTOSTART from generic autopilot boards

### DIFF
--- a/boards/corvon/743v1/init/rc.board_defaults
+++ b/boards/corvon/743v1/init/rc.board_defaults
@@ -13,7 +13,6 @@ param set-default PWM_MAIN_TIM0 -4
 param set-default RC_INPUT_PROTO -1
 
 param set-default IMU_GYRO_CUTOFF 80
-param set-default SYS_AUTOSTART 4001
 param set-default MC_PITCHRATE_K 0.4
 param set-default MC_ROLLRATE_K 0.35
 param set-default MC_YAWRATE_K 1.2

--- a/boards/flywoo/gn-f405/init/rc.board_defaults
+++ b/boards/flywoo/gn-f405/init/rc.board_defaults
@@ -3,9 +3,6 @@
 # Flywoo GNF405 board specific defaults
 #------------------------------------------------------------------------------
 
-# default airframe quadrotor
-param set-default SYS_AUTOSTART 4001
-
 # system_power unavailable
 param set-default CBRK_SUPPLY_CHK 894281
 

--- a/boards/hkust/nxt-dual/init/rc.board_defaults
+++ b/boards/hkust/nxt-dual/init/rc.board_defaults
@@ -13,7 +13,6 @@ param set-default PWM_MAIN_TIM0 -4
 param set-default RC_INPUT_PROTO -1
 
 param set-default IMU_GYRO_RATEMAX 2000
-param set-default SYS_AUTOSTART 4001
 param set-default MC_PITCHRATE_K 0.4
 param set-default MC_ROLLRATE_K 0.35
 param set-default MC_YAWRATE_K 1.2

--- a/boards/holybro/kakutef7/init/rc.board_defaults
+++ b/boards/holybro/kakutef7/init/rc.board_defaults
@@ -9,9 +9,6 @@ param set-default BAT1_A_PER_V 17
 # system_power unavailable
 param set-default CBRK_SUPPLY_CHK 894281
 
-# Select the Generic 250 Racer by default
-param set-default SYS_AUTOSTART 4050
-
 param set-default SYS_HAS_MAG 0
 
 # enable gravity fusion

--- a/boards/holybro/kakuteh7/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7/init/rc.board_defaults
@@ -19,9 +19,6 @@ param set-default BAT1_A_PER_V 59.5
 # system_power unavailable
 param set-default CBRK_SUPPLY_CHK 894281
 
-# Select the Generic 250 Racer by default
-param set-default SYS_AUTOSTART 4050
-
 # use EKF2 without mag
 param set-default SYS_HAS_MAG 0
 # and enable gravity fusion

--- a/boards/holybro/kakuteh7dualimu/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7dualimu/init/rc.board_defaults
@@ -19,9 +19,6 @@ param set-default BAT1_A_PER_V 59.5
 # system_power unavailable
 param set-default CBRK_SUPPLY_CHK 894281
 
-# Select the Generic 250 Racer by default
-param set-default SYS_AUTOSTART 4050
-
 # use EKF2 without mag
 param set-default SYS_HAS_MAG 0
 # and enable gravity fusion

--- a/boards/holybro/kakuteh7mini/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7mini/init/rc.board_defaults
@@ -19,9 +19,6 @@ param set-default BAT1_A_PER_V 59.5
 # system_power unavailable
 param set-default CBRK_SUPPLY_CHK 894281
 
-# Select the Generic 250 Racer by default
-param set-default SYS_AUTOSTART 4050
-
 # use EKF2 without mag
 param set-default SYS_HAS_MAG 0
 # and enable gravity fusion

--- a/boards/holybro/kakuteh7v2/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7v2/init/rc.board_defaults
@@ -19,9 +19,6 @@ param set-default BAT1_A_PER_V 59.5
 # system_power unavailable
 param set-default CBRK_SUPPLY_CHK 894281
 
-# Select the Generic 250 Racer by default
-param set-default SYS_AUTOSTART 4050
-
 # use EKF2 without mag
 param set-default SYS_HAS_MAG 0
 # and enable gravity fusion

--- a/boards/micoair/h743-aio/init/rc.board_defaults
+++ b/boards/micoair/h743-aio/init/rc.board_defaults
@@ -13,7 +13,6 @@ param set-default PWM_MAIN_TIM0 -4
 param set-default RC_INPUT_PROTO -1
 
 param set-default IMU_GYRO_CUTOFF 100
-param set-default SYS_AUTOSTART 4001
 param set-default MC_PITCHRATE_K 0.4
 param set-default MC_ROLLRATE_K 0.35
 param set-default MC_YAWRATE_K 1.2

--- a/boards/micoair/h743-lite/init/rc.board_defaults
+++ b/boards/micoair/h743-lite/init/rc.board_defaults
@@ -17,7 +17,6 @@ param set-default MAV_2_CONFIG 104
 param set-default SER_TEL4_BAUD 115200
 
 param set-default IMU_GYRO_CUTOFF 80
-param set-default SYS_AUTOSTART 4001
 param set-default MC_PITCHRATE_K 0.4
 param set-default MC_ROLLRATE_K 0.35
 param set-default MC_YAWRATE_K 1.2

--- a/boards/micoair/h743-v2/init/rc.board_defaults
+++ b/boards/micoair/h743-v2/init/rc.board_defaults
@@ -16,7 +16,6 @@ param set-default MAV_2_CONFIG 104
 param set-default SER_TEL4_BAUD 115200
 
 param set-default IMU_GYRO_CUTOFF 80
-param set-default SYS_AUTOSTART 4001
 param set-default MC_PITCHRATE_K 0.4
 param set-default MC_ROLLRATE_K 0.35
 param set-default MC_YAWRATE_K 1.2

--- a/boards/micoair/h743/init/rc.board_defaults
+++ b/boards/micoair/h743/init/rc.board_defaults
@@ -13,7 +13,6 @@ param set-default PWM_MAIN_TIM0 -4
 param set-default RC_INPUT_PROTO -1
 
 param set-default IMU_GYRO_CUTOFF 80
-param set-default SYS_AUTOSTART 4001
 param set-default MC_PITCHRATE_K 0.4
 param set-default MC_ROLLRATE_K 0.35
 param set-default MC_YAWRATE_K 1.2

--- a/boards/spracing/h7extreme/init/rc.board_defaults
+++ b/boards/spracing/h7extreme/init/rc.board_defaults
@@ -9,7 +9,4 @@ param set-default BAT1_A_PER_V 17
 # system_power unavailable
 param set-default CBRK_SUPPLY_CHK 894281
 
-# Select the Generic 250 Racer by default
-param set-default SYS_AUTOSTART 4050
-
 param set-default SYS_HAS_MAG 0

--- a/boards/x-mav/ap-h743r1/init/rc.board_defaults
+++ b/boards/x-mav/ap-h743r1/init/rc.board_defaults
@@ -13,7 +13,6 @@ param set-default PWM_MAIN_TIM0 -4
 param set-default RC_INPUT_PROTO -1
 
 param set-default IMU_GYRO_RATEMAX 2000
-param set-default SYS_AUTOSTART 4001
 param set-default MC_PITCHRATE_K 0.4
 param set-default MC_ROLLRATE_K 0.35
 param set-default MC_YAWRATE_K 1.2

--- a/boards/x-mav/ap-h743v2/init/rc.board_defaults
+++ b/boards/x-mav/ap-h743v2/init/rc.board_defaults
@@ -13,7 +13,6 @@ param set-default PWM_MAIN_TIM0 -4
 param set-default RC_INPUT_PROTO -1
 
 param set-default IMU_GYRO_RATEMAX 2000
-param set-default SYS_AUTOSTART 4001
 param set-default MC_PITCHRATE_K 0.4
 param set-default MC_ROLLRATE_K 0.35
 param set-default MC_YAWRATE_K 1.2


### PR DESCRIPTION
These are generic flight controller boards (not drone-specific products), so they should not come with a pre-selected airframe like every other PX4 board. Drop the SYS_AUTOSTART default, matching the convention used across the rest of the tree.

Drone-specific products (bitcraze/crazyflie, atl/mantis-edu) retain their default airframe.

Any objections @dakejahl?