### PR TITLE
fix(tools/uploader): handle USB CDC reconnect race during reboot

### DIFF
--- a/Tools/px4_uploader.py
+++ b/Tools/px4_uploader.py
@@ -520,14 +520,31 @@ class SerialTransport:
 
     def flush(self) -> None:
         """Flush output buffer."""
-        if self._port is not None:
+        if self._port is None:
+            return
+        # tcdrain() can raise termios.error (a bare OSError) if the device
+        # disappeared mid-flush — common right after a reboot-to-bootloader
+        # when the USB CDC node is being torn down and re-enumerated.
+        try:
             self._port.flush()
+        except (OSError, serial.SerialException) as e:
+            raise ConnectionError(
+                f"Flush failed: {e}", port=self.port_name, operation="flush"
+            )
 
     def reset_buffers(self) -> None:
         """Reset input and output buffers."""
-        if self._port is not None:
+        if self._port is None:
+            return
+        try:
             self._port.reset_input_buffer()
             self._port.reset_output_buffer()
+        except (OSError, serial.SerialException) as e:
+            raise ConnectionError(
+                f"Buffer reset failed: {e}",
+                port=self.port_name,
+                operation="reset_buffers",
+            )
 
     def set_baudrate(self, baudrate: int) -> None:
         """Change baud rate.
@@ -1737,7 +1754,7 @@ class Uploader:
                 port=transport.port_name,
             )
             return True
-        except (ProtocolError, TimeoutError):
+        except (ProtocolError, TimeoutError, ConnectionError):
             pass
 
         # Try rebooting at each baud rate
@@ -1802,8 +1819,10 @@ class Uploader:
                         port=transport.port_name,
                     )
                     return True
-                except (ProtocolError, TimeoutError):
-                    # Board may still be rebooting, wait a bit and retry
+                except (ProtocolError, TimeoutError, ConnectionError):
+                    # Board may still be rebooting, wait a bit and retry.
+                    # ConnectionError covers the USB CDC node briefly going
+                    # away as the bootloader re-enumerates.
                     time.sleep(0.3)
 
         return False


### PR DESCRIPTION
## Summary

`make <board> upload` intermittently crashes with `termios.error: (5, 'Input/output error')` after sending reboot-to-bootloader. Retrying immediately works. Funnel the underlying OS error into the existing transport-retry path so a single transient I/O hiccup during USB CDC re-enumeration no longer aborts the upload.

## Problem

After the uploader sends the reboot-to-bootloader sequence, the running PX4 application's USB CDC node is torn down and the bootloader re-enumerates a moment later. The uploader closes the port, sleeps, and reopens the same `/dev/ttyACMx`, but it can land on a half-broken file descriptor. The first `flush()` in `sync()` then calls `termios.tcdrain(fd)`, which raises `termios.error` — a bare `OSError` that is not a `serial.SerialException`.

`SerialTransport.flush()` / `reset_buffers()` did not catch `OSError`, and the two identify retry loops in `_try_identify` only caught `ProtocolError` / `TimeoutError`. So the error escaped every retry layer and crashed the script, even though the bootloader was genuinely there a fraction of a second later (which is why a manual re-run succeeded).

Traceback observed:

```
File ".../Tools/px4_uploader.py", line 1796, in _try_identify
    protocol.identify()
File ".../Tools/px4_uploader.py", line 644, in _get_sync
    self.transport.flush()
File ".../Tools/px4_uploader.py", line 524, in flush
    self._port.flush()
File "/usr/lib/python3/dist-packages/serial/serialposix.py", line 673, in flush
    termios.tcdrain(self.fd)
termios.error: (5, 'Input/output error')
```

## Solution

- `SerialTransport.flush()` and `reset_buffers()` now catch `OSError` (covers `termios.error`) and `serial.SerialException`, re-raising as the module's `ConnectionError` — consistent with how `send()` / `recv()` already behave.
- Both identify retry loops in `_try_identify` now also catch `ConnectionError`, so a transient I/O failure during the reboot/re-enumeration window costs one retry iteration instead of aborting the run. The outer `main()` loop already retries on `ConnectionError`, so this slots in cleanly.

No behavior change for the happy path; only the error funnel for the reboot-window race is fixed.