### PR TITLE
feat(control_allocator): control surface preflight check in functional groups

### DIFF
--- a/msg/ControlAllocatorStatus.msg
+++ b/msg/ControlAllocatorStatus.msg
@@ -18,5 +18,7 @@ int8[16] actuator_saturation            # Indicates actuator saturation status.
                                         # Note 1: actuator saturation does not necessarily imply that the thrust setpoint or the torque setpoint were not achieved.
                                         # Note 2: an actuator with limited dynamics can be indicated as upper-saturated even if it as not reached its maximum value.
 
-uint16 handled_motor_failure_mask        # Bitmask of failed motors that were removed from the allocation / effectiveness matrix. Not necessarily identical to the report from FailureDetector
-uint16 motor_stop_mask                   # Bitmaks of motors stopped by failure injection
+uint16 handled_motor_failure_mask       # Bitmask of failed motors that were removed from the allocation / effectiveness matrix. Not necessarily identical to the report from FailureDetector
+uint16 motor_stop_mask                  # Bitmaks of motors stopped by failure injection
+
+bool cs_preflight_check_active          # True while a control-surface preflight check (VEHICLE_CMD_ACTUATOR_GROUP_TEST) is overriding the torque setpoint or collective-tilt

--- a/msg/versioned/VehicleCommand.msg
+++ b/msg/versioned/VehicleCommand.msg
@@ -78,6 +78,7 @@ uint16 VEHICLE_CMD_DO_SET_STANDARD_MODE=262 # Enable the specified standard MAVL
 uint16 VEHICLE_CMD_GIMBAL_DEVICE_INFORMATION = 283 # Command to ask information about a low level gimbal.
 
 uint16 VEHICLE_CMD_MISSION_START = 300 # Start running a mission. |first_item: the first mission item to run|last_item: the last mission item to run (after this item is run, the mission ends)|
+uint16 VEHICLE_CMD_ACTUATOR_GROUP_TEST = 309 # Test groups of related actuators (e.g. all actuators contributing to roll torque). |group (ACTUATOR_TEST_GROUP_*)|value [-1, 1]|Unused|Unused|Unused|Unused|Unused|
 uint16 VEHICLE_CMD_ACTUATOR_TEST = 310 # Actuator testing command. |[@range -1,1] value|[s] timeout|Unused|Unused|output function|
 uint16 VEHICLE_CMD_CONFIGURE_ACTUATOR = 311 # Actuator configuration command. |configuration|Unused|Unused|Unused|output function|
 uint16 VEHICLE_CMD_ESC_REQUEST_EEPROM = 312 # Request EEPROM data from an ESC. |ESC Index|Firmware Type|Unused|Unused|Unused|
@@ -202,6 +203,12 @@ uint8 GRIPPER_ACTION_GRAB = 1
 # Used as param1 in DO_SET_SAFETY_SWITCH_STATE command.
 uint8 SAFETY_OFF = 0
 uint8 SAFETY_ON = 1
+
+# param1 in VEHICLE_CMD_ACTUATOR_GROUP_TEST (matches MAVLink ACTUATOR_TEST_GROUP enum)
+uint8 ACTUATOR_TEST_GROUP_ROLL_TORQUE = 0
+uint8 ACTUATOR_TEST_GROUP_PITCH_TORQUE = 1
+uint8 ACTUATOR_TEST_GROUP_YAW_TORQUE = 2
+uint8 ACTUATOR_TEST_GROUP_COLLECTIVE_TILT = 3
 
 uint8 ORB_QUEUE_LENGTH = 8
 

--- a/src/lib/control_allocation/actuator_effectiveness/ActuatorEffectiveness.hpp
+++ b/src/lib/control_allocation/actuator_effectiveness/ActuatorEffectiveness.hpp
@@ -221,6 +221,15 @@ public:
 	 */
 	virtual void stopMaskedMotorsWithZeroThrust(ActuatorBitmask stoppable_motors_mask, ActuatorVector &actuator_sp);
 
