### PR TITLE
feat(fw-tecs): increase default of FW_T_HRATE_FF from 0.3 to 0.5

### DIFF
--- a/src/modules/fw_lateral_longitudinal_control/fw_lat_long_params.yaml
+++ b/src/modules/fw_lateral_longitudinal_control/fw_lat_long_params.yaml
@@ -182,7 +182,7 @@ parameters:
       description:
         short: Height rate feed forward
       type: float
-      default: 0.3
+      default: 0.5
       min: 0.0
       max: 1.0
       decimal: 2


### PR DESCRIPTION

### Solved Problem
The target sink rate is poorly tracked with default tuning. Is especially relevant when coming in for the landing.
<img width="1096" height="621" alt="image" src="https://github.com/user-attachments/assets/e3b5cbcd-9c3c-40e3-a2be-fe83c05dcadc" />


### Solution
Reason for the loose tracking is that the feed-forward gain is set to 0.3 by default. The sink rate setpoint is FF*height_rate_reference + P*height_rate_error. With a small FF value the error has to grow quite high until the controller reaches the target sink rate setpoint. 

### Changelog Entry
For release notes:
```
Feature: feat(fw-tecs): increase default of FW_T_HRATE_FF from 0.3 to 0.5
```

### Alternatives
Put `FW_T_HRATE_FF` even higher (on paper 1 should be ideal). For the sake of small iterations that are applicable without re-tuning I would though do it in steps. 

### Test coverage
We have many vehicles flying with a high `FW_T_HRATE_FF`. See screenshot below with `FW_T_HRATE_FF`=1, `FW_T_ALT_TC`=10. Notice the tighter altitude ramp tracking.  

<img width="1167" height="575" alt="image" src="https://github.com/user-attachments/assets/efe1fdb3-63cd-46a6-933b-2a55796562d2" />
 

### Context
When this param default was [last touched](https://github.com/PX4/PX4-Autopilot/pull/16362) the TECS controller looked vastly different. 
