### PR TITLE
fix(bootloader): remove broken PROTO_SET_DELAY boot-delay feature

### DIFF
--- a/Tools/px4_uploader.py
+++ b/Tools/px4_uploader.py
@@ -198,7 +198,6 @@ class BootloaderCommand(IntEnum):
     GET_OTP = 0x2A  # rev4+, get a word from OTP area
     GET_SN = 0x2B  # rev4+, get a word from SN area
     GET_CHIP = 0x2C  # rev5+, get chip version
-    SET_BOOT_DELAY = 0x2D  # rev5+, set boot delay
     GET_CHIP_DES = 0x2E  # rev5+, get chip description in ASCII
     GET_VERSION = 0x2F  # rev5+, get bootloader version in ASCII
     REBOOT = 0x30
@@ -1148,20 +1147,6 @@ class BootloaderProtocol:
         else:
             self.verify_read(firmware, progress_callback)
 
-    def set_boot_delay(self, delay_ms: int) -> None:
-        """Set boot delay in flash (v5+).
-
-        Args:
-            delay_ms: Boot delay in milliseconds
-        """
-        if self.bl_rev < 5:
-            logger.warning("Boot delay requires bootloader v5+")
-            return
-
-        self._send_command(BootloaderCommand.SET_BOOT_DELAY, struct.pack("b", delay_ms))
-        self._get_sync()
-        logger.info(f"Boot delay set to {delay_ms}ms")
-
     def reboot(self) -> None:
         """Reboot into the application.
 
@@ -1569,7 +1554,6 @@ class UploaderConfig:
     baud_flightstack: list[int] = field(default_factory=lambda: [57600])
     force: bool = False
     force_erase: bool = False
-    boot_delay: Optional[int] = None
     use_protocol_splitter: bool = False
     retry_count: int = 3
     windowed: bool = False
@@ -1924,10 +1908,6 @@ class Uploader:
         # Verify
         protocol.verify(firmware, progress_callback=progress.update_verify)
 
-        # Set boot delay if requested
-        if self.config.boot_delay is not None:
-            protocol.set_boot_delay(self.config.boot_delay)
-
         # Reboot and show summary
         protocol.reboot()
         progress.finish()
@@ -2010,9 +1990,6 @@ Examples:
         help="Force full chip erase (v6+ bootloader)",
     )
     parser.add_argument(
-        "--boot-delay", type=int, help="Boot delay in milliseconds to store in flash"
-    )
-    parser.add_argument(
         "--use-protocol-splitter-format",
         action="store_true",
         help="Use protocol splitter framing for reboot commands",
@@ -2068,7 +2045,6 @@ Examples:
         baud_flightstack=baud_flightstack,
         force=args.force,
         force_erase=args.force_erase,
-        boot_delay=args.boot_delay,
         use_protocol_splitter=args.use_protocol_splitter_format,
         windowed=args.windowed,
         noninteractive=args.noninteractive or args.noninteractive_json,

--- a/Tools/teensy_uploader.py
+++ b/Tools/teensy_uploader.py
@@ -80,7 +80,6 @@ def main():
     parser = argparse.ArgumentParser(description="Firmware uploader for the PX autopilot system.")
     parser.add_argument('--port', action="store", required=True, help="Comma-separated list of serial port(s) to which the FMU may be attached")
     parser.add_argument('--force', action='store_true', default=False, help='Override board type check, or silicon errata checks and continue loading')
-    parser.add_argument('--boot-delay', type=int, default=None, help='minimum boot delay to store in flash')
     parser.add_argument('--vendor-id', type=lambda x: int(x,0), default=None, help='PX4 USB vendorid')
     parser.add_argument('--product-id', type=lambda x: int(x,0), default=None, help='PX4 USB productid')
     parser.add_argument('firmware', action="store", nargs='+', help="Firmware file(s)")

--- a/boards/3dr/ctrl-zero-h7-oem-revg/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/3dr/ctrl-zero-h7-oem-revg/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/3dr/ctrl-zero-h7-oem-revg/nuttx-config/scripts/script.ld
+++ b/boards/3dr/ctrl-zero-h7-oem-revg/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/3dr/ctrl-zero-h7-oem-revg/src/hw_config.h
+++ b/boards/3dr/ctrl-zero-h7-oem-revg/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1124
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/accton-godwit/ga1/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/accton-godwit/ga1/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/accton-godwit/ga1/nuttx-config/scripts/script.ld
+++ b/boards/accton-godwit/ga1/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/accton-godwit/ga1/src/hw_config.h
+++ b/boards/accton-godwit/ga1/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,1500000"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     7120
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/airmind/mindpx-v2/nuttx-config/scripts/script.ld
+++ b/boards/airmind/mindpx-v2/nuttx-config/scripts/script.ld
@@ -65,20 +65,12 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/ark/can-flow-mr/nuttx-config/scripts/script.ld
+++ b/boards/ark/can-flow-mr/nuttx-config/scripts/script.ld
@@ -64,8 +64,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/ark/can-flow/nuttx-config/scripts/script.ld
+++ b/boards/ark/can-flow/nuttx-config/scripts/script.ld
@@ -64,8 +64,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/ark/can-gps/nuttx-config/scripts/script.ld
+++ b/boards/ark/can-gps/nuttx-config/scripts/script.ld
@@ -64,8 +64,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/ark/can-rtk-gps/nuttx-config/scripts/script.ld
+++ b/boards/ark/can-rtk-gps/nuttx-config/scripts/script.ld
@@ -64,8 +64,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/ark/cannode/nuttx-config/scripts/script.ld
+++ b/boards/ark/cannode/nuttx-config/scripts/script.ld
@@ -64,8 +64,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/ark/dist/nuttx-config/scripts/script.ld
+++ b/boards/ark/dist/nuttx-config/scripts/script.ld
@@ -64,8 +64,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/ark/f9p-gps/nuttx-config/scripts/script.ld
+++ b/boards/ark/f9p-gps/nuttx-config/scripts/script.ld
@@ -64,8 +64,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/ark/fmu-v6x/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/ark/fmu-v6x/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/ark/fmu-v6x/nuttx-config/scripts/script.ld
+++ b/boards/ark/fmu-v6x/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/ark/fmu-v6x/src/hw_config.h
+++ b/boards/ark/fmu-v6x/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     57
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/ark/fpv/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/ark/fpv/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/ark/fpv/nuttx-config/scripts/script.ld
+++ b/boards/ark/fpv/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/ark/fpv/src/hw_config.h
+++ b/boards/ark/fpv/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,921600"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     59
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (14)

--- a/boards/ark/mag/nuttx-config/scripts/script.ld
+++ b/boards/ark/mag/nuttx-config/scripts/script.ld
@@ -64,8 +64,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/ark/pi6x/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/ark/pi6x/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/ark/pi6x/nuttx-config/scripts/script.ld
+++ b/boards/ark/pi6x/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/ark/pi6x/src/hw_config.h
+++ b/boards/ark/pi6x/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS5,921600"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     58
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (14)

--- a/boards/ark/septentrio-gps/nuttx-config/scripts/script.ld
+++ b/boards/ark/septentrio-gps/nuttx-config/scripts/script.ld
@@ -64,8 +64,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/ark/teseo-gps/nuttx-config/scripts/script.ld
+++ b/boards/ark/teseo-gps/nuttx-config/scripts/script.ld
@@ -64,8 +64,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/ark/x20-gps/nuttx-config/scripts/script.ld
+++ b/boards/ark/x20-gps/nuttx-config/scripts/script.ld
@@ -64,8 +64,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/atl/mantis-edu/nuttx-config/scripts/script.ld
+++ b/boards/atl/mantis-edu/nuttx-config/scripts/script.ld
@@ -90,7 +90,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(_main_toc)
 
 SECTIONS
@@ -99,12 +98,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xb4ecc2925d7d05c5)
-		. += 8;
 		*(.main_toc)
 		*(.text .text.*)
 		*(.fixup)

--- a/boards/auterion/fmu-v6s/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/auterion/fmu-v6s/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/auterion/fmu-v6s/nuttx-config/scripts/script.ld
+++ b/boards/auterion/fmu-v6s/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/auterion/fmu-v6s/src/hw_config.h
+++ b/boards/auterion/fmu-v6s/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -64,7 +62,6 @@
 #define INTERFACE_USB                  0
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,1500000"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     60
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/auterion/fmu-v6x/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/auterion/fmu-v6x/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/auterion/fmu-v6x/nuttx-config/scripts/script.ld
+++ b/boards/auterion/fmu-v6x/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/auterion/fmu-v6x/src/hw_config.h
+++ b/boards/auterion/fmu-v6x/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -65,7 +63,6 @@
 #define INTERFACE_USB                  0
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,1500000"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     53
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/av/x-v1/nuttx-config/scripts/script.ld
+++ b/boards/av/x-v1/nuttx-config/scripts/script.ld
@@ -89,20 +89,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/bitcraze/crazyflie/nuttx-config/scripts/script.ld
+++ b/boards/bitcraze/crazyflie/nuttx-config/scripts/script.ld
@@ -72,12 +72,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/bitcraze/crazyflie21/nuttx-config/scripts/script.ld
+++ b/boards/bitcraze/crazyflie21/nuttx-config/scripts/script.ld
@@ -71,12 +71,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/corvon/743v1/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/corvon/743v1/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/corvon/743v1/nuttx-config/scripts/script.ld
+++ b/boards/corvon/743v1/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/corvon/743v1/src/hw_config.h
+++ b/boards/corvon/743v1/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1189
 #define BOARD_FLASH_SECTORS            (14)
 #define BOARD_FLASH_SIZE               (16 * 128 * 1024)

--- a/boards/cuav/7-nano/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/cuav/7-nano/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cuav/7-nano/nuttx-config/scripts/script.ld
+++ b/boards/cuav/7-nano/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cuav/7-nano/src/hw_config.h
+++ b/boards/cuav/7-nano/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,1500000"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     7000
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/cuav/can-gps-v1/nuttx-config/scripts/script.ld
+++ b/boards/cuav/can-gps-v1/nuttx-config/scripts/script.ld
@@ -65,8 +65,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/cuav/fmu-v6x/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/cuav/fmu-v6x/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cuav/fmu-v6x/nuttx-config/scripts/script.ld
+++ b/boards/cuav/fmu-v6x/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cuav/fmu-v6x/src/hw_config.h
+++ b/boards/cuav/fmu-v6x/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,1500000"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     7001
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/cuav/nora/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/cuav/nora/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cuav/nora/nuttx-config/scripts/script.ld
+++ b/boards/cuav/nora/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cuav/nora/src/hw_config.h
+++ b/boards/cuav/nora/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS4,57600"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1009
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/cuav/x25-evo/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/cuav/x25-evo/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cuav/x25-evo/nuttx-config/scripts/script.ld
+++ b/boards/cuav/x25-evo/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cuav/x25-evo/src/hw_config.h
+++ b/boards/cuav/x25-evo/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,1500000"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     7002
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/cuav/x25-super/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/cuav/x25-super/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cuav/x25-super/nuttx-config/scripts/script.ld
+++ b/boards/cuav/x25-super/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cuav/x25-super/src/hw_config.h
+++ b/boards/cuav/x25-super/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,1500000"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     7003
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/cuav/x7pro/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/cuav/x7pro/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cuav/x7pro/nuttx-config/scripts/script.ld
+++ b/boards/cuav/x7pro/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cuav/x7pro/src/hw_config.h
+++ b/boards/cuav/x7pro/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS4,57600"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1010
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/cubepilot/cubeorange/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/cubepilot/cubeorange/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cubepilot/cubeorange/nuttx-config/scripts/script.ld
+++ b/boards/cubepilot/cubeorange/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cubepilot/cubeorange/src/hw_config.h
+++ b/boards/cubepilot/cubeorange/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     140
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/cubepilot/cubeorangeplus/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/cubepilot/cubeorangeplus/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cubepilot/cubeorangeplus/nuttx-config/scripts/script.ld
+++ b/boards/cubepilot/cubeorangeplus/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/cubepilot/cubeorangeplus/src/hw_config.h
+++ b/boards/cubepilot/cubeorangeplus/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1063
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/cubepilot/cubeyellow/nuttx-config/scripts/script.ld
+++ b/boards/cubepilot/cubeyellow/nuttx-config/scripts/script.ld
@@ -89,20 +89,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/freefly/can-rtk-gps/nuttx-config/scripts/script.ld
+++ b/boards/freefly/can-rtk-gps/nuttx-config/scripts/script.ld
@@ -84,8 +84,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/gearup/airbrainh743/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/gearup/airbrainh743/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/gearup/airbrainh743/nuttx-config/scripts/script.ld
+++ b/boards/gearup/airbrainh743/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/gearup/airbrainh743/src/hw_config.h
+++ b/boards/gearup/airbrainh743/src/hw_config.h
@@ -41,7 +41,6 @@
 
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,57600"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1209
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (14)

--- a/boards/hkust/nxt-dual/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/hkust/nxt-dual/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/hkust/nxt-dual/nuttx-config/scripts/script.ld
+++ b/boards/hkust/nxt-dual/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/hkust/nxt-dual/src/hw_config.h
+++ b/boards/hkust/nxt-dual/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                6
 #define INTERFACE_USART_CONFIG         "/dev/ttyS5,57600"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1013
 #define BOARD_FLASH_SECTORS            (14)
 #define BOARD_FLASH_SIZE               (16 * 128 * 1024)

--- a/boards/hkust/nxt-v1/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/hkust/nxt-v1/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/hkust/nxt-v1/nuttx-config/scripts/script.ld
+++ b/boards/hkust/nxt-v1/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/hkust/nxt-v1/src/hw_config.h
+++ b/boards/hkust/nxt-v1/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,57600"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1013
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/holybro/can-gps-v1/nuttx-config/scripts/script.ld
+++ b/boards/holybro/can-gps-v1/nuttx-config/scripts/script.ld
@@ -64,8 +64,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/holybro/durandal-v1/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/holybro/durandal-v1/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/holybro/durandal-v1/nuttx-config/scripts/script.ld
+++ b/boards/holybro/durandal-v1/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/holybro/durandal-v1/src/hw_config.h
+++ b/boards/holybro/durandal-v1/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     139
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/holybro/h-flow/nuttx-config/scripts/script.ld
+++ b/boards/holybro/h-flow/nuttx-config/scripts/script.ld
@@ -64,8 +64,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/holybro/kakutef7/nuttx-config/scripts/script.ld
+++ b/boards/holybro/kakutef7/nuttx-config/scripts/script.ld
@@ -88,20 +88,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/holybro/kakuteh7-wing/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/holybro/kakuteh7-wing/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/holybro/kakuteh7-wing/nuttx-config/scripts/script.ld
+++ b/boards/holybro/kakuteh7-wing/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/holybro/kakuteh7-wing/src/hw_config.h
+++ b/boards/holybro/kakuteh7-wing/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1105
 #define BOARD_FLASH_SECTORS            (13)
 #define BOARD_FLASH_SIZE               (16 * 128 * 1024)

--- a/boards/holybro/kakuteh7/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/holybro/kakuteh7/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/holybro/kakuteh7/nuttx-config/scripts/script.ld
+++ b/boards/holybro/kakuteh7/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/holybro/kakuteh7/src/hw_config.h
+++ b/boards/holybro/kakuteh7/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -68,7 +66,6 @@
 #define BOARD_VBUS                     MK_GPIO_INPUT(GPIO_OTGFS_VBUS)
 
 //#define USE_VBUS_PULL_DOWN
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1048
 #define BOARD_FLASH_SECTORS            (14)
 #define BOARD_FLASH_SIZE               (16 * 128 * 1024)

--- a/boards/holybro/kakuteh7dualimu/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/holybro/kakuteh7dualimu/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/holybro/kakuteh7dualimu/nuttx-config/scripts/script.ld
+++ b/boards/holybro/kakuteh7dualimu/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/holybro/kakuteh7dualimu/src/hw_config.h
+++ b/boards/holybro/kakuteh7dualimu/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -68,7 +66,6 @@
 #define BOARD_VBUS                     MK_GPIO_INPUT(GPIO_OTGFS_VBUS)
 
 //#define USE_VBUS_PULL_DOWN
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     5409
 #define BOARD_FLASH_SECTORS            (14)
 #define BOARD_FLASH_SIZE               (16 * 128 * 1024)

--- a/boards/holybro/kakuteh7mini/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/holybro/kakuteh7mini/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/holybro/kakuteh7mini/nuttx-config/scripts/script.ld
+++ b/boards/holybro/kakuteh7mini/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/holybro/kakuteh7mini/src/hw_config.h
+++ b/boards/holybro/kakuteh7mini/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -68,7 +66,6 @@
 #define BOARD_VBUS                     MK_GPIO_INPUT(GPIO_OTGFS_VBUS)
 
 //#define USE_VBUS_PULL_DOWN
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1058
 #define BOARD_FLASH_SECTORS            (14)
 #define BOARD_FLASH_SIZE               (16 * 128 * 1024)

--- a/boards/holybro/kakuteh7v2/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/holybro/kakuteh7v2/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/holybro/kakuteh7v2/nuttx-config/scripts/script.ld
+++ b/boards/holybro/kakuteh7v2/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/holybro/kakuteh7v2/src/hw_config.h
+++ b/boards/holybro/kakuteh7v2/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -68,7 +66,6 @@
 #define BOARD_VBUS                     MK_GPIO_INPUT(GPIO_OTGFS_VBUS)
 
 //#define USE_VBUS_PULL_DOWN
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1053
 #define BOARD_FLASH_SECTORS            (14)
 #define BOARD_FLASH_SIZE               (16 * 128 * 1024)

--- a/boards/holybro/pix32v5/nuttx-config/scripts/script.ld
+++ b/boards/holybro/pix32v5/nuttx-config/scripts/script.ld
@@ -89,20 +89,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/matek/gnss-m9n-f4/nuttx-config/scripts/script.ld
+++ b/boards/matek/gnss-m9n-f4/nuttx-config/scripts/script.ld
@@ -64,8 +64,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {

--- a/boards/matek/h743-mini/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/matek/h743-mini/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/matek/h743-mini/nuttx-config/scripts/script.ld
+++ b/boards/matek/h743-mini/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/matek/h743-mini/src/hw_config.h
+++ b/boards/matek/h743-mini/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,57600"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     139
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/matek/h743-slim/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/matek/h743-slim/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/matek/h743-slim/nuttx-config/scripts/script.ld
+++ b/boards/matek/h743-slim/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/matek/h743-slim/src/hw_config.h
+++ b/boards/matek/h743-slim/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,57600"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1013
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/matek/h743/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/matek/h743/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/matek/h743/nuttx-config/scripts/script.ld
+++ b/boards/matek/h743/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/matek/h743/src/hw_config.h
+++ b/boards/matek/h743/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,57600"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     139
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/micoair/h743-aio/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/micoair/h743-aio/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/micoair/h743-aio/nuttx-config/scripts/script.ld
+++ b/boards/micoair/h743-aio/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/micoair/h743-aio/src/hw_config.h
+++ b/boards/micoair/h743-aio/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1176
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/micoair/h743-lite/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/micoair/h743-lite/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/micoair/h743-lite/nuttx-config/scripts/script.ld
+++ b/boards/micoair/h743-lite/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/micoair/h743-lite/src/hw_config.h
+++ b/boards/micoair/h743-lite/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1202
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/micoair/h743-v2/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/micoair/h743-v2/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/micoair/h743-v2/nuttx-config/scripts/script.ld
+++ b/boards/micoair/h743-v2/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/micoair/h743-v2/src/hw_config.h
+++ b/boards/micoair/h743-v2/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1179
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/micoair/h743/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/micoair/h743/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/micoair/h743/nuttx-config/scripts/script.ld
+++ b/boards/micoair/h743/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/micoair/h743/src/hw_config.h
+++ b/boards/micoair/h743/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1166
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/modalai/fc-v1/nuttx-config/scripts/script.ld
+++ b/boards/modalai/fc-v1/nuttx-config/scripts/script.ld
@@ -89,20 +89,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/modalai/fc-v2/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/modalai/fc-v2/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/modalai/fc-v2/nuttx-config/scripts/script.ld
+++ b/boards/modalai/fc-v2/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/modalai/fc-v2/src/hw_config.h
+++ b/boards/modalai/fc-v2/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     41776
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/mro/ctrl-zero-classic/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/mro/ctrl-zero-classic/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/mro/ctrl-zero-classic/nuttx-config/scripts/script.ld
+++ b/boards/mro/ctrl-zero-classic/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/mro/ctrl-zero-classic/src/hw_config.h
+++ b/boards/mro/ctrl-zero-classic/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1024
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/mro/ctrl-zero-f7-oem/nuttx-config/scripts/script.ld
+++ b/boards/mro/ctrl-zero-f7-oem/nuttx-config/scripts/script.ld
@@ -89,20 +89,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/mro/ctrl-zero-f7/nuttx-config/scripts/script.ld
+++ b/boards/mro/ctrl-zero-f7/nuttx-config/scripts/script.ld
@@ -89,20 +89,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/mro/ctrl-zero-h7-oem/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/mro/ctrl-zero-h7-oem/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/mro/ctrl-zero-h7-oem/nuttx-config/scripts/script.ld
+++ b/boards/mro/ctrl-zero-h7-oem/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/mro/ctrl-zero-h7-oem/src/hw_config.h
+++ b/boards/mro/ctrl-zero-h7-oem/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1024
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/mro/ctrl-zero-h7/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/mro/ctrl-zero-h7/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/mro/ctrl-zero-h7/nuttx-config/scripts/script.ld
+++ b/boards/mro/ctrl-zero-h7/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/mro/ctrl-zero-h7/src/hw_config.h
+++ b/boards/mro/ctrl-zero-h7/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1024
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/mro/pixracerpro/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/mro/pixracerpro/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/mro/pixracerpro/nuttx-config/scripts/script.ld
+++ b/boards/mro/pixracerpro/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/mro/pixracerpro/src/hw_config.h
+++ b/boards/mro/pixracerpro/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1017
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/mro/x21-777/nuttx-config/scripts/script.ld
+++ b/boards/mro/x21-777/nuttx-config/scripts/script.ld
@@ -89,20 +89,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/mro/x21/nuttx-config/scripts/script.ld
+++ b/boards/mro/x21/nuttx-config/scripts/script.ld
@@ -65,20 +65,12 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/narinfc/h7/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/narinfc/h7/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/narinfc/h7/nuttx-config/scripts/script.ld
+++ b/boards/narinfc/h7/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/narinfc/h7/src/hw_config.h
+++ b/boards/narinfc/h7/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS4,57600"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1183
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/nxp/mr-tropic/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/nxp/mr-tropic/nuttx-config/scripts/bootloader_script.ld
@@ -34,8 +34,6 @@ EXTERN(g_flash_config)
 EXTERN(g_image_vector_table)
 EXTERN(g_boot_data)
 EXTERN(board_get_manifest)
-EXTERN(_bootdelay_signature)
-
 ENTRY(_stext)
 
 SECTIONS
@@ -81,12 +79,6 @@ SECTIONS
         _stext = ABSOLUTE(.);
         *(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)

--- a/boards/nxp/mr-tropic/nuttx-config/scripts/script.ld
+++ b/boards/nxp/mr-tropic/nuttx-config/scripts/script.ld
@@ -35,8 +35,6 @@ EXTERN(g_flash_config)
 EXTERN(g_image_vector_table)
 EXTERN(g_boot_data)
 EXTERN(board_get_manifest)
-EXTERN(_bootdelay_signature)
-
 ENTRY(_stext)
 
 SECTIONS
@@ -90,12 +88,6 @@ SECTIONS
         _stext = ABSOLUTE(.);
         *(.vectors)
 	. = ALIGN(32);
-	/*
-	This signature provides the bootloader with a way to delay booting
-	*/
-	_bootdelay_signature = ABSOLUTE(.);
-	FILL(0xffecc2925d7d05c5)
-	. += 8;
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)

--- a/boards/nxp/mr-tropic/src/hw_config.h
+++ b/boards/nxp/mr-tropic/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,1500000"
-#define BOOT_DELAY_ADDRESS             0x00039FA0
 #define BOARD_TYPE                     37
 // The board has a 64 Mb part with 16384, 4K secors, but we artificialy limit it to 4 Mb
 // as 1024, 4K sectors

--- a/boards/px4/fmu-v2/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v2/nuttx-config/scripts/script.ld
@@ -66,20 +66,12 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/px4/fmu-v3/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v3/nuttx-config/scripts/script.ld
@@ -65,20 +65,12 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/px4/fmu-v4/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v4/nuttx-config/scripts/script.ld
@@ -65,20 +65,12 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		KEEP(*(.app_descriptor))
 		*(.text .text.*)
 		*(.fixup)

--- a/boards/px4/fmu-v4pro/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v4pro/nuttx-config/scripts/script.ld
@@ -65,7 +65,6 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -74,12 +73,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/px4/fmu-v5/nuttx-config/scripts/kernel-space.ld
+++ b/boards/px4/fmu-v5/nuttx-config/scripts/kernel-space.ld
@@ -46,7 +46,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 /*
  * TODO: Fill in the signature location into TOC from user-space elf
 EXTERN(_main_toc)
@@ -58,12 +57,6 @@ SECTIONS
         _stext = ABSOLUTE(.);
         *(.vectors)
 	. = ALIGN(32);
-	/*
-	This signature provides the bootloader with a way to delay booting
-	*/
-	_bootdelay_signature = ABSOLUTE(.);
-	FILL(0xffecc2925d7d05c5)
-	. += 8;
         /*
         *(.main_toc)
         */

--- a/boards/px4/fmu-v5/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v5/nuttx-config/scripts/script.ld
@@ -89,7 +89,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(_main_toc)
 
 SECTIONS
@@ -98,12 +97,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.main_toc)
 		*(.text .text.*)
 		*(.fixup)

--- a/boards/px4/fmu-v5x/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v5x/nuttx-config/scripts/script.ld
@@ -89,7 +89,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -112,12 +111,6 @@ SECTIONS
 	.text : {
 		_stext = ABSOLUTE(.);
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/px4/fmu-v6c/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/px4/fmu-v6c/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/px4/fmu-v6c/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v6c/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/px4/fmu-v6c/src/hw_config.h
+++ b/boards/px4/fmu-v6c/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     56
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/px4/fmu-v6u/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/px4/fmu-v6u/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/px4/fmu-v6u/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v6u/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/px4/fmu-v6u/src/hw_config.h
+++ b/boards/px4/fmu-v6u/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     54
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/px4/fmu-v6x/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/px4/fmu-v6x/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/px4/fmu-v6x/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v6x/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/px4/fmu-v6x/src/hw_config.h
+++ b/boards/px4/fmu-v6x/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,1500000"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     53
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/px4/fmu-v6xrt/nuttx-config/scripts/allyes-script.ld
+++ b/boards/px4/fmu-v6xrt/nuttx-config/scripts/allyes-script.ld
@@ -46,7 +46,6 @@ EXTERN(g_flash_config)
 EXTERN(g_image_vector_table)
 EXTERN(g_boot_data)
 EXTERN(board_get_manifest)
-EXTERN(_bootdelay_signature)
 EXTERN(imxrt_flexspi_initialize)
 
 ENTRY(__start)
@@ -101,12 +100,6 @@ SECTIONS
         _stext = ABSOLUTE(.);
         *(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)

--- a/boards/px4/fmu-v6xrt/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/px4/fmu-v6xrt/nuttx-config/scripts/bootloader_script.ld
@@ -46,8 +46,6 @@ EXTERN(g_flash_config)
 EXTERN(g_image_vector_table)
 EXTERN(g_boot_data)
 EXTERN(board_get_manifest)
-EXTERN(_bootdelay_signature)
-
 ENTRY(__start)
 
 SECTIONS
@@ -99,12 +97,6 @@ SECTIONS
         _stext = ABSOLUTE(.);
         *(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)

--- a/boards/px4/fmu-v6xrt/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v6xrt/nuttx-config/scripts/script.ld
@@ -46,7 +46,6 @@ EXTERN(g_flash_config)
 EXTERN(g_image_vector_table)
 EXTERN(g_boot_data)
 EXTERN(board_get_manifest)
-EXTERN(_bootdelay_signature)
 EXTERN(imxrt_flexspi_initialize)
 
 ENTRY(__start)
@@ -97,12 +96,6 @@ SECTIONS
         _stext = ABSOLUTE(.);
         *(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)

--- a/boards/px4/fmu-v6xrt/src/hw_config.h
+++ b/boards/px4/fmu-v6xrt/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,1500000"
-#define BOOT_DELAY_ADDRESS             0x3003b540
 #define BOARD_TYPE                     35
 // The board has a 64 Mb part with 16384, 4K secors, but we artificialy limit it to 4 Mb
 // as 1024, 4K sectors

--- a/boards/radiolink/PIX6/nuttx-config/scripts/kernel-space.ld
+++ b/boards/radiolink/PIX6/nuttx-config/scripts/kernel-space.ld
@@ -46,7 +46,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 /*
  * TODO: Fill in the signature location into TOC from user-space elf
 EXTERN(_main_toc)
@@ -58,12 +57,6 @@ SECTIONS
         _stext = ABSOLUTE(.);
         *(.vectors)
 	. = ALIGN(32);
-	/*
-	This signature provides the bootloader with a way to delay booting
-	*/
-	_bootdelay_signature = ABSOLUTE(.);
-	FILL(0xffecc2925d7d05c5)
-	. += 8;
         /*
         *(.main_toc)
         */

--- a/boards/radiolink/PIX6/nuttx-config/scripts/script.ld
+++ b/boards/radiolink/PIX6/nuttx-config/scripts/script.ld
@@ -89,20 +89,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/saam/saampixv1_1/nuttx-config/scripts/script.ld
+++ b/boards/saam/saampixv1_1/nuttx-config/scripts/script.ld
@@ -65,20 +65,12 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/siyi/n7/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/siyi/n7/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/siyi/n7/nuttx-config/scripts/script.ld
+++ b/boards/siyi/n7/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/siyi/n7/src/hw_config.h
+++ b/boards/siyi/n7/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1123
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/sky-drones/smartap-airlink/nuttx-config/scripts/script.ld
+++ b/boards/sky-drones/smartap-airlink/nuttx-config/scripts/script.ld
@@ -89,7 +89,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -98,12 +97,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/spracing/h7extreme/nuttx-config/scripts/script.ld
+++ b/boards/spracing/h7extreme/nuttx-config/scripts/script.ld
@@ -131,8 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 
@@ -184,12 +182,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.rodata .rodata.*)
 		*(.fixup)

--- a/boards/svehicle/e2/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/svehicle/e2/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/svehicle/e2/nuttx-config/scripts/script.ld
+++ b/boards/svehicle/e2/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/svehicle/e2/src/hw_config.h
+++ b/boards/svehicle/e2/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,1500000"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     6110
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/thepeach/k1/nuttx-config/scripts/script.ld
+++ b/boards/thepeach/k1/nuttx-config/scripts/script.ld
@@ -65,20 +65,12 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/thepeach/r1/nuttx-config/scripts/script.ld
+++ b/boards/thepeach/r1/nuttx-config/scripts/script.ld
@@ -65,20 +65,12 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/uvify/core/nuttx-config/scripts/script.ld
+++ b/boards/uvify/core/nuttx-config/scripts/script.ld
@@ -65,20 +65,12 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/x-mav/ap-h743r1/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/x-mav/ap-h743r1/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/x-mav/ap-h743r1/nuttx-config/scripts/script.ld
+++ b/boards/x-mav/ap-h743r1/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/x-mav/ap-h743r1/src/hw_config.h
+++ b/boards/x-mav/ap-h743r1/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 // #define INTERFACE_USART                6
 #define INTERFACE_USART_CONFIG         "/dev/ttyS5,57600"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1203
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/boards/x-mav/ap-h743v2/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/x-mav/ap-h743v2/nuttx-config/scripts/bootloader_script.ld
@@ -130,20 +130,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/x-mav/ap-h743v2/nuttx-config/scripts/script.ld
+++ b/boards/x-mav/ap-h743v2/nuttx-config/scripts/script.ld
@@ -131,20 +131,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/x-mav/ap-h743v2/src/hw_config.h
+++ b/boards/x-mav/ap-h743v2/src/hw_config.h
@@ -53,8 +53,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -95,7 +93,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                6
 #define INTERFACE_USART_CONFIG         "/dev/ttyS5,57600"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1200
 #define BOARD_FLASH_SECTORS            (14)
 #define BOARD_FLASH_SIZE               (16 * 128 * 1024)

--- a/boards/zeroone/x6/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/zeroone/x6/nuttx-config/scripts/bootloader_script.ld
@@ -132,20 +132,12 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
-
 SECTIONS
 {
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/zeroone/x6/nuttx-config/scripts/script.ld
+++ b/boards/zeroone/x6/nuttx-config/scripts/script.ld
@@ -131,7 +131,6 @@ ENTRY(_stext)
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
-EXTERN(_bootdelay_signature)
 EXTERN(board_get_manifest)
 
 SECTIONS
@@ -140,12 +139,6 @@ SECTIONS
 		_stext = ABSOLUTE(.);
 		*(.vectors)
 		. = ALIGN(32);
-		/*
-		This signature provides the bootloader with a way to delay booting
-		*/
-		_bootdelay_signature = ABSOLUTE(.);
-		FILL(0xffecc2925d7d05c5)
-		. += 8;
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/zeroone/x6/src/hw_config.h
+++ b/boards/zeroone/x6/src/hw_config.h
@@ -28,8 +28,6 @@
  * INTERFACE_USART      1                     - (Optional) Scan and use the Serial interface for bootloading
  * USBDEVICESTRING      "PX4 BL FMU v2.x"     - USB id string
  * USBPRODUCTID         0x0011                - PID Should match defconfig
- * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
- *                                               delay provided by an APP FW
  * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
@@ -70,7 +68,6 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,1500000"
-#define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     5600
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)

--- a/platforms/nuttx/src/bootloader/common/bl.c
+++ b/platforms/nuttx/src/bootloader/common/bl.c
@@ -104,7 +104,7 @@
 #define PROTO_GET_OTP               0x2a    // read a byte from OTP at the given address
 #define PROTO_GET_SN                0x2b    // read a word from UDID area ( Serial)  at the given address
 #define PROTO_GET_CHIP              0x2c    // read chip version (MCU IDCODE)
-#define PROTO_SET_DELAY             0x2d    // set minimum boot delay
+#define PROTO_SET_DELAY             0x2d    // set boot delay (deprecated; always NACKed)
 #define PROTO_GET_CHIP_DES          0x2e    // read chip version In ASCII
 #define PROTO_GET_VERSION           0x2f    // read version
 #define PROTO_BOOT                  0x30    // boot the application
@@ -1021,49 +1021,19 @@ bootloader(unsigned timeout)
 			}
 			break;
 
-#ifdef BOOT_DELAY_ADDRESS
-
-		case PROTO_SET_DELAY: {
-				/*
-				  Allow for the bootloader to setup a
-				  boot delay signature which tells the
-				  board to delay for at least a
-				  specified number of seconds on boot.
-				 */
-				int v = cin_wait(100);
-
-				if (v < 0) {
-					goto cmd_bad;
-				}
-
-				uint8_t boot_delay = v & 0xFF;
-
-				if (boot_delay > BOOT_DELAY_MAX) {
-					goto cmd_bad;
-				}
-
-				// expect EOC
-				if (!wait_for_eoc(2)) {
-					goto cmd_bad;
-				}
-
-				uint32_t sig1 = flash_func_read_word(BOOT_DELAY_ADDRESS);
-				uint32_t sig2 = flash_func_read_word(BOOT_DELAY_ADDRESS + 4);
-
-				if (sig1 != BOOT_DELAY_SIGNATURE1 ||
-				    sig2 != BOOT_DELAY_SIGNATURE2) {
-					goto cmd_bad;
-				}
-
-				uint32_t value = (BOOT_DELAY_SIGNATURE1 & 0xFFFFFF00) | boot_delay;
-				flash_func_write_word(BOOT_DELAY_ADDRESS, value);
-
-				if (flash_func_read_word(BOOT_DELAY_ADDRESS) != value) {
-					goto cmd_fail;
-				}
-			}
-			break;
-#endif
+		case PROTO_SET_DELAY:
+			/*
+			 * Boot delay used to let the bootloader pause before
+			 * starting the app by writing a signature next to the
+			 * vector table. It never worked correctly on modern
+			 * FMUs (signature was placed past where the bootloader
+			 * looked, H7 flash granularity prevented single-word
+			 * writes, and the flash cache never flushed the write),
+			 * so it has been removed. NACK so a client that still
+			 * sends it gets a clear rejection instead of silent
+			 * fake success.
+			 */
+			goto cmd_bad;
 
 		// finalise programming and boot the system
 		//

--- a/platforms/nuttx/src/bootloader/common/bl.h
+++ b/platforms/nuttx/src/bootloader/common/bl.h
@@ -89,12 +89,6 @@ extern int buf_get(void);
 #define LED_ACTIVITY  1
 #define LED_BOOTLOADER  2
 
-#ifdef BOOT_DELAY_ADDRESS
-# define BOOT_DELAY_SIGNATURE1  0x92c2ecff
-# define BOOT_DELAY_SIGNATURE2  0xc5057d5d
-# define BOOT_DELAY_MAX   30
-#endif
-
 #define MAX_DES_LENGTH 20
 #define MAX_VERSION_LENGTH 32
 

--- a/platforms/nuttx/src/bootloader/common/image_toc.c
+++ b/platforms/nuttx/src/bootloader/common/image_toc.c
@@ -41,6 +41,13 @@
 #include "image_toc.h"
 
 #include "bl.h"
+#include "crypto.h"
+
+#ifdef BOOTLOADER_USE_TOC
+
+#ifndef BOARD_IMAGE_TOC_OFFSET
+# error "BOARD_IMAGE_TOC_OFFSET must be defined when BOOTLOADER_USE_TOC is enabled"
+#endif
 
 /* Helper macros to define flash start and end addresses, based on info from
  * hw_config.h
@@ -50,7 +57,7 @@
 
 bool find_toc(const image_toc_entry_t **toc_entries, uint8_t *len)
 {
-	const uintptr_t toc_start_u32 = APP_LOAD_ADDRESS + BOOT_DELAY_ADDRESS + 8;
+	const uintptr_t toc_start_u32 = APP_LOAD_ADDRESS + BOARD_IMAGE_TOC_OFFSET;
 	const image_toc_start_t *toc_start = (const image_toc_start_t *)toc_start_u32;
 	const image_toc_entry_t *entry = (const image_toc_entry_t *)(toc_start_u32 + sizeof(image_toc_start_t));
 
@@ -105,3 +112,14 @@ bool find_toc(const image_toc_entry_t **toc_entries, uint8_t *len)
 	*len = 0;
 	return false;
 }
+
+#else // BOOTLOADER_USE_TOC
+
+bool find_toc(const image_toc_entry_t **toc_entries, uint8_t *len)
+{
+	(void)toc_entries;
+	(void)len;
+	return false;
+}
+
+#endif // BOOTLOADER_USE_TOC

--- a/platforms/nuttx/src/bootloader/nxp/imxrt_common/main.c
+++ b/platforms/nuttx/src/bootloader/nxp/imxrt_common/main.c
@@ -744,33 +744,6 @@ bootloader_main(void)
 		board_set_rtc_signature(0);
 	}
 
-#ifdef BOOT_DELAY_ADDRESS
-	{
-		/*
-		  if a boot delay signature is present then delay the boot
-		  by at least that amount of time in seconds. This allows
-		  for an opportunity for a companion computer to load a
-		  new firmware, while still booting fast by sending a BOOT
-		  command
-		 */
-		uint32_t sig1 = flash_func_read_word(BOOT_DELAY_ADDRESS);
-		uint32_t sig2 = flash_func_read_word(BOOT_DELAY_ADDRESS + 4);
-
-		if (sig2 == BOOT_DELAY_SIGNATURE2 &&
-		    (sig1 & 0xFFFFFF00) == (BOOT_DELAY_SIGNATURE1 & 0xFFFFFF00)) {
-			unsigned boot_delay = sig1 & 0xFF;
-
-			if (boot_delay <= BOOT_DELAY_MAX) {
-				try_boot = false;
-
-				if (timeout < boot_delay * 1000) {
-					timeout = boot_delay * 1000;
-				}
-			}
-		}
-	}
-#endif
-
 	/*
 	 * Check if the force-bootloader pins are strapped; if strapped,
 	 * don't try booting.

--- a/platforms/nuttx/src/bootloader/stm/stm32_common/main.c
+++ b/platforms/nuttx/src/bootloader/stm/stm32_common/main.c
@@ -687,33 +687,6 @@ bootloader_main(void)
 		board_set_rtc_signature(0);
 	}
 
-#ifdef BOOT_DELAY_ADDRESS
-	{
-		/*
-		  if a boot delay signature is present then delay the boot
-		  by at least that amount of time in seconds. This allows
-		  for an opportunity for a companion computer to load a
-		  new firmware, while still booting fast by sending a BOOT
-		  command
-		 */
-		uint32_t sig1 = flash_func_read_word(BOOT_DELAY_ADDRESS);
-		uint32_t sig2 = flash_func_read_word(BOOT_DELAY_ADDRESS + 4);
-
-		if (sig2 == BOOT_DELAY_SIGNATURE2 &&
-		    (sig1 & 0xFFFFFF00) == (BOOT_DELAY_SIGNATURE1 & 0xFFFFFF00)) {
-			unsigned boot_delay = sig1 & 0xFF;
-
-			if (boot_delay <= BOOT_DELAY_MAX) {
-				try_boot = false;
-
-				if (timeout < boot_delay * 1000) {
-					timeout = boot_delay * 1000;
-				}
-			}
-		}
-	}
-#endif
-
 	/*
 	 * Check if the force-bootloader pins are strapped; if strapped,
 	 * don't try booting.


### PR DESCRIPTION
The bootloader boot-delay feature has been mechanically broken on every modern FMU board since the STM32F7/H7 transition. It has three independent bugs that prevent it from ever working:

1. Offset mismatch: BOOT_DELAY_ADDRESS is hardcoded to 0x1a0, but the NuttX vector table is 504 B (F76x) to 664 B (H743) long. The linker places _bootdelay_signature at ALIGN(32) past end of vectors (e.g. 0x2a0 on CubeOrange), never at 0x1a0. The bootloader reads random exception_common pointers in place of the magic and never matches BOOT_DELAY_SIGNATURE1/2. Verified on CubeOrange with objdump of cubepilot_cubeorange_default.elf.

2. Flash cache never flushes: fc_write() stores arbitrary writes in cache line 1 and only flushes on a very specific condition tied to the sequential firmware upload flow. A standalone write during PROTO_SET_DELAY is cached forever. fc_read() then returns the cached value, so the post-write verify lies and the bootloader reports success. Nothing ever reaches flash.

3. H7 write granularity: the STM32H7 flash controller requires a full 32-byte program cycle per write. Single 32-bit writes from flash_func_write_word() would not be accepted by the controller even if they reached it.

The feature has been silently dead on every H7/F7 FMU board for years and no one noticed, which is strong evidence nothing actually depends on it. Rather than fix it (which would mean rewriting PROTO_SET_DELAY, the flash cache path, and the H7 flash programming path), remove it.

Changes:
- bl.c: PROTO_SET_DELAY case now immediately NACKs (goto cmd_bad) so clients that still send the command get a clear rejection instead of the previous silent fake-success. The opcode stays in the protocol enum for backwards compatibility.
- bl.h: drop BOOT_DELAY_SIGNATURE1/2 and BOOT_DELAY_MAX.
- stm/stm32_common/main.c, nxp/imxrt_common/main.c: drop the startup boot-delay sig check block.
- image_toc.c: decouple find_toc() from BOOT_DELAY_ADDRESS. BOARD_IMAGE_TOC_OFFSET is now the required define when BOOTLOADER_USE_TOC is enabled. The body is wrapped in #ifdef BOOTLOADER_USE_TOC and falls back to a stub returning false when the TOC is not in use (no upstream board currently enables it).
- Linker scripts: strip EXTERN(_bootdelay_signature) and the FILL/. += 8 block from all 142 affected .ld files across boards/.
- hw_config.h: strip the #define BOOT_DELAY_ADDRESS and its comment block entry from all 48 affected boards.
- Tools/px4_uploader.py, Tools/teensy_uploader.py: remove --boot-delay, set_boot_delay(), and SET_BOOT_DELAY client-side counterpart.

Smoke-built on cubepilot_cubeorange_default and
cubepilot_cubeorange_bootloader; no link errors, no unresolved symbols, flash usage unchanged.