### PR TITLE
docs(tools): Improve rendering of boolean parameters

### DIFF
--- a/src/lib/parameters/px4params/markdownout.py
+++ b/src/lib/parameters/px4params/markdownout.py
@@ -85,10 +85,19 @@ If a listed parameter is missing from the Firmware see: [Finding/Updating Parame
                         bitmask_output+=f"- `{bit}`: {bit_text}\n"
                     bitmask_output+='\n\n'
 
-                if is_boolean and def_val=='1':
-                    def_val='Enabled (1)'
-                if is_boolean and def_val=='0':
-                    def_val='Disabled (0)'
+                if is_boolean:
+                    STATUS_LABELS = {
+                        '0': 'Disabled',
+                        '1': 'Enabled'
+                    }
+                    # Give def_value an explanatory string (is def_value if no match)
+                    def_val = f"{STATUS_LABELS[def_val]} ({def_val})" if def_val in STATUS_LABELS else def_val
+
+                    # Format values and their descriptions for display.
+                    boolean_values = '**Values:**\n\n'
+                    for key, label in STATUS_LABELS.items():
+                        boolean_values += f"- `{key}`: {label}\n"
+                    boolean_values += '\n'
 
                 result += f'### {name} (`{type}`)' + ' {#' + name + '}\n\n'
                 if apply_note_board_specific_group:
@@ -99,6 +108,8 @@ If a listed parameter is missing from the Firmware see: [Finding/Updating Parame
                     result += f'{short_desc}\n\n'
                 if long_desc:
                     result += f'{long_desc}\n\n'
+                if is_boolean:
+                    result += boolean_values
                 if enum_codes:
                     result += enum_output
                 if bitmask_list:

--- a/src/lib/parameters/px4params/markdownout.py
+++ b/src/lib/parameters/px4params/markdownout.py
@@ -86,16 +86,16 @@ If a listed parameter is missing from the Firmware see: [Finding/Updating Parame
                     bitmask_output+='\n\n'
 
                 if is_boolean:
-                    STATUS_LABELS = {
+                    BOOLEAN_LABELS = {
                         '0': 'Disabled',
                         '1': 'Enabled'
                     }
                     # Give def_value an explanatory string (is def_value if no match)
-                    def_val = f"{STATUS_LABELS[def_val]} ({def_val})" if def_val in STATUS_LABELS else def_val
+                    def_val = f"{BOOLEAN_LABELS[def_val]} ({def_val})" if def_val in BOOLEAN_LABELSelse def_val
 
                     # Format values and their descriptions for display.
                     boolean_values = '**Values:**\n\n'
-                    for key, label in STATUS_LABELS.items():
+                    for key, label in BOOLEAN_LABELS.items():
                         boolean_values += f"- `{key}`: {label}\n"
                     boolean_values += '\n'
 

--- a/src/lib/parameters/px4params/markdownout.py
+++ b/src/lib/parameters/px4params/markdownout.py
@@ -91,7 +91,7 @@ If a listed parameter is missing from the Firmware see: [Finding/Updating Parame
                         '1': 'Enabled'
                     }
                     # Give def_value an explanatory string (is def_value if no match)
-                    def_val = f"{BOOLEAN_LABELS[def_val]} ({def_val})" if def_val in BOOLEAN_LABELSelse def_val
+def_val = f"{BOOLEAN_LABELS[def_val]} ({def_val})" if def_val in BOOLEAN_LABELS else def_val
 
                     # Format values and their descriptions for display.
                     boolean_values = '**Values:**\n\n'

--- a/src/lib/parameters/px4params/markdownout.py
+++ b/src/lib/parameters/px4params/markdownout.py
@@ -91,7 +91,7 @@ If a listed parameter is missing from the Firmware see: [Finding/Updating Parame
                         '1': 'Enabled'
                     }
                     # Give def_value an explanatory string (is def_value if no match)
-def_val = f"{BOOLEAN_LABELS[def_val]} ({def_val})" if def_val in BOOLEAN_LABELS else def_val
+                    def_val = f"{BOOLEAN_LABELS[def_val]} ({def_val})" if def_val in BOOLEAN_LABELS else def_val
 
                     # Format values and their descriptions for display.
                     boolean_values = '**Values:**\n\n'


### PR DESCRIPTION
This adds allowed values for boolean parameters - the section shown in the blue box below. This mirrors the pattern used for enum values and makes it clear what you can select.

<img width="1129" height="627" alt="image" src="https://github.com/user-attachments/assets/4844361e-ab7e-4afd-9829-23c6cad1adef" />

FYI only this came out of discussion of why the source marks up variables like this as type `boolean` but the actual type is shown as INT32. 