### PR TITLE
fix(gain_compression): guard against NaN inputs

### DIFF
--- a/src/lib/rate_control/gain_compression.cpp
+++ b/src/lib/rate_control/gain_compression.cpp
@@ -96,6 +96,10 @@ void GainCompression3d::update(const Vector3f &input, const float dt)
 
 float GainCompression::update(const float input, const float dt)
 {
+	if (!PX4_ISFINITE(input)) {
+		return _compression_gain;
+	}
+
 	_hpf = _alpha_hpf * _hpf + _alpha_hpf * (input - _input_prev);
 	_lpf.update(_hpf * _hpf);
 


### PR DESCRIPTION
### Solved Problem

If the input to the gain compression algorithm is ever NaN, then it never recovers, even when the rate controller is no longer setting NaN  setpoints. 

### Solution

When the input is NaN, keep the last `_compression_gain`.  

### Changelog Entry
For release notes:
```
Feature/Bugfix guard against NaN input in gain compression filter 
```

### Test coverage

Tested in SITL. For one cycle, I set [the input](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/fw_rate_control/FixedwingRateControl.cpp#L385) to NaN. After this, the inputs were finite again. 

Without fix: 

<img width="879" height="669" alt="image" src="https://github.com/user-attachments/assets/dd21dd23-ae89-428e-bee8-8f67ca35a2ab" />



With fix: 

<img width="879" height="669" alt="image" src="https://github.com/user-attachments/assets/49439721-1225-4df0-8a75-ca5b38ad1a7c" />


