### PR TITLE
fix(commander): prevent delay of non-deferred failsafes

### DIFF
--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -497,7 +497,8 @@ void FailsafeBase::getSelectedAction(const State &state, const failsafe_flags_s 
 					   selected_action != Action::Hold;
 
 	if (_current_delay > 0 && !_user_takeover_active && allow_user_takeover <= UserTakeoverAllowed::AlwaysModeSwitchOnly
-	    && action_can_be_delayed) {
+	    && action_can_be_delayed
+	    && allow_failsafe_to_be_deferred) {
 		returned_state.delayed_action = selected_action;
 		selected_action = Action::Hold;
 		allow_user_takeover = UserTakeoverAllowed::AlwaysModeSwitchOnly;


### PR DESCRIPTION
### Solved Problem

Failsafe actions marked as non-deferrable could still be delayed into Hold if a failsafe delay was already active.

`cannotBeDeferred()` was respected by the explicit failsafe deferral path, but not by the delayed Hold path controlled by `COM_FAIL_ACT_T`. This meant that after one failsafe started a delay, a later non-deferrable action, such as a mode fallback after Offboard signal loss, could still be replaced by Hold until the remaining delay expired.

### Solution

Respect `cannotBeDeferred()` in the delayed Hold path, matching the existing deferred failsafe handling.

### Changelog Entry

For release notes:
```
Bugfix: prevent non-deferrable failsafe actions from being delayed
```

### Test coverage

Manual verification with the failsafe state machine simulation:
- Start a delayed Hold failsafe.
- Clear it while the delay is still active.
- Trigger an Offboard loss mode fallback.
- Confirm the fallback is applied immediately instead of being delayed into Hold.

before patch:

https://github.com/user-attachments/assets/59e6f971-44fc-4c7a-90e2-4759f4175f55

after patch:

https://github.com/user-attachments/assets/5cf80eb7-66f4-4009-a4f4-be7b948cd94a
