### PR TITLE
feat(control_allocator): actuator group preflight check

### DIFF
--- a/msg/ControlAllocatorStatus.msg
+++ b/msg/ControlAllocatorStatus.msg
@@ -18,5 +18,7 @@ int8[16] actuator_saturation            # Indicates actuator saturation status.
                                         # Note 1: actuator saturation does not necessarily imply that the thrust setpoint or the torque setpoint were not achieved.
                                         # Note 2: an actuator with limited dynamics can be indicated as upper-saturated even if it as not reached its maximum value.
 
-uint16 handled_motor_failure_mask        # Bitmask of failed motors that were removed from the allocation / effectiveness matrix. Not necessarily identical to the report from FailureDetector
-uint16 motor_stop_mask                   # Bitmaks of motors stopped by failure injection
+uint16 handled_motor_failure_mask       # Bitmask of failed motors that were removed from the allocation / effectiveness matrix. Not necessarily identical to the report from FailureDetector
+uint16 motor_stop_mask                  # Bitmaks of motors stopped by failure injection
+
+bool actuator_group_preflight_check_active   # True while an actuator group preflight check (VEHICLE_CMD_ACTUATOR_GROUP_TEST) is overriding the torque/thrust setpoint or collective-tilt

--- a/msg/versioned/VehicleCommand.msg
+++ b/msg/versioned/VehicleCommand.msg
@@ -78,6 +78,7 @@ uint16 VEHICLE_CMD_DO_SET_STANDARD_MODE=262 # Enable the specified standard MAVL
 uint16 VEHICLE_CMD_GIMBAL_DEVICE_INFORMATION = 283 # Command to ask information about a low level gimbal.
 
 uint16 VEHICLE_CMD_MISSION_START = 300 # Start running a mission. |first_item: the first mission item to run|last_item: the last mission item to run (after this item is run, the mission ends)|
+uint16 VEHICLE_CMD_ACTUATOR_GROUP_TEST = 309 # Test groups of related actuators (e.g. all actuators contributing to roll torque). |[@enum ACTUATOR_TEST_GROUP] Group|[@range -1,1] Value|Unused|Unused|Unused|Unused|Unused|
 uint16 VEHICLE_CMD_ACTUATOR_TEST = 310 # Actuator testing command. |[@range -1,1] value|[s] timeout|Unused|Unused|output function|
 uint16 VEHICLE_CMD_CONFIGURE_ACTUATOR = 311 # Actuator configuration command. |configuration|Unused|Unused|Unused|output function|
 uint16 VEHICLE_CMD_ESC_REQUEST_EEPROM = 312 # Request EEPROM data from an ESC. |ESC Index|Firmware Type|Unused|Unused|Unused|
@@ -209,6 +210,15 @@ uint8 GRIPPER_ACTION_GRAB = 1
 # Used as param1 in DO_SET_SAFETY_SWITCH_STATE command.
 uint8 SAFETY_OFF = 0
 uint8 SAFETY_ON = 1
+
+# param1 in VEHICLE_CMD_ACTUATOR_GROUP_TEST (matches MAVLink ACTUATOR_TEST_GROUP enum)
+uint8 ACTUATOR_TEST_GROUP_ROLL_TORQUE = 0
+uint8 ACTUATOR_TEST_GROUP_PITCH_TORQUE = 1
+uint8 ACTUATOR_TEST_GROUP_YAW_TORQUE = 2
+uint8 ACTUATOR_TEST_GROUP_COLLECTIVE_TILT = 3
+uint8 ACTUATOR_TEST_GROUP_X_THRUST = 4
+uint8 ACTUATOR_TEST_GROUP_Y_THRUST = 5
+uint8 ACTUATOR_TEST_GROUP_Z_THRUST = 6
 
 uint8 ORB_QUEUE_LENGTH = 8
 

