### PR TITLE
fix(ekf2): disable mag fusion while constant_pos is active

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
@@ -186,17 +186,16 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 							       && !_control_status.flags.mag_field_disturbed
 							       && !_control_status.flags.ev_yaw
 							       && !_control_status.flags.gnss_yaw
-							       && (!_control_status.flags.yaw_manual || _control_status.flags.mag_aligned_in_flight);
+							       && (!_control_status.flags.yaw_manual || _control_status.flags.mag_aligned_in_flight)
+							       && !_control_status.flags.constant_pos;
 
 			_control_status.flags.mag_3D = common_conditions_passing
 						       && (_params.ekf2_mag_type == static_cast<int32_t>(MagFuseType::AUTO))
-						       && _control_status.flags.mag_aligned_in_flight
-						       && !_control_status.flags.constant_pos;
+						       && _control_status.flags.mag_aligned_in_flight;
 
 			_control_status.flags.mag_hdg = common_conditions_passing
 							&& ((_params.ekf2_mag_type == static_cast<int32_t>(MagFuseType::HEADING))
-							    || (_params.ekf2_mag_type == static_cast<int32_t>(MagFuseType::AUTO) && !_control_status.flags.mag_3D))
-							&& !_control_status.flags.constant_pos;
+							    || (_params.ekf2_mag_type == static_cast<int32_t>(MagFuseType::AUTO) && !_control_status.flags.mag_3D));
 		}
 
 		if (_control_status.flags.mag_3D && !_control_status_prev.flags.mag_3D) {

--- a/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
@@ -190,11 +190,13 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 
 			_control_status.flags.mag_3D = common_conditions_passing
 						       && (_params.ekf2_mag_type == static_cast<int32_t>(MagFuseType::AUTO))
-						       && _control_status.flags.mag_aligned_in_flight;
+						       && _control_status.flags.mag_aligned_in_flight
+						       && !_control_status.flags.constant_pos;
 
 			_control_status.flags.mag_hdg = common_conditions_passing
 							&& ((_params.ekf2_mag_type == static_cast<int32_t>(MagFuseType::HEADING))
-							    || (_params.ekf2_mag_type == static_cast<int32_t>(MagFuseType::AUTO) && !_control_status.flags.mag_3D));
+							    || (_params.ekf2_mag_type == static_cast<int32_t>(MagFuseType::AUTO) && !_control_status.flags.mag_3D))
+							&& !_control_status.flags.constant_pos;
 		}
 
 		if (_control_status.flags.mag_3D && !_control_status_prev.flags.mag_3D) {


### PR DESCRIPTION

### Solved problem
During fixed-wing catapult pre-launch (motors ramped), EKF the heading can drift around significantly (>20°) while position stays pinned by `constant_pos`. The integrated raw `gyro_z` would stay mostly consistent and raw mag body-frame readings barely move, so the drift is purely in the estimator, not physical motion.

Cause: with `mag_hdg = 1` and `in_air = 0`, `fuseMag` runs and adjusts the heading estimate. While position is pinned and we're not giving the EKF any other yaw reference, the mag is free to pull on yaw.

### Solution
Gate `mag_hdg` and `mag_3D` off whenever `constant_pos` is active. While position is pinned, yaw aiding by mag is also suppressed, mirroring how `constant_pos` already disables horizontal position aiding. Mag re-engages automatically on the next cycle once `constant_pos` clears (launch detected).

The same protection already exists when the operator sets heading manually via MAV_CMD: that path sets `yaw_manual = true`, which already disables mag fusion until takeoff. This change applies the same idea to the default catapult workflow when no manual heading is sent.

### Changelog
- `mag_control.cpp`: add `&& !_control_status.flags.constant_pos` to the `mag_3D` and `mag_hdg` enable conditions.

### Alternative
A `fake_yaw` aid source mirroring `fake_pos_control.cpp` would also pin yaw actively, but this would be over-engineered.
