### PR TITLE
ci(ros_integration_tests): restart XRCE-DDS Agent between tests

### DIFF
--- a/.github/workflows/ros_integration_tests.yml
+++ b/.github/workflows/ros_integration_tests.yml
@@ -121,7 +121,10 @@ jobs:
       shell: bash
       run: |
         . /opt/px4_ws/install/setup.bash
-        /opt/Micro-XRCE-DDS-Agent/build/MicroXRCEAgent udp4 localhost -p 8888 -v 0 &
+        # The Agent is started (and restarted between tests) by ros_test_runner.py
+        # so DDS graph state from a previous PX4 instance does not leak into the
+        # next test. Make the Agent binary discoverable on PATH.
+        export PATH="/opt/Micro-XRCE-DDS-Agent/build:$PATH"
         test/ros_test_runner.py --verbose --model iris --force-color
       timeout-minutes: 45
 

--- a/test/mavsdk_tests/integration_test_runner/test_runner.py
+++ b/test/mavsdk_tests/integration_test_runner/test_runner.py
@@ -5,7 +5,7 @@ import os
 import re
 import sys
 import time
-from typing import Any, Dict, List, NoReturn, TextIO, Optional
+from typing import Any, Callable, Dict, List, NoReturn, TextIO, Optional
 from types import FrameType
 from . import process_helper as ph
 from .logger_helper import color, colorize
@@ -75,6 +75,7 @@ class Tester:
         self.tester_interface = tester_interface
         self.tests = self.determine_tests(config['tests'], model, case)
         self.active_runners = []
+        self.pre_test_hook: Optional[Callable[[str, str], None]] = None
 
     @staticmethod
     def wildcard_match(pattern: str, potential_match: str) -> bool:
@@ -202,6 +203,9 @@ class Tester:
                     print("Creating log directory: {}"
                           .format(log_dir))
                 os.makedirs(log_dir, exist_ok=True)
+
+                if self.pre_test_hook is not None:
+                    self.pre_test_hook(test['model'], key)
 
                 was_success = self.run_test_case(test, key, log_dir)
 

--- a/test/ros_test_runner.py
+++ b/test/ros_test_runner.py
@@ -7,6 +7,7 @@ import psutil  # type: ignore
 import signal
 import subprocess
 import sys
+import time
 from mavsdk_tests.integration_test_runner import test_runner, process_helper as ph, logger_helper
 from typing import Any, Dict, List, NoReturn
 
@@ -45,7 +46,20 @@ class MicroXrceAgent:
         if self._verbose:
             print('Stopping micro-xrce-dds-agent')
         self._proc.kill()
+        self._proc.wait()
         self._proc = None
+
+    def restart(self):
+        """Force a fresh Agent process so DDS graph state does not leak across tests.
+
+        The Agent retains writer entries from prior PX4 instances; a fresh PX4 reconnects
+        but the stale entries make count_publishers() return >0 before the new writers
+        are matched, breaking waitForFMU's two-phase discovery in px4-ros2-interface-lib.
+        """
+        self.stop_process_if_started()
+        # Give the OS a moment to release the UDP port before rebinding.
+        time.sleep(0.2)
+        self.start_process()
 
 
 class TesterInterfaceRos(test_runner.TesterInterface):
@@ -187,8 +201,14 @@ def main() -> NoReturn:
 
     # Automatically start & stop the XRCE Agent if not running already
     micro_xrce_agent = MicroXrceAgent(args.verbose)
-    if not micro_xrce_agent.is_running():
+    agent_managed_here = not micro_xrce_agent.is_running()
+    if agent_managed_here:
         micro_xrce_agent.start_process()
+
+        def restart_agent(_model: str, _case: str) -> None:
+            micro_xrce_agent.restart()
+
+        tester.pre_test_hook = restart_agent
 
     try:
         result = tester.run()


### PR DESCRIPTION
Restart the Micro-XRCE-DDS Agent before each ROS integration test so DDS graph state from the previous PX4 instance does not leak into the next test.

The `MicroXRCEAgent` runs once for the entire test session, but PX4 reboots between tests. The Agent retains writer entries from the previous PX4 process, so when a new PX4 reconnects, `count_publishers()` in `px4-ros2-interface-lib`'s `waitForFMU` returns `> 0` instantly against the stale entry. Phase 1 (discovery) succeeds against a ghost, then Phase 2 (heartbeat) waits 5s for a message on a subscription matched to a dead writer and times out.

This is consistent with what every failing CI run shows: `ModesTest.denyArming` (the first test) passes, every later `ModesTest` fails at ~5s elapsed with `timeout while waiting for FMU heartbeat` at `mode.cpp:251`. The `bc: not found` errors that #27328 also calls out are pre-existing in the green May 7 run and are unrelated to the test failures.

The fix:

- `test/mavsdk_tests/integration_test_runner/test_runner.py` gets an optional `pre_test_hook` so ROS-specific lifecycle stays out of the shared test runner (MAVSDK tests don't need it).
- `test/ros_test_runner.py` wires the hook to `MicroXrceAgent.restart()`, which kills the Agent, briefly waits for the UDP port to free, then re-launches it.
- `.github/workflows/ros_integration_tests.yml` stops starting the Agent externally; the test runner now owns its lifecycle. The Agent binary directory is added to `PATH`.

Marking this draft because the fix needs to be validated against real CI before going green. Watching the runs now.

Refs #27328

The proper long-term fix is upstream in [px4-ros2-interface-lib](https://github.com/Auterion/px4-ros2-interface-lib): `waitForFMU`'s two-phase split (commit `84a1c4d`) changed semantics such that a cached publisher entry trips Phase 1 before the new writer is matched. Either revert the split, raise the Phase 2 timeout, or require a *fresh* match in Phase 1. This PR is the workaround on our side so main isn't red while that's sorted out.