### PR TITLE
feat(baro): add PX4Barometer wrapper and migrate barometer drivers

### DIFF
--- a/src/drivers/barometer/bmp280/BMP280.cpp
+++ b/src/drivers/barometer/bmp280/BMP280.cpp
@@ -176,14 +176,10 @@ BMP280::collect()
 	const float P = (pf * _fcal.p9 + _fcal.p8) * pf + _fcal.p7;
 
 	// publish
-	sensor_baro_s sensor_baro{};
-	sensor_baro.timestamp_sample = timestamp_sample;
-	sensor_baro.device_id = _interface->get_device_id();
-	sensor_baro.pressure = P;
-	sensor_baro.temperature = T;
-	sensor_baro.error_count = perf_event_count(_comms_errors);
-	sensor_baro.timestamp = hrt_absolute_time();
-	_sensor_baro_pub.publish(sensor_baro);
+	_px4_baro.set_device_id(_interface->get_device_id());
+	_px4_baro.set_error_count(perf_event_count(_comms_errors));
+	_px4_baro.set_temperature(T);
+	_px4_baro.update(timestamp_sample, P);
 
 	perf_end(_sample_perf);
 

--- a/src/drivers/barometer/bmp280/BMP280.cpp
+++ b/src/drivers/barometer/bmp280/BMP280.cpp
@@ -35,6 +35,7 @@
 
 BMP280::BMP280(const I2CSPIDriverConfig &config, bmp280::IBMP280 *interface) :
 	I2CSPIDriver(config),
+	_px4_baro{interface->get_device_id()},
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": sample")),
 	_measure_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": measure")),
@@ -176,7 +177,6 @@ BMP280::collect()
 	const float P = (pf * _fcal.p9 + _fcal.p8) * pf + _fcal.p7;
 
 	// publish
-	_px4_baro.set_device_id(_interface->get_device_id());
 	_px4_baro.set_error_count(perf_event_count(_comms_errors));
 	_px4_baro.set_temperature(T);
 	_px4_baro.update(timestamp_sample, P);

--- a/src/drivers/barometer/bmp280/BMP280.hpp
+++ b/src/drivers/barometer/bmp280/BMP280.hpp
@@ -63,7 +63,7 @@ private:
 	int			measure(); //start measure
 	int			collect(); //get results and publish
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 
 	bmp280::IBMP280		*_interface;
 

--- a/src/drivers/barometer/bmp280/BMP280.hpp
+++ b/src/drivers/barometer/bmp280/BMP280.hpp
@@ -36,6 +36,7 @@
 #include "bmp280.h"
 
 #include <drivers/drv_hrt.h>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <px4_platform_common/px4_config.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
@@ -62,7 +63,7 @@ private:
 	int			measure(); //start measure
 	int			collect(); //get results and publish
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 
 	bmp280::IBMP280		*_interface;
 

--- a/src/drivers/barometer/bmp280/CMakeLists.txt
+++ b/src/drivers/barometer/bmp280/CMakeLists.txt
@@ -42,5 +42,6 @@ px4_add_module(
 
 		bmp280_main.cpp
 	DEPENDS
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/bmp388/CMakeLists.txt
+++ b/src/drivers/barometer/bmp388/CMakeLists.txt
@@ -40,5 +40,6 @@ px4_add_module(
 		bmp388.cpp
 		bmp388_main.cpp
 	DEPENDS
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/bmp388/bmp388.cpp
+++ b/src/drivers/barometer/bmp388/bmp388.cpp
@@ -188,14 +188,10 @@ BMP388::collect()
 	float pressure = (float)(data.pressure / 100.0f); // to Pascal
 
 	// publish
-	sensor_baro_s sensor_baro{};
-	sensor_baro.timestamp_sample = timestamp_sample;
-	sensor_baro.device_id = _interface->get_device_id();
-	sensor_baro.pressure = pressure;
-	sensor_baro.temperature = temperature;
-	sensor_baro.error_count = perf_event_count(_comms_errors);
-	sensor_baro.timestamp = hrt_absolute_time();
-	_sensor_baro_pub.publish(sensor_baro);
+	_px4_baro.set_device_id(_interface->get_device_id());
+	_px4_baro.set_error_count(perf_event_count(_comms_errors));
+	_px4_baro.set_temperature(temperature);
+	_px4_baro.update(timestamp_sample, pressure);
 
 	perf_end(_sample_perf);
 

--- a/src/drivers/barometer/bmp388/bmp388.cpp
+++ b/src/drivers/barometer/bmp388/bmp388.cpp
@@ -43,6 +43,7 @@
 
 BMP388::BMP388(const I2CSPIDriverConfig &config, IBMP388 *interface) :
 	I2CSPIDriver(config),
+	_px4_baro{interface->get_device_id()},
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_measure_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": measure")),
@@ -82,6 +83,9 @@ BMP388::init()
 		_interface->set_device_type(DRV_BARO_DEVTYPE_BMP390);
 		this->_item_name = "bmp390";
 	}
+
+	// device type may have been refined above (BMP388 vs BMP390); latch the final device id
+	_px4_baro.set_device_id(_interface->get_device_id());
 
 	if (_interface->get_reg(BMP3_REV_ID_ADDR, &_chip_rev_id) != OK) {
 		PX4_WARN("failed to get chip rev id");
@@ -188,7 +192,6 @@ BMP388::collect()
 	float pressure = (float)(data.pressure / 100.0f); // to Pascal
 
 	// publish
-	_px4_baro.set_device_id(_interface->get_device_id());
 	_px4_baro.set_error_count(perf_event_count(_comms_errors));
 	_px4_baro.set_temperature(temperature);
 	_px4_baro.update(timestamp_sample, pressure);

--- a/src/drivers/barometer/bmp388/bmp388.h
+++ b/src/drivers/barometer/bmp388/bmp388.h
@@ -41,6 +41,7 @@
 #include <math.h>
 #include <drivers/drv_hrt.h>
 #include <lib/cdev/CDev.hpp>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <perf/perf_counter.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
@@ -330,7 +331,7 @@ private:
 	static constexpr uint8_t			odr{BMP3_ODR_50_HZ};			// output data rate (not used)
 	static constexpr uint8_t			iir_coef{BMP3_IIR_FILTER_DISABLE};	// IIR coefficient
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 	IBMP388			*_interface{nullptr};
 
 	unsigned		_measure_interval{0};			// interval in microseconds needed to measure

--- a/src/drivers/barometer/bmp388/bmp388.h
+++ b/src/drivers/barometer/bmp388/bmp388.h
@@ -331,7 +331,7 @@ private:
 	static constexpr uint8_t			odr{BMP3_ODR_50_HZ};			// output data rate (not used)
 	static constexpr uint8_t			iir_coef{BMP3_IIR_FILTER_DISABLE};	// IIR coefficient
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 	IBMP388			*_interface{nullptr};
 
 	unsigned		_measure_interval{0};			// interval in microseconds needed to measure

--- a/src/drivers/barometer/bmp581/CMakeLists.txt
+++ b/src/drivers/barometer/bmp581/CMakeLists.txt
@@ -40,5 +40,6 @@ px4_add_module(
 		bmp581.cpp
 		bmp581_main.cpp
 	DEPENDS
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/bmp581/bmp581.cpp
+++ b/src/drivers/barometer/bmp581/bmp581.cpp
@@ -157,14 +157,10 @@ int BMP581::collect()
 	}
 
 	//publish
-	sensor_baro_s sensor_baro{};
-	sensor_baro.timestamp_sample = timestamp_sample;
-	sensor_baro.device_id = _interface->get_device_id();
-	sensor_baro.pressure = data.pressure;
-	sensor_baro.temperature = data.temperature;
-	sensor_baro.error_count = perf_event_count(_comms_errors);
-	sensor_baro.timestamp = hrt_absolute_time();
-	_sensor_baro_pub.publish(sensor_baro);
+	_px4_baro.set_device_id(_interface->get_device_id());
+	_px4_baro.set_error_count(perf_event_count(_comms_errors));
+	_px4_baro.set_temperature(data.temperature);
+	_px4_baro.update(timestamp_sample, data.pressure);
 
 	perf_end(_sample_perf);
 

--- a/src/drivers/barometer/bmp581/bmp581.cpp
+++ b/src/drivers/barometer/bmp581/bmp581.cpp
@@ -36,6 +36,7 @@
 
 BMP581::BMP581(const I2CSPIDriverConfig &config, IBMP581 *interface) :
 	I2CSPIDriver(config),
+	_px4_baro{interface->get_device_id()},
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_measure_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": measure")),
@@ -157,7 +158,6 @@ int BMP581::collect()
 	}
 
 	//publish
-	_px4_baro.set_device_id(_interface->get_device_id());
 	_px4_baro.set_error_count(perf_event_count(_comms_errors));
 	_px4_baro.set_temperature(data.temperature);
 	_px4_baro.update(timestamp_sample, data.pressure);

--- a/src/drivers/barometer/bmp581/bmp581.h
+++ b/src/drivers/barometer/bmp581/bmp581.h
@@ -283,7 +283,7 @@ private:
 	static constexpr uint8_t	INTERRUPT_POLARITY{BMP5_INT_POL_ACTIVE_HIGH};
 	static constexpr uint8_t 	INTERRUPT_DRIVE{BMP5_INT_OD_PUSHPULL};
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 	IBMP581 		*_interface{nullptr};
 
 	unsigned		_measure_interval{0};			// interval in microseconds needed to measure

--- a/src/drivers/barometer/bmp581/bmp581.h
+++ b/src/drivers/barometer/bmp581/bmp581.h
@@ -41,6 +41,7 @@
 #include <math.h>
 #include <drivers/drv_hrt.h>
 #include <lib/cdev/CDev.hpp>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <perf/perf_counter.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
@@ -282,7 +283,7 @@ private:
 	static constexpr uint8_t	INTERRUPT_POLARITY{BMP5_INT_POL_ACTIVE_HIGH};
 	static constexpr uint8_t 	INTERRUPT_DRIVE{BMP5_INT_OD_PUSHPULL};
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 	IBMP581 		*_interface{nullptr};
 
 	unsigned		_measure_interval{0};			// interval in microseconds needed to measure

