### PR TITLE
fix(simulation): correct apparent wind sign and fixed-wing pitot model in SIH

### DIFF
--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -625,7 +625,7 @@ void Sih::ecefToNed()
 
 	// Transform velocity to NED frame
 	_v_N = C_SE * _v_E;
-	_v_apparent_N = _v_N + _v_wind_N;
+	_v_apparent_N = _v_N - _v_wind_N;
 
 	_q = Quatf(C_SE) * _q_E;
 	_q.normalize();
@@ -669,8 +669,8 @@ void Sih::send_airspeed(const hrt_abstime &time_now_us)
 	airspeed_s airspeed{};
 	airspeed.timestamp_sample = time_now_us;
 
-	// Assume the pitot tube always points against the wind to not have tailsitter edge cases
-	airspeed.true_airspeed_m_s = fmaxf(0.1f, _v_apparent_N.norm() + generate_wgn() * 0.2f);
+	// for fixed-wing use body-x component (pitot measures forward airspeed); keep magnitude for tailsitter/VTOL
+	airspeed.true_airspeed_m_s = fmaxf(0.1f, (_vehicle == VehicleType::FixedWing ? _v_B(0) : _v_apparent_N.norm()) + generate_wgn() * 0.2f);
 	airspeed.indicated_airspeed_m_s = airspeed.true_airspeed_m_s * sqrtf(_wing_l.get_rho() / RHO);
 	airspeed.confidence = 0.7f;
 	airspeed.timestamp = hrt_absolute_time();

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -669,8 +669,8 @@ void Sih::send_airspeed(const hrt_abstime &time_now_us)
 	airspeed_s airspeed{};
 	airspeed.timestamp_sample = time_now_us;
 
-	// for fixed-wing use body-x component (pitot measures forward airspeed); keep magnitude for tailsitter/VTOL
-	airspeed.true_airspeed_m_s = fmaxf(0.1f, (_vehicle == VehicleType::FixedWing ? _v_B(0) : _v_apparent_N.norm()) + generate_wgn() * 0.2f);
+	// pitot tube measures forward (body-x) airspeed
+	airspeed.true_airspeed_m_s = fmaxf(0.1f, _v_B(0) + generate_wgn() * 0.2f);
 	airspeed.indicated_airspeed_m_s = airspeed.true_airspeed_m_s * sqrtf(_wing_l.get_rho() / RHO);
 	airspeed.confidence = 0.7f;
 	airspeed.timestamp = hrt_absolute_time();


### PR DESCRIPTION
### Solved Problem
Fixes #27344
 
### Solution
Two bugs in the SIH simulator:
 
1. [ecefToNed()](cci:1://file:///c:/Users/dimit/Desktop/px4-autopilot/PX4-Autopilot/src/modules/simulation/simulator_sih/sih.cpp:618:0-631:1) computed apparent airflow as vehicle velocity plus
   wind instead of minus, reversing the effect of any non-zero wind.
 
2. [send_airspeed()](cci:1://file:///c:/Users/dimit/Desktop/px4-autopilot/PX4-Autopilot/src/modules/simulation/simulator_sih/sih.cpp:665:0-677:1) reported the 3D magnitude of the apparent wind
   vector rather than the body-x component. A pitot tube aligned with
   the fuselage measures forward airspeed only. For tailsitter/VTOL
   the magnitude is kept to avoid near-zero reads during hover.
 
### Changelog Entry
Bugfix: SIH apparent wind sign and fixed-wing pitot model corrected

 
### Test coverage
Latent in zero-wind SITL (default). To reproduce bug 1: set
`SIH_WIND_N=5.0`, observe aircraft drifts opposite to expected
wind effect before this fix.