### PR TITLE
fix(fuzzing): revert to old container image

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -14,16 +14,17 @@ jobs:
   Fuzzing:
     runs-on: [runs-on,runner=4cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
     container:
-      image: ghcr.io/px4/px4-dev:v1.17.0-rc2
+      image: px4io/px4-dev:v1.16.0-rc2-4-gb67c65bfe6
     steps:
       - uses: runs-on/action@v2
 
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
 
       - name: Configure Git Safe Directory
         run: git config --system --add safe.directory '*'
+
+      - name: Install clang
+        run: apt-get update && apt-get install -y clang
 
       - uses: ./.github/actions/setup-ccache
         id: ccache


### PR DESCRIPTION
Reverts the fuzzing workflow to `px4io/px4-dev:v1.16.0-rc2-4-gb67c65bfe6`. The `v1.17.0-rc2` container's clang 18 breaks abseil's cmake configure (C++17 and pthreads try_compile tests fail). Verified locally: old container passes, new container fails, `apt install clang` on the new container is a no-op since clang 18 is already installed.

Also removes the explicit `fetch-depth: 0` from the previous fix attempt since the original workflow used the default depth and worked fine.

The clang 18 + cmake 3.28 + abseil incompatibility needs to be fixed in the container image separately.

Fixes #27060