### PR TITLE
fix(airframes/10043): Fix pusher being too weak

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10043_sihsim_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10043_sihsim_standard_vtol
@@ -93,5 +93,18 @@ param set SIH_IXZ 0
 param set SIH_KDV 0.2
 param set SIH_L_ROLL 0.2
 
+# pusher propeller model with advance ratio, model from UIUC APC 8x6"
+param set SIH_F_T_MAX 6
+param set SIH_F_Q_MAX 0.03
+# if SIH_F_CT0 > 0, SIH_F_T_MAX and SIH_F_Q_MAX will be overridden
+param set SIH_F_CT0 0.131
+param set SIH_F_CT1 0.004
+param set SIH_F_CT2 -0.146
+param set SIH_F_CP0 0.0777
+param set SIH_F_CP1 0.0498
+param set SIH_F_CP2 -0.11
+param set SIH_F_DIA_INCH 8
+param set SIH_F_RPM_MAX 9000
+
 # sih as standard vtol
 param set SIH_VEHICLE_TYPE 3


### PR DESCRIPTION
### Problem 

The airframe 10043 (`make px4_sitl sihsim_standard_vtol`) currently does not have enough forward thrust to reach `VT_ARSP_TRANS` (10) or `VT_ARSP_BLEND` (8), so we get front transition timeouts.

### Root cause

#26720 breaks it: The PR introduces a new dynamic prop model, which is now used in the airframes 1101, 1102, 1103, and 1105 (new addition), but not 10043.

The PR also removes a previous magic number that gave the standard VTOL pusher twice the max thrust of the hover motors (2 * 2N = 4N). It introduces a separate `SIH_F_T_MAX`, but by default it is 2N, causing the weak pusher for 10043.

### Solution

Fix by using the new dynamic propeller model by default, with the same params that #26720 introduces for airframe 1103 (It would also suffice to only set `SIH_F_T_MAX=6`, but now that we have the nicer model let's use it).


### Context

Note that 10041 (`sihsim_airplane`) is not broken by #26720 in this way, as it already has `SIH_T_MAX` of 6N, and the now removed magic number was specific to standard VTOL airframes.
