### PR TITLE
feat(navigator): Support terrain following for MAV_CMD_DO_REPOSITION

### DIFF
--- a/msg/PositionSetpoint.msg
+++ b/msg/PositionSetpoint.msg
@@ -21,7 +21,9 @@ float32 vz			# local velocity setpoint in m/s in NED
 
 float64 lat			# latitude, in deg
 float64 lon			# longitude, in deg
-float32 alt			# altitude AMSL, in m
+float32 alt			# altitude AMSL, in m. Authoritative field consumed by the position controller. When alt_is_terrain_relative is true, the navigator re-resolves this each loop as alt_above_terrain + terrain_alt
+bool alt_is_terrain_relative	# true if the setpoint is meant to track terrain. The navigator keeps `alt` in sync with `alt_above_terrain + vehicle_global_position.terrain_alt`
+float32 alt_above_terrain	# [m] desired AGL when alt_is_terrain_relative is true; ignored otherwise. NaN means undefined
 float32 yaw			# yaw (only in hover), in rad [-PI..PI), NaN = leave to flight task
 
 float32 loiter_radius		# [m] [@range 0, INF] loiter major axis radius

--- a/msg/translation_node/translations/all_translations.h
+++ b/msg/translation_node/translations/all_translations.h
@@ -19,6 +19,7 @@
 #include "translation_register_ext_component_request_v1.h"
 #include "translation_register_ext_component_request_v2.h"
 #include "translation_vehicle_attitude_setpoint_v1.h"
+#include "translation_vehicle_command_v1.h"
 #include "translation_vehicle_command_ack_v1.h"
 #include "translation_vehicle_local_position_v1.h"
 #include "translation_vehicle_status_v1.h"

--- a/msg/translation_node/translations/translation_vehicle_command_v1.h
+++ b/msg/translation_node/translations/translation_vehicle_command_v1.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * Copyright (c) 2026 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+#pragma once
+
+// Translate VehicleCommand v0 <--> v1
+#include <px4_msgs_old/msg/vehicle_command_v0.hpp>
+#include <px4_msgs/msg/vehicle_command.hpp>
+
+class VehicleCommandV1Translation
+{
+public:
+	using MessageOlder = px4_msgs_old::msg::VehicleCommandV0;
+	static_assert(MessageOlder::MESSAGE_VERSION == 0);
+
+	using MessageNewer = px4_msgs::msg::VehicleCommand;
+	static_assert(MessageNewer::MESSAGE_VERSION == 1);
+
+	static constexpr const char *kTopic = "fmu/in/vehicle_command";
+
+	static void fromOlder(const MessageOlder &msg_older, MessageNewer &msg_newer)
+	{
+		msg_newer.timestamp = msg_older.timestamp;
+		msg_newer.param1 = msg_older.param1;
+		msg_newer.param2 = msg_older.param2;
+		msg_newer.param3 = msg_older.param3;
+		msg_newer.param4 = msg_older.param4;
+		msg_newer.param5 = msg_older.param5;
+		msg_newer.param6 = msg_older.param6;
+		msg_newer.param7 = msg_older.param7;
+		msg_newer.frame = MessageNewer::FRAME_GLOBAL; // New field in v1, default to MAV_FRAME_GLOBAL
+		msg_newer.command = msg_older.command;
+		msg_newer.target_system = msg_older.target_system;
+		msg_newer.target_component = msg_older.target_component;
+		msg_newer.source_system = msg_older.source_system;
+		msg_newer.source_component = msg_older.source_component;
+		msg_newer.confirmation = msg_older.confirmation;
+		msg_newer.from_external = msg_older.from_external;
+	}
+
+	static void toOlder(const MessageNewer &msg_newer, MessageOlder &msg_older)
+	{
+		msg_older.timestamp = msg_newer.timestamp;
+		msg_older.param1 = msg_newer.param1;
+		msg_older.param2 = msg_newer.param2;
+		msg_older.param3 = msg_newer.param3;
+		msg_older.param4 = msg_newer.param4;
+		msg_older.param5 = msg_newer.param5;
+		msg_older.param6 = msg_newer.param6;
+		msg_older.param7 = msg_newer.param7;
+		// Note: frame from v1 is dropped in v0
+		msg_older.command = msg_newer.command;
+		msg_older.target_system = msg_newer.target_system;
+		msg_older.target_component = msg_newer.target_component;
+		msg_older.source_system = msg_newer.source_system;
+		msg_older.source_component = msg_newer.source_component;
+		msg_older.confirmation = msg_newer.confirmation;
+		msg_older.from_external = msg_newer.from_external;
+	}
+};
+
+REGISTER_TOPIC_TRANSLATION_DIRECT(VehicleCommandV1Translation);

