### PR TITLE
fix(navigator): guard terrain altitude check for position mission items

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -1016,6 +1016,7 @@ void MissionBlock::updateAltToAvoidTerrainCollisionAndRepublishTriplet(const mis
 	if (_navigator->get_nav_min_gnd_dist_param() > FLT_EPSILON && _mission_item.nav_cmd != NAV_CMD_LAND
 	    && _mission_item.nav_cmd != NAV_CMD_VTOL_LAND && _mission_item.nav_cmd != NAV_CMD_DO_VTOL_TRANSITION
 	    && _mission_item.nav_cmd != NAV_CMD_IDLE
+	    && item_contains_position(mission_item)
 	    && _navigator->get_local_position()->dist_bottom_valid
 	    && _navigator->get_local_position()->dist_bottom < _navigator->get_nav_min_gnd_dist_param()
 	    && _navigator->get_local_position()->vz > FLT_EPSILON

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -1004,7 +1004,7 @@ void MissionBlock::startPrecLand(uint16_t land_precision)
 void MissionBlock::updateAltToAvoidTerrainCollisionAndRepublishTriplet(const mission_item_s &mission_item)
 {
 	// Avoid flying into terrain using the distance sensor. Enable through the parameter NAV_MIN_GND_DIST.
-	// Only active during commanded descents with vz>0 (to prevent climb-aways), excluding landing and VTOL transitions.
+	// Only active during commanded descents with vz>0 (to prevent climb-aways) on position mission items, excluding landing.
 	// It changes the altitude setpoint in the triplet to maintain the current altitude and republish the triplet.
 	// We also change the mission item altitude used for acceptance calculations to prevent getting stuck in a loop.
 
@@ -1014,8 +1014,7 @@ void MissionBlock::updateAltToAvoidTerrainCollisionAndRepublishTriplet(const mis
 
 
 	if (_navigator->get_nav_min_gnd_dist_param() > FLT_EPSILON && _mission_item.nav_cmd != NAV_CMD_LAND
-	    && _mission_item.nav_cmd != NAV_CMD_VTOL_LAND && _mission_item.nav_cmd != NAV_CMD_DO_VTOL_TRANSITION
-	    && _mission_item.nav_cmd != NAV_CMD_IDLE
+	    && _mission_item.nav_cmd != NAV_CMD_VTOL_LAND
 	    && item_contains_position(mission_item)
 	    && _navigator->get_local_position()->dist_bottom_valid
 	    && _navigator->get_local_position()->dist_bottom < _navigator->get_nav_min_gnd_dist_param()


### PR DESCRIPTION
### Solved Problem

`updateAltToAvoidTerrainCollisionAndRepublishTriplet()` used `get_absolute_altitude_for_item()` without first checking whether the current mission item contains a position.

This follows the same bug pattern as #26662: mission altitude handling used the `altitude` field of a non-position mission item, where that field has no setpoint meaning. For items such as `NAV_CMD_DELAY` or DO commands, the altitude can be zero/unused, but the terrain descent condition still treated it as a valid target altitude.

### Solution
Only run the terrain-collision altitude check for mission items that contain a position by adding an `item_contains_position(mission_item)` guard before reading the mission item altitude.

Landing and VTOL landing exclusions remain unchanged, as those are position items but should still be excluded from this terrain avoidance path.

### Changelog Entry
For release notes:
```text
Bugfix: prevent mission terrain avoidance from using altitude fields of non-position mission items
```
### Test coverage

One way to reproduce in SITL:

1. Start a vehicle with a downward distance sensor:
   ```sh
   make px4_sitl gz_x500_lidar_down
   ```

2. Set `NAV_MIN_GND_DIST` above the expected delay altitude, for example:
   ```sh
   param set NAV_MIN_GND_DIST 6.5
   ```

3. Upload a mission like:
   ```text
    QGC WPL 110
    0	1	3	22	0	0	0	0	47.3979711	8.5455940	20	1
    1	0	3	16	0	0	0	0	47.3979711	8.5455940	5	1
    2	0	2	93	30	0	0	0	0	0	0	1
    3	0	2	20	0	0	0	0	0	0	0	1
   ```

4. Run the mission.

If the vehicle enters `NAV_CMD_DELAY` while still slightly descending and `dist_bottom < NAV_MIN_GND_DIST`, the unpatched code can emit:

```text
Terrain collision risk, descent is stopped
```

The warning is caused by the delay item's unused altitude being treated as a valid descent target.

From the expected behavior of `NAV_CMD_DELAY`, this warning should not be produced by the delay item itself. `DELAY` pauses mission progression and keeps the existing position setpoint; it does not define a new position or altitude target, and therefore should not be used as the mission item altitude source for terrain descent avoidance.

log before patch:
https://logs.px4.io/plot_app?log=b8349f64-91f4-4406-bf54-b9593fecd7a5

log after patch:
https://logs.px4.io/plot_app?log=619965fc-e603-4fc1-89a7-95acfec5cd5e

before:
<img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/c51a7c60-77fe-4511-88be-a501bf34b789" />

after:
<img width="1920" height="1080" alt="after" src="https://github.com/user-attachments/assets/3ce5d5cc-1422-4d75-a34f-589e0ad318cb" />