### PR TITLE
[BACKPORT v1.16] Mavlink Receiver: Don't ack DO_SET_MODE commands (#27343)

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -608,6 +608,7 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 
 	} else if (cmd_mavlink.command == MAV_CMD_DO_SET_MODE) {
 		_cmd_pub.publish(vehicle_command);
+		send_ack = false;	//Acknowledgement handled by Commander
 
 	} else if (cmd_mavlink.command == MAV_CMD_DO_AUTOTUNE_ENABLE) {
 


### PR DESCRIPTION
Backport of https://github.com/PX4/PX4-Autopilot/pull/27343.