### PR TITLE
fix(drivers/distance_sensor/vl53l1x): map rangestatus to quality

### DIFF
--- a/src/drivers/distance_sensor/vl53l1x/vl53l1x.cpp
+++ b/src/drivers/distance_sensor/vl53l1x/vl53l1x.cpp
@@ -196,7 +196,7 @@ VL53L1X::~VL53L1X()
 int VL53L1X::collect()
 {
 	uint8_t ret = 0;
-	uint8_t raw_status = 0;
+	uint8_t raw_status = VL53L1X_RANGE_STATUS_OK;
 	uint16_t distance_mm = 0;
 	static constexpr float DOWNWARD_FACING_THETA = -1.57f;
 	static constexpr float RIGHT_PSI = 0.117809725;
@@ -208,7 +208,7 @@ int VL53L1X::collect()
 
 	RangeStatus rangeStatus = static_cast<RangeStatus>(raw_status);
 
-	if ((ret != PX4_OK) | (rangeStatus == RangeStatus::RoiOutOfBounds)) {
+	if ((ret != PX4_OK) || (rangeStatus == RangeStatus::RoiOutOfBounds)) {
 		perf_count(_comms_errors);
 		perf_end(_sample_perf);
 		return PX4_ERROR;
@@ -217,16 +217,9 @@ int VL53L1X::collect()
 	int8_t quality = 0;
 
 	if (rangeStatus == RangeStatus::Ok) {
-		if (_status_error_count > 0) { _status_error_count--; }
-
 		quality = 100;
 
-	} else if (rangeStatus == RangeStatus::SigmaFail || rangeStatus == RangeStatus::SignalFail) {
-		_status_error_count++;
-		quality = (_status_error_count < STATUS_HYSTERESIS_MAX) ? 50 : 0;
-
 	} else {
-		_status_error_count = STATUS_HYSTERESIS_MAX;
 		quality = 0;
 	}
 
@@ -250,8 +243,7 @@ int VL53L1X::collect()
 
 	perf_end(_sample_perf);
 
-	float distance_m_raw = distance_mm / 1000.f;
-	float distance_m = _distance_filter.apply(distance_m_raw);
+	float distance_m = distance_mm / 1000.f;
 	float psi = 0.f;
 	float theta = 0.f;
 

--- a/src/drivers/distance_sensor/vl53l1x/vl53l1x.cpp
+++ b/src/drivers/distance_sensor/vl53l1x/vl53l1x.cpp
@@ -42,7 +42,6 @@
 #define VL53L1X_INTER_MEAS_MS				           250 // ms
 #define VL53L1X_SHORT_RANGE			            1  // sub-2 meter distance mode
 #define VL53L1X_LONG_RANGE			            2  // sub-4 meter distance mode
-#define VL53L1X_RANGE_STATUS_OUT_OF_BOUNDS     13 // region of interest out of bounds error
 #define VL53L1X_RANGE_STATUS_OK                 0 // range status ok
 #define VL53L1X_ROI_MID_RIGHT                 231 // ROI middle right of optical center
 #define VL53L1X_ROI_MID_LEFT                  167 // ROI middle left of optical center
@@ -197,7 +196,7 @@ VL53L1X::~VL53L1X()
 int VL53L1X::collect()
 {
 	uint8_t ret = 0;
-	uint8_t rangeStatus = VL53L1X_RANGE_STATUS_OK;
+	uint8_t raw_status = 0;
 	uint16_t distance_mm = 0;
 	static constexpr float DOWNWARD_FACING_THETA = -1.57f;
 	static constexpr float RIGHT_PSI = 0.117809725;
@@ -205,12 +204,30 @@ int VL53L1X::collect()
 	perf_begin(_sample_perf);
 
 
-	const int8_t quality = VL53L1X_GetRangeStatus(&rangeStatus);
+	ret = VL53L1X_GetRangeStatus(&raw_status);
 
-	if ((ret != PX4_OK) | (rangeStatus == VL53L1X_RANGE_STATUS_OUT_OF_BOUNDS)) {
+	RangeStatus rangeStatus = static_cast<RangeStatus>(raw_status);
+
+	if ((ret != PX4_OK) | (rangeStatus == RangeStatus::RoiOutOfBounds)) {
 		perf_count(_comms_errors);
 		perf_end(_sample_perf);
 		return PX4_ERROR;
+	}
+
+	int8_t quality = 0;
+
+	if (rangeStatus == RangeStatus::Ok) {
+		if (_status_error_count > 0) { _status_error_count--; }
+
+		quality = 100;
+
+	} else if (rangeStatus == RangeStatus::SigmaFail || rangeStatus == RangeStatus::SignalFail) {
+		_status_error_count++;
+		quality = (_status_error_count < STATUS_HYSTERESIS_MAX) ? 50 : 0;
+
+	} else {
+		_status_error_count = STATUS_HYSTERESIS_MAX;
+		quality = 0;
 	}
 
 	const hrt_abstime timestamp_sample = hrt_absolute_time();
@@ -233,7 +250,8 @@ int VL53L1X::collect()
 
 	perf_end(_sample_perf);
 
-	float distance_m = distance_mm / 1000.f;
+	float distance_m_raw = distance_mm / 1000.f;
+	float distance_m = _distance_filter.apply(distance_m_raw);
 	float psi = 0.f;
 	float theta = 0.f;
 

--- a/src/drivers/distance_sensor/vl53l1x/vl53l1x.hpp
+++ b/src/drivers/distance_sensor/vl53l1x/vl53l1x.hpp
@@ -48,6 +48,7 @@
 #include <drivers/drv_hrt.h>
 #include <lib/perf/perf_counter.h>
 #include <lib/drivers/rangefinder/PX4Rangefinder.hpp>
+#include <lib/mathlib/math/filter/MedianFilter.hpp>
 #include <matrix/math.hpp>
 /* ST */
 #define SOFT_RESET                                          0x0000
@@ -101,7 +102,17 @@ class VL53L1X : public device::I2C, public I2CSPIDriver<VL53L1X>
 {
 public:
 	VL53L1X(const I2CSPIDriverConfig &config);
-
+	enum class RangeStatus : uint8_t {
+		Ok = 0,
+		SigmaFail = 1,
+		SignalFail = 2,
+		RangeValidMinRangeClipped = 3,
+		OutOfBounds = 4,
+		HardwareFail = 5,
+		RangeValidNoUpdate = 6,
+		Wraparound = 7,
+		RoiOutOfBounds = 13
+	};
 	~VL53L1X() override;
 
 	static void print_usage();
@@ -156,6 +167,10 @@ private:
 	int8_t VL53L1X_SetInterMeasurementInMs(uint32_t InterMeasurementInMs);
 	int8_t VL53L1X_SetROICenter(uint8_t data);
 	int8_t VL53L1X_SetROI(uint16_t x, uint16_t y);
+
+	math::MedianFilter<float, 3> _distance_filter;
+	int _status_error_count{0};
+	static constexpr int STATUS_HYSTERESIS_MAX = 3;
 	PX4Rangefinder    _px4_rangefinder;
 	Rotation _sensor_orientation{ROTATION_PITCH_270};
 	perf_counter_t _comms_errors{perf_alloc(PC_COUNT, MODULE_NAME": com_err")};

--- a/src/drivers/distance_sensor/vl53l1x/vl53l1x.hpp
+++ b/src/drivers/distance_sensor/vl53l1x/vl53l1x.hpp
@@ -33,8 +33,9 @@
 
 /**
  * @file vl53l1x.hpp
- *
  * Driver for the ST VL53L1X ToF Sensor connected via I2C.
+ * Datasheet: https://www.st.com/resource/en/datasheet/vl53l1x.pdf
+ * API User Manual: https://www.st.com/resource/en/user_manual/um2356-vl53l1x-api-user-manual-stmicroelectronics.pdf
  */
 
 #pragma once
@@ -106,12 +107,11 @@ public:
 		Ok = 0,
 		SigmaFail = 1,
 		SignalFail = 2,
-		RangeValidMinRangeClipped = 3,
 		OutOfBounds = 4,
 		HardwareFail = 5,
-		RangeValidNoUpdate = 6,
 		Wraparound = 7,
-		RoiOutOfBounds = 13
+		ProcessingFail  = 8,
+		RoiOutOfBounds = 14
 	};
 	~VL53L1X() override;
 
@@ -168,9 +168,6 @@ private:
 	int8_t VL53L1X_SetROICenter(uint8_t data);
 	int8_t VL53L1X_SetROI(uint16_t x, uint16_t y);
 
-	math::MedianFilter<float, 3> _distance_filter;
-	int _status_error_count{0};
-	static constexpr int STATUS_HYSTERESIS_MAX = 3;
 	PX4Rangefinder    _px4_rangefinder;
 	Rotation _sensor_orientation{ROTATION_PITCH_270};
 	perf_counter_t _comms_errors{perf_alloc(PC_COUNT, MODULE_NAME": com_err")};


### PR DESCRIPTION


### Solved Problem
fix(drivers/distance_sensor/vl53l1x):fixed missing rangestatus to quality conversion

For the quality field being passed for vl53l1x, the raw Rangestatus value seems to be passed. It seems like a traslation layer to convert from raw rangestatus to quality wasn't implemented 
https://github.com/PX4/PX4-Autopilot/blob/78abda4e9bab25a7cd7f251719b2482a746b552c/src/drivers/distance_sensor/vl53l1x/vl53l1x.cpp#L208

### Solution
I have added code for quality to be converted from range status
### Changelog Entry
fix(drivers/distance_sensor/vl53l1x):fixed missing rangestatus to quality conversion




### Context
<img width="1746" height="965" alt="Screenshot from 2026-05-10 01-32-37" src="https://github.com/user-attachments/assets/6b565f14-4693-4c9d-b165-6970268f65ea" />
<img width="1746" height="965" alt="Screenshot from 2026-05-10 02-15-35" src="https://github.com/user-attachments/assets/c3f16ea5-f09d-472a-ac72-28bbaff98e56" />

<img width="769" height="496" alt="image" src="https://github.com/user-attachments/assets/81c4a05a-449e-40f9-b54b-acaea881ebfc" />

Log file testing the changes: https://review.px4.io/plot_app?log=a4b8caf4-07b3-4aec-8145-6664f898d296
Before vs After comparison in which previously , the quality always showed a fixed value of 1, shows 100 after the change for valid measurement.
There also seems to be a translation layer that converts 0 quality to 1 in this context

