### PR TITLE
docs(zh): fix ROS 2 coordinate frame table

### DIFF
--- a/docs/zh/ros2/user_guide.md
+++ b/docs/zh/ros2/user_guide.md
@@ -435,7 +435,7 @@ subscription_ = this->create_subscription<0>("/fmu/out/sensor_combined", qos,
 
 ROS与 PX4所使用的本地 / 世界坐标系和机体坐标系存在差异。
 
-| 框架    | ROS                                                                 | ROS                                                              |
+| 框架    | PX4                                                                 | ROS                                                              |
 | ----- | ------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | 机体    | FRD (X **F**orward, Y **R**ight, Z **D**own)     | FLU (X **F**orward, Y **L**eft, Z **U**p)     |
 | 世界坐标系 | FRD or NED (X **N**orth, Y **E**ast, Z **D**own) | FLU 或 ENU (X **E**ast, Y **N**orth, Z **U**p) |


### PR DESCRIPTION
Fix the Chinese ROS 2 user guide coordinate frame table header. The left data column describes PX4 FRD/NED frames, so its header should be PX4 instead of ROS.