### PR TITLE
fix(ekf2): fix external heading accuracy-to-variance conversion for yaw reset

### DIFF
--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -426,11 +426,13 @@ public:
 
 	void resetHeadingToExternalObservation(float heading, float heading_accuracy)
 	{
+		const float heading_variance = sq(heading_accuracy);
+
 		if (_control_status.flags.yaw_align) {
-			resetYawByFusion(heading, heading_accuracy);
+			resetYawByFusion(heading, heading_variance);
 
 		} else {
-			resetQuatStateYaw(heading, heading_accuracy);
+			resetQuatStateYaw(heading, heading_variance);
 			_control_status.flags.yaw_align = true;
 		}
 


### PR DESCRIPTION
### Solved Problem
`VEHICLE_CMD_EXTERNAL_ATTITUDE_ESTIMATE` provides yaw uncertainty as accuracy (1-sigma, deg), but EKF yaw reset paths (`resetYawByFusion` / `resetQuatStateYaw`) expect variance (rad^2).  
Previously, `heading_accuracy` (rad) was passed through directly, causing unit/semantic mismatch and incorrect weighting of external heading resets.
### Changelog Entry
For release notes:
```
Bugfix: Correct external heading uncertainty handling in EKF2 yaw reset path
```