### PR TITLE
feat(fw_latlon_control): limit bank angle to not exceed max airspeed

### DIFF
--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -282,8 +282,13 @@ void FwLateralLongitudinalControl::Run()
 			}
 
 			lateral_accel_sp = getCorrectedLateralAccelSetpoint(lateral_accel_sp, now);
-			lateral_accel_sp = math::constrain(lateral_accel_sp, -_lateral_configuration.lateral_accel_max,
-							   _lateral_configuration.lateral_accel_max);
+
+			const float lateral_accel_max = math::min(
+								_lateral_configuration.lateral_accel_max,
+								getMaxLateralAccelForLoadFactor()
+							);
+
+			lateral_accel_sp = math::constrain(lateral_accel_sp, -lateral_accel_max, lateral_accel_max);
 			roll_sp = mapLateralAccelerationToRollAngle(lateral_accel_sp);
 
 			fixed_wing_lateral_status_s fixed_wing_lateral_status{};
@@ -367,6 +372,39 @@ void FwLateralLongitudinalControl::updateControllerConfiguration(hrt_abstime tim
 		}
 	}
 }
+
+float
+FwLateralLongitudinalControl::getMaxLateralAccelForLoadFactor() const
+{
+	// Tighten the lateral acceleration (≈ bank angle) limit to not exceed
+	// the maximum load factor.
+
+	// There is no user given maximium load factor but the airspeed limits
+	// imply one: If the min CAS (compensated for weight ratio, bank angle,
+	// flaps setpoint, air density) is above the max airspeed then the given
+	// load factor is not flyable (without exceeding max airspeed).
+
+	const float min_cas_unitload = _performance_model.getMinimumCalibratedAirspeed(1.0f, _flaps_setpoint);
+	const float max_cas = _performance_model.getMaximumCalibratedAirspeed();
+
+	// from getMinimumCalibratedAirspeed:
+	//     min_cas(load_factor) = min_cas_unitload * sqrt(load_factor) = max_cas
+	// solve min_cas(load_factor) = max_cas for the load_factor:
+	//     min_cas_unitload * sqrt(load_factor) = max_cas
+	//     sqrt(load_factor) = max_cas / min_cas_unitload
+	//     load_factor = (max_cas / min_cas_unitload)^2
+	const float load_factor_max = math::sq(max_cas / math::max(min_cas_unitload, FLT_EPSILON));
+
+	// In a coordinated turn at bank angle phi:
+	//     load_factor = 1/cos(phi)
+	//     lat_accel/g = tan(phi)
+	// Pythagoras says: load_factor^2 = 1^2 + (lat_accel/g)^2, which we solve for lat_accel:
+	//     load_factor^2 - 1 = (lat_accel/g)^2
+	//     sqrt(load_factor^2 - 1) = lat_accel/g
+	//     g * sqrt(load_factor^2 - 1) = lat_accel
+	return CONSTANTS_ONE_G * sqrtf(math::max(math::sq(load_factor_max) - 1.0f, 0.0f));
+}
+
 
 uint8_t
 FwLateralLongitudinalControl::tecs_update_pitch_throttle(const float control_interval, float alt_sp, float airspeed_sp,

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -402,7 +402,11 @@ FwLateralLongitudinalControl::getMaxLateralAccelForLoadFactor() const
 	//     load_factor^2 - 1 = (lat_accel/g)^2
 	//     sqrt(load_factor^2 - 1) = lat_accel/g
 	//     g * sqrt(load_factor^2 - 1) = lat_accel
-	return CONSTANTS_ONE_G * sqrtf(math::max(math::sq(load_factor_max) - 1.0f, 0.0f));
+	const float max_lat_accel = CONSTANTS_ONE_G * sqrtf(math::max(math::sq(load_factor_max) - 1.0f, 0.0f));
+
+	// Avoid constraining roll too much on misconfiguration
+	const float min_lat_accel_limit = 1.729177f; // = g * tan(10 deg), increases load factor by 1.5%
+	return fmaxf(max_lat_accel, min_lat_accel_limit);
 }
 
 

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -380,16 +380,16 @@ FwLateralLongitudinalControl::getMaxLateralAccelForLoadFactor() const
 	// the maximum load factor.
 
 	// There is no user given maximium load factor but the airspeed limits
-	// imply one: If the min CAS (compensated for weight ratio, bank angle,
-	// flaps setpoint, air density) is above the max airspeed then the given
+	// imply one: If the min CAS (FW_AIRSPD_MIN compensated for bank angle,
+	// weight ratio, flaps setpoint) is above FW_AIRSPD_MAX, then the given
 	// load factor is not flyable (without exceeding max airspeed).
 
 	const float min_cas_unitload = _performance_model.getMinimumCalibratedAirspeed(1.0f, _flaps_setpoint);
 	const float max_cas = _performance_model.getMaximumCalibratedAirspeed();
 
-	// from getMinimumCalibratedAirspeed:
-	//     min_cas(load_factor) = min_cas_unitload * sqrt(load_factor) = max_cas
-	// solve min_cas(load_factor) = max_cas for the load_factor:
+	// From getMinimumCalibratedAirspeed:
+	//     min_cas(load_factor) = min_cas_unitload * sqrt(load_factor)
+	// Set this equal to max_cas and solve for the load_factor:
 	//     min_cas_unitload * sqrt(load_factor) = max_cas
 	//     sqrt(load_factor) = max_cas / min_cas_unitload
 	//     load_factor = (max_cas / min_cas_unitload)^2

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
@@ -249,6 +249,8 @@ private:
 
 	void updateControllerConfiguration(hrt_abstime now);
 
+	float getMaxLateralAccelForLoadFactor() const;
+
 	/**
 	 * @brief Returns an adapted calibrated airspeed setpoint
 	 *


### PR DESCRIPTION
### Problem

When banking, we have to increase the min airspeed to account for the increased load factor. Sometimes the needed airspeed (`PerformanceModel::getMinimumCalibratedAirspeed`) may end up being above the maximum airspeed.

For most vehicles this never happens, it is an edge case that can show up with a combination of:
 - narrow range between `FW_AIRSPD_{MIN,MAX}`
 - high weight ratio
 - large roll setpoint

### Solution

Increasing the max airspeed is an easy config fix, but not always an option (mechanical limits, aeroelastic instability, legal constraints...). Therefore I propose avoiding the situation by limiting the bank angle to never reach load factors that require flying above max airspeed.

### Changelog Entry

```
Fixed-wing: Limit bank angle to not exceed load factor given by max airspeed
```

### Alternatives / other considerations
 - This is a (somewhat) user facing change, should we put it in some docs or parameter descriptions that a larger turn radius is expected with narrow airspeed range and/or high weight ratio?
 - Could add some small safety margin to not even bank _close to_ the angle that gives min = max airspeed. But given that previously there was no limiting at all I'd say this simple version is enough

### Test coverage

Fly around with `gz_advanced_plane`, tighten airspeed limits to be only a bit above/below trim, limiting works as expected.
