### PR TITLE
fix(geo): correct get_distance_to_arc projection and sector logic

### DIFF
--- a/src/lib/geo/geo.cpp
+++ b/src/lib/geo/geo.cpp
@@ -284,6 +284,7 @@ int get_distance_to_arc(struct crosstrack_error_s *crosstrack_error, double lat_
 	// arc_start_bearing and arc_sweep are referenced to the center, so test membership with the
 	// center->vehicle bearing. Measuring it in the direction of the sweep handles either sign and
 	// any zero crossing without special cases.
+	// NOLINTNEXTLINE(readability-suspicious-call-argument) intentional reverse bearing: center -> vehicle
 	const float bearing_center_to_now = get_bearing_to_next_waypoint(lat_center, lon_center, lat_now, lon_now);
 	const float bearing_from_start = wrap_2pi((bearing_center_to_now - arc_start_bearing) * (arc_sweep < 0.0f ? -1.0f :
 					 1.0f));

--- a/src/lib/geo/geo.cpp
+++ b/src/lib/geo/geo.cpp
@@ -339,10 +339,11 @@ int get_distance_to_arc(struct crosstrack_error_s *crosstrack_error, double lat_
 		double start_disp_y = (double)radius * cos((double)arc_start_bearing);
 		double end_disp_x = (double)radius * sin((double)wrap_pi(arc_start_bearing + arc_sweep));
 		double end_disp_y = (double)radius * cos((double)wrap_pi(arc_start_bearing + arc_sweep));
-		double lon_start = lon_now + start_disp_x / 111111.0;
-		double lat_start = lat_now + start_disp_y * cos(lat_now) / 111111.0;
-		double lon_end = lon_now + end_disp_x / 111111.0;
-		double lat_end = lat_now + end_disp_y * cos(lat_now) / 111111.0;
+		const double cos_lat_center = cos(math::radians(lat_center));
+		double lon_start = lon_center + start_disp_x / (111111.0 * cos_lat_center);
+		double lat_start = lat_center + start_disp_y / 111111.0;
+		double lon_end = lon_center + end_disp_x / (111111.0 * cos_lat_center);
+		double lat_end = lat_center + end_disp_y / 111111.0;
 		float dist_to_start = get_distance_to_next_waypoint(lat_now, lon_now, lat_start, lon_start);
 		float dist_to_end = get_distance_to_next_waypoint(lat_now, lon_now, lat_end, lon_end);
 

--- a/src/lib/geo/geo.cpp
+++ b/src/lib/geo/geo.cpp
@@ -269,9 +269,7 @@ int get_distance_to_arc(struct crosstrack_error_s *crosstrack_error, double lat_
 
 	// Determine if the current position is inside or outside the sector between the line from the center
 	// to the arc start and the line from the center to the arc end
-	float bearing_sector_start = 0.0f;
-	float bearing_sector_end = 0.0f;
-	float bearing_now = get_bearing_to_next_waypoint(lat_now, lon_now, lat_center, lon_center);
+	const float bearing_now = get_bearing_to_next_waypoint(lat_now, lon_now, lat_center, lon_center);
 
 	int return_value = -1;		// Set error flag, cleared when valid result calculated.
 	crosstrack_error->past_end = false;
@@ -283,34 +281,13 @@ int get_distance_to_arc(struct crosstrack_error_s *crosstrack_error, double lat_
 		return return_value;
 	}
 
-	if (arc_sweep >= 0.0f) {
-		bearing_sector_start = arc_start_bearing;
-		bearing_sector_end = arc_start_bearing + arc_sweep;
-
-		if (bearing_sector_end > 2.0f * M_PI_F) { bearing_sector_end -= (2 * M_PI_F); }
-
-	} else {
-		bearing_sector_end = arc_start_bearing;
-		bearing_sector_start = arc_start_bearing - arc_sweep;
-
-		if (bearing_sector_start < 0.0f) { bearing_sector_start += (2 * M_PI_F); }
-	}
-
-	bool in_sector = false;
-
-	// Case where sector does not span zero
-	if (bearing_sector_end >= bearing_sector_start && bearing_now >= bearing_sector_start
-	    && bearing_now <= bearing_sector_end) {
-
-		in_sector = true;
-	}
-
-	// Case where sector does span zero
-	if (bearing_sector_end < bearing_sector_start && (bearing_now > bearing_sector_start
-			|| bearing_now < bearing_sector_end)) {
-
-		in_sector = true;
-	}
+	// arc_start_bearing and arc_sweep are referenced to the center, so test membership with the
+	// center->vehicle bearing. Measuring it in the direction of the sweep handles either sign and
+	// any zero crossing without special cases.
+	const float bearing_center_to_now = get_bearing_to_next_waypoint(lat_center, lon_center, lat_now, lon_now);
+	const float bearing_from_start = wrap_2pi((bearing_center_to_now - arc_start_bearing) * (arc_sweep < 0.0f ? -1.0f :
+					 1.0f));
+	const bool in_sector = bearing_from_start <= fabsf(arc_sweep);
 
 	// If in the sector then calculate distance and bearing to closest point
 	if (in_sector) {

--- a/src/lib/geo/test_geo.cpp
+++ b/src/lib/geo/test_geo.cpp
@@ -217,43 +217,106 @@ TEST_F(GeoTest, waypoint_from_line_and_negative_distance)
 
 TEST_F(GeoTest, get_distance_to_arc_outside_sector)
 {
-	// GIVEN: an arc centered at a mid-latitude (so the longitude cosine scaling
-	// matters), sweeping from due-North of the center (start) to due-East (end).
+	// GIVEN: an arc at a mid-latitude (so the longitude cosine scaling matters), sweeping from
+	// due-North of the center (start) to due-East (end).
 	const double lat_center = 47.0;
 	const double lon_center = 8.0;
 	const float radius = 10000.f;            // [m]
 	const float arc_start_bearing = 0.f;     // start point due North of the center
 	const float arc_sweep = M_PI_F / 2.f;    // end point due East of the center
-
-	// Endpoints placed with the same equirectangular approximation the implementation
-	// uses: 1 deg latitude ~= 111111 m, 1 deg longitude ~= 111111 m * cos(latitude).
-	const double meters_per_deg = 111111.0;
-	const double radius_m = static_cast<double>(radius);
+	const double mpd = 111111.0;
 	const double cos_lat = cos(math::radians(lat_center));
-	const double lat_start = lat_center + radius_m / meters_per_deg;
-	const double lon_start = lon_center;
-	const double lat_end = lat_center;
-	const double lon_end = lon_center + radius_m / (meters_per_deg * cos_lat);
+
+	// The implementation locates the endpoints with an equirectangular approximation; mirror it so we
+	// can predict which endpoint is nearer and at what distance.
+	auto endpoint = [&](double bearing, double & lat, double & lon) {
+		lat = lat_center + static_cast<double>(radius) * cos(bearing) / mpd;
+		lon = lon_center + static_cast<double>(radius) * sin(bearing) / (mpd * cos_lat);
+	};
+	double lat_start, lon_start, lat_end, lon_end;
+	endpoint(static_cast<double>(arc_start_bearing), lat_start, lon_start);
+	endpoint(static_cast<double>(arc_start_bearing + arc_sweep), lat_end, lon_end);
 
 	crosstrack_error_s err{};
+	double lat_v, lon_v;
 
-	// WHEN: the vehicle sits exactly on the arc start point (outside the sector)
-	get_distance_to_arc(&err, lat_start, lon_start, lat_center, lon_center, radius, arc_start_bearing, arc_sweep);
-	// THEN: the crosstrack distance is ~zero and we are not past the end
-	EXPECT_NEAR(err.distance, 0.f, 0.1f);
+	// WHEN: the vehicle is outside the wedge on the start side (0.5 rad before the start bearing)
+	waypoint_from_heading_and_distance(lat_center, lon_center, arc_start_bearing - 0.5f, radius, &lat_v, &lon_v);
+	get_distance_to_arc(&err, lat_v, lon_v, lat_center, lon_center, radius, arc_start_bearing, arc_sweep);
+	// THEN: the result is the distance to the nearer (start) endpoint, not past the end
+	EXPECT_LT(get_distance_to_next_waypoint(lat_v, lon_v, lat_start, lon_start),
+		  get_distance_to_next_waypoint(lat_v, lon_v, lat_end, lon_end));
+	EXPECT_NEAR(err.distance, get_distance_to_next_waypoint(lat_v, lon_v, lat_start, lon_start), 0.5f);
 	EXPECT_FALSE(err.past_end);
 
-	// WHEN: the vehicle sits exactly on the arc end point (outside the sector)
-	get_distance_to_arc(&err, lat_end, lon_end, lat_center, lon_center, radius, arc_start_bearing, arc_sweep);
-	// THEN: the crosstrack distance is ~zero and we are past the end
-	EXPECT_NEAR(err.distance, 0.f, 0.1f);
+	// WHEN: the vehicle is outside the wedge on the end side (0.5 rad past the end bearing)
+	waypoint_from_heading_and_distance(lat_center, lon_center, arc_start_bearing + arc_sweep + 0.5f, radius, &lat_v, &lon_v);
+	get_distance_to_arc(&err, lat_v, lon_v, lat_center, lon_center, radius, arc_start_bearing, arc_sweep);
+	// THEN: the result is the distance to the nearer (end) endpoint, past the end
+	EXPECT_LT(get_distance_to_next_waypoint(lat_v, lon_v, lat_end, lon_end),
+		  get_distance_to_next_waypoint(lat_v, lon_v, lat_start, lon_start));
+	EXPECT_NEAR(err.distance, get_distance_to_next_waypoint(lat_v, lon_v, lat_end, lon_end), 0.5f);
 	EXPECT_TRUE(err.past_end);
+}
 
-	// WHEN: the vehicle is offset radially outward from the start point
-	const double lat_offset = 500.0 / meters_per_deg;
-	get_distance_to_arc(&err, lat_start + lat_offset, lon_start, lat_center, lon_center, radius, arc_start_bearing,
-			    arc_sweep);
-	// THEN: the crosstrack distance equals the distance to the (nearer) start point
-	EXPECT_NEAR(err.distance, get_distance_to_next_waypoint(lat_start + lat_offset, lon_start, lat_start, lon_start), 0.1f);
+TEST_F(GeoTest, get_distance_to_arc_inside_sector)
+{
+	// GIVEN: an arc sweeping from due-North (start) to due-East (end) of the center
+	const double lat_center = 47.0;
+	const double lon_center = 8.0;
+	const float radius = 10000.f;
+	const float arc_start_bearing = 0.f;
+	const float arc_sweep = M_PI_F / 2.f;
+	const float mid_bearing = arc_start_bearing + arc_sweep / 2.f;   // pi/4, inside the wedge
+
+	crosstrack_error_s err{};
+	double lat_v, lon_v;
+
+	// WHEN: the vehicle is exactly on the arc (on the circle, inside the wedge). This is the case the
+	// previous in-sector logic mis-classified and reported kilometers off.
+	waypoint_from_heading_and_distance(lat_center, lon_center, mid_bearing, radius, &lat_v, &lon_v);
+	get_distance_to_arc(&err, lat_v, lon_v, lat_center, lon_center, radius, arc_start_bearing, arc_sweep);
+	// THEN: distance to the arc is ~zero
+	EXPECT_NEAR(err.distance, 0.f, 1.f);
 	EXPECT_FALSE(err.past_end);
+
+	// WHEN: the vehicle is inside the circle, within the wedge (half a radius from the center)
+	waypoint_from_heading_and_distance(lat_center, lon_center, mid_bearing, radius / 2.f, &lat_v, &lon_v);
+	get_distance_to_arc(&err, lat_v, lon_v, lat_center, lon_center, radius, arc_start_bearing, arc_sweep);
+	// THEN: the distance is the radial gap to the arc (~radius/2)
+	EXPECT_NEAR(err.distance, radius / 2.f, 1.f);
+	EXPECT_FALSE(err.past_end);
+
+	// WHEN: the vehicle is outside the circle, within the wedge (1.5 radius from the center)
+	waypoint_from_heading_and_distance(lat_center, lon_center, mid_bearing, 1.5f * radius, &lat_v, &lon_v);
+	get_distance_to_arc(&err, lat_v, lon_v, lat_center, lon_center, radius, arc_start_bearing, arc_sweep);
+	// THEN: the distance is again the radial gap (~radius/2)
+	EXPECT_NEAR(err.distance, radius / 2.f, 1.f);
+	EXPECT_FALSE(err.past_end);
+}
+
+TEST_F(GeoTest, get_distance_to_arc_negative_sweep)
+{
+	// GIVEN: the same NE-quadrant arc, but defined from due-East (start) sweeping negatively to North (end)
+	const double lat_center = 47.0;
+	const double lon_center = 8.0;
+	const float radius = 10000.f;
+	const float arc_start_bearing = M_PI_F / 2.f;
+	const float arc_sweep = -M_PI_F / 2.f;
+
+	crosstrack_error_s err{};
+	double lat_v, lon_v;
+
+	// WHEN: the vehicle is on the arc midpoint (bearing pi/4 from the center) -> in sector
+	waypoint_from_heading_and_distance(lat_center, lon_center, M_PI_F / 4.f, radius, &lat_v, &lon_v);
+	get_distance_to_arc(&err, lat_v, lon_v, lat_center, lon_center, radius, arc_start_bearing, arc_sweep);
+	// THEN: distance to the arc is ~zero
+	EXPECT_NEAR(err.distance, 0.f, 1.f);
+	EXPECT_FALSE(err.past_end);
+
+	// WHEN: the vehicle is due South of the center, far outside the wedge -> out of sector
+	waypoint_from_heading_and_distance(lat_center, lon_center, M_PI_F, radius, &lat_v, &lon_v);
+	get_distance_to_arc(&err, lat_v, lon_v, lat_center, lon_center, radius, arc_start_bearing, arc_sweep);
+	// THEN: it is NOT treated as on the arc (the old negative-sweep sector math returned ~zero here)
+	EXPECT_GT(err.distance, radius);
 }

--- a/src/lib/geo/test_geo.cpp
+++ b/src/lib/geo/test_geo.cpp
@@ -214,3 +214,46 @@ TEST_F(GeoTest, waypoint_from_line_and_negative_distance)
 	EXPECT_FLOAT_EQ(lat_start - lat_offset, lat_target);
 	EXPECT_DOUBLE_EQ(lon_start, lon_target);
 }
+
+TEST_F(GeoTest, get_distance_to_arc_outside_sector)
+{
+	// GIVEN: an arc centered at a mid-latitude (so the longitude cosine scaling
+	// matters), sweeping from due-North of the center (start) to due-East (end).
+	const double lat_center = 47.0;
+	const double lon_center = 8.0;
+	const float radius = 10000.f;            // [m]
+	const float arc_start_bearing = 0.f;     // start point due North of the center
+	const float arc_sweep = M_PI_F / 2.f;    // end point due East of the center
+
+	// Endpoints placed with the same equirectangular approximation the implementation
+	// uses: 1 deg latitude ~= 111111 m, 1 deg longitude ~= 111111 m * cos(latitude).
+	const double meters_per_deg = 111111.0;
+	const double radius_m = static_cast<double>(radius);
+	const double cos_lat = cos(math::radians(lat_center));
+	const double lat_start = lat_center + radius_m / meters_per_deg;
+	const double lon_start = lon_center;
+	const double lat_end = lat_center;
+	const double lon_end = lon_center + radius_m / (meters_per_deg * cos_lat);
+
+	crosstrack_error_s err{};
+
+	// WHEN: the vehicle sits exactly on the arc start point (outside the sector)
+	get_distance_to_arc(&err, lat_start, lon_start, lat_center, lon_center, radius, arc_start_bearing, arc_sweep);
+	// THEN: the crosstrack distance is ~zero and we are not past the end
+	EXPECT_NEAR(err.distance, 0.f, 0.1f);
+	EXPECT_FALSE(err.past_end);
+
+	// WHEN: the vehicle sits exactly on the arc end point (outside the sector)
+	get_distance_to_arc(&err, lat_end, lon_end, lat_center, lon_center, radius, arc_start_bearing, arc_sweep);
+	// THEN: the crosstrack distance is ~zero and we are past the end
+	EXPECT_NEAR(err.distance, 0.f, 0.1f);
+	EXPECT_TRUE(err.past_end);
+
+	// WHEN: the vehicle is offset radially outward from the start point
+	const double lat_offset = 500.0 / meters_per_deg;
+	get_distance_to_arc(&err, lat_start + lat_offset, lon_start, lat_center, lon_center, radius, arc_start_bearing,
+			    arc_sweep);
+	// THEN: the crosstrack distance equals the distance to the (nearer) start point
+	EXPECT_NEAR(err.distance, get_distance_to_next_waypoint(lat_start + lat_offset, lon_start, lat_start, lon_start), 0.1f);
+	EXPECT_FALSE(err.past_end);
+}

--- a/src/lib/geo/test_geo.cpp
+++ b/src/lib/geo/test_geo.cpp
@@ -215,7 +215,7 @@ TEST_F(GeoTest, waypoint_from_line_and_negative_distance)
 	EXPECT_DOUBLE_EQ(lon_start, lon_target);
 }
 
-TEST_F(GeoTest, get_distance_to_arc_outside_sector)
+TEST_F(GeoTest, getDistanceToArcOutsideSector)
 {
 	// GIVEN: an arc at a mid-latitude (so the longitude cosine scaling matters), sweeping from
 	// due-North of the center (start) to due-East (end).
@@ -259,7 +259,7 @@ TEST_F(GeoTest, get_distance_to_arc_outside_sector)
 	EXPECT_TRUE(err.past_end);
 }
 
-TEST_F(GeoTest, get_distance_to_arc_inside_sector)
+TEST_F(GeoTest, getDistanceToArcInsideSector)
 {
 	// GIVEN: an arc sweeping from due-North (start) to due-East (end) of the center
 	const double lat_center = 47.0;
@@ -295,7 +295,7 @@ TEST_F(GeoTest, get_distance_to_arc_inside_sector)
 	EXPECT_FALSE(err.past_end);
 }
 
-TEST_F(GeoTest, get_distance_to_arc_negative_sweep)
+TEST_F(GeoTest, getDistanceToArcNegativeSweep)
 {
 	// GIVEN: the same NE-quadrant arc, but defined from due-East (start) sweeping negatively to North (end)
 	const double lat_center = 47.0;


### PR DESCRIPTION
## Summary
fixes #27557

`get_distance_to_arc()` was broken in several independent ways. This corrects the geometry for both the out-of-sector and in-sector cases and adds unit tests covering each path.

## Problem
The function has no callers today, so this is latent, but the math was wrong in four ways.

Out-of-sector endpoint placement:
- Reported in the issue: the cosine scaling was inverted and evaluated in degrees instead of radians — `cos()` multiplied the latitude term and was absent from the longitude term. One degree of longitude spans `111111 m * cos(latitude)`, so the east displacement must be divided by `cos(lat)` in radians, while latitude needs no cosine.
- The displacement (a vector of length `radius` measured from the center) was added to the vehicle position instead of the arc center, so the endpoints were meaningless.

In-sector classification:
- Membership compared the vehicle→center bearing against bounds defined as center→endpoint bearings — off by π. A point lying exactly on the arc was classified out-of-sector and reported kilometers of crosstrack error instead of ~zero.
- The negative-sweep branch computed the sector bounds with the wrong sign (`arc_start_bearing - arc_sweep`), reflecting the wedge to the wrong side.

## Solution
Anchor the endpoints to the center with the correct equirectangular conversion (cosine on longitude, in the denominator, in radians), and replace the sector-bound bookkeeping with a single sweep-direction-aware test on the center→vehicle bearing that handles either sweep sign and any zero crossing. Add unit tests for the out-of-sector, in-sector, and negative-sweep paths.
