### PR TITLE
fix(fw_latlon): align airspeed load factor

### DIFF
--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -607,13 +607,13 @@ void FwLateralLongitudinalControl::updateAttitude() {
 		_long_control_state.pitch_rad = euler_angles.theta();
 		_yaw = euler_angles.psi();
 
-		const float load_factor_from_bank_angle = 1.0f / max(cosf(euler_angles.phi()), FLT_EPSILON);
+		_load_factor_from_bank_angle = 1.0f / max(cosf(euler_angles.phi()), FLT_EPSILON);
 
 		// Used to compensate for higher induced drag during banking
-		_tecs.set_load_factor(load_factor_from_bank_angle);
+		_tecs.set_load_factor(_load_factor_from_bank_angle);
 		// Used to give underspeed mitigation the correct minimum airspeed
 		_tecs.set_equivalent_airspeed_min(
-			_performance_model.getMinimumCalibratedAirspeed(load_factor_from_bank_angle, _flaps_setpoint)
+			_performance_model.getMinimumCalibratedAirspeed(_load_factor_from_bank_angle, _flaps_setpoint)
 		);
 	}
 }
@@ -649,7 +649,7 @@ float
 FwLateralLongitudinalControl::adapt_airspeed_setpoint(const float control_interval, float calibrated_airspeed_setpoint,
 		float calibrated_min_airspeed_guidance, float wind_speed)
 {
-	float system_min_airspeed = _performance_model.getMinimumCalibratedAirspeed(getLoadFactor(), _flaps_setpoint);
+	float system_min_airspeed = _performance_model.getMinimumCalibratedAirspeed(_load_factor_from_bank_angle, _flaps_setpoint);
 
 	const float system_max_airspeed = _performance_model.getMaximumCalibratedAirspeed();
 
@@ -851,19 +851,6 @@ void FwLateralLongitudinalControl::updateLongitudinalControlConfiguration(const 
 	} else {
 		_long_configuration.speed_weight = _param_t_spdweight.get();
 	}
-}
-
-float FwLateralLongitudinalControl::getLoadFactor() const
-{
-	float load_factor_from_bank_angle = 1.f;
-
-	const float roll_body = Eulerf(Quatf(_att_sp.q_d)).phi();
-
-	if (PX4_ISFINITE(roll_body)) {
-		load_factor_from_bank_angle = 1.f / math::max(cosf(roll_body), FLT_EPSILON);
-	}
-
-	return load_factor_from_bank_angle;
 }
 
 extern "C" __EXPORT int fw_lat_lon_control_main(int argc, char *argv[])

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
@@ -201,6 +201,7 @@ private:
 	vehicle_attitude_setpoint_s _att_sp{};
 	bool _landed{false};
 	float _can_run_factor{0.f};
+	float _load_factor_from_bank_angle{1.f};
 	SlewRate<float> _airspeed_slew_rate_controller;
 
 	perf_counter_t _loop_perf; // loop performance counter
@@ -247,8 +248,6 @@ private:
 	void updateLongitudinalControlConfiguration(const longitudinal_control_configuration_s &configuration_in);
 
 	void updateControllerConfiguration(hrt_abstime now);
-
-	float getLoadFactor() const;
 
 	/**
 	 * @brief Returns an adapted calibrated airspeed setpoint


### PR DESCRIPTION
### Solved Problem
Follow-up to #27441.

#27441 made TECS update its load-factor-compensated minimum airspeed from the actual vehicle attitude. However, the airspeed setpoint adaptation still used the attitude setpoint via `getLoadFactor()`, so the TECS underspeed threshold and the airspeed setpoint floor could be based on different bank angles.

### Solution
Store the load factor computed from the actual vehicle attitude and use it consistently for both TECS minimum airspeed compensation and airspeed setpoint adaptation.

This keeps the setpoint floor aligned with TECS underspeed mitigation when actual bank differs from the commanded bank.

### Changelog Entry
For release notes:
```
Bugfix: Align fixed-wing load-factor-compensated minimum airspeed handling
```