### PR TITLE
fix(navigator): use int32_t lower bound for mission index

### DIFF
--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -73,8 +73,8 @@ MissionBase::updateDatamanCache()
 {
 	if ((_mission.count > 0) && (_mission.current_seq != _load_mission_index)) {
 
-		const int32_t start_index = math::constrain(_mission.current_seq, INT32_C(0), int32_t(_mission.count) - 1);
-		const int32_t end_index = math::constrain(start_index + _dataman_cache_size_signed, INT32_C(0),
+		const int32_t start_index = math::constrain(_mission.current_seq, int32_t{0}, int32_t(_mission.count) - 1);
+		const int32_t end_index = math::constrain(start_index + _dataman_cache_size_signed, int32_t{0},
 					  int32_t(_mission.count) - 1);
 
 		for (int32_t index = start_index; index != end_index; index += math::signNoZero(_dataman_cache_size_signed)) {
@@ -98,7 +98,7 @@ void MissionBase::updateMavlinkMission()
 		const bool mission_data_changed = checkMissionDataChanged(new_mission);
 
 		if (new_mission.current_seq < 0) {
-			new_mission.current_seq = math::constrain(_mission.current_seq, INT32_C(0),
+			new_mission.current_seq = math::constrain(_mission.current_seq, int32_t{0},
 						  static_cast<int32_t>(new_mission.count) - 1);
 		}
 


### PR DESCRIPTION

### Solved Problem

  MissionBase used INT32_C(0) as the lower bound in several math::constrain() calls for mission indexes.

  math::constrain() is a single-type template, so all arguments must deduce to the same type. The mission
  indexes are int32_t, but INT32_C(0) can expand to a toolchain-dependent integer literal type, which can
  cause template type deduction issues on some toolchains.

  ### Solution

  Use an explicitly typed int32_t{0} lower bound in the affected mission index math::constrain() calls.

  This keeps the change minimal while making the intended argument type explicit.

  ### Changelog Entry

  No changelog entry required.

  ### Alternatives

  Cast all arguments in the affected calls to int32_t. This also works, but was avoided to keep the diff
  smaller and focused on the actual type deduction issue.

  ### Test coverage

  Built successfully in the ModalAI PX4 build Docker.

  ### Context

  This is a preparation change for building navigator with the VOXL2 SLPI/QURT toolchain, where the
  stricter type deduction issue is exposed when navigator is enabled.
