### PR TITLE
feat(commander): add companion computer temperature warning check

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
+++ b/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
@@ -40,6 +40,7 @@ px4_add_library(health_and_arming_checks
 	checks/armPermissionCheck.cpp
 	checks/baroCheck.cpp
 	checks/batteryCheck.cpp
+	checks/companionComputerCheck.cpp
 	checks/cpuResourceCheck.cpp
 	checks/distanceSensorChecks.cpp
 	checks/opticalFlowCheck.cpp

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
@@ -44,6 +44,7 @@
 #include "checks/airspeedCheck.hpp"
 #include "checks/armPermissionCheck.hpp"
 #include "checks/baroCheck.hpp"
+#include "checks/companionComputerCheck.hpp"
 #include "checks/cpuResourceCheck.hpp"
 #include "checks/distanceSensorChecks.hpp"
 #include "checks/opticalFlowCheck.hpp"
@@ -135,6 +136,7 @@ private:
 	AirspeedChecks _airspeed_checks;
 	ArmPermissionChecks _arm_permission_checks;
 	BaroChecks _baro_checks;
+	CompanionComputerChecks _companion_computer_checks;
 	CpuResourceChecks _cpu_resource_checks;
 	DistanceSensorChecks _distance_sensor_checks;
 	OpticalFlowCheck _optical_flow_check;
@@ -170,7 +172,7 @@ private:
 	ExternalChecks _external_checks;
 #endif
 
-	HealthAndArmingCheckBase *_checks[41] = {
+	HealthAndArmingCheckBase *_checks[42] = {
 #ifndef CONSTRAINED_FLASH
 		&_external_checks,
 #endif
@@ -178,6 +180,7 @@ private:
 		&_airspeed_checks,
 		&_arm_permission_checks,
 		&_baro_checks,
+		&_companion_computer_checks,
 		&_cpu_resource_checks,
 		&_distance_sensor_checks,
 		&_optical_flow_check,

--- a/src/modules/commander/HealthAndArmingChecks/checks/companionComputerCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/companionComputerCheck.cpp
@@ -1,0 +1,71 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "companionComputerCheck.hpp"
+
+using namespace time_literals;
+
+void CompanionComputerChecks::checkAndReport(const Context &context, Report &reporter)
+{
+	const float temperature_warn_threshold = _param_com_cc_temp_warn.get();
+
+	if (temperature_warn_threshold < FLT_EPSILON) {
+		return;
+	}
+
+	onboard_computer_status_s onboard_computer_status;
+
+	// Skip if no companion computer is connected or reporting.
+	if (!_onboard_computer_status_sub.copy(&onboard_computer_status)
+	    || hrt_elapsed_time(&onboard_computer_status.timestamp) > 5_s
+	    || onboard_computer_status.temperature_board == INT8_MAX) {
+		return;
+	}
+
+	const float temperature_board = (float)onboard_computer_status.temperature_board;
+
+	if (temperature_board >= temperature_warn_threshold) {
+		/* EVENT
+		 * @description
+		 * The companion computer temperature is above the warning threshold.
+		 *
+		 * <profile name="dev">
+		 * The threshold can be adjusted via <param>COM_CC_TEMP_WARN</param> parameter.
+		 * </profile>
+		 */
+		reporter.healthFailure<int8_t>(NavModes::None, health_component_t::system,
+					       events::ID("check_companion_computer_temperature_high"),
+					       events::Log::Warning, "Companion computer temperature high: {1} degC",
+					       onboard_computer_status.temperature_board);
+	}
+}

--- a/src/modules/commander/HealthAndArmingChecks/checks/companionComputerCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/companionComputerCheck.cpp
@@ -65,7 +65,7 @@ void CompanionComputerChecks::checkAndReport(const Context &context, Report &rep
 		 */
 		reporter.healthFailure<int8_t>(NavModes::None, health_component_t::system,
 					       events::ID("check_companion_computer_temperature_high"),
-					       events::Log::Warning, "Companion computer temperature high: {1} degC",
+					       events::Log::Warning, "Companion computer temperature warning, {1} C",
 					       onboard_computer_status.temperature_board);
 	}
 }

--- a/src/modules/commander/HealthAndArmingChecks/checks/companionComputerCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/companionComputerCheck.hpp
@@ -1,0 +1,55 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "../Common.hpp"
+
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/onboard_computer_status.h>
+
+class CompanionComputerChecks : public HealthAndArmingCheckBase
+{
+public:
+	CompanionComputerChecks() = default;
+	~CompanionComputerChecks() = default;
+
+	void checkAndReport(const Context &context, Report &reporter) override;
+
+private:
+	uORB::Subscription _onboard_computer_status_sub{ORB_ID(onboard_computer_status)};
+
+	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
+					(ParamFloat<px4::params::COM_CC_TEMP_WARN>) _param_com_cc_temp_warn
+				       )
+};

--- a/src/modules/commander/commander_params.yaml
+++ b/src/modules/commander/commander_params.yaml
@@ -599,7 +599,7 @@ parameters:
       description:
         short: Companion computer high-temperature warning threshold
         long: |-
-          A warning is triggered if the currently estimated companion computer (SOM) board temperature,
+          A warning is triggered if the currently estimated companion computer board temperature,
           reported by the ONBOARD_COMPUTER_STATUS message, is above this value.
           Arming is not prevented as the temperature typically drops in flight.
           The check is skipped when no companion computer is reporting a temperature.
@@ -611,7 +611,7 @@ parameters:
       max: 127
       decimal: 0
       increment: 1
-      unit: celcius
+      unit: celsius
     COM_WIND_WARN:
       description:
         short: Wind speed warning threshold

--- a/src/modules/commander/commander_params.yaml
+++ b/src/modules/commander/commander_params.yaml
@@ -595,6 +595,23 @@ parameters:
       decimal: 1
       increment: 0.1
       unit: s
+    COM_CC_TEMP_WARN:
+      description:
+        short: Companion computer high-temperature warning threshold
+        long: |-
+          A warning is triggered if the currently estimated companion computer (SOM) board temperature,
+          reported by the ONBOARD_COMPUTER_STATUS message, is above this value.
+          Arming is not prevented as the temperature typically drops in flight.
+          The check is skipped when no companion computer is reporting a temperature.
+
+          Set to -1 to disable.
+      type: float
+      default: 80.0
+      min: -1
+      max: 127
+      decimal: 0
+      increment: 1
+      unit: celcius
     COM_WIND_WARN:
       description:
         short: Wind speed warning threshold

--- a/src/modules/commander/commander_params.yaml
+++ b/src/modules/commander/commander_params.yaml
@@ -599,10 +599,9 @@ parameters:
       description:
         short: Companion computer high-temperature warning threshold
         long: |-
-          A warning is triggered if the currently estimated companion computer board temperature,
-          reported by the ONBOARD_COMPUTER_STATUS message, is above this value.
+          
+          
           Arming is not prevented as the temperature typically drops in flight.
-          The check is skipped when no companion computer is reporting a temperature.
 
           Set to -1 to disable.
       type: float
@@ -611,7 +610,7 @@ parameters:
       max: 127
       decimal: 0
       increment: 1
-      unit: celsius
+      unit: celcius
     COM_WIND_WARN:
       description:
         short: Wind speed warning threshold


### PR DESCRIPTION
Adds a non-blocking preflight/health check that warns when the companion computer (SOM) temperature is too high.  Warning only: does not block arming (temperature drops quickly in flight).

### Changes
- New check class*`src/modules/commander/HealthAndArmingChecks/checks/companionComputerCheck.{hpp,cpp}`
  - `CompanionComputerChecks` subscribes to `onboard_computer_status`.
  -  Disabled on a board without a companion.
  -  Warning appears in the health panel (see picture)
- Parameter (`commander_params.yaml`): single `COM_CC_TEMP_WARN`, float,
  default `80`, range `-1..127`, `unit: celcius`. Set to `-1` to disable.

<img width="1685" height="1400" alt="Screenshot From 2026-06-11 13-36-56" src="https://github.com/user-attachments/assets/8065fb84-7ff7-4ee9-b7f4-297ac254d000" />