### PR TITLE
fix(sensors): af9838 minor code style and architecture updates

### DIFF
--- a/src/drivers/magnetometer/voltafield/af9838/af9838.cpp
+++ b/src/drivers/magnetometer/voltafield/af9838/af9838.cpp
@@ -35,232 +35,232 @@ using namespace AF9838;
 using namespace time_literals;
 
 AF9838_Driver::AF9838_Driver(const I2CSPIDriverConfig &config)
-    : device::I2C(config),
-      I2CSPIDriver(config),
-      _px4_mag(get_device_id(), config.rotation)
+	: device::I2C(config),
+	  I2CSPIDriver(config),
+	  _px4_mag(get_device_id(), config.rotation)
 {
-    _px4_mag.set_device_type(DRV_MAG_DEVTYPE_AF9838);
-    _px4_mag.set_device_id(get_device_id());
+	_px4_mag.set_device_type(DRV_MAG_DEVTYPE_AF9838);
+	_px4_mag.set_device_id(get_device_id());
 }
 
 I2CSPIDriverBase *AF9838_Driver::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
-    PX4_INFO("AF9838: instantiate bus=%d addr=0x%02X freq=%u",
-         config.bus, config.i2c_address, config.bus_frequency);
+	PX4_INFO("AF9838: instantiate bus=%d addr=0x%02X freq=%u",
+		 config.bus, config.i2c_address, config.bus_frequency);
 
-    AF9838_Driver *dev = new AF9838_Driver(config);
+	AF9838_Driver *dev = new AF9838_Driver(config);
 
-    if (!dev) { return nullptr; }
+	if (!dev) { return nullptr; }
 
-    const int ret = dev->init();
-    PX4_INFO("AF9838: I2C::init ret=%d", ret);
+	const int ret = dev->init();
+	PX4_INFO("AF9838: I2C::init ret=%d", ret);
 
-    if (ret != PX4_OK) {
-        delete dev;
-        return nullptr;
-    }
+	if (ret != PX4_OK) {
+		delete dev;
+		return nullptr;
+	}
 
