### PR TITLE
feat(uorb): add SOURCE_LEO to AGP-msg source-enum

### DIFF
--- a/msg/versioned/AuxGlobalPosition.msg
+++ b/msg/versioned/AuxGlobalPosition.msg
@@ -17,6 +17,7 @@ uint8 SOURCE_PSEUDOLITES = 3 # Pseudolites
 uint8 SOURCE_TERRAIN = 4 # Terrain
 uint8 SOURCE_MAGNETIC = 5 # Magnetic
 uint8 SOURCE_ESTIMATOR = 6 # Estimator
+uint8 SOURCE_LEO = 7 # Low Earth Orbit satellite-based positioning
 
 # lat, lon: required for horizontal position fusion, alt: required for vertical position fusion
 float64 lat # [deg] Latitude in WGS84


### PR DESCRIPTION
### Solved Problem & Solution
The mavlink message `GLOBAL_POSITION_SENSOR ` now also supports `GLOBAL_POSITION_SRC_LEO` for low-earth-orbit satellite systems ([here](https://github.com/mavlink/mavlink/pull/2475)).

We only need to add this enum entry to the AGP uorb message to log it correctly, otherwise there's not diff needed on the PX4 side.