--- a/src/drivers/barometer/dps310/CMakeLists.txt
+++ b/src/drivers/barometer/dps310/CMakeLists.txt
@@ -41,5 +41,6 @@ px4_add_module(
 		dps310_main.cpp
 	DEPENDS
 		drivers__device
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/dps310/DPS310.cpp
+++ b/src/drivers/barometer/dps310/DPS310.cpp
@@ -233,14 +233,10 @@ DPS310::RunImpl()
 	const float Tcomp = c0 * 0.5f + c1 * Traw_sc;
 
 	// publish
-	sensor_baro_s sensor_baro{};
-	sensor_baro.timestamp_sample = timestamp_sample;
-	sensor_baro.device_id = _interface->get_device_id();
-	sensor_baro.pressure = Pcomp;
-	sensor_baro.temperature = Tcomp;
-	sensor_baro.error_count = perf_event_count(_comms_errors);
-	sensor_baro.timestamp = hrt_absolute_time();
-	_sensor_baro_pub.publish(sensor_baro);
+	_px4_baro.set_device_id(_interface->get_device_id());
+	_px4_baro.set_error_count(perf_event_count(_comms_errors));
+	_px4_baro.set_temperature(Tcomp);
+	_px4_baro.update(timestamp_sample, Pcomp);
 
 	perf_end(_sample_perf);
 }

--- a/src/drivers/barometer/dps310/DPS310.cpp
+++ b/src/drivers/barometer/dps310/DPS310.cpp
@@ -48,6 +48,7 @@ static void getTwosComplement(T &raw, uint8_t length)
 
 DPS310::DPS310(const I2CSPIDriverConfig &config, device::Device *interface) :
 	I2CSPIDriver(config),
+	_px4_baro{interface->get_device_id()},
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_comms_errors(perf_alloc(PC_COUNT, MODULE_NAME": comm errors"))
@@ -233,7 +234,6 @@ DPS310::RunImpl()
 	const float Tcomp = c0 * 0.5f + c1 * Traw_sc;
 
 	// publish
-	_px4_baro.set_device_id(_interface->get_device_id());
 	_px4_baro.set_error_count(perf_event_count(_comms_errors));
 	_px4_baro.set_temperature(Tcomp);
 	_px4_baro.update(timestamp_sample, Pcomp);

--- a/src/drivers/barometer/dps310/DPS310.hpp
+++ b/src/drivers/barometer/dps310/DPS310.hpp
@@ -81,7 +81,7 @@ private:
 
 	static constexpr uint32_t SAMPLE_RATE{32};
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 
 	device::Device		*_interface;
 

--- a/src/drivers/barometer/goertek/spa06/CMakeLists.txt
+++ b/src/drivers/barometer/goertek/spa06/CMakeLists.txt
@@ -43,5 +43,6 @@ px4_add_module(
 	MODULE_CONFIG
 		parameters.yaml
 	DEPENDS
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/goertek/spa06/SPA06.cpp
+++ b/src/drivers/barometer/goertek/spa06/SPA06.cpp
@@ -35,6 +35,7 @@
 
 SPA06::SPA06(const I2CSPIDriverConfig &config, spa06::ISPA06 *interface) :
 	I2CSPIDriver(config),
+	_px4_baro{interface->get_device_id()},
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": sample")),
 	_measure_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": measure")),
@@ -235,7 +236,6 @@ SPA06::collect()
 	float temperature = (float)_cal.c0 * 0.5f + (float)_cal.c1 * ftsc;
 
 
-	_px4_baro.set_device_id(_interface->get_device_id());
 	_px4_baro.set_error_count(perf_event_count(_comms_errors));
 	_px4_baro.set_temperature(temperature);
 	_px4_baro.update(timestamp_sample, fp);

--- a/src/drivers/barometer/goertek/spa06/SPA06.cpp
+++ b/src/drivers/barometer/goertek/spa06/SPA06.cpp
@@ -235,14 +235,10 @@ SPA06::collect()
 	float temperature = (float)_cal.c0 * 0.5f + (float)_cal.c1 * ftsc;
 
 
-	sensor_baro_s sensor_baro{};
-	sensor_baro.timestamp_sample = timestamp_sample;
-	sensor_baro.device_id = _interface->get_device_id();
-	sensor_baro.pressure = fp;
-	sensor_baro.temperature = temperature;
-	sensor_baro.error_count = perf_event_count(_comms_errors);
-	sensor_baro.timestamp = hrt_absolute_time();
-	_sensor_baro_pub.publish(sensor_baro);
+	_px4_baro.set_device_id(_interface->get_device_id());
+	_px4_baro.set_error_count(perf_event_count(_comms_errors));
+	_px4_baro.set_temperature(temperature);
+	_px4_baro.update(timestamp_sample, fp);
 
 	perf_end(_sample_perf);
 

--- a/src/drivers/barometer/goertek/spa06/SPA06.hpp
+++ b/src/drivers/barometer/goertek/spa06/SPA06.hpp
@@ -40,6 +40,7 @@
 #include <px4_platform_common/i2c_spi_buses.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <lib/perf/perf_counter.h>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_baro.h>
 
@@ -63,7 +64,7 @@ private:
 	int			collect(); //get results and publish
 	int			calibrate();
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 
 	spa06::ISPA06		*_interface;
 	spa06::data_s		_data;

--- a/src/drivers/barometer/goertek/spa06/SPA06.hpp
+++ b/src/drivers/barometer/goertek/spa06/SPA06.hpp
@@ -64,7 +64,7 @@ private:
 	int			collect(); //get results and publish
 	int			calibrate();
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 
 	spa06::ISPA06		*_interface;
 	spa06::data_s		_data;

--- a/src/drivers/barometer/goertek/spl06/CMakeLists.txt
+++ b/src/drivers/barometer/goertek/spl06/CMakeLists.txt
@@ -43,5 +43,6 @@ px4_add_module(
 	MODULE_CONFIG
 		parameters.yaml
 	DEPENDS
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/goertek/spl06/SPL06.cpp
+++ b/src/drivers/barometer/goertek/spl06/SPL06.cpp
@@ -224,14 +224,10 @@ SPL06::collect()
 	float temperature = (float)_cal.c0 * 0.5f + (float)_cal.c1 * ftsc;
 
 
-	sensor_baro_s sensor_baro{};
-	sensor_baro.timestamp_sample = timestamp_sample;
-	sensor_baro.device_id = _interface->get_device_id();
-	sensor_baro.pressure = fp;
-	sensor_baro.temperature = temperature;
-	sensor_baro.error_count = perf_event_count(_comms_errors);
-	sensor_baro.timestamp = hrt_absolute_time();
-	_sensor_baro_pub.publish(sensor_baro);
+	_px4_baro.set_device_id(_interface->get_device_id());
+	_px4_baro.set_error_count(perf_event_count(_comms_errors));
+	_px4_baro.set_temperature(temperature);
+	_px4_baro.update(timestamp_sample, fp);
 
 	perf_end(_sample_perf);
 

--- a/src/drivers/barometer/goertek/spl06/SPL06.cpp
+++ b/src/drivers/barometer/goertek/spl06/SPL06.cpp
@@ -35,6 +35,7 @@
 
 SPL06::SPL06(const I2CSPIDriverConfig &config, spl06::ISPL06 *interface) :
 	I2CSPIDriver(config),
+	_px4_baro{interface->get_device_id()},
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": sample")),
 	_measure_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": measure")),
@@ -224,7 +225,6 @@ SPL06::collect()
 	float temperature = (float)_cal.c0 * 0.5f + (float)_cal.c1 * ftsc;
 
 
-	_px4_baro.set_device_id(_interface->get_device_id());
 	_px4_baro.set_error_count(perf_event_count(_comms_errors));
 	_px4_baro.set_temperature(temperature);
 	_px4_baro.update(timestamp_sample, fp);

--- a/src/drivers/barometer/goertek/spl06/SPL06.hpp
+++ b/src/drivers/barometer/goertek/spl06/SPL06.hpp
@@ -64,7 +64,7 @@ private:
 	int			collect(); //get results and publish
 	int			calibrate();
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 
 	spl06::ISPL06		*_interface;
 	spl06::data_s		_data;

--- a/src/drivers/barometer/goertek/spl06/SPL06.hpp
+++ b/src/drivers/barometer/goertek/spl06/SPL06.hpp
@@ -40,6 +40,7 @@
 #include <px4_platform_common/i2c_spi_buses.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <lib/perf/perf_counter.h>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_baro.h>
 
@@ -63,7 +64,7 @@ private:
 	int			collect(); //get results and publish
 	int			calibrate();
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 
 	spl06::ISPL06		*_interface;
 	spl06::data_s		_data;

--- a/src/drivers/barometer/invensense/icp101xx/CMakeLists.txt
+++ b/src/drivers/barometer/invensense/icp101xx/CMakeLists.txt
@@ -41,5 +41,6 @@ px4_add_module(
 		ICP101XX.hpp
 		icp101xx_main.cpp
 	DEPENDS
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/invensense/icp101xx/ICP101XX.cpp
+++ b/src/drivers/barometer/invensense/icp101xx/ICP101XX.cpp
@@ -37,7 +37,8 @@ using namespace time_literals;
 
 ICP101XX::ICP101XX(const I2CSPIDriverConfig &config) :
 	I2C(config),
-	I2CSPIDriver(config)
+	I2CSPIDriver(config),
+	_px4_baro{get_device_id()}
 {
 }
 
@@ -237,7 +238,6 @@ ICP101XX::RunImpl()
 				float pressure = _pressure_Pa;
 
 				// publish
-				_px4_baro.set_device_id(get_device_id());
 				_px4_baro.set_error_count(perf_event_count(_bad_transfer_perf));
 				_px4_baro.set_temperature(temperature);
 				_px4_baro.update(now, pressure);

--- a/src/drivers/barometer/invensense/icp101xx/ICP101XX.cpp
+++ b/src/drivers/barometer/invensense/icp101xx/ICP101XX.cpp
@@ -237,14 +237,10 @@ ICP101XX::RunImpl()
 				float pressure = _pressure_Pa;
 
 				// publish
-				sensor_baro_s sensor_baro{};
-				sensor_baro.timestamp_sample = now;
-				sensor_baro.device_id = get_device_id();
-				sensor_baro.pressure = pressure;
-				sensor_baro.temperature = temperature;
-				sensor_baro.error_count = perf_event_count(_bad_transfer_perf);
-				sensor_baro.timestamp = hrt_absolute_time();
-				_sensor_baro_pub.publish(sensor_baro);
+				_px4_baro.set_device_id(get_device_id());
+				_px4_baro.set_error_count(perf_event_count(_bad_transfer_perf));
+				_px4_baro.set_temperature(temperature);
+				_px4_baro.update(now, pressure);
 
 				success = true;
 

--- a/src/drivers/barometer/invensense/icp101xx/ICP101XX.hpp
+++ b/src/drivers/barometer/invensense/icp101xx/ICP101XX.hpp
@@ -37,6 +37,7 @@
 
 #include <drivers/drv_hrt.h>
 #include <lib/drivers/device/i2c.h>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_baro.h>
 #include <lib/perf/perf_counter.h>
@@ -70,7 +71,7 @@ private:
 	int send_command(Cmd cmd);
 	int send_command(Cmd cmd, uint8_t *data, uint8_t len);
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 
 	perf_counter_t _reset_perf{perf_alloc(PC_COUNT, MODULE_NAME": reset")};
 	perf_counter_t _sample_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": read")};

