### PR TITLE
fix(drivers/imu/invensense): force bank 0 at probe startup

### DIFF
--- a/src/drivers/imu/invensense/icm20649/ICM20649.cpp
+++ b/src/drivers/imu/invensense/icm20649/ICM20649.cpp
@@ -108,23 +108,18 @@ void ICM20649::print_status()
 int ICM20649::probe()
 {
 	for (int i = 0; i < 3; i++) {
+		// force bank 0: the actual register bank after a soft reset is unknown,
+		// but _last_register_bank is default-initialized to 0, so RegisterRead
+		// would otherwise skip the bank select and read from the wrong bank
+		SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_0, true);
+
 		uint8_t whoami = RegisterRead(Register::BANK_0::WHO_AM_I);
 
 		if (whoami == WHOAMI) {
 			return PX4_OK;
-
-		} else {
-			DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
-
-			uint8_t reg_bank_sel = RegisterRead(Register::BANK_0::REG_BANK_SEL);
-			int bank = reg_bank_sel >> 4;
-
-			if (bank >= 1 && bank <= 3) {
-				DEVICE_DEBUG("incorrect register bank for WHO_AM_I REG_BANK_SEL:0x%02x, bank:%d", reg_bank_sel, bank);
-				// force bank selection and retry
-				SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_0, true);
-			}
 		}
+
+		DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
 	}
 
 	return PX4_ERROR;

--- a/src/drivers/imu/invensense/icm20948/ICM20948.cpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948.cpp
@@ -137,23 +137,18 @@ void ICM20948::print_status()
 int ICM20948::probe()
 {
 	for (int i = 0; i < 3; i++) {
+		// force bank 0: the actual register bank after a soft reset is unknown,
+		// but _last_register_bank is default-initialized to 0, so RegisterRead
+		// would otherwise skip the bank select and read from the wrong bank
+		SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_0, true);
+
 		uint8_t whoami = RegisterRead(Register::BANK_0::WHO_AM_I);
 
 		if (whoami == WHOAMI) {
 			return PX4_OK;
-
-		} else {
-			DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
-
-			uint8_t reg_bank_sel = RegisterRead(Register::BANK_0::REG_BANK_SEL);
-			int bank = reg_bank_sel >> 4;
-
-			if (bank >= 1 && bank <= 3) {
-				DEVICE_DEBUG("incorrect register bank for WHO_AM_I REG_BANK_SEL:0x%02x, bank:%d", reg_bank_sel, bank);
-				// force bank selection and retry
-				SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_0, true);
-			}
 		}
+
+		DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
 	}
 
 	return PX4_ERROR;

--- a/src/drivers/imu/invensense/icm20948/ICM20948_I2C_Passthrough.cpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948_I2C_Passthrough.cpp
@@ -88,24 +88,18 @@ int ICM20948_I2C_Passthrough::probe()
 {
 	// 3 retries
 	for (int i = 0; i < 3; i++) {
+		// force bank 0: the actual register bank after a soft reset is unknown,
+		// but _last_register_bank is default-initialized to 0, so RegisterRead
+		// would otherwise skip the bank select and read from the wrong bank
+		SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_0, true);
 
 		const uint8_t WHO_AM_I = RegisterRead(Register::BANK_0::WHO_AM_I);
 
 		if (WHO_AM_I == WHOAMI) {
 			return PX4_OK;
-
-		} else {
-			DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", WHO_AM_I);
-
-			uint8_t reg_bank_sel = RegisterRead(Register::BANK_0::REG_BANK_SEL);
-			int bank = reg_bank_sel >> 4;
-
-			if (bank >= 1 && bank <= 3) {
-				DEVICE_DEBUG("incorrect register bank for WHO_AM_I REG_BANK_SEL:0x%02x, bank:%d", reg_bank_sel, bank);
-				// force bank selection and retry
-				SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_0, true);
-			}
 		}
+
+		DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", WHO_AM_I);
 	}
 
 	return PX4_ERROR;

