### PR TITLE
fix(dshot): pick bit width per timer clock for accurate rate

### DIFF
--- a/platforms/nuttx/src/px4/stm/stm32_common/include/px4_arch/dshot.h
+++ b/platforms/nuttx/src/px4/stm/stm32_common/include/px4_arch/dshot.h
@@ -36,8 +36,32 @@
 
 #include <drivers/drv_pwm_output.h>
 #include <stm32_dma.h>
+#include <arch/board/board.h>
 
-#define DSHOT_MOTOR_PWM_BIT_WIDTH		20u
+// Pick WIDTH so floor(TIM_CLK / 600000) divides cleanly into it, keeping the
+// prescaler integer. Guard skips F1 IO co-processors (no TIM8, no DSHOT).
+#if defined(STM32_APB1_TIM5_CLKIN) && defined(STM32_APB2_TIM8_CLKIN)
+
+#define _DSHOT600_TICKS_APB1 (STM32_APB1_TIM5_CLKIN / 600000U)
+#define _DSHOT600_TICKS_APB2 (STM32_APB2_TIM8_CLKIN / 600000U)
+
+#if   (_DSHOT600_TICKS_APB1 % 20U == 0U)
+#  define DSHOT_MOTOR_PWM_BIT_WIDTH		20u
+#elif (_DSHOT600_TICKS_APB1 % 19U == 0U)
+#  define DSHOT_MOTOR_PWM_BIT_WIDTH		19u
+#elif (_DSHOT600_TICKS_APB1 % 18U == 0U)
+#  define DSHOT_MOTOR_PWM_BIT_WIDTH		18u
+#else
+#  define DSHOT_MOTOR_PWM_BIT_WIDTH		20u
+#endif
+
+#if (_DSHOT600_TICKS_APB1 % DSHOT_MOTOR_PWM_BIT_WIDTH) != (_DSHOT600_TICKS_APB2 % DSHOT_MOTOR_PWM_BIT_WIDTH)
+#  pragma message "DSHOT bit width: APB1 and APB2 timer clocks emit DSHOT at different rates on this board"
+#endif
+
+#else
+#  define DSHOT_MOTOR_PWM_BIT_WIDTH		20u
+#endif
 
 /* Configuration for each timer to setup DShot. Some timers have only one while others have two choices for the stream.
  *


### PR DESCRIPTION
## Summary

Auto-selects `DSHOT_MOTOR_PWM_BIT_WIDTH` per timer clock at compile time so ARK FPV emits DSHOT at the same bit period as the rest of the fleet. Supersedes #27401.

## Problem

`io_timer_set_dshot_burst_mode()` sets `ARR = WIDTH` and `PSC = floor(CLK/DSHOT_FREQ)/WIDTH - 1` with hardcoded `WIDTH = 20`. The actual bit period is `(PSC+1) * (ARR+1)` timer-clock ticks. ARK FPV's 160 MHz APB1 (PLL1N=40) gives `floor(160e6/600e3) = 266`, not divisible by 20 — BIT_1/BIT_0 duty cycles end up at 66.7%/33.3% vs DSHOT600 spec 75%/37.5%.

#27401 fixed this with hardcoded `WIDTH = 19`, but that breaks every F4/F7 board with an 84/108 MHz timer clock.

## Solution

Compile-time ladder against `STM32_APB1_TIM5_CLKIN`: try `WIDTH ∈ {20, 19, 18}` and pick the first where `floor(CLK/600000) % W == 0`. Falls back to 20 otherwise. ARK FPV lands on W=19; every other DSHOT-capable board keeps W=20 unchanged.

Scope traces on ARK FPV (160 MHz APB):

| | DSHOT600 spec | Before (W=20) | After (W=19) |
|---|---|---|---|
| Bit period | 1667 ns | 1706 ns | 1750 ns |
| BIT_1 HIGH | 1250 ns (75%) | 1138 ns (66.7%) | 1225 ns (70%) |
| BIT_0 HIGH | 625 ns (37.5%) | 568 ns (33.3%) | 612 ns (35%) |

ARK FPV's post-fix 1.75 us bit period matches all 240 MHz boards (FMU-v6X/v6S/PI6X, durandal, kakuteh7*, ctrl-zero-h7, etc.). 200 MHz boards (CubeOrange/Orange+, spracing/h7extreme) keep W=20 (unchanged — none of {20, 19, 18} divides 333; fix needs W=22 with scaled BIT_1/BIT_0, out of scope).

A `#warning` flags boards where APB1 and APB2 timer clocks would emit DSHOT at different rates (currently only `fmu-v4pro`: APB1=90 MHz, APB2=180 MHz — pre-existing on master, not regressed by this PR).

Builds verified on `ark_fpv_default`, `ark_fmu-v6x_default`, `ark_cannode_default`, `cubepilot_cubeorange_default`.
