### PR TITLE
refactor(parachuteCheck): remove unnecessary namespace and newlines

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/parachuteCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/parachuteCheck.cpp
@@ -33,9 +33,6 @@
 
 #include "parachuteCheck.hpp"
 
-
-using namespace time_literals;
-
 void ParachuteChecks::checkAndReport(const Context &context, Report &reporter)
 {
 	if (_param_com_parachute.get() < 1) { // COM_PARACHUTE 0 disables the check


### PR DESCRIPTION
### Solved Problem
Minor detail I saw while browsing through the implementation. This include got obsolete with the review addressing in https://github.com/PX4/PX4-Autopilot/pull/26918 but I didn't see that back then.
