### PR TITLE
fix(airspeed_selector): always compute airspeed derivative for airspeed_validated

### DIFF
--- a/src/modules/airspeed_selector/AirspeedValidator.cpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.cpp
@@ -284,38 +284,43 @@ void
 AirspeedValidator::check_first_principle(const uint64_t timestamp, const float throttle_fw, const float throttle_trim,
 		const uint64_t tecs_timestamp, const Quatf &att_q)
 {
-	if (! _first_principle_check_enabled) {
+	const float pitch = matrix::Eulerf(att_q).theta();
+	const hrt_abstime tecs_dt = timestamp - tecs_timestamp; // TECS data is old (TECS not running) if this is large
+
+	const bool inputs_valid = _in_fixed_wing_flight && tecs_dt <= 500_ms && PX4_ISFINITE(_IAS)
+				  && PX4_ISFINITE(throttle_fw) && PX4_ISFINITE(throttle_trim) && PX4_ISFINITE(pitch);
+
+	if (inputs_valid) {
+		const float dt = static_cast<float>(timestamp - _time_last_first_principle_check) * 1e-6f;
+		_time_last_first_principle_check = timestamp;
+
+		// Update the filters whenever inputs are valid, independent of whether the first principle check
+		// is enabled, so that the airspeed derivative is always available in the airspeed_validated topic.
+		if (dt < FLT_EPSILON || dt > 1.f) {
+			// reset if dt is too large
+			_IAS_derivative.reset(0.f);
+			_pitch_filtered.reset(pitch);
+			_time_last_first_principle_check_passing = timestamp;
+
+		} else {
+			// update filters, with different time constant
+			_IAS_derivative.setParameters(dt, 5.f);
+			_pitch_filtered.setParameters(dt, 1.5f);
+
+			_IAS_derivative.update(_IAS);
+			_pitch_filtered.update(pitch);
+		}
+	}
+
+	if (!_first_principle_check_enabled) {
 		_first_principle_check_failed = false;
 		_time_last_first_principle_check_passing = timestamp;
 		return;
 	}
 
-	const float pitch = matrix::Eulerf(att_q).theta();
-	const hrt_abstime tecs_dt = timestamp - tecs_timestamp; // return if TECS data is old (TECS not running)
-
-	if (!_in_fixed_wing_flight || tecs_dt > 500_ms || !PX4_ISFINITE(_IAS) || !PX4_ISFINITE(throttle_fw)
-	    || !PX4_ISFINITE(throttle_trim) || !PX4_ISFINITE(pitch)) {
-		// do not do anything in that case
+	if (!inputs_valid) {
+		// do not run the check without valid inputs
 		return;
-	}
-
-	const float dt = static_cast<float>(timestamp - _time_last_first_principle_check) * 1e-6f;
-	_time_last_first_principle_check = timestamp;
-
-	// update filters
-	if (dt < FLT_EPSILON || dt > 1.f) {
-		// reset if dt is too large
-		_IAS_derivative.reset(0.f);
-		_pitch_filtered.reset(pitch);
-		_time_last_first_principle_check_passing = timestamp;
-
-	} else {
-		// update filters, with different time constant
-		_IAS_derivative.setParameters(dt, 5.f);
-		_pitch_filtered.setParameters(dt, 1.5f);
-
-		_IAS_derivative.update(_IAS);
-		_pitch_filtered.update(pitch);
 	}
 
 	// declare high throttle if more than 5% above trim

--- a/src/modules/airspeed_selector/AirspeedValidator.cpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.cpp
@@ -291,24 +291,11 @@ AirspeedValidator::check_first_principle(const uint64_t timestamp, const float t
 				  && PX4_ISFINITE(throttle_fw) && PX4_ISFINITE(throttle_trim) && PX4_ISFINITE(pitch);
 
 	if (inputs_valid) {
-		const float dt = static_cast<float>(timestamp - _time_last_first_principle_check) * 1e-6f;
-		_time_last_first_principle_check = timestamp;
-
-		// Update the filters whenever inputs are valid, independent of whether the first principle check
-		// is enabled, so that the airspeed derivative is always available in the airspeed_validated topic.
-		if (dt < FLT_EPSILON || dt > 1.f) {
-			// reset if dt is too large
-			_IAS_derivative.reset(0.f);
-			_pitch_filtered.reset(pitch);
+		// Update the airspeed derivative whenever inputs are valid, independent of whether the first
+		// principle check is enabled, so the derivative is always available in the airspeed_validated topic.
+		if (!update_filtered_airspeed_derivative(timestamp, pitch)) {
+			// filters were reset after a time gap; restart the failure timeout window
 			_time_last_first_principle_check_passing = timestamp;
-
-		} else {
-			// update filters, with different time constant
-			_IAS_derivative.setParameters(dt, 5.f);
-			_pitch_filtered.setParameters(dt, 1.5f);
-
-			_IAS_derivative.update(_IAS);
-			_pitch_filtered.update(pitch);
 		}
 	}
 
@@ -340,6 +327,29 @@ AirspeedValidator::check_first_principle(const uint64_t timestamp, const float t
 		// only update the test_failed flag once the timeout since first principle check failing is over
 		_first_principle_check_failed = check_failing;
 	}
+}
+
+bool
+AirspeedValidator::update_filtered_airspeed_derivative(const uint64_t timestamp, const float pitch)
+{
+	const float dt = static_cast<float>(timestamp - _time_last_airspeed_derivative_update) * 1e-6f;
+	_time_last_airspeed_derivative_update = timestamp;
+
+	if (dt < FLT_EPSILON || dt > 1.f) {
+		// reset if dt is invalid or too large
+		_IAS_derivative.reset(0.f);
+		_pitch_filtered.reset(pitch);
+		return false;
+	}
+
+	// update filters, with different time constants
+	_IAS_derivative.setParameters(dt, 5.f);
+	_pitch_filtered.setParameters(dt, 1.5f);
+
+	_IAS_derivative.update(_IAS);
+	_pitch_filtered.update(pitch);
+
+	return true;
 }
 
 void

--- a/src/modules/airspeed_selector/AirspeedValidator.hpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.hpp
@@ -172,10 +172,12 @@ private:
 	// first principle check
 	bool _first_principle_check_failed{false}; ///< first principle check has detected failure
 	float _aspd_fp_t_window{0.f}; ///< time window for first principle check
-	FilteredDerivative<float> _IAS_derivative; ///< indicated airspeed derivative for first principle check
-	AlphaFilter<float> _pitch_filtered; ///< filtered pitch for first principle check
-	hrt_abstime _time_last_first_principle_check{0}; ///< time airspeed first principle was last checked (uSec)
 	hrt_abstime _time_last_first_principle_check_passing{0}; ///< time airspeed first principle was last passing (uSec)
+
+	// filtered airspeed derivative and pitch (decoupled from the first principle check, also published in airspeed_validated)
+	FilteredDerivative<float> _IAS_derivative; ///< filtered indicated airspeed derivative
+	AlphaFilter<float> _pitch_filtered; ///< filtered pitch
+	hrt_abstime _time_last_airspeed_derivative_update{0}; ///< time the airspeed derivative filter was last updated (uSec)
 	float _param_psp_off{0.0f}; ///< parameter pitch in level flight [rad]
 	float _param_throttle_max{0.0f}; ///< parameter maximum throttle value
 
@@ -208,6 +210,7 @@ private:
 	void check_load_factor(float accel_z);
 	void check_first_principle(const uint64_t timestamp, const float throttle, const float throttle_trim,
 				   const uint64_t tecs_timestamp, const Quatf &att_q);
+	bool update_filtered_airspeed_derivative(const uint64_t timestamp, const float pitch);
 	void update_airspeed_valid_status(const uint64_t timestamp);
 	void reset();
 	void reset_CAS_scale_check();


### PR DESCRIPTION
The `airspeed_derivative_filtered` (and `pitch_filtered`) fields of the `airspeed_validated` topic are reported as always zero (#26916). These fields are populated from filters (`_IAS_derivative`, `_pitch_filtered`) that were only updated inside `check_first_principle()`, behind its enable gate. Since the first-principle check is disabled by default (`ASPD_DO_CHECKS = 7`, bit 4 unset), those filters were never updated and the published derivative stayed at zero for any default configuration.

This moves the filter update so it runs whenever the inputs are valid (in fixed-wing flight, fresh TECS data, finite IAS/throttle/pitch), independent of whether the first-principle check is enabled:

- the IAS-derivative and pitch filters now update on every valid cycle, so `airspeed_derivative_filtered` is meaningful in `airspeed_validated` regardless of `ASPD_DO_CHECKS`
- the first-principle check's pass/fail decision remains gated on its enable bit, so the enabled+valid path is behaviorally identical to before and the safety behavior is unchanged

`AirspeedValidator` has no existing unit-test harness (it pulls in the wind estimator and other dependencies), so a dedicated gtest would be disproportionate for this change. Verified that `make px4_sitl` and `make px4_fmu-v6x` build and link cleanly. Behaviorally, in fixed-wing SITL with a real airspeed sensor selected, `listener airspeed_validated` now shows a non-zero `airspeed_derivative_filtered` in flight instead of a constant zero; on the ground / before fixed-wing flight it remains zero as expected.

Fixes #26916