### PR TITLE
[BACKPORT v1.17] fix(bmp581): add pressure range validation (#26373)

### DIFF
--- a/src/drivers/barometer/bmp581/bmp581.cpp
+++ b/src/drivers/barometer/bmp581/bmp581.cpp
@@ -710,6 +710,10 @@ int BMP581::get_sensor_data(bmp5_sensor_data *sensor_data)
 		/* Division by 2^6(whose equivalent value is 64) is performed to get pressure data in Pa */
 		sensor_data->pressure = (float)(raw_data_p / 64.0);
 
+		if (sensor_data->pressure < BMP5_PRESSURE_MIN_PA || sensor_data->pressure > BMP5_PRESSURE_MAX_PA) {
+			return PX4_ERROR;
+		}
+
 	} else {
 		sensor_data->pressure = 0.0;
 	}

--- a/src/drivers/barometer/bmp581/bmp581.h
+++ b/src/drivers/barometer/bmp581/bmp581.h
@@ -101,6 +101,10 @@
 #define BMP5_DEEP_ENABLED		(0)
 #define BMP5_DEEP_DISABLED              (1)
 
+/* Pressure operating range (Pa) */
+#define BMP5_PRESSURE_MIN_PA            (30000.0f)
+#define BMP5_PRESSURE_MAX_PA            (125000.0f)
+
 /* ODR settings */
 #define BMP5_ODR_50_HZ                  (0x0F)
 #define BMP5_ODR_05_HZ                  (0x18)


### PR DESCRIPTION
**Backporting #26373 to v1.17**

Reject pressure readings outside the sensor's operating range (30-125 kPa) to detect I2C data corruption. When I2C transfers complete successfully but return corrupted data, this check prevents invalid samples from being published.