### PR TITLE
fix(navigator): clear course on loiter reposition

### DIFF
--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -164,6 +164,7 @@ Loiter::reposition()
 		pos_sp_triplet->previous.lon = _navigator->get_global_position()->lon;
 		pos_sp_triplet->previous.alt = _navigator->get_global_position()->alt;
 		memcpy(&pos_sp_triplet->current, &rep->current, sizeof(rep->current));
+		pos_sp_triplet->current.course = NAN;
 		pos_sp_triplet->next.valid = false;
 
 		_navigator->set_position_setpoint_triplet_updated();


### PR DESCRIPTION
### Solved Problem
Follow-up to #27487: address the initialization issue mentioned in review where an unused `PositionSetpoint.course` can remain zero-initialized instead of `NaN`.

### Solution
Clear `course` to `NaN` when applying a loiter reposition setpoint.

### Changelog Entry
For release notes:
```text
Bugfix: clear unused course on loiter reposition
```