### PR TITLE
feat(uORB): Add an own type, orb_sub_t, for subscription handles

### DIFF
--- a/boards/modalai/voxl2/src/drivers/qurt/dsp_hitl/dsp_hitl.cpp
+++ b/boards/modalai/voxl2/src/drivers/qurt/dsp_hitl/dsp_hitl.cpp
@@ -272,8 +272,8 @@ void *send_actuator(void *)
 void send_actuator_data()
 {
 
-	int _actuator_outputs_sub = orb_subscribe_multi(ORB_ID(actuator_outputs_sim), 0);
-	int _vehicle_control_mode_sub_ = orb_subscribe(ORB_ID(vehicle_control_mode));
+	orb_sub_t _actuator_outputs_sub = orb_subscribe_multi(ORB_ID(actuator_outputs_sim), 0);
+	orb_sub_t _vehicle_control_mode_sub_ = orb_subscribe(ORB_ID(vehicle_control_mode));
 	uint64_t last_heartbeat_timestamp = hrt_absolute_time();
 	int previous_timestamp = 0;
 	int previous_uorb_timestamp = 0;
@@ -424,7 +424,7 @@ void task_main(int argc, char *argv[])
 	pthread_create(&sender_thread, &sender_thread_attr, send_actuator, nullptr);
 	pthread_attr_destroy(&sender_thread_attr);
 
-	int _vehicle_status_sub = orb_subscribe(ORB_ID(vehicle_status));
+	orb_sub_t _vehicle_status_sub = orb_subscribe(ORB_ID(vehicle_status));
 
 	_is_running = true;
 

--- a/boards/modalai/voxl2/src/drivers/qurt/elrs_led/elrs_led.cpp
+++ b/boards/modalai/voxl2/src/drivers/qurt/elrs_led/elrs_led.cpp
@@ -109,7 +109,7 @@ void elrs_led_task()
 	PX4_INFO("Starting task for elrs_led");
 
 	int ret = 0;
-	int manual_control_input_fd  = orb_subscribe(ORB_ID(manual_control_input));
+	orb_sub_t manual_control_input_fd  = orb_subscribe(ORB_ID(manual_control_input));
 	uint8_t pwmPacket[11] = {0xEC, 0x09, 0x32, 0x70, 0x77, 0x6D, 0x07, 0x75, 0x00, 0x00, 0x00};
 
 	px4_pollfd_struct_t fds[1] = { { .fd = manual_control_input_fd,  .events = POLLIN }	};

--- a/platforms/common/uORB/CMakeLists.txt
+++ b/platforms/common/uORB/CMakeLists.txt
@@ -81,7 +81,7 @@ if (NOT DEFINED CONFIG_BUILD_FLAT AND "${PX4_PLATFORM}" MATCHES "nuttx")
 		${SRCS_COMMON}
 		${SRCS_KERNEL}
 		)
-	target_link_libraries(uORB_kernel PRIVATE cdev uorb_msgs nuttx_mm heatshrink)
+	target_link_libraries(uORB_kernel PRIVATE cdev uorb_msgs nuttx_mm heatshrink nuttx_kmm)
 	target_compile_options(uORB_kernel PRIVATE ${MAX_CUSTOM_OPT_LEVEL} -D__KERNEL__)
 
 	# User side library in nuttx kernel/protected build

--- a/platforms/common/uORB/SubscriptionCallback.cpp
+++ b/platforms/common/uORB/SubscriptionCallback.cpp
@@ -53,7 +53,7 @@ bool SubscriptionCallback::registerCallback()
 
 		} else {
 			// force topic creation by subscribing with old API
-			int fd = orb_subscribe_multi(_subscription.get_topic(), _subscription.get_instance());
+			orb_sub_t fd = orb_subscribe_multi(_subscription.get_topic(), _subscription.get_instance());
 
 			// try to register callback again
 			if (_subscription.subscribe()) {

--- a/platforms/common/uORB/uORB.cpp
+++ b/platforms/common/uORB/uORB.cpp
@@ -146,27 +146,27 @@ int orb_publish(const struct orb_metadata *meta, orb_advert_t handle, const void
 	return uORB::Manager::get_instance()->orb_publish(meta, handle, data);
 }
 
-int orb_subscribe(const struct orb_metadata *meta)
+orb_sub_t orb_subscribe(const struct orb_metadata *meta)
 {
 	return uORB::Manager::get_instance()->orb_subscribe(meta);
 }
 
-int orb_subscribe_multi(const struct orb_metadata *meta, unsigned instance)
+orb_sub_t orb_subscribe_multi(const struct orb_metadata *meta, unsigned instance)
 {
 	return uORB::Manager::get_instance()->orb_subscribe_multi(meta, instance);
 }
 
-int orb_unsubscribe(int handle)
+int orb_unsubscribe(orb_sub_t handle)
 {
 	return uORB::Manager::get_instance()->orb_unsubscribe(handle);
 }
 
-int orb_copy(const struct orb_metadata *meta, int handle, void *buffer)
+int orb_copy(const struct orb_metadata *meta, orb_sub_t handle, void *buffer)
 {
 	return uORB::Manager::get_instance()->orb_copy(meta, handle, buffer);
 }
 
-int orb_check(int handle, bool *updated)
+int orb_check(orb_sub_t handle, bool *updated)
 {
 	return uORB::Manager::get_instance()->orb_check(handle, updated);
 }
@@ -187,12 +187,12 @@ int orb_group_count(const struct orb_metadata *meta)
 	return instance;
 }
 
-int orb_set_interval(int handle, unsigned interval)
+int orb_set_interval(orb_sub_t handle, unsigned interval)
 {
 	return uORB::Manager::get_instance()->orb_set_interval(handle, interval);
 }
 
-int orb_get_interval(int handle, unsigned *interval)
+int orb_get_interval(orb_sub_t handle, unsigned *interval)
 {
 	return uORB::Manager::get_instance()->orb_get_interval(handle, interval);
 }

--- a/platforms/common/uORB/uORB.h
+++ b/platforms/common/uORB/uORB.h
@@ -134,6 +134,16 @@ void uorb_shutdown(void);
  * publisher.
  */
 typedef void 	*orb_advert_t;
+typedef int 	orb_sub_t;
+
+#if defined(__cplusplus)
+# define ORB_ADVERT_INVALID nullptr
+#else
+# define ORB_ADVERT_INVALID ((orb_advert_t)NULL)
+#endif
+static inline bool orb_advert_valid(orb_advert_t handle) {return handle != ORB_ADVERT_INVALID;}
+static inline bool orb_sub_valid(orb_sub_t handle) {return handle >= 0;}
+#define ORB_SUB_INVALID ((orb_sub_t)-1)
 
 /**
  * @see uORB::Manager::orb_advertise()
@@ -183,27 +193,27 @@ static inline int orb_publish_auto(const struct orb_metadata *meta, orb_advert_t
 /**
  * @see uORB::Manager::orb_subscribe()
  */
-extern int	orb_subscribe(const struct orb_metadata *meta) __EXPORT;
+extern orb_sub_t	orb_subscribe(const struct orb_metadata *meta) __EXPORT;
 
 /**
  * @see uORB::Manager::orb_subscribe_multi()
  */
-extern int	orb_subscribe_multi(const struct orb_metadata *meta, unsigned instance) __EXPORT;
+extern orb_sub_t	orb_subscribe_multi(const struct orb_metadata *meta, unsigned instance) __EXPORT;
 
 /**
  * @see uORB::Manager::orb_unsubscribe()
  */
-extern int	orb_unsubscribe(int handle) __EXPORT;
+extern int	orb_unsubscribe(orb_sub_t handle) __EXPORT;
 
 /**
  * @see uORB::Manager::orb_copy()
  */
-extern int	orb_copy(const struct orb_metadata *meta, int handle, void *buffer) __EXPORT;
+extern int	orb_copy(const struct orb_metadata *meta, orb_sub_t handle, void *buffer) __EXPORT;
 
 /**
  * @see uORB::Manager::orb_check()
  */
-extern int	orb_check(int handle, bool *updated) __EXPORT;
+extern int	orb_check(orb_sub_t handle, bool *updated) __EXPORT;
 
 /**
  * @see uORB::Manager::orb_exists()
@@ -221,12 +231,12 @@ extern int	orb_group_count(const struct orb_metadata *meta) __EXPORT;
 /**
  * @see uORB::Manager::orb_set_interval()
  */
-extern int	orb_set_interval(int handle, unsigned interval) __EXPORT;
+extern int	orb_set_interval(orb_sub_t handle, unsigned interval) __EXPORT;
 
 /**
  * @see uORB::Manager::orb_get_interval()
  */
-extern int	orb_get_interval(int handle, unsigned *interval) __EXPORT;
+extern int	orb_get_interval(orb_sub_t handle, unsigned *interval) __EXPORT;
 
 /**
  * Returns the C type string from a short type in message fields metadata, or nullptr

--- a/platforms/common/uORB/uORBManager.cpp
+++ b/platforms/common/uORB/uORBManager.cpp
@@ -344,18 +344,18 @@ int uORB::Manager::orb_unadvertise(orb_advert_t handle)
 	return uORB::DeviceNode::unadvertise(handle);
 }
 
-int uORB::Manager::orb_subscribe(const struct orb_metadata *meta)
+orb_sub_t uORB::Manager::orb_subscribe(const struct orb_metadata *meta)
 {
 	return node_open(meta, false);
 }
 
-int uORB::Manager::orb_subscribe_multi(const struct orb_metadata *meta, unsigned instance)
+orb_sub_t uORB::Manager::orb_subscribe_multi(const struct orb_metadata *meta, unsigned instance)
 {
 	int inst = instance;
 	return node_open(meta, false, &inst);
 }
 
-int uORB::Manager::orb_unsubscribe(int fd)
+int uORB::Manager::orb_unsubscribe(orb_sub_t fd)
 {
 	return px4_close(fd);
 }
@@ -373,7 +373,7 @@ int uORB::Manager::orb_publish(const struct orb_metadata *meta, orb_advert_t han
 	return uORB::DeviceNode::publish(meta, handle, data);
 }
 
-int uORB::Manager::orb_copy(const struct orb_metadata *meta, int handle, void *buffer)
+int uORB::Manager::orb_copy(const struct orb_metadata *meta, orb_sub_t handle, void *buffer)
 {
 	int ret;
 
@@ -391,19 +391,19 @@ int uORB::Manager::orb_copy(const struct orb_metadata *meta, int handle, void *b
 	return PX4_OK;
 }
 
-int uORB::Manager::orb_check(int handle, bool *updated)
+int uORB::Manager::orb_check(orb_sub_t handle, bool *updated)
 {
 	/* Set to false here so that if `px4_ioctl` fails to false. */
 	*updated = false;
 	return px4_ioctl(handle, ORBIOCUPDATED, (unsigned long)(uintptr_t)updated);
 }
 
