### PR TITLE
fix(navigator): fix navigator_mission_item origin field assignment

### DIFF
--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -939,7 +939,7 @@ void MissionBase::publish_navigator_mission_item()
 	navigator_mission_item.yaw = _mission_item.yaw;
 
 	navigator_mission_item.frame = _mission_item.frame;
-	navigator_mission_item.frame = _mission_item.origin;
+	navigator_mission_item.origin = _mission_item.origin;
 
 	navigator_mission_item.loiter_exit_xtrack = _mission_item.loiter_exit_xtrack;
 	navigator_mission_item.force_heading = _mission_item.force_heading;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -990,7 +990,7 @@ void Navigator::geofence_breach_check()
 			current_latitude = _gps_pos.latitude_deg;
 			current_longitude = _gps_pos.longitude_deg;
 			current_altitude = _gps_pos.altitude_msl_m;
-			position_valid = _gps_pos.timestamp > 0;
+			position_valid = _global_pos.timestamp > 0;
 		}
 
 		if (!position_valid) {

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -990,7 +990,7 @@ void Navigator::geofence_breach_check()
 			current_latitude = _gps_pos.latitude_deg;
 			current_longitude = _gps_pos.longitude_deg;
 			current_altitude = _gps_pos.altitude_msl_m;
-			position_valid = _global_pos.timestamp > 0;
+			position_valid = _gps_pos.timestamp > 0;
 		}
 
 		if (!position_valid) {

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -592,7 +592,7 @@ void RtlDirect::publish_rtl_direct_navigator_mission_item()
 	navigator_mission_item.yaw = _mission_item.yaw;
 
 	navigator_mission_item.frame = _mission_item.frame;
-	navigator_mission_item.frame = _mission_item.origin;
+	navigator_mission_item.origin = _mission_item.origin;
 
 	navigator_mission_item.loiter_exit_xtrack = _mission_item.loiter_exit_xtrack;
 	navigator_mission_item.force_heading = _mission_item.force_heading;


### PR DESCRIPTION
@Drone-Lab Fix a copy-paste bug in `publish_navigator_mission_item()`and `publish_rtl_direct_navigator_mission_item()`where `navigator_mission_item.origin` was incorrectly assigned to `navigator_mission_item.frame`, overwriting the frame value and leaving origin always zero-initialized.

 https://github.com/PX4/PX4-Autopilot/blob/9b457698786c2f439ac9e2247f6b6b25ae9d8215/src/modules/navigator/rtl_direct.cpp#L594-L595

- [mission_base.cpp](cci:7://file:///d:/1project/PX4_27105fix/PX4-Autopilot/src/modules/navigator/mission_base.cpp:0:0-0:0): `navigator_mission_item.frame = _mission_item.origin` → `navigator_mission_item.origin = _mission_item.origin`
- [rtl_direct.cpp](cci:7://file:///d:/1project/PX4_27105fix/PX4-Autopilot/src/modules/navigator/rtl_direct.cpp:0:0-0:0): same fix