### PR TITLE
fix(fmu-v5x): use single EKF on Skynode

### DIFF
--- a/boards/px4/fmu-v5x/init/rc.board_defaults
+++ b/boards/px4/fmu-v5x/init/rc.board_defaults
@@ -12,6 +12,10 @@ then
 
 	# The buzzer draws too much power (0.2A) on the GPS power rail (limit 0.45A).
 	param set-default CBRK_BUZZER 782097
+
+	# Single EKF: Skynode too loaded for the F7-default 3x Multi-EKF
+	param set-default -s EKF2_MULTI_IMU 0
+	param set-default SENS_IMU_MODE 1
 else
 	# Mavlink ethernet (CFG 1000)
 	param set-default MAV_2_CONFIG 1000


### PR DESCRIPTION
### Solved Problem
On Skynode (fmu-v5x / STM32F765) the STM32F7 arch default `EKF2_MULTI_IMU=3`
saturates CPU and RAM so the CPU/RAM preflight checks fail.

### Solution
  Use a single EKF on Skynode (EKF2_MULTI_IMU=0, SENS_IMU_MODE=1). Preflight passes;
  other F7 boards and the bare Pixhawk 5X are unaffected.
