### PR TITLE
fix(mavlink): avoid reinitializing command sender semaphore

### DIFF
--- a/src/modules/mavlink/mavlink_command_sender.cpp
+++ b/src/modules/mavlink/mavlink_command_sender.cpp
@@ -48,9 +48,8 @@ px4_sem_t MavlinkCommandSender::_lock;
 
 void MavlinkCommandSender::initialize()
 {
-	px4_sem_init(&_lock, 1, 1);
-
 	if (_instance == nullptr) {
+		px4_sem_init(&_lock, 1, 1);
 		_instance = new MavlinkCommandSender();
 
 		if (_instance == nullptr) {


### PR DESCRIPTION
`Mavlink::start()` calls `MavlinkCommandSender::initialize()` for each `Mavlink` startup, while `MavlinkCommandSender` and its semaphore are shared static state.

Before this change, initialize() reinitialized the semaphore before checking whether `MavlinkCommandSender` had already been created. That could reset the semaphore after the shared command sender was already active.

Move `px4_sem_init()` inside `(_instance == nullptr)` guard so semaphore is initialized only once together with `MavlinkCommandSender`.

Fixes 9th item in https://github.com/PX4/PX4-Autopilot/issues/27124.


<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
