### PR TITLE
feat(oot): support external MAVLink handler, stream, and dialect with opt in custom init scripts in Out of Tree modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,6 +452,33 @@ if (NOT EXTERNAL_MODULES_LOCATION STREQUAL "")
 		add_subdirectory(${EXTERNAL_MODULES_LOCATION}/src/${external_module} external_modules/${external_module})
 		list(APPEND external_module_paths ${EXTERNAL_MODULES_LOCATION}/src/${external_module})
 	endforeach()
+
+	# external MAVLink dialect: EXTERNAL_MODULES_LOCATION/mavlink/<name>.xml
+	file(GLOB _ext_mavlink_xmls "${EXTERNAL_MODULES_LOCATION}/mavlink/*.xml")
+	if(_ext_mavlink_xmls)
+		list(LENGTH _ext_mavlink_xmls _n_xmls)
+		if(_n_xmls GREATER 1)
+			message(FATAL_ERROR "Multiple MAVLink dialect XMLs found in "
+				"${EXTERNAL_MODULES_LOCATION}/mavlink/. "
+				"Only one external dialect is supported.")
+		endif()
+		list(GET _ext_mavlink_xmls 0 _ext_xml)
+		get_filename_component(_ext_dialect_name "${_ext_xml}" NAME_WE)
+
+		# Copy into mavgen search path (configure_file tracks dependencies)
+		set(_mavlink_defs "${PX4_SOURCE_DIR}/src/modules/mavlink/mavlink/message_definitions/v1.0")
+		configure_file("${_ext_xml}" "${_mavlink_defs}/${_ext_dialect_name}.xml" COPYONLY)
+
+		# Override dialect if currently 'common' (external dialect must include common.xml)
+		if(CONFIG_MAVLINK_DIALECT STREQUAL "common")
+			set(CONFIG_MAVLINK_DIALECT "${_ext_dialect_name}"
+				CACHE STRING "MAVLink dialect (external: ${_ext_dialect_name})" FORCE)
+			message(STATUS "External MAVLink dialect: ${_ext_dialect_name} (auto-set from common)")
+		else()
+			message(STATUS "External MAVLink dialect: ${_ext_dialect_name} "
+				"(CONFIG_MAVLINK_DIALECT=${CONFIG_MAVLINK_DIALECT} kept as-is)")
+		endif()
+	endif()
 endif()
 
 #=============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ define_property(GLOBAL PROPERTY PX4_SRC_FILES
 #
 
 include(px4_add_module)
+include(px4_add_external_mavlink_dialect)
 set(config_module_list)
 set(config_kernel_list)
 
@@ -453,30 +454,23 @@ if (NOT EXTERNAL_MODULES_LOCATION STREQUAL "")
 		list(APPEND external_module_paths ${EXTERNAL_MODULES_LOCATION}/src/${external_module})
 	endforeach()
 
-	# external MAVLink dialect: EXTERNAL_MODULES_LOCATION/mavlink/<name>.xml
-	file(GLOB _ext_mavlink_xmls "${EXTERNAL_MODULES_LOCATION}/mavlink/*.xml")
-	if(_ext_mavlink_xmls)
-		list(LENGTH _ext_mavlink_xmls _n_xmls)
-		if(_n_xmls GREATER 1)
-			message(FATAL_ERROR "Multiple MAVLink dialect XMLs found in "
-				"${EXTERNAL_MODULES_LOCATION}/mavlink/. "
-				"Only one external dialect is supported.")
-		endif()
-		list(GET _ext_mavlink_xmls 0 _ext_xml)
-		get_filename_component(_ext_dialect_name "${_ext_xml}" NAME_WE)
+	# External MAVLink dialects (registered via px4_add_external_mavlink_dialect)
+	get_property(_ext_dialects GLOBAL PROPERTY PX4_EXTERNAL_MAVLINK_DIALECTS)
+	if(_ext_dialects)
+		list(LENGTH _ext_dialects _n_dialects)
+		list(GET _ext_dialects 0 _primary_ext_dialect)
 
-		# Copy into mavgen search path (configure_file tracks dependencies)
-		set(_mavlink_defs "${PX4_SOURCE_DIR}/src/modules/mavlink/mavlink/message_definitions/v1.0")
-		configure_file("${_ext_xml}" "${_mavlink_defs}/${_ext_dialect_name}.xml" COPYONLY)
-
-		# Override dialect if currently 'common' (external dialect must include common.xml)
 		if(CONFIG_MAVLINK_DIALECT STREQUAL "common")
-			set(CONFIG_MAVLINK_DIALECT "${_ext_dialect_name}"
-				CACHE STRING "MAVLink dialect (external: ${_ext_dialect_name})" FORCE)
-			message(STATUS "External MAVLink dialect: ${_ext_dialect_name} (auto-set from common)")
+			set(CONFIG_MAVLINK_DIALECT "${_primary_ext_dialect}"
+				CACHE STRING "MAVLink dialect (external: ${_primary_ext_dialect})" FORCE)
+			message(STATUS "External MAVLink dialect: ${_primary_ext_dialect} (auto-set from common)")
 		else()
