### PR TITLE
fix(ekf2): guard EV position bias updates on active fusion

### DIFF
--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -201,7 +201,11 @@ bool Ekf::resetLatLonTo(const double latitude, const double longitude, const flo
 	const Vector2f delta_horz_pos = getLocalHorizontalPosition() - pos_prev;
 
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
-	_ev_pos_b_est.setBias(_ev_pos_b_est.getBias() - delta_horz_pos);
+
+	if (_control_status.flags.ev_pos) {
+		_ev_pos_b_est.setBias(_ev_pos_b_est.getBias() - delta_horz_pos);
+	}
+
 #endif // CONFIG_EKF2_EXTERNAL_VISION
 
 	updateHorizontalPositionResetStatus(delta_horz_pos);

--- a/src/modules/ekf2/EKF/position_fusion.cpp
+++ b/src/modules/ekf2/EKF/position_fusion.cpp
@@ -107,7 +107,6 @@ void Ekf::resetHorizontalPositionTo(const double &new_latitude, const double &ne
 	}
 
 #endif // CONFIG_EKF2_EXTERNAL_VISION
-	//_gps_pos_b_est.setBias(_gps_pos_b_est.getBias() + _state_reset_status.posNE_change);
 
 	_gpos.setLatLonDeg(new_latitude, new_longitude);
 	_output_predictor.resetLatLonTo(new_latitude, new_longitude);

--- a/src/modules/ekf2/EKF/position_fusion.cpp
+++ b/src/modules/ekf2/EKF/position_fusion.cpp
@@ -101,7 +101,11 @@ void Ekf::resetHorizontalPositionTo(const double &new_latitude, const double &ne
 	updateHorizontalPositionResetStatus(delta_horz_pos);
 
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
-	_ev_pos_b_est.setBias(_ev_pos_b_est.getBias() - delta_horz_pos);
+
+	if (_control_status.flags.ev_pos) {
+		_ev_pos_b_est.setBias(_ev_pos_b_est.getBias() - delta_horz_pos);
+	}
+
 #endif // CONFIG_EKF2_EXTERNAL_VISION
 	//_gps_pos_b_est.setBias(_gps_pos_b_est.getBias() + _state_reset_status.posNE_change);
 


### PR DESCRIPTION
### Solved Problem
Fixes the EV horizontal position version of the bug pattern addressed in #27094.

`resetAltitudeTo()` only adjusts `_ev_hgt_b_est` when EV height fusion is active via `_control_status.flags.ev_hgt`. The horizontal reset paths were missing the equivalent guard and always adjusted `_ev_pos_b_est`.

Those paths can be reached from normal horizontal/global position resets, such as GNSS/global position reset handling, even when EV position fusion is not currently active.

### Solution

Only shift the EV position bias estimator during horizontal position resets when EV position fusion is active:

```cpp
if (_control_status.flags.ev_pos) {
	_ev_pos_b_est.setBias(_ev_pos_b_est.getBias() - delta_horz_pos);
}
```

This was applied to:

- `Ekf::resetHorizontalPositionTo()`
- `Ekf::resetLatLonTo()`

This matches the existing `resetAltitudeTo()` guard used for EV height bias.

### Changelog Entry
For release notes:
```
Bugfix: Guard external vision position bias updates during EKF horizontal position resets
```
### Test coverage
SITL