### PR TITLE
feat(commander): add ESC over-temperature warning

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/escCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/escCheck.cpp
@@ -91,6 +91,10 @@ void EscChecks::checkAndReport(const Context &context, Report &reporter)
 			mask |= checkMotorStatus(context, reporter, esc_status, now);
 		}
 
+		if (_param_com_esc_ot_warn.get() >= FLT_EPSILON) {
+			checkEscTemperature(reporter, esc_status);
+		}
+
 		_motor_failure_mask = mask;
 		reporter.setIsPresent(health_component_t::motors_escs);
 		reporter.failsafeFlags().fd_motor_failure = (mask != 0);
@@ -212,6 +216,61 @@ uint16_t EscChecks::checkEscStatus(const Context &context, Report &reporter, con
 	}
 
 	return mask;
+}
+
+void EscChecks::checkEscTemperature(Report &reporter, const esc_status_s &esc_status)
+{
+	const float warn_temp = _param_com_esc_ot_warn.get();
+
+	int hottest_esc_index = -1;
+	float max_temperature = -FLT_MAX;
+
+	for (int esc_index = 0; esc_index < esc_status_s::CONNECTED_ESC_MAX; esc_index++) {
+		if (!math::isInRange(esc_status.esc[esc_index].actuator_function,
+				     esc_report_s::ACTUATOR_FUNCTION_MOTOR1, esc_report_s::ACTUATOR_FUNCTION_MOTOR_MAX)) {
+			continue;
+		}
+
+		const float temperature = esc_status.esc[esc_index].esc_temperature;
+
+		if (!PX4_ISFINITE(temperature)) {
+			continue;
+		}
+
+		if (temperature > max_temperature) {
+			max_temperature = temperature;
+			hottest_esc_index = esc_index;
+		}
+	}
+
+	if (hottest_esc_index < 0) {
+		return;
+	}
+
+	if (max_temperature > warn_temp) {
+		/* EVENT
+		 * @description
+		 * <profile name="dev">
+		 * This check can be configured via <param>COM_ESC_OT_WARN</param> parameter.
+		 * </profile>
+		 */
+		reporter.healthFailure<uint8_t, float>(NavModes::None, health_component_t::motors_escs,
+						       events::ID("check_esc_over_temperature"),
+						       events::Log::Warning,
+						       "ESC temperature above warning threshold, highest is ESC {1} ({2} degC)",
+						       static_cast<uint8_t>(hottest_esc_index + 1), max_temperature);
+
+
+		if (!_esc_over_temp_warned && reporter.mavlink_log_pub()) {
+			mavlink_log_warning(reporter.mavlink_log_pub(),
+					    "ESC temperature above warning threshold, highest is ESC%d (%.0f degC)",
+					    hottest_esc_index + 1, (double)max_temperature);
+			_esc_over_temp_warned = true;
+		}
+
+	} else if (max_temperature < warn_temp - ESC_OVER_TEMP_RESET_MARGIN) {
+		_esc_over_temp_warned = false;
+	}
 }
 
 uint16_t EscChecks::checkMotorStatus(const Context &context, Report &reporter, const esc_status_s &esc_status, hrt_abstime now)

--- a/src/modules/commander/HealthAndArmingChecks/checks/escCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/escCheck.cpp
@@ -91,7 +91,7 @@ void EscChecks::checkAndReport(const Context &context, Report &reporter)
 			mask |= checkMotorStatus(context, reporter, esc_status, now);
 		}
 
