### PR TITLE
fix(commander): gate heading innovation check on global origin

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -89,7 +89,9 @@ void EstimatorChecks::checkAndReport(const Context &context, Report &reporter)
 		estimator_status_s estimator_status;
 
 		if (_estimator_status_sub.copy(&estimator_status)) {
-			pre_flt_fail_innov_heading = estimator_status.pre_flt_fail_innov_heading;
+			// Only require a heading reference when a global origin is set (i.e. global ops are intended)
+			pre_flt_fail_innov_heading = estimator_status.pre_flt_fail_innov_heading && lpos.xy_global;
+			estimator_status.pre_flt_fail_innov_heading = pre_flt_fail_innov_heading;
 			pre_flt_fail_innov_vel_horiz = estimator_status.pre_flt_fail_innov_vel_horiz;
 			pre_flt_fail_innov_pos_horiz = estimator_status.pre_flt_fail_innov_pos_horiz;
 
@@ -138,7 +140,7 @@ void EstimatorChecks::checkAndReport(const Context &context, Report &reporter)
 void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &reporter,
 		const estimator_status_s &estimator_status, NavModes required_groups)
 {
-	// Heading is required to arm for all modes that need any form of local position, plus FW AUTO_TAKEOFF
+	// Heading failures affect all modes that need any form of local position, plus FW AUTO_TAKEOFF
 	const NavModes heading_required_groups = (NavModes)(
 				reporter.failsafeFlags().mode_req_local_position |
 				reporter.failsafeFlags().mode_req_local_position_relaxed |


### PR DESCRIPTION
### Summary

Follow-up to [#27371](https://github.com/PX4/PX4-Autopilot/pull/27371).

Keep heading innovation preflight failures consistent with the global-origin gating added for heading-reference checks.

### Problem

[#27371](https://github.com/PX4/PX4-Autopilot/pull/27371) relaxed heading-reference enforcement for local-only operation, but one heading preflight failure path still did not account for whether a global origin exists.

This could still deny arming for local-only setups with a heading-related preflight error.

### Solution

Apply the same global-origin requirement to the heading innovation preflight failure path.

Globally referenced operation keeps the stricter heading validation, while local-only operation remains allowed.