### PR TITLE
feat(adsb): improve traffic warnings, and warn only when disarmed

### DIFF
--- a/src/lib/adsb/AdsbConflict.cpp
+++ b/src/lib/adsb/AdsbConflict.cpp
@@ -168,8 +168,9 @@ void AdsbConflict::remove_expired_conflicts()
 	}
 }
 
-bool AdsbConflict::handle_traffic_conflict()
+bool AdsbConflict::handle_traffic_conflict(bool vehicle_armed)
 {
+	_vehicle_armed = vehicle_armed;
 	const hrt_abstime now = hrt_absolute_time();
 
 	get_traffic_state(now);
@@ -237,7 +238,14 @@ bool AdsbConflict::send_traffic_warning(int traffic_direction, int traffic_seper
 					char tr_callsign[UTM_CALLSIGN_LENGTH], uint32_t icao_address, hrt_abstime now)
 {
 
-	switch (_conflict_detection_params.traffic_avoidance_mode) {
+	uint8_t effective_mode = _conflict_detection_params.traffic_avoidance_mode;
+
+	if (!_vehicle_armed && _conflict_detection_params.traffic_avoidance_mode >= 2) {
+		// When not armed, only demote actions to warnings
+		effective_mode = 1;
+	}
+
+	switch (effective_mode) {
 
 	case 0: {
 

--- a/src/lib/adsb/AdsbConflict.cpp
+++ b/src/lib/adsb/AdsbConflict.cpp
@@ -157,9 +157,8 @@ void AdsbConflict::remove_expired_conflicts()
 {
 	for (uint8_t traffic_index = 0; traffic_index < _traffic_buffer.timestamp.size();) {
 		if (hrt_elapsed_time(&_traffic_buffer.timestamp[traffic_index]) > TRAFFIC_CONFLICT_LIFETIME) {
-			events::send<uint32_t>(events::ID("navigator_traffic_expired"), events::Log::Notice,
-					       "Traffic Conflict {1} Expired and removed from buffer",
-					       _traffic_buffer.icao_address[traffic_index]);
+			events::send(events::ID("navigator_traffic_expired"), events::Log::Notice,
+				     "Traffic cleared");
 			remove_icao_address_from_conflict_list(traffic_index);
 
 		} else {
@@ -182,17 +181,14 @@ bool AdsbConflict::handle_traffic_conflict(bool vehicle_armed)
 	case TRAFFIC_STATE::ADD_CONFLICT:
 	case TRAFFIC_STATE::REMIND_CONFLICT: {
 			take_action = send_traffic_warning((int)math::degrees(_transponder_report.heading),
-							   (int)fabsf(_crosstrack_error.distance), _transponder_report.flags,
-							   _transponder_report.callsign,
-							   _transponder_report.icao_address,
+							   (int)fabsf(_crosstrack_error.distance),
 							   now);
 		}
 		break;
 
 	case TRAFFIC_STATE::REMOVE_OLD_CONFLICT: {
-			events::send<uint32_t>(events::ID("navigator_traffic_resolved"), events::Log::Notice,
-					       "Traffic Conflict Resolved {1}!",
-					       _transponder_report.icao_address);
+			events::send(events::ID("navigator_traffic_resolved"), events::Log::Notice,
+				     "Traffic cleared");
 			_last_traffic_warning_time = now;
 		}
 		break;
@@ -201,7 +197,7 @@ bool AdsbConflict::handle_traffic_conflict(bool vehicle_armed)
 
 			if ((_traffic_state_previous != TRAFFIC_STATE::BUFFER_FULL)
 			    && (hrt_elapsed_time(&_last_buffer_full_warning_time) > TRAFFIC_WARNING_TIMESTEP)) {
-				events::send(events::ID("buffer_full"), events::Log::Notice, "Too much traffic! Showing all messages from now on");
+				events::send(events::ID("buffer_full"), events::Log::Warning, "Traffic buffer full");
 				_last_buffer_full_warning_time = now;
 			}
 
@@ -234,8 +230,7 @@ void AdsbConflict::set_conflict_detection_params(float crosstrack_separation, fl
 }
 
 
-bool AdsbConflict::send_traffic_warning(int traffic_direction, int traffic_seperation, uint16_t tr_flags,
-					char tr_callsign[UTM_CALLSIGN_LENGTH], uint32_t icao_address, hrt_abstime now)
+bool AdsbConflict::send_traffic_warning(int traffic_direction, int traffic_seperation, hrt_abstime now)
 {
 
 	uint8_t effective_mode = _conflict_detection_params.traffic_avoidance_mode;
@@ -248,96 +243,55 @@ bool AdsbConflict::send_traffic_warning(int traffic_direction, int traffic_seper
 	switch (effective_mode) {
 
 	case 0: {
-
-			if (tr_flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_CALLSIGN) {
-
-				PX4_WARN("Traffic alert - UTM callsign %s! Separation Distance %d, Heading %d, ICAO Address %d",
-					 tr_callsign,
-					 traffic_seperation,
-					 traffic_direction, (int)icao_address);
-
-			}
-
-
+			PX4_WARN("Traffic! %dm, %d degrees", traffic_seperation, traffic_direction);
 			_last_traffic_warning_time = now;
-
 			break;
 		}
 
 	case 1: {
-
-
-			if (tr_flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_CALLSIGN) {
-
-				PX4_WARN("Traffic alert - UTM callsign %s! Separation Distance %d, Heading %d, ICAO Address %d",
-					 tr_callsign,
-					 traffic_seperation,
-					 traffic_direction, (int)icao_address);
-
-			}
-
 			/* EVENT
 			 * @description
-			 * - ICAO Address: {1}
-			 * - Traffic Separation Distance: {2m}
-			 * - Heading: {3} degrees
+			 * - Distance: {1m}
+			 * - Heading: {2} degrees
 			 */
-			events::send<uint32_t, int32_t, int16_t>(events::ID("navigator_traffic"), events::Log::Notice,
-					"Traffic alert - ICAO Address {1}! Separation Distance {2}, Heading {3}",
-					icao_address, traffic_seperation, traffic_direction);
-
+			events::send<int32_t, int16_t>(events::ID("navigator_traffic"), events::Log::Warning,
+						       "Traffic! {1m}, {2} degrees", traffic_seperation, traffic_direction);
 			_last_traffic_warning_time = now;
-
 			break;
 		}
 
 	case 2: {
 			/* EVENT
 			 * @description
-			 * - ICAO Address: {1}
-			 * - Traffic Separation Distance: {2m}
-			 * - Heading: {3} degrees
+			 * - Distance: {1m}
+			 * - Heading: {2} degrees
 			 */
-			events::send<uint32_t, int32_t, int16_t>(events::ID("navigator_traffic_rtl"), events::Log::Notice,
-					"Traffic alert - ICAO Address {1}! Separation Distance {2}, Heading {3}, returning home",
-					icao_address, traffic_seperation, traffic_direction);
-
+			events::send<int32_t, int16_t>(events::ID("navigator_traffic_rtl"), events::Log::Warning,
+						       "Traffic! {1m}, {2} degrees, returning home", traffic_seperation, traffic_direction);
 			_last_traffic_warning_time = now;
-
 			return true;
-
-			break;
 		}
 
 	case 3: {
 			/* EVENT
 			 * @description
-			 * - ICAO Address: {1}
-			 * - Traffic Separation Distance: {2m}
-			 * - Heading: {3} degrees
+			 * - Distance: {1m}
+			 * - Heading: {2} degrees
 			 */
-			events::send<uint32_t, int32_t, int16_t>(events::ID("navigator_traffic_land"), events::Log::Notice,
-					"Traffic alert - ICAO Address {1}! Separation Distance {2}, Heading {3}, landing",
-					icao_address, traffic_seperation, traffic_direction);
-
+			events::send<int32_t, int16_t>(events::ID("navigator_traffic_land"), events::Log::Warning,
+						       "Traffic! {1m}, {2} degrees, landing", traffic_seperation, traffic_direction);
 			_last_traffic_warning_time = now;
-
 			return true;
-
-			break;
-
 		}
 
 	case 4: {
 			/* EVENT
 			 * @description
-			 * - ICAO Address: {1}
-			 * - Traffic Separation Distance: {2m}
-			 * - Heading: {3} degrees
+			 * - Distance: {1m}
+			 * - Heading: {2} degrees
 			 */
-			events::send<uint32_t, int32_t, int16_t>(events::ID("navigator_traffic_hold"), events::Log::Notice,
-					"Traffic alert - ICAO Address {1}! Separation Distance {2}, Heading {3}, holding position",
-					icao_address, traffic_seperation, traffic_direction);
+			events::send<int32_t, int16_t>(events::ID("navigator_traffic_hold"), events::Log::Warning,
+						       "Traffic! {1m}, {2} degrees, holding position", traffic_seperation, traffic_direction);
 
 			_last_traffic_warning_time = now;
 

--- a/src/lib/adsb/AdsbConflict.h
+++ b/src/lib/adsb/AdsbConflict.h
@@ -122,7 +122,7 @@ public:
 
 	transponder_report_s _transponder_report{};
 
-	bool handle_traffic_conflict();
+	bool handle_traffic_conflict(bool vehicle_armed);
 
 	void fake_traffic(const char *const callsign, float distance, float direction, float traffic_heading,
 			  float altitude_diff,
@@ -144,6 +144,7 @@ protected:
 	traffic_buffer_s _traffic_buffer;
 
 private:
+	bool _vehicle_armed{false};
 
 	crosstrack_error_s _crosstrack_error{};
 

--- a/src/lib/adsb/AdsbConflict.h
+++ b/src/lib/adsb/AdsbConflict.h
@@ -117,8 +117,7 @@ public:
 					   int collision_time_threshold, uint8_t traffic_avoidance_mode);
 
 
-	bool send_traffic_warning(int traffic_direction, int traffic_seperation, uint16_t tr_flags,
-				  char tr_callsign[UTM_CALLSIGN_LENGTH], uint32_t icao_address, hrt_abstime now);
+	bool send_traffic_warning(int traffic_direction, int traffic_seperation, hrt_abstime now);
 
 	transponder_report_s _transponder_report{};
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1308,7 +1308,7 @@ void Navigator::check_traffic()
 			_adsb_conflict.detect_traffic_conflict(get_global_position()->lat, get_global_position()->lon,
 							       get_global_position()->alt, _local_pos.vx, _local_pos.vy, _local_pos.vz);
 
-			if (_adsb_conflict.handle_traffic_conflict()) {
+			if (_adsb_conflict.handle_traffic_conflict(_vstatus.arming_state == vehicle_status_s::ARMING_STATE_ARMED)) {
 				take_traffic_conflict_action();
 			}
 		}


### PR DESCRIPTION
### Solved Problem
1. Traffic warnings were too long and confusing to the operator, especially when the ICAO adress gets read out as a number
<img width="856" height="108" alt="image" src="https://github.com/user-attachments/assets/ac729cae-083e-4cdb-8a15-1860cc7d2c0a" />
2. the actions defined via NAV_TRAFF_AVOID would also trigger when disarmed on the ground, 

### Solution
1. Simplify the communication by focusing on the key information
2. gate the NAV_TRAFF_AVOID action to be only warning when disarmed
 