### PR TITLE
fix(mavlink): leave LOITER_TO_ALT yaw unspecified

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1488,6 +1488,9 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 			mission_item->force_heading = (mavlink_mission_item->param1 > 0);
 			mission_item->loiter_radius = mavlink_mission_item->param2;
 			mission_item->loiter_exit_xtrack = (mavlink_mission_item->param4 > 0);
+			// MAV_CMD_NAV_LOITER_TO_ALT has no yaw field. Leave yaw unspecified so multicopters don't
+			// use the zero-initialized default as an unintended north-facing heading setpoint.
+			mission_item->yaw = NAN;
 			break;
 
 		case MAV_CMD_NAV_ROI:


### PR DESCRIPTION
### Solved Problem

`MAV_CMD_NAV_LOITER_TO_ALT` does not define a yaw field. Its `param4` is `Xtrack Location`, not a multicopter yaw setpoint.

However, the MAVLink mission parser left `mission_item->yaw` unset for `LOITER_TO_ALT`. Since `mission_item_s` is zero-initialized before parsing, this left `yaw` as `0.0f`, which PX4 interpreted as a valid north-facing yaw setpoint. A multicopter entering a `LOITER_TO_ALT` mission item could turn to heading `0 deg` / north even though the mission did not request a yaw change.

### Solution
Set `mission_item->yaw = NAN` when parsing `MAV_CMD_NAV_LOITER_TO_ALT`.

### Changelog Entry
For release notes:
```text
Bugfix: Prevent multicopters from turning to north during MAV_CMD_NAV_LOITER_TO_ALT missions
```

### Test coverage
mission plan for reproduction:
```json
{
    "fileType": "Plan",
    "geoFence": {
        "circles": [],
        "polygons": [],
        "version": 2
    },
    "groundStation": "QGroundControl",
    "mission": {
        "cruiseSpeed": 15,
        "firmwareType": 12,
        "globalPlanAltitudeMode": 0,
        "hoverSpeed": 5,
        "items": [
            {
                "AMSLAltAboveTerrain": null,
                "Altitude": 50,
                "AltitudeMode": 1,
                "autoContinue": true,
                "command": 22,
                "doJumpId": 1,
                "frame": 3,
                "params": [
                    0,
                    0,
                    0,
                    null,
                    47.3979708,
                    8.5461636,
                    50
                ],
                "type": "SimpleItem"
            },
            {
                "AMSLAltAboveTerrain": null,
                "Altitude": 50,
                "AltitudeMode": 1,
                "autoContinue": true,
                "command": 16,
                "doJumpId": 2,
                "frame": 3,
                "params": [
                    0,
                    0,
                    0,
                    90,
                    47.3979692,
                    8.5468068,
                    50
                ],
                "type": "SimpleItem"
            },
            {
                "AMSLAltAboveTerrain": null,
                "Altitude": 65,
                "AltitudeMode": 1,
                "autoContinue": true,
                "command": 31,
                "doJumpId": 3,
                "frame": 3,
                "params": [
                    0,
                    5,
                    0,
                    0,
                    47.3979692,
                    8.5468068,
                    65
                ],
                "type": "SimpleItem"
            },
            {
                "AMSLAltAboveTerrain": null,
                "Altitude": 65,
                "AltitudeMode": 1,
                "autoContinue": true,
                "command": 16,
                "doJumpId": 4,
                "frame": 3,
                "params": [
                    0,
                    0,
                    0,
                    null,
                    47.39745439,
                    8.54601864,
                    65
                ],
                "type": "SimpleItem"
            }
        ],
        "plannedHomePosition": [
            47.3979708,
            8.5461636,
            491
        ],
        "vehicleType": 2,
        "version": 2
    },
    "rallyPoints": {
        "points": [],
        "version": 2
    },
    "version": 1
}
```

log before patch:
https://logs.px4.io/plot_app?log=643ede56-5225-4e13-a639-bc3556a8062c

log after patch:
https://logs.px4.io/plot_app?log=efb020b1-4d19-443d-86e1-a509b73964f8