### PR TITLE
ci(build): split stm32f7 group to reduce build wall-clock

### DIFF
--- a/Tools/ci/build_all_config.yml
+++ b/Tools/ci/build_all_config.yml
@@ -30,7 +30,7 @@ grouping:
   # Max targets per group, tuned for ~10 min wall-clock with warm cache
   chip_split_limits:
     stm32h7: 10
-    stm32f7: 12
+    stm32f7: 7
     stm32f4: 20
     stm32f1: 39
     imxrt: 12


### PR DESCRIPTION
## Summary

Split the `misc-stm32f7` build group so its targets are spread across two jobs instead of one.

## Problem

`Build [x64][misc-stm32f7]` builds 13 diverse board firmwares back-to-back on a 4-CPU runner, and its shared ccache is pinned at the 800M cap (99.99% full). With that many heterogeneous boards the cache working set no longer fits, so it thrashes and recompiles cold — pushing the job past 16min while the matrix is tuned for ~10min with a warm cache.

## Solution

Lower `grouping.chip_split_limits.stm32f7` from 12 to 7 in `Tools/ci/build_all_config.yml`. The misc pool (13 targets) now splits into two balanced groups, `misc-stm32f7-0` (7) and `misc-stm32f7-1` (6), each well under the wall-clock target and with more cache headroom.

Side effect: `px4-stm32f7` (10 targets) now renders as `px4-stm32f7-0` because it crosses the lower limit into the chunked-naming branch. It remains a single 10-target job — not actually split — so the only cost is a one-time ccache reseed from the `ccache-stm32f7-x64-` fallback key.