### PR TITLE
fix(ci): set GH_REPO so labeler works without checkout

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Label PR title type
       env:
         GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         PR_TITLE: ${{ github.event.pull_request.title }}
       run: |


### PR DESCRIPTION
The auto-label step added in #27204 has been failing on every conventional-commit PR since it merged. The job runs under `pull_request_target` without an `actions/checkout` step, so `gh pr view`/`gh pr edit` fall back to git remote detection in the working directory and fail with `fatal: not a git repository`.

Setting `GH_REPO=${{ github.repository }}` points `gh` at the base repo directly, no checkout needed. This works for fork PRs too since `github.repository` always resolves to the base (`PX4/PX4-Autopilot`) and the PR number lives in the base namespace.

Verified failure mode in run [25075347980](https://github.com/PX4/PX4-Autopilot/actions/runs/25075347980/job/71608775815) on PR #27198.