### PR TITLE
fix(fw_mode_manager/navigator): use the correct waypoint switching distance

### DIFF
--- a/msg/FixedWingLateralGuidanceStatus.msg
+++ b/msg/FixedWingLateralGuidanceStatus.msg
@@ -9,5 +9,6 @@ float32 bearing_feas            # [@range 0,1] bearing feasibility
 float32 bearing_feas_on_track   # [@range 0,1] on-track bearing feasibility
 float32 signed_track_error      # [m] signed track error
 float32 track_error_bound       # [m] track error bound
+float32 switch_distance         # [m] [@range 0, INF] distance from the current waypoint at which the navigator should advance to the next one (turn anticipation)
 float32 adapted_period          # [s] adapted period (if auto-tuning enabled)
 uint8 wind_est_valid            # [boolean] true = wind estimate is valid and/or being used by controller (also indicates if wind estimate usage is disabled despite being valid)

--- a/msg/FixedWingLateralGuidanceStatus.msg
+++ b/msg/FixedWingLateralGuidanceStatus.msg
@@ -9,6 +9,6 @@ float32 bearing_feas            # [@range 0,1] bearing feasibility
 float32 bearing_feas_on_track   # [@range 0,1] on-track bearing feasibility
 float32 signed_track_error      # [m] signed track error
 float32 track_error_bound       # [m] track error bound
