### PR TITLE
fix(mavlink): fix autotune param handle check

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -731,11 +731,11 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 
 				switch (vehicle_status.vehicle_type) {
 				case vehicle_status_s::VEHICLE_TYPE_FIXED_WING:
-					has_module = param_find("FW_AT_APPLY");
+					has_module = param_find("FW_AT_APPLY") != PARAM_INVALID;
 					break;
 
 				case vehicle_status_s::VEHICLE_TYPE_ROTARY_WING:
-					has_module = param_find("MC_AT_APPLY");
+					has_module = param_find("MC_AT_APPLY") != PARAM_INVALID;
 					break;
 
 				default:


### PR DESCRIPTION
### Solved Problem
Fixes incorrect autotune module availability detection when the FW/MC autotune parameter is not present.

### Changelog Entry
For release notes:
```
Bugfix: Fix MAVLink autotune command handling when autotune module parameters are unavailable.
```