### PR TITLE
ci(compile_ubuntu): only run on push to main

### DIFF
--- a/.github/workflows/compile_ubuntu.yml
+++ b/.github/workflows/compile_ubuntu.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'stable'
-      - 'beta'
-      - 'release/**'
     paths-ignore:
       - 'docs/**'
   pull_request:


### PR DESCRIPTION
`compile_ubuntu.yml` is a PR-focused Ubuntu container smoke check (22.04 + 24.04) but it currently also fires on pushes to `stable`, `beta`, and `release/**`. On those branches it duplicates `build_all_targets.yml`, which already covers them with the full board matrix and handles the S3 uploads for QGC. Every backport or release branch push ends up kicking off an extra Ubuntu container matrix that nothing else depends on.

This drops `stable`, `beta`, and `release/**` from the push branch list so the trigger matches the pattern already used by `compile_macos.yml`, `checks.yml`, and `clang-tidy.yml` (push to `main` + PRs).

Fixes #27171