### PR TITLE
docs(docs): Hide the sidebar on the failsafe simulation page

### DIFF
--- a/docs/en/config/safety_simulation.md
+++ b/docs/en/config/safety_simulation.md
@@ -1,3 +1,7 @@
+---
+aside: false
+---
+
 # Failsafe State Machine Simulation
 
 <Badge type="tip" text="PX4 v1.14" />


### PR DESCRIPTION
The failsafe simulation wasn't allowing you to select right-side options because these were being overlayed by the (invisible) right-side TOC. This minor change to the frontmatter turns off the TOC. Works locally. 