### PR TITLE
fix(commander): size ArmingCheckReply queue to MAX_NUM_REGISTRATIONS

### DIFF
--- a/msg/versioned/ArmingCheckReply.msg
+++ b/msg/versioned/ArmingCheckReply.msg
@@ -40,4 +40,7 @@ bool mode_req_home_position # Requires a home position (such as RTL/Return mode)
 bool mode_req_prevent_arming # Prevent arming (such as in Land mode)
 bool mode_req_manual_control # Requires a manual controller
 
-uint8 ORB_QUEUE_LENGTH = 4
+# Must be >= ExternalChecks::MAX_NUM_REGISTRATIONS so replies from all registered
+# modes fit in the queue within a single request cycle (otherwise replies from the
+# 5th+ mode overwrite earlier ones, causing spurious "unresponsive mode" failures).
+uint8 ORB_QUEUE_LENGTH = 8

--- a/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.cpp
@@ -33,6 +33,10 @@
 
 #include "externalChecks.hpp"
 
+// The reply queue must hold one reply from every registered mode within a single request cycle (https://github.com/PX4/PX4-Autopilot/issues/27271)
+static_assert(arming_check_reply_s::ORB_QUEUE_LENGTH >= ExternalChecks::MAX_NUM_REGISTRATIONS,
+	      "ArmingCheckReply ORB_QUEUE_LENGTH must be >= ExternalChecks::MAX_NUM_REGISTRATIONS");
+
 static void setOrClearRequirementBits(bool requirement_set, int8_t nav_state, int8_t replaces_nav_state, uint32_t &bits)
 {
 	if (requirement_set) {


### PR DESCRIPTION
The `ArmingCheckReply` uORB queue is sized to 4 (`ORB_QUEUE_LENGTH`), but `ExternalChecks` supports up to `MAX_NUM_REGISTRATIONS` (8) external modes, each of which publishes a reply for every `ArmingCheckRequest`. When more than 4 modes are registered, replies from the 5th+ mode overwrite earlier ones within a single request cycle, so those modes are flagged "unresponsive" and silently fail to activate (`[health_and_arming_checks] No response from 0, flagging unresponsive`).

As discussed in #27271, this is more likely to surface in SITL: on hardware the high request rate (100 Hz) plus jitter/delays in the responses tends to space replies out enough that the small queue isn't overrun, whereas in Gazebo SITL the failure reproduces reliably with 5 registered modes. @bkueng approved increasing the queue size.

- bump `ORB_QUEUE_LENGTH` from 4 to 8 in `msg/versioned/ArmingCheckReply.msg` so the queue can hold one reply from every registered mode in a single cycle (this constant also bounds the per-cycle read loop in `externalChecks.cpp`)
- add a `static_assert(ORB_QUEUE_LENGTH >= MAX_NUM_REGISTRATIONS)` so the two limits cannot silently drift apart again

`ExternalChecks` has no existing unit-test harness and is driven entirely by cross-process uORB pub/sub, so the `static_assert` serves as the practical compile-time regression guard rather than a dedicated SITL test. Verified with `make px4_sitl` and `make px4_fmu-v6x` (both build and link cleanly; the static_assert holds at 8 >= 8).

Fixes #27271