--- a/src/drivers/barometer/invensense/icp101xx/ICP101XX.hpp
+++ b/src/drivers/barometer/invensense/icp101xx/ICP101XX.hpp
@@ -71,7 +71,7 @@ private:
 	int send_command(Cmd cmd);
 	int send_command(Cmd cmd, uint8_t *data, uint8_t len);
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 
 	perf_counter_t _reset_perf{perf_alloc(PC_COUNT, MODULE_NAME": reset")};
 	perf_counter_t _sample_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": read")};

--- a/src/drivers/barometer/invensense/icp201xx/CMakeLists.txt
+++ b/src/drivers/barometer/invensense/icp201xx/CMakeLists.txt
@@ -41,5 +41,6 @@ px4_add_module(
 		ICP201XX.hpp
 		icp201xx_main.cpp
 	DEPENDS
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/invensense/icp201xx/ICP201XX.cpp
+++ b/src/drivers/barometer/invensense/icp201xx/ICP201XX.cpp
@@ -304,14 +304,10 @@ ICP201XX::RunImpl()
 				perf_end(_sample_perf);
 				perf_begin(_sample_perf);
 
-				sensor_baro_s sensor_baro{};
-				sensor_baro.timestamp_sample = now;
-				sensor_baro.device_id = get_device_id();
-				sensor_baro.pressure = pressure;
-				sensor_baro.temperature = temperature;
-				sensor_baro.error_count = perf_event_count(_bad_transfer_perf);
-				sensor_baro.timestamp = hrt_absolute_time();
-				_sensor_baro_pub.publish(sensor_baro);
+				_px4_baro.set_device_id(get_device_id());
+				_px4_baro.set_error_count(perf_event_count(_bad_transfer_perf));
+				_px4_baro.set_temperature(temperature);
+				_px4_baro.update(now, pressure);
 
 				success = true;
 

--- a/src/drivers/barometer/invensense/icp201xx/ICP201XX.cpp
+++ b/src/drivers/barometer/invensense/icp201xx/ICP201XX.cpp
@@ -38,7 +38,8 @@ using namespace time_literals;
 
 ICP201XX::ICP201XX(const I2CSPIDriverConfig &config) :
 	I2C(config),
-	I2CSPIDriver(config)
+	I2CSPIDriver(config),
+	_px4_baro{get_device_id()}
 {
 }
 
@@ -304,7 +305,6 @@ ICP201XX::RunImpl()
 				perf_end(_sample_perf);
 				perf_begin(_sample_perf);
 
-				_px4_baro.set_device_id(get_device_id());
 				_px4_baro.set_error_count(perf_event_count(_bad_transfer_perf));
 				_px4_baro.set_temperature(temperature);
 				_px4_baro.update(now, pressure);

--- a/src/drivers/barometer/invensense/icp201xx/ICP201XX.hpp
+++ b/src/drivers/barometer/invensense/icp201xx/ICP201XX.hpp
@@ -37,6 +37,7 @@
 
 #include <drivers/drv_hrt.h>
 #include <lib/drivers/device/i2c.h>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_baro.h>
 #include <lib/perf/perf_counter.h>
@@ -72,7 +73,7 @@ private:
 	bool flush_fifo();
 	bool configure();
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 
 	perf_counter_t _reset_perf{perf_alloc(PC_COUNT, MODULE_NAME": reset")};
 	perf_counter_t _sample_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": read")};

--- a/src/drivers/barometer/invensense/icp201xx/ICP201XX.hpp
+++ b/src/drivers/barometer/invensense/icp201xx/ICP201XX.hpp
@@ -73,7 +73,7 @@ private:
 	bool flush_fifo();
 	bool configure();
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 
 	perf_counter_t _reset_perf{perf_alloc(PC_COUNT, MODULE_NAME": reset")};
 	perf_counter_t _sample_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": read")};

