### PR TITLE
fix(boards/corvon_743v2): correct analog airspeed ADC macro

### DIFF
--- a/boards/corvon/743v2/init/rc.board_defaults
+++ b/boards/corvon/743v2/init/rc.board_defaults
@@ -7,11 +7,6 @@
 # ----------------------------------------------------------------------------
 # Safety / arming
 # ----------------------------------------------------------------------------
-# 743V2 has NO dedicated safety switch pad - bypass the IO safety check so
-# the vehicle can arm without a physical button.  Magic value 22027 matches
-# the circuit-breaker "skip safety" constant in PX4.
-param set-default CBRK_IO_SAFETY 22027
-
 # Disable the 5V supply check (board is powered via PM, no separate rail sense)
 param set-default CBRK_SUPPLY_CHK 894281
 

--- a/boards/corvon/743v2/nuttx-config/scripts/bootloader_script.ld
+++ b/boards/corvon/743v2/nuttx-config/scripts/bootloader_script.ld
@@ -34,7 +34,7 @@
  *
  ****************************************************************************/
 
-/* The Durandal-v1 uses an STM32H743II has 2048Kb of main FLASH memory.
+/* The CORVON 743V2 uses an STM32H743VI and has 2048Kb of main FLASH memory.
  * The flash memory is partitioned into a User Flash memory and a System
  * Flash memory. Each of these memories has two banks:
  *
@@ -50,7 +50,7 @@
  *
  *   3) User option bytes for user configuration, only in Bank 1.
  *
- * In the STM32H743II, two different boot spaces can be selected through
+ * In the STM32H743VI, two different boot spaces can be selected through
  * the BOOT pin and the boot base address programmed in the BOOT_ADD0 and
  * BOOT_ADD1 option bytes:
  *
@@ -59,11 +59,10 @@
  *   2) BOOT=1: Boot address defined by user option byte BOOT_ADD1[15:0].
  *      ST programmed value: System bootloader at 0x1FF0:0000
  *
- * The Durandal has a Switch on board, the BOOT0 pin is at ground so by default,
- * the STM32 will boot to address 0x0800:0000 in FLASH unless the swiutch is
- * drepresed, then the boot will be from 0x1FF0:0000
+ * On the 743V2 the BOOT0 pin is tied to ground, so the STM32 always boots
+ * from address 0x0800:0000 in FLASH.
  *
- * The STM32H743ZI also has 1024Kb of data SRAM.
+ * The STM32H743VI also has 1024Kb of data SRAM.
  * SRAM is split up into several blocks and into three power domains:
  *
  *   1) TCM SRAMs are dedicated to the Cortex-M7 and are accessible with

--- a/boards/corvon/743v2/nuttx-config/scripts/script.ld
+++ b/boards/corvon/743v2/nuttx-config/scripts/script.ld
@@ -34,7 +34,7 @@
  *
  ****************************************************************************/
 
-/* The board uses an STM32H743II and has 2048Kb of main FLASH memory.
+/* The board uses an STM32H743VI and has 2048Kb of main FLASH memory.
  * The flash memory is partitioned into a User Flash memory and a System
  * Flash memory. Each of these memories has two banks:
  *
@@ -50,7 +50,7 @@
  *
  *   3) User option bytes for user configuration, only in Bank 1.
  *
- * In the STM32H743II, two different boot spaces can be selected through
+ * In the STM32H743VI, two different boot spaces can be selected through
  * the BOOT pin and the boot base address programmed in the BOOT_ADD0 and
  * BOOT_ADD1 option bytes:
  *
@@ -59,11 +59,10 @@
  *   2) BOOT=1: Boot address defined by user option byte BOOT_ADD1[15:0].
  *      ST programmed value: System bootloader at 0x1FF0:0000
  *
- * There's a switch on board, the BOOT0 pin is at ground so by default,
- * the STM32 will boot to address 0x0800:0000 in FLASH unless the switch is
- * drepresed, then the boot will be from 0x1FF0:0000
+ * On the 743V2 the BOOT0 pin is tied to ground, so the STM32 always boots
+ * from address 0x0800:0000 in FLASH.
  *
- * The STM32H743ZI also has 1024Kb of data SRAM.
+ * The STM32H743VI also has 1024Kb of data SRAM.
  * SRAM is split up into several blocks and into three power domains:
  *
  *   1) TCM SRAMs are dedicated to the Cortex-M7 and are accessible with

--- a/boards/corvon/743v2/src/board_config.h
+++ b/boards/corvon/743v2/src/board_config.h
@@ -113,7 +113,7 @@
 #define ADC_BATTERY2_CURRENT_CHANNEL    8     /* PC5 - ADC12_INP8 */
 
 /* Airspeed (analog) */
-#define ADC_AIRSPEED_IN_CHANNEL         18    /* PA4 - ADC12_INP18 */
+#define ADC_AIRSPEED_VOLTAGE_CHANNEL    18    /* PA4 - ADC12_INP18 */
 
 /* RSSI (analog) */
 #define ADC_RSSI_IN_CHANNEL             3     /* PA6 - ADC12_INP3 */
@@ -123,7 +123,7 @@
 	 (1 << ADC_BATTERY1_CURRENT_CHANNEL) | \
 	 (1 << ADC_BATTERY2_VOLTAGE_CHANNEL) | \
 	 (1 << ADC_BATTERY2_CURRENT_CHANNEL) | \
-	 (1 << ADC_AIRSPEED_IN_CHANNEL)      | \
+	 (1 << ADC_AIRSPEED_VOLTAGE_CHANNEL) | \
 	 (1 << ADC_RSSI_IN_CHANNEL))
 
 /* Battery voltage divider R82=20K (top) / R62=1K (bottom), V_IN = V_ADC * 21.2 */

--- a/boards/corvon/743v2/src/timer_config.cpp
+++ b/boards/corvon/743v2/src/timer_config.cpp
@@ -44,7 +44,7 @@
  *   M7  = PD12  TIM4_CH1   (DMA)
  *   M8  = PD13  TIM4_CH2   (DMA)
  *   M9  = PD14  TIM4_CH3   (DMA)
- *   M10 = PD15  TIM4_CH4   (DMA)
+ *   M10 = PD15  TIM4_CH4   (DMA, no BDShot - TIM4_CH4 has no capture DMA)
  *   M11 = PB14  TIM12_CH1  (no DMA, PWM only - servo / gimbal)
  *   M12 = PB15  TIM12_CH2  (no DMA, PWM only - servo / gimbal)
  *


### PR DESCRIPTION
### Solved Problem
The analog airspeed input on the CORVON 743V2 never reached the sensors module: the board defined `ADC_AIRSPEED_IN_CHANNEL`, but the sensors module only compiles the analog airspeed path when `ADC_AIRSPEED_VOLTAGE_CHANNEL` is defined.

### Solution
- Rename the macro so the analog airspeed input works (PA4, ADC channel 18, already part of the ADC mask).
- Clean up leftovers spotted while going over the board files:
  - drop the redundant `CBRK_IO_SAFETY` default (22027 is already the PX4 default)
  - fix linker-script comments inherited from the Durandal template (wrong MCU variant, removed mention of a boot switch this board doesn't have)
  - note that M10 (TIM4_CH4) has no capture DMA, so no BDShot on that output

### Test coverage
- `make corvon_743v2_default` and `make corvon_743v2_bootloader` build clean.
