### PR TITLE
fix(navigator): use takeoff position for default transition yaw in vtol_takeoff

### DIFF
--- a/src/modules/navigator/vtol_takeoff.cpp
+++ b/src/modules/navigator/vtol_takeoff.cpp
@@ -73,8 +73,8 @@ VtolTakeoff::on_active()
 				_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
 
 				if (!PX4_ISFINITE(_transition_direction_deg)) {
-					_mission_item.yaw = wrap_pi(get_bearing_to_next_waypoint(_navigator->get_home_position()->lat,
-								    _navigator->get_home_position()->lon, _loiter_location(0), _loiter_location(1)));
+					_mission_item.yaw = wrap_pi(get_bearing_to_next_waypoint(_mission_item.lat,
+								    _mission_item.lon, _loiter_location(0), _loiter_location(1)));
 
 				} else {
 					_mission_item.yaw = wrap_pi(math::radians(_transition_direction_deg));


### PR DESCRIPTION
### Solved Problem

VTOL takeoff default transition yaw was computed from home position to the loiter location. Home and the actual takeoff position can differ, which can make the vehicle align to the wrong heading before transitioning to fixed-wing flight.

### Solution

Use the stored takeoff mission item position as the bearing origin when no explicit transition direction is provided.

### Changelog Entry

For release notes:
```
Bugfix: VTOL takeoff default transition yaw now uses the actual takeoff position instead of home position.
```

### Test coverage

Test in SITL. Offset home, set an east loiter target, and trigger default VTOL takeoff to reveal `home -> loiter` misalignment.

reproduction script:
https://gist.github.com/AkaiEurus/05df7974bca8a09e9caeb1f5d4f17aa6

log before patch:
https://logs.px4.io/plot_app?log=e90fae7c-f89d-409b-b2a9-fbf4f72bf197

log after patch:
https://logs.px4.io/plot_app?log=b5c06d61-55e6-4db7-bcfc-b71b8e8f8b1b
