### PR TITLE
build(simulation): install OpenCV and GStreamer runtime deps in gazeb…

### DIFF
--- a/Tools/packaging/Dockerfile.gazebo
+++ b/Tools/packaging/Dockerfile.gazebo
@@ -29,7 +29,7 @@ LABEL description="PX4 SITL with Gazebo Harmonic simulation"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV RUNS_IN_DOCKER=true
 
-# Install Gazebo Harmonic with buildkit cache mounts for apt
+# Install Gazebo Harmonic and run-time dependencies with buildkit cache mounts for apt
 # The --mount=type=cache persists /var/cache/apt and /var/lib/apt across builds
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -46,7 +46,17 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         > /etc/apt/sources.list.d/gazebo-stable.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        gz-harmonic
+        gz-harmonic \
+        gstreamer1.0-plugins-bad \
+        gstreamer1.0-plugins-base \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-ugly \
+        gstreamer1.0-libav \
+        libopencv-core406t64 \
+        libopencv-imgproc406t64 \
+        libopencv-video406t64 \
+        libopencv-calib3d406t64 \
+        libopencv-features2d406t64
 
 # Install PX4 files from .deb
 COPY --from=extract /staging/opt/px4-gazebo /opt/px4-gazebo


### PR DESCRIPTION
### Solved Problem

The published `px4io/px4-sitl-gazebo` image cannot load the
  `OpticalFlowSystem` and `GstCameraSystem` Gazebo plugins at startup
  because their runtime shared-library dependencies are not installed
  in the container.

Reproduction:
```shell
docker run --rm -it -p 14550:14550/udp \
  -e PX4_SIM_MODEL=gz_x500_mono_cam \
  -e PX4_GZ_WORLD=walls \
  px4io/px4-sitl-gazebo:v1.17.0-alpha1-1361-g9f9171575e
```
```
...
[Err] [SystemLoader.cc:107] Failed to load system plugin: (Reason: No plugins detected in library)
- Requested plugin name: [custom::OpticalFlowSystem]
- Requested library name: [libOpticalFlowSystem.so]
- Resolved library path: [/opt/px4-gazebo/lib/gz/plugins/libOpticalFlowSystem.so]
Error while loading the library [/opt/px4-gazebo/lib/gz/plugins/libGstCameraSystem.so]: libgstreamer-1.0.so.0: cannot open shared object file: No such file or directory
[Err] [SystemLoader.cc:107] Failed to load system plugin: (Reason: No plugins detected in library)
- Requested plugin name: [custom::GstCameraSystem]
- Requested library name: [libGstCameraSystem.so]
- Resolved library path: [/opt/px4-gazebo/lib/gz/plugins/libGstCameraSystem.so]
...
```

### Solution
Identify missing dependencies, add them to Dockerfile.gazebo, build locally, verify absence of log messages on container startup and working simulation.

```bash
docker build \
    -f Tools/packaging/Dockerfile.gazebo \
    -t px4-sitl-gazebo:local \
    docker-context/
```
docker-context contains build/px4_sitl_default/px4-gazebo_*.deb, Tools/packaging/px4-entrypoint.sh

Running the container:
```bash
docker run --rm -it --network -e PX4_SIM_MODEL=gz_x500_mono_cam -e PX4_GZ_WORLD=walls px4-sitl-gazebo:local
```

### Test coverage

The logs no longer contain the errors and the gstreamer pipeline in the README.md of GstCameraSystem outputs the feed from the simulated camera sensor:
```bash
gst-launch-1.0 udpsrc port=5600 \
    ! application/x-rtp,encoding-name=H264,payload=96 \
    ! rtph264depay \
    ! avdec_h264 \
    ! videoconvert \
    ! autovideosink
```