### PR TITLE
mavlink_mission: prioritize protocol timeout cleanup during GETLIST

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -558,14 +558,8 @@ MavlinkMissionManager::send()
 	}
 
 	/* check for timed-out operations */
-	if (_state == MAVLINK_WPM_STATE_GETLIST && (_time_last_sent > 0)
-	    && hrt_elapsed_time(&_time_last_sent) > MAVLINK_MISSION_RETRY_TIMEOUT_DEFAULT) {
-
-		// try to request item again after timeout
-		send_mission_request(_transfer_partner_sysid, _transfer_partner_compid, _transfer_seq);
-
-	} else if (_state != MAVLINK_WPM_STATE_IDLE && (_time_last_recv > 0)
-		   && hrt_elapsed_time(&_time_last_recv) > MAVLINK_MISSION_PROTOCOL_TIMEOUT_DEFAULT) {
+	if (_state != MAVLINK_WPM_STATE_IDLE && (_time_last_recv > 0)
+	    && hrt_elapsed_time(&_time_last_recv) > MAVLINK_MISSION_PROTOCOL_TIMEOUT_DEFAULT) {
 
 		_mavlink.send_statustext_critical("Operation timeout\t");
 		events::send(events::ID("mavlink_mission_op_timeout"), events::Log::Error,
@@ -577,6 +571,12 @@ MavlinkMissionManager::send()
 
 		// since we are giving up, reset this state also, so another request can be started.
 		_transfer_in_progress = false;
+
+	} else if (_state == MAVLINK_WPM_STATE_GETLIST && (_time_last_sent > 0)
+		   && hrt_elapsed_time(&_time_last_sent) > MAVLINK_MISSION_RETRY_TIMEOUT_DEFAULT) {
+
+		// try to request item again after timeout
+		send_mission_request(_transfer_partner_sysid, _transfer_partner_compid, _transfer_seq);
 
 	} else if (_state == MAVLINK_WPM_STATE_IDLE) {
 		// reset flags


### PR DESCRIPTION
Fixes #27132

## Problem

When a mission transfer stalls after PX4 has entered GETLIST, the retry resend path can match before the protocol-timeout path on every pass through `send()`. That lets PX4 keep resending `MISSION_REQUEST` without ever reaching the cleanup code that returns the mission manager to idle and clears `_transfer_in_progress`.

In practice that can leave later `MISSION_COUNT` requests rejected until reboot.

## Fix

Reorder the timeout handling so protocol timeout is evaluated before the GETLIST resend retry.

That preserves the existing retry behavior while the transfer is still alive, but once the link has been silent longer than `MAVLINK_MISSION_PROTOCOL_TIMEOUT_DEFAULT`, PX4 aborts the transfer, returns to idle, and clears `_transfer_in_progress`.

## Validation

- workspace diagnostics report no syntax errors after the change
- this matches the locally inspected stalled-transfer path in `mavlink_mission.cpp`
- no local PX4 build was run in this environment
