### PR TITLE
refactor(wind-estimator): remove unused parameters and unify coding style

### DIFF
--- a/src/lib/wind_estimator/WindEstimator.cpp
+++ b/src/lib/wind_estimator/WindEstimator.cpp
@@ -45,8 +45,8 @@ WindEstimator::initialise(const matrix::Vector3f &velI, const float hor_vel_vari
 {
 	if (PX4_ISFINITE(tas_meas) && PX4_ISFINITE(tas_variance)) {
 
-		constexpr float initial_heading_var = sq(math::radians(INITIAL_HEADING_ERROR_DEG));
-		constexpr float initial_sideslip_var = sq(math::radians(INITIAL_BETA_ERROR_DEG));
+		constexpr float initial_heading_var = sq(math::radians(kInitialHeadingErrorDeg));
+		constexpr float initial_sideslip_var = sq(math::radians(kInitialBetaErrorDeg));
 
 		matrix::SquareMatrix<float, 2> P_wind_init;
 		matrix::Vector2f wind_init;
@@ -64,7 +64,7 @@ WindEstimator::initialise(const matrix::Vector3f &velI, const float hor_vel_vari
 		_state.setZero();
 		_state(INDEX_TAS_SCALE) = 1.0f;
 		_P.setZero();
-		_P(INDEX_W_N, INDEX_W_N) = _P(INDEX_W_E, INDEX_W_E) = sq(INITIAL_WIND_ERROR);
+		_P(INDEX_W_N, INDEX_W_N) = _P(INDEX_W_E, INDEX_W_E) = sq(kInitialWindError);
 	}
 
 	_wind_estimator_reset = true;
@@ -95,14 +95,14 @@ WindEstimator::update(uint64_t time_now)
 	const float dt = (float)(time_now - _time_last_update) * 1e-6f;
 	_time_last_update = time_now;
 
-	// if airspeed scale is at default (1.0) and we are in the first 5 minutes of flight time, multiply _tas_scale_psd by 100 for faster learning
+	// if airspeed scale is at default (1.0) and we are in the first 5 minutes of flight time, multiply kTasScalePsd by 100 for faster learning
 	const float tas_psd_multiplier = (fabsf(_scale_init - 1.0f) < FLT_EPSILON && (time_now - _time_initialised < kTASScaleFastLearnTime)) ?
 					 kTASScalePSDMultiplier : 1.f;
 
 	matrix::Matrix3f Qk;
 	Qk(INDEX_W_N, INDEX_W_N) = _wind_psd * dt;
 	Qk(INDEX_W_E, INDEX_W_E) = Qk(INDEX_W_N, INDEX_W_N);
-	Qk(INDEX_TAS_SCALE, INDEX_TAS_SCALE) = _tas_scale_psd * tas_psd_multiplier * dt;
+	Qk(INDEX_TAS_SCALE, INDEX_TAS_SCALE) = kTasScalePsd * tas_psd_multiplier * dt;
 	_P += Qk;
 }
 
@@ -130,7 +130,7 @@ WindEstimator::fuse_airspeed(uint64_t time_now, const float true_airspeed, const
 	sym::FuseAirspeed(velI, _state, _P, true_airspeed, _tas_var, FLT_EPSILON,
 			  &H_tas, &K, &_tas_innov_var, &_tas_innov);
 
-	const bool meas_is_rejected = check_if_meas_is_rejected(_tas_innov, _tas_innov_var, _tas_gate);
+	const bool meas_is_rejected = check_if_meas_is_rejected(_tas_innov, _tas_innov_var, kTasGate);
 
 	if (_tas_innov_var < FLT_EPSILON) {
 		// re init filter in case of a negative variance, and trigger early return to not fuse measurement
@@ -172,10 +172,10 @@ WindEstimator::fuse_beta(uint64_t time_now, const matrix::Vector3f &velI, const 
 	matrix::Matrix<float, 1, 3> H_beta;
 	matrix::Matrix<float, 3, 1> K;
 
-	sym::FuseBeta(velI, _state, _P, q_att, _beta_var, FLT_EPSILON,
+	sym::FuseBeta(velI, _state, _P, q_att, kBetaVar, FLT_EPSILON,
 		      &H_beta, &K, &_beta_innov_var, &_beta_innov);
 
-	const bool meas_is_rejected = check_if_meas_is_rejected(_beta_innov, _beta_innov_var, _beta_gate);
+	const bool meas_is_rejected = check_if_meas_is_rejected(_beta_innov, _beta_innov_var, kBetaGate);
 
 	if (_beta_innov_var < FLT_EPSILON) {
 		// re init filter in case of a negative variance, and trigger early return to not fuse measurement

--- a/src/lib/wind_estimator/WindEstimator.hpp
+++ b/src/lib/wind_estimator/WindEstimator.hpp
@@ -86,12 +86,9 @@ public:
 
 	// unaided, the state uncertainty (diagonal of sqrt(P)) grows by the process noise spectral density every second
 	void set_wind_process_noise_spectral_density(float wind_nsd) { _wind_psd = wind_nsd * wind_nsd; }
-	void set_tas_scale_process_noise_spectral_density(float tas_scale_nsd) { _tas_scale_psd = tas_scale_nsd * tas_scale_nsd; }
 
 	void set_tas_noise(float tas_sigma) { _tas_var = tas_sigma * tas_sigma; }
-	void set_beta_noise(float beta_var) { _beta_var = beta_var * beta_var; }
-	void set_tas_gate(uint8_t gate_size) {_tas_gate = gate_size; }
-	void set_beta_gate(uint8_t gate_size) {_beta_gate = gate_size; }
+
 	void set_scale_init(float scale_init) {_scale_init = 1.f / math::constrain(scale_init, 0.1f, 10.f); }
 
 	void reset_scale_to_init()
@@ -109,11 +106,11 @@ private:
 		INDEX_TAS_SCALE
 	};	///< enum which can be used to access state.
 
-	static constexpr float INITIAL_WIND_ERROR =
+	static constexpr float kInitialWindError =
 		2.5f; // initial uncertainty of each wind state when filter is initialised without airspeed [m/s]
-	static constexpr float INITIAL_BETA_ERROR_DEG =
+	static constexpr float kInitialBetaErrorDeg =
 		15.0f;	// sidelip uncertainty used to initialise the filter with a true airspeed measurement [deg]
-	static constexpr float INITIAL_HEADING_ERROR_DEG =
+	static constexpr float kInitialHeadingErrorDeg =
 		10.0f; // heading uncertainty used to initialise the filter with a true airspeed measurement [deg]
 
 	matrix::Vector3f _state{0.f, 0.f, 1.f};
@@ -127,12 +124,12 @@ private:
 
 	bool _initialised{false};	///< True: filter has been initialised
 
-	float _wind_psd{0.1f};	///< wind process noise power spectral density (m^2/s^4/Hz)
-	float _tas_scale_psd{0.0001f};	///< true airspeed process noise power spectral density (1/s^2/Hz)
-	float _tas_var{1.4f};		///< true airspeed measurement noise variance
-	float _beta_var{0.5f};	///< sideslip measurement noise variance
-	uint8_t _tas_gate{3};	///< airspeed fusion gate size
-	uint8_t _beta_gate{1};	///< sideslip fusion gate size
+	float _wind_psd{0.01f};	///< wind process noise power spectral density (m^2/s^4/Hz), (0.1 m/s^2/sqrt(Hz))^2
+	static constexpr float kTasScalePsd{1e-8f};	///< true airspeed scale process noise power spectral density (1/s^2/Hz), (0.0001 1/s/sqrt(Hz))^2
+	float _tas_var{1.96f};		///< true airspeed measurement noise variance (m/s)^2, (1.4 m/s)^2
+	static constexpr float kBetaVar{0.0225f};	///< sideslip measurement noise variance (rad)^2, (0.15 rad)^2
+	static constexpr uint8_t kTasGate{4};	///< airspeed fusion gate size (SD)
+	static constexpr uint8_t kBetaGate{1};	///< sideslip fusion gate size (SD)
 
 	float _scale_init{1.f};
 

--- a/src/modules/airspeed_selector/AirspeedValidator.hpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.hpp
@@ -95,20 +95,12 @@ public:
 
 	// setters wind estimator parameters
 	void set_wind_estimator_wind_process_noise_spectral_density(float wind_nsd) { _wind_estimator.set_wind_process_noise_spectral_density(wind_nsd); }
-	void set_wind_estimator_tas_scale_process_noise_spectral_density(float tas_scale_nsd) { _wind_estimator.set_tas_scale_process_noise_spectral_density(tas_scale_nsd); }
+	void set_wind_estimator_tas_noise(float tas_sigma) { _wind_estimator.set_tas_noise(tas_sigma); }
+
 	void set_wind_estimator_tas_scale_init(float tas_scale_init)
 	{
 		_tas_scale_init = tas_scale_init;
 	}
-
-	void set_wind_estimator_tas_noise(float tas_sigma) { _wind_estimator.set_tas_noise(tas_sigma); }
-	void set_wind_estimator_beta_noise(float beta_var) { _wind_estimator.set_beta_noise(beta_var); }
-	void set_wind_estimator_tas_gate(uint8_t gate_size)
-	{
-		_wind_estimator.set_tas_gate(gate_size);
-	}
-
-	void set_wind_estimator_beta_gate(uint8_t gate_size) { _wind_estimator.set_beta_gate(gate_size); }
 
 	// setters for failure detection tuning parameters
 	void set_tas_innov_threshold(float tas_innov_threshold) { _tas_innov_threshold = tas_innov_threshold; }

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -188,11 +188,7 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::ASPD_WIND_NSD>) _param_aspd_wind_nsd,
-		(ParamFloat<px4::params::ASPD_SCALE_NSD>) _param_aspd_scale_nsd,
 		(ParamFloat<px4::params::ASPD_TAS_NOISE>) _param_west_tas_noise,
-		(ParamFloat<px4::params::ASPD_BETA_NOISE>) _param_west_beta_noise,
-		(ParamInt<px4::params::ASPD_TAS_GATE>) _param_west_tas_gate,
-		(ParamInt<px4::params::ASPD_BETA_GATE>) _param_west_beta_gate,
 		(ParamInt<px4::params::ASPD_SCALE_APPLY>) _param_aspd_scale_apply,
 		(ParamFloat<px4::params::ASPD_SCALE_1>) _param_airspeed_scale_1,
 		(ParamFloat<px4::params::ASPD_SCALE_2>) _param_airspeed_scale_2,
@@ -518,19 +514,10 @@ void AirspeedModule::update_params()
 	}
 
 	_wind_estimator_sideslip.set_wind_process_noise_spectral_density(_param_aspd_wind_nsd.get());
-	_wind_estimator_sideslip.set_tas_scale_process_noise_spectral_density(_param_aspd_scale_nsd.get());
-	_wind_estimator_sideslip.set_tas_noise(_param_west_tas_noise.get());
-	_wind_estimator_sideslip.set_beta_noise(_param_west_beta_noise.get());
-	_wind_estimator_sideslip.set_tas_gate(_param_west_tas_gate.get());
-	_wind_estimator_sideslip.set_beta_gate(_param_west_beta_gate.get());
 
 	for (int i = 0; i < MAX_NUM_AIRSPEED_SENSORS; i++) {
 		_airspeed_validator[i].set_wind_estimator_wind_process_noise_spectral_density(_param_aspd_wind_nsd.get());
-		_airspeed_validator[i].set_wind_estimator_tas_scale_process_noise_spectral_density(_param_aspd_scale_nsd.get());
 		_airspeed_validator[i].set_wind_estimator_tas_noise(_param_west_tas_noise.get());
-		_airspeed_validator[i].set_wind_estimator_beta_noise(_param_west_beta_noise.get());
-		_airspeed_validator[i].set_wind_estimator_tas_gate(_param_west_tas_gate.get());
-		_airspeed_validator[i].set_wind_estimator_beta_gate(_param_west_beta_gate.get());
 
 		_airspeed_validator[i].set_tas_scale_apply(_param_aspd_scale_apply.get());
 		_airspeed_validator[i].set_wind_estimator_tas_scale_init(_param_airspeed_scale[i]);

--- a/src/modules/airspeed_selector/airspeed_selector_params.yaml
+++ b/src/modules/airspeed_selector/airspeed_selector_params.yaml
@@ -14,18 +14,6 @@ parameters:
       max: 1
       unit: m/s^2/sqrt(Hz)
       decimal: 2
-    ASPD_SCALE_NSD:
-      description:
-        short: Wind estimator true airspeed scale process noise spectral density
-        long: |-
-          Airspeed scale process noise of the internal wind estimator(s) of the airspeed selector.
-          When unaided, the scale uncertainty (1-sigma, unitless) increases by this amount every second.
-      type: float
-      default: 0.0001
-      min: 0
-      max: 0.1
-      unit: 1/s/sqrt(Hz)
-      decimal: 5
     ASPD_TAS_NOISE:
       description:
         short: Wind estimator true airspeed measurement noise
@@ -37,37 +25,6 @@ parameters:
       max: 4
       unit: m/s
       decimal: 1
-    ASPD_BETA_NOISE:
-      description:
-        short: Wind estimator sideslip measurement noise
-        long: Sideslip measurement noise of the internal wind estimator(s) of the
-          airspeed selector.
-      type: float
-      default: 0.15
-      min: 0
-      max: 1
-      unit: rad
-      decimal: 3
-    ASPD_TAS_GATE:
-      description:
-        short: Gate size for true airspeed fusion
-        long: Sets the number of standard deviations used by the innovation consistency
-          test.
-      type: int32
-      default: 4
-      min: 1
-      max: 5
-      unit: SD
-    ASPD_BETA_GATE:
-      description:
-        short: Gate size for sideslip angle fusion
-        long: Sets the number of standard deviations used by the innovation consistency
-          test.
-      type: int32
-      default: 1
-      min: 1
-      max: 5
-      unit: SD
     ASPD_SCALE_APPLY:
       description:
         short: Controls when to apply the new estimated airspeed scale(s)


### PR DESCRIPTION

### Solved Problem
No one really touches these wind estimator tuning parameters. At least, I have never changed them for any platform ranging from gliders to high speed vehicles. 

### Solution

- Hardcode them as constants 
- Unify code style in `WindEstimator`

### Changelog Entry
For release notes:
```
Feature/Bugfix (cleanup) remove unnecessary parameters in WindEstimator 
```

### Alternatives

Since the WindEstimator is a library, I did consider leaving them as configurable there and hardcoding them as constants in the AirspeedValidator / airspeed_selector_main, but I felt that was unnecessarily complicated. 

### Test coverage

No functional change, did a quick sanity test in SITL. 



