### PR TITLE
fix(navigator): load geofence from requested file

### DIFF
--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -548,8 +548,8 @@ Geofence::loadFromFile(const char *filename)
 
 	dm_item_t write_fence_dataman_id{static_cast<dm_item_t>(stat.dataman_id) == DM_KEY_FENCE_POINTS_0 ? DM_KEY_FENCE_POINTS_1 : DM_KEY_FENCE_POINTS_0};
 
-	/* open the mixer definition file */
-	fp = fopen(GEOFENCE_FILENAME, "r");
+	/* open the geofence file */
+	fp = fopen(filename, "r");
 
 	if (fp == nullptr) {
 		return PX4_ERROR;


### PR DESCRIPTION
### Solved Problem

  Geofence::loadFromFile(const char *filename) ignored its filename argument and always opened
  GEOFENCE_FILENAME.

  Current navigator call sites pass GEOFENCE_FILENAME, so this does not change current default behavior,
  but the function implementation did not match its API and would fail for any caller that provides a
  different file path.

  ### Solution

  Open the file passed through the filename argument.

  Also fix the adjacent stale comment, which referred to a mixer definition file instead of the geofence
  file.

  ### Changelog Entry

  No changelog entry required.

  ### Alternatives

  Leave the implementation as-is because current navigator call sites pass GEOFENCE_FILENAME. This was
  avoided because the function API explicitly accepts a filename and should honor it.

  ### Test coverage

  Built successfully in the ModalAI PX4 build Docker.

  ### Context

  This is a small correctness fix for the navigator geofence file import path.

