### PR TITLE
fix(drivers/device): make I2C::init() idempotent

### DIFF
--- a/src/lib/drivers/device/nuttx/I2C.cpp
+++ b/src/lib/drivers/device/nuttx/I2C.cpp
@@ -104,6 +104,10 @@ I2C::init()
 	int ret = PX4_ERROR;
 	unsigned bus_index;
 
+	if (_dev != nullptr) {
+		return PX4_OK;
+	}
+
 	// attach to the i2c bus
 	_dev = px4_i2cbus_initialize(get_device_bus());
 

--- a/src/lib/drivers/device/posix/I2C.cpp
+++ b/src/lib/drivers/device/posix/I2C.cpp
@@ -82,6 +82,10 @@ I2C::init()
 {
 	int ret = PX4_ERROR;
 
+	if (_fd >= 0) {
+		return PX4_OK;
+	}
+
 	// Open the actual I2C device
 	char dev_path[16] {};
 	snprintf(dev_path, sizeof(dev_path), "/dev/i2c-%i", get_device_bus());

--- a/src/lib/drivers/device/qurt/I2C.cpp
+++ b/src/lib/drivers/device/qurt/I2C.cpp
@@ -99,6 +99,10 @@ I2C::init()
 {
 	int ret = PX4_ERROR;
 
+	if (_i2c_fd != -1) {
+		return PX4_OK;
+	}
+
 	if (_config_i2c_bus == NULL) {
 		PX4_ERR("NULL i2c init function");
 		goto out;


### PR DESCRIPTION
## Summary

Make `device::I2C::init()` idempotent across NuttX, POSIX, and QuRT so drivers that retry init on failure no longer leak the underlying bus handle.

## Problem

`I2C::init()` unconditionally reattaches to the bus on every call — `px4_i2cbus_initialize()` on NuttX (which `kmm_malloc`s a fresh `i2c_master_s` inst and bumps a per-port refcount), `::open("/dev/i2c-N")` on POSIX, `_config_i2c_bus()` on QuRT. The previous handle is overwritten and only the destructor releases anything, so any driver that calls `init()` more than once on the same instance leaks. On NuttX it also leaves the per-port refcount permanently above zero, so destruction never powers the bus down.

The pattern that triggers this is "retry init on failure" — used by `keep_running` mode and by drivers like INA228, whose `RunImpl()` re-enters `init()` whenever a later step (e.g. a register write) fails. Drivers that call `init()` exactly once from `instantiate()` are unaffected.

`SPI::init()` (in `nuttx/SPI.cpp`) already guards its bus-bind step with `if (_dev == nullptr)`; this just brings I2C in line.

## Solution

Early-return `PX4_OK` from `I2C::init()` when the bus handle is already valid, on all three platforms. The early return also intentionally skips re-running `probe()` and `CDev::init()` on an already-attached device — the existing cleanup path would otherwise uninitialize the preserved bus handle on a re-probe failure, tearing the bus out from under earlier callers.