### PR TITLE
fix(rcS): Use CONFIG_BOARD_ROOT_PATH as root path.

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -157,6 +157,7 @@ add_custom_command(
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/filepaths/generate_config.py
 		--rc-dir ${romfs_gen_root_dir}/init.d
 		--params-file ${CONFIG_BOARD_PARAM_FILE}
+		--board-root-path ${CONFIG_BOARD_ROOT_PATH}
 	COMMAND ${CMAKE_COMMAND} -E touch ${romfs_copy_stamp}
 	WORKING_DIRECTORY ${romfs_gen_root_dir}
 	DEPENDS ${romfs_tar_file}

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -21,18 +21,19 @@ set +e
 # it wastes flash
 #
 set R /
-set FCONFIG /fs/microsd/etc/config.txt
-set FEXTRAS /fs/microsd/etc/extras.txt
-set FRC /fs/microsd/etc/rc.txt
+# Load default filepaths
+. ${R}etc/init.d/rc.filepaths
+set FCONFIG ${BOARD_ROOT_PATH}/etc/config.txt
+set FEXTRAS ${BOARD_ROOT_PATH}/etc/extras.txt
+set FRC ${BOARD_ROOT_PATH}/etc/rc.txt
 set IOFW "/etc/extras/px4_io-v2_default.bin"
 set LOGGER_ARGS ""
 set LOGGER_BUF 8
-set PARAM_FILE ""
 set PARAM_BACKUP_FILE ""
 set RC_INPUT_ARGS ""
 set STORAGE_AVAILABLE no
 set STORAGE_CHECK yes
-set SDCARD_EXT_PATH /fs/microsd/ext_autostart
+set SDCARD_EXT_PATH ${BOARD_ROOT_PATH}/ext_autostart
 set SDCARD_FORMAT no
 set STARTUP_TUNE 1
 set VEHICLE_TYPE none
@@ -127,8 +128,7 @@ then
 	set USE_PARAM_BACKUPS yes
 	set USE_PARAM_IMPORT_DEBUG yes
 	set USE_ALT_UPDATE_DIRS yes
-	set PARAM_FILE /fs/microsd/params
-	set PARAM_BACKUP_FILE "/fs/microsd/parameters_backup.bson"
+	set PARAM_BACKUP_FILE "${BOARD_ROOT_PATH}/parameters_backup.bson"
 fi
 
 if [ $USE_HARDFAULT_LOG = yes ]
@@ -151,11 +151,11 @@ fi
 if [ $USE_ALT_UPDATE_DIRS = yes ]
 then
 	# Check for an update of the ext_autostart folder, and replace the old one with it
-	if [ -e /fs/microsd/ext_autostart_new ]
+	if [ -e ${BOARD_ROOT_PATH}/ext_autostart_new ]
 	then
 		echo "Updating external autostart files"
 		rm -r $SDCARD_EXT_PATH
-		mv /fs/microsd/ext_autostart_new $SDCARD_EXT_PATH
+		mv ${BOARD_ROOT_PATH}/ext_autostart_new $SDCARD_EXT_PATH
 	fi
 fi
 
@@ -195,12 +195,12 @@ else
 
 		bsondump $PARAM_FILE
 
-		if [ -d "/fs/microsd" ]
+		if [ -d "${BOARD_ROOT_PATH}" ]
 		then
 			if [ $USE_PARAM_IMPORT_DEBUG = yes ]
 			then
 				# save copy of the failed param file for debugging
-				cp $PARAM_FILE /fs/microsd/param_import_fail.bson
+				cp $PARAM_FILE ${BOARD_ROOT_PATH}/param_import_fail.bson
 			fi
 
 			# try importing from backup file
@@ -221,7 +221,7 @@ else
 
 			if [ $USE_PARAM_IMPORT_DEBUG = yes ]
 			then
-				dmesg >> /fs/microsd/param_import_fail.txt &
+				dmesg >> ${BOARD_ROOT_PATH}/param_import_fail.txt &
 			fi
 		fi
 	fi

--- a/Tools/filepaths/generate_config.py
+++ b/Tools/filepaths/generate_config.py
@@ -35,6 +35,8 @@ parser.add_argument('--rc-dir', type=str, action='store',
                     help='ROMFS output directory', default=None)
 parser.add_argument('--params-file', type=str, action='store',
                     help='Parameter output file', default=None)
+parser.add_argument('--board-root-path', type=str, action='store',
+                    help='Root path', default=None)
 parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
                     help='Verbose Output')
 
@@ -56,6 +58,6 @@ if rc_filepaths_output_dir is not None:
     if verbose: print("Generating {:}".format(rc_filepath_output_file))
     template = jinja_env.get_template(rc_filepaths_template)
     with open(rc_filepath_output_file, 'w') as fid:
-        fid.write(template.render(constrained_flash=constrained_flash, params_file=args.params_file))
+        fid.write(template.render(constrained_flash=constrained_flash, params_file=args.params_file, board_root_path=args.board_root_path))
 else:
     raise Exception("--rc-dir needs to be specified")

--- a/Tools/filepaths/rc.filepaths.jinja
+++ b/Tools/filepaths/rc.filepaths.jinja
@@ -4,3 +4,4 @@
 
 
 set PARAM_FILE {{ params_file }}
+set BOARD_ROOT_PATH {{ board_root_path }}


### PR DESCRIPTION
### Solved Problem
#23003 Introduce the `CONFIG_BOARD_ROOT_PATH` as an override for `/fs/microsd` but `rcS` still had hardcoded entries.
This PR removes the hardcoded /fs/microsd and uses the BOARD_ROOT_PATH Kconfig variable instead.

### Solution
Expose BOARD_ROOT_PATH to `rc.filepaths`
