### PR TITLE
docs(params): Fix up params that render badly after prettier

### DIFF
--- a/src/lib/mixer_module/motor_params.yaml
+++ b/src/lib/mixer_module/motor_params.yaml
@@ -9,8 +9,12 @@ parameters:
           Parameter used to model the nonlinear relationship between
           motor control signal (e.g. PWM) and static thrust.
 
-          The model is: rel_thrust = factor * rel_signal^2 + (1-factor) * rel_signal,
-          where rel_thrust is the normalized thrust between 0 and 1, and
+          The model is:
+
+          ```
+          rel_thrust = factor * rel_signal^2 + (1-factor) * rel_signal
+          ```
+          , where rel_thrust is the normalized thrust between 0 and 1, and
           rel_signal is the relative motor control signal between 0 and 1.
       type: float
       default: 0.0

--- a/src/lib/rover_control/rovercontrol_params.yaml
+++ b/src/lib/rover_control/rovercontrol_params.yaml
@@ -235,7 +235,9 @@ parameters:
       description:
         short: Tuning parameter for the speed reduction based on the course error
         long: |-
+          ```
           Reduced_speed = RO_MAX_THR_SPEED * (1 - normalized_course_error * RO_SPEED_RED)
+          ```
           The normalized course error is the angle between the current course and the bearing setpoint
           interpolated from [0, 180] -> [0, 1].
           Higher value -> More speed reduction.

--- a/src/modules/mc_rate_control/mc_rate_control_params.yaml
+++ b/src/modules/mc_rate_control/mc_rate_control_params.yaml
@@ -60,9 +60,11 @@ parameters:
           Global gain of the controller.
 
           This gain scales the P, I and D terms of the controller:
+          ```
           output = MC_ROLLRATE_K * (MC_ROLLRATE_P * error
           + MC_ROLLRATE_I * error_integral
           + MC_ROLLRATE_D * error_derivative)
+          ```
           Set MC_ROLLRATE_P=1 to implement a PID in the ideal form.
           Set MC_ROLLRATE_K=1 to implement a PID in the parallel form.
       type: float
@@ -128,9 +130,11 @@ parameters:
           Global gain of the controller.
 
           This gain scales the P, I and D terms of the controller:
+          ```
           output = MC_PITCHRATE_K * (MC_PITCHRATE_P * error
           + MC_PITCHRATE_I * error_integral
           + MC_PITCHRATE_D * error_derivative)
+          ```
           Set MC_PITCHRATE_P=1 to implement a PID in the ideal form.
           Set MC_PITCHRATE_K=1 to implement a PID in the parallel form.
       type: float
@@ -196,9 +200,11 @@ parameters:
           Global gain of the controller.
 
           This gain scales the P, I and D terms of the controller:
+          ```
           output = MC_YAWRATE_K * (MC_YAWRATE_P * error
           + MC_YAWRATE_I * error_integral
           + MC_YAWRATE_D * error_derivative)
+          ```
           Set MC_YAWRATE_P=1 to implement a PID in the ideal form.
           Set MC_YAWRATE_K=1 to implement a PID in the parallel form.
       type: float


### PR DESCRIPTION
Prettier is run on generated files, and soon all files. One change this makes is that it turns `*` into `_` (for emphasis markup). Most of the time this is good, but in a few cases in params `*` is use to mean "multiply".

This escapes the characters so they are  ignored by prettier.
This MIGHT render not so well in QGC though. I think that takes from the JSON

An alternative is to try wrapping those blocks in a markdown code block. Open to suggestions on what is better?


