### PR TITLE
docs(update): Add OEM section

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -403,6 +403,7 @@
   - [Serial Port Configuration](peripherals/serial_configuration.md)
   - [PX4 Ethernet Setup](advanced_config/ethernet_setup.md)
   - [Standard Configuration](config/index.md)
+  - [OEM Configuration](advanced_config/oem.md)
   - [Advanced Configuration](advanced_config/index.md)
     - [Using PX4's Navigation Filter (EKF2)](advanced_config/tuning_the_ecl_ekf.md)
     - [GNSS-Denied & Degraded Flight](advanced_config/gnss_degraded_or_denied_flight.md)

--- a/docs/en/advanced_config/advanced_flight_controller_orientation_leveling.md
+++ b/docs/en/advanced_config/advanced_flight_controller_orientation_leveling.md
@@ -21,7 +21,7 @@ The other parameters can then be set in order to fine-tune the orientation of th
 You can locate the parameters in QGroundControl as shown below:
 
 1. Open QGroundControl menu: **Settings > Parameters > Sensor Calibration**.
-1. The parameters as located in the section as shown below (or you can search for them):
+2. The parameters as located in the section as shown below (or you can search for them):
 
    ![FC Orientation QGC v2](../../assets/qgc/setup/sensor/fc_orientation_qgc_v2.png)
 
@@ -34,3 +34,7 @@ You can locate the parameters in QGroundControl as shown below:
   Positive angles increase in CCW direction, negative angles increase in CW direction.
 - [SENS_BOARD_Z_OFF](../advanced_config/parameter_reference.md#SENS_BOARD_Z_OFF): Rotation, in degrees, around PX4FMU's Z axis Yaw axis.
   Positive angles increase in CCW direction, negative angles increase in CW direction.
+
+## See Also
+
+- [OEM/Factory Configuration](../advanced_config/oem.md)

--- a/docs/en/advanced_config/bootloader_update.md
+++ b/docs/en/advanced_config/bootloader_update.md
@@ -195,3 +195,7 @@ To update the bootloader:
 Boards that are not part of the [Pixhawk Series](../flight_controller/pixhawk_series.md) will have their own mechanisms for bootloader update.
 
 For boards that are preflashed with Betaflight, see [Bootloader Flashing onto Betaflight Systems](bootloader_update_from_betaflight.md).
+
+## See Also
+
+- [OEM/Factory Configuration](../advanced_config/oem.md)

--- a/docs/en/advanced_config/compass_power_compensation.md
+++ b/docs/en/advanced_config/compass_power_compensation.md
@@ -17,24 +17,24 @@ The process is demonstrated for a multicopter, but is equally valid for other ve
 Performing this power compensation is advisable only if all the following statements are true:
 
 1. The compass cannot be moved away from the power-carrying cables.
-1. There is a strong correlation between the compass readings and the thrust setpoint, and/or the battery current.
+2. There is a strong correlation between the compass readings and the thrust setpoint, and/or the battery current.
 
    ![Corrupted mag](../../assets/advanced_config/corrupted_mag.png)
 
-1. The drone cables are all fixed in place/do not move (calculated compensation parameters will be invalid if the current-carrying cables can move).
+3. The drone cables are all fixed in place/do not move (calculated compensation parameters will be invalid if the current-carrying cables can move).
 
 ## How to Compensate the Compass
 
 1. Make sure your drone runs a Firmware version supporting power compensation (current master, or releases from v.1.11.0).
-1. Perform the [standard compass calibration](../config/compass.md#compass-calibration).
-1. Set the parameter [SDLOG_MODE](../advanced_config/parameter_reference.md#SDLOG_MODE) to 2 to enable logging of data from boot.
-1. Set the parameter [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) checkbox for _Sensor comparison_ (bit 6) to get more data points.
-1. Secure the drone so that it cannot move, and attach the propellers (so the motors can draw the same current as in flight).
+2. Perform the [standard compass calibration](../config/compass.md#compass-calibration).
+3. Set the parameter [SDLOG_MODE](../advanced_config/parameter_reference.md#SDLOG_MODE) to 2 to enable logging of data from boot.
+4. Set the parameter [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) checkbox for _Sensor comparison_ (bit 6) to get more data points.
+5. Secure the drone so that it cannot move, and attach the propellers (so the motors can draw the same current as in flight).
    This example secures the vehicle using straps.
 
    ![strap](../../assets/advanced_config/strap.png)
 
-1. Power the vehicle and switch into [ACRO flight mode](../flight_modes_mc/acro.md) (using this mode ensures the vehicle won't attempt to compensate for movement resulting from the straps).
+6. Power the vehicle and switch into [ACRO flight mode](../flight_modes_mc/acro.md) (using this mode ensures the vehicle won't attempt to compensate for movement resulting from the straps).
    - Arm the vehicle and slowly raise the throttle to the maximum
    - Slowly lower the throttle down to zero
    - Disarm the vehicle
@@ -43,7 +43,7 @@ Performing this power compensation is advisable only if all the following statem
    Perform the test carefully and closely monitor the vibrations.
    :::
 
-1. Retrieve the ulog and use the python script [mag_compensation.py](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation.py) to identify the compensation parameters.
+7. Retrieve the ulog and use the python script [mag_compensation.py](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation.py) to identify the compensation parameters.
 
    ```sh
    python mag_compensation.py ~/path/to/log/logfile.ulg <type> [--instance <number>]
@@ -57,14 +57,18 @@ Performing this power compensation is advisable only if all the following statem
    If your log does not contain battery current measurements, you will need to comment out the respective lines in the Python script, such that it does the calculation for thrust only.
    :::
 
-1. The script will return the parameter identification for thrust as well as for current and print them to the console.
+8. The script will return the parameter identification for thrust as well as for current and print them to the console.
    The figures that pop up from the script show the "goodness of fit" for each compass instance, and how the data would look if compensated with the suggested values.
    If a current measurement is available, using the current-compensation usually yields the better results.
    Here is an example of a log, where the current fit is good, but the thrust parameters are unusable as the relationship is not linear.
 
    ![line fit](../../assets/advanced_config/line_fit.png)
 
-1. Once the parameters are identified, the power compensation must be enabled by setting [CAL_MAG_COMP_TYP](../advanced_config/parameter_reference.md#CAL_MAG_COMP_TYP) to 1 (when using thrust parameters) or 2 (when using current parameters).
+9. Once the parameters are identified, the power compensation must be enabled by setting [CAL_MAG_COMP_TYP](../advanced_config/parameter_reference.md#CAL_MAG_COMP_TYP) to 1 (when using thrust parameters) or 2 (when using current parameters).
    Additionally, the compensation parameters for each axis of each compass must be set.
 
    ![comp params](../../assets/advanced_config/comp_params.png)
+
+## See Also
+
+- [OEM/Factory Configuration](../advanced_config/oem.md)

--- a/docs/en/advanced_config/imu_factory_calibration.md
+++ b/docs/en/advanced_config/imu_factory_calibration.md
@@ -18,10 +18,10 @@ These values cannot be stored in the [frame configuration](../dev_airframes/addi
 ## Performing the Factory Calibration
 
 1. Set the parameter [SYS_FAC_CAL_MODE](../advanced_config/parameter_reference.md#SYS_FAC_CAL_MODE) to 1.
-1. Perform all IMU calibrations: [accelerometer](../config/accelerometer.md#performing-the-calibration), [gyroscope](../config/gyroscope.md#performing-the-calibration) and [magnetometer](../config/compass.md#performing-the-calibration).
-1. Reboot the vehicle.
+2. Perform all IMU calibrations: [accelerometer](../config/accelerometer.md#performing-the-calibration), [gyroscope](../config/gyroscope.md#performing-the-calibration) and [magnetometer](../config/compass.md#performing-the-calibration).
+3. Reboot the vehicle.
    This will write all `CAL_ACC*`, `CAL_GYRO*` and `CAL_MAG*` parameters into `/fs/mtd_caldata`.
-1. Set the parameter `SYS_FAC_CAL_MODE` back to 0 (default).
+4. Set the parameter `SYS_FAC_CAL_MODE` back to 0 (default).
 
 ::: info
 If you only want to factory calibrate the accelerometer and the gyroscope you can set [SYS_FAC_CAL_MODE](../advanced_config/parameter_reference.md#SYS_FAC_CAL_MODE) to 2, in which case the magnetometer is omitted.
@@ -32,3 +32,4 @@ Subsequent user calibrations will then take effect as usual (factory calibration
 ## Further Information
 
 - [QGroundControl User Guide > Sensors](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/setup_view/sensors_px4.html)
+- [OEM/Factory Configuration](../advanced_config/oem.md)

--- a/docs/en/advanced_config/index.md
+++ b/docs/en/advanced_config/index.md
@@ -7,7 +7,7 @@ This topic lists configuration topics that are not particularly vehicle specific
 - [Finding/Updating Parameters](../advanced_config/parameters.md)
 - [Full Parameter Reference](../advanced_config/parameter_reference.md)
 
-## Feature configuration
+## Feature Configuration
 
 - [Using PX4's Navigation Filter (EKF2)](../advanced_config/tuning_the_ecl_ekf.md)
 - [GNSS-Denied and Degraded Flight](../advanced_config/gnss_degraded_or_denied_flight.md)
@@ -17,13 +17,9 @@ This topic lists configuration topics that are not particularly vehicle specific
 
 ## OEM/Factory Calibration
 
-- [IMU Factory Calibration](../advanced_config/imu_factory_calibration.md)
-- [Sensor Thermal Compensation](../advanced_config/sensor_thermal_calibration.md)
-- [Compass Power Compensation](../advanced_config/compass_power_compensation.md)
-- [Advanced Controller Orientation](../advanced_config/advanced_flight_controller_orientation_leveling.md)
-- [Static Pressure Buildup](../advanced_config/static_pressure_buildup.md)
+- [OEM/Factory Configuration](../advanced_config/oem.md)
 
-## Serial port/Ethernet configuration
+## Serial port/Ethernet Configuration
 
 - [Serial Port Configuration](../peripherals/serial_configuration.md)
 - [MAVLink Telemetry (OSD/GCS)](../peripherals/mavlink_peripherals.md)

--- a/docs/en/advanced_config/oem.md
+++ b/docs/en/advanced_config/oem.md
@@ -1,0 +1,20 @@
+# OEM/Factory Configuration
+
+This topic lists configuration and calibration topics that are more relevant to manufacturers/OEMs (though is some cases individual developers may find some relevant).
+
+- [IMU Factory Calibration](../advanced_config/imu_factory_calibration.md)
+- [Sensor Thermal Compensation](../advanced_config/sensor_thermal_calibration.md)
+- [Compass Power Compensation](../advanced_config/compass_power_compensation.md)
+- [Advanced Controller Orientation](../advanced_config/advanced_flight_controller_orientation_leveling.md)
+- [Static Pressure Buildup](../advanced_config/static_pressure_buildup.md)
+- [Bootloader Update](../advanced_config/bootloader_update.md)
+
+## See Also
+
+- [Standard Configuration](../config/index.md) - Setup essential sensors/features needed for most PX4 vehicles.
+- [Advanced Configuration](../advanced_config/index.md)
+- Vehicle Config/Tuning:
+  - [Multicopter Config/Tuning](../config_mc/index.md)
+  - [Helicopter Config/Tuning](../config_heli/index.md)
+  - [Fixed-wing Config/Tuning](../config_fw/index.md)
+  - [VTOL Config/Tuning](../config_vtol/index.md)

--- a/docs/en/advanced_config/sensor_thermal_calibration.md
+++ b/docs/en/advanced_config/sensor_thermal_calibration.md
@@ -77,14 +77,14 @@ Offboard calibration is run on a development computer using data collected durin
 To perform an offboard calibration:
 
 1. Ensure the frame type is set before calibration, otherwise calibration parameters will be lost when the board is setup.
-1. Power up the board and set the [TC_A_ENABLE](../advanced_config/parameter_reference.md#TC_A_ENABLE), [TC_B_ENABLE](../advanced_config/parameter_reference.md#TC_B_ENABLE), [TC_G_ENABLE](../advanced_config/parameter_reference.md#TC_G_ENABLE), and [TC_M_ENABLE](../advanced_config/parameter_reference.md#TC_M_ENABLE) parameters to `1`.
-1. Set all [CAL_ACC\*](../advanced_config/parameter_reference.md#CAL_ACC0_ID), [CAL_GYRO\*](../advanced_config/parameter_reference.md#CAL_GYRO0_ID), [CAL_MAG\*](../advanced_config/parameter_reference.md#CAL_MAG0_ID), and [CAL_BARO\*](../advanced_config/parameter_reference.md#CAL_BARO0_ID) parameters to defaults.
-1. Set the [SDLOG_MODE](../advanced_config/parameter_reference.md#SDLOG_MODE) parameter to 2 to enable logging of data from boot.
-1. Set the [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) checkbox for _thermal calibration_ (bit 2) to log the raw sensor data required for calibration.
-1. Cold soak the board to the minimum temperature it will be required to operate in.
-1. Apply power and keeping the board still [^2], warm it slowly to the maximum required operating temperature. [^3]
-1. Remove power and extract the .ulog file.
-1. Open a terminal window in the **Firmware/Tools** directory and run the python calibration script:
+2. Power up the board and set the [TC_A_ENABLE](../advanced_config/parameter_reference.md#TC_A_ENABLE), [TC_B_ENABLE](../advanced_config/parameter_reference.md#TC_B_ENABLE), [TC_G_ENABLE](../advanced_config/parameter_reference.md#TC_G_ENABLE), and [TC_M_ENABLE](../advanced_config/parameter_reference.md#TC_M_ENABLE) parameters to `1`.
+3. Set all [CAL_ACC\*](../advanced_config/parameter_reference.md#CAL_ACC0_ID), [CAL_GYRO\*](../advanced_config/parameter_reference.md#CAL_GYRO0_ID), [CAL_MAG\*](../advanced_config/parameter_reference.md#CAL_MAG0_ID), and [CAL_BARO\*](../advanced_config/parameter_reference.md#CAL_BARO0_ID) parameters to defaults.
+4. Set the [SDLOG_MODE](../advanced_config/parameter_reference.md#SDLOG_MODE) parameter to 2 to enable logging of data from boot.
+5. Set the [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) checkbox for _thermal calibration_ (bit 2) to log the raw sensor data required for calibration.
+6. Cold soak the board to the minimum temperature it will be required to operate in.
+7. Apply power and keeping the board still [^2], warm it slowly to the maximum required operating temperature. [^3]
+8. Remove power and extract the .ulog file.
+9. Open a terminal window in the **Firmware/Tools** directory and run the python calibration script:
 
    ```sh
    python process_sensor_caldata.py <full path name to .ulog file>
@@ -92,9 +92,9 @@ To perform an offboard calibration:
 
    This will generate a **.pdf** file showing the measured data and curve fits for each sensor, and a **.params** file containing the calibration parameters.
 
-1. Power the board, connect _QGroundControl_ and load the parameter from the generated **.params** file onto the board using _QGroundControl_. Due to the number of parameters, loading them may take some time.
-1. After parameters have finished loading, set `SDLOG_MODE` to 1 to re-enable normal logging and remove power.
-1. Power the board and perform a normal accelerometer sensor calibration using _QGroundControl_. It is important that this step is performed when board is within the calibration temperature range. The board must be repowered after this step before flying as the sudden offset changes can upset the navigation estimator and some parameters are not loaded by the algorithms that use them until the next startup.
+10. Power the board, connect _QGroundControl_ and load the parameter from the generated **.params** file onto the board using _QGroundControl_. Due to the number of parameters, loading them may take some time.
+11. After parameters have finished loading, set `SDLOG_MODE` to 1 to re-enable normal logging and remove power.
+12. Power the board and perform a normal accelerometer sensor calibration using _QGroundControl_. It is important that this step is performed when board is within the calibration temperature range. The board must be repowered after this step before flying as the sudden offset changes can upset the navigation estimator and some parameters are not loaded by the algorithms that use them until the next startup.
 
 ## Implementation Detail {#implementation}
 
@@ -141,19 +141,19 @@ Examples:
 The correction for thermal offsets (using the calibration parameters) is performed in the [sensors module](../modules/modules_system.md#sensors).
 The reference temperature is subtracted from the measured temperature to obtain a delta temperature where:
 
-```
+```txt
 delta = measured_temperature - reference_temperature
 ```
 
 The delta temperature is then used to calculate a offset, where:
 
-```
+```txt
 offset = X0 + X1*delta + X2*delta**2 + ... + Xn*delta**n
 ```
 
 The offset and temperature scale factor are then used to correct the sensor measurement where:
 
-```
+```txt
 corrected_measurement = (raw_measurement - offset) * scale_factor
 ```
 
@@ -186,3 +186,7 @@ Scale factors are assumed to be temperature invariant due to the difficulty asso
 [^2]: Calibration of the barometric pressure sensor offsets requires a stable air pressure environment. The air pressure will change slowly due to weather and inside buildings can change rapidly due to external wind fluctuations and HVAC system operation.
 
 [^3]: Care must be taken when warming a cold soaked board to avoid formation of condensation on the board that can cause board damage under some circumstances.
+
+## See Also
+
+- [OEM/Factory Configuration](../advanced_config/oem.md)

--- a/docs/en/advanced_config/static_pressure_buildup.md
+++ b/docs/en/advanced_config/static_pressure_buildup.md
@@ -9,7 +9,7 @@ The problem is particularly visible on multicopters because fixed wing vehicles 
 
 One solution is to use foam-filled venting holes to reduce the buildup (as much as possible) and then attempt dynamic calibration to remove any remaining effects.
 
-:::tip
+::: tip
 Before "fixing" the problem you should first check that the Z setpoint tracks the estimated altitude (to verify that there are no controller issues).
 :::
 
@@ -27,7 +27,7 @@ By looking at the ground station you can review the effects of movement-induced 
 
 This process allows rapid iteration without draining batteries: modify drone, drive/review, repeat!
 
-:::tip
+::: tip
 Aim for a barometer altitude drop of less than 2 metres at maximum horizontal speed before attempting software-based calibration below.
 :::
 
@@ -40,3 +40,7 @@ For more information see [Using PX4's Navigation Filter (EKF2) > Correction for 
 The approach works well if the relationship between the error due to static pressure and the velocity varies linearly.
 If the vehicle has a more complex aerodynamic model it will be less effective.
 :::
+
+## See Also
+
+- [OEM/Factory Configuration](../advanced_config/oem.md)

--- a/docs/en/sensor/index.md
+++ b/docs/en/sensor/index.md
@@ -41,7 +41,7 @@ Optional:
   Enables a more accurate position lock than GPS alone, and can be used indoors when no GPS signal is available.
 - [Tachometers (Revolution Counters)](../sensor/tachometers.md) — Only used for logging.
 
-Other optional:
+Primarily for OEMs/Manufacturers:
 
 - [IMU/Compass Factory Calibration](../advanced_config/imu_factory_calibration.md) — Save calibration settings to persistent storage.
 - [Sensor Thermal Compensation](../advanced_config/sensor_thermal_calibration.md) — Compensate sensors for temperature variations.


### PR DESCRIPTION
This creates an OEM config/calibration section to group those topics, and then cross links it.
We have enough OEM stuff to justify this.

Trigger was https://github.com/PX4/PX4-Autopilot/pull/27237 which adds secure bootloader - no other great home.

Have prettiered up the docs while doing it.