-float32 switch_distance         # [m] [@range 0, INF] distance from the current waypoint at which the navigator should advance to the next one (turn anticipation)
+float32 switch_distance         # [m] [@range 0, INF] [@INVALID NaN] distance from the current waypoint at which the navigator should advance to the next one (turn anticipation). If below NAV_ACC_RAD, the parameter value is used instead.
 float32 adapted_period          # [s] adapted period (if auto-tuning enabled)
 uint8 wind_est_valid            # [boolean] true = wind estimate is valid and/or being used by controller (also indicates if wind estimate usage is disabled despite being valid)

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -941,8 +941,7 @@ FixedWingModeManager::control_auto_loiter(const float control_interval, const Ve
 	Vector2f curr_wp_local{_global_local_proj_ref.project(curr_wp(0), curr_wp(1))};
 	Vector2f vehicle_to_loiter_center{curr_wp_local - curr_pos_local};
 
-	const bool close_to_circle = vehicle_to_loiter_center.norm() < loiter_radius + _directional_guidance.switchDistance(
-					     500);
+	const bool close_to_circle = vehicle_to_loiter_center.norm() < loiter_radius + _directional_guidance.switchDistance(500);
 
 	bool enforce_low_height{false};
 
@@ -2772,6 +2771,7 @@ void FixedWingModeManager::publish_lateral_guidance_status(const hrt_abstime now
 	fixed_wing_lateral_guidance_status.bearing_feas_on_track = _directional_guidance.getBearingFeasibilityOnTrack();
 	fixed_wing_lateral_guidance_status.signed_track_error = _directional_guidance.getSignedTrackError();
 	fixed_wing_lateral_guidance_status.track_error_bound = _directional_guidance.getTrackErrorBound();
+	fixed_wing_lateral_guidance_status.switch_distance = _directional_guidance.switchDistance(500.0f);
 	fixed_wing_lateral_guidance_status.adapted_period = _directional_guidance.getAdaptedPeriod();
 	fixed_wing_lateral_guidance_status.wind_est_valid = _wind_valid;
 

--- a/src/modules/fw_mode_manager/FixedWingModeManager.hpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.hpp
@@ -75,7 +75,6 @@
 #include <uORB/topics/normalized_unsigned_setpoint.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/position_controller_landing_status.h>
-#include <uORB/topics/position_controller_status.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/trajectory_setpoint.h>
 #include <uORB/topics/vehicle_angular_velocity.h>

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -72,6 +72,7 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/distance_sensor_mode_change_request.h>
+#include <uORB/topics/fixed_wing_lateral_guidance_status.h>
 #include <uORB/topics/geofence_result.h>
 #include <uORB/topics/gimbal_manager_set_attitude.h>
 #include <uORB/topics/home_position.h>
@@ -321,6 +322,7 @@ private:
 	int _vehicle_status_sub{-1};
 
 	uORB::SubscriptionData<position_controller_status_s>	_position_controller_status_sub{ORB_ID(position_controller_status)};
+	uORB::SubscriptionData<fixed_wing_lateral_guidance_status_s> _fw_lateral_guidance_status_sub{ORB_ID(fixed_wing_lateral_guidance_status)};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -252,6 +252,7 @@ void Navigator::run()
 
 		_land_detected_sub.update(&_land_detected);
 		_position_controller_status_sub.update();
+		_fw_lateral_guidance_status_sub.update();
 		_home_pos_sub.update(&_home_pos);
 
 		// Handle Vehicle commands
@@ -1288,13 +1289,23 @@ float Navigator::get_cruising_throttle()
 float Navigator::get_acceptance_radius()
 {
 	float acceptance_radius = get_default_acceptance_radius(); // the value specified in the parameter NAV_ACC_RAD
-	const position_controller_status_s &pos_ctrl_status = _position_controller_status_sub.get();
 
 	// for fixed-wing and rover, return the max of NAV_ACC_RAD and the controller acceptance radius (e.g. navigation switch distance)
-	if (_vstatus.vehicle_type != vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
-	    && PX4_ISFINITE(pos_ctrl_status.acceptance_radius) && pos_ctrl_status.timestamp != 0) {
+	if (_vstatus.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
 
-		acceptance_radius = math::max(acceptance_radius, pos_ctrl_status.acceptance_radius);
+		const fixed_wing_lateral_guidance_status_s &fw_guidance_status = _fw_lateral_guidance_status_sub.get();
+
+		if (PX4_ISFINITE(fw_guidance_status.switch_distance) && fw_guidance_status.timestamp != 0) {
+			acceptance_radius = math::max(acceptance_radius, fw_guidance_status.switch_distance);
+		}
+
+	} else if (_vstatus.vehicle_type != vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+
+		const position_controller_status_s &pos_ctrl_status = _position_controller_status_sub.get();
+
+		if (PX4_ISFINITE(pos_ctrl_status.acceptance_radius) && pos_ctrl_status.timestamp != 0) {
+			acceptance_radius = math::max(acceptance_radius, pos_ctrl_status.acceptance_radius);
+		}
 	}
 
 	return acceptance_radius;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1299,7 +1299,7 @@ float Navigator::get_acceptance_radius()
 			acceptance_radius = math::max(acceptance_radius, fw_guidance_status.switch_distance);
 		}
 
-	} else if (_vstatus.vehicle_type != vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+	} else if (_vstatus.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROVER) {
 
 		const position_controller_status_s &pos_ctrl_status = _position_controller_status_sub.get();
 

--- a/src/modules/navigator/navigator_params.yaml
+++ b/src/modules/navigator/navigator_params.yaml
@@ -22,7 +22,7 @@ parameters:
         short: Acceptance Radius
         long: |-
           Default acceptance radius, overridden by acceptance radius of waypoint if set.
-          For fixed wing the npfg switch distance is used for horizontal acceptance.
+          For fixed-wing and rovers, the high level controllers output their own acceptance radius. Those values are used instead only when above this parameter.
       type: float
       default: 10.0
       unit: m


### PR DESCRIPTION
### Problem

Before https://github.com/PX4/PX4-Autopilot/pull/24056, the fixed-wing position controller used to publish the acceptance radius (calculated depending on params and state by `DirectionalGuidance::switchDistance`) in the position controller status.

The refactor migrated that to individual lateral/longitudinal topics, but left the receiving code in the navigator unchanged. As a consequence, fixed-wing vehicles now rely on `NAV_ACC_RAD` for the acceptance radius, rather than the adaptively calculated switch distance.

As `NAV_ACC_RAD` is only 10m by default this leads to overshoot, especially on tight corners, or and large fast vehicles. 

### Solution 

Fix by reintroducing the publication (now from `FixedWingModeManager` through `fixed_wing_lateral_guidance_status`) and adapting the navigator to use that if fixed wing.

### Changelog entry

```
Fix: Correctly infer fixed-wing waypoint switching distance from NPFG parameters
```

### Testing

Short mission with a variety of corner angles on `gz_standard_vtol`. Before: 
<img width="1378" height="954" alt="Screenshot from 2026-06-04 14-49-02" src="https://github.com/user-attachments/assets/18e32b5f-26c2-4e1d-8a8c-4bdda6b184c8" />

After:
<img width="1378" height="954" alt="Screenshot from 2026-06-04 14-41-47" src="https://github.com/user-attachments/assets/89d3705b-209a-461c-a6f1-4d5c0a7638bc" />
