### PR TITLE
feat(heater): add more temp sources & heating modes

### DIFF
--- a/msg/HeaterStatus.msg
+++ b/msg/HeaterStatus.msg
@@ -15,6 +15,14 @@ float32 proportional_value
 float32 integrator_value
 float32 feed_forward_value
 
+float32 supply_voltage		# Supply voltage (V)
+float32 heater_current		# Heater current (A)
+float32 nominal_multiplier
+
 uint8 MODE_GPIO  = 1
 uint8 MODE_PX4IO = 2
 uint8 mode
+
+uint8 TEMPERATURE_SOURCE_IMU   = 0
+uint8 TEMPERATURE_SOURCE_HYGRO = 1
+uint8 temperature_source

--- a/src/drivers/heater/Kconfig
+++ b/src/drivers/heater/Kconfig
@@ -3,3 +3,18 @@ menuconfig DRIVERS_HEATER
 	default n
 	---help---
 		Enable support for heater
+
+if DRIVERS_HEATER
+
+config HEATER_FAST_UPDATE_MODE
+	bool "Enable fast update mode"
+	default n
+	---help---
+		When enabled, the heater will use the last known temperature reading
+		for up to a defined threshold if no new temperature update is received. This allows
+		faster update time compared to the default behavior where the heater
+		waits idle for an entire control period on each missed update.
+		After a certain time without a valid update, the heater is turned off for
+		safety reasons and remains off until a new temperature reading is received.
+
+endif # DRIVERS_HEATER

--- a/src/drivers/heater/heater.cpp
+++ b/src/drivers/heater/heater.cpp
@@ -81,6 +81,27 @@
 
 Heater *Heater::g_heater[HEATER_MAX_INSTANCES] {}; //! 0-based
 
+template<typename T>
+static int8_t find_sensor_instance(orb_id_t id, int32_t target, uint32_t &out_device_id)
+{
+	for (uint8_t i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
+		uORB::Subscription s{id, i};
+
+		if (!s.advertised()) { continue; }
+
+		T msg{};
+
+		if (!s.copy(&msg)) { continue; }
+
+		if (target == 0 || (uint32_t)target == msg.device_id) {
+			out_device_id = msg.device_id;
+			return i;
+		}
+	}
+
+	return -1;
+}
+
 Heater::Heater(uint8_t instance) :
 	ScheduledWorkItem(heater_instance_name(instance), px4::wq_configurations::lp_default),
 	ModuleParams(nullptr),
@@ -105,6 +126,15 @@ Heater::Heater(uint8_t instance) :
 
 	snprintf(name, sizeof(name), "HEATER%u_TEMP_FF", (unsigned)_instance);
 	_param_handles.temp_ff = param_find(name); //
+
+	snprintf(name, sizeof(name), "HEATER%u_IMAX", (unsigned)_instance);
+	_param_handles.temp_imax = param_find(name);
+
+	snprintf(name, sizeof(name), "HEATER%u_TEMP_SRC", (unsigned)_instance);
+	_param_handles.temp_src = param_find(name);
+
+	snprintf(name, sizeof(name), "HEATER%u_NOM_V", (unsigned)_instance);
+	_param_handles.nom_v = param_find(name);
 
 	_heater_status_pub.advertise(); //
 
@@ -295,56 +325,43 @@ bool Heater::initialize_topics()
 	}
 
 	const int32_t target = _params.imu_id;
+	const bool use_hygro = (_params.temp_src == heater_status_s::TEMPERATURE_SOURCE_HYGRO);
 
-	// Scan multiple instances of accel, matching device_id or auto-select
 	int8_t selected_instance = -1;
-	sensor_accel_s accel{};
+	uint32_t selected_device_id = 0;
 
