### PR TITLE
fix(stick_yaw): reset yaw setpoint when unaided yaw recovers

### DIFF
--- a/src/lib/stick_yaw/StickYaw.cpp
+++ b/src/lib/stick_yaw/StickYaw.cpp
@@ -73,6 +73,7 @@ void StickYaw::generateYawSetpoint(float &yawspeed_setpoint, float &yaw_setpoint
 bool StickYaw::updateYawCorrection(const float yaw, const float unaided_yaw, const float deltatime)
 {
 	if (!PX4_ISFINITE(unaided_yaw)) {
+		_unaided_yaw_was_invalid = true;
 		// If unaided yaw is not available we leave yaw_correction_ unchanged
 		// Meaning yaw_setpoint - yaw_correction_prev + _yaw_correction = yaw_setpoint
 		return false;
@@ -81,6 +82,15 @@ bool StickYaw::updateYawCorrection(const float yaw, const float unaided_yaw, con
 	// Detect the convergence phase of the yaw estimate by monitoring its relative
 	// distance from an unaided yaw source.
 	const float yaw_error = wrap_pi(yaw - unaided_yaw);
+
+	if (_unaided_yaw_was_invalid) {
+		_unaided_yaw_was_invalid = false;
+		_yaw_error_lpf.reset(yaw_error);
+		_yaw_error_ref = yaw_error;
+		_yaw_correction = 0.f;
+		_yaw_estimate_converging = false;
+		return true;
+	}
 
 	// Run it through a high-pass filter to detect transients
 	const float yaw_error_hpf = wrap_pi(yaw_error - _yaw_error_lpf.getState());

--- a/src/lib/stick_yaw/StickYaw.hpp
+++ b/src/lib/stick_yaw/StickYaw.hpp
@@ -60,6 +60,7 @@ private:
 	float _yaw_error_ref{0.f};
 	float _yaw_correction{0.f};
 	bool _yaw_estimate_converging{false};
+	bool _unaided_yaw_was_invalid{false};
 	AlphaFilter<float> _yaw_error_lpf{_kYawErrorTimeConstant}; ///< used to create a high-pass filter
 	static constexpr float _kYawErrorTimeConstant{1.f}; ///< time constant of the high-pass filter used to detect yaw convergence
 	static constexpr float _kYawErrorChangeThreshold{radians(1.f)}; ///< we consider the yaw estimate as "converging" when above this threshold

--- a/src/lib/stick_yaw/StickYawTest.cpp
+++ b/src/lib/stick_yaw/StickYawTest.cpp
@@ -75,3 +75,46 @@ TEST(StickYawTest, UnaidedYawNanTransitionNoYawJump)
 			<< "Yaw setpoint jumped from " << yaw_sp_before << " to " << yaw_sp
 			<< " when unaided_yaw became NAN";
 }
+
+TEST(StickYawTest, UnaidedYawNanToFiniteTransitionResetsYawLock)
+{
+	// When unaided_yaw recovers from NAN, stale yaw correction state from before
+	// the outage must not be applied to the locked yaw setpoint.
+
+	param_control_autosave(false);
+
+	StickYaw stick_yaw{nullptr};
+	float yawspeed_sp = 0.f;
+	float yaw_sp = NAN;
+	const float dt = 0.01f;
+
+	// Phase 1: Establish yaw lock at yaw=0 with unaided_yaw=0.
+	stick_yaw.reset(0.f, 0.f);
+
+	for (int i = 0; i < 10; i++) {
+		stick_yaw.generateYawSetpoint(yawspeed_sp, yaw_sp, 0.f, 0.f, dt, 0.f);
+	}
+
+	EXPECT_NEAR(yaw_sp, 0.f, 0.01f);
+
+	// Phase 2: Simulate a yaw estimate correction while unaided_yaw is valid.
+	for (int i = 0; i < 20; i++) {
+		stick_yaw.generateYawSetpoint(yawspeed_sp, yaw_sp, 0.f, 0.3f, dt, 0.f);
+	}
+
+	EXPECT_NEAR(yaw_sp, 0.3f, 0.01f);
+
+	// Phase 3: unaided_yaw becomes unavailable. The yaw setpoint is held by the
+	// existing correction state.
+	stick_yaw.generateYawSetpoint(yawspeed_sp, yaw_sp, 0.f, 0.3f, dt, NAN);
+
+	EXPECT_NEAR(yaw_sp, 0.3f, 0.01f);
+
+	// Phase 4: unaided_yaw recovers with a new yaw error baseline. The yaw lock
+	// should reset to the current yaw instead of applying stale correction state.
+	stick_yaw.generateYawSetpoint(yawspeed_sp, yaw_sp, 0.f, 0.3f, dt, 0.3f);
+
+	EXPECT_NEAR(yaw_sp, 0.3f, 0.01f)
+			<< "Yaw setpoint jumped to " << yaw_sp
+			<< " when unaided_yaw recovered from NAN";
+}


### PR DESCRIPTION
### Solved Problem
Fixes a yaw setpoint discontinuity in `StickYaw` when `unaided_yaw` recovers after being unavailable.

#25710 fixed the finite-to-NaN transition by preserving `_yaw_correction` while `unaided_yaw` is not available. However, when `unaided_yaw` becomes finite again, the yaw correction logic can still use stale yaw error filter/reference state from before the outage. This can apply an invalid correction delta to the locked yaw setpoint.

### Solution
Track whether `unaided_yaw` was invalid during the previous update. When it becomes valid again, reset the yaw error filter/reference to the current yaw error, clear the stale correction state, and force the yaw lock to reinitialize from the current yaw.

Added a regression test covering the `finite -> NaN -> finite` transition to ensure the yaw setpoint does not jump when `unaided_yaw` recovers.

### Changelog Entry
For release notes:
```text
Bugfix: avoid yaw setpoint jumps when unaided yaw recovers in StickYaw
```

### Test coverage
```sh
make tests TESTFILTER=StickYaw
```