### PR TITLE
fix(astyle): ignore Micro-XRCE-DDS-Client-v3 submodule in format checks

### DIFF
--- a/Tools/astyle/files_to_check_code_style.sh
+++ b/Tools/astyle/files_to_check_code_style.sh
@@ -36,6 +36,7 @@ exec find boards msg src platforms test \
     -path src/lib/crypto/libtommath -prune -o \
     -path src/lib/heatshrink/heatshrink -prune -o \
     -path src/modules/uxrce_dds_client/Micro-XRCE-DDS-Client -prune -o \
+    -path src/modules/uxrce_dds_client/Micro-XRCE-DDS-Client-v3 -prune -o \
     -path src/lib/cdrstream/cyclonedds -prune -o \
     -path src/lib/cdrstream/rosidl -prune -o \
     -path src/modules/zenoh/zenoh-pico -prune -o \


### PR DESCRIPTION
## Summary

Add the `Micro-XRCE-DDS-Client-v3` submodule to the astyle exclusion list so `make format` and `make check_format` no longer touch its vendored sources.

## Problem

The `Micro-XRCE-DDS-Client-v3` submodule was added without a matching prune entry in `Tools/astyle/files_to_check_code_style.sh`. The existing `Micro-XRCE-DDS-Client` prune is an exact `-path` match and does not cover the `-v3` directory, so its 200+ vendored C/C++ files get pulled into the format check and reformatted.

## Solution

Add a `-prune` entry for `src/modules/uxrce_dds_client/Micro-XRCE-DDS-Client-v3` next to the existing `Micro-XRCE-DDS-Client` entry.