+	/**
+	 * Override the collective tilt setpoint that would normally come from
+	 * tiltrotor_extra_controls. Base implementation is a no-op.
+	 *
+	 * @param do_override When true, use @p collective_tilt instead of the uORB value.
+	 * @param collective_tilt Normalised setpoint in [0, 1]. 0: vertical, 1: horizontal.
+	 */
+	virtual void overrideCollectiveTilt(bool /*do_override*/, float /*collective_tilt*/) {}
+
 protected:
 	FlightPhase _flight_phase{FlightPhase::HOVER_FLIGHT};
 	ActuatorBitmask _stopped_motors_mask{0};

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -346,6 +346,48 @@ int Commander::custom_command(int argc, char *argv[])
 		return 0;
 	}
 
+	if (!strcmp(argv[0], "cs_check")) {
+		if (argc < 2) {
+			PX4_ERR("missing argument");
+			return 1;
+		}
+
+		int group;
+
+		if (!strcmp(argv[1], "roll")) {
+			group = vehicle_command_s::ACTUATOR_TEST_GROUP_ROLL_TORQUE;
+
+		} else if (!strcmp(argv[1], "pitch")) {
+			group = vehicle_command_s::ACTUATOR_TEST_GROUP_PITCH_TORQUE;
+
+		} else if (!strcmp(argv[1], "yaw")) {
+			group = vehicle_command_s::ACTUATOR_TEST_GROUP_YAW_TORQUE;
+
+		} else if (!strcmp(argv[1], "tilt")) {
+			group = vehicle_command_s::ACTUATOR_TEST_GROUP_COLLECTIVE_TILT;
+
+		} else {
+			PX4_ERR("argument %s unsupported.", argv[1]);
+			return 1;
+		}
+
+		float value = 1.f;
+
+		if (argc > 2) {
+			const float user_value = std::atof(argv[2]);
+
+			if (PX4_ISFINITE(user_value)) {
+				value = user_value;
+
+			} else {
+				PX4_WARN("cs_check: value \"%s\" is invalid. Using default +1.0.", argv[2]);
+			}
+		}
+
+		send_vehicle_command(vehicle_command_s::VEHICLE_CMD_ACTUATOR_GROUP_TEST, group, value);
+		return 0;
+	}
+
 	if (!strcmp(argv[0], "arm")) {
 		float param2 = 0.f;
 
@@ -3169,6 +3211,9 @@ The commander module contains the state machine for mode switching and failsafe 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("check", "Run preflight checks");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("safety", "Change prearm safety state");
 	PRINT_MODULE_USAGE_ARG("on|off", "[on] to activate safety, [off] to deactivate safety and allow control surface movements", false);
+	PRINT_MODULE_USAGE_COMMAND_DESCR("cs_check", "Run control surface preflight checks");
+	PRINT_MODULE_USAGE_ARG("roll|pitch|yaw|tilt", "Axis", false);
+	PRINT_MODULE_USAGE_ARG("torque", "Normalized torque command [-1.0, +1.0], default +1.0", true);
 	PRINT_MODULE_USAGE_COMMAND("arm");
 	PRINT_MODULE_USAGE_PARAM_FLAG('f', "Force arming (do not run preflight checks)", true);
 	PRINT_MODULE_USAGE_COMMAND("disarm");

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1650,6 +1650,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 	case vehicle_command_s::VEHICLE_CMD_EXTERNAL_ATTITUDE_ESTIMATE:
 	case vehicle_command_s::VEHICLE_CMD_DO_AUTOTUNE_ENABLE:
 	case vehicle_command_s::VEHICLE_CMD_ESTIMATOR_SENSOR_ENABLE:
+	case vehicle_command_s::VEHICLE_CMD_ACTUATOR_GROUP_TEST:
 		/* ignore commands that are handled by other parts of the system */
 		break;
 

--- a/src/modules/control_allocator/CMakeLists.txt
+++ b/src/modules/control_allocator/CMakeLists.txt
@@ -44,6 +44,8 @@ px4_add_module(
 	SRCS
 		ControlAllocator.cpp
 		ControlAllocator.hpp
+		ControlSurfacePreflightCheck.cpp
+		ControlSurfacePreflightCheck.hpp
 	MODULE_CONFIG
 		module.yaml
 	DEPENDS

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -639,6 +639,7 @@ ControlAllocator::publish_control_allocator_status(int matrix_index)
 {
 	control_allocator_status_s control_allocator_status{};
 	control_allocator_status.timestamp = hrt_absolute_time();
+	control_allocator_status.cs_preflight_check_active = _cs_preflight_check.isActive();
 
 	// TODO: disabled motors (?)
 

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -380,6 +380,9 @@ ControlAllocator::Run()
 	const hrt_abstime now = hrt_absolute_time();
 	const float dt = math::constrain(((now - _last_run) / 1e6f), 0.0002f, 0.02f);
 
+	_cs_preflight_check.handleCommand(now, _armed,
+					  _effectiveness_source_id == EffectivenessSource::TILTROTOR_VTOL);
+
 	bool do_update = false;
 	vehicle_torque_setpoint_s vehicle_torque_setpoint;
 	vehicle_thrust_setpoint_s vehicle_thrust_setpoint;
@@ -426,6 +429,9 @@ ControlAllocator::Run()
 				c[1](5) = vehicle_thrust_setpoint.xyz[2];
 			}
 		}
+
+		_cs_preflight_check.updateState(now, _armed);
+		_cs_preflight_check.applyOverrides(c, _is_vtol, *_actuator_effectiveness);
 
 		for (int i = 0; i < _num_control_allocation; ++i) {
 

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -55,6 +55,8 @@
 #include <ActuatorEffectivenessHelicopterCoaxial.hpp>
 #include <ActuatorEffectivenessSpacecraft.hpp>
 
+#include "ControlSurfacePreflightCheck.hpp"
+
 #include <ControlAllocation.hpp>
 #include <ControlAllocationPseudoInverse.hpp>
 #include <ControlAllocationSequentialDesaturation.hpp>
@@ -220,6 +222,8 @@ private:
 	// For example, the system might report two motor failures, but only the first one is handled by CA
 	uint16_t _handled_motor_failure_bitmask{0};
 	uint16_t _motor_stop_mask{0};
+
+	ControlSurfacePreflightCheck _cs_preflight_check;
 
 	perf_counter_t	_loop_perf;			/**< loop duration performance counter */
 

--- a/src/modules/control_allocator/ControlSurfacePreflightCheck.cpp
+++ b/src/modules/control_allocator/ControlSurfacePreflightCheck.cpp
@@ -1,0 +1,142 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "ControlSurfacePreflightCheck.hpp"
+
+#include <math.h>
+
+#include <px4_platform_common/log.h>
+
+void ControlSurfacePreflightCheck::handleCommand(hrt_abstime now, bool armed, bool is_tiltrotor)
+{
+	vehicle_command_s vehicle_command;
+
+	if (!_vehicle_command_sub.update(&vehicle_command)) {
+		return;
+	}
+
+	if (vehicle_command.command != vehicle_command_s::VEHICLE_CMD_ACTUATOR_GROUP_TEST) {
+		return;
+	}
+
+	const uint8_t axis = (uint8_t) lroundf(vehicle_command.param1);
+	const char *reject_reason = nullptr;
+	actuator_armed_s actuator_armed;
+
+	if (armed) {
+		reject_reason = "armed";
+
+	} else if (!_armed_sub.copy(&actuator_armed)) {
+		reject_reason = "failed to get prearmed state";
+
+	} else if (!actuator_armed.prearmed) {
+		reject_reason = "not prearmed";
+
+	} else if (axis == vehicle_command_s::ACTUATOR_TEST_GROUP_COLLECTIVE_TILT && !is_tiltrotor) {
+		reject_reason = "tilt commanded but not available";
+	}
+
+	uint8_t result;
+
+	if (reject_reason != nullptr) {
+		result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED;
+		PX4_WARN("Control surface preflight check rejected (%s)", reject_reason);
+
+	} else {
+		if (_running) {
+			// Cancel the previous check (still targeted at its original requester).
+			sendAck(vehicle_command_ack_s::VEHICLE_CMD_RESULT_CANCELLED, now);
+		}
+
+		_axis = axis;
+		_input = vehicle_command.param2;
+		_started = now;
+		_running = true;
+		result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_IN_PROGRESS;
+	}
+
+	// Store the command so sendAck() can target the originating system/component.
+	_last_command = vehicle_command;
+	sendAck(result, now);
+}
+
+void ControlSurfacePreflightCheck::updateState(hrt_abstime now, bool armed)
+{
+	if (!_running) {
+		return;
+	}
+
+	if (armed) {
+		_running = false;
+		sendAck(vehicle_command_ack_s::VEHICLE_CMD_RESULT_CANCELLED, now);
+
+	} else if (now - _started >= PREFLIGHT_CHECK_DURATION) {
+		_running = false;
+		sendAck(vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED, now);
+	}
+}
+
+void ControlSurfacePreflightCheck::applyOverrides(matrix::Vector<float, NUM_AXES> (&c)[MAX_NUM_MATRICES],
+		bool is_vtol, ActuatorEffectiveness &effectiveness)
+{
+	// Clear/refresh tilt override every tick so it doesn't outlive the check
+	// or any effectiveness-source change.
+	const bool tilt_active = _running && _axis == vehicle_command_s::ACTUATOR_TEST_GROUP_COLLECTIVE_TILT;
+	effectiveness.overrideCollectiveTilt(tilt_active, tilt_active ? _input : 0.f);
+
+	// ACTUATOR_TEST_GROUP_{ROLL,PITCH,YAW}_TORQUE are 0/1/2 - used directly as torque-vector indices.
+	if (!_running || _axis > vehicle_command_s::ACTUATOR_TEST_GROUP_YAW_TORQUE) {
+		return;
+	}
+
+	// On a VTOL, instance 1 drives the fixed-wing surfaces; otherwise instance 0.
+	const int instance = is_vtol ? 1 : 0;
+
+	c[instance](0) = 0.f;
+	c[instance](1) = 0.f;
+	c[instance](2) = 0.f;
+	c[instance](_axis) = _input;
+}
+
+void ControlSurfacePreflightCheck::sendAck(uint8_t result, hrt_abstime now)
+{
+	if (_last_command.from_external) {
+		vehicle_command_ack_s command_ack{};
+		command_ack.timestamp = now;
+		command_ack.command = _last_command.command;
+		command_ack.result = result;
+		command_ack.target_system = _last_command.source_system;
+		command_ack.target_component = _last_command.source_component;
+		_command_ack_pub.publish(command_ack);
+	}
+}

--- a/src/modules/control_allocator/ControlSurfacePreflightCheck.hpp
+++ b/src/modules/control_allocator/ControlSurfacePreflightCheck.hpp
@@ -1,0 +1,89 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <ActuatorEffectiveness.hpp>
+#include <ControlAllocation.hpp>
+
+#include <drivers/drv_hrt.h>
+#include <lib/matrix/matrix/math.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/actuator_armed.h>
+#include <uORB/topics/vehicle_command.h>
+#include <uORB/topics/vehicle_command_ack.h>
+
+/**
+ * Drives the VEHICLE_CMD_ACTUATOR_GROUP_TEST state machine: holds a fixed
+ * torque (or collective tilt) on a single axis for a short duration so the
+ * operator can verify control-surface motion before flight. Runs only while
+ * disarmed.
+ */
+class ControlSurfacePreflightCheck
+{
+public:
+	static constexpr int NUM_AXES = ControlAllocation::NUM_AXES;
+	static constexpr int MAX_NUM_MATRICES = ActuatorEffectiveness::MAX_NUM_MATRICES;
+
+	ControlSurfacePreflightCheck() = default;
+	~ControlSurfacePreflightCheck() = default;
+
+	/** Poll vehicle_command for a preflight-check request and start it if conditions allow. */
+	void handleCommand(hrt_abstime now, bool armed, bool is_tiltrotor);
+
+	/** Finish the check after PREFLIGHT_CHECK_DURATION, or abort if armed mid-check. */
+	void updateState(hrt_abstime now, bool armed);
+
+	/**
+	 * Apply the test torque setpoint and/or collective-tilt override for this tick.
+	 * Always called so the tilt override is cleared once the check ends.
+	 */
+	void applyOverrides(matrix::Vector<float, NUM_AXES> (&c)[MAX_NUM_MATRICES], bool is_vtol,
+			    ActuatorEffectiveness &effectiveness);
+
+private:
+	static constexpr uint32_t PREFLIGHT_CHECK_DURATION = 500'000;  // 500 ms
+
+	void sendAck(uint8_t result, hrt_abstime now);
+
+	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};
+	uORB::Subscription _armed_sub{ORB_ID(actuator_armed)};
+	uORB::Publication<vehicle_command_ack_s> _command_ack_pub{ORB_ID(vehicle_command_ack)};
+
+	bool _running{false};
+	uint8_t _axis{0};
+	float _input{0.0f};
+	vehicle_command_s _last_command{};
+	hrt_abstime _started{0};
+};

--- a/src/modules/control_allocator/ControlSurfacePreflightCheck.hpp
+++ b/src/modules/control_allocator/ControlSurfacePreflightCheck.hpp
@@ -59,6 +59,8 @@ public:
 	ControlSurfacePreflightCheck() = default;
 	~ControlSurfacePreflightCheck() = default;
 
+	bool isActive() const { return _running; }
+
 	/** Poll vehicle_command for a preflight-check request and start it if conditions allow. */
 	void handleCommand(hrt_abstime now, bool armed, bool is_tiltrotor);
 

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
@@ -124,14 +124,29 @@ void ActuatorEffectivenessTiltrotorVTOL::allocateAuxilaryControls(const float dt
 
 }
 
+void ActuatorEffectivenessTiltrotorVTOL::overrideCollectiveTilt(bool do_override, float collective_tilt)
+{
+	// When set, updateSetpoint() takes the collective tilt from
+	// _collective_tilt_normalized_setpoint instead of the uORB message and
+	// drives the tilt actuators even when motors are not yet spooled up. Used
+	// by the control-surface preflight check.
+	_do_override_collective_tilt = do_override;
+	_collective_tilt_normalized_setpoint = collective_tilt;
+}
+
 void ActuatorEffectivenessTiltrotorVTOL::updateSetpoint(const matrix::Vector<float, NUM_AXES> &control_sp,
 		int matrix_index, ActuatorVector &actuator_sp, const ActuatorVector &actuator_min, const ActuatorVector &actuator_max)
 {
 	// apply tilt
 	if (matrix_index == 0) {
-		tiltrotor_extra_controls_s tiltrotor_extra_controls;
+		tiltrotor_extra_controls_s tiltrotor_extra_controls{};
+		const bool has_tiltrotor_extra_controls = _tiltrotor_extra_controls_sub.copy(&tiltrotor_extra_controls);
 
-		if (_tiltrotor_extra_controls_sub.copy(&tiltrotor_extra_controls)) {
+		if (has_tiltrotor_extra_controls || _do_override_collective_tilt) {
+			if (_do_override_collective_tilt) {
+				tiltrotor_extra_controls.collective_tilt_normalized_setpoint = _collective_tilt_normalized_setpoint;
+			}
+
 			float control_collective_tilt = tiltrotor_extra_controls.collective_tilt_normalized_setpoint * 2.f - 1.f;
 
 			// set control_collective_tilt to exactly -1 or 1 if close to these end points
@@ -165,7 +180,7 @@ void ActuatorEffectivenessTiltrotorVTOL::updateSetpoint(const matrix::Vector<flo
 				if (_tilts.config(i).tilt_direction == ActuatorEffectivenessTilts::TiltDirection::TowardsFront) {
 
 					// as long as throttle spoolup is not completed, leave the tilts in the disarmed position (in hover)
-					if (throttleSpoolupFinished() || _flight_phase != FlightPhase::HOVER_FLIGHT) {
+					if (throttleSpoolupFinished() || _flight_phase != FlightPhase::HOVER_FLIGHT || _do_override_collective_tilt) {
 						actuator_sp(i + _first_tilt_idx) += control_collective_tilt;
 
 					} else {

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
@@ -87,6 +87,8 @@ public:
 
 	void getUnallocatedControl(int matrix_index, control_allocator_status_s &status) override;
 
+	void overrideCollectiveTilt(bool do_override, float collective_tilt) override;
+
 protected:
 	bool _collective_tilt_updated{true};
 	ActuatorEffectivenessRotors _mc_rotors;
@@ -112,6 +114,9 @@ protected:
 	YawTiltSaturationFlags _yaw_tilt_saturation_flags{};
 
 	uORB::Subscription _tiltrotor_extra_controls_sub{ORB_ID(tiltrotor_extra_controls)};
+
+	bool _do_override_collective_tilt{false};
+	float _collective_tilt_normalized_setpoint{0.5f};
 
 private:
 


### PR DESCRIPTION
### Solved Problem

The current preflight check works by sending individual actuator commands over mavlink. This can only be done sequentially, so the surfaces do not move in a coordinated way, instilling little confidence.

### Solution

Add handling for the `{MAV,VEHICLE}_CMD_ACTUATOR_GROUP_TEST` (https://github.com/mavlink/mavlink/pull/2224). It causes the allocator to command torque in the given direction, so the control surfaces move in coordinated manner as a functional group, as they would in flight.

 - Only runs in pre-armed state (`COM_PREARM_MODE` > 0), otherwise the command is rejected. 
 - Roll, pitch and yaw are handled by overriding the torque setpoint within the allocator before it is used for allocation
 - Tilt is handled by overriding the collective tilt in `ActuatorEffectivenessTiltrotorVTOL.cpp`

### Context

This is a rebased and improved version of https://github.com/PX4/PX4-Autopilot/pull/24391. Changes beyond rebasing:
 - Preflight check logic is now in own class, minimising diff and bloat in `ControlAllocator.cpp`
 - Vehicle command that is added matches the [MAVLink change](https://github.com/mavlink/mavlink/pull/2224) that ended up being merged
 - Addition of `cs_preflight_check_active` field in `ControlAllocatorStatus.msg`, so we know from the log whether the incoming torque setpoint is used (normal operation) or overridden (preflight check). 
 - Separate commits semantically
 - Many small simplifications and refactorings 

### Release note
```
Feature: Control-surface preflight check via `MAV_CMD_ACTUATOR_GROUP_TEST`. Roll, pitch, yaw, or collective tilt are driven as a single control axis while prearmed.
```

### Alternatives

Some possible nits I am happy to adapt:
 - Not sure if directly using the constants defined in the mav command as indices in the allocator is the cleanest way (in `ControlSurfacePreflightCheck::applyOverrides`). We could uncouple them easily by adding a switch case translating from one to the other (1:1 at the moment but then we are prepared if the mav command changes)
 - the `commander cs_check` was added mostly for testing, I think may still be useful and would leave it. If you disagree and consider it bloat, we can remove it. 
 - subscribing to actuator_armed from the new class even though we have it (but only store parts of it) in the allocator could probably be optimised...

### Test coverage
Verified basic functionality in sim with `gz_standard_vtol`, `gz_tiltrotor_vtol`, `gz_advanced_plane`. 

