### PR TITLE
build(simulation): depend on gz-harmonic for SITL deb

### DIFF
--- a/Tools/packaging/Dockerfile.gazebo
+++ b/Tools/packaging/Dockerfile.gazebo
@@ -51,7 +51,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 COPY px4-gazebo_*.deb /tmp/
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get install -y --no-install-recommends \
+    apt-get update \
+    && apt-get install -y --no-install-recommends \
         /tmp/px4-gazebo_*.deb \
         binutils \
     && strip /opt/px4-gazebo/bin/px4 \

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -92,7 +92,7 @@ if("${CMAKE_SYSTEM}" MATCHES "Linux")
 			set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/px4-gazebo")
 			set(CPACK_DEBIAN_PACKAGE_NAME "px4-gazebo")
 			set(CPACK_DEBIAN_FILE_NAME "px4-gazebo_${DEB_VERSION}-${DEB_CODENAME}_${DEB_ARCHITECTURE}.deb")
-			set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, libstdc++6, gz-sim8-cli, libgz-sim8-plugins, libgz-physics7-dartsim, gz-tools2, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good, gstreamer1.0-plugins-bad, gstreamer1.0-plugins-ugly, gstreamer1.0-libav")
+			set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, libstdc++6, gz-harmonic, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good, gstreamer1.0-plugins-bad, gstreamer1.0-plugins-ugly, gstreamer1.0-libav")
 			set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "PX4 SITL autopilot with Gazebo Harmonic simulation resources")
 			set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
 				"${PX4_SOURCE_DIR}/Tools/packaging/postinst;${PX4_SOURCE_DIR}/Tools/packaging/postrm")


### PR DESCRIPTION
### Solved Problem
  The current `px4-gazebo` Debian package (and resulting `px4io/px4-sitl-gazebo` Docker image) cannot start the simulation. Command:

```
docker run --rm -it -p 14550:14550/udp \
  -e PX4_SIM_MODEL=gz_x500_mono_cam \
  -e PX4_GZ_WORLD=walls \
  px4io/px4-sitl-gazebo:latest
```

 Here are the following issues that were encountered in order of appearance:

  1. **World never loads.** `INFO [init] Waiting for Gazebo world...` repeats until `ERROR [init] Timed out waiting for Gazebo world`. 
  Root cause: `gz-transport13-cli` is missing, so the `gz
  topic` / `gz service` subcommands used by `ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim` (specifically `check_scene_info`) fall through to the top-level help menu. The readiness poll greps
   for `"Service providers"`, never finds it, and exhausts its 30 retries.

  2. **Camera scenes segfault.** With the transport CLI fixed, camera-equipped airframes (e.g. `gz_x500_mono_cam`) crash the Sensors system:
     [Err] Failed to load plugin [gz-rendering-ogre2] : couldn't find shared library.
     Segmentation fault (Address not mapped to object [(nil)])
  Root cause: `libgz-rendering8-ogre2` (the ogre2 render-engine backend requested by `server.config`) is not in the curated dependency list.

  3. **Ogre2 can't initialize.** After pulling the ogre2 plugin, Ogre2 throws:
     OGRE EXCEPTION(6:FileNotFoundException): Data folder provided contains no
     valid template shader files. Folder: /usr/share/gz/gz-rendering8/ogre2/src/media/Hlms/Unlit/GLSL Root cause: the HLMS shader resources live in a separate package pulled in by gz-harmonic.

Each gap is invisible because the components are loaded at runtime.

### Solution

Changes:
cmake/package.cmake: append gz-harmonic to the px4-gazebo Depends line
After attempting to reduce the number of packages and respectively the docker image size, the only stable fix was to apply [upstream's recommendations](https://gazebosim.org/docs/harmonic/install_ubuntu).

### Test coverage
The logs no longer contain the errors above and I am able to locally build the deb and docker image from Dockerfile.gazebo, then run it and view the output of the simulated camera sensor:

```
gst-launch-1.0 udpsrc port=5600 \
    ! application/x-rtp,encoding-name=H264,payload=96 \
    ! rtph264depay \
    ! avdec_h264 \
    ! videoconvert \
    ! autovideosink
```