### PR TITLE
fix(spacecraft): remove redundant uORB copy

### DIFF
--- a/src/modules/spacecraft/SpacecraftRateControl/SpacecraftRateControl.cpp
+++ b/src/modules/spacecraft/SpacecraftRateControl/SpacecraftRateControl.cpp
@@ -153,12 +153,10 @@ void SpacecraftRateControl::updateRateControl()
 
 		} else if (_vehicle_rates_setpoint_sub.update(&vehicle_rates_setpoint)) {
 			// Get rates from other controllers (e.g. position or attitude controller)
-			if (_vehicle_rates_setpoint_sub.copy(&vehicle_rates_setpoint)) {
-				_rates_setpoint(0) = PX4_ISFINITE(vehicle_rates_setpoint.roll) ? vehicle_rates_setpoint.roll : rates(0);
-				_rates_setpoint(1) = PX4_ISFINITE(vehicle_rates_setpoint.pitch) ? vehicle_rates_setpoint.pitch : rates(1);
-				_rates_setpoint(2) = PX4_ISFINITE(vehicle_rates_setpoint.yaw) ? vehicle_rates_setpoint.yaw : rates(2);
-				_thrust_setpoint = Vector3f(vehicle_rates_setpoint.thrust_body);
-			}
+			_rates_setpoint(0) = PX4_ISFINITE(vehicle_rates_setpoint.roll) ? vehicle_rates_setpoint.roll : rates(0);
+			_rates_setpoint(1) = PX4_ISFINITE(vehicle_rates_setpoint.pitch) ? vehicle_rates_setpoint.pitch : rates(1);
+			_rates_setpoint(2) = PX4_ISFINITE(vehicle_rates_setpoint.yaw) ? vehicle_rates_setpoint.yaw : rates(2);
+			_thrust_setpoint = Vector3f(vehicle_rates_setpoint.thrust_body);
 		}
 
 		// run the rate controller


### PR DESCRIPTION
### Summary
Remove the extra `copy()` call after `_vehicle_rates_setpoint_sub.update(&vehicle_rates_setpoint)`, since `update()` already copies the rate setpoint data when it returns true.

### Changelog Entry
For release notes:
```
Bugfix: remove redundant uORB copy in spacecraft rate control
```