### PR TITLE
fix(ci): repair broken ccache in docs metadata jobs

### DIFF
--- a/.github/workflows/docs-orchestrator.yml
+++ b/.github/workflows/docs-orchestrator.yml
@@ -80,37 +80,22 @@ jobs:
       - name: Configure Git Safe Directory
         run: git config --system --add safe.directory '*'
 
-      - name: Cache Restore - ccache
-        id: cache-ccache
-        uses: actions/cache/restore@v5
+      - uses: ./.github/actions/setup-ccache
+        id: ccache
         with:
-          path: ~/.ccache
-          key: ccache-docs-metadata-${{ github.sha }}
-          restore-keys: |
-            ccache-docs-metadata-
-
-      - name: Setup ccache
-        run: |
-          mkdir -p ~/.ccache
-          echo "max_size = 1G" > ~/.ccache/ccache.conf
+          cache-key-prefix: ccache-docs-metadata
+          max-size: 1G
 
       - name: Build px4_sitl_default
-        run: |
-          make px4_sitl_default
-        env:
-          CCACHE_DIR: ~/.ccache
+        run: make px4_sitl_default
 
-      - name: Cache Save - ccache
-        uses: actions/cache/save@v5
+      - uses: ./.github/actions/save-ccache
         if: always()
         with:
-          path: ~/.ccache
-          key: ccache-docs-metadata-${{ github.sha }}
+          cache-primary-key: ${{ steps.ccache.outputs.cache-primary-key }}
 
       - name: Generate and sync metadata
         run: Tools/ci/metadata_sync.sh --generate --sync parameters airframes modules msg_docs failsafe_web
-        env:
-          CCACHE_DIR: ~/.ccache
 
       - name: Upload metadata artifact
         uses: actions/upload-artifact@v7
@@ -143,37 +128,22 @@ jobs:
       - name: Git ownership workaround
         run: git config --system --add safe.directory '*'
 
-      - name: Cache Restore - ccache
-        id: cache-ccache
-        uses: actions/cache/restore@v5
+      - uses: ./.github/actions/setup-ccache
+        id: ccache
         with:
-          path: ~/.ccache
-          key: ccache-docs-metadata-${{ github.sha }}
-          restore-keys: |
-            ccache-docs-metadata-
-
-      - name: Setup ccache
-        run: |
-          mkdir -p ~/.ccache
-          echo "max_size = 1G" > ~/.ccache/ccache.conf
+          cache-key-prefix: ccache-docs-metadata
+          max-size: 1G
 
       - name: Build px4_sitl_default
-        run: |
-          make px4_sitl_default
-        env:
-          CCACHE_DIR: ~/.ccache
+        run: make px4_sitl_default
 
-      - name: Cache Save - ccache
-        uses: actions/cache/save@v5
+      - uses: ./.github/actions/save-ccache
         if: always()
         with:
-          path: ~/.ccache
-          key: ccache-docs-metadata-${{ github.sha }}
+          cache-primary-key: ${{ steps.ccache.outputs.cache-primary-key }}
 
       - name: Generate and sync metadata
         run: Tools/ci/metadata_sync.sh --generate --sync parameters airframes modules msg_docs failsafe_web
-        env:
-          CCACHE_DIR: ~/.ccache
 
       - name: Install Node.js and Yarn
         run: |


### PR DESCRIPTION
## Summary
The docs pipeline's metadata jobs never reused ccache — every run rebuilt `px4_sitl_default` from scratch. This switches them to the shared ccache actions so the compiler cache actually persists.

## Problem
`pr-metadata-regen` and `metadata-regen` set `CCACHE_DIR: ~/.ccache` through the job `env`. GitHub Actions stores `env` values literally and ccache does not expand `~`, so ccache wrote to `$GITHUB_WORKSPACE/~/.ccache` while `actions/cache` saved and restored the real `$HOME/.ccache`. The two never met: every restore came back empty and the `Cache Save` step uploaded nothing (0s in the run logs), so the cache lineage stayed permanently empty and the build never warmed up. The inline `ccache.conf` was also missing the `base_dir`, `compiler_check`, and compression settings every other workflow uses.

## Solution
Replace the bespoke restore/configure/save steps in both jobs with the shared `./.github/actions/setup-ccache` and `./.github/actions/save-ccache` actions (key prefix `ccache-docs-metadata`, 1G), and remove the literal `CCACHE_DIR` overrides. ccache now defaults to `$HOME/.ccache`, matching the cached path, and inherits the tuned config and branch-scoped restore-keys used across the rest of CI.