--- a/msg/versioned/VehicleCommand.msg
+++ b/msg/versioned/VehicleCommand.msg
@@ -1,9 +1,18 @@
 # Vehicle Command uORB message. Used for commanding a mission / action / etc.
 # Follows the MAVLink COMMAND_INT / COMMAND_LONG definition
 
-uint32 MESSAGE_VERSION = 0
+uint32 MESSAGE_VERSION = 1
 
 uint64 timestamp # [us] Time since system start.
+
+# Frame of reference for the lat/lon/alt fields (param5/6/7), mirrors MAV_FRAME.
+# Only frames relevant to position-bearing commands are listed.
+uint8 FRAME_GLOBAL = 0                  # WGS84 (MSL altitude)
+uint8 FRAME_GLOBAL_RELATIVE_ALT = 3     # Altitude is relative to home
+uint8 FRAME_GLOBAL_INT = 5              # Same as FRAME_GLOBAL but coordinates are int32
+uint8 FRAME_GLOBAL_RELATIVE_ALT_INT = 6 # Same as FRAME_GLOBAL_RELATIVE_ALT but int32 coords
+uint8 FRAME_GLOBAL_TERRAIN_ALT = 10     # Altitude is meters above terrain (AGL)
+uint8 FRAME_GLOBAL_TERRAIN_ALT_INT = 11 # Same as FRAME_GLOBAL_TERRAIN_ALT but int32 coords
 
 uint16 VEHICLE_CMD_CUSTOM_0 = 0 # Test command.
 uint16 VEHICLE_CMD_CUSTOM_1 = 1 # Test command.
@@ -231,6 +240,7 @@ float32 param4 # Parameter 4, as defined by MAVLink uint16 VEHICLE_CMD enum.
 float64 param5 # Parameter 5, as defined by MAVLink uint16 VEHICLE_CMD enum.
 float64 param6 # Parameter 6, as defined by MAVLink uint16 VEHICLE_CMD enum.
 float32 param7 # Parameter 7, as defined by MAVLink uint16 VEHICLE_CMD enum.
+uint8 frame # Frame of reference for param5/6/7 (FRAME_* constants above). Defaults to FRAME_GLOBAL when received via COMMAND_LONG which has no frame field.
 uint32 command # Command ID.
 uint8 target_system # System which should execute the command.
 uint8 target_component # Component which should execute the command, 0 for all components.

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -159,6 +159,25 @@ bool FlightTaskAuto::update()
 		break;
 	}
 
+	// Terrain-relative altitude tracking: inject a Z velocity feedforward so the
+	// climb/descend response isn't dominated by the path's XY-direction unit
+	// vector. PositionSmoothing allocates Z velocity proportional to the
+	// (pos -> target) unit vector which leaves Z severely under-actuated when
+	// the XY distance is much larger than the Z change as terrain varies.
+	// Gain MPC_Z_P matches the position controller's altitude P gain, so users
+	// tune one knob for both manual (FlightTaskManualAltitude relies entirely
+	// on MPC_Z_P in mc_pos_control) and auto terrain following. Caps mirror
+	// the smoother's MPC_Z_V_AUTO limits so we don't command faster than the
+	// trajectory generator would actually allow.
+	if (_position_setpoint_triplet_sub.get().current.alt_is_terrain_relative
+	    && PX4_ISFINITE(_position_setpoint(2))
+	    && PX4_ISFINITE(_position(2))) {
+		const float z_error = _position_setpoint(2) - _position(2);
+		_velocity_setpoint(2) = math::constrain(z_error * _param_mpc_z_p.get(),
+							-_param_mpc_z_v_auto_up.get(),
+							_param_mpc_z_v_auto_dn.get());
+	}
+
 	_checkEmergencyBraking();
 	Vector3f waypoints[] = {_triplet_previous, _position_setpoint, _triplet_next};
 

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -172,6 +172,7 @@ protected:
 					(ParamFloat<px4::params::MPC_LAND_ALT3>) _param_mpc_land_alt3,
 					(ParamFloat<px4::params::MPC_Z_V_AUTO_UP>) _param_mpc_z_v_auto_up,
 					(ParamFloat<px4::params::MPC_Z_V_AUTO_DN>) _param_mpc_z_v_auto_dn,
+					(ParamFloat<px4::params::MPC_Z_P>) _param_mpc_z_p,
 					(ParamFloat<px4::params::MPC_TKO_SPEED>) _param_mpc_tko_speed,
 					(ParamFloat<px4::params::MPC_TKO_RAMP_T>) _param_mpc_tko_ramp_t
 				       );

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -512,6 +512,7 @@ MavlinkReceiver::handle_message_command_long(mavlink_message_t *msg)
 	vcmd.param5 = (double)cmd_mavlink.param5;
 	vcmd.param6 = (double)cmd_mavlink.param6;
 	vcmd.param7 = cmd_mavlink.param7;
