### PR TITLE
fix(mavlink): execute CONDITION_DELAY mission items as NAV_DELAY

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1639,12 +1639,17 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 		case MAV_CMD_NAV_RETURN_TO_LAUNCH:
 		case MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET:
 		case MAV_CMD_DO_SET_ROI_NONE:
-		case MAV_CMD_CONDITION_DELAY:
 		case MAV_CMD_CONDITION_DISTANCE:
 		case MAV_CMD_DO_SET_ACTUATOR:
 		case MAV_CMD_DO_AUTOTUNE_ENABLE:
 		case MAV_CMD_COMPONENT_ARM_DISARM:
 			mission_item->nav_cmd = (NAV_CMD)mavlink_mission_item->command;
+			break;
+
+		case MAV_CMD_CONDITION_DELAY:
+			// PX4 has no dedicated condition-delay execution; treat it as a NAV_DELAY,
+			// which holds for param1 (stored in params[0], aliasing time_inside) seconds.
+			mission_item->nav_cmd = NAV_CMD_DELAY;
 			break;
 
 		default:


### PR DESCRIPTION
A mission item with `MAV_CMD_CONDITION_DELAY` is accepted during upload but parsed into a `nav_cmd` value (112) that no navigator code recognizes. As a result the mission feasibility check rejects the mission ("unsupported cmd: 112"), and even if it reached execution the requested hold would never run — the delay duration is effectively lost.

PX4 already implements exactly this behavior through `NAV_CMD_DELAY`, which holds at the current position for `param1` seconds (stored in `params[0]`, which aliases `time_inside`). Since `MAV_CMD_CONDITION_DELAY`'s `param1` carries the same delay-in-seconds, this maps the command to `NAV_CMD_DELAY` at parse time, so the hold is honored by the existing, tested delay execution and feasibility logic without duplicating it.

Behavior is identical to a normal `NAV_DELAY` item: the vehicle holds position for the requested duration, then continues. Like `NAV_DELAY`, the item is uploaded in the `MAV_FRAME_MISSION` frame.

Fixes #27289