### PR TITLE
docs(flight_modes_mc): clarify hold mode position and stick override behavior

### DIFF
--- a/docs/en/flight_modes_mc/hold.md
+++ b/docs/en/flight_modes_mc/hold.md
@@ -2,7 +2,7 @@
 
 <img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />
 
-The _Hold_ flight mode causes the vehicle to stop and hover at its current GPS position and altitude.
+The _Hold_ flight mode causes the vehicle to stop and hover, maintaining its position and altitude.
 
 :::tip
 _Hold mode_ can be used to pause a mission or to help you regain control of a vehicle in an emergency.
@@ -18,7 +18,7 @@ It is usually activated with a pre-programmed switch.
   - Disarmed vehicles can switch to mode without valid position estimate but can't arm.
 - Mode requires wind and flight time are within allowed limits (specified via parameters).
 - RC control switches can be used to change flight modes on any vehicle.
-- RC stick movement will [by default](#COM_RC_OVERRIDE) change the vehicle to [Position mode](../flight_modes_mc/position.md) unless handling a critical battery failsafe.
+- RC stick movement will [by default](#COM_RC_OVERRIDE) change the vehicle to [Position mode](../flight_modes_mc/position.md) unless prevented by the active failsafe state.
 
 <!-- https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/commander/ModeUtil/mode_requirements.cpp -->
 
@@ -26,7 +26,7 @@ It is usually activated with a pre-programmed switch.
 
 ## Technical Summary
 
-The vehicle hovers at the current position and altitude.
+The vehicle stops and hovers, maintaining its position and altitude.
 The vehicle will first ascend to [NAV_MIN_LTR_ALT](#NAV_MIN_LTR_ALT) if the mode is engaged below this altitude.
 
 RC stick movement will change the vehicle to [Position mode](../flight_modes_mc/position.md) (by [default](#COM_RC_OVERRIDE)).


### PR DESCRIPTION
### Solved Problem

The Hold mode page had two slightly misleading descriptions:

- "current position and altitude" could be interpreted as the exact position where Hold was entered.
- The RC stick override note only mentioned critical battery failsafe, although stick override can also be blocked during other failsafe states, for example during the `COM_FAIL_ACT_T` failsafe hold delay.

### Solution

Update the wording to describe the behavior more generally, and clarify that stick override depends on the active failsafe state.

### Changelog Entry

For release notes:

```text
Documentation: Clarify Hold mode position wording and stick override behavior during failsafe.