### PR TITLE
fix(bootloader): Fix V6X-RT bootloader on GCC13 and above

### DIFF
--- a/platforms/nuttx/src/bootloader/nxp/imxrt_common/CMakeLists.txt
+++ b/platforms/nuttx/src/bootloader/nxp/imxrt_common/CMakeLists.txt
@@ -41,3 +41,8 @@ target_link_libraries(arch_bootloader
 		bootloader_lib
 		nuttx_arch
 )
+
+target_compile_options(arch_bootloader PRIVATE
+    -O1
+    -fno-builtin   # disable builtin functions
+)

--- a/platforms/nuttx/src/px4/nxp/imxrt/romapi/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/imxrt/romapi/CMakeLists.txt
@@ -34,3 +34,8 @@
 px4_add_library(arch_board_romapi
 	imxrt_romapi.c
 )
+
+target_compile_options(arch_board_romapi PRIVATE
+    -O1
+    -fno-builtin   # disable builtin functions
+)


### PR DESCRIPTION
### Solved Problem
Fix V6X-RT bootloader on GCC13 and above

### Solution

GCC13 does aggresive optimizations that causes a RWW violation. Causing the bootloader to crash while updating. Add compiler arguments to reduce optimizations fixing the issue.

