### PR TITLE
fix(flight_mode_manager): prevent auto-takeoff stall on a moving platform

### DIFF
--- a/docs/en/flight_modes_mc/takeoff.md
+++ b/docs/en/flight_modes_mc/takeoff.md
@@ -36,6 +36,22 @@ Takeoff is affected by the following parameters:
 | <a id="COM_RC_OVERRIDE"></a>[COM_RC_OVERRIDE](../advanced_config/parameter_reference.md#COM_RC_OVERRIDE) | Controls whether stick movement on a multicopter (or VTOL in MC mode) causes a mode change to [Position mode](../flight_modes_mc/position.md). This can be separately enabled for auto modes and for offboard mode, and is enabled in auto modes by default. |
 | <a id="COM_RC_STICK_OV"></a>[COM_RC_STICK_OV](../advanced_config/parameter_reference.md#COM_RC_STICK_OV) | The amount of stick movement that causes a transition to [Position mode](../flight_modes_mc/position.md) (if [COM_RC_OVERRIDE](#COM_RC_OVERRIDE) is enabled)                                                                                                 |
 
+## Takeoff From a Moving Platform (Boat Deck) <Badge type="tip" text="PX4 v1.18" />
+
+Automatic takeoff from a moving platform, such as a boat deck, is supported. The multicopter climbs and holds the point where it left the deck, rather than following the boat.
+
+::: warning
+Given that the vehicle holds the point where it left the deck and does not travel along with the boat, always take off from the **back (stern) of the boat**, with clear open space behind it.
+Taking off from the bow or the middle of the boat can leave it behind across the deck and into masts, antennas, superstructure, or crew.
+:::
+
+::: info
+Takeoff from a moving platform is only supported in [Takeoff mode](#technical-summary) (or the equivalent coordinate-less takeoff commanded from a ground station), not as part of a [Mission](../flight_modes_mc/mission.md).
+To run a mission from a boat, take off first in Takeoff mode and then start the mission once the vehicle is airborne.
+:::
+
+The moving-platform case can be exercised in simulation with the Gazebo [Moving Platform world](../sim_gazebo_gz/worlds.md#moving-platform).
+
 ## See Also
 
 - [Throw Launch (MC)](../flight_modes_mc/throw_launch.md)

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -74,6 +74,7 @@ bool FlightTaskAuto::activate(const trajectory_setpoint_s &last_setpoint)
 	_updateTrajConstraints();
 	_is_emergency_braking_active = false;
 	_time_last_cruise_speed_override = 0;
+	_takeoff_locked_xy.setNaN();
 
 	return ret;
 }
@@ -84,6 +85,7 @@ void FlightTaskAuto::reActivate()
 
 	// On ground, reset acceleration and velocity to zero
 	_position_smoothing.reset({0.f, 0.f, 0.f}, {0.f, 0.f, 0.7f}, _position);
+	_takeoff_locked_xy.setNaN();
 }
 
 bool FlightTaskAuto::updateInitialize()
@@ -157,6 +159,21 @@ bool FlightTaskAuto::update()
 		// Simple waypoint navigation: go to xyz target, with standard limitations
 		_position_setpoint = _triplet_current;
 		_velocity_setpoint.setNaN();
+
+		// During takeoff, lock the lift-off XY so the climb stays vertical and wind-robust:
+		// track the live position through the ramp (freezes at FLIGHT as the deck moves), then
+		// hold it as the target until takeoff completes. Z stays at the takeoff target altitude.
+		if (_type == WaypointType::takeoff) {
+			if (_inTakeoffRamp()) {
+				_takeoff_locked_xy = Vector2f(_position);
+			}
+
+			if (_takeoff_locked_xy.isAllFinite()) {
+				_position_setpoint(0) = _takeoff_locked_xy(0);
+				_position_setpoint(1) = _takeoff_locked_xy(1);
+			}
+		}
+
 		break;
 	}
 

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018-2023 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018-2026 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -93,6 +93,7 @@ bool FlightTaskAuto::updateInitialize()
 	_sub_home_position.update();
 	_sub_vehicle_status.update();
 	_position_setpoint_triplet_sub.update();
+	_takeoff_status_sub.update();
 #if defined(CONFIG_MODULES_VISION_TARGET_ESTIMATOR) && CONFIG_MODULES_VISION_TARGET_ESTIMATOR
 	_prec_land_status_sub.update();
 #endif // CONFIG_MODULES_VISION_TARGET_ESTIMATOR
@@ -171,6 +172,12 @@ bool FlightTaskAuto::update()
 					       && !_yaw_sp_aligned;
 	const bool force_zero_velocity_setpoint = should_wait_for_yaw_align || _is_emergency_braking_active;
 	_updateTrajConstraints();
+
+	if (_inTakeoffRamp()) {
+		// Hold the live horizontal position during the takeoff ramp so the climb isn't slowed and tracks a moving deck
+		_position_smoothing.forceSetPosition({_position(0), _position(1), NAN});
+	}
+
 	PositionSmoothing::PositionSmoothingSetpoints smoothed_setpoints;
 	_position_smoothing.generateSetpoints(
 		_position,
@@ -704,6 +711,12 @@ bool FlightTaskAuto::isTargetModified() const
 	const bool z_modified =  z_valid && std::fabs((_triplet_current - _position_setpoint)(2)) > FLT_EPSILON;
 
 	return xy_modified || z_modified;
+}
+
+bool FlightTaskAuto::_inTakeoffRamp() const
+{
+	return (_type == WaypointType::takeoff)
+	       && (_takeoff_status_sub.get().takeoff_state < takeoff_status_s::TAKEOFF_STATE_FLIGHT);
 }
 
 void FlightTaskAuto::_updateTrajConstraints()

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -40,6 +40,9 @@
 
 using namespace matrix;
 
+// First meter after lift-off prioritises altitude over horizontal tracking.
+static constexpr float kTakeoffClimbPriorityHeight = 1.0f; // [m]
+
 bool FlightTaskAuto::activate(const trajectory_setpoint_s &last_setpoint)
 {
 	bool ret = FlightTask::activate(last_setpoint);
@@ -75,6 +78,7 @@ bool FlightTaskAuto::activate(const trajectory_setpoint_s &last_setpoint)
 	_is_emergency_braking_active = false;
 	_time_last_cruise_speed_override = 0;
 	_takeoff_locked_xy.setNaN();
+	_takeoff_liftoff_z = NAN;
 
 	return ret;
 }
@@ -86,6 +90,7 @@ void FlightTaskAuto::reActivate()
 	// On ground, reset acceleration and velocity to zero
 	_position_smoothing.reset({0.f, 0.f, 0.f}, {0.f, 0.f, 0.7f}, _position);
 	_takeoff_locked_xy.setNaN();
+	_takeoff_liftoff_z = NAN;
 }
 
 bool FlightTaskAuto::updateInitialize()