--- a/src/drivers/barometer/lps22hb/CMakeLists.txt
+++ b/src/drivers/barometer/lps22hb/CMakeLists.txt
@@ -39,5 +39,6 @@ px4_add_module(
 		LPS22HB_I2C.cpp
 		LPS22HB_SPI.cpp
 	DEPENDS
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/lps22hb/LPS22HB.cpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB.cpp
@@ -44,6 +44,7 @@
 
 LPS22HB::LPS22HB(const I2CSPIDriverConfig &config, device::Device *interface) :
 	I2CSPIDriver(config),
+	_px4_baro{interface->get_device_id()},
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_comms_errors(perf_alloc(PC_COUNT, MODULE_NAME": comms errors"))
@@ -164,7 +165,6 @@ int LPS22HB::collect()
 	float pressure_pa = pressure * 100.f;
 
 	// publish
-	_px4_baro.set_device_id(_interface->get_device_id());
 	_px4_baro.set_error_count(perf_event_count(_comms_errors));
 	_px4_baro.set_temperature(temperature);
 	_px4_baro.update(timestamp_sample, pressure_pa);

--- a/src/drivers/barometer/lps22hb/LPS22HB.cpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB.cpp
@@ -164,14 +164,10 @@ int LPS22HB::collect()
 	float pressure_pa = pressure * 100.f;
 
 	// publish
-	sensor_baro_s sensor_baro{};
-	sensor_baro.timestamp_sample = timestamp_sample;
-	sensor_baro.device_id = _interface->get_device_id();
-	sensor_baro.pressure = pressure_pa;
-	sensor_baro.temperature = temperature;
-	sensor_baro.error_count = perf_event_count(_comms_errors);
-	sensor_baro.timestamp = hrt_absolute_time();
-	_sensor_baro_pub.publish(sensor_baro);
+	_px4_baro.set_device_id(_interface->get_device_id());
+	_px4_baro.set_error_count(perf_event_count(_comms_errors));
+	_px4_baro.set_temperature(temperature);
+	_px4_baro.update(timestamp_sample, pressure_pa);
 
 	perf_end(_sample_perf);
 	return PX4_OK;

--- a/src/drivers/barometer/lps22hb/LPS22HB.hpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB.hpp
@@ -36,6 +36,7 @@
 #include <cstring>
 
 #include <drivers/device/Device.hpp>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <lib/perf/perf_counter.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
@@ -93,7 +94,7 @@ public:
 	void			RunImpl();
 
 private:
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 
 	device::Device		*_interface;
 

--- a/src/drivers/barometer/lps22hb/LPS22HB.hpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB.hpp
@@ -94,7 +94,7 @@ public:
 	void			RunImpl();
 
 private:
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 
 	device::Device		*_interface;
 

--- a/src/drivers/barometer/lps25h/CMakeLists.txt
+++ b/src/drivers/barometer/lps25h/CMakeLists.txt
@@ -40,5 +40,6 @@ px4_add_module(
 		lps25h_i2c.cpp
 		lps25h_spi.cpp
 	DEPENDS
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/lps25h/LPS25H.cpp
+++ b/src/drivers/barometer/lps25h/LPS25H.cpp
@@ -176,14 +176,10 @@ int LPS25H::collect()
 	float pressure_pa = pressure * 100.f;
 
 	// publish
-	sensor_baro_s sensor_baro{};
-	sensor_baro.timestamp_sample = timestamp_sample;
-	sensor_baro.device_id = _interface->get_device_id();
-	sensor_baro.pressure = pressure_pa;
-	sensor_baro.temperature = temperature;
-	sensor_baro.error_count = perf_event_count(_comms_errors);
-	sensor_baro.timestamp = hrt_absolute_time();
-	_sensor_baro_pub.publish(sensor_baro);
+	_px4_baro.set_device_id(_interface->get_device_id());
+	_px4_baro.set_error_count(perf_event_count(_comms_errors));
+	_px4_baro.set_temperature(temperature);
+	_px4_baro.update(timestamp_sample, pressure_pa);
 
 	perf_end(_sample_perf);
 	return PX4_OK;

--- a/src/drivers/barometer/lps25h/LPS25H.cpp
+++ b/src/drivers/barometer/lps25h/LPS25H.cpp
@@ -35,6 +35,7 @@
 
 LPS25H::LPS25H(const I2CSPIDriverConfig &config, device::Device *interface) :
 	I2CSPIDriver(config),
+	_px4_baro{interface->get_device_id()},
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_comms_errors(perf_alloc(PC_COUNT, MODULE_NAME": comms_errors"))
@@ -176,7 +177,6 @@ int LPS25H::collect()
 	float pressure_pa = pressure * 100.f;
 
 	// publish
-	_px4_baro.set_device_id(_interface->get_device_id());
 	_px4_baro.set_error_count(perf_event_count(_comms_errors));
 	_px4_baro.set_temperature(temperature);
 	_px4_baro.update(timestamp_sample, pressure_pa);

--- a/src/drivers/barometer/lps25h/LPS25H.hpp
+++ b/src/drivers/barometer/lps25h/LPS25H.hpp
@@ -178,7 +178,7 @@ private:
 	int			measure();
 	int			collect();
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 
 	device::Device		*_interface;
 

--- a/src/drivers/barometer/lps25h/LPS25H.hpp
+++ b/src/drivers/barometer/lps25h/LPS25H.hpp
@@ -42,6 +42,7 @@
 #include "lps25h.h"
 
 #include <drivers/device/Device.hpp>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <lib/perf/perf_counter.h>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_baro.h>
@@ -177,7 +178,7 @@ private:
 	int			measure();
 	int			collect();
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 
 	device::Device		*_interface;
 

--- a/src/drivers/barometer/lps33hw/CMakeLists.txt
+++ b/src/drivers/barometer/lps33hw/CMakeLists.txt
@@ -40,5 +40,6 @@ px4_add_module(
 		lps33hw_spi.cpp
 		lps33hw_main.cpp
 	DEPENDS
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/lps33hw/lps33hw.cpp
+++ b/src/drivers/barometer/lps33hw/lps33hw.cpp
@@ -49,6 +49,7 @@ static void getTwosComplement(T &raw, uint8_t length)
 
 LPS33HW::LPS33HW(const I2CSPIDriverConfig &config, device::Device *interface) :
 	I2CSPIDriver(config),
+	_px4_baro{interface->get_device_id()},
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_comms_errors(perf_alloc(PC_COUNT, MODULE_NAME": comm errors")),
@@ -179,7 +180,6 @@ LPS33HW::RunImpl()
 		float pressure_pa = pressure_hPa * 100.f;
 
 		// publish
-		_px4_baro.set_device_id(_interface->get_device_id());
 		_px4_baro.set_error_count(perf_event_count(_comms_errors));
 		_px4_baro.set_temperature(temp);
 		_px4_baro.update(timestamp_sample, pressure_pa);

--- a/src/drivers/barometer/lps33hw/lps33hw.cpp
+++ b/src/drivers/barometer/lps33hw/lps33hw.cpp
@@ -179,14 +179,10 @@ LPS33HW::RunImpl()
 		float pressure_pa = pressure_hPa * 100.f;
 
 		// publish
-		sensor_baro_s sensor_baro{};
-		sensor_baro.timestamp_sample = timestamp_sample;
-		sensor_baro.device_id = _interface->get_device_id();
-		sensor_baro.pressure = pressure_pa;
-		sensor_baro.temperature = temp;
-		sensor_baro.error_count = perf_event_count(_comms_errors);
-		sensor_baro.timestamp = hrt_absolute_time();
-		_sensor_baro_pub.publish(sensor_baro);
+		_px4_baro.set_device_id(_interface->get_device_id());
+		_px4_baro.set_error_count(perf_event_count(_comms_errors));
+		_px4_baro.set_temperature(temp);
+		_px4_baro.update(timestamp_sample, pressure_pa);
 
 		perf_end(_sample_perf);
 		ScheduleDelayed(1000000 / SAMPLE_RATE);

--- a/src/drivers/barometer/lps33hw/lps33hw.hpp
+++ b/src/drivers/barometer/lps33hw/lps33hw.hpp
@@ -40,6 +40,7 @@
 #pragma once
 
 #include <drivers/device/Device.hpp>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_baro.h>
 #include <lib/perf/perf_counter.h>
@@ -83,7 +84,7 @@ private:
 
 	static constexpr uint32_t SAMPLE_RATE{75};
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 
 	device::Device		*_interface;
 

--- a/src/drivers/barometer/lps33hw/lps33hw.hpp
+++ b/src/drivers/barometer/lps33hw/lps33hw.hpp
@@ -84,7 +84,7 @@ private:
 
 	static constexpr uint32_t SAMPLE_RATE{75};
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 
 	device::Device		*_interface;
 

--- a/src/drivers/barometer/maiertek/mpc2520/MPC2520.cpp
+++ b/src/drivers/barometer/maiertek/mpc2520/MPC2520.cpp
@@ -44,7 +44,8 @@ static constexpr int32_t combine(uint8_t h, uint8_t m, uint8_t l)
 
 MPC2520::MPC2520(const I2CSPIDriverConfig &config) :
 	I2C(config),
-	I2CSPIDriver(config)
+	I2CSPIDriver(config),
+	_px4_baro{get_device_id()}
 {
 	//_debug_enabled = true;
 }
@@ -243,7 +244,6 @@ void MPC2520::RunImpl()
 					      Traw_sc * Praw_sc * (_prom.c11 + Praw_sc * _prom.c21);
 
 				// publish
-				_px4_baro.set_device_id(get_device_id());
 				_px4_baro.set_error_count(perf_event_count(_bad_transfer_perf) + perf_event_count(_bad_register_perf));
 				_px4_baro.set_temperature(Tcomp);
 				_px4_baro.update(now, Pcomp);

--- a/src/drivers/barometer/maiertek/mpc2520/MPC2520.cpp
+++ b/src/drivers/barometer/maiertek/mpc2520/MPC2520.cpp
@@ -243,14 +243,10 @@ void MPC2520::RunImpl()
 					      Traw_sc * Praw_sc * (_prom.c11 + Praw_sc * _prom.c21);
 
 				// publish
-				sensor_baro_s sensor_baro{};
-				sensor_baro.timestamp_sample = now;
-				sensor_baro.device_id = get_device_id();
-				sensor_baro.pressure = Pcomp;
-				sensor_baro.temperature = Tcomp;
-				sensor_baro.error_count = perf_event_count(_bad_transfer_perf) + perf_event_count(_bad_register_perf);
-				sensor_baro.timestamp = hrt_absolute_time();
-				_sensor_baro_pub.publish(sensor_baro);
+				_px4_baro.set_device_id(get_device_id());
+				_px4_baro.set_error_count(perf_event_count(_bad_transfer_perf) + perf_event_count(_bad_register_perf));
+				_px4_baro.set_temperature(Tcomp);
+				_px4_baro.update(now, Pcomp);
 
 				success = true;
 

--- a/src/drivers/barometer/maiertek/mpc2520/MPC2520.hpp
+++ b/src/drivers/barometer/maiertek/mpc2520/MPC2520.hpp
@@ -37,6 +37,7 @@
 
 #include <drivers/drv_hrt.h>
 #include <lib/drivers/device/i2c.h>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_baro.h>
 #include <lib/perf/perf_counter.h>
@@ -77,7 +78,7 @@ private:
 	void RegisterWrite(Register reg, uint8_t value);
 	void RegisterSetAndClearBits(Register reg, uint8_t setbits, uint8_t clearbits);
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 
 	perf_counter_t _bad_register_perf{perf_alloc(PC_COUNT, MODULE_NAME": bad register")};
 	perf_counter_t _bad_transfer_perf{perf_alloc(PC_COUNT, MODULE_NAME": bad transfer")};

--- a/src/drivers/barometer/maiertek/mpc2520/MPC2520.hpp
+++ b/src/drivers/barometer/maiertek/mpc2520/MPC2520.hpp
@@ -78,7 +78,7 @@ private:
 	void RegisterWrite(Register reg, uint8_t value);
 	void RegisterSetAndClearBits(Register reg, uint8_t setbits, uint8_t clearbits);
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 
 	perf_counter_t _bad_register_perf{perf_alloc(PC_COUNT, MODULE_NAME": bad register")};
 	perf_counter_t _bad_transfer_perf{perf_alloc(PC_COUNT, MODULE_NAME": bad transfer")};

--- a/src/drivers/barometer/mpl3115a2/CMakeLists.txt
+++ b/src/drivers/barometer/mpl3115a2/CMakeLists.txt
@@ -40,5 +40,6 @@ px4_add_module(
 		MPL3115A2.cpp
 		mpl3115a2_main.cpp
 	DEPENDS
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/mpl3115a2/MPL3115A2.cpp
+++ b/src/drivers/barometer/mpl3115a2/MPL3115A2.cpp
@@ -56,6 +56,7 @@
 MPL3115A2::MPL3115A2(const I2CSPIDriverConfig &config) :
 	I2C(config),
 	I2CSPIDriver(config),
+	_px4_baro{get_device_id()},
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_measure_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": measure")),
 	_comms_errors(perf_alloc(PC_COUNT, MODULE_NAME": com_err"))
@@ -268,7 +269,6 @@ int MPL3115A2::collect()
 	float P = (float)(reading.pressure.q >> 8) + ((float)(reading.pressure.b[0]) / 4.0f);
 
 	// publish
-	_px4_baro.set_device_id(get_device_id());
 	_px4_baro.set_error_count(perf_event_count(_comms_errors));
 	_px4_baro.set_temperature(T);
 	_px4_baro.update(timestamp_sample, P);

--- a/src/drivers/barometer/mpl3115a2/MPL3115A2.cpp
+++ b/src/drivers/barometer/mpl3115a2/MPL3115A2.cpp
@@ -268,14 +268,10 @@ int MPL3115A2::collect()
 	float P = (float)(reading.pressure.q >> 8) + ((float)(reading.pressure.b[0]) / 4.0f);
 
 	// publish
-	sensor_baro_s sensor_baro{};
-	sensor_baro.timestamp_sample = timestamp_sample;
-	sensor_baro.device_id = get_device_id();
-	sensor_baro.pressure = P;
-	sensor_baro.temperature = T;
-	sensor_baro.error_count = perf_event_count(_comms_errors);
-	sensor_baro.timestamp = hrt_absolute_time();
-	_sensor_baro_pub.publish(sensor_baro);
+	_px4_baro.set_device_id(get_device_id());
+	_px4_baro.set_error_count(perf_event_count(_comms_errors));
+	_px4_baro.set_temperature(T);
+	_px4_baro.update(timestamp_sample, P);
 
 	perf_end(_sample_perf);
 

--- a/src/drivers/barometer/mpl3115a2/MPL3115A2.hpp
+++ b/src/drivers/barometer/mpl3115a2/MPL3115A2.hpp
@@ -42,6 +42,7 @@
 #include <drivers/device/i2c.h>
 #include <drivers/drv_hrt.h>
 #include <lib/perf/perf_counter.h>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_baro.h>
 #include <px4_platform_common/px4_config.h>
@@ -77,7 +78,7 @@ private:
 	int RegisterRead(uint8_t reg, void *data, unsigned count = 1);
 	int RegisterWrite(uint8_t reg, uint8_t data);
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 
 	bool _collect_phase{false};
 

--- a/src/drivers/barometer/mpl3115a2/MPL3115A2.hpp
+++ b/src/drivers/barometer/mpl3115a2/MPL3115A2.hpp
@@ -78,7 +78,7 @@ private:
 	int RegisterRead(uint8_t reg, void *data, unsigned count = 1);
 	int RegisterWrite(uint8_t reg, uint8_t data);
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 
 	bool _collect_phase{false};
 

--- a/src/drivers/barometer/ms5611/CMakeLists.txt
+++ b/src/drivers/barometer/ms5611/CMakeLists.txt
@@ -44,5 +44,6 @@ px4_add_module(
 	DEPENDS
 		cdev
 		drivers__device
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/ms5611/MS5611.hpp
+++ b/src/drivers/barometer/ms5611/MS5611.hpp
@@ -34,6 +34,7 @@
 #pragma once
 
 #include <drivers/device/device.h>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_baro.h>
 #include <lib/perf/perf_counter.h>
@@ -115,7 +116,7 @@ public:
 protected:
 	void print_status() override;
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 
 	device::Device		*_interface;
 

--- a/src/drivers/barometer/ms5611/MS5611.hpp
+++ b/src/drivers/barometer/ms5611/MS5611.hpp
@@ -116,7 +116,7 @@ public:
 protected:
 	void print_status() override;
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 
 	device::Device		*_interface;
 

--- a/src/drivers/barometer/ms5611/ms5611.cpp
+++ b/src/drivers/barometer/ms5611/ms5611.cpp
@@ -342,14 +342,10 @@ MS5611::collect()
 
 		// publish
 		if (_initialized && PX4_ISFINITE(_last_pressure) && PX4_ISFINITE(_last_temperature)) {
-			sensor_baro_s sensor_baro{};
-			sensor_baro.timestamp_sample = timestamp_sample;
-			sensor_baro.device_id = _interface->get_device_id();
-			sensor_baro.pressure = P;
-			sensor_baro.temperature = _last_temperature;
-			sensor_baro.error_count = perf_event_count(_comms_errors);
-			sensor_baro.timestamp = hrt_absolute_time();
-			_sensor_baro_pub.publish(sensor_baro);
+			_px4_baro.set_device_id(_interface->get_device_id());
+			_px4_baro.set_error_count(perf_event_count(_comms_errors));
+			_px4_baro.set_temperature(_last_temperature);
+			_px4_baro.update(timestamp_sample, P);
 		}
 
 	}

--- a/src/drivers/barometer/ms5611/ms5611.cpp
+++ b/src/drivers/barometer/ms5611/ms5611.cpp
@@ -43,6 +43,7 @@
 
 MS5611::MS5611(device::Device *interface, ms5611::prom_u &prom_buf, const I2CSPIDriverConfig &config) :
 	I2CSPIDriver(config),
+	_px4_baro{interface->get_device_id()},
 	_interface(interface),
 	_prom(prom_buf.s),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
@@ -132,6 +133,9 @@ MS5611::init()
 			_interface->set_device_type(DRV_BARO_DEVTYPE_MS5607);
 			break;
 		}
+
+		// device type was just refined (MS5611 vs MS5607); latch the final device id
+		_px4_baro.set_device_id(_interface->get_device_id());
 
 		ret = OK;
 
@@ -342,7 +346,6 @@ MS5611::collect()
 
 		// publish
 		if (_initialized && PX4_ISFINITE(_last_pressure) && PX4_ISFINITE(_last_temperature)) {
-			_px4_baro.set_device_id(_interface->get_device_id());
 			_px4_baro.set_error_count(perf_event_count(_comms_errors));
 			_px4_baro.set_temperature(_last_temperature);
 			_px4_baro.update(timestamp_sample, P);

--- a/src/drivers/barometer/ms5837/CMakeLists.txt
+++ b/src/drivers/barometer/ms5837/CMakeLists.txt
@@ -41,5 +41,6 @@ px4_add_module(
 		MS5837.cpp
 		MS5837.hpp
 	DEPENDS
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/ms5837/MS5837.cpp
+++ b/src/drivers/barometer/ms5837/MS5837.cpp
@@ -41,6 +41,7 @@
 MS5837::MS5837(const I2CSPIDriverConfig &config) :
 	I2C(config),
 	I2CSPIDriver(config),
+	_px4_baro{get_device_id()},
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_measure_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": measure")),
 	_comms_errors(perf_alloc(PC_COUNT, MODULE_NAME": com_err"))
@@ -340,7 +341,6 @@ int MS5837::_collect()
 		int32_t pressure_pascal = ((((raw * _SENS) >> 21) - _OFF) >> 13) * 10;
 
 		// publish
-		_px4_baro.set_device_id(get_device_id());
 		_px4_baro.set_error_count(perf_event_count(_comms_errors));
 		_px4_baro.set_temperature(_last_temperature);
 		_px4_baro.update(timestamp_sample, pressure_pascal);

--- a/src/drivers/barometer/ms5837/MS5837.cpp
+++ b/src/drivers/barometer/ms5837/MS5837.cpp
@@ -340,14 +340,10 @@ int MS5837::_collect()
 		int32_t pressure_pascal = ((((raw * _SENS) >> 21) - _OFF) >> 13) * 10;
 
 		// publish
-		sensor_baro_s sensor_baro{};
-		sensor_baro.timestamp_sample = timestamp_sample;
-		sensor_baro.device_id = get_device_id();
-		sensor_baro.pressure = pressure_pascal;
-		sensor_baro.temperature = _last_temperature;
-		sensor_baro.error_count = perf_event_count(_comms_errors);
-		sensor_baro.timestamp = hrt_absolute_time();
-		_sensor_baro_pub.publish(sensor_baro);
+		_px4_baro.set_device_id(get_device_id());
+		_px4_baro.set_error_count(perf_event_count(_comms_errors));
+		_px4_baro.set_temperature(_last_temperature);
+		_px4_baro.update(timestamp_sample, pressure_pascal);
 	}
 
 	/* update the measurement state machine */

