### PR TITLE
docs(arkv6x): note bootloader UART7/TELEM1 mapping

### DIFF
--- a/docs/en/flight_controller/ark_v6x.md
+++ b/docs/en/flight_controller/ark_v6x.md
@@ -73,7 +73,7 @@ For pinout of the ARKV6X see the [DS-10 Pixhawk Autopilot Bus Standard](https://
 | UART8  | /dev/ttyS7 | GPS2          |
 
 ::: info
-The mapping above applies to the running PX4 firmware. The ARKV6X bootloader enables only `UART7` (TELEM1), so when flashing firmware over UART with `px_uploader.py` you must connect to the **TELEM1** port — no other UART will respond in bootloader mode.
+The mapping above applies to the running PX4 firmware. The ARKV6X bootloader enables only `UART7` (TELEM1), so when flashing firmware over UART with [`px4_uploader.py`](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/px4_uploader.py) you must connect to the **TELEM1** port — no other UART will respond in bootloader mode.
 :::
 
 ## Building Firmware

--- a/docs/en/flight_controller/ark_v6x.md
+++ b/docs/en/flight_controller/ark_v6x.md
@@ -72,6 +72,10 @@ For pinout of the ARKV6X see the [DS-10 Pixhawk Autopilot Bus Standard](https://
 | UART7  | /dev/ttyS6 | TELEM1        |
 | UART8  | /dev/ttyS7 | GPS2          |
 
+::: info
+The mapping above applies to the running PX4 firmware. The ARKV6X bootloader enables only `UART7` (TELEM1), so when flashing firmware over UART with `px_uploader.py` you must connect to the **TELEM1** port — no other UART will respond in bootloader mode.
+:::
+
 ## Building Firmware
 
 ```sh


### PR DESCRIPTION
## Summary

Add a note on the ARKV6X board page that the bootloader's serial port mapping differs from the running firmware's, so users know to target TELEM1 when flashing over UART.

## Problem

The existing Serial Port Mapping table reflects the runtime firmware (e.g. `/dev/ttyS0` is GPS1). The ARKV6X bootloader enables only `UART7` (TELEM1), so inside the bootloader `ttyS0` is TELEM1 instead. Users running `px_uploader.py` from a companion computer against GPS1 see the FC reboot into the bootloader and then go silent, with nothing in the docs to explain why.

## Solution

Add an `::: info` admonition immediately below the serial port mapping table calling out the bootloader-only TELEM1 mapping and the implication for `px_uploader.py`.