### PR TITLE
fix(fw_latlon_control): compensate TECS min airspeed for load factor

### DIFF
--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -608,9 +608,14 @@ void FwLateralLongitudinalControl::updateAttitude() {
 		_long_control_state.pitch_rad = euler_angles.theta();
 		_yaw = euler_angles.psi();
 
-		// load factor due to banking
 		const float load_factor_from_bank_angle = 1.0f / max(cosf(euler_angles.phi()), FLT_EPSILON);
+
+		// Used to compensate for higher induced drag during banking
 		_tecs.set_load_factor(load_factor_from_bank_angle);
+		// Used to give underspeed mitigation the correct minimum airspeed
+		_tecs.set_equivalent_airspeed_min(
+			_performance_model.getMinimumCalibratedAirspeed(load_factor_from_bank_angle, _flaps_setpoint)
+		);
 	}
 }
 

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -95,7 +95,6 @@ FwLateralLongitudinalControl::parameters_update()
 	_tecs.set_max_sink_rate(_param_fw_t_sink_max.get());
 	_tecs.set_min_sink_rate(_performance_model.getMinimumSinkRate(_air_density));
 	_tecs.set_equivalent_airspeed_trim(_performance_model.getCalibratedTrimAirspeed());
-	_tecs.set_equivalent_airspeed_min(_performance_model.getMinimumCalibratedAirspeed(getLoadFactor(), _flaps_setpoint));
 	_tecs.set_equivalent_airspeed_max(_performance_model.getMaximumCalibratedAirspeed());
 	_tecs.set_throttle_damp(_param_fw_t_thr_damping.get());
 	_tecs.set_integrator_gain_throttle(_param_fw_t_thr_integ.get());


### PR DESCRIPTION
### Problem

TECS has underspeed mitigation (airspeed too low -> higher speed weight, more throttle) with the decision boundary based on `params.tas_min`: 

https://github.com/PX4/PX4-Autopilot/blob/82c8d965d0f914150f387e0114be9b93c10f9d30/src/lib/tecs/TECS.cpp#L375-L379

That param is currently only updated by `FwLatLonControl` on param updates:

https://github.com/PX4/PX4-Autopilot/blob/82c8d965d0f914150f387e0114be9b93c10f9d30/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp#L88-L98

Therefore, TECS has a minimum airspeed that is compensated correctly for bank-induced load factor, weight ratio and flaps, but with the input data mostly being stale (only updated on param update -- probably this confusion came from fact that some TECS params are in fact real time inputs).

### Solution

Set the correctly compensated min airspeed continuously with `set_equivalent_airspeed_min` whenever attitude updates. 

Note that while other places in `FwLateralLongitudinalControl` use the attitude _setpoint_ through `getLoadFactor()` we use the actual attitude.
 - attitude setpoint is smoother - noise from roll loop does not pollute TECS
 - attitude is the real attitude obvs, so better in case of bad tracking
 
I don't think either is clearly better, did it this way to match the existing load factor passed to TECS, we can also change to use `getLoadFactor` -- then I would put both into `adapt_airspeed_setpoint` which already calculates it. 

We remove the previous update on param change, which is not necessary anymore. 

### Changelog Entry

```
Fix: Correctly update load-factor compensated minimum airspeed for TECS underspeed mitigation
```

### Testing

Sanity check with `gz_standard_vtol`, altitude mode, max input banked turns. No difference to before because no underspeed happened. 