### PR TITLE
Fixedwing: Airbrake augmented TECS

### DIFF
--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -245,6 +245,11 @@ void TECSControl::initialize(const Setpoint &setpoint, const Input &input, Param
 
 	ControlValues ste_rate{_calcThrottleControlSteRate(limit, specific_energy_rate, param)};
 
+	_spoiler_setpoint = math::constrain((limit.STE_rate_min - ste_rate.setpoint) / (-limit.STE_rate_min),
+					    0.0f, param.spoiler_max);
+
+	ste_rate.setpoint = constrain(ste_rate.setpoint, limit.STE_rate_min, limit.STE_rate_max);
+
 	_throttle_setpoint = _calcThrottleControlOutput(limit, ste_rate, param, flag);
 
 	// Debug output
@@ -514,6 +519,15 @@ void TECSControl::_calcThrottleControl(float dt, const SpecificEnergyRates &spec
 	_ste_rate_estimate_filter.setParameters(dt, param.ste_rate_time_const);
 	_ste_rate_estimate_filter.update(STE_rate_estimate_raw);
 	ControlValues ste_rate{_calcThrottleControlSteRate(limit, specific_energy_rates, param)};
+
+	// Spoiler: non-zero when unconstrained STE rate demand exceeds what min throttle can dissipate.
+	// Normalised by |STE_rate_min|: 1.0 = needing one additional min_sink_rate * g of energy removal.
+	_spoiler_setpoint = math::constrain((limit.STE_rate_min - ste_rate.setpoint) / (-limit.STE_rate_min),
+					    0.0f, param.spoiler_max);
+
+	// Constrain STE rate setpoint to achievable range before using it for throttle control.
+	ste_rate.setpoint = constrain(ste_rate.setpoint, limit.STE_rate_min, limit.STE_rate_max);
+
 	float throttle_setpoint{param.throttle_min};
 
 	if (1.f - param.fast_descend < FLT_EPSILON) {
@@ -554,7 +568,6 @@ TECSControl::ControlValues TECSControl::_calcThrottleControlSteRate(const STERat
 	// The additional normal load factor is given by (1/cos(bank angle) - 1)
 	ste_rate.setpoint += param.load_factor_correction * (param.load_factor - 1.f);
 
-	ste_rate.setpoint = constrain(ste_rate.setpoint, limit.STE_rate_min, limit.STE_rate_max);
 	ste_rate.estimate = _ste_rate_estimate_filter.getState();
 
 	return ste_rate;

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -245,10 +245,11 @@ public:
 		float integrator_gain_pitch;				///< Integrator gain used by the pitch demand calculation.
 		float pitch_damping_gain;				///< Damping gain of the pitch demand calculation [s].
 
-		// Throttle control param
+		// Throttle/spoiler control param
 		float integrator_gain_throttle;				///< Integrator gain used by the throttle demand calculation.
 		float throttle_damping_gain;				///< Damping gain of the throttle demand calculation [s].
 		float throttle_slewrate;				///< Throttle demand slew rate limit [1/s].
+		float spoiler_max;					///< Maximum spoiler setpoint upper limit [0,1].
 
 		float load_factor_correction;				///< Gain from normal load factor increase to total energy rate demand [m²/s³].
 		float load_factor;					///< Additional normal load factor.
@@ -335,6 +336,14 @@ public:
 	 * @return throttle setpoint.
 	 */
 	float getThrottleSetpoint() const {return _throttle_setpoint;};
+	/**
+	 * @brief Get the spoiler setpoint.
+	 * Non-zero only when the unconstrained STE rate setpoint falls below the min-throttle dissipation limit,
+	 * i.e. when excess energy cannot be shed by reducing throttle alone.
+	 *
+	 * @return Spoiler setpoint in [0, 1].
+	 */
+	float getSpoilerSetpoint() const {return _spoiler_setpoint;};
 	/**
 	 * @brief Get the pitch setpoint.
 	 *
@@ -512,12 +521,14 @@ private:
 				  const Flag &flag);
 
 	/**
-	 * @brief Calculate throttle control specific total energy
+	 * @brief Calculate throttle control specific total energy rate.
+	 * Returns the unconstrained STE rate setpoint (load-factor-corrected sum of SPE and SKE rate setpoints).
+	 * Callers are responsible for applying [STE_rate_min, STE_rate_max] before using the setpoint for throttle.
 	 *
 	 * @param limit is the specific total energy rate limits in [m²/s³].
 	 * @param specific_energy_rate is the specific energy rates in [m²/s³].
 	 * @param param is the control parameters.
-	 * @return specific total energy rate values in [m²/s³]
+	 * @return specific total energy rate values in [m²/s³] with unconstrained setpoint.
 	 */
 	ControlValues _calcThrottleControlSteRate(const STERateLimit &limit, const SpecificEnergyRates &specific_energy_rate,
 			const Param &param) const;
@@ -557,6 +568,7 @@ private:
 	DebugOutput _debug_output;				///< Debug output.
 	float _pitch_setpoint{0.0f};				///< Controlled pitch setpoint above trim [rad].
 	float _throttle_setpoint{0.0f};				///< Controlled throttle setpoint [0,1].
+	float _spoiler_setpoint{0.0f};				///< Controlled spoiler setpoint [0,1].
 	float _ratio_undersped{0.0f};				///< A continuous representation of how "undersped" the TAS is [0,1]
 };
 
@@ -663,6 +675,9 @@ public:
 
 	float get_pitch_setpoint() {return _control.getPitchSetpoint();}
 	float get_throttle_setpoint() {return _control.getThrottleSetpoint();}
+	float get_spoiler_setpoint() {return _control.getSpoilerSetpoint();}
+
+	void set_spoiler_max(float spoiler_max) { _control_param.spoiler_max = math::constrain(spoiler_max, 0.0f, 1.0f); };
 
 	/**
 	 * Returns the altitude tracking time constant
@@ -759,6 +774,7 @@ private:
 		.integrator_gain_throttle = 0.0f,
 		.throttle_damping_gain = 0.0f,
 		.throttle_slewrate = 0.0f,
+		.spoiler_max = 1.0f,
 		.load_factor_correction = 0.0f,
 		.load_factor = 1.0f,
 		.fast_descend = 0.f

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -76,6 +76,7 @@ FwLateralLongitudinalControl::FwLateralLongitudinalControl(bool is_vtol) :
 	_tecs_status_pub.advertise();
 	_flight_phase_estimation_pub.advertise();
 	_fixed_wing_lateral_status_pub.advertise();
+	_spoilers_setpoint_pub.advertise();
 	parameters_update();
 	_airspeed_slew_rate_controller.setSlewRate(ASPD_SP_SLEW_RATE);
 }
@@ -110,6 +111,7 @@ FwLateralLongitudinalControl::parameters_update()
 	_tecs.set_airspeed_error_time_constant(_param_fw_t_tas_error_tc.get());
 	_tecs.set_ste_rate_time_const(_param_ste_rate_time_const.get());
 	_tecs.set_seb_rate_ff_gain(_param_seb_rate_ff.get());
+	_tecs.set_spoiler_max(_param_fw_t_spoiler_max.get());
 
 	_roll_slew_rate.setSlewRate(radians(_param_fw_pn_r_slew_max.get()));
 
@@ -228,6 +230,11 @@ void FwLateralLongitudinalControl::Run()
 			pitch_sp = PX4_ISFINITE(_long_control_sp.pitch_direct) ? _long_control_sp.pitch_direct : _tecs.get_pitch_setpoint();
 			throttle_sp = PX4_ISFINITE(_long_control_sp.throttle_direct) ? _long_control_sp.throttle_direct :
 				      _tecs.get_throttle_setpoint();
+
+			normalized_unsigned_setpoint_s spoilers_sp{};
+			spoilers_sp.timestamp = now;
+			spoilers_sp.normalized_setpoint = _tecs.get_spoiler_setpoint();
+			_spoilers_setpoint_pub.publish(spoilers_sp);
 
 			// ----- Lateral ------
 			float roll_sp {NAN};

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
@@ -137,6 +137,7 @@ private:
 	uORB::Publication <tecs_status_s> _tecs_status_pub{ORB_ID(tecs_status)};
 	uORB::PublicationData <flight_phase_estimation_s> _flight_phase_estimation_pub{ORB_ID(flight_phase_estimation)};
 	uORB::Publication <fixed_wing_lateral_status_s> _fixed_wing_lateral_status_pub{ORB_ID(fixed_wing_lateral_status)};
+	uORB::Publication <normalized_unsigned_setpoint_s> _spoilers_setpoint_pub{ORB_ID(spoilers_setpoint)};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::FW_PSP_OFF>) _param_fw_psp_off,
@@ -170,7 +171,8 @@ private:
 		(ParamFloat<px4::params::FW_WIND_ARSP_SC>) _param_fw_wind_arsp_sc,
 		(ParamFloat<px4::params::FW_GND_SPD_MIN>) _param_fw_gnd_spd_min,
 		(ParamFloat<px4::params::NPFG_DAMPING>) _param_npfg_damping,
-		(ParamFloat<px4::params::NPFG_PERIOD>) _param_npfg_period
+		(ParamFloat<px4::params::NPFG_PERIOD>) _param_npfg_period,
+		(ParamFloat<px4::params::FW_T_SPOILER_MAX>) _param_fw_t_spoiler_max
 	)
 
 	hrt_abstime _last_time_loop_ran{};

--- a/src/modules/fw_lateral_longitudinal_control/fw_lat_long_params.yaml
+++ b/src/modules/fw_lateral_longitudinal_control/fw_lat_long_params.yaml
@@ -202,3 +202,17 @@ parameters:
       max: 15.0
       decimal: 1
       increment: 0.5
+    FW_T_SPOILER_MAX:
+      description:
+        short: Maximum TECS spoiler setpoint
+        long: |-
+          Upper limit on the spoiler setpoint commanded by TECS when excess energy
+          cannot be dissipated through throttle reduction alone (e.g. ridge soaring).
+          Set to 0 to disable TECS-driven spoiler commands.
+      type: float
+      default: 0.0
+      unit: norm
+      min: 0.0
+      max: 1.0
+      decimal: 2
+      increment: 0.01


### PR DESCRIPTION
### Solved Problem
High aspect ratio fixed-wing platforms can lose control authority in updrafts due to their small sink rate under zero throttle. 


Fixes #{Github issue ID}

### Solution
This PR adds spoilers to enduce sink rate to be able bleed energy off under zero throttle.

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video
