### PR TITLE
refactor(esc_battery): remove average temperature tracking from batte…

### DIFF
--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -93,24 +93,17 @@ EscBattery::Run()
 		const uint8_t online_esc_count = math::countSetBits(esc_status.esc_online_flags);
 		float average_voltage_v = 0.0f;
 		float total_current_a = 0.0f;
-		float average_temperature_c = 0.0f;
 
 		for (unsigned i = 0; i < esc_status.esc_count; ++i) {
 			if ((1 << i) & esc_status.esc_online_flags) {
 				average_voltage_v += esc_status.esc[i].esc_voltage;
 				total_current_a += esc_status.esc[i].esc_current;
-
-				if (PX4_ISFINITE(esc_status.esc[i].esc_temperature)) {
-					average_temperature_c += esc_status.esc[i].esc_temperature;
-				}
 			}
 		}
 
 		average_voltage_v /= online_esc_count;
-		average_temperature_c /= online_esc_count;
 
 		_battery.setConnected(true);
-		_battery.updateTemperature(average_temperature_c);
 		_battery.updateVoltage(average_voltage_v);
 		_battery.updateCurrent(total_current_a);
 		_battery.updateAndPublishBatteryStatus(esc_status.timestamp);


### PR DESCRIPTION
### Description
In [this commit](https://github.com/PX4/PX4-Autopilot/commit/98cba19f50b5e83c900b2fd48947705777f368a3) it was added in PX4 upstream the filling of battery_status.temperature with the temperature of the ESC power source.

This arose a false warning when ESC temperature was high even if battery temperature was not since the temperature indicated is not the one of the battery cells but the ESC's.

Since there is no battery temperature sensor for the cells, the solution was to remove it.

### Test
Verified that esc_battery still publishes the remaining core battery data, on temperature now it gets nan