--- a/src/drivers/barometer/ms5837/MS5837.hpp
+++ b/src/drivers/barometer/ms5837/MS5837.hpp
@@ -81,7 +81,7 @@ public:
 private:
 	int			probe() override;
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 
 	ms5837::prom_u	   	_prom{};
 

--- a/src/drivers/barometer/ms5837/MS5837.hpp
+++ b/src/drivers/barometer/ms5837/MS5837.hpp
@@ -35,6 +35,7 @@
 
 #include <drivers/device/device.h>
 #include <drivers/device/i2c.h>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_baro.h>
 #include <lib/perf/perf_counter.h>
@@ -80,7 +81,7 @@ public:
 private:
 	int			probe() override;
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 
 	ms5837::prom_u	   	_prom{};
 

--- a/src/drivers/barometer/tcbp001ta/CMakeLists.txt
+++ b/src/drivers/barometer/tcbp001ta/CMakeLists.txt
@@ -39,5 +39,6 @@ px4_add_module(
 		tcbp001ta_spi.cpp
 		tcbp001ta_main.cpp
 	DEPENDS
+		drivers_barometer
 		px4_work_queue
 	)

--- a/src/drivers/barometer/tcbp001ta/tcbp001ta.cpp
+++ b/src/drivers/barometer/tcbp001ta/tcbp001ta.cpp
@@ -251,14 +251,10 @@ TCBP001TA::collect()
 			Praw_sc * Praw_sc * (_fcal.c11 + Praw_sc * _fcal.c21);
 
 	// publish
-	sensor_baro_s sensor_baro{};
-	sensor_baro.timestamp_sample = timestamp_sample;
-	sensor_baro.device_id = _interface->get_device_id();
-	sensor_baro.pressure = P;
-	sensor_baro.temperature = T;
-	sensor_baro.error_count = perf_event_count(_comms_errors);
-	sensor_baro.timestamp = hrt_absolute_time();
-	_sensor_baro_pub.publish(sensor_baro);
+	_px4_baro.set_device_id(_interface->get_device_id());
+	_px4_baro.set_error_count(perf_event_count(_comms_errors));
+	_px4_baro.set_temperature(T);
+	_px4_baro.update(timestamp_sample, P);
 
 	perf_end(_sample_perf);
 

--- a/src/drivers/barometer/tcbp001ta/tcbp001ta.cpp
+++ b/src/drivers/barometer/tcbp001ta/tcbp001ta.cpp
@@ -45,6 +45,7 @@
 
 TCBP001TA::TCBP001TA(tcbp001ta::ITCBP001TA *interface) :
 	ScheduledWorkItem(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id())),
+	_px4_baro{interface->get_device_id()},
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": sample")),
 	_measure_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": measure")),
@@ -251,7 +252,6 @@ TCBP001TA::collect()
 			Praw_sc * Praw_sc * (_fcal.c11 + Praw_sc * _fcal.c21);
 
 	// publish
-	_px4_baro.set_device_id(_interface->get_device_id());
 	_px4_baro.set_error_count(perf_event_count(_comms_errors));
 	_px4_baro.set_temperature(T);
 	_px4_baro.update(timestamp_sample, P);

--- a/src/drivers/barometer/tcbp001ta/tcbp001ta.hpp
+++ b/src/drivers/barometer/tcbp001ta/tcbp001ta.hpp
@@ -65,7 +65,7 @@ private:
 	int			measure(); //start measure
 	int			collect(); //get results and publish
 
-	PX4Barometer _px4_baro{0};
+	PX4Barometer _px4_baro;
 
 	tcbp001ta::ITCBP001TA	*_interface;
 

--- a/src/drivers/barometer/tcbp001ta/tcbp001ta.hpp
+++ b/src/drivers/barometer/tcbp001ta/tcbp001ta.hpp
@@ -38,6 +38,7 @@
 #include <drivers/drv_hrt.h>
 #include <px4_platform_common/px4_config.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_baro.h>
 #include <lib/perf/perf_counter.h>
@@ -64,7 +65,7 @@ private:
 	int			measure(); //start measure
 	int			collect(); //get results and publish
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{0};
 
 	tcbp001ta::ITCBP001TA	*_interface;
 

--- a/src/lib/drivers/CMakeLists.txt
+++ b/src/lib/drivers/CMakeLists.txt
@@ -32,6 +32,7 @@
 ############################################################################
 
 add_subdirectory(accelerometer)
+add_subdirectory(barometer)
 add_subdirectory(device)
 add_subdirectory(gyroscope)
 add_subdirectory(led)

--- a/src/lib/drivers/barometer/CMakeLists.txt
+++ b/src/lib/drivers/barometer/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2020-2021 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2026 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,16 +31,4 @@
 #
 ############################################################################
 
-px4_add_module(
-	MODULE drivers__maiertek__mpc2520
-	MAIN mpc2520
-	COMPILE_FLAGS
-	SRCS
-		MaierTek_MPC2520_registers.hpp
-		mpc2520_main.cpp
-		MPC2520.cpp
-		MPC2520.hpp
-	DEPENDS
-		drivers_barometer
-		px4_work_queue
-)
+px4_add_library(drivers_barometer PX4Barometer.cpp)

--- a/src/lib/drivers/barometer/PX4Barometer.cpp
+++ b/src/lib/drivers/barometer/PX4Barometer.cpp
@@ -37,7 +37,7 @@
 PX4Barometer::PX4Barometer(uint32_t device_id)
 {
 	_report.device_id = device_id;
-	_report.temperature = 15; // if no temperature is set, report 15°C as a default value
+	_report.temperature = 15; // if no temperature is set, report the sea level standard temperature of 15°C. As used in VehicleAirData
 }
 
 void PX4Barometer::update(const hrt_abstime &timestamp_sample, float pressure)

--- a/src/lib/drivers/barometer/PX4Barometer.cpp
+++ b/src/lib/drivers/barometer/PX4Barometer.cpp
@@ -37,7 +37,7 @@
 PX4Barometer::PX4Barometer(uint32_t device_id)
 {
 	_report.device_id = device_id;
-	_report.temperature = NAN; // if no temperature is set, report NaN to indicate invalid data
+	_report.temperature = 15; // if no temperature is set, report 15°C as a default value
 }
 
 void PX4Barometer::update(const hrt_abstime &timestamp_sample, float pressure)

--- a/src/lib/drivers/barometer/PX4Barometer.cpp
+++ b/src/lib/drivers/barometer/PX4Barometer.cpp
@@ -34,8 +34,9 @@
 
 #include "PX4Barometer.hpp"
 
-PX4Barometer::PX4Barometer()
+PX4Barometer::PX4Barometer(uint32_t device_id)
 {
+	_report.device_id = device_id;
 	_report.temperature = NAN; // if no temperature is set, report NaN to indicate invalid data
 }
 

