### PR TITLE
fix(vtol): prevent divide-by-zero in tiltrotor transition weight

### DIFF
--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -251,17 +251,23 @@ void Tiltrotor::update_transition_state()
 		_mc_roll_weight = 1.0f;
 		_mc_yaw_weight = 1.0f;
 
-		if (PX4_ISFINITE(_attc->get_calibrated_airspeed()) &&
+		const float airspeed_trans_blend_margin = getTransitionAirspeed() - getBlendAirspeed();
+
+		if (airspeed_trans_blend_margin > FLT_EPSILON &&
+		    PX4_ISFINITE(_attc->get_calibrated_airspeed()) &&
 		    _attc->get_calibrated_airspeed() >= getBlendAirspeed()) {
 			_mc_roll_weight = 1.0f - (_attc->get_calibrated_airspeed() - getBlendAirspeed()) /
-					  (getTransitionAirspeed()  - getBlendAirspeed());
+					  airspeed_trans_blend_margin;
 		}
 
 		// without airspeed do timed weight changes
+		const float time_trans_open_loop_margin = getOpenLoopFrontTransitionTime() - getMinimumFrontTransitionTime();
+
 		if ((!PX4_ISFINITE(_attc->get_calibrated_airspeed())) &&
+		    time_trans_open_loop_margin > FLT_EPSILON &&
 		    _time_since_trans_start > getMinimumFrontTransitionTime()) {
 			_mc_roll_weight = 1.0f - (_time_since_trans_start - getMinimumFrontTransitionTime()) /
-					  (getOpenLoopFrontTransitionTime() - getMinimumFrontTransitionTime());
+					  time_trans_open_loop_margin;
 		}
 
 		// add minimum throttle for front transition


### PR DESCRIPTION
## Solved Problem
@Drone-Lab 
[Tiltrotor::update_transition_state()](https://github.com/PX4/PX4-Autopilot/blob/f7fd8bb57ae6d41909b70467c3fb4dd7fbb7dca8/src/modules/vtol_att_control/tiltrotor.cpp#L200) divides by
`(getTransitionAirspeed() - getBlendAirspeed())` without checking that the
margin is positive. When the two airspeeds are equal, `_mc_roll_weight`
becomes `NaN` and propagates to actuator outputs during the front
transition.

Reachable conditions:
- User sets `VT_ARSP_BLEND == VT_ARSP_TRANS` (no cross-validation, both in `[0, 30]`).
- `getTransitionAirspeed()`scales `VT_ARSP_TRANS` by `sqrt(weight_ratio)`,
  so with defaults (`8`, `10`) a `weight_ratio ≈ 0.64` makes the margin zero.
- `VT_ARSP_BLEND > VT_ARSP_TRANS` produces a negative margin and `_mc_roll_weight > 1`.

The Standard VTOL already guards the same expression ([`standard.cpp:220-230`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/vtol_att_control/standard.cpp#L220-L230)) with `_airspeed_trans_blend_margin > 0.0f`. 
This PR brings [`tiltrotor.cpp:254-258`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/vtol_att_control/tiltrotor.cpp#L254-L258) to parity.

## Solution

Guard the division and clamp the result:

```cpp
const float trans_blend_margin = getTransitionAirspeed() - getBlendAirspeed();

if (trans_blend_margin > FLT_EPSILON &&
    PX4_ISFINITE(_attc->get_calibrated_airspeed()) &&
    _attc->get_calibrated_airspeed() >= getBlendAirspeed()) {
    _mc_roll_weight = math::constrain(
        1.0f - (_attc->get_calibrated_airspeed() - getBlendAirspeed()) / trans_blend_margin,
        0.0f, 1.0f);
}