### PR TITLE
feat(uavcan): allow board to override hw name

### DIFF
--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -36,6 +36,13 @@
 #include "boot_app_shared.h"
 #include "boot_alt_app_shared.h"
 
+// Weak default: return the compile-time name from uavcan_board_identity.
+// Boards that resolve the name at runtime can provide a strong override.
+extern "C" __attribute__((weak)) const char *board_get_uavcan_hw_name(void)
+{
+	return HW_UAVCAN_NAME;
+}
+
 #include <drivers/drv_watchdog.h>
 #include <lib/geo/geo.h>
 #include <lib/version/version.h>
@@ -351,7 +358,7 @@ void UavcanNode::cb_beginfirmware_update(const uavcan::ReceivedDataStructure<Uav
 
 int UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 {
-	_node.setName(HW_UAVCAN_NAME);
+	_node.setName(board_get_uavcan_hw_name());
 
 	// Was the node_id supplied by the bootloader?
 


### PR DESCRIPTION
### Solved Problem
We are currently working on a new set of CAN devices that use the same firmware across different HW platforms to keep maintenance low. As they are different HW products they need to show different names. This is currently not possible as the name is hardcoded in the FW.

### Solution
- Have a weak func, for backwards compatibility it will work as before for any boards
- If a board wants to set the name dynamically it can overwrite the function
- As an example (will be upstreamed later):

```
const char *board_get_uavcan_hw_name(void)
{
	return board_otp_get_uavcan_name(board_otp_get_mft_ver_id());
}
```

### Test coverage
- Tested with the Auterion CANIO
- By design does not change the behavior of all other boards