### PR TITLE
fix(drivers): PCA9685 use correct internal OSC frequency

### DIFF
--- a/src/drivers/pca9685_pwm_out/Kconfig
+++ b/src/drivers/pca9685_pwm_out/Kconfig
@@ -15,7 +15,7 @@ if DRIVERS_PCA9685_PWM_OUT
         default 25000000
 
     config PCA9685_INTERNAL_CRYSTAL_FREQ
-        int "Corrected frequency of internal oscillator"
+        int "Internal oscillator frequency"
         depends on !PCA9685_USE_EXTERNAL_CRYSTAL
-        default 26075000
+        default 25000000
 endif


### PR DESCRIPTION
### Solved Problem
- The PCA9685 has a very coarse internal OSC, reported to have an accuracy of +- 5%
- Due to this the Adafruit compensation frequency was copied to PX4 a while ago, yet
  - This causes big offsets on our boards, for example 1570us when commanded to output 1500us, a 4.6% error
  - Even the Adafruit code does not contain this frequency anymore, they also use 25Mhz now 

### Solution
- Use the actual internal OSC frequency of 25Mhz
- This reduced the error in our case to 1.21%, still not perfect but way better

### Alternatives
- If someone needs very precise PWM they should use an external OSC instead of the internal one
- The offset seems to be constant so the controllers should be able to handle it when its used for control surfaces

### Test coverage
- Tested with a PCA9685 and a v6s

