### PR TITLE
feat(ekf2): add estimator_fusion_control logging

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1001,19 +1001,21 @@ void EKF2::initFusionControl()
 
 		const int32_t sens_en = _param_ekf2_sens_en.get();
 
-		_fc.gps.enabled    = sens_en & (1 << SENS_EN_GPS0);
-		_fc.of.enabled     = sens_en & (1 << SENS_EN_OF);
-		_fc.ev.enabled     = sens_en & (1 << SENS_EN_EV);
+		_fc.gps.enabled    = sens_en & SensEn::GPS0;
+		_fc.of.enabled     = sens_en & SensEn::OF;
+		_fc.ev.enabled     = sens_en & SensEn::EV;
+
+		static constexpr SensEn kAgpBits[MAX_AGP_INSTANCES] = {SensEn::AGP0, SensEn::AGP1, SensEn::AGP2, SensEn::AGP3};
 
 		for (uint8_t i = 0; i < MAX_AGP_INSTANCES; i++) {
-			_fc.agp[i].enabled = sens_en & (1 << (SENS_EN_AGP0 + i));
+			_fc.agp[i].enabled = sens_en & kAgpBits[i];
 		}
 
-		_fc.baro.enabled   = sens_en & (1 << SENS_EN_BARO);
-		_fc.rng.enabled    = sens_en & (1 << SENS_EN_RNG);
-		_fc.mag.enabled    = sens_en & (1 << SENS_EN_MAG);
-		_fc.aspd.enabled   = sens_en & (1 << SENS_EN_ASPD);
-		_fc.rngbcn.enabled = sens_en & (1 << SENS_EN_RNGBCN);
+		_fc.baro.enabled   = sens_en & SensEn::BARO;
+		_fc.rng.enabled    = sens_en & SensEn::RNG;
+		_fc.mag.enabled    = sens_en & SensEn::MAG;
+		_fc.aspd.enabled   = sens_en & SensEn::ASPD;
+		_fc.rngbcn.enabled = sens_en & SensEn::RNGBCN;
 	}
 }
 
@@ -1069,25 +1071,27 @@ void EKF2::syncSensEnParam()
 {
 	int32_t sens_en = 0;
 
-	if (_fc.gps.enabled)    { sens_en |= (1 << SENS_EN_GPS0); }
+	if (_fc.gps.enabled)    { sens_en |= SensEn::GPS0; }
 
-	if (_fc.of.enabled)     { sens_en |= (1 << SENS_EN_OF); }
+	if (_fc.of.enabled)     { sens_en |= SensEn::OF; }
 
-	if (_fc.ev.enabled)     { sens_en |= (1 << SENS_EN_EV); }
+	if (_fc.ev.enabled)     { sens_en |= SensEn::EV; }
+
+	static constexpr SensEn kAgpBits[MAX_AGP_INSTANCES] = {SensEn::AGP0, SensEn::AGP1, SensEn::AGP2, SensEn::AGP3};
 
 	for (uint8_t i = 0; i < MAX_AGP_INSTANCES; i++) {
-		if (_fc.agp[i].enabled) { sens_en |= (1 << (SENS_EN_AGP0 + i)); }
+		if (_fc.agp[i].enabled) { sens_en |= kAgpBits[i]; }
 	}
 
-	if (_fc.baro.enabled)   { sens_en |= (1 << SENS_EN_BARO); }
+	if (_fc.baro.enabled)   { sens_en |= SensEn::BARO; }
 
-	if (_fc.rng.enabled)    { sens_en |= (1 << SENS_EN_RNG); }
+	if (_fc.rng.enabled)    { sens_en |= SensEn::RNG; }
 
-	if (_fc.mag.enabled)    { sens_en |= (1 << SENS_EN_MAG); }
+	if (_fc.mag.enabled)    { sens_en |= SensEn::MAG; }
 
-	if (_fc.aspd.enabled)   { sens_en |= (1 << SENS_EN_ASPD); }
+	if (_fc.aspd.enabled)   { sens_en |= SensEn::ASPD; }
 
-	if (_fc.rngbcn.enabled) { sens_en |= (1 << SENS_EN_RNGBCN); }
+	if (_fc.rngbcn.enabled) { sens_en |= SensEn::RNGBCN; }
 
 	_param_ekf2_sens_en.set(sens_en);
 	_param_ekf2_sens_en.commit_no_notification();

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -407,18 +407,20 @@ private:
 	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};
 	uORB::Publication<vehicle_command_ack_s> _vehicle_command_ack_pub{ORB_ID(vehicle_command_ack)};
 
-	enum SensEnBit : uint16_t {
-		SENS_EN_GPS0   = 0,
-		SENS_EN_GPS1   = 1,
-		SENS_EN_OF     = 2,
-		SENS_EN_EV     = 3,
-		SENS_EN_AGP0   = 4,
-		// bit: 5-7 reserved for AGP1..3
-		SENS_EN_BARO   = 8,
-		SENS_EN_RNG    = 9,
-		SENS_EN_MAG    = 10,
-		SENS_EN_ASPD   = 11,
-		SENS_EN_RNGBCN = 12,
+	enum SensEn : uint16_t {
+		GPS0   = 1 << 0,
+		GPS1   = 1 << 1,
+		OF     = 1 << 2,
+		EV     = 1 << 3,
+		AGP0   = 1 << 4,
+		AGP1   = 1 << 5,
+		AGP2   = 1 << 6,
+		AGP3   = 1 << 7,
+		BARO   = 1 << 8,
+		RNG    = 1 << 9,
+		MAG    = 1 << 10,
+		ASPD   = 1 << 11,
+		RNGBCN = 1 << 12,
 	};
 	bool _prev_armed{false};
 

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -190,6 +190,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("estimator_selector_status", 10);
 	add_optional_topic_multi("estimator_event_flags", 10);
 	add_optional_topic_multi("estimator_optical_flow_vel", 200);
+	add_optional_topic_multi("estimator_fusion_control", 1000);
 	add_optional_topic_multi("estimator_sensor_bias", 1000);
 	add_optional_topic_multi("estimator_status", 200);
 	add_optional_topic_multi("estimator_status_flags", 10);


### PR DESCRIPTION
### Solved Problem
It can be tricky to understand the behavior of the estimator control status flags if we don't know the values of `estimator_fusion_control`.

### Solution
Log it as low rate (1Hz).

Additional changes: define `SensEn` as masking values instead of bit postiion.


