### PR TITLE
fix(simulation): fix macOS gz SITL build

### DIFF
--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -80,7 +80,7 @@ bool GZMixingInterfaceESC::updateOutputs(float outputs[MAX_ACTUATORS], unsigned 
 		rotor_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
 
 		for (unsigned i = 0; i < active_output_count; i++) {
-			rotor_velocity_message.set_velocity(i, outputs[i]);
+			rotor_velocity_message.set_velocity(i, static_cast<double>(outputs[i]));
 		}
 
 		if (_actuators_pub.Valid()) {

--- a/src/modules/simulation/gz_plugins/gstreamer/CMakeLists.txt
+++ b/src/modules/simulation/gz_plugins/gstreamer/CMakeLists.txt
@@ -45,6 +45,11 @@ else()
         GstCameraSystem.cpp
     )
 
+    target_link_directories(${PROJECT_NAME}
+        PUBLIC ${GSTREAMER_LIBRARY_DIRS}
+        PUBLIC ${GSTREAMER_APP_LIBRARY_DIRS}
+    )
+
     target_link_libraries(${PROJECT_NAME}
         PUBLIC px4_gz_msgs
         PUBLIC ${GZ_SENSORS_TARGET}


### PR DESCRIPTION
### Solved Problem

On macOS with Homebrew, `make px4_sitl gz_x500` can fail in two places:
- `GstCameraSystem` links only bare GStreamer library names, so the linker cannot resolve `gstreamer-1.0`
- `GZMixingInterfaceESC` passes a `float` to `set_velocity()`, which trips clang's `-Wdouble-promotion`

Related to #27026.

### Solution

- add the GStreamer and GStreamer App pkg-config library directories to the `GstCameraSystem` target
- cast ESC outputs to `double` before publishing rotor velocities

### Test coverage

- macOS / Homebrew: `make px4_sitl gz_x500`
- build completed, PX4 started, Gazebo world became ready, and the x500 model spawned