### PR TITLE
camera_trigger: fix interval command to apply at runtime

### DIFF
--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -618,6 +618,7 @@ CameraTrigger::Run()
 			if (cmd.param1 > 0.0f) {
 				_interval = cmd.param1;
 				param_set_no_notification(_p_interval, &(_interval));
+				update_intervalometer();
 			}
 
 			// We can only control the shutter integration time of the camera in GPIO mode


### PR DESCRIPTION
### Solved Problem
When a companion computer sends `MAV_CMD_DO_SET_CAM_TRIGG_INTERVAL` (e.g. via DDS or MAVLink), the new interval value is saved to the parameter store but the running trigger timer is not updated. The camera keeps firing at the old rate until the FMU is restarted.

### Solution
- Call `update_intervalometer()` after the interval is updated in the `DO_SET_CAM_TRIGG_INTERVAL` handler. This reschedules the trigger timer with the new interval immediately. The function already guards with `if (_trigger_enabled && !_trigger_paused)` so it only takes effect when triggering is active. This is consistent with how `DO_SET_CAM_TRIGG_DIST` already applies its changes at runtime.

### Changelog Entry
```
Bugfix: camera_trigger interval change now applies at runtime without requiring a restart
```

### Test coverage
- Bench tested via ROS2 DDS: sending `DO_SET_CAM_TRIGG_INTERVAL` command and verifying camera_trigger uORB rate changes immediately without FMU restart