### PR TITLE
fix(ekf2): publish HAGL variance in dist_bottom_var

### DIFF
--- a/msg/versioned/VehicleLocalPosition.msg
+++ b/msg/versioned/VehicleLocalPosition.msg
@@ -59,7 +59,7 @@ float32 ref_alt				# Reference altitude AMSL, (metres)
 # Distance to surface
 bool dist_bottom_valid			# true if distance to bottom surface is valid
 float32 dist_bottom			# Distance from from bottom surface to ground, (metres)
-float32 dist_bottom_var                 # terrain estimate variance (m^2)
+float32 dist_bottom_var                 # height above ground estimate variance (m^2)
 
 float32 delta_dist_bottom               # Amount of vertical shift of dist bottom estimate in latest reset [m]
 uint8 dist_bottom_reset_counter         # Index of latest dist bottom estimate reset

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -119,7 +119,7 @@ public:
 	{
 		float hagl_var = 0.f;
 		sym::ComputeHaglInnovVar(P, 0.f, &hagl_var);
-		return hagl_var;
+		return fmaxf(hagl_var, 0.f);
 	}
 
 #endif // CONFIG_EKF2_TERRAIN

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -56,6 +56,10 @@
 
 #include <ekf_derivation/generated/state.h>
 
+#if defined(CONFIG_EKF2_TERRAIN)
+# include <ekf_derivation/generated/compute_hagl_innov_var.h>
+#endif // CONFIG_EKF2_TERRAIN
+
 #include <uORB/topics/estimator_aid_source1d.h>
 #include <uORB/topics/estimator_aid_source2d.h>
 #include <uORB/topics/estimator_aid_source3d.h>
@@ -108,6 +112,15 @@ public:
 
 	// get the terrain variance
 	float getTerrainVariance() const { return P(State::terrain.idx, State::terrain.idx); }
+
+	// get the variance of the height above ground (HAGL) estimate; accounts for terrain and
+	// vertical position uncertainty as well as their covariance
+	float getHaglVariance() const
+	{
+		float hagl_var = 0.f;
+		sym::ComputeHaglInnovVar(P, 0.f, &hagl_var);
+		return hagl_var;
+	}
 
 #endif // CONFIG_EKF2_TERRAIN
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1760,7 +1760,7 @@ void EKF2::PublishLocalPosition(const hrt_abstime &timestamp)
 	// Distance to bottom surface (ground) in meters, must be positive
 	lpos.dist_bottom_valid = _ekf.isTerrainEstimateValid() || (_ekf.getHeightSensorRef() == HeightSensor::RANGE);
 	lpos.dist_bottom = math::max(_ekf.getHagl(), 0.f);
-	lpos.dist_bottom_var = _ekf.getTerrainVariance();
+	lpos.dist_bottom_var = _ekf.getHaglVariance();
 	_ekf.get_hagl_reset(&lpos.delta_dist_bottom, &lpos.dist_bottom_reset_counter);
 
 	lpos.dist_bottom_sensor_bitfield = vehicle_local_position_s::DIST_BOTTOM_SENSOR_NONE;


### PR DESCRIPTION
## Summary

Publish the variance of `dist_bottom` (height above ground) in `vehicle_local_position.dist_bottom_var`, instead of just the variance of the terrain state.

## Problem

`dist_bottom = getHagl() = terrain + altitude` is a function of two EKF states, so its variance is

```
Var(HAGL) = Var(terrain) + Var(pos.z) − 2·Cov(terrain, pos.z)
```

`dist_bottom_var` was assigned from `getTerrainVariance()`, i.e. `P(terrain, terrain)` only. That is the variance of the terrain state, not of HAGL — it ignores the vertical position variance and the cross-covariance. It was a usable approximation while the terrain variance dominated (range or optical-flow terrain fusion active, vertical position bounded by baro/GNSS), but it is the wrong quantity by definition. The mismatch becomes obvious now that #27339 makes `dist_bottom_valid` true when range is the height reference: in that mode `_state.terrain` is pinned to 0 and the meaningful HAGL uncertainty lives in the vertical position state, which `P(terrain, terrain)` does not see.

## Solution

Add `Ekf::getHaglVariance()` which calls the existing `ComputeHaglInnovVar(P, 0)` to return `P(terrain,terrain) + P(pos.z,pos.z) − 2·P(terrain,pos.z)`. This is a direct algebraic identity for the variance of `terrain − pos.z` (`= getHagl()` in NED), so it is strictly correct in every configuration: range height ref, range/optical-flow terrain fusion, or no terrain aiding at all. Publish it as `lpos.dist_bottom_var` and update the field comment in `VehicleLocalPosition.msg` accordingly.

Verified `px4_sitl_default` and `px4_fmu-v6x_default` build, all EKF unit tests pass.