--- a/src/lib/drivers/barometer/PX4Barometer.cpp
+++ b/src/lib/drivers/barometer/PX4Barometer.cpp
@@ -34,29 +34,9 @@
 
 #include "PX4Barometer.hpp"
 
-#include <lib/drivers/device/Device.hpp>
-
-PX4Barometer::PX4Barometer(uint32_t device_id) :
-	_device_id{device_id}
+PX4Barometer::PX4Barometer()
 {
-}
-
-PX4Barometer::~PX4Barometer()
-{
-	_sensor_pub.unadvertise();
-}
-
-void PX4Barometer::set_device_type(uint8_t devtype)
-{
-	// current DeviceStructure
-	union device::Device::DeviceId device_id;
-	device_id.devid = _device_id;
-
-	// update to new device type
-	device_id.devid_s.devtype = devtype;
-
-	// copy back
-	_device_id = device_id.devid;
+	_report.temperature = NAN; // if no temperature is set, report NaN to indicate invalid data
 }
 
 void PX4Barometer::update(const hrt_abstime &timestamp_sample, float pressure)
@@ -65,13 +45,9 @@ void PX4Barometer::update(const hrt_abstime &timestamp_sample, float pressure)
 		return;
 	}
 
-	sensor_baro_s report;
-	report.timestamp_sample = timestamp_sample;
-	report.device_id = _device_id;
-	report.pressure = pressure;
-	report.temperature = _temperature;
-	report.error_count = _error_count;
+	_report.timestamp_sample = timestamp_sample;
+	_report.pressure = pressure;
+	_report.timestamp = hrt_absolute_time();
 
-	report.timestamp = hrt_absolute_time();
-	_sensor_pub.publish(report);
+	_sensor_pub.publish(_report);
 }

--- a/src/lib/drivers/barometer/PX4Barometer.cpp
+++ b/src/lib/drivers/barometer/PX4Barometer.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019-2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,64 +31,47 @@
  *
  ****************************************************************************/
 
-/**
- * @file DPS310.hpp
- *
- * Driver for the Infineon DPS310 barometer connected via I2C or SPI.
- */
 
-#pragma once
+#include "PX4Barometer.hpp"
 
-#include <drivers/device/Device.hpp>
-#include <lib/drivers/barometer/PX4Barometer.hpp>
-#include <uORB/PublicationMulti.hpp>
-#include <uORB/topics/sensor_baro.h>
-#include <lib/perf/perf_counter.h>
-#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
-#include <px4_platform_common/i2c_spi_buses.h>
+#include <lib/drivers/device/Device.hpp>
 
-#include "Infineon_DPS310_Registers.hpp"
-
-namespace dps310
+PX4Barometer::PX4Barometer(uint32_t device_id) :
+	_device_id{device_id}
 {
+}
 
-using Infineon_DPS310::CalibrationCoefficients;
-using Infineon_DPS310::Register;
-
-class DPS310 : public I2CSPIDriver<DPS310>
+PX4Barometer::~PX4Barometer()
 {
-public:
-	DPS310(const I2CSPIDriverConfig &config, device::Device *interface);
-	virtual ~DPS310();
+	_sensor_pub.unadvertise();
+}
 
-	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
-	static void print_usage();
+void PX4Barometer::set_device_type(uint8_t devtype)
+{
+	// current DeviceStructure
+	union device::Device::DeviceId device_id;
+	device_id.devid = _device_id;
 
-	int			init();
+	// update to new device type
+	device_id.devid_s.devtype = devtype;
 
-	void			print_status();
-	void			RunImpl();
+	// copy back
+	_device_id = device_id.devid;
+}
 
-private:
+void PX4Barometer::update(const hrt_abstime &timestamp_sample, float pressure)
+{
+	if (!PX4_ISFINITE(pressure)) {
+		return;
+	}
 
-	void			start();
-	int			reset();
+	sensor_baro_s report;
+	report.timestamp_sample = timestamp_sample;
+	report.device_id = _device_id;
+	report.pressure = pressure;
+	report.temperature = _temperature;
+	report.error_count = _error_count;
 
-	uint8_t			RegisterRead(Register reg);
-	void			RegisterWrite(Register reg, uint8_t val);
-	void			RegisterSetBits(Register reg, uint8_t setbits);
-	void			RegisterClearBits(Register reg, uint8_t clearbits);
-
-	static constexpr uint32_t SAMPLE_RATE{32};
-
-	PX4Barometer _px4_baro{0};
-
-	device::Device		*_interface;
-
-	CalibrationCoefficients	_calibration{};
-
-	perf_counter_t		_sample_perf;
-	perf_counter_t		_comms_errors;
-};
-
-} // namespace dps310
+	report.timestamp = hrt_absolute_time();
+	_sensor_pub.publish(report);
+}

--- a/src/lib/drivers/barometer/PX4Barometer.hpp
+++ b/src/lib/drivers/barometer/PX4Barometer.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019-2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,64 +31,35 @@
  *
  ****************************************************************************/
 
-/**
- * @file DPS310.hpp
- *
- * Driver for the Infineon DPS310 barometer connected via I2C or SPI.
- */
-
 #pragma once
 
-#include <drivers/device/Device.hpp>
-#include <lib/drivers/barometer/PX4Barometer.hpp>
+#include <math.h>
+
+#include <drivers/drv_hrt.h>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_baro.h>
-#include <lib/perf/perf_counter.h>
-#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
-#include <px4_platform_common/i2c_spi_buses.h>
 
-#include "Infineon_DPS310_Registers.hpp"
-
-namespace dps310
-{
-
-using Infineon_DPS310::CalibrationCoefficients;
-using Infineon_DPS310::Register;
-
-class DPS310 : public I2CSPIDriver<DPS310>
+class PX4Barometer
 {
 public:
-	DPS310(const I2CSPIDriverConfig &config, device::Device *interface);
-	virtual ~DPS310();
+	PX4Barometer(uint32_t device_id);
+	~PX4Barometer();
 
-	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
-	static void print_usage();
+	void set_device_id(uint32_t device_id) { _device_id = device_id; }
+	void set_device_type(uint8_t devtype);
+	void set_error_count(uint32_t error_count) { _error_count = error_count; }
+	void set_temperature(float temperature) { _temperature = temperature; }
 
-	int			init();
+	void update(const hrt_abstime &timestamp_sample, float pressure);
 
-	void			print_status();
-	void			RunImpl();
+	int get_instance() { return _sensor_pub.get_instance(); };
+	uint32_t get_device_id() const { return _device_id; }
 
 private:
+	uORB::PublicationMulti<sensor_baro_s> _sensor_pub{ORB_ID(sensor_baro)};
 
-	void			start();
-	int			reset();
+	uint32_t		_device_id{0};
 
-	uint8_t			RegisterRead(Register reg);
-	void			RegisterWrite(Register reg, uint8_t val);
-	void			RegisterSetBits(Register reg, uint8_t setbits);
-	void			RegisterClearBits(Register reg, uint8_t clearbits);
-
-	static constexpr uint32_t SAMPLE_RATE{32};
-
-	PX4Barometer _px4_baro{0};
-
-	device::Device		*_interface;
-
-	CalibrationCoefficients	_calibration{};
-
-	perf_counter_t		_sample_perf;
-	perf_counter_t		_comms_errors;
+	float			_temperature{NAN};
+	uint32_t		_error_count{0};
 };
-
-} // namespace dps310

--- a/src/lib/drivers/barometer/PX4Barometer.hpp
+++ b/src/lib/drivers/barometer/PX4Barometer.hpp
@@ -42,24 +42,19 @@
 class PX4Barometer
 {
 public:
-	PX4Barometer(uint32_t device_id);
-	~PX4Barometer();
+	PX4Barometer();
 
-	void set_device_id(uint32_t device_id) { _device_id = device_id; }
-	void set_device_type(uint8_t devtype);
-	void set_error_count(uint32_t error_count) { _error_count = error_count; }
-	void set_temperature(float temperature) { _temperature = temperature; }
+	void set_device_id(uint32_t device_id) { _report.device_id = device_id; }
+	void set_error_count(uint32_t error_count) { _report.error_count = error_count; }
+	void set_temperature(float temperature) { _report.temperature = temperature; }
 
 	void update(const hrt_abstime &timestamp_sample, float pressure);
 
 	int get_instance() { return _sensor_pub.get_instance(); };
-	uint32_t get_device_id() const { return _device_id; }
+	uint32_t get_device_id() const { return _report.device_id; }
 
 private:
 	uORB::PublicationMulti<sensor_baro_s> _sensor_pub{ORB_ID(sensor_baro)};
 
-	uint32_t		_device_id{0};
-
-	float			_temperature{NAN};
-	uint32_t		_error_count{0};
+	sensor_baro_s	_report{};
 };

