### PR TITLE
fix(mavlink): guard mission download completion

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -736,9 +736,9 @@ MavlinkMissionManager::handle_mission_request_list(const mavlink_message_t *msg)
 	mavlink_msg_mission_request_list_decode(msg, &wprl);
 
 	if (CHECK_SYSID_COMPID_MISSION(wprl)) {
-		const bool maybe_completed = (_transfer_seq == current_item_count());
+		const bool maybe_completed = (_state == MAVLINK_WPM_STATE_SENDLIST) && (_transfer_seq == current_item_count());
 
-		// If all mission items have been sent and a new mission request list comes in, we can proceed even if  MISSION_ACK was
+		// If all mission items have been sent and a new mission request list comes in, we can proceed even if MISSION_ACK was
 		// never received. This could happen on a quick reconnect that doesn't trigger MAVLINK_MISSION_PROTOCOL_TIMEOUT_DEFAULT
 		if (maybe_completed) {
 			switch_to_idle_state();


### PR DESCRIPTION
### Solved Problem
A mission upload can be aborted by an unrelated `MISSION_REQUEST_LIST`.

In `MavlinkMissionManager::handle_mission_request_list()`, the missing-`MISSION_ACK` recovery path only checked whether `_transfer_seq == current_item_count()`. During `GETLIST`, that condition can also become true when the upload sequence happens to match the currently stored mission count. If a mission download request arrives then, the manager switches to `IDLE` and starts `SENDLIST`, interrupting the upload.

### Solution
Only allow the missing-`MISSION_ACK` recovery path while in `SENDLIST`.

### Changelog Entry
For release notes:
```
Bugfix: mission upload no longer gets aborted by an unrelated mission download request
```