### PR TITLE
docs(pwm_out): list supported protocols in timer param description

### DIFF
--- a/src/drivers/pwm_out/module.yaml
+++ b/src/drivers/pwm_out/module.yaml
@@ -15,7 +15,7 @@ actuator_output:
         description:
             short: Output Protocol Configuration for ${label}
             long: |
-                Select which Output Protocol to use for outputs ${label}.
+                Select the output protocol for ${label}: PWM, OneShot, DShot, or Bidirectional DShot.
 
                 Custom PWM rates can be used by directly setting any value >0.
         type: enum


### PR DESCRIPTION
## Summary
- List PWM, OneShot, DShot, and Bidirectional DShot in the `PWM_*_TIM*` parameter long description so users can discover the parameter by searching for keywords like "bidirectional" or "dshot" in QGC.