-    return dev;
+	return dev;
 }
 
 
 int AF9838_Driver::probe()
 {
-    constexpr int MAX_TRIES = 3;
-    uint8_t id = 0xff;
+	constexpr int MAX_TRIES = 3;
+	uint8_t id = 0xff;
 
-    PX4_INFO("AF9838: probe() on bus=%d addr=0x%02X", get_device_bus(), get_device_address());
+	PX4_INFO("AF9838: probe() on bus=%d addr=0x%02X", get_device_bus(), get_device_address());
 
-    for (int i = 0; i < MAX_TRIES; i++) {
-        if (transfer(&REG_PCODE, 1, &id, 1) == PX4_OK) {
-            PX4_INFO("AF9838: REG_PCODE=0x%02X (try %d)", id, i + 1);
-            return PX4_OK;
-        }
+	for (int i = 0; i < MAX_TRIES; i++) {
+		if (transfer(&REG_PCODE, 1, &id, 1) == PX4_OK) {
+			PX4_INFO("AF9838: REG_PCODE=0x%02X (try %d)", id, i + 1);
+			return PX4_OK;
+		}
 
-        px4_usleep(1_ms);
-    }
+		px4_usleep(1_ms);
+	}
 
-    PX4_ERR("AF9838: probe() failed (no response) bus=%d addr=0x%02X",
-        get_device_bus(), get_device_address());
-    return PX4_ERROR;
+	PX4_ERR("AF9838: probe() failed (no response) bus=%d addr=0x%02X",
+		get_device_bus(), get_device_address());
+	return PX4_ERROR;
 }
 
 
 int AF9838_Driver::init()
 {
-    PX4_INFO("AF9838: init() enter");
+	PX4_INFO("AF9838: init() enter");
 
-    int ret = device::I2C::init();
-    PX4_INFO("AF9838: device::I2C::init ret=%d", ret);
+	int ret = device::I2C::init();
+	PX4_INFO("AF9838: device::I2C::init ret=%d", ret);
 
-    if (ret != PX4_OK) { return ret; }
+	if (ret != PX4_OK) { return ret; }
 
-    PX4_INFO("AF9838: soft_reset...");
-    (void)soft_reset();
+	PX4_INFO("AF9838: soft_reset...");
+	(void)soft_reset();
 
-    PX4_INFO("AF9838: configure BISC...");
+	PX4_INFO("AF9838: configure BISC...");
 
-    if (configure() != PX4_OK) {
-        PX4_ERR("AF9838: configure failed");
-        return PX4_ERROR;
-    }
+	if (configure() != PX4_OK) {
+		PX4_ERR("AF9838: configure failed");
+		return PX4_ERROR;
+	}
 
-    float hz = AF9838::DEFAULT_RATE_HZ;
+	float hz = AF9838::DEFAULT_RATE_HZ;
 
-    if (hz < 1.f) { hz = 1.f; }
+	if (hz < 1.f) { hz = 1.f; }
 
-    if (hz > 1000.f) { hz = 1000.f; }
+	if (hz > 1000.f) { hz = 1000.f; }
 
-    _measure_interval_us = (uint32_t)(1000000.0f / hz);
+	_measure_interval_us = (uint32_t)(1000000.0f / hz);
 
-    _running = true;
-    ScheduleOnInterval(_measure_interval_us);
-    PX4_INFO("AF9838: scheduled every %u us (%.1f Hz)",
-         (unsigned)_measure_interval_us,
-         1e6 / static_cast<double>(_measure_interval_us));
+	_running = true;
+	ScheduleOnInterval(_measure_interval_us);
+	PX4_INFO("AF9838: scheduled every %u us (%.1f Hz)",
+		 (unsigned)_measure_interval_us,
+		 1e6 / static_cast<double>(_measure_interval_us));
 
-    const hrt_abstime now = hrt_absolute_time();
-    _px4_mag.update(now, 0.f, 0.f, 0.f);
-    PX4_INFO("AF9838: init() done");
-    return PX4_OK;
+	const hrt_abstime now = hrt_absolute_time();
+	_px4_mag.update(now, 0.f, 0.f, 0.f);
+	PX4_INFO("AF9838: init() done");
+	return PX4_OK;
 }
 
 
 int AF9838_Driver::soft_reset()
 {
-    if (write_reg(REG_SWR, 0x81) != PX4_OK) {
-        PX4_ERR("soft reset write failed");
-        return PX4_ERROR;
-    }
+	if (write_reg(REG_SWR, 0x81) != PX4_OK) {
+		PX4_ERR("soft reset write failed");
+		return PX4_ERROR;
+	}
 
-    px4_usleep(5_ms);
+	px4_usleep(5_ms);
 
-    return PX4_OK;
+	return PX4_OK;
 }
 
 int AF9838_Driver::configure()
 {
-    PX4_INFO("AF9838: Triggering BISC in configure...");
+	PX4_INFO("AF9838: Triggering BISC in configure...");
 
-    if (write_reg(REG_STATE, STATE_SELF_TEST) != PX4_OK) {
-        return PX4_ERROR;
-    }
+	if (write_reg(REG_STATE, STATE_SELF_TEST) != PX4_OK) {
+		return PX4_ERROR;
+	}
 
-    px4_usleep(40_ms);
+	px4_usleep(40_ms);
 
-    if (write_reg(REG_STATE, STATE_SINGLE) != PX4_OK) {
-        return PX4_ERROR;
-    }
+	if (write_reg(REG_STATE, STATE_SINGLE) != PX4_OK) {
+		return PX4_ERROR;
+	}
 
-    px4_usleep(6_ms);
+	px4_usleep(6_ms);
 
-    return PX4_OK;
+	return PX4_OK;
 }
 
 uint8_t AF9838_Driver::read_reg(uint8_t reg)
 {
-    uint8_t v{0};
-    transfer(&reg, 1, &v, 1);
-    return v;
+	uint8_t v{0};
+	transfer(&reg, 1, &v, 1);
+	return v;
 }
 
 int AF9838_Driver::read_block(uint8_t reg, uint8_t *buf, size_t len)
 {
-    return transfer(&reg, 1, buf, len);
+	return transfer(&reg, 1, buf, len);
 }
 
 int AF9838_Driver::write_reg(uint8_t reg, uint8_t val)
 {
-    const uint8_t cmd[2] = {reg, val};
-    return transfer(cmd, sizeof(cmd), nullptr, 0);
+	const uint8_t cmd[2] = {reg, val};
+	return transfer(cmd, sizeof(cmd), nullptr, 0);
 }
 
 
 void AF9838_Driver::RunImpl()
 {
-    if (!_running) {
-        return;
-    }
+	if (!_running) {
+		return;
+	}
 
-    static bool in_run = false;
+	static bool in_run = false;
 
-    if (in_run) {
-        return;
-    }
+	if (in_run) {
+		return;
+	}
 
-    in_run = true;
+	in_run = true;
 
-    const hrt_abstime now = hrt_absolute_time();
+	const hrt_abstime now = hrt_absolute_time();
 
-    if (_last_run != 0 && (now - _last_run) < _measure_interval_us) {
-        in_run = false;
-        return;
-    }
+	if (_last_run != 0 && (now - _last_run) < _measure_interval_us) {
+		in_run = false;
+		return;
+	}
 
-    _last_run = now;
+	_last_run = now;
 
-    if (_waiting_data) {
-        if (now - _last_trigger >= 5000) {
-            uint8_t b[6] {};
-            int16_t rx = 0, ry = 0, rz = 0;
-            float mx_uT = 0.f, my_uT = 0.f, mz_uT = 0.f;
-            float mx_G = 0.f, my_G = 0.f, mz_G = 0.f;
+	if (_waiting_data) {
+		if (now - _last_trigger >= 5000) {
+			uint8_t b[6] {};
+			int16_t rx = 0, ry = 0, rz = 0;
+			float mx_uT = 0.f, my_uT = 0.f, mz_uT = 0.f;
+			float mx_G = 0.f, my_G = 0.f, mz_G = 0.f;
 
-            if (read_block(REG_CH1_LSB, b, sizeof(b)) == PX4_OK) {
-                rx = (int16_t)((b[1] << 8) | b[0]);
-                ry = (int16_t)((b[3] << 8) | b[2]);
-                rz = (int16_t)((b[5] << 8) | b[4]);
+			if (read_block(REG_CH1_LSB, b, sizeof(b)) == PX4_OK) {
+				rx = (int16_t)((b[1] << 8) | b[0]);
+				ry = (int16_t)((b[3] << 8) | b[2]);
+				rz = (int16_t)((b[5] << 8) | b[4]);
 
-                mx_uT = rx * AF9838::LSB_TO_uT;
-                my_uT = ry * AF9838::LSB_TO_uT;
-                mz_uT = rz * AF9838::LSB_TO_uT;
+				mx_uT = rx * AF9838::LSB_TO_uT;
+				my_uT = ry * AF9838::LSB_TO_uT;
+				mz_uT = rz * AF9838::LSB_TO_uT;
 
-                mx_G = mx_uT * AF9838::uT_TO_G;
-                my_G = my_uT * AF9838::uT_TO_G;
-                mz_G = mz_uT * AF9838::uT_TO_G;
+				mx_G = mx_uT * AF9838::uT_TO_G;
+				my_G = my_uT * AF9838::uT_TO_G;
+				mz_G = mz_uT * AF9838::uT_TO_G;
 
-                _px4_mag.update(now, mx_G, my_G, mz_G);
+				_px4_mag.update(now, mx_G, my_G, mz_G);
 
-            }
+			}
 
-            _waiting_data = false;
-        }
+			_waiting_data = false;
+		}
 
-    } else {
-        if (write_reg(REG_STATE, STATE_SINGLE) == PX4_OK) {
-            _last_trigger = now;
-            _waiting_data = true;
-        }
-    }
+	} else {
+		if (write_reg(REG_STATE, STATE_SINGLE) == PX4_OK) {
+			_last_trigger = now;
+			_waiting_data = true;
+		}
+	}
 
 #if defined(STATUS_HOFL)
-    uint8_t st = read_reg(REG_STATUS);
+	uint8_t st = read_reg(REG_STATUS);
 
-    if (st & STATUS_HOFL) {
-        PX4_WARN("AF9838: overflow");
-    }
+	if (st & STATUS_HOFL) {
+		PX4_WARN("AF9838: overflow");
+	}
 
 #endif
 
-    in_run = false;
+	in_run = false;
 }
 
 
 void AF9838_Driver::start()
 {
-    _running = true;
-    ScheduleOnInterval(_measure_interval_us);
-    PX4_INFO("AF9838: start() with interval %u us (%.1f Hz)",
-         (unsigned)_measure_interval_us, 1e6 / static_cast<double>(_measure_interval_us));
+	_running = true;
+	ScheduleOnInterval(_measure_interval_us);
+	PX4_INFO("AF9838: start() with interval %u us (%.1f Hz)",
+		 (unsigned)_measure_interval_us, 1e6 / static_cast<double>(_measure_interval_us));
 
 }
 void AF9838_Driver::stop()
 {
-    _running = false;
-    ScheduleClear();
+	_running = false;
+	ScheduleClear();
 }
 
 void AF9838_Driver::print_status()
 {
-    PX4_INFO("AF9838 @ I2C addr 0x%02x, running=%d", get_device_address(), _running ? 1 : 0);
+	PX4_INFO("AF9838 @ I2C addr 0x%02x, running=%d", get_device_address(), _running ? 1 : 0);
 }

