### PR TITLE
feat(actuators): increase servo channel count from 8 to 15

### DIFF
--- a/msg/ActuatorServosTrim.msg
+++ b/msg/ActuatorServosTrim.msg
@@ -1,5 +1,5 @@
 # Servo trims, added as offset to servo outputs
 uint64 timestamp			# time since system start (microseconds)
 
-uint8 NUM_CONTROLS = 8
-float32[8] trim    # range: [-1, 1]
+uint8 NUM_CONTROLS = 15
+float32[15] trim    # range: [-1, 1]

--- a/msg/ActuatorTest.msg
+++ b/msg/ActuatorTest.msg
@@ -8,7 +8,7 @@ uint8 ACTION_DO_CONTROL = 1			# enable actuator test mode
 uint8 FUNCTION_MOTOR1 = 101
 uint8 MAX_NUM_MOTORS  = 12
 uint8 FUNCTION_SERVO1 = 201
-uint8 MAX_NUM_SERVOS  = 8
+uint8 MAX_NUM_SERVOS  = 15
 
 uint8 action					# one of ACTION_*
 uint16 function					# actuator output function

--- a/msg/px4_msgs_old/msg/ActuatorServosV0.msg
+++ b/msg/px4_msgs_old/msg/ActuatorServosV0.msg
@@ -1,0 +1,12 @@
+# Servo control message
+#
+# Normalised output setpoint for up to 8 servos.
+# Published by the vehicle's allocation and consumed by the actuator output drivers.
+
+uint32 MESSAGE_VERSION = 0
+
+uint64 timestamp # [us] Time since system start
+uint64 timestamp_sample # [us] Sampling timestamp of the data this control response is based on
+
+uint8 NUM_CONTROLS = 8
+float32[8] control # [-] [@range -1, 1] Normalized output. 1 means maximum positive position. -1 maximum negative position (if not supported by the output, <0 maps to NaN). NaN maps to disarmed.

--- a/msg/translation_node/translations/all_translations.h
+++ b/msg/translation_node/translations/all_translations.h
@@ -6,6 +6,7 @@
 
 #include <translation_util.h>
 
+#include "translation_actuator_servos_v1.h"
 #include "translation_airspeed_validated_v1.h"
 #include "translation_aux_global_position_v1.h"
 #include "translation_arming_check_reply_v1.h"

