### PR TITLE
fix(fw_mode_manager): honor DO_CHANGE_SPEED in manual airspeed modes

### DIFF
--- a/docs/en/flight_modes_fw/altitude.md
+++ b/docs/en/flight_modes_fw/altitude.md
@@ -65,8 +65,9 @@ The following commands are relevant to this mode:
 
   This requires an airspeed sensor.
   At centered throttle the vehicle holds the commanded airspeed (`param2`) if set.
-  The value is constrained between [FW_AIRSPD_MIN](../advanced_config/parameter_reference.md#FW_AIRSPD_MIN) and [FW_AIRSPD_MAX](../advanced_config/parameter_reference.md#FW_AIRSPD_MAX), and defaults to [FW_AIRSPD_TRIM](../advanced_config/parameter_reference.md#FW_AIRSPD_TRIM) if `param2` was not set.
+  The value is constrained between [FW_AIRSPD_MIN](../advanced_config/parameter_reference.md#FW_AIRSPD_MIN) and [FW_AIRSPD_MAX](../advanced_config/parameter_reference.md#FW_AIRSPD_MAX), and defaults to [FW_AIRSPD_TRIM](../advanced_config/parameter_reference.md#FW_AIRSPD_TRIM) if no airspeed has been commanded.
   Deflecting the throttle stick scales the airspeed toward `FW_AIRSPD_MIN` (back) or `FW_AIRSPD_MAX` (forward) around this value.
+  The commanded airspeed resets to `FW_AIRSPD_TRIM` on every flight mode change.
 
 Note, other commands may be supported.
 

--- a/docs/en/flight_modes_fw/altitude.md
+++ b/docs/en/flight_modes_fw/altitude.md
@@ -64,7 +64,8 @@ The following commands are relevant to this mode:
 - [MAV_CMD_DO_CHANGE_SPEED](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED) — Sets the cruise airspeed for centred throttle stick.
 
   This requires an airspeed sensor.
-  At centered throttle the vehicle holds the commanded airspeed (`param2`) if set.
+  Only the airspeed speed type is handled (`param1` must be `0`); other speed types are ignored.
+  At centered throttle the vehicle holds the commanded airspeed (`param2`) if a positive value is set (non-positive values are ignored).
   The value is constrained between [FW_AIRSPD_MIN](../advanced_config/parameter_reference.md#FW_AIRSPD_MIN) and [FW_AIRSPD_MAX](../advanced_config/parameter_reference.md#FW_AIRSPD_MAX), and defaults to [FW_AIRSPD_TRIM](../advanced_config/parameter_reference.md#FW_AIRSPD_TRIM) if no airspeed has been commanded.
   Deflecting the throttle stick scales the airspeed toward `FW_AIRSPD_MIN` (back) or `FW_AIRSPD_MAX` (forward) around this value.
   The commanded airspeed resets to `FW_AIRSPD_TRIM` on every flight mode change.

--- a/docs/en/flight_modes_fw/altitude.md
+++ b/docs/en/flight_modes_fw/altitude.md
@@ -57,6 +57,14 @@ The mode is affected by the following parameters:
 | <a id="FW_T_CLMB_R_SP"></a>[FW_T_CLMB_R_SP](../advanced_config/parameter_reference.md#FW_T_CLMB_R_SP) | Max climb rate setpoint. Default: 3 m/s.                             |
 | <a id="FW_T_SINK_R_SP"></a>[FW_T_SINK_R_SP](../advanced_config/parameter_reference.md#FW_T_SINK_R_SP) | Max sink rate setpoint. Default: 2 m/s.                              |
 
+## MAVLink Commands
+
+The following commands are relevant to this mode:
+
+- [MAV_CMD_DO_CHANGE_SPEED](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED) - Set the cruise airspeed that the throttle stick interpolates around, as described for [Position mode](../flight_modes_fw/position.md#mavlink-commands). The commanded value is shared between the two modes.
+
+Note, other commands may be supported.
+
 <!--
 FW notes:
 FW position controller is basically 2 independent pieces

--- a/docs/en/flight_modes_fw/altitude.md
+++ b/docs/en/flight_modes_fw/altitude.md
@@ -61,7 +61,12 @@ The mode is affected by the following parameters:
 
 The following commands are relevant to this mode:
 
-- [MAV_CMD_DO_CHANGE_SPEED](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED) - Set the cruise airspeed that the throttle stick interpolates around, as described for [Position mode](../flight_modes_fw/position.md#mavlink-commands). The commanded value is shared between the two modes.
+- [MAV_CMD_DO_CHANGE_SPEED](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED) — Sets the cruise airspeed for centred throttle stick.
+
+  This requires an airspeed sensor.
+  At centered throttle the vehicle holds the commanded airspeed (`param2`) if set.
+  The value is constrained between [FW_AIRSPD_MIN](../advanced_config/parameter_reference.md#FW_AIRSPD_MIN) and [FW_AIRSPD_MAX](../advanced_config/parameter_reference.md#FW_AIRSPD_MAX), and defaults to [FW_AIRSPD_TRIM](../advanced_config/parameter_reference.md#FW_AIRSPD_TRIM) if `param2` was not set.
+  Deflecting the throttle stick scales the airspeed toward `FW_AIRSPD_MIN` (back) or `FW_AIRSPD_MAX` (forward) around this value.
 
 Note, other commands may be supported.
 

--- a/docs/en/flight_modes_fw/position.md
+++ b/docs/en/flight_modes_fw/position.md
@@ -60,7 +60,8 @@ The following commands are relevant to this mode:
 
   This requires an airspeed sensor.
   At centered throttle the vehicle holds the commanded airspeed (`param2`) if set.
-  The value is constrained between [FW_AIRSPD_MIN](../advanced_config/parameter_reference.md#FW_AIRSPD_MIN) and [FW_AIRSPD_MAX](../advanced_config/parameter_reference.md#FW_AIRSPD_MAX), and defaults to [FW_AIRSPD_TRIM](../advanced_config/parameter_reference.md#FW_AIRSPD_TRIM) if `param2` was not set.
+  The value is constrained between [FW_AIRSPD_MIN](../advanced_config/parameter_reference.md#FW_AIRSPD_MIN) and [FW_AIRSPD_MAX](../advanced_config/parameter_reference.md#FW_AIRSPD_MAX), and defaults to [FW_AIRSPD_TRIM](../advanced_config/parameter_reference.md#FW_AIRSPD_TRIM) if no airspeed has been commanded.
   Deflecting the throttle stick scales the airspeed toward `FW_AIRSPD_MIN` (back) or `FW_AIRSPD_MAX` (forward) around this value.
+  The commanded airspeed resets to `FW_AIRSPD_TRIM` on every flight mode change.
 
 Note, other commands may be supported.

--- a/docs/en/flight_modes_fw/position.md
+++ b/docs/en/flight_modes_fw/position.md
@@ -56,9 +56,11 @@ The mode is affected by the following parameters:
 
 The following commands are relevant to this mode:
 
-- [MAV_CMD_DO_CHANGE_SPEED](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED) - Set the cruise airspeed that the throttle stick interpolates around (requires an airspeed sensor).
-  At centered throttle the vehicle holds the commanded airspeed (`param2`, constrained between [FW_AIRSPD_MIN](../advanced_config/parameter_reference.md#FW_AIRSPD_MIN) and [FW_AIRSPD_MAX](../advanced_config/parameter_reference.md#FW_AIRSPD_MAX)), defaulting to [FW_AIRSPD_TRIM](../advanced_config/parameter_reference.md#FW_AIRSPD_TRIM) if none was sent.
+- [MAV_CMD_DO_CHANGE_SPEED](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED) — Sets the cruise airspeed for centred throttle stick.
+
+  This requires an airspeed sensor.
+  At centered throttle the vehicle holds the commanded airspeed (`param2`) if set.
+  The value is constrained between [FW_AIRSPD_MIN](../advanced_config/parameter_reference.md#FW_AIRSPD_MIN) and [FW_AIRSPD_MAX](../advanced_config/parameter_reference.md#FW_AIRSPD_MAX), and defaults to [FW_AIRSPD_TRIM](../advanced_config/parameter_reference.md#FW_AIRSPD_TRIM) if `param2` was not set.
   Deflecting the throttle stick scales the airspeed toward `FW_AIRSPD_MIN` (back) or `FW_AIRSPD_MAX` (forward) around this value.
-  The value is shared with [Altitude mode](../flight_modes_fw/altitude.md) and resets to trim when entered from any other mode.
 
 Note, other commands may be supported.

--- a/docs/en/flight_modes_fw/position.md
+++ b/docs/en/flight_modes_fw/position.md
@@ -51,3 +51,14 @@ The mode is affected by the following parameters:
 | <a id="FW_T_CLMB_R_SP"></a>[FW_T_CLMB_R_SP](../advanced_config/parameter_reference.md#FW_T_CLMB_R_SP)       | Max climb rate setpoint. Default: 3 m/s.                             |
 | <a id="FW_T_SINK_R_SP"></a>[FW_T_SINK_R_SP](../advanced_config/parameter_reference.md#FW_T_SINK_R_SP)       | Max sink rate setpoint. Default: 2 m/s.                              |
 | <a id="FW_PN_R_SLEW_MAX"></a>[FW_PN_R_SLEW_MAX](../advanced_config/parameter_reference.md#FW_PN_R_SLEW_MAX) | Roll setpoint slew rate limit. Default: 90 °/s.                      |
+
+## MAVLink Commands
+
+The following commands are relevant to this mode:
+
+- [MAV_CMD_DO_CHANGE_SPEED](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED) - Set the cruise airspeed that the throttle stick interpolates around (requires an airspeed sensor).
+  At centered throttle the vehicle holds the commanded airspeed (`param2`, constrained between [FW_AIRSPD_MIN](../advanced_config/parameter_reference.md#FW_AIRSPD_MIN) and [FW_AIRSPD_MAX](../advanced_config/parameter_reference.md#FW_AIRSPD_MAX)), defaulting to [FW_AIRSPD_TRIM](../advanced_config/parameter_reference.md#FW_AIRSPD_TRIM) if none was sent.
+  Deflecting the throttle stick scales the airspeed toward `FW_AIRSPD_MIN` (back) or `FW_AIRSPD_MAX` (forward) around this value.
+  The value is shared with [Altitude mode](../flight_modes_fw/altitude.md) and resets to trim when entered from any other mode.
+
+Note, other commands may be supported.

--- a/docs/en/flight_modes_fw/position.md
+++ b/docs/en/flight_modes_fw/position.md
@@ -59,7 +59,8 @@ The following commands are relevant to this mode:
 - [MAV_CMD_DO_CHANGE_SPEED](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED) — Sets the cruise airspeed for centred throttle stick.
 
   This requires an airspeed sensor.
-  At centered throttle the vehicle holds the commanded airspeed (`param2`) if set.
+  Only the airspeed speed type is handled (`param1` must be `0`); other speed types are ignored.
+  At centered throttle the vehicle holds the commanded airspeed (`param2`) if a positive value is set (non-positive values are ignored).
   The value is constrained between [FW_AIRSPD_MIN](../advanced_config/parameter_reference.md#FW_AIRSPD_MIN) and [FW_AIRSPD_MAX](../advanced_config/parameter_reference.md#FW_AIRSPD_MAX), and defaults to [FW_AIRSPD_TRIM](../advanced_config/parameter_reference.md#FW_AIRSPD_TRIM) if no airspeed has been commanded.
   Deflecting the throttle stick scales the airspeed toward `FW_AIRSPD_MIN` (back) or `FW_AIRSPD_MAX` (forward) around this value.
   The commanded airspeed resets to `FW_AIRSPD_TRIM` on every flight mode change.

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -276,8 +276,8 @@ FixedWingModeManager::get_manual_airspeed_setpoint()
 		// neutral throttle corresponds to last MAV_CMD_DO_CHANGE_SPEED, or trim airspeed if none received
 		const float base_airspeed = PX4_ISFINITE(_commanded_manual_airspeed_setpoint)
 					    ? math::constrain(_commanded_manual_airspeed_setpoint,
-							      _param_fw_airspd_min.get(),
-							      _param_fw_airspd_max.get())
+							    _param_fw_airspd_min.get(),
+							    _param_fw_airspd_max.get())
 					    : _param_fw_airspd_trim.get();
 		return math::interpolateNXY(_manual_control_setpoint_for_airspeed,
 		{-1.f, 0.f, 1.f},
@@ -508,9 +508,20 @@ FixedWingModeManager::set_control_mode_current(const hrt_abstime &now)
 			_yaw_lock_engaged = false;
 		}
 
+		if (previous_position_control_mode != FW_POSCTRL_MODE_MANUAL_POSITION
+		    && previous_position_control_mode != FW_POSCTRL_MODE_MANUAL_ALTITUDE) {
+			// forget any prior MAV_CMD_DO_CHANGE_SPEED override when entering manual airspeed control from outside
+			_commanded_manual_airspeed_setpoint = NAN;
+		}
+
 		_control_mode_current = FW_POSCTRL_MODE_MANUAL_POSITION;
 
 	} else if (_control_mode.flag_control_manual_enabled && _control_mode.flag_control_altitude_enabled) {
+		if (previous_position_control_mode != FW_POSCTRL_MODE_MANUAL_POSITION
+		    && previous_position_control_mode != FW_POSCTRL_MODE_MANUAL_ALTITUDE) {
+			// forget any prior MAV_CMD_DO_CHANGE_SPEED override when entering manual airspeed control from outside
+			_commanded_manual_airspeed_setpoint = NAN;
+		}
 
 		_control_mode_current = FW_POSCTRL_MODE_MANUAL_ALTITUDE;
 

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -508,25 +508,18 @@ FixedWingModeManager::set_control_mode_current(const hrt_abstime &now)
 			_yaw_lock_engaged = false;
 		}
 
-		if (previous_position_control_mode != FW_POSCTRL_MODE_MANUAL_POSITION
-		    && previous_position_control_mode != FW_POSCTRL_MODE_MANUAL_ALTITUDE) {
-			// forget any prior MAV_CMD_DO_CHANGE_SPEED override when entering manual airspeed control from outside
-			_commanded_manual_airspeed_setpoint = NAN;
-		}
-
 		_control_mode_current = FW_POSCTRL_MODE_MANUAL_POSITION;
 
 	} else if (_control_mode.flag_control_manual_enabled && _control_mode.flag_control_altitude_enabled) {
-		if (previous_position_control_mode != FW_POSCTRL_MODE_MANUAL_POSITION
-		    && previous_position_control_mode != FW_POSCTRL_MODE_MANUAL_ALTITUDE) {
-			// forget any prior MAV_CMD_DO_CHANGE_SPEED override when entering manual airspeed control from outside
-			_commanded_manual_airspeed_setpoint = NAN;
-		}
 
 		_control_mode_current = FW_POSCTRL_MODE_MANUAL_ALTITUDE;
 
 	} else {
 		_control_mode_current = FW_POSCTRL_MODE_OTHER;
+	}
+
+	if (_control_mode_current != previous_position_control_mode) {
+		_commanded_manual_airspeed_setpoint = NAN;
 	}
 }
 

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -272,20 +272,19 @@ void FixedWingModeManager::vehicle_attitude_setpoint_poll()
 float
 FixedWingModeManager::get_manual_airspeed_setpoint()
 {
-	float manual_airspeed_setpoint = NAN;
-
 	if (_param_fw_pos_stk_conf.get() & STICK_CONFIG_ENABLE_AIRSPEED_SP_MANUAL_BIT) {
-		// neutral throttle corresponds to trim airspeed
-		manual_airspeed_setpoint = math::interpolateNXY(_manual_control_setpoint_for_airspeed,
+		// neutral throttle corresponds to last MAV_CMD_DO_CHANGE_SPEED, or trim airspeed if none received
+		const float base_airspeed = PX4_ISFINITE(_commanded_manual_airspeed_setpoint)
+					    ? math::constrain(_commanded_manual_airspeed_setpoint,
+							      _param_fw_airspd_min.get(),
+							      _param_fw_airspd_max.get())
+					    : _param_fw_airspd_trim.get();
+		return math::interpolateNXY(_manual_control_setpoint_for_airspeed,
 		{-1.f, 0.f, 1.f},
-		{_param_fw_airspd_min.get(), _param_fw_airspd_trim.get(), _param_fw_airspd_max.get()});
-
-	} else if (PX4_ISFINITE(_commanded_manual_airspeed_setpoint)) {
-		// override stick by commanded airspeed
-		manual_airspeed_setpoint = _commanded_manual_airspeed_setpoint;
+		{_param_fw_airspd_min.get(), base_airspeed, _param_fw_airspd_max.get()});
 	}
 
-	return manual_airspeed_setpoint;
+	return _commanded_manual_airspeed_setpoint;
 }
 
 void


### PR DESCRIPTION
Re-anchor the throttle-stick airspeed interpolation on the last MAV_CMD_DO_CHANGE_SPEED value (falling back to FW_AIRSPD_TRIM if none). Previously, _commanded_manual_airspeed_setpoint was stored but never read when FW_POS_STK_CONF bit 1 was set (the default), so DO_CHANGE_SPEED had no effect in Position/Altitude.

With this change:
- Stick centered = commanded cruise speed (= FW_AIRSPD_TRIM if no command).
- Stick deflection deviates from cruise between FW_AIRSPD_MIN/MAX.
- Disconnecting the controller collapses the interpolation to the cruise (Sticks zeroes the throttle channel on manual_control_signal_lost).
- No setpoint jump when a controller is plugged in with stick centered.
- No behavior change for users who never send DO_CHANGE_SPEED.

