### PR TITLE
fix(commander): Only require a heading reference when a global origin set

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -626,9 +626,11 @@ void EstimatorChecks::checkEstimatorStatusFlags(const Context &context, Report &
 			}
 		}
 
+		// Only require a heading reference when a global origin is set (i.e. global ops are intended)
 		if (!context.isArmed()
 		    && (hrt_absolute_time() - estimator_status_flags.timestamp < 5_s)
-		    && !estimator_status_flags.cs_yaw_align) {
+		    && !estimator_status_flags.cs_yaw_align
+		    && lpos.xy_global) {
 
 			const NavModes heading_required_groups = (NavModes)(
 						reporter.failsafeFlags().mode_req_local_position |


### PR DESCRIPTION
### Solved Problem
This fixes https://github.com/PX4/PX4-Autopilot/issues/27031 and supersedes https://github.com/PX4/PX4-Autopilot/pull/27302.

The previous PR removed the ability to arm in Position mode without a valid heading estimate. This was initially introduced to fix Optical Flow behavior, based on the definition of `VehicleLocalPosition.msg`, where the local frame is explicitly defined as NED:

```cpp
# Position in local NED frame
float32 x				# North position in NED earth-fixed frame, (metres)
float32 y				# East position in NED earth-fixed frame, (metres)
float32 z				# Down position (negative altitude) in NED earth-fixed frame, (metres)
```

From that perspective, the previous behavior was technically inconsistent, since a NED frame implicitly requires a valid heading reference.

However, it became clear that there are use-cases for that. Especially for indoor and manually controlled vehicles where arming without a heading estimate is both useful and expected.

### Solution
This PR relaxes the requirement by only enforcing a valid heading once a global reference has been established.

As a result:
- Indoor or manually controlled vehicles can still arm and operate as before.
- Systems using a global reference continue to benefit from the stricter consistency checks introduced in the original PR.
- The behavior now better reflects the distinction between purely local operation and globally referenced navigation.