### PR TITLE
feat(boards/ark): whitelist generic airframes on ARK FMU boards

### DIFF
--- a/boards/ark/fmu-v6s/init/rc.board_airframes
+++ b/boards/ark/fmu-v6s/init/rc.board_airframes
@@ -1,0 +1,29 @@
+# Generic multirotor
+4001_quad_x
+4014_s500
+4050_generic_250
+5001_quad_+
+6001_hexa_x
+7001_hexa_+
+8001_octo_x
+9001_octo_+
+11001_hexa_cox
+12001_octo_cox
+14001_generic_mc_with_tilt
+16001_helicopter
+24001_dodeca_cox
+
+# Generic fixed-wing
+2100_standard_plane
+3000_generic_wing
+
+# Generic VTOL
+13000_generic_vtol_standard
+13030_generic_vtol_quad_tiltrotor
+13100_generic_vtol_tiltrotor
+13200_generic_vtol_tailsitter
+
+# Generic rover
+50000_generic_rover_differential
+51000_generic_rover_ackermann
+52000_generic_rover_mecanum

--- a/boards/ark/fmu-v6x/init/rc.board_airframes
+++ b/boards/ark/fmu-v6x/init/rc.board_airframes
@@ -1,0 +1,29 @@
+# Generic multirotor
+4001_quad_x
+4014_s500
+4050_generic_250
+5001_quad_+
+6001_hexa_x
+7001_hexa_+
+8001_octo_x
+9001_octo_+
+11001_hexa_cox
+12001_octo_cox
+14001_generic_mc_with_tilt
+16001_helicopter
+24001_dodeca_cox
+
+# Generic fixed-wing
+2100_standard_plane
+3000_generic_wing
+
+# Generic VTOL
+13000_generic_vtol_standard
+13030_generic_vtol_quad_tiltrotor
+13100_generic_vtol_tiltrotor
+13200_generic_vtol_tailsitter
+
+# Generic rover
+50000_generic_rover_differential
+51000_generic_rover_ackermann
+52000_generic_rover_mecanum


### PR DESCRIPTION
## Summary

Add a board-level airframe whitelist (`rc.board_airframes`) to `ark_fmu-v6x` and `ark_fmu-v6s` so the ROMFS only contains generic frame types. Same mechanism the `ark_fpv` and `ark_pi6x` boards already use.

## Problem

`ark_fmu-v6x` is at 99.98% flash on the default variant — only 372 B free. The ROMFS still includes vendor-specific airframes that have no relevance on ARK hardware (Holybro X500/PX4Vision, ATL Mantis, UVify IFO, COEX Clover, Bitcraze Crazyflie, Applied Aeronautics Albatross, ThunderFly TF-B1). `ark_fmu-v6s` is in the same situation and is starting from an even less-pruned baseline (no existing `@board ark_fmu-v6s exclude` directives anywhere).

The existing `@board <board> exclude` workflow requires editing each individual airframe file and is easy to forget — @Phil-Engljaehringer  noticed several of these were missing the `ark_fmu-v6x` exclude.

## Solution

Add `boards/ark/fmu-v6x/init/rc.board_airframes` and `boards/ark/fmu-v6s/init/rc.board_airframes` containing only generic airframe types: generic quad/hexa/octo/dodeca, generic 250/S500, helicopter, MC-with-tilt, standard plane, flying wing, the four generic VTOL geometries, and the three generic rover types (22 entries).

Flash impact on the `default` variant:

| Board | Before | After | Δ | Free after |
|---|---:|---:|---:|---:|
| `ark_fmu-v6x` | 1,965,708 B (99.98%) | 1,957,772 B (99.58%) | −7,936 B | 8,308 B |
| `ark_fmu-v6s` | 1,960,212 B (99.70%) | 1,945,748 B (98.97%) | −14,464 B | 22,572 B |

Verified the `default`, `rover`, and `encrypted_logs` variants of both boards build with the correct ROMFS contents (generic MC/FW/VTOL on default, three generic rovers on rover, generic MC only on encrypted_logs which disables FW/VTOL).