### PR TITLE
fix(driver): use correct device id for sht3x

### DIFF
--- a/src/drivers/hygrometer/sht3x/sht3x.cpp
+++ b/src/drivers/hygrometer/sht3x/sht3x.cpp
@@ -144,7 +144,7 @@ void SHT3X::sensor_compouse_msg(bool send)
 			msg.timestamp_sample = measurement_time;
 			msg.temperature = measured_temperature;
 			msg.humidity = measured_humidity;
-			msg.device_id = _sht_info.serial_number;
+			msg.device_id = get_device_id();
 			_sensor_hygrometer_pub.publish(msg);
 		}
 	}


### PR DESCRIPTION
### Solved Problem
- The SHT3x driver does not set the device id according to the way it is intended in PX4
  - This causes unstable device ids as they change depending on the connected sensor HW
  - In addition the info shown about the device id in `sht3x -X status` is also incorrect, as it may not show the correct bus type and bus number

### Solution
- Set the device id like its done in all other drivers

### Test coverage
- Tested on the bench with a SHT3x and a v6x