### PR TITLE
fix(navigator): fall back to rootfs for geofence file

### DIFF
--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -54,7 +54,11 @@
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/sensor_gps.h>
 
+#if defined(PX4_STORAGEDIR)
 #define GEOFENCE_FILENAME PX4_STORAGEDIR"/etc/geofence.txt"
+#else
+#define GEOFENCE_FILENAME PX4_ROOTFSDIR"/etc/geofence.txt"
+#endif
 
 class Navigator;
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -153,8 +153,7 @@ void Navigator::params_update()
 void Navigator::run()
 {
 
-	/* Try to load the geofence:
-	 * if /fs/microsd/etc/geofence.txt load from this file */
+	/* Try to load the geofence file if it exists. */
 	struct stat buffer;
 
 	if (stat(GEOFENCE_FILENAME, &buffer) == 0) {


### PR DESCRIPTION
### Solved Problem

  Navigator uses `GEOFENCE_FILENAME` for the optional `etc/geofence.txt` import path, but that macro was
  based unconditionally on `PX4_STORAGEDIR`.

  QURT intentionally does not define `PX4_STORAGEDIR`, so navigator does not build there when enabled.

  ### Solution

  Use `PX4_STORAGEDIR` for the geofence file path when it is available, and fall back to `PX4_ROOTFSDIR`
  otherwise.

  This keeps the fix local to navigator. `PX4_STORAGEDIR` has broader meaning across PX4: it is used by
  dataman, logging, SD-card checks, temporary files, and other general storage users. This change avoids
  defining `PX4_STORAGEDIR` for QURT just to provide navigator with a path for an optional geofence file.

  Also update the nearby comment to avoid hard-coding the NuttX `/fs/microsd` path.

  ### Changelog Entry

  No changelog entry required.

  ### Alternatives

  Define `PX4_STORAGEDIR` for QURT. This was avoided because it would change broader platform storage
  semantics and could affect unrelated modules that key behavior off `PX4_STORAGEDIR`.

  ### Test coverage

  Built `modalai_voxl2_slpi` in the ModalAI PX4 build Docker.

  ### Context

  This is a preparation change for enabling navigator in the QURT/SLPI build.

