### PR TITLE
feat(romfs): per-target board airframe whitelist

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -85,8 +85,14 @@ endif()
 if(PX4_ETHERNET)
 	set(added_arguments ${added_arguments} --ethernet)
 endif()
-# Check if board has an rc.board_airframes file to filter airframes
+# Check if board has an rc.board_airframes file to filter airframes.
+# A label-specific list (rc.board_airframes_<label>, e.g. rc.board_airframes_rover)
+# overrides the board-wide default (rc.board_airframes), so a single board can ship
+# a different airframe set per .px4board target.
 set(board_airframes_file "${PX4_BOARD_DIR}/init/rc.board_airframes")
+if(EXISTS "${PX4_BOARD_DIR}/init/rc.board_airframes_${LABEL}")
+	set(board_airframes_file "${PX4_BOARD_DIR}/init/rc.board_airframes_${LABEL}")
+endif()
 set(airframes_whitelist "")
 if(EXISTS "${board_airframes_file}")
 	message(STATUS "ROMFS: Using board-specific airframes list: ${board_airframes_file}")

--- a/boards/ark/pi6x/init/rc.board_airframes_rover
+++ b/boards/ark/pi6x/init/rc.board_airframes_rover
@@ -1,0 +1,16 @@
+# Airframe whitelist for the ark_pi6x_rover (.px4board) target.
+
+# Differential / tracked
+50000_generic_rover_differential
+50001_aion_robotics_r1_rover
+50002_hiwonder_tracked
+
+# Ackermann
+51000_generic_rover_ackermann
+51001_axial_scx10_2_trail_honcho
+51002_nxp_b3rb
+51003_hiwonder_ackermann
+
+# Mecanum
+52000_generic_rover_mecanum
+52001_hiwonder_mecanum


### PR DESCRIPTION
## Summary

Add per-`.px4board`-target airframe whitelists to the ROMFS build, and use it to ship the rover airframes on `ark_pi6x_rover`.

## Problem

The ROMFS airframe whitelist (`boards/<vendor>/<board>/init/rc.board_airframes`) is resolved once per board and shared across every `.px4board` target. `ark_pi6x` therefore applied its multicopter-only list (`4001_quad_x`, `4601_droneblocks_dexi_5`) to the `rover` target as well, so `ark_pi6x_rover` shipped no rover airframes despite enabling the rover modules. Selecting "Generic Rover Differential" in QGroundControl set `SYS_AUTOSTART=50000`, which matched no airframe at boot; the startup script reset `SYS_AUTOSTART` to 0, surfacing as "Airframe needs to be defined" in QGC.

## Solution

Resolve a label-specific list `rc.board_airframes_<label>` before falling back to the board-wide `rc.board_airframes`, so a board can curate a different airframe set per target. Add `boards/ark/pi6x/init/rc.board_airframes_rover` listing the differential/ackermann/mecanum frames. Existing boards are unaffected — none define a label-specific file, so they fall through to the current behavior.

Verified by building `ark_pi6x_rover`: the generated ROMFS now contains the nine rover airframes and `rc.autostart` wires IDs 50000–52001, while `ark_pi6x_default` is unchanged. `px4_fmu-v6x` and `px4_sitl` build clean.
