### PR TITLE
fix(navigator): don't surface empty mission as a rejection

### DIFF
--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -62,10 +62,9 @@ MissionFeasibilityChecker::checkMissionFeasible(const mission_s &mission)
 	const bool home_valid = _navigator->home_global_position_valid();
 	const bool home_alt_valid = _navigator->home_alt_valid();
 
-	// trivial case: A mission with length zero cannot be valid
+	// An empty mission is the normal "no mission loaded" state, not a rejection: the commander
+	// surfaces auto_mission_missing via arming checks when mission mode is actually requested.
 	if ((int)mission.count <= 0) {
-		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: empty\t");
-		events::send(events::ID("navigator_mis_empty"), {events::Log::Error, events::LogInternal::Info}, "Mission rejected: empty");
 		return false;
 	}
 


### PR DESCRIPTION
## Summary

Stop sending "Mission rejected: empty" to QGC when no mission is loaded and the vehicle is not attempting a mission.

## Problem

#27254 added a `mavlink_log_critical` + `events::send` inside `MissionFeasibilityChecker::checkMissionFeasible()` for the empty-mission early return. But `MissionBase::check_mission_valid()` runs in the background whenever any of its trigger conditions change (`mission_id`, `geofence_id`, `home_position_counter`) — not only when entering mission mode. The result: the warning fires repeatedly even when the pilot is not in mission mode and has no mission on board. The pre-existing `_mission.count > 0U` gate on the local `PX4_WARN` in `mission_base.cpp` was bypassed.

## Solution

Drop the two added lines for the empty case. An empty mission is the normal "no mission loaded" state, not a rejection. The dataman-read-failure logging from #27254 is preserved — those are real rejections. When the pilot actually requests mission mode without a mission loaded, the commander already surfaces this via the `auto_mission_missing` failsafe flag in `missionCheck.cpp`.