### PR TITLE
feat(boards/modalai/voxl2): Add timeout to voxl-reset-slpi command

### DIFF
--- a/boards/modalai/voxl2/cmake/package.cmake
+++ b/boards/modalai/voxl2/cmake/package.cmake
@@ -47,7 +47,7 @@ set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
 set(CPACK_INSTALL_PREFIX "/usr")
 set(CPACK_SET_DESTDIR true)
 
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libfc-sensor (>=1.0.10), voxl-px4-params (>=0.3.10), voxl3-system-image(>=0.0.2) | voxl2-system-image(>=1.5.4) | rb5-system-image(>=1.6.2), modalai-slpi(>=1.2.2) | modalai-adsp(>=1.0.5)")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "voxl-reset-slpi(>=0.0.3), libfc-sensor (>=1.0.10), voxl-px4-params (>=0.3.10), voxl3-system-image(>=0.0.2) | voxl2-system-image(>=1.5.4) | rb5-system-image(>=1.6.2), modalai-slpi(>=1.2.3) | modalai-adsp(>=1.0.7)")
 set(CPACK_DEBIAN_PACKAGE_CONFLICTS "px4-rb5-flight")
 set(CPACK_DEBIAN_PACKAGE_REPLACES "px4-rb5-flight")
 set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "PX4 Autopilot for ModalAI VOXL2")

--- a/boards/modalai/voxl2/debian/voxl-px4.service
+++ b/boards/modalai/voxl2/debian/voxl-px4.service
@@ -6,7 +6,7 @@ Requires=sscrpcd.service
 [Service]
 ExecStartPre=/bin/sleep 2
 ExecStart=/usr/bin/voxl-px4
-ExecStopPost=/usr/bin/voxl-reset-slpi
+ExecStopPost=/usr/bin/voxl-reset-slpi -t 10000
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
### Solved Problem

Add timeout to voxl-reset-slpi command in the service file. This will reset the DSP and wait for it to come back. After the timeout it will give up. Update package dependencies to get this new feature. This makes it more robust across different VOXL board variants.

