### PR TITLE
docs(compass): clarify priority is set automatically during calibration

### DIFF
--- a/docs/en/config/compass.md
+++ b/docs/en/config/compass.md
@@ -203,6 +203,7 @@ These are prefixed with [CAL*MAGx*](../advanced_config/parameter_reference.md#CA
 - [CAL_MAGn_ROT](../advanced_config/parameter_reference.md#CAL_MAG0_ROT) can be used to determine which compasses are internal.
   A compass is internal if `CAL_MAGn_ROT==1`.
 - [CAL_MAGx_PRIO](../advanced_config/parameter_reference.md#CAL_MAG0_PRIO) sets the relative compass priority and can be used to disable a compass.
+  Priority is assigned automatically during calibration (external compasses are preferred over internal ones), so manual configuration is not normally required.
 
 ## Debugging
 


### PR DESCRIPTION
﻿/claim #19970

## Summary  Added a one-line clarification to the compass calibration docs explaining that CAL_MAGx_PRIO is set automatically during calibration, directly addressing the priority confusion raised in the issue body.  ## Closes  Fixes Algora bounty: https://github.com/PX4/PX4-Autopilot/issues/19970  ## Disclosure  This PR was AI-assisted (Claude Code) and reviewed by a human before submission. 
