### PR TITLE
docs(simulation): document SITL GPS failure injection

### DIFF
--- a/docs/en/debug/failure_injection.md
+++ b/docs/en/debug/failure_injection.md
@@ -61,6 +61,10 @@ where:
 - _instance number_ (optional): Instance number of affected sensor.
   0 (default) indicates all sensors of specified type.
 
+::: info
+The simulated GPS (SITL) implements only the `off`, `stuck`, and `wrong` failure modes; the other failure types have no effect on it.
+:::
+
 ## MAVSDK Failure Plugin
 
 The [MAVSDK failure plugin](https://mavsdk.mavlink.io/main/en/cpp/api_reference/classmavsdk_1_1_failure.html) can be used to programmatically inject failures.

--- a/docs/en/simulation/failsafes.md
+++ b/docs/en/simulation/failsafes.md
@@ -54,17 +54,25 @@ The simulated battery can be completely disabled by setting [SIM_BAT_DRAIN](../a
 [Failure injection](../debug/failure_injection.md) can be used to simulate different types of failures in many sensors and systems.
 For example, this can be used to simulate absent or intermittent GPS, RC signal that has stopped or got stuck on a particular value, failure of the avoidance system, and much more.
 
-For example, to simulate GPS failure:
+Failure injection is gated by the [SYS_FAILURE_EN](../advanced_config/parameter_reference.md#SYS_FAILURE_EN) parameter.
 
-1. Enable the parameter [SYS_FAILURE_EN](../advanced_config/parameter_reference.md#SYS_FAILURE_EN).
-1. Enter the following commands on the SITL instance _pxh shell_:
+For example, to simulate GPS failure, enter the following commands on the SITL instance _pxh shell_:
 
-   ```sh
-   # Turn (all) GPS off
-   failure gps off
+```sh
+# Turn (all) GPS off (no position reported, as for a dead receiver)
+failure gps off
 
-   # Turn (all) GPS on
-   failure gps ok
-   ```
+# Freeze (all) GPS on the last reported position (a "stuck" fix)
+failure gps stuck
 
-See [System Failure Injection](../debug/failure_injection.md) for a list of supported target sensors and failure modes.
+# Report a diverging position (offset by ~111 km, trips the GNSS redundancy checks)
+failure gps wrong
+
+# Restore normal GPS output
+failure gps ok
+```
+
+:::tip
+To test the [GNSS redundancy failsafe](../advanced_config/parameter_reference.md#COM_GNSSLOSS_ACT) you can simulate a second GPS receiver: set the antenna-offset parameter [SENS_GPS1_OFFX](../advanced_config/parameter_reference.md#SENS_GPS1_OFFX) or [SENS_GPS1_OFFY](../advanced_config/parameter_reference.md#SENS_GPS1_OFFY) to a non-zero value, and the simulator publishes a second `sensor_gps` instance offset by that distance (in metres).
+You can then fail an individual receiver with the `-i` flag (`-i 0` = all instances, `-i 1` = first GPS, `-i 2` = second), for example `failure gps wrong -i 2`.
+:::


### PR DESCRIPTION
Documents the GNSS failure-injection and dual GNSS simulation added in #27396