### PR TITLE
fix(fw_mode_manager): correct loiter direction in trajectory setpoint interface

### DIFF
--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -2151,7 +2151,7 @@ FixedWingModeManager::Run()
 						Vector2f acceleration_sp_2d(trajectory_setpoint.acceleration[0], trajectory_setpoint.acceleration[1]);
 						Vector2f acceleration_normal = acceleration_sp_2d - acceleration_sp_2d.dot(normalized_velocity_sp_2d) *
 									       normalized_velocity_sp_2d;
-						float direction = -normalized_velocity_sp_2d.cross(acceleration_normal.normalized());
+						float direction = normalized_velocity_sp_2d.cross(acceleration_normal.normalized());
 						_pos_sp_triplet.current.loiter_radius = direction * velocity_sp_2d.norm() * velocity_sp_2d.norm() /
 											acceleration_normal.norm();
 


### PR DESCRIPTION
### Solved Problem

The trajectory setpoint interface for fixed-wings is currently passing an incorrect loiter direction to the NPFG controller.

### Solution

Corrected the loiter direction sign to comply with the NED (North-East-Down) right-hand rule convention.

By convention, a positive loiter radius corresponds to a clockwise turn, and a negative loiter radius corresponds to a counter-clockwise turn. Therefore, the correct sign for the loiter direction is calculated using the 2D cross product:

$$\text{sign}(v_x a_y - v_y a_x)$$

where

$$\vec{v} = [v_x, v_y, v_z]$$

is the tangential velocity and

$$\vec{a} = [a_x, a_y, a_z]$$

is the centripetal acceleration, both represented in the NED frame.

### Changelog Entry

For release notes:

```text
Bugfix: Corrected the loiter direction sign in the Trajectory Setpoint Interface for fixed-wings to comply with NED conventions.

```

### Alternatives

### Test coverage

Tested in gazebo harmonic SITL, using the ROS2 humble interface "px4_msgs/msg/TrajectorySetpoint.msg". Commanded horizontal loitering maneuvers via position, tangential velocity, and centripedal acceleration setpoints. Verified the loiter direction and tracker performance manually.

### Context
