### PR TITLE
docs(quickstart): clarify environment variable usage in vehicle selection in simulation guide

### DIFF
--- a/docs/en/simulation/px4_simulation_quickstart.md
+++ b/docs/en/simulation/px4_simulation_quickstart.md
@@ -12,7 +12,7 @@ That's it — open [QGroundControl](https://qgroundcontrol.com) and fly!
 
 ::: tip
 
-To try [other vehicle types](../sim_sih/#supported-vehicle-types) append the corresponding line below to the command:
+To try [other vehicle types](../sim_sih/#supported-vehicle-types), pass the `PX4_SIM_MODEL` environment variable to the `docker run` command, for example:
 
 ```sh
 -e PX4_SIM_MODEL=sihsim_airplane # Plane

--- a/docs/en/simulation/px4_simulation_quickstart.md
+++ b/docs/en/simulation/px4_simulation_quickstart.md
@@ -12,12 +12,24 @@ That's it — open [QGroundControl](https://qgroundcontrol.com) and fly!
 
 ::: tip
 
-To try [other vehicle types](../sim_sih/#supported-vehicle-types), pass the `PX4_SIM_MODEL` environment variable to the `docker run` command, for example:
+To try [other vehicle types](../sim_sih/#supported-vehicle-types), use the `-e` flag to pass the `PX4_SIM_MODEL` environment variable to the `docker run` command:
+
+Plane
 
 ```sh
--e PX4_SIM_MODEL=sihsim_airplane # Plane
--e PX4_SIM_MODEL=sihsim_standard_vtol # Standard VTOL
--e PX4_SIM_MODEL=sihsim_rover # Ackermann rover
+docker run --rm -it -p 14550:14550/udp -e PX4_SIM_MODEL=sihsim_airplane px4io/px4-sitl:latest
+```
+
+Standard VTOL
+
+```sh
+docker run --rm -it -p 14550:14550/udp -e PX4_SIM_MODEL=sihsim_standard_vtol px4io/px4-sitl:latest
+```
+
+Ackermann rover
+
+```sh
+docker run --rm -it -p 14550:14550/udp -e PX4_SIM_MODEL=sihsim_rover px4io/px4-sitl:latest
 ```
 
 For more information and options see [Container Images](../simulation/px4_sitl_prebuilt_packages.md#container-images) (in _Pre-built SITL Packages_) and [SIH Simulation](../sim_sih/index.md).


### PR DESCRIPTION
Passing the environment variable as suggested causes PX4 to interpret it directly, rather than the Docker host. This behavior persists across both `sh` and `zsh` shells

**sh**

```
enf@muddica-atturrata:~
> docker run --rm -it -p 14550:14550/udp px4io/px4-sitl:latest -e PX4_SIM_MODEL=sihsim_airplane
ERROR [px4] unrecognized flag
Usage for Server/daemon process: 

    px4 [-h|-d] [-s <startup_file>] [-t <test_data_directory>] [<rootfs_directory>] [-i <instance>] [-w <working_directory>]

    -s <startup_file>      shell script to be used as startup (default=etc/init.d-posix/rcS)
    <rootfs_directory>     directory where startup files and mixers are located,
                           (if not given, CWD is used)
    -i <instance>          px4 instance id to run multiple instances [0...N], default=0
    -w <working_directory> directory to change to
    -h                     help/usage information
    -d                     daemon mode, don't start pxh shell

Usage for client: 

    px4-MODULE [--instance <instance>] command using symlink.
        e.g.: px4-commander status

```

**zsh**

```
enf@muddica-atturrata:~
> bash 
[enf@muddica-atturrata ~]$ docker run --rm -it -p 14550:14550/udp px4io/px4-sitl:latest -e PX4_SIM_MODEL=sihsim_airplane
ERROR [px4] unrecognized flag
Usage for Server/daemon process: 

    px4 [-h|-d] [-s <startup_file>] [-t <test_data_directory>] [<rootfs_directory>] [-i <instance>] [-w <working_directory>]

    -s <startup_file>      shell script to be used as startup (default=etc/init.d-posix/rcS)
    <rootfs_directory>     directory where startup files and mixers are located,
                           (if not given, CWD is used)
    -i <instance>          px4 instance id to run multiple instances [0...N], default=0
    -w <working_directory> directory to change to
    -h                     help/usage information
    -d                     daemon mode, don't start pxh shell

Usage for client: 

    px4-MODULE [--instance <instance>] command using symlink.
        e.g.: px4-commander status
```