### PR TITLE
docs(docs): correct broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Run PX4 in simulation with a single command. No build tools, no dependencies bey
 docker run --rm -it -p 14550:14550/udp px4io/px4-sitl:latest
 ```
 
-Open [QGroundControl](https://qgroundcontrol.com) and fly. See [PX4 Simulation Quickstart](../dev_setup/px4_simulation_quickstart.md) for more options.
+Open [QGroundControl](https://qgroundcontrol.com) and fly. See [PX4 Simulation Quickstart](https://docs.px4.io/main/en/simulation/px4_simulation_quickstart) for more options.
 
 ## Build from Source
 


### PR DESCRIPTION
<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->

correct  "PX4 Simulation Quickstart" broken link on readme:

<img width="1226" height="254" alt="image" src="https://github.com/user-attachments/assets/35ea1e66-2622-4541-8ee5-205f0c495241" />