+	if (use_hygro) {
+		selected_instance = find_sensor_instance<sensor_hygrometer_s>(ORB_ID(sensor_hygrometer), target, selected_device_id);
 
-	for (uint8_t i = 0; i < HEATER_MAX_INSTANCES; i++) {
-		uORB::Subscription s{ORB_ID(sensor_accel), i};
-
-		if (!s.advertised()) {
-			continue;
-		}
-
-		sensor_accel_s a{};
-
-		if (!s.copy(&a)) {
-			continue;
-		}
-
-		if (target == 0) {
-			// Select the first available option
-			selected_instance = i;
-			accel = a;
-			break;
-		}
-
-		if ((uint32_t)target == a.device_id) {
-			selected_instance = i;
-			accel = a;
-			break;
-		}
+	} else {
+		selected_instance = find_sensor_instance<sensor_accel_s>(ORB_ID(sensor_accel), target, selected_device_id);
 	}
 
 	if (selected_instance < 0) {
 		if (target == 0) {
-			PX4_ERR("heater %u: no sensor_accel instances available", (unsigned)_instance);
+			PX4_ERR("heater %u: no %s instances available", (unsigned)_instance,
+				use_hygro ? "sensor_hygrometer" : "sensor_accel");
 
 		} else {
-			PX4_ERR("heater %u: no accel matches device_id=%ld", (unsigned)_instance, (long)target);
+			PX4_ERR("heater %u: no %s matches device_id=%ld", (unsigned)_instance,
+				use_hygro ? "hygrometer" : "accel", (long)target);
 		}
 
 		return false;
 	}
 
-	_sensor_device_id = accel.device_id;
+	_sensor_device_id = selected_device_id;
 
-	// Switch subscription to this instance
-	_sensor_accel_sub.ChangeInstance(selected_instance);
-	PX4_INFO("heater %u bound accel instance %d (device_id=%lu)",
-		 (unsigned)_instance, selected_instance, (unsigned long)_sensor_device_id);
+	if (use_hygro) {
+		_sensor_hygrometer_sub.ChangeInstance(selected_instance);
+
+	} else {
+		_sensor_accel_sub.ChangeInstance(selected_instance);
+	}
+
+	PX4_INFO("heater %u bound %s instance %d (device_id=%lu)",
+		 (unsigned)_instance, use_hygro ? "hygrometer" : "accel",
+		 selected_instance, (unsigned long)_sensor_device_id);
 
 	return true;
 }
@@ -382,8 +399,17 @@ void Heater::Run()
 		}
 	}
 
-	sensor_accel_s sensor_accel;
 	float temperature_delta {0.f};
