### PR TITLE
fix: replace deprecated Protobuf Resize() API in gz_bridge

### DIFF
--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -1,5 +1,4 @@
 /****************************************************************************
- * BBR - Edit to avoid Resize failure in make build
  *
  *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
  *
@@ -79,13 +78,6 @@ bool GZMixingInterfaceESC::updateOutputs(float outputs[MAX_ACTUATORS], unsigned 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators rotor_velocity_message;
 		
-		/*
-		rotor_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
-
-		for (unsigned i = 0; i < active_output_count; i++) {
-			rotor_velocity_message.set_velocity(i, static_cast<double>(outputs[i]));
-		}
-		*/
 		auto *vel = rotor_velocity_message.mutable_velocity();
 		vel->Clear();
 		vel->Reserve(active_output_count);

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -77,12 +77,13 @@ bool GZMixingInterfaceESC::updateOutputs(float outputs[MAX_ACTUATORS], unsigned 
 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators rotor_velocity_message;
-		
+
 		auto *vel = rotor_velocity_message.mutable_velocity();
 		vel->Clear();
 		vel->Reserve(active_output_count);
+
 		for (unsigned i = 0; i < active_output_count; ++i) {
-		    vel->Add(static_cast<double>(outputs[i]));
+			vel->Add(static_cast<double>(outputs[i]));
 		}
 
 		if (_actuators_pub.Valid()) {

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -1,4 +1,5 @@
 /****************************************************************************
+ * BBR - Edit to avoid Resize failure in make build
  *
  *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
  *
@@ -77,10 +78,19 @@ bool GZMixingInterfaceESC::updateOutputs(float outputs[MAX_ACTUATORS], unsigned 
 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators rotor_velocity_message;
+		
+		/*
 		rotor_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
 
 		for (unsigned i = 0; i < active_output_count; i++) {
 			rotor_velocity_message.set_velocity(i, static_cast<double>(outputs[i]));
+		}
+		*/
+		auto *vel = rotor_velocity_message.mutable_velocity();
+		vel->Clear();
+		vel->Reserve(active_output_count);
+		for (unsigned i = 0; i < active_output_count; ++i) {
+		    vel->Add(static_cast<double>(outputs[i]));
 		}
 
 		if (_actuators_pub.Valid()) {

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
@@ -60,36 +60,41 @@ bool GZMixingInterfaceWheel::init(const std::string &model_name)
 	return true;
 }
 
-bool GZMixingInterfaceWheel::updateOutputs(float outputs[MAX_ACTUATORS], unsigned num_outputs, unsigned num_control_groups_updated)
+bool GZMixingInterfaceWheel::updateOutputs(float outputs[MAX_ACTUATORS],
+                                           unsigned num_outputs,
+                                           unsigned num_control_groups_updated)
 {
-	unsigned active_output_count = 0;
+    unsigned active_output_count = 0;
 
-	for (unsigned i = 0; i < num_outputs; i++) {
-		if (_mixing_output.isFunctionSet(i)) {
-			active_output_count++;
+    for (unsigned i = 0; i < num_outputs; i++) {
+        if (_mixing_output.isFunctionSet(i)) {
+            active_output_count++;
+        } else {
+            break;
+        }
+    }
 
-		} else {
-			break;
-		}
-	}
+    if (active_output_count > 0) {
+        gz::msgs::Actuators wheel_velocity_message;
 
-	if (active_output_count > 0) {
-		gz::msgs::Actuators wheel_velocity_message;
+        auto *vel = wheel_velocity_message.mutable_velocity();
+        vel->Clear();
+        vel->Reserve(active_output_count);
 
-		auto *vel = wheel_velocity_message.mutable_velocity();
-		vel->Clear();
-		vel->Reserve(active_output_count);
+        // Offsetting the output allows for negative values despite unsigned integer to reverse the wheels
+        static constexpr double output_offset = 100.0;
 
-		for (unsigned i = 0; i < active_output_count; i++) {
-			vel->Add(static_cast<double>(outputs[i]));
-		}
+        for (unsigned i = 0; i < active_output_count; i++) {
+            double scaled_output = static_cast<double>(outputs[i]) - output_offset;
+            vel->Add(scaled_output);
+        }
 
-		if (_actuators_pub.Valid()) {
-			return _actuators_pub.Publish(wheel_velocity_message);
-		}
-	}
+        if (_actuators_pub.Valid()) {
+            return _actuators_pub.Publish(wheel_velocity_message);
+        }
+    }
 
-	return false;
+    return false;
 }
 
 void GZMixingInterfaceWheel::Run()

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
@@ -1,5 +1,4 @@
 /****************************************************************************
- * BBR - Edit to avoid Resize failure in make build
  *
  *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
  *
@@ -76,16 +75,7 @@ bool GZMixingInterfaceWheel::updateOutputs(float outputs[MAX_ACTUATORS], unsigne
 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators wheel_velocity_message;
-		/*
-		wheel_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
 
-		for (unsigned i = 0; i < active_output_count; i++) {
-			// Offsetting the output allows for negative values despite unsigned integer to reverse the wheels
-			static constexpr double output_offset = 100.0;
-			double scaled_output = (double)outputs[i] - output_offset;
-			wheel_velocity_message.set_velocity(i, scaled_output);
-		}
-		*/
 		auto *vel = wheel_velocity_message.mutable_velocity();
 		vel->Clear();
 		vel->Reserve(active_output_count);

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
@@ -1,4 +1,5 @@
 /****************************************************************************
+ * BBR - Edit to avoid Resize failure in make build
  *
  *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
  *
@@ -75,6 +76,7 @@ bool GZMixingInterfaceWheel::updateOutputs(float outputs[MAX_ACTUATORS], unsigne
 
 	if (active_output_count > 0) {
 		gz::msgs::Actuators wheel_velocity_message;
+		/*
 		wheel_velocity_message.mutable_velocity()->Resize(active_output_count, 0);
 
 		for (unsigned i = 0; i < active_output_count; i++) {
@@ -83,8 +85,13 @@ bool GZMixingInterfaceWheel::updateOutputs(float outputs[MAX_ACTUATORS], unsigne
 			double scaled_output = (double)outputs[i] - output_offset;
 			wheel_velocity_message.set_velocity(i, scaled_output);
 		}
-
-
+		*/
+		auto *vel = wheel_velocity_message.mutable_velocity();
+		vel->Clear();
+		vel->Reserve(active_output_count);
+		for (unsigned i = 0; i < active_output_count; i++) {
+		    vel->Add(static_cast<double>(outputs[i]));
+		}
 		if (_actuators_pub.Valid()) {
 			return _actuators_pub.Publish(wheel_velocity_message);
 		}

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
@@ -61,40 +61,41 @@ bool GZMixingInterfaceWheel::init(const std::string &model_name)
 }
 
 bool GZMixingInterfaceWheel::updateOutputs(float outputs[MAX_ACTUATORS],
-                                           unsigned num_outputs,
-                                           unsigned num_control_groups_updated)
+		unsigned num_outputs,
+		unsigned num_control_groups_updated)
 {
-    unsigned active_output_count = 0;
+	unsigned active_output_count = 0;
 
-    for (unsigned i = 0; i < num_outputs; i++) {
-        if (_mixing_output.isFunctionSet(i)) {
-            active_output_count++;
-        } else {
-            break;
-        }
-    }
+	for (unsigned i = 0; i < num_outputs; i++) {
+		if (_mixing_output.isFunctionSet(i)) {
+			active_output_count++;
 
-    if (active_output_count > 0) {
-        gz::msgs::Actuators wheel_velocity_message;
+		} else {
+			break;
+		}
+	}
 
-        auto *vel = wheel_velocity_message.mutable_velocity();
-        vel->Clear();
-        vel->Reserve(active_output_count);
+	if (active_output_count > 0) {
+		gz::msgs::Actuators wheel_velocity_message;
 
-        // Offsetting the output allows for negative values despite unsigned integer to reverse the wheels
-        static constexpr double output_offset = 100.0;
+		auto *vel = wheel_velocity_message.mutable_velocity();
+		vel->Clear();
+		vel->Reserve(active_output_count);
 
-        for (unsigned i = 0; i < active_output_count; i++) {
-            double scaled_output = static_cast<double>(outputs[i]) - output_offset;
-            vel->Add(scaled_output);
-        }
+		// Offsetting the output allows for negative values despite unsigned integer to reverse the wheels
+		static constexpr double output_offset = 100.0;
 
-        if (_actuators_pub.Valid()) {
-            return _actuators_pub.Publish(wheel_velocity_message);
-        }
-    }
+		for (unsigned i = 0; i < active_output_count; i++) {
+			double scaled_output = static_cast<double>(outputs[i]) - output_offset;
+			vel->Add(scaled_output);
+		}
 
-    return false;
+		if (_actuators_pub.Valid()) {
+			return _actuators_pub.Publish(wheel_velocity_message);
+		}
+	}
+
+	return false;
 }
 
 void GZMixingInterfaceWheel::Run()

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
@@ -79,9 +79,11 @@ bool GZMixingInterfaceWheel::updateOutputs(float outputs[MAX_ACTUATORS], unsigne
 		auto *vel = wheel_velocity_message.mutable_velocity();
 		vel->Clear();
 		vel->Reserve(active_output_count);
+
 		for (unsigned i = 0; i < active_output_count; i++) {
-		    vel->Add(static_cast<double>(outputs[i]));
+			vel->Add(static_cast<double>(outputs[i]));
 		}
+
 		if (_actuators_pub.Valid()) {
 			return _actuators_pub.Publish(wheel_velocity_message);
 		}


### PR DESCRIPTION
…cOS compatibility

Homebrew now ships Protobuf 35.x, which marks RepeatedField::Resize() as [[deprecated]]. PX4 builds with -Werror, so SITL builds fail on macOS ARM when Gazebo Harmonic is installed.

This patch replaces the deprecated Resize() + Set() pattern with the recommended Clear() + Reserve() + Add() sequence.

- No behavior change
- No message format change
- Fixes SITL build on macOS ARM with Protobuf 35.x
- Forward-compatible with future Protobuf versions

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
