### PR TITLE
feat(uxrce_dds_client): add support for Micro-XRCE-DDS_Client v3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -72,6 +72,10 @@
 	path = src/lib/heatshrink/heatshrink
 	url = https://github.com/PX4/heatshrink.git
 	branch = px4
+[submodule "src/modules/uxrce_dds_client/Micro-XRCE-DDS-Client-v3"]
+	path = src/modules/uxrce_dds_client/Micro-XRCE-DDS-Client-v3
+	url = https://github.com/PX4/Micro-XRCE-DDS-Client.git
+	branch = px4-release/3
 [submodule "Tools/simulation/gz"]
 	path = Tools/simulation/gz
 	url = https://github.com/PX4/PX4-gazebo-models.git

--- a/src/modules/uxrce_dds_client/CMakeLists.txt
+++ b/src/modules/uxrce_dds_client/CMakeLists.txt
@@ -35,8 +35,12 @@ if(${CMAKE_VERSION} VERSION_LESS_EQUAL "3.15")
 	message(WARNING "skipping uxrce_dds_client, Micro-XRCE-DDS-Client needs to be fixed to work with CMAKE_VERSION ${CMAKE_VERSION}")
 
 else()
-
-	set(microxrceddsclient_src_dir   ${CMAKE_CURRENT_SOURCE_DIR}/Micro-XRCE-DDS-Client)
+	if(CONFIG_UXRCE_DDS_CLIENT_USE_DDS_V3)
+		message(WARNING "Using Micro-XRCE-DDS-Client v3 for uxrce_dds_client module")
+		set(microxrceddsclient_src_dir   ${CMAKE_CURRENT_SOURCE_DIR}/Micro-XRCE-DDS-Client-v3)
+	else()
+		set(microxrceddsclient_src_dir   ${CMAKE_CURRENT_SOURCE_DIR}/Micro-XRCE-DDS-Client)
+	endif()
 	set(microxrceddsclient_build_dir ${CMAKE_CURRENT_BINARY_DIR})
 
 	px4_add_git_submodule(TARGET git_micro_xrce_dds_client PATH "${microxrceddsclient_src_dir}")

--- a/src/modules/uxrce_dds_client/Kconfig
+++ b/src/modules/uxrce_dds_client/Kconfig
@@ -3,3 +3,10 @@ menuconfig MODULES_UXRCE_DDS_CLIENT
 	default n
 	---help---
 		Enable support for the UXRCE-DDS Client
+
+menuconfig UXRCE_DDS_CLIENT_USE_DDS_V3
+depends on MODULES_UXRCE_DDS_CLIENT
+	bool "use DDS v3"
+	default n
+	---help---
+		Enable support for Micro-XRCE-DDS-Client version 3.


### PR DESCRIPTION
This PR add optional support for Micro-XRCE-DDS version 3.

### Motivation

Starting from Lyrical, ROS 2 adopts Fast-DDS version `3.6.x`.
Therefore, _Micro-XRCE-DDS-Agent_ needs to be updated to version `>=3.x` as versions `<3.x` runs DDS `2.x`.
If _Micro-XRCE-DDS-Agent_ `>=3.x` is used then _Micro-XRCE-DDS-Client_ also needs to be updated to version `>=3.x`.

### Proposed approach

Since all ROS 2 releases before Lyrical use Fast-DDS version `<3.x`, which requires _Micro-XRCE-DDS-Client_  version  `<3.x` and backcompatibilty must be preserved, this PR:

- Adds _Micro-XRCE-DDS-Client_ version three as a parallel submodule of _Micro-XRCE-DDS-Client_ version two.
- The new submodule tracks https://github.com/PX4/Micro-XRCE-DDS-Client/tree/px4-release/3 which adds PX4 supports to the current  _Micro-XRCE-DDS-Client_ `develop` branch
- Switching between the two versions of the client is controlled by the new Kconfig option `UXRCE_DDS_CLIENT_USE_DDS_V3`
- When `UXRCE_DDS_CLIENT_USE_DDS_V3` is set users get a warning message during compilation.

The default behavior remained unchanged

### Changelog Entry

For release notes:

```
feat(uxrce) added support for Fast DDS v3 and ROS 2 Lyrical and newer versions
```

---

As this PR does not alter current behaviour, documentation will be added on a later PR.