### PR TITLE
fix(PositionControl): Prevent vehicle flipping on landing if MPC_ACC_DECOUPLE disabled

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -547,6 +547,7 @@ void MulticopterPositionControl::Run()
 				math::min(speed_up, _param_mpc_z_vel_max_up.get()), // takeoff ramp starts with negative velocity limit
 				math::max(speed_down, 0.f));
 
+			_control.setGroundContact(not_taken_off || flying_but_ground_contact);
 			_control.setInputSetpoint(_setpoint);
 
 			// update states

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -201,7 +201,6 @@ void MulticopterPositionControl::parameters_update(bool force)
 			Vector3f(_param_mpc_xy_vel_i_acc.get(), _param_mpc_xy_vel_i_acc.get(), _param_mpc_z_vel_i_acc.get()),
 			Vector3f(_param_mpc_xy_vel_d_acc.get(), _param_mpc_xy_vel_d_acc.get(), _param_mpc_z_vel_d_acc.get()));
 		_control.setHorizontalThrustMargin(_param_mpc_thr_xy_marg.get());
-		_control.decoupleHorizontalAndVecticalAcceleration(_param_mpc_acc_decouple.get());
 		_goto_control.setParamMpcAccHor(_param_mpc_acc_hor.get());
 		_goto_control.setParamMpcAccDownMax(_param_mpc_acc_down_max.get());
 		_goto_control.setParamMpcAccUpMax(_param_mpc_acc_up_max.get());
@@ -503,6 +502,9 @@ void MulticopterPositionControl::Run()
 			const bool flying                    = (_takeoff.getTakeoffState() >= TakeoffState::flight);
 			const bool flying_but_ground_contact = (flying && _vehicle_land_detected.ground_contact);
 
+			// Ignore value of MPC_ACC_DECOUPLE on ground
+			_control.decoupleHorizontalAndVecticalAcceleration(_param_mpc_acc_decouple.get() || not_taken_off || flying_but_ground_contact);
+
 			if (!flying) {
 				_control.setHoverThrust(_param_mpc_thr_hover.get());
 			}
@@ -547,7 +549,6 @@ void MulticopterPositionControl::Run()
 				math::min(speed_up, _param_mpc_z_vel_max_up.get()), // takeoff ramp starts with negative velocity limit
 				math::max(speed_down, 0.f));
 
-			_control.setGroundContact(not_taken_off || flying_but_ground_contact);
 			_control.setInputSetpoint(_setpoint);
 
 			// update states

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -209,8 +209,8 @@ void PositionControl::_accelerationControl()
 	// Assume standard acceleration due to gravity in vertical direction for attitude generation
 	float z_specific_force = -CONSTANTS_ONE_G;
 
