### PR TITLE
fix(commander): allow RC-switch arming in Auto Takeoff

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -633,9 +633,11 @@ transition_result_t Commander::arm(arm_disarm_reason_t calling_reason, bool run_
 				}
 			}
 
-		} else if (calling_reason == arm_disarm_reason_t::stick_gesture
-			   || calling_reason == arm_disarm_reason_t::rc_switch
-			   || calling_reason == arm_disarm_reason_t::rc_button) {
+		} else if ((calling_reason == arm_disarm_reason_t::stick_gesture
+			    || calling_reason == arm_disarm_reason_t::rc_switch
+			    || calling_reason == arm_disarm_reason_t::rc_button)
+			   && _vehicle_status.nav_state != vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF
+			   && _vehicle_status.nav_state != vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF) {
 
 			mavlink_log_critical(&_mavlink_log_pub, "Arming denied: switch to manual mode first\t");
 			events::send(events::ID("commander_arm_denied_not_manual"), {events::Log::Critical, events::LogInternal::Info},


### PR DESCRIPTION
The Fixed-Wing Takeoff Mode docs ([`flight_modes_fw/takeoff.md:29`](https://docs.px4.io/main/en/flight_modes_fw/takeoff.html#technical-summary)) describe the workflow as: "switch to the mode, **and then arm the vehicle**." On real FW hardware this is the natural one-step launch flow, especially with the v1.17 [two-state climb-out + loiter](https://github.com/PX4/PX4-Autopilot/commit/782e510105b) implementation. Code in `Commander.cpp:636` denied this with `"Arming denied: switch to manual mode first"` for any non-manual mode, including Auto Takeoff. The denial branch dates to [`af607e30404e`](https://github.com/PX4/PX4-Autopilot/commit/af607e30404e891030c09fdd1845ad6973c05887) (Oct 2021) and predates Silvan's Takeoff feature work, so it never got a carve-out for the case the docs now describe.

This change narrowly exempts `NAVIGATION_STATE_AUTO_TAKEOFF` and `NAVIGATION_STATE_AUTO_VTOL_TAKEOFF` from the rc_switch / rc_button / stick_gesture denial. Other auto modes are unchanged: AUTO_MISSION still requires arming first per [`flight_modes_fw/mission.md:11`](https://docs.px4.io/main/en/flight_modes_fw/mission.html), AUTO_LOITER and the rest also stay denied as before.

Reproduction and validation done locally in SIH SITL (`make px4_sitl_sih sihsim_airplane`) with a python bench that drives the full real-RC chain via `RC_CHANNELS_OVERRIDE` (gist: https://gist.github.com/mrpollo/0e5b83736b9af00a69727aa72ec066da). Sweep results on the patched branch:

| Mode | Result |
|------|--------|
| AUTO_MISSION | DENIED (unchanged) |
| AUTO_TAKEOFF | **ARMED** (fixed) |
| AUTO_LOITER | DENIED (unchanged) |
| POSCTL | ARMED (unchanged) |
| ALTCTL | ARMED (unchanged) |
| MANUAL | ARMED (unchanged) |

After arming in Takeoff mode, the vehicle correctly emits `Using default takeoff altitude: 25.0 m` and engages the two-state climb-out path.

Closes #27012 (Takeoff portion). Supersedes #27223, which widened the wrong gate and would have lifted the AUTO_MISSION safety contract.
