### PR TITLE
docs(boards/nxp/tropic-community): correct serial port mapping comments

### DIFF
--- a/boards/nxp/tropic-community/init/rc.board_sensors
+++ b/boards/nxp/tropic-community/init/rc.board_sensors
@@ -5,10 +5,10 @@
 #
 # UART mapping on Tropic Community:
 #
-# LPUART5       /dev/ttyS0      CONSOLE
-# LPUART3       /dev/ttyS1      GPS
-# LPUART2       /dev/ttyS2      TELEM1
-# LPUART4       /dev/ttyS3      TELEM2
+# LPUART5       /dev/ttyS0      DEBUG
+# LPUART3       /dev/ttyS2      TELEM
+# LPUART2       /dev/ttyS1      GPS
+# LPUART4       /dev/ttyS3      AUX
 # LPUART8       /dev/ttyS4      RC
 #
 #------------------------------------------------------------------------------


### PR DESCRIPTION
### Solved Problem
The serial port mapping comments have the GPS and TELEM1 swapped so it is confusing.

### Solution
Correct the comments and modify the names to show them as they appear on the board.
