### PR TITLE
fix(mavlink): validate GPS UTC timestamps

### DIFF
--- a/src/modules/mavlink/streams/OPEN_DRONE_ID_SYSTEM.hpp
+++ b/src/modules/mavlink/streams/OPEN_DRONE_ID_SYSTEM.hpp
@@ -90,8 +90,13 @@ private:
 				msg.operator_altitude_geo = home_position.alt + wgs84_amsl_offset;
 
 				// timestamp: 32 bit Unix Timestamp in seconds since 00:00:00 01/01/2019.
-				static uint64_t utc_offset_s = 1'546'300'800; // UTC seconds since 00:00:00 01/01/2019
-				msg.timestamp = vehicle_gps_position.time_utc_usec / 1e6 - utc_offset_s;
+				// Timestamp not available is indicated by 0.
+				static uint64_t utc_offset_us = 1'546'300'800ULL * 1'000'000ULL;
+
+				if (vehicle_gps_position.time_utc_usec >= utc_offset_us) {
+					const uint64_t timestamp_s = (vehicle_gps_position.time_utc_usec - utc_offset_us) / 1'000'000ULL;
+					msg.timestamp = static_cast<uint32_t>(timestamp_s);
+				}
 
 				mavlink_msg_open_drone_id_system_send_struct(_mavlink->get_channel(), &msg);
 

--- a/src/modules/mavlink/streams/OPEN_DRONE_ID_SYSTEM.hpp
+++ b/src/modules/mavlink/streams/OPEN_DRONE_ID_SYSTEM.hpp
@@ -91,7 +91,7 @@ private:
 
 				// timestamp: 32 bit Unix Timestamp in seconds since 00:00:00 01/01/2019.
 				// Timestamp not available is indicated by 0.
-				static uint64_t utc_offset_us = 1'546'300'800ULL * 1'000'000ULL;
+				static constexpr uint64_t utc_offset_us = 1'546'300'800ULL * 1'000'000ULL;
 
 				if (vehicle_gps_position.time_utc_usec >= utc_offset_us) {
 					const uint64_t timestamp_s = (vehicle_gps_position.time_utc_usec - utc_offset_us) / 1'000'000ULL;

--- a/src/modules/mavlink/streams/UAVIONIX_ADSB_OUT_DYNAMIC.hpp
+++ b/src/modules/mavlink/streams/UAVIONIX_ADSB_OUT_DYNAMIC.hpp
@@ -113,7 +113,7 @@ private:
 		};
 
 		if (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
-			dynamic_msg.state |= ~UAVIONIX_ADSB_OUT_DYNAMIC_STATE_ON_GROUND;
+			dynamic_msg.state &= ~UAVIONIX_ADSB_OUT_DYNAMIC_STATE_ON_GROUND;
 		}
 
 		mavlink_msg_uavionix_adsb_out_dynamic_send_struct(_mavlink->get_channel(), &dynamic_msg);

--- a/src/modules/mavlink/streams/UAVIONIX_ADSB_OUT_DYNAMIC.hpp
+++ b/src/modules/mavlink/streams/UAVIONIX_ADSB_OUT_DYNAMIC.hpp
@@ -83,9 +83,18 @@ private:
 		vehicle_air_data_s vehicle_air_data;
 		_vehicle_air_data_sub.copy(&vehicle_air_data);
 
+		// UTC seconds since 00:00:00 01/06/1980 (GPS epoch). If unknown set to UINT32_MAX.
+		static uint64_t gps_epoch_offset_us = 315'964'800ULL * 1'000'000ULL;
+		uint32_t gps_epoch_time_s = UINT32_MAX;
+
+		if (vehicle_gps_position.time_utc_usec >= gps_epoch_offset_us) {
+			const uint64_t timestamp_s = (vehicle_gps_position.time_utc_usec - gps_epoch_offset_us) / 1'000'000ULL;
+			gps_epoch_time_s = static_cast<uint32_t>(timestamp_s);
+		}
+
 		// Required update for dynamic message is 5 [Hz]
 		mavlink_uavionix_adsb_out_dynamic_t dynamic_msg = {
-			.utcTime = static_cast<uint32_t>(vehicle_gps_position.time_utc_usec / 1000000ULL),
+			.utcTime = gps_epoch_time_s,
 			.gpsLat = static_cast<int32_t>(round(vehicle_gps_position.latitude_deg * 1e7)),
 			.gpsLon = static_cast<int32_t>(round(vehicle_gps_position.longitude_deg * 1e7)),
 			.gpsAlt = static_cast<int32_t>(round(vehicle_gps_position.altitude_ellipsoid_m * 1e3)), // convert [m] to [mm]

--- a/src/modules/mavlink/streams/UAVIONIX_ADSB_OUT_DYNAMIC.hpp
+++ b/src/modules/mavlink/streams/UAVIONIX_ADSB_OUT_DYNAMIC.hpp
@@ -84,7 +84,7 @@ private:
 		_vehicle_air_data_sub.copy(&vehicle_air_data);
 
 		// UTC seconds since 00:00:00 01/06/1980 (GPS epoch). If unknown set to UINT32_MAX.
-		static uint64_t gps_epoch_offset_us = 315'964'800ULL * 1'000'000ULL;
+		static constexpr uint64_t gps_epoch_offset_us = 315'964'800ULL * 1'000'000ULL;
 		uint32_t gps_epoch_time_s = UINT32_MAX;
 
 		if (vehicle_gps_position.time_utc_usec >= gps_epoch_offset_us) {


### PR DESCRIPTION
### Solved Problem
Fixes invalid timestamps when GPS UTC time is not available.

`OPEN_DRONE_ID_SYSTEM` used `time_utc_usec` without checking whether it was valid. When it was 0, the timestamp calculation could produce an invalid wrapped value instead of the protocol's unavailable timestamp value.

`UAVIONIX_ADSB_OUT_DYNAMIC` also used `time_utc_usec` directly. When it was 0, it sent `utcTime = 0` instead of `UINT32_MAX`, and valid UTC time was not converted to GPS epoch seconds as required by the message definition.

### Solution
For `OPEN_DRONE_ID_SYSTEM`, only calculate the timestamp when GPS UTC time is valid for the OpenDroneID epoch. Otherwise keep the default unavailable value, 0.

For `UAVIONIX_ADSB_OUT_DYNAMIC`, default `utcTime` to `UINT32_MAX` and only fill it when GPS UTC time is valid, converting from Unix epoch UTC time to GPS epoch seconds.

### Changelog Entry
For release notes:
```
Bugfix: validate GPS UTC timestamps in OpenDroneID and uAvionix ADS-B MAVLink streams
```