### PR TITLE
fix(optical_flow): report actual integration timespan in PAW3902/PAA3905

### DIFF
--- a/src/drivers/optical_flow/paa3905/PAA3905.cpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.cpp
@@ -89,6 +89,7 @@ bool PAA3905::Reset()
 	_state = STATE::RESET;
 	DataReadyInterruptDisable();
 	_drdy_timestamp_sample.store(0);
+	_timestamp_sample_last = 0;
 	ScheduleClear();
 	ScheduleNow();
 	return true;
@@ -391,6 +392,15 @@ void PAA3905::RunImpl()
 					break;
 				}
 
+				// override the per-mode default with the actual interval between burst reads
+				// (the chip accumulates delta_x/delta_y until Motion_Burst is read), so the
+				// gyro integration window downstream lines up with what the chip actually saw.
+				if (_timestamp_sample_last != 0 && timestamp_sample > _timestamp_sample_last) {
+					const hrt_abstime dt = timestamp_sample - _timestamp_sample_last;
+					sensor_optical_flow.integration_timespan_us = math::constrain(static_cast<uint32_t>(dt),
+							static_cast<uint32_t>(1000), static_cast<uint32_t>(200000));
+				}
+
 				// motion in burst transfer
 				const bool motion_reported = (buffer.data.Motion & Motion_Bit::MotionOccurred);
 
@@ -480,6 +490,10 @@ void PAA3905::RunImpl()
 				_shutter_prev = shutter;
 				_raw_data_sum_prev = buffer.data.RawData_Sum;
 				_quality_prev = buffer.data.SQUAL;
+
+				// chip clears its delta accumulator on every Motion_Burst read,
+				// regardless of whether we publish, so track every successful read.
+				_timestamp_sample_last = timestamp_sample;
 
 			} else {
 				perf_count(_bad_transfer_perf);

--- a/src/drivers/optical_flow/paa3905/PAA3905.cpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.cpp
@@ -398,7 +398,7 @@ void PAA3905::RunImpl()
 				if (_timestamp_sample_last != 0 && timestamp_sample > _timestamp_sample_last) {
 					const hrt_abstime dt = timestamp_sample - _timestamp_sample_last;
 					sensor_optical_flow.integration_timespan_us = math::constrain(static_cast<uint32_t>(dt),
-							static_cast<uint32_t>(1000), static_cast<uint32_t>(200000));
+							static_cast<uint32_t>(1_ms), static_cast<uint32_t>(200_ms));
 				}
 
 				// motion in burst transfer

--- a/src/drivers/optical_flow/paa3905/PAA3905.hpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.hpp
@@ -115,6 +115,7 @@ private:
 	hrt_abstime _reset_timestamp{0};
 	hrt_abstime _last_publish{0};
 	hrt_abstime _last_motion{0};
+	hrt_abstime _timestamp_sample_last{0};
 
 	int16_t _delta_x_raw_prev{0};
 	int16_t _delta_y_raw_prev{0};

--- a/src/drivers/optical_flow/paw3902/PAW3902.cpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.cpp
@@ -401,7 +401,7 @@ void PAW3902::RunImpl()
 				if (_timestamp_sample_last != 0 && timestamp_sample > _timestamp_sample_last) {
 					const hrt_abstime dt = timestamp_sample - _timestamp_sample_last;
 					sensor_optical_flow.integration_timespan_us = math::constrain(static_cast<uint32_t>(dt),
-							static_cast<uint32_t>(1000), static_cast<uint32_t>(200000));
+							static_cast<uint32_t>(1_ms), static_cast<uint32_t>(200_ms));
 				}
 
 				// motion in burst transfer

--- a/src/drivers/optical_flow/paw3902/PAW3902.cpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.cpp
@@ -89,6 +89,7 @@ bool PAW3902::Reset()
 	_state = STATE::RESET;
 	DataReadyInterruptDisable();
 	_drdy_timestamp_sample.store(0);
+	_timestamp_sample_last = 0;
 	ScheduleClear();
 	ScheduleNow();
 	return true;
@@ -394,6 +395,15 @@ void PAW3902::RunImpl()
 					break;
 				}
 
