### PR TITLE
fix(gz_bridge): suppress protobuf Resize() deprecation warning on macOS

### DIFF
--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -85,6 +85,11 @@ if (gz-transport_FOUND)
 	target_include_directories(modules__simulation__gz_bridge PUBLIC px4_gz_msgs)
 	target_link_libraries(modules__simulation__gz_bridge PUBLIC px4_gz_msgs)
 
+	# TODO: remove once gz-msgs uses resize() instead of deprecated Resize() (protobuf >= 5.26)
+	if (APPLE)
+		target_compile_options(modules__simulation__gz_bridge PRIVATE -Wno-deprecated-declarations)
+	endif()
+
 	include(ExternalProject)
 	ExternalProject_Add(gz
 		SOURCE_DIR ${PX4_SOURCE_DIR}/Tools/simulation/gz

--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -85,11 +85,6 @@ if (gz-transport_FOUND)
 	target_include_directories(modules__simulation__gz_bridge PUBLIC px4_gz_msgs)
 	target_link_libraries(modules__simulation__gz_bridge PUBLIC px4_gz_msgs)
 
-	# TODO: remove once gz-msgs uses resize() instead of deprecated Resize() (protobuf >= 5.26)
-	if (APPLE)
-		target_compile_options(modules__simulation__gz_bridge PRIVATE -Wno-deprecated-declarations)
-	endif()
-
 	include(ExternalProject)
 	ExternalProject_Add(gz
 		SOURCE_DIR ${PX4_SOURCE_DIR}/Tools/simulation/gz

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -77,7 +77,12 @@ bool GZMixingInterfaceESC::updateOutputs(float outputs[MAX_ACTUATORS], unsigned 
 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators rotor_velocity_message;
+		// resize() added and Resize() deprecated in protobuf edition 35 (PROTOBUF_VERSION 5035000)
+#if defined(PROTOBUF_VERSION) && PROTOBUF_VERSION >= 5035000
+		rotor_velocity_message.mutable_velocity()->resize(active_output_count, 0);
+#else
 		rotor_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
+#endif
 
 		for (unsigned i = 0; i < active_output_count; i++) {
 			rotor_velocity_message.set_velocity(i, static_cast<double>(outputs[i]));

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
@@ -75,7 +75,12 @@ bool GZMixingInterfaceWheel::updateOutputs(float outputs[MAX_ACTUATORS], unsigne
 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators wheel_velocity_message;
+		// resize() added and Resize() deprecated in protobuf edition 35 (PROTOBUF_VERSION 5035000)
+#if defined(PROTOBUF_VERSION) && PROTOBUF_VERSION >= 5035000
+		wheel_velocity_message.mutable_velocity()->resize(active_output_count, 0);
+#else
 		wheel_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
+#endif
 
 		for (unsigned i = 0; i < active_output_count; i++) {
 			// Offsetting the output allows for negative values despite unsigned integer to reverse the wheels


### PR DESCRIPTION
Homebrew protobuf >= 5.26 deprecated the uppercase `Resize()` method on `RepeatedField`, which causes a `-Wdeprecated-declarations` error under `-Werror` when building on macOS with a current Homebrew environment.

The straightforward fix migrating to the lowercase `resize()` STL alias is not yet possible: Ubuntu 22.04 ships protobuf 3.12 and Ubuntu 24.04 ships protobuf 3.21, neither of which provides `resize()`. Switching unconditionally would break both Ubuntu CI targets.

This PR instead suppresses `-Wno-deprecated-declarations` for the `gz_bridge` module on Apple builds only, following the same pattern already used in this file for the gcc-15 / gz-transport15 `maybe-uninitialized` workaround. 

**Note:**  comment marks the suppression for removal once gz-msgs migrates to `resize()` and Ubuntu LTS distros ship a new enough protobuf.

Supersedes #27550.