-	if (!_decouple_horizontal_and_vertical_acceleration) {
-		// Include vertical acceleration setpoint for better horizontal acceleration tracking
+	if (!_decouple_horizontal_and_vertical_acceleration && !_ground_contact) {
+		// Include vertical acceleration setpoint for better horizontal acceleration tracking except during ground contact due to high downwards acceleration setpoint.
 		z_specific_force += _acc_sp(2);
 	}
 

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -209,7 +209,7 @@ void PositionControl::_accelerationControl()
 	// Assume standard acceleration due to gravity in vertical direction for attitude generation
 	float z_specific_force = -CONSTANTS_ONE_G;
 
-	if (!_decouple_horizontal_and_vertical_acceleration && !_ground_contact) {
+	if (!_decouple_horizontal_and_vertical_acceleration) {
 		// Include vertical acceleration setpoint for better horizontal acceleration tracking except during ground contact due to high downwards acceleration setpoint.
 		z_specific_force += _acc_sp(2);
 	}

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -168,6 +168,7 @@ public:
 	 * If set, the tilt setpoint is computed by assuming no vertical acceleration
 	 */
 	void decoupleHorizontalAndVecticalAcceleration(bool val) { _decouple_horizontal_and_vertical_acceleration = val; }
+	void setGroundContact(bool val) { _ground_contact = val; }
 
 	/**
 	 * Get the controllers output local position setpoint
@@ -218,6 +219,7 @@ private:
 
 	float _hover_thrust{}; ///< Thrust [HOVER_THRUST_MIN, HOVER_THRUST_MAX] with which the vehicle hovers not accelerating down or up with level orientation
 	bool _decouple_horizontal_and_vertical_acceleration{true}; ///< Ignore vertical acceleration setpoint to remove its effect on the tilt setpoint
+	bool _ground_contact{false}; ///< Prevents high acceleration setpoints during ground-contact affecting the tilt setpoint
 
 	// States
 	matrix::Vector3f _pos; /**< current position */

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -168,7 +168,6 @@ public:
 	 * If set, the tilt setpoint is computed by assuming no vertical acceleration
 	 */
 	void decoupleHorizontalAndVecticalAcceleration(bool val) { _decouple_horizontal_and_vertical_acceleration = val; }
-	void setGroundContact(bool val) { _ground_contact = val; }
 
 	/**
 	 * Get the controllers output local position setpoint
@@ -219,7 +218,6 @@ private:
 
 	float _hover_thrust{}; ///< Thrust [HOVER_THRUST_MIN, HOVER_THRUST_MAX] with which the vehicle hovers not accelerating down or up with level orientation
 	bool _decouple_horizontal_and_vertical_acceleration{true}; ///< Ignore vertical acceleration setpoint to remove its effect on the tilt setpoint
-	bool _ground_contact{false}; ///< Prevents high acceleration setpoints during ground-contact affecting the tilt setpoint
 
 	// States
 	matrix::Vector3f _pos; /**< current position */


### PR DESCRIPTION

### Solved Problem
Fixes #24628 

- During landing, the position controller checks for ground contact and sets acceleration setpoints to [0,0,100] if detected. https://github.com/PX4/PX4-Autopilot/blob/19d3e6285be505303e91ba4da4beac6ff291da75/src/modules/mc_pos_control/MulticopterPositionControl.cpp#L509-L513

- If `MPC_ACC_DECOUPLE` is disabled, 100m/s^2 is then added to `z_specific_force`. https://github.com/PX4/PX4-Autopilot/blob/19d3e6285be505303e91ba4da4beac6ff291da75/src/modules/mc_pos_control/PositionControl/PositionControl.cpp#L209-L212

- In [ _accelerationControl](https://github.com/PX4/PX4-Autopilot/blob/8b3bd398b57da5619d8ec811d853d4597018e2b5/src/modules/mc_pos_control/PositionControl/PositionControl.cpp#L207-L225)  `body_z` is normalised to [0,0,-1]. https://github.com/PX4/PX4-Autopilot/blob/5c7e9d79d4f537b9e883d219d61848ceb1804d54/src/modules/mc_pos_control/PositionControl/PositionControl.cpp#L217-L218

- This is passed onto [limitTilt](https://github.com/PX4/PX4-Autopilot/blob/5c7e9d79d4f537b9e883d219d61848ceb1804d54/src/modules/mc_pos_control/PositionControl/ControlMath.cpp#L53-L68) where it hits the corner case and a rejection is picked. e.g. [1,0,0], and `body_z` becomes [0.707, 0.000, 0.707]  . https://github.com/PX4/PX4-Autopilot/blob/5c7e9d79d4f537b9e883d219d61848ceb1804d54/src/modules/mc_pos_control/PositionControl/ControlMath.cpp#L62-L66

- A thrust setpoint is calculated that tries to flip the vehicle.
https://github.com/PX4/PX4-Autopilot/blob/5c7e9d79d4f537b9e883d219d61848ceb1804d54/src/modules/mc_pos_control/PositionControl/PositionControl.cpp#L224-L225
### Solution

Create a flag within the `PositionControl` class to ensure the z component of `acc_sp` is not added to the `z_specific_force` if there is ground contact.

### Changelog Entry
For release notes:
```
Bugfix : Prevent vehicle flipping on landing if MPC_ACC_DECOUPLE disabled
```

### Test coverage
Tested fix in SITL, see #24628 


