### PR TITLE
[BACKPORT] Add support for NXP i.MX RT1170B to 1.16

### DIFF
--- a/platforms/nuttx/src/px4/nxp/imxrt/romapi/imxrt_romapi.c
+++ b/platforms/nuttx/src/px4/nxp/imxrt/romapi/imxrt_romapi.c
@@ -105,11 +105,11 @@ locate_code(".ramfunc")
 void ROM_API_Init(void)
 {
 
-	if ((getreg32(IMXRT_ANADIG_MISC_MISC_DIFPROG) & ANADIG_MISC_MISC_DIFPROG_CHIPID(0x10U)) != 0U) {
-		g_bootloaderTree = ((bootloader_api_entry_t *) * (uint32_t *)0x0021001cU);
+	if (getreg32(IMXRT_ANADIG_MISC_MISC_DIFPROG) == 0x001170A0U) {
+		g_bootloaderTree = ((bootloader_api_entry_t *) * (uint32_t *)0x0020001cU);
 
 	} else {
-		g_bootloaderTree = ((bootloader_api_entry_t *) * (uint32_t *)0x0020001cU);
+		g_bootloaderTree = ((bootloader_api_entry_t *) * (uint32_t *)0x0021001cU);
 	}
 }
 
@@ -248,11 +248,14 @@ void ROM_FLEXSPI_NorFlash_ClearCache(uint32_t instance)
 {
 	uint32_t clearCacheFunctionAddress;
 
-	if ((getreg32(IMXRT_ANADIG_MISC_MISC_DIFPROG) & ANADIG_MISC_MISC_DIFPROG_CHIPID(0x10U)) != 0U) {
+	if (getreg32(IMXRT_ANADIG_MISC_MISC_DIFPROG) == 0x001170a0U) {
+		clearCacheFunctionAddress = 0x0020426bU;
+
+	} else if (getreg32(IMXRT_ANADIG_MISC_MISC_DIFPROG) == 0x001170b0U) {
 		clearCacheFunctionAddress = 0x0021a3b7U;
 
 	} else {
-		clearCacheFunctionAddress = 0x0020426bU;
+		clearCacheFunctionAddress = 0x0021a3bfU;
 	}
 
 	clearCacheCommand_t clearCacheCommand;


### PR DESCRIPTION
### Solved Problem
Backport of #25998 to 1.16

### Solution
Allows to use new IMXRT1176DVAB silicon revision, otherwise it crashes