### PR TITLE
fix(ekf2): fix published terrain reset delta

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1361,7 +1361,7 @@ void EKF2::PublishGlobalPosition(const hrt_abstime &timestamp)
 
 		float delta_hagl = 0.f;
 		_ekf.get_hagl_reset(&delta_hagl, &global_pos.terrain_reset_counter);
-		global_pos.delta_terrain = -delta_z;
+		global_pos.delta_terrain = -delta_hagl;
 #endif // CONFIG_EKF2_TERRAIN
 
 		global_pos.dead_reckoning = _ekf.control_status_flags().inertial_dead_reckoning


### PR DESCRIPTION
### Solved Problem
Fix `EKF2::PublishGlobalPosition()` so `global_pos.delta_terrain` is published from the terrain/HAGL reset delta returned by `get_hagl_reset()`, instead of incorrectly reusing the vertical position reset delta (`delta_z`).
This keeps `delta_terrain` consistent with `terrain_reset_counter` and matches the reset source already used in local position publication.
### Changelog Entry
For release notes:
```
Bugfix: EKF2 terrain reset delta publication
```