### PR TITLE
fix(commander): increase esc_telemetry_timeout

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/escCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/escCheck.cpp
@@ -123,11 +123,11 @@ uint16_t EscChecks::checkEscOnline(const Context &context, Report &reporter, con
 			continue; // Skip unmapped ESC status entries
 		}
 
-		const bool timeout = now > esc_status.esc[esc_index].timestamp + ESC_TIMEOUT_US;
+		const bool esc_telemetry_timeout = now > esc_status.esc[esc_index].timestamp + ESC_TIMEOUT_US;
 		const bool is_offline = (esc_status.esc_online_flags & (1 << esc_index)) == 0;
 
 		// Set failure bits for this motor
-		if (timeout || is_offline) {
+		if (esc_telemetry_timeout || is_offline) {
 			mask |= (1u << esc_index);
 
 			uint8_t esc_nr = esc_index + 1;

--- a/src/modules/commander/HealthAndArmingChecks/checks/escCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/escCheck.hpp
@@ -58,7 +58,7 @@ private:
 	uint16_t checkMotorStatus(const Context &context, Report &reporter, const esc_status_s &esc_status, hrt_abstime now);
 	void updateEscsStatus(const Context &context, Report &reporter, const esc_status_s &esc_status, hrt_abstime now);
 
-	static constexpr hrt_abstime ESC_TIMEOUT_US = 300_ms;
+	static constexpr hrt_abstime ESC_TIMEOUT_US = 400_ms;
 
 	uORB::Subscription _esc_status_sub{ORB_ID(esc_status)};
 	uORB::Subscription _actuator_motors_sub{ORB_ID(actuator_motors)};


### PR DESCRIPTION
### Solved Problem
The logic to check, whether an ESC is online (in `EscChecks::checkAndReport(...)`) changed with commit [`96c5c7b`](https://github.com/PX4/PX4-Autopilot/commit/96c5c7ba024df263d0aa7e7985329f86ddc5cfc5#diff-b1bcce3805e298f2466d3c57682545f35110056fef391668cf5d76f7803d5312):

Previously: When the esc telemetry timed out (checked via timestamp), the driver had to report the esc as offline to trigger  a failure.
New: A motor failure is triggered, when the esc telemetry times out or when the driver reports the esc as offline.

The new approach causes custom esc's to trigger the motor failure earlier, since the esc telemetry timeout (300ms) is smaller than offline check timeouts of drivers (voxl: 500ms, uavcan: 1200ms)

Reasoning for the new approach: a hung up esc driver, which publishes no telemetry anymore, previously didn't trigger a motor failure. Also a naive approach of an esc driver, which always reports the esc's as online, didn't trigger motor failure when the esc went offline. With the new approach, the motor failure is triggered independently of the driver implementation.

### Solution

Increase ESC_TIMEOUT_US from 300ms to 400ms.
Rename timeout to esc_telemetry_timeout for clarity.

### Changelog Entry
For release notes:
```
Fix: increase the esc telemetry timeout
```
<!--
### Alternatives


### Test coverage


### Context
Related links, screenshot before/after, video
-->