+	bool temperature_updated = false;
+
+	// Update input voltage/current monitoring
+	battery_status_s battery_status;
+
+	if (_battery_status_sub.update(&battery_status)) {
+		_supply_voltage = battery_status.voltage_v;
+		_heater_current = battery_status.current_a;
+		_battery_status_last_update_time = hrt_absolute_time();
+	}
 
 	if (_heater_on) {
 		// Turn the heater off.
@@ -391,36 +417,87 @@ void Heater::Run()
 		heater_off();
 		ScheduleDelayed(CONTROLLER_PERIOD_DEFAULT - _controller_time_on_usec);
 
-	} else if (_sensor_accel_sub.update(&sensor_accel)) {
+	} else {
+		float current_temp = NAN;
+		const bool use_hygro = (_params.temp_src == heater_status_s::TEMPERATURE_SOURCE_HYGRO);
 
-		// Update the current IMU sensor temperature if valid.
-		if (PX4_ISFINITE(sensor_accel.temperature)) {
-			temperature_delta = _params.temp - sensor_accel.temperature;
-			_temperature_last = sensor_accel.temperature;
-		}
+		if (use_hygro) {
+			sensor_hygrometer_s sensor_hygrometer;
 
-		_proportional_value = temperature_delta * _params.temp_p;
-		_integrator_value += temperature_delta * _params.temp_i;
-
-		_integrator_value = math::constrain(_integrator_value, -0.25f, 0.25f);
-
-		_controller_time_on_usec = static_cast<int>((_params.temp_ff + _proportional_value +
-					   _integrator_value) * static_cast<float>(CONTROLLER_PERIOD_DEFAULT));
-
-		_controller_time_on_usec = math::constrain(_controller_time_on_usec, 0, CONTROLLER_PERIOD_DEFAULT);
-
-		if (fabsf(temperature_delta) < TEMPERATURE_TARGET_THRESHOLD) {
-			_temperature_target_met = true;
+			if (_sensor_hygrometer_sub.update(&sensor_hygrometer)) {
+				current_temp = sensor_hygrometer.temperature;
+			}
 
 		} else {
+			sensor_accel_s sensor_accel;
 
-			_temperature_target_met = false;
+			if (_sensor_accel_sub.update(&sensor_accel)) {
+				current_temp = sensor_accel.temperature;
+			}
 		}
 
-		if (_controller_time_on_usec > 0) {
-			_heater_on = true;
-			heater_on();
-			ScheduleDelayed(_controller_time_on_usec);
+		if (PX4_ISFINITE(current_temp)) {
+			temperature_delta = _params.temp - current_temp;
+			_temperature_last = current_temp;
+			temperature_updated = true;
+#ifdef CONFIG_HEATER_FAST_UPDATE_MODE
+			_temperature_last_update_time = hrt_absolute_time();
+#endif
+		}
+
+#ifdef CONFIG_HEATER_FAST_UPDATE_MODE
+
+		// No fresh sensor update: use cached temperature if still within a certain window.
+		if (!temperature_updated
+		    && _temperature_last_update_time != 0
+		    && hrt_elapsed_time(&_temperature_last_update_time) < 500_ms) {
+			temperature_delta = _params.temp - _temperature_last;
+			temperature_updated = true;
+		}
+
+#endif
+
+		if (temperature_updated) {
+			_proportional_value = temperature_delta * _params.temp_p;
+
+			_integrator_value += temperature_delta * _params.temp_i;
+
+			_integrator_value = math::constrain(_integrator_value, -_params.temp_imax, _params.temp_imax);
+
+			_controller_time_on_usec = static_cast<int>((_params.temp_ff + _proportional_value +
+						   _integrator_value) * static_cast<float>(CONTROLLER_PERIOD_DEFAULT));
+
+			_controller_time_on_usec = math::constrain(_controller_time_on_usec, 0, CONTROLLER_PERIOD_DEFAULT);
+
+			const float nom_v = _params.nom_v;
+
+			if (nom_v > 0.f) {
+				if (_battery_status_last_update_time == 0 || hrt_elapsed_time(&_battery_status_last_update_time) > 500_ms) {
+					_controller_time_on_usec = 0;
+
+				} else if (PX4_ISFINITE(_supply_voltage) && _supply_voltage > nom_v) {
+					// Scale duty cycle by (V_nom/V)^2 so delivered power is the same regardless of supply voltage.
+					const float ratio = nom_v / _supply_voltage;
+					_nominal_multiplier = ratio * ratio;
+					_controller_time_on_usec = static_cast<int>(_controller_time_on_usec * _nominal_multiplier);
+				}
+			}
+
+			if (fabsf(temperature_delta) < TEMPERATURE_TARGET_THRESHOLD) {
+				_temperature_target_met = true;
+
+			} else {
+				_temperature_target_met = false;
+			}
+
+			if (_controller_time_on_usec > 0) {
+				_heater_on = true;
+				heater_on();
+				ScheduleDelayed(_controller_time_on_usec);
+
+			} else {
+				ScheduleDelayed(CONTROLLER_PERIOD_DEFAULT);
+			}
 
 		} else {
 			ScheduleDelayed(CONTROLLER_PERIOD_DEFAULT);
@@ -443,6 +520,10 @@ void Heater::publish_status()
 	status.proportional_value      = _proportional_value;
 	status.integrator_value        = _integrator_value;
 	status.feed_forward_value      = _params.temp_ff;
+	status.supply_voltage          = _supply_voltage;
+	status.heater_current          = _heater_current;
+	status.nominal_multiplier      = _nominal_multiplier;
+	status.temperature_source      = _params.temp_src;
 
 #ifdef HEATER_PX4IO
 	status.mode = heater_status_s::MODE_PX4IO;
@@ -492,8 +573,8 @@ int Heater::status(uint8_t instance)
 	if (instance > 0 && instance <= HEATER_MAX_INSTANCES) {
 		if (Heater::is_running_instance(instance)) {
 			PX4_INFO("instance %u: running", (unsigned)instance);
-			PX4_INFO("instance %u: IMU ID is %lu", (unsigned)instance, Heater::g_heater[instance - 1]->_sensor_device_id);
-			PX4_INFO("instance %u: IMU Temperature is %f", (unsigned)instance, (double)Heater::g_heater[instance - 1]->_temperature_last);
+			PX4_INFO("instance %u: Sensor ID is %lu", (unsigned)instance, Heater::g_heater[instance - 1]->_sensor_device_id);
+			PX4_INFO("instance %u: Sensor Temperature is %f", (unsigned)instance, (double)Heater::g_heater[instance - 1]->_temperature_last);
 			PX4_INFO("instance %u: Set Temperature is %f", (unsigned)instance, (double)Heater::g_heater[instance - 1]->_params.temp);
 
 		}
@@ -502,8 +583,8 @@ int Heater::status(uint8_t instance)
 		for (instance = 1; instance <= HEATER_MAX_INSTANCES; instance++) {
 			if (Heater::is_running_instance(instance)) {
 				PX4_INFO("instance %u: running", (unsigned)instance);
-				PX4_INFO("instance %u: IMU ID is %lu", (unsigned)instance, Heater::g_heater[instance - 1]->_sensor_device_id);
-				PX4_INFO("instance %u: IMU Temperature is %f", (unsigned)instance, (double)Heater::g_heater[instance - 1]->_temperature_last);
+				PX4_INFO("instance %u: Sensor ID is %lu", (unsigned)instance, Heater::g_heater[instance - 1]->_sensor_device_id);
+				PX4_INFO("instance %u: Sensor Temperature is %f", (unsigned)instance, (double)Heater::g_heater[instance - 1]->_temperature_last);
 				PX4_INFO("instance %u: Set Temperature is %f", (unsigned)instance, (double)Heater::g_heater[instance - 1]->_params.temp);
 			}
 		}
@@ -616,6 +697,18 @@ void Heater::update_params(const bool force)
 			param_get(_param_handles.temp_ff, &_params.temp_ff);
 		}
 
+		if (_param_handles.temp_imax != PARAM_INVALID) {
+			param_get(_param_handles.temp_imax, &_params.temp_imax);
+		}
+
+		if (_param_handles.temp_src != PARAM_INVALID) {
+			param_get(_param_handles.temp_src, &_params.temp_src);
+		}
+
+		if (_param_handles.nom_v != PARAM_INVALID) {
+			param_get(_param_handles.nom_v, &_params.nom_v);
+		}
+
 		_heater_initialized = true;
 	}
 }
@@ -630,7 +723,7 @@ int Heater::print_usage(const char *reason)
 	PRINT_MODULE_DESCRIPTION(
 		R"DESCR_STR(
 ### Description
-Background process running periodically on the INS{i} queue to regulate IMU temperature at a setpoint.
+Background process running periodically on the INS{i} queue to regulate temperature at a setpoint.
 
 This task can be started at boot from the startup scripts by setting SENS_EN_THERMAL or via CLI.
 )DESCR_STR");

--- a/src/drivers/heater/heater.h
+++ b/src/drivers/heater/heater.h
@@ -52,14 +52,19 @@
 #include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/heater_status.h>
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/battery_status.h>
 #include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_hygrometer.h>
 #include <parameters/param.h>
+#include <drivers/drv_hrt.h>
 
 #include <mathlib/mathlib.h>
 
 using namespace time_literals;
 
+#ifndef CONTROLLER_PERIOD_DEFAULT
 #define CONTROLLER_PERIOD_DEFAULT    10000
+#endif
 #define TEMPERATURE_TARGET_THRESHOLD 2.5f
 #define HEATER_MAX_INSTANCES 3 	// If changed, also need to change `max_num_config_instances` in module.yaml
 #if HEATER_NUM > HEATER_MAX_INSTANCES
@@ -141,6 +146,13 @@ private:
 	bool _heater_on              = false;
 	bool _temperature_target_met = false;
 
+#ifdef CONFIG_HEATER_FAST_UPDATE_MODE
+	hrt_abstime _temperature_last_update_time {0};
+#endif
+
+	hrt_abstime _battery_status_last_update_time{0};
+	float _nominal_multiplier = 0.0f;
+
 	int _controller_time_on_usec = 0;
 
 	float _integrator_value   = 0.0f;
@@ -151,10 +163,14 @@ private:
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	uORB::Subscription _sensor_accel_sub{ORB_ID(sensor_accel)};
+	uORB::Subscription _sensor_hygrometer_sub{ORB_ID(sensor_hygrometer)};
+	uORB::Subscription _battery_status_sub{ORB_ID(battery_status)};
 
 	uint32_t _sensor_device_id{0};
 
 	float _temperature_last{NAN};
+	float _supply_voltage{NAN};
+	float _heater_current{NAN};
 
 	const uint8_t _instance; //! 1-based
 
@@ -165,6 +181,9 @@ private:
 		param_t temp_p;
 		param_t temp_i;
 		param_t temp_ff;
+		param_t temp_imax;
+		param_t temp_src;
+		param_t nom_v;
 	} _param_handles;
 
 	struct {
@@ -173,6 +192,9 @@ private:
 		float   temp_p;
 		float   temp_i;
 		float   temp_ff;
+		float   temp_imax;
+		int32_t temp_src; // 0 = IMU, 1 = hygrometer
+		float   nom_v;    // nominal supply voltage for power limiting (0 = disabled)
 	} _params;
 
 };

