### PR TITLE
fix(navigator): remove feasibility checker reverse dependencies

### DIFF
--- a/src/modules/navigator/MissionFeasibility/CMakeLists.txt
+++ b/src/modules/navigator/MissionFeasibility/CMakeLists.txt
@@ -2,6 +2,6 @@ px4_add_library(mission_feasibility_checker
 	FeasibilityChecker.cpp
 )
 
-target_link_libraries(mission_feasibility_checker PUBLIC modules__navigator modules__dataman)
+target_link_libraries(mission_feasibility_checker PUBLIC geo)
 
 px4_add_functional_gtest(SRC FeasibilityCheckerTest.cpp LINKLIBS mission_feasibility_checker)

--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
@@ -35,7 +35,7 @@
 #include <systemlib/mavlink_log.h>
 #include <px4_platform_common/events.h>
 #include <drivers/drv_pwm_output.h>
-#include "../mission_block.h"
+#include "../mission_item_utils.h"
 #include <lib/mathlib/mathlib.h>
 #include <lib/geo/geo.h>
 
@@ -230,7 +230,7 @@ bool FeasibilityChecker::checkMissionItemValidity(mission_item_s &mission_item, 
 {
 	/* reject relative alt without home set */
 	if (mission_item.altitude_is_relative && !PX4_ISFINITE(_home_alt_msl)
-	    && MissionBlock::item_contains_position(mission_item)) {
+	    && mission_item_contains_position(mission_item)) {
 
 
 
@@ -382,7 +382,7 @@ bool FeasibilityChecker::checkFixedWingLandApproach(mission_item_s &mission_item
 {
 	if (mission_item.nav_cmd == NAV_CMD_LAND && current_index > 0) {
 
-		if (MissionBlock::item_contains_position(_mission_item_previous)) {
+		if (mission_item_contains_position(_mission_item_previous)) {
 
 			const float land_alt_amsl = mission_item.altitude_is_relative ? mission_item.altitude +
 						    _home_alt_msl : mission_item.altitude;
@@ -624,7 +624,7 @@ bool FeasibilityChecker::checkHorizontalDistanceToFirstWaypoint(mission_item_s &
 {
 	if (_param_mis_dist_1wp > FLT_EPSILON &&
 	    (_home_lat_lon.isAllFinite()) &&
-	    MissionBlock::item_contains_position(mission_item)) {
+	    mission_item_contains_position(mission_item)) {
 
 		_first_waypoint_found = true;
 
@@ -660,7 +660,7 @@ bool FeasibilityChecker::checkHorizontalDistanceToFirstWaypoint(mission_item_s &
 bool FeasibilityChecker::checkDistancesBetweenWaypoints(const mission_item_s &mission_item)
 {
 	/* check only items with valid lat/lon */
-	if (!MissionBlock::item_contains_position(mission_item)) {
+	if (!mission_item_contains_position(mission_item)) {
 		return true;
 	}
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -46,6 +46,7 @@
  */
 
 #include "mission.h"
+#include "mission_item_utils.h"
 #include "navigator.h"
 
 #include <string.h>
@@ -197,7 +198,7 @@ void Mission::setActiveMissionItems()
 		}
 	}
 
-	if (item_contains_position(_mission_item)) {
+	if (mission_item_contains_position(_mission_item)) {
 
 		handleTakeoff(new_work_item_type, next_mission_items, num_found_items);
 

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -41,6 +41,7 @@
 
 #include "mission_base.h"
 
+#include "mission_item_utils.h"
 #include "px4_platform_common/defines.h"
 
 #include "mission_feasibility_checker.h"
@@ -1086,7 +1087,7 @@ bool MissionBase::findNextPositionIndex(int32_t start_index, int32_t &next_index
 			return false;
 		}
 
-		if (item_contains_position(mission_item)) {
+		if (mission_item_contains_position(mission_item)) {
 			next_index = traversed_index;
 			return true;
 		}
@@ -1108,7 +1109,7 @@ bool MissionBase::findPreviousPositionIndex(int32_t start_index, int32_t &previo
 			return false;
 		}
 
-		if (item_contains_position(mission_item)) {
+		if (mission_item_contains_position(mission_item)) {
 			previous_index = traversed_index;
 			return true;
 		}
@@ -1277,7 +1278,7 @@ int MissionBase::setMissionToClosestItem(double lat, double lon, float alt, floa
 			return PX4_ERROR;
 		}
 
-		if (MissionBlock::item_contains_position(mission)) {
+		if (mission_item_contains_position(mission)) {
 			// do not consider land waypoints for a fw
 			if (!((mission.nav_cmd == NAV_CMD_LAND) &&
 			      (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) &&
@@ -1538,7 +1539,7 @@ void MissionBase::updateMissionAltAfterHomeChanged()
 {
 	if (_navigator->get_home_position()->update_count > _home_update_counter) {
 
-		if (item_contains_position(_mission_item)) {
+		if (mission_item_contains_position(_mission_item)) {
 			const float new_alt = get_absolute_altitude_for_item(_mission_item);
 			const float altitude_diff = new_alt - _navigator->get_position_setpoint_triplet()->current.alt;
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -41,6 +41,7 @@
  */
 
 #include "mission_block.h"
+#include "mission_item_utils.h"
 #include "navigator.h"
 
 #include <math.h>
@@ -520,7 +521,7 @@ MissionBlock::reset_mission_item_reached()
 void
 MissionBlock::issue_command(const mission_item_s &item)
 {
-	if (item_contains_position(item)
+	if (mission_item_contains_position(item)
 	    || item_contains_gate(item)
 	    || item_contains_marker(item)) {
 		return;
@@ -590,19 +591,6 @@ MissionBlock::item_has_timeout(const mission_item_s &item)
 }
 
 bool
-MissionBlock::item_contains_position(const mission_item_s &item)
-{
-	return item.nav_cmd == NAV_CMD_WAYPOINT ||
-	       item.nav_cmd == NAV_CMD_LOITER_UNLIMITED ||
-	       item.nav_cmd == NAV_CMD_LOITER_TIME_LIMIT ||
-	       item.nav_cmd == NAV_CMD_LAND ||
-	       item.nav_cmd == NAV_CMD_TAKEOFF ||
-	       item.nav_cmd == NAV_CMD_LOITER_TO_ALT ||
-	       item.nav_cmd == NAV_CMD_VTOL_TAKEOFF ||
-	       item.nav_cmd == NAV_CMD_VTOL_LAND;
-}
-
-bool
 MissionBlock::item_contains_gate(const mission_item_s &item)
 {
 	return item.nav_cmd == NAV_CMD_CONDITION_GATE;
@@ -618,7 +606,7 @@ bool
 MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, position_setpoint_s *sp)
 {
 	// Don't change the setpoint for non-position items
-	if (!item_contains_position(item)) {
+	if (!mission_item_contains_position(item)) {
 		return false;
 	}
 
@@ -1015,7 +1003,7 @@ void MissionBlock::updateAltToAvoidTerrainCollisionAndRepublishTriplet(const mis
 
 	if (_navigator->get_nav_min_gnd_dist_param() > FLT_EPSILON && _mission_item.nav_cmd != NAV_CMD_LAND
 	    && _mission_item.nav_cmd != NAV_CMD_VTOL_LAND
-	    && item_contains_position(mission_item)
+	    && mission_item_contains_position(mission_item)
 	    && _navigator->get_local_position()->dist_bottom_valid
 	    && _navigator->get_local_position()->dist_bottom < _navigator->get_nav_min_gnd_dist_param()
 	    && _navigator->get_local_position()->vz > FLT_EPSILON

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -73,13 +73,6 @@ public:
 	void initialize() override;
 
 	/**
-	 * Check if the mission item contains a navigation position
-	 *
-	 * @return false if the mission item does not contain a valid position
-	 */
-	static bool item_contains_position(const mission_item_s &item);
-
-	/**
 	 * Returns true if the mission item is not an instant action, but has a delay / timeout
 	 */
 	bool item_has_timeout(const mission_item_s &item);

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -42,7 +42,7 @@
 
 #include "mission_feasibility_checker.h"
 
-#include "mission_block.h"
+#include "mission_item_utils.h"
 #include "navigator.h"
 
 #include <drivers/drv_pwm_output.h>
@@ -141,7 +141,7 @@ MissionFeasibilityChecker::checkMissionAgainstGeofence(const mission_s &mission,
 			// Geofence function checks against home altitude amsl
 			missionitem.altitude = missionitem.altitude_is_relative ? missionitem.altitude + home_alt : missionitem.altitude;
 
-			if (MissionBlock::item_contains_position(missionitem) && !_navigator->get_geofence().checkPointAgainstAllGeofences(
+			if (mission_item_contains_position(missionitem) && !_navigator->get_geofence().checkPointAgainstAllGeofences(
 				    missionitem.lat, missionitem.lon, missionitem.altitude)) {
 
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence violation for waypoint %zu\t", i + 1);

--- a/src/modules/navigator/mission_item_utils.h
+++ b/src/modules/navigator/mission_item_utils.h
@@ -1,0 +1,53 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file mission_item_utils.h
+ *
+ * Helpers for classifying mission items.
+ */
+
+#pragma once
+
+#include "navigation.h"
+
+inline bool mission_item_contains_position(const mission_item_s &item)
+{
+	return item.nav_cmd == NAV_CMD_WAYPOINT ||
+	       item.nav_cmd == NAV_CMD_LOITER_UNLIMITED ||
+	       item.nav_cmd == NAV_CMD_LOITER_TIME_LIMIT ||
+	       item.nav_cmd == NAV_CMD_LAND ||
+	       item.nav_cmd == NAV_CMD_TAKEOFF ||
+	       item.nav_cmd == NAV_CMD_LOITER_TO_ALT ||
+	       item.nav_cmd == NAV_CMD_VTOL_TAKEOFF ||
+	       item.nav_cmd == NAV_CMD_VTOL_LAND;
+}

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -43,6 +43,7 @@
 #include <float.h>
 
 #include "rtl_direct.h"
+#include "mission_item_utils.h"
 #include "navigator.h"
 #include <px4_platform_common/events.h>
 
@@ -373,7 +374,7 @@ void RtlDirect::set_rtl_item()
 	reset_mission_item_reached();
 
 	// Execute command if set. This is required for commands like VTOL transition.
-	if (!MissionBlock::item_contains_position(_mission_item)) {
+	if (!mission_item_contains_position(_mission_item)) {
 		issue_command(_mission_item);
 
 	} else {

--- a/src/modules/navigator/rtl_direct_mission_land.cpp
+++ b/src/modules/navigator/rtl_direct_mission_land.cpp
@@ -40,6 +40,7 @@
  */
 
 #include "rtl_direct_mission_land.h"
+#include "mission_item_utils.h"
 #include "navigator.h"
 
 #include <drivers/drv_hrt.h>
@@ -168,7 +169,7 @@ void RtlDirectMissionLand::setActiveMissionItems()
 
 		new_work_item_type = WorkItemType::WORK_ITEM_TYPE_TRANSITION_AFTER_TAKEOFF;
 
-	} else if (item_contains_position(_mission_item)) {
+	} else if (mission_item_contains_position(_mission_item)) {
 
 		static constexpr size_t max_num_next_items{1u};
 		int32_t next_mission_items_index[max_num_next_items];

--- a/src/modules/navigator/rtl_mission_fast.cpp
+++ b/src/modules/navigator/rtl_mission_fast.cpp
@@ -40,6 +40,7 @@
  */
 
 #include "rtl_mission_fast.h"
+#include "mission_item_utils.h"
 #include "navigator.h"
 
 #include <drivers/drv_hrt.h>
@@ -139,7 +140,7 @@ void RtlMissionFast::setActiveMissionItems()
 
 		new_work_item_type = WorkItemType::WORK_ITEM_TYPE_TRANSITION_AFTER_TAKEOFF;
 
-	} else if (item_contains_position(_mission_item)) {
+	} else if (mission_item_contains_position(_mission_item)) {
 
 		static constexpr size_t max_num_next_items{1u};
 		int32_t next_mission_items_index[max_num_next_items];

--- a/src/modules/navigator/rtl_mission_fast_reverse.cpp
+++ b/src/modules/navigator/rtl_mission_fast_reverse.cpp
@@ -40,6 +40,7 @@
  */
 
 #include "rtl_mission_fast_reverse.h"
+#include "mission_item_utils.h"
 #include "navigator.h"
 
 #include <drivers/drv_hrt.h>
@@ -127,7 +128,7 @@ void RtlMissionFastReverse::setActiveMissionItems()
 
 		new_work_item_type = WorkItemType::WORK_ITEM_TYPE_TRANSITION_AFTER_TAKEOFF;
 
-	} else if (item_contains_position(_mission_item)) {
+	} else if (mission_item_contains_position(_mission_item)) {
 		int32_t next_mission_item_index;
 		size_t num_found_items = 0;
 		getPreviousPositionItems(_mission.current_seq, &next_mission_item_index, num_found_items, 1u);

--- a/src/modules/navigator/test/CMakeLists.txt
+++ b/src/modules/navigator/test/CMakeLists.txt
@@ -33,5 +33,5 @@
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-px4_add_functional_gtest(SRC test_mission_base.cpp LINKLIBS modules__navigator)
-px4_add_functional_gtest(SRC test_RTL.cpp LINKLIBS modules__navigator)
+px4_add_functional_gtest(SRC test_mission_base.cpp LINKLIBS modules__navigator modules__dataman)
+px4_add_functional_gtest(SRC test_RTL.cpp LINKLIBS modules__navigator modules__dataman)


### PR DESCRIPTION
### Solved Problem

  The mission_feasibility_checker library linked back against modules__navigator and modules__dataman.

  This creates an unnecessary reverse dependency: modules__navigator already depends on
  mission_feasibility_checker, while the feasibility checker library itself does not depend on the
  navigator module or the dataman module. This can become problematic for split builds where navigator is
  built without the dataman server module in the same image.

  ### Solution

  Remove the unnecessary target_link_libraries() entry from mission_feasibility_checker.

  The functional test still links against mission_feasibility_checker directly, and the common functional
  test libraries provide the platform/uORB/parameter support needed by the test.

  ### Changelog Entry

  No changelog entry required.

  ### Alternatives

  Keep the reverse dependency. This was avoided because the dependency direction is incorrect and can
  introduce circular or unavailable module dependencies in split builds.

  ### Test coverage

  Built successfully for several targets in the ModalAI PX4 build Docker.

  ### Context

  This is a preparation change for split builds where navigator and dataman may be built into separate
  images.

