### PR TITLE
fix(build): add cubeorangeplus to px4io_update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,6 +350,7 @@ px4io_update:
 	cp build/px4_io-v2_default/px4_io-v2_default.bin boards/px4/fmu-v6c/extras/px4_io-v2_default.bin
 	# cubepilot_io-v2_default
 	cp build/cubepilot_io-v2_default/cubepilot_io-v2_default.bin boards/cubepilot/cubeorange/extras/cubepilot_io-v2_default.bin
+	cp build/cubepilot_io-v2_default/cubepilot_io-v2_default.bin boards/cubepilot/cubeorangeplus/extras/cubepilot_io-v2_default.bin
 	cp build/cubepilot_io-v2_default/cubepilot_io-v2_default.bin boards/cubepilot/cubeyellow/extras/cubepilot_io-v2_default.bin
 	git status
 


### PR DESCRIPTION
### Solved Problem
Fixes #27091
 
### Solution
The `px4io_update` target builds `cubepilot_io-v2_default` and copies
the result to `cubeorange` and `cubeyellow` but skips `cubeorangeplus`,
leaving its co-processor firmware stale after every build.
 
### Changelog Entry
Bugfix: cubeorangeplus firmware not updated by px4io_update

 
### Test coverage
Build-only change, no runtime tests required.