### PR TITLE
build(sim): resolve SITL runtime deps via .deb Depends

### DIFF
--- a/Tools/packaging/Dockerfile.gazebo
+++ b/Tools/packaging/Dockerfile.gazebo
@@ -14,13 +14,12 @@
 #   docker run --rm -it --network host \
 #     -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix \
 #     --gpus all px4io/px4-sitl-gazebo:v1.17.0
-
-FROM ubuntu:24.04 AS extract
-COPY px4-gazebo_*.deb /tmp/
-RUN apt-get update && apt-get install -y --no-install-recommends binutils \
-    && dpkg -x /tmp/px4-gazebo_*.deb /staging \
-    && strip /staging/opt/px4-gazebo/bin/px4 \
-    && rm -rf /var/lib/apt/lists/*
+#
+# Persist flight logs on the host (ulog files):
+#   mkdir -p ./px4-logs
+#   docker run --rm -it --network host \
+#     -v $(pwd)/px4-logs:/root/.local/share/px4/rootfs/log \
+#     px4io/px4-sitl-gazebo:v1.17.0
 
 FROM ubuntu:24.04
 LABEL maintainer="PX4 Development Team"
@@ -29,8 +28,8 @@ LABEL description="PX4 SITL with Gazebo Harmonic simulation"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV RUNS_IN_DOCKER=true
 
-# Install Gazebo Harmonic with buildkit cache mounts for apt
-# The --mount=type=cache persists /var/cache/apt and /var/lib/apt across builds
+# Configure the OSRF Gazebo apt repo so Gazebo Harmonic (a Depends: of the
+# px4-gazebo .deb) resolves from it in the install step below.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update \
@@ -44,13 +43,22 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" \
         > /etc/apt/sources.list.d/gazebo-stable.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        gz-harmonic
+    && apt-get update
 
-# Install PX4 files from .deb
-COPY --from=extract /staging/opt/px4-gazebo /opt/px4-gazebo
-RUN ln -sf /opt/px4-gazebo/bin/px4-gazebo /usr/bin/px4-gazebo
+# Install px4-gazebo via apt so its Depends (Gazebo Harmonic, OpenCV, GStreamer
+# core libs, gstreamer plugin packages) are resolved automatically. The binary
+# is stripped after install to trim image size (~a few MB).
+COPY px4-gazebo_*.deb /tmp/
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get install -y --no-install-recommends \
+        /tmp/px4-gazebo_*.deb \
+        binutils \
+    && strip /opt/px4-gazebo/bin/px4 \
+    && apt-get purge -y binutils \
+    && apt-get autoremove -y \
+    && rm -f /tmp/px4-gazebo_*.deb \
+    && ln -sf /opt/px4-gazebo/bin/px4-gazebo /usr/bin/px4-gazebo
 
 # Create the DART physics engine symlink (avoids needing the -dev package)
 RUN GZ_PHYSICS_DIR=$(find /usr/lib -maxdepth 3 -type d -name "engine-plugins" -path "*/gz-physics-7/*" 2>/dev/null | head -1) \

--- a/Tools/packaging/Dockerfile.sih
+++ b/Tools/packaging/Dockerfile.sih
@@ -11,26 +11,34 @@
 #
 # Run (macOS / Windows):
 #   docker run --rm -it -p 14550:14550/udp -p 14540:14540/udp -p 19410:19410/udp -p 8888:8888/udp px4io/px4-sitl:v1.17.0
-
-FROM ubuntu:24.04 AS build
-COPY px4_*.deb /tmp/
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update \
-    && apt-get install -y --no-install-recommends binutils \
-    && dpkg -x /tmp/px4_*.deb /staging \
-    && strip /staging/opt/px4/bin/px4
+#
+# Persist flight logs on the host (ulog files):
+#   mkdir -p ./px4-logs
+#   docker run --rm -it --network host \
+#     -v $(pwd)/px4-logs:/root/.local/share/px4/rootfs/log \
+#     px4io/px4-sitl:v1.17.0
 
 FROM ubuntu:24.04
 LABEL maintainer="PX4 Development Team"
 LABEL description="PX4 SITL with SIH physics (no simulator dependencies)"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install px4 via apt so Depends: are resolved automatically. The binary is
+# stripped after install to trim image size (~a few MB).
+COPY px4_*.deb /tmp/
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends bc
-
-COPY --from=build /staging/opt/px4 /opt/px4
-RUN ln -sf /opt/px4/bin/px4 /usr/bin/px4
+    apt-get update \
+    && apt-get install -y --no-install-recommends \
+        /tmp/px4_*.deb \
+        bc \
+        binutils \
+    && strip /opt/px4/bin/px4 \
+    && apt-get purge -y binutils \
+    && apt-get autoremove -y \
+    && rm -f /tmp/px4_*.deb \
+    && ln -sf /opt/px4/bin/px4 /usr/bin/px4
 
 # Platform-adaptive entrypoint: detects Docker Desktop (macOS/Windows) via
 # host.docker.internal and configures MAVLink + DDS to target the host.

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -92,7 +92,7 @@ if("${CMAKE_SYSTEM}" MATCHES "Linux")
 			set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/px4-gazebo")
 			set(CPACK_DEBIAN_PACKAGE_NAME "px4-gazebo")
 			set(CPACK_DEBIAN_FILE_NAME "px4-gazebo_${DEB_VERSION}-${DEB_CODENAME}_${DEB_ARCHITECTURE}.deb")
-			set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, libstdc++6, gz-sim8-cli, libgz-sim8-plugins, libgz-physics7-dartsim, gz-tools2")
+			set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, libstdc++6, gz-sim8-cli, libgz-sim8-plugins, libgz-physics7-dartsim, gz-tools2, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good, gstreamer1.0-plugins-bad, gstreamer1.0-plugins-ugly, gstreamer1.0-libav")
 			set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "PX4 SITL autopilot with Gazebo Harmonic simulation resources")
 			set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
 				"${PX4_SOURCE_DIR}/Tools/packaging/postinst;${PX4_SOURCE_DIR}/Tools/packaging/postrm")


### PR DESCRIPTION
Fixes the same plugin-load errors as #27160 (`libOpticalFlowSystem.so` and `libGstCameraSystem.so` failing at Gazebo startup due to missing OpenCV and GStreamer runtime libraries in the published `px4io/px4-sitl-gazebo` image), but moves the fix out of the Dockerfile and into the `.deb` packaging so the package becomes self-describing for non-Docker consumers too.

The root cause is that `Tools/packaging/Dockerfile.gazebo` uses `dpkg -x` to extract the `.deb` into a staging dir, which bypasses dependency resolution entirely. The `.deb` itself already declares most of the right libs via `dpkg-shlibdeps` (inspecting a recent CI artifact: `libopencv-core406t64`, `libopencv-imgproc406t64`, `libopencv-video406t64`, `libopencv-calib3d406t64`, `libopencv-features2d406t64`, `libgstreamer1.0-0`, `libgstreamer-plugins-base1.0-0` are all in Depends already). Switching from `dpkg -x` to `apt install ./px4-gazebo_*.deb` is enough to resolve all of those automatically.

GStreamer plugin packages are a separate matter: `GstCameraSystem` loads elements like `x264enc`, `rtph264pay`, `udpsink` via `gst_element_factory_make()` at runtime, so `dpkg-shlibdeps` can't see them. These are added to `CPACK_DEBIAN_PACKAGE_DEPENDS` explicitly in `cmake/package.cmake`: `gstreamer1.0-plugins-{base,good,bad,ugly,libav}`. Note that `plugins-ugly` is required because that's where `x264enc` lives on Debian/Ubuntu, and it's on the default H264 path in `GstCameraSystem.cpp`.

`Dockerfile.sih` is updated to follow the same pattern (apt-installing its own `.deb` even though the SIH variant only depends on libc/libstdc++), so both images build the same way.

Changes:

- `cmake/package.cmake`: append the 5 gstreamer plugin packages to the `px4-gazebo` Depends line
- `Tools/packaging/Dockerfile.gazebo`: drop the extract stage, install the `.deb` via apt in the final stage, strip the binary in place, purge `binutils` after
- `Tools/packaging/Dockerfile.sih`: same pattern

Verified locally on `linux/amd64` by repacking the existing CI `.deb` artifact with the new Depends and building both Dockerfiles:

- `ldd` on `libOpticalFlowSystem.so` and `libGstCameraSystem.so`: zero unresolved entries
- All expected GStreamer plugins present on disk (`libgstx264.so`, `libgstrtp.so`, `libgstudp.so`, `libgstapp.so`, `libgstrtmp.so`, `libgstvideorate.so`)
- SIH `px4` binary launches and prints usage
- Image size: gazebo ~1.18 GB (vs ~1.23 GB with deps hard-coded in the Dockerfile), sih 97 MB (vs 107 MB published)

Supersedes #27160.