### PR TITLE
chore(issues): Add auto `status:needs-triage` labeling workflow

### DIFF
--- a/.github/workflows/issue_triage_label.yml
+++ b/.github/workflows/issue_triage_label.yml
@@ -1,0 +1,24 @@
+name: Issue Triage Label
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  add-triage-label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add status:needs-triage label to new issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: ['status:needs-triage'],
+            });


### PR DESCRIPTION
Adds a gha workflow that applies the `status:needs-triage` label to every newly opened issue. This gives maintainers a clear queue of unreviewed issues and lets them remove the label once the issue has been triaged and more specific labels have been assigned.

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