--- a/src/lib/drivers/barometer/PX4Barometer.hpp
+++ b/src/lib/drivers/barometer/PX4Barometer.hpp
@@ -42,7 +42,7 @@
 class PX4Barometer
 {
 public:
-	PX4Barometer();
+	PX4Barometer(uint32_t device_id);
 
 	void set_device_id(uint32_t device_id) { _report.device_id = device_id; }
 	void set_error_count(uint32_t error_count) { _report.error_count = error_count; }

--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -73,6 +73,7 @@ if (gz-transport_FOUND)
 			drivers_gyroscope
 			drivers_magnetometer
 			drivers_rangefinder
+			drivers_barometer
 			mixer_module
 			px4_work_queue
 			${GZ_TRANSPORT_TARGET}

--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -52,6 +52,7 @@ GZBridge::GZBridge(const std::string &world, const std::string &model_name) :
 	_model_name(model_name)
 {
 	updateParams();
+	_px4_baro.set_device_id(6619404); // 6619404: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
 }
 
 GZBridge::~GZBridge()

--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -52,7 +52,6 @@ GZBridge::GZBridge(const std::string &world, const std::string &model_name) :
 	_model_name(model_name)
 {
 	updateParams();
-	_px4_baro.set_device_id(6619404); // 6619404: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
 }
 
 GZBridge::~GZBridge()
@@ -401,7 +400,7 @@ void GZBridge::magnetometerCallback(const gz::msgs::Magnetometer &msg)
 
 void GZBridge::airPressureCallback(const gz::msgs::FluidPressure &msg)
 {
-	_px4_baro.set_temperature(_temperature);
+	_px4_baro.set_temperature(_temperature); // this will be static if no airspeed sensor is on the model.
 	_px4_baro.update(hrt_absolute_time(), msg.pressure());
 }
 

--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -400,21 +400,8 @@ void GZBridge::magnetometerCallback(const gz::msgs::Magnetometer &msg)
 
 void GZBridge::airPressureCallback(const gz::msgs::FluidPressure &msg)
 {
-	const uint64_t timestamp = hrt_absolute_time();
-
-	device::Device::DeviceId id{};
-	id.devid_s.bus_type = device::Device::DeviceBusType::DeviceBusType_SIMULATION;
-	id.devid_s.devtype = DRV_BARO_DEVTYPE_BAROSIM;
-	id.devid_s.bus = 1;
-	id.devid_s.address = 1;
-
-	sensor_baro_s report{};
-	report.timestamp = timestamp;
-	report.timestamp_sample = timestamp;
-	report.device_id = id.devid;
-	report.pressure = msg.pressure();
-	report.temperature = _temperature; // this will be static if no airspeed sensor is on the model.
-	_sensor_baro_pub.publish(report);
+	_px4_baro.set_temperature(_temperature);
+	_px4_baro.update(hrt_absolute_time(), msg.pressure());
 }
 
 void GZBridge::airspeedCallback(const gz::msgs::AirSpeed &msg)

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -148,7 +148,7 @@ private:
 	PX4Gyroscope     _px4_gyro{1310988};  // 1310988: DRV_IMU_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
 	PX4Magnetometer  _px4_mag{197388};    // 197388: DRV_MAG_DEVTYPE_MAGSIM, BUS: 1, ADDR: 3, TYPE: SIMULATION
 	PX4Rangefinder   _px4_rangefinder{10092812}; // 10092812: DRV_DIST_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
-	PX4Barometer     _px4_baro;
+	PX4Barometer     _px4_baro{6619404};  // 6619404: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
 
 	uORB::Publication<differential_pressure_s>    _differential_pressure_pub{ORB_ID(differential_pressure)};
 	uORB::Publication<obstacle_distance_s>        _obstacle_distance_pub{ORB_ID(obstacle_distance)};

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -49,6 +49,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/drivers/magnetometer/PX4Magnetometer.hpp>
 #include <lib/drivers/rangefinder/PX4Rangefinder.hpp>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <lib/geo/geo.h>
 
 #include <uORB/PublicationMulti.hpp>
@@ -56,9 +57,7 @@
 #include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/differential_pressure.h>
-#include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/sensor_gps.h>
-#include <uORB/topics/sensor_baro.h>
 #include <uORB/topics/sensor_optical_flow.h>
 #include <uORB/topics/obstacle_distance.h>
 #include <uORB/topics/wheel_encoders.h>
@@ -149,6 +148,7 @@ private:
 	PX4Gyroscope     _px4_gyro{1310988};  // 1310988: DRV_IMU_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
 	PX4Magnetometer  _px4_mag{197388};    // 197388: DRV_MAG_DEVTYPE_MAGSIM, BUS: 1, ADDR: 3, TYPE: SIMULATION
 	PX4Rangefinder   _px4_rangefinder{10092812}; // 10092812: DRV_DIST_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
+	PX4Barometer     _px4_baro{6619404};  // 6619404: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
 
 	uORB::Publication<differential_pressure_s>    _differential_pressure_pub{ORB_ID(differential_pressure)};
 	uORB::Publication<obstacle_distance_s>        _obstacle_distance_pub{ORB_ID(obstacle_distance)};
@@ -157,7 +157,6 @@ private:
 	uORB::Publication<vehicle_global_position_s>  _gpos_ground_truth_pub{ORB_ID(vehicle_global_position_groundtruth)};
 	uORB::Publication<vehicle_local_position_s>   _lpos_ground_truth_pub{ORB_ID(vehicle_local_position_groundtruth)};
 	uORB::PublicationMulti<sensor_gps_s>          _sensor_gps_pub{ORB_ID(sensor_gps)};
-	uORB::PublicationMulti<sensor_baro_s>         _sensor_baro_pub{ORB_ID(sensor_baro)};
 	uORB::PublicationMulti<vehicle_odometry_s>    _visual_odometry_pub{ORB_ID(vehicle_visual_odometry)};
 	uORB::PublicationMulti<sensor_optical_flow_s> _optical_flow_pub{ORB_ID(sensor_optical_flow)};
 

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -148,7 +148,7 @@ private:
 	PX4Gyroscope     _px4_gyro{1310988};  // 1310988: DRV_IMU_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
 	PX4Magnetometer  _px4_mag{197388};    // 197388: DRV_MAG_DEVTYPE_MAGSIM, BUS: 1, ADDR: 3, TYPE: SIMULATION
 	PX4Rangefinder   _px4_rangefinder{10092812}; // 10092812: DRV_DIST_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
-	PX4Barometer     _px4_baro{6619404};  // 6619404: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
+	PX4Barometer     _px4_baro;
 
 	uORB::Publication<differential_pressure_s>    _differential_pressure_pub{ORB_ID(differential_pressure)};
 	uORB::Publication<obstacle_distance_s>        _obstacle_distance_pub{ORB_ID(obstacle_distance)};

--- a/src/modules/simulation/sensor_baro_sim/CMakeLists.txt
+++ b/src/modules/simulation/sensor_baro_sim/CMakeLists.txt
@@ -41,6 +41,7 @@ px4_add_module(
 	MODULE_CONFIG
 		parameters.yaml
 	DEPENDS
+		drivers_barometer
 		geo
 		px4_work_queue
 	)

--- a/src/modules/simulation/sensor_baro_sim/SensorBaroSim.cpp
+++ b/src/modules/simulation/sensor_baro_sim/SensorBaroSim.cpp
@@ -164,14 +164,8 @@ void SensorBaroSim::Run()
 			float temperature = temperature_local - 273.0f + _sim_baro_off_t.get();
 
 			// publish
-			sensor_baro_s sensor_baro{};
-			sensor_baro.timestamp_sample = gpos.timestamp;
-			sensor_baro.device_id = 6620172; // 6620172: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 4, TYPE: SIMULATION
-			sensor_baro.pressure = pressure;
-			sensor_baro.temperature = temperature;
-			sensor_baro.timestamp = hrt_absolute_time();
-			_sensor_baro_pub.publish(sensor_baro);
-
+			_px4_baro.set_temperature(temperature);
+			_px4_baro.update(hrt_absolute_time(), pressure);
 
 			_last_update_time = gpos.timestamp;
 		}

--- a/src/modules/simulation/sensor_baro_sim/SensorBaroSim.cpp
+++ b/src/modules/simulation/sensor_baro_sim/SensorBaroSim.cpp
@@ -44,7 +44,6 @@ SensorBaroSim::SensorBaroSim() :
 	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default)
 {
 	srand(1234); // initialize the random seed once before calling generate_wgn()
-	_px4_baro.set_device_id(6620172); // 6620172: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 4, TYPE: SIMULATION
 }
 
 SensorBaroSim::~SensorBaroSim()

--- a/src/modules/simulation/sensor_baro_sim/SensorBaroSim.cpp
+++ b/src/modules/simulation/sensor_baro_sim/SensorBaroSim.cpp
@@ -44,6 +44,7 @@ SensorBaroSim::SensorBaroSim() :
 	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default)
 {
 	srand(1234); // initialize the random seed once before calling generate_wgn()
+	_px4_baro.set_device_id(6620172); // 6620172: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 4, TYPE: SIMULATION
 }
 
 SensorBaroSim::~SensorBaroSim()

--- a/src/modules/simulation/sensor_baro_sim/SensorBaroSim.hpp
+++ b/src/modules/simulation/sensor_baro_sim/SensorBaroSim.hpp
@@ -82,7 +82,7 @@ private:
 
 	hrt_abstime _last_update_time{0};
 
-	PX4Barometer _px4_baro;
+	PX4Barometer _px4_baro{6620172}; // 6620172: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 4, TYPE: SIMULATION
 
 	perf_counter_t _loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
 

--- a/src/modules/simulation/sensor_baro_sim/SensorBaroSim.hpp
+++ b/src/modules/simulation/sensor_baro_sim/SensorBaroSim.hpp
@@ -38,12 +38,11 @@
 #include <px4_platform_common/module.h>
 #include <px4_platform_common/module_params.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <uORB/Publication.hpp>
-#include <uORB/PublicationMulti.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/parameter_update.h>
-#include <uORB/topics/sensor_baro.h>
 #include <uORB/topics/vehicle_global_position.h>
 
 using namespace time_literals;
@@ -83,7 +82,7 @@ private:
 
 	hrt_abstime _last_update_time{0};
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
+	PX4Barometer _px4_baro{6620172}; // 6620172: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 4, TYPE: SIMULATION
 
 	perf_counter_t _loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
 

--- a/src/modules/simulation/sensor_baro_sim/SensorBaroSim.hpp
+++ b/src/modules/simulation/sensor_baro_sim/SensorBaroSim.hpp
@@ -82,7 +82,7 @@ private:
 
 	hrt_abstime _last_update_time{0};
 
-	PX4Barometer _px4_baro{6620172}; // 6620172: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 4, TYPE: SIMULATION
+	PX4Barometer _px4_baro;
 
 	perf_counter_t _loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
 

--- a/src/modules/simulation/simulator_mavlink/CMakeLists.txt
+++ b/src/modules/simulation/simulator_mavlink/CMakeLists.txt
@@ -49,6 +49,7 @@ px4_add_module(
 		conversion
 		geo
 		drivers_accelerometer
+		drivers_barometer
 		drivers_gyroscope
 		drivers_magnetometer
 	)

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
@@ -306,28 +306,22 @@ void SimulatorMavlink::update_sensors(const hrt_abstime &time, const mavlink_hil
 	}
 
 	// baro
