### PR TITLE
Update 4901_crazyflie21to prevent M4 from spinning when disarmed

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4901_crazyflie21
+++ b/ROMFS/px4fmu_common/init.d/airframes/4901_crazyflie21
@@ -74,14 +74,17 @@ param set-default PWM_MAIN_DIS0 0
 param set-default PWM_MAIN_DIS1 0
 param set-default PWM_MAIN_DIS2 0
 param set-default PWM_MAIN_DIS3 0
+param set-default PWM_MAIN_DIS4 0
 param set-default PWM_MAIN_MIN0 20
 param set-default PWM_MAIN_MIN1 20
 param set-default PWM_MAIN_MIN2 20
 param set-default PWM_MAIN_MIN3 20
+param set-default PWM_MAIN_MIN4 20
 param set-default PWM_MAIN_MAX0 255
 param set-default PWM_MAIN_MAX1 255
 param set-default PWM_MAIN_MAX2 255
 param set-default PWM_MAIN_MAX3 255
+param set-default PWM_MAIN_MAX4 255
 
 param set-default SENS_FLOW_MINRNG 0.05
 


### PR DESCRIPTION
This commit is to add some default parameter values for motor 4 to prevent it from spinning immediately after startup or when disarmed.

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