--- a/src/drivers/magnetometer/voltafield/af9838/af9838.cpp
+++ b/src/drivers/magnetometer/voltafield/af9838/af9838.cpp
@@ -31,298 +31,236 @@
  ****************************************************************************/
 #include "af9838.hpp"
 
-#ifdef VTC_DRIVER_MED_FILTER
-void AF9838_Driver::af9838_median_filter(float *mag)
-{
-	uint16_t i, j, k;
-	float mft_tmp[3][MED_FILTER_MAX_NUM];
-	float tmp;
-
-	if (_mdf_init_idx < _mdf_num) {
-		for (i = 0; i < 3; i++) {
-			_mdf_data[i][_mdf_init_idx] = mag[i];
-		}
-
-		_mdf_init_idx++;
-		return;
-
-	} else {
-		for (i = 0; i < 3; i++) {
-			_mdf_data[i][_mdf_data_idx] = mag[i];
-		}
-	}
-
-	if (++_mdf_data_idx >= _mdf_num) {
-		_mdf_data_idx = 0;
-	}
-
-	for (i = 0; i < 3; i++) {
-		for (j = 0; j < _mdf_num; j++) {
-			mft_tmp[i][j] = _mdf_data[i][j];
-		}
-	}
-
-	for (i = 0; i < 3; i++) {
-		for (j = 0; j < (_mdf_num - 1); j++) {
-			for (k = 0; k < (_mdf_num - 1 - j); k++) {
-				if (mft_tmp[i][k] < mft_tmp[i][k + 1]) {
-					tmp = mft_tmp[i][k];
-					mft_tmp[i][k] = mft_tmp[i][k + 1];
-					mft_tmp[i][k + 1] = tmp;
-				}
-			}
-		}
-	}
-
-	for (i = 0; i < 3; i++) {
-		mag[i] = mft_tmp[i][(uint16_t)((_mdf_num - 1) / 2)];
-	}
-}
-#endif
-
-
 using namespace AF9838;
 using namespace time_literals;
 
-
-float AF9838::g_cli_rate_hz = 100.0f;
-
-
 AF9838_Driver::AF9838_Driver(const I2CSPIDriverConfig &config)
