### PR TITLE
fix(ekf2): fix invalid dist bottom with range height ref

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1758,14 +1758,14 @@ void EKF2::PublishLocalPosition(const hrt_abstime &timestamp)
 
 #if defined(CONFIG_EKF2_TERRAIN)
 	// Distance to bottom surface (ground) in meters, must be positive
-	lpos.dist_bottom_valid = _ekf.isTerrainEstimateValid();
+	lpos.dist_bottom_valid = _ekf.isTerrainEstimateValid() || (_ekf.getHeightSensorRef() == HeightSensor::RANGE);
 	lpos.dist_bottom = math::max(_ekf.getHagl(), 0.f);
 	lpos.dist_bottom_var = _ekf.getTerrainVariance();
 	_ekf.get_hagl_reset(&lpos.delta_dist_bottom, &lpos.dist_bottom_reset_counter);
 
 	lpos.dist_bottom_sensor_bitfield = vehicle_local_position_s::DIST_BOTTOM_SENSOR_NONE;
 
-	if (_ekf.control_status_flags().rng_terrain) {
+	if (_ekf.control_status_flags().rng_terrain || _ekf.control_status_flags().rng_hgt) {
 		lpos.dist_bottom_sensor_bitfield |= vehicle_local_position_s::DIST_BOTTOM_SENSOR_RANGE;
 	}
 


### PR DESCRIPTION
### Solved Problem

When the range sensor is the EKF height reference (`EKF2_HGT_REF=2`), `vehicle_local_position.dist_bottom` is valid because HAGL is directly provided by range height fusion. However, `dist_bottom_valid` was incorrectly published as false because it only checked terrain estimate validity. The sensor bitfield also reported `DIST_BOTTOM_SENSOR_NONE` because it only checked `rng_terrain`, not `rng_hgt`.

This produced inconsistent output: `cs_rng_hgt=true`, finite `dist_bottom`, but `dist_bottom_valid=false`.

### Solution
Mark `dist_bottom_valid` true when the terrain estimate is valid or the EKF height reference is `HeightSensor::RANGE`.

Also include `rng_hgt` when setting `DIST_BOTTOM_SENSOR_RANGE`, so the range sensor is reported as the source when it provides height above ground via range height fusion.

### Changelog Entry
For release notes:
```text
Bugfix: report valid distance-to-bottom when range sensor is EKF height reference
```

### Test coverage
SITL reproduction with down-facing lidar:

```sh
make px4_sitl gz_x500_lidar_down
```

In the PX4 shell:

```sh
param set EKF2_HGT_REF 2
param set EKF2_RNG_CTRL 2
param save
```

Before the fix:
<img width="1382" height="961" alt="截图 2026-05-15 15-21-28" src="https://github.com/user-attachments/assets/9b8777ba-31e6-4d0a-a162-1536dbbb140b" />

After the fix:
<img width="1382" height="961" alt="after" src="https://github.com/user-attachments/assets/cd366dcb-654b-45c1-8950-3d5365110460" />