### PR TITLE
fix(posix): make pxh app map initialization thread-safe

### DIFF
--- a/platforms/posix/src/px4/common/px4_daemon/pxh.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/pxh.cpp
@@ -56,6 +56,7 @@ namespace px4_daemon
 {
 
 apps_map_type Pxh::_apps = {};
+pthread_once_t Pxh::_apps_once = PTHREAD_ONCE_INIT;
 Pxh *Pxh::_instance = nullptr;
 
 Pxh::Pxh()
@@ -72,15 +73,18 @@ Pxh::~Pxh()
 	}
 }
 
+void Pxh::_init_apps()
+{
+	init_app_map(_apps);
+}
+
 int Pxh::process_line(const std::string &line, bool silently_fail)
 {
 	if (line.empty()) {
 		return 0;
 	}
 
-	if (_apps.empty()) {
-		init_app_map(_apps);
-	}
+	pthread_once(&_apps_once, Pxh::_init_apps);
 
 	std::stringstream line_stream(line);
 	std::string word;
@@ -458,6 +462,8 @@ void Pxh::_move_cursor(int position)
 
 void Pxh::_tab_completion(std::string &mystr)
 {
+	pthread_once(&_apps_once, Pxh::_init_apps);
+
 	// parse line and get command
 	std::stringstream line(mystr);
 	std::string cmd;

--- a/platforms/posix/src/px4/common/px4_daemon/pxh.h
+++ b/platforms/posix/src/px4/common/px4_daemon/pxh.h
@@ -45,6 +45,7 @@
 #include <vector>
 #include <string>
 #include <termios.h>
+#include <pthread.h>
 
 #include <platforms/posix/apps.h>
 #include "history.h"
@@ -90,6 +91,7 @@ private:
 
 	void _setup_term();
 	static void _restore_term();
+	static void _init_apps();
 
 	bool _should_exit{false};
 	bool _local_terminal{false};
@@ -97,6 +99,7 @@ private:
 	struct termios _orig_term {};
 
 	static apps_map_type _apps;
+	static pthread_once_t _apps_once;
 	static Pxh *_instance;
 };
 


### PR DESCRIPTION
### Solved Problem
  Fixes a POSIX PX4 daemon race where multiple client handler threads can concurrently initialize the static `Pxh::_apps` map on first command execution.

  ### Solution
  Use `pthread_once()` to initialize the PX4 shell builtin app map exactly once before `process_line()` or tab completion accesses it. This prevents concurrent first-use calls from both entering `init_app_map(_apps)` and mutating the same static `std::map`.

  ### Changelog Entry
  For release notes:

  Bugfix: prevent POSIX PX4 daemon crash from concurrent shell app map initialization


  ### Alternatives
  A mutex around the `_apps.empty()` / `init_app_map()` block would also serialize initialization, but `pthread_once()` more directly models the intended one-time initialization behavior and avoids locking after initialization completes. Eagerly initializing `_apps` during daemon startup would also avoid the race, but keeping initialization local to `Pxh` preserves the existing lazy initialization behavior.

  ### Test coverage
  Built successfully, runs on voxl2

  ### Context
  A downstream crash report showed a segfault with a backtrace through `Pxh::process_line()`, `init_app_map()`, and `std::_Rb_tree` internals, consistent with concurrent mutation of the static builtin app map during early daemon/client startup.