-	: device::I2C(config),
-	  I2CSPIDriver(config),
-	  _px4_mag(get_device_id(), config.rotation)
+    : device::I2C(config),
+      I2CSPIDriver(config),
+      _px4_mag(get_device_id(), config.rotation)
 {
-	_px4_mag.set_device_type(DRV_MAG_DEVTYPE_AF9838);
-	_px4_mag.set_device_id(get_device_id());
+    _px4_mag.set_device_type(DRV_MAG_DEVTYPE_AF9838);
+    _px4_mag.set_device_id(get_device_id());
 }
 
 I2CSPIDriverBase *AF9838_Driver::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
-	PX4_INFO("AF9838: instantiate bus=%d addr=0x%02X freq=%u",
-		 config.bus, config.i2c_address, config.bus_frequency);
+    PX4_INFO("AF9838: instantiate bus=%d addr=0x%02X freq=%u",
+         config.bus, config.i2c_address, config.bus_frequency);
 
-	AF9838_Driver *dev = new AF9838_Driver(config);
+    AF9838_Driver *dev = new AF9838_Driver(config);
 
-	if (!dev) { return nullptr; }
+    if (!dev) { return nullptr; }
 
-	const int ret = dev->init();
-	PX4_INFO("AF9838: I2C::init ret=%d", ret);
+    const int ret = dev->init();
+    PX4_INFO("AF9838: I2C::init ret=%d", ret);
 
-	if (ret != PX4_OK) {
-		delete dev;
-		return nullptr;
-	}
+    if (ret != PX4_OK) {
+        delete dev;
+        return nullptr;
+    }
 
