### PR TITLE
fix(mavlink): preserve invalid battery values on receive

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1952,23 +1952,28 @@ MavlinkReceiver::handle_message_battery_status(mavlink_message_t *msg)
 	}
 
 	battery_status.voltage_v = voltage_sum;
-	battery_status.current_a = (float)(battery_mavlink.current_battery) / 100.0f;
-	battery_status.remaining = (float)battery_mavlink.battery_remaining / 100.0f;
+	battery_status.current_a = (battery_mavlink.current_battery == -1) ?
+				   -1.0f : (float)(battery_mavlink.current_battery) / 100.0f;
+	battery_status.remaining = (battery_mavlink.battery_remaining == -1) ?
+				   -1.0f : (float)battery_mavlink.battery_remaining / 100.0f;
 	battery_status.discharged_mah = (float)battery_mavlink.current_consumed;
 	battery_status.cell_count = cell_count;
-	battery_status.temperature = (float)battery_mavlink.temperature;
+	battery_status.temperature = (battery_mavlink.temperature == INT16_MAX) ?
+				     NAN : (float)battery_mavlink.temperature / 100.0f;
 	battery_status.connected = true;
 
-	// Set the battery warning based on remaining charge.
+	// Set the battery warning based on remaining charge, if available.
 	//  Note: Smallest values must come first in evaluation.
-	if (battery_status.remaining < _param_bat_emergen_thr.get()) {
-		battery_status.warning = battery_status_s::WARNING_EMERGENCY;
+	if (battery_status.remaining >= 0.0f) {
+		if (battery_status.remaining < _param_bat_emergen_thr.get()) {
+			battery_status.warning = battery_status_s::WARNING_EMERGENCY;
 
-	} else if (battery_status.remaining < _param_bat_crit_thr.get()) {
-		battery_status.warning = battery_status_s::WARNING_CRITICAL;
+		} else if (battery_status.remaining < _param_bat_crit_thr.get()) {
+			battery_status.warning = battery_status_s::WARNING_CRITICAL;
 
-	} else if (battery_status.remaining < _param_bat_low_thr.get()) {
-		battery_status.warning = battery_status_s::WARNING_LOW;
+		} else if (battery_status.remaining < _param_bat_low_thr.get()) {
+			battery_status.warning = battery_status_s::WARNING_LOW;
+		}
 	}
 
 	_battery_pub.publish(battery_status);


### PR DESCRIPTION
### Solved Problem

Received MAVLink `BATTERY_STATUS` messages did not preserve invalid `-1` markers for battery current and remaining charge when converting them to uORB values. This could also cause an unavailable remaining charge value to be reported as an emergency battery warning.

Additionally, received battery temperature was published without converting from centidegrees Celsius to degrees Celsius or handling its invalid value.

### Solution
Preserve invalid values and apply the correct received-field conversions.

### Changelog Entry
For release notes:
```
Bugfix: Fix handling of received MAVLink BATTERY_STATUS values
```