### PR TITLE
fix(mavlink): check protocol timeout before GETLIST retry

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -558,8 +558,22 @@ MavlinkMissionManager::send()
 	}
 
 	/* check for timed-out operations */
-	if (_state == MAVLINK_WPM_STATE_GETLIST && (_time_last_sent > 0)
-	    && hrt_elapsed_time(&_time_last_sent) > MAVLINK_MISSION_RETRY_TIMEOUT_DEFAULT) {
+	if (_state != MAVLINK_WPM_STATE_IDLE && (_time_last_recv > 0)
+	    && hrt_elapsed_time(&_time_last_recv) > MAVLINK_MISSION_PROTOCOL_TIMEOUT_DEFAULT) {
+
+		_mavlink.send_statustext_critical("Mission sync timeout\t");
+		events::send(events::ID("mavlink_mission_sync_timeout"), events::Log::Error,
+			     "Mission sync timeout, aborting transfer");
+
+		PX4_DEBUG("WPM: Last operation (state=%d) timed out, changing state to MAVLINK_WPM_STATE_IDLE", _state);
+
+		switch_to_idle_state();
+
+		// since we are giving up, reset this state also, so another request can be started.
+		_transfer_in_progress = false;
+
+	} else if (_state == MAVLINK_WPM_STATE_GETLIST && (_time_last_sent > 0)
+		   && hrt_elapsed_time(&_time_last_sent) > MAVLINK_MISSION_RETRY_TIMEOUT_DEFAULT) {
 
 		// try to request item again after timeout
 		send_mission_request(_transfer_partner_sysid, _transfer_partner_compid, _transfer_seq);
@@ -572,20 +586,6 @@ MavlinkMissionManager::send()
 		PX4_DEBUG("WPM: SENDLIST resending MISSION_COUNT (no MISSION_ACK received yet)");
 		send_mission_count(_transfer_partner_sysid, _transfer_partner_compid, _transfer_count, _mission_type,
 				   get_current_mission_type_crc());
-
-	} else if (_state != MAVLINK_WPM_STATE_IDLE && (_time_last_recv > 0)
-		   && hrt_elapsed_time(&_time_last_recv) > MAVLINK_MISSION_PROTOCOL_TIMEOUT_DEFAULT) {
-
-		_mavlink.send_statustext_critical("Mission sync timeout\t");
-		events::send(events::ID("mavlink_mission_sync_timeout"), events::Log::Error,
-			     "Mission sync timeout, aborting transfer");
-
-		PX4_DEBUG("WPM: Last operation (state=%d) timed out, changing state to MAVLINK_WPM_STATE_IDLE", _state);
-
-		switch_to_idle_state();
-
-		// since we are giving up, reset this state also, so another request can be started.
-		_transfer_in_progress = false;
 
 	} else if (_state == MAVLINK_WPM_STATE_IDLE) {
 		// reset flags


### PR DESCRIPTION
### Solved Problem
Fixes #27132
 
### Solution
In [MavlinkMissionManager::send()](cci:1://file:///c:/Users/dimit/Desktop/px4-autopilot/PX4-Autopilot/src/modules/mavlink/mavlink_mission.cpp:493:0-594:1) the protocol-timeout cleanup was the
last branch of an if/else chain. On any tick where the GETLIST retry
condition also matched, the retry fired first and the timeout branch was
skipped, leaving `_transfer_in_progress = true` indefinitely and
blocking all subsequent mission uploads.
 
Moving the protocol-timeout check to the top of the chain ensures it
fires as soon as the transfer is genuinely dead, regardless of retry
state.
 
### Changelog Entry
Bugfix: mission upload no longer permanently blocked after timeout

 
### Test coverage
Timing-dependent issue. Reproduction: upload a mission, kill the link
mid-transfer, restore it — mission upload was permanently blocked before
this fix.