### PR TITLE
fix(pid): fixed typo in PID output calculation

### DIFF
--- a/src/lib/pid/PID.cpp
+++ b/src/lib/pid/PID.cpp
@@ -44,7 +44,7 @@ void PID::setGains(const float P, const float I, const float D)
 float PID::update(const float feedback, const float dt, const bool update_integral)
 {
 	const float error = _setpoint - feedback;
-	const float output = (_gain_proportional * error) + _integral + (_gain_derivative * updateDerivative(feedback, dt));
+	const float output = (_gain_proportional * error) + _integral - (_gain_derivative * updateDerivative(feedback, dt));
 
 	if (update_integral) {
 		updateIntegral(error, dt);


### PR DESCRIPTION

### Solved Problem & Solution
Fixed sign-typo in PID.cpp when computing the output upon calling update().

### Test coverage
Tested the implementation on a gimbal.
