### PR TITLE
fix(make): register aggregate check targets into .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -644,6 +644,7 @@ help:
 list_config_targets:
 	@for targ in $(patsubst %_default,%[_default],$(ALL_CONFIG_TARGETS)); do echo $$targ; done
 
+.PHONY: check_nuttx check_linux check_px4 check_nxp
 check_nuttx : $(call make_list,nuttx) \
 	sizes
 


### PR DESCRIPTION
These targets are currently broken and needs to be registered into `.PHONY`.

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