-		if (_param_com_esc_ot_warn.get() >= FLT_EPSILON) {
+		if (_param_esc_temp_warn_th.get() >= FLT_EPSILON) {
 			checkEscTemperature(reporter, esc_status);
 		}
 
@@ -220,12 +220,12 @@ uint16_t EscChecks::checkEscStatus(const Context &context, Report &reporter, con
 
 void EscChecks::checkEscTemperature(Report &reporter, const esc_status_s &esc_status)
 {
-	const float warn_temp = _param_com_esc_ot_warn.get();
+	const float warn_temp = _param_esc_temp_warn_th.get();
 
-	int hottest_esc_index = -1;
+	uint8_t hottest_esc_index = UINT8_MAX;
 	float max_temperature = -FLT_MAX;
 
-	for (int esc_index = 0; esc_index < esc_status_s::CONNECTED_ESC_MAX; esc_index++) {
+	for (uint8_t esc_index = 0; esc_index < esc_status_s::CONNECTED_ESC_MAX; esc_index++) {
 		if (!math::isInRange(esc_status.esc[esc_index].actuator_function,
 				     esc_report_s::ACTUATOR_FUNCTION_MOTOR1, esc_report_s::ACTUATOR_FUNCTION_MOTOR_MAX)) {
 			continue;
@@ -246,7 +246,7 @@ void EscChecks::checkEscTemperature(Report &reporter, const esc_status_s &esc_st
 			/* EVENT
 			* @description
 			* <profile name="dev">
-			* This check can be configured via <param>COM_ESC_OT_WARN</param> parameter.
+			* Configured by <param>ESC_TEMP_WARN_TH</param>
 			* </profile>
 			*/
 			reporter.healthFailure<uint8_t, uint8_t>(NavModes::None, health_component_t::motors_escs,
@@ -257,18 +257,17 @@ void EscChecks::checkEscTemperature(Report &reporter, const esc_status_s &esc_st
 		}
 	}
 
-	if (hottest_esc_index < 0) {
+	if (hottest_esc_index == UINT8_MAX) {
 		return;
 	}
 
-	if (max_temperature > warn_temp) {
+	if (max_temperature >= warn_temp) {
 		if (!_esc_over_temp_warned && reporter.mavlink_log_pub()) {
-			mavlink_log_warning(reporter.mavlink_log_pub(),
-					    "High ESC temperature. Reduce throttle!");
+			mavlink_log_warning(reporter.mavlink_log_pub(), "High ESC temperature. Reduce throttle!");
 			_esc_over_temp_warned = true;
 		}
 
-	} else if (max_temperature < warn_temp - ESC_OVER_TEMP_RESET_MARGIN) {
+	} else if (max_temperature < warn_temp - 5.f) {
 		_esc_over_temp_warned = false;
 	}
 }

--- a/src/modules/commander/HealthAndArmingChecks/checks/escCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/escCheck.cpp
@@ -241,6 +241,20 @@ void EscChecks::checkEscTemperature(Report &reporter, const esc_status_s &esc_st
 			max_temperature = temperature;
 			hottest_esc_index = esc_index;
 		}
+
+		if (temperature > warn_temp) {
+			/* EVENT
+			* @description
+			* <profile name="dev">
+			* This check can be configured via <param>COM_ESC_OT_WARN</param> parameter.
+			* </profile>
+			*/
+			reporter.healthFailure<uint8_t, uint8_t>(NavModes::None, health_component_t::motors_escs,
+					events::ID("check_esc_over_temperature"),
+					events::Log::Warning,
+					"ESC {1} temperature warning, {2:C}",
+					static_cast<uint8_t>(esc_index + 1), static_cast<uint8_t>(temperature));
+		}
 	}
 
 	if (hottest_esc_index < 0) {
@@ -248,23 +262,9 @@ void EscChecks::checkEscTemperature(Report &reporter, const esc_status_s &esc_st
 	}
 
 	if (max_temperature > warn_temp) {
-		/* EVENT
-		 * @description
-		 * <profile name="dev">
-		 * This check can be configured via <param>COM_ESC_OT_WARN</param> parameter.
-		 * </profile>
-		 */
-		reporter.healthFailure<uint8_t, float>(NavModes::None, health_component_t::motors_escs,
-						       events::ID("check_esc_over_temperature"),
-						       events::Log::Warning,
-						       "ESC temperature above warning threshold, highest is ESC {1} ({2} degC)",
-						       static_cast<uint8_t>(hottest_esc_index + 1), max_temperature);
-
-
 		if (!_esc_over_temp_warned && reporter.mavlink_log_pub()) {
 			mavlink_log_warning(reporter.mavlink_log_pub(),
-					    "ESC temperature above warning threshold, highest is ESC%d (%.0f degC)",
-					    hottest_esc_index + 1, (double)max_temperature);
+					    "High ESC temperature. Reduce throttle!");
 			_esc_over_temp_warned = true;
 		}
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/escCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/escCheck.hpp
@@ -57,9 +57,11 @@ private:
 	uint16_t checkEscStatus(const Context &context, Report &reporter, const esc_status_s &esc_status);
 	uint16_t checkMotorStatus(const Context &context, Report &reporter, const esc_status_s &esc_status, hrt_abstime now);
 	void updateEscsStatus(const Context &context, Report &reporter, const esc_status_s &esc_status, hrt_abstime now);
+	void checkEscTemperature(Report &reporter, const esc_status_s &esc_status);
+
 
 	static constexpr hrt_abstime ESC_TIMEOUT_US = 400_ms;
-
+	static constexpr float ESC_OVER_TEMP_RESET_MARGIN = 5.f;
 	uORB::Subscription _esc_status_sub{ORB_ID(esc_status)};
 	uORB::Subscription _actuator_motors_sub{ORB_ID(actuator_motors)};
 
@@ -67,6 +69,7 @@ private:
 
 	uint16_t _motor_failure_mask = 0;
 	bool _esc_has_reported_current[esc_status_s::CONNECTED_ESC_MAX] {};
+	bool _esc_over_temp_warned{false};
 	systemlib::Hysteresis _esc_undercurrent_hysteresis[esc_status_s::CONNECTED_ESC_MAX];
 	systemlib::Hysteresis _esc_overcurrent_hysteresis[esc_status_s::CONNECTED_ESC_MAX];
 	systemlib::Hysteresis _esc_arm_hysteresis;
@@ -76,5 +79,6 @@ private:
 					(ParamBool<px4::params::FD_ACT_EN>) _param_fd_act_en,
 					(ParamFloat<px4::params::MOTFAIL_C2T>) _param_motfail_c2t,
 					(ParamFloat<px4::params::MOTFAIL_TIME>) _param_motfail_time,
-					(ParamFloat<px4::params::MOTFAIL_OFF>) _param_motfail_off);
+					(ParamFloat<px4::params::MOTFAIL_OFF>) _param_motfail_off,
+					(ParamFloat<px4::params::COM_ESC_OT_WARN>) _param_com_esc_ot_warn);
 };

--- a/src/modules/commander/HealthAndArmingChecks/checks/escCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/escCheck.hpp
@@ -61,7 +61,7 @@ private:
 
 
 	static constexpr hrt_abstime ESC_TIMEOUT_US = 400_ms;
-	static constexpr float ESC_OVER_TEMP_RESET_MARGIN = 5.f;
+
 	uORB::Subscription _esc_status_sub{ORB_ID(esc_status)};
 	uORB::Subscription _actuator_motors_sub{ORB_ID(actuator_motors)};
 
@@ -80,5 +80,5 @@ private:
 					(ParamFloat<px4::params::MOTFAIL_C2T>) _param_motfail_c2t,
 					(ParamFloat<px4::params::MOTFAIL_TIME>) _param_motfail_time,
 					(ParamFloat<px4::params::MOTFAIL_OFF>) _param_motfail_off,
-					(ParamFloat<px4::params::COM_ESC_OT_WARN>) _param_com_esc_ot_warn);
+					(ParamFloat<px4::params::ESC_TEMP_WARN_TH>) _param_esc_temp_warn_th);
 };

--- a/src/modules/commander/HealthAndArmingChecks/esc_check_params.yaml
+++ b/src/modules/commander/HealthAndArmingChecks/esc_check_params.yaml
@@ -49,3 +49,18 @@ parameters:
       max: 10
       decimal: 2
       increment: 1
+- group: ESC
+  definitions:
+    COM_ESC_OT_WARN:
+      description:
+        short: ESC over-temperature warning threshold
+        long: |-
+          Warning raised if ESC temperature gets above threshold: no failsafe action triggered or arming prevented.
+          Set to -1 to disable the check.
+      type: float
+      default: 90.0
+      min: -1
+      max: 150
+      unit: celcius
+      decimal: 1
+      increment: 1

--- a/src/modules/commander/HealthAndArmingChecks/esc_check_params.yaml
+++ b/src/modules/commander/HealthAndArmingChecks/esc_check_params.yaml
@@ -51,12 +51,12 @@ parameters:
       increment: 1
 - group: ESC
   definitions:
-    COM_ESC_OT_WARN:
+    ESC_TEMP_WARN_TH:
       description:
-        short: ESC over-temperature warning threshold
+        short: ESC temperature warning threshold
         long: |-
-          Warning raised if ESC temperature gets above threshold: no failsafe action triggered or arming prevented.
-          Set to -1 to disable the check.
+          Warning only, no failsafe or arming blocked.
+          -1 disables the check.
       type: float
       default: 90.0
       min: -1

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -117,7 +117,9 @@ void GZMixingInterfaceESC::motorSpeedCallback(const gz::msgs::Actuators &actuato
 	for (int i = 0; i < limited_escs; i++) {
 		esc_status.esc[i].timestamp = hrt_absolute_time();
 		esc_status.esc[i].esc_rpm = actuators.velocity(i);
+		esc_status.esc[i].esc_temperature = 50.f; // arbitrary, fixed ESC temperature
 		esc_status.esc_online_flags |= 1 << i;
+		esc_status.esc[i].actuator_function = (uint8_t)_mixing_output.outputFunction(i);
 
 		// This is a race condition with the failure detector, for smaller models it always resolves before
 		// the failure detector runs, but for larger models (with more than 8 ESCs) the failure detector

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -342,7 +342,69 @@ void Sih::read_motors(const float dt)
 				_u[i] = _u[i] + dt / _T_TAU * (u_sp - _u[i]); // first order transfer function with time constant tau
 			}
 		}
+
+		publish_esc_status();
 	}
+}
+
+uint8_t Sih::num_motors() const
+{
+	switch (_vehicle) {
+	case VehicleType::Quadcopter:     return 4;
+
+	case VehicleType::Hexacopter:     return 6;
+
+	case VehicleType::TailsitterVTOL: return NUM_DYN_THRUSTER; // motors at index 0..1, surfaces at 4..5
+
+	case VehicleType::StandardVTOL:   return 4;                // hover motors at 0..3; pusher at 7 excluded for simplicity
+
+	case VehicleType::FixedWing:      return 1;                // motor at index 3, surfaces at 0..2 are skipped
+
+	case VehicleType::RoverAckermann: return 1;
+
+	default:                          return 0;
+	}
+}
+
+void Sih::publish_esc_status()
+{
+	esc_status_s esc_status{};
+	esc_status.timestamp = hrt_absolute_time();
+	int motor_idx = 0;
+	bool any_motor_running = false;
+	float max_rpm = 10000.f;
+
+	if (_vehicle == VehicleType::FixedWing || _vehicle == VehicleType::TailsitterVTOL || _vehicle == VehicleType::StandardVTOL) {
+		max_rpm = _sih_forward_rpm_max.get();
+	}
+
+	for (int i = 0; i < NUM_ACTUATORS_MAX && motor_idx < num_motors(); i++) {
+		if ((_vehicle == VehicleType::FixedWing && i < 3)
+		    || (_vehicle == VehicleType::TailsitterVTOL && i > 3)
+		    || (_vehicle == VehicleType::RoverAckermann && i == 0)) {
+			continue; // control surface / steering channel, not a motor
+		}
+
+		esc_status.esc[motor_idx].timestamp = hrt_absolute_time();
+		esc_status.esc[motor_idx].actuator_function = esc_report_s::ACTUATOR_FUNCTION_MOTOR1 + motor_idx;
+		esc_status.esc[motor_idx].esc_temperature = 50.f;
+		esc_status.esc[motor_idx].esc_rpm = (int32_t)roundf(Thruster::throttle_to_rpm(_u[i], max_rpm));
+		esc_status.esc_online_flags |= 1u << motor_idx;
+
+		if (_u[i] > FLT_EPSILON) {
+			any_motor_running = true;
+		}
+
+		motor_idx++;
+	}
+
+	esc_status.esc_count = motor_idx;
+
+	if (any_motor_running) {
+		esc_status.esc_armed_flags = (1u << motor_idx) - 1;
+	}
+
+	_esc_status_pub.publish(esc_status);
 }
 
 void Sih::generate_force_and_torques(const float dt)

