### PR TITLE
fix(failsafe): Inform user about every failsafe triggered

### DIFF
--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -89,8 +89,8 @@ uint8_t FailsafeBase::update(const hrt_abstime &time_us, const State &state, boo
 	updateStartDelay(time_us - _last_update, action_state.delayed_action != Action::None);
 	updateFailsafeDeferState(time_us, action_state.failsafe_deferred);
 
-	// Notify user if the action is worse than before, or a new action got added
-	if (action_state.action > _selected_action || (action_state.action != Action::None && _notification_required)) {
+	// Notify user if the action is worse than before, or a new warn action got added
+	if (action_state.action > _selected_action || (action_state.action == Action::Warn && _notification_required)) {
 		notifyUser(state.user_intended_mode, action_state.action, action_state.delayed_action, action_state.cause);
 	}
 

--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -89,12 +89,15 @@ uint8_t FailsafeBase::update(const hrt_abstime &time_us, const State &state, boo
 	updateStartDelay(time_us - _last_update, action_state.delayed_action != Action::None);
 	updateFailsafeDeferState(time_us, action_state.failsafe_deferred);
 
-	// Notify user if the action is worse than before, or a new warn action got added
-	if (action_state.action > _selected_action || (action_state.action == Action::Warn && _notification_required)) {
+	// Notify about escalation, or about any new subsumed condition as an informational warning
+	if (action_state.action > _selected_action) {
 		notifyUser(state.user_intended_mode, action_state.action, action_state.delayed_action, action_state.cause);
+
+	} else if (_pending_notification_cause != Cause::Count) {
+		notifyUser(state.user_intended_mode, Action::Warn, Action::None, _pending_notification_cause);
 	}
 
-	_notification_required = false;
+	_pending_notification_cause = Cause::Count;
 
 	_last_user_intended_mode = modifyUserIntendedMode(_selected_action, action_state.action,
 				   action_state.updated_user_intended_mode);
@@ -361,9 +364,7 @@ bool FailsafeBase::checkFailsafe(int caller_id, bool last_state_failure, bool cu
 					}
 				}
 
-				if (options.action == Action::Warn) {
-					_notification_required = true;
-				}
+				_pending_notification_cause = options.cause;
 
 				if (options.action >= Action::Hold) { // If not a Fallback
 					_user_takeover_active = false; // Clear takeover

--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -364,7 +364,9 @@ bool FailsafeBase::checkFailsafe(int caller_id, bool last_state_failure, bool cu
 					}
 				}
 
-				_pending_notification_cause = options.cause;
+				if (options.action != Action::None) { // If not disabled
+					_pending_notification_cause = options.cause;
+				}
 
 				if (options.action >= Action::Hold) { // If not a Fallback
 					_user_takeover_active = false; // Clear takeover

--- a/src/modules/commander/failsafe/framework.h
+++ b/src/modules/commander/failsafe/framework.h
@@ -275,7 +275,7 @@ private:
 	failsafe_flags_s _last_status_flags{};
 	Action _selected_action{Action::None};
 	bool _user_takeover_active{false};
-	bool _notification_required{false};
+	Cause _pending_notification_cause{Cause::Count};
 
 	bool _defer_failsafes{false};
 	hrt_abstime _defer_timeout{0};


### PR DESCRIPTION



### Solved Problem
If a warn-level failsafe triggers (like motor failure) while in termination, the user is notified about the termination. This behavior spams the user with meaningless notifications, if the failsafe switches continuously.

### Solution
Inform the user about every failsafe triggered. If the failsafe is not highest severity, we inform the user with a warn-level failsafe notification.

### Changelog Entry
For release notes:
```
Bugfix: Inform user about every failsafe triggered.
```

<!--
### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
