### PR TITLE
fix(mavlink): scale DO_REPOSITION coordinates in COMMAND_INT

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -517,6 +517,7 @@ MavlinkReceiver::command_has_location(uint16_t command)
 	case MAV_CMD_NAV_VTOL_TAKEOFF:                       // 84
 	case MAV_CMD_DO_SET_HOME:                            // 179
 	case MAV_CMD_DO_LAND_START:                          // 189
+	case MAV_CMD_DO_REPOSITION:                          // 192
 	case MAV_CMD_DO_SET_ROI_LOCATION:                    // 195
 	case MAV_CMD_DO_SET_ROI:                             // 201
 	case MAV_CMD_PAYLOAD_PREPARE_DEPLOY:                 // 30001
@@ -537,7 +538,6 @@ MavlinkReceiver::command_has_location(uint16_t command)
 	// case MAV_CMD_NAV_VTOL_LAND:                       // 85
 	// case MAV_CMD_NAV_PAYLOAD_PLACE:                   // 94
 	// case MAV_CMD_DO_RETURN_PATH_START:                // 188
-	// case MAV_CMD_DO_REPOSITION:                       // 192
 	// case MAV_CMD_OVERRIDE_GOTO:                       // 252
 	// case MAV_CMD_SET_GUIDED_SUBMODE_CIRCLE:           // 4001
 	// case MAV_CMD_CONDITION_GATE:                      // 4501


### PR DESCRIPTION
### Solved Problem
This fixes a regression introduced by #27335.

`MAV_CMD_DO_REPOSITION` was accidentally excluded from `command_has_location()`, so when it was received via `COMMAND_INT`, `x` and `y` were copied directly into `vehicle_command.param5/param6` without coordinate scaling.

For global frames this meant values such as `473977000` were forwarded to navigator as `473977000.0` degrees instead of `47.3977`.

### Solution

Add `MAV_CMD_DO_REPOSITION` back to the list of PX4-supported `COMMAND_INT` commands that carry location data.

### Changelog Entry
For release notes:
```text
Bugfix: Fixed COMMAND_INT DO_REPOSITION latitude/longitude scaling regression.
```