### PR TITLE
docs(rc_update): clarify that RC_CHAN_CNT gates RC input validity

### DIFF
--- a/src/modules/rc_update/params.yaml
+++ b/src/modules/rc_update/params.yaml
@@ -688,11 +688,10 @@ parameters:
       max: 1
     RC_CHAN_CNT:
       description:
-        short: RC channel count
+        short: Calibrated RC channel count
         long: |-
-          This parameter is used by Ground Station software to save the number
-          of channels which were used during RC calibration. It is only meant
-          for ground station use.
+          Number of channels detected during RC calibration. Must be non-zero
+          for RC manual control input to be accepted.
       type: int32
       default: 0
       min: 0


### PR DESCRIPTION
## Summary
fixes #27439

Correct the `RC_CHAN_CNT` parameter description so it no longer claims the value is "only meant for ground station use".

## Problem
The current description says `RC_CHAN_CNT` is only for GCS bookkeeping. In practice, `rc_update` reads it: at `src/modules/rc_update/rc_update.cpp:154`, `_rc_calibrated` is computed from `RC_CHAN_CNT > 0` combined with valid roll/pitch/yaw/throttle mappings. That flag is then assigned to `manual_control_input.valid` at `src/modules/rc_update/rc_update.cpp:683`. When `valid` is false, `ManualControlSelector::isInputValid()` rejects the sample (`src/modules/manual_control/ManualControlSelector.cpp:114`), so flight mode switching and stick inputs from RC silently stop working — the symptom reported in the issue.

## Solution
Tighten the `short` to hint at calibration state, and rewrite the `long` to state the actual rule the firmware enforces. Kept both fields short to stay flash-conscious.