-	return dev;
+    return dev;
 }
 
 
 int AF9838_Driver::probe()
 {
-	constexpr int MAX_TRIES = 3;
-	uint8_t id = 0xff;
+    constexpr int MAX_TRIES = 3;
+    uint8_t id = 0xff;
 
-	PX4_INFO("AF9838: probe() on bus=%d addr=0x%02X", get_device_bus(), get_device_address());
+    PX4_INFO("AF9838: probe() on bus=%d addr=0x%02X", get_device_bus(), get_device_address());
 
-	for (int i = 0; i < MAX_TRIES; i++) {
-		if (transfer(&REG_PCODE, 1, &id, 1) == PX4_OK) {
-			PX4_INFO("AF9838: REG_PCODE=0x%02X (try %d)", id, i + 1);
-			return PX4_OK;
-		}
+    for (int i = 0; i < MAX_TRIES; i++) {
+        if (transfer(&REG_PCODE, 1, &id, 1) == PX4_OK) {
+            PX4_INFO("AF9838: REG_PCODE=0x%02X (try %d)", id, i + 1);
+            return PX4_OK;
+        }
 
-		px4_usleep(1_ms);
-	}
+        px4_usleep(1_ms);
+    }
 
-	PX4_ERR("AF9838: probe() failed (no response) bus=%d addr=0x%02X",
-		get_device_bus(), get_device_address());
-	return PX4_ERROR;
+    PX4_ERR("AF9838: probe() failed (no response) bus=%d addr=0x%02X",
+        get_device_bus(), get_device_address());
+    return PX4_ERROR;
 }
 
 
 int AF9838_Driver::init()
 {
-	PX4_INFO("AF9838: init() enter");
+    PX4_INFO("AF9838: init() enter");
 
-	int ret = device::I2C::init();
-	PX4_INFO("AF9838: device::I2C::init ret=%d", ret);
+    int ret = device::I2C::init();
+    PX4_INFO("AF9838: device::I2C::init ret=%d", ret);
 
-	if (ret != PX4_OK) { return ret; }
+    if (ret != PX4_OK) { return ret; }
 
-	PX4_INFO("AF9838: soft_reset...");
-	(void)soft_reset();
+    PX4_INFO("AF9838: soft_reset...");
+    (void)soft_reset();
 
-	PX4_INFO("AF9838: configure BISC...");
+    PX4_INFO("AF9838: configure BISC...");
 
-	if (configure() != PX4_OK) {
-		PX4_ERR("AF9838: configure failed");
-		return PX4_ERROR;
-	}
+    if (configure() != PX4_OK) {
+        PX4_ERR("AF9838: configure failed");
+        return PX4_ERROR;
+    }
 
-	float hz = g_cli_rate_hz;
+    float hz = AF9838::DEFAULT_RATE_HZ;
 
-	if (hz < 1.f) { hz = 1.f; }
+    if (hz < 1.f) { hz = 1.f; }
 
-	if (hz > 1000.f) { hz = 1000.f; }
+    if (hz > 1000.f) { hz = 1000.f; }
 
-	_measure_interval_us = (uint32_t)(1000000.0f / hz);
+    _measure_interval_us = (uint32_t)(1000000.0f / hz);
 
-	_running = true;
-	ScheduleOnInterval(_measure_interval_us);
-	PX4_INFO("AF9838: scheduled every %u us (%.1f Hz)",
-		 (unsigned)_measure_interval_us,
-		 1e6 / static_cast<double>(_measure_interval_us));
+    _running = true;
+    ScheduleOnInterval(_measure_interval_us);
+    PX4_INFO("AF9838: scheduled every %u us (%.1f Hz)",
+         (unsigned)_measure_interval_us,
+         1e6 / static_cast<double>(_measure_interval_us));
 
-	const hrt_abstime now = hrt_absolute_time();
-	_px4_mag.update(now, 0.f, 0.f, 0.f);
-	PX4_INFO("AF9838: init() done");
-	return PX4_OK;
+    const hrt_abstime now = hrt_absolute_time();
+    _px4_mag.update(now, 0.f, 0.f, 0.f);
+    PX4_INFO("AF9838: init() done");
+    return PX4_OK;
 }
 
 
 int AF9838_Driver::soft_reset()
 {
-	if (write_reg(REG_SWR, 0x81) != PX4_OK) {
-		PX4_ERR("soft reset write failed");
-		return PX4_ERROR;
-	}
+    if (write_reg(REG_SWR, 0x81) != PX4_OK) {
+        PX4_ERR("soft reset write failed");
+        return PX4_ERROR;
+    }
 
-	px4_usleep(5_ms);
+    px4_usleep(5_ms);
 
-	return PX4_OK;
+    return PX4_OK;
 }
 
 int AF9838_Driver::configure()
 {
-	PX4_INFO("AF9838: Triggering BISC in configure...");
+    PX4_INFO("AF9838: Triggering BISC in configure...");
 
-	if (write_reg(REG_STATE, STATE_SELF_TEST) != PX4_OK) {
-		return PX4_ERROR;
-	}
+    if (write_reg(REG_STATE, STATE_SELF_TEST) != PX4_OK) {
+        return PX4_ERROR;
+    }
 
-	px4_usleep(40_ms);
+    px4_usleep(40_ms);
 
-	if (write_reg(REG_STATE, STATE_SINGLE) != PX4_OK) {
-		return PX4_ERROR;
-	}
+    if (write_reg(REG_STATE, STATE_SINGLE) != PX4_OK) {
+        return PX4_ERROR;
+    }
 
-	px4_usleep(6_ms);
+    px4_usleep(6_ms);
 
-	return PX4_OK;
+    return PX4_OK;
 }
 
 uint8_t AF9838_Driver::read_reg(uint8_t reg)
 {
-	uint8_t v{0};
-	transfer(&reg, 1, &v, 1);
-	return v;
+    uint8_t v{0};
+    transfer(&reg, 1, &v, 1);
+    return v;
 }
 
 int AF9838_Driver::read_block(uint8_t reg, uint8_t *buf, size_t len)
 {
-	return transfer(&reg, 1, buf, len);
+    return transfer(&reg, 1, buf, len);
 }
 
 int AF9838_Driver::write_reg(uint8_t reg, uint8_t val)
 {
-	const uint8_t cmd[2] = {reg, val};
-	return transfer(cmd, sizeof(cmd), nullptr, 0);
+    const uint8_t cmd[2] = {reg, val};
+    return transfer(cmd, sizeof(cmd), nullptr, 0);
 }
 
 
 void AF9838_Driver::RunImpl()
 {
-	if (!_running) {
-		return;
-	}
+    if (!_running) {
+        return;
+    }
 
-	static bool in_run = false;
+    static bool in_run = false;
 
-	if (in_run) {
-		return;
-	}
+    if (in_run) {
+        return;
+    }
 
-	in_run = true;
+    in_run = true;
 
-	const hrt_abstime now = hrt_absolute_time();
+    const hrt_abstime now = hrt_absolute_time();
 
-	if (_last_run != 0 && (now - _last_run) < _measure_interval_us) {
-		in_run = false;
-		return;
-	}
+    if (_last_run != 0 && (now - _last_run) < _measure_interval_us) {
+        in_run = false;
+        return;
+    }
 
-	_last_run = now;
+    _last_run = now;
 
-	if (_waiting_data) {
-		if (now - _last_trigger >= 5000) {
-			uint8_t b[6] {};
-			int16_t rx = 0, ry = 0, rz = 0;
-			float mx_uT = 0.f, my_uT = 0.f, mz_uT = 0.f;
-			float mx_G = 0.f, my_G = 0.f, mz_G = 0.f;
+    if (_waiting_data) {
+        if (now - _last_trigger >= 5000) {
+            uint8_t b[6] {};
+            int16_t rx = 0, ry = 0, rz = 0;
+            float mx_uT = 0.f, my_uT = 0.f, mz_uT = 0.f;
+            float mx_G = 0.f, my_G = 0.f, mz_G = 0.f;
 
-			if (read_block(REG_CH1_LSB, b, sizeof(b)) == PX4_OK) {
-				rx = (int16_t)((b[1] << 8) | b[0]);
-				ry = (int16_t)((b[3] << 8) | b[2]);
-				rz = (int16_t)((b[5] << 8) | b[4]);
+            if (read_block(REG_CH1_LSB, b, sizeof(b)) == PX4_OK) {
+                rx = (int16_t)((b[1] << 8) | b[0]);
+                ry = (int16_t)((b[3] << 8) | b[2]);
+                rz = (int16_t)((b[5] << 8) | b[4]);
 
-				mx_uT = rx * AF9838::LSB_TO_uT;
-				my_uT = ry * AF9838::LSB_TO_uT;
-				mz_uT = rz * AF9838::LSB_TO_uT;
+                mx_uT = rx * AF9838::LSB_TO_uT;
+                my_uT = ry * AF9838::LSB_TO_uT;
+                mz_uT = rz * AF9838::LSB_TO_uT;
 
-#ifdef VTC_DRIVER_MED_FILTER
-				float mag_uT[3] = { mx_uT, my_uT, mz_uT };
-				af9838_median_filter(mag_uT);
-				mx_uT = mag_uT[0];
-				my_uT = mag_uT[1];
-				mz_uT = mag_uT[2];
-#endif
+                mx_G = mx_uT * AF9838::uT_TO_G;
+                my_G = my_uT * AF9838::uT_TO_G;
+                mz_G = mz_uT * AF9838::uT_TO_G;
 
-				mx_G = mx_uT * AF9838::uT_TO_G;
-				my_G = my_uT * AF9838::uT_TO_G;
-				mz_G = mz_uT * AF9838::uT_TO_G;
+                _px4_mag.update(now, mx_G, my_G, mz_G);
 
-				_px4_mag.update(now, mx_G, my_G, mz_G);
+            }
 
-			}
+            _waiting_data = false;
+        }
 
-			_waiting_data = false;
-		}
-
-	} else {
-		if (write_reg(REG_STATE, STATE_SINGLE) == PX4_OK) {
-			_last_trigger = now;
-			_waiting_data = true;
-		}
-	}
+    } else {
+        if (write_reg(REG_STATE, STATE_SINGLE) == PX4_OK) {
+            _last_trigger = now;
+            _waiting_data = true;
+        }
+    }
 
 #if defined(STATUS_HOFL)
-	uint8_t st = read_reg(REG_STATUS);
+    uint8_t st = read_reg(REG_STATUS);
 
-	if (st & STATUS_HOFL) {
-		PX4_WARN("AF9838: overflow");
-	}
+    if (st & STATUS_HOFL) {
+        PX4_WARN("AF9838: overflow");
+    }
 
 #endif
 
-	in_run = false;
+    in_run = false;
 }
 
 
 void AF9838_Driver::start()
 {
-	_running = true;
-	ScheduleOnInterval(_measure_interval_us);
-	PX4_INFO("AF9838: start() with interval %u us (%.1f Hz)",
-		 (unsigned)_measure_interval_us, 1e6 / static_cast<double>(_measure_interval_us));
+    _running = true;
+    ScheduleOnInterval(_measure_interval_us);
+    PX4_INFO("AF9838: start() with interval %u us (%.1f Hz)",
+         (unsigned)_measure_interval_us, 1e6 / static_cast<double>(_measure_interval_us));
 
 }
 void AF9838_Driver::stop()
 {
-	_running = false;
-	ScheduleClear();
+    _running = false;
+    ScheduleClear();
 }
 
 void AF9838_Driver::print_status()
 {
-	PX4_INFO("AF9838 @ I2C addr 0x%02x, running=%d", get_device_address(), _running ? 1 : 0);
+    PX4_INFO("AF9838 @ I2C addr 0x%02x, running=%d", get_device_address(), _running ? 1 : 0);
 }