-	if ((sensors.fields_updated & SensorSource::BARO) == SensorSource::BARO && !_baro_blocked) {
-
-		if (!_baro_stuck) {
-			_last_baro_pressure = sensors.abs_pressure * 100.f; // hPa to Pa
-			_last_baro_temperature = sensors.temperature;
+	if ((sensors.fields_updated & SensorSource::BARO) == SensorSource::BARO) {
+		if (sensors.id >= BARO_COUNT_MAX) {
+			PX4_ERR("Number of simulated barometer %d out of range. Max: %d", sensors.id, BARO_COUNT_MAX);
+			return;
 		}
 
-		// publish
-		sensor_baro_s sensor_baro{};
-		sensor_baro.timestamp_sample = time;
-		sensor_baro.pressure = _last_baro_pressure;
-		sensor_baro.temperature = _last_baro_temperature;
+		if (_baro_stuck[sensors.id]) {
+			_px4_baro[sensors.id].set_temperature(_last_baro_temperature[sensors.id]);
+			_px4_baro[sensors.id].update(time, _last_baro_pressure[sensors.id]);
 
-		// publish 1st baro
-		sensor_baro.device_id = 6620172; // 6620172: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 4, TYPE: SIMULATION
-		sensor_baro.timestamp = hrt_absolute_time();
-		_sensor_baro_pubs[0].publish(sensor_baro);
-
-		// publish 2nd baro
-		sensor_baro.device_id = 6620428; // 6620428: DRV_BARO_DEVTYPE_BAROSIM, BUS: 2, ADDR: 4, TYPE: SIMULATION
-		sensor_baro.timestamp = hrt_absolute_time();
-		_sensor_baro_pubs[1].publish(sensor_baro);
+		} else if (!_baro_blocked[sensors.id]) {
+			_last_baro_pressure[sensors.id] = sensors.abs_pressure * 100.f; // hPa to Pa
+			_last_baro_temperature[sensors.id] = sensors.temperature;
+			_px4_baro[sensors.id].set_temperature(_last_baro_temperature[sensors.id]);
+			_px4_baro[sensors.id].update(time, _last_baro_pressure[sensors.id]);
+		}
 	}
 
 	// differential pressure
@@ -1708,20 +1702,55 @@ void SimulatorMavlink::check_failure_injections()
 			handled = true;
 
 			if (failure_type == vehicle_command_s::FAILURE_TYPE_OFF) {
-				PX4_WARN("CMD_INJECT_FAILURE, baro off");
 				supported = true;
-				_baro_blocked = true;
+
+				// 0 to signal all
+				if (instance == 0) {
+					for (int i = 0; i < BARO_COUNT_MAX; i++) {
+						PX4_WARN("CMD_INJECT_FAILURE, baro %d off", i);
+						_baro_blocked[i] = true;
+						_baro_stuck[i] = false;
+					}
+
+				} else if (instance >= 1 && instance <= BARO_COUNT_MAX) {
+					PX4_WARN("CMD_INJECT_FAILURE, baro %d off", instance - 1);
+					_baro_blocked[instance - 1] = true;
+					_baro_stuck[instance - 1] = false;
+				}
 
 			} else if (failure_type == vehicle_command_s::FAILURE_TYPE_STUCK) {
-				PX4_WARN("CMD_INJECT_FAILURE, baro stuck");
 				supported = true;
-				_baro_stuck = true;
-				_baro_blocked = false;
+
+				// 0 to signal all
+				if (instance == 0) {
+					for (int i = 0; i < BARO_COUNT_MAX; i++) {
+						PX4_WARN("CMD_INJECT_FAILURE, baro %d stuck", i);
+						_baro_blocked[i] = false;
+						_baro_stuck[i] = true;
+					}
+
+				} else if (instance >= 1 && instance <= BARO_COUNT_MAX) {
+					PX4_WARN("CMD_INJECT_FAILURE, baro %d stuck", instance - 1);
+					_baro_blocked[instance - 1] = false;
+					_baro_stuck[instance - 1] = true;
+				}
 
 			} else if (failure_type == vehicle_command_s::FAILURE_TYPE_OK) {
-				PX4_INFO("CMD_INJECT_FAILURE, baro ok");
 				supported = true;
-				_baro_blocked = false;
+
+				// 0 to signal all
+				if (instance == 0) {
+					for (int i = 0; i < BARO_COUNT_MAX; i++) {
+						PX4_WARN("CMD_INJECT_FAILURE, baro %d ok", i);
+						_baro_blocked[i] = false;
+						_baro_stuck[i] = false;
+					}
+
+				} else if (instance >= 1 && instance <= BARO_COUNT_MAX) {
+					PX4_WARN("CMD_INJECT_FAILURE, baro %d ok", instance - 1);
+					_baro_blocked[instance - 1] = false;
+					_baro_stuck[instance - 1] = false;
+				}
 			}
 
 		} else if (failure_unit == vehicle_command_s::FAILURE_UNIT_SENSOR_AIRSPEED) {

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
@@ -96,9 +96,6 @@ SimulatorMavlink::SimulatorMavlink() :
 		param_get(param_find(param_name), &_output_functions[i]);
 	}
 
-	_px4_baro[0].set_device_id(6620172); // 6620172: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 4, TYPE: SIMULATION
-	_px4_baro[1].set_device_id(6620428); // 6620428: DRV_BARO_DEVTYPE_BAROSIM, BUS: 2, ADDR: 4, TYPE: SIMULATION
-
 	_esc_status_pub.advertise();
 #if defined(CONFIG_MODULES_VISION_TARGET_ESTIMATOR) && CONFIG_MODULES_VISION_TARGET_ESTIMATOR
 	_fiducial_marker_pos_report_pub.advertise();

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
@@ -96,6 +96,9 @@ SimulatorMavlink::SimulatorMavlink() :
 		param_get(param_find(param_name), &_output_functions[i]);
 	}
 
+	_px4_baro[0].set_device_id(6620172); // 6620172: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 4, TYPE: SIMULATION
+	_px4_baro[1].set_device_id(6620428); // 6620428: DRV_BARO_DEVTYPE_BAROSIM, BUS: 2, ADDR: 4, TYPE: SIMULATION
+
 	_esc_status_pub.advertise();
 #if defined(CONFIG_MODULES_VISION_TARGET_ESTIMATOR) && CONFIG_MODULES_VISION_TARGET_ESTIMATOR
 	_fiducial_marker_pos_report_pub.advertise();

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.hpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.hpp
@@ -200,10 +200,7 @@ private:
 	};
 
 	static constexpr uint8_t BARO_COUNT_MAX = 2;
-	PX4Barometer _px4_baro[BARO_COUNT_MAX] {
-		{6620172}, // 6620172: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 4, TYPE: SIMULATION
-		{6620428}, // 6620428: DRV_BARO_DEVTYPE_BAROSIM, BUS: 2, ADDR: 4, TYPE: SIMULATION
-	};
+	PX4Barometer _px4_baro[BARO_COUNT_MAX];
 
 	float _sensors_temperature{0};
 

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.hpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.hpp
@@ -44,6 +44,7 @@
 
 #include <drivers/drv_hrt.h>
 #include <lib/drivers/accelerometer/PX4Accelerometer.hpp>
+#include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/drivers/magnetometer/PX4Magnetometer.hpp>
 #include <lib/geo/geo.h>
@@ -71,7 +72,6 @@
 #endif // CONFIG_MODULES_VISION_TARGET_ESTIMATOR
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/parameter_update.h>
-#include <uORB/topics/sensor_baro.h>
 #include <uORB/topics/sensor_gps.h>
 #include <uORB/topics/sensor_optical_flow.h>
 #include <uORB/topics/vehicle_angular_velocity.h>
@@ -199,7 +199,11 @@ private:
 		{197644, ROTATION_NONE},
 	};
 
-	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pubs[2] {{ORB_ID(sensor_baro)}, {ORB_ID(sensor_baro)}};
+	static constexpr uint8_t BARO_COUNT_MAX = 2;
+	PX4Barometer _px4_baro[BARO_COUNT_MAX] {
+		{6620172}, // 6620172: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 4, TYPE: SIMULATION
+		{6620428}, // 6620428: DRV_BARO_DEVTYPE_BAROSIM, BUS: 2, ADDR: 4, TYPE: SIMULATION
+	};
 
 	float _sensors_temperature{0};
 
@@ -314,8 +318,8 @@ private:
 	sensor_gyro_fifo_s _last_gyro_fifo{};
 	matrix::Vector3f _last_gyro[GYRO_COUNT_MAX] {};
 
-	bool _baro_blocked{false};
-	bool _baro_stuck{false};
+	bool _baro_blocked[BARO_COUNT_MAX] {};
+	bool _baro_stuck[BARO_COUNT_MAX] {};
 
 	bool _mag_blocked[MAG_COUNT_MAX] {};
 	bool _mag_stuck[MAG_COUNT_MAX] {};
@@ -332,8 +336,8 @@ private:
 	float _last_magy[MAG_COUNT_MAX] {};
 	float _last_magz[MAG_COUNT_MAX] {};
 
-	float _last_baro_pressure{0.0f};
-	float _last_baro_temperature{0.0f};
+	float _last_baro_pressure[BARO_COUNT_MAX] {};
+	float _last_baro_temperature[BARO_COUNT_MAX] {};
 
 	int32_t _output_functions[actuator_outputs_s::NUM_ACTUATOR_OUTPUTS] {};
 

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.hpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.hpp
@@ -200,7 +200,10 @@ private:
 	};
 
 	static constexpr uint8_t BARO_COUNT_MAX = 2;
-	PX4Barometer _px4_baro[BARO_COUNT_MAX];
+	PX4Barometer _px4_baro[BARO_COUNT_MAX] {
+		{6620172}, // 6620172: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 4, TYPE: SIMULATION
+		{6620428}, // 6620428: DRV_BARO_DEVTYPE_BAROSIM, BUS: 2, ADDR: 4, TYPE: SIMULATION
+	};
 
 	float _sensors_temperature{0};
 


### PR DESCRIPTION
## Summary

  Introduces a `PX4Barometer` driver wrapper (mirroring `PX4Accelerometer`/`PX4Gyroscope`/`PX4Magnetometer`/`PX4Rangefinder`) and migrates every barometer publisher onto it — all 16 hardware drivers under `src/drivers/barometer/` plus the simulation publishers (gz_bridge, sensor_baro_sim, simulator_mavlink).

  ## Problem

  Each barometer driver had the identical `sensor_baro` publishing boilerplate: its own `uORB::PublicationMulti<sensor_baro_s>`, plus per-publish `device_id`, `error_count`, temperature, and timestamp assignment. The pattern was duplicated across every driver, and there was no single point that owns baro publication.

  ## Motivation

  The motivation for this change is future expansion of failure injection: failures can be injected directly in `PX4Barometer`, making the functionality available across all drivers and simulators at once.

  ## Solution

  Add `PX4Barometer`, which owns the `sensor_baro` publication and the `device_id`/`error_count`/`temperature`/timestamp handling behind a small `update(timestamp_sample, pressure)` API. Drivers construct it with their device id and call `update()`; the per-driver publish boilerplate is removed.

  ## Other changes/fixes

  - **SimulatorMavlink** — the barometer now follows the same multi-instance pattern as the IMUs: `BARO_COUNT_MAX` instances, publication keyed on the incoming `HIL_SENSOR` id, and per-instance failure injection (off/stuck/ok). It supports multiple baros but only publishes the instances the simulator actually sends. Previously the same measurement was published to two simulated baros, and I couldn't determine the reason for this.

  - **Gazebo** — drop the simulated baro temperature. It was only populated when an airspeed sensor happened to be attached, and otherwise reported Kelvin, which is wrong anyway (`sensor_baro.temperature` is degrees Celsius).
