### PR TITLE
feat(docs):  ufw-firmware flashing

### DIFF
--- a/docs/en/dronecan/index.md
+++ b/docs/en/dronecan/index.md
@@ -310,10 +310,37 @@ Most DroneCAN nodes require no further setup, unless specifically noted in their
 ## Firmware Update
 
 PX4 can upgrade device firmware over DroneCAN.
-To upgrade the device, all you need to do is copy the firmware binary into the root directory of the flight controller's SD card and reboot.
+On boot the flight controller scans for firmware binaries, migrates them to the firmware directory, and automatically transfers the firmware to any connected node whose version does not match.
 
-Upon boot the flight controller will automatically transfer the firmware onto the device and upgrade it.
-If successful, the firmware binary will be removed from the root directory and there will be a file named **XX.bin** in the **/ufw** directory of the SD card.
+### Placing Firmware Files
+
+Place firmware binaries (`.bin` files with a valid APDescriptor) in one of these locations on the SD card before rebooting:
+
+- **SD card root** (`/fs/microsd/`): Simplest option for manual updates.
+- **Staging directory** (`/fs/microsd/ufw_staging/`): Preferred for remote/programmatic updates. The directory is swapped in atomically at boot, avoiding write conflicts if files are uploaded while the vehicle is running.
+
+On boot, the UAVCAN server scans both locations, reads the board ID from the APDescriptor of each file, and copies it to `/fs/microsd/ufw/<board_id>.bin`. The source file is then deleted. Any connected node whose running version does not match is then flashed over the CAN bus.
+
+### Firmware Database
+
+A flat-file database at `/fs/microsd/ufw/FW.db` maps each board ID filename to the original filename that was installed. Stale entries are removed automatically on every boot. Example entry:
+
+```
+122.bin=122-1.17.63eeff1a.uavcan.bin
+```
+
+### Remote Update
+
+Firmware can be delivered remotely by bundling `.bin` files into an update archive. An external update tool can extract the archive on the target and copy the CAN firmware files into `/fs/microsd/ufw_staging/`. They are then picked up on the next boot.
+
+Before uploading, the tool can read `/fs/microsd/ufw/FW.db` to check which firmware is already installed and skip files that haven't changed, reducing transfer size.
+
+`upload_skynode.sh` handles the bundling via the `--ext-fw` flag (repeatable for multiple nodes):
+
+```
+./Tools/auterion/upload_skynode.sh \
+  --ext-fw=build/auterion_canio_default/auterion_canio_default.uavcan.bin
+```
 
 ## Troubleshooting
 

