### PR TITLE
Fix typo in Python package name in user guide (empty==3.3.4 => empy==3.3.4)

### DIFF
--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -134,7 +134,7 @@ To install ROS 2 and its dependencies:
 1. Some Python dependencies must also be installed (using **`pip`** or **`apt`**):
 
    ```sh
-   pip install --user -U empty==3.3.4 pyros-genmsg setuptools
+   pip install --user -U empy==3.3.4 pyros-genmsg setuptools
    ```
 
 ### Setup Micro XRCE-DDS Agent & Client


### PR DESCRIPTION
<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
