### PR TITLE
fix(navigator): fix navigator_mission_item origin field assignment

### DIFF
--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -939,7 +939,7 @@ void MissionBase::publish_navigator_mission_item()
 	navigator_mission_item.yaw = _mission_item.yaw;
 
 	navigator_mission_item.frame = _mission_item.frame;
-	navigator_mission_item.frame = _mission_item.origin;
+	navigator_mission_item.origin = _mission_item.origin;
 
 	navigator_mission_item.loiter_exit_xtrack = _mission_item.loiter_exit_xtrack;
 	navigator_mission_item.force_heading = _mission_item.force_heading;

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -592,7 +592,7 @@ void RtlDirect::publish_rtl_direct_navigator_mission_item()
 	navigator_mission_item.yaw = _mission_item.yaw;
 
 	navigator_mission_item.frame = _mission_item.frame;
-	navigator_mission_item.frame = _mission_item.origin;
+	navigator_mission_item.origin = _mission_item.origin;
 
 	navigator_mission_item.loiter_exit_xtrack = _mission_item.loiter_exit_xtrack;
 	navigator_mission_item.force_heading = _mission_item.force_heading;


### PR DESCRIPTION
### Solved Problem
`navigator_mission_item` published by Navigator incorrectly overwrote `frame` with `_mission_item.origin` in `MissionBase::publish_navigator_mission_item()`.  
This appears to be a simple copy-paste mistake: `frame` was assigned twice, and `origin` was never assigned.
### Changelog Entry
For release notes:
```
Bugfix: Navigator mission item metadata publishing
```