### PR TITLE
fix(mavlink): don't write empty signing key file on shutdown

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -121,7 +121,6 @@ public:
 	{
 		_task_should_exit.store(true);
 		_receiver.request_stop();
-		_sign_control.write_key_and_timestamp();
 	}
 
 	void display_status();


### PR DESCRIPTION
On flight controllers running mainline PX4, `mavlink-signing-key.bin` is being created on the SD card with a zeroed key and zero timestamp even on systems that never enabled MAVLink signing. Reported by Jake Dahl on two separate FCs.

The cause is `Mavlink::request_stop()` calling `_sign_control.write_key_and_timestamp()` unconditionally on every instance shutdown. The write is redundant: every signing state transition (`KEY_ACCEPTED`, `SIGNING_DISABLED`) already persists synchronously inside `check_for_signing()` before returning, so the in-memory state is always flushed to disk at the moment it changes. The shutdown call has no work to do, but it does open the file with `O_CREAT | O_WRONLY | O_TRUNC` and writes 32 zero bytes plus an 8-byte zero timestamp, creating the phantom file.

Aggravated by `mavlink_main.cpp:3334` calling `request_stop()` in a tight loop up to 1000 times while waiting for the thread to exit, plus the destructor path. Each iteration re-truncates and rewrites the file.

Introduced in #25284. Fix is the minimal one-line removal.

Verified locally on SIH SITL (`make px4_sitl_sih sihsim_quadx`):

- Started with empty rootfs, no signing configured. After `SIGINT`, `/fs/microsd/mavlink/` is empty, no phantom file.
- Sent a real `SETUP_SIGNING` over UDP. File appeared immediately at `mavlink-signing-key.bin` (mode 600, exact 40 bytes, content matches sent key + timestamp). After `SIGINT`, file is still there with the same content, so the reload-from-disk path on next boot is intact.