### PR TITLE
fix(commander): refuse stale config_control_setpoints cache on activation

### DIFF
--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -533,13 +533,38 @@ uint8_t ModeManagement::getNavStateDisplay(uint8_t nav_state) const
 	}
 }
 
-bool ModeManagement::updateControlMode(uint8_t nav_state, vehicle_control_mode_s &control_mode) const
+bool ModeManagement::updateControlMode(uint8_t nav_state, vehicle_control_mode_s &control_mode)
 {
 	bool ret = false;
 
+	const bool activation = (nav_state != _last_served_nav_state);
+
+	if (activation) {
+		_last_served_nav_state = nav_state;
+		_last_served_change_us = hrt_absolute_time();
+	}
+
 	if (nav_state >= Modes::FIRST_EXTERNAL_NAV_STATE && nav_state <= Modes::LAST_EXTERNAL_NAV_STATE) {
 		if (_modes.valid(nav_state)) {
-			control_mode = _modes.mode(nav_state).config_control_setpoint;
+			const Modes::Mode &mode = _modes.mode(nav_state);
+
+			// Refuse a cached config_control_setpoints entry that predates the current
+			// activation of this nav_state; publish safe defaults until a fresh one arrives.
+			const bool stale = (mode.config_control_setpoint.timestamp == 0)
+					   || (mode.config_control_setpoint.timestamp + 10_ms < _last_served_change_us);
+
+			if (stale) {
+				Modes::Mode::setControlModeDefaults(control_mode);
+
+				if (activation) {
+					PX4_DEBUG("External mode %i: stale config_control_setpoints on activation, using safe defaults",
+						  nav_state);
+				}
+
+			} else {
+				control_mode = mode.config_control_setpoint;
+			}
+
 			ret = true;
 
 		} else {
@@ -606,7 +631,9 @@ bool ModeManagement::checkConfigControlSetpointUpdates()
 
 	while (_config_control_setpoints_sub.update(&config_control_setpoint) && --max_updates >= 0) {
 		if (_modes.valid(config_control_setpoint.source_id)) {
-			_modes.mode(config_control_setpoint.source_id).config_control_setpoint = config_control_setpoint;
+			Modes::Mode &mode = _modes.mode(config_control_setpoint.source_id);
+			mode.config_control_setpoint = config_control_setpoint;
+			mode.config_control_setpoint.timestamp = hrt_absolute_time();
 			had_update = true;
 
 		} else {

--- a/src/modules/commander/ModeManagement.hpp
+++ b/src/modules/commander/ModeManagement.hpp
@@ -33,6 +33,8 @@
 
 #pragma once
 
+#include <drivers/drv_hrt.h>
+
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/register_ext_component_request.h>
@@ -164,7 +166,7 @@ public:
 
 	uint8_t getNavStateReplacementIfValid(uint8_t nav_state, bool report_error = true);
 
-	bool updateControlMode(uint8_t nav_state, vehicle_control_mode_s &control_mode) const;
+	bool updateControlMode(uint8_t nav_state, vehicle_control_mode_s &control_mode);
 
 	void printStatus() const;
 
@@ -197,6 +199,9 @@ private:
 	int _mode_executor_in_charge{ModeExecutors::AUTOPILOT_EXECUTOR_ID};
 
 	bool _invalid_mode_printed{false};
+
+	uint8_t _last_served_nav_state{0xff};
+	hrt_abstime _last_served_change_us{0};
 };
 
 #else /* CONSTRAINED_FLASH */
@@ -225,7 +230,7 @@ public:
 
 	uint8_t getNavStateReplacementIfValid(uint8_t nav_state, bool report_error = true) { return nav_state; }
 
-	bool updateControlMode(uint8_t nav_state, vehicle_control_mode_s &control_mode) const { return false; }
+	bool updateControlMode(uint8_t nav_state, vehicle_control_mode_s &control_mode) { return false; }
 
 	void printStatus() const {}
 


### PR DESCRIPTION
ModeManagement caches the most recent config_control_setpoints entry per source_id (one per external mode) and reads it on every nav_state change to decide which flight controllers to enable. The cache was read verbatim regardless of when the entry was written, so a contract authored during an earlier activation of the same mode -- e.g. a ground configuration that disables all controllers, followed by re-entering the same mode in the air -- briefly forced the new activation onto a controller configuration intended for the previous one.

Stamp every cache write with the PX4-local receive time. On the first updateControlMode() call for a new nav_state, refuse any cached entry whose receive time predates the activation and publish the safe default contract (every control loop enabled) instead, until a fresh entry arrives. A single warning is emitted per activation when the
fallback engages.