### PR TITLE
feat(mavlink): map @MAV_LOG virtual directory to log root

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -48,6 +48,8 @@
 using namespace time_literals;
 
 constexpr const char MavlinkFTP::_root_dir[];
+constexpr const char MavlinkFTP::_mav_log_prefix[];
+constexpr const char MavlinkFTP::_mav_log_dir[];
 
 MavlinkFTP::MavlinkFTP(Mavlink &mavlink) :
 	_mavlink(mavlink)
@@ -310,6 +312,24 @@ MavlinkFTP::_reply(mavlink_file_transfer_protocol_t *ftp_req)
 }
 void MavlinkFTP::_constructPath(char *dst, int dst_len, const char *path) const
 {
+	// MAVLink FTP virtual directory: paths starting with "@MAV_LOG" (optionally prefixed with '/')
+	// are remapped to the flight-stack log root directory.
+	const char *p = path;
+
+	if (p[0] == '/') {
+		p++;
+	}
+
+	if (strncmp(p, _mav_log_prefix, _mav_log_prefix_len) == 0
+	    && (p[_mav_log_prefix_len] == '\0' || p[_mav_log_prefix_len] == '/')) {
+		strncpy(dst, _mav_log_dir, dst_len);
+		dst[dst_len - 1] = '\0';
+		int used = strlen(dst);
+		strncpy(dst + used, p + _mav_log_prefix_len, dst_len - used);
+		dst[dst_len - 1] = '\0';
+		return;
+	}
+
 	strncpy(dst, _root_dir, dst_len);
 	int root_dir_len = _root_dir_len;
 

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -312,13 +312,9 @@ MavlinkFTP::_reply(mavlink_file_transfer_protocol_t *ftp_req)
 }
 void MavlinkFTP::_constructPath(char *dst, int dst_len, const char *path) const
 {
-	// MAVLink FTP virtual directory: paths starting with "@MAV_LOG" (optionally prefixed with '/')
+	// MAVLink FTP virtual directory: paths starting with "@MAV_LOG"
 	// are remapped to the flight-stack log root directory.
 	const char *p = path;
-
-	if (p[0] == '/') {
-		p++;
-	}
 
 	if (strncmp(p, _mav_log_prefix, _mav_log_prefix_len) == 0
 	    && (p[_mav_log_prefix_len] == '\0' || p[_mav_log_prefix_len] == '/')) {

--- a/src/modules/mavlink/mavlink_ftp.h
+++ b/src/modules/mavlink/mavlink_ftp.h
@@ -195,6 +195,13 @@ private:
 	static constexpr const char _root_dir[] = PX4_ROOTFSDIR;
 	static constexpr const int _root_dir_len = sizeof(_root_dir) - 1;
 
+	// Virtual directory prefix for log files as defined by the MAVLink FTP spec.
+	// Paths that start with this prefix are mapped to the flight-stack log root.
+	static constexpr const char _mav_log_prefix[] = "@MAV_LOG";
+	static constexpr const int _mav_log_prefix_len = sizeof(_mav_log_prefix) - 1;
+	static constexpr const char _mav_log_dir[] = CONFIG_BOARD_ROOT_PATH "/log";
+	static constexpr const int _mav_log_dir_len = sizeof(_mav_log_dir) - 1;
+
 	bool _last_reply_valid = false;
 	uint8_t _last_reply[MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL_LEN - MAVLINK_MSG_FILE_TRANSFER_PROTOCOL_FIELD_PAYLOAD_LEN
 								      + sizeof(PayloadHeader) + sizeof(uint32_t)];


### PR DESCRIPTION
Implements the MAVLink FTP "Virtual Directory Entries" convention so that clients can access log files without knowing the flight-stack storage layout. Requests whose path starts with @MAV_LOG are remapped to CONFIG_BOARD_ROOT_PATH "/log", matching the logger's LOG_ROOT.

See https://github.com/mavlink/mavlink-devguide/pull/668.

Tested against https://github.com/mavlink/qgroundcontrol/pull/14290.