### PR TITLE
fix(gps): guard against unsigned integer underflow in dumpGpsData

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -738,6 +738,11 @@ void GPS::dumpGpsData(const uint8_t *data, size_t len, gps_dump_comm_mode_t mode
 	while (len > 0) {
 		size_t write_len = len;
 
+		// Guard against unsigned underflow: if len is already at or beyond buffer size, stop
+		if (dump_data->len >= sizeof(dump_data->data)) {
+			break;
+		}
+
 		if (write_len > sizeof(dump_data->data) - dump_data->len) {
 			write_len = sizeof(dump_data->data) - dump_data->len;
 		}


### PR DESCRIPTION
## Summary
An integer underflow vulnerability was identified in `dumpGpsData()` using formal verification (ESBMC v8.1.0 and CBMC 5.95.1).

## Problem
The function computed `sizeof(dump_data->data) - dump_data->len` without first checking if `dump_data->len` had already reached or exceeded the buffer size. Since both operands are unsigned, this caused an integer underflow (CWE-191), producing a very large `write_len` value and an out-of-bounds `memcpy` (CWE-119).

## Fix
Added a guard that breaks the loop if `dump_data->len` is already at or beyond the buffer boundary, preventing the underflow before the subtraction occurs.

## Verification
Formally verified using ESBMC v8.1.0 (Boolector 3.2.4) and CBMC 5.95.1.
- Before fix: VERIFICATION FAILED (underflow + out-of-bounds memcpy confirmed)
- After fix: VERIFICATION SUCCESSFUL (0 of 7 failed)

Fixes #26866