--- a/src/drivers/magnetometer/voltafield/af9838/af9838.hpp
+++ b/src/drivers/magnetometer/voltafield/af9838/af9838.hpp
@@ -65,40 +65,40 @@ static constexpr uint32_t I2C_SPEED           = 100000;           // 100 kHz
 class AF9838_Driver : public device::I2C, public I2CSPIDriver<AF9838_Driver>
 {
 public:
-    AF9838_Driver(const I2CSPIDriverConfig &config);
+	AF9838_Driver(const I2CSPIDriverConfig &config);
 
-    static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 
-    int  init() override;
-    int  probe() override;
-    void RunImpl();
-    void start();
-    void stop();
-    void print_status();
-    static void print_usage();
+	int  init() override;
+	int  probe() override;
+	void RunImpl();
+	void start();
+	void stop();
+	void print_status();
+	static void print_usage();
 
 private:
-    orb_advert_t _mavlink_log_pub{nullptr};
-    int8_t _last_accuracy{-1};
+	orb_advert_t _mavlink_log_pub{nullptr};
+	int8_t _last_accuracy{-1};
 
-    using device::I2C::transfer;
-    uint8_t read_reg(uint8_t reg);
-    int     read_block(uint8_t reg, uint8_t *buf, size_t len);
-    int     write_reg(uint8_t reg, uint8_t val);
+	using device::I2C::transfer;
+	uint8_t read_reg(uint8_t reg);
+	int     read_block(uint8_t reg, uint8_t *buf, size_t len);
+	int     write_reg(uint8_t reg, uint8_t val);
 
-    int     soft_reset();
-    int     configure();
-    int     read_measurement();
+	int     soft_reset();
+	int     configure();
+	int     read_measurement();
 
-    hrt_abstime _last_run{0};
-    uint32_t _measure_interval_us{10000};
+	hrt_abstime _last_run{0};
+	uint32_t _measure_interval_us{10000};
 
-    PX4Magnetometer _px4_mag;
-    bool            _running{false};
-    bool _waiting_data{false};
-    hrt_abstime _last_trigger{0};
+	PX4Magnetometer _px4_mag;
+	bool            _running{false};
+	bool _waiting_data{false};
+	hrt_abstime _last_trigger{0};
 
-    uORB::Subscription _accel_sub {ORB_ID(vehicle_acceleration)};
-    hrt_abstime _last_accel_ts{0};
+	uORB::Subscription _accel_sub {ORB_ID(vehicle_acceleration)};
+	hrt_abstime _last_accel_ts{0};
 
 };

