### PR TITLE
fix(ekf2): allow external position reset heading correction

### DIFF
--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -356,6 +356,11 @@ bool Ekf::resetGlobalPosToExternalObservation(const double latitude, const doubl
 		} else {
 			ECL_INFO("fuse external observation as position measurement");
 
+			// External position reset by fusion can correct heading through cross-correlations.
+			// Setting heading_observable = true prevents clearInhibitedStateKalmanGains() from
+			// inhibiting the update.
+			_control_status.flags.heading_observable = true;
+
 			VectorState H;
 			VectorState K;
 			Vector2f innov_var_temp = Vector2f(getStateVariance<State::pos>()) + 0.1f;


### PR DESCRIPTION
### Solved Problem
Fixes heading correction inhibition in the `VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE` reset-by-fusion path.

This is the same class of bug as #27232. VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE is handled in `EKF2::Run()` before `_ekf.update()`, so `heading_observable` can still reflect the previous `controlFusionModes()` result.

The affected reset-by-fusion path explicitly intends to correct correlated states. The existing comment in `src/modules/ekf2/EKF/ekf.cpp` says the artificial Kalman gain increase:

```cpp
// Artificially setting the observation variance to a small value to
// increase the Kalman gain to basically 1 to force a reset of the position
// through fusion. This also enforces a strong correction of the correlated states
// (e.g.: velocity, heading, wind)
// The update of the covariance matrix is still performed with the correct observation variance
// to not artificially reduce the state uncertainty and cross-correlations.
```
However, this path calls `clearInhibitedStateKalmanGains(K)` before `fuse(K, innov(index))`. When stale `heading_observable` is false, that helper zeros the heading gain:
```cpp
if (!_control_status.flags.heading_observable) {
    K(State::quat_nominal.idx + 2) = 0.f;
}
```
`measurementUpdate()` also calls `clearInhibitedStateKalmanGains(K)` again, and then `constrainStateVariances()` can remove heading cross-correlations while `heading_observable` is false. As a result, the external position reset may fail to apply the intended heading correction.

### Solution

Set `_control_status.flags.heading_observable = true` before fusing the external position observation in `Ekf::resetGlobalPosToExternalObservation()`.

This preserves the documented correction of correlated states during the reset operation. The normal EKF update path recomputes `heading_observable` afterwards in `controlFusionModes()`:
```cpp
_control_status.flags.heading_observable = isNorthEastAidingActive() || yaw_aiding;
```
### Changelog Entry
For release notes:
```
Bugfix: EKF2 external position reset now preserves the intended heading correction through correlated states.
```
### Test coverage
SITL