### PR TITLE
fix(fw_mode_manager): guard course guidance on GUIDED_COURSE nav state

### DIFF
--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -571,7 +571,8 @@ FixedWingModeManager::control_auto(const float control_interval, const Vector2d 
 	move_position_setpoint_for_vtol_transition(current_sp);
 
 	// Course setpoints are handled directly to avoid entering hold mode
-	if (PX4_ISFINITE(current_sp.course)) {
+	if (PX4_ISFINITE(current_sp.course)
+	    && _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_GUIDED_COURSE) {
 		control_auto_position(control_interval, curr_pos, ground_speed, pos_sp_prev, current_sp);
 		return;
 	}
@@ -775,7 +776,8 @@ FixedWingModeManager::control_auto_position(const float control_interval, const 
 		const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr)
 {
 	// Course Hold: if a course is explicitly set, navigate along that bearing (ground track)
-	if (PX4_ISFINITE(pos_sp_curr.course)) {
+	if (PX4_ISFINITE(pos_sp_curr.course)
+	    && _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_GUIDED_COURSE) {
 		const float target_airspeed = pos_sp_curr.cruising_speed > FLT_EPSILON ? pos_sp_curr.cruising_speed : NAN;
 
 		const Vector2f curr_pos_local{_local_pos.x, _local_pos.y};


### PR DESCRIPTION
### Solved Problem

The newly added course field in `PositionSetpoint.msg` defaults to 0.0f when the reposition triplet struct is zero-initialized and when [repositioning a loiter](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/navigator/loiter.cpp#L172). 

Since 0.0f is a finite value, the FW position controller's [PX4_ISFINITE(course)](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/fw_mode_manager/FixedWingModeManager.cpp#L574) guard treated every GCS-commanded loiter setpoint as a course guidance command, causing the vehicle to fly north (0 deg) instead of entering the intended loiter pattern.

### Solution

hotfix: guard the course setpoint on the nav_state being `GUIDED_COURSE`. 

I think ideally this needs to be fixed in the reset/initialization logic so we don't require the mode for the setpoint - but that would need a bit more testing. For now this works, and as the course setpoint is not consumed anywhere else, it doesn't break anything. 

### Changelog Entry
For release notes:
```
Feature/Bugfix (hotfix): prevent FW from flying north when GCS commands a position setpoint outside of Guided Course mode
```

### Test coverage
- Tested in SITL 