--- a/msg/translation_node/translations/translation_actuator_servos_v1.h
+++ b/msg/translation_node/translations/translation_actuator_servos_v1.h
@@ -1,0 +1,45 @@
+/****************************************************************************
+ * Copyright (c) 2026 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+#pragma once
+
+// Translate ActuatorServos v0 <--> v1
+#include <px4_msgs_old/msg/actuator_servos_v0.hpp>
+#include <px4_msgs/msg/actuator_servos.hpp>
+
+class ActuatorServosV1Translation {
+public:
+	using MessageOlder = px4_msgs_old::msg::ActuatorServosV0;
+	static_assert(MessageOlder::MESSAGE_VERSION == 0);
+
+	using MessageNewer = px4_msgs::msg::ActuatorServos;
+	static_assert(MessageNewer::MESSAGE_VERSION == 1);
+
+	static constexpr const char* kTopic = "fmu/in/actuator_servos";
+
+	static void fromOlder(const MessageOlder &msg_older, MessageNewer &msg_newer) {
+		msg_newer.timestamp = msg_older.timestamp;
+		msg_newer.timestamp_sample = msg_older.timestamp_sample;
+
+		for (int i = 0; i < 8; ++i) {
+			msg_newer.control[i] = msg_older.control[i];
+		}
+
+		// Channels 8-14 did not exist in v0; treat as disarmed
+		for (int i = 8; i < 15; ++i) {
+			msg_newer.control[i] = NAN;
+		}
+	}
+
+	static void toOlder(const MessageNewer &msg_newer, MessageOlder &msg_older) {
+		msg_older.timestamp = msg_newer.timestamp;
+		msg_older.timestamp_sample = msg_newer.timestamp_sample;
+
+		for (int i = 0; i < 8; ++i) {
+			msg_older.control[i] = msg_newer.control[i];
+		}
+	}
+};
+
+REGISTER_TOPIC_TRANSLATION_DIRECT(ActuatorServosV1Translation);

--- a/msg/versioned/ActuatorServos.msg
+++ b/msg/versioned/ActuatorServos.msg
@@ -1,12 +1,12 @@
 # Servo control message
 #
-# Normalised output setpoint for up to 8 servos.
+# Normalised output setpoint for up to 15 servos.
 # Published by the vehicle's allocation and consumed by the actuator output drivers.
 
-uint32 MESSAGE_VERSION = 0
+uint32 MESSAGE_VERSION = 1
 
 uint64 timestamp # [us] Time since system start
 uint64 timestamp_sample # [us] Sampling timestamp of the data this control response is based on
 
-uint8 NUM_CONTROLS = 8
-float32[8] control # [-] [@range -1, 1] Normalized output. 1 means maximum positive position. -1 maximum negative position (if not supported by the output, <0 maps to NaN). NaN maps to disarmed.
+uint8 NUM_CONTROLS = 15
+float32[15] control # [-] [@range -1, 1] Normalized output. 1 means maximum positive position. -1 maximum negative position (if not supported by the output, <0 maps to NaN). NaN maps to disarmed.

--- a/src/drivers/uavcan/actuators/servo.hpp
+++ b/src/drivers/uavcan/actuators/servo.hpp
@@ -45,7 +45,7 @@
 class UavcanServoController
 {
 public:
-	static constexpr int MAX_ACTUATORS = 8;
+	static constexpr int MAX_ACTUATORS = 15;
 	static constexpr unsigned MAX_RATE_HZ = 50;
 	static constexpr unsigned UAVCAN_COMMAND_TRANSFER_PRIORITY = 6;	///< 0..31, inclusive, 0 - highest, 31 - lowest
 

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -1,4 +1,5 @@
 __max_num_uavcan_lights: &max_num_uavcan_lights 2 # NOTE: This value must match MAX_NUM_UAVCAN_LIGHTS in rgbled.hpp
+__max_num_uavcan_servos: &max_num_uavcan_servos 15 # NOTE: This value must match MAX_ACTUATORS in actuators/servo.hpp
 
 
 module_name: UAVCAN
@@ -97,4 +98,4 @@ actuator_output:
         min: { min: 0, max: 1000, default: 0 }
         max: { min: 0, max: 1000, default: 1000 }
         failsafe: { min: 0, max: 1000 }
-      num_channels: 8
+      num_channels: *max_num_uavcan_servos

--- a/src/drivers/voxl2_io/voxl2_io.cpp
+++ b/src/drivers/voxl2_io/voxl2_io.cpp
@@ -158,7 +158,7 @@ int Voxl2IO::load_params(voxl2_io_params_t *params)
 
 	// PWM output functions
 	//0: disabled, 1: constant min, 2: constant max
-	//101-112: motors, 201-208: servos, 402: RC Roll, 403: RC Pitch, 404: RC Throttle,
+	//101-112: motors, 201-215: servos, 402: RC Roll, 403: RC Pitch, 404: RC Throttle,
 	//405: RC Yaw, 406: RC Flaps, 407-412: RC AUX 1-6, 420-422: Gimbal RPY
 	param_get(param_find("VOXL2_IO_FUNC1"),  &params->function_map[0]);
 	param_get(param_find("VOXL2_IO_FUNC2"),  &params->function_map[1]);

--- a/src/lib/mixer_module/output_functions.yaml
+++ b/src/lib/mixer_module/output_functions.yaml
@@ -12,7 +12,7 @@ functions:
       count: 12
     Servo:
       start: 201
-      count: 8
+      count: 15
     Peripheral_via_Actuator_Set:
       start: 301
       count: 6

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -1,5 +1,6 @@
 __max_num_mc_motors: &max_num_mc_motors 12
-__max_num_servos: &max_num_servos 8
+__max_num_servos: &max_num_servos 15
+__max_num_control_surfaces: &max_num_control_surfaces 8
 __max_num_tilts: &max_num_tilts 4
 
 module_name: Control Allocation
@@ -278,7 +279,7 @@ parameters:
                 16: Steering Wheel
                 17: Left Spoiler
                 18: Right Spoiler
-            num_instances: *max_num_servos
+            num_instances: *max_num_control_surfaces
             instance_start: 0
             default: 0
 
@@ -287,7 +288,7 @@ parameters:
                 short: Control Surface ${i} roll torque scaling
             type: float
             decimal: 2
-            num_instances: *max_num_servos
+            num_instances: *max_num_control_surfaces
             instance_start: 0
             default: 0.0
 
@@ -296,7 +297,7 @@ parameters:
                 short: Control Surface ${i} pitch torque scaling
             type: float
             decimal: 2
-            num_instances: *max_num_servos
+            num_instances: *max_num_control_surfaces
             instance_start: 0
             default: 0.0
 
@@ -305,7 +306,7 @@ parameters:
                 short: Control Surface ${i} yaw torque scaling
             type: float
             decimal: 2
-            num_instances: *max_num_servos
+            num_instances: *max_num_control_surfaces
             instance_start: 0
             default: 0.0
 
@@ -321,7 +322,7 @@ parameters:
             decimal: 2
             min: -1.0
             max: 1.0
-            num_instances: *max_num_servos
+            num_instances: *max_num_control_surfaces
             instance_start: 0
             default: 0.0
 
@@ -332,7 +333,7 @@ parameters:
             decimal: 2
             min: -1.0
             max: 1.0
-            num_instances: *max_num_servos
+            num_instances: *max_num_control_surfaces
             instance_start: 0
             default: 0
 
@@ -352,7 +353,7 @@ parameters:
             decimal: 2
             min: -1.0
             max: 1.0
-            num_instances: *max_num_servos
+            num_instances: *max_num_control_surfaces
             instance_start: 0
             default: 0
 


### PR DESCRIPTION
### Solved Problem
Vehicles get more and more complex and the current maximum of 8 servos is not enough to control some of them.
As those 8 servos are a shared pool across all outputs (PWM, UAVCAN, PCF9685 ...) it is not enough to for example map 8 to PWM_MAIN and 8 to PWM_AUX.

### Solution
Increase the amount of supported servos to 15. This value was chosen as it is enough for future use-cases and avoids consuming too much FLASH. In addition it is the size that can be sent out over UAVCAN without needing to split the `ArrayCommand` messages.

As the backends themselves define how much outputs they actually have this will also not create "fake" servos for PWM_MAIN and PWM_AUX. It does however do so for UAVCAN, but this was already the case before (needs a separate fix).

**Note**: This creates a new version of `ActuatorServos.msg`, so it breaks a versioned message. I added the translation code but users may need to adapt.

### Changelog Entry

For release notes:
```
Feature: Increase servo channel count from 8 to 15. New version of ActuatorServo, please update your ROS uses of this message
```

### Test coverage
Tested on a v6x, mapped Servo1 - Servo15 to different outputs on PWM_MAIN, PWM_AUX and UAVCAN, checked that all params exist, set min/max/center/disarm/rev, check servo movement.