### PR TITLE
fix(mavlink): gate UAVCAN param bridge on observed camera heartbeat

### DIFF
--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -63,7 +63,7 @@ MavlinkParametersManager::get_size()
 void
 MavlinkParametersManager::update_observed_camera_components()
 {
-	camera_status_s cam_status;
+	camera_status_s cam_status {};
 
 	while (_camera_status_sub.update(&cam_status)) {
 		if (cam_status.active_comp_id >= MAV_COMP_ID_CAMERA

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -63,12 +63,44 @@ MavlinkParametersManager::get_size()
 void
 MavlinkParametersManager::update_observed_camera_components()
 {
-	camera_status_s status;
+	camera_status_s cam_status;
 
-	while (_camera_status_sub.update(&status)) {
-		if (status.active_comp_id >= MAV_COMP_ID_CAMERA
-		    && status.active_comp_id <= MAV_COMP_ID_CAMERA6) {
-			_camera_comp_last_seen[status.active_comp_id - MAV_COMP_ID_CAMERA] = status.timestamp;
+	while (_camera_status_sub.update(&cam_status)) {
+		if (cam_status.active_comp_id >= MAV_COMP_ID_CAMERA
+		    && cam_status.active_comp_id <= MAV_COMP_ID_CAMERA6) {
+			_camera_comp_last_seen[cam_status.active_comp_id - MAV_COMP_ID_CAMERA] = cam_status.timestamp;
+		}
+	}
+
+	// Warn once per comp ID when a MAVLink camera and a DroneCAN node share an
+	// ID in 100..105. Camera takes precedence at the UAVCAN bridge, so the CAN
+	// node's params become unreachable via MAVLink until the user reassigns
+	// the CAN node ID. Fires regardless of which side joined first.
+	static constexpr uint8_t kAllWarned = (1u << CAMERA_COMP_ID_COUNT) - 1;
+
+	if (_camera_cannode_collision_warned_mask == kAllWarned) {
+		return;
+	}
+
+	for (unsigned i = 0; i < CAMERA_COMP_ID_COUNT; ++i) {
+		const uint8_t warn_bit = 1u << i;
+
+		if (_camera_cannode_collision_warned_mask & warn_bit) {
+			continue;
+		}
+
+		if (_camera_comp_last_seen[i] == 0
+		    || hrt_elapsed_time(&_camera_comp_last_seen[i]) >= CAMERA_OBSERVATION_TIMEOUT) {
+			continue;
+		}
+
+		const uint8_t comp_id = MAV_COMP_ID_CAMERA + i;
+
+		if (is_dronecan_node_online(comp_id)) {
+			_camera_cannode_collision_warned_mask |= warn_bit;
+			mavlink_log_warning(_mavlink.get_mavlink_log_pub(),
+					    "CAN node %u blocked by MAV camera (reassign ID)\t",
+					    comp_id);
 		}
 	}
 }
@@ -87,6 +119,23 @@ MavlinkParametersManager::is_observed_mavlink_camera(uint8_t target_component) c
 	}
 
 	return hrt_elapsed_time(&last_seen) < CAMERA_OBSERVATION_TIMEOUT;
+}
+
+bool
+MavlinkParametersManager::is_dronecan_node_online(uint8_t node_id)
+{
+	dronecan_node_status_s status;
+
+	for (auto &sub : _dronecan_node_status_subs) {
+		if (sub.copy(&status)
+		    && status.node_id == node_id
+		    && status.mode != dronecan_node_status_s::MODE_OFFLINE
+		    && hrt_elapsed_time(&status.timestamp) < CAMERA_OBSERVATION_TIMEOUT) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 #endif // CONFIG_MAVLINK_UAVCAN_PARAMETERS

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -58,9 +58,46 @@ MavlinkParametersManager::get_size()
 	return MAVLINK_MSG_ID_PARAM_VALUE_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
 }
 
+#if defined(CONFIG_MAVLINK_UAVCAN_PARAMETERS)
+
+void
+MavlinkParametersManager::update_observed_camera_components()
+{
+	camera_status_s status;
+
+	while (_camera_status_sub.update(&status)) {
+		if (status.active_comp_id >= MAV_COMP_ID_CAMERA
+		    && status.active_comp_id <= MAV_COMP_ID_CAMERA6) {
+			_camera_comp_last_seen[status.active_comp_id - MAV_COMP_ID_CAMERA] = status.timestamp;
+		}
+	}
+}
+
+bool
+MavlinkParametersManager::is_observed_mavlink_camera(uint8_t target_component) const
+{
+	if (target_component < MAV_COMP_ID_CAMERA || target_component > MAV_COMP_ID_CAMERA6) {
+		return false;
+	}
+
+	const hrt_abstime last_seen = _camera_comp_last_seen[target_component - MAV_COMP_ID_CAMERA];
+
+	if (last_seen == 0) {
+		return false;
+	}
+
+	return hrt_elapsed_time(&last_seen) < CAMERA_OBSERVATION_TIMEOUT;
+}
+
+#endif // CONFIG_MAVLINK_UAVCAN_PARAMETERS
+
 void
 MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 {
+#if defined(CONFIG_MAVLINK_UAVCAN_PARAMETERS)
+	update_observed_camera_components();
+#endif // CONFIG_MAVLINK_UAVCAN_PARAMETERS
+
 	switch (msg->msgid) {
 	case MAVLINK_MSG_ID_PARAM_REQUEST_LIST: {
 			/* request all parameters */
@@ -81,7 +118,7 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 #if defined(CONFIG_MAVLINK_UAVCAN_PARAMETERS)
 
 			if (req_list.target_system == mavlink_system.sysid && req_list.target_component < 127 &&
-			    !(req_list.target_component >= MAV_COMP_ID_CAMERA && req_list.target_component <= MAV_COMP_ID_CAMERA6) &&
+			    !is_observed_mavlink_camera(req_list.target_component) &&
 			    (req_list.target_component != mavlink_system.compid || req_list.target_component == MAV_COMP_ID_ALL)) {
 				// publish list request to UAVCAN driver via uORB.
 				uavcan_parameter_request_s req{};
@@ -151,7 +188,7 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 #if defined(CONFIG_MAVLINK_UAVCAN_PARAMETERS)
 
 			if (set.target_system == mavlink_system.sysid && set.target_component < 127 &&
-			    !(set.target_component >= MAV_COMP_ID_CAMERA && set.target_component <= MAV_COMP_ID_CAMERA6) &&
+			    !is_observed_mavlink_camera(set.target_component) &&
 			    (set.target_component != mavlink_system.compid || set.target_component == MAV_COMP_ID_ALL)) {
 				// publish set request to UAVCAN driver via uORB.
 				uavcan_parameter_request_s req{};
@@ -244,7 +281,7 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 #if defined(CONFIG_MAVLINK_UAVCAN_PARAMETERS)
 
 			if (req_read.target_system == mavlink_system.sysid && req_read.target_component < 127 &&
-			    !(req_read.target_component >= MAV_COMP_ID_CAMERA && req_read.target_component <= MAV_COMP_ID_CAMERA6) &&
+			    !is_observed_mavlink_camera(req_read.target_component) &&
 			    (req_read.target_component != mavlink_system.compid || req_read.target_component == MAV_COMP_ID_ALL)) {
 				// publish set request to UAVCAN driver via uORB.
 				uavcan_parameter_request_s req{};

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -124,7 +124,7 @@ MavlinkParametersManager::is_observed_mavlink_camera(uint8_t target_component) c
 bool
 MavlinkParametersManager::is_dronecan_node_online(uint8_t node_id)
 {
-	dronecan_node_status_s status;
+	dronecan_node_status_s status {};
 
 	for (auto &sub : _dronecan_node_status_subs) {
 		if (sub.copy(&status)

--- a/src/modules/mavlink/mavlink_parameters.h
+++ b/src/modules/mavlink/mavlink_parameters.h
@@ -48,6 +48,7 @@
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
+#include <uORB/SubscriptionMultiArray.hpp>
 #include <uORB/topics/rc_parameter_map.h>
 #include <uORB/topics/parameter_update.h>
 #include <drivers/drv_hrt.h>
@@ -56,6 +57,7 @@
 # include <uORB/topics/uavcan_parameter_request.h>
 # include <uORB/topics/uavcan_parameter_value.h>
 # include <uORB/topics/camera_status.h>
+# include <uORB/topics/dronecan_node_status.h>
 #endif // CONFIG_MAVLINK_UAVCAN_PARAMETERS
 
 using namespace time_literals;
@@ -187,11 +189,19 @@ protected:
 	 */
 	bool is_observed_mavlink_camera(uint8_t target_component) const;
 
+	/**
+	 * True if any dronecan_node_status instance reports a live (non-OFFLINE,
+	 * recently updated) node at the given node_id.
+	 */
+	bool is_dronecan_node_online(uint8_t node_id);
+
 	static constexpr hrt_abstime CAMERA_OBSERVATION_TIMEOUT = 5_s;
 	static constexpr unsigned CAMERA_COMP_ID_COUNT = MAV_COMP_ID_CAMERA6 - MAV_COMP_ID_CAMERA + 1;
 
 	uORB::Subscription _camera_status_sub{ORB_ID(camera_status)};
+	uORB::SubscriptionMultiArray<dronecan_node_status_s, ORB_MULTI_MAX_INSTANCES> _dronecan_node_status_subs{ORB_ID::dronecan_node_status};
 	hrt_abstime _camera_comp_last_seen[CAMERA_COMP_ID_COUNT] {};
+	uint8_t _camera_cannode_collision_warned_mask{0}; ///< bit i: already warned for MAV_COMP_ID_CAMERA + i
 #endif // CONFIG_MAVLINK_UAVCAN_PARAMETERS
 
 	uORB::Publication<rc_parameter_map_s>	_rc_param_map_pub{ORB_ID(rc_parameter_map)};

--- a/src/modules/mavlink/mavlink_parameters.h
+++ b/src/modules/mavlink/mavlink_parameters.h
@@ -55,6 +55,7 @@
 #if defined(CONFIG_MAVLINK_UAVCAN_PARAMETERS)
 # include <uORB/topics/uavcan_parameter_request.h>
 # include <uORB/topics/uavcan_parameter_value.h>
+# include <uORB/topics/camera_status.h>
 #endif // CONFIG_MAVLINK_UAVCAN_PARAMETERS
 
 using namespace time_literals;
@@ -169,6 +170,28 @@ protected:
 		      "uavcan_parameter_request_s MAV_PARAM_TYPE_INT64 constant mismatch");
 
 	uORB::Subscription _uavcan_parameter_value_sub{ORB_ID(uavcan_parameter_value)};
+
+	/**
+	 * Poll camera_status uORB and record the last time each comp ID in the
+	 * MAV_COMP_ID_CAMERA..MAV_COMP_ID_CAMERA6 range was seen as a MAVLink
+	 * camera (HEARTBEAT with MAV_TYPE_CAMERA).
+	 */
+	void update_observed_camera_components();
+
+	/**
+	 * True if target_component is in MAV_COMP_ID_CAMERA..MAV_COMP_ID_CAMERA6
+	 * and we have observed a MAVLink camera heartbeat on it within
+	 * CAMERA_OBSERVATION_TIMEOUT. When false, the UAVCAN parameter bridge may
+	 * forward to CAN node target_component even if that ID falls in 100..105,
+	 * which is required for DroneCAN peripherals (e.g. ESCs) assigned those IDs.
+	 */
+	bool is_observed_mavlink_camera(uint8_t target_component) const;
+
+	static constexpr hrt_abstime CAMERA_OBSERVATION_TIMEOUT = 5_s;
+	static constexpr unsigned CAMERA_COMP_ID_COUNT = MAV_COMP_ID_CAMERA6 - MAV_COMP_ID_CAMERA + 1;
+
+	uORB::Subscription _camera_status_sub{ORB_ID(camera_status)};
+	hrt_abstime _camera_comp_last_seen[CAMERA_COMP_ID_COUNT] {};
 #endif // CONFIG_MAVLINK_UAVCAN_PARAMETERS
 
 	uORB::Publication<rc_parameter_map_s>	_rc_param_map_pub{ORB_ID(rc_parameter_map)};


### PR DESCRIPTION
## Summary

Only exclude `target_component` 100–105 from the MAVLink → UAVCAN parameter bridge when PX4 has observed a MAVLink camera heartbeat (`MAV_TYPE_CAMERA`) on that component ID within the last 5 seconds. When no camera has been seen there, forward to the matching UAVCAN node as before.

## Context

The bridge in `mavlink_parameters.cpp` maps `target_component` 1:1 onto UAVCAN `node_id`. PR #25651 added an unconditional exclusion of 100–105 (`MAV_COMP_ID_CAMERA..MAV_COMP_ID_CAMERA6`) from the bridge, which also made DroneCAN peripherals at those node IDs unreachable via `PARAM_REQUEST_LIST` / `PARAM_SET` / `PARAM_REQUEST_READ`.

Field symptom: QGroundControl's parameter download hangs / times out when a DroneCAN ESC is powered at a node ID in 100–105. Node IDs outside that range are unaffected. The ArduPilot convention (ESC node IDs counting down from 125) means users following that convention rarely hit this, which is why the regression escaped detection.

Full analysis and alternatives in #27180 (this implements option A).

## Approach

`MavlinkReceiver` already publishes `camera_status` (`timestamp`, `active_comp_id`) on every `MAV_TYPE_CAMERA` heartbeat. `MavlinkParametersManager` now subscribes to `camera_status`, caches the last-seen time per comp ID in `MAV_COMP_ID_CAMERA..MAV_COMP_ID_CAMERA6`, and replaces the raw 100–105 range guard at the three bridge sites with `!is_observed_mavlink_camera(target_component)` — true only when a camera heartbeat was seen on that ID within `CAMERA_OBSERVATION_TIMEOUT` (5 s).

Preserves #25651's intent for real MAVLink cameras; unblocks DroneCAN peripherals assigned IDs in 100–105.

## Deconfliction

A second commit adds a one-shot warning for the actual-collision case: when PX4 sees both a `MAV_TYPE_CAMERA` heartbeat and an online DroneCAN node at the same comp ID in 100–105, it emits `mavlink_log_warning` like:

> CAN node 100 blocked by MAV camera (reassign ID)

Fires regardless of which side joined first, sticky per comp ID for the boot. Only triggers when both conditions hold — users with a camera but no CAN collision see nothing. `dronecan_node_status` is a pre-existing multi-instance uORB topic published by the UAVCAN driver, so no cross-module coupling is added beyond one subscription.

Builds clean locally on `ark_fmu-v6x_default` (exercises the UAVCAN path) and `px4_sitl_default` (non-UAVCAN, `#ifdef`'d out). `make check_format` passes.

## References

- Fixes #27180
- Regression introduced in #25651 (main) / #25658 (release/1.16, v1.16.1)