### PR TITLE
fix(labels): rename documentation label

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_bug_report.yml
@@ -1,7 +1,7 @@
 name: 📑 Documentation Bug report
 description: Create a report to help us improve the docs
 title: "[Docs] [Bug] "
-labels: ["Documentation 📑"]
+labels: ["scope:docs"]
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_bug_report.yml
@@ -1,6 +1,6 @@
 name: 📑 Documentation Bug report
 description: Create a report to help us improve the docs
-title: "[Docs] [Bug] "
+title: "docs(bug): "
 labels: ["scope:docs"]
 body:
   - type: textarea

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,6 +5,6 @@
 
 
 # Add 'Documentation' label to any changes within 'docs' folder or any subfolders
-"Documentation 📑":
+"scope:docs":
 - changed-files:
   - any-glob-to-any-file: docs/**

--- a/.github/workflows/docs_crowdin_download.yml
+++ b/.github/workflows/docs_crowdin_download.yml
@@ -41,7 +41,7 @@ jobs:
           pull_request_base_branch_name: 'main'
           pull_request_title: 'docs(i18n): PX4 guide translations (Crowdin) - ${{ matrix.lc }}'
           pull_request_body: 'docs(i18n): PX4 guide Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action) for ${{ matrix.lc }}'
-          pull_request_labels: 'Documentation 📑'
+          pull_request_labels: 'scope:docs'
           pull_request_reviewers: hamishwillee
           download_language: ${{ matrix.lc }}
         env:


### PR DESCRIPTION
Migrates old `Documentation 📑` label to `scope:docs` to fit into the new format.

**Note that** the `scope:docs` label currently does not exist. Once this PR is merged, `Documentation 📑` label on this repo should be immediately renamed to `scope:docs` with `#1D76DB` color code.

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