--- a/src/drivers/magnetometer/voltafield/af9838/af9838.hpp
+++ b/src/drivers/magnetometer/voltafield/af9838/af9838.hpp
@@ -53,7 +53,7 @@
 
 namespace AF9838
 {
-extern float g_cli_rate_hz;
+static constexpr float DEFAULT_RATE_HZ = 100.0f;
 static constexpr float LSB_TO_uT = 0.1f;    // micro-Tesla / LSB
 static constexpr float uT_TO_G   = 0.01f;   // µT → Gauss
 static constexpr float ONE_G = 9.80665f;
@@ -65,51 +65,40 @@ static constexpr uint32_t I2C_SPEED           = 100000;           // 100 kHz
 class AF9838_Driver : public device::I2C, public I2CSPIDriver<AF9838_Driver>
 {
 public:
-	AF9838_Driver(const I2CSPIDriverConfig &config);
+    AF9838_Driver(const I2CSPIDriverConfig &config);
 
-	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
+    static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 
-	int  init() override;
-	int  probe() override;
-	void RunImpl();
-	void start();
-	void stop();
-	void print_status();
-	static void print_usage();
+    int  init() override;
+    int  probe() override;
+    void RunImpl();
+    void start();
+    void stop();
+    void print_status();
+    static void print_usage();
 
 private:
-	orb_advert_t _mavlink_log_pub{nullptr};
-	int8_t _last_accuracy{-1};
+    orb_advert_t _mavlink_log_pub{nullptr};
+    int8_t _last_accuracy{-1};
 
-	using device::I2C::transfer;
-	uint8_t read_reg(uint8_t reg);
-	int     read_block(uint8_t reg, uint8_t *buf, size_t len);
-	int     write_reg(uint8_t reg, uint8_t val);
+    using device::I2C::transfer;
+    uint8_t read_reg(uint8_t reg);
+    int     read_block(uint8_t reg, uint8_t *buf, size_t len);
+    int     write_reg(uint8_t reg, uint8_t val);
 
-	int     soft_reset();
-	int     configure();
-	int     read_measurement();
+    int     soft_reset();
+    int     configure();
+    int     read_measurement();
 
-	hrt_abstime _last_run{0};
-	uint32_t _measure_interval_us{10000};
+    hrt_abstime _last_run{0};
+    uint32_t _measure_interval_us{10000};
 
-	PX4Magnetometer _px4_mag;
-	bool            _running{false};
-	bool _waiting_data{false};
-	hrt_abstime _last_trigger{0};
-	bool            _algo_inited{false};
+    PX4Magnetometer _px4_mag;
+    bool            _running{false};
+    bool _waiting_data{false};
+    hrt_abstime _last_trigger{0};
 
-	static constexpr uint16_t AF9838_MED_FILTER_MAX_NUM = 15;
-	static constexpr uint16_t AF9838_MED_FILTER_NUMBER  = 5;
-
-	uint16_t _mdf_num      = AF9838_MED_FILTER_NUMBER;
-	uint16_t _mdf_init_idx = 0;
-	uint16_t _mdf_data_idx = 0;
-	float    _mdf_data[3][AF9838_MED_FILTER_MAX_NUM] {};
-
-	void af9838_median_filter(float mag[3]);
-
-	uORB::Subscription _accel_sub {ORB_ID(vehicle_acceleration)};
-	hrt_abstime _last_accel_ts{0};
+    uORB::Subscription _accel_sub {ORB_ID(vehicle_acceleration)};
+    hrt_abstime _last_accel_ts{0};
 
 };

--- a/src/drivers/magnetometer/voltafield/af9838/af9838_main.cpp
+++ b/src/drivers/magnetometer/voltafield/af9838/af9838_main.cpp
@@ -36,13 +36,13 @@
 #include <drivers/drv_sensor.h>
 void AF9838_Driver::print_usage()
 {
-    PRINT_MODULE_USAGE_NAME("af9838", "driver");
-    PRINT_MODULE_USAGE_SUBCATEGORY("magnetometer");
-    PRINT_MODULE_USAGE_COMMAND("start");
-    PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
-    PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x0C);
-    PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
-    PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+	PRINT_MODULE_USAGE_NAME("af9838", "driver");
+	PRINT_MODULE_USAGE_SUBCATEGORY("magnetometer");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x0C);
+	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
 #ifndef MODULE_NAME
@@ -51,42 +51,42 @@ void AF9838_Driver::print_usage()
 
 extern "C" __EXPORT int af9838_main(int argc, char *argv[])
 {
-    int ch;
-    using ThisDriver = AF9838_Driver;
+	int ch;
+	using ThisDriver = AF9838_Driver;
 
-    BusCLIArguments cli{true, false};
-    cli.i2c_address = I2C_ADDRESS_DEFAULT;
-    cli.default_i2c_frequency = I2C_SPEED;
+	BusCLIArguments cli{true, false};
+	cli.i2c_address = I2C_ADDRESS_DEFAULT;
+	cli.default_i2c_frequency = I2C_SPEED;
 
-    while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
-        switch (ch) {
-        case 'R':
-            cli.rotation = (enum Rotation)atoi(cli.optArg());
-            break;
-        }
-    }
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
+		switch (ch) {
+		case 'R':
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
+			break;
+		}
+	}
 
-    const char *verb = cli.optArg();
+	const char *verb = cli.optArg();
 
-    if (!verb) {
-        ThisDriver::print_usage();
-        return -1;
-    }
+	if (!verb) {
+		ThisDriver::print_usage();
+		return -1;
+	}
 
