### PR TITLE
fix(ekf2): add HAGL validity check for range height ref

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
@@ -380,8 +380,7 @@ bool Ekf::checkHaglYawResetReq() const
 		// Check if height has increased sufficiently to be away from ground magnetic anomalies
 		// and request a yaw reset if not already requested.
 		static constexpr float mag_anomalies_max_hagl = 1.5f;
-		const bool above_mag_anomalies = (getTerrainVPos() + _gpos.altitude()) > mag_anomalies_max_hagl;
-		return above_mag_anomalies;
+		return isHeightAboveGroundEstimateValid() && (getHagl() > mag_anomalies_max_hagl);
 	}
 
 #endif // CONFIG_EKF2_TERRAIN

--- a/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
@@ -380,7 +380,8 @@ bool Ekf::checkHaglYawResetReq() const
 		// Check if height has increased sufficiently to be away from ground magnetic anomalies
 		// and request a yaw reset if not already requested.
 		static constexpr float mag_anomalies_max_hagl = 1.5f;
-		return isHeightAboveGroundEstimateValid() && (getHagl() > mag_anomalies_max_hagl);
+		const bool above_mag_anomalies = (getTerrainVPos() + _gpos.altitude()) > mag_anomalies_max_hagl;
+		return above_mag_anomalies;
 	}
 
 #endif // CONFIG_EKF2_TERRAIN

--- a/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_control.cpp
@@ -157,7 +157,7 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 				&& is_magnitude_good
 				&& is_tilt_good
 				&& (_flow_counter > 10)
-				&& (isTerrainEstimateValid() || isHorizontalAidingActive() || (_height_sensor_ref == HeightSensor::RANGE))
+				&& (isHeightAboveGroundEstimateValid() || isHorizontalAidingActive())
 				&& isTimedOut(_aid_src_optical_flow.time_last_fuse, (uint64_t)2e6); // Prevent rapid switching
 
 		// If the height is relative to the ground, terrain height cannot be observed.
@@ -205,7 +205,7 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 					}
 
 				} else {
-					if (isTerrainEstimateValid() || (_height_sensor_ref == HeightSensor::RANGE)) {
+					if (isHeightAboveGroundEstimateValid()) {
 						ECL_INFO("starting optical flow, resetting");
 						resetFlowFusion(flow_sample);
 						_control_status.flags.opt_flow = true;

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -105,6 +105,10 @@ public:
 #if defined(CONFIG_EKF2_TERRAIN)
 	// terrain estimate
 	bool isTerrainEstimateValid() const { return _terrain_valid; }
+	bool isHeightAboveGroundEstimateValid() const
+	{
+		return isTerrainEstimateValid() || (_height_sensor_ref == HeightSensor::RANGE);
+	}
 
 	// get the estimated terrain vertical position relative to the NED origin
 	float getTerrainVertPos() const { return _state.terrain + getEkfGlobalOriginAltitude(); };

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -711,7 +711,7 @@ uint16_t Ekf::get_ekf_soln_status() const
 
 	// 64	ESTIMATOR_POS_VERT_AGL	True if the vertical position (above ground) estimate is good
 #if defined(CONFIG_EKF2_TERRAIN)
-	soln_status.flags.pos_vert_agl = isTerrainEstimateValid();
+	soln_status.flags.pos_vert_agl = isHeightAboveGroundEstimateValid();
 #endif // CONFIG_EKF2_TERRAIN
 
 	// 128	ESTIMATOR_CONST_POS_MODE	True if the EKF is in a constant position mode and is not using external measurements (eg GNSS or optical flow)
@@ -952,8 +952,8 @@ void Ekf::updateGroundEffect()
 	if (_control_status.flags.in_air && !_control_status.flags.fixed_wing) {
 #if defined(CONFIG_EKF2_TERRAIN)
 
-		if (isTerrainEstimateValid()) {
-			// automatically set ground effect if terrain is valid
+		if (isHeightAboveGroundEstimateValid()) {
+			// automatically set ground effect if HAGL is valid
 			float height = getHagl();
 			_control_status.flags.gnd_effect = (height < _params.ekf2_gnd_max_hgt);
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1758,7 +1758,7 @@ void EKF2::PublishLocalPosition(const hrt_abstime &timestamp)
 
 #if defined(CONFIG_EKF2_TERRAIN)
 	// Distance to bottom surface (ground) in meters, must be positive
-	lpos.dist_bottom_valid = _ekf.isTerrainEstimateValid() || (_ekf.getHeightSensorRef() == HeightSensor::RANGE);
+	lpos.dist_bottom_valid = _ekf.isHeightAboveGroundEstimateValid();
 	lpos.dist_bottom = math::max(_ekf.getHagl(), 0.f);
 	lpos.dist_bottom_var = _ekf.getHaglVariance();
 	_ekf.get_hagl_reset(&lpos.delta_dist_bottom, &lpos.dist_bottom_reset_counter);


### PR DESCRIPTION
### Solved Problem

Follow-up to #26960, #27339, and #27349.

When the range finder is the EKF height reference, terrain is not estimated, so `isTerrainEstimateValid()` remains false. However, height above ground is still valid because ground is the height datum. Some AGL/HAGL consumers were still gated on terrain estimate validity.

### Solution
Add an EKF helper for height-above-ground validity and use it only for AGL/HAGL consumers:
- `dist_bottom_valid`
- `ESTIMATOR_POS_VERT_AGL`
- automatic ground effect detection
- optical flow start/reset gates

Terrain-specific outputs and checks remain based on `isTerrainEstimateValid()`.

### Changelog Entry
For release notes:
```text
Bugfix: improve EKF height-above-ground validity reporting when range finder is the height reference
```