### PR TITLE
Altitude unlock in Altitude/Position mode when absolute altitude is flagged to be drifting

### DIFF
--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -184,6 +184,11 @@ void FlightTaskManualAltitude::_updateAltitudeLock()
 		}
 	}
 
+	// When absolute altitude estimate is drifting, unlock altitude and temporarily use vertical velocity control only
+	if (!_is_altitude_good_for_local_control) {
+		_position_setpoint(2) = _dist_to_ground_lock = NAN;
+	}
+
 	_respectMaxAltitude();
 }
 
@@ -305,22 +310,6 @@ bool FlightTaskManualAltitude::update()
 	_updateConstraintsFromEstimator();
 	_scaleSticks();
 	_updateSetpoints();
-
-	// When altitude estimate is degraded, fall back to velocity-only control
-	if (!_is_altitude_good_for_local_control) {
-		if (_altitude_was_good_for_local_control) {
-		}
-
-		_position_setpoint(2) = NAN;
-		_dist_to_ground_lock = NAN;
-		_altitude_was_good_for_local_control = false;
-
-	} else if (!_altitude_was_good_for_local_control) {
-		// Altitude recovered: reset reference to current position
-		_position_setpoint(2) = _position(2);
-		_altitude_was_good_for_local_control = true;
-	}
-
 	_constraints.want_takeoff = _checkTakeoff();
 	_max_distance_to_ground = INFINITY;
 

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -97,13 +97,8 @@ void FlightTaskManualAltitude::_scaleSticks()
 
 void FlightTaskManualAltitude::_updateAltitudeLock()
 {
-	// Depending on stick inputs and velocity, position is locked.
-	// If not locked, altitude setpoint is set to NAN.
-
-	// Check if user wants to break
+	// Depending on stick inputs and velocity, altitude is locked. If not locked, altitude setpoint is set to NAN.
 	const bool apply_brake = fabsf(_sticks.getThrottleZeroCenteredExpo()) <= FLT_EPSILON;
-
-	// Check if vehicle has stopped
 	const bool stopped = (_param_mpc_hold_max_z.get() < FLT_EPSILON || fabsf(_velocity(2)) < _param_mpc_hold_max_z.get());
 
 	// Manage transition between use of distance to ground and distance to local origin
@@ -155,13 +150,11 @@ void FlightTaskManualAltitude::_updateAltitudeLock()
 
 	} else {
 		// normal mode where height is dependent on local frame
-
 		if (apply_brake && stopped && !PX4_ISFINITE(_position_setpoint(2))) {
 			// lock position
 			_position_setpoint(2) = _position(2);
 
-			// Ensure that minimum altitude is respected if
-			// there is a distance sensor and distance to bottom is below minimum.
+			// Ensure that minimum altitude is respected if there is a distance sensor and distance to bottom is below minimum.
 			if (PX4_ISFINITE(_dist_to_bottom) && _dist_to_bottom < _min_distance_to_ground) {
 				_terrainFollowing(apply_brake, stopped);
 
@@ -170,8 +163,7 @@ void FlightTaskManualAltitude::_updateAltitudeLock()
 			}
 
 		} else if (PX4_ISFINITE(_position_setpoint(2)) && apply_brake) {
-			// Position is locked but check if a reset event has happened.
-			// We will shift the setpoints.
+			// Position is locked but check if a reset event has happened. We will shift the setpoints.
 			if (_sub_vehicle_local_position.get().z_reset_counter != _reset_counter) {
 				_position_setpoint(2) = _position(2);
 				_reset_counter = _sub_vehicle_local_position.get().z_reset_counter;
@@ -180,7 +172,6 @@ void FlightTaskManualAltitude::_updateAltitudeLock()
 		} else  {
 			// user demands velocity change
 			_position_setpoint(2) = NAN;
-			// ensure that maximum altitude is respected
 		}
 	}
 

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -126,7 +126,6 @@ private:
 	bool _updateYawCorrection();
 
 	uint8_t _reset_counter = 0; /**< counter for estimator resets in z-direction */
-	bool _altitude_was_good_for_local_control{true}; /**< tracks previous state for edge detection */
 
 	float _min_distance_to_ground{(float)(-INFINITY)}; /**< min distance to ground constraint */
 	float _max_distance_to_ground{(float)INFINITY};  /**< max distance to ground constraint */

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -132,7 +132,7 @@ private:
 
 	/**
 	 * Distance to ground during terrain following.
-	 * If user does not demand velocity change in D-direction and the vehcile
+	 * If user does not demand velocity change in D-direction and the vehicle
 	 * is in terrain-following mode, then height to ground will be locked to
 	 * _dist_to_ground_lock.
 	 */


### PR DESCRIPTION
### Solved Problem
Cooperation on https://github.com/PX4/PX4-Autopilot/pull/27155 to hopefully achieve the user experience of no drift in the inspection use case when the absolute altitude estimate gets more accurate and slowly changes for that.

### Solution
Simplify the unlocking when an absolute altitude drift is flagged by the estimator.

### Test coverage
Couldn't test yet. Apparently there's a code block to make the estimate drift and test this. Would be nice to add as error injection for an automated integration test.