### PR TITLE
fix(navigator): honor NAV_LAND mission item abort altitude (param1)

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1471,7 +1471,9 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 
 		case MAV_CMD_NAV_LAND:
 			mission_item->nav_cmd = NAV_CMD_LAND;
-			// TODO: abort alt param1
+			// param1 is the minimum abort altitude above the landing point (0 = use the
+			// MIS_LND_ABRT_ALT default). Carry it in the otherwise-unused time_inside field.
+			mission_item->time_inside = mavlink_mission_item->param1;
 			mission_item->yaw = wrap_2pi(math::radians(mavlink_mission_item->param4));
 			mission_item->land_precision = mavlink_mission_item->param2;
 			break;
@@ -1802,7 +1804,7 @@ MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *
 			break;
 
 		case NAV_CMD_LAND:
-			// TODO: param1 abort alt
+			mavlink_mission_item->param1 = mission_item->time_inside; // minimum abort altitude (0 = default)
 			mavlink_mission_item->param2 = mission_item->land_precision;
 			mavlink_mission_item->param4 = math::degrees(mission_item->yaw);
 			break;

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1471,9 +1471,8 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 
 		case MAV_CMD_NAV_LAND:
 			mission_item->nav_cmd = NAV_CMD_LAND;
-			// param1 is the minimum abort altitude above the landing point (0 = use the
-			// MIS_LND_ABRT_ALT default). Carry it in the otherwise-unused time_inside field.
-			mission_item->time_inside = mavlink_mission_item->param1;
+			// param1 is the minimum abort altitude above the landing point (0 = use the MIS_LND_ABRT_ALT default).
+			mission_item->land_abort_min_alt = mavlink_mission_item->param1;
 			mission_item->yaw = wrap_2pi(math::radians(mavlink_mission_item->param4));
 			mission_item->land_precision = mavlink_mission_item->param2;
 			break;
@@ -1804,7 +1803,7 @@ MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *
 			break;
 
 		case NAV_CMD_LAND:
-			mavlink_mission_item->param1 = mission_item->time_inside; // minimum abort altitude (0 = default)
+			mavlink_mission_item->param1 = mission_item->land_abort_min_alt; // minimum abort altitude (0 = default)
 			mavlink_mission_item->param2 = mission_item->land_precision;
 			mavlink_mission_item->param4 = math::degrees(mission_item->yaw);
 			break;

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -873,8 +873,16 @@ MissionBase::do_abort_landing()
 	}
 
 	const float alt_landing = get_absolute_altitude_for_item(_mission_item);
-	const float alt_sp = math::max(alt_landing + _navigator->get_landing_abort_min_alt(),
-				       _global_pos_sub.get().alt);
+
+	// Use the landing item's per-item abort altitude (NAV_CMD_LAND param1, carried in time_inside)
+	// if specified, otherwise fall back to the global MIS_LND_ABRT_ALT parameter.
+	float abort_min_alt = _navigator->get_landing_abort_min_alt();
+
+	if (_mission_item.time_inside > FLT_EPSILON) {
+		abort_min_alt = _mission_item.time_inside;
+	}
+
+	const float alt_sp = math::max(alt_landing + abort_min_alt, _global_pos_sub.get().alt);
 
 	// turn current landing waypoint into an indefinite loiter
 	_mission_item.nav_cmd = NAV_CMD_LOITER_UNLIMITED;

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -874,12 +874,12 @@ MissionBase::do_abort_landing()
 
 	const float alt_landing = get_absolute_altitude_for_item(_mission_item);
 
-	// Use the landing item's per-item abort altitude (NAV_CMD_LAND param1, carried in time_inside)
-	// if specified, otherwise fall back to the global MIS_LND_ABRT_ALT parameter.
+	// Use the landing item's per-item abort altitude (NAV_CMD_LAND param1) if specified,
+	// otherwise fall back to the global MIS_LND_ABRT_ALT parameter.
 	float abort_min_alt = _navigator->get_landing_abort_min_alt();
 
-	if (_mission_item.time_inside > FLT_EPSILON) {
-		abort_min_alt = _mission_item.time_inside;
+	if (PX4_ISFINITE(_mission_item.land_abort_min_alt) && _mission_item.land_abort_min_alt > FLT_EPSILON) {
+		abort_min_alt = _mission_item.land_abort_min_alt;
 	}
 
 	const float alt_sp = math::max(alt_landing + abort_min_alt, _global_pos_sub.get().alt);

--- a/src/modules/navigator/mission_params.yaml
+++ b/src/modules/navigator/mission_params.yaml
@@ -92,6 +92,8 @@ parameters:
         long: |-
           Minimum altitude above landing point that the vehicle will climb to after an aborted landing.
           Then vehicle will loiter in this altitude until further command is received.
+          Used as the default when the landing mission item does not specify its own abort altitude
+          (MAV_CMD_NAV_LAND param1).
           Only applies to fixed-wing vehicles.
       type: int32
       default: 30

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -151,6 +151,7 @@ struct mission_item_s {
 			union {
 				float time_inside;		/**< time that the MAV should stay inside the radius before advancing in seconds */
 				float circle_radius;		/**< geofence circle radius in meters (only used for NAV_CMD_NAV_FENCE_CIRCLE*) */
+				float land_abort_min_alt;	/**< minimum abort altitude above landing point in meters (only used for NAV_CMD_LAND) */
 			};
 			float acceptance_radius;		/**< default radius in which the mission is accepted as reached in meters */
 			float loiter_radius;			/**< loiter radius in meters, 0 for a VTOL to hover, negative for counter-clockwise */


### PR DESCRIPTION
A `MAV_CMD_NAV_LAND` mission item carries a `param1` "minimum abort altitude" (the height above the landing point to climb to if the landing is aborted; `0` = use the system default). PX4 parsed and dropped it — there was a long-standing `// TODO: abort alt param1` — so an aborted landing always climbed to the global `MIS_LND_ABRT_ALT`, ignoring the per-item value.

This carries `param1` in the otherwise-unused `time_inside` field on upload (nothing reads `time_inside` for a LAND item), and in `MissionBase::do_abort_landing()` uses it as the climb-above-landing-point height when set (`> 0`), falling back to `MIS_LND_ABRT_ALT` otherwise. The value also round-trips on mission download (the reverse `format_mavlink_mission_item()` TODO is resolved too).

- Items with `param1 = 0`, including missions stored by older firmware (parsed into a zero-initialized item), keep using the `MIS_LND_ABRT_ALT` default — no behavior change for existing missions.
- Normal (non-aborted) landings are unaffected; `time_inside` is not consumed for LAND items elsewhere.
- Scope is fixed-wing `NAV_CMD_LAND` aborts, matching the existing abort behavior; `VTOL_LAND` is unchanged.
- `MIS_LND_ABRT_ALT` parameter docs now note it is the default when the item doesn't specify its own abort altitude.

Fixes #27290