### PR TITLE
chore(claude): update commit and pr skills

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: commit
 description: Create a conventional commit for PX4 changes
-disable-model-invocation: true
 argument-hint: "[optional: description of changes]"
 allowed-tools: Bash, Read, Glob, Grep
 ---
@@ -19,7 +18,7 @@ Follow [CONTRIBUTING.md](../../CONTRIBUTING.md) for full project conventions.
 1. **Read [CONTRIBUTING.md](../../CONTRIBUTING.md)** for commit message format, types, scopes, and conventions.
 2. Check branch (`git branch --show-current`). If on `main`, create a feature branch. Use `<username>/<description>` format where `<username>` comes from `gh api user --jq .login`. If unavailable, just use `<description>`.
 3. Run `git status` and `git diff --staged`. If nothing staged, ask what to stage.
-4. Follow the commit message convention from CONTRIBUTING.md: pick the correct **type** and **scope**, write a concise imperative description.
+4. Follow the commit message convention from CONTRIBUTING.md: pick the correct **type** and **scope**, write a concise imperative description. The scope table is not exhaustive — derive the scope from the directory path of the changed files.
 5. Body (if needed): explain **why**, not what.
 6. Run `make format` or `./Tools/astyle/fix_code_style.sh <file>` on changed C/C++ files before committing.
 7. Check if GPG signing is available: `git config --get user.signingkey`. If set, use `git commit -S -s`. Otherwise, use `git commit -s`.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pr
 description: Create a pull request with conventional commit title and description
-disable-model-invocation: true
 argument-hint: "[optional: target branch or description]"
 allowed-tools: Bash, Read, Glob, Grep
 ---


### PR DESCRIPTION
## Summary

- Remove `disable-model-invocation` from `commit` and `pr` skills so Claude can auto-invoke them
- Clarify in commit skill that scopes should be derived from directory paths, not limited to the table in CONTRIBUTING.md