### PR TITLE
docs(releases): v1.17.0 release notes

### DIFF
--- a/docs/en/releases/1.17.md
+++ b/docs/en/releases/1.17.md
@@ -14,7 +14,7 @@ const { site } = useData();
 </div>
 
 PX4 v1.17 builds on [PX4 v1.16](../releases/1.16.md), with the changes below landing since v1.16.2.
-This release adds Altitude Cruise mode, improves Fixed Wing Takeoff behaviour on navigation loss, and exposes cleaner high-level fixed-wing and rover control interfaces for ROS 2 workflows.
+This release adds [Altitude Cruise](../flight_modes_mc/altitude_cruise.md) mode, improves Fixed Wing Takeoff behaviour on navigation loss, and exposes cleaner high-level fixed-wing and rover control interfaces for ROS 2 workflows.
 The in-tree Zenoh middleware matures to `rmw_zenoh` compatibility, simulation gains Gazebo Jetty support and Ackermann SIH, and three new INS drivers (MicroStrain, sbgECom, EULER-NAV) join the ecosystem alongside Septentrio GNSS resilience reporting and barometer auto-calibration against GNSS height.
 PX4 v1.17 also includes user-visible MAVLink, RC, logging, failsafe, and rover refinements across the stack.
 
@@ -29,41 +29,60 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 ## Major Changes
 
