### PR TITLE
docs(dronecan): document FW.db index and --ext-fw upload flag

### DIFF
--- a/docs/en/companion_computer/auterion_skynode.md
+++ b/docs/en/companion_computer/auterion_skynode.md
@@ -65,6 +65,33 @@ make px4_fmu-v5x upload_skynode_wifi
 
 ::::
 
+## Bundling CAN Node Firmware
+
+CAN node firmware binaries can be bundled with the FMU firmware in a single upload by invoking `upload_skynode.sh` directly with one or more `--ext-fw=<file>` flags (the flag is repeatable).
+Each file is packaged under `ufw/` inside the upload tarball, staged on the SD card under `/fs/microsd/ufw_staging/`, then migrated to `/fs/microsd/ufw/` during PX4 startup and flashed to the matching CAN node (see [DroneCAN > Firmware Update](../dronecan/index.md#firmware-update)).
+
+:::: tabs
+
+::: tab "Skynode connected via USB"
+
+```
+./Tools/auterion/upload_skynode.sh --ext-fw=path/to/canio-v2.1.0.uavcan.bin --ext-fw=path/to/gps.uavcan.bin
+```
+
+:::
+
+::: tab "Skynode connected via WiFi"
+
+```
+./Tools/auterion/upload_skynode.sh --ext-fw=path/to/canio-v2.1.0.uavcan.bin --ext-fw=path/to/gps.uavcan.bin --wifi
+```
+
+:::
+
+::::
+
+`--ext-fw` can be combined with `--file=<px4_firmware.px4>` to upload FMU firmware and CAN node firmware in the same step.
+
 ## Restoring the Default PX4 Firmware
 
 To reinstall the original Skynode version of PX4 when connected via USB run the following command in the repository:

--- a/docs/en/dronecan/index.md
+++ b/docs/en/dronecan/index.md
@@ -313,7 +313,11 @@ PX4 can upgrade device firmware over DroneCAN.
 To upgrade the device, all you need to do is copy the firmware binary into the root directory of the flight controller's SD card and reboot.
 
 Upon boot the flight controller will automatically transfer the firmware onto the device and upgrade it.
-If successful, the firmware binary will be removed from the root directory and there will be a file named **XX.bin** in the **/ufw** directory of the SD card.
+If successful, the firmware binary will be removed from the root directory and there will be a file named `<board_id>.bin` in the `/ufw` directory of the SD card (where `<board_id>` is the numeric board ID from the firmware's application descriptor).
+
+Alongside each migrated binary, PX4 records the original source filename in `/ufw/FW.db`, with one `<board_id>.bin=<original_filename>` entry per line.
+The index is accessible over MAVLink FTP, allowing external update tools to detect previously-uploaded firmware by its source filename and skip redundant transfers.
+Stale entries (referencing binaries that no longer exist on disk) are pruned automatically on the next boot.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Adds user-facing documentation for the changes introduced by #27043, which the author originally judged didn't require docs. The DroneCAN firmware update section now describes the new `/ufw/FW.db` index file (filename map exposed over MAVLink FTP for dedup), and the Skynode upload guide gains a section covering the new repeatable `--ext-fw=<file>` flag on `upload_skynode.sh` for bundling CAN node firmware alongside FMU firmware in a single upload.

- `docs/en/dronecan/index.md` — replace the `XX.bin` placeholder with the actual `<board_id>.bin` naming and document the companion `FW.db` index file, including how stale entries are auto-pruned on the next boot.
- `docs/en/companion_computer/auterion_skynode.md` — new "Bundling CAN Node Firmware" section showing the `--ext-fw=` invocation for both USB and WiFi, with a cross-link to the DroneCAN firmware update flow.