### PR TITLE
docs(sim_sih): link Hawkeye visualizer, add stub page

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -469,6 +469,7 @@
       - [Gazebo Models Repository](sim_gazebo_gz/gazebo_models.md)
       - [Multi-Vehicle Sim](sim_gazebo_gz/multi_vehicle_simulation.md)
     - [SIH Simulation](sim_sih/index.md)
+      - [Hawkeye Visualizer](sim_hawkeye/index.md)
     - [Gazebo Classic Simulation](sim_gazebo_classic/index.md)
       - [Vehicles](sim_gazebo_classic/vehicles.md)
       - [Worlds](sim_gazebo_classic/worlds.md)

--- a/docs/en/sim_hawkeye/index.md
+++ b/docs/en/sim_hawkeye/index.md
@@ -1,0 +1,54 @@
+# Hawkeye Visualizer
+
+[Hawkeye](https://github.com/PX4/Hawkeye) is a real-time 3D flight visualizer for PX4.
+It renders vehicle state from MAVLink `HIL_STATE_QUATERNION` messages, so it pairs naturally with [SIH](../sim_sih/index.md) — SIH runs the physics, Hawkeye shows you what's happening.
+Hawkeye has zero runtime dependencies, supports up to 16 vehicles simultaneously, and can replay PX4 ULog (`.ulg`) flight logs with transport controls, markers, and multi-drone correlation analysis.
+
+It's a visualizer only — no physics are simulated inside Hawkeye.
+
+## Install
+
+### macOS (Homebrew)
+
+```sh
+brew tap PX4/px4
+brew install PX4/px4/hawkeye
+```
+
+### Linux (Debian/Ubuntu)
+
+Download the `.deb` from the [Hawkeye releases page](https://github.com/PX4/Hawkeye/releases/latest):
+
+```sh
+sudo dpkg -i hawkeye-*.deb
+```
+
+### Windows and source builds
+
+See [Building from source](https://px4.github.io/Hawkeye/developer/build) in the Hawkeye docs.
+
+## Usage with SIH
+
+Start PX4 SIH, then launch Hawkeye in a separate terminal:
+
+```sh
+# Terminal 1
+make px4_sitl sihsim_quadx
+
+# Terminal 2
+hawkeye
+```
+
+Hawkeye listens on UDP port 19410 — the same port SIH sends `HIL_STATE_QUATERNION` on — so no configuration is needed.
+The vehicle appears in the Hawkeye window as soon as SIH starts streaming.
+
+For fixed-wing or tailsitter simulation, Hawkeye auto-detects the vehicle type from MAVLink `HEARTBEAT` and loads the matching 3D model.
+
+## Full documentation
+
+Complete documentation — including multi-vehicle SITL, ULog replay, HUD modes, camera controls, and correlation analysis — lives at **[px4.github.io/Hawkeye](https://px4.github.io/Hawkeye/)**.
+
+- [First SITL run](https://px4.github.io/Hawkeye/first-sitl) — the shortest path from install to seeing a vehicle move
+- [Multi-Drone Replay](https://px4.github.io/Hawkeye/multi_drone) — compare multiple flights with deconfliction and correlation
+- [Live SITL Integration](https://px4.github.io/Hawkeye/sitl) — single-vehicle and multi-instance swarm workflows
+- [Command-Line Reference](https://px4.github.io/Hawkeye/cli) — every CLI flag with examples

--- a/docs/en/sim_hawkeye/index.md
+++ b/docs/en/sim_hawkeye/index.md
@@ -1,10 +1,10 @@
 # Hawkeye Visualizer
 
-[Hawkeye](https://github.com/PX4/Hawkeye) is a real-time 3D flight visualizer for PX4.
-It renders vehicle state from MAVLink `HIL_STATE_QUATERNION` messages, so it pairs naturally with [SIH](../sim_sih/index.md) — SIH runs the physics, Hawkeye shows you what's happening.
-Hawkeye has zero runtime dependencies, supports up to 16 vehicles simultaneously, and can replay PX4 ULog (`.ulg`) flight logs with transport controls, markers, and multi-drone correlation analysis.
+[Hawkeye](https://px4.github.io/Hawkeye/) is a real-time 3D flight _visualizer_ for PX4.
 
-It's a visualizer only — no physics are simulated inside Hawkeye.
+Hawkeye is the natural pair for [SIH](../sim_sih/index.md) — SIH runs the physics of an aircraft simulation and outputs MAVLink [HIL_STATE_QUATERNION](https://mavlink.io/en/messages/common.html#HIL_STATE_QUATERNION) messages, Hawkeye uses these to show you what's happening.
+
+Hawkeye has zero runtime dependencies, supports up to 16 vehicles simultaneously, and can replay PX4 ULog (`.ulg`) flight logs with transport controls, markers, and multi-drone correlation analysis.
 
 ## Install
 
@@ -25,7 +25,13 @@ sudo dpkg -i hawkeye-*.deb
 
 ### Windows and source builds
 
-See [Building from source](https://px4.github.io/Hawkeye/developer/build) in the Hawkeye docs.
+For Ubuntu 24.04 or later in WSL2 you can install the packages in the same way:
+
+```sh
+sudo dpkg -i hawkeye-*.deb
+```
+
+For other versions of Ubuntu (or native Windows builds) you may need to [Build from source](https://px4.github.io/Hawkeye/developer/build) (Hawkeye docs).
 
 ## Usage with SIH
 
@@ -39,7 +45,7 @@ make px4_sitl sihsim_quadx
 hawkeye
 ```
 
-Hawkeye listens on UDP port 19410 — the same port SIH sends `HIL_STATE_QUATERNION` on — so no configuration is needed.
+Hawkeye listens on UDP port 19410 — the same port SIH sends [HIL_STATE_QUATERNION](https://mavlink.io/en/messages/common.html#HIL_STATE_QUATERNION) on — so no configuration is needed.
 The vehicle appears in the Hawkeye window as soon as SIH starts streaming.
 
 For fixed-wing or tailsitter simulation, Hawkeye auto-detects the vehicle type from MAVLink `HEARTBEAT` and loads the matching 3D model.
@@ -52,3 +58,4 @@ Complete documentation — including multi-vehicle SITL, ULog replay, HUD modes,
 - [Multi-Drone Replay](https://px4.github.io/Hawkeye/multi_drone) — compare multiple flights with deconfliction and correlation
 - [Live SITL Integration](https://px4.github.io/Hawkeye/sitl) — single-vehicle and multi-instance swarm workflows
 - [Command-Line Reference](https://px4.github.io/Hawkeye/cli) — every CLI flag with examples
+- [Source code](https://github.com/PX4/Hawkeye)

--- a/docs/en/sim_sih/index.md
+++ b/docs/en/sim_sih/index.md
@@ -79,27 +79,26 @@ The `px4_sitl` target will work, but will also build Gazebo libraries.
 ### Visualization (Optional) {#sitl-visualization}
 
 SIH is intentionally headless by default.
-If you need a visual aid to see what the vehicle is doing you can use QGroundControl to track path over ground, and/or jMAVSim as a 3D viewer.
+If you need a visual aid to see what the vehicle is doing you can use QGroundControl to track path over ground, and/or [Hawkeye](../sim_hawkeye/index.md) as a 3D viewer.
 
 #### QGroundControl
 
 QGC auto-connects on UDP port 14550. Open QGC while SIH is running and the vehicle appears on the map view with attitude, position, and telemetry.
 
-#### jMAVSim (3D Display-Only)
+#### Hawkeye (3D Visualizer)
 
-jMAVSim can render a 3D view of the vehicle using MAVLink position data. No physics are simulated in jMAVSim — it is display-only.
+[Hawkeye](../sim_hawkeye/index.md) renders a real-time 3D view of the vehicle using MAVLink position data. No physics are simulated in Hawkeye — it is a visualizer only.
+
+In a separate terminal, run:
 
 ```sh
-./Tools/simulation/jmavsim/jmavsim_run.sh -p 19410 -u -q -o
+hawkeye
 ```
 
-Flags:
+Hawkeye connects on UDP port 19410 by default (the same port SIH sends `HIL_STATE_QUATERNION` on).
 
-- `-a` for airplane model
-- `-t` for tailsitter model
-- `-o` enables display-only mode.
-
-See [jMAVSim Display-Only Mode](../sim_jmavsim/index.md#display-only-mode) for details.
+Use `-fw` for fixed-wing or `-ts` for tailsitter models.
+See the [Hawkeye docs](https://px4.github.io/Hawkeye/) for install, ULog replay, and multi-vehicle visualization.
 
 ### Environment Configuration
 
@@ -159,7 +158,7 @@ PX4 SITL opens the following UDP ports (all instance-aware, offset by instance n
 | **14540** (+N)        | 14580 (+N)             | MAVSDK, MAVROS, offboard APIs   | Yes (capped at 14549 for 10+ instances)   |
 | **14030** (+N)        | 14280 (+N)             | Onboard camera/payload          | Yes                                       |
 | **13280** (+N)        | 13030 (+N)             | Gimbal control                  | Yes                                       |
-| **19410** (+N)        | 19450 (+N)             | jMAVSim display-only (SIH only) | Yes                                       |
+| **19410** (+N)        | 19450 (+N)             | Hawkeye visualizer (SIH only)   | Yes                                       |
 | **8888**              | -                      | uXRCE-DDS / ROS 2               | No (use DDS namespace for multi-instance) |
 
 QGC auto-connects on port **14550** by default. MAVSDK connects on **14540**. No manual port configuration needed for single-instance use.

--- a/docs/en/sim_sih/index.md
+++ b/docs/en/sim_sih/index.md
@@ -87,7 +87,8 @@ QGC auto-connects on UDP port 14550. Open QGC while SIH is running and the vehic
 
 #### Hawkeye (3D Visualizer)
 
-[Hawkeye](../sim_hawkeye/index.md) renders a real-time 3D view of the vehicle using MAVLink position data. No physics are simulated in Hawkeye — it is a visualizer only.
+[Hawkeye](../sim_hawkeye/index.md) renders a real-time 3D view of the vehicle using MAVLink position data.
+No physics are simulated in Hawkeye — it is a visualizer only.
 
 In a separate terminal, run:
 
@@ -96,9 +97,10 @@ hawkeye
 ```
 
 Hawkeye connects on UDP port 19410 by default (the same port SIH sends `HIL_STATE_QUATERNION` on).
+It then auto-detects the vehicle type from the MAVLink `HEARTBEAT` and loads the matching 3D model.
 
-Use `-fw` for fixed-wing or `-ts` for tailsitter models.
-See the [Hawkeye docs](https://px4.github.io/Hawkeye/) for install, ULog replay, and multi-vehicle visualization.
+The [Hawkeye](../sim_hawkeye/index.md) overview page explains how to install the software.
+See the [Hawkeye docs](https://px4.github.io/Hawkeye/) for other features, such as ULog replay, and multi-vehicle visualization.
 
 ### Environment Configuration
 
@@ -152,14 +154,14 @@ See [uXRCE-DDS (PX4-ROS 2/DDS Bridge)](../middleware/uxrce_dds.md) for full setu
 
 PX4 SITL opens the following UDP ports (all instance-aware, offset by instance number N).
 
-| PX4 sends to (remote) | PX4 listens on (local) | Use for                         | Instance offset                           |
-| --------------------- | ---------------------- | ------------------------------- | ----------------------------------------- |
-| **14550**             | 18570 (+N)             | QGroundControl, GCS tools       | Yes                                       |
-| **14540** (+N)        | 14580 (+N)             | MAVSDK, MAVROS, offboard APIs   | Yes (capped at 14549 for 10+ instances)   |
-| **14030** (+N)        | 14280 (+N)             | Onboard camera/payload          | Yes                                       |
-| **13280** (+N)        | 13030 (+N)             | Gimbal control                  | Yes                                       |
-| **19410** (+N)        | 19450 (+N)             | Hawkeye visualizer (SIH only)   | Yes                                       |
-| **8888**              | -                      | uXRCE-DDS / ROS 2               | No (use DDS namespace for multi-instance) |
+| PX4 sends to (remote) | PX4 listens on (local) | Use for                       | Instance offset                           |
+| --------------------- | ---------------------- | ----------------------------- | ----------------------------------------- |
+| **14550**             | 18570 (+N)             | QGroundControl, GCS tools     | Yes                                       |
+| **14540** (+N)        | 14580 (+N)             | MAVSDK, MAVROS, offboard APIs | Yes (capped at 14549 for 10+ instances)   |
+| **14030** (+N)        | 14280 (+N)             | Onboard camera/payload        | Yes                                       |
+| **13280** (+N)        | 13030 (+N)             | Gimbal control                | Yes                                       |
+| **19410** (+N)        | 19450 (+N)             | Hawkeye visualizer (SIH only) | Yes                                       |
+| **8888**              | -                      | uXRCE-DDS / ROS 2             | No (use DDS namespace for multi-instance) |
 
 QGC auto-connects on port **14550** by default. MAVSDK connects on **14540**. No manual port configuration needed for single-instance use.
 


### PR DESCRIPTION
Replaces the superseded #26965 with a slimmer version. That PR added 9 deep Hawkeye documentation pages plus 35 screenshots and animations directly into the PX4 user guide. After conversations with @hamishwillee, we agreed the deep documentation should live in the Hawkeye repo so PX4 docs don't carry the maintenance burden of two parallel sources. The Hawkeye docs are now live at [px4.github.io/Hawkeye](https://px4.github.io/Hawkeye/).

This PR adds only what PX4 readers actually need: a short pointer page, the SIH integration details, and the jMAVSim → Hawkeye swap in the SIH docs.

Changes:

- `docs/en/sim_sih/index.md` — replaces the jMAVSim display-only section with a Hawkeye section covering the `hawkeye` command, UDP 19410 port alignment, and a link to the full Hawkeye docs. The port reference table now labels UDP 19410 as "Hawkeye visualizer" instead of "jMAVSim display-only".
- `docs/en/sim_hawkeye/index.md` — new stub page (~65 lines) with what Hawkeye is, install one-liners for macOS and Linux, the SIH quickstart, and links out to the hosted docs for multi-vehicle, ULog replay, HUD, and CLI reference.
- `docs/en/SUMMARY.md` — adds the stub as a single entry nested under SIH Simulation.