### PR TITLE
fix(Tools): exclude PX4-OpticalFlow submodule from format checks

### DIFF
--- a/Tools/astyle/files_to_check_code_style.sh
+++ b/Tools/astyle/files_to_check_code_style.sh
@@ -28,6 +28,7 @@ exec find boards msg src platforms test \
     -path src/modules/gyro_fft/CMSIS_5 -prune -o \
     -path src/modules/mavlink/mavlink -prune -o \
     -path src/modules/mc_raptor/blob -prune -o \
+    -path src/modules/simulation/gz_plugins/optical_flow/PX4-OpticalFlow -prune -o \
     -path test/fuzztest -prune -o \
     -path test/mavsdk_tests/catch2 -prune -o \
     -path src/lib/crypto/monocypher -prune -o \


### PR DESCRIPTION
It's an external submodule we don't own, same treatment as the other third-party libs already pruned in this list.