### PR TITLE
build(macos): make gz SITL work out-of-box after homebrew 4.5

### DIFF
--- a/Tools/setup/macos.sh
+++ b/Tools/setup/macos.sh
@@ -6,11 +6,11 @@
 ## Installs:
 ##	- Common dependencies and tools for building PX4
 ##	- Cross compilers for building hardware targets using NuttX
-##	- Can also install the default simulation provided by the px4-sim homebrew
-##		Formula
+##	- With --sim-tools: Gazebo Harmonic and jMAVSim simulation stack
 ##
-## For more information regarding the Homebrew Formulas see:
-##		https://github.com/PX4/homebrew-px4/
+## Homebrew 4.5+ no longer auto-resolves cross-tap dependencies, so
+## every tap and package is listed explicitly here rather than hidden
+## behind meta-formulae. See PX4/homebrew-px4#104 for background.
 ##
 
 # script directory
@@ -97,10 +97,37 @@ fi
 
 # Optional, but recommended additional simulation tools:
 if [[ $INSTALL_SIM == "--sim-tools" ]]; then
-	if ! brew ls --versions px4-sim > /dev/null; then
-		brew install px4-sim
-	elif [[ $REINSTALL_FORMULAS == "--reinstall" ]]; then
-		brew reinstall px4-sim
+	# Simulation packages. This replaces the px4-sim / px4-sim-gazebo
+	# meta-formulae, which declared cross-tap dependencies that
+	# Homebrew 4.5+ no longer auto-resolves. Same migration pattern as
+	# the toolchain block above. See PX4/homebrew-px4#104 for the
+	# px4-dev precedent.
+	#
+	# osrf/simulation: gz-harmonic (Gazebo Harmonic meta-formula)
+	brew tap osrf/simulation
+
+	PX4_SIM_BREW_PACKAGES=(
+		exiftool
+		glog
+		graphviz
+		gstreamer
+		opencv
+		osrf/simulation/gz-harmonic
+		protobuf
+	)
+
+	if [[ $REINSTALL_FORMULAS == "--reinstall" ]]; then
+		echo "[macos.sh] Re-installing PX4 simulation dependencies"
+		brew reinstall "${PX4_SIM_BREW_PACKAGES[@]}"
+	else
+		echo "[macos.sh] Installing PX4 simulation dependencies"
+		brew install "${PX4_SIM_BREW_PACKAGES[@]}"
+	fi
+
+	# XQuartz is required for Gazebo GUI display on macOS.
+	if ! brew list --cask xquartz &> /dev/null; then
+		echo "[macos.sh] Installing XQuartz (required for Gazebo display)"
+		brew install --cask xquartz
 	fi
 
 	# jMAVSim requires a JDK (Java 17 LTS recommended)

--- a/platforms/posix/cmake/px4_impl_os.cmake
+++ b/platforms/posix/cmake/px4_impl_os.cmake
@@ -31,6 +31,24 @@
 #
 ############################################################################
 
+# Homebrew's qt@5 is keg-only on macOS. gz-gui8 (pulled in by gz-sim8
+# from the Gazebo simulation modules) links against Qt5 and CMake
+# cannot locate it without a prefix hint. This file is included early
+# from the root CMakeLists.txt, before any add_subdirectory descends
+# into find_package(gz-sim8). Only runs when the user has not already
+# set Qt5_DIR.
+if(APPLE AND NOT DEFINED Qt5_DIR)
+	execute_process(
+		COMMAND brew --prefix qt@5
+		OUTPUT_VARIABLE _brew_qt5_prefix
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+		ERROR_QUIET
+	)
+	if(_brew_qt5_prefix AND EXISTS "${_brew_qt5_prefix}/lib/cmake/Qt5")
+		list(APPEND CMAKE_PREFIX_PATH "${_brew_qt5_prefix}")
+	endif()
+endif()
+
 #=============================================================================
 #
 #	Defined functions in this file

--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -121,7 +121,9 @@ if (gz-transport_FOUND)
 	endforeach()
 
 	# Setup the environment variables: PX4_GZ_MODELS, PX4_GZ_WORLDS, GZ_SIM_RESOURCE_PATH
