### PR TITLE
docs(releases): add list of removed parameters with notes

### DIFF
--- a/docs/en/releases/1.17.md
+++ b/docs/en/releases/1.17.md
@@ -147,6 +147,7 @@ For users upgrading from v1.16, please take a moment to review the following bef
 - UAVCAN battery: better remaining-time calculation ([PX4-Autopilot#25500](https://github.com/PX4/PX4-Autopilot/pull/25500)) and filter sample interval increased to 500 ms ([PX4-Autopilot#25454](https://github.com/PX4/PX4-Autopilot/pull/25454)).
 - Battery instances are capped at 3 (loggable batteries also raised to 3).
 - Remaining-flight-time failsafe disabled by default.
+- Removed parameter `COM_RC_ARM_HYST`, arm and disarm gesture needs to be held for the default of one second. ([PX4-Autopilot#25999](https://github.com/PX4/PX4-Autopilot/pull/25999))
 
 ### Control
 
@@ -300,6 +301,8 @@ The in-tree [Zenoh middleware](../middleware/zenoh.md) (added in v1.16) matures 
 - Hexarotor X added to SIH and to `ActuatorEffectivenessRotorsTest`.
 - `MC_RATE*` parameter metadata unified.
   ([PX4-Autopilot#25133](https://github.com/PX4/PX4-Autopilot/pull/25133))
+- Removed parameters `MPC_{XY/Z/YAW}_MAN_EXPO` and use default value instead, as they were not deemed necessary anymore. ([PX4-Autopilot#25435](https://github.com/PX4/PX4-Autopilot/pull/25435)).
+- Renamed `MPC_HOLD_DZ` to `MAN_DEADZONE` to have it globally available in modes that allow for a dead zone. ([PX4-Autopilot#25435](https://github.com/PX4/PX4-Autopilot/pull/25435)).
 
 ### VTOL
 

--- a/docs/en/releases/1.18.md
+++ b/docs/en/releases/1.18.md
@@ -47,17 +47,18 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 - [QGroundControl Bootloader Update](../advanced_config/bootloader_update.md#qgc-bootloader-update-sys-bl-update) via the [SYS_BL_UPDATE](../advanced_config/parameter_reference.md#SYS_BL_UPDATE) parameter has been re-enabled after being broken for a number of releases. ([PX4-Autopilot#25032: build: romf: fix generation of rc.board_bootloader_upgrade](https://github.com/PX4/PX4-Autopilot/pull/25032)).
 - [Feature: Allow prioritization of manual control inputs based on their instance number in ascending or descending order](../config/manual_control.md#px4-configuration). ([PX4-Autopilot#25602: Ascending and descending manual control input priorities](https://github.com/PX4/PX4-Autopilot/pull/25602)).
 - Removed parameters:
-   | Name | Notes |
-   | --- | --- |
-   | `COM_FLT_PROFILE` | Unused ([PX4-Autopilot#26735](https://github.com/PX4/PX4-Autopilot/pull/26735)) |
-   | `COM_KILL_DISARM` | After staying killed for 5 seconds the autopilot disarms which was the default. ([PX4-Autopilot#26736](https://github.com/PX4/PX4-Autopilot/pull/26736)) |
-   | `COM_MOT_TEST_EN` | Motor tests are always possible which was the default. ([PX4-Autopilot#26775](https://github.com/PX4/PX4-Autopilot/pull/26775)) |
-   | `COM_TAKEOFF_ACT` | Vehicle always switches to Hold mode when the takeoff is done. If you want to automatically do a mission, take off in Mission mode. ([PX4-Autopilot#26808](https://github.com/PX4/PX4-Autopilot/pull/26808)) |
-   | `COM_HLDL_REG_T` | When a high latency link is regained it's considered regained immediately which was the default. ([PX4-Autopilot#26809](https://github.com/PX4/PX4-Autopilot/pull/26809)) |
-   | `COM_ARM_SDCARD` | There's a warning when the autopilot SD card is missing which was the default. Boards that don't have an SD card need to skip the check with a compile time define. ([PX4-Autopilot#27259](https://github.com/PX4/PX4-Autopilot/pull/27259)) |
-   | `COM_IMB_PROP_ACT` | There's a warning when imbalanced propellers (high vibration) is detected which was the default. ([PX4-Autopilot#27260](https://github.com/PX4/PX4-Autopilot/pull/27260)) |
-   | `COM_OBC_LOSS_T` | The timeout for missing heartbeats from the onboard computer is the previous default of 5 seconds. ([PX4-Autopilot#27261](https://github.com/PX4/PX4-Autopilot/pull/27261)) |
-   | `COM_LKDOWN_TKO` | Takeoff failure detection runs for 3 seconds which was the default. ([PX4-Autopilot#27262](https://github.com/PX4/PX4-Autopilot/pull/27262)) |
+
+  | Name               | Notes                                                                                                                                                                                                                                             |
+  | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | `COM_FLT_PROFILE`  | Unused ([PX4-Autopilot#26735](https://github.com/PX4/PX4-Autopilot/pull/26735))                                                                                                                                                                   |
+  | `COM_KILL_DISARM`  | Autopilot now always disarms if still killed after 5 sections (previous default). ([PX4-Autopilot#26736](https://github.com/PX4/PX4-Autopilot/pull/26736))                                                                                        |
+  | `COM_MOT_TEST_EN`  | Motor tests now always possible (was the default). ([PX4-Autopilot#26775](https://github.com/PX4/PX4-Autopilot/pull/26775))                                                                                                                       |
+  | `COM_TAKEOFF_ACT`  | Vehicle always switches to Hold mode when the takeoff is done. If you want to automatically do a mission, take off in Mission mode. ([PX4-Autopilot#26808](https://github.com/PX4/PX4-Autopilot/pull/26808))                                      |
+  | `COM_HLDL_REG_T`   | When a high latency link is regained it's always considered regained immediately (was the default). ([PX4-Autopilot#26809](https://github.com/PX4/PX4-Autopilot/pull/26809))                                                                      |
+  | `COM_ARM_SDCARD`   | There's now always warning when the autopilot SD card is missing (was the default). Boards that don't have an SD card need to skip the check with a compile time define. ([PX4-Autopilot#27259](https://github.com/PX4/PX4-Autopilot/pull/27259)) |
+  | `COM_IMB_PROP_ACT` | There's now always a warning when imbalanced propellers (high vibration) is detected (was the default). ([PX4-Autopilot#27260](https://github.com/PX4/PX4-Autopilot/pull/27260))                                                                  |
+  | `COM_OBC_LOSS_T`   | Timeout for missing heartbeats from the onboard computer is always 5 seconds (was the default). ([PX4-Autopilot#27261](https://github.com/PX4/PX4-Autopilot/pull/27261))                                                                          |
+  | `COM_LKDOWN_TKO`   | Takeoff failure detection always runs for 3 seconds (was the default). ([PX4-Autopilot#27262](https://github.com/PX4/PX4-Autopilot/pull/27262))                                                                                                   |
 
 ### Control
 

--- a/docs/en/releases/1.18.md
+++ b/docs/en/releases/1.18.md
@@ -46,6 +46,18 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 - [Remote ID (Open Drone ID) in-flight failsafe](../peripherals/remote_id.md): extended [COM_ARM_ODID](../advanced_config/parameter_reference.md#COM_ARM_ODID) to also trigger a configurable failsafe action (Return, Land, or Terminate) if the Remote ID heartbeat is lost while airborne. Users previously on `COM_ARM_ODID=2` retain the same arming behaviour; set to `3` or higher to enable the in-flight action. ([PX4-Autopilot#27029](https://github.com/PX4/PX4-Autopilot/pull/27029))
 - [QGroundControl Bootloader Update](../advanced_config/bootloader_update.md#qgc-bootloader-update-sys-bl-update) via the [SYS_BL_UPDATE](../advanced_config/parameter_reference.md#SYS_BL_UPDATE) parameter has been re-enabled after being broken for a number of releases. ([PX4-Autopilot#25032: build: romf: fix generation of rc.board_bootloader_upgrade](https://github.com/PX4/PX4-Autopilot/pull/25032)).
 - [Feature: Allow prioritization of manual control inputs based on their instance number in ascending or descending order](../config/manual_control.md#px4-configuration). ([PX4-Autopilot#25602: Ascending and descending manual control input priorities](https://github.com/PX4/PX4-Autopilot/pull/25602)).
+- Removed parameters:
+   | Name | Notes |
+   | --- | --- |
+   | `COM_FLT_PROFILE` | Unused ([PX4-Autopilot#26735](https://github.com/PX4/PX4-Autopilot/pull/26735)) |
+   | `COM_KILL_DISARM` | After staying killed for 5 seconds the autopilot disarms which was the default. ([PX4-Autopilot#26736](https://github.com/PX4/PX4-Autopilot/pull/26736)) |
+   | `COM_MOT_TEST_EN` | Motor tests are always possible which was the default. ([PX4-Autopilot#26775](https://github.com/PX4/PX4-Autopilot/pull/26775)) |
+   | `COM_TAKEOFF_ACT` | Vehicle always switches to Hold mode when the takeoff is done. If you want to automatically do a mission, take off in Mission mode. ([PX4-Autopilot#26808](https://github.com/PX4/PX4-Autopilot/pull/26808)) |
+   | `COM_HLDL_REG_T` | When a high latency link is regained it's considered regained immediately which was the default. ([PX4-Autopilot#26809](https://github.com/PX4/PX4-Autopilot/pull/26809)) |
+   | `COM_ARM_SDCARD` | There's a warning when the autopilot SD card is missing which was the default. Boards that don't have an SD card need to skip the check with a compile time define. ([PX4-Autopilot#27259](https://github.com/PX4/PX4-Autopilot/pull/27259)) |
+   | `COM_IMB_PROP_ACT` | There's a warning when imbalanced propellers (high vibration) is detected which was the default. ([PX4-Autopilot#27260](https://github.com/PX4/PX4-Autopilot/pull/27260)) |
+   | `COM_OBC_LOSS_T` | The timeout for missing heartbeats from the onboard computer is the previous default of 5 seconds. ([PX4-Autopilot#27261](https://github.com/PX4/PX4-Autopilot/pull/27261)) |
+   | `COM_LKDOWN_TKO` | Takeoff failure detection runs for 3 seconds which was the default. ([PX4-Autopilot#27262](https://github.com/PX4/PX4-Autopilot/pull/27262)) |
 
 ### Control
 
@@ -114,9 +126,6 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 - Parse ELRS Status and Link Statistics TX messages in the CRSF parser.
 
 ### Multi-Rotor
-
-- Removed parameters `MPC_{XY/Z/YAW}_MAN_EXPO` and use default value instead, as they were not deemed necessary anymore. ([PX4-Autopilot#25435: Add new flight mode: Altitude Cruise](https://github.com/PX4/PX4-Autopilot/pull/25435)).
-- Renamed `MPC_HOLD_DZ` to `MAN_DEADZONE` to have it globally available in modes that allow for a dead zone. ([PX4-Autopilot#25435: Add new flight mode: Altitude Cruise](https://github.com/PX4/PX4-Autopilot/pull/25435)).
 
 ### VTOL
 


### PR DESCRIPTION
### Solved Problem
I had removed quite some parameters to safe user confusion, resources and testing complexity. I forgot to mention them in an adequate way in the release notes.

### Solution
List them consistently in the right release's notes.