### PR TITLE
fix(platforms/i2c): report current bus, not filter, in iterator external()

### DIFF
--- a/platforms/common/include/px4_platform_common/i2c.h
+++ b/platforms/common/include/px4_platform_common/i2c.h
@@ -84,7 +84,7 @@ public:
 
 	int externalBusIndex() const { return _external_bus_counter; }
 
-	bool external() const { return px4_i2c_bus_external(_bus); }
+	bool external() const { return px4_i2c_bus_external(bus().bus); }
 
 private:
 	const FilterType _filter;


### PR DESCRIPTION
## Summary

Drivers started with `-I` (e.g. `iis2mdc -I start`, `bmp388 -I start`) are mislabeled as `(external)` in the boot log even when the bus is internal. `sensors status` reports them correctly because that path uses a different `external()` override.

Discovered in https://github.com/PX4/PX4-Autopilot/pull/26631

## Problem

`I2CBusIterator::external()` returns `px4_i2c_bus_external(_bus)`, where `_bus` is the *constructor filter argument* — the user's `-b` value, which defaults to `-1` when not passed. With `-1` not matching any populated entry in `px4_i2c_buses[]`, `px4_i2c_bus_external` falls through to its "not found" return-`true` fallback, so every internal-bus device prints as `(external)`.

Regressed in 8080ca966a8a435ba550f4bc8dda39eab20af2fb, which collapsed the `const px4_i2c_bus_t &` overload but changed the argument from `bus()` (current iterator position) to `_bus` (filter).

## Solution

Pass `bus().bus` instead so the result reflects the bus the iterator is currently positioned on. Matches `SPIBusIterator::external()`.