+	vcmd.frame = vehicle_command_s::FRAME_GLOBAL; // COMMAND_LONG has no frame field; default to AMSL
 	vcmd.command = cmd_mavlink.command;
 	vcmd.target_system = cmd_mavlink.target_system;
 	vcmd.target_component = cmd_mavlink.target_component;
@@ -637,6 +638,7 @@ MavlinkReceiver::handle_message_command_int(mavlink_message_t *msg)
 	}
 
 	vcmd.param7 = cmd_mavlink.z;
+	vcmd.frame = cmd_mavlink.frame;
 	vcmd.command = cmd_mavlink.command;
 	vcmd.target_system = cmd_mavlink.target_system;
 	vcmd.target_component = cmd_mavlink.target_component;

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -163,6 +163,9 @@ Loiter::reposition()
 		pos_sp_triplet->previous.lat = _navigator->get_global_position()->lat;
 		pos_sp_triplet->previous.lon = _navigator->get_global_position()->lon;
 		pos_sp_triplet->previous.alt = _navigator->get_global_position()->alt;
+		pos_sp_triplet->previous.valid = true;
+		pos_sp_triplet->previous.alt_is_terrain_relative = false;
+		pos_sp_triplet->previous.alt_above_terrain = NAN;
 		memcpy(&pos_sp_triplet->current, &rep->current, sizeof(rep->current));
 		pos_sp_triplet->next.valid = false;
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -421,6 +421,17 @@ private:
 	void params_update();
 
 	/**
+	 * Re-resolve `alt` of every triplet entry whose `alt_is_terrain_relative`
+	 * flag is set, using the latest EKF terrain estimate. Called every loop
+	 * before the triplet is published so terrain-relative setpoints track
+	 * the surface continuously as the vehicle moves over varying terrain.
+	 *
+	 * This is a no-op until something (DO_REPOSITION with frame
+	 * MAV_FRAME_GLOBAL_TERRAIN_ALT_INT) actually sets the flag.
+	 */
+	void refresh_terrain_relative_setpoints();
+
+	/**
 	 * Publish a new position setpoint triplet for position controllers
 	 */
 	void publish_position_setpoint_triplet();

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -294,7 +294,44 @@ void Navigator::run()
 					position_setpoint.lon = get_global_position()->lon;
 				}
 
