### PR TITLE
fix(build): enable gz sim 10 LTS(jetty)

### DIFF
--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -32,12 +32,17 @@
 ############################################################################
 
 if(NOT DEFINED ENV{GZ_DISTRO} OR NOT "$ENV{GZ_DISTRO}" STREQUAL "harmonic")
-    find_package(gz-transport NAMES gz-transport gz-transport14 gz-transport13)
+    find_package(gz-transport NAMES gz-transport gz-transport15 gz-transport14 gz-transport13)
 else()
     find_package(gz-transport NAMES gz-transport13)
 endif()
 
 if (gz-transport_FOUND)
+	# gcc-15 spurious -Wmaybe-uninitialized in gz-transport15 FullyQualifiedTopic, will probably be fixed by gazebo in the future
+	if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15
+		AND gz-transport_VERSION VERSION_GREATER_EQUAL 15)
+		add_compile_options(-Wno-error=maybe-uninitialized)
+	endif()
 	px4_add_git_submodule(TARGET git_gz PATH "${PX4_SOURCE_DIR}/Tools/simulation/gz")
 
 	file(GLOB gz_worlds ${PX4_SOURCE_DIR}/Tools/simulation/gz/worlds/*.sdf)

--- a/src/modules/simulation/gz_plugins/CMakeLists.txt
+++ b/src/modules/simulation/gz_plugins/CMakeLists.txt
@@ -34,10 +34,10 @@
 project(px4_gz_plugins)
 
 if(NOT DEFINED ENV{GZ_DISTRO} OR NOT "$ENV{GZ_DISTRO}"  STREQUAL "harmonic")
-    find_package(gz-transport NAMES gz-transport gz-transport14 gz-transport13)
-    find_package(gz-sim NAMES gz-sim gz-sim9 gz-sim8)
-    find_package(gz-sensors NAMES gz-sensors gz-sensors9 gz-sensors8)
-    find_package(gz-plugin NAMES gz-plugin gz-plugin3 gz-plugin2 COMPONENTS register)
+    find_package(gz-transport NAMES gz-transport gz-transport15 gz-transport14 gz-transport13)
+    find_package(gz-sim NAMES gz-sim gz-sim10 gz-sim9 gz-sim8)
+    find_package(gz-sensors NAMES gz-sensors gz-sensors10 gz-sensors9 gz-sensors8)
+    find_package(gz-plugin NAMES gz-plugin gz-plugin4 gz-plugin3 gz-plugin2 COMPONENTS register)
 else()
     find_package(gz-transport NAMES gz-transport13)
     find_package(gz-sim NAMES gz-sim8)
@@ -46,6 +46,13 @@ else()
 endif()
 
 if (gz-transport_FOUND)
+    # gcc-15 + libstdc++ emits spurious -Wmaybe-uninitialized inside
+    # gz-transport15's FullyQualifiedTopic::FullTopic() (std::optional<string>).
+    # Keep warning visible but don't make it fatal. will probably be fixed by gazebo in the future
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15
+        AND gz-transport_VERSION VERSION_GREATER_EQUAL 15)
+        add_compile_options(-Wno-error=maybe-uninitialized)
+    endif()
     if (gz-transport_VERSION VERSION_LESS "15")
         set(GZ_TRANSPORT_TARGET "gz-transport${gz-transport_VERSION_MAJOR}::gz-transport${gz-transport_VERSION_MAJOR}")
         set(GZ_SIM_TARGET "gz-sim${gz-sim_VERSION_MAJOR}::gz-sim${gz-sim_VERSION_MAJOR}")


### PR DESCRIPTION
## Summary
  
  Adds build support for **Gazebo Jetty** so PX4 SITL compiles against the vendored Gazebo
  stack shipped with ROS 2 Lyrical Luth, in addition to the existing
  Harmonic / Garden paths.

  ## Changes

 ### GCC 15 workaround (both CMake files)

  GCC 15 emits a spurious `-Wmaybe-uninitialized` inside
  `std::optional<std::string>` when `gz::transport::v15::FullyQualifiedTopic::FullTopic()`
  is called from inlined templates (e.g. `Node::SubscribeImpl`). The
  warning is attributed to PX4 plugin sources, killing the `-Werror`
  build.
  
  Demote the warning to non-fatal only when:
  - compiler is GCC ≥ 15, **and**
  - `gz-transport_VERSION` ≥ 15

  so existing Harmonic / Garden / Jetty builds are unaffected.

  This is a known GCC regression (GCC PR
  [#114253](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114253)). An
  [upstream fix is in progress at gazebosim/gz-transport](https://github.com/gazebosim/gz-transport/pull/872)

  ## Compatibility

  | Stack | Status |
  |-------|--------|
  | Harmonic (gz-sim 8) | unchanged |
  | Garden (gz-sim 7) | unchanged |
  | Jetty (gz-sim 9) | unchanged |
  | **Ionic (gz-sim 10)** | **newly supported** |

  The `GZ_DISTRO=harmonic` opt-in branch is left intact for users who
  explicitly pin Harmonic.

  ## Test plan

  - [x] `make px4_sitl gz_x500` on Ubuntu 26.04, ROS 2 Lyrical Luth,
        GCC 15, vendored gz stack (`/opt/ros/lyrical/opt/gz_*_vendor`).
  - [x] World loads, bridge connects, EKF2 initialises (with mag),
        arm + takeoff works.