### PR TITLE
ci(compile-ubuntu): replace quick_check with targeted builds

### DIFF
--- a/.github/workflows/compile_ubuntu.yml
+++ b/.github/workflows/compile_ubuntu.yml
@@ -63,8 +63,11 @@ jobs:
           cache-key-prefix: ccache-ubuntu-${{ matrix.version }}
           max-size: 200M
 
-      - name: Make Quick Check
-        run: make quick_check
+      - name: Build px4_sitl_default
+        run: make px4_sitl_default
+
+      - name: Build px4_fmu-v5_default
+        run: make px4_fmu-v5_default
 
       - uses: ./.github/actions/save-ccache
         if: always()


### PR DESCRIPTION
Replaces `make quick_check` with two explicit build targets: `px4_sitl_default` (native SITL toolchain) and `px4_fmu-v5_default` (NuttX cross-compile toolchain).

`quick_check` built four targets including `tests` and `check_format` which are already covered by `checks.yml`. Two targeted builds are sufficient to validate that PX4 builds from a fresh `./Tools/setup/ubuntu.sh` install.

Expected duration per matrix entry drops from 16-17 min to 6-8 min.