### PR TITLE
fix(ekf2): dont adjust inactive height bias estimators on altitude reset

### DIFF
--- a/src/modules/ekf2/EKF/position_fusion.cpp
+++ b/src/modules/ekf2/EKF/position_fusion.cpp
@@ -201,13 +201,25 @@ void Ekf::resetAltitudeTo(const float new_altitude, float new_vert_pos_var)
 	updateVerticalPositionResetStatus(delta_z);
 
 #if defined(CONFIG_EKF2_BAROMETER)
-	_baro_b_est.setBias(_baro_b_est.getBias() + delta_z);
+
+	if (_control_status.flags.baro_hgt) {
+		_baro_b_est.setBias(_baro_b_est.getBias() + delta_z);
+	}
+
 #endif // CONFIG_EKF2_BAROMETER
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
-	_ev_hgt_b_est.setBias(_ev_hgt_b_est.getBias() - delta_z);
+
+	if (_control_status.flags.ev_hgt) {
+		_ev_hgt_b_est.setBias(_ev_hgt_b_est.getBias() - delta_z);
+	}
+
 #endif // CONFIG_EKF2_EXTERNAL_VISION
 #if defined(CONFIG_EKF2_GNSS)
-	_gps_hgt_b_est.setBias(_gps_hgt_b_est.getBias() + delta_z);
+
+	if (_control_status.flags.gps_hgt) {
+		_gps_hgt_b_est.setBias(_gps_hgt_b_est.getBias() + delta_z);
+	}
+
 #endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_TERRAIN)

--- a/src/modules/ekf2/EKF/position_fusion.cpp
+++ b/src/modules/ekf2/EKF/position_fusion.cpp
@@ -201,13 +201,25 @@ void Ekf::resetAltitudeTo(const float new_altitude, float new_vert_pos_var)
 	updateVerticalPositionResetStatus(delta_z);
 
 #if defined(CONFIG_EKF2_BAROMETER)
-	_baro_b_est.setBias(_baro_b_est.getBias() + delta_z);
+
+	if (control_status_flags().baro_hgt) {
+		_baro_b_est.setBias(_baro_b_est.getBias() + delta_z);
+	}
+
 #endif // CONFIG_EKF2_BAROMETER
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
-	_ev_hgt_b_est.setBias(_ev_hgt_b_est.getBias() - delta_z);
+
+	if (control_status_flags().ev_hgt) {
+		_ev_hgt_b_est.setBias(_ev_hgt_b_est.getBias() - delta_z);
+	}
+
 #endif // CONFIG_EKF2_EXTERNAL_VISION
 #if defined(CONFIG_EKF2_GNSS)
-	_gps_hgt_b_est.setBias(_gps_hgt_b_est.getBias() + delta_z);
+
+	if (control_status_flags().gps_hgt) {
+		_gps_hgt_b_est.setBias(_gps_hgt_b_est.getBias() + delta_z);
+	}
+
 #endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_TERRAIN)


### PR DESCRIPTION
### Solved Problem

When the EKF2 altitude is reset externally (via `VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE`) while one or more height aid sources are inactive, the inactive sources bias estimators still adjsuted. When such a source is later enabled, it starts fusion with a bias corresponding to the full delta between the initial altitude and the externally set altitude.

Concrete failure observed in SIH with `EKF2_HGT_REF=GPS`, `EKF2_GPS_MODE=1` (dead reckoning), `EKF2_GPS_CTRL=0` at boot:

1. Boot with GPS disabled. `_gpos.altitude() = 0`, all height bias estimators at 0.
2. `EXTERNAL_POSITION_ESTIMATE(altitude=489)` is received.
   `resetAltitudeTo()` applies `delta_z = -489` to all height bias estimators, including the inactive GNSS one.
   Result: GNSS height bias = -489m, baro bias shifted accordingly.
3. `EKF2_GPS_CTRL` is set to 7, enabling GPS.
4. In `controlGnssHeightFusion`, the `altitude_initialisation_conditions_passing` path (the only one that calls `bias_est.reset()` for GNSS) is gated by `!PX4_ISFINITE(_local_origin_alt)`, which is false since step 2 set it. The path is skipped.
5. Dead-reckoning mode + active baro causes `isGnssHgtResetAllowed()` to return false, so the reset-and-start path is also blocked. GPS height fusion starts through the no-reset path with the stale bias of -489.
6. Innovation = `-_gpos.altitude() + GPS_alt - bias = -489 + 489 - (-489) = 489 m` -> rejected every cycle -> fusion timeout -> `gnss_hgt_fault = true`.
7. `gnss_hgt_fault` stays true, fault triggers cascade to disable all GNSS fusion.


### Solution

gate each bias update in `resetAltitudeTo` on the corresponding `control_status_flags()` fusion flag, so only bias estimators that are currently fusing track the altitude reset.

### Changelog Entry

For release notes:
```
Bugfix EKF2: don't adjust inactive height bias estimators on altitude reset
```

### Test coverage

- Reproduced and verified in SIH: boot with `EKF2_GPS_CTRL=0`, `EKF2_GPS_MODE=1`, `EKF2_HGT_REF=1`, send `EXTERNAL_POSITION_ESTIMATE` with an arbitrary altitude offset, then set `EKF2_GPS_CTRL=7`.

