### PR TITLE
feat(uavcan): param for enabling/disabling tracing

### DIFF
--- a/boards/auterion/fmu-v6s/init/rc.board_defaults
+++ b/boards/auterion/fmu-v6s/init/rc.board_defaults
@@ -9,6 +9,8 @@ param set-default SYS_DM_BACKEND 1
 param set-default MAV_0_CONFIG 0
 # Disable logger writing to FRAM, only stream over MAVLINK
 param set-default SDLOG_BACKEND 2
+# Disable UAVCAN tracing
+param set-default UAVCAN_TRACE_EN 0
 
 # 200kOhm/10kOhm voltage divider on V_BAT
 param set-default BAT1_V_DIV 21

--- a/src/drivers/uavcan/uavcan_drivers/posix/include/uavcan_posix/dynamic_node_id_server/file_event_tracer.hpp
+++ b/src/drivers/uavcan/uavcan_drivers/posix/include/uavcan_posix/dynamic_node_id_server/file_event_tracer.hpp
@@ -37,10 +37,13 @@ class FileEventTracer : public uavcan::dynamic_node_id_server::IEventTracer
 	typedef uavcan::MakeString<MaxPathLength>::Type PathString;
 
 	PathString path_;
+	bool initialized_ = false;
 
 protected:
 	virtual void onEvent(uavcan::dynamic_node_id_server::TraceCode code, uavcan::int64_t argument)
 	{
+		if (!initialized_) { return; }
+
 		using namespace std;
 
 		timespec ts = timespec();               // If clock_gettime() fails, zero time will be used
@@ -89,6 +92,8 @@ public:
 			if (fd >= 0) {
 				(void)close(fd);
 			}
+
+			initialized_ = true;
 		}
 
 		return rv;

--- a/src/drivers/uavcan/uavcan_params.yaml
+++ b/src/drivers/uavcan/uavcan_params.yaml
@@ -30,6 +30,13 @@ parameters:
       min: 1
       max: 125
       reboot_required: true
+    UAVCAN_TRACE_EN:
+      description:
+        short: UAVCAN event tracing
+        long: Enable logging of UAVCAN events
+      type: boolean
+      default: 1
+      reboot_required: true
     UAVCAN_BITRATE:
       description:
         short: UAVCAN CAN bus bitrate

--- a/src/drivers/uavcan/uavcan_servers.cpp
+++ b/src/drivers/uavcan/uavcan_servers.cpp
@@ -104,11 +104,16 @@ int UavcanServers::init()
 	}
 
 	/* Initialize trace in the UAVCAN_NODE_DB_PATH directory */
-	ret = _tracer.init(UAVCAN_LOG_FILE);
+	int32_t trace_en = 1;
+	(void)param_get(param_find("UAVCAN_TRACE_EN"), &trace_en);
 
-	if (ret < 0) {
-		PX4_ERR("FileEventTracer init: %d, errno: %d", ret, errno);
-		return ret;
+	if (trace_en) {
+		ret = _tracer.init(UAVCAN_LOG_FILE);
+
+		if (ret < 0) {
+			PX4_ERR("FileEventTracer init: %d, errno: %d", ret, errno);
+			return ret;
+		}
 	}
 
 	/* hardware version */


### PR DESCRIPTION
### Solved Problem

- UAVCAN trace files can take a couple KB storage, which can be too much for very storage-constrained devices

### Solution

- Add a param to enable / disable trace files

### Test coverage

- Tested on the bench with a v6s
