### PR TITLE
refactor(uORB): hoist Publication advertise/publish to base

### DIFF
--- a/platforms/common/uORB/Publication.hpp
+++ b/platforms/common/uORB/Publication.hpp
@@ -54,6 +54,15 @@ public:
 
 	bool advertised() const { return _handle != nullptr; }
 
+	bool advertise()
+	{
+		if (!advertised()) {
+			_handle = orb_advertise(get_topic(), nullptr);
+		}
+
+		return advertised();
+	}
+
 	bool unadvertise() { return (Manager::orb_unadvertise(_handle) == PX4_OK); }
 
 	orb_id_t get_topic() const { return get_orb_meta(_orb_id); }
@@ -70,6 +79,16 @@ protected:
 				unadvertise();
 			}
 		}
+	}
+
+	// type-independent publish; data points to a message of the topic's type
+	bool publish(const void *data)
+	{
+		if (!advertised()) {
+			advertise();
+		}
+
+		return (Manager::orb_publish(get_topic(), _handle, data) == PX4_OK);
 	}
 
 	orb_advert_t _handle{nullptr};
@@ -92,27 +111,11 @@ public:
 	Publication(ORB_ID id) : PublicationBase(id) {}
 	Publication(const orb_metadata *meta) : PublicationBase(static_cast<ORB_ID>(meta->o_id)) {}
 
-	bool advertise()
-	{
-		if (!advertised()) {
-			_handle = orb_advertise(get_topic(), nullptr);
-		}
-
-		return advertised();
-	}
-
 	/**
 	 * Publish the struct
 	 * @param data The uORB message struct we are updating.
 	 */
-	bool publish(const T &data)
-	{
-		if (!advertised()) {
-			advertise();
-		}
-
-		return (Manager::orb_publish(get_topic(), _handle, &data) == PX4_OK);
-	}
+	bool publish(const T &data) { return PublicationBase::publish(&data); }
 };
 
 /**


### PR DESCRIPTION
## Summary
Move the type-independent `advertise()` and `publish()` bodies out of the `Publication<T>` template into the non-template `PublicationBase`, leaving `Publication<T>::publish(const T &)` as a thin typed forwarder. The advertise/publish machinery is now emitted once instead of once per published topic type.

## Problem
`Publication<T>::advertise()` is fully type-independent, and `publish()` differs only by the address of the message struct, yet both are instantiated for every topic type. PX4 links with bfd `ld` (no identical-code folding) and without LTO, so each distinct `Publication<T>` emits its own copy of this machinery — dead-weight flash that grows with the number of published topics.

## Solution
Hoist `advertise()` (it only ever touched base state) and a new `publish(const void *)` into `PublicationBase`; the typed `Publication<T>::publish` forwards `&data`. This is pure code motion — behavior is unchanged and the forwarder inlines to a direct call, so the publish hot path is identical. The saving applies to every board and scales with the number of distinct published topics.