--- a/src/drivers/imu/invensense/icm40609d/ICM40609D.cpp
+++ b/src/drivers/imu/invensense/icm40609d/ICM40609D.cpp
@@ -108,23 +108,18 @@ void ICM40609D::print_status()
 int ICM40609D::probe()
 {
 	for (int i = 0; i < 3; i++) {
+		// force bank 0: the actual register bank after a soft reset is unknown,
+		// but _last_register_bank is default-initialized to 0, so RegisterRead
+		// would otherwise skip the bank select and read from the wrong bank
+		SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_0, true);
+
 		uint8_t whoami = RegisterRead(Register::BANK_0::WHO_AM_I);
 
 		if (whoami == WHOAMI) {
 			return PX4_OK;
-
-		} else {
-			DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
-
-			uint8_t reg_bank_sel = RegisterRead(Register::BANK_0::REG_BANK_SEL);
-			int bank = reg_bank_sel >> 4;
-
-			if (bank >= 1 && bank <= 3) {
-				DEVICE_DEBUG("incorrect register bank for WHO_AM_I REG_BANK_SEL:0x%02x, bank:%d", reg_bank_sel, bank);
-				// force bank selection and retry
-				SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_0, true);
-			}
 		}
+
+		DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
 	}
 
 	return PX4_ERROR;

--- a/src/drivers/imu/invensense/icm42605/ICM42605.cpp
+++ b/src/drivers/imu/invensense/icm42605/ICM42605.cpp
@@ -108,23 +108,18 @@ void ICM42605::print_status()
 int ICM42605::probe()
 {
 	for (int i = 0; i < 3; i++) {
+		// force bank 0: the actual register bank after a soft reset is unknown,
+		// but _last_register_bank is default-initialized to 0, so RegisterRead
+		// would otherwise skip the bank select and read from the wrong bank
+		SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_0, true);
+
 		uint8_t whoami = RegisterRead(Register::BANK_0::WHO_AM_I);
 
 		if (whoami == WHOAMI) {
 			return PX4_OK;
-
-		} else {
-			DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
-
-			uint8_t reg_bank_sel = RegisterRead(Register::BANK_0::REG_BANK_SEL);
-			int bank = reg_bank_sel >> 4;
-
-			if (bank >= 1 && bank <= 3) {
-				DEVICE_DEBUG("incorrect register bank for WHO_AM_I REG_BANK_SEL:0x%02x, bank:%d", reg_bank_sel, bank);
-				// force bank selection and retry
-				SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_0, true);
-			}
 		}
