### PR TITLE
ci(dev_container): drop branch push trigger on release branches

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'stable'
-      - 'beta'
-      - 'release/**'
     tags:
       - 'v*'
   pull_request:


### PR DESCRIPTION
The `dev_container.yml` workflow was triggering a full matrix build whenever `stable`, `beta`, or `release/**` moved. In practice these branches only ever move when a release is cut, and the matching `v*` tag push already built and pushed the image seconds earlier. The branch-push run reproduced the exact same arm64 + amd64 digest (~8 min of runner time) before discarding the result, because the registry push is already gated on `refs/tags/`.

Simplest fix: remove those branches from `on.push.branches`. The `v*` tag trigger remains the authoritative release trigger, `main` still builds on every push, and `workflow_dispatch` is still available for manual rebuilds.

Fixes #27170.

Concrete wins from recent history: the tag+branch pairs on 2026-04-22 (`v1.16.2` + `stable`), 2026-01-21 (`v1.16.1` + `stable`), and `v1.17.0-beta1` + `beta` would each have skipped the second full matrix build.

The older workflow still present on `stable` / `beta` / `release/1.16` re-pushes the image on every branch update. I'll open separate backport PRs that apply the same trigger trim there, so the next retag doesn't overwrite the tagged image from the branch ref.