### PR TITLE
feat(boards/px4_fmu-v6c): support internal RM3100 compass on Holybro FMUv6C variants

### DIFF
--- a/boards/px4/fmu-v6c/init/rc.board_sensors
+++ b/boards/px4/fmu-v6c/init/rc.board_sensors
@@ -25,7 +25,11 @@ fi
 ms5611 -X -b 4 -a 0x77 start
 
 # Internal compass on IMU I2C4 (The same bus is also exposed externally, and therefore marked as external)
-ist8310 -X -b 4 -a 0xc  start
+# Standard FMUv6C uses IST8310; the variant board falls back to RM3100.
+if ! ist8310 -X -b 4 -a 0xc -q start
+then
+	rm3100 -X -b 4 -R 8 start
+fi
 
 # External compass on GPS/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
 ist8310 -X -b 1 -R 10 start

--- a/boards/px4/fmu-v6c/src/i2c.cpp
+++ b/boards/px4/fmu-v6c/src/i2c.cpp
@@ -71,6 +71,17 @@ bool px4_i2c_device_external(const uint32_t device_id)
 		if (device_id_mag.devid == device_id) {
 			return false;
 		}
+
+		// device_id: RM3100 on I2C4 address 0x20
+		device::Device::DeviceId device_id_rm3100{};
+		device_id_rm3100.devid_s.bus_type = device::Device::DeviceBusType_I2C;
+		device_id_rm3100.devid_s.bus = 4;
+		device_id_rm3100.devid_s.address = 0x20;
+		device_id_rm3100.devid_s.devtype = DRV_MAG_DEVTYPE_RM3100;
+
+		if (device_id_rm3100.devid == device_id) {
+			return false;
+		}
 	}
 
 	device::Device::DeviceId dev_id{};


### PR DESCRIPTION
### Solved Problem

Some Holybro FMUv6C variants use an internal RM3100 compass on I2C4.
The standard FMUv6C board startup only probes the internal IST8310, so these variants do not bring up their onboard magnetometer correctly.

### Solution

- In `rc.board_sensors`, probe IST8310 first with `-q`; if it is not present, fall back to RM3100 on the same bus.
- In `px4_i2c_device_external()`, add an RM3100 device ID match for I2C4 at address `0x20` so the board treats it as an internal compass.
- The RM3100 variant uses `ROTATION_ROLL_180` (`-R 8`).

Standard FMUv6C hardware is unaffected because the RM3100 path only runs when IST8310 is not detected.

### Changelog Entry

```
Feature: support internal RM3100 compass on Holybro FMUv6C variants
```

### Test coverage

No flight test was performed. This change only affects board startup and device classification, not driver logic.

Validation:
- `make px4_fmu-v6c_default` builds successfully
- Bench-tested on FMUv6C variant with internal RM3100
- RM3100 detected at startup
- Magnetometer calibration completes successfully
- Coarse phone-compass cross-checks showed consistent RM3100 heading behavior across multiple orientations.
