### PR TITLE
fix(CDev): Fix clang-tidy error "bugprone-dynamic-static-initializers"

### DIFF
--- a/src/lib/cdev/CDev.cpp
+++ b/src/lib/cdev/CDev.cpp
@@ -89,7 +89,7 @@ CDev::register_class_devname(const char *class_devname)
 	while (class_instance < 4) {
 		char name[32];
 		snprintf(name, sizeof(name), "%s%d", class_devname, class_instance);
-		ret = register_driver(name, &fops, 0666, (void *)this);
+		ret = register_driver(name, &fops_ref(), 0666, (void *)this);
 
 		if (ret == OK) {
 			break;
@@ -124,7 +124,7 @@ CDev::init()
 
 	// now register the driver
 	if (_devname != nullptr) {
-		ret = register_driver(_devname, &fops, 0666, (void *)this);
+		ret = register_driver(_devname, &fops_ref(), 0666, (void *)this);
 
 		if (ret == PX4_OK) {
 			_registered = true;

--- a/src/lib/cdev/CDev.hpp
+++ b/src/lib/cdev/CDev.hpp
@@ -170,10 +170,11 @@ public:
 
 protected:
 	/**
-	 * Pointer to the default cdev file operations table; useful for
-	 * registering clone devices etc.
+	 * Accessor for the default cdev file operations table; useful for
+	 * registering clone devices etc. Defined in the platform-specific
+	 * cdev_platform.cpp.
 	 */
-	static const px4_file_operations_t	fops;
+	static const px4_file_operations_t	&fops_ref();
 
 	/**
 	 * Check the current state of the device for poll events from the

--- a/src/lib/cdev/nuttx/cdev_platform.cpp
+++ b/src/lib/cdev/nuttx/cdev_platform.cpp
@@ -71,7 +71,7 @@ static int	cdev_poll(file_t *filp, px4_pollfd_struct_t *fds, bool setup);
  * Note that we use the GNU extension syntax here because we don't get designated
  * initialisers in gcc 4.6.
  */
-const struct file_operations cdev::CDev::fops = {
+static const struct file_operations g_fops = {
 open	: cdev_open,
 close	: cdev_close,
 read	: cdev_read,
@@ -83,6 +83,8 @@ poll	: cdev_poll,
 unlink	: nullptr
 #endif
 };
+
+const cdev::px4_file_operations_t &cdev::CDev::fops_ref() { return g_fops; }
 
 static int
 cdev_open(file_t *filp)

--- a/src/lib/cdev/posix/cdev_platform.cpp
+++ b/src/lib/cdev/posix/cdev_platform.cpp
@@ -42,7 +42,8 @@
 
 #include <stdlib.h>
 
-const cdev::px4_file_operations_t cdev::CDev::fops = {};
+static const cdev::px4_file_operations_t g_fops = {};
+const cdev::px4_file_operations_t &cdev::CDev::fops_ref() { return g_fops; }
 
 pthread_mutex_t devmutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t filemutex = PTHREAD_MUTEX_INITIALIZER;


### PR DESCRIPTION
### Solved Problem

Fixes the remaining clang-tidy issue in https://github.com/PX4/PX4-Autopilot/pull/26215

### Solution

Replace static fops member with platform-defined fops_ref() accessor to avoid bugprone-dynamic-static-initializers warning. This is a mechanical style-change, doesn't change functionality.

### Alternatives

Simply use "NOLINT" because essentially this is a false positive. Static initializers can be bugprone but there is no
bugs in this case. I liked this better, because it makes it explicit also for the static code analyzers that there are no errors in the initialization.

### Test coverage

Running clang-tidy locally, quickly tried out "px4_sitl_default gz_x500" and px4_fmu-v5_default.
