### PR TITLE
fix(navigator): use _gps_pos.timestamp for validity check

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -990,7 +990,7 @@ void Navigator::geofence_breach_check()
 			current_latitude = _gps_pos.latitude_deg;
 			current_longitude = _gps_pos.longitude_deg;
 			current_altitude = _gps_pos.altitude_msl_m;
-			position_valid = _global_pos.timestamp > 0;
+			position_valid = _gps_pos.timestamp > 0;
 		}
 
 		if (!position_valid) {


### PR DESCRIPTION
fix #27069
@Drone-Lab We noticed a small logic inconsistency in geofence_breach_check. When the source is set to GF_SOURCE_GPS, the code currently checks _global_pos.timestamp for validity. Wouldn't it be more reasonable to check _gps_pos.timestamp here to match the data source? Just a tiny thing I thought I'd mention 🙂