--- a/src/drivers/heater/module.yaml
+++ b/src/drivers/heater/module.yaml
@@ -88,3 +88,51 @@ parameters:
             num_instances: *max_num_config_instances
             instance_start: 1
             default: [1.0, 1.0, 1.0]
+
+        HEATER${i}_IMAX:
+            description:
+                short: Heater controller ${i} integrator clamp
+                long: |
+                    Limits the maximum (and minimum) contribution of the integrator term to the controller output.
+
+            type: float
+            min: 0.0
+            max: 0.25
+            decimal: 3
+            reboot_required: false
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: [0.25, 0.25, 0.25]
+
+        HEATER${i}_TEMP_SRC:
+            description:
+                short: Temperature source for heater ${i}
+                long: |
+                    Selects the sensor used as the temperature input for heater control.
+                    0 = IMU (sensor_accel temperature), 1 = Hygrometer (sensor_hygrometer temperature).
+
+            type: int32
+            values:
+                0: IMU
+                1: Hygrometer
+            reboot_required: true
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: [0, 0, 0]
+
+        HEATER${i}_NOM_V:
+            description:
+                short: Nominal supply voltage for heater ${i}
+                long: |
+                    Used to limit the PWM duty cycle when the actual supply voltage exceeds this value,
+                    to prevent excess power dissipation. Set to 0 to disable voltage-based limiting.
+
+            type: float
+            unit: V
+            min: 0
+            max: 100.0
+            decimal: 1
+            reboot_required: false
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: [0.0, 0.0, 0.0]


