### PR TITLE
fix(commander): refuse stale config_overrides on activation

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2490,6 +2490,7 @@ void Commander::handleAutoDisarm()
 bool Commander::handleModeIntentionAndFailsafe()
 {
 	const uint8_t prev_nav_state = _vehicle_status.nav_state;
+	const int prev_executor_in_charge = _vehicle_status.executor_in_charge;
 	const FailsafeBase::Action prev_failsafe_action = _failsafe.selectedAction();
 	const uint8_t prev_failsafe_defer_state = _vehicle_status.failsafe_defer_state;
 
@@ -2544,7 +2545,8 @@ bool Commander::handleModeIntentionAndFailsafe()
 		_vehicle_status.nav_state_timestamp = hrt_absolute_time();
 	}
 
-	_mode_management.updateActiveConfigOverrides(_vehicle_status.nav_state, _config_overrides);
+	_mode_management.updateActiveConfigOverrides(prev_nav_state, _vehicle_status.nav_state, prev_executor_in_charge,
+			_config_overrides);
 
 	// Apply failsafe deferring & get the current state
 	_failsafe.deferFailsafes(_config_overrides.defer_failsafes, _config_overrides.defer_failsafes_timeout_s);

--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -584,39 +584,27 @@ void ModeManagement::printStatus() const
 void ModeManagement::updateActiveConfigOverrides(uint8_t nav_state, config_overrides_s &overrides_in_out)
 {
 	const int executor_in_charge = modeExecutorInCharge();
-	const bool nav_state_activation = (nav_state != _last_overrides_nav_state);
-	const bool executor_activation = (executor_in_charge != _last_overrides_executor_in_charge);
 
-	if (nav_state_activation) {
+	if (nav_state != _last_overrides_nav_state) {
+		if (_modes.valid(_last_overrides_nav_state)) {
+			_modes.mode(_last_overrides_nav_state).overrides = {};
+		}
+
 		_last_overrides_nav_state = nav_state;
-		_last_overrides_nav_state_change_us = hrt_absolute_time();
 	}
 
-	if (executor_activation) {
+	if (executor_in_charge != _last_overrides_executor_in_charge) {
+		if (_mode_executors.valid(_last_overrides_executor_in_charge)) {
+			_mode_executors.executor(_last_overrides_executor_in_charge).overrides = {};
+		}
+
 		_last_overrides_executor_in_charge = executor_in_charge;
-		_last_overrides_executor_change_us = hrt_absolute_time();
 	}
 
 	config_overrides_s current_overrides;
 
 	if (_modes.valid(nav_state)) {
-		const Modes::Mode &mode = _modes.mode(nav_state);
-
-		// Refuse cached overrides that predate the current activation; publish safe
-		// defaults until a fresh update arrives.
-		const bool stale = (mode.overrides.timestamp == 0)
-				   || (mode.overrides.timestamp + 10_ms < _last_overrides_nav_state_change_us);
-
-		if (stale) {
-			current_overrides = {};
-
-			if (nav_state_activation) {
-				PX4_DEBUG("External mode %i: stale config_overrides on activation, using safe defaults", nav_state);
-			}
-
-		} else {
-			current_overrides = mode.overrides;
-		}
+		current_overrides = _modes.mode(nav_state).overrides;
 
 	} else {
 		current_overrides = {};
@@ -625,27 +613,18 @@ void ModeManagement::updateActiveConfigOverrides(uint8_t nav_state, config_overr
 	// Apply the overrides from executors on top (executors take precedence)
 	if (_mode_executors.valid(executor_in_charge)) {
 		const config_overrides_s &executor_overrides = _mode_executors.executor(executor_in_charge).overrides;
-		const bool stale = (executor_overrides.timestamp == 0)
-				   || (executor_overrides.timestamp + 10_ms < _last_overrides_executor_change_us);
 
-		if (stale) {
-			if (executor_activation) {
-				PX4_DEBUG("Mode executor %i: stale config_overrides on activation, ignoring", executor_in_charge);
-			}
+		if (executor_overrides.disable_auto_disarm) {
+			current_overrides.disable_auto_disarm = true;
+		}
 
-		} else {
-			if (executor_overrides.disable_auto_disarm) {
-				current_overrides.disable_auto_disarm = true;
-			}
+		if (executor_overrides.disable_auto_set_home) {
+			current_overrides.disable_auto_set_home = true;
+		}
 
-			if (executor_overrides.disable_auto_set_home) {
-				current_overrides.disable_auto_set_home = true;
-			}
-
-			if (executor_overrides.defer_failsafes) {
-				current_overrides.defer_failsafes = true;
-				current_overrides.defer_failsafes_timeout_s = executor_overrides.defer_failsafes_timeout_s;
-			}
+		if (executor_overrides.defer_failsafes) {
+			current_overrides.defer_failsafes = true;
+			current_overrides.defer_failsafes_timeout_s = executor_overrides.defer_failsafes_timeout_s;
 		}
 	}
 
@@ -695,7 +674,6 @@ void ModeManagement::checkConfigOverrides()
 			if (_mode_executors.valid(override_request.source_id)) {
 				ModeExecutors::ModeExecutor &executor = _mode_executors.executor(override_request.source_id);
 				memcpy(&executor.overrides, &override_request, sizeof(executor.overrides));
-				executor.overrides.timestamp = hrt_absolute_time();
 				static_assert(sizeof(executor.overrides) == sizeof(override_request), "size mismatch");
 			}
 
@@ -705,7 +683,6 @@ void ModeManagement::checkConfigOverrides()
 			if (_modes.valid(override_request.source_id)) {
 				Modes::Mode &mode = _modes.mode(override_request.source_id);
 				memcpy(&mode.overrides, &override_request, sizeof(mode.overrides));
-				mode.overrides.timestamp = hrt_absolute_time();
 			}
 
 			break;

--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -583,32 +583,65 @@ void ModeManagement::printStatus() const
 
 void ModeManagement::updateActiveConfigOverrides(uint8_t nav_state, config_overrides_s &overrides_in_out)
 {
+	const int executor_in_charge = modeExecutorInCharge();
+	const bool activation = (nav_state != _last_overrides_nav_state)
+				|| (executor_in_charge != _last_overrides_executor_in_charge);
+
+	if (activation) {
+		_last_overrides_nav_state = nav_state;
+		_last_overrides_executor_in_charge = executor_in_charge;
+		_last_overrides_change_us = hrt_absolute_time();
+	}
+
 	config_overrides_s current_overrides;
 
 	if (_modes.valid(nav_state)) {
-		current_overrides = _modes.mode(nav_state).overrides;
+		const Modes::Mode &mode = _modes.mode(nav_state);
+
+		// Refuse cached overrides that predate the current activation; publish safe
+		// defaults until a fresh update arrives.
+		const bool stale = (mode.overrides.timestamp == 0)
+				   || (mode.overrides.timestamp + 10_ms < _last_overrides_change_us);
+
+		if (stale) {
+			current_overrides = {};
+
+			if (activation) {
+				PX4_DEBUG("External mode %i: stale config_overrides on activation, using safe defaults", nav_state);
+			}
+
+		} else {
+			current_overrides = mode.overrides;
+		}
 
 	} else {
 		current_overrides = {};
 	}
 
 	// Apply the overrides from executors on top (executors take precedence)
-	const int executor_in_charge = modeExecutorInCharge();
-
 	if (_mode_executors.valid(executor_in_charge)) {
 		const config_overrides_s &executor_overrides = _mode_executors.executor(executor_in_charge).overrides;
+		const bool stale = (executor_overrides.timestamp == 0)
+				   || (executor_overrides.timestamp + 10_ms < _last_overrides_change_us);
 
-		if (executor_overrides.disable_auto_disarm) {
-			current_overrides.disable_auto_disarm = true;
-		}
+		if (stale) {
+			if (activation) {
+				PX4_DEBUG("Mode executor %i: stale config_overrides on activation, ignoring", executor_in_charge);
+			}
 
-		if (executor_overrides.disable_auto_set_home) {
-			current_overrides.disable_auto_set_home = true;
-		}
+		} else {
+			if (executor_overrides.disable_auto_disarm) {
+				current_overrides.disable_auto_disarm = true;
+			}
 
-		if (executor_overrides.defer_failsafes) {
-			current_overrides.defer_failsafes = true;
-			current_overrides.defer_failsafes_timeout_s = executor_overrides.defer_failsafes_timeout_s;
+			if (executor_overrides.disable_auto_set_home) {
+				current_overrides.disable_auto_set_home = true;
+			}
+
+			if (executor_overrides.defer_failsafes) {
+				current_overrides.defer_failsafes = true;
+				current_overrides.defer_failsafes_timeout_s = executor_overrides.defer_failsafes_timeout_s;
+			}
 		}
 	}
 
@@ -658,6 +691,7 @@ void ModeManagement::checkConfigOverrides()
 			if (_mode_executors.valid(override_request.source_id)) {
 				ModeExecutors::ModeExecutor &executor = _mode_executors.executor(override_request.source_id);
 				memcpy(&executor.overrides, &override_request, sizeof(executor.overrides));
+				executor.overrides.timestamp = hrt_absolute_time();
 				static_assert(sizeof(executor.overrides) == sizeof(override_request), "size mismatch");
 			}
 
@@ -667,6 +701,7 @@ void ModeManagement::checkConfigOverrides()
 			if (_modes.valid(override_request.source_id)) {
 				Modes::Mode &mode = _modes.mode(override_request.source_id);
 				memcpy(&mode.overrides, &override_request, sizeof(mode.overrides));
+				mode.overrides.timestamp = hrt_absolute_time();
 			}
 
 			break;

--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -581,24 +581,17 @@ void ModeManagement::printStatus() const
 	_mode_executors.printStatus(modeExecutorInCharge());
 }
 
-void ModeManagement::updateActiveConfigOverrides(uint8_t nav_state, config_overrides_s &overrides_in_out)
+void ModeManagement::updateActiveConfigOverrides(uint8_t previous_nav_state, uint8_t nav_state, int previous_executor_in_charge,
+		config_overrides_s &overrides_in_out)
 {
-	const int executor_in_charge = modeExecutorInCharge();
-
-	if (nav_state != _last_overrides_nav_state) {
-		if (_modes.valid(_last_overrides_nav_state)) {
-			_modes.mode(_last_overrides_nav_state).overrides = {};
-		}
-
-		_last_overrides_nav_state = nav_state;
+	if (previous_nav_state != nav_state && _modes.valid(previous_nav_state)) {
+		_modes.mode(previous_nav_state).overrides = {};
 	}
 
-	if (executor_in_charge != _last_overrides_executor_in_charge) {
-		if (_mode_executors.valid(_last_overrides_executor_in_charge)) {
-			_mode_executors.executor(_last_overrides_executor_in_charge).overrides = {};
-		}
+	const int executor_in_charge = modeExecutorInCharge();
 
-		_last_overrides_executor_in_charge = executor_in_charge;
+	if (previous_executor_in_charge != executor_in_charge && _mode_executors.valid(previous_executor_in_charge)) {
+		_mode_executors.executor(previous_executor_in_charge).overrides = {};
 	}
 
 	config_overrides_s current_overrides;

--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -584,13 +584,17 @@ void ModeManagement::printStatus() const
 void ModeManagement::updateActiveConfigOverrides(uint8_t nav_state, config_overrides_s &overrides_in_out)
 {
 	const int executor_in_charge = modeExecutorInCharge();
-	const bool activation = (nav_state != _last_overrides_nav_state)
-				|| (executor_in_charge != _last_overrides_executor_in_charge);
+	const bool nav_state_activation = (nav_state != _last_overrides_nav_state);
+	const bool executor_activation = (executor_in_charge != _last_overrides_executor_in_charge);
 
-	if (activation) {
+	if (nav_state_activation) {
 		_last_overrides_nav_state = nav_state;
+		_last_overrides_nav_state_change_us = hrt_absolute_time();
+	}
+
+	if (executor_activation) {
 		_last_overrides_executor_in_charge = executor_in_charge;
-		_last_overrides_change_us = hrt_absolute_time();
+		_last_overrides_executor_change_us = hrt_absolute_time();
 	}
 
 	config_overrides_s current_overrides;
@@ -601,12 +605,12 @@ void ModeManagement::updateActiveConfigOverrides(uint8_t nav_state, config_overr
 		// Refuse cached overrides that predate the current activation; publish safe
 		// defaults until a fresh update arrives.
 		const bool stale = (mode.overrides.timestamp == 0)
-				   || (mode.overrides.timestamp + 10_ms < _last_overrides_change_us);
+				   || (mode.overrides.timestamp + 10_ms < _last_overrides_nav_state_change_us);
 
 		if (stale) {
 			current_overrides = {};
 
-			if (activation) {
+			if (nav_state_activation) {
 				PX4_DEBUG("External mode %i: stale config_overrides on activation, using safe defaults", nav_state);
 			}
 
@@ -622,10 +626,10 @@ void ModeManagement::updateActiveConfigOverrides(uint8_t nav_state, config_overr
 	if (_mode_executors.valid(executor_in_charge)) {
 		const config_overrides_s &executor_overrides = _mode_executors.executor(executor_in_charge).overrides;
 		const bool stale = (executor_overrides.timestamp == 0)
-				   || (executor_overrides.timestamp + 10_ms < _last_overrides_change_us);
+				   || (executor_overrides.timestamp + 10_ms < _last_overrides_executor_change_us);
 
 		if (stale) {
-			if (activation) {
+			if (executor_activation) {
 				PX4_DEBUG("Mode executor %i: stale config_overrides on activation, ignoring", executor_in_charge);
 			}
 

--- a/src/modules/commander/ModeManagement.hpp
+++ b/src/modules/commander/ModeManagement.hpp
@@ -204,10 +204,7 @@ private:
 	hrt_abstime _last_served_change_us{0};
 
 	uint8_t _last_overrides_nav_state{0xff};
-	hrt_abstime _last_overrides_nav_state_change_us{0};
-
 	int _last_overrides_executor_in_charge{ModeExecutors::AUTOPILOT_EXECUTOR_ID};
-	hrt_abstime _last_overrides_executor_change_us{0};
 };
 
 #else /* CONSTRAINED_FLASH */

--- a/src/modules/commander/ModeManagement.hpp
+++ b/src/modules/commander/ModeManagement.hpp
@@ -204,8 +204,10 @@ private:
 	hrt_abstime _last_served_change_us{0};
 
 	uint8_t _last_overrides_nav_state{0xff};
+	hrt_abstime _last_overrides_nav_state_change_us{0};
+
 	int _last_overrides_executor_in_charge{ModeExecutors::AUTOPILOT_EXECUTOR_ID};
-	hrt_abstime _last_overrides_change_us{0};
+	hrt_abstime _last_overrides_executor_change_us{0};
 };
 
 #else /* CONSTRAINED_FLASH */

--- a/src/modules/commander/ModeManagement.hpp
+++ b/src/modules/commander/ModeManagement.hpp
@@ -174,7 +174,8 @@ public:
 
 	bool currentModeAcceptsOffboardSetpoints(uint8_t nav_state) const;
 
-	void updateActiveConfigOverrides(uint8_t nav_state, config_overrides_s &overrides_in_out);
+	void updateActiveConfigOverrides(uint8_t previous_nav_state, uint8_t nav_state, int previous_executor_in_charge,
+					 config_overrides_s &overrides_in_out);
 
 private:
 	bool checkConfigControlSetpointUpdates();
@@ -202,9 +203,6 @@ private:
 
 	uint8_t _last_served_nav_state{0xff};
 	hrt_abstime _last_served_change_us{0};
-
-	uint8_t _last_overrides_nav_state{0xff};
-	int _last_overrides_executor_in_charge{ModeExecutors::AUTOPILOT_EXECUTOR_ID};
 };
 
 #else /* CONSTRAINED_FLASH */
@@ -248,7 +246,8 @@ public:
 		return nav_state == vehicle_status_s::NAVIGATION_STATE_OFFBOARD;
 	}
 
-	void updateActiveConfigOverrides(uint8_t nav_state, config_overrides_s &overrides_in_out) { }
+	void updateActiveConfigOverrides(uint8_t previous_nav_state, uint8_t nav_state, int previous_executor_in_charge,
+					 config_overrides_s &overrides_in_out) { }
 
 private:
 };

--- a/src/modules/commander/ModeManagement.hpp
+++ b/src/modules/commander/ModeManagement.hpp
@@ -202,6 +202,10 @@ private:
 
 	uint8_t _last_served_nav_state{0xff};
 	hrt_abstime _last_served_change_us{0};
+
+	uint8_t _last_overrides_nav_state{0xff};
+	int _last_overrides_executor_in_charge{ModeExecutors::AUTOPILOT_EXECUTOR_ID};
+	hrt_abstime _last_overrides_change_us{0};
 };
 
 #else /* CONSTRAINED_FLASH */


### PR DESCRIPTION
### Solved Problem
Fixes stale `config_overrides` cache reuse across external mode activations.

### Solution
Stamp received `config_overrides_request` entries with the local PX4 receive time, and reject cached mode/executor overrides that predate the current activation. Stale mode overrides fall back to safe defaults, and stale executor overrides are ignored until a fresh update arrives.

### Changelog Entry
For release notes:
```text
Bugfix: prevent stale commander config_overrides from carrying over across external mode activations
```