-- <Badge type="warning" text="Experimental" /> [MC Neural Network Control](../neural_networks/mc_neural_network_control.md): PX4 gains first-class on-device neural-network inference.
-  With [TensorFlow Lite Micro](../neural_networks/tflm.md) now integrated into the firmware, you can take a network you trained externally (e.g. via reinforcement learning in [Aerial Gym](https://ntnu-arl.github.io/aerial_gym_simulator/)), convert it to tflite, and run it on the autopilot as a full replacement for the multicopter controller stack.
-  ([PX4-Autopilot#24366](https://github.com/PX4/PX4-Autopilot/pull/24366))
 - New multicopter flight mode: [Altitude Cruise](../flight_modes_mc/altitude_cruise.md).
   Holds tilt and heading on stick release so the vehicle keeps cruising at a steady velocity instead of stopping like Altitude mode does.
 - [Fixed Wing Takeoff mode](../flight_modes_fw/takeoff.md) now keeps climbing with level wings on navigation loss and can use the takeoff waypoint latitude and longitude to define the loiter position.
   ([PX4-Autopilot#25226](https://github.com/PX4/PX4-Autopilot/pull/25226))
 - Fixed-wing vehicles (and VTOLs in fixed-wing mode) can now be controlled from ROS 2 via the new [`FwLateralLongitudinalSetpointType`](../ros2/px4_ros2_control_interface.md#fw-lateral-longitudinal-setpoint) in the PX4 ROS 2 Control Interface, exposing direct lateral and longitudinal setpoints.
 - Rovers can now be controlled from ROS 2 via the new [`RoverSetpointTypes`](../ros2/px4_ros2_control_interface.md#rover-setpoints) in the PX4 ROS 2 Control Interface, with valid combinations of position, speed, throttle, attitude, rate, and steering setpoints exposed as guaranteed-valid setpoint types. See [Rovers Apps & API](../flight_modes_rover/api.md).
-- <Badge type="warning" text="Experimental" /> The in-tree [Zenoh middleware](../middleware/zenoh.md) matures to `rmw_zenoh` compatibility (CDRv1 serialization, ROS 2 graph liveliness, auto-generated config from `dds_topics.yaml`, Domain ID parameter, Zenoh CLI). Zenoh is built into the default firmware on FMU-v6xRT (`make px4_fmu-v6xrt_default`); on FMU-v6x and SITL it ships as an opt-in `zenoh` build variant (`make px4_fmu-v6x_zenoh`, `make px4_sitl_zenoh`).
+- <Badge type="warning" text="Experimental" /> The in-tree [Zenoh middleware](../middleware/zenoh.md) matures to `rmw_zenoh` compatibility (CDRv1 serialization, ROS 2 graph liveliness, auto-generated config from `dds_topics.yaml`, Domain ID parameter, Zenoh CLI). Zenoh is built into the default firmware on FMU-v6xRT (`make px4_fmu-v6xrt_default`); on FMU-v6x and SITL it ships as a `zenoh` build variant (`make px4_fmu-v6x_zenoh`, `make px4_sitl_zenoh`).
+- <Badge type="warning" text="Experimental" /> Initial [MC Neural Network Control](../neural_networks/mc_neural_network_control.md) test path: PX4 v1.17 integrates [TensorFlow Lite Micro](../neural_networks/tflm.md) on-device so an externally trained network (for example trained with reinforcement learning in [Aerial Gym](https://ntnu-arl.github.io/aerial_gym_simulator/)) can be loaded as a tflite model and substituted for the multicopter controller for research and bench testing. It is not a replacement for the production controller stack.
+  ([PX4-Autopilot#24366](https://github.com/PX4/PX4-Autopilot/pull/24366))
 
 ## Upgrade Guide
 
-- Removed `MPC_XY_MAN_EXPO`, `MPC_Z_MAN_EXPO`, and `MPC_YAW_MAN_EXPO`.
-  Renamed `MPC_HOLD_DZ` to [`MAN_DEADZONE`](../advanced_config/parameter_reference.md#MAN_DEADZONE) and made it globally available across modes that allow a deadzone.
-- Added [`SENS_BAR_AUTOCAL`](../advanced_config/parameter_reference.md#SENS_BAR_AUTOCAL) for barometer auto-calibration against GNSS height; enabled by default in v1.17.
-  ([PX4-Autopilot#24859](https://github.com/PX4/PX4-Autopilot/pull/24859))
-- [`MAV_PROTO_VER`](../advanced_config/parameter_reference.md#MAV_PROTO_VER) now defaults to `2`, making MAVLink v1 opt-in instead of the default fallback.
-  ([PX4-Autopilot#25583](https://github.com/PX4/PX4-Autopilot/pull/25583))
-- Removed `EKF2_RNG_A_IGATE` from range-aid tuning during the EKF2 parameter-naming consistency refactor.
-  ([PX4-Autopilot#25137](https://github.com/PX4/PX4-Autopilot/pull/25137))
-- Reduced [`EKF2_MIN_RNG`](../advanced_config/parameter_reference.md#EKF2_MIN_RNG) default from 0.1 m to 0.01 m.
-  ([PX4-Autopilot#25574](https://github.com/PX4/PX4-Autopilot/pull/25574))
-- Servo trim parameters `PWM_*_TRIM` are replaced by `PWM_*_CENTER` with asymmetric deflection.
-  ([PX4-Autopilot#25897](https://github.com/PX4/PX4-Autopilot/pull/25897))
-- The default 1 percent deadzone on RC channels 1 to 8 has been removed; configure deadzone explicitly per channel if required.
-  ([PX4-Autopilot#25502](https://github.com/PX4/PX4-Autopilot/pull/25502))
-- Magnetometer calibration is only allowed when at least one mag is available and enabled (priority not 0).
-  ([PX4-Autopilot#25714](https://github.com/PX4/PX4-Autopilot/pull/25714))
-- `SYS_AUTOSTART=0` is now treated the same as no valid airframe.
-  ([PX4-Autopilot#25645](https://github.com/PX4/PX4-Autopilot/pull/25645))
-- `commander lockdown on` shell command renamed to `commander termination`; `FORCE_FAILSAFE` renamed to `TERMINATION` and `manual_lockdown` renamed to `kill` for clarity.
-- The `serial_number` field has moved from `battery_status` to a new `battery_info` uORB message; consumers reading the serial number must migrate.
-- `parameters_injected.xml` removed from the build system.
-  ([PX4-Autopilot#25549](https://github.com/PX4/PX4-Autopilot/pull/25549))
+For users upgrading from v1.16, please take a moment to review the following before flying:
+
+1. **Re-check RC stick deadzones.**
+   The hardcoded 1 percent deadzone on RC channels 1 to 8 has been removed. If your transmitter has any centre-stick jitter, configure a per-channel deadzone explicitly via `RC<N>_DZ` after upgrading, otherwise the vehicle may respond to small stick noise that v1.16 quietly ignored.
+   ([PX4-Autopilot#25502](https://github.com/PX4/PX4-Autopilot/pull/25502))
+
+2. **Re-trim servos with the new `PWM_*_CENTER` parameters.**
+   The old `PWM_*_TRIM` servo trim parameters have been replaced by `PWM_*_CENTER` with asymmetric deflection. Trim values are not auto-migrated. Open the actuator configuration in QGC after upgrade and re-set the centre for each servo channel that previously used `PWM_*_TRIM`.
+   ([PX4-Autopilot#25897](https://github.com/PX4/PX4-Autopilot/pull/25897))
+
+3. **Update your GCS or companion if it relies on MAVLink v1.**
+   [`MAV_PROTO_VER`](../advanced_config/parameter_reference.md#MAV_PROTO_VER) now defaults to `2`. MAVLink v1 is still available, but only as an explicit opt-in. If your ground station, telemetry radio, or companion computer link was implicitly relying on the v1 fallback, either update the GCS/companion to MAVLink v2 or set `MAV_PROTO_VER=1` on the affected channel.
+   ([PX4-Autopilot#25583](https://github.com/PX4/PX4-Autopilot/pull/25583))
+
+4. **Migrate manual-control expo and deadzone parameters.**
+   `MPC_XY_MAN_EXPO`, `MPC_Z_MAN_EXPO`, and `MPC_YAW_MAN_EXPO` are removed and fall back to a fixed default. `MPC_HOLD_DZ` has been renamed to [`MAN_DEADZONE`](../advanced_config/parameter_reference.md#MAN_DEADZONE) and now applies globally across modes that allow a deadzone. If you previously tuned expo or hold deadzone, set [`MAN_DEADZONE`](../advanced_config/parameter_reference.md#MAN_DEADZONE) explicitly; expo customisation is no longer available.
+
+5. **Confirm barometer auto-calibration behaviour matches your setup.**
+   The new [`SENS_BAR_AUTOCAL`](../advanced_config/parameter_reference.md#SENS_BAR_AUTOCAL) parameter enables barometer offset calibration against GNSS height when GNSS is the height reference, and is **enabled by default**. This is the desired behaviour for typical outdoor flight; if you operate indoor or in heavily GNSS-degraded environments and want to keep baro offsets locked, disable `SENS_BAR_AUTOCAL`.
+   ([PX4-Autopilot#24859](https://github.com/PX4/PX4-Autopilot/pull/24859))
+
+6. **Re-tune range finder range-aid if you depended on `EKF2_RNG_A_IGATE`.**
+   `EKF2_RNG_A_IGATE` has been removed as part of the EKF2 parameter-naming consistency refactor. Range-aid tuning now relies on the remaining `EKF2_RNG_A_*` parameters. The default [`EKF2_MIN_RNG`](../advanced_config/parameter_reference.md#EKF2_MIN_RNG) was also reduced from 0.1 m to 0.01 m.
+   ([PX4-Autopilot#25137](https://github.com/PX4/PX4-Autopilot/pull/25137), [PX4-Autopilot#25574](https://github.com/PX4/PX4-Autopilot/pull/25574))
+
+7. **Verify magnetometer configuration.**
+   Magnetometer calibration is only allowed when at least one mag is available and enabled (priority not 0). If you previously disabled all mags via priority 0, you must enable at least one before running calibration.
+   ([PX4-Autopilot#25714](https://github.com/PX4/PX4-Autopilot/pull/25714))
+
+8. **Check airframe selection.**
+   `SYS_AUTOSTART=0` is now treated the same as no valid airframe. If you relied on `SYS_AUTOSTART=0` for any custom workflow, select an explicit airframe.
+   ([PX4-Autopilot#25645](https://github.com/PX4/PX4-Autopilot/pull/25645))
+
+9. **Update scripts and external tooling for renamed commander/termination interfaces.**
+   The `commander lockdown on` shell command is now `commander termination`. The `FORCE_FAILSAFE` action is now `TERMINATION`, and `manual_lockdown` is now `kill`. Update any startup scripts, test harnesses, or external tooling that calls these by name.
+
+10. **Migrate consumers of `battery_status.serial_number`.**
+    The `serial_number` field has moved from `battery_status` to a new `battery_info` uORB message. Any consumer (logger, GCS, companion software) reading the serial number from `battery_status` must subscribe to `battery_info` instead.
+
+11. **Remove `parameters_injected.xml` from custom build flows.**
+    `parameters_injected.xml` has been removed from the build system. If you maintained a board layer or downstream fork that referenced it, drop the reference.
+    ([PX4-Autopilot#25549](https://github.com/PX4/PX4-Autopilot/pull/25549))
 
 ## Other changes
 
@@ -250,7 +269,8 @@ The in-tree [Zenoh middleware](../middleware/zenoh.md) (added in v1.16) matures 
 - MAVFTP hardening: rejects path-traversal sequences in FTP operations and validates sessions in FTP write/burst.
 - MAVLink v1 is now opt-in via [`MAV_PROTO_VER`](../advanced_config/parameter_reference.md#MAV_PROTO_VER).
   ([PX4-Autopilot#25583](https://github.com/PX4/PX4-Autopilot/pull/25583))
-- Extended `MISSION_CURRENT` message implemented.
+- Extended `MISSION_CURRENT` message implemented (populates `mission_state` and related fields per [mavlink/mavlink#1869](https://github.com/mavlink/mavlink/pull/1869)).
+  ([PX4-Autopilot#25034](https://github.com/PX4/PX4-Autopilot/pull/25034))
 - `MAV_CMD_REQUEST_MESSAGE` supported for `MESSAGE_INTERVAL`.
   ([PX4-Autopilot#25460](https://github.com/PX4/PX4-Autopilot/pull/25460))
 - The low-bandwidth stream profile includes additional important streams with updated rates.
@@ -317,12 +337,6 @@ The in-tree [Zenoh middleware](../middleware/zenoh.md) (added in v1.16) matures 
 
 ### Safety / Commander
 
-- Pilot can take over from a degraded failsafe action.
-  ([PX4-Autopilot#26269](https://github.com/PX4/PX4-Autopilot/pull/26269))
-- Offboard to Position (hold) is no longer entered without RC.
-  ([PX4-Autopilot#26391](https://github.com/PX4/PX4-Autopilot/pull/26391))
-- Motor-failure detector uses robust timeout checks.
-  ([PX4-Autopilot#25757](https://github.com/PX4/PX4-Autopilot/pull/25757))
 - Failure injection refactored into its own class; `failure motor off -i <n>` now requires `CA_FAILURE_MODE` to be set. See [motor failure injection and detection](../debug/failure_injection.md).
   ([PX4-Autopilot#25756](https://github.com/PX4/PX4-Autopilot/pull/25756))
 - Naming for clarity: `FORCE_FAILSAFE` renamed to `TERMINATION`; `commander lockdown on` renamed to `commander termination`; `manual_lockdown` renamed to `kill`; `ACTION_TERMINATE` renamed to `ACTION_TERMINATION`.

--- a/docs/en/releases/1.17.md
+++ b/docs/en/releases/1.17.md
@@ -13,122 +13,336 @@ const { site } = useData();
   </div>
 </div>
 
-This contains changes in PX4 v1.17 (since the last major release [PX v1.16](../releases/1.16.md)).
+PX4 v1.17 builds on [PX4 v1.16](../releases/1.16.md), with the changes below landing since v1.16.2.
+This release adds Altitude Cruise mode, improves Fixed Wing Takeoff behaviour on navigation loss, and exposes cleaner high-level fixed-wing and rover control interfaces for ROS 2 workflows.
+The in-tree Zenoh middleware matures to `rmw_zenoh` compatibility, simulation gains Gazebo Jetty support and Ackermann SIH, and three new INS drivers (MicroStrain, sbgECom, EULER-NAV) join the ecosystem alongside Septentrio GNSS resilience reporting and barometer auto-calibration against GNSS height.
+PX4 v1.17 also includes user-visible MAVLink, RC, logging, failsafe, and rover refinements across the stack.
 
 ::: warning
-PX4 v1.17 is in alpha/beta testing.
-Update these notes with features that are going to be in PX4 v1.17 release.
-New features that are not expected to go into the v1.17 release are in [PX4-Autopilot `main` Release Notes](../releases/main.md).
+PX4 v1.17 is documented on an alpha/beta release branch.
+See [PX4-Autopilot `main` Release Notes](../releases/main.md) for newer changes on `main`.
 :::
 
 ## Read Before Upgrading
-
-TBD …
 
 Please continue reading for [upgrade instructions](#upgrade-guide).
 
 ## Major Changes
 
-- TBD
+- <Badge type="warning" text="Experimental" /> [MC Neural Network Control](../neural_networks/mc_neural_network_control.md): PX4 gains first-class on-device neural-network inference.
+  With [TensorFlow Lite Micro](../neural_networks/tflm.md) now integrated into the firmware, you can take a network you trained externally (e.g. via reinforcement learning in [Aerial Gym](https://ntnu-arl.github.io/aerial_gym_simulator/)), convert it to tflite, and run it on the autopilot as a full replacement for the multicopter controller stack.
+  ([PX4-Autopilot#24366](https://github.com/PX4/PX4-Autopilot/pull/24366))
+- New multicopter flight mode: [Altitude Cruise](../flight_modes_mc/altitude_cruise.md).
+  Holds tilt and heading on stick release so the vehicle keeps cruising at a steady velocity instead of stopping like Altitude mode does.
+- [Fixed Wing Takeoff mode](../flight_modes_fw/takeoff.md) now keeps climbing with level wings on navigation loss and can use the takeoff waypoint latitude and longitude to define the loiter position.
+  ([PX4-Autopilot#25226](https://github.com/PX4/PX4-Autopilot/pull/25226))
+- Fixed-wing vehicles (and VTOLs in fixed-wing mode) can now be controlled from ROS 2 via the new [`FwLateralLongitudinalSetpointType`](../ros2/px4_ros2_control_interface.md#fw-lateral-longitudinal-setpoint) in the PX4 ROS 2 Control Interface, exposing direct lateral and longitudinal setpoints.
+- Rovers can now be controlled from ROS 2 via the new [`RoverSetpointTypes`](../ros2/px4_ros2_control_interface.md#rover-setpoints) in the PX4 ROS 2 Control Interface, with valid combinations of position, speed, throttle, attitude, rate, and steering setpoints exposed as guaranteed-valid setpoint types. See [Rovers Apps & API](../flight_modes_rover/api.md).
+- <Badge type="warning" text="Experimental" /> The in-tree [Zenoh middleware](../middleware/zenoh.md) matures to `rmw_zenoh` compatibility (CDRv1 serialization, ROS 2 graph liveliness, auto-generated config from `dds_topics.yaml`, Domain ID parameter, Zenoh CLI). Zenoh is built into the default firmware on FMU-v6xRT (`make px4_fmu-v6xrt_default`); on FMU-v6x and SITL it ships as an opt-in `zenoh` build variant (`make px4_fmu-v6x_zenoh`, `make px4_sitl_zenoh`).
 
 ## Upgrade Guide
+
+- Removed `MPC_XY_MAN_EXPO`, `MPC_Z_MAN_EXPO`, and `MPC_YAW_MAN_EXPO`.
+  Renamed `MPC_HOLD_DZ` to [`MAN_DEADZONE`](../advanced_config/parameter_reference.md#MAN_DEADZONE) and made it globally available across modes that allow a deadzone.
+- Added [`SENS_BAR_AUTOCAL`](../advanced_config/parameter_reference.md#SENS_BAR_AUTOCAL) for barometer auto-calibration against GNSS height; enabled by default in v1.17.
+  ([PX4-Autopilot#24859](https://github.com/PX4/PX4-Autopilot/pull/24859))
+- [`MAV_PROTO_VER`](../advanced_config/parameter_reference.md#MAV_PROTO_VER) now defaults to `2`, making MAVLink v1 opt-in instead of the default fallback.
+  ([PX4-Autopilot#25583](https://github.com/PX4/PX4-Autopilot/pull/25583))
+- Removed `EKF2_RNG_A_IGATE` from range-aid tuning during the EKF2 parameter-naming consistency refactor.
+  ([PX4-Autopilot#25137](https://github.com/PX4/PX4-Autopilot/pull/25137))
+- Reduced [`EKF2_MIN_RNG`](../advanced_config/parameter_reference.md#EKF2_MIN_RNG) default from 0.1 m to 0.01 m.
+  ([PX4-Autopilot#25574](https://github.com/PX4/PX4-Autopilot/pull/25574))
+- Servo trim parameters `PWM_*_TRIM` are replaced by `PWM_*_CENTER` with asymmetric deflection.
+  ([PX4-Autopilot#25897](https://github.com/PX4/PX4-Autopilot/pull/25897))
+- The default 1 percent deadzone on RC channels 1 to 8 has been removed; configure deadzone explicitly per channel if required.
+  ([PX4-Autopilot#25502](https://github.com/PX4/PX4-Autopilot/pull/25502))
+- Magnetometer calibration is only allowed when at least one mag is available and enabled (priority not 0).
+  ([PX4-Autopilot#25714](https://github.com/PX4/PX4-Autopilot/pull/25714))
+- `SYS_AUTOSTART=0` is now treated the same as no valid airframe.
+  ([PX4-Autopilot#25645](https://github.com/PX4/PX4-Autopilot/pull/25645))
+- `commander lockdown on` shell command renamed to `commander termination`; `FORCE_FAILSAFE` renamed to `TERMINATION` and `manual_lockdown` renamed to `kill` for clarity.
+- The `serial_number` field has moved from `battery_status` to a new `battery_info` uORB message; consumers reading the serial number must migrate.
+- `parameters_injected.xml` removed from the build system.
+  ([PX4-Autopilot#25549](https://github.com/PX4/PX4-Autopilot/pull/25549))
 
 ## Other changes
 
 ### Hardware Support
 
-- **[New Hardware]** boards: [MicoAir743-Lite FC](../flight_controller/micoair743-lite.md) <!-- CHECK is this version and add PR link (or fix up doc version tag and move this) -->
-- **[New Hardware]** boards: [RadiolinkPIX6 FC](../flight_controller/radiolink_pix6.md) <!-- CHECK is this version and add PR! -->
-- **[New Hardware]** boards: [AP-H743-R1 FC](../flight_controller/x-mav_ap-h743r1.md) <!-- CHECK is this version and add PR! -->
+#### New Flight Controllers
 
-<!--
+- [Radiolink PIX6](../flight_controller/radiolink_pix6.md).
+  ([PX4-Autopilot#25562](https://github.com/PX4/PX4-Autopilot/pull/25562))
+- [CUAV X25-Evo](../flight_controller/cuav_x25-evo.md).
+  ([PX4-Autopilot#25176](https://github.com/PX4/PX4-Autopilot/pull/25176))
+- [Accton Godwit GA1](../flight_controller/accton-godwit_ga1.md).
+  ([PX4-Autopilot#25411](https://github.com/PX4/PX4-Autopilot/pull/25411))
+- Kakute H7 dual-IMU build target (no English docs page).
+- NarinFC-H7 (no English docs page).
+- ESP32 generic-target support, sponsored by AutonoSky (no English docs page; experimental).
+
+#### New Build Targets for Existing Hardware
+
+- `cuav/fmu-v6x` build target for the [CUAV Pixhawk V6X](../flight_controller/cuav_pixhawk_v6x.md).
+- `auterion/fmu-v6x` build target for the Auterion FMU-v6x.
+
+#### New CAN Peripherals & Vehicle Platforms
+
+- MR-CANHUBK344 NXP B3RB Rover platform.
+  ([PX4-Autopilot#23897](https://github.com/PX4/PX4-Autopilot/pull/23897))
+- NXP MR-Tropic target with imxrt-related fixes.
+  ([PX4-Autopilot#26052](https://github.com/PX4/PX4-Autopilot/pull/26052))
+- ARK X20 and F9P GPS receivers.
+  ([PX4-Autopilot#25149](https://github.com/PX4/PX4-Autopilot/pull/25149))
+- ARK DIST distance sensor.
+
+#### Existing Boards: Improvements
+
+- FMU-v6xRT: V6XRT001 and V6XRT002 sensor sets, LIS2MDL and BMM350 magnetometer support, DTCM added to heap.
+  ([PX4-Autopilot#25733](https://github.com/PX4/PX4-Autopilot/pull/25733))
+- FMU-v6s: PCA9685 PWM expander driver, INA226 / INA228 / INA238 power-monitor support, HSE used as the RTC clock, init script reordered to start internal sensors first.
+- ARK FPV: rover board variant, payload-deliverer module, and `encrypted_logs` flash savings (FW and VTOL stripped).
+  ([PX4-Autopilot#25319](https://github.com/PX4/PX4-Autopilot/pull/25319), [PX4-Autopilot#25322](https://github.com/PX4/PX4-Autopilot/pull/25322))
+- ARK SCH16T driver updated for new Murata modules.
+  ([PX4-Autopilot#24029](https://github.com/PX4/PX4-Autopilot/pull/24029))
+- mRO PixracerPro: enable additional UARTs.
+  ([PX4-Autopilot#22516](https://github.com/PX4/PX4-Autopilot/pull/22516))
+- 3DR Control Zero H7 OEM Rev G: MTD driver fix and missing module that prevented USB enumeration.
+  ([PX4-Autopilot#25015](https://github.com/PX4/PX4-Autopilot/pull/25015))
+- ESP32: PWM register updates correctly on change.
+  ([PX4-Autopilot#25653](https://github.com/PX4/PX4-Autopilot/pull/25653))
+- Tropic-Community baseboard (Teensy 4.1): PX4 config refresh, DTCM moved to heap with vectors in ITCM.
 
 ### Common
 
-- [QGroundControl Bootloader Update](../advanced_config/bootloader_update.md#qgc-bootloader-update-sys-bl-update) via the [SYS_BL_UPDATE](../advanced_config/parameter_reference.md#SYS_BL_UPDATE) parameter has been re-enabled after being broken for a number of releases. ([PX4-Autopilot#25032: build: romf: fix generation of rc.board_bootloader_upgrade](https://github.com/PX4/PX4-Autopilot/pull/25032)).
--->
+- [QGC Bootloader Update](../advanced_config/bootloader_update.md#qgc-bootloader-update-sys-bl-update) via the [`SYS_BL_UPDATE`](../advanced_config/parameter_reference.md#SYS_BL_UPDATE) parameter has been re-enabled after being broken for several releases.
+  ([PX4-Autopilot#25032](https://github.com/PX4/PX4-Autopilot/pull/25032))
+- Failsafe handling now lets the pilot take over from a degraded failsafe state.
+  ([PX4-Autopilot#26269](https://github.com/PX4/PX4-Autopilot/pull/26269))
+- Offboard to Position (hold) mode change is no longer entered without RC.
+  ([PX4-Autopilot#26391](https://github.com/PX4/PX4-Autopilot/pull/26391))
+- Motor failure detection uses more robust timeout checks.
+  ([PX4-Autopilot#25757](https://github.com/PX4/PX4-Autopilot/pull/25757))
+- New `battery_info` uORB message with serial number compatible with UAVCAN, MAVLink, and battery drivers; `battery_status.serial_number` is removed.
+- UAVCAN battery: better remaining-time calculation ([PX4-Autopilot#25500](https://github.com/PX4/PX4-Autopilot/pull/25500)) and filter sample interval increased to 500 ms ([PX4-Autopilot#25454](https://github.com/PX4/PX4-Autopilot/pull/25454)).
+- Battery instances are capped at 3 (loggable batteries also raised to 3).
+- Remaining-flight-time failsafe disabled by default.
 
 ### Control
 
-<!--
-
-- Added new flight mode(s): [Altitude Cruise (MC)](../flight_modes_mc/altitude_cruise.md), Altitude Cruise (FW).
-  For fixed-wing the mode behaves the same as Altitude mode but you can disable the manual control loss failsafe. ([PX4-Autopilot#25435: Add new flight mode: Altitude Cruise](https://github.com/PX4/PX4-Autopilot/pull/25435)).
-
--->
-
-- <Badge type="warning" text="Experimental" /> [MC Neural Network Module](../advanced/neural_networks.md)
+- Servo PWM gains center setting and asymmetric deflection (`PWM_*_CENTER`).
+  ([PX4-Autopilot#25897](https://github.com/PX4/PX4-Autopilot/pull/25897))
+- PWM center support extended to wheel and gimbal actuators.
+  ([PX4-Autopilot#26211](https://github.com/PX4/PX4-Autopilot/pull/26211))
+- Configurable board PWM frequency from Kconfig.
+  ([PX4-Autopilot#24787](https://github.com/PX4/PX4-Autopilot/pull/24787))
+- DShot telemetry refactored to the platform serial abstraction with RX/TX pin-swap support.
+- UAVCAN ESC initialization no longer publishes random values when stopped.
+  ([PX4-Autopilot#25485](https://github.com/PX4/PX4-Autopilot/pull/25485))
+- UAVCAN bootloader watchdog pet during long flashes.
+  ([PX4-Autopilot#25523](https://github.com/PX4/PX4-Autopilot/pull/25523))
+- Control allocator enabled for spacecraft on v6x.
+  ([PX4-Autopilot#25276](https://github.com/PX4/PX4-Autopilot/pull/25276))
 
 ### Estimation
 
-- TBD
-
-<!--
+- [Barometer auto-calibration](../advanced_config/parameter_reference.md#SENS_BAR_AUTOCAL) can calibrate offsets against GNSS height when GNSS is the height reference, enabled by default.
+  ([PX4-Autopilot#24859](https://github.com/PX4/PX4-Autopilot/pull/24859))
+- Septentrio GNSS resilience reporting (jamming, spoofing, authentication state) is now exposed in PX4.
+  ([PX4-Autopilot#25012](https://github.com/PX4/PX4-Autopilot/pull/25012))
+- EKF2 GPS checks include a GPS fix type validation bit.
+  ([PX4-Autopilot#25215](https://github.com/PX4/PX4-Autopilot/pull/25215))
+- EKF2 GNSS aiding: dedicated `gnss_fault` flag added to `EstimatorStatusFlags`; lat/lon/vel fusion is disabled on `gnss_hgt_fault`; hysteresis added for re-enabling fusion; GNSS-based altitude reset is suppressed in dead-reckoning mode.
+- EKF2 range fusion: skip unhealthy samples while respecting timeout ([PX4-Autopilot#25634](https://github.com/PX4/PX4-Autopilot/pull/25634)); reject bad measurements during `bad_acc_vertical` ([PX4-Autopilot#25636](https://github.com/PX4/PX4-Autopilot/pull/25636)).
+- EKF2 mag: post-takeoff yaw reset is never skipped; mag heading and declination updates no longer perturb the xy gyro biases.
+- EKF2 gravity: tilt alignment accelerated; gravity fusion start now uses an accel low-pass instead of peak hold.
+- EKF2 airspeed/wind: distinguish airspeed source so wind dead-reckoning logic can use a synthetic airspeed.
+- External heading update via `MAV_CMD_EXTERNAL_ATTITUDE_ESTIMATE` is now consumed by EKF2.
+- RTCM telemetry stream now also published for UAVCAN GNSS receivers.
+  ([PX4-Autopilot#25315](https://github.com/PX4/PX4-Autopilot/pull/25315))
+- EKF2 GNSS reset improvements.
+  ([PX4-Autopilot#25297](https://github.com/PX4/PX4-Autopilot/pull/25297))
 
 ### Sensors
 
-- Add [sbgECom INS driver](../sensor/sbgecom.md) ([PX4-Autopilot#24137](https://github.com/PX4/PX4-Autopilot/pull/24137))
-- Quick magnetometer calibration now supports specifying an arbitrary initial heading ([PX4-Autopilot#24637](https://github.com/PX4/PX4-Autopilot/pull/24637))
-
--->
+- Added [MicroStrain Inertial Sensors](../sensor/microstrain.md) driver support.
+  ([PX4-Autopilot#23858](https://github.com/PX4/PX4-Autopilot/pull/23858))
+- [MicroStrain Inertial Sensors](../sensor/microstrain.md) gain expanded aiding support.
+  ([PX4-Autopilot#25673](https://github.com/PX4/PX4-Autopilot/pull/25673))
+- Added [sbgECom INS driver](../sensor/sbgecom.md).
+  ([PX4-Autopilot#24137](https://github.com/PX4/PX4-Autopilot/pull/24137))
+- Added EULER-NAV Baro-Inertial AHRS driver.
+  ([PX4-Autopilot#24534](https://github.com/PX4/PX4-Autopilot/pull/24534))
+- Added QMC5883P compass driver.
+  ([PX4-Autopilot#25115](https://github.com/PX4/PX4-Autopilot/pull/25115))
+- Added ICM42688P IMU support on the Mamba F405 MK2 V2.
+  ([PX4-Autopilot#25047](https://github.com/PX4/PX4-Autopilot/pull/25047))
+- Added LightWare SF30/d binary protocol.
+  ([PX4-Autopilot#25570](https://github.com/PX4/PX4-Autopilot/pull/25570))
+- Airspeed calibration only saves the offset when the full procedure succeeds.
+  ([PX4-Autopilot#25412](https://github.com/PX4/PX4-Autopilot/pull/25412))
+- AirspeedSelector adds a synthetic airspeed option.
+- IMU gyro: default angular-acceleration filter lowered from 30 Hz to 20 Hz.
 
 ### Simulation
 
-- Overhaul rover simulation:
-  - Add synthetic differential rover model: [PX4-gazebo-models#107](https://github.com/PX4/PX4-gazebo-models/pull/107)
-  - Add synthetic mecanum rover model: [PX4-gazebo-models#113](https://github.com/PX4/PX4-gazebo-models/pull/113)
-  - Update synthetic ackermann rover model: [PX4-gazebo-models#117](https://github.com/PX4/PX4-gazebo-models/pull/117)
+#### Gazebo
 
-- [Simulation-in-Hardware (SIH)](../sim_sih/index.md#supported-vehicle-types) <!-- Listed in https://docs.px4.io/main/en/sim_sih/#compatibility : Check the PRs -->
-  - New simulation: MC Hexacopter X
-  - New simulation: Ackermann Rover
+- Gazebo CMake linking is now version-agnostic across `gz-transport`, `gz-sim`, `gz-sensors`, and `gz-plugin`, removing the hard pin to Harmonic in the build glue. Harmonic remains the supported, CI-tested version; building against newer Gazebo releases (e.g. Jetty / v15) is up to the developer to install and verify locally.
+  ([PX4-Autopilot#25521](https://github.com/PX4/PX4-Autopilot/pull/25521))
+- [Rover simulation](../frames_rover/index.md#simulation) updated to match the current rover-control architecture.
+  ([PX4-Autopilot#25644](https://github.com/PX4/PX4-Autopilot/pull/25644))
+- Gazebo bridge sensors can be selectively disabled.
+  ([PX4-Autopilot#25484](https://github.com/PX4/PX4-Autopilot/pull/25484))
+- Gimbal yaw fix and DDS attitude publisher in the Gazebo bridge.
+  ([PX4-Autopilot#25754](https://github.com/PX4/PX4-Autopilot/pull/25754))
+- `PX4_GZ_MODEL_POSE` for custom spawn pose.
+  ([PX4-Autopilot#24956](https://github.com/PX4/PX4-Autopilot/pull/24956))
+- Updated Gazebo 24.04 documentation.
+  ([PX4-Autopilot#25586](https://github.com/PX4/PX4-Autopilot/pull/25586))
+
+#### Simulation-in-Hardware (SIH)
+
+- [SIH](../sim_sih/index.md#supported-vehicle-types) now supports Hexacopter X and Ackermann rovers.
+  ([PX4-Autopilot#25194](https://github.com/PX4/PX4-Autopilot/pull/25194), [PX4-Autopilot#25405](https://github.com/PX4/PX4-Autopilot/pull/25405))
+- HITL/SIH battery status now driven by battery configuration parameters.
+  ([PX4-Autopilot#24103](https://github.com/PX4/PX4-Autopilot/pull/24103))
 
 ### Debug & Logging
 
-- TBD
+- `AirspeedValidated` promoted to a standard uORB topic.
+  ([PX4-Autopilot#25579](https://github.com/PX4/PX4-Autopilot/pull/25579))
+- `upload_log.py` can target a custom upload server via CLI argument.
+  ([PX4-Autopilot#25702](https://github.com/PX4/PX4-Autopilot/pull/25702))
+- ULog tooling can recover UTC timestamps even when `sensor_gps` is not present.
+  ([PX4-Autopilot#25534](https://github.com/PX4/PX4-Autopilot/pull/25534))
+- UAVCAN node status is now logged to uORB for debugging.
+  ([PX4-Autopilot#23890](https://github.com/PX4/PX4-Autopilot/pull/23890))
+- ULog file format documentation expanded.
+  ([PX4-Autopilot#25624](https://github.com/PX4/PX4-Autopilot/pull/25624))
 
-### Ethernet
+### ROS 2 / uXRCE-DDS
 
-- TBD
+- [PX4 ROS 2 Control Interface](../ros2/px4_ros2_control_interface.md) support for [Fixed Wing lateral and longitudinal setpoint](../ros2/px4_ros2_control_interface.md#fw-lateral-longitudinal-setpoint) and [VTOL transitions](../ros2/px4_ros2_control_interface.md#controlling-a-vtol).
+- [Simple index-based namespace (`UXRCE_DDS_NS_IDX`)](../middleware/uxrce_dds.md#customizing-the-namespace) for uXRCE-DDS.
+  ([PX4-Autopilot#25444](https://github.com/PX4/PX4-Autopilot/pull/25444))
+- Namespace support for the uXRCE-DDS client during firmware upload.
+  ([PX4-Autopilot#25291](https://github.com/PX4/PX4-Autopilot/pull/25291))
+- New DDS topics: `TransponderReport` (ADS-B) ([PX4-Autopilot#25652](https://github.com/PX4/PX4-Autopilot/pull/25652)), `landing_gear` command from external modes ([PX4-Autopilot#25496](https://github.com/PX4/PX4-Autopilot/pull/25496)), `Wind` topic with 1 Hz rate limit, gimbal device attitude status, and FW high-level setpoint/configuration interfaces.
 
-### uXRCE-DDS / Zenoh / ROS2
+### ROS 2 / Zenoh
 
-- [PX4 ROS 2 Interface Library](../ros2/px4_ros2_control_interface.md) support for [Fixed Wing lateral/longitudinal setpoint](../ros2/px4_ros2_control_interface.md#fixed-wing-lateral-and-longitudinal-setpoint-fwlaterallongitudinalsetpointtype) (`FwLateralLongitudinalSetpointType`) and [VTOL transitions](../ros2/px4_ros2_control_interface.md#controlling-a-vtol). ([PX4-Autopilot#24056](https://github.com/PX4/PX4-Autopilot/pull/24056)).
-- [UXRCE_DDS: Simple index based namespace (UXRCE_DDS_NS_IDX)](../middleware/uxrce_dds.md#customizing-the-namespace)
-- [Zenoh (PX4 ROS 2 rmw_zenoh)](../middleware/zenoh.md)
+<Badge type="warning" text="Experimental" />
+
+The in-tree [Zenoh middleware](../middleware/zenoh.md) (added in v1.16) matures toward `rmw_zenoh` compatibility in v1.17. Most of this work landed as direct commits without PR numbers; the following list groups it by area:
+
+- **rmw_zenoh compatibility**: implement `rmw_zenoh` features in the Zenoh module, move ROS 2 Rmw attachment code to `rmw_attachment.h`, switch to CDRv1 to match ROS 2, set transport lease to 60 s to match ROS 2, omit timestamp attachment, experimental liveliness so the ROS 2 graph works.
+- **Configuration and CLI**: auto-generate default Zenoh config from `dds_topics.yaml`, new Domain ID parameter (and move `gid` into Zenoh), Zenoh CLI improvements, instance selection and pub/sub deletion, copy the uXRCE config layout for Zenoh.
+- **Boards**: Zenoh is now built into the default firmware on `px4/fmu-v6xrt` (`make px4_fmu-v6xrt_default`). On `px4/fmu-v6x` and SITL it ships as an opt-in `zenoh` build variant (`make px4_fmu-v6x_zenoh`, `make px4_sitl_zenoh`); the same opt-in `zenoh.px4board` is also provided for `auterion/fmu-v6s` and `auterion/fmu-v6x`. Zenoh is additionally compiled in by default on `nxp/mr-canhubk3`, `nxp/mr-tropic`, and `nxp/tropic-community`.
+- **NuttX support**: update NuttX config for use with Zenoh; backport NuttX FMU-v6x config for Zenoh ([PX4-Autopilot#26213](https://github.com/PX4/PX4-Autopilot/pull/26213)).
+- **SITL**: new `px4_sitl_zenoh` cmake variant, default to `127.0.0.1` on SITL/POSIX, autostart Zenoh in SITL when enabled, friendlier error message when scouting finds nothing, GCC/SITL compile fixes.
+- **Robustness**: validate payload size before stack allocation, increase CDR safety margin, handle parsing errors and non-existing types in config, fix topic-name and datatype mapping, pubsub-factory datatype-naming fix, fix status `keyexpr` printf, prevent integer-conversion warnings in zenoh-pico, optimize memory usage with optional publish-on-matching.
+- **Docs and OOM fixes (backport)**: [PX4-Autopilot#26053](https://github.com/PX4/PX4-Autopilot/pull/26053).
+- **Submodule**: `zenoh-pico` updated.
 
 ### MAVLink
 
-- TBD
-
-<!--
+- MAVFTP hardening: rejects path-traversal sequences in FTP operations and validates sessions in FTP write/burst.
+- MAVLink v1 is now opt-in via [`MAV_PROTO_VER`](../advanced_config/parameter_reference.md#MAV_PROTO_VER).
+  ([PX4-Autopilot#25583](https://github.com/PX4/PX4-Autopilot/pull/25583))
+- Extended `MISSION_CURRENT` message implemented.
+- `MAV_CMD_REQUEST_MESSAGE` supported for `MESSAGE_INTERVAL`.
+  ([PX4-Autopilot#25460](https://github.com/PX4/PX4-Autopilot/pull/25460))
+- The low-bandwidth stream profile includes additional important streams with updated rates.
+  ([PX4-Autopilot#25524](https://github.com/PX4/PX4-Autopilot/pull/25524))
+- Parameter transmission throttled on low-bandwidth links.
+  ([PX4-Autopilot#25126](https://github.com/PX4/PX4-Autopilot/pull/25126))
+- Set system clock from `SYSTEM_TIME`.
+  ([PX4-Autopilot#24807](https://github.com/PX4/PX4-Autopilot/pull/24807))
+- Hardfault streaming over MAVLink option added.
+- MAVLink fuzz test added.
 
 ### RC
 
-- Parse ELRS Status and Link Statistics TX messages in the CRSF parser.
+- Removed the hardcoded 1 percent deadzone on RC channels 1 to 8.
+  ([PX4-Autopilot#25502](https://github.com/PX4/PX4-Autopilot/pull/25502))
+- ManualControlSelector reworked: robust timeout checks, unified validity conditions, simplified prioritization, and an option to prioritize RC or MAVLink with fallback.
+- `COM_RC_IN_MODE` extended with source-ID ascending and descending priority modes; documentation rewritten.
+- Payload power switch generalized: optional 3-way switch, allowed on boards beyond ARK FPV, with unit tests.
 
 ### Multi-Rotor
 
-- Removed parameters `MPC_{XY/Z/YAW}_MAN_EXPO` and use default value instead, as they were not deemed necessary anymore. ([PX4-Autopilot#25435: Add new flight mode: Altitude Cruise](https://github.com/PX4/PX4-Autopilot/pull/25435)).
-- Renamed `MPC_HOLD_DZ` to `MAN_DEADZONE` to have it globally available in modes that allow for a dead zone. ([PX4-Autopilot#25435: Add new flight mode: Altitude Cruise](https://github.com/PX4/PX4-Autopilot/pull/25435)).
--->
+- New multicopter flight mode: [Altitude Cruise](../flight_modes_mc/altitude_cruise.md). Like Altitude mode, but when the roll/pitch/yaw sticks are released the vehicle holds the current tilt and heading (rather than returning to level), letting it cruise at a steady velocity without constant stick input. Intended for long-distance flights where the same tilt is held for an extended period. The manual-control-loss failsafe can optionally be disabled for this mode by setting the corresponding bit in [`COM_RCL_EXCEPT`](../advanced_config/parameter_reference.md#COM_RCL_EXCEPT); when doing so, configure the data-link-loss failsafe via [`NAV_DLL_ACT`](../advanced_config/parameter_reference.md#NAV_DLL_ACT) to avoid fly-aways.
+- Stick library refactored: globally available, getter-based, expo computed on getter call; `FixedWingModeManager` now uses the Sticks library.
+- Orbit mode: configurable max speed replaces the 10 m/s hardcode ([PX4-Autopilot#25192](https://github.com/PX4/PX4-Autopilot/pull/25192)) and `HeadingSmoothing` is applied to avoid step changes during the approach; documentation clarified ([PX4-Autopilot#25208](https://github.com/PX4/PX4-Autopilot/pull/25208)).
+- MC PositionControl: switch out of goto setpoint immediately when receiving `trajectory_setpoint`.
+- Hexarotor X added to SIH and to `ActuatorEffectivenessRotorsTest`.
+- `MC_RATE*` parameter metadata unified.
+  ([PX4-Autopilot#25133](https://github.com/PX4/PX4-Autopilot/pull/25133))
 
 ### VTOL
 
-- TBD
+- Fixed VTOL stuck after back-transition in Mission Fast RTL.
+- VTOL takeoff requires relaxed position only during the fixed-wing phase; on completion of takeoff, the state is forced to Loiter.
+- VTOL airspeed measurement handling centralized.
+- [PX4 ROS 2 Control Interface](../ros2/px4_ros2_control_interface.md#controlling-a-vtol) can command VTOL transitions from external modes.
 
 ### Fixed-wing
 
-- [Fixed Wing Takeoff mode](../flight_modes_fw/takeoff.md) will now keep climbing with level wings on position loss.
-  A target takeoff waypoint can be set to control takeoff course and loiter altitude. ([PX4-Autopilot#25083](https://github.com/PX4/PX4-Autopilot/pull/25083)).
-- Automatically suppress angular rate oscillations using [Gain compression](../features_fw/gain_compression.md). ([PX4-Autopilot#25840: FW rate control: add gain compression algorithm](https://github.com/PX4/PX4-Autopilot/pull/25840))
+- [Fixed Wing Takeoff mode](../flight_modes_fw/takeoff.md) keeps climbing with level wings on navigation loss and can use the takeoff waypoint latitude and longitude to define the loiter position.
+  ([PX4-Autopilot#25226](https://github.com/PX4/PX4-Autopilot/pull/25226))
+- Reworked fixed-wing high-level control exposes clean lateral and longitudinal control interfaces for external integrations.
+- FW Attitude Controller wheel controller rework.
+- FW Autotune: identification maneuver auto-ramps the 1 Hz amplitude until R/P/Y rates of 0.8/0.5/0.5 rad/s are reached, then scales the identification signal accordingly.
+- TECS hardening: NaN protection on airspeed and altitude inputs.
 
 ### Rover
 
-- Removed deprecated rover module ([PX4-Autopilot#25054](https://github.com/PX4/PX4-Autopilot/pull/25054)).
-- Add support for [Apps & API](../flight_modes_rover/api.md) including [Rover Setpoints](../ros2/px4_ros2_control_interface.md#rover-setpoints) ([PX4-Autopilot#25074](https://github.com/PX4/PX4-Autopilot/pull/25074), [PX4-ROS2-Interface-Lib#140](https://github.com/Auterion/px4-ros2-interface-lib/pull/140)).
-- Update [rover simulation](../frames_rover/index.md#simulation) ([PX4-Autopilot#25644](https://github.com/PX4/PX4-Autopilot/pull/25644)) (see [Simulation](#simulation) release note for details).
+- Removed deprecated rover module.
+- Added [Apps & API](../flight_modes_rover/api.md) support including [Rover Setpoints](../ros2/px4_ros2_control_interface.md#rover-setpoints).
+- [Rover simulation](../frames_rover/index.md#simulation) updated to match the reworked rover architecture.
+  ([PX4-Autopilot#25644](https://github.com/PX4/PX4-Autopilot/pull/25644))
+- Continued per-vehicle (Ackermann/differential/mecanum) restructuring with separated actuator control, position-control updates, mode-management centralization, and module split into folders.
+- New stick-input scaling parameters.
+  ([PX4-Autopilot#25427](https://github.com/PX4/PX4-Autopilot/pull/25427))
+- Improved rover hold-position logic.
+  ([PX4-Autopilot#25466](https://github.com/PX4/PX4-Autopilot/pull/25466))
+- `RX_MAX_THR_YAW_R` replaced by `RO_YAW_RATE_CORR`.
+- Manual yaw-rate input: exponential scaling.
+- Comprehensive [Rover API documentation](../flight_modes_rover/api.md).
+  ([PX4-Autopilot#25499](https://github.com/PX4/PX4-Autopilot/pull/25499))
+- MR-CANHUBK344 NXP B3RB rover platform.
+  ([PX4-Autopilot#23897](https://github.com/PX4/PX4-Autopilot/pull/23897))
+- Aion Robotics R1 Rover airframe (`50001`) marked discontinued.
 
-### ROS 2
+### Safety / Commander
 
-- TBD
+- Pilot can take over from a degraded failsafe action.
+  ([PX4-Autopilot#26269](https://github.com/PX4/PX4-Autopilot/pull/26269))
+- Offboard to Position (hold) is no longer entered without RC.
+  ([PX4-Autopilot#26391](https://github.com/PX4/PX4-Autopilot/pull/26391))
+- Motor-failure detector uses robust timeout checks.
+  ([PX4-Autopilot#25757](https://github.com/PX4/PX4-Autopilot/pull/25757))
+- Failure injection refactored into its own class; `failure motor off -i <n>` now requires `CA_FAILURE_MODE` to be set. See [motor failure injection and detection](../debug/failure_injection.md).
+  ([PX4-Autopilot#25756](https://github.com/PX4/PX4-Autopilot/pull/25756))
+- Naming for clarity: `FORCE_FAILSAFE` renamed to `TERMINATION`; `commander lockdown on` renamed to `commander termination`; `manual_lockdown` renamed to `kill`; `ACTION_TERMINATE` renamed to `ACTION_TERMINATION`.
+- New RC termination switch with PWM-input default for ATS-based flight termination.
+  ([PX4-Autopilot#25209](https://github.com/PX4/PX4-Autopilot/pull/25209))
+- Commander never overrides a user-intended termination (with unit test).
+- Remaining-flight-time failsafe disabled by default.
+- Home position is not reset if landed during an uncompleted mission.
+  ([PX4-Autopilot#24902](https://github.com/PX4/PX4-Autopilot/pull/24902))
+- Off-track mission landing fix.
+  ([PX4-Autopilot#25725](https://github.com/PX4/PX4-Autopilot/pull/25725))
+
+### Infrastructure
+
+- `parameters_injected.xml` removed from the build system.
+  ([PX4-Autopilot#25549](https://github.com/PX4/PX4-Autopilot/pull/25549))
+- [QGC Bootloader Update](../advanced_config/bootloader_update.md#qgc-bootloader-update-sys-bl-update) via `SYS_BL_UPDATE` restored.
+  ([PX4-Autopilot#25032](https://github.com/PX4/PX4-Autopilot/pull/25032))
+- NuttX submodule updates: dcache fix and semaphore-holder-list fix.
+- ITCM checker added in CI; ITCM mapping updated for v6xRT and Tropic-Community.
+- Flash savings on KakuteH7 encrypted-logs variants and on selected ARK targets.
+- Spacecraft tooling for Commander and `VehicleStatus`.
+  ([PX4-Autopilot#24716](https://github.com/PX4/PX4-Autopilot/pull/24716))

--- a/docs/en/releases/main.md
+++ b/docs/en/releases/main.md
@@ -96,7 +96,7 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 <!-- MOVED THIS TO v1.17
 
-- [PX4 ROS 2 Interface Library](../ros2/px4_ros2_control_interface.md) support for [Fixed Wing lateral/longitudinal setpoint](../ros2/px4_ros2_control_interface.md#fixed-wing-lateral-and-longitudinal-setpoint-fwlaterallongitudinalsetpointtype) (`FwLateralLongitudinalSetpointType`) and [VTOL transitions](../ros2/px4_ros2_control_interface.md#controlling-a-vtol). ([PX4-Autopilot#24056](https://github.com/PX4/PX4-Autopilot/pull/24056)).
+- [PX4 ROS 2 Interface Library](../ros2/px4_ros2_control_interface.md) support for [Fixed Wing lateral/longitudinal setpoint](../ros2/px4_ros2_control_interface.md#fw-lateral-longitudinal-setpoint) (`FwLateralLongitudinalSetpointType`) and [VTOL transitions](../ros2/px4_ros2_control_interface.md#controlling-a-vtol). ([PX4-Autopilot#24056](https://github.com/PX4/PX4-Autopilot/pull/24056)).
 - [PX4 ROS 2 Interface Library](../ros2/px4_ros2_control_interface.md) support for [ROS-based waypoint missions](../ros2/px4_ros2_waypoint_missions.md).
 -->
 

--- a/docs/en/ros2/px4_ros2_control_interface.md
+++ b/docs/en/ros2/px4_ros2_control_interface.md
@@ -347,7 +347,7 @@ The used types also define the compatibility with different vehicle types.
 The following sections provide a list of supported setpoint types:
 
 - [MulticopterGotoSetpointType](#go-to-setpoint-multicoptergotosetpointtype): <Badge type="warning" text="MC only" /> Smooth position and (optionally) heading control
-- [FwLateralLongitudinalSetpointType](#fixed-wing-lateral-and-longitudinal-setpoint-fwlaterallongitudinalsetpointtype): <Badge type="warning" text="FW only" /> <Badge type="tip" text="PX4 v1.17" /> Direct control of lateral and longitudinal fixed wing dynamics
+- [FwLateralLongitudinalSetpointType](#fw-lateral-longitudinal-setpoint): <Badge type="warning" text="FW only" /> <Badge type="tip" text="PX4 v1.17" /> Direct control of lateral and longitudinal fixed wing dynamics
 - [DirectActuatorsSetpointType](#direct-actuator-control-setpoint-directactuatorssetpointtype): Direct control of motors and flight surface servo setpoints
 - [Rover Setpoints](#rover-setpoints): <Badge type="tip" text="PX4 v1.17" /> Direct access to rover control setpoints (Position, Speed, Attitude, Rate, Throttle and Steering).
 
@@ -414,7 +414,7 @@ _goto_setpoint->update(
   max_heading_rate_rad_s);
 ```
 
-#### Fixed-Wing Lateral and Longitudinal Setpoint (FwLateralLongitudinalSetpointType)
+#### Fixed-Wing Lateral and Longitudinal Setpoint (FwLateralLongitudinalSetpointType) {#fw-lateral-longitudinal-setpoint}
 
 <Badge type="warning" text="Fixed wing only" /> <Badge type="tip" text="PX4 v1.17" />
 
@@ -597,7 +597,7 @@ An example for a rover specific drive mode using the `RoverSpeedAttitudeSetpoint
 To control a VTOL in an external flight mode, ensure you're returning the correct setpoint type based on the current flight configuration:
 
 - Multicopter mode: use a setpoint type that is compatible with multicopter control. For example: either the [`MulticopterGotoSetpointType`](#go-to-setpoint-multicoptergotosetpointtype) or the [`TrajectorySetpointType`](https://auterion.github.io/px4-ros2-interface-lib/classpx4__ros2_1_1TrajectorySetpointType.html).
-- Fixed-wing mode: Use the [`FwLateralLongitudinalSetpointType`](#fixed-wing-lateral-and-longitudinal-setpoint-fwlaterallongitudinalsetpointtype).
+- Fixed-wing mode: Use the [`FwLateralLongitudinalSetpointType`](#fw-lateral-longitudinal-setpoint).
 
 As long as the VTOL remains in either multicopter or fixed-wing mode throughout the external mode, no additional handling is required.
 


### PR DESCRIPTION
Draft of the v1.17.0 release notes for review. Posting against `main` so the docs maintainers can see the rendered output and weigh in on backport strategy before this lands anywhere user-facing.

The content was derived from `origin/release/1.16..origin/release/1.17`, with every PR citation ancestry-checked against `release/1.17` and filtered against PRs shared with `release/1.16` (so v1.16.x users don't see things they already have).

Major Changes leads with:
- Experimental [MC Neural Network Control](https://docs.px4.io/main/en/neural_networks/mc_neural_network_control.html) mode and the on-device [TensorFlow Lite Micro](https://docs.px4.io/main/en/neural_networks/tflm.html) integration.
- New multicopter [Altitude Cruise](https://docs.px4.io/main/en/flight_modes_mc/altitude_cruise.html) mode.
- [Fixed Wing Takeoff](https://docs.px4.io/main/en/flight_modes_fw/takeoff.html) keeps climbing on navigation loss and accepts a takeoff waypoint.
- Fixed-wing and rover control via the [PX4 ROS 2 Control Interface](https://docs.px4.io/main/en/ros2/px4_ros2_control_interface.html) (FwLateralLongitudinal, RoverSetpointTypes).
- Experimental [Zenoh](https://docs.px4.io/main/en/middleware/zenoh.html) middleware maturing toward `rmw_zenoh` compatibility, default-on for FMU-v6xRT and selected NXP boards, opt-in `zenoh` build variant for FMU-v6x and SITL.

Hardware Support is reorganized into:
- **New Flight Controllers** (Radiolink PIX6, CUAV X25-Evo, Accton Godwit GA1, Kakute H7 dual-IMU, NarinFC-H7, ESP32 generic).
- **New Build Targets for Existing Hardware** (`cuav/fmu-v6x` for the existing CUAV Pixhawk V6X product, `auterion/fmu-v6x`).
- **New CAN Peripherals & Vehicle Platforms** (NXP B3RB Rover via MR-CANHUBK344, NXP MR-Tropic, ARK X20/F9P GPS, ARK DIST).
- **Existing Boards: Improvements** (FMU-v6xRT/v6s sensor adds, ARK FPV variants, ESP32 PWM, etc.).

The Simulation section is split into Gazebo and SIH sub-groups. The ROS 2 / DDS section is split into uXRCE-DDS and Zenoh.

A few smaller items:
- xc-fly was deliberately dropped (board was removed from `main` post-rc2, listing it would be misleading).
- Holybro Kakute H743-Wing was dropped (already shipped in v1.16 via backport).
- Cross-page anchor scroll-bug fix: gave `#### Fixed-Wing Lateral and Longitudinal Setpoint (FwLateralLongitudinalSetpointType)` an explicit short anchor `{#fw-lateral-longitudinal-setpoint}`, updated 3 in-page TOC/cross-page links and the `releases/main.md` reference. The long auto-generated slug was making VitePress's hash scroll land short of the heading because lazy-loaded content above shifts the layout. Verified the fix in Chromium via Playwright; Safari may also need a hard reload to pick up the new anchor.

Asks:
- @hamishwillee — would appreciate your steer on backport mechanics. The current file has the alpha/beta release-branch banner block (`<Badge type="danger">`, `<script setup>`, `<div v-if>`, `::: warning`). On `main` this should arguably switch to a stable banner (no warning, `<Badge type="info" text="Stable" />`) once v1.17.0 actually ships. Happy to follow whatever pattern you'd like for splitting this into a `release/1.17` PR plus a separate `main` PR, or doing it as a single conditional file, or any other approach you prefer.
- Reviewers welcome to flag any factual mistakes, missing-but-important features, or wording I should sharpen. Every PR citation has been ancestry-verified, but the prose framing is up for debate.