### PR TITLE
fix(mavlink): preserve COMPONENT_ARM_DISARM param2 force flag on mission upload

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1545,6 +1545,7 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 		case MAV_CMD_COMPONENT_ARM_DISARM:
 			mission_item->nav_cmd = (NAV_CMD)mavlink_mission_item->command;
 			mission_item->params[0] = (uint16_t)mavlink_mission_item->param1;
+			mission_item->params[1] = (uint16_t)mavlink_mission_item->param2; // force flag (21196)
 			break;
 
 		case MAV_CMD_DO_AUTOTUNE_ENABLE:

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1839,6 +1839,10 @@ MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *
 		case MAV_CMD_NAV_RALLY_POINT:
 			break;
 
+		case MAV_CMD_COMPONENT_ARM_DISARM:
+			mavlink_mission_item->param1 = mission_item->params[0];
+			mavlink_mission_item->param2 = mission_item->params[1];
+			break;
 
 		default:
 			return PX4_ERROR;


### PR DESCRIPTION
A mission item with `MAV_CMD_COMPONENT_ARM_DISARM` (`param1=0`, `param2=21196`) is accepted on upload but the force flag is silently dropped, so a disarm that should be forced is evaluated as a normal disarm and can be rejected ("Disarming denied: not landed"). Direct `COMPONENT_ARM_DISARM` commands honor the flag, so mission-based and direct commands behave inconsistently.

The cause is in the global-frame branch of `parse_mavlink_mission_item()`, which stored `param1` into `params[0]` but never copied `param2`. The navigator later republishes the item as a `vehicle_command` reading `param2` from `params[1]`, and Commander forces the disarm only when `lround(param2) == 21196` — which can never happen if `params[1]` was left at zero. This copies `param2` into `params[1]`, matching the adjacent `DO_AUTOTUNE_ENABLE` case and the existing `MAV_FRAME_MISSION` path (which already preserves it generically, so GCSs that send the item in that frame are unaffected).

Fixes #27288