### PR TITLE
fix(airspeed_selector): guard synthetic source in sensor validity check

### DIFF
--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -639,7 +639,7 @@ void AirspeedModule::select_airspeed_and_publish()
 	bool airspeed_sensor_switching_necessary = false;
 	const int prev_airspeed_index = static_cast<int>(_prev_airspeed_src);
 
-	if (_prev_airspeed_src < AirspeedSource::SENSOR_1) {
+	if (_prev_airspeed_src < AirspeedSource::SENSOR_1 || _prev_airspeed_src > AirspeedSource::SENSOR_3) {
 		airspeed_sensor_switching_necessary = true;
 
 	} else {


### PR DESCRIPTION
### Solved Problem
`AirspeedModule::select_airspeed_and_publish()` can access `_airspeed_validator` out of bounds when the previously selected airspeed source is synthetic airspeed.

This was introduced across the synthetic airspeed commits. `c3c863ad95 AirspeedSelector: clean up in preparation of synthetic airspeed` converted the previous integer source tracking to `AirspeedSource` and added `SYNTHETIC` after `SENSOR_3`:

```cpp
enum class AirspeedSource : int {
	DISABLED = -1,
	GROUND_MINUS_WIND,
	SENSOR_1,
	SENSOR_2,
	SENSOR_3,
	SYNTHETIC
};
```

With this ordering, `SYNTHETIC` has integer value `4`. The previous-source check still kept the old assumption that every source greater than or equal to `SENSOR_1` is a physical sensor:

```cpp
if (_prev_airspeed_src < AirspeedSource::SENSOR_1) {
	airspeed_sensor_switching_necessary = true;

} else {
	airspeed_sensor_switching_necessary = !_airspeed_validator[prev_airspeed_index - 1].get_airspeed_valid();
}
```

That assumption became unsafe once `5842c991ec AirspeedSelector: add synthetic airspeed option` made synthetic airspeed selectable through `ASPD_PRIMARY = 4` and `ASPD_FALLBACK = 2`. The selected source can become `SYNTHETIC`:

```cpp
_valid_airspeed_src = AirspeedSource::SYNTHETIC;
```

and is then stored as the previous source for the next cycle:

```cpp
_prev_airspeed_src = _valid_airspeed_src;
```

On the next invocation, `_prev_airspeed_src == AirspeedSource::SYNTHETIC` gives `prev_airspeed_index == 4`, so the existing validator check reads `_airspeed_validator[3]`. However, `_airspeed_validator` is sized for the three physical sensors only:

```cpp
static constexpr int MAX_NUM_AIRSPEED_SENSORS = 3;
AirspeedValidator _airspeed_validator[MAX_NUM_AIRSPEED_SENSORS] {};
```

so its valid indices are only `0..2`.

### Solution

Treat sources above `SENSOR_3` as non-sensor sources before indexing `_airspeed_validator`:

```cpp
if (_prev_airspeed_src < AirspeedSource::SENSOR_1 || _prev_airspeed_src > AirspeedSource::SENSOR_3) {
	airspeed_sensor_switching_necessary = true;

} else {
	airspeed_sensor_switching_necessary = !_airspeed_validator[prev_airspeed_index - 1].get_airspeed_valid();
}
```

This keeps validator access limited to `SENSOR_1..SENSOR_3`.

### Changelog Entry
For release notes:
```
Bugfix: prevent out-of-bounds airspeed validator access when synthetic airspeed was previously selected
```