-    BusInstanceIterator iterator(MODULE_NAME, cli, DRV_MAG_DEVTYPE_AF9838);
+	BusInstanceIterator iterator(MODULE_NAME, cli, DRV_MAG_DEVTYPE_AF9838);
 
-    if (!strcmp(verb, "start")) {
-        return ThisDriver::module_start(cli, iterator);
-    }
+	if (!strcmp(verb, "start")) {
+		return ThisDriver::module_start(cli, iterator);
+	}
 
-    if (!strcmp(verb, "stop")) {
-        return ThisDriver::module_stop(iterator);
-    }
+	if (!strcmp(verb, "stop")) {
+		return ThisDriver::module_stop(iterator);
+	}
 
-    if (!strcmp(verb, "status")) {
-        return ThisDriver::module_status(iterator);
-    }
+	if (!strcmp(verb, "status")) {
+		return ThisDriver::module_status(iterator);
+	}
 
-    ThisDriver::print_usage();
-    return -1;
+	ThisDriver::print_usage();
+	return -1;
 }

--- a/src/drivers/magnetometer/voltafield/af9838/af9838_main.cpp
+++ b/src/drivers/magnetometer/voltafield/af9838/af9838_main.cpp
@@ -36,14 +36,13 @@
 #include <drivers/drv_sensor.h>
 void AF9838_Driver::print_usage()
 {
-	PRINT_MODULE_USAGE_NAME("af9838", "driver");
-	PRINT_MODULE_USAGE_SUBCATEGORY("magnetometer");
-	PRINT_MODULE_USAGE_COMMAND("start");
-	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
-	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x0C);
-	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
-	PRINT_MODULE_USAGE_PARAM_FLOAT('r', 100.f, 1.f, 1000.f, "Output rate (Hz)", true);
-	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+    PRINT_MODULE_USAGE_NAME("af9838", "driver");
+    PRINT_MODULE_USAGE_SUBCATEGORY("magnetometer");
+    PRINT_MODULE_USAGE_COMMAND("start");
+    PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+    PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x0C);
+    PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
+    PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
 #ifndef MODULE_NAME
@@ -52,50 +51,42 @@ void AF9838_Driver::print_usage()
 
 extern "C" __EXPORT int af9838_main(int argc, char *argv[])
 {
-	int ch;
-	using ThisDriver = AF9838_Driver;
+    int ch;
+    using ThisDriver = AF9838_Driver;
 
-	BusCLIArguments cli{true, false};
-	cli.i2c_address = I2C_ADDRESS_DEFAULT;
-	cli.default_i2c_frequency = I2C_SPEED;
+    BusCLIArguments cli{true, false};
+    cli.i2c_address = I2C_ADDRESS_DEFAULT;
+    cli.default_i2c_frequency = I2C_SPEED;
 
-	AF9838::g_cli_rate_hz = 100.0f;
+    while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
+        switch (ch) {
+        case 'R':
+            cli.rotation = (enum Rotation)atoi(cli.optArg());
+            break;
+        }
+    }
 
-	while ((ch = cli.getOpt(argc, argv, "R:r:")) != EOF) {
-		switch (ch) {
-		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optArg());
-			break;
+    const char *verb = cli.optArg();
 
-		case 'r': {
-				const float rate = atof(cli.optArg());
-				AF9838::g_cli_rate_hz = rate;
-				break;
-			}
-		}
-	}
+    if (!verb) {
+        ThisDriver::print_usage();
+        return -1;
+    }
 
-	const char *verb = cli.optArg();
+    BusInstanceIterator iterator(MODULE_NAME, cli, DRV_MAG_DEVTYPE_AF9838);
 
-	if (!verb) {
-		ThisDriver::print_usage();
-		return -1;
-	}
+    if (!strcmp(verb, "start")) {
+        return ThisDriver::module_start(cli, iterator);
+    }
 
-	BusInstanceIterator iterator(MODULE_NAME, cli, DRV_MAG_DEVTYPE_AF9838);
+    if (!strcmp(verb, "stop")) {
+        return ThisDriver::module_stop(iterator);
+    }
 
-	if (!strcmp(verb, "start")) {
-		return ThisDriver::module_start(cli, iterator);
-	}
+    if (!strcmp(verb, "status")) {
+        return ThisDriver::module_status(iterator);
+    }
 
-	if (!strcmp(verb, "stop")) {
-		return ThisDriver::module_stop(iterator);
-	}
-
-	if (!strcmp(verb, "status")) {
-		return ThisDriver::module_status(iterator);
-	}
-
-	ThisDriver::print_usage();
-	return -1;
+    ThisDriver::print_usage();
+    return -1;
 }


### PR DESCRIPTION
### Solution
This PR is a minor follow-up to address reviewer feedback and clean up the recently merged AF9838 driver.
- Moved `using namespace` declarations to the top of `af9838.cpp`.
- Removed the global mutable variable `g_cli_rate_hz` and `-r` CLI parameter.
- Replaced the rate with a clean `constexpr` in the header to ensure the driver is fully multi-instance safe.
- Removed the custom `med_filter` implementation and its related dead code to align with PX4 standards (filtering should be handled downstream by the sensor module/EKF).

### Changelog Entry
Fix: address code style, global variable, and clean up dead code in AF9838 driver

### Test coverage
- Driver builds successfully.

### Context
Follow-up adjustments and cleanups for the AF9838 driver integration.