### PR TITLE
fix(ekf2): stuck GNSS control logic on intermittent data

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.cpp
@@ -47,17 +47,16 @@ bool GnssChecks::run(const gnssSample &gnss, uint64_t time_us)
 		_time_last_fail_us = time_us;
 	}
 
-	bool passed = false;
-
 	// Run strict checks while not flying yet
 	if (!_control_status.flags.in_air) {
 		_initial_checks_passed = false;
 	}
 
+	_passed = false;
+
 	if (_initial_checks_passed) {
 		if (runSimplifiedChecks(gnss)) {
-			_time_last_pass_us = time_us;
-			passed = isTimedOut(_time_last_fail_us, time_us, math::max((uint64_t)1e6, (uint64_t)_params.min_health_time_us / 10));
+			_passed = isTimedOut(_time_last_fail_us, time_us, math::max((uint64_t)1e6, (uint64_t)_params.min_health_time_us / 10));
 
 		} else {
 			_time_last_fail_us = time_us;
@@ -65,11 +64,9 @@ bool GnssChecks::run(const gnssSample &gnss, uint64_t time_us)
 
 	} else {
 		if (runInitialFixChecks(gnss)) {
-			_time_last_pass_us = time_us;
-
 			if (isTimedOut(_time_last_fail_us, time_us, (uint64_t)_params.min_health_time_us)) {
 				_initial_checks_passed = true;
-				passed = true;
+				_passed = true;
 			}
 
 		} else {
@@ -80,8 +77,11 @@ bool GnssChecks::run(const gnssSample &gnss, uint64_t time_us)
 	lat_lon_prev.initReference(gnss.lat, gnss.lon, gnss.time_us);
 	_alt_prev = gnss.alt;
 
-	_passed = passed;
-	return passed;
+	if (_passed) {
+		_time_last_pass_us = time_us;
+	}
+
+	return _passed;
 }
 
 bool GnssChecks::runSimplifiedChecks(const gnssSample &gnss)

--- a/src/modules/ekf2/test/test_EKF_gps.cpp
+++ b/src/modules/ekf2/test/test_EKF_gps.cpp
@@ -283,3 +283,32 @@ TEST_F(EkfGpsTest, gnssJumpDetectionDRMode)
 	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsHeightFusion());
 	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsFusion());
 }
+
+TEST_F(EkfGpsTest, gnssIntermittentSaccFailureDisablesFusion)
+{
+	// GIVEN: EKF that fuses GPS on the ground after passing the initial checks
+	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsFusion());
+
+	// WHEN: speed accuracy fails most of the time but briefly passes 1 sample every 2s.
+	// Each good sample passes runInitialFixChecks() but run() still returns false because
+	// the last failure is too recent (min_health_time_us = 10s not satisfied).
+	// The fusion must therefore never actually fuse any data.
+	const float bad_sacc = 5.0f;   // fails ekf2_req_sacc (default 1.0 m/s)
+	const float good_sacc = 0.2f;  // passes ekf2_req_sacc
+
+	for (int i = 0; i < 4; i++) {
+		gnssSample gps_data = _sensor_simulator._gps.getData();
+		gps_data.sacc = bad_sacc;
+		_sensor_simulator._gps.setData(gps_data);
+		_sensor_simulator.runSeconds(1.8f);
+
+		gps_data = _sensor_simulator._gps.getData();
+		gps_data.sacc = good_sacc;
+		_sensor_simulator._gps.setData(gps_data);
+		_sensor_simulator.runSeconds(0.2f);  // 1 GPS sample at 5 Hz
+	}
+
+	// THEN: GNSS fusion must be disabled because the checks never truly pass
+	// and reset_timeout_max was exceeded since the last real pass.
+	EXPECT_FALSE(_ekf_wrapper.isIntendingGpsFusion());
+}


### PR DESCRIPTION
### Solved Problem
I found a race condition where the GNSS checks initially passed and then started to fail intermittently while the drone was on the ground (no relaxed checks). This caused the `GnssChecks::run` function to always return false, which prevents the samples to be fused, but the GNSS fusion never gets disabled as `_time_last_pass_us` is still updated by the intermittent good samples.
[This logic](https://github.com/PX4/PX4-Autopilot/blob/e3595fedf36f4749f4b99d8216038bf70bb32f80/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp#L81) is supposed to stop the GNSS fusion when quality is degraded.

<img width="1054" height="446" alt="Screenshot from 2026-05-19 17-30-08" src="https://github.com/user-attachments/assets/e4fe2b0f-865b-4d1a-a798-5501097f53bb" />

### Solution
Only update `_time_last_pass_us` when the full check really passes (includes the hysteresis).

### Test coverage
add unit test to re-create the race condition (fails without the fix)