--- a/src/modules/simulation/simulator_sih/sih.hpp
+++ b/src/modules/simulation/simulator_sih/sih.hpp
@@ -72,10 +72,11 @@
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
-#include <uORB/topics/parameter_update.h>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/actuator_outputs.h>
 #include <uORB/topics/distance_sensor.h>
+#include <uORB/topics/esc_status.h>
+#include <uORB/topics/parameter_update.h>
 #include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_global_position.h>
@@ -131,6 +132,7 @@ private:
 	PX4Rangefinder   _px4_rangefinder{10092548}; // 10092548: DRV_DIST_DEVTYPE_SIM, BUS: 0, ADDR: 0, TYPE: SIMULATION
 	uORB::Publication<airspeed_s>         _airspeed_pub{ORB_ID(airspeed)};
 	uORB::Publication<ranging_beacon_s>   _ranging_beacon_pub{ORB_ID(ranging_beacon)};
+	uORB::Publication<esc_status_s>       _esc_status_pub{ORB_ID(esc_status)};
 
 	// groundtruth
 	uORB::Publication<vehicle_angular_velocity_s> _angular_velocity_ground_truth_pub{ORB_ID(vehicle_angular_velocity_groundtruth)};
@@ -179,6 +181,8 @@ private:
 
 	// read the motor signals outputted from the mixer
 	void read_motors(const float dt);
