### PR TITLE
feat(drivers): VectorNav option to select IMU rate and output port

### DIFF
--- a/docs/en/sensor/vectornav.md
+++ b/docs/en/sensor/vectornav.md
@@ -32,7 +32,8 @@ VectorNav IMU/AHRS, GNSS/INS, and Dual GNSS/INS solutions are available directly
 
 ### Wiring
 
-Connect any unused flight controller serial interface, such as a spare `GPS` or `TELEM` port, to the VectorNav UART2 port (default). If UART1 is used, set [VN_PORT](../advanced_config/parameter_reference.md#VN_PORT) accordingly.
+Connect any unused flight controller serial interface, such as a spare `GPS` or `TELEM` port, to the VectorNav `UART2` port (default).
+If `UART1` is used, set [VN_PORT](../advanced_config/parameter_reference.md#VN_PORT) accordingly.
 
 ### Mounting
 

--- a/docs/en/sensor/vectornav.md
+++ b/docs/en/sensor/vectornav.md
@@ -33,7 +33,7 @@ VectorNav IMU/AHRS, GNSS/INS, and Dual GNSS/INS solutions are available directly
 ### Wiring
 
 Connect any unused flight controller serial interface, such as a spare `GPS` or `TELEM` port, to the VectorNav `UART2` port (default).
-If `UART1` is used, set [VN_PORT](../advanced_config/parameter_reference.md#VN_PORT) accordingly.
+Note that you can also connect to the VectorNav `UART1` port, but in this case you must set [VN_PORT](../advanced_config/parameter_reference.md#VN_PORT) to `1`.
 
 ### Mounting
 

--- a/docs/en/sensor/vectornav.md
+++ b/docs/en/sensor/vectornav.md
@@ -32,7 +32,7 @@ VectorNav IMU/AHRS, GNSS/INS, and Dual GNSS/INS solutions are available directly
 
 ### Wiring
 
-Connect any unused flight controller serial interface, such as a spare `GPS` or `TELEM` port, to the VectorNav UART2 port (required by PX4).
+Connect any unused flight controller serial interface, such as a spare `GPS` or `TELEM` port, to the VectorNav UART2 port (default). If UART1 is used, set [VN_PORT](../advanced_config/parameter_reference.md#VN_PORT) accordingly.
 
 ### Mounting
 

--- a/src/drivers/ins/vectornav/VectorNav.cpp
+++ b/src/drivers/ins/vectornav/VectorNav.cpp
@@ -619,11 +619,13 @@ bool VectorNav::configure()
 	// VnSensor_readGpsCompassBaseline
 
 
+	const AsyncMode async_mode = (_param_vn_port.get() == 1) ? ASYNCMODE_PORT1 : ASYNCMODE_PORT2;
+
 	// binary output 1: max rate IMU
 	BinaryOutputRegister_initialize(
 		&_binary_output_group_1,
-		ASYNCMODE_PORT2,
-		1, // divider
+		async_mode,
+		(uint32_t)_param_vn_imu_rate.get(),
 		COMMONGROUP_NONE,
 		TIMEGROUP_TIMESTARTUP,
 		(ImuGroup)(IMUGROUP_ACCEL | IMUGROUP_ANGULARRATE),
@@ -647,7 +649,7 @@ bool VectorNav::configure()
 	// binary output 2: medium rate AHRS, INS, baro, mag
 	BinaryOutputRegister_initialize(
 		&_binary_output_group_2,
-		ASYNCMODE_PORT2,
+		async_mode,
 		8, // divider
 		COMMONGROUP_NONE,
 		TIMEGROUP_TIMESTARTUP,
@@ -668,7 +670,7 @@ bool VectorNav::configure()
 	// binary output 3: low rate GNSS
 	BinaryOutputRegister_initialize(
 		&_binary_output_group_3,
-		ASYNCMODE_PORT2,
+		async_mode,
 		80, // divider
 		COMMONGROUP_NONE,
 		TIMEGROUP_TIMESTARTUP,

--- a/src/drivers/ins/vectornav/VectorNav.hpp
+++ b/src/drivers/ins/vectornav/VectorNav.hpp
@@ -109,7 +109,9 @@ private:
 
 private:
 	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::VN_MODE>) _param_vn_mode
+		(ParamInt<px4::params::VN_MODE>) _param_vn_mode,
+		(ParamInt<px4::params::VN_PORT>) _param_vn_port,
+		(ParamInt<px4::params::VN_IMU_RATE>) _param_vn_imu_rate
 	)
 	char _port[20] {};
 

--- a/src/drivers/ins/vectornav/module.yaml
+++ b/src/drivers/ins/vectornav/module.yaml
@@ -10,6 +10,19 @@ parameters:
     - group: Sensors
       definitions:
 
+        VN_PORT:
+            description:
+                short: VectorNav output port
+                long: |
+                    Selects which serial port the sensor streams output to.
+            category: System
+            type: enum
+            values:
+                1: Port 1
+                2: Port 2
+            default: 2
+            reboot_required: true
+
         VN_MODE:
             description:
                 short: VectorNav driver mode
@@ -20,3 +33,20 @@ parameters:
                 0: Sensors Only (default)
                 1: INS
             default: 0
+
+        VN_IMU_RATE:
+            description:
+                short: VectorNav IMU output rate
+                long: |
+                    Rate of the IMU output.
+                    The VectorNav base rate is 800 Hz. This parameter sets the
+                    divider, so the effective rate is 800 / divider.
+            category: System
+            type: enum
+            values:
+                1: 800 Hz
+                2: 400 Hz
+                4: 200 Hz
+                8: 100 Hz
+            default: 1
+            reboot_required: true


### PR DESCRIPTION
### Solved Problem

- The user may want to connect to a different port on the VectorNav
- The user may want a different IMU output rate (as it currently causes very high CPU load)

### Solution

- Add parameters for both

### Test coverage

- Tested with a v6x and a VN 210 S

