### PR TITLE
fix(make): clean NuttX submodules when board target changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,20 @@ define cmake-build
 	@$(eval BUILD_DIR = "$(SRC_DIR)/build/$(1)")
 	@# check if the desired cmake configuration matches the cache then CMAKE_CACHE_CHECK stays empty
 	@$(call cmake-cache-check)
+	@# NuttX builds into the shared submodule trees under platforms/nuttx/NuttX/{nuttx,apps},
+	@# not into build/$(1)/. Recursive make there does not treat PX4 defconfig changes as a
+	@# reason to recompile, so switching board configs links stale objects (e.g. kmm_* from a
+	@# protected build into a flat build). Wipe the submodules when the active target changes,
+	@# mirroring Tools/ci/build_all_runner.sh.
+	@mkdir -p "$(SRC_DIR)/build"
+	@stamp="$(SRC_DIR)/build/.last_target"; \
+	prev=$$(cat "$$stamp" 2>/dev/null || echo ""); \
+	if [ "$$prev" != "$(1)" ]; then \
+		[ -n "$$prev" ] && echo "switching NuttX target $$prev -> $(1): wiping submodule state"; \
+		git -C "$(SRC_DIR)/platforms/nuttx/NuttX/nuttx" clean -dXfq 2>/dev/null || true; \
+		git -C "$(SRC_DIR)/platforms/nuttx/NuttX/apps"  clean -dXfq 2>/dev/null || true; \
+		echo "$(1)" > "$$stamp"; \
+	fi
 	@# make sure to start from scratch when switching from GNU Make to Ninja
 	@if [ $(PX4_CMAKE_GENERATOR) = "Ninja" ] && [ -e $(BUILD_DIR)/Makefile ]; then rm -rf $(BUILD_DIR); fi
 	@# make sure to start from scratch if ninja build file is missing


### PR DESCRIPTION
## Summary

Auto-wipe the shared NuttX submodule trees when the active `make` board target changes, so switching board configs locally no longer fails to link with stale objects from a previous build.

## Problem

NuttX builds into `platforms/nuttx/NuttX/{nuttx,apps}`, not into per-board `build/<target>/`. Its recursive make does not treat PX4 defconfig changes as a reason to recompile, so consecutive board builds in one workspace re-use stale `.o` files. After a `px4_fmu-v5_protected` build, a follow-up `make ark_fmu-v6x` link fails with hundreds of undefined references (`kmm_*`, `stm32_spi4select`/`status`, `net_initialize`, `nsh_main`, `up_pthread_start`, etc.) — kernel-only and fmu-v5-only symbols pulled into a flat fmu-v6x link from the prior board's leftover objects.

`Tools/ci/build_all_runner.sh` already handles this in CI (`clean_nuttx_state` between iterations from #27360), but the cleanup was never wired up for local builds, so devs hit the failure as soon as they alternate between board configs.

## Solution

Stamp the active target in `build/.last_target` (gitignored) inside the `cmake-build` Makefile define. When the next invocation has a different target, run `git -C platforms/nuttx/NuttX/{nuttx,apps} clean -dXfq` before configuring — same operation `build_all_runner.sh` performs. Same-target rebuilds are unaffected, so #27324's incremental no-op win is preserved (`make ark_fmu-v6x` no-op stays at ~0.14 s).

Verified locally:
- `make px4_fmu-v5_protected` → `make ark_fmu-v6x`: prints `switching NuttX target …: wiping submodule state`, then links cleanly.
- `make ark_fmu-v6x` (no-op): 0.14 s, unchanged.
- `make px4_fmu-v6x` and `make px4_sitl` build successfully.