### PR TITLE
feat(drivers): add AUAV L60D support

### DIFF
--- a/src/drivers/differential_pressure/auav/AUAV_Differential.cpp
+++ b/src/drivers/differential_pressure/auav/AUAV_Differential.cpp
@@ -55,6 +55,10 @@ AUAV_Differential::AUAV_Differential(const I2CSPIDriverConfig &config) :
 		_cal_range = 60;
 		break;
 
+	case 4: /* AUAV L60D (+- 60 inH20) */
+		_cal_range = 120;
+		break;
+
 	default:
 		_cal_range = 10; /* Default fallback */
 		break;
@@ -151,7 +155,7 @@ int AUAV_Differential::read_factory_data()
 	int32_t sensor_type = ((char_high - '0') * 10) + (char_low - '0');
 
 	/* Check if the detected sensor type is valid */
-	if (sensor_type != AUAV_LD_05 && sensor_type != AUAV_LD_10 && sensor_type != AUAV_LD_30) {
+	if (sensor_type != AUAV_LD_05 && sensor_type != AUAV_LD_10 && sensor_type != AUAV_LD_30 && sensor_type != AUAV_LD_60) {
 		return PX4_ERROR;
 	}
 

--- a/src/drivers/differential_pressure/auav/AUAV_Differential.hpp
+++ b/src/drivers/differential_pressure/auav/AUAV_Differential.hpp
@@ -62,6 +62,7 @@ static constexpr float INH_TO_PA = 249.08f;
 static constexpr int32_t AUAV_LD_05 = 5;
 static constexpr int32_t AUAV_LD_10 = 10;
 static constexpr int32_t AUAV_LD_30 = 30;
+static constexpr int32_t AUAV_LD_60 = 60;
 
 class AUAV_Differential : public AUAV
 {

--- a/src/drivers/differential_pressure/auav/parameters.yaml
+++ b/src/drivers/differential_pressure/auav/parameters.yaml
@@ -11,5 +11,6 @@ parameters:
         1: AUAV L05D
         2: AUAV L10D
         3: AUAV L30D
+        4: AUAV L60D
       default: 0
       reboot_required: true


### PR DESCRIPTION
### Solved Problem
- The driver currently does not support the L60D variant, which is still sort of useable for fixed wing planes

### Solution
- Add the L60D variant

### Test coverage
- Tested with a L60D in a CAN airspeed sensor