### PR TITLE
fix(vtol): smooth standard transition pitch handoff

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -136,6 +136,7 @@ void Standard::update_vtol_state()
 
 				// don't set pusher throttle here as it's being ramped up elsewhere
 				_trans_finished_ts = hrt_absolute_time();
+				_front_transition_pitch = Eulerf(Quatf(_v_att_sp->q_d)).theta();
 			}
 		}
 	}
@@ -368,12 +369,25 @@ void Standard::fill_actuator_outputs()
 void
 Standard::waiting_on_tecs()
 {
-	// keep thrust from transition
-	_v_att_sp->thrust_body[0] = _pusher_throttle;
+	// keep thrust and pitch from transition
+	blendThrottleAfterFrontTransition(0.0f);
+	blendPitchAfterFrontTransition(0.0f);
 };
 
 void Standard::blendThrottleAfterFrontTransition(float scale)
 {
 	const float tecs_throttle = _v_att_sp->thrust_body[0];
 	_v_att_sp->thrust_body[0] = scale * tecs_throttle + (1.0f - scale) * _pusher_throttle;
+}
+
+void Standard::blendPitchAfterFrontTransition(float scale)
+{
+	if (!PX4_ISFINITE(_front_transition_pitch)) {
+		return;
+	}
+
+	const Eulerf fw_attitude_setpoint(Quatf(_v_att_sp->q_d));
+	const float pitch_body = scale * fw_attitude_setpoint.theta() + (1.0f - scale) * _front_transition_pitch;
+	const Quatf q_sp(Eulerf(fw_attitude_setpoint.phi(), pitch_body, fw_attitude_setpoint.psi()));
+	q_sp.copyTo(_v_att_sp->q_d);
 }

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -62,6 +62,7 @@ public:
 	void fill_actuator_outputs() override;
 	void waiting_on_tecs() override;
 	void blendThrottleAfterFrontTransition(float scale) override;
+	void blendPitchAfterFrontTransition(float scale) override;
 
 private:
 
@@ -77,6 +78,7 @@ private:
 	float _pusher_throttle{0.0f};
 	float _airspeed_trans_blend_margin{0.0f};
 	hrt_abstime _last_time_pusher_transition_update{0};
+	float _front_transition_pitch{NAN};
 
 	void parameters_update() override;
 

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -143,6 +143,10 @@ void VtolType::update_fw_state()
 
 		} else {
 			blendThrottleAfterFrontTransition(progress);
+
+			if (_v_control_mode->flag_control_altitude_enabled) {
+				blendPitchAfterFrontTransition(progress);
+			}
 		}
 	}
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -219,6 +219,7 @@ public:
 	float pusher_assist();
 
 	virtual void blendThrottleAfterFrontTransition(float scale) {};
+	virtual void blendPitchAfterFrontTransition(float scale) {};
 
 	mode get_mode() {return _common_vtol_mode;}
 


### PR DESCRIPTION
### Solved Problem

Standard VTOL already protects the first moments after a front transition by
holding/blending pusher throttle until TECS has published a fresh fixed-wing
setpoint.

The remaining discontinuity is on the attitude setpoint: when the vehicle enters
FW mode, the transition pitch setpoint can be replaced by the fixed-wing
controller output in the same handoff window. On larger/high-inertia Standard
VTOLs this can produce an avoidable pitch transient while TECS is still
initializing.

This PR is intentionally scoped to the Standard VTOL pitch handoff only. It does
not change the pusher-throttle output path.

### Solution

- Add a separate post-front-transition setpoint blend hook next to the existing
  throttle blend hook.
- Store the Standard VTOL transition pitch once when FW mode is entered.
- While waiting for TECS, keep the transition pitch.
- During the existing post-transition blend window, blend pitch from the
  transition value to the fixed-wing controller value.
- Keep roll, yaw, and pusher throttle behavior unchanged.

No new parameter is added.

### Validation

- `git diff --check`
- `make px4_sitl_default`
- Diagnostic A/B test with plain Gazebo Standard VTOL, used to narrow the PR
  scope:
  - current PX4 main: `make px4_sitl gz_standard_vtol`
  - previous PR revision cherry-picked on current main:
    `make px4_sitl gz_standard_vtol`

Flight Review logs:

- Current main baseline:
  https://logs.px4.io/plot_app?log=dc9a2d78-3950-4603-abbc-d44fad9f1c77
- Previous PR revision:
  https://logs.px4.io/plot_app?log=c57988cc-a87a-487f-9ea5-f25179fd5c7a

The A/B logs show that `gz_standard_vtol` current main already blends pusher
throttle through the front-transition handoff. This PR was narrowed based on
that result: it no longer modifies the throttle path and only smooths the pitch
setpoint across the same handoff window.

### Changelog Entry

For release notes:

```text
Bugfix: Smooth Standard VTOL pitch setpoint across the front-transition handoff.
```
