### PR TITLE
fix(mavlink): Remove legacy mavlink message requestors

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -583,24 +583,7 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 		return;
 	}
 
-	// First we handle legacy support requests which were used before we had
-	// the generic MAV_CMD_REQUEST_MESSAGE.
-	if (cmd_mavlink.command == MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES) {
-		result = handle_request_message_command(MAVLINK_MSG_ID_AUTOPILOT_VERSION);
-
-	} else if (cmd_mavlink.command == MAV_CMD_REQUEST_PROTOCOL_VERSION) {
-		result = handle_request_message_command(MAVLINK_MSG_ID_PROTOCOL_VERSION);
-
-	} else if (cmd_mavlink.command == MAV_CMD_GET_HOME_POSITION) {
-		result = handle_request_message_command(MAVLINK_MSG_ID_HOME_POSITION);
-
-	} else if (cmd_mavlink.command == MAV_CMD_REQUEST_FLIGHT_INFORMATION) {
-		result = handle_request_message_command(MAVLINK_MSG_ID_FLIGHT_INFORMATION);
-
-	} else if (cmd_mavlink.command == MAV_CMD_REQUEST_STORAGE_INFORMATION) {
-		result = handle_request_message_command(MAVLINK_MSG_ID_STORAGE_INFORMATION);
-
-	} else if (cmd_mavlink.command == MAV_CMD_SET_MESSAGE_INTERVAL) {
+	if (cmd_mavlink.command == MAV_CMD_SET_MESSAGE_INTERVAL) {
 		if (set_message_interval(
 			    (int)(cmd_mavlink.param1 + 0.5f), cmd_mavlink.param2, cmd_mavlink.param3, cmd_mavlink.param4, vehicle_command.param7)) {
 			result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_FAILED;


### PR DESCRIPTION
This removes legacy message requestors that can be requested via MAV_CMD_REQUEST_MESSAGE

Apparently QGC has exclusively supported the generic requestor since 2021 and does not use any of them. PX4 has supported the requestor for these since PX4 v1.11 (according to Claude. It makes sense to remove them, as that allows us to start moving towards removing them from the standard.

MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES, MAV_CMD_REQUEST_PROTOCOL_VERSION, MAV_CMD_GET_HOME_POSITION, MAV_CMD_REQUEST_FLIGHT_INFORMATION, MAV_CMD_REQUEST_STORAGE_INFORMATION.

Note this should rebase on #27251, which removes the first two commands, once it merges.

@julianoes If you think 2021 is an old enough QGC and PX4 v1.11 is an old enough PX4 version, then accepting this (after  #27251 goes in) should be a no-brainer.
