### PR TITLE
fix(mavlink): Hardcode PX4_MAX_FILEPATH for log handler

### DIFF
--- a/src/modules/mavlink/mavlink_log_handler.h
+++ b/src/modules/mavlink/mavlink_log_handler.h
@@ -41,12 +41,9 @@
 #define PX4_MAX_FILEPATH       CONFIG_PATH_MAX
 #define PX4_MAX_FILEPATH_SCANF 255
 #else
-#ifndef PATH_MAX
-#define PATH_MAX 1024 // maximum on macOS
-#endif
 #define PX4LOG_REGULAR_FILE    DT_REG
 #define PX4LOG_DIRECTORY       DT_DIR
-#define PX4_MAX_FILEPATH       PATH_MAX
+#define PX4_MAX_FILEPATH       1024
 #define PX4_MAX_FILEPATH_SCANF 1023
 #endif
 


### PR DESCRIPTION
### Solved Problem

On POSIX/SITL builds running more than one MAVLink instance, log download over MAVLink (LOG_REQUEST_LIST /
LOG_REQUEST_DATA, e.g. QGroundControl's Log Download) is broken: the instance that receives the request never delivers its LOG_ENTRY/LOG_DATA replies back to the GCS, so the log list stays empty.

It reproduces reliably on a setup with separate onboard and GCS MAVLink instances (e.g. ModalAI VOXL2: mavlink start  -m onboard plus a second normal-mode instance). The request reaches the correct instance, but its replies go out a different MAVLink channel and are dropped.

### Solution

It's a One Definition Rule (ODR) violation: sizeof(Mavlink) is compiled differently in mavlink_log_handler.cpp than in the rest of the module.

mavlink_log_handler.h defined the path-buffer size as the system PATH_MAX, with a fallback:

```
  #ifndef PATH_MAX
  #define PATH_MAX 1024 // maximum on macOS
  #endif
  #define PX4_MAX_FILEPATH PATH_MAX
```

PATH_MAX is only visible once <limits.h> has been included, so the resulting value is include-order dependent:

  - Most mavlink TUs (mavlink_main.cpp, mavlink_receiver.cpp, …) pull in system/POSIX headers first, so PATH_MAX is already defined (4096 on Linux) when this header is reached.
  - mavlink_log_handler.cpp includes its own header first, before anything defines PATH_MAX, so it takes the 1024 fallback.

  MavlinkLogHandler contains a char[PX4_MAX_FILEPATH] member (LogEntry::filepath, via _current_entry) and is embedded by value in MavlinkReceiver, which is embedded by value in Mavlink. So PX4_MAX_FILEPATH directly changes sizeof(Mavlink) — and mavlink_log_handler.cpp ends up with a layout where Mavlink's members sit ~3072 bytes (4096 − 1024) earlier than where every other TU — including the one that constructs the object — placed them.

  Result: in mavlink_log_handler.cpp, _mavlink.get_channel() reads the wrong offset and returns 0, so
  mavlink_msg_log_entry_send_struct(_mavlink.get_channel(), …) transmits on channel 0 regardless of which instance is
  actually handling the request.

### Test coverage

Tested on VOXL2
