### PR TITLE
fix(ekf2): use variance for EV yaw and mag declination

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/external_vision/ev_yaw_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/external_vision/ev_yaw_control.cpp
@@ -45,7 +45,7 @@ void Ekf::controlEvYawFusion(const imuSample &imu_sample, const extVisionSample 
 	static constexpr const char *AID_SRC_NAME = "EV yaw";
 
 	float obs = getEulerYaw(ev_sample.quat);
-	float obs_var = math::max(ev_sample.orientation_var(2), _params.ekf2_eva_noise, sq(0.01f));
+	float obs_var = math::max(ev_sample.orientation_var(2), sq(_params.ekf2_eva_noise), sq(0.01f));
 
 	float innov = wrap_pi(getEulerYaw(_R_to_earth) - obs);
 	float innov_var = 0.f;

--- a/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
@@ -254,7 +254,7 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 						    && PX4_ISFINITE(_wmm_declination_rad)
 						   ) {
 							// using declination from the world magnetic model
-							fuseDeclination(_wmm_declination_rad, 0.5f, update_all_states, update_tilt);
+							fuseDeclination(_wmm_declination_rad, R_DECL, update_all_states, update_tilt);
 
 						} else if ((_params.ekf2_decl_type & GeoDeclinationMask::SAVE_GEO_DECL)
 							   && PX4_ISFINITE(_params.ekf2_mag_decl) && (fabsf(_params.ekf2_mag_decl) > 0.f)

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -470,7 +470,7 @@ struct parameters {
 	float ekf2_ev_delay{175.0f};            ///< off-board vision measurement delay relative to the IMU (mSec)
 	float ekf2_evv_noise{0.1f};             ///< minimum allowed observation noise for EV velocity fusion (m/sec)
 	float ekf2_evp_noise{0.1f};             ///< minimum allowed observation noise for EV position fusion (m)
-	float ekf2_eva_noise{0.1f};             ///< minimum allowed observation noise for EV attitude fusion (rad/sec)
+	float ekf2_eva_noise{0.1f};             ///< minimum allowed observation noise for EV attitude fusion (rad)
 	int32_t ekf2_ev_qmin{0};                ///< vision minimum acceptable quality integer
 	float ekf2_evv_gate{3.0f};              ///< vision velocity fusion innovation consistency gate size (STD)
 	float ekf2_evp_gate{5.0f};              ///< vision position fusion innovation consistency gate size (STD)


### PR DESCRIPTION
### Solved Problem

For EV yaw fusion, `EKF2_EVA_NOISE` is an angular noise value in rad, while the EV yaw aid source stores observation variance in rad^2. 

For magnetic declination fusion, the WMM declination path passed `0.5` directly. I assume that it's a overlook of #23215.

### Solution

Square the EV attitude noise before using it as a yaw observation variance.

Use the existing declination variance for the WMM declination path as well.

### Test coverage

How to trigger:
Enable EV yaw fusion and provide EV yaw variance below the `EKF2_EVA_NOISE` floor.
Use default geo declination handling with WMM declination available and mag declination fusion active.
