### PR TITLE
fix(msg): Increase orb queue length for ActionRequest

### DIFF
--- a/msg/ActionRequest.msg
+++ b/msg/ActionRequest.msg
@@ -24,3 +24,5 @@ uint8 SOURCE_RC_BUTTON = 2 # Triggered by a momentary button on the RC being pre
 uint8 SOURCE_RC_MODE_SLOT = 3 # Mode change through the RC mode selection mechanism
 
 uint8 mode # Requested mode. Only applies when `action` is `ACTION_SWITCH_MODE`. Values for this field are defined by the `vehicle_status_s::NAVIGATION_STATE_*` enumeration.
+
+uint8 ORB_QUEUE_LENGTH = 4


### PR DESCRIPTION
Fixes #27535


Increase `ORB_QUEUE_LENGTH` to 4 in `ActionRequest.msg` so that multiple simultaneous actions from eg. MAVLink RC switches are processed.

I set the size to 4 as I thought it was feasible that there could be two or more actions at once  - the linked issue has two. (`ACTION_SWITCH_MODE` and `ACTION_KILL`)
