### PR TITLE
feat(navigator): add logging to surface reason for mission invalidity

### DIFF
--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -64,6 +64,8 @@ MissionFeasibilityChecker::checkMissionFeasible(const mission_s &mission)
 
 	// trivial case: A mission with length zero cannot be valid
 	if ((int)mission.count <= 0) {
+		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: empty\t");
+		events::send(events::ID("navigator_mis_empty"), {events::Log::Error, events::LogInternal::Info}, "Mission rejected: empty");
 		return false;
 	}
 
@@ -85,6 +87,7 @@ MissionFeasibilityChecker::checkMissionFeasible(const mission_s &mission)
 		if (!success) {
 			_navigator->get_mission_result()->warning = true;
 			/* not supposed to happen unless the datamanager can't access the SD card, etc. */
+			logDatamanReadFailure(i, mission.mission_dataman_id);
 			return false;
 		}
 
@@ -125,6 +128,7 @@ MissionFeasibilityChecker::checkMissionAgainstGeofence(const mission_s &mission,
 
 			if (!success) {
 				/* not supposed to happen unless the datamanager can't access the SD card, etc. */
+				logDatamanReadFailure(i, mission.mission_dataman_id);
 				return false;
 			}
 
@@ -151,4 +155,12 @@ MissionFeasibilityChecker::checkMissionAgainstGeofence(const mission_s &mission,
 	}
 
 	return true;
+}
+
+void MissionFeasibilityChecker::logDatamanReadFailure(const size_t mission_item, const uint8_t dataman_id)
+{
+	mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: dataman read failed at item %zu (dm_id=%u)\t", mission_item,
+			     static_cast<unsigned>(dataman_id));
+	events::send<uint16_t, uint8_t>(events::ID("navigator_mis_dm_read_fail"), {events::Log::Error, events::LogInternal::Info},
+					"Mission rejected: dataman read failed at item {1} (dm_id={2})", static_cast<uint16_t>(mission_item), dataman_id);
 }

--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -57,6 +57,7 @@ private:
 	FeasibilityChecker _feasibility_checker;
 
 	bool checkMissionAgainstGeofence(const mission_s &mission, float home_alt, bool home_valid);
+	void logDatamanReadFailure(const size_t mission_item, const uint8_t dataman_id);
 
 public:
 	MissionFeasibilityChecker(Navigator *navigator, DatamanClient &dataman_client) :


### PR DESCRIPTION
### Solved Problem
We have observed a couple
```
0:07:36 WARNING: Invalid Mission: Previous mission has been restored
```
and have been unable to precisely find the reason. 

While the inner `FeasibilityChecker.cpp` always outputs the reason for invalidity (through `mavlink_log_critical` and `events::send` at the point of detection), the outer `mission_feasibility_checker.cpp` has a couple of early returns which declare the mission invalid but do not surface the reason. 

### Solution

Add the typical combination of `mavlink_log_critical` and `events::send` on those remaining paths. 

### Changelog Entry
For release notes:
```
feat(navigator): add logging to surface reason for mission invalidity
```

### Alternatives

I initially also logged the `_checks_failed` flags from `FeasibilityChecker.cpp` in `MissionResult.msg` but that's probably redundant, as the events sent by `FeasibilityChecker` are already more specific than these flags.

### Test coverage

Sim test that the event fires when adding a ` || true)` to the condition for it to fire...

