### PR TITLE
fix(control_allocator): restore airship tail-thruster yaw

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/2507_cloudship
+++ b/ROMFS/px4fmu_common/init.d/airframes/2507_cloudship
@@ -17,17 +17,17 @@
 
 param set-default COM_PREARM_MODE 2
 
-param set-default CA_AIRFRAME 9
+param set-default CA_AIRFRAME 16
 
 param set-default CA_ROTOR_COUNT 3
 param set-default CA_ROTOR0_AX 1
 param set-default CA_ROTOR0_AZ 0
 param set-default CA_ROTOR0_KM 0
-param set-default CA_ROTOR0_PY 2
+param set-default CA_ROTOR0_PY 0
 param set-default CA_ROTOR1_AX 1
 param set-default CA_ROTOR1_AZ 0
 param set-default CA_ROTOR1_KM 0
-param set-default CA_ROTOR1_PY -2
+param set-default CA_ROTOR1_PY 0
 param set-default CA_ROTOR2_AY -1
 param set-default CA_ROTOR2_AZ 0
 param set-default CA_ROTOR2_KM 0
@@ -36,4 +36,4 @@ param set-default CA_ROTOR2_PX -10
 param set-default CA_SV_CS_COUNT 1
 param set-default CA_SV_CS0_TRQ_P 1
 
-param set-default CA_R_REV 7
+param set-default CA_R_REV 4

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -263,6 +263,10 @@ ControlAllocator::update_effectiveness_source()
 			tmp = new ActuatorEffectivenessSpacecraft(this);
 			break;
 
+		case EffectivenessSource::AIRSHIP:
+			tmp = new ActuatorEffectivenessAirship(this);
+			break;
+
 		case EffectivenessSource::ROVER_ACKERMANN: // Unreachable: Rover startup scripts don't load control_allocator. Controllers publish actuator_outputs directly.
 		case EffectivenessSource::ROVER_DIFFERENTIAL:
 		case EffectivenessSource::ROVER_MECANUM:

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -49,6 +49,7 @@
 #include <ActuatorEffectivenessFixedWing.hpp>
 #include <ActuatorEffectivenessMCTilt.hpp>
 #include <ActuatorEffectivenessCustom.hpp>
+#include <ActuatorEffectivenessAirship.hpp>
 #include <ActuatorEffectivenessUUV.hpp>
 #include <ActuatorEffectivenessHelicopter.hpp>
 #include <ActuatorEffectivenessHelicopterCoaxial.hpp>
@@ -173,6 +174,7 @@ private:
 		HELICOPTER_COAXIAL = 12,
 		ROVER_MECANUM = 13,
 		SPACECRAFT_2D = 14,
+		AIRSHIP = 16,
 	};
 
 	enum class FailureMode {

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessAirship.cpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessAirship.cpp
@@ -1,0 +1,65 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "ActuatorEffectivenessAirship.hpp"
+
+#include <float.h>
+
+bool
+ActuatorEffectivenessAirship::getEffectivenessMatrix(Configuration &configuration,
+		EffectivenessUpdateReason external_update)
+{
+	if (!ActuatorEffectivenessCustom::getEffectivenessMatrix(configuration, external_update)) {
+		return false;
+	}
+
+	EffectivenessMatrix &matrix = configuration.effectiveness_matrices[configuration.selected_matrix];
+
+	for (int i = 0; i < NUM_ACTUATORS; ++i) {
+		matrix(ControlAxis::THRUST_Y, i) = 0.f;
+	}
+
+	float yaw_scale = 0.f;
+
+	for (int i = 0; i < NUM_ACTUATORS; ++i) {
+		yaw_scale = fmaxf(yaw_scale, fabsf(matrix(ControlAxis::YAW, i)));
+	}
+
+	if (yaw_scale > FLT_EPSILON) {
+		for (int i = 0; i < NUM_ACTUATORS; ++i) {
+			matrix(ControlAxis::YAW, i) /= yaw_scale;
+		}
+	}
+
+	return true;
+}

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessAirship.hpp
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/ActuatorEffectivenessAirship.hpp
@@ -1,0 +1,47 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "ActuatorEffectivenessCustom.hpp"
+
+class ActuatorEffectivenessAirship : public ActuatorEffectivenessCustom
+{
+public:
+	ActuatorEffectivenessAirship(ModuleParams *parent) : ActuatorEffectivenessCustom(parent) {}
+	virtual ~ActuatorEffectivenessAirship() = default;
+
+	bool getEffectivenessMatrix(Configuration &configuration, EffectivenessUpdateReason external_update) override;
+
+	const char *name() const override { return "Airship"; }
+};

--- a/src/modules/control_allocator/VehicleActuatorEffectiveness/CMakeLists.txt
+++ b/src/modules/control_allocator/VehicleActuatorEffectiveness/CMakeLists.txt
@@ -5,6 +5,8 @@ px4_add_library(VehicleActuatorEffectiveness
 	ActuatorEffectivenessControlSurfaces.hpp
 	ActuatorEffectivenessCustom.cpp
 	ActuatorEffectivenessCustom.hpp
+	ActuatorEffectivenessAirship.cpp
+	ActuatorEffectivenessAirship.hpp
 	ActuatorEffectivenessFixedWing.cpp
 	ActuatorEffectivenessFixedWing.hpp
 	ActuatorEffectivenessHelicopter.cpp

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -34,6 +34,7 @@ parameters:
                 13: Rover (Mecanum)
                 14: Spacecraft 2D
                 15: Spacecraft 3D
+                16: Airship
             default: 0
 
         CA_METHOD:


### PR DESCRIPTION
## Solved Problem
On the Cloudship airframe the tail thruster is unused; yaw is produced by main-motor differential thrust. The 2020 mixer (cloudship.main.mix) routed the yaw channel directly to the tail thruster; that mapping was not carried over when the airframe moved to control allocation (f454dcef6b; mixer removed in cac9c51ac8). `airship_att_control` leaves the lateral-thrust (body-Y) setpoint at zero, and the tail thruster is the only actuator with a body-Y component (CA_ROTOR2_AY=-1), so the allocator drives it to zero.

PX4/PX4-SITL_gazebo-classic#854 reports the same symptom in SITL (rear thruster does not activate, no yaw). This PR does not modify the SITL airframe.

## Solution
Add `ActuatorEffectivenessAirship` (CA_AIRFRAME=16), based on `Custom`:
- zeros the lateral-thrust row, so the tail thruster is not pinned to zero by the Fy=0 setpoint;
- normalizes the yaw row so a full yaw command maps to full tail output.

Cloudship airframe: CA_AIRFRAME=16, main rotors PY=0, CA_R_REV=4 (tail reversible; mains forward-only).

## Test coverage
- `control_allocator` and `ActuatorEffectivenessAirship` compile against current `main`.
- On Cube Orange: `control_allocator status` reports `Effectiveness Source: Airship`; the effectiveness matrix has the lateral-thrust row zeroed and the yaw column normalized; a full yaw command drives the tail thruster output to 1.0, the main thrusters stay equal, throttle drives both mains, pitch drives the servo.
- Tested with a unidirectional tail (CA_R_REV=0): only one yaw direction was exercised. Bidirectional yaw (CA_R_REV=4) is not bench-tested.

## Notes for reviewers
- `AIRSHIP=16`: `module.yaml` value 15 is still `Spacecraft 3D`, so 16 is the next free value.