### PR TITLE
fix(boards/saam_saampixv1_1): correct firmware board_id to 200

### DIFF
--- a/boards/saam/saampixv1_1/firmware.prototype
+++ b/boards/saam/saampixv1_1/firmware.prototype
@@ -1,5 +1,5 @@
 {
-    "board_id": 1,
+    "board_id": 200,
     "magic": "PX4FWv1",
     "description": "Firmware for the SaamPixV1_1 board",
     "image": "", 


### PR DESCRIPTION
Summary

Correct the SaamPix v1.1 firmware package metadata to use the registered bootloader board ID.

Problem

PR #26902 set firmware.prototype board_id to 1.
The bootloader maps TARGET_HW_SAAMPIX_V1_1 to board ID 200, which caused uploader-side board mismatch failures when flashing the generated .px4 artifact.

Fix
Change boards/saam/saampixv1_1/firmware.prototype board_id: 1 → 200
Validation
Rebuilt firmware locally for saam_saampixv1_1_default
Verified the generated .px4 header advertises board_id: 200
Confirmed bootloader runtime reports BOARD_ID=200, VID:PID=26AC:008E (fixed in PX4-Bootloader #265)
End-to-end GCS communication confirmed working ✅
Related PRs
PX4-Autopilot #26902 — initial board support (merged)
PX4-Bootloader #264 — bootloader target and board type mapping (merged)
PX4-Bootloader #265 — runtime board ID fix: BOARD_TYPE set to numeric 200 (merged)