### PR TITLE
fix(mavlink): preserve OpenDroneID system timestamp

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -3235,7 +3235,7 @@ void MavlinkReceiver::handle_message_open_drone_id_system(
 	open_drone_id_system_s odid_system{};
 	memset(&odid_system, 0, sizeof(odid_system));
 
-	odid_system.timestamp = hrt_absolute_time();
+	odid_system.timestamp = odid_module.timestamp;
 	memcpy(odid_system.id_or_mac, odid_module.id_or_mac, sizeof(odid_system.id_or_mac));
 	odid_system.operator_location_type = odid_module.operator_location_type;
 	odid_system.classification_type = odid_module.classification_type;


### PR DESCRIPTION
Fixes #27243 

The `OPEN_DRONE_ID_SYSTEM.timestamp` field received from MAVLink follows the MAVLink Open Drone ID definition: seconds since `00:00:00 01/01/2019 UTC`.

This timestamp is part of the Open Drone ID protocol data and should not be interpreted as a PX4 boot-relative timestamp or `hrt_absolute_time()` value.

Using `hrt_absolute_time()` to obtain the timestamp will cause the system ID information sent to the Drongcan device in the absence of GPS to have a timestamp in microseconds, leading to timestamp parsing errors.

Without preserving this semantic across the MAVLink -> uORB -> DroneCAN Open Drone ID path, the DroneCAN output may use an incorrect timestamp.

### Solution

Preserve the MAVLink-defined `OPEN_DRONE_ID_SYSTEM.timestamp` value when publishing `open_drone_id_system_s`.

The timestamp is treated as an Open Drone ID protocol timestamp:

```c++
mavlink_open_drone_id_system_t odid_module;
	mavlink_msg_open_drone_id_system_decode(msg, &odid_module);

	open_drone_id_system_s odid_system{};
	memset(&odid_system, 0, sizeof(odid_system));

	//odid_system.timestamp = hrt_absolute_time();
	odid_system.timestamp = odid_module.timestamp;