### PR TITLE
docs(rover): fix rover simulation command

### DIFF
--- a/docs/en/sim_sih/index.md
+++ b/docs/en/sim_sih/index.md
@@ -37,7 +37,7 @@ The following vehicle types are supported:
 | Fixed-wing (airplane) <Badge type="tip" text="PX4 v1.13" />     | `make px4_sitl_sih sihsim_airplane`      | Experimental |
 | Tailsitter VTOL <Badge type="tip" text="PX4 v1.13" />           | `make px4_sitl_sih sihsim_xvert`         | Experimental |
 | Standard VTOL (QuadPlane) <Badge type="tip" text="PX4 v1.16" /> | `make px4_sitl_sih sihsim_standard_vtol` | Experimental |
-| Ackermann Rover <Badge type="tip" text="PX4 v1.16" />           | `make px4_sitl_sih sihsim_rover`         | Experimental |
+| Ackermann Rover <Badge type="tip" text="PX4 v1.16" />           | `make px4_sitl_sih sihsim_rover_ackermann`| Experimental |
 
 ::: warning
 Only the quadrotor vehicle type is stable and recommended for development. All other vehicle types (hexarotor, fixed-wing, VTOL, rover) are experimental and may have aerodynamic model or controller interaction issues that produce unrealistic flight behaviour.
@@ -301,7 +301,7 @@ If not, the SIH uses a simple model with maximum thrust force given by `SIH_F_T_
 
 ## Video
 
-SIH demo with a fixed-wing vehicle @[youtube](https://youtu.be/PzIpSCRD8Jo)  
+SIH demo with a fixed-wing vehicle @[youtube](https://youtu.be/PzIpSCRD8Jo)
 How to parametrize the thrust and power coefficients CT & CP @[youtube](https://www.youtube.com/watch?v=KNSd9ge0sSw)
 
 ## Credits

--- a/docs/en/simulation/px4_simulation_quickstart.md
+++ b/docs/en/simulation/px4_simulation_quickstart.md
@@ -29,7 +29,7 @@ docker run --rm -it -p 14550:14550/udp -e PX4_SIM_MODEL=sihsim_standard_vtol px4
 Ackermann rover
 
 ```sh
-docker run --rm -it -p 14550:14550/udp -e PX4_SIM_MODEL=sihsim_rover px4io/px4-sitl:latest
+docker run --rm -it -p 14550:14550/udp -e PX4_SIM_MODEL=sihsim_rover_ackermann px4io/px4-sitl:latest
 ```
 
 For more information and options see [Container Images](../simulation/px4_sitl_prebuilt_packages.md#container-images) (in _Pre-built SITL Packages_) and [SIH Simulation](../sim_sih/index.md).


### PR DESCRIPTION
### Solved Problem
The simulation target must have changed:
<img width="1420" height="568" alt="image" src="https://github.com/user-attachments/assets/aa7a6b2b-d10f-457f-835d-cba024c49501" />

### Solution
Update the docs.

### Changelog Entry
```
Documentation: Fix rover simulation command
```

### Test coverage
1. The `make px4_sitl_sih sihsim_rover_ackermann` I tested as you can see in the screenshot.
Also the exact match for this is here:
https://github.com/PX4/PX4-Autopilot/blob/e1befdea29bed3efddeac5e4382ba0f1769b000a/src/modules/simulation/simulator_sih/CMakeLists.txt#L60

2. The docker command I haven't tested it follows the same pattern just setting `PX4_SIM_MODEL` directly which with the make command corrected in 1. is done here: https://github.com/PX4/PX4-Autopilot/blob/e1befdea29bed3efddeac5e4382ba0f1769b000a/src/modules/simulation/simulator_sih/CMakeLists.txt#L101