--- a/src/lib/control_allocation/actuator_effectiveness/ActuatorEffectiveness.hpp
+++ b/src/lib/control_allocation/actuator_effectiveness/ActuatorEffectiveness.hpp
@@ -221,6 +221,15 @@ public:
 	 */
 	virtual void stopMaskedMotorsWithZeroThrust(ActuatorBitmask stoppable_motors_mask, ActuatorVector &actuator_sp);
 
+	/**
+	 * Override the collective tilt setpoint that would normally come from
+	 * tiltrotor_extra_controls. Base implementation is a no-op.
+	 *
+	 * @param do_override When true, use @p collective_tilt instead of the uORB value.
+	 * @param collective_tilt Normalised setpoint in [0, 1]. 0: vertical, 1: horizontal.
+	 */
+	virtual void overrideCollectiveTilt(bool /*do_override*/, float /*collective_tilt*/) {}
+
 protected:
 	FlightPhase _flight_phase{FlightPhase::HOVER_FLIGHT};
 	ActuatorBitmask _stopped_motors_mask{0};

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -346,6 +346,60 @@ int Commander::custom_command(int argc, char *argv[])
 		return 0;
 	}
 
+	if (!strcmp(argv[0], "actuator_group_test")) {
+		if (argc < 2) {
+			PX4_ERR("missing argument");
+			return 1;
+		}
+
+		uint8_t group;
+		float value = 1.f;
+
+		if (!strcmp(argv[1], "roll")) {
+			group = vehicle_command_s::ACTUATOR_TEST_GROUP_ROLL_TORQUE;
+
+		} else if (!strcmp(argv[1], "pitch")) {
+			group = vehicle_command_s::ACTUATOR_TEST_GROUP_PITCH_TORQUE;
+
+		} else if (!strcmp(argv[1], "yaw")) {
+			group = vehicle_command_s::ACTUATOR_TEST_GROUP_YAW_TORQUE;
+
+		} else if (!strcmp(argv[1], "tilt")) {
+			group = vehicle_command_s::ACTUATOR_TEST_GROUP_COLLECTIVE_TILT;
+
+		} else if (!strcmp(argv[1], "xthrust")) {
+			group = vehicle_command_s::ACTUATOR_TEST_GROUP_X_THRUST;
+			value = 0.1f; // For thrust use a lower default to avoid unintended takeoffs
+
+		} else if (!strcmp(argv[1], "ythrust")) {
+			group = vehicle_command_s::ACTUATOR_TEST_GROUP_Y_THRUST;
+			value = 0.1f;
+
+		} else if (!strcmp(argv[1], "zthrust")) {
+			group = vehicle_command_s::ACTUATOR_TEST_GROUP_Z_THRUST;
+			value = -0.1f;
+
+		} else {
+			PX4_ERR("argument %s unsupported.", argv[1]);
+			return 1;
+		}
+
+		if (argc > 2) {
+			char *end;
+			const float user_value = strtof(argv[2], &end);
+
+			if (*end == '\0' && PX4_ISFINITE(user_value)) {
+				value = user_value;
+
+			} else {
+				PX4_WARN("actuator_group_test: value \"%s\" is invalid. Using default %.1f", argv[2], (double) value);
+			}
+		}
+
+		send_vehicle_command(vehicle_command_s::VEHICLE_CMD_ACTUATOR_GROUP_TEST, group, value);
+		return 0;
+	}
+
 	if (!strcmp(argv[0], "arm")) {
 		float param2 = 0.f;
 
@@ -3152,6 +3206,9 @@ The commander module contains the state machine for mode switching and failsafe 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("check", "Run preflight checks");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("safety", "Change prearm safety state");
 	PRINT_MODULE_USAGE_ARG("on|off", "[on] to activate safety, [off] to deactivate safety and allow control surface movements", false);
+	PRINT_MODULE_USAGE_COMMAND_DESCR("actuator_group_test", "Drive a functional actuator group (torque/thrust/tilt) for a brief preflight check");
+	PRINT_MODULE_USAGE_ARG("roll|pitch|yaw|tilt|xthrust|ythrust|zthrust", "Group", false);
+	PRINT_MODULE_USAGE_ARG("value", "Normalized command [-1.0, +1.0]; default 1.0 for torque/tilt, 0.1 for thrust", true);
 	PRINT_MODULE_USAGE_COMMAND("arm");
 	PRINT_MODULE_USAGE_PARAM_FLAG('f', "Force arming (do not run preflight checks)", true);
 	PRINT_MODULE_USAGE_COMMAND("disarm");

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1640,6 +1640,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 	case vehicle_command_s::VEHICLE_CMD_EXTERNAL_ATTITUDE_ESTIMATE:
 	case vehicle_command_s::VEHICLE_CMD_DO_AUTOTUNE_ENABLE:
 	case vehicle_command_s::VEHICLE_CMD_ESTIMATOR_SENSOR_ENABLE:
+	case vehicle_command_s::VEHICLE_CMD_ACTUATOR_GROUP_TEST:
 		/* ignore commands that are handled by other parts of the system */
 		break;
 

--- a/src/modules/control_allocator/ActuatorGroupPreflightCheck.cpp
+++ b/src/modules/control_allocator/ActuatorGroupPreflightCheck.cpp
@@ -1,0 +1,242 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "ActuatorGroupPreflightCheck.hpp"
+
+bool ActuatorGroupPreflightCheck::isThrust(uint8_t group)
+{
+	// Thrust groups require different handling for a couple reasons:
+	//  - requires being armed to be useful
+	//  - on VTOLs, thrust and control surfaces are handled by different allocator instances
+	return group == vehicle_command_s::ACTUATOR_TEST_GROUP_X_THRUST
+	       || group == vehicle_command_s::ACTUATOR_TEST_GROUP_Y_THRUST
+	       || group == vehicle_command_s::ACTUATOR_TEST_GROUP_Z_THRUST;
+}
+
+bool ActuatorGroupPreflightCheck::isKnownGroup(uint8_t group)
+{
+	switch (group) {
+	case vehicle_command_s::ACTUATOR_TEST_GROUP_ROLL_TORQUE:
+	case vehicle_command_s::ACTUATOR_TEST_GROUP_PITCH_TORQUE:
+	case vehicle_command_s::ACTUATOR_TEST_GROUP_YAW_TORQUE:
+	case vehicle_command_s::ACTUATOR_TEST_GROUP_COLLECTIVE_TILT:
+	case vehicle_command_s::ACTUATOR_TEST_GROUP_X_THRUST:
+	case vehicle_command_s::ACTUATOR_TEST_GROUP_Y_THRUST:
+	case vehicle_command_s::ACTUATOR_TEST_GROUP_Z_THRUST:
+		return true;
+
+	default:
+		return false;
+	}
+}
+
+const char *ActuatorGroupPreflightCheck::validateCommand(uint8_t group, bool is_tiltrotor, uint8_t &ack_result)
+{
+	// Permanent failures: the airframe does not support the command
+	ack_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;
+
+	if (!isKnownGroup(group)) {
+		return "unknown actuator group";
+	}
+
+	if (group == vehicle_command_s::ACTUATOR_TEST_GROUP_COLLECTIVE_TILT && !is_tiltrotor) {
+		ack_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;
+		return "not a tiltrotor";
+	}
+
+	// Transient: arming state mismatch. The user can change it and retry.
+	ack_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED;
+
+	actuator_armed_s actuator_armed{};
+	_armed_sub.copy(&actuator_armed);
+
+	if (isThrust(group)) {
+
+		if (!actuator_armed.armed) {
+			return "thrust test requires armed";
+		}
+
+	} else {
+
+		if (!actuator_armed.prearmed && !actuator_armed.armed) {
+			return "not (pre)armed";
+		}
+	}
+
+	// Transient: landed state mismatch
+	vehicle_land_detected_s vehicle_land_detected{};
+	_vehicle_land_detected_sub.copy(&vehicle_land_detected);
+
+	if (!vehicle_land_detected.landed) {
+		return "not landed";
+	}
+
+	return nullptr;
+}
+
+void ActuatorGroupPreflightCheck::handleCommand(hrt_abstime now, bool is_tiltrotor)
+{
+	vehicle_command_s vehicle_command;
+
+	if (!_vehicle_command_sub.update(&vehicle_command)) { return; }
+
+	if (vehicle_command.command != vehicle_command_s::VEHICLE_CMD_ACTUATOR_GROUP_TEST) { return; }
+
+	const uint8_t group = (uint8_t) lroundf(vehicle_command.param1);
+
+	// Torque and thrust have inputs in [-1, 1]. Tilt expects [0, 1] (0=vertical, 1=horizontal);
+	const float min_input = group == vehicle_command_s::ACTUATOR_TEST_GROUP_COLLECTIVE_TILT ? 0.f : -1.f;
+
+	const float input = math::constrain(vehicle_command.param2, min_input, 1.f);
+
+	uint8_t reject_result;  // Is written to by validateCommand
+	const char *reject_reason = validateCommand(group, is_tiltrotor, reject_result);
+
+	if (reject_reason) {
+		PX4_WARN("Actuator group preflight check rejected (%s)", reject_reason);
+
+		// Ack the rejected command directly without affecting any running check.
+		sendAck(vehicle_command, reject_result, now);
+		return;
+	}
+
+	if (_running) {
+		// Cancel the previous check, still targeted at its original requester.
+		stop(vehicle_command_ack_s::VEHICLE_CMD_RESULT_CANCELLED, now);
+	}
+
+	vehicle_status_s vehicle_status{};
+	_vehicle_status_sub.copy(&vehicle_status);
+
+	start(now, group, input, vehicle_status.nav_state, vehicle_command);
+}
+
+void ActuatorGroupPreflightCheck::updateState(hrt_abstime now)
+{
+	if (!_running) { return; }
+
+	actuator_armed_s actuator_armed{};
+	vehicle_land_detected_s vehicle_land_detected{};
+	vehicle_status_s vehicle_status{};
+
+	if (_armed_sub.copy(&actuator_armed)
+	    && _vehicle_land_detected_sub.copy(&vehicle_land_detected)
+	    && _vehicle_status_sub.copy(&vehicle_status)) {
+
+		// Cancel if any of the conditions we depend on are lost (thrust -> armed,
+		// torque/tilt -> pre-armed or armed, always !landed), or when nav_state
+		// changes (safety measure).
+		const bool is_thrust = isThrust(_active_check.group);
+		const bool armed_requirement_lost = is_thrust && !actuator_armed.armed;
+		const bool prearmed_requirement_lost = !is_thrust && (!actuator_armed.prearmed && !actuator_armed.armed);
+		const bool nav_state_changed = vehicle_status.nav_state != _active_check.started_nav_state;
+
+		if (armed_requirement_lost || prearmed_requirement_lost || !vehicle_land_detected.landed || nav_state_changed) {
+			stop(vehicle_command_ack_s::VEHICLE_CMD_RESULT_CANCELLED, now);
+			return;
+		}
+	}
+
+	if (now >= _active_check.started + PREFLIGHT_CHECK_DURATION_US) {
+		stop(vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED, now);
+	}
+}
+
+void ActuatorGroupPreflightCheck::applyOverrides(matrix::Vector<float, NUM_AXES> (&c)[MAX_NUM_MATRICES],
+		bool is_vtol, ActuatorEffectiveness &effectiveness)
+{
+	bool do_override_tilt = false;
+	int override_index = -1;
+
+	// Map vehicle command constants to indices of the c matrix used in ControlAllocator
+	switch (_active_check.group) {
+	case vehicle_command_s::ACTUATOR_TEST_GROUP_ROLL_TORQUE:
+		override_index = 0; break;
+
+	case vehicle_command_s::ACTUATOR_TEST_GROUP_PITCH_TORQUE:
+		override_index = 1; break;
+
+	case vehicle_command_s::ACTUATOR_TEST_GROUP_YAW_TORQUE:
+		override_index = 2; break;
+
+	case vehicle_command_s::ACTUATOR_TEST_GROUP_X_THRUST:
+		override_index = 3; break;
+
+	case vehicle_command_s::ACTUATOR_TEST_GROUP_Y_THRUST:
+		override_index = 4; break;
+
+	case vehicle_command_s::ACTUATOR_TEST_GROUP_Z_THRUST:
+		override_index = 5; break;
+
+	case vehicle_command_s::ACTUATOR_TEST_GROUP_COLLECTIVE_TILT:
+		do_override_tilt = _running;
+		break;
+	}
+
+	// Always update tilt override, even when not running. We need an
+	// explicit call with do_override_tilt = false to undo the override.
+	effectiveness.overrideCollectiveTilt(do_override_tilt, _active_check.input);
+
+	if (_running && override_index >= 0) {
+		// On a VTOL, control surfaces are in instance 1; thrust always lives in instance 0.
+		const int instance = (is_vtol && !isThrust(_active_check.group)) ? 1 : 0;
+		c[instance](override_index) = _active_check.input;
+	}
+}
+
+void ActuatorGroupPreflightCheck::start(hrt_abstime now, uint8_t group, float input, uint8_t nav_state,
+					const vehicle_command_s &cmd)
+{
+	_active_check = {group, input, now, nav_state, cmd};
+	_running = true;
+	sendAck(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_IN_PROGRESS, now);
+}
+
+void ActuatorGroupPreflightCheck::stop(uint8_t result, hrt_abstime now)
+{
+	_running = false;
+	sendAck(_active_check.last_command, result, now);
+}
+
+void ActuatorGroupPreflightCheck::sendAck(const vehicle_command_s &cmd, uint8_t result, hrt_abstime now)
+{
+	if (cmd.from_external) {
+		vehicle_command_ack_s command_ack{};
+		command_ack.timestamp = now;
+		command_ack.command = cmd.command;
+		command_ack.result = result;
+		command_ack.target_system = cmd.source_system;
+		command_ack.target_component = cmd.source_component;
+		_command_ack_pub.publish(command_ack);
+	}
+}

--- a/src/modules/control_allocator/ActuatorGroupPreflightCheck.hpp
+++ b/src/modules/control_allocator/ActuatorGroupPreflightCheck.hpp
@@ -1,0 +1,118 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <ActuatorEffectiveness.hpp>
+#include <ControlAllocation.hpp>
+
+#include <math.h>
+#include <mathlib/math/Limits.hpp>
+#include <drivers/drv_hrt.h>
+#include <lib/matrix/matrix/math.hpp>
+#include <px4_platform_common/log.h>
+
+#include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+
+#include <uORB/topics/actuator_armed.h>
+#include <uORB/topics/vehicle_command.h>
+#include <uORB/topics/vehicle_command_ack.h>
+#include <uORB/topics/vehicle_land_detected.h>
+#include <uORB/topics/vehicle_status.h>
+
+/**
+ * Drives the VEHICLE_CMD_ACTUATOR_GROUP_TEST state machine: holds a fixed
+ * torque, thrust or collective tilt on a single functional group for a short
+ * duration so the operator can verify actuator motion before flight.
+ *
+ * Pre-conditions (enforced at start, cancelled if not given while running):
+ *  - torque and collective tilt groups: prearmed or armed
+ *  - thrust groups: armed
+ *  - landed
+ *
+ * Losing the required state mid-check results in a CANCELLED ack.
+ */
+class ActuatorGroupPreflightCheck
+{
+public:
+	static constexpr int NUM_AXES = ControlAllocation::NUM_AXES;
+	static constexpr int MAX_NUM_MATRICES = ActuatorEffectiveness::MAX_NUM_MATRICES;
+
+	ActuatorGroupPreflightCheck() = default;
+	~ActuatorGroupPreflightCheck() = default;
+
+	bool isActive() const { return _running; }
+
+	// Poll vehicle_command for a group test request and start it if conditions allow.
+	void handleCommand(hrt_abstime now, bool is_tiltrotor);
+
+	// Finish the check after the group-specific duration, or abort if the required arming state is lost.
+	void updateState(hrt_abstime now);
+
+	// Apply the test torque/thrust setpoint and/or collective tilt override.
+	void applyOverrides(matrix::Vector<float, NUM_AXES> (&c)[MAX_NUM_MATRICES], bool is_vtol,
+			    ActuatorEffectiveness &effectiveness);
+
+private:
+	static constexpr hrt_abstime PREFLIGHT_CHECK_DURATION_US = 500'000;  // 500 ms
+
+	static bool isThrust(uint8_t group);
+	static bool isKnownGroup(uint8_t group);
+
+	// Returns
+	//  - nullptr, if the command is acceptable
+	//  - char* with rejection reason, if not
+	// On rejection, also writes the appropriate VEHICLE_CMD_RESULT_* into ack_result.
+	const char *validateCommand(uint8_t group, bool is_tiltrotor, uint8_t &ack_result);
+
+	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};
+	uORB::Subscription _armed_sub{ORB_ID(actuator_armed)};
+	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+
+	uORB::Publication<vehicle_command_ack_s> _command_ack_pub{ORB_ID(vehicle_command_ack)};
+
+	void start(hrt_abstime now, uint8_t group, float input, uint8_t nav_state, const vehicle_command_s &cmd);
+	void stop(uint8_t result, hrt_abstime now);
+	void sendAck(const vehicle_command_s &cmd, uint8_t result, hrt_abstime now);
+
+	bool _running{false};
+	struct ActiveCheck {
+		uint8_t           group;
+		float             input;
+		hrt_abstime       started;
+		uint8_t           started_nav_state;
+		vehicle_command_s last_command;
+	} _active_check{};
+};

