### PR TITLE
fix(commander): acknowledge DO_REPOSITION by mode, not UNSUPPORTED

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -868,14 +868,9 @@ Commander::handle_command(const vehicle_command_s &cmd)
 			// to not require navigator and command to receive / process
 			// the data at the exact same time.
 
-			const uint32_t change_mode_flags = uint32_t(cmd.param2);
-			const bool mode_switch_not_requested = (change_mode_flags & 1) == 0;
-			const bool unsupported_bits_set = (change_mode_flags & ~1) != 0;
+			const bool change_mode_requested = (uint32_t(cmd.param2) & 1) != 0;
 
-			if (mode_switch_not_requested || unsupported_bits_set) {
-				answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED);
-
-			} else {
+			if (change_mode_requested) {
 				// If already in course mode, stay in course mode (navigator handles any altitude update)
 				// Only switch to loiter if a specific lat/lon target is given, or we are not in course mode.
 				const bool has_position_target = PX4_ISFINITE(cmd.param5) && PX4_ISFINITE(cmd.param6);
@@ -891,6 +886,14 @@ Commander::handle_command(const vehicle_command_s &cmd)
 					printRejectMode(target_state);
 					cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED;
 				}
+
+			} else if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER) {
+				// No mode switch requested: reposition the current hold setpoint in place.
+				cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED;
+
+			} else {
+				// Supported, but no mode switch requested and not in hold: nothing to act on.
+				cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_DENIED;
 			}
 		}
 		break;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -276,9 +276,12 @@ void Navigator::run()
 				publish_vehicle_command_ack(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED);
 
 			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_REPOSITION
-				   && _vstatus.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
-				// only update the reposition setpoint if armed, as it otherwise won't get executed until the vehicle switches to loiter,
-				// which can lead to dangerous and unexpected behaviors (see loiter.cpp, there is an if(armed) in there too)
+				   && _vstatus.arming_state == vehicle_status_s::ARMING_STATE_ARMED
+				   && (((uint32_t)cmd.param2 & 1) != 0
+				       || _vstatus.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER)) {
+				// Only apply the reposition setpoint when armed and either a mode switch into Hold was requested
+				// (CHANGE_MODE flag) or we're already in Hold. Otherwise a later switch into Hold could execute a
+				// stale setpoint (loiter.cpp applies it within a 500ms window).
 
 				// Wait for vehicle_status before handling the next command, otherwise the setpoint could be overwritten
 				_wait_for_vehicle_status_timestamp = hrt_absolute_time();


### PR DESCRIPTION
## Summary
fixes #27556

`MAV_CMD_DO_REPOSITION` no longer returns `MAV_RESULT_UNSUPPORTED`. Commander acknowledges it by mode, and the navigator only applies the reposition setpoint when the command will actually be executed.

## Problem
With the `CHANGE_MODE` flag clear (`param2=0`) — a valid "reposition without forcing a mode change" per the MAVLink spec — Commander acked `UNSUPPORTED`, yet the navigator still applied the setpoint whenever armed (it is consumed by Hold within a 500 ms window). So an armed vehicle in Hold moved despite reporting `UNSUPPORTED`. The `UNSUPPORTED` ack dates to [bec0d83](https://github.com/PX4/PX4-Autopilot/commit/bec0d83) (2023), which aimed to avoid stale setpoints when switching into Hold but only changed the ack and never the navigator, so the intent was never realized.

Both major clients always set `MAV_DO_REPOSITION_FLAGS_CHANGE_MODE` (`param2=1`), so this only ever affected other senders:
- QGC `PX4FirmwarePlugin`: every call site (pause, go-to-location, change altitude, change heading) sets `CHANGE_MODE`.
- MAVSDK `Action::goto_location`: sets `CHANGE_MODE`, and for PX4 additionally switches to Hold first.

The case that hit `UNSUPPORTED` is exactly the spec-conformant client that caches the result and abandons the command — e.g. QGC's ArduPilot plugin records an unsupported result on an `UNSUPPORTED` ack and falls back to mission items.

## Solution
Commander acks by mode: `CHANGE_MODE` set switches to Hold (or stays in Course without a position target) and acks `ACCEPTED`/`TEMPORARILY_REJECTED`; `param2=0` in Hold acks `ACCEPTED` (reposition in place); otherwise `DENIED`. It never returns `UNSUPPORTED`. Non-`CHANGE_MODE` flag bits (e.g. `RELATIVE_YAW`) are now ignored rather than rejected, matching the navigator, which already treats yaw as absolute.

The navigator only applies the reposition setpoint when armed and either `CHANGE_MODE` was requested or it is already in Hold, so it no longer leaves a stale setpoint for a later switch into Hold to execute.

QGC and MAVSDK always take the `CHANGE_MODE` path, so their behavior is unchanged.