-int uORB::Manager::orb_set_interval(int handle, unsigned interval)
+int uORB::Manager::orb_set_interval(orb_sub_t handle, unsigned interval)
 {
 	return px4_ioctl(handle, ORBIOCSETINTERVAL, interval * 1000);
 }
 
-int uORB::Manager::orb_get_interval(int handle, unsigned *interval)
+int uORB::Manager::orb_get_interval(orb_sub_t handle, unsigned *interval)
 {
 	int ret = px4_ioctl(handle, ORBIOCGETINTERVAL, (unsigned long)interval);
 	*interval /= 1000;

--- a/platforms/common/uORB/uORBManager.hpp
+++ b/platforms/common/uORB/uORBManager.hpp
@@ -307,7 +307,7 @@ public:
 	 * @return    PX4_ERROR on error, otherwise returns a handle
 	 *      that can be used to read and update the topic.
 	 */
-	int  orb_subscribe(const struct orb_metadata *meta);
+	orb_sub_t orb_subscribe(const struct orb_metadata *meta);
 
 	/**
 	 * Subscribe to a multi-instance of a topic.
@@ -345,7 +345,7 @@ public:
 	 *      ORB_DEFINE_OPTIONAL with no corresponding ORB_DECLARE)
 	 *      this function will return -1 and set errno to ENOENT.
 	 */
-	int  orb_subscribe_multi(const struct orb_metadata *meta, unsigned instance);
+	orb_sub_t orb_subscribe_multi(const struct orb_metadata *meta, unsigned instance);
 
 	/**
 	 * Unsubscribe from a topic.
@@ -353,7 +353,7 @@ public:
 	 * @param handle  A handle returned from orb_subscribe.
 	 * @return    OK on success, PX4_ERROR otherwise with errno set accordingly.
 	 */
-	int  orb_unsubscribe(int handle);
+	int orb_unsubscribe(orb_sub_t handle);
 
 	/**
 	 * Fetch data from a topic.
@@ -371,7 +371,7 @@ public:
 	 *      using the data.
 	 * @return    OK on success, PX4_ERROR otherwise with errno set accordingly.
 	 */
-	int  orb_copy(const struct orb_metadata *meta, int handle, void *buffer);
+	int orb_copy(const struct orb_metadata *meta, orb_sub_t handle, void *buffer);
 
 	/**
 	 * Check whether a topic has been published to since the last orb_copy.
@@ -389,7 +389,7 @@ public:
 	 * @return    OK if the check was successful, PX4_ERROR otherwise with
 	 *      errno set accordingly.
 	 */
-	int  orb_check(int handle, bool *updated);
+	int orb_check(orb_sub_t handle, bool *updated);
 
 	/**
 	 * Check if a topic has already been created and published (advertised)
@@ -418,7 +418,7 @@ public:
 	 * @param interval  An interval period in milliseconds.
 	 * @return    OK on success, PX4_ERROR otherwise with ERRNO set accordingly.
 	 */
-	int  orb_set_interval(int handle, unsigned interval);
+	int orb_set_interval(orb_sub_t handle, unsigned interval);
 
 
 	/**
@@ -430,7 +430,7 @@ public:
 	 * @param interval  The returned interval period in milliseconds.
 	 * @return    OK on success, PX4_ERROR otherwise with ERRNO set accordingly.
 	 */
-	int	orb_get_interval(int handle, unsigned *interval);
+	int	orb_get_interval(orb_sub_t handle, unsigned *interval);
 
 	static bool orb_device_node_exists(ORB_ID orb_id, uint8_t instance);
 

--- a/platforms/common/uORB/uORBManagerUsr.cpp
+++ b/platforms/common/uORB/uORBManagerUsr.cpp
@@ -129,18 +129,18 @@ int uORB::Manager::orb_unadvertise(orb_advert_t handle)
 	return data.ret;
 }
 
