### PR TITLE
feat(control_allocator): add mixer subcommand to print mixing matrix

### DIFF
--- a/src/lib/control_allocation/control_allocation/ControlAllocation.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocation.cpp
@@ -41,6 +41,23 @@
 
 #include "ControlAllocation.hpp"
 
+#include <cmath>
+#include <cstdio>
+
+void
+ControlAllocation::printMatrixCell(double d)
+{
+	if (fabs(d - 0.0) < 1e-9) {
+		printf(" 0       ");
+
+	} else if ((fabs(d) < 1e-4) || (fabs(d) >= 10.0)) {
+		printf("% .1e ", d);
+
+	} else {
+		printf("% 6.5f ", d);
+	}
+}
+
 ControlAllocation::ControlAllocation()
 {
 	_control_allocation_scale.setAll(1.f);

--- a/src/lib/control_allocation/control_allocation/ControlAllocation.hpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocation.hpp
@@ -154,6 +154,25 @@ public:
 	const matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &getEffectivenessMatrix() const { return _effectiveness; }
 
 	/**
+	 * Get the per-axis scale applied during allocation (roll, pitch, yaw, thrust x/y/z).
+	 */
+	const matrix::Vector<float, NUM_AXES> &getControlAllocationScale() const { return _control_allocation_scale; }
+
+	/**
+	 * Print the mixing matrix (if the allocation method has one).
+	 *
+	 * Default: no-op. Derived methods that compute a mix should override to print
+	 * both the raw pseudo-inverse and the normalized form actually applied.
+	 */
+	virtual void printMixingMatrix() const {}
+
+	/**
+	 * Shared formatter for matrix cells used by status/mixer prints.
+	 * Matches the display convention of print_status(): 0 / scientific / fixed.
+	 */
+	static void printMatrixCell(double d);
+
+	/**
 	 * Set the minimum actuator values
 	 *
 	 * @param actuator_min Minimum actuator values

--- a/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.cpp
@@ -41,6 +41,9 @@
 
 #include "ControlAllocationPseudoInverse.hpp"
 
+#include <cstdio>
+#include <px4_platform_common/log.h>
+
 void
 ControlAllocationPseudoInverse::setEffectivenessMatrix(
 	const matrix::Matrix<float, ControlAllocation::NUM_AXES, ControlAllocation::NUM_ACTUATORS> &effectiveness,
@@ -186,4 +189,49 @@ ControlAllocationPseudoInverse::allocate()
 
 	// Allocate
 	_actuator_sp = _actuator_trim + _mix * (_control_sp - _control_trim);
+}
+
+void
+ControlAllocationPseudoInverse::printMixingMatrix() const
+{
+	const char *col_labels[NUM_AXES] = {"Mx", "My", "Mz", "Fx", "Fy", "Fz"};
+
+	// Recompute the raw pseudo-inverse on demand (not cached — this is a debug-only path).
+	matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> raw_mix;
+	matrix::geninv(_effectiveness, raw_mix);
+
+	auto print_mix = [&](const matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> &m) {
+		printf("    ");
+
+		for (int col = 0; col < NUM_AXES; col++) {
+			printf("|%-8s", col_labels[col]);
+		}
+
+		printf("\n");
+
+		for (int row = 0; row < _num_actuators; row++) {
+			printf("%2d |", row);
+
+			for (int col = 0; col < NUM_AXES; col++) {
+				ControlAllocation::printMatrixCell(static_cast<double>(m(row, col)));
+			}
+
+			printf("\n");
+		}
+	};
+
+	PX4_INFO("  Raw mixing matrix (pseudo-inverse of effectiveness) =");
+	print_mix(raw_mix);
+
+	PX4_INFO("  Normalization scale (moments): Mx=%.5f My=%.5f Mz=%.5f",
+		 static_cast<double>(_control_allocation_scale(0)),
+		 static_cast<double>(_control_allocation_scale(1)),
+		 static_cast<double>(_control_allocation_scale(2)));
+	PX4_INFO("  Normalization scale (forces):  Fx=%.5f Fy=%.5f Fz=%.5f",
+		 static_cast<double>(_control_allocation_scale(3)),
+		 static_cast<double>(_control_allocation_scale(4)),
+		 static_cast<double>(_control_allocation_scale(5)));
+
+	PX4_INFO("  Mixing matrix (normalized, applied) =");
+	print_mix(_mix);
 }

--- a/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.hpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.hpp
@@ -59,6 +59,8 @@ public:
 				    bool update_normalization_scale) override;
 	void setMetricAllocation(bool metric_allocation) { _metric_allocation = metric_allocation; }
 
+	void printMixingMatrix() const override;
+
 protected:
 	matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> _mix;
 

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -898,19 +898,7 @@ int ControlAllocator::print_status()
 			printf("%2s|", row_labels[row]);
 
 			for (int col = 0; col < num_configured; col++) {
-				double d = static_cast<double>(effectiveness(row, col));
-
-				// avoid -0.0 for display
-				if (fabs(d - 0.0) < 1e-9) {
-					// print fixed width zero
-					printf(" 0       ");
-
-				} else if ((fabs(d) < 1e-4) || (fabs(d) >= 10.0)) {
-					printf("% .1e ", d);
-
-				} else {
-					printf("% 6.5f ", d);
-				}
+				ControlAllocation::printMatrixCell(static_cast<double>(effectiveness(row, col)));
 			}
 
 			printf("\n");
@@ -932,19 +920,7 @@ int ControlAllocator::print_status()
 		printf("  |");
 
 		for (int col = 0; col < num_configured; col++) {
-			double d = static_cast<double>(_control_allocation[i]->getActuatorMin()(col));
-
-			// avoid -0.0 for display
-			if (fabs(d - 0.0) < 1e-9) {
-				// print fixed width zero
-				printf(" 0       ");
-
-			} else if ((fabs(d) < 1e-4) || (fabs(d) >= 10.0)) {
-				printf("% .1e ", d);
-
-			} else {
-				printf("% 6.5f ", d);
-			}
+			ControlAllocation::printMatrixCell(static_cast<double>(_control_allocation[i]->getActuatorMin()(col)));
 		}
 
 		printf("\n");
@@ -964,19 +940,7 @@ int ControlAllocator::print_status()
 		printf("  |");
 
 		for (int col = 0; col < num_configured; col++) {
-			double d = static_cast<double>(_control_allocation[i]->getActuatorMax()(col));
-
-			// avoid -0.0 for display
-			if (fabs(d - 0.0) < 1e-9) {
-				// print fixed width zero
-				printf(" 0       ");
-
-			} else if ((fabs(d) < 1e-4) || (fabs(d) >= 10.0)) {
-				printf("% .1e ", d);
-
-			} else {
-				printf("% 6.5f ", d);
-			}
+			ControlAllocation::printMatrixCell(static_cast<double>(_control_allocation[i]->getActuatorMax()(col)));
 		}
 
 		printf("\n");
@@ -994,8 +958,30 @@ int ControlAllocator::print_status()
 	return 0;
 }
 
+int ControlAllocator::print_mixer()
+{
+	for (int i = 0; i < _num_control_allocation; ++i) {
+		if (_num_control_allocation > 1) {
+			PX4_INFO("Instance: %i", i);
+		}
+
+		_control_allocation[i]->printMixingMatrix();
+	}
+
+	return 0;
+}
+
 int ControlAllocator::custom_command(int argc, char *argv[])
 {
+	if (argc >= 1 && !strcmp(argv[0], "mixer")) {
+		if (!is_running(desc)) {
+			print_usage("not running");
+			return 1;
+		}
+
+		return get_instance<ControlAllocator>(desc)->print_mixer();
+	}
+
 	return print_usage("unknown command");
 }
 
@@ -1014,6 +1000,7 @@ as inputs and outputs actuator setpoint messages.
 
 	PRINT_MODULE_USAGE_NAME("control_allocator", "controller");
 	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("mixer", "Print mixing matrix (raw pseudo-inverse + normalization scale + normalized form)");
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 
 	return 0;

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -114,6 +114,9 @@ public:
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
+	/** Print the mixing matrix (raw pseudo-inverse + normalization scale + normalized form) for each instance. */
+	int print_mixer();
+
 	void Run() override;
 
 	bool init();


### PR DESCRIPTION
## Problem

Debugging control allocation on real frames currently requires reading the source to understand what `_mix` becomes after `ControlAllocationPseudoInverse::updateControlAllocationMatrixScale()` and `normalizeControlAllocationMatrix()`. `control_allocator status` already prints the 6×N effectiveness matrix, but there is no runtime way to see the N×6 mixing matrix actually applied inside `allocate()`, nor the per-axis normalization scale that produced it. This makes it hard to diagnose new or asymmetric frames, and unexpected mixing behavior on ground tests or during post-flight log review.

## Solution

Add a new shell subcommand `control_allocator mixer` that, for each allocation instance, prints:

1. **The raw pseudo-inverse of the effectiveness matrix** — recomputed on demand via `matrix::geninv`, not cached.
2. **The per-axis normalization scale** (`_control_allocation_scale`) — one line for moments (`Mx`, `My`, `Mz`), one for forces (`Fx`, `Fy`, `Fz`).
3. **The normalized mixing matrix actually applied** in `ControlAllocationPseudoInverse::allocate()`.

Implementation notes:

- A new `virtual void printMixingMatrix() const {}` on the `ControlAllocation` base class (default no-op), overridden in `ControlAllocationPseudoInverse`. The override is inherited by `ControlAllocationSequentialDesaturation` automatically. The `NONE` method silently skips.
- The raw pseudo-inverse is **recomputed on demand** inside the override rather than cached. Keeps the per-instance memory footprint and the allocation hot path unchanged — the `geninv` cost is paid only when a human types `control_allocator mixer`.
- The numeric cell formatter previously duplicated across the three number-print blocks in `ControlAllocator::print_status()` is extracted into a shared `static ControlAllocation::printMatrixCell()`. Both the existing effectiveness / min / max blocks and the new mixer block use it. Formatting behavior of `control_allocator status` is unchanged.
- `ControlAllocator::custom_command()` dispatches `"mixer"` via `get_instance<ControlAllocator>(desc)`, the same pattern `commander` uses for its subcommands. The subcommand is registered in the module usage with `PRINT_MODULE_USAGE_COMMAND_DESCR`.
- A public getter `getControlAllocationScale()` is added on the base class, matching the existing non-virtual-getter-for-protected-data pattern used by `getEffectivenessMatrix()`.

Example output on an x500 quad (four motors):

```
pxh> control_allocator mixer
INFO  [ControlAllocation]   Raw mixing matrix (pseudo-inverse of effectiveness) =
    |Mx      |My      |Mz      |Fx      |Fy      |Fz
 0 |-0.18315  0.29586  0.73260  0        0       -0.03846
 1 | 0.18315 -0.29586  0.80586  0        0       -0.03846
 2 | 0.18315  0.29586 -0.73260  0        0       -0.03846
 3 |-0.18315 -0.29586 -0.80586  0        0       -0.03846
INFO  [ControlAllocation]   Normalization scale (moments): Mx=0.41841 My=0.41841 Mz=0.80586
INFO  [ControlAllocation]   Normalization scale (forces):  Fx=0.03846 Fy=0.03846 Fz=0.03846
INFO  [ControlAllocation]   Mixing matrix (normalized, applied) =
    |Mx      |My      |Mz      |Fx      |Fy      |Fz
 0 |-0.43773  0.70711  0.90909  0        0       -1.00000
 1 | 0.43773 -0.70711  1.00000  0        0       -1.00000
 2 | 0.43773  0.70711 -0.90909  0        0       -1.00000
 3 |-0.43773 -0.70711 -1.00000  0        0       -1.00000
```

## Changelog Entry

> `control_allocator`: new `mixer` shell subcommand prints the raw (pseudo-inverse) mixing matrix and the normalized mixing matrix for each allocation instance, and the normalization scale per axis.

## Alternatives

- **Extend `control_allocator status` instead of adding a subcommand.** Rejected because `status` would grow by up to ~200 numbers per call (6 columns × up to 16 rows, printed twice, plus scale). Hostile to a low-bandwidth pxh shell, and `status` is the wrong place for opt-in diagnostic dumps. PX4 has a well-established subcommand pattern (`commander calibrate`, `commander check`, etc.) — this follows it.
- **Cache the raw pseudo-inverse as a second member updated inside `updatePseudoInverse()`.** Rejected because it adds 24 floats per instance and pollutes the allocation hot path for a debug-only feature. On-demand recomputation via `matrix::geninv` on shell command is essentially free.
- **Nullable-pointer getter virtual (`virtual const Matrix* getMixingMatrix() const { return nullptr; }`)** so `ControlAllocator::print_status()` could grab the mix and format it. Rejected after grepping `src/` turned up zero precedents for that pattern in PX4. The virtual-action-method form (`printMixingMatrix()` overridden in derived classes that own the data) is more idiomatic and keeps the formatting next to the data.

## Test coverage

Manual verification in SITL on `gz_x500`:

- `make px4_sitl gz_x500` → pxh shell.
- `control_allocator status`: output is unchanged compared to pre-change (the refactor to the shared `printMatrixCell()` helper preserved formatting byte-for-byte).
- `control_allocator mixer`: output cross-checks algebraically against the effectiveness matrix printed by `control_allocator status`:
  - Raw Fz column = −1/(N · CA_AIRFRAME thrust coefficient) for a symmetric quad.
  - Pitch normalization scale = √(Σcol²/(N_nonzero/2)) per `updateControlAllocationMatrixScale()`.
  - Normalized column = raw column ÷ scale, up to the 1e-3 snap-to-zero applied in `normalizeControlAllocationMatrix()`.
- Additionally cross-checked by temporarily printing `_mix` directly inside `updatePseudoInverse()` right after `matrix::geninv(_effectiveness, _mix)` and before normalization: output matched the mixer subcommand's "Raw mixing matrix" block byte-for-byte, confirming the on-demand `geninv` path in `printMixingMatrix()` produces identical results to the internal allocation path. Temporary debug print removed before this PR.
- `control_allocator help`: `mixer` appears in the usage text.

No automated test changes. The feature is a read-only diagnostic print with no effect on allocation behavior.

## Context

Standalone — no linked issue. Proactive diagnostics improvement motivated by control-allocation debugging on asymmetric frames.