### PR DESCRIPTION
### Solved Problem
This addresses multiple topics observed while developing a more complex heater
- The current heater can only listen to `sensor_accel`.
- Currently the update rate is limited by the refresh rate of a temperature source, which is problematic for temperature drivers with slow update rate
- It is not possible to set the IMAX term (integrator clamp)
- The design can not handle variable heater supply voltage

### Solution
- Add support to get temperature from `sensor_hygrometer`. The structure also allows adding more sources in the future
- Add a `HEATER_FAST_UPDATE_MODE` to `Kconfig`. This allows using the last received temperature for up to a defined timeout where the heater will be turned off for safety reasons. The fast update is needed for slow temperature sources, otherwise the heater will be turned off most of the time and will not heat enough. If this is not set everything behaves as previously
- Add a param to set the IMAX term
- Add a `HEATER${I}_NOM_V` parameter. With this it is possible to set the nominal voltage the controller was designed. This is also the voltage the heater network can sustain with 100% duty cycle. A higher supply voltage will adapt the controller output accordingly to not overload the heater network. This requires reading supply voltage and will disable the heater when no supply voltage can be read. If the parameter is not set everything behaves as previously.

### Test coverage
- Tested the `HEATER_FAST_UPDATE_MODE` with a new product with a quite strong heater network