### PR TITLE
fix(docs): invert vectorized diagram SVGs in dark mode

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -220,14 +220,13 @@ html {
 }
 
 
-  /**
-   * Dark mode: invert vectorized diagram SVGs (Google Drawings exports where all
-   * text and arrows are black paths — invisible on a dark background without this).
-   * hue-rotate(180deg) keeps blue tones from turning orange after the invert.
-   * -------------------------------------------------------------------------- */
+/**
+ * Dark mode: invert vectorized diagram SVGs (Google Drawings exports where all
+ * text and arrows are black paths — invisible on a dark background without this).
+ * hue-rotate(180deg) keeps blue tones from turning orange after the invert.
+ * Apply class="diagram-invert" to any image that needs this treatment.
+ * -------------------------------------------------------------------------- */
 
-  .dark img[src*="diagrams/px4_companion_computer_simple"],
-  .dark img[src*="diagrams/px4_arch_fc_companion"],
-  .dark img[src*="diagrams/px4_arch_fc"] {
-    filter: invert(1) hue-rotate(180deg);
-  }
+.dark .diagram-invert {
+  filter: invert(1) hue-rotate(180deg);
+}

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -218,3 +218,16 @@ html {
   }
 
 }
+
+
+  /**
+   * Dark mode: invert vectorized diagram SVGs (Google Drawings exports where all
+   * text and arrows are black paths — invisible on a dark background without this).
+   * hue-rotate(180deg) keeps blue tones from turning orange after the invert.
+   * -------------------------------------------------------------------------- */
+
+  .dark img[src*="diagrams/px4_companion_computer_simple"],
+  .dark img[src*="diagrams/px4_arch_fc_companion"],
+  .dark img[src*="diagrams/px4_arch_fc"] {
+    filter: invert(1) hue-rotate(180deg);
+  }

--- a/docs/en/companion_computer/index.md
+++ b/docs/en/companion_computer/index.md
@@ -4,7 +4,7 @@ Companion computers ("mission computers"), are separate on-vehicle computers tha
 
 The diagram below shows a possible architecture for an unmanned vehicle architecture that includes a flight controller and companion computer.
 
-![PX4 architecture - FC + Companion Computer](../../assets/diagrams/px4_companion_computer_simple.svg)
+<img src="../../assets/diagrams/px4_companion_computer_simple.svg" alt="PX4 architecture - FC + Companion Computer" class="diagram-invert">
 
 <!-- source for drawing: https://docs.google.com/drawings/d/1ZDSyj5djKCEbabgx8K4ESdTeEUizgEt8spUWrMGbHUE/edit?usp=sharing -->
 

--- a/docs/en/concept/pwm_limit.md
+++ b/docs/en/concept/pwm_limit.md
@@ -24,4 +24,4 @@ Provides a delay between assertion of "armed" and a ramp-up of throttle on asser
 
 ## State Transition Diagram
 
-![PWM Limit state machine diagram](../../assets/diagrams/pwm_limit_state_diagram.svg)
+<img src="../../assets/diagrams/pwm_limit_state_diagram.svg" alt="PWM Limit state machine diagram" class="diagram-invert">

--- a/docs/en/concept/px4_systems_architecture.md
+++ b/docs/en/concept/px4_systems_architecture.md
@@ -11,7 +11,7 @@ Offboard APIs are covered in [ROS](../ros/index.md) and [MAVSDK](https://mavsdk.
 
 The diagram below provides a high level overview of a typical "simple" PX4 system based around a flight controller.
 
-![PX4 architecture - FC only system](../../assets/diagrams/px4_arch_fc.svg)
+<img src="../../assets/diagrams/px4_arch_fc.svg" alt="PX4 architecture - FC only system" class="diagram-invert">
 
 <!-- Source for drawing: https://docs.google.com/drawings/d/1_2n43WrbkWTs1kz0w0avVEeebJbfTj5SSqvCmvSOBdU/edit -->
 
@@ -34,7 +34,7 @@ The left hand side of the diagram shows the software stack, which is horizontall
 
 The diagram below shows a PX4 system that includes both a flight controller and a companion computer (here referred to as a "mission computer").
 
-![PX4 architecture - FC + Companion Computer](../../assets/diagrams/px4_arch_fc_companion.svg)
+<img src="../../assets/diagrams/px4_arch_fc_companion.svg" alt="PX4 architecture - FC + Companion Computer" class="diagram-invert">
 
 <!-- source for drawing: https://docs.google.com/drawings/d/1zFtvA_B-BmfmxFmAd-XIvAZ-jRqOydj0aBtqSolBcqI/edit -->
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "prettier": "^3.8.3",
-    "markdown_link_checker_sc": "^0.0.144"
+    "markdown_link_checker_sc": "^0.0.145"
   },
   "resolutions": {
     "markdown-it": "^14.1.1",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1259,10 +1259,10 @@ markdown-it@^13.0.1, markdown-it@^14.1.1:
     punycode.js "^2.3.1"
     uc.micro "^2.1.0"
 
-markdown_link_checker_sc@^0.0.144:
-  version "0.0.144"
-  resolved "https://registry.npmjs.org/markdown_link_checker_sc/-/markdown_link_checker_sc-0.0.144.tgz"
-  integrity sha512-8gt9nTvFrg8aIBwvd3uVYBmt0NNQyBIknzrNpaeYXQBs91jM1DtEJIELmVwOsUAilIxu2gI3NzLIoBG3dXkPcQ==
+markdown_link_checker_sc@^0.0.145:
+  version "0.0.145"
+  resolved "https://registry.yarnpkg.com/markdown_link_checker_sc/-/markdown_link_checker_sc-0.0.145.tgz#b4849df81c9fdb437fc2edb87ee3b8d5afaf199f"
+  integrity sha512-IH3AVF1pcc5PaBIce9ZhU0cEqNhwtcRrEAS2w1CjFk4WVD2YJfyLeOsUfeYqlE53lHn5a1pditHPjOKWrYdHow==
   dependencies:
     commander "^10.0.0"
     normalize-path "^3.0.0"


### PR DESCRIPTION
 ### Solved Problem
  Vectorized diagram SVGs (exported from Google Drawings) use hardcoded black fills for all text and arrows. In dark mode these are invisible against the dark background.

  ### Solution
  Added a CSS filter rule in the VitePress theme that applies `invert(1) hue-rotate(180deg)` to the three affected SVGs when the `.dark`  class is active. `hue-rotate(180deg)` prevents the blue tones from turning orange.

  Affected diagrams:
  - `px4_companion_computer_simple.svg`
  - `px4_arch_fc_companion.svg`
  - `px4_arch_fc.svg`

  ### Test coverage
  Verified locally with `yarn docs:dev`. The toggled dark mode on the companion computer page and confirmed diagrams are readable.

  ### Context
| Before | After |
|--------|-------|
| ![](https://github.com/user-attachments/assets/861dd2fb-227e-4ad9-abc2-b37e0f91b7a7) | ![](https://github.com/user-attachments/assets/aa3f2f62-098e-494c-9fb3-256a1af7c378) |
| ![](https://github.com/user-attachments/assets/85c8ca81-30fb-41d1-8d93-866b72efac12) | ![](https://github.com/user-attachments/assets/6714f16f-0691-4c5f-97ca-5a379a33b90e) |
| ![](https://github.com/user-attachments/assets/5270cd3a-135a-4e92-a29a-09f20476d1ad) | ![](https://github.com/user-attachments/assets/b6b212c8-6707-4a85-92d2-faab82edd4d9) |