### PR TITLE
ci(sbom): check out submodules recursively in PR license check

### DIFF
--- a/.github/workflows/sbom_license_check.yml
+++ b/.github/workflows/sbom_license_check.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          submodules: false
+          submodules: recursive
 
       - name: Install PyYAML
         run: pip install pyyaml --break-system-packages


### PR DESCRIPTION
The PR-time SBOM license check was using `submodules: false`, so when `generate_sbom.py` ran the submodule directories were empty. The script treats uninitialized submodules as `(not checked out) -> NOASSERTION (skipped)` rather than a failure, which is how PR #27184 (adding `PX4-OpticalFlow` as a submodule) passed `verify-licenses` without ever inspecting the actual repo for a LICENSE file. The monthly audit then caught it (#27217) because it uses `submodules: recursive`.

Switch the PR-time job to `submodules: recursive` so license issues are caught at PR time rather than on the next monthly audit. The workflow only runs when `.gitmodules`, `Tools/ci/license-overrides.yaml`, or `Tools/ci/generate_sbom.py` change, so the extra clone cost is bounded to the rare PRs that touch submodule wiring or the SBOM tooling itself.