### PR TITLE
fix(mavlink): don't derive multicopter yaw from LOITER_TIME param4

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1464,9 +1464,10 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 			mission_item->force_heading = (mavlink_mission_item->param2 > 0);
 			mission_item->loiter_radius = mavlink_mission_item->param3;
 			mission_item->loiter_exit_xtrack = (mavlink_mission_item->param4 > 0);
-			// Yaw is only valid for multicopter but we set it always because
-			// it's just ignored for fixedwing.
-			mission_item->yaw = wrap_2pi(math::radians(mavlink_mission_item->param4));
+			// Per the MAVLink spec param4 selects the loiter-circle exit cross-track behavior
+			// (forward-only vehicles), not a yaw setpoint. Don't derive a heading from it, so
+			// multicopters keep their current heading instead of being forced to ~param4 degrees.
+			mission_item->yaw = NAN;
 			break;
 
 		case MAV_CMD_NAV_LAND:


### PR DESCRIPTION
For `MAV_CMD_NAV_LOITER_TIME` the parser overloaded `param4`, using it both as the loiter exit cross-track flag and as a multicopter yaw setpoint (`wrap_2pi(radians(param4))`). Per the [MAVLink spec](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LOITER_TIME), `param4` only selects the loiter-circle exit behavior for forward-only (fixed-wing) vehicles and is **not** a yaw field. A ground station following the spec — e.g. `param4=1` to request a tangent exit — therefore unintentionally forced a ~1° multicopter heading, and larger values forced larger headings, which could also trip the yaw-reached timeout and fail the mission.

This sets `yaw` to `NAN` instead of deriving it from `param4`, so multicopters keep their current heading and no heading is enforced. `Navigator::get_yaw_to_be_accepted()` already treats a non-finite yaw as reached, so the loiter completes normally. The exit cross-track flag (`loiter_exit_xtrack = param4 > 0`) is unchanged, fixed-wing behavior is unaffected (yaw is always considered reached for non-rotary-wing), and the mission download path already maps `param4` to the exit cross-track flag so it stays consistent.

Note — behavior change for multicopters: missions that previously relied on PX4's de-facto use of `LOITER_TIME` `param4` as a loiter heading will no longer rotate to that heading. This aligns PX4 with the MAVLink specification. Spec-compliant per-vehicle yaw for a loiter isn't expressed through this command's `param4`. Fine-grained fixed-wing exit-angle semantics (exit angle in degrees / NaN default) are intentionally out of scope here; this keeps the existing boolean cross-track behavior and only removes the incorrect yaw coupling.

Fixes #27287