### PR TITLE
fix(simulation): revert wind sign regression from #27376

### DIFF
--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -625,7 +625,7 @@ void Sih::ecefToNed()
 
 	// Transform velocity to NED frame
 	_v_N = C_SE * _v_E;
-	_v_apparent_N = _v_N - _v_wind_N;
+	_v_apparent_N = _v_N + _v_wind_N;
 
 	_q = Quatf(C_SE) * _q_E;
 	_q.normalize();


### PR DESCRIPTION
Fixes regression introduced in #27376.

The sign change in _v_apparent_N was wrong. SIH_WIND_N/E use a "from"
direction convention, so the original + was correct — #27376 mistakenly
flipped it to minus, which contradicts the param description and reverses
wind effects for any non-zero wind setting.

Reverts the sign while keeping the pitot body-x fix from #27376.

Closes regression flagged by @mbjd 