### PR TITLE
fix(ekf2): set cs.heading_observable to true prior to manual reset

### DIFF
--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -429,6 +429,9 @@ public:
 
 	void resetHeadingToExternalObservation(float heading, float heading_accuracy)
 	{
+		// External heading is an observation of yaw. Setting heading_observable = true
+		// prevents clearInhibitedStateKalmanGains() from inhibiting the update
+		_control_status.flags.heading_observable = true;
 		const float heading_variance = sq(heading_accuracy);
 
 		if (_control_status.flags.yaw_align) {


### PR DESCRIPTION
### Solved Problem

`MAV_CMD_EXTERNAL_ATTITUDE_ESTIMATE` (cmd 620) silently has no effect when the EKF has no active yaw aider. ack is
`ACCEPTED`, but yaw does not get adjusted.

`resetHeadingToExternalObservation` routes to `resetYawByFusion` when `yaw_align` is set, which forces `K(quat_z)`. `measurementUpdate` then calls `clearInhibitedStateKalmanGains`, which zeros that gain when `heading_observable` is false. Result: the reset is not applied. This can be the case even when mag-fusion is active, but `heading_observable` is set to false after a first manual heading reset.

### Solution

Mark heading observable for this single reset call so the forced gain survives `clearInhibitedStateKalmanGains`. The next EKF cycle recomputes the flag from real aiding sources, so no other fusion path is affected.

### Test coverage
SIHSIM
