### PR TITLE
fix(cmake): pin Python to project-local .venv on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,9 +172,16 @@ include(px4_add_module)
 set(config_module_list)
 set(config_kernel_list)
 
-# Find Python. The call below sets Python3_EXECUTABLE; we then provide
-# PYTHON_EXECUTABLE as a backward-compat alias for the rest of the
-# codebase that still uses the legacy name.
+# find_package(Python3) on macOS defaults to picking the highest-versioned
+# framework Python over PATH and hints, missing the venv where pip
+# installed our requirements. Pin to the project-local .venv when
+# present; otherwise stop at the first location hint and keep macOS
+# frameworks last. PYTHON_EXECUTABLE is bridged below for legacy callers.
+if(NOT DEFINED Python3_EXECUTABLE AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/.venv/bin/python")
+	set(Python3_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/.venv/bin/python")
+endif()
+set(Python3_FIND_STRATEGY LOCATION)
+set(Python3_FIND_FRAMEWORK LAST)
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 # Preserve PYTHON_EXECUTABLE as passed if any (e.g. via -D on command


### PR DESCRIPTION
## Summary
Follow-up to #27324. Fixes the `MacOS build` workflow on `main`, broken since b990430cdc.

## Problem
PR #27324 swapped `find_package(PythonInterp 3)` for `find_package(Python3 COMPONENTS Interpreter REQUIRED)`. On macOS the new module's defaults (`FIND_FRAMEWORK=FIRST` + `FIND_STRATEGY=VERSION`) prefer the highest-versioned framework Python over `Python3_ROOT_DIR` and `PATH`. CI then matched Homebrew's 3.14 while pip installed kconfiglib into the actions-managed 3.10 venv, so `make px4_sitl` configure failed with:

```
ModuleNotFoundError: No module named 'menuconfig'
CMake Error at cmake/kconfig.cmake:6 (message):
  kconfiglib is not installed or not in PATH
```

Every `MacOS build` on `main` since b990430cdc has hit this.

## Solution
Pin `Python3_EXECUTABLE` to the project-local `.venv` when present — CI prepends `.venv/bin` to `PATH` but does not export `VIRTUAL_ENV`, so `find_package` has no other signal to descend into it. Fall back to `FIND_STRATEGY=LOCATION` + `FIND_FRAMEWORK=LAST` for environments without a venv (Linux containers via `ubuntu.sh`; clean macOS dev machines).