### PR TITLE
fix(nuttx): unblock multi-board and protected builds

### DIFF
--- a/Tools/ci/build_all_runner.sh
+++ b/Tools/ci/build_all_runner.sh
@@ -3,6 +3,14 @@
 # Please only modify if you know what you are doing
 set -e
 
+# NuttX .o/.a live in the shared submodule trees, not per-board build dirs.
+# Wipe them between boards so stale objects from a prior board's defconfig
+# don't get linked into the next board's elf.
+clean_nuttx_state() {
+    git -C platforms/nuttx/NuttX/nuttx clean -dXf -q
+    git -C platforms/nuttx/NuttX/apps  clean -dXf -q
+}
+
 targets=$1
 for target in ${targets//,/ }
 do
@@ -14,4 +22,5 @@ do
     build_time="$(($diff /60/60))h $(($diff /60))m $(($diff % 60))s elapsed"
     echo -e "\033[0;32mBuild Time: [$build_time]"
     echo "::endgroup::"
+    clean_nuttx_state
 done

--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -181,8 +181,15 @@ function(add_nuttx_dir nuttx_lib nuttx_lib_dir kernel extra target)
 		${CMAKE_CURRENT_SOURCE_DIR}/nuttx/${nuttx_lib_dir}/*.h
 	)
 
+	# Route kernel pass for mm/libc to kbin/; user pass uses bin/ for the
+	# same sources and would otherwise overwrite the kernel objects.
+	set(bindir_arg)
+	if(${kernel} STREQUAL y AND (${nuttx_lib_dir} STREQUAL mm OR ${nuttx_lib_dir} STREQUAL libs/libc))
+		set(bindir_arg BINDIR=kbin)
+	endif()
+
 	add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/nuttx/${nuttx_lib_dir}/lib${nuttx_lib}.a
-		COMMAND make -C ${nuttx_lib_dir} --no-print-directory --silent ${nuttx_lib_target} TOPDIR="${NUTTX_DIR}" KERNEL=${kernel} EXTRAFLAGS=${extra}
+		COMMAND make -C ${nuttx_lib_dir} --no-print-directory --silent ${nuttx_lib_target} TOPDIR="${NUTTX_DIR}" KERNEL=${kernel} EXTRAFLAGS=${extra} ${bindir_arg}
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_DIR}/${nuttx_lib_dir}/lib${nuttx_lib}.a ${CMAKE_CURRENT_BINARY_DIR}/nuttx/${nuttx_lib_dir}/lib${nuttx_lib}.a
 		DEPENDS
 			${nuttx_lib_files}


### PR DESCRIPTION
## Summary
fixes #27358

Two regressions from #27324 break `Build all targets`: stale NuttX objects leak between boards in the multi-board CI loop, and the protected build links kernel-mode `.o`s into the user-mode `libmm.a` / `libc.a`.

## Problem
**Between boards.** NuttX `.o` and `lib*.a` live in `platforms/nuttx/NuttX/{nuttx,apps}`, not in per-board `build/<board>/`. NuttX's recursive make does not see PX4's per-board defconfig changes, so consecutive `make <board>` invocations in one workspace link stale objects (e.g. `stm32_spi.o` from `px4_fmu-v2_default`, which enables `CONFIG_STM32_SPI4`, into `px4_fmu-v4pro_default`, which doesn't), producing `undefined reference to stm32_spi4{select,status}`.

**Within a protected board.** NuttX compiles `mm/` and `libs/libc/` twice from the same sources — once kernel-mode (`libkmm.a`, `libkc.a`), once user-mode (`libmm.a`, `libc.a`). `add_nuttx_dir` did not pass `BINDIR=kbin` for the kernel pass, so both wrote into `bin/*.o`. The kernel pass runs first via `add_dependencies(...)`; the user pass then finds the objects mtime-fresh, skips recompile, and archives the kernel-mode objects into `libmm.a` / `libc.a`. The user ELF link then fails on `nxsem_wait`, `g_current_regs`, `nx_read`, `nx_write`, `g_mmheap`, `work_usrstart`, etc.

Both were masked before #27324 by the destructive cleanup `COMMAND`s in `platforms/nuttx/NuttX/CMakeLists.txt`.

## Solution
1. Run `git clean -dXf` on both NuttX submodules after each board build in `Tools/ci/build_all_runner.sh`. Drops only gitignored files (`.o`, `lib*.a`, generated `builtin_*.h`, etc.) — same mechanism `make clean` uses for submodules at `Makefile:591`.
2. Pass `BINDIR=kbin` for kernel-mode `mm` / `libs/libc` builds in `platforms/nuttx/NuttX/CMakeLists.txt`. Matches NuttX upstream's `tools/LibTargets.mk`.

#27324's no-op-rebuild speedup on single-board builds is preserved.
