### PR TITLE
fix(zenoh): add new uorb topics to  `Kconfig.topics`

### DIFF
--- a/docs/en/middleware/zenoh.md
+++ b/docs/en/middleware/zenoh.md
@@ -251,3 +251,15 @@ For setup details and supported message types, refer to the [PX4 ROS 2 Interface
 ::: info
 The PX4 ROS 2 Interface Library is not compatible with ROS 2 Humble and earlier, as it requires the message type hash (RIHS01, as defined in REP-2016) to be included in the Zenoh key expression.
 :::
+
+### Troubleshooting
+
+1. When starting the client you might see
+
+   ```
+   ERROR [zenoh] Could not create a subscriber for type ***
+   ```
+
+   When it happens, check if `src/modules/zenoh/Kconfig.topics` has unstaged changes.
+   If there are any it means that new uorb topics have been added and the previous build updated the `Kconfig.topics` file accordingly.
+   Please perform a clean build so that the new `Kconfig.topics` can be used.

--- a/src/modules/zenoh/Kconfig.topics
+++ b/src/modules/zenoh/Kconfig.topics
@@ -61,6 +61,10 @@ menu "Zenoh publishers/subscribers"
 		bool "autotune_attitude_control_status"
 		default n
 
+	config ZENOH_PUBSUB_AUX_GLOBAL_POSITION
+		bool "aux_global_position"
+		default n
+
 	config ZENOH_PUBSUB_BATTERY_INFO
 		bool "battery_info"
 		default n
@@ -133,6 +137,10 @@ menu "Zenoh publishers/subscribers"
 		bool "debug_vect"
 		default n
 
+	config ZENOH_PUBSUB_DEVICE_INFORMATION
+		bool "device_information"
+		default n
+
 	config ZENOH_PUBSUB_DIFFERENTIAL_PRESSURE
 		bool "differential_pressure"
 		default n
@@ -151,6 +159,14 @@ menu "Zenoh publishers/subscribers"
 
 	config ZENOH_PUBSUB_EKF2_TIMESTAMPS
 		bool "ekf2_timestamps"
+		default n
+
+	config ZENOH_PUBSUB_ESC_EEPROM_READ
+		bool "esc_eeprom_read"
+		default n
+
+	config ZENOH_PUBSUB_ESC_EEPROM_WRITE
+		bool "esc_eeprom_write"
 		default n
 
 	config ZENOH_PUBSUB_ESC_REPORT
@@ -183,6 +199,10 @@ menu "Zenoh publishers/subscribers"
 
 	config ZENOH_PUBSUB_ESTIMATOR_EVENT_FLAGS
 		bool "estimator_event_flags"
+		default n
+
+	config ZENOH_PUBSUB_ESTIMATOR_FUSION_CONTROL
+		bool "estimator_fusion_control"
 		default n
 
 	config ZENOH_PUBSUB_ESTIMATOR_GPS_STATUS
@@ -223,6 +243,14 @@ menu "Zenoh publishers/subscribers"
 
 	config ZENOH_PUBSUB_FAILURE_DETECTOR_STATUS
 		bool "failure_detector_status"
+		default n
+
+	config ZENOH_PUBSUB_FIDUCIAL_MARKER_POS_REPORT
+		bool "fiducial_marker_pos_report"
+		default n
+
+	config ZENOH_PUBSUB_FIDUCIAL_MARKER_YAW_REPORT
+		bool "fiducial_marker_yaw_report"
 		default n
 
 	config ZENOH_PUBSUB_FIGURE_EIGHT_STATUS
@@ -267,6 +295,10 @@ menu "Zenoh publishers/subscribers"
 
 	config ZENOH_PUBSUB_FUEL_TANK_STATUS
 		bool "fuel_tank_status"
+		default n
+
+	config ZENOH_PUBSUB_GAIN_COMPRESSION
+		bool "gain_compression"
 		default n
 
 	config ZENOH_PUBSUB_GENERATOR_STATUS
@@ -581,6 +613,10 @@ menu "Zenoh publishers/subscribers"
 		bool "pps_capture"
 		default n
 
+	config ZENOH_PUBSUB_PREC_LAND_STATUS
+		bool "prec_land_status"
+		default n
+
 	config ZENOH_PUBSUB_PURE_PURSUIT_STATUS
 		bool "pure_pursuit_status"
 		default n
@@ -603,6 +639,18 @@ menu "Zenoh publishers/subscribers"
 
 	config ZENOH_PUBSUB_RADIO_STATUS
 		bool "radio_status"
+		default n
+
+	config ZENOH_PUBSUB_RANGING_BEACON
+		bool "ranging_beacon"
+		default n
+
+	config ZENOH_PUBSUB_RAPTOR_INPUT
+		bool "raptor_input"
+		default n
+
+	config ZENOH_PUBSUB_RAPTOR_STATUS
+		bool "raptor_status"
 		default n
 
 	config ZENOH_PUBSUB_RATE_CTRL_STATUS
@@ -769,6 +817,10 @@ menu "Zenoh publishers/subscribers"
 		bool "takeoff_status"
 		default n
 
+	config ZENOH_PUBSUB_TARGET_GNSS
+		bool "target_gnss"
+		default n
+
 	config ZENOH_PUBSUB_TASK_STACK_INFO
 		bool "task_stack_info"
 		default n
@@ -929,8 +981,36 @@ menu "Zenoh publishers/subscribers"
 		bool "velocity_limits"
 		default n
 
+	config ZENOH_PUBSUB_VTE_AID_SOURCE1D
+		bool "vte_aid_source1d"
+		default n
+
+	config ZENOH_PUBSUB_VTE_AID_SOURCE3D
+		bool "vte_aid_source3d"
+		default n
+
+	config ZENOH_PUBSUB_VTE_BIAS_INIT_STATUS
+		bool "vte_bias_init_status"
+		default n
+
+	config ZENOH_PUBSUB_VTE_INPUT
+		bool "vte_input"
+		default n
+
+	config ZENOH_PUBSUB_VTE_ORIENTATION
+		bool "vte_orientation"
+		default n
+
+	config ZENOH_PUBSUB_VTE_POSITION
+		bool "vte_position"
+		default n
+
 	config ZENOH_PUBSUB_VTOL_VEHICLE_STATUS
 		bool "vtol_vehicle_status"
+		default n
+
+	config ZENOH_PUBSUB_VTX
+		bool "vtx"
 		default n
 
 	config ZENOH_PUBSUB_WHEEL_ENCODERS
@@ -965,6 +1045,7 @@ config ZENOH_PUBSUB_ALL_SELECTION
 	select ZENOH_PUBSUB_ARMING_CHECK_REPLY
 	select ZENOH_PUBSUB_ARMING_CHECK_REQUEST
 	select ZENOH_PUBSUB_AUTOTUNE_ATTITUDE_CONTROL_STATUS
+	select ZENOH_PUBSUB_AUX_GLOBAL_POSITION
 	select ZENOH_PUBSUB_BATTERY_INFO
 	select ZENOH_PUBSUB_BATTERY_STATUS
 	select ZENOH_PUBSUB_BUTTON_EVENT
@@ -983,11 +1064,14 @@ config ZENOH_PUBSUB_ALL_SELECTION
 	select ZENOH_PUBSUB_DEBUG_KEY_VALUE
 	select ZENOH_PUBSUB_DEBUG_VALUE
 	select ZENOH_PUBSUB_DEBUG_VECT
+	select ZENOH_PUBSUB_DEVICE_INFORMATION
 	select ZENOH_PUBSUB_DIFFERENTIAL_PRESSURE
 	select ZENOH_PUBSUB_DISTANCE_SENSOR
 	select ZENOH_PUBSUB_DISTANCE_SENSOR_MODE_CHANGE_REQUEST
 	select ZENOH_PUBSUB_DRONECAN_NODE_STATUS
 	select ZENOH_PUBSUB_EKF2_TIMESTAMPS
+	select ZENOH_PUBSUB_ESC_EEPROM_READ
+	select ZENOH_PUBSUB_ESC_EEPROM_WRITE
 	select ZENOH_PUBSUB_ESC_REPORT
 	select ZENOH_PUBSUB_ESC_STATUS
 	select ZENOH_PUBSUB_ESTIMATOR_AID_SOURCE1D
@@ -996,6 +1080,7 @@ config ZENOH_PUBSUB_ALL_SELECTION
 	select ZENOH_PUBSUB_ESTIMATOR_BIAS
 	select ZENOH_PUBSUB_ESTIMATOR_BIAS3D
 	select ZENOH_PUBSUB_ESTIMATOR_EVENT_FLAGS
+	select ZENOH_PUBSUB_ESTIMATOR_FUSION_CONTROL
 	select ZENOH_PUBSUB_ESTIMATOR_GPS_STATUS
 	select ZENOH_PUBSUB_ESTIMATOR_INNOVATIONS
 	select ZENOH_PUBSUB_ESTIMATOR_SELECTOR_STATUS
@@ -1006,6 +1091,8 @@ config ZENOH_PUBSUB_ALL_SELECTION
 	select ZENOH_PUBSUB_EVENT
 	select ZENOH_PUBSUB_FAILSAFE_FLAGS
 	select ZENOH_PUBSUB_FAILURE_DETECTOR_STATUS
+	select ZENOH_PUBSUB_FIDUCIAL_MARKER_POS_REPORT
+	select ZENOH_PUBSUB_FIDUCIAL_MARKER_YAW_REPORT
 	select ZENOH_PUBSUB_FIGURE_EIGHT_STATUS
 	select ZENOH_PUBSUB_FIXED_WING_LATERAL_GUIDANCE_STATUS
 	select ZENOH_PUBSUB_FIXED_WING_LATERAL_SETPOINT
@@ -1017,6 +1104,7 @@ config ZENOH_PUBSUB_ALL_SELECTION
 	select ZENOH_PUBSUB_FOLLOW_TARGET_ESTIMATOR
 	select ZENOH_PUBSUB_FOLLOW_TARGET_STATUS
 	select ZENOH_PUBSUB_FUEL_TANK_STATUS
+	select ZENOH_PUBSUB_GAIN_COMPRESSION
 	select ZENOH_PUBSUB_GENERATOR_STATUS
 	select ZENOH_PUBSUB_GEOFENCE_RESULT
 	select ZENOH_PUBSUB_GEOFENCE_STATUS
@@ -1095,12 +1183,16 @@ config ZENOH_PUBSUB_ALL_SELECTION
 	select ZENOH_PUBSUB_POWER_BUTTON_STATE
 	select ZENOH_PUBSUB_POWER_MONITOR
 	select ZENOH_PUBSUB_PPS_CAPTURE
+	select ZENOH_PUBSUB_PREC_LAND_STATUS
 	select ZENOH_PUBSUB_PURE_PURSUIT_STATUS
 	select ZENOH_PUBSUB_PWM_INPUT
 	select ZENOH_PUBSUB_PX4IO_STATUS
 	select ZENOH_PUBSUB_QSHELL_REQ
 	select ZENOH_PUBSUB_QSHELL_RETVAL
 	select ZENOH_PUBSUB_RADIO_STATUS
+	select ZENOH_PUBSUB_RANGING_BEACON
+	select ZENOH_PUBSUB_RAPTOR_INPUT
+	select ZENOH_PUBSUB_RAPTOR_STATUS
 	select ZENOH_PUBSUB_RATE_CTRL_STATUS
 	select ZENOH_PUBSUB_RC_CHANNELS
 	select ZENOH_PUBSUB_RC_PARAMETER_MAP
@@ -1142,6 +1234,7 @@ config ZENOH_PUBSUB_ALL_SELECTION
 	select ZENOH_PUBSUB_SENSORS_STATUS_IMU
 	select ZENOH_PUBSUB_SYSTEM_POWER
 	select ZENOH_PUBSUB_TAKEOFF_STATUS
+	select ZENOH_PUBSUB_TARGET_GNSS
 	select ZENOH_PUBSUB_TASK_STACK_INFO
 	select ZENOH_PUBSUB_TECS_STATUS
 	select ZENOH_PUBSUB_TELEMETRY_STATUS
@@ -1182,7 +1275,14 @@ config ZENOH_PUBSUB_ALL_SELECTION
 	select ZENOH_PUBSUB_VEHICLE_THRUST_SETPOINT
 	select ZENOH_PUBSUB_VEHICLE_TORQUE_SETPOINT
 	select ZENOH_PUBSUB_VELOCITY_LIMITS
+	select ZENOH_PUBSUB_VTE_AID_SOURCE1D
+	select ZENOH_PUBSUB_VTE_AID_SOURCE3D
+	select ZENOH_PUBSUB_VTE_BIAS_INIT_STATUS
+	select ZENOH_PUBSUB_VTE_INPUT
+	select ZENOH_PUBSUB_VTE_ORIENTATION
+	select ZENOH_PUBSUB_VTE_POSITION
 	select ZENOH_PUBSUB_VTOL_VEHICLE_STATUS
+	select ZENOH_PUBSUB_VTX
 	select ZENOH_PUBSUB_WHEEL_ENCODERS
 	select ZENOH_PUBSUB_WIND
 	select ZENOH_PUBSUB_YAW_ESTIMATOR_STATUS


### PR DESCRIPTION
### Solved Problem

When new topics are added and zenoh is enabled, the `src/modules/zenoh/Kconfig.topics` is automatically updated at build-time by

https://github.com/PX4/PX4-Autopilot/blob/8ae02ec48275e283e6ca3ccc6990080727c22541/msg/CMakeLists.txt#L586-L592

The changes should be committed.

### Remaining issue

It should be noted that even if `Kconfig.topics` is updated whenever the list of messages and topics change (one adds new messages or the value of `CONFIG_MODULES_VISION_TARGET_ESTIMATOR` changes), the zenoh submodule **won't** use the updated file.

In oder to use the updaed file one needs to perform a clean build with `Kconfig.topics`  already updated.

### Solution

This PR

- updates  `src/modules/zenoh/Kconfig.topics` with the latest list of available topics.
- updates zenoh doc adding a troubleshooting section

### Changelog Entry
For release notes:
```
none
```

### Alternatives

- We could have a CI action that automatically updates the file.

### Test coverage

### Context

Even if `src/modules/zenoh/Kconfig.topics` is updated during build time, the fist zenoh build will use the _previous_ configuration.
This causes

```sh
ERROR [zenoh] Could not create a subscriber for type aux_global_position
```

on `main` as the defaul topic list containes `aux_global_position` but that topic is not included in the `Kconfig.topics`.
Right now one have to perform a clean build so that the updated `Kconfig.topics` is used.


