### PR TITLE
[BACKPORT v1.17] fix(zenoh): default config topic type to use actual uORB topic name

### DIFF
--- a/src/modules/zenoh/default_topics.c.em
+++ b/src/modules/zenoh/default_topics.c.em
@@ -18,15 +18,15 @@ import os
 
 const char* default_pub_config =
 @[    for pub in publications]@
-	"@(pub['topic']);@(pub['simple_base_type']);0\n"
+	"@(pub['topic']);@(pub['topic_simple']);0\n"
 @[    end for]@
 ;
 
 const char* default_sub_config =
 @[    for sub in subscriptions]@
-	"@(sub['topic']);@(sub['simple_base_type']);0\n"
+	"@(sub['topic']);@(sub['topic_simple']);0\n"
 @[    end for]@
 @[    for sub in subscriptions_multi]@
-	"@(sub['topic']);@(sub['simple_base_type']);-1\n"
+	"@(sub['topic']);@(sub['topic_simple']);-1\n"
 @[    end for]@
 ;


### PR DESCRIPTION
Backport of https://github.com/PX4/PX4-Autopilot/pull/26564

Closes #26183 