--- a/docs/en/dronecan/index.md
+++ b/docs/en/dronecan/index.md
@@ -6,7 +6,7 @@
 
 - DroneCAN is not enabled by default, and nor are specific sensors and features that use it.
   For setup information see [PX4 Configuration](#px4-configuration).
-- PX4 requires an SD card to enable dynamic node allocation and for firmware update.
+- PX4 requires an SD card to enable dynamic node allocation and for [firmware update](#firmware-update).
   The SD card is not used in flight.
 
 :::
@@ -310,34 +310,44 @@ Most DroneCAN nodes require no further setup, unless specifically noted in their
 ## Firmware Update
 
 PX4 can upgrade device firmware over DroneCAN.
-On boot the flight controller scans for firmware binaries, migrates them to the firmware directory, and automatically transfers the firmware to any connected node whose version does not match.
 
-### Placing Firmware Files
+::: info
+PX4 identifies valid firmware binaries (`.bin`) based on the presence of an **APDescriptor** — a metadata block embedded in the `.bin` file that contains the target board ID, firmware version, and a checksum.
+PX4 uses this descriptor to match each binary to the correct node and to determine whether an update is needed.
+:::
 
-Place firmware binaries (`.bin` files with a valid APDescriptor) in one of these locations on the SD card before rebooting:
+### Firmware Directories
+
+Place firmware binaries in one of these locations on the SD card before rebooting:
 
 - **SD card root** (`/fs/microsd/`): Simplest option for manual updates.
-- **Staging directory** (`/fs/microsd/ufw_staging/`): Preferred for remote/programmatic updates. The directory is swapped in atomically at boot, avoiding write conflicts if files are uploaded while the vehicle is running.
+- **Staging directory** (`/fs/microsd/ufw_staging/`): Preferred for remote/programmatic updates.
+  Files are moved to `/fs/microsd/ufw/` at boot before any node is flashed, avoiding write conflicts if firmware is uploaded while the vehicle is running.
 
-On boot, the UAVCAN server scans both locations, reads the board ID from the APDescriptor of each file, and copies it to `/fs/microsd/ufw/<board_id>.bin`. The source file is then deleted. Any connected node whose running version does not match is then flashed over the CAN bus.
+On boot, PX4 scans both locations, reads the board ID from the _APDescriptor_ of each file, and copies them to `/fs/microsd/ufw/<board_id>.bin`.
+The source file is then deleted.
+Any connected node whose running version does not match is then flashed over the CAN bus.
 
 ### Firmware Database
 
-A flat-file database at `/fs/microsd/ufw/FW.db` maps each board ID filename to the original filename that was installed. Stale entries are removed automatically on every boot. Example entry:
+A flat-file database at `/fs/microsd/ufw/FW.db` maps each board ID to the original firmware filename that was installed.
+Stale entries are removed automatically on every boot.
+Example entry:
 
-```
+```txt
 122.bin=122-1.17.63eeff1a.uavcan.bin
 ```
 
 ### Remote Update
 
-Firmware can be delivered remotely by bundling `.bin` files into an update archive. An external update tool can extract the archive on the target and copy the CAN firmware files into `/fs/microsd/ufw_staging/`. They are then picked up on the next boot.
+Firmware can be delivered remotely by bundling `.bin` files into an update archive.
+An external update tool can extract the archive on the target and copy the CAN firmware files into `/fs/microsd/ufw_staging/`. They are then picked up on the next boot.
 
 Before uploading, the tool can read `/fs/microsd/ufw/FW.db` to check which firmware is already installed and skip files that haven't changed, reducing transfer size.
 
 `upload_skynode.sh` handles the bundling via the `--ext-fw` flag (repeatable for multiple nodes):
 
-```
+```sh
 ./Tools/auterion/upload_skynode.sh \
   --ext-fw=build/auterion_canio_default/auterion_canio_default.uavcan.bin
 ```

--- a/docs/en/dronecan/index.md
+++ b/docs/en/dronecan/index.md
@@ -331,27 +331,43 @@ Any connected node whose running version does not match is then flashed over the
 ### Firmware Database
 
 A flat-file database at `/fs/microsd/ufw/FW.db` maps each board ID to the original firmware filename that was installed.
-Stale entries are removed automatically on every boot.
+This may be queried by external tools to determine current firmware versions.
+
 Example entry:
 
 ```txt
 122.bin=122-1.17.63eeff1a.uavcan.bin
 ```
 
+Entries are removed on boot if their corresponding firmware is not present.
+
 ### Remote Update
 
-Firmware can be delivered remotely via an update archive — a bundle (e.g. a `.zip` or `.tar`) containing one or more `.bin` files for the target CAN nodes.
-An external update tool extracts the archive on the companion/host computer and copies the `.bin` files into `/fs/microsd/ufw_staging/`, where they are picked up on the next boot.
+Remote updates can be made by uploading the corresponding bin files to `/fs/microsd/ufw_staging/`.
+PX4 will then update firmware on next boot.
 
-Before uploading, the tool can read `/fs/microsd/ufw/FW.db` to check which firmware is already installed and skip files that haven't changed, reducing transfer size.
+This approach enables efficient mass-update of binaries from archives (`.zip` or `.tar` that contains `.bin` files for the target CAN nodes).
+Tools can:
 
-[`Tools/auterion/upload_skynode.sh`] is a working example of this workflow.
-It bundles CAN firmware into an update archive using the `--ext-fw` flag (repeatable for multiple firmware files):
+1. Read the PX4 firmware database to determine what firmware is present
+2. Extract the more-recent versions of matching firmware to the staging directory
+
+PX4 does not provide such tools.
+
+::: info
+Auterion uses a form of this workflow to update CAN firmware to SkyNode based devices.
+The `upload_skynode.sh` script with multiple `--ext-fw` flags is used to bundle a number of firmware files and upload them to a directory on the companion-computer part.
 
 ```sh
 ./Tools/auterion/upload_skynode.sh \
   --ext-fw=build/auterion_canio_default/auterion_canio_default.uavcan.bin
+  --ext-fw=build/auterion_canio_default/another_default.uavcan.bin
+  ...
+  --ext-fw=build/auterion_canio_default/some_other_default.uavcan.bin
 ```
+
+Another tool then checks the firmware database and extracts just the relevant files to the PX4 firmware staging area.
+:::
 
 ## Troubleshooting
 

--- a/docs/en/dronecan/index.md
+++ b/docs/en/dronecan/index.md
@@ -340,12 +340,13 @@ Example entry:
 
 ### Remote Update
 
-Firmware can be delivered remotely by bundling `.bin` files into an update archive.
-An external update tool can extract the archive on the target and copy the CAN firmware files into `/fs/microsd/ufw_staging/`. They are then picked up on the next boot.
+Firmware can be delivered remotely via an update archive — a bundle (e.g. a `.zip` or `.tar`) containing one or more `.bin` files for the target CAN nodes.
+An external update tool extracts the archive on the companion/host computer and copies the `.bin` files into `/fs/microsd/ufw_staging/`, where they are picked up on the next boot.
 
 Before uploading, the tool can read `/fs/microsd/ufw/FW.db` to check which firmware is already installed and skip files that haven't changed, reducing transfer size.
 
-`upload_skynode.sh` handles the bundling via the `--ext-fw` flag (repeatable for multiple nodes):
+[`Tools/auterion/upload_skynode.sh`] is a working example of this workflow.
+It bundles CAN firmware into an update archive using the `--ext-fw` flag (repeatable for multiple firmware files):
 
 ```sh
 ./Tools/auterion/upload_skynode.sh \


### PR DESCRIPTION
### Solved Problem

The Firmware Update section of the DroneCAN docs did not reflect the firmware upload and flashing pipeline added in this PR: https://github.com/PX4/PX4-Autopilot/pull/27043

### Solution
Expanded the ## Firmware Update section in [index.md](vscode-file://vscode-app/snap/code/238/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to document the staging directory, the boot-time migration flow, the FW.db tracking database, and the remote update workflow via upload_skynode.sh --ext-fw.