@@ -160,11 +165,8 @@ bool FlightTaskAuto::update()
 		_position_setpoint = _triplet_current;
 		_velocity_setpoint.setNaN();
 
-		// During takeoff, lock the lift-off XY so the climb stays vertical and wind-robust:
-		// track the live position through the ramp (freezes at FLIGHT as the deck moves), then
-		// hold it as the target until takeoff completes. Z stays at the takeoff target altitude.
 		if (_type == WaypointType::takeoff) {
-			if (_inTakeoffRamp()) {
+			if (_takeoff_status_sub.get().takeoff_state < takeoff_status_s::TAKEOFF_STATE_FLIGHT) {
 				_takeoff_locked_xy = Vector2f(_position);
 			}
 
@@ -190,9 +192,16 @@ bool FlightTaskAuto::update()
 	const bool force_zero_velocity_setpoint = should_wait_for_yaw_align || _is_emergency_braking_active;
 	_updateTrajConstraints();
 
-	if (_inTakeoffRamp()) {
-		// Hold the live horizontal position during the takeoff ramp so the climb isn't slowed and tracks a moving deck
-		_position_smoothing.forceSetPosition({_position(0), _position(1), NAN});
+	if (_type == WaypointType::takeoff) {
+		if (_takeoff_status_sub.get().takeoff_state < takeoff_status_s::TAKEOFF_STATE_FLIGHT) {
+			_takeoff_liftoff_z = _position(2);
+			_position_smoothing.forceSetPosition({_position(0), _position(1), NAN});
+		}
+
+		if (!PX4_ISFINITE(_takeoff_liftoff_z)
+		    || (_takeoff_liftoff_z - _position(2)) < kTakeoffClimbPriorityHeight) {
+			_position_smoothing.forceSetVelocity({_velocity(0), _velocity(1), NAN});
+		}
 	}
 
 	PositionSmoothing::PositionSmoothingSetpoints smoothed_setpoints;
@@ -728,12 +737,6 @@ bool FlightTaskAuto::isTargetModified() const
 	const bool z_modified =  z_valid && std::fabs((_triplet_current - _position_setpoint)(2)) > FLT_EPSILON;
 
 	return xy_modified || z_modified;
-}
-
-bool FlightTaskAuto::_inTakeoffRamp() const
-{
-	return (_type == WaypointType::takeoff)
-	       && (_takeoff_status_sub.get().takeoff_state < takeoff_status_s::TAKEOFF_STATE_FLIGHT);
 }
 
 void FlightTaskAuto::_updateTrajConstraints()

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018-2023 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018-2026 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,6 +48,7 @@
 #include <uORB/topics/prec_land_status.h>
 #endif // CONFIG_MODULES_VISION_TARGET_ESTIMATOR
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/takeoff_status.h>
 #include <lib/geo/geo.h>
 #include <lib/mathlib/math/filter/AlphaFilter.hpp>
 #include <lib/motion_planning/HeadingSmoothing.hpp>
@@ -106,6 +107,7 @@ protected:
 	bool _generateHeadingAlongTraj(); /**< Generates heading along trajectory. */
 	bool isTargetModified() const;
 	void _updateTrajConstraints();
+	bool _inTakeoffRamp() const; /**< taking off and not yet at TAKEOFF_STATE_FLIGHT */
 
 	void rcHelpModifyYaw(float &yaw_sp);
 
@@ -128,6 +130,7 @@ protected:
 #endif // CONFIG_MODULES_VISION_TARGET_ESTIMATOR
 	uORB::SubscriptionData<home_position_s>			_sub_home_position {ORB_ID(home_position)};
 	uORB::SubscriptionData<vehicle_status_s>		_sub_vehicle_status{ORB_ID(vehicle_status)};
+	uORB::SubscriptionData<takeoff_status_s>		_takeoff_status_sub{ORB_ID(takeoff_status)};
 
 	float _target_acceptance_radius{0.0f}; /**< Acceptances radius of the target */
 

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -181,6 +181,7 @@ protected:
 
 private:
 	matrix::Vector2f _lock_position_xy{NAN, NAN}; /**< if no valid triplet is received, lock positition to current position */
+	matrix::Vector2f _takeoff_locked_xy{NAN, NAN}; /**< lift-off XY tracked during the takeoff ramp and frozen at FLIGHT to keep the climb vertical */
 	bool _yaw_lock{false}; /**< if within acceptance radius, lock yaw to current yaw */
 
 	matrix::Vector3f _triplet_previous; ///< previous waypoint in triplet from navigator

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -107,7 +107,6 @@ protected:
 	bool _generateHeadingAlongTraj(); /**< Generates heading along trajectory. */
 	bool isTargetModified() const;
 	void _updateTrajConstraints();
-	bool _inTakeoffRamp() const; /**< taking off and not yet at TAKEOFF_STATE_FLIGHT */
 
 	void rcHelpModifyYaw(float &yaw_sp);
 
@@ -182,6 +181,7 @@ protected:
 private:
 	matrix::Vector2f _lock_position_xy{NAN, NAN}; /**< if no valid triplet is received, lock positition to current position */
 	matrix::Vector2f _takeoff_locked_xy{NAN, NAN}; /**< lift-off XY tracked during the takeoff ramp and frozen at FLIGHT to keep the climb vertical */
+	float _takeoff_liftoff_z{NAN}; /**< lift-off altitude (NED z), frozen at FLIGHT */
 	bool _yaw_lock{false}; /**< if within acceptance radius, lock yaw to current yaw */
 
 	matrix::Vector3f _triplet_previous; ///< previous waypoint in triplet from navigator

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -51,6 +51,7 @@
 #include <systemlib/mavlink_log.h>
 #include <mathlib/mathlib.h>
 #include <uORB/uORB.h>
+#include <uORB/topics/takeoff_status.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vtol_vehicle_status.h>
 
@@ -643,23 +644,32 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 		break;
 
 	case NAV_CMD_TAKEOFF:
-	case NAV_CMD_VTOL_TAKEOFF:
+	case NAV_CMD_VTOL_TAKEOFF: {
 
-		// if already flying (armed and !landed) treat TAKEOFF like regular POSITION
-		if ((_navigator->get_vstatus()->arming_state == vehicle_status_s::ARMING_STATE_ARMED)
-		    && !_navigator->get_land_detected()->landed && !_navigator->get_land_detected()->maybe_landed) {
+			// if already flying (armed and !landed) treat TAKEOFF like regular POSITION
+			bool already_flying = (_navigator->get_vstatus()->arming_state == vehicle_status_s::ARMING_STATE_ARMED)
+					      && !_navigator->get_land_detected()->landed && !_navigator->get_land_detected()->maybe_landed;
 
-			sp->type = position_setpoint_s::SETPOINT_TYPE_POSITION;
+			// land_detected (above) is unreliable on a moving deck, so for multicopters additionally
+			// require the takeoff state machine to report FLIGHT (it only exists on multicopters).
+			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+				already_flying &= (_navigator->get_takeoff_state() == takeoff_status_s::TAKEOFF_STATE_FLIGHT);
+			}
 
-		} else {
-			sp->type = position_setpoint_s::SETPOINT_TYPE_TAKEOFF;
+			if (already_flying) {
 
-			// Don't set a yaw setpoint for takeoff, as Navigator doesn't handle the yaw reset.
-			// The yaw setpoint generation is handled by FlightTaskAuto.
-			sp->yaw = NAN;
+				sp->type = position_setpoint_s::SETPOINT_TYPE_POSITION;
+
+			} else {
+				sp->type = position_setpoint_s::SETPOINT_TYPE_TAKEOFF;
+
+				// Don't set a yaw setpoint for takeoff, as Navigator doesn't handle the yaw reset.
+				// The yaw setpoint generation is handled by FlightTaskAuto.
+				sp->yaw = NAN;
+			}
+
+			break;
 		}
-
-		break;
 
 	case NAV_CMD_LAND:
 	case NAV_CMD_VTOL_LAND:

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -81,6 +81,7 @@
 #include <uORB/topics/position_controller_landing_status.h>
 #include <uORB/topics/position_controller_status.h>
 #include <uORB/topics/position_setpoint_triplet.h>
+#include <uORB/topics/takeoff_status.h>
 #include <uORB/topics/transponder_report.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_command_ack.h>
@@ -172,6 +173,7 @@ public:
 	position_setpoint_triplet_s *get_takeoff_triplet() { return &_takeoff_triplet; }
 	vehicle_global_position_s   *get_global_position() { return &_global_pos; }
 	vehicle_land_detected_s     *get_land_detected() { return &_land_detected; }
+	uint8_t                      get_takeoff_state() { return _takeoff_status_sub.get().takeoff_state; }
 	vehicle_local_position_s    *get_local_position() { return &_local_pos; }
 	vehicle_status_s            *get_vstatus() { return &_vstatus; }
 
@@ -321,6 +323,7 @@ private:
 
 	uORB::SubscriptionData<position_controller_status_s>	_position_controller_status_sub{ORB_ID(position_controller_status)};
 	uORB::SubscriptionData<fixed_wing_lateral_guidance_status_s> _fw_lateral_guidance_status_sub{ORB_ID(fixed_wing_lateral_guidance_status)};
+	uORB::SubscriptionData<takeoff_status_s>		_takeoff_status_sub{ORB_ID(takeoff_status)};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -251,6 +251,7 @@ void Navigator::run()
 		_land_detected_sub.update(&_land_detected);
 		_position_controller_status_sub.update();
 		_fw_lateral_guidance_status_sub.update();
+		_takeoff_status_sub.update();
 		_home_pos_sub.update(&_home_pos);
 
 		// Handle Vehicle commands


### PR DESCRIPTION
### Solved Problem
Auto-takeoff stalls off a moving platform (boat deck). `PositionSmoothing`'s single horizontal time-stretch slows all axes, including the climb, once the vehicle lags the trajectory by more than `MPC_XY_ERR_MAX`: the deck drags the grounded vehicle off the fixed takeoff setpoint, the error grows, the time-stretch collapses to ~0, and the climb freezes.

### Solution
- **Navigator:** a coordinate-less multicopter takeoff leaves the horizontal target unset (`NAN`)instead of pinning the current position. Rotary-wing only, looks like fixed-wing needs a finite setpoint to enter `AUTO_TAKEOFF`.
- **FlightTaskAuto:** the existing `_lock_position_xy` re-anchors to the live position during the takeoff ramp and freezes when the vehicle is actually flying (`TAKEOFF_STATE_FLIGHT`). The moving target keeps the smoother chasing the deck-carried vehicle so the time-stretch can't freeze the climb; the lift-off point is then held.

No-op on static ground and scoped to coordinate-less takeoff, so explicit takeoff coordinates and normal flight/landing are unaffected.

**Known limitation:** a **mission** takeoff isn't covered, the item carries a finite (current-position) target and the land detector demotes it to a `POSITION` setpoint, so the lock doesn't engage. Fixing it touches the safety-critical land detector, left out.

### Test coverage
SITL (multicopter): straight-up climb and hold over the lift-off point, with and without wind; explicit coordinates still fly to target. 