### PR TITLE
fix(commander): skip preflight checks until topics are advertised

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/cpuResourceCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/cpuResourceCheck.cpp
@@ -50,6 +50,10 @@ void CpuResourceChecks::checkAndReport(const Context &context, Report &reporter)
 		return;
 	}
 
+	if (!_cpuload_sub.advertised()) {
+		return;
+	}
+
 	cpuload_s cpuload;
 
 	if (!_cpuload_sub.copy(&cpuload) || hrt_elapsed_time(&cpuload.timestamp) > 2_s) {

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -109,14 +109,16 @@ void EstimatorChecks::checkAndReport(const Context &context, Report &reporter)
 	}
 
 	if (missing_data && (param_ekf2_en == 1)) {
-		/* EVENT
-		 */
-		reporter.armingCheckFailure(required_groups, health_component_t::local_position_estimate,
-					    events::ID("check_estimator_missing_data"),
-					    events::Log::Info, "Waiting for estimator to initialize");
+		if (_estimator_status_sub.advertised()) {
+			/* EVENT
+			 */
+			reporter.armingCheckFailure(required_groups, health_component_t::local_position_estimate,
+						    events::ID("check_estimator_missing_data"),
+						    events::Log::Info, "Waiting for estimator to initialize");
 
-		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: ekf2 missing data");
+			if (reporter.mavlink_log_pub()) {
+				mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: ekf2 missing data");
+			}
 		}
 
 	} else {


### PR DESCRIPTION
## Summary
fixes #27301

Suppress spurious "Preflight Fail" messages emitted at boot on boards with a slow startup sequence (e.g. FMU-V6XRT), without delaying real failure reporting.

## Problem
`CpuResourceChecks` and `EstimatorChecks` run before `load_mon` and `ekf2` have published their first message on slow-booting boards. The missing data is reported as a preflight failure, producing false "Preflight Fail: ekf2 missing data" and "Preflight Fail: No CPU and RAM load information" entries in dmesg.

## Solution
Gate both checks on `uORB::Subscription::advertised()`. While the topic has never been advertised, the publisher has not started yet, so the check returns early without reporting. Once the topic is advertised, missing or stale data is reported exactly as before, so real failures are still caught.