+				// override the per-mode default with the actual interval between burst reads
+				// (the chip accumulates delta_x/delta_y until Motion_Burst is read), so the
+				// gyro integration window downstream lines up with what the chip actually saw.
+				if (_timestamp_sample_last != 0 && timestamp_sample > _timestamp_sample_last) {
+					const hrt_abstime dt = timestamp_sample - _timestamp_sample_last;
+					sensor_optical_flow.integration_timespan_us = math::constrain(static_cast<uint32_t>(dt),
+							static_cast<uint32_t>(1000), static_cast<uint32_t>(200000));
+				}
+
 				// motion in burst transfer
 				const bool motion_reported = (buffer.data.Motion & Motion_Bit::MOT);
 
@@ -483,6 +493,10 @@ void PAW3902::RunImpl()
 				_shutter_prev = shutter;
 				_raw_data_sum_prev = buffer.data.RawData_Sum;
 				_quality_prev = buffer.data.SQUAL;
+
+				// chip clears its delta accumulator on every Motion_Burst read,
+				// regardless of whether we publish, so track every successful read.
+				_timestamp_sample_last = timestamp_sample;
 
 			} else {
 				perf_count(_bad_transfer_perf);

--- a/src/drivers/optical_flow/paw3902/PAW3902.hpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.hpp
@@ -115,6 +115,7 @@ private:
 	hrt_abstime _reset_timestamp{0};
 	hrt_abstime _last_publish{0};
 	hrt_abstime _last_motion{0};
+	hrt_abstime _timestamp_sample_last{0};
 
 	int16_t _delta_x_raw_prev{0};
 	int16_t _delta_y_raw_prev{0};


### PR DESCRIPTION
## Summary

PAW3902 and PAA3905 drivers hardcode `sensor_optical_flow.integration_timespan_us` to the nominal mode frame period (e.g. `1/126 s`). The chips actually accumulate delta_x/delta_y until the Motion_Burst register is read, so when reads happen less often than every frame the reported timespan no longer matches reality. Derive it from the actual interval between consecutive burst reads.

## Problem

The Motion pin only asserts when the chip detects motion since the last burst read. In a hover with no chip-detectable flow (textureless patch, sub-pixel translation, slow drift), the pin never falls and the driver's backup watchdog reads every `kBackupScheduleIntervalUs` (20 ms in mode 2) instead of every frame. The chip has been integrating that whole interval, but the driver still reports the hardcoded `SAMPLE_INTERVAL_MODE_X`.

Downstream consequences:

- `src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp:124,151` uses `integration_timespan_us` to size the gyro integration window for body-rate compensation. A wrong length means the gyro integral does not cover the same physical interval the chip integrated over, so the rotational-LOS compensation `flow_compensated = flow_rate - gyro_rate.xy()` does not cleanly cancel rotation from the observation.
- `src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_control.cpp:293-298` updates `_flow_gyro_bias` via an LPF on `flow_sample.gyro_rate - _ref_body_rate`. With a persistently misaligned window the difference is no longer just a real bias - it contains the timing skew, which the LPF accumulates. That bias is then applied to every fusion including the motion-reported ones on the clean DRDY path.

The practical magnitude is small for steady hover (gyro ~= 0), but non-zero whenever the body rate is non-zero during a zero-flow publish (e.g. yaw scanning in hover, attitude wobble below the chip's pixel resolution, vibration). It is also a message-contract violation - `msg/SensorOpticalFlow.msg` defines the field as "accumulation timespan".

## Solution

Track the timestamp of the previous successful Motion_Burst read in `_timestamp_sample_last`, and override the per-mode default with `timestamp_sample - _timestamp_sample_last` (clamped to `[1 ms, 200 ms]`). Update `_timestamp_sample_last` on every successful burst read since the chip clears its accumulator on each read, and reset it to 0 in `Reset()`. The first read after reset falls back to the per-mode default; subsequent reads use the measured interval.

Builds verified: `make ark_can-flow_default`, `make ark_can-flow-mr_default`.

Marking draft for review of the approach before flight testing.