### PR TITLE
fix(navigator): re-evaluate climb requirement on mission cursor change

### DIFF
--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -450,6 +450,11 @@ void MissionBase::update_mission()
 	_navigator->reset_vroi();
 
 	if (_navigator->get_mission_result()->valid) {
+		/* re-issue the climb ticket on cursor change while in takeoff phase */
+		if (_land_detected_sub.get().landed || _work_item_type == WorkItemType::WORK_ITEM_TYPE_CLIMB) {
+			checkClimbRequired(_mission.current_seq);
+		}
+
 		/* reset work item if new mission has been accepted */
 		_work_item_type = WorkItemType::WORK_ITEM_TYPE_DEFAULT;
 


### PR DESCRIPTION
### Solved Problem

The mission navigator could command a diagonal takeoff trajectory when the mission cursor changed while the vehicle was still below the target altitude.

The trigger paths are:

- MAVLink `MISSION_SET_CURRENT` (msg id 41)
- `MAV_CMD_DO_SET_MISSION_CURRENT` (cmd 224)
- `MAV_CMD_MISSION_START` (cmd 300) with `param1 ≠ current_seq`
- Full mission re-upload (MAVLink mission upload protocol)

All four arrive on the `mission` uORB topic and go through `MissionBase::update_mission()`, which resets `_work_item_type` to `DEFAULT` but does not re-issue `_mission_init_climb_altitude_amsl`. The climb ticket is set once in `checkClimbRequired()` from `on_activation()` and consumed on the first `handleTakeoff()` call; after that it stays `NaN`. The combination "DEFAULT work item + NaN ticket" makes `handleTakeoff()` skip the climb-injection branch and publish the raw mission item lat/lon as a `POSITION` setpoint.

When one of these triggers arrives during the takeoff phase the resulting POSITION setpoint asks the controller to fly directly to the new item's lat/lon at the new item's altitude. The vehicle then translates horizontally while still climbing, producing a diagonal takeoff trajectory instead of the expected vertical climb at the current position followed by horizontal flight to the waypoint.

Observed in real-world flight logs and reproduced in SITL with both `MISSION_SET_CURRENT` and `MISSION_START` triggers fired mid-climb.

### Solution

Call `checkClimbRequired()` inside `update_mission()` so the climb ticket is re-evaluated against the new current item every time the cursor changes via any of the four trigger paths above. `handleTakeoff()` then fires its climb-injection branch correctly and inserts a vertical climb at the vehicle's current GPS position before proceeding to the actual waypoint.

### Alternatives

Another option considered was to ignore (or defer) mission cursor changes while the vehicle is in CLIMB phase. This would prevent the diagonal too, but any GCS or service that surfaces the current mission waypoint would keep showing the stale value during takeoff, confusing for the operator. The current fix repairs the navigator's climb-injection mechanism directly, so any trigger reaching `update_mission()` is handled correctly without dropping user input.

### Test coverage

Reproduced the diagonal takeoff in SITL (`sihsim_quadx`) for each trigger path listed above and confirmed it no longer occurs with this fix.


