### PR TITLE
fix(ekf2): update good accel time after fault status clears

### DIFF
--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -123,6 +123,7 @@ void Ekf::reset()
 
 	_time_bad_vert_accel = 0;
 	_time_good_vert_accel = 0;
+	_time_bad_vert_accel_hgt_reset = 0;
 
 	for (auto &clip_count : _clip_counter) {
 		clip_count = 0;

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -671,6 +671,7 @@ private:
 	// imu fault status
 	uint64_t _time_bad_vert_accel{0};	///< last time a bad vertical accel was detected (uSec)
 	uint64_t _time_good_vert_accel{0};	///< last time a good vertical accel was detected (uSec)
+	uint64_t _time_bad_vert_accel_hgt_reset{0}; ///< last height reset caused by bad vertical accel (uSec)
 	uint16_t _clip_counter[3];		///< counter per axis that increments when clipping ad decrements when not
 
 	// initialise filter states of both the delayed ekf and the real time complementary filter

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -49,11 +49,13 @@ bool Ekf::isHeightResetRequired() const
 {
 	// check if height is continuously failing because of accel errors
 	const bool continuous_bad_accel_hgt = isTimedOut(_time_good_vert_accel, (uint64_t)_params.bad_acc_reset_delay_us);
+	const bool bad_accel_hgt_reset_recent = _fault_status.flags.bad_acc_vertical
+						&& isRecent(_time_bad_vert_accel_hgt_reset, BADACC_PROBATION);
 
 	// check if height has been inertial deadreckoning for too long
 	const bool hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, _params.hgt_fusion_timeout_max);
 
-	return (continuous_bad_accel_hgt || hgt_fusion_timeout);
+	return ((continuous_bad_accel_hgt && !bad_accel_hgt_reset_recent) || hgt_fusion_timeout);
 }
 
 Vector3f Ekf::calcEarthRateNED(float lat_rad) const

--- a/src/modules/ekf2/EKF/height_control.cpp
+++ b/src/modules/ekf2/EKF/height_control.cpp
@@ -163,9 +163,6 @@ void Ekf::checkVerticalAccelerationHealth(const imuSample &imu_delayed)
 
 	if (bad_vert_accel) {
 		_time_bad_vert_accel = imu_delayed.time_us;
-
-	} else {
-		_time_good_vert_accel = imu_delayed.time_us;
 	}
 
 	// declare a bad vertical acceleration measurement and make the declaration persist
@@ -175,6 +172,10 @@ void Ekf::checkVerticalAccelerationHealth(const imuSample &imu_delayed)
 
 	} else {
 		_fault_status.flags.bad_acc_vertical = bad_vert_accel;
+	}
+
+	if (!_fault_status.flags.bad_acc_vertical) {
+		_time_good_vert_accel = imu_delayed.time_us;
 	}
 }
 

--- a/src/modules/ekf2/EKF/position_fusion.cpp
+++ b/src/modules/ekf2/EKF/position_fusion.cpp
@@ -187,6 +187,11 @@ void Ekf::resetHorizontalPositionTo(const Vector2f &new_pos,
 
 void Ekf::resetAltitudeTo(const float new_altitude, float new_vert_pos_var)
 {
+	if (_fault_status.flags.bad_acc_vertical
+	    && isTimedOut(_time_good_vert_accel, (uint64_t)_params.bad_acc_reset_delay_us)) {
+		_time_bad_vert_accel_hgt_reset = _time_delayed_us;
+	}
+
 	const float old_altitude = _gpos.altitude();
 	_gpos.setAltitude(new_altitude);
 


### PR DESCRIPTION
### Solved Problem

`bad_acc_vertical` is intended to persist for `BADACC_PROBATION`, but `_time_good_vert_accel` was updated as soon as the raw check briefly passed. This violated the probation semantics and could prevent the bad-accel height reset timeout from triggering.

### Solution
Update `_time_good_vert_accel` only after the final `bad_acc_vertical` fault status has cleared.

### Changelog Entry
For release notes:
```
Bugfix: Fix EKF bad vertical acceleration recovery timing
```