### PR TITLE
fix(gz_bridge): update protobuf Resize() to lowercase for macOS

### DIFF
--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -77,7 +77,7 @@ bool GZMixingInterfaceESC::updateOutputs(float outputs[MAX_ACTUATORS], unsigned 
 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators rotor_velocity_message;
-		rotor_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
+		rotor_velocity_message.mutable_velocity()->resize(active_output_count, 0);
 
 		for (unsigned i = 0; i < active_output_count; i++) {
 			rotor_velocity_message.set_velocity(i, static_cast<double>(outputs[i]));

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -78,9 +78,9 @@ bool GZMixingInterfaceESC::updateOutputs(float outputs[MAX_ACTUATORS], unsigned 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators rotor_velocity_message;
 #if GOOGLE_PROTOBUF_VERSION >= 4022000
-	rotor_velocity_message.mutable_velocity()->resize(active_output_count, 0);
+		rotor_velocity_message.mutable_velocity()->resize(active_output_count, 0);
 #else
-	rotor_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
+		rotor_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
 #endif
 
 		for (unsigned i = 0; i < active_output_count; i++) {

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -77,11 +77,11 @@ bool GZMixingInterfaceESC::updateOutputs(float outputs[MAX_ACTUATORS], unsigned 
 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators rotor_velocity_message;
-		#if GOOGLE_PROTOBUF_VERSION >= 4022000
-			rotor_velocity_message.mutable_velocity()->resize(active_output_count, 0);
-		#else
-			rotor_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
-		#endif
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+	rotor_velocity_message.mutable_velocity()->resize(active_output_count, 0);
+#else
+	rotor_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
+#endif
 
 		for (unsigned i = 0; i < active_output_count; i++) {
 			rotor_velocity_message.set_velocity(i, static_cast<double>(outputs[i]));

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -77,7 +77,11 @@ bool GZMixingInterfaceESC::updateOutputs(float outputs[MAX_ACTUATORS], unsigned 
 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators rotor_velocity_message;
-		rotor_velocity_message.mutable_velocity()->resize(active_output_count, 0);
+		#if GOOGLE_PROTOBUF_VERSION >= 4022000
+			rotor_velocity_message.mutable_velocity()->resize(active_output_count, 0);
+		#else
+			rotor_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
+		#endif
 
 		for (unsigned i = 0; i < active_output_count; i++) {
 			rotor_velocity_message.set_velocity(i, static_cast<double>(outputs[i]));

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -77,11 +77,7 @@ bool GZMixingInterfaceESC::updateOutputs(float outputs[MAX_ACTUATORS], unsigned 
 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators rotor_velocity_message;
-#if GOOGLE_PROTOBUF_VERSION >= 4022000
 		rotor_velocity_message.mutable_velocity()->resize(active_output_count, 0);
-#else
-		rotor_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
-#endif
 
 		for (unsigned i = 0; i < active_output_count; i++) {
 			rotor_velocity_message.set_velocity(i, static_cast<double>(outputs[i]));

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
@@ -75,11 +75,11 @@ bool GZMixingInterfaceWheel::updateOutputs(float outputs[MAX_ACTUATORS], unsigne
 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators wheel_velocity_message;
-		#if GOOGLE_PROTOBUF_VERSION >= 4022000
-			wheel_velocity_message.mutable_velocity()->resize(active_output_count, 0);
-		#else
-			wheel_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
-		#endif
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+	wheel_velocity_message.mutable_velocity()->resize(active_output_count, 0);
+#else
+	wheel_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
+#endif
 
 		for (unsigned i = 0; i < active_output_count; i++) {
 			// Offsetting the output allows for negative values despite unsigned integer to reverse the wheels

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
@@ -75,7 +75,11 @@ bool GZMixingInterfaceWheel::updateOutputs(float outputs[MAX_ACTUATORS], unsigne
 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators wheel_velocity_message;
-		wheel_velocity_message.mutable_velocity()->resize(active_output_count, 0);
+		#if GOOGLE_PROTOBUF_VERSION >= 4022000
+			wheel_velocity_message.mutable_velocity()->resize(active_output_count, 0);
+		#else
+			wheel_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
+		#endif
 
 		for (unsigned i = 0; i < active_output_count; i++) {
 			// Offsetting the output allows for negative values despite unsigned integer to reverse the wheels

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
@@ -76,9 +76,9 @@ bool GZMixingInterfaceWheel::updateOutputs(float outputs[MAX_ACTUATORS], unsigne
 	if (active_output_count > 0) {
 		gz::msgs::Actuators wheel_velocity_message;
 #if GOOGLE_PROTOBUF_VERSION >= 4022000
-	wheel_velocity_message.mutable_velocity()->resize(active_output_count, 0);
+		wheel_velocity_message.mutable_velocity()->resize(active_output_count, 0);
 #else
-	wheel_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
+		wheel_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
 #endif
 
 		for (unsigned i = 0; i < active_output_count; i++) {

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
@@ -75,11 +75,7 @@ bool GZMixingInterfaceWheel::updateOutputs(float outputs[MAX_ACTUATORS], unsigne
 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators wheel_velocity_message;
-#if GOOGLE_PROTOBUF_VERSION >= 4022000
 		wheel_velocity_message.mutable_velocity()->resize(active_output_count, 0);
-#else
-		wheel_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
-#endif
 
 		for (unsigned i = 0; i < active_output_count; i++) {
 			// Offsetting the output allows for negative values despite unsigned integer to reverse the wheels

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
@@ -75,7 +75,7 @@ bool GZMixingInterfaceWheel::updateOutputs(float outputs[MAX_ACTUATORS], unsigne
 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators wheel_velocity_message;
-		wheel_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
+		wheel_velocity_message.mutable_velocity()->resize(active_output_count, 0);
 
 		for (unsigned i = 0; i < active_output_count; i++) {
 			// Offsetting the output allows for negative values despite unsigned integer to reverse the wheels


### PR DESCRIPTION
Fixes the compilation failure on macOS when building the flight stack with the latest Google Protobuf library (v35.0+) installed via Homebrew. Because the PX4 build system compiles with -Werror (Warnings as Errors), the compilation completely halts with a fatal error: 'Resize' is deprecated [-Wdeprecated-declarations] due to the uppercase Resize() method being deprecated upstream.

Updated the deprecated uppercase .Resize() method calls to the standard lowercase .resize() method within the Gazebo bridge interface modules. This resolves the deprecation warning and allows the flight stack to compile cleanly on macOS environments utilizing current Homebrew dependencies.

Bugfix: Update protobuf Resize() to lowercase for macOS Homebrew compatibility

For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

Successfully executed make px4_sitl gazebo-classic on macOS after applying the modifications. The entire codebase compiled completely with zero errors, and the Gazebo simulation environment launched successfully.

Modules verified: src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp and src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp