### PR TITLE
fix(drivers/distance_sensor/vl53l0x): filter out invalid 8.19m distance readings

### DIFF
--- a/src/drivers/distance_sensor/vl53l0x/VL53L0X.cpp
+++ b/src/drivers/distance_sensor/vl53l0x/VL53L0X.cpp
@@ -115,6 +115,10 @@ int VL53L0X::collect()
 	uint16_t distance_mm = (val[0] << 8) | val[1];
 	float distance_m = distance_mm / 1000.f;
 
+	if (distance_m > 2.0f) {
+		return PX4_OK;
+	}
+
 	_px4_rangefinder.update(timestamp_sample, distance_m);
 
 	return PX4_OK;


### PR DESCRIPTION



### Solved Problem
fix(drivers/distance_sensor/vl53l0x): filter out invalid 8.19m distance readings which gets read when the distance sensor cannot detect anything

### Solution
add a simple check to only allow distance less than it's max bound of 2.0 m

### Changelog Entry:
fix: [drivers/vl53l0x] Drop invalid 8.19m readings and cap range to 2.0m.

### Alternatives
The distance value could be rejected right after reading the raw sensor value.

### Test coverage
Hardware: Tested on a VL53L0X sensor connected via I2C.

Verification: Observed distance readings in mavlink_inspector. Values above 2.0m are now correctly ignored.




