### PR TITLE
refactor(sticks): Localize math::expo_deadzone usage in Sticks.cpp to save flash

### DIFF
--- a/src/lib/sticks/Sticks.cpp
+++ b/src/lib/sticks/Sticks.cpp
@@ -83,6 +83,11 @@ bool Sticks::checkAndUpdateStickInputs()
 	return _input_available;
 }
 
+float Sticks::expoDeadzone(float value, float expo, float deadzone)
+{
+	return math::expo(math::deadzone(value, deadzone), expo);
+}
+
 void Sticks::limitStickUnitLengthXY(Vector2f &v)
 {
 	const float vl = v.length();

--- a/src/lib/sticks/Sticks.hpp
+++ b/src/lib/sticks/Sticks.hpp
@@ -64,10 +64,12 @@ public:
 	float getYaw() const { return _positions(2); }
 	float getThrottleZeroCentered() const { return _positions(3); }
 
-	float getRollExpo(float expo = .6f) const { return math::expo_deadzone(getRoll(), expo, _param_man_deadzone.get()); }
-	float getPitchExpo(float expo = .6f) const { return math::expo_deadzone(getPitch(), expo, _param_man_deadzone.get()); }
-	float getYawExpo(float expo = .6f) const { return math::expo_deadzone(getYaw(), expo, _param_man_deadzone.get()); }
-	float getThrottleZeroCenteredExpo(float expo = .6f) const { return math::expo_deadzone(getThrottleZeroCentered(), expo, _param_man_deadzone.get()); }
+	float getRollExpo(float expo = .6f) const { return expoDeadzone(getRoll(), expo, _param_man_deadzone.get()); }
+	float getPitchExpo(float expo = .6f) const { return expoDeadzone(getPitch(), expo, _param_man_deadzone.get()); }
+	float getYawExpo(float expo = .6f) const { return expoDeadzone(getYaw(), expo, _param_man_deadzone.get()); }
+	float getThrottleZeroCenteredExpo(float expo = .6f) const { return expoDeadzone(getThrottleZeroCentered(), expo, _param_man_deadzone.get()); }
+
+	static float expoDeadzone(float value, float expo, float deadzone);
 
 	const matrix::Vector2f getPitchRoll() { return {getPitch(), getRoll()}; }
 	const matrix::Vector2f getPitchRollExpo() { return {getPitchExpo(), getRollExpo()}; }

--- a/src/modules/mc_att_control/CMakeLists.txt
+++ b/src/modules/mc_att_control/CMakeLists.txt
@@ -47,5 +47,6 @@ px4_add_module(
 		AttitudeControl
 		mathlib
 		px4_work_queue
+		Sticks
 		StickYaw
 	)

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -48,6 +48,7 @@
 #include <drivers/drv_hrt.h>
 #include <mathlib/math/Limits.hpp>
 #include <mathlib/math/Functions.hpp>
+#include <Sticks.hpp>
 
 #include "AttitudeControl/AttitudeControlMath.hpp"
 
@@ -149,7 +150,7 @@ MulticopterAttitudeControl::generate_attitude_setpoint(const Quatf &q, float dt)
 	}
 
 	const float yaw = Eulerf(q).psi();
-	const float yaw_stick_input = math::expo_deadzone(_manual_control_setpoint.yaw, .6f, _param_man_deadzone.get());
+	const float yaw_stick_input = Sticks::expoDeadzone(_manual_control_setpoint.yaw, .6f, _param_man_deadzone.get());
 	_stick_yaw.generateYawSetpoint(attitude_setpoint.yaw_sp_move_rate, _yaw_setpoint_stabilized, yaw_stick_input, yaw, dt,
 				       _unaided_heading);
 


### PR DESCRIPTION
### Solved Problem

Saves ~2KB of flash space on 32-bit arm targets

### Solution

math::expo_deadzone generates ~240bytes of code for 32-bit arm platform, and it gets currently inlined several times.

Localizing the function in Sticks.cpp saves ~2KB of flash, measured on px4_fmu-v5_default target.

### Context

Partly solving size issues in https://github.com/PX4/PX4-Autopilot/pull/26215
