### PR TITLE
fix(ekf2): prevent GNSS height fusion re-enable after runtime disable

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
@@ -40,6 +40,11 @@
 
 void Ekf::controlGnssHeightFusion(const gnssSample &gps_sample)
 {
+	if (!_fc.gps.intended()) {
+		stopGpsHgtFusion();
+		return;
+	}
+
 	static constexpr const char *HGT_SRC_NAME = "GNSS";
 
 	auto &aid_src = _aid_src_gnss_hgt;

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
@@ -40,12 +40,16 @@
 
 void Ekf::controlGnssHeightFusion(const gnssSample &gps_sample)
 {
+	static constexpr const char *HGT_SRC_NAME = "GNSS";
+
 	if (!_fc.gps.intended()) {
+		if (_control_status.flags.gps_hgt) {
+			ECL_WARN("stopping %s height fusion, GNSS not intended", HGT_SRC_NAME);
+		}
+
 		stopGpsHgtFusion();
 		return;
 	}
-
-	static constexpr const char *HGT_SRC_NAME = "GNSS";
 
 	auto &aid_src = _aid_src_gnss_hgt;
 	HeightBiasEstimator &bias_est = _gps_hgt_b_est;

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
@@ -42,6 +42,11 @@ void Ekf::controlGnssHeightFusion(const gnssSample &gps_sample)
 {
 	static constexpr const char *HGT_SRC_NAME = "GNSS";
 
+	auto &aid_src = _aid_src_gnss_hgt;
+	HeightBiasEstimator &bias_est = _gps_hgt_b_est;
+
+	bias_est.predict(_dt_ekf_avg);
+
 	if (!_fc.gps.intended()) {
 		if (_control_status.flags.gps_hgt) {
 			ECL_WARN("stopping %s height fusion, GNSS not intended", HGT_SRC_NAME);
@@ -50,11 +55,6 @@ void Ekf::controlGnssHeightFusion(const gnssSample &gps_sample)
 		stopGpsHgtFusion();
 		return;
 	}
-
-	auto &aid_src = _aid_src_gnss_hgt;
-	HeightBiasEstimator &bias_est = _gps_hgt_b_est;
-
-	bias_est.predict(_dt_ekf_avg);
 
 	if (_gps_data_ready) {
 

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_yaw_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_yaw_control.cpp
@@ -48,7 +48,7 @@
 void Ekf::controlGnssYawFusion(const gnssSample &gnss_sample)
 {
 	if (!(_params.ekf2_gps_ctrl & static_cast<int32_t>(GnssCtrl::YAW))
-	    || _control_status.flags.gnss_yaw_fault) {
+	    || !_fc.gps.intended() || _control_status.flags.gnss_yaw_fault) {
 
 		stopGnssYawFusion();
 		return;

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_yaw_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_yaw_control.cpp
@@ -48,7 +48,7 @@
 void Ekf::controlGnssYawFusion(const gnssSample &gnss_sample)
 {
 	if (!(_params.ekf2_gps_ctrl & static_cast<int32_t>(GnssCtrl::YAW))
-	    || !_fc.gps.intended() || _control_status.flags.gnss_yaw_fault) {
+	    || _control_status.flags.gnss_yaw_fault) {
 
 		stopGnssYawFusion();
 		return;

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -132,6 +132,11 @@ void EkfWrapper::disableGpsFusion()
 	_ekf_params->ekf2_gps_ctrl &= ~(static_cast<int32_t>(GnssCtrl::HPOS) | static_cast<int32_t>(GnssCtrl::VEL));
 }
 
+void EkfWrapper::setGpsEnabled(bool enabled)
+{
+	_fc->gps.enabled = enabled;
+}
+
 bool EkfWrapper::isIntendingGpsFusion() const
 {
 	return _ekf->control_status_flags().gnss_vel || _ekf->control_status_flags().gnss_pos;

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
@@ -77,6 +77,7 @@ public:
 
 	void enableGpsFusion();
 	void disableGpsFusion();
+	void setGpsEnabled(bool enabled);
 	bool isIntendingGpsFusion() const;
 	bool isGnssFaultDetected() const;
 	void setGnssDeadReckonMode();

--- a/src/modules/ekf2/test/test_EKF_height_fusion.cpp
+++ b/src/modules/ekf2/test/test_EKF_height_fusion.cpp
@@ -208,6 +208,34 @@ TEST_F(EkfHeightFusionTest, gpsRef)
 	EXPECT_NEAR(_ekf->aid_src_rng_hgt().innovation, 0.f, 0.2f);
 }
 
+TEST_F(EkfHeightFusionTest, gpsHeightFusionStopsWhenGpsNotEnabled)
+{
+	// GIVEN: GPS reference with GPS height fusion active
+	_ekf_wrapper.setGpsHeightRef();
+	_ekf_wrapper.enableGpsHeightFusion();
+	_sensor_simulator.runSeconds(1);
+
+	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsHeightFusion());
+
+	// WHEN: GPS is no longer intended at runtime without a new GNSS sample
+	_sensor_simulator.stopGps();
+	_ekf_wrapper.setGpsEnabled(false);
+	_sensor_simulator.runSeconds(0.1);
+
+	// THEN: GPS height fusion stops and does not restart while GPS is disabled
+	EXPECT_FALSE(_ekf_wrapper.isIntendingGpsHeightFusion());
+	_sensor_simulator.runSeconds(0.1);
+	EXPECT_FALSE(_ekf_wrapper.isIntendingGpsHeightFusion());
+
+	// AND WHEN: GPS is intended again
+	_sensor_simulator.startGps();
+	_ekf_wrapper.setGpsEnabled(true);
+	_sensor_simulator.runSeconds(10);
+
+	// THEN: GPS height fusion can restart
+	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsHeightFusion());
+}
+
 TEST_F(EkfHeightFusionTest, gpsRefNoAltFusion)
 {
 	// GIVEN: GNSS alt reference but not selected as an aiding source


### PR DESCRIPTION
### Solved Problem
When GNSS is not in use, EKF2 should completely disable GNSS-based height and yaw fusion to prevent using unreliable or unavailable GNSS sources for critical estimation. There is a race between modules, one disables fusion and the other tries to enable it.

### Solution
- Added early return in `controlGnssHeightFusion()` when GNSS source is not intended, preventing height fusion initialization.
- Added additional check in `controlGnssYawFusion()` to skip yaw fusion when GNSS is not intended.

### Changelog Entry
```
Bugfix: Prevent GNSS height fusion from re-enabling after a runtime GNSS disable
```

### Test coverage
- Manual testing with SITL simulator using different GNSS failure injections.
