### PR TITLE
astrm_dronesim: x500 + gz mods for SITL+GS rendering on macOS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -74,8 +74,8 @@
 	branch = px4
 [submodule "Tools/simulation/gz"]
 	path = Tools/simulation/gz
-	url = https://github.com/PX4/PX4-gazebo-models.git
-	branch = main
+	url = https://github.com/shashank4pi/PX4-gazebo-models.git
+	branch = astrm_dronesim
 [submodule "boards/modalai/voxl2/libfc-sensor-api"]
 	path = boards/modalai/voxl2/libfc-sensor-api
 	url = https://gitlab.com/voxl-public/voxl-sdk/core-libs/libfc-sensor-api.git

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500
@@ -49,3 +49,4 @@ param set-default SIM_GZ_EC_MAX4 1000
 
 param set-default MPC_THR_HOVER 0.60
 param set-default NAV_DLL_ACT 2
+

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -80,7 +80,7 @@ bool GZMixingInterfaceESC::updateOutputs(float outputs[MAX_ACTUATORS], unsigned 
 		rotor_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
 
 		for (unsigned i = 0; i < active_output_count; i++) {
-			rotor_velocity_message.set_velocity(i, outputs[i]);
+			rotor_velocity_message.set_velocity(i, static_cast<double>(outputs[i]));
 		}
 
 		if (_actuators_pub.Valid()) {

--- a/src/modules/simulation/gz_bridge/server.config
+++ b/src/modules/simulation/gz_bridge/server.config
@@ -12,6 +12,9 @@
     <plugin entity_name="*" entity_type="world" filename="gz-sim-magnetometer-system" name="gz::sim::systems::Magnetometer"/>
     <plugin entity_name="*" entity_type="world" filename="gz-sim-sensors-system" name="gz::sim::systems::Sensors">
       <render_engine>ogre2</render_engine>
+      <background_color>0.8 0.8 0.8</background_color>
+      <ambient_light>1.0 1.0 1.0</ambient_light>
+      <headless_rendering>true</headless_rendering>
     </plugin>
     <plugin entity_name="*" entity_type="world" filename="libOpticalFlowSystem.so" name="custom::OpticalFlowSystem"/>
     <plugin entity_name="*" entity_type="world" filename="libGstCameraSystem.so" name="custom::GstCameraSystem"/>


### PR DESCRIPTION
- .gitmodules: repoint Tools/simulation/gz at shashank4pi/PX4-gazebo-models branch astrm_dronesim (carries the satellite-ground texture, white world, enlarged ground plane, magnetometer for our test site, mac gui split).
- 4001_gz_x500: trailing newline only (no behavioural change yet).
- gz_bridge/GZMixingInterfaceESC.cpp: cast actuator output to double before set_velocity — gz-msgs Actuators rotor_velocity is a double field; the implicit float promotion was generating a clang ambiguity on macOS builds.
- gz_bridge/server.config: render with grey background + ambient light + headless rendering enabled so the GS bridge can grab clean frames even when the gz-sim GUI window is closed.

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