-			message(STATUS "External MAVLink dialect: ${_ext_dialect_name} "
+			message(STATUS "External MAVLink dialect: ${_primary_ext_dialect} "
 				"(CONFIG_MAVLINK_DIALECT=${CONFIG_MAVLINK_DIALECT} kept as-is)")
+		endif()
+
+		if(_n_dialects GREATER 1)
+			message(STATUS "  Additional external dialects: ${_ext_dialects}")
 		endif()
 	endif()
 endif()

--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -226,6 +226,31 @@ foreach(board_rc_file ${OPTIONAL_BOARD_RC})
 
 endforeach()
 
+# External module init scripts
+if(NOT "${EXTERNAL_MODULES_LOCATION}" STREQUAL "")
+	set(_ext_init "${EXTERNAL_MODULES_LOCATION}/init/rc.ext_modules")
+	if(EXISTS "${_ext_init}")
+		file(RELATIVE_PATH _ext_init_relative ${PX4_SOURCE_DIR} ${_ext_init})
+		message(STATUS "ROMFS:  Adding ${_ext_init_relative} -> /etc/init.d/rc.ext_modules")
+
+		add_custom_command(
+			OUTPUT
+				${romfs_gen_root_dir}/init.d/rc.ext_modules
+				rc.ext_modules.stamp
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different
+				${_ext_init} ${romfs_gen_root_dir}/init.d/rc.ext_modules
+			COMMAND ${CMAKE_COMMAND} -E touch rc.ext_modules.stamp
+			DEPENDS
+				${_ext_init}
+				romfs_copy.stamp
+			COMMENT "ROMFS: copying rc.ext_modules"
+		)
+
+		list(APPEND extras_dependencies rc.ext_modules.stamp)
+	endif()
+endif()
+
+
 if(config_additional_init)
 	if(EXISTS "${PX4_BOARD_DIR}/init/${config_additional_init}")
 		file(RELATIVE_PATH rc_file_relative ${PX4_SOURCE_DIR} ${PX4_BOARD_DIR}/init/${config_additional_init})

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -668,17 +668,6 @@ else
 	unset BOARD_RC_EXTRAS
 
 	#
-	# Optional external module auto-start: rc.ext_modules
-	#
-	set EXT_MODULE_RC ${R}etc/init.d/rc.ext_modules
-	if [ -f $EXT_MODULE_RC ]
-	then
-		echo "External modules: ${EXT_MODULE_RC}"
-		. $EXT_MODULE_RC
-	fi
-	unset EXT_MODULE_RC
-
-	#
 	# Start any custom addons from the sdcard.
 	#
 	if [ -f $FEXTRAS ]
@@ -696,6 +685,17 @@ else
 		. ${RC_LOGGING}
 	fi
 	unset RC_LOGGING
+
+	#
+	# Optional external module auto-start: rc.ext_modules
+	#
+	set EXT_MODULE_RC ${R}etc/init.d/rc.ext_modules
+	if [ -f $EXT_MODULE_RC ]
+	then
+		echo "External modules: ${EXT_MODULE_RC}"
+		. $EXT_MODULE_RC
+	fi
+	unset EXT_MODULE_RC
 
 	#
 	# Start the VTX services.

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -668,6 +668,17 @@ else
 	unset BOARD_RC_EXTRAS
 
 	#
+	# Optional external module auto-start: rc.ext_modules
+	#
+	set EXT_MODULE_RC ${R}etc/init.d/rc.ext_modules
+	if [ -f $EXT_MODULE_RC ]
+	then
+		echo "External modules: ${EXT_MODULE_RC}"
+		. $EXT_MODULE_RC
+	fi
+	unset EXT_MODULE_RC
+
+	#
 	# Start any custom addons from the sdcard.
 	#
 	if [ -f $FEXTRAS ]

--- a/cmake/px4_add_external_mavlink_dialect.cmake
+++ b/cmake/px4_add_external_mavlink_dialect.cmake
@@ -1,0 +1,77 @@
+############################################################################
+#
+#   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+#=============================================================================
+#
+#	px4_add_external_mavlink_dialect
+#
+#	Registers an external MAVLink dialect XML for mavgen code generation.
+#	The dialect XML should <include>common.xml</include> (or another base
+#	dialect) so that all standard MAVLink messages remain available.
+#
+#	Multiple external dialects are supported. The first registered dialect
+#	becomes the primary dialect (overrides CONFIG_MAVLINK_DIALECT from
+#	"common" if applicable).
+#
+#	Usage:
+#		px4_add_external_mavlink_dialect(
+#			XML ${CMAKE_CURRENT_SOURCE_DIR}/../../mavlink/se05x.xml
+#		)
+#
+#	Effects:
+#		1. Copies the XML into mavgen's message_definitions/v1.0/ search path
+#		2. Appends the dialect name to PX4_EXTERNAL_MAVLINK_DIALECTS global property
+#		3. Dialect override happens in root CMakeLists.txt after all add_subdirectory()
+#		   calls have completed
+#
+function(px4_add_external_mavlink_dialect)
+	px4_parse_function_args(
+		NAME px4_add_external_mavlink_dialect
+		ONE_VALUE XML
+		REQUIRED XML
+		ARGN ${ARGN}
+	)
+
+	if(NOT EXISTS "${XML}")
+		message(FATAL_ERROR "px4_add_external_mavlink_dialect: XML not found: ${XML}")
+	endif()
+
+	get_filename_component(_dialect_name "${XML}" NAME_WE)
+	set(_mavlink_defs "${PX4_SOURCE_DIR}/src/modules/mavlink/mavlink/message_definitions/v1.0")
+
+	configure_file("${XML}" "${_mavlink_defs}/${_dialect_name}.xml" COPYONLY)
+
+	set_property(GLOBAL APPEND PROPERTY PX4_EXTERNAL_MAVLINK_DIALECTS "${_dialect_name}")
+
+	message(STATUS "External MAVLink dialect registered: ${_dialect_name} (from ${XML})")
+endfunction()

--- a/cmake/px4_add_external_mavlink_dialect.cmake
+++ b/cmake/px4_add_external_mavlink_dialect.cmake
@@ -45,7 +45,7 @@
 #
 #	Usage:
 #		px4_add_external_mavlink_dialect(
-#			XML ${CMAKE_CURRENT_SOURCE_DIR}/../../mavlink/se05x.xml
+#			XML ${CMAKE_CURRENT_SOURCE_DIR}/../../mavlink/my_dialect.xml
 #		)
 #
 #	Effects:

--- a/docs/en/advanced/out_of_tree_modules.md
+++ b/docs/en/advanced/out_of_tree_modules.md
@@ -82,3 +82,122 @@ Any other build target can be used, but the build directory must not yet exist.
 If it already exists, you can also just set the _cmake_ variable in the build folder.
 
 For subsequent incremental builds `EXTERNAL_MODULES_LOCATION` does not need to be specified.
+
+## Out-of-Tree MAVLink Dialect Definitions
+
+External modules can register custom MAVLink dialect XML files for mavgen code generation without modifying PX4 source.
+
+### Registering a Dialect
+
+Call `px4_add_external_mavlink_dialect()` from your module's `CMakeLists.txt`:
+
+```cmake
+px4_add_external_mavlink_dialect(
+    XML ${CMAKE_CURRENT_SOURCE_DIR}/../../mavlink/my_dialect.xml
+)
+```
+
+The dialect XML must `<include>common.xml</include>` so that all standard MAVLink messages remain available.
+The function copies the XML into mavgen's search path and, if `CONFIG_MAVLINK_DIALECT` is `common`, automatically overrides it with your dialect name.
+
+Multiple external dialects from different modules are supported.
+
+### Directory Layout
+
+```
+my_external_module/
+├── mavlink/
+│   └── my_dialect.xml      # Custom MAVLink dialect
+├── src/
+│   ├── CMakeLists.txt       # Calls px4_add_external_mavlink_dialect()
+│   └── modules/
+│       └── my_module/
+```
+
+## External MAVLink Message Handlers and Streams
+
+External modules can register callbacks for custom inbound and outbound MAVLink messages at runtime, without patching `mavlink_receiver.cpp` or `mavlink_main.cpp`.
+
+### Inbound Message Handlers
+
+Register a handler for a custom message ID from your module's `init` or `task_spawn`:
+
+```cpp
+#include <modules/mavlink/mavlink_ext_handler.h>
+
+static bool handle_my_message(const mavlink_message_t *msg, void *user_data)
+{
+    // Decode and process message
+    return true;
+}
+
+// Registration (typically in module init)
+mavlink_ext_handler_register(MAVLINK_MSG_ID_MY_MESSAGE, handle_my_message, this);
+
+// Cleanup (module stop)
+mavlink_ext_handler_unregister(MAVLINK_MSG_ID_MY_MESSAGE);
+```
+
+Registered handlers are invoked from the MAVLink receiver thread's `default` switch case.
+Registration is mutex-protected; dispatch is lock-free.
+
+### Outbound Streams
+
+Register a stream callback to periodically emit custom messages:
+
+```cpp
+#include <modules/mavlink/mavlink_ext_stream.h>
+
+static bool emit_my_message(uint8_t channel, void *user_data)
+{
+    mavlink_my_message_t msg{};
+    // Fill message fields...
+    mavlink_msg_my_message_send_struct((mavlink_channel_t)channel, &msg);
+    return true;
+}
+
+// Register with rate limiting (500000 = 2 Hz)
+mavlink_ext_stream_register(MAVLINK_MSG_ID_MY_MESSAGE, "MY_MESSAGE",
+                            emit_my_message, this, 500000);
+```
+
+The `interval_us` parameter controls rate limiting:
+- `-1`: unlimited (fire every iteration)
+- `0`: disabled
+- `>0`: minimum microseconds between sends
+
+External stream rates can also be controlled at runtime via the standard MAVLink `SET_MESSAGE_INTERVAL` command from QGC or pymavlink:
+
+```cpp
+// Programmatic rate change
+mavlink_ext_stream_set_interval(MAVLINK_MSG_ID_MY_MESSAGE, 1000000); // 1 Hz
+```
+
+## Boot-Time Auto-Start
+
+External modules can declare startup commands that are baked into the firmware ROMFS image at build time, eliminating the need for manual SD card `extras.txt` files.
+
+### Setup
+
+Create `init/rc.ext_modules` in your external module directory:
+
+```sh
+#!/bin/sh
+my_driver start
+my_mavlink_bridge start
+```
+
+When building with `EXTERNAL_MODULES_LOCATION`, PX4's build system automatically copies this file into the ROMFS.
+At boot, `rcS` sources it after `rc.board_extras` and before the SD card `extras.txt`.
+
+### Boot Order
+
+```
+rcS boot sequence:
+├── rc.board_extras           # Board-specific init
+├── rc.ext_modules            # External module auto-start (ROMFS, build-time)
+├── extras.txt                # SD card overrides (runtime)
+└── rc.logging                # Logger start
+```
+
+The SD card `extras.txt` remains available as a runtime override for development and testing without reflashing.

--- a/docs/en/advanced/out_of_tree_modules.md
+++ b/docs/en/advanced/out_of_tree_modules.md
@@ -195,9 +195,10 @@ At boot, `rcS` sources it after `rc.board_extras` and before the SD card `extras
 ```
 rcS boot sequence:
 ├── rc.board_extras           # Board-specific init
-├── rc.ext_modules            # External module auto-start (ROMFS, build-time)
 ├── extras.txt                # SD card overrides (runtime)
-└── rc.logging                # Logger start
+├── rc.logging                # Logger start
+└── rc.ext_modules            # External module auto-start (ROMFS, build-time)
 ```
 
+External modules run after the logger, ensuring that any slow hardware initialization (e.g. I2C secure elements) doesn't delay flight logging in a brownout recovery scenario.
 The SD card `extras.txt` remains available as a runtime override for development and testing without reflashing.

--- a/docs/en/mavlink/custom_messages.md
+++ b/docs/en/mavlink/custom_messages.md
@@ -13,6 +13,11 @@ Custom definitions can be added in a new dialect file in the same directory as [
 For example, create `PX4-Autopilot/src/modules/mavlink/mavlink/message_definitions/v1.0/custom_messages.xml`, and set `CONFIG_MAVLINK_DIALECT` to build the new file for SITL.
 This dialect file should include `development.xml` so that all the standard definitions are also included.
 
+:::tip
+If you are building an [external (out-of-tree) module](../advanced/out_of_tree_modules.md), use `px4_add_external_mavlink_dialect()` in your `CMakeLists.txt` instead of manually placing files in the PX4 source tree.
+See [Out-of-Tree MAVLink Dialect Definitions](../advanced/out_of_tree_modules.md#out-of-tree-mavlink-dialect-definitions).
+:::
+
 For initial prototyping, or if you intend your message to be "standard", you can also add your messages to `common.xml` (or `development.xml`).
 This simplifies building, because you don't need to modify the dialect that is built.
 

--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -124,6 +124,8 @@ px4_add_module(
 		MavlinkStatustextHandler.cpp
 		open_drone_id_translations.cpp
 		tune_publisher.cpp
+		mavlink_ext_handler.cpp
+		mavlink_ext_stream.cpp
 	MODULE_CONFIG
 		module.yaml
 		mavlink_params.yaml

--- a/src/modules/mavlink/mavlink_ext_handler.cpp
+++ b/src/modules/mavlink/mavlink_ext_handler.cpp
@@ -1,0 +1,127 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file mavlink_ext_handler.cpp
+ *
+ * External MAVLink message handler registry implementation.
+ *
+ * Uses a simple static array with atomic count for lock-free dispatch.
+ * Registration is not thread-safe with itself (callers must not register
+ * concurrently), but dispatch is safe to call from the mavlink receiver
+ * thread while registration happens from a module init context.
+ */
+
+#include "mavlink_bridge_header.h"  // Full mavlink_message_t definition (for ->msgid)
+#include "mavlink_ext_handler.h"
+
+#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/log.h>
+#include <cstring>
+
+struct mavlink_ext_handler_entry_t {
+	uint32_t msg_id;
+	mavlink_ext_handler_fn handler;
+	void *user_data;
+};
+
+static mavlink_ext_handler_entry_t _handlers[MAVLINK_EXT_HANDLER_MAX] {};
+static px4::atomic<unsigned> _handler_count {0};
+
+int mavlink_ext_handler_register(uint32_t msg_id, mavlink_ext_handler_fn handler, void *user_data)
+{
+	if (!handler) {
+		return -1;
+	}
+
+	unsigned count = _handler_count.load();
+
+	// Check for duplicate
+	for (unsigned i = 0; i < count; i++) {
+		if (_handlers[i].msg_id == msg_id) {
+			return -1;
+		}
+	}
+
+	if (count >= MAVLINK_EXT_HANDLER_MAX) {
+		return -1;
+	}
+
+	// Write entry before publishing count (release semantics via atomic store)
+	_handlers[count].msg_id = msg_id;
+	_handlers[count].handler = handler;
+	_handlers[count].user_data = user_data;
+	_handler_count.store(count + 1);
+
+	PX4_INFO("ext_handler: registered msgid %lu (count=%u)", (unsigned long)msg_id, count + 1);
+
+	return 0;
+}
+
+int mavlink_ext_handler_unregister(uint32_t msg_id)
+{
+	unsigned count = _handler_count.load();
+
+	for (unsigned i = 0; i < count; i++) {
+		if (_handlers[i].msg_id == msg_id) {
+			// Shift remaining entries down
+			if (i < count - 1) {
+				memmove(&_handlers[i], &_handlers[i + 1],
+					(count - i - 1) * sizeof(mavlink_ext_handler_entry_t));
+			}
+
+			_handler_count.store(count - 1);
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+bool mavlink_ext_handler_dispatch(const mavlink_message_t *msg)
+{
+	if (!msg) {
+		return false;
+	}
+
+	unsigned count = _handler_count.load();
+
+	for (unsigned i = 0; i < count; i++) {
+		if (_handlers[i].msg_id == msg->msgid) {
+			PX4_DEBUG("ext_handler: dispatching msgid %lu", (unsigned long)msg->msgid);
+			return _handlers[i].handler(msg, _handlers[i].user_data);
+		}
+	}
+
+	return false;
+}

--- a/src/modules/mavlink/mavlink_ext_handler.cpp
+++ b/src/modules/mavlink/mavlink_ext_handler.cpp
@@ -82,7 +82,7 @@ int mavlink_ext_handler_register(uint32_t msg_id, mavlink_ext_handler_fn handler
 
 	pthread_mutex_unlock(&_handler_mutex);
 
-	PX4_INFO("ext_handler: registered msgid %lu (count=%u)", (unsigned long)msg_id, count + 1);
+	PX4_DEBUG("ext_handler: registered msgid %lu (count=%u)", (unsigned long)msg_id, count + 1);
 
 	return 0;
 }

--- a/src/modules/mavlink/mavlink_ext_handler.cpp
+++ b/src/modules/mavlink/mavlink_ext_handler.cpp
@@ -33,13 +33,6 @@
 
 /**
  * @file mavlink_ext_handler.cpp
- *
- * External MAVLink message handler registry implementation.
- *
- * Uses a simple static array with atomic count for lock-free dispatch.
- * Registration is not thread-safe with itself (callers must not register
- * concurrently), but dispatch is safe to call from the mavlink receiver
- * thread while registration happens from a module init context.
  */
 
 #include "mavlink_bridge_header.h"  // Full mavlink_message_t definition (for ->msgid)
@@ -48,6 +41,7 @@
 #include <px4_platform_common/atomic.h>
 #include <px4_platform_common/log.h>
 #include <cstring>
+#include <pthread.h>
 
 struct mavlink_ext_handler_entry_t {
 	uint32_t msg_id;
@@ -57,6 +51,7 @@ struct mavlink_ext_handler_entry_t {
 
 static mavlink_ext_handler_entry_t _handlers[MAVLINK_EXT_HANDLER_MAX] {};
 static px4::atomic<unsigned> _handler_count {0};
+static pthread_mutex_t _handler_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 int mavlink_ext_handler_register(uint32_t msg_id, mavlink_ext_handler_fn handler, void *user_data)
 {
@@ -64,24 +59,28 @@ int mavlink_ext_handler_register(uint32_t msg_id, mavlink_ext_handler_fn handler
 		return -1;
 	}
 
+	pthread_mutex_lock(&_handler_mutex);
+
 	unsigned count = _handler_count.load();
 
-	// Check for duplicate
 	for (unsigned i = 0; i < count; i++) {
 		if (_handlers[i].msg_id == msg_id) {
+			pthread_mutex_unlock(&_handler_mutex);
 			return -1;
 		}
 	}
 
 	if (count >= MAVLINK_EXT_HANDLER_MAX) {
+		pthread_mutex_unlock(&_handler_mutex);
 		return -1;
 	}
 
-	// Write entry before publishing count (release semantics via atomic store)
 	_handlers[count].msg_id = msg_id;
 	_handlers[count].handler = handler;
 	_handlers[count].user_data = user_data;
 	_handler_count.store(count + 1);
+
+	pthread_mutex_unlock(&_handler_mutex);
 
 	PX4_INFO("ext_handler: registered msgid %lu (count=%u)", (unsigned long)msg_id, count + 1);
 
@@ -90,21 +89,24 @@ int mavlink_ext_handler_register(uint32_t msg_id, mavlink_ext_handler_fn handler
 
 int mavlink_ext_handler_unregister(uint32_t msg_id)
 {
+	pthread_mutex_lock(&_handler_mutex);
+
 	unsigned count = _handler_count.load();
 
 	for (unsigned i = 0; i < count; i++) {
 		if (_handlers[i].msg_id == msg_id) {
-			// Shift remaining entries down
 			if (i < count - 1) {
 				memmove(&_handlers[i], &_handlers[i + 1],
 					(count - i - 1) * sizeof(mavlink_ext_handler_entry_t));
 			}
 
 			_handler_count.store(count - 1);
+			pthread_mutex_unlock(&_handler_mutex);
 			return 0;
 		}
 	}
 
+	pthread_mutex_unlock(&_handler_mutex);
 	return -1;
 }
 

--- a/src/modules/mavlink/mavlink_ext_handler.h
+++ b/src/modules/mavlink/mavlink_ext_handler.h
@@ -1,0 +1,91 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file mavlink_ext_handler.h
+ *
+ * Generic external MAVLink message handler registration.
+ *
+ * Allows out-of-tree / external modules to register callbacks for
+ * custom MAVLink message IDs without modifying mavlink_receiver.cpp.
+ * Callbacks are invoked from the receiver's default switch case.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+// Forward declaration — the full definition comes from the dialect headers
+struct __mavlink_message;
+typedef struct __mavlink_message mavlink_message_t;
+
+/**
+ * Callback signature for external MAVLink message handlers.
+ * Receives the raw mavlink_message_t; the handler is responsible for
+ * decoding (e.g. mavlink_msg_*_decode) and publishing to uORB.
+ *
+ * @param msg        Parsed MAVLink message (CRC already validated)
+ * @param user_data  Opaque pointer passed at registration time
+ * @return true if the message was handled
+ */
+typedef bool (*mavlink_ext_handler_fn)(const mavlink_message_t *msg, void *user_data);
+
+/** Maximum number of concurrently registered external handlers */
+static constexpr unsigned MAVLINK_EXT_HANDLER_MAX = 8;
+
+/**
+ * Register a handler for a custom MAVLink message ID.
+ *
+ * @param msg_id     MAVLink message ID to handle
+ * @param handler    Callback function
+ * @param user_data  Opaque context pointer (e.g. module instance)
+ * @return 0 on success, -1 if table full or msg_id already registered
+ */
+int mavlink_ext_handler_register(uint32_t msg_id, mavlink_ext_handler_fn handler, void *user_data);
+
+/**
+ * Unregister a previously registered handler.
+ *
+ * @param msg_id  MAVLink message ID to unregister
+ * @return 0 on success, -1 if msg_id not found
+ */
+int mavlink_ext_handler_unregister(uint32_t msg_id);
+
+/**
+ * Dispatch a message to registered external handlers.
+ * Called from MavlinkReceiver::handle_message() default case.
+ *
+ * @param msg  Parsed MAVLink message
+ * @return true if a handler was found and invoked
+ */
+bool mavlink_ext_handler_dispatch(const mavlink_message_t *msg);

--- a/src/modules/mavlink/mavlink_ext_stream.cpp
+++ b/src/modules/mavlink/mavlink_ext_stream.cpp
@@ -1,0 +1,110 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file mavlink_ext_stream.cpp
+ *
+ * External MAVLink outbound stream registry implementation.
+ */
+
+#include "mavlink_ext_stream.h"
+
+#include <px4_platform_common/atomic.h>
+#include <cstring>
+
+struct mavlink_ext_stream_entry_t {
+	uint32_t msg_id;
+	const char *name;
+	mavlink_ext_stream_fn fn;
+	void *user_data;
+};
+
+static mavlink_ext_stream_entry_t _streams[MAVLINK_EXT_STREAM_MAX] {};
+static px4::atomic<unsigned> _stream_count {0};
+
+int mavlink_ext_stream_register(uint32_t msg_id, const char *name,
+				mavlink_ext_stream_fn fn, void *user_data)
+{
+	if (!fn) {
+		return -1;
+	}
+
+	unsigned count = _stream_count.load();
+
+	// Check for duplicate
+	for (unsigned i = 0; i < count; i++) {
+		if (_streams[i].msg_id == msg_id) {
+			return -1;
+		}
+	}
+
+	if (count >= MAVLINK_EXT_STREAM_MAX) {
+		return -1;
+	}
+
+	_streams[count].msg_id = msg_id;
+	_streams[count].name = name;
+	_streams[count].fn = fn;
+	_streams[count].user_data = user_data;
+	_stream_count.store(count + 1);
+
+	return 0;
+}
+
+int mavlink_ext_stream_unregister(uint32_t msg_id)
+{
+	unsigned count = _stream_count.load();
+
+	for (unsigned i = 0; i < count; i++) {
+		if (_streams[i].msg_id == msg_id) {
+			if (i < count - 1) {
+				memmove(&_streams[i], &_streams[i + 1],
+					(count - i - 1) * sizeof(mavlink_ext_stream_entry_t));
+			}
+
+			_stream_count.store(count - 1);
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+void mavlink_ext_stream_dispatch(uint8_t channel)
+{
+	unsigned count = _stream_count.load();
+
+	for (unsigned i = 0; i < count; i++) {
+		_streams[i].fn(channel, _streams[i].user_data);
+	}
+}

--- a/src/modules/mavlink/mavlink_ext_stream.cpp
+++ b/src/modules/mavlink/mavlink_ext_stream.cpp
@@ -33,42 +33,49 @@
 
 /**
  * @file mavlink_ext_stream.cpp
- *
- * External MAVLink outbound stream registry implementation.
  */
 
 #include "mavlink_ext_stream.h"
 
 #include <px4_platform_common/atomic.h>
+#include <drivers/drv_hrt.h>
 #include <cstring>
+#include <pthread.h>
 
 struct mavlink_ext_stream_entry_t {
 	uint32_t msg_id;
 	const char *name;
 	mavlink_ext_stream_fn fn;
 	void *user_data;
+	int interval_us;        // -1 = unlimited, 0 = disabled
+	hrt_abstime last_sent;
 };
 
 static mavlink_ext_stream_entry_t _streams[MAVLINK_EXT_STREAM_MAX] {};
 static px4::atomic<unsigned> _stream_count {0};
+static pthread_mutex_t _stream_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 int mavlink_ext_stream_register(uint32_t msg_id, const char *name,
-				mavlink_ext_stream_fn fn, void *user_data)
+				mavlink_ext_stream_fn fn, void *user_data,
+				int interval_us)
 {
 	if (!fn) {
 		return -1;
 	}
 
+	pthread_mutex_lock(&_stream_mutex);
+
 	unsigned count = _stream_count.load();
 
-	// Check for duplicate
 	for (unsigned i = 0; i < count; i++) {
 		if (_streams[i].msg_id == msg_id) {
+			pthread_mutex_unlock(&_stream_mutex);
 			return -1;
 		}
 	}
 
 	if (count >= MAVLINK_EXT_STREAM_MAX) {
+		pthread_mutex_unlock(&_stream_mutex);
 		return -1;
 	}
 
@@ -76,13 +83,19 @@ int mavlink_ext_stream_register(uint32_t msg_id, const char *name,
 	_streams[count].name = name;
 	_streams[count].fn = fn;
 	_streams[count].user_data = user_data;
+	_streams[count].interval_us = interval_us;
+	_streams[count].last_sent = 0;
 	_stream_count.store(count + 1);
+
+	pthread_mutex_unlock(&_stream_mutex);
 
 	return 0;
 }
 
 int mavlink_ext_stream_unregister(uint32_t msg_id)
 {
+	pthread_mutex_lock(&_stream_mutex);
+
 	unsigned count = _stream_count.load();
 
 	for (unsigned i = 0; i < count; i++) {
@@ -93,18 +106,47 @@ int mavlink_ext_stream_unregister(uint32_t msg_id)
 			}
 
 			_stream_count.store(count - 1);
+			pthread_mutex_unlock(&_stream_mutex);
 			return 0;
 		}
 	}
 
+	pthread_mutex_unlock(&_stream_mutex);
 	return -1;
 }
 
 void mavlink_ext_stream_dispatch(uint8_t channel)
 {
 	unsigned count = _stream_count.load();
+	hrt_abstime now = hrt_absolute_time();
 
 	for (unsigned i = 0; i < count; i++) {
-		_streams[i].fn(channel, _streams[i].user_data);
+		if (_streams[i].interval_us == 0) {
+			continue;
+		}
+
+		if (_streams[i].interval_us > 0) {
+			if (now - _streams[i].last_sent < (hrt_abstime)_streams[i].interval_us) {
+				continue;
+			}
+		}
+
+		if (_streams[i].fn(channel, _streams[i].user_data)) {
+			_streams[i].last_sent = now;
+		}
 	}
+}
+
+int mavlink_ext_stream_set_interval(uint32_t msg_id, int interval_us)
+{
+	unsigned count = _stream_count.load();
+
+	for (unsigned i = 0; i < count; i++) {
+		if (_streams[i].msg_id == msg_id) {
+			_streams[i].interval_us = interval_us;
+			return 0;
+		}
+	}
+
+	return -1;
 }

--- a/src/modules/mavlink/mavlink_ext_stream.h
+++ b/src/modules/mavlink/mavlink_ext_stream.h
@@ -1,0 +1,93 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file mavlink_ext_stream.h
+ *
+ * Generic external MAVLink outbound stream registration.
+ *
+ * Allows out-of-tree / external modules to register callbacks that
+ * emit custom MAVLink messages on all active channels. The callbacks
+ * are invoked from the mavlink module's stream update loop.
+ *
+ * The callback receives a mavlink_channel_t and should call the
+ * appropriate mavlink_msg_*_send_struct() to emit the message.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+/**
+ * Callback signature for external outbound streams.
+ *
+ * Called from the mavlink main loop for each active mavlink instance.
+ * The callback should check for new data (e.g. uORB subscription) and
+ * send a MAVLink message via mavlink_msg_*_send_struct(channel, &msg).
+ *
+ * @param channel    MAVLink channel index (cast to mavlink_channel_t in callback)
+ * @param user_data  Opaque pointer passed at registration time
+ * @return true if a message was sent
+ */
+typedef bool (*mavlink_ext_stream_fn)(uint8_t channel, void *user_data);
+
+/** Maximum number of concurrently registered external streams */
+static constexpr unsigned MAVLINK_EXT_STREAM_MAX = 8;
+
+/**
+ * Register an external outbound stream.
+ *
+ * @param msg_id     MAVLink message ID (for identification/logging)
+ * @param name       Human-readable stream name (for `mavlink stream` command)
+ * @param fn         Callback function invoked each iteration
+ * @param user_data  Opaque context pointer
+ * @return 0 on success, -1 if table full or msg_id already registered
+ */
+int mavlink_ext_stream_register(uint32_t msg_id, const char *name,
+				mavlink_ext_stream_fn fn, void *user_data);
+
+/**
+ * Unregister a previously registered external stream.
+ *
+ * @param msg_id  MAVLink message ID to unregister
+ * @return 0 on success, -1 if not found
+ */
+int mavlink_ext_stream_unregister(uint32_t msg_id);
+
+/**
+ * Dispatch all registered external streams on a given channel.
+ * Called from Mavlink::task_main() after the regular stream update loop.
+ *
+ * @param chan  MAVLink channel to emit on
+ */
+void mavlink_ext_stream_dispatch(uint8_t channel);

--- a/src/modules/mavlink/mavlink_ext_stream.h
+++ b/src/modules/mavlink/mavlink_ext_stream.h
@@ -74,7 +74,8 @@ static constexpr unsigned MAVLINK_EXT_STREAM_MAX = 8;
  * @return 0 on success, -1 if table full or msg_id already registered
  */
 int mavlink_ext_stream_register(uint32_t msg_id, const char *name,
-				mavlink_ext_stream_fn fn, void *user_data);
+				mavlink_ext_stream_fn fn, void *user_data,
+				int interval_us = -1);
 
 /**
  * Unregister a previously registered external stream.
@@ -91,3 +92,15 @@ int mavlink_ext_stream_unregister(uint32_t msg_id);
  * @param chan  MAVLink channel to emit on
  */
 void mavlink_ext_stream_dispatch(uint8_t channel);
+
+/**
+ * Set the send interval for a registered external stream.
+ *
+ * Allows integration with SET_MESSAGE_INTERVAL so that QGC/pymavlink
+ * can control OOT stream rates the same way as built-in streams.
+ *
+ * @param msg_id       MAVLink message ID
+ * @param interval_us  Interval in microseconds (-1 = unlimited, 0 = disabled)
+ * @return 0 on success, -1 if not found
+ */
+int mavlink_ext_stream_set_interval(uint32_t msg_id, int interval_us);

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -60,6 +60,7 @@
 #include <uORB/topics/event.h>
 #include "mavlink_receiver.h"
 #include "mavlink_main.h"
+#include "mavlink_ext_stream.h"
 
 #ifdef MAVLINK_UDP
 #include <sys/time.h>
@@ -2539,6 +2540,9 @@ Mavlink::task_main(int argc, char *argv[])
 				}
 			}
 		}
+
+		/* dispatch registered external outbound streams */
+		mavlink_ext_stream_dispatch(static_cast<uint8_t>(get_channel()));
 
 		/* check for ulog streaming messages */
 		if (_mavlink_ulog) {

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -60,6 +60,7 @@
 #include "mavlink_command_sender.h"
 #include "mavlink_main.h"
 #include "mavlink_receiver.h"
+#include "mavlink_ext_handler.h"
 
 #include <lib/drivers/device/Device.hpp> // For DeviceId union
 #include <containers/LockGuard.hpp>
@@ -351,6 +352,7 @@ MavlinkReceiver::handle_message(mavlink_message_t *msg)
 #endif
 
 	default:
+		mavlink_ext_handler_dispatch(msg);
 		break;
 	}
 
@@ -1344,6 +1346,8 @@ MavlinkReceiver::handle_message_esc_eeprom(mavlink_message_t *msg)
 	_esc_eeprom_write_pub.publish(eeprom);
 }
 #endif // MAVLINK_MSG_ID_ESC_EEPROM
+
+
 
 void
 MavlinkReceiver::handle_message_vision_position_estimate(mavlink_message_t *msg)

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -61,6 +61,7 @@
 #include "mavlink_main.h"
 #include "mavlink_receiver.h"
 #include "mavlink_ext_handler.h"
+#include "mavlink_ext_stream.h"
 
 #include <lib/drivers/device/Device.hpp> // For DeviceId union
 #include <containers/LockGuard.hpp>
@@ -2334,6 +2335,18 @@ MavlinkReceiver::set_message_interval(int msgId, float interval, float param3, f
 		if (stream_name != nullptr) {
 			_mavlink.configure_stream_threadsafe(stream_name, rate);
 			found_id = true;
+
+		} else {
+			// Fallback: check external (OOT) streams
+			int ext_interval_us = (interval > 0.00001f) ? (int)interval : -1;
+
+			if (interval < -0.00001f) {
+				ext_interval_us = 0; // stop
+			}
+
+			if (mavlink_ext_stream_set_interval((uint32_t)msgId, ext_interval_us) == 0) {
+				found_id = true;
+			}
 		}
 	}
 


### PR DESCRIPTION
# mavlink: external handler, stream, and dialect support for out-of-tree modules

## Summary

References https://github.com/PX4/PX4-Autopilot/issues/26261 , specifically to attempt to address some difficulties I bumped into with a "clean cut" [out of tree external module](https://docs.px4.io/main/en/advanced/out_of_tree_modules)

Adds first-class MAVLink support for out-of-tree (OOT) modules: custom dialect
code generation, inbound message handling, outbound streaming, and ROMFS init
script injection — all without patching PX4 source.

Currently, OOT modules that need custom MAVLink messages must manually symlink
dialect XMLs, patch `mavlink_receiver.cpp`, and hand-edit `rcS`. This PR
eliminates all of that with a convention-based approach.

**Tested end-to-end** with a PX4 module and driver for the SE05x secure element present on Pixhawk 6X boards that uses 6 custom MAVLink messages for PKI enrollment over USB, running on Pixhawk 6X-RT hardware.

## Changes

### 1. External MAVLink handler registry (`mavlink_ext_handler.{h,cpp}`)

Static callback table (max 8 entries, probably should be configurable) for inbound custom messages. Registration
is mutex-protected; dispatch is lock-free from the receiver thread's `default`
case:

```
MavlinkReceiver::handle_message()
  └─ switch(msg->msgid)
       ├─ case HEARTBEAT: ...
       ├─ case ...: (built-in handlers)
       └─ default:
            mavlink_ext_handler_dispatch(msg)  ← NEW
              └─ iterates registered callbacks
```

It should have no overhead in the hot / happy path as it injects at the `default` case handler which currently hard drops any unknown MAVLink message IDs.

OOT module usage:

```cpp
#include <modules/mavlink/mavlink_ext_handler.h>

// In module init:
mavlink_ext_handler_register(MAVLINK_MSG_ID_SE05X_PROVISION,
                             handle_provision, this);

// In module stop:
mavlink_ext_handler_unregister(MAVLINK_MSG_ID_SE05X_PROVISION);
```

### 2. External MAVLink stream registry (`mavlink_ext_stream.{h,cpp}`)

Static callback table for outbound streams, dispatched from `Mavlink::task_main()`
after the built-in stream loop. Supports rate-limited intervals and integrates
with `SET_MESSAGE_INTERVAL` so QGC/pymavlink can control OOT stream rates
identically to built-in streams:

```cpp
#include <modules/mavlink/mavlink_ext_stream.h>

mavlink_ext_stream_register(
    MAVLINK_MSG_ID_SE05X_CSR, "SE05X_CSR",
    emit_csr_fragment, this,
    100000);  // 10 Hz

// SET_MESSAGE_INTERVAL fallback in mavlink_receiver.cpp:
mavlink_ext_stream_set_interval(msg_id, interval_us);
```

### 3. CMake dialect registration (`px4_add_external_mavlink_dialect`)

Shared CMake function that copies OOT dialect XMLs into mavgen's search path
and auto-overrides `CONFIG_MAVLINK_DIALECT` from `common`:

```cmake
# In OOT module's CMakeLists.txt:
px4_add_external_mavlink_dialect(
    XML ${CMAKE_CURRENT_SOURCE_DIR}/../../mavlink/standard.xml
)
```

The dialect XML uses standard `<include>common.xml</include>` inheritance, so
all built-in messages remain available. Multiple dialects from different OOT
modules are supported.

### 4. ROMFS init script injection (`ROMFS/CMakeLists.txt`, `rcS`)

OOT modules can provide `init/rc.ext_modules` which is automatically copied
into the ROMFS image and sourced by `rcS` after the logger starts:

```
rcS boot sequence:
  ...
  rc.logging           ← logger starts first
  rc.ext_modules       ← OOT module init (if file exists)
  rc.vtxtable
  ...
  mavlink boot_complete
```

Example `init/rc.ext_modules`:

```sh
se05x start
se05x_mavlink start
se05x derive-keys &
```

Directory convention:

```
my_external_module/
├── init/
│   └── rc.ext_modules       ← auto-injected into ROMFS, optional
├── mavlink/
│   └── my_dialect.xml       ← custom MAVLink messages, optional
├── msg/
│   └── MyTopic.msg          ← custom uORB topics, already supported upstream
└── src/
    ├── CMakeLists.txt
    └── modules/
        └── my_module/
```

> **Note on `msg/`:** OOT uORB message definitions currently must live in the
> OOT module's `msg/` directory and are registered via `px4_add_module()` with
> the `MSG_SRCS` parameter. PX4's `msg/` directory is reserved for in-tree
> topics. See [Out-of-Tree Modules](https://docs.px4.io/main/en/advanced/out_of_tree_modules.html).

## Integration points (minimal PX4 source changes)

| File | Change | Lines |
|------|--------|-------|
| `mavlink_receiver.cpp` | `#include` + `dispatch()` in `default:` + `set_interval` fallback | +17 |
| `mavlink_main.cpp` | `#include` + `ext_stream_dispatch()` in main loop | +4 |
| `CMakeLists.txt` | `include()` dialect cmake + dialect auto-override after `add_subdirectory` | +21 |
| `ROMFS/CMakeLists.txt` | Copy `rc.ext_modules` into ROMFS image | +25 |
| `rcS` | Source `rc.ext_modules` after `rc.logging` | +11 |

All new files: `mavlink_ext_handler.{h,cpp}`, `mavlink_ext_stream.{h,cpp}`,
`px4_add_external_mavlink_dialect.cmake`.

## Design decisions

- **Static arrays, not dynamic allocation.** Both registries use fixed-size
  arrays (8 slots each, can be configurable). No heap allocation at runtime. Lock-free dispatch.
- **Mutex on registration only.** `register`/`unregister` are mutex-protected
  (called once at init/shutdown). `dispatch` iterates the array without locking
  — safe because entries are only appended/cleared while the slot count is
  atomically visible.
- **Dialect override is opt-in.** Only overrides `CONFIG_MAVLINK_DIALECT` if
  it's the default `common`. If a board already sets a specific dialect, it's
  preserved.
- **Init script is optional.** The `rc.ext_modules` hook is `if [ -f ... ]`
  guarded. No impact on builds without `EXTERNAL_MODULES_LOCATION`.

## Testing

Validated on Pixhawk 6X-RT (fmu-v6xrt) with the SE05x secure element OOT
module performing:

- Full PKI enrollment pipeline (6 custom MAVLink messages, fragmented
  certificate transfers)
- Bidirectional ECIES crypto verification (ECDH + HKDF + AES-256-CBC +
  HMAC-SHA384)
- ECDSA-P384 signature verification
- Session key derivation with HMAC proof
- ROMFS init auto-start

## Example usage in OOT module

### Header file of the MAVLink handler concerns

```C++
/**
 * @file se05x_mavlink.h
 * @brief SE05x MAVLink bridge (uORB ↔ SE05x driver for PKI enrollment)
 */

#pragma once

#define MODULE_NAME "se05x_mavlink"

#include <px4_platform_common/px4_config.h>
#include <px4_platform_common/module.h>
#include <px4_platform_common/module_params.h>
#include <px4_platform_common/posix.h>
#include <px4_platform_common/time.h>
#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
#include <pthread.h>

#include <uORB/Subscription.hpp>
#include <uORB/Publication.hpp>
#include <uORB/topics/se05x_certificate_enrollment_response.h>
#include <uORB/topics/se05x_certificate_signing_request.h>
#include <uORB/topics/se05x_provision.h>
#include <uORB/topics/se05x_ecies_test_request.h>
#include <uORB/topics/se05x_ecies_test_response.h>
#include <uORB/topics/se05x_command.h>
#include <uORB/topics/se05x_response.h>

/**
 * @brief SE05x MAVLink bridge module
 *
 * Processes uORB-based PKI requests and delegates to the SE05x driver library.
 */
class SE05xMavlink : public ModuleBase, public ModuleParams, public px4::ScheduledWorkItem
{
public:
    SE05xMavlink();
    ~SE05xMavlink() override;

    static Descriptor desc;

    /** @see ModuleBase */
    static int task_spawn(int argc, char *argv[]);

    /** @see ModuleBase */
    static int custom_command(int argc, char *argv[]);

    /** @see ModuleBase */
    static int print_usage(const char *reason = nullptr);

    /** @see ScheduledWorkItem::Run() */
    void Run() override;

    /** Print driver status */
    int print_status() override;

    /**
     * @brief Sign data with ECDSA-P384 (CNSA Suite 2.0) via the SE05x
     *
     * Hashes the input with SHA-384, then signs the hash using the SE05x
     * signing key. Returns the signature in ASN.1 DER format.
     *
     * @param command_data Data to sign
     * @param command_len Length of data
     * @param signature Output buffer for signature (ASN.1 DER, typically 104-106 bytes)
     * @param signature_len Input: buffer size, Output: actual signature length
     * @return 0 on success, negative on error
     */
    int sign_command(const uint8_t *command_data, size_t command_len,
                     uint8_t *signature, size_t *signature_len);

    // emit_csr_stream is a static free function used as a mavlink ext_stream callback.
    friend bool emit_csr_stream(uint8_t channel, void *user_data);

    // emit_enc_csr_stream streams the encryption CSR (key_purpose=1) after the signing CSR.
    friend bool emit_enc_csr_stream(uint8_t channel, void *user_data);

    // emit_ecies_response is a static free function used as a mavlink ext_stream callback.
    friend bool emit_ecies_response(uint8_t channel, void *user_data);

    /**
     * @brief Store an enrollment fragment directly (called from MAVLink handler)
     *
     * Bypasses uORB to avoid single-slot publication races when the host
     * sends multiple fragments faster than the 100ms Run() cycle.
     */
    void handle_enrollment_fragment(uint16_t total, uint16_t offset,
                                    const uint8_t *data, uint8_t data_len);

    /**
     * @brief Store an encryption enrollment fragment (called from MAVLink handler)
     */
    void handle_enc_enrollment_fragment(uint16_t total, uint16_t offset,
                                        const uint8_t *data, uint8_t data_len);

    /**
     * @brief Store the provisioner encryption public key (called from MAVLink handler)
     */
    void store_provisioner_key(const uint8_t *key, size_t len);

private:
    /**
     * @brief Initialize the module and schedule work
     */
    int init();

    /**
     * @brief Process incoming uORB requests and call library functions
     */
    void process_uorb_requests();

    /**
     * @brief Check for responses from the SE05x service thread
     */
    void process_service_responses();

    /**
     * @brief Provisioning state machine (driven by service thread responses)
     */
    enum class ProvState : uint8_t {
        Idle = 0,
        WaitProvision,       // Waiting for OP_PROVISION response
        WaitSigningCSR,      // Waiting for OP_GENERATE_CSR(signing) response
        WaitEnrollment,      // Waiting for OP_ENROLLMENT response
        WaitEncCSR,          // Waiting for OP_GENERATE_CSR(encryption) response
        WaitEncEnrollment,   // Waiting for OP_ENC_ENROLLMENT response
        WaitEciesTest,       // Waiting for OP_ECIES_TEST response
    };

    ProvState _prov_state{ProvState::Idle};

    /** Publish a command to the SE05x service thread */
    void publish_command(uint8_t op, const uint8_t *payload = nullptr, uint16_t payload_len = 0);

    // uORB subscriptions for inbound PKI material (offboard → vehicle)
    uORB::Subscription _provision_sub{ORB_ID(se05x_provision)};

    // uORB subscription for ECIES test requests
    uORB::Subscription _ecies_test_request_sub{ORB_ID(se05x_ecies_test_request)};

    // uORB command/response for SE05x service thread
    orb_advert_t _cmd_pub{nullptr};
    uORB::Subscription _resp_sub{ORB_ID(se05x_response)};

    // Fragment reassembly buffer for CA certificate (from multiple uORB messages)
    static constexpr size_t CA_CERT_MAX = 480;  // P-384 DER certs ~441 bytes
    uint8_t  _ca_cert_buf[CA_CERT_MAX]{};
    uint16_t _ca_cert_total_len{0};
    uint16_t _ca_cert_received{0};
    uint8_t  _ca_cert_target_system{0};
    uint8_t  _ca_cert_target_component{0};
    uint8_t  _ca_cert_force_regenerate{0};

    // Provisioner encryption public key (from SE05X_PROVISIONER_KEY, stored before provisioning)
    uint8_t  _provisioner_key[97]{};
    bool     _provisioner_key_received{false};

    // Device identity for CSR generation (populated from board info during provisioning)
    char     _csr_serial[40]{};
    char     _csr_model[16]{};

    // CSR output buffer (populated from service response, fragmented by emit_csr_stream)
    static constexpr size_t CSR_MAX = 512;
    static constexpr size_t CSR_FRAG_MAX = 190;  // csr_data[190] per MAVLink frame
    uint8_t  _csr_buf[CSR_MAX]{};
    uint16_t _csr_total_len{0};
    uint16_t _csr_send_offset{0};
    bool     _csr_ready{false};

    // Fragment reassembly buffer for device certificate enrollment
    // Populated directly by handle_mavlink_enrollment (not via uORB)
    static constexpr size_t DEV_CERT_MAX = 480;
    uint8_t  _dev_cert_buf[DEV_CERT_MAX]{};
    uint16_t _dev_cert_total_len{0};
    uint16_t _dev_cert_received{0};
    bool     _enrollment_ready{false};

    // Encryption CSR output buffer (populated from service response after signing CSR)
    uint8_t  _enc_csr_buf[CSR_MAX]{};
    uint16_t _enc_csr_total_len{0};
    uint16_t _enc_csr_send_offset{0};
    bool     _enc_csr_ready{false};

    // Encryption certificate enrollment (key_purpose=1)
    uint8_t  _enc_cert_buf[DEV_CERT_MAX]{};
    uint16_t _enc_cert_total_len{0};
    uint16_t _enc_cert_received{0};
    bool     _enc_enrollment_ready{false};

    // ECIES test state (populated by handle_mavlink_ecies_test, consumed by service thread)
    uint8_t  _ecies_phase{0};  // 0=ECIES encrypt, 1=ECDSA sign, 2=session key derivation
    uint8_t  _ecies_host_pubkey[97]{};
    uint8_t  _ecies_plaintext[32]{};
    uint8_t  _ecies_target_system{0};
    uint8_t  _ecies_target_component{0};

    // ECIES test response (populated from service response, sent by emit_ecies_response)
    int8_t   _ecies_resp_result{0};
    uint8_t  _ecies_resp_phase{0};
    uint8_t  _ecies_resp_ephem_pubkey[97]{};
    uint8_t  _ecies_resp_iv[12]{};
    uint8_t  _ecies_resp_ciphertext[32]{};
    uint8_t  _ecies_resp_hmac_tag[48]{};
    uint8_t  _ecies_response_sends{0};  // >0 = send on next N dispatch cycles (covers all channels)

    static constexpr uint32_t SCHEDULE_INTERVAL_US = 100000; // 100ms
};
```

### Custom MAVLink SE05x dialect

Includes `common.xml`

```xml
<?xml version="1.0"?>
<mavlink>
    <include>common.xml</include>
    <version>3</version>
    <dialect>1</dialect>
    <!--
        SE05x Secure Element Custom MAVLink Messages

        These messages provide secure provisioning capabilities for the NXP SE05x
        secure element (CNSA Suite 2.0 / FIPS 140-3).

        Message IDs: 55000-55005 (custom range, outside common/standard allocation)

        P-384 certificates exceed a single MAVLink frame (253-byte payload limit).
        All certificate/CSR fields support fragment-based delivery via offset and
        total_len fields.  The receiver reassembles fragments by offset before
        triggering provisioning.
    -->
    <messages>
        <!-- SE05X_PROVISION: Trigger CSR/keypair generation on-vehicle -->
        <message id="55000" name="SE05X_PROVISION">
            <description>Trigger SE05x provisioning: generate (or reuse) keypair and publish CSR+attestation for server-side signing. CA certificate may span multiple fragments.</description>
            <field type="uint8_t" name="target_system">Target system ID (0 = broadcast)</field>
            <field type="uint8_t" name="target_component">Target component ID (0 = broadcast)</field>
            <field type="uint8_t" name="force_regenerate">0 = reuse existing if present, 1 = regenerate keypair</field>
            <field type="uint16_t" name="ca_certificate_total_len">Total CA certificate length in bytes (across all fragments)</field>
            <field type="uint16_t" name="ca_certificate_offset">Byte offset of this fragment within the full certificate</field>
            <field type="uint8_t" name="ca_certificate_len">Length of certificate data in this fragment (0-244)</field>
            <field type="uint8_t[244]" name="ca_certificate">CA certificate fragment (DER, max 244 bytes per frame)</field>
        </message>

        <!-- SE05X_CERTIFICATE_SIGNING_REQUEST: Device CSR response (outbound) -->
        <message id="55001" name="SE05X_CERTIFICATE_SIGNING_REQUEST">
            <description>Device certificate signing request for PKI enrollment. CSR data may span multiple fragments. Device identity fields are populated in every fragment.</description>
            <field type="uint8_t" name="target_system">Target system ID (0 = broadcast)</field>
            <field type="uint8_t" name="target_component">Target component ID (0 = broadcast)</field>
            <field type="uint16_t" name="csr_data_total_len">Total CSR length in bytes (across all fragments)</field>
            <field type="uint16_t" name="csr_data_offset">Byte offset of this fragment</field>
            <field type="uint8_t" name="csr_data_len">Length of CSR data in this fragment (0-190)</field>
            <field type="uint8_t[190]" name="csr_data">CSR fragment in DER format (PKCS#10, max 190 bytes per frame)</field>
            <field type="uint8_t[40]" name="device_serial">PX4 GUID hex string (null-terminated)</field>
            <field type="uint8_t[16]" name="device_model">Device model identifier (null-terminated)</field>
            <field type="uint8_t" name="key_purpose">0 = signing (digitalSignature), 1 = encryption (keyAgreement)</field>
        </message>

        <!-- SE05X_CERTIFICATE_ENROLLMENT_RESPONSE: CA-signed device certificate (inbound) -->
        <message id="55002" name="SE05X_CERTIFICATE_ENROLLMENT_RESPONSE">
            <description>CA-signed device certificate for enrollment into the SE05x secure element. Certificate may span multiple fragments.</description>
            <field type="uint8_t" name="target_system">Target system ID</field>
            <field type="uint8_t" name="target_component">Target component ID</field>
            <field type="int8_t" name="result">Result code (0 = success, negative = error code)</field>
            <field type="uint16_t" name="device_certificate_total_len">Total certificate length (across all fragments)</field>
            <field type="uint16_t" name="device_certificate_offset">Byte offset of this fragment</field>
            <field type="uint8_t" name="device_certificate_len">Length of certificate data in this fragment (0-244)</field>
            <field type="uint8_t[244]" name="device_certificate">Device certificate fragment (DER, max 244 bytes per frame)</field>
            <field type="uint8_t" name="key_purpose">0 = signing cert, 1 = encryption cert</field>
        </message>

        <!-- SE05X_ECIES_TEST_REQUEST: Host-initiated ECIES encryption test (host → FC) -->
        <message id="55003" name="SE05X_ECIES_TEST_REQUEST">
            <description>ECIES encryption test request. Host sends its ephemeral P-384 public key and a 32-byte plaintext challenge. The FC encrypts the challenge using ECIES (P-384 ECDH + HKDF-SHA384 + AES-256-CBC + HMAC-SHA384) and returns the result in SE05X_ECIES_TEST_RESPONSE.</description>
            <field type="uint8_t" name="target_system">Target system ID</field>
            <field type="uint8_t" name="target_component">Target component ID</field>
            <field type="uint8_t" name="phase">Test phase: 0=ECIES encrypt (FC encrypts challenge), 1=ECDSA sign (FC signs challenge), 2=session key derivation (FC derives and returns HMAC proof)</field>
            <field type="uint8_t[97]" name="host_public_key">Host P-384 public key (uncompressed: 0x04 || X || Y, 97 bytes). Used in phase 0.</field>
            <field type="uint8_t[32]" name="plaintext">Challenge plaintext (32 random bytes from host). Used in phase 0 and 1.</field>
        </message>

        <!-- SE05X_ECIES_TEST_RESPONSE: FC ECIES encryption result (FC → host) -->
        <message id="55004" name="SE05X_ECIES_TEST_RESPONSE">
            <description>ECIES encryption test response. Contains the FC's ephemeral public key and the encrypted challenge (IV + ciphertext + HMAC-SHA384 tag). The host decrypts by performing ECDH with its private key against the ephemeral public key, then HKDF + AES-CBC-decrypt + HMAC-verify.</description>
            <field type="uint8_t" name="target_system">Target system ID</field>
            <field type="uint8_t" name="target_component">Target component ID</field>
            <field type="int8_t" name="result">0 = success, negative = error code</field>
            <field type="uint8_t" name="phase">Test phase (mirrors request phase)</field>
            <field type="uint8_t[97]" name="ephemeral_public_key">Phase 0: FC ephemeral P-384 public key. Phase 1: ECDSA signature bytes [0..96]. Phase 2: session ephemeral P-384 public key.</field>
            <field type="uint8_t[12]" name="iv">Phase 0: AES-CBC IV. Phase 1: signature bytes [97..103] + signature_len at [7].</field>
            <field type="uint8_t[32]" name="ciphertext">Phase 0: AES-256-CBC encrypted challenge. Phase 1: echo of signed plaintext. Phase 2: unused.</field>
            <field type="uint8_t[48]" name="hmac_tag">Phase 0: HMAC-SHA384 tag. Phase 1: unused. Phase 2: HMAC-SHA384(derived_hmac_key, "PX4-SE05X-SESSION-TEST") proof.</field>
        </message>

        <!-- SE05X_PROVISIONER_KEY: Provisioner encryption public key for session key derivation -->
        <message id="55005" name="SE05X_PROVISIONER_KEY">
            <description>Provisioner P-384 encryption public key. Stored on the SE05x during provisioning. Used for ECDH in session key derivation, enabling the provisioner to decrypt ULog files offline via ECDH(provisioner_priv, boot_ephemeral_pub). Send this before SE05X_PROVISION.</description>
            <field type="uint8_t" name="target_system">Target system ID</field>
            <field type="uint8_t" name="target_component">Target component ID</field>
            <field type="uint8_t[97]" name="provisioner_encryption_key">Provisioner P-384 public key (uncompressed: 0x04 || X || Y, 97 bytes)</field>
        </message>
    </messages>
</mavlink>
```

### Custom init to boostrap the SE05x driver, MAVLink handler and session keys

```
#!/bin/sh
# SE05x auto-start (baked into ROMFS at build time)
echo "[SE05x ext] Starting se05x driver..."
se05x start
echo "[SE05x ext] se05x rc=$?"
echo "[SE05x ext] Starting se05x_mavlink..."
se05x_mavlink start
echo "[SE05x ext] se05x_mavlink rc=$?"
se05x derive-keys &
```

### Build output demonstrating MAVLink dialect and ROMFS integration

```
methodmissing@Mac PX4-Autopilot % make px4_fmu-v6xrt_default CONFIG_SYSTEMCMDS_SE05X=y CONFIG_CRYPTO=y CONFIG_MBEDTLS_VERSION=3.4.0 CONFIG_CRYPTO_MBEDTLS=y CONFIG_CLOCK_GETTIME=y CONFIG_GETTIMEOFDAY=y CONFIG_SE05X_DEBUG_LOGS=y EXTERNAL_MODULES_LOCATION=/Users/methodmissing/src/px4-se05x upload
-- PX4_GIT_TAG: v1.18.0-alpha1-75-g26f188d5e9
-- PX4 config file: /Users/methodmissing/src/PX4-Autopilot/boards/px4/fmu-v6xrt/default.px4board
-- PLATFORM nuttx
-- TOOLCHAIN arm-none-eabi
-- ARCHITECTURE cortex-m7
-- ROMFSROOT px4fmu_common
-- IO px4_io-v2_default
-- ETHERNET y
-- SERIAL_GPS1 /dev/ttyS1
-- SERIAL_GPS2 /dev/ttyS3
-- SERIAL_TEL1 /dev/ttyS2
-- SERIAL_TEL2 /dev/ttyS5
-- SERIAL_TEL3 /dev/ttyS6
-- SERIAL_RC /dev/ttyS4
-- ROOT_PATH /fs/microsd
-- PARAM_FILE /fs/mtd_params
-- UAVCAN_INTERFACES 3
-- PWM_FREQ 1000000
-- PX4 config: px4_fmu-v6xrt_default
-- PX4 platform: nuttx
warning: ARCH_CHIP_UNSET (defined at platforms/nuttx/Kconfig:5) was assigned the value 'y' but got the value 'n' -- check dependencies
-- Enabling double FP precision hardware instructions
-- cmake build type: MinSizeRel
-- ccache enabled (export CCACHE_DISABLE=1 to disable)
-- Board forcing alignment
Synchronizing submodule url for 'src/lib/cdrstream/cyclonedds'
Submodule path 'src/lib/cdrstream/cyclonedds': checked out '314887ca403c2fb0a0316add22672102936ed36c'
-- Configuring idlc :/Users/methodmissing/src/PX4-Autopilot/build/px4_fmu-v6xrt_default/msg/idlc
-- Building idlc :/Users/methodmissing/src/PX4-Autopilot/build/px4_fmu-v6xrt_default/msg/idlc
-- External modules: /Users/methodmissing/src/px4-se05x
-- SE05x: Copied mbedtls_config.h to NuttX apps/include/crypto/
-- External MAVLink dialect registered: se05x (from /Users/methodmissing/src/px4-se05x/mavlink/se05x.xml)
-- External MAVLink dialect: se05x (auto-set from common)
-- Unable to determine version from Git, defaulting to version v0.0.0
-- Defaulting MIP_ARCH to cortex-m7
-- C Standard: 99
-- C++ Standard: 14
-- Build Examples: OFF
-- Build Tools: OFF
-- Use Deprecated Macros: ON
-- drivers/px4io: ROMFS including px4_io-v2_default
-- Release build type: MinSizeRel
-- ROMFS: ROMFS/px4fmu_common
-- ROMFS:  Adding platforms/nuttx/init/imxrt/rc.board_arch_defaults -> /etc/init.d/rc.board_arch_defaults
-- ROMFS:  Adding boards/px4/fmu-v6xrt/init/rc.board_defaults -> /etc/init.d/rc.board_defaults
-- ROMFS:  Adding boards/px4/fmu-v6xrt/init/rc.board_sensors -> /etc/init.d/rc.board_sensors
-- ROMFS:  Adding boards/px4/fmu-v6xrt/init/rc.board_mavlink -> /etc/init.d/rc.board_mavlink
-- ROMFS:  Adding ../px4-se05x/init/rc.ext_modules -> /etc/init.d/rc.ext_modules
-- ROMFS:  Adding boards/px4/fmu-v6xrt/extras/px4_io-v2_default.bin -> /etc/extras/px4_io-v2_default.bin
-- Configuring done (4.6s)
-- Generating done (0.8s)
-- Build files have been written to: /Users/methodmissing/src/PX4-Autopilot/build/px4_fmu-v6xrt_default
```