### PR TITLE
build(macos): inline homebrew deps in setup script, drop px4-dev meta-formula

### DIFF
--- a/Tools/setup/macos.sh
+++ b/Tools/setup/macos.sh
@@ -40,31 +40,43 @@ then
 	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 fi
 
-# Install px4-dev formula
+# Required taps. Homebrew 4.5+ no longer auto-resolves cross-tap
+# dependencies, so every tap that a package lives in must be added
+# explicitly here before `brew install`.
+#
+# - osx-cross/arm: arm-gcc-bin@13 (ARM cross-compiler)
+# - PX4/px4:       fastdds, genromfs, kconfig-frontends (PX4-specific)
+brew tap osx-cross/arm
+brew tap PX4/px4
+
+# Package list. This replaces the px4-dev meta-formula, which is kept
+# as a deprecated no-op upstream. See PX4/homebrew-px4 for history.
+PX4_BREW_PACKAGES=(
+	ant
+	astyle
+	bash-completion
+	ccache
+	cmake
+	fastdds
+	genromfs
+	kconfig-frontends
+	ncurses
+	ninja
+	osx-cross/arm/arm-gcc-bin@13
+	python
+	python-tk
+)
+
 if [[ $REINSTALL_FORMULAS == "--reinstall" ]]; then
-	echo "[macos.sh] Re-installing dependencies (homebrew px4-dev)"
-
-	# confirm Homebrew installed correctly
+	echo "[macos.sh] Re-installing PX4 toolchain dependencies"
 	brew doctor
-
-	brew tap osx-cross/arm
-	brew tap PX4/px4
-
-	brew reinstall px4-dev
-	brew link --overwrite --force arm-gcc-bin@13
+	brew reinstall "${PX4_BREW_PACKAGES[@]}"
 else
-	if brew ls --versions px4-dev > /dev/null; then
-		echo "[macos.sh] px4-dev already installed"
-	else
-		echo "[macos.sh] Installing general dependencies (homebrew px4-dev)"
-
-		brew tap osx-cross/arm
-		brew tap PX4/px4
-
-		brew install px4-dev
-		brew link --overwrite --force arm-gcc-bin@13
-	fi
+	echo "[macos.sh] Installing PX4 toolchain dependencies"
+	brew install "${PX4_BREW_PACKAGES[@]}"
 fi
+
+brew link --overwrite --force arm-gcc-bin@13
 
 # Python dependencies
 echo "[macos.sh] Installing Python3 dependencies"

--- a/docs/en/dev_setup/dev_env_mac.md
+++ b/docs/en/dev_setup/dev_env_mac.md
@@ -59,7 +59,7 @@ To build for [other targets](../dev_setup/dev_env.md#supported-targets) you will
    ```
 
    This installs:
-   - **`px4-dev`** — ARM cross-compiler (`arm-gcc-bin@13`), `cmake`, `ninja`, `ccache`, and other build tools
+   - **Toolchain packages** from the `osx-cross/arm` and `PX4/px4` Homebrew taps — ARM cross-compiler (`arm-gcc-bin@13`), `cmake`, `ninja`, `ccache`, `fastdds`, `genromfs`, `kconfig-frontends`, and other build tools
    - **Python packages** from `requirements.txt`
    - **`px4-sim`** (via `--sim-tools`) — Gazebo Harmonic simulation (`gz-harmonic`) and related tools
 


### PR DESCRIPTION
Homebrew 4.5 (released early April 2026) stopped auto-tapping cross-tap dependencies declared in formulae, as a security and performance change. The `px4-dev` meta-formula in [PX4/homebrew-px4](https://github.com/PX4/homebrew-px4) pulls in packages from `osx-cross/arm`, `PX4/px4`, and (until recently) `discoteq/discoteq`, so `brew install px4-dev` now aborts before any real work happens unless the consumer has already tapped every source explicitly. On macos-latest CI runners this surfaced as the entire [MacOS build workflow](https://github.com/PX4/PX4-Autopilot/actions/workflows/compile_macos.yml) going red on every push to `main` since April 15: the install chain failed at the first unreachable dep and subsequent `make` steps errored with `ccache: command not found`.

Homebrew explicitly disallows `brew tap` from inside a formula (it's an audit error for exactly the security reason the 4.5 change is meant to address), so the formula cannot self-heal. Since `Tools/setup/macos.sh` is the canonical install path and already tapped `osx-cross/arm` and `PX4/px4` before calling `brew install`, the simplest fix is to inline the package list and call `brew install` directly. That also ends the SHA-bump maintenance loop on the formula's `url` pointer to `Tools/px4.py`.

The inlined package list is the same set `px4-dev` depended on, minus the dead-weight `discoteq/discoteq/flock` dependency that hadn't been invoked in the PX4 build since the NuttX 9.1.x era (verified by a full grep of the tree including the NuttX submodule). The companion PR on [PX4/homebrew-px4](https://github.com/PX4/homebrew-px4) keeps `px4-dev` around as a deprecated no-op so older copies of `macos.sh` on long-lived branches and cached Docker images continue to work.

Docs updated to match: `docs/en/dev_setup/dev_env_mac.md` no longer names the `px4-dev` formula and describes the package list directly.

Verified locally on macOS ARM64 (Sonoma, Homebrew 4.6):
- `./Tools/setup/macos.sh` runs to completion with both taps resolved and all 13 packages reporting expected install state
- `make distclean && make px4_fmu-v6x_default` builds successfully (1250/1250 ninja steps, 1930096 B FLASH used — identical to the previous baseline)

Related: [PX4/homebrew-px4#103](https://github.com/PX4/homebrew-px4/pull/103) (flock-drop, will be superseded by a follow-up that gutters the formula into a no-op).