### PR TITLE
fix(dshot): STM32 PWM bit-width 20→19 for cleaner 600 kHz division

### DIFF
--- a/platforms/nuttx/src/px4/stm/stm32_common/include/px4_arch/dshot.h
+++ b/platforms/nuttx/src/px4/stm/stm32_common/include/px4_arch/dshot.h
@@ -37,7 +37,14 @@
 #include <drivers/drv_pwm_output.h>
 #include <stm32_dma.h>
 
-#define DSHOT_MOTOR_PWM_BIT_WIDTH		20u
+// 19, not the more obvious 20, so that ARK FPV's 160 MHz APB1_TIM5_CLKIN
+// divides evenly into DSHOT600/300/150 rates. 160e6 / 600e3 = 266.67 doesn't
+// factor into (PSC+1)·20 cleanly (best is 1.625 µs/bit, +2.5% fast — outside
+// some AM32 builds' decode tolerance). 266 = 14·19, so PSC=13 with WIDTH=19
+// gives 1.6625 µs/bit, +0.25% off spec, accepted by every reasonable ESC.
+// BIT_1=14 (73.7% LOW) and BIT_0=7 (36.8% LOW) under inverted PWM land
+// closer to the BDShot spec (75% / 37.5%) than the prior 70% / 35%.
+#define DSHOT_MOTOR_PWM_BIT_WIDTH		19u
 
 /* Configuration for each timer to setup DShot. Some timers have only one while others have two choices for the stream.
  *


### PR DESCRIPTION
PX4's prescaler math at io_timer.c:605 truncates clock/(rate·WIDTH)-1 toward zero, which on the ARK FPV (160 MHz APB1_TIM5_CLKIN) yields PSC=12 with WIDTH=20 — 615.4 kHz/bit, +2.5% off DSHOT600 spec. Some AM32 ESCs in rate-locked / BDShot-locked configurations reject frames outside ±2% tolerance and beep "no signal" or arpeggio strangely.

With WIDTH=19 the same 160 MHz clock divides through 266 = 14·19, PSC=13, 601.5 kHz/bit (+0.25%). At 240 MHz timer clocks (Pixhawk-class boards) the new value lands at 601.5 kHz instead of the exact 600 kHz — still well within tolerance. BIT_1=14 (73.7% LOW under inverted PWM) and BIT_0=7 (36.8% LOW) move closer to BDShot spec (75% / 37.5%) than the prior 70% / 35%, so no downside there either.

Verified via Digilent Discovery 2 on a bare ARK FPV board: 100% BDShot eRPM CRC success post-patch (was ~50%) and 99.85% line-HIGH duty cycle on inverted output, matching DSHOT600 bit pairs ≈1.66 µs.

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