-	configure_file(gz_env.sh.in ${PX4_BINARY_DIR}/rootfs/gz_env.sh)
+	# @ONLY disables ${VAR} substitution so that shell $VAR references in the
+	# template are passed through untouched.
+	configure_file(gz_env.sh.in ${PX4_BINARY_DIR}/rootfs/gz_env.sh @ONLY)
 
 else()
 	# Create fallback targets that provide helpful error messages when Gazebo dependencies are missing

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -80,7 +80,7 @@ bool GZMixingInterfaceESC::updateOutputs(float outputs[MAX_ACTUATORS], unsigned 
 		rotor_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
 
 		for (unsigned i = 0; i < active_output_count; i++) {
-			rotor_velocity_message.set_velocity(i, outputs[i]);
+			rotor_velocity_message.set_velocity(i, static_cast<double>(outputs[i]));
 		}
 
 		if (_actuators_pub.Valid()) {

--- a/src/modules/simulation/gz_bridge/gz_env.sh.in
+++ b/src/modules/simulation/gz_bridge/gz_env.sh.in
@@ -19,3 +19,15 @@ export PX4_GZ_SERVER_CONFIG=@PX4_SOURCE_DIR@/src/modules/simulation/gz_bridge/se
 export GZ_SIM_RESOURCE_PATH=$GZ_SIM_RESOURCE_PATH:$PX4_GZ_MODELS:$PX4_GZ_WORLDS
 export GZ_SIM_SYSTEM_PLUGIN_PATH=$GZ_SIM_SYSTEM_PLUGIN_PATH:$PX4_GZ_PLUGINS
 export GZ_SIM_SERVER_CONFIG_PATH=$PX4_GZ_SERVER_CONFIG
+
+# macOS: dyld does not search /opt/homebrew/lib by default. Many
+# gobject-introspection typelibs reference libs by bare basename,
+# which fails to resolve unless we add Homebrew's lib dir to the
+# fallback search path. Prepend so it beats any system-placed libs,
+# and preserve any existing value the user has set.
+if [ "$(uname)" = "Darwin" ]; then
+	HOMEBREW_PREFIX=${HOMEBREW_PREFIX:-$(brew --prefix 2>/dev/null)}
+	if [ -n "$HOMEBREW_PREFIX" ]; then
+		export DYLD_FALLBACK_LIBRARY_PATH="$HOMEBREW_PREFIX/lib:${DYLD_FALLBACK_LIBRARY_PATH}"
+	fi
+fi

--- a/src/modules/simulation/gz_plugins/gstreamer/CMakeLists.txt
+++ b/src/modules/simulation/gz_plugins/gstreamer/CMakeLists.txt
@@ -45,6 +45,11 @@ else()
         GstCameraSystem.cpp
     )
 
+    target_link_directories(${PROJECT_NAME}
+        PUBLIC ${GSTREAMER_LIBRARY_DIRS}
+        PUBLIC ${GSTREAMER_APP_LIBRARY_DIRS}
+    )
+
     target_link_libraries(${PROJECT_NAME}
         PUBLIC px4_gz_msgs
         PUBLIC ${GZ_SENSORS_TARGET}


### PR DESCRIPTION
Homebrew 4.5 stopped auto-resolving cross-tap dependencies, which broke `brew install px4-sim`. [homebrew-px4#104](https://github.com/PX4/homebrew-px4/pull/104) deprecated `px4-dev` into a no-op; [#111](https://github.com/PX4/homebrew-px4/pull/111) does the same for `px4-sim` / `px4-sim-gazebo` / `px4-sim-jmavsim`. This PR is the PX4-side counterpart: `Tools/setup/macos.sh --sim-tools` now taps `osrf/simulation` and installs the Gazebo Harmonic dep set directly, same pattern as the toolchain block above it. XQuartz is installed here too.

Supersedes #27131. @CuriousDima's two-line fix (`c8b5965`) for the GStreamer link directories and `set_velocity` double-promotion is included as its own commit with original authorship preserved. Without it the build fails before reaching anything else in this PR.

Beyond install, three gaps were preventing `make px4_sitl gz_x500` from working on a clean macOS setup:

- `gz-gui8` (pulled in by `gz-sim8`) links against Qt5, but Homebrew's `qt@5` is keg-only and CMake cannot locate it without a hint. Added a POSIX-scoped block in `platforms/posix/cmake/px4_impl_os.cmake` that resolves `brew --prefix qt@5` and appends it to `CMAKE_PREFIX_PATH`. Only runs when `Qt5_DIR` is not already set. No effect on NuttX cross builds or Linux SITL.
- On macOS, dyld does not search `/opt/homebrew/lib` by default. `gobject-introspection` typelibs reference libs by bare basename (`libgobject-2.0.0.dylib`), which causes `gst-plugin-scanner` to fail plugin loads and adds ~90s of timeout waiting to Gazebo's cold start. Setting `DYLD_FALLBACK_LIBRARY_PATH` to the Homebrew prefix `lib` dir in `gz_env.sh` fixes it. Darwin-scoped, no effect on Linux or CI.
- `configure_file` on `gz_env.sh.in` now uses `@ONLY` so shell `${VAR}` syntax in the template passes through untouched.

Verified on macOS 26.4 / arm64 / Homebrew 5.1.7: configure clean, 1119/1119 targets compile and link, vehicle spawns in Gazebo Harmonic 8.11.0 with a single `Waiting for Gazebo world` wait (was ~18 before the dyld fix). Companion PRs: #26702 (venv, merged), homebrew-px4#111 (sim formula deprecation).