### PR TITLE
feat(docs): Fix deep-link anchor offset and improve layout stability i…

### DIFF
--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -52,6 +52,27 @@ export default {
     };
     onMounted(() => {
       initZoom();
+      // Re-scroll to hash after fonts/layout settle. Firefox does not re-scroll
+      // after late layout shifts on huge pages (e.g. parameter_reference), so
+      // the initial anchor jump lands far off. Run only on initial load.
+      if (inBrowser && location.hash) {
+        const id = decodeURIComponent(location.hash.slice(1));
+        const fontsReady = document.fonts?.ready ?? Promise.resolve();
+        const loadReady =
+          document.readyState === "complete"
+            ? Promise.resolve()
+            : new Promise((r) =>
+                window.addEventListener("load", r, { once: true })
+              );
+        Promise.all([fontsReady, loadReady]).then(() => {
+          requestAnimationFrame(() =>
+            requestAnimationFrame(() => {
+              const el = document.getElementById(id);
+              if (el) el.scrollIntoView();
+            })
+          );
+        });
+      }
     });
     watch(
       () => route.path,

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -161,6 +161,14 @@
   display: inline; /* block by default set by vitepress */
 }
 
+/* Fix deep-link anchor offset under fixed navbar.
+   Also guards against Firefox layout-shift drift on huge pages (e.g. parameter_reference). */
+html {
+  scroll-padding-top: calc(var(--vp-nav-height, 64px) + 16px);
+}
+:target {
+  scroll-margin-top: calc(var(--vp-nav-height, 64px) + 16px);
+}
 
 /**
  * Custom style to hide search on the ome page


### PR DESCRIPTION
## Issue

  When jumping to a parameter like [VTQ_NUM_CVS](https://docs.px4.io/main/en/advanced_config/parameter_reference.html#VTQ_NUM_CVS) from another doc page, I often landed somewhere else (mid-section, several parameters down).

  ## Solution
  Fix anchor deep-link drift on docs.px4.io (e.g. `parameter_reference.html#COM_ARM_ODID`). Anchors landed under fixed navbar in all browsers, and far off-section in Firefox on huge pages.                                                                                                
   
  ## Cause                                                                                                                                                                                                                                                                                  
                                                         
  1. No `scroll-padding-top` / `scroll-margin-top` — anchor hidden under VitePress navbar (~64px).                                                                                                                                                                                          
  2. On `parameter_reference.html` (~45k source lines, thousands of headings/tables), browser scrolls at parse time. Web fonts + progressive table layout shift content after. Firefox does not re-scroll once layout settles; Chrome's paint-holding masks it.
                                                                                                                                                                                                                                                                                            
  ## Fix                                                 
                                                                                                                                                                                                                                                                                            
  - `docs/.vitepress/theme/style.css` — `html { scroll-padding-top }` + `:target { scroll-margin-top }` using `--vp-nav-height` (fallback 64px) + 16px.                                                                                                                                     
  - `docs/.vitepress/theme/index.js` — on mount, if `location.hash` set, wait for `document.fonts.ready` + `window.load` + 2× `rAF`, then re-run `scrollIntoView()`. Initial-load only.
                                                                                                                                                                                                                                                                                            
  Mirror of [mavlink/mavlink-devguide#697](https://github.com/mavlink/mavlink-devguide/pull/697) — same VitePress theme, same bug.                                                                                                                                                          
                                                                                                                                                                                                                                                                                            
  ## Before / After                                                                                                                                                                                                                                                                         
https://github.com/user-attachments/assets/4c945871-47d8-485b-9d63-532e0d363a4e

                                                                                                                                                                                                                                            
                                                         
  **After (Firefox, fixed):**

https://github.com/user-attachments/assets/ac318dc2-d602-49a0-9d75-79d75ec83f21

  ## Test plan

  - [x] Firefox: `/en/advanced_config/parameter_reference.html#VTQ_NUM_CVS` lands on heading                                                                                                                                                                                               
  - [x] Chrome: same URLs — no regression, no double-jump flicker                                                                                                                                                                     
