### PR TITLE
docs(filter_tuning): clarify DNF param as bitmask

### DIFF
--- a/docs/en/config_mc/filter_tuning.md
+++ b/docs/en/config_mc/filter_tuning.md
@@ -78,8 +78,8 @@ The following parameters should be set to enable and configure dynamic notch fil
 
 | Parameter                                                                                                   | Description                                                              |
 | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| <a id="IMU_GYRO_DNF_EN"></a>[IMU_GYRO_DNF_EN](../advanced_config/parameter_reference.md#IMU_GYRO_DNF_EN)    | Enable IMU gyro dynamic notch filtering. `0`: ESC RPM, `1`: Onboard FFT. |
-| <a id="IMU_GYRO_FFT_EN"></a>[IMU_GYRO_FFT_EN](../advanced_config/parameter_reference.md#IMU_GYRO_FFT_EN)    | Enable onboard FFT (required if `IMU_GYRO_DNF_EN` is set to `1`).        |
+| <a id="IMU_GYRO_DNF_EN"></a>[IMU_GYRO_DNF_EN](../advanced_config/parameter_reference.md#IMU_GYRO_DNF_EN)    | Enable IMU gyro dynamic notch filtering (bitmask). Bit `0`: ESC RPM, Bit `1`: Onboard FFT. |
+| <a id="IMU_GYRO_FFT_EN"></a>[IMU_GYRO_FFT_EN](../advanced_config/parameter_reference.md#IMU_GYRO_FFT_EN)    | Enable onboard FFT (required if bit `1` of `IMU_GYRO_DNF_EN` is set).      |
 | <a id="IMU_GYRO_DNF_MIN"></a>[IMU_GYRO_DNF_MIN](../advanced_config/parameter_reference.md#IMU_GYRO_DNF_MIN) | Minimum dynamic notch frequency in Hz.                                   |
 | <a id="IMU_GYRO_DNF_BW"></a>[IMU_GYRO_DNF_BW](../advanced_config/parameter_reference.md#IMU_GYRO_DNF_BW)    | Bandwidth for each notch filter in Hz.                                   |
 | <a id="IMU_GYRO_DNF_HMC"></a>[IMU_GYRO_DNF_HMC](../advanced_config/parameter_reference.md#IMU_GYRO_NF0_BW)  | Number of harmonics to filter.                                           |


### PR DESCRIPTION
### Solved Problem
In https://docs.px4.io/main/en/config_mc/filter_tuning#dynamic-notch-filters, the `IMU_GYRO_DNF_EN` was not specified as a bitmask. This incorrectly led a user to believe that the field was an integer instead of a bitmask and apply the wrong param.

<img width="2378" height="238" alt="image" src="https://github.com/user-attachments/assets/e4448953-b3ff-4240-b296-2795d59b500c" />

### Solution
Specify the type of the param as a bitmask and explicitly call positions `Bit 0` and `Bit 1`.

### Changelog Entry
For release notes:
```
Documentation: Clarified IMU_GYRO_DNF_EN parameter type in Filter Tuning page
```