-				position_setpoint.alt = PX4_ISFINITE(cmd.param7) ? cmd.param7 : get_global_position()->alt;
+				// Resolve the requested altitude frame to AMSL so the controller and geofence can consume it.
+				// For TERRAIN_ALT frames we additionally mark the setpoint as terrain-relative so the per-loop
+				// refresh in run() keeps `alt` in sync with the EKF terrain estimate as the vehicle moves.
+				const bool is_terrain_frame =
+					(cmd.frame == vehicle_command_s::FRAME_GLOBAL_TERRAIN_ALT
+					 || cmd.frame == vehicle_command_s::FRAME_GLOBAL_TERRAIN_ALT_INT);
+				const bool is_relative_frame =
+					(cmd.frame == vehicle_command_s::FRAME_GLOBAL_RELATIVE_ALT
+					 || cmd.frame == vehicle_command_s::FRAME_GLOBAL_RELATIVE_ALT_INT);
+
+				position_setpoint.alt = [&] {
+					if (!PX4_ISFINITE(cmd.param7))
+					{
+						return get_global_position()->alt;
+					}
+
+					if (is_terrain_frame)
+					{
+						if (get_global_position()->terrain_alt_valid) {
+							return cmd.param7 + get_global_position()->terrain_alt;
+
+						} else {
+							mavlink_log_warning(&_mavlink_log_pub,
+									    "Reposition: terrain estimate invalid, seeding AMSL from home\t");
+							events::send(events::ID("navigator_reposition_terrain_seed_home"),
+							{events::Log::Warning, events::LogInternal::Info},
+							"Reposition: terrain invalid, seeding from home");
+							return cmd.param7 + _home_pos.alt;
+						}
+					}
+
+					if (is_relative_frame)
+					{
+						return cmd.param7 + _home_pos.alt;
+					}
+
+					return cmd.param7;
+				}();
 
 				if (geofence_allows_position(position_setpoint)) {
 					position_setpoint_triplet_s *rep = get_reposition_triplet();
@@ -305,9 +342,13 @@ void Navigator::run()
 					rep->previous.lat = get_global_position()->lat;
 					rep->previous.lon = get_global_position()->lon;
 					rep->previous.alt = get_global_position()->alt;
+					rep->previous.alt_is_terrain_relative = false;
+					rep->previous.alt_above_terrain = NAN;
 
 
 					rep->current.type = position_setpoint_s::SETPOINT_TYPE_LOITER;
+					rep->current.alt_is_terrain_relative = is_terrain_frame && PX4_ISFINITE(cmd.param7);
+					rep->current.alt_above_terrain = rep->current.alt_is_terrain_relative ? cmd.param7 : NAN;
 
 					bool only_alt_change_requested = false;
 
@@ -342,7 +383,7 @@ void Navigator::run()
 						rep->current.lon = cmd.param6;
 
 						if (PX4_ISFINITE(cmd.param7)) {
-							rep->current.alt = cmd.param7;
+							rep->current.alt = position_setpoint.alt;
 
 						} else {
 							rep->current.alt = get_global_position()->alt;
@@ -354,7 +395,7 @@ void Navigator::run()
 						rep->current.lon = PX4_ISFINITE(curr->current.lon) ? curr->current.lon : get_global_position()->lon;
 
 						if (PX4_ISFINITE(cmd.param7)) {
-							rep->current.alt = cmd.param7;
+							rep->current.alt = position_setpoint.alt;
 							only_alt_change_requested = true;
 
 						} else {
@@ -975,6 +1016,8 @@ void Navigator::run()
 			reset_triplets();
 		}
 
+		refresh_terrain_relative_setpoints();
+
 		if (_pos_sp_triplet_updated) {
 			publish_position_setpoint_triplet();
 		}
@@ -1197,6 +1240,37 @@ int Navigator::print_status()
 
 	_geofence.printStatus();
 	return 0;
+}
+
+void Navigator::refresh_terrain_relative_setpoints()
+{
+	if (!_global_pos.terrain_alt_valid) {
+		// No usable terrain estimate; leave any pre-resolved AMSL `alt`
+		// values in place (held over from when the estimate was valid).
+		return;
+	}
+
+	const float terrain_alt = _global_pos.terrain_alt;
+	bool changed = false;
+
+	auto refresh = [&](position_setpoint_s & sp) {
+		if (sp.valid && sp.alt_is_terrain_relative && PX4_ISFINITE(sp.alt_above_terrain)) {
+			const float new_alt = sp.alt_above_terrain + terrain_alt;
+
+			if (!PX4_ISFINITE(sp.alt) || fabsf(sp.alt - new_alt) > FLT_EPSILON) {
+				sp.alt = new_alt;
+				changed = true;
+			}
+		}
+	};
+
+	refresh(_pos_sp_triplet.previous);
+	refresh(_pos_sp_triplet.current);
+	refresh(_pos_sp_triplet.next);
+
+	if (changed) {
+		_pos_sp_triplet_updated = true;
+	}
 }
 
 void Navigator::publish_position_setpoint_triplet()


### PR DESCRIPTION
### Solved Problem

Tracks frame that is sent with `MAV_CMD_DO_REPOSITION` when sent using [COMMAND_INT](https://mavlink.io/en/messages/common.html#COMMAND_INT).

If frame is `MAV_FRAME_GLOBAL_TERRAIN_ALT_INT` continuous terrain following to the goto location is applied.

Previously the command's frame was dropped at the mavlink_receiver boundary
and `MAV_CMD_DO_REPOSITION` always meant AMSL.

### Solution

- `VehicleCommand.msg` v0 → v1, adds `frame` + a v0 translation.
- `mavlink_receiver` propagates `COMMAND_INT.frame`.
- `PositionSetpoint.msg` adds `alt_is_terrain_relative` + `alt_above_terrain`.
- Navigator rewrites `alt = alt_above_terrain + terrain_alt` every loop.
- `FlightTaskAuto` injects a Z velocity feedforward so the trajectory smoother
  actually tracks the moving Z target (otherwise the path's XY-dominant unit
  vector starves Z to ~0.02 m/s).
- `Loiter::reposition()` now marks `previous.valid = true` (was always false,
  which collapsed the trajectory and starved climb on every reposition).
- Add small terrain example with a ridge for Gz

### Changelog Entry
For release notes:
```
Feature Support terrain following for MAV_CMD_DO_REPOSITION
```

### Alternatives

### Test coverage

- [x] SITL test (using `PX4_GZ_WORLD=terrain make px4_sitl gz_x500_lidar_down`

- [ ] Real world test

### Context

Closes https://github.com/PX4/PX4-Autopilot/issues/10246.
Closes https://github.com/PX4/PX4-Autopilot/issues/15411.

FYI @reedev