### PR TITLE
fix(ekf2): count EV velocity as NE aiding

### DIFF
--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -748,7 +748,7 @@ bool EstimatorInterface::isNorthEastAidingActive() const
 	       || _control_status.flags.gnss_vel
 	       || _control_status.flags.aux_gpos
 	       || (_control_status.flags.ev_pos && _control_status.flags.yaw_align)
-	       || (_control_status.flags.ev_vel && ev_vel_ned && _control_status.flags.yaw_align);
+	       || (_control_status.flags.ev_vel && ev_vel_ned);
 }
 
 void EstimatorInterface::printBufferAllocationFailed(const char *buffer_name)

--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -738,11 +738,17 @@ int EstimatorInterface::getNumberOfActiveVerticalVelocityAidingSources() const
 
 bool EstimatorInterface::isNorthEastAidingActive() const
 {
+	bool ev_vel_ned = false;
+
+#if defined(CONFIG_EKF2_EXTERNAL_VISION)
+	ev_vel_ned = _ev_sample_prev.vel_frame == VelocityFrame::LOCAL_FRAME_NED;
+#endif // CONFIG_EKF2_EXTERNAL_VISION
+
 	return _control_status.flags.gnss_pos
 	       || _control_status.flags.gnss_vel
 	       || _control_status.flags.aux_gpos
 	       || (_control_status.flags.ev_pos && _control_status.flags.yaw_align)
-	       || (_control_status.flags.ev_vel && _control_status.flags.yaw_align);
+	       || (_control_status.flags.ev_vel && ev_vel_ned && _control_status.flags.yaw_align);
 }
 
 void EstimatorInterface::printBufferAllocationFailed(const char *buffer_name)

--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -741,7 +741,8 @@ bool EstimatorInterface::isNorthEastAidingActive() const
 	return _control_status.flags.gnss_pos
 	       || _control_status.flags.gnss_vel
 	       || _control_status.flags.aux_gpos
-	       || (_control_status.flags.ev_pos && _control_status.flags.yaw_align);
+	       || (_control_status.flags.ev_pos && _control_status.flags.yaw_align)
+	       || (_control_status.flags.ev_vel && _control_status.flags.yaw_align);
 }
 
 void EstimatorInterface::printBufferAllocationFailed(const char *buffer_name)

--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -738,16 +738,18 @@ int EstimatorInterface::getNumberOfActiveVerticalVelocityAidingSources() const
 
 bool EstimatorInterface::isNorthEastAidingActive() const
 {
+	bool ev_pos_ned = false;
 	bool ev_vel_ned = false;
 
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
+	ev_pos_ned = _ev_sample_prev.pos_frame == PositionFrame::LOCAL_FRAME_NED;
 	ev_vel_ned = _ev_sample_prev.vel_frame == VelocityFrame::LOCAL_FRAME_NED;
 #endif // CONFIG_EKF2_EXTERNAL_VISION
 
 	return _control_status.flags.gnss_pos
 	       || _control_status.flags.gnss_vel
 	       || _control_status.flags.aux_gpos
-	       || (_control_status.flags.ev_pos && _control_status.flags.yaw_align)
+	       || (_control_status.flags.ev_pos && ev_pos_ned)
 	       || (_control_status.flags.ev_vel && ev_vel_ned);
 }
 


### PR DESCRIPTION
### Solved Problem

EV velocity can be fused without EV position, but it was not counted as North-East aiding. This could make yaw/mag logic treat EV-velocity-only setups as having no NE aiding.

### Solution
Count EV velocity as NE aiding when yaw is aligned, matching the EV position handling added in #26622.

### Changelog Entry
For release notes:
```
Bugfix: Count yaw-aligned EV velocity as North-East aiding
```

### Alternatives
I considered distinguishing EV velocity frames, since body-frame velocity may not be equivalent to local-frame NE aiding. The current helper only has `ev_vel`; the frame is available on EV samples, but not as explicit current fusion state. Adding that state would be larger, so this PR keeps the fix minimal and aligned with #26622.