### PR TITLE
feat(astyle): add option to only format diff with respect to HEAD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ The [developer guide](https://docs.px4.io/main/en/development/development.html) 
 
 ### Coding standards
 
-All C/C++ code must follow the [PX4 coding style](https://docs.px4.io/main/en/contribute/code.html). Formatting is enforced by [astyle](http://astyle.sourceforge.net/) in CI (`make check_format`). Code quality checks run via [clang-tidy](https://clang.llvm.org/extra/clang-tidy/). Pull requests that fail either check will not be merged.
+All C/C++ code must follow the [PX4 coding style](https://docs.px4.io/main/en/contribute/code.html). Formatting is enforced by [astyle](http://astyle.sourceforge.net/) in CI (`make check_format`, ``make format`, `make format_changed`). Code quality checks run via [clang-tidy](https://clang.llvm.org/extra/clang-tidy/). Pull requests that fail either check will not be merged.
 
 Python code is checked with [mypy](https://mypy-lang.org/) and [flake8](https://flake8.pycqa.org/).
 

--- a/Makefile
+++ b/Makefile
@@ -404,7 +404,7 @@ px4_metadata: parameters_metadata airframe_metadata module_documentation extract
 
 # Style
 # --------------------------------------------------------------------
-.PHONY: check_format format check_newlines
+.PHONY: check_format format format_changed check_newlines
 
 check_format:
 	$(call colorecho,'Checking formatting with astyle')
@@ -414,6 +414,10 @@ check_format:
 format:
 	$(call colorecho,'Formatting with astyle')
 	@"$(SRC_DIR)"/Tools/astyle/check_code_style_all.sh --fix
+
+format_changed:
+	$(call colorecho,'Formatting changed files with astyle')
+	@"$(SRC_DIR)"/Tools/astyle/check_code_style_all.sh --fix --diff-only
 
 check_newlines:
 	$(call colorecho,'Checking for missing or duplicate newlines at the end of files')

--- a/Tools/astyle/check_code_style.sh
+++ b/Tools/astyle/check_code_style.sh
@@ -16,7 +16,7 @@ if [ -n "$CHECK_FAILED" ]; then
 	if [[ $PX4_ASTYLE_FIX -eq 1 ]]; then
 		${DIR}/fix_code_style.sh $FILE
 	else
-		echo 'to fix automatically run "make format" or "./Tools/astyle/fix_code_style.sh' $FILE'"'
+		echo 'to fix automatically run "make format", "make format_changed" or "./Tools/astyle/fix_code_style.sh' $FILE'"'
 		exit 1
 	fi
 fi

--- a/Tools/astyle/check_code_style_all.sh
+++ b/Tools/astyle/check_code_style_all.sh
@@ -36,9 +36,13 @@ fi
 CI="${CI:-false}"
 DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 
-if [[ "$@" == "--fix" ]]; then
-    export PX4_ASTYLE_FIX=1
-fi
+DIFF_ONLY=false
+for arg in "$@"; do
+    case "$arg" in
+        --fix) export PX4_ASTYLE_FIX=1 ;;
+        --diff-only) DIFF_ONLY=true ;;
+    esac
+done
 
 
 # install git pre-commit hook
@@ -59,7 +63,24 @@ if [[ ! -f "$HOOK_FILE" && "$CI" != "true" && $- == *i* ]]; then
 	fi
 fi
 
-${DIR}/files_to_check_code_style.sh | xargs -P 8 -I % ${DIR}/check_code_style.sh %
+FILE_LIST=$(${DIR}/files_to_check_code_style.sh)
+
+if [ "$DIFF_ONLY" = true ]; then
+    # --diff-filter=d: do not list deleted files (no need to format)
+    CHANGED=$(git -C "$DIR/../.." diff --name-only --diff-filter=d HEAD -- '*.c' '*.h' '*.cpp' '*.hpp')
+    if [ -z "$CHANGED" ]; then
+        FILE_LIST=""
+    else
+        FILE_LIST=$(echo "$FILE_LIST" | grep -Fx -f <(echo "$CHANGED") || true)
+    fi
+fi
+
+if [ -z "$FILE_LIST" ]; then
+    echo "No files to check"
+    exit 0
+fi
+
+echo "$FILE_LIST" | xargs -P 8 -I % ${DIR}/check_code_style.sh %
 
 if [ $? -eq 0 ]; then
     echo "Format checks passed"


### PR DESCRIPTION
### Solved Problem

`make format` is pretty slow (25s on my thinkpad X1 with an already clean state). When iterating quickly this adds major friction and discourages use of the auto formatter, even though it is mostly just a handful of files that need to be formatted. 

### Solution

Add `make format_changed`, which only considers the files that differ from `HEAD` as reported by `git diff`. The existing `make format` is unchanged and considers the entire tree. 


### Changelog Entry
Dev tooling, not needed

### Test coverage

Mess up formatting in some files, stash. `make format_changed`:
 
```
balduin@balduin-thinkpad:~/PX4-Autopilot$ git stash apply && time make format_changed && git diff && echo git diff exited $? 
On branch pr-faster-make-format
Your branch is up to date with 'upstream/pr-faster-make-format'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   src/lib/tecs/TECS.cpp
	modified:   src/modules/airspeed_selector/AirspeedValidator.cpp
	modified:   src/modules/commander/Commander.cpp

no changes added to commit (use "git add" and/or "git commit -a")
Formatting changed files with astyle 
Formatting issue found in src/modules/airspeed_selector/AirspeedValidator.cpp

 [ ... the entire diff ... ]

Formatted  src/modules/commander/Commander.cpp
Format checks passed

real	0m0.245s
user	0m0.199s
sys	0m0.167s
git diff exited 0
```
`make format`
```
balduin@balduin-thinkpad:~/PX4-Autopilot$ git stash apply && time make format && git diff && echo git diff exited $? 
On branch pr-faster-make-format
Your branch is up to date with 'upstream/pr-faster-make-format'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   src/lib/tecs/TECS.cpp
	modified:   src/modules/airspeed_selector/AirspeedValidator.cpp
	modified:   src/modules/commander/Commander.cpp

no changes added to commit (use "git add" and/or "git commit -a")
Formatting with astyle 
Formatting issue found in src/lib/tecs/TECS.cpp

 [ ... the same diff ... ]

Formatted  src/modules/commander/Commander.cpp
Format checks passed

real	0m26.410s
user	0m59.843s
sys	1m50.289s
git diff exited 0
```

For a nice ~100x speedup :) 