### PR TITLE
fix(battery): Add invalid sentinel for BatteryStatus values

### DIFF
--- a/msg/versioned/BatteryStatus.msg
+++ b/msg/versioned/BatteryStatus.msg
@@ -65,9 +65,9 @@ uint8 FAULT_FAILED_TO_ARM = 10 # Battery had a problem while arming
 uint8 FAULT_COUNT = 11 # Counter. Keep this as last element
 
 float32 full_charge_capacity_wh # [Wh] Compensated battery capacity
-float32 remaining_capacity_wh # [Wh] Compensated battery capacity remaining
+float32 remaining_capacity_wh # [Wh] [@invalid NaN] Compensated battery capacity remaining
 uint16 over_discharge_count # [-] Number of battery overdischarge
-float32 nominal_voltage # [V] Nominal voltage of the battery pack
+float32 nominal_voltage # [V] [@invalid NaN] Nominal voltage of the battery pack
 
 float32 internal_resistance_estimate # [Ohm] Internal resistance per cell estimate
 float32 ocv_estimate # [V] Open circuit voltage estimate

--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -184,7 +184,8 @@ UavcanBatteryBridge::battery_aux_sub_cb(const uavcan::ReceivedDataStructure<ardu
 	_battery_status[instance].cell_count = math::min((uint8_t)msg.voltage_cell.size(), (uint8_t)14);
 	_battery_status[instance].cycle_count = msg.cycle_count;
 	_battery_status[instance].over_discharge_count = msg.over_discharge_count;
-	_battery_status[instance].nominal_voltage = msg.nominal_voltage;
+	// ArduPilot BatteryInfoAux convention: nominal_voltage == 0 means "not provided"
+	_battery_status[instance].nominal_voltage = (msg.nominal_voltage > FLT_EPSILON) ? msg.nominal_voltage : NAN;
 	_battery_status[instance].is_powering_off = msg.is_powering_off;
 
 	if (msg.nominal_voltage > FLT_EPSILON) {

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -184,6 +184,8 @@ battery_status_s Battery::getBatteryStatus()
 	battery_status.warning = _warning;
 	battery_status.timestamp = hrt_absolute_time();
 	battery_status.faults = determineFaults();
+	battery_status.remaining_capacity_wh = NAN; // not measured by dumb power module; smart-battery drivers overwrite
+	battery_status.nominal_voltage = NAN;        // not measured by dumb power module; smart-battery drivers overwrite
 	battery_status.internal_resistance_estimate = _internal_resistance_estimate;
 	battery_status.ocv_estimate = _voltage_v + _internal_resistance_estimate * _params.n_cells * _current_a;
 	battery_status.ocv_estimate_filtered = _ocv_filter_v.getState();


### PR DESCRIPTION
This adds `@invalid NaN` sentinels for `remaining_capacity_wh` and `nominal_voltage`.

This fell out of suggestion in https://github.com/PX4/PX4-Autopilot/pull/25347/changes#r3134701150 by Jake that there were inadequate guards on  `remaining_capacity_wh` or   `nominal_voltage`

### Problem

`BatteryStatus.msg` had no `@invalid` annotation on `remaining_capacity_wh` or   `nominal_voltage`.
Dumb power modules go through `lib/battery/battery.cpp::getBatteryStatus()`, which zero-initialises the struct and never assigns these two smart-battery-only fields, leaving them at `0.0f`.

The `BATTERY_STATUS_V2` stream code guards `capacity_remaining` with `!math::isZero(nominal_voltage)`, which accidentally produces `NaN` when both fields are `0` (the common dumb-module case).
However, if `nominal_voltage` were ever non-zero while `remaining_capacity_wh` was unpopulated (e.g. a hybrid or partially-populated driver), all guards would pass and `0 / nominal_voltage = 0 Ah`  would be transmitted — indistinguishable from a genuinely flat battery.

### Changes

  **`msg/versioned/BatteryStatus.msg`**
  - Added `[@invalid NaN]` annotation to `remaining_capacity_wh`
  - Added `[@invalid NaN]` annotation to `nominal_voltage`

  **`src/lib/battery/battery.cpp`** (`getBatteryStatus()`)
  - Explicitly initialise `remaining_capacity_wh = NAN` and `nominal_voltage = NAN`
    after the struct zero-init, so dumb power modules publish the correct invalid
    sentinel. Smart-battery drivers (UAVCAN/Cyphal) overwrite these fields with
    measured values as before.

  **`src/drivers/uavcan/sensors/battery.cpp`** (`battery_aux_sub_cb`)
  - Guard `nominal_voltage` on ingress: `(msg.nominal_voltage > FLT_EPSILON) ? msg.nominal_voltage : NAN`
    Per the ArduPilot `BatteryPeriodic.uavcan` spec, `nominal_voltage == 0` means
    "field not provided", so translate that to `NaN` rather than storing `0`.

  ### Result

  The existing `PX4_ISFINITE()` guards in `BATTERY_STATUS_V2.hpp` now correctly
  produce `NaN` whenever either field is not measured, with no reliance on the
  coincidental `isZero` backstop.