### PR TITLE
fix(mtd): fix registration of multiple ONCHIP devices

### DIFF
--- a/platforms/nuttx/src/px4/common/px4_mtd.cpp
+++ b/platforms/nuttx/src/px4/common/px4_mtd.cpp
@@ -300,6 +300,7 @@ int px4_mtd_config(const px4_mtd_manifest_t *mft_mtd)
 
 	for (uint8_t i = num_instances, num_entry = 0u; i < total_new_instances; ++i, ++num_entry) {
 
+		rv = -ENOMEM;
 		instances[i] = new mtd_instance_s;
 
 		if (instances[i] == nullptr) {
@@ -315,7 +316,6 @@ memoryout:
 		instances[i]->mtd_dev = nullptr;
 		instances[i]->n_partitions_current = 0;
 
-		rv = -ENOMEM;
 		instances[i]->part_dev = new FAR struct mtd_dev_s *[nparts];
 
 		if (instances[i]->part_dev == nullptr) {
@@ -358,8 +358,12 @@ memoryout:
 #endif
 
 		} else if (mtd_list->entries[num_entry]->device->bus_type == px4_mft_device_t::ONCHIP) {
-			instances[i]->n_partitions_current++;
-			return 0;
+			/* ONCHIP type is registered externally.
+			 * Populate the query table for all partitions and skip the MTD attach / geometry
+			 * steps. */
+			instances[i]->n_partitions_current = nparts;
+			rv = 0;
+			continue;
 		}
 
 		if (rv != 0) {


### PR DESCRIPTION
### Solved Problem
- When having a `ONCHIP` device with a different device following the other device will not be handled as it directly returns in case of `ONCHIP`
- When having more than one partition in `ONCHIP` it will still be set to `1`
- When the first device is successfully created but the second fails mem allocation at line 304 it will incorrectly return `0`

### Solution
- Don't return but `continue`
- Set the number of partitions to the number of parts (matches the behavior for other devices)
- Return `-ENOMEM` in case of the allocation failing after the first one passed

### Test coverage
- Tested on an Auterion CANIO node
