### PR TITLE
fix(ekf2): guard EKF-GSF emergency yaw reset

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
@@ -107,16 +107,22 @@ void Ekf::controlGpsFusion(const imuSample &imu_delayed)
 		bool do_vel_pos_reset = false;
 
 		if (!_control_status.flags.gnss_fault && _control_status.flags.in_air && isYawFailure()) {
-			const bool velocity_fusion_failure =  _aid_src_gnss_vel.innovation_rejected
-							      && isTimedOut(_time_last_hor_vel_fuse, _params.EKFGSF_reset_delay)
-							      && (_time_last_hor_vel_fuse > _time_last_on_ground_us);
+			const bool velocity_fusion_failure = _control_status.flags.gnss_vel
+							     && _aid_src_gnss_vel.innovation_rejected
+							     && isTimedOut(_time_last_hor_vel_fuse, _params.EKFGSF_reset_delay)
+							     && (_time_last_hor_vel_fuse > _time_last_on_ground_us);
 
-			const bool position_fusion_failure =  _aid_src_gnss_pos.innovation_rejected
-							      && isTimedOut(_time_last_hor_pos_fuse, _params.EKFGSF_reset_delay)
-							      && (_time_last_hor_pos_fuse > _time_last_on_ground_us);
+			// While GNSS velocity aiding is active, require velocity rejection
+			// before using EKF-GSF yaw rescue. Position-only rejection can be
+			// caused by transient position inconsistency while velocity still
+			// provides the yaw-observable measurement used by EKF-GSF.
+			const bool position_fusion_failure = !_control_status.flags.gnss_vel
+							     && _control_status.flags.gnss_pos
+							     && _aid_src_gnss_pos.innovation_rejected
+							     && isTimedOut(_time_last_hor_pos_fuse, _params.EKFGSF_reset_delay)
+							     && (_time_last_hor_pos_fuse > _time_last_on_ground_us);
 
-			if ((_control_status.flags.gnss_vel && velocity_fusion_failure)
-			    || (_control_status.flags.gnss_pos && position_fusion_failure)) {
+			if (velocity_fusion_failure || position_fusion_failure) {
 				do_vel_pos_reset = tryYawEmergencyReset();
 			}
 		}
@@ -408,6 +414,10 @@ bool Ekf::tryYawEmergencyReset()
 	 * This enables recovery from a bad yaw estimate. A reset is not performed if the fault condition was
 	 * present before flight to prevent triggering due to GPS glitches or other sensor errors.
 	 */
+	if (_control_status.flags.in_transition) {
+		return false;
+	}
+
 	if (resetYawToEKFGSF()) {
 		ECL_WARN("GPS emergency yaw reset");
 


### PR DESCRIPTION
### Solved Problem

EKF-GSF emergency yaw reset can currently be accepted from GNSS position-only rejection while GNSS velocity aiding is still active and healthy.

I hit this while validating the X-Plane VTOL SITL integration in #22493, but the estimator condition is not simulator-specific. During VTOL transition, non-coordinated acceleration, aggressive maneuvering, or a brief GNSS/local-position inconsistency, position fusion can reject while velocity fusion remains a better source for the velocity-aided EKF-GSF yaw estimate. If the EKF-GSF yaw is wrong at that moment, accepting it can replace a valid yaw solution and then fault the active heading source.

The behavior appears after #26033 / `d62f112017`, which broadened the rescue trigger from horizontal velocity timeout to velocity or position innovation rejection. That fixed the case where velocity fusion has stopped and position fusion resumes, but it also allows position-only rejection to trigger yaw rescue while velocity fusion is still active.

In the failing SITL log:

- main EKF yaw, magnetic heading, and GPS course were all near `-85 deg`
- EKF-GSF yaw was near `-54 deg`
- GNSS velocity innovation was healthy, with horizontal velocity test ratio about `0.06`
- GNSS position rejected transiently
- the old logic reset yaw by about `30 deg`, then raised a compass fault

### Solution

- Require GNSS velocity rejection before EKF-GSF emergency yaw rescue when GNSS velocity aiding is active.
- Keep the position-only fallback for the case where GNSS position aiding is active and GNSS velocity aiding is not active.
- Suppress the emergency yaw reset during VTOL transition, where sustained non-coordinated acceleration can make the EKF-GSF yaw estimate a poor rescue source.

This does not block the normal initial EKF-GSF yaw alignment path; it only guards the in-flight emergency yaw reset.

### Changelog Entry

For release notes:

```
Bugfix: guard EKF-GSF emergency yaw reset against GNSS position-only rejection while velocity aiding is active
```

### Alternatives

I considered handling this as a SITL/airframe parameter workaround by increasing GNSS position noise or gates. That hides the symptom, but it weakens position fault detection and does not address the estimator decision logic.

The tradeoff in this patch is that a real yaw failure can be rescued later if GNSS velocity innovations remain inside the gate while position rejects first, or after VTOL transition exits. That is preferable to resetting from EKF-GSF when the velocity-aided yaw estimate itself is not supported by a velocity fusion failure.

### Test coverage

- `make px4_sitl_default`
- `make tests TESTFILTER=EKF_yaw_estimator`
- Re-tested the original Alia VTOL SITL mission that reproduced the compass fault; the yaw reset was no longer triggered during transition and the mission completed without the compass fault.

### Context

This came up while preparing #22493 for review after rebasing the X-Plane SITL branch onto current `main`.
