### PR TITLE
ci(labeler): stop auto-applying risk:safety-critical label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -260,25 +260,6 @@
     - "**/*_test.*"
     - "**/test_*.*"
 
-"risk:safety-critical":
-- changed-files:
-  - any-glob-to-any-file:
-    - src/modules/commander/**
-    - src/modules/navigator/**
-    - src/modules/ekf2/**
-    - src/modules/sensors/**
-    - src/modules/*_control/**
-    - src/modules/control_allocator/**
-    - src/modules/land_detector/**
-    - src/modules/flight_mode_manager/**
-    - src/drivers/actuators/**
-    - src/drivers/imu/**
-    - src/drivers/ins/**
-    - src/drivers/pwm_out/**
-    - src/lib/collision_prevention/**
-    - src/lib/flight_tasks/**
-    - src/lib/geofence/**
-
 "risk:security":
 - changed-files:
   - any-glob-to-any-file:


### PR DESCRIPTION
Removes the automatic application of the `risk:safety-critical` label by the labeler workflow. The label is now applied manually during review.

The path globs that triggered it (`.github/labeler.yml`) matched a large fraction of the source tree — `src/modules/*_control/**` and `src/modules/sensors/**` alone cover much of the flight stack — and matching is `any-glob-to-any-file` with no diff-size or content filter, so a single touched file (even a comment- or docs-only change) flagged the whole PR. The result was the label being applied far too liberally to PRs that aren't meaningfully safety-critical, diluting its signal.

The label itself is unchanged and can still be applied by reviewers when a change genuinely warrants extra scrutiny.