-int uORB::Manager::orb_subscribe(const struct orb_metadata *meta)
+orb_sub_t uORB::Manager::orb_subscribe(const struct orb_metadata *meta)
 {
 	return node_open(meta, false);
 }
 
-int uORB::Manager::orb_subscribe_multi(const struct orb_metadata *meta, unsigned instance)
+orb_sub_t uORB::Manager::orb_subscribe_multi(const struct orb_metadata *meta, unsigned instance)
 {
 	int inst = instance;
 	return node_open(meta, false, &inst);
 }
 
-int uORB::Manager::orb_unsubscribe(int fd)
+int uORB::Manager::orb_unsubscribe(orb_sub_t fd)
 {
 	return px4_close(fd);
 }
@@ -153,7 +153,7 @@ int uORB::Manager::orb_publish(const struct orb_metadata *meta, orb_advert_t han
 	return d.ret;
 }
 
-int uORB::Manager::orb_copy(const struct orb_metadata *meta, int handle, void *buffer)
+int uORB::Manager::orb_copy(const struct orb_metadata *meta, orb_sub_t handle, void *buffer)
 {
 	int ret;
 
@@ -171,19 +171,19 @@ int uORB::Manager::orb_copy(const struct orb_metadata *meta, int handle, void *b
 	return PX4_OK;
 }
 
-int uORB::Manager::orb_check(int handle, bool *updated)
+int uORB::Manager::orb_check(orb_sub_t handle, bool *updated)
 {
 	/* Set to false here so that if `px4_ioctl` fails to false. */
 	*updated = false;
 	return px4_ioctl(handle, ORBIOCUPDATED, (unsigned long)(uintptr_t)updated);
 }
 
-int uORB::Manager::orb_set_interval(int handle, unsigned interval)
+int uORB::Manager::orb_set_interval(orb_sub_t handle, unsigned interval)
 {
 	return px4_ioctl(handle, ORBIOCSETINTERVAL, interval * 1000);
 }
 
-int uORB::Manager::orb_get_interval(int handle, unsigned *interval)
+int uORB::Manager::orb_get_interval(orb_sub_t handle, unsigned *interval)
 {
 	int ret = px4_ioctl(handle, ORBIOCGETINTERVAL, (unsigned long)interval);
 	*interval /= 1000;

--- a/platforms/common/uORB/uORB_tests/uORBTest_UnitTest.cpp
+++ b/platforms/common/uORB/uORB_tests/uORBTest_UnitTest.cpp
@@ -56,7 +56,7 @@ int uORBTest::UnitTest::pubsublatency_main()
 	/* wakeup source(s) */
 	px4_pollfd_struct_t fds[1] {};
 
-	int test_multi_sub = orb_subscribe_multi(ORB_ID(orb_test_medium), 0);
+	orb_sub_t test_multi_sub = orb_subscribe_multi(ORB_ID(orb_test_medium), 0);
 
 	orb_test_medium_s t{};
 
@@ -269,9 +269,9 @@ int uORBTest::UnitTest::test_single()
 		return test_fail("advertise failed: %d", errno);
 	}
 
-	int sfd = orb_subscribe(ORB_ID(orb_test));
+	orb_sub_t sfd = orb_subscribe(ORB_ID(orb_test));
 
-	if (sfd < 0) {
+	if (!orb_sub_valid(sfd)) {
 		return test_fail("subscribe failed: %d", errno);
 	}
 
@@ -362,7 +362,7 @@ int uORBTest::UnitTest::test_multi()
 	}
 
 	/* subscribe to both topics and ensure valid data is received */
-	int sfd0 = orb_subscribe_multi(ORB_ID(orb_multitest), 0);
+	orb_sub_t sfd0 = orb_subscribe_multi(ORB_ID(orb_multitest), 0);
 
 	if (PX4_OK != orb_copy(ORB_ID(orb_multitest), sfd0, &u)) {
 		return test_fail("sub #0 copy failed: %d", errno);
@@ -372,7 +372,7 @@ int uORBTest::UnitTest::test_multi()
 		return test_fail("sub #0 val. mismatch: %d", u.val);
 	}
 
-	int sfd1 = orb_subscribe_multi(ORB_ID(orb_multitest), 1);
+	orb_sub_t sfd1 = orb_subscribe_multi(ORB_ID(orb_multitest), 1);
 
 	if (PX4_OK != orb_copy(ORB_ID(orb_multitest), sfd1, &u)) {
 		return test_fail("sub #1 copy failed: %d", errno);
@@ -456,7 +456,7 @@ int uORBTest::UnitTest::test_multi2()
 
 	_thread_should_exit = false;
 	const int num_instances = 3;
-	int orb_data_fd[num_instances] {-1, -1, -1};
+	orb_sub_t orb_data_fd[num_instances] {ORB_SUB_INVALID, ORB_SUB_INVALID, ORB_SUB_INVALID};
 	int orb_data_next = 0;
 
 	for (int i = 0; i < num_instances; ++i) {
@@ -483,7 +483,7 @@ int uORBTest::UnitTest::test_multi2()
 		px4_usleep(1000);
 
 		bool updated = false;
-		int orb_data_cur_fd = orb_data_fd[orb_data_next];
+		orb_sub_t orb_data_cur_fd = orb_data_fd[orb_data_next];
 		orb_check(orb_data_cur_fd, &updated);
 
 		if (updated) {
@@ -515,9 +515,9 @@ int uORBTest::UnitTest::test_multi_reversed()
 	/* For these tests 0 and 1 instances are taken from before, therefore continue with 2 and 3. */
 
 	/* Subscribe first and advertise afterwards. */
-	int sfd2 = orb_subscribe_multi(ORB_ID(orb_multitest), 2);
+	orb_sub_t sfd2 = orb_subscribe_multi(ORB_ID(orb_multitest), 2);
 
-	if (sfd2 < 0) {
+	if (!orb_sub_valid(sfd2)) {
 		return test_fail("sub. id2: ret: %d", sfd2);
 	}
 
@@ -558,7 +558,7 @@ int uORBTest::UnitTest::test_multi_reversed()
 		return test_fail("sub #3 val. mismatch: %d", u.val);
 	}
 
-	int sfd3 = orb_subscribe_multi(ORB_ID(orb_multitest), 3);
+	orb_sub_t sfd3 = orb_subscribe_multi(ORB_ID(orb_multitest), 3);
 
 	if (PX4_OK != orb_copy(ORB_ID(orb_multitest), sfd3, &u)) {
 		return test_fail("sub #3 copy failed: %d", errno);
@@ -607,9 +607,9 @@ int uORBTest::UnitTest::test_wrap_around()
 	t.val = 0;
 	orb_publish(ORB_ID(orb_test_medium_wrap_around), ptopic, &t);
 
-	int sfd = orb_subscribe(ORB_ID(orb_test_medium_wrap_around));
+	orb_sub_t sfd = orb_subscribe(ORB_ID(orb_test_medium_wrap_around));
 
-	if (sfd < 0) {
+	if (!orb_sub_valid(sfd)) {
 		return test_fail("subscribe failed: %d", errno);
 	}
 
@@ -829,9 +829,9 @@ int uORBTest::UnitTest::test_queue()
 	orb_advert_t ptopic{nullptr};
 	bool updated{false};
 
-	int sfd = orb_subscribe(ORB_ID(orb_test_medium_queue));
+	orb_sub_t sfd = orb_subscribe(ORB_ID(orb_test_medium_queue));
 
-	if (sfd < 0) {
+	if (!orb_sub_valid(sfd)) {
 		return test_fail("subscribe failed: %d", errno);
 	}
 
@@ -981,9 +981,9 @@ int uORBTest::UnitTest::test_queue_poll_notify()
 	test_note("Testing orb queuing (poll & notify)");
 
 	orb_test_medium_s t{};
-	int sfd = orb_subscribe(ORB_ID(orb_test_medium_queue_poll));
+	orb_sub_t sfd = orb_subscribe(ORB_ID(orb_test_medium_queue_poll));
 
-	if (sfd < 0) {
+	if (!orb_sub_valid(sfd)) {
 		return test_fail("subscribe failed: %d", errno);
 	}
 

--- a/src/drivers/qshell/qurt/qshell.cpp
+++ b/src/drivers/qshell/qurt/qshell.cpp
@@ -66,9 +66,9 @@ int QShell::main()
 
 	usleep(2000);
 
-	int sub_qshell_req = orb_subscribe(ORB_ID(qshell_req));
+	orb_sub_t sub_qshell_req = orb_subscribe(ORB_ID(qshell_req));
 
-	if (sub_qshell_req == PX4_ERROR) {
+	if (!orb_sub_valid(sub_qshell_req)) {
 		PX4_ERR("Error subscribing to qshell_req topic");
 		return -1;
 	}

--- a/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
@@ -396,7 +396,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 
 		float filtered_alt = NAN;
 		float last_baro_alt = 0.f;
-		int airdata_sub = orb_subscribe(ORB_ID(vehicle_air_data));
+		orb_sub_t airdata_sub = orb_subscribe(ORB_ID(vehicle_air_data));
 
 		uint32_t lastBATV_ms = 0;
 		uint32_t lastCUR_ms = 0;

--- a/src/drivers/telemetry/hott/messages.cpp
+++ b/src/drivers/telemetry/hott/messages.cpp
@@ -58,12 +58,12 @@
 /* The board is very roughly 5 deg warmer than the surrounding air */
 #define BOARD_TEMP_OFFSET_DEG 5
 
-static int _battery_sub = -1;
-static int _gps_sub = -1;
-static int _home_sub = -1;
-static int _airdata_sub = -1;
-static int _airspeed_sub = -1;
-static int _esc_sub = -1;
+static orb_sub_t _battery_sub = ORB_SUB_INVALID;
+static orb_sub_t _gps_sub = ORB_SUB_INVALID;
+static orb_sub_t _home_sub = ORB_SUB_INVALID;
+static orb_sub_t _airdata_sub = ORB_SUB_INVALID;
+static orb_sub_t _airspeed_sub = ORB_SUB_INVALID;
+static orb_sub_t _esc_sub = ORB_SUB_INVALID;
 
 static orb_advert_t _esc_pub = nullptr;
 

--- a/src/examples/matlab_csv_serial/matlab_csv_serial.c
+++ b/src/examples/matlab_csv_serial/matlab_csv_serial.c
@@ -42,6 +42,7 @@
 
 #include <px4_platform_common/px4_config.h>
 #include <px4_platform_common/tasks.h>
+#include <px4_platform_common/posix.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -190,22 +191,22 @@ int matlab_csv_serial_thread_main(int argc, char *argv[])
 	struct sensor_gyro_s gyro1;
 
 	/* subscribe to parameter changes */
-	int accel0_sub = orb_subscribe_multi(ORB_ID(sensor_accel), 0);
-	int accel1_sub = orb_subscribe_multi(ORB_ID(sensor_accel), 1);
-	int gyro0_sub = orb_subscribe_multi(ORB_ID(sensor_gyro), 0);
-	int gyro1_sub = orb_subscribe_multi(ORB_ID(sensor_gyro), 1);
+	orb_sub_t accel0_sub = orb_subscribe_multi(ORB_ID(sensor_accel), 0);
+	orb_sub_t accel1_sub = orb_subscribe_multi(ORB_ID(sensor_accel), 1);
+	orb_sub_t gyro0_sub = orb_subscribe_multi(ORB_ID(sensor_gyro), 0);
+	orb_sub_t gyro1_sub = orb_subscribe_multi(ORB_ID(sensor_gyro), 1);
 
 	thread_running = true;
 
 	while (!thread_should_exit) {
 
 		/*This runs at the rate of the sensors */
-		struct pollfd fds[] = {
+		px4_pollfd_struct_t fds[] = {
 			{ .fd = accel0_sub, .events = POLLIN }
 		};
 
 		/* wait for a sensor update, check for exit condition every 500 ms */
-		int ret = poll(fds, sizeof(fds) / sizeof(fds[0]), 500);
+		int ret = px4_poll(fds, sizeof(fds) / sizeof(fds[0]), 500);
 
 		if (ret < 0) {
 			/* poll error, ignore */

--- a/src/examples/px4_simple_app/px4_simple_app.c
+++ b/src/examples/px4_simple_app/px4_simple_app.c
@@ -59,7 +59,7 @@ int px4_simple_app_main(int argc, char *argv[])
 	PX4_INFO("Hello Sky!");
 
 	/* subscribe to vehicle_acceleration topic */
-	int sensor_sub_fd = orb_subscribe(ORB_ID(vehicle_acceleration));
+	orb_sub_t sensor_sub_fd = orb_subscribe(ORB_ID(vehicle_acceleration));
 	/* limit the update rate to 5 Hz */
 	orb_set_interval(sensor_sub_fd, 200);
 

--- a/src/lib/dataman_client/DatamanClient.cpp
+++ b/src/lib/dataman_client/DatamanClient.cpp
@@ -44,7 +44,7 @@ DatamanClient::DatamanClient()
 	_dataman_request_pub.advertise();
 	_dataman_response_sub = orb_subscribe(ORB_ID(dataman_response));
 
-	if (_dataman_response_sub < 0) {
+	if (!orb_sub_valid(_dataman_response_sub)) {
 		PX4_ERR("Failed to subscribe (%i)", errno);
 
 	} else {
@@ -78,7 +78,7 @@ DatamanClient::~DatamanClient()
 {
 	perf_free(_sync_perf);
 
-	if (_dataman_response_sub >= 0) {
+	if (orb_sub_valid(_dataman_response_sub)) {
 		orb_unsubscribe(_dataman_response_sub);
 	}
 }

--- a/src/lib/dataman_client/DatamanClient.hpp
+++ b/src/lib/dataman_client/DatamanClient.hpp
@@ -39,6 +39,7 @@
 #include <uORB/topics/dataman_response.h>
 #include <dataman/dataman.h>
 #include <lib/perf/perf_counter.h>
+#include <px4_platform_common/posix.h>
 
 using namespace time_literals;
 
@@ -178,7 +179,7 @@ private:
 	Request _active_request{};
 	uint8_t _response_status{};
 
-	int32_t _dataman_response_sub{};
+	orb_sub_t _dataman_response_sub{ORB_SUB_INVALID};
 	uORB::Publication<dataman_request_s> _dataman_request_pub{ORB_ID(dataman_request)};
 
 	px4_pollfd_struct_t _fds;

--- a/src/lib/parameters/parameters_primary.cpp
+++ b/src/lib/parameters/parameters_primary.cpp
@@ -58,7 +58,7 @@ static const char *sync_thread_name = "param_primary_sync";
 static orb_advert_t param_set_value_req_h = nullptr;
 static orb_advert_t param_reset_req_h     = nullptr;
 
-static int param_set_rsp_fd = PX4_ERROR;
+static orb_sub_t param_set_rsp_fd = ORB_SUB_INVALID;
 
 static int primary_sync_thread(int argc, char *argv[])
 {
@@ -71,8 +71,8 @@ static int primary_sync_thread(int argc, char *argv[])
 
 	orb_advert_t _set_value_rsp_h = nullptr;
 
-	int _set_used_req_fd  = orb_subscribe(ORB_ID(parameter_set_used_request));
-	int _set_value_req_fd = orb_subscribe(ORB_ID(parameter_primary_set_value_request));
+	orb_sub_t _set_used_req_fd  = orb_subscribe(ORB_ID(parameter_set_used_request));
+	orb_sub_t _set_value_req_fd = orb_subscribe(ORB_ID(parameter_primary_set_value_request));
 
 	struct parameter_set_used_request_s   _set_used_request;
 	struct parameter_set_value_request_s  _set_value_request;
@@ -200,14 +200,14 @@ void param_primary_set_value(param_t param, const void *val)
 		break;
 	}
 
-	if (param_set_rsp_fd == PX4_ERROR) {
+	if (!orb_sub_valid(param_set_rsp_fd)) {
 		if (debug) {
 			PX4_INFO("Subscribing to parameter_client_set_value_response");
 		}
 
 		param_set_rsp_fd = orb_subscribe(ORB_ID(parameter_remote_set_value_response));
 
-		if (param_set_rsp_fd == PX4_ERROR) {
+		if (!orb_sub_valid(param_set_rsp_fd)) {
 			PX4_ERR("Subscription to parameter_remote_set_value_response failed");
 
 		} else {

--- a/src/lib/parameters/parameters_remote.cpp
+++ b/src/lib/parameters/parameters_remote.cpp
@@ -57,7 +57,7 @@ static struct param_remote_counters param_remote_counters;
 static orb_advert_t parameter_set_used_h = nullptr;
 static orb_advert_t param_set_value_req_h = nullptr;
 
-static int param_set_rsp_fd = PX4_ERROR;
+static orb_sub_t param_set_rsp_fd = ORB_SUB_INVALID;
 
 static px4_task_t sync_thread_tid;
 static const char *sync_thread_name = "param_remote_sync";
@@ -74,8 +74,8 @@ static int remote_sync_thread(int argc, char *argv[])
 
 	orb_advert_t _set_value_rsp_h = nullptr;
 
-	int _reset_req_fd  = orb_subscribe(ORB_ID(parameter_reset_request));
-	int _set_value_req_fd = orb_subscribe(ORB_ID(parameter_remote_set_value_request));
+	orb_sub_t _reset_req_fd  = orb_subscribe(ORB_ID(parameter_reset_request));
+	orb_sub_t _set_value_req_fd = orb_subscribe(ORB_ID(parameter_remote_set_value_request));
 
 	struct parameter_reset_request_s      _reset_request;
 	struct parameter_set_value_request_s  _set_value_request;
@@ -236,14 +236,14 @@ void param_remote_set_value(param_t param, const void *val)
 		break;
 	}
 
-	if (param_set_rsp_fd == PX4_ERROR) {
+	if (!orb_sub_valid(param_set_rsp_fd)) {
 		if (debug) {
 			PX4_INFO("Subscribing to parameter_primary_set_value_response");
 		}
 
 		param_set_rsp_fd = orb_subscribe(ORB_ID(parameter_primary_set_value_response));
 
-		if (param_set_rsp_fd == PX4_ERROR) {
+		if (!orb_sub_valid(param_set_rsp_fd)) {
 			PX4_ERR("Subscription to parameter_primary_set_value_response failed");
 
 		} else {

--- a/src/modules/commander/Arming/ArmAuthorization/ArmAuthorization.cpp
+++ b/src/modules/commander/Arming/ArmAuthorization/ArmAuthorization.cpp
@@ -46,7 +46,7 @@
 using namespace time_literals;
 
 static orb_advert_t *mavlink_log_pub;
-static int command_ack_sub = -1;
+static orb_sub_t command_ack_sub = ORB_SUB_INVALID;
 
 static hrt_abstime auth_timeout;
 static hrt_abstime auth_req_time;

--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -686,9 +686,9 @@ task_main(int argc, char *argv[])
 	g_task_should_exit = false;
 
 	uORB::Publication<dataman_response_s> dataman_response_pub{ORB_ID(dataman_response)};
-	const int dataman_request_sub = orb_subscribe(ORB_ID(dataman_request));
+	const orb_sub_t dataman_request_sub = orb_subscribe(ORB_ID(dataman_request));
 
-	if (dataman_request_sub < 0) {
+	if (!orb_sub_valid(dataman_request_sub)) {
 		PX4_ERR("Failed to subscribe (%i)", errno);
 	}
 

--- a/src/modules/gimbal/input_mavlink.cpp
+++ b/src/modules/gimbal/input_mavlink.cpp
@@ -53,11 +53,11 @@ InputMavlinkROI::InputMavlinkROI(Parameters &parameters) :
 
 InputMavlinkROI::~InputMavlinkROI()
 {
-	if (_vehicle_roi_sub >= 0) {
+	if (orb_sub_valid(_vehicle_roi_sub)) {
 		orb_unsubscribe(_vehicle_roi_sub);
 	}
 
-	if (_position_setpoint_triplet_sub >= 0) {
+	if (orb_sub_valid(_position_setpoint_triplet_sub)) {
 		orb_unsubscribe(_position_setpoint_triplet_sub);
 	}
 }
@@ -66,13 +66,13 @@ int InputMavlinkROI::initialize()
 {
 	_vehicle_roi_sub = orb_subscribe(ORB_ID(vehicle_roi));
 
-	if (_vehicle_roi_sub < 0) {
+	if (!orb_sub_valid(_vehicle_roi_sub)) {
 		return -errno;
 	}
 
 	_position_setpoint_triplet_sub = orb_subscribe(ORB_ID(position_setpoint_triplet));
 
-	if (_position_setpoint_triplet_sub < 0) {
+	if (!orb_sub_valid(_position_setpoint_triplet_sub)) {
 		return -errno;
 	}
 
@@ -175,7 +175,7 @@ InputMavlinkCmdMount::InputMavlinkCmdMount(Parameters &parameters) :
 
 InputMavlinkCmdMount::~InputMavlinkCmdMount()
 {
-	if (_vehicle_command_sub >= 0) {
+	if (orb_sub_valid(_vehicle_command_sub)) {
 		orb_unsubscribe(_vehicle_command_sub);
 	}
 }
@@ -184,7 +184,7 @@ int InputMavlinkCmdMount::initialize()
 {
 	_vehicle_command_sub = orb_subscribe(ORB_ID(vehicle_command));
 
-	if (_vehicle_command_sub < 0) {
+	if (!orb_sub_valid(_vehicle_command_sub)) {
 		return -errno;
 	}
 
@@ -393,23 +393,23 @@ InputMavlinkGimbalV2::InputMavlinkGimbalV2(Parameters &parameters) :
 
 InputMavlinkGimbalV2::~InputMavlinkGimbalV2()
 {
-	if (_vehicle_roi_sub >= 0) {
+	if (orb_sub_valid(_vehicle_roi_sub)) {
 		orb_unsubscribe(_vehicle_roi_sub);
 	}
 
-	if (_position_setpoint_triplet_sub >= 0) {
+	if (orb_sub_valid(_position_setpoint_triplet_sub)) {
 		orb_unsubscribe(_position_setpoint_triplet_sub);
 	}
 
-	if (_gimbal_manager_set_attitude_sub >= 0) {
+	if (orb_sub_valid(_gimbal_manager_set_attitude_sub)) {
 		orb_unsubscribe(_gimbal_manager_set_attitude_sub);
 	}
 
-	if (_vehicle_command_sub >= 0) {
+	if (orb_sub_valid(_vehicle_command_sub)) {
 		orb_unsubscribe(_vehicle_command_sub);
 	}
 
-	if (_gimbal_manager_set_manual_control_sub >= 0) {
+	if (orb_sub_valid(_gimbal_manager_set_manual_control_sub)) {
 		orb_unsubscribe(_gimbal_manager_set_manual_control_sub);
 	}
 }
@@ -424,31 +424,31 @@ int InputMavlinkGimbalV2::initialize()
 {
 	_vehicle_roi_sub = orb_subscribe(ORB_ID(vehicle_roi));
 
-	if (_vehicle_roi_sub < 0) {
+	if (!orb_sub_valid(_vehicle_roi_sub)) {
 		return -errno;
 	}
 
 	_position_setpoint_triplet_sub = orb_subscribe(ORB_ID(position_setpoint_triplet));
 
-	if (_position_setpoint_triplet_sub < 0) {
+	if (!orb_sub_valid(_position_setpoint_triplet_sub)) {
 		return -errno;
 	}
 
 	_gimbal_manager_set_attitude_sub = orb_subscribe(ORB_ID(gimbal_manager_set_attitude));
 
-	if (_gimbal_manager_set_attitude_sub < 0) {
+	if (!orb_sub_valid(_gimbal_manager_set_attitude_sub)) {
 		return -errno;
 	}
 
 	_vehicle_command_sub = orb_subscribe(ORB_ID(vehicle_command));
 
-	if (_vehicle_command_sub < 0) {
+	if (!orb_sub_valid(_vehicle_command_sub)) {
 		return -errno;
 	}
 
 	_gimbal_manager_set_manual_control_sub = orb_subscribe(ORB_ID(gimbal_manager_set_manual_control));
 
-	if (_gimbal_manager_set_manual_control_sub < 0) {
+	if (!orb_sub_valid(_gimbal_manager_set_manual_control_sub)) {
 		return -errno;
 	}
 

--- a/src/modules/gimbal/input_mavlink.h
+++ b/src/modules/gimbal/input_mavlink.h
@@ -69,8 +69,8 @@ public:
 private:
 	void _read_control_data_from_position_setpoint_sub(ControlData &control_data);
 
-	int _vehicle_roi_sub = -1;
-	int _position_setpoint_triplet_sub = -1;
+	orb_sub_t _vehicle_roi_sub = ORB_SUB_INVALID;
+	orb_sub_t _position_setpoint_triplet_sub = ORB_SUB_INVALID;
 	uint8_t _cur_roi_mode {vehicle_roi_s::ROI_NONE};
 };
 
@@ -90,7 +90,7 @@ private:
 	UpdateResult _process_command(ControlData &control_data, const vehicle_command_s &vehicle_command);
 	void _ack_vehicle_command(const vehicle_command_s &cmd);
 
-	int _vehicle_command_sub = -1;
+	orb_sub_t _vehicle_command_sub = ORB_SUB_INVALID;
 };
 
 class InputMavlinkGimbalV2 : public InputBase
@@ -119,11 +119,11 @@ private:
 	void _stream_gimbal_manager_status(const ControlData &control_data);
 	void _read_control_data_from_position_setpoint_sub(ControlData &control_data);
 
-	int _vehicle_roi_sub = -1;
-	int _gimbal_manager_set_attitude_sub = -1;
-	int _gimbal_manager_set_manual_control_sub = -1;
-	int _position_setpoint_triplet_sub = -1;
-	int _vehicle_command_sub = -1;
+	orb_sub_t _vehicle_roi_sub = ORB_SUB_INVALID;
+	orb_sub_t _gimbal_manager_set_attitude_sub = ORB_SUB_INVALID;
+	orb_sub_t _gimbal_manager_set_manual_control_sub = ORB_SUB_INVALID;
+	orb_sub_t _position_setpoint_triplet_sub = ORB_SUB_INVALID;
+	orb_sub_t _vehicle_command_sub = ORB_SUB_INVALID;
 
 	uORB::Subscription _gimbal_device_attitude_status_sub{ORB_ID(gimbal_device_attitude_status)};
 	uORB::Subscription _gimbal_device_information_sub{ORB_ID(gimbal_device_information)};

--- a/src/modules/gimbal/input_rc.cpp
+++ b/src/modules/gimbal/input_rc.cpp
@@ -51,7 +51,7 @@ InputRC::InputRC(Parameters &parameters) :
 
 InputRC::~InputRC()
 {
-	if (_manual_control_setpoint_sub >= 0) {
+	if (orb_sub_valid(_manual_control_setpoint_sub)) {
 		orb_unsubscribe(_manual_control_setpoint_sub);
 	}
 }
@@ -60,7 +60,7 @@ int InputRC::initialize()
 {
 	_manual_control_setpoint_sub = orb_subscribe(ORB_ID(manual_control_setpoint));
 
-	if (_manual_control_setpoint_sub < 0) {
+	if (!orb_sub_valid(_manual_control_setpoint_sub)) {
 		return -errno;
 	}
 

--- a/src/modules/gimbal/input_rc.h
+++ b/src/modules/gimbal/input_rc.h
@@ -59,7 +59,7 @@ private:
 	virtual UpdateResult _read_control_data_from_subscription(ControlData &control_data, bool already_active);
 	float _get_aux_value(const manual_control_setpoint_s &manual_control_setpoint, int channel_idx);
 
-	int _manual_control_setpoint_sub{-1};
+	orb_sub_t _manual_control_setpoint_sub{ORB_SUB_INVALID};
 
 	float _last_set_aux_values[3] {};
 };

--- a/src/modules/logger/log_writer_mavlink.cpp
+++ b/src/modules/logger/log_writer_mavlink.cpp
@@ -57,14 +57,14 @@ bool LogWriterMavlink::init()
 
 LogWriterMavlink::~LogWriterMavlink()
 {
-	if (_ulog_stream_ack_sub >= 0) {
+	if (orb_sub_valid(_ulog_stream_ack_sub)) {
 		orb_unsubscribe(_ulog_stream_ack_sub);
 	}
 }
 
 void LogWriterMavlink::start_log()
 {
-	if (_ulog_stream_ack_sub == -1) {
+	if (!orb_sub_valid(_ulog_stream_ack_sub)) {
 		_ulog_stream_ack_sub = orb_subscribe(ORB_ID(ulog_stream_ack));
 	}
 

--- a/src/modules/logger/log_writer_mavlink.h
+++ b/src/modules/logger/log_writer_mavlink.h
@@ -78,7 +78,7 @@ private:
 
 	ulog_stream_s _ulog_stream_data{};
 	uORB::Publication<ulog_stream_s> _ulog_stream_pub{ORB_ID(ulog_stream)};
-	int _ulog_stream_ack_sub{-1};
+	orb_sub_t _ulog_stream_ack_sub{ORB_SUB_INVALID};
 	bool _need_reliable_transfer{false};
 	bool _is_started{false};
 };

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -672,12 +672,12 @@ void Logger::run()
 	/* timer_semaphore use case is a signal */
 	px4_sem_setprotocol(&_timer_callback_data.semaphore, SEM_PRIO_NONE);
 
-	int polling_topic_sub = -1;
+	orb_sub_t polling_topic_sub = ORB_SUB_INVALID;
 
 	if (_polling_topic_meta) {
 		polling_topic_sub = orb_subscribe(_polling_topic_meta);
 
-		if (polling_topic_sub < 0) {
+		if (!orb_sub_valid(polling_topic_sub)) {
 			PX4_ERR("Failed to subscribe (%i)", errno);
 		}
 
@@ -700,7 +700,7 @@ void Logger::run()
 	hrt_abstime next_subscribe_check = 0;
 	int next_subscribe_topic_index = -1; // this is used to distribute the checks over time
 
-	if (polling_topic_sub >= 0) {
+	if (orb_sub_valid(polling_topic_sub)) {
 		_lockstep_component = px4_lockstep_register_component();
 	}
 
@@ -917,7 +917,7 @@ void Logger::run()
 		update_params();
 
 		// wait for next loop iteration...
-		if (polling_topic_sub >= 0) {
+		if (orb_sub_valid(polling_topic_sub)) {
 			px4_lockstep_progress(_lockstep_component);
 
 			px4_pollfd_struct_t fds[1];
@@ -958,7 +958,7 @@ void Logger::run()
 	// stop the writer thread
 	_writer.thread_stop();
 
-	if (polling_topic_sub >= 0) {
+	if (orb_sub_valid(polling_topic_sub)) {
 		orb_unsubscribe(polling_topic_sub);
 	}
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -315,9 +315,9 @@ public:
 
 private:
 
-	int _local_pos_sub{-1};
-	int _mission_sub{-1};
-	int _vehicle_status_sub{-1};
+	orb_sub_t _local_pos_sub{ORB_SUB_INVALID};
+	orb_sub_t _mission_sub{ORB_SUB_INVALID};
+	orb_sub_t _vehicle_status_sub{ORB_SUB_INVALID};
 
 	uORB::SubscriptionData<position_controller_status_s>	_position_controller_status_sub{ORB_ID(position_controller_status)};
 	uORB::SubscriptionData<fixed_wing_lateral_guidance_status_s> _fw_lateral_guidance_status_sub{ORB_ID(fixed_wing_lateral_guidance_status)};

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.hpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.hpp
@@ -292,7 +292,7 @@ private:
 	std::default_random_engine _gen{};
 
 	// uORB subscription handlers
-	int _actuator_outputs_sub{-1};
+	orb_sub_t _actuator_outputs_sub{ORB_SUB_INVALID};
 	actuator_outputs_s _actuator_outputs{};
 
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};

--- a/src/modules/temperature_compensation/temperature_calibration/accel.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/accel.cpp
@@ -68,7 +68,7 @@ TemperatureCalibrationAccel::~TemperatureCalibrationAccel()
 	}
 }
 
-int TemperatureCalibrationAccel::update_sensor_instance(PerSensorData &data, int sensor_sub)
+int TemperatureCalibrationAccel::update_sensor_instance(PerSensorData &data, orb_sub_t sensor_sub)
 {
 	bool finished = data.hot_soaked;
 

--- a/src/modules/temperature_compensation/temperature_calibration/accel.h
+++ b/src/modules/temperature_compensation/temperature_calibration/accel.h
@@ -49,7 +49,7 @@ public:
 
 private:
 
-	virtual inline int update_sensor_instance(PerSensorData &data, int sensor_sub);
+	virtual inline int update_sensor_instance(PerSensorData &data, orb_sub_t sensor_sub);
 
 	inline int finish_sensor_instance(PerSensorData &data, int sensor_index);
 };

--- a/src/modules/temperature_compensation/temperature_calibration/baro.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/baro.cpp
@@ -68,7 +68,7 @@ TemperatureCalibrationBaro::~TemperatureCalibrationBaro()
 	}
 }
 
-int TemperatureCalibrationBaro::update_sensor_instance(PerSensorData &data, int sensor_sub)
+int TemperatureCalibrationBaro::update_sensor_instance(PerSensorData &data, orb_sub_t sensor_sub)
 {
 	bool finished = data.hot_soaked;
 

--- a/src/modules/temperature_compensation/temperature_calibration/baro.h
+++ b/src/modules/temperature_compensation/temperature_calibration/baro.h
@@ -52,7 +52,7 @@ public:
 
 private:
 
-	virtual int update_sensor_instance(PerSensorData &data, int sensor_sub);
+	virtual int update_sensor_instance(PerSensorData &data, orb_sub_t sensor_sub);
 
 	inline int finish_sensor_instance(PerSensorData &data, int sensor_index);
 };

--- a/src/modules/temperature_compensation/temperature_calibration/common.h
+++ b/src/modules/temperature_compensation/temperature_calibration/common.h
@@ -43,6 +43,7 @@
 #include <px4_platform_common/log.h>
 #include <mathlib/mathlib.h>
 #include <lib/parameters/param.h>
+#include <uORB/uORB.h>
 
 #include "polyfit.hpp"
 
@@ -188,8 +189,8 @@ protected:
 	 * update a single sensor instance
 	 * @return 0 when done, 1 not finished yet, <0 for an error
 	 */
-	virtual int update_sensor_instance(PerSensorData &data, int sensor_sub) = 0;
+	virtual int update_sensor_instance(PerSensorData &data, orb_sub_t sensor_sub) = 0;
 
 	unsigned _num_sensor_instances{0};
-	int _sensor_subs[SENSOR_COUNT_MAX];
+	orb_sub_t _sensor_subs[SENSOR_COUNT_MAX];
 };

--- a/src/modules/temperature_compensation/temperature_calibration/gyro.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/gyro.cpp
@@ -45,7 +45,7 @@
 #include <drivers/drv_hrt.h>
 
 TemperatureCalibrationGyro::TemperatureCalibrationGyro(float min_temperature_rise, float min_start_temperature,
-		float max_start_temperature, int gyro_subs[], int num_gyros)
+		float max_start_temperature, orb_sub_t gyro_subs[], int num_gyros)
 	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature, max_start_temperature)
 {
 	for (int i = 0; i < num_gyros; ++i) {
@@ -55,7 +55,7 @@ TemperatureCalibrationGyro::TemperatureCalibrationGyro(float min_temperature_ris
 	_num_sensor_instances = num_gyros;
 }
 
-int TemperatureCalibrationGyro::update_sensor_instance(PerSensorData &data, int sensor_sub)
+int TemperatureCalibrationGyro::update_sensor_instance(PerSensorData &data, orb_sub_t sensor_sub)
 {
 	bool finished = data.hot_soaked;
 

--- a/src/modules/temperature_compensation/temperature_calibration/gyro.h
+++ b/src/modules/temperature_compensation/temperature_calibration/gyro.h
@@ -40,7 +40,7 @@ class TemperatureCalibrationGyro : public TemperatureCalibrationCommon<3, 3>
 {
 public:
 	TemperatureCalibrationGyro(float min_temperature_rise, float min_start_temperature, float max_start_temperature,
-				   int gyro_subs[], int num_gyros);
+				   orb_sub_t gyro_subs[], int num_gyros);
 	virtual ~TemperatureCalibrationGyro() {}
 
 	/**
@@ -50,7 +50,7 @@ public:
 
 private:
 
-	virtual int update_sensor_instance(PerSensorData &data, int sensor_sub);
+	virtual int update_sensor_instance(PerSensorData &data, orb_sub_t sensor_sub);
 
 	inline int finish_sensor_instance(PerSensorData &data, int sensor_index);
 };

--- a/src/modules/temperature_compensation/temperature_calibration/mag.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/mag.cpp
@@ -68,7 +68,7 @@ TemperatureCalibrationMag::~TemperatureCalibrationMag()
 	}
 }
 
-int TemperatureCalibrationMag::update_sensor_instance(PerSensorData &data, int sensor_sub)
+int TemperatureCalibrationMag::update_sensor_instance(PerSensorData &data, orb_sub_t sensor_sub)
 {
 	bool finished = data.hot_soaked;
 

--- a/src/modules/temperature_compensation/temperature_calibration/mag.h
+++ b/src/modules/temperature_compensation/temperature_calibration/mag.h
@@ -49,7 +49,7 @@ public:
 
 private:
 
-	virtual inline int update_sensor_instance(PerSensorData &data, int sensor_sub);
+	virtual inline int update_sensor_instance(PerSensorData &data, orb_sub_t sensor_sub);
 
 	inline int finish_sensor_instance(PerSensorData &data, int sensor_index);
 };

--- a/src/modules/temperature_compensation/temperature_calibration/task.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/task.cpp
@@ -103,7 +103,7 @@ private:
 void TemperatureCalibration::task_main()
 {
 	// subscribe to all gyro instances
-	int gyro_sub[SENSOR_COUNT_MAX] {-1, -1, -1};
+	orb_sub_t gyro_sub[SENSOR_COUNT_MAX] {ORB_SUB_INVALID, ORB_SUB_INVALID, ORB_SUB_INVALID};
 	px4_pollfd_struct_t fds[SENSOR_COUNT_MAX] {};
 	unsigned num_gyro = orb_group_count(ORB_ID(sensor_gyro));
 

--- a/src/modules/uxrce_dds_client/dds_topics.h.em
+++ b/src/modules/uxrce_dds_client/dds_topics.h.em
@@ -121,7 +121,7 @@ void SendTopicsSubs::reset() {
 	for (unsigned idx = 0; idx < sizeof(send_subscriptions)/sizeof(send_subscriptions[0]); ++idx) {
 		send_subscriptions[idx].data_writer = uxr_object_id(0, UXR_INVALID_ID);
 		orb_unsubscribe(fds[idx].fd);
-		fds[idx].fd = -1;
+		fds[idx].fd = ORB_SUB_INVALID;
 		fds[idx].events = 0;  // force re-subscribe on reconnect (init() skips when events != 0)
 	}
 };

--- a/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
+++ b/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
@@ -673,10 +673,10 @@ void UxrceddsClient::run()
 			int orb_poll_timeout_ms = 1;
 
 			if (_fd >= 0) {
-				px4_pollfd_struct_t transport_pollfd {};
+				struct pollfd transport_pollfd {};
 				transport_pollfd.fd = _fd;
 				transport_pollfd.events = POLLIN;
-				const int transport_poll = px4_poll(&transport_pollfd, 1, 0);
+				const int transport_poll = poll(&transport_pollfd, 1, 0);
 
 				if (transport_poll > 0) {
 					orb_poll_timeout_ms = 0;

--- a/src/modules/zenoh/publishers/uorb_publisher.hpp
+++ b/src/modules/zenoh/publishers/uorb_publisher.hpp
@@ -118,6 +118,6 @@ public:
 
 private:
 	const orb_metadata *_uorb_meta;
-	int _uorb_sub;
+	orb_sub_t _uorb_sub{ORB_SUB_INVALID};
 	const uint32_t *_cdr_ops;
 };

--- a/src/systemcmds/microbench/test_microbench_uorb.cpp
+++ b/src/systemcmds/microbench/test_microbench_uorb.cpp
@@ -146,10 +146,10 @@ ut_declare_test_c(test_microbench_uorb, MicroBenchORB)
 
 bool MicroBenchORB::time_px4_uorb()
 {
-	int fd_status = orb_subscribe(ORB_ID(failsafe_flags));
-	int fd_lpos = orb_subscribe(ORB_ID(vehicle_local_position));
-	int fd_gyro = orb_subscribe(ORB_ID(sensor_gyro));
-	int fd_gyro_fifo = orb_subscribe(ORB_ID(sensor_gyro_fifo));
+	orb_sub_t fd_status = orb_subscribe(ORB_ID(failsafe_flags));
+	orb_sub_t fd_lpos = orb_subscribe(ORB_ID(vehicle_local_position));
+	orb_sub_t fd_gyro = orb_subscribe(ORB_ID(sensor_gyro));
+	orb_sub_t fd_gyro_fifo = orb_subscribe(ORB_ID(sensor_gyro_fifo));
 
 	int ret = 0;
 	bool updated = false;

--- a/src/systemcmds/tests/test_rc.cpp
+++ b/src/systemcmds/tests/test_rc.cpp
@@ -37,6 +37,7 @@
  */
 
 #include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/posix.h>
 
 #include <sys/types.h>
 
@@ -59,7 +60,7 @@
 
 int test_rc(int argc, char *argv[])
 {
-	int _rc_sub = orb_subscribe(ORB_ID(input_rc));
+	orb_sub_t _rc_sub = orb_subscribe(ORB_ID(input_rc));
 
 	/* read low-level values from FMU or IO RC inputs (PPM, Spektrum, S.Bus) */
 	struct input_rc_s rc_input;
@@ -85,7 +86,7 @@ int test_rc(int argc, char *argv[])
 		rc_last.channel_count = rc_input.channel_count;
 
 		/* poll descriptor */
-		struct pollfd fds[2];
+		px4_pollfd_struct_t fds[2];
 		fds[0].fd = _rc_sub;
 		fds[0].events = POLLIN;
 		fds[1].fd = 0;
@@ -93,7 +94,7 @@ int test_rc(int argc, char *argv[])
 
 		while (true) {
 
-			int ret = poll(fds, 2, 200);
+			int ret = px4_poll(fds, 2, 200);
 
 			if (ret > 0) {
 

--- a/src/systemcmds/topic_listener/topic_listener.hpp
+++ b/src/systemcmds/topic_listener/topic_listener.hpp
@@ -50,7 +50,7 @@
 #include <stdlib.h>
 #include <inttypes.h>
 
-inline int listener_print_topic(const orb_id_t &orb_id, int subscription)
+inline int listener_print_topic(const orb_id_t &orb_id, orb_sub_t subscription)
 {
 	static constexpr int max_size = 512;
 	alignas(8) char container[max_size];


### PR DESCRIPTION
This PR suggest introducing a separate type for orb subscription, orb_sub_t. This is similar to orb_advert_t.

This PR should not introduce any functional change, it is mechanical, and related to discussion / request from @dakejahl  in this PR: https://github.com/PX4/PX4-Autopilot/pull/27331 .

The changes in nutshell:
- Introduce a type orb_sub_t , typedef it to int (which is the current type)
- Add inline functions for checking the subscription validity, instead of simply comparing the file descriptor number
- Add an initializer for invalid/uninitialized subscription (ORB_SUB_INVALID)
- Take the new type and initializer in use accross the codebase

This allows changing the subscription type later on (in case we want to progress with PR#27331), and harmonizes the checking of invalid subscription handle accross the codebase. It also treats the subscription handle symmetrically with advertisement handle, which has an own type already.