+
+		DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
 	}
 
 	return PX4_ERROR;

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
@@ -125,24 +125,19 @@ void ICM42688P::print_status()
 int ICM42688P::probe()
 {
 	for (int i = 0; i < 3; i++) {
+		// force bank 0: the actual register bank after a soft reset is unknown,
+		// but _last_register_bank is default-initialized to 0, so RegisterRead
+		// would otherwise skip the bank select and read from the wrong bank
+		SelectRegisterBank(REG_BANK_SEL_BIT::BANK_SEL_0, true);
+
 		uint8_t whoami = RegisterRead(Register::BANK_0::WHO_AM_I);
 		uint8_t expected_whoami = isICM686 ? WHOAMI686 : WHOAMI;
 
 		if (whoami == expected_whoami) {
 			return PX4_OK;
-
-		} else {
-			DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
-
-			uint8_t reg_bank_sel = RegisterRead(Register::BANK_0::REG_BANK_SEL);
-			int bank = reg_bank_sel >> 4;
-
-			if (bank >= 1 && bank <= 3) {
-				DEVICE_DEBUG("incorrect register bank for WHO_AM_I REG_BANK_SEL:0x%02x, bank:%d", reg_bank_sel, bank);
-				// force bank selection and retry
-				SelectRegisterBank(REG_BANK_SEL_BIT::BANK_SEL_0, true);
-			}
 		}
+
+		DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
 	}
 
 	return PX4_ERROR;

--- a/src/drivers/imu/invensense/iim42652/IIM42652.cpp
+++ b/src/drivers/imu/invensense/iim42652/IIM42652.cpp
@@ -123,23 +123,18 @@ void IIM42652::print_status()
 int IIM42652::probe()
 {
 	for (int i = 0; i < 3; i++) {
+		// force bank 0: the actual register bank after a soft reset is unknown,
+		// but _last_register_bank is default-initialized to 0, so RegisterRead
+		// would otherwise skip the bank select and read from the wrong bank
+		SelectRegisterBank(REG_BANK_SEL_BIT::BANK_SEL_0, true);
+
 		uint8_t whoami = RegisterRead(Register::BANK_0::WHO_AM_I);
 
 		if (whoami == WHOAMI) {
 			return PX4_OK;
-
-		} else {
-			DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
-
-			uint8_t reg_bank_sel = RegisterRead(Register::BANK_0::REG_BANK_SEL);
-			int bank = reg_bank_sel >> 4;
-
-			if (bank >= 1 && bank <= 3) {
-				DEVICE_DEBUG("incorrect register bank for WHO_AM_I REG_BANK_SEL:0x%02x, bank:%d", reg_bank_sel, bank);
-				// force bank selection and retry
-				SelectRegisterBank(REG_BANK_SEL_BIT::BANK_SEL_0, true);
-			}
 		}
+
+		DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
 	}
 
 	return PX4_ERROR;

--- a/src/drivers/imu/invensense/iim42653/IIM42653.cpp
+++ b/src/drivers/imu/invensense/iim42653/IIM42653.cpp
@@ -123,23 +123,18 @@ void IIM42653::print_status()
 int IIM42653::probe()
 {
 	for (int i = 0; i < 3; i++) {
+		// force bank 0: the actual register bank after a soft reset is unknown,
+		// but _last_register_bank is default-initialized to 0, so RegisterRead
+		// would otherwise skip the bank select and read from the wrong bank
+		SelectRegisterBank(REG_BANK_SEL_BIT::BANK_SEL_0, true);
+
 		uint8_t whoami = RegisterRead(Register::BANK_0::WHO_AM_I);
 
 		if (whoami == WHOAMI) {
 			return PX4_OK;
-
-		} else {
-			DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
-
-			uint8_t reg_bank_sel = RegisterRead(Register::BANK_0::REG_BANK_SEL);
-			int bank = reg_bank_sel >> 4;
-
-			if (bank >= 1 && bank <= 3) {
-				DEVICE_DEBUG("incorrect register bank for WHO_AM_I REG_BANK_SEL:0x%02x, bank:%d", reg_bank_sel, bank);
-				// force bank selection and retry
-				SelectRegisterBank(REG_BANK_SEL_BIT::BANK_SEL_0, true);
-			}
 		}
+
+		DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
 	}
 
 	return PX4_ERROR;


### PR DESCRIPTION
## Summary

Supersedes #25894 (author @spiderkeys went silent; auto-closed after 120d inactivity). Applies the bank-0 probe fix there to all multi-bank Invensense drivers.

After a soft reset with a non-zero bank selected, the driver cannot re-initialize: `_last_register_bank` is default-initialized to `0` but the hardware state is unknown. `RegisterRead` then skips the bank select (cached value matches), so reads target the wrong bank and `DEVICE_CONFIG` comes back non-zero. Device is stuck until a power cycle.

**Fix:** force bank 0 as the first transfer of each `probe()` retry, synchronizing the cached bank with hardware. The post-fail bank inspection becomes unreachable and is removed.

## Affected drivers

- `IIM42652`, `IIM42653`, `ICM42688P` (`BANK_SEL_0`)
- `ICM42605`, `ICM40609D`, `ICM20948` (main + `I2C_Passthrough`), `ICM20649` (`USER_BANK_0`)
- `ICM45686` and `ICM42670P` have a single bank — not affected

## Test

- Tested on ARK FPV hardware (IIM42653)
- Builds verified: `ark_fpv_default`, `matek_h743_default`, `px4_fmu-v6x_default`
- Original evidence (scope traces from soft-reset repro): see #25894