### PR TITLE
fix(dataman): expose mission item limit to clients

### DIFF
--- a/src/modules/dataman/Kconfig
+++ b/src/modules/dataman/Kconfig
@@ -23,8 +23,9 @@ menuconfig DATAMAN_PERSISTENT_STORAGE
 menuconfig NUM_MISSION_ITMES_SUPPORTED
 	int "Maximum number of mission items"
 	default 500
-	depends on MODULES_DATAMAN
 	---help---
-		This limit always applies if mission items are stored on the SD card or in RAM. It should be set
-		adequately per boards such that if the items are stored in RAM they still fit the available memory.
+		This limit sizes mission storage constants used by dataman and dataman clients.
+		It applies whether mission items are stored on the SD card or in RAM. It should
+		be set adequately per board such that if the items are stored in RAM they still
+		fit the available memory.
 		The runtime parameter to configure the storage option is `SYS_DM_BACKEND`.


### PR DESCRIPTION
### Solved Problem

  CONFIG_NUM_MISSION_ITMES_SUPPORTED is used by dataman.h to size dataman mission storage constants. That
  header is also used by dataman clients, not only by the dataman module itself.

  When CONFIG_MODULES_DATAMAN=n, the Kconfig symbol was hidden by depends on MODULES_DATAMAN, so dataman-
  client-only builds could miss CONFIG_NUM_MISSION_ITMES_SUPPORTED even though they still include the
  shared dataman headers.

Side note: That misspelling of the identifier is annoying but I decided not to mix that up with this particular PR.

  ### Solution

  Remove the MODULES_DATAMAN dependency from NUM_MISSION_ITMES_SUPPORTED so the mission item limit is
  available to dataman clients (like navigator) as well as the dataman server module.

  Update the help text to clarify that this limit sizes constants used by both dataman and dataman clients.

  ### Changelog Entry

  No changelog entry required.

  ### Alternatives

  Keep the symbol dependent on MODULES_DATAMAN. This was avoided because split builds can build dataman
  clients without building the dataman server in the same image.

  ### Test coverage

  Built successfully in the ModalAI PX4 build Docker.

  ### Context

  This is a preparation change for split builds where the dataman server runs in one image and dataman
  clients run in another.

