### PR TITLE
fix(gimbal): handle NaN pitch/yaw in DO_GIMBAL_MANAGER_PITCHYAW

### DIFF
--- a/src/modules/gimbal/input_mavlink.cpp
+++ b/src/modules/gimbal/input_mavlink.cpp
@@ -910,8 +910,10 @@ InputMavlinkGimbalV2::_process_command(ControlData &control_data, const vehicle_
 		if (vehicle_command.source_system == control_data.sysid_primary_control &&
 		    vehicle_command.source_component == control_data.compid_primary_control) {
 
-			const matrix::Eulerf euler(0.0f, math::radians(vehicle_command.param1),
-						   math::radians(vehicle_command.param2));
+			const matrix::Eulerf euler(
+				0.0f,
+				PX4_ISFINITE(vehicle_command.param1) ? math::radians(vehicle_command.param1) : 0.0f,
+				PX4_ISFINITE(vehicle_command.param2) ? math::radians(vehicle_command.param2) : 0.0f);
 			const matrix::Quatf q(euler);
 			const matrix::Vector3f angular_velocity(NAN, math::radians(vehicle_command.param3),
 								math::radians(vehicle_command.param4));


### PR DESCRIPTION
### Solved Problem

Fixes #26640. NaN on a `DO_GIMBAL_MANAGER_PITCHYAW` axis means "unset" per MAVLink. Without a guard, NaN propagates through `Eulerf` -> `Quatf` and freezes the gimbal.

### Solution

Wrap `param1`/`param2` with `PX4_ISFINITE(...) ? math::radians(...) : 0.0f`. Matches `input_mavlink.cpp:951`.

### Changelog Entry

```
Bugfix: gimbal no longer freezes on DO_GIMBAL_MANAGER_PITCHYAW with NaN on the unset axis.
```

### Test

`gz_x500_gimbal` SITL + pymavlink: `DO_GIMBAL_MANAGER_CONFIGURE`, then `DO_GIMBAL_MANAGER_PITCHYAW pitch=45 yaw=NaN`. `COMMAND_ACK result=0`. `GIMBAL_DEVICE_SET_ATTITUDE.q = [0.9239, 0, 0.3827, 0]`.