--- a/src/modules/control_allocator/CMakeLists.txt
+++ b/src/modules/control_allocator/CMakeLists.txt
@@ -44,6 +44,8 @@ px4_add_module(
 	SRCS
 		ControlAllocator.cpp
 		ControlAllocator.hpp
+		ActuatorGroupPreflightCheck.cpp
+		ActuatorGroupPreflightCheck.hpp
 	MODULE_CONFIG
 		module.yaml
 	DEPENDS

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -371,6 +371,9 @@ ControlAllocator::Run()
 	const hrt_abstime now = hrt_absolute_time();
 	const float dt = math::constrain(((now - _last_run) / 1e6f), 0.0002f, 0.02f);
 
+	_actuator_group_preflight_check.handleCommand(now, _effectiveness_source_id == EffectivenessSource::TILTROTOR_VTOL);
+	_actuator_group_preflight_check.updateState(now);
+
 	bool do_update = false;
 	vehicle_torque_setpoint_s vehicle_torque_setpoint;
 	vehicle_thrust_setpoint_s vehicle_thrust_setpoint;
@@ -417,6 +420,8 @@ ControlAllocator::Run()
 				c[1](5) = vehicle_thrust_setpoint.xyz[2];
 			}
 		}
+
+		_actuator_group_preflight_check.applyOverrides(c, _is_vtol, *_actuator_effectiveness);
 
 		for (int i = 0; i < _num_control_allocation; ++i) {
 
@@ -624,6 +629,7 @@ ControlAllocator::publish_control_allocator_status(int matrix_index)
 {
 	control_allocator_status_s control_allocator_status{};
 	control_allocator_status.timestamp = hrt_absolute_time();
+	control_allocator_status.actuator_group_preflight_check_active = _actuator_group_preflight_check.isActive();
 
 	// TODO: disabled motors (?)
 

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -54,6 +54,8 @@
 #include <ActuatorEffectivenessHelicopterCoaxial.hpp>
 #include <ActuatorEffectivenessSpacecraft.hpp>
 
+#include "ActuatorGroupPreflightCheck.hpp"
+
 #include <ControlAllocation.hpp>
 #include <ControlAllocationPseudoInverse.hpp>
 #include <ControlAllocationSequentialDesaturation.hpp>
@@ -219,6 +221,8 @@ private:
 	// For example, the system might report two motor failures, but only the first one is handled by CA
 	uint16_t _handled_motor_failure_bitmask{0};
 	uint16_t _motor_stop_mask{0};
+
+	ActuatorGroupPreflightCheck _actuator_group_preflight_check;
 
 	perf_counter_t	_loop_perf;			/**< loop duration performance counter */
 

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
@@ -124,14 +124,45 @@ void ActuatorEffectivenessTiltrotorVTOL::allocateAuxilaryControls(const float dt
 
 }
 
+void ActuatorEffectivenessTiltrotorVTOL::overrideCollectiveTilt(bool do_override, float collective_tilt)
+{
+	// When set, updateSetpoint() takes the collective tilt from
+	// _collective_tilt_normalized_setpoint instead of the uORB message and
+	// drives the tilt actuators even when motors are not yet spooled up. Used
+	// by the actuator-group preflight check.
+
+	// TODO: revise. This is a pretty hacky way to pass around the
+	// collective tilt setpoint.
+
+	// The main flaw is that overrideCollectiveTilt(false, ...) is
+	// explicitly needed to clear the override.
+
+	// Ideally we would send a separate tiltrotor_extra_controls style
+	// message that contains a flag which enables the necessary override
+	// here, and stop the override if only the usual tiltrotor controls
+	// arrive.
+
+	// But tiltrotor_extra_controls is a hack in the first place and I am
+	// noting this technical debt for the time when it is replaced by a
+	// better way.
+
+	_do_override_collective_tilt = do_override;
+	_collective_tilt_normalized_setpoint = collective_tilt;
+}
+
 void ActuatorEffectivenessTiltrotorVTOL::updateSetpoint(const matrix::Vector<float, NUM_AXES> &control_sp,
 		int matrix_index, ActuatorVector &actuator_sp, const ActuatorVector &actuator_min, const ActuatorVector &actuator_max)
 {
 	// apply tilt
 	if (matrix_index == 0) {
-		tiltrotor_extra_controls_s tiltrotor_extra_controls;
+		tiltrotor_extra_controls_s tiltrotor_extra_controls{};
+		const bool has_tiltrotor_extra_controls = _tiltrotor_extra_controls_sub.copy(&tiltrotor_extra_controls);
 
-		if (_tiltrotor_extra_controls_sub.copy(&tiltrotor_extra_controls)) {
+		if (has_tiltrotor_extra_controls || _do_override_collective_tilt) {
+			if (_do_override_collective_tilt) {
+				tiltrotor_extra_controls.collective_tilt_normalized_setpoint = _collective_tilt_normalized_setpoint;
+			}
+
 			float control_collective_tilt = tiltrotor_extra_controls.collective_tilt_normalized_setpoint * 2.f - 1.f;
 
 			// set control_collective_tilt to exactly -1 or 1 if close to these end points
@@ -165,7 +196,7 @@ void ActuatorEffectivenessTiltrotorVTOL::updateSetpoint(const matrix::Vector<flo
 				if (_tilts.config(i).tilt_direction == ActuatorEffectivenessTilts::TiltDirection::TowardsFront) {
 
 					// as long as throttle spoolup is not completed, leave the tilts in the disarmed position (in hover)
-					if (throttleSpoolupFinished() || _flight_phase != FlightPhase::HOVER_FLIGHT) {
+					if (throttleSpoolupFinished() || _flight_phase != FlightPhase::HOVER_FLIGHT || _do_override_collective_tilt) {
 						actuator_sp(i + _first_tilt_idx) += control_collective_tilt;
 
 					} else {

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
@@ -87,6 +87,8 @@ public:
 
 	void getUnallocatedControl(int matrix_index, control_allocator_status_s &status) override;
 
+	void overrideCollectiveTilt(bool do_override, float collective_tilt) override;
+
 protected:
 	bool _collective_tilt_updated{true};
 	ActuatorEffectivenessRotors _mc_rotors;
@@ -112,6 +114,9 @@ protected:
 	YawTiltSaturationFlags _yaw_tilt_saturation_flags{};
 
 	uORB::Subscription _tiltrotor_extra_controls_sub{ORB_ID(tiltrotor_extra_controls)};
+
+	bool _do_override_collective_tilt{false};
+	float _collective_tilt_normalized_setpoint{0.5f};
 
 private:
 


### PR DESCRIPTION
### Solved Problem

The current control surface preflight check works by sending individual actuator commands over mavlink. This can only be done sequentially, so the control surfaces do not move in a coordinated way, instilling little confidence. 

To conduct an _engine_ preflight check, we currently have to arm in manual / stabilised and give throttle using manual input -- so for pure autonomous operation there is no good option for an engine pre-flight check.

### Solution

Add handling for `{MAV,VEHICLE}_CMD_ACTUATOR_GROUP_TEST`. It causes the allocator to command torque or thrust in the given direction, so the actuators move in coordinated manner as a functional group, as they would in flight.

 - We overwrite the torque / thrust setpoint in the given axis, others are kept intact. 
 - Torque and tilt test lasts 0.5s, thrust test 2s (to account for larger FW vehicles with significant slew rate)
 - Torque and tilt requires being pre-armed, thrust requires being armed. If these are not given when the command comes in, we respond with `TEMPORARILY_REJECTED`, if they stop holding while the check is running it is stopped and we respond with `CANCELLED`
 - If a new check is requested while one is already running, the previous one is also cancelled with corresponding response. 
 - A new `commander actuator_group_test` allows conducting these checks through the mavlink console, regardless of GS implementation of the mavlink command.


### Release note
```
Feature: Actuator group preflight check via `MAV_CMD_ACTUATOR_GROUP_TEST`. Actuators can be tested in functional groups (torque or thrust in each axis, collective tilt).  
```

### Open question / possible nits / alternatives

Sorry if the list is too long. 

Safety:
 - It is possible to give maximum thrust with the thrust check (while armed). While max thrust is a valid use case (vehicle fastened, on catapult, etc) this is a huge footgun for inattentive users. Should we: 
   - restrict it to a lower value in the commander command? -> done
   - give some warning if it is high (double check the vehicle is fastened and clear of obstacles), only running it if the command is repeated within x seconds? 
   - ignore it and hand the responsibility to the user who arms the vehicle / the GS user interface? 
  
Usability
 - `COM_DISARM_PRFLT` makes the feature a bit of a hassle to use. Users  may be inclined to set a higher value. Should we reset the timeout whenever a (thrust) preflight check is running? 

Cleanup:
 - the `commander actuator_group_test` was added mostly for testing -- If you think it's bloat, we can remove it. 
   - If we keep it, I would then add `mavlink_log_critical` alongside all `PX4_WARN` to give feedback also on an actual vehicle
 - We do use a bit over 2 kB flash -- should we gate the feature behind a build flag? 
 - The duration of the checks is currently hardcoded. We could expose it in the mavlink command (falling back to sensible default) or add a param. But I would prefer not to for something that 99% of users will not change 


### Test coverage
 - Verified basic functionality in sim with `gz_standard_vtol`, `gz_tiltrotor_vtol`, `gz_advanced_plane`, calling through the commander.
 - Tested control surfaces and x thrust on hardware (standard VTOL platform) starting through the `commander` interface (not mavlink)
