### PR TITLE
fix(commander): gate checks on topic advertisement

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/rallyPointCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/rallyPointCheck.cpp
@@ -46,6 +46,10 @@ void RallyPointChecks::checkAndReport(const Context &context, Report &reporter)
 		return;
 	}
 
+	if (!_rtl_status_sub.advertised()) {
+		return;
+	}
+
 	rtl_status_s rtl_status;
 
 	if (!_rtl_status_sub.copy(&rtl_status) || rtl_status.safe_point_index == UINT8_MAX) {

--- a/src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.cpp
@@ -37,36 +37,37 @@ using namespace time_literals;
 
 void RcAndDataLinkChecks::checkAndReport(const Context &context, Report &reporter)
 {
-	manual_control_setpoint_s manual_control_setpoint;
+	if (_manual_control_setpoint_sub.advertised()) {
+		manual_control_setpoint_s manual_control_setpoint;
 
-	if (!_manual_control_setpoint_sub.copy(&manual_control_setpoint)) {
-		manual_control_setpoint = {};
-		reporter.failsafeFlags().manual_control_signal_lost = true;
-	}
-
-	// Check if manual control is valid
-	if (!manual_control_setpoint.valid
-	    || hrt_elapsed_time(&manual_control_setpoint.timestamp) > _param_com_rc_loss_t.get() * 1_s) {
-
-		if (!reporter.failsafeFlags().manual_control_signal_lost && _last_valid_manual_control_setpoint > 0) {
-
-			events::send(events::ID("commander_rc_lost"), {events::Log::Info, events::LogInternal::Info},
-				     "Manual control lost");
+		if (!_manual_control_setpoint_sub.copy(&manual_control_setpoint)) {
+			manual_control_setpoint = {};
 		}
 
-		reporter.failsafeFlags().manual_control_signal_lost = true;
+		// Check if manual control is valid
+		if (!manual_control_setpoint.valid
+		    || hrt_elapsed_time(&manual_control_setpoint.timestamp) > _param_com_rc_loss_t.get() * 1_s) {
 
-	} else {
-		reporter.setIsPresent(health_component_t::remote_control);
+			if (!reporter.failsafeFlags().manual_control_signal_lost && _last_valid_manual_control_setpoint > 0) {
 
-		if (reporter.failsafeFlags().manual_control_signal_lost && _last_valid_manual_control_setpoint > 0) {
-			float elapsed = hrt_elapsed_time(&_last_valid_manual_control_setpoint) * 1e-6f;
-			events::send<float>(events::ID("commander_rc_regained"), events::Log::Info,
-					    "Manual control regained after {1:.1} s", elapsed);
+				events::send(events::ID("commander_rc_lost"), {events::Log::Info, events::LogInternal::Info},
+					     "Manual control lost");
+			}
+
+			reporter.failsafeFlags().manual_control_signal_lost = true;
+
+		} else {
+			reporter.setIsPresent(health_component_t::remote_control);
+
+			if (reporter.failsafeFlags().manual_control_signal_lost && _last_valid_manual_control_setpoint > 0) {
+				float elapsed = hrt_elapsed_time(&_last_valid_manual_control_setpoint) * 1e-6f;
+				events::send<float>(events::ID("commander_rc_regained"), events::Log::Info,
+						    "Manual control regained after {1:.1} s", elapsed);
+			}
+
+			reporter.failsafeFlags().manual_control_signal_lost = false;
+			_last_valid_manual_control_setpoint = manual_control_setpoint.timestamp;
 		}
-
-		reporter.failsafeFlags().manual_control_signal_lost = false;
-		_last_valid_manual_control_setpoint = manual_control_setpoint.timestamp;
 	}
 
 	// Manual control check is in modeCheck as mode requirement


### PR DESCRIPTION
## Summary
Follow-up to [#27341](https://github.com/PX4/PX4-Autopilot/pull/27341).

Skip additional commander checks until the uORB topics they depend on have been advertised.

## Problem
Commander can evaluate these checks before the corresponding publishers have produced their first topic advertisement. This can happen during startup before `manual_control_setpoint` is published by `manual_control`, and before `rtl_status` is published by `navigator`/RTL evaluation.

That startup window can produce spurious preflight failures even though the publisher simply has not initialized yet.

## Solution
Use the same `uORB::Subscription::advertised()` gating pattern as #27341: while a topic has not been advertised, skip the dependent check. Once the topic is advertised, keep the existing `copy()`, timestamp/validity, and rally point availability handling unchanged so real missing, stale, or invalid data is still reported as before.