### PR TITLE
docs(maintainers): add Jonas Perolini as Reviewer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -32,6 +32,7 @@ Reviewers help maintain PX4 across the project without ownership of a specific c
 | Name | GitHub | Chat | email
 |------|--------|------|----------------------
 | Onur Ozkan | [@onur-ozkan](https://github.com/onur-ozkan) | onur_ozkan0126 | <onur@orkavian.com>
+| Jonas Perolini | [@JonasPerolini](https://github.com/JonasPerolini) | jonasperolini | <jonas.perolini@rigi.tech>
 
 
 **Documentation Maintainers**


### PR DESCRIPTION
## Summary

- Adds [Jonas Perolini](https://github.com/JonasPerolini) as a Reviewer in `MAINTAINERS.md`
- Jonas has contributed to PX4-Autopilot across navigator, MAVLink, EKF2, and vision-based target estimation

## References

- Follows the Reviewer role introduced in #27010