+	void publish_esc_status();
+	uint8_t num_motors() const;
 
 	// generate the motors thrust and torque in the body frame
 	void generate_force_and_torques(const float dt);


### PR DESCRIPTION
## Problem
ESCs report their temperature over telemetry, but PX4 did nothing with that
value. So an operator got no warning before a heat-related failure. 

## Solution
Add a vehicle-side over-temperature check to the ESC HealthAndArmingCheck.
When an ESC reports `esc_temperature` above a configurable threshold, PX4 raises a warning (logged and pop-up).

- New parameter `COM_ESC_OT_WARN` (degC, default `90`, `-1` disables).
- Warning-only (does not prevent arming nor trigger failsafe)

<img width="1546" height="265" alt="Screenshot From 2026-06-10 12-01-38" src="https://github.com/user-attachments/assets/f533b71c-5964-461a-9b15-0cd48b148f4b" />

<img width="1512" height="1263" alt="image" src="https://github.com/user-attachments/assets/50691aff-d429-4d6c-8b9a-0455283f551f" />



## Implementation notes

Severity here only controls presentation, not action.

PX4 also appends a trailing tab (`\t`) to the legacy STATUSTEXT of such messages as a
"this is also an event" marker, which the GCS uses to suppress the STATUSTEXT. The key point was
removing the trailing tab to have a pop-up notification (and read the message aloud).

A per-ESC latch (`_esc_over_temp_warned[]`) makes the pop-up fire once per over-temperature episode instead than at every report cycle. The latch is cleared only after the ESC cools `ESC_OVER_TEMP_RESET_MARGIN` (5 degC) below the threshold, so a new heat-up warns again without flapping around the threshold. The health-panel event is still reported every cycle.