### PR TITLE
fix(drivers/uavcannode): make CANNODE_NODE_ID the sole node ID policy

### DIFF
--- a/docs/en/dronecan/ark_cannode.md
+++ b/docs/en/dronecan/ark_cannode.md
@@ -85,7 +85,7 @@ On the ARK CANnode, you may need to configure the following parameters:
 
 | Parameter                                                                                                | Description                                                                                                                           |
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-127 to use a static node ID. |
+| <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-125 to use a static node ID. |
 | <a id="CANNODE_TERM"></a>[CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM)          | CAN built-in bus termination.                                                                                                         |
 
 ## LED Meanings

--- a/docs/en/dronecan/ark_flow.md
+++ b/docs/en/dronecan/ark_flow.md
@@ -112,7 +112,7 @@ On the ARK Flow, you may need to configure the following parameters:
 
 | Parameter                                                                                                | Description                                                                                                                           |
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-127 to use a static node ID. |
+| <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-125 to use a static node ID. |
 | <a id="CANNODE_TERM"></a>[CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM)          | CAN built-in bus termination.                                                                                                         |
 
 ## LED Meanings

--- a/docs/en/dronecan/ark_flow_mr.md
+++ b/docs/en/dronecan/ark_flow_mr.md
@@ -107,7 +107,7 @@ You may need to [configure the following parameters](../dronecan/index.md#qgc-ca
 
 | Parameter                                                                                                | Description                                                                                                                           |
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-127 to use a static node ID. |
+| <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-125 to use a static node ID. |
 | <a id="CANNODE_TERM"></a>[CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM)          | CAN built-in bus termination.                                                                                                         |
 
 ## LED Meanings

--- a/docs/en/dronecan/ark_gps.md
+++ b/docs/en/dronecan/ark_gps.md
@@ -99,7 +99,7 @@ You may need to [configure the following parameters](../dronecan/index.md#qgc-ca
 
 | Parameter                                                                                                | Description                                                                                                                           |
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-127 to use a static node ID. |
+| <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-125 to use a static node ID. |
 | <a id="CANNODE_TERM"></a>[CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM)          | CAN built-in bus termination. Set to `1` if this is the last node on the CAN bus.                                                     |
 
 ## LED Meanings

--- a/docs/en/dronecan/ark_rtk_gps.md
+++ b/docs/en/dronecan/ark_rtk_gps.md
@@ -94,7 +94,7 @@ You may need to [configure the following parameters](../dronecan/index.md#qgc-ca
 
 | Parameter                                                                                                | Description                                                                                                                           |
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-127 to use a static node ID. |
+| <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-125 to use a static node ID. |
 | <a id="CANNODE_TERM"></a>[CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM)          | CAN built-in bus termination. Set to `1` if this is the last node on the CAN bus.                                                     |
 
 ### Setting Up Rover and Fixed Base

--- a/docs/en/dronecan/ark_rtk_gps_l1_l2.md
+++ b/docs/en/dronecan/ark_rtk_gps_l1_l2.md
@@ -93,7 +93,7 @@ You may need to [configure the following parameters](../dronecan/index.md#qgc-ca
 
 | Parameter                                                                                                | Description                                                                                                                           |
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-127 to use a static node ID. |
+| <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-125 to use a static node ID. |
 | <a id="CANNODE_TERM"></a>[CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM)          | CAN built-in bus termination. Set to `1` if this is the last node on the CAN bus.                                                     |
 
 ### Setting Up Rover and Fixed Base

--- a/docs/en/dronecan/ark_x20_rtk_gps.md
+++ b/docs/en/dronecan/ark_x20_rtk_gps.md
@@ -96,7 +96,7 @@ You may need to [configure the following parameters](../dronecan/index.md#qgc-ca
 
 | Parameter                                                                                                | Description                                                                                                                           |
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-127 to use a static node ID. |
+| <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-125 to use a static node ID. |
 | <a id="CANNODE_TERM"></a>[CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM)          | CAN built-in bus termination. Set to `1` if this is the last node on the CAN bus.                                                     |
 
 ### Setting Up Rover and Fixed Base

--- a/docs/en/dronecan/index.md
+++ b/docs/en/dronecan/index.md
@@ -103,7 +103,7 @@ The parameter is set to 1 by default.
 
 Devices running the [PX4 DroneCAN firmware](px4_cannode_fw.md) (such as [ARK CANnode](ark_cannode.md)) can use the
 [CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) parameter to set a static node ID.
-Set it to 0 (default) for dynamic allocation, or to a value between 1-127 to use a specific static node ID.
+Set it to 0 (default) for dynamic allocation, or to a value between 1-125 to use a specific static node ID.
 :::
 
 :::warning
@@ -300,7 +300,7 @@ For example, the screenshot below shows the parameters for a CAN GPS with node i
 
 Common CANNODE parameters that you can configure include:
 
-- [CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID): Set a static node ID (1-127) or use 0 for dynamic allocation. See [PX4 DroneCAN Firmware > Static Node ID](px4_cannode_fw.md#static-node-id) for more information.
+- [CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID): Set a static node ID (1-125) or use 0 for dynamic allocation. See [PX4 DroneCAN Firmware > Static Node ID](px4_cannode_fw.md#static-node-id) for more information.
 - [CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM): Enable CAN bus termination on the last node in the bus.
 
 ## Device Specific Setup

--- a/docs/en/dronecan/px4_cannode_fw.md
+++ b/docs/en/dronecan/px4_cannode_fw.md
@@ -29,7 +29,7 @@ However, you can configure a static node ID using the [CANNODE_NODE_ID](../advan
 
 To configure a static node ID:
 
-1. Set [CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) to a value between 1-127 using [QGroundControl](index.md#qgc-cannode-parameter-configuration)
+1. Set [CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) to a value between 1-125 using [QGroundControl](index.md#qgc-cannode-parameter-configuration)
 2. Reboot the device
 
 To return to dynamic allocation, set `CANNODE_NODE_ID` back to 0.

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -837,13 +837,18 @@ extern "C" int uavcannode_start(int argc, char *argv[])
 		valid = bootloader_app_shared_read(&shared, BootLoader);
 	}
 
-	if (valid == 0 && shared.bus_speed > 0) {
+	// Consume the region even when the handoff is rejected below: on boards
+	// booted by a non-PX4 bootloader nothing else ever invalidates it
+	if (valid == 0) {
+		bootloader_app_shared_invalidate();
+	}
+
+	// Trust the handoff only if it carries a plausible bitrate (CANNODE_BITRATE
+	// minimum), healing regions poisoned by firmware running previous code
+	if (valid == 0 && shared.bus_speed >= 20000) {
 
 		bitrate = shared.bus_speed;
 		node_id = shared.node_id;
-
-		// Invalidate to prevent deja vu
-		bootloader_app_shared_invalidate();
 
 	} else {
 		// Node ID
@@ -867,7 +872,7 @@ extern "C" int uavcannode_start(int argc, char *argv[])
 	param_get(param_find("CANNODE_NODE_ID"), &cannode_node_id);
 
 	if (cannode_node_id < 0 || cannode_node_id > uavcan::NodeID::MaxRecommendedForRegularNodes) {
-		PX4_ERR("Invalid CANNODE_NODE_ID %" PRId32 ", using dynamic node ID allocation", cannode_node_id);
+		PX4_ERR("Invalid CANNODE_NODE_ID %" PRId32 ", ignoring", cannode_node_id);
 
 	} else if (cannode_node_id > 0) {
 		node_id = cannode_node_id;

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -360,7 +360,8 @@ int UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events
 {
 	_node.setName(board_get_uavcan_hw_name());
 
-	// Was the node_id supplied by the bootloader?
+	// Nonzero node_id came from the bootloader handoff or CANNODE_NODE_ID;
+	// zero means dynamic node ID allocation runs in Run()
 
 	if (node_id != 0) {
 		_node.setNodeID(node_id);
@@ -836,7 +837,7 @@ extern "C" int uavcannode_start(int argc, char *argv[])
 		valid = bootloader_app_shared_read(&shared, BootLoader);
 	}
 
-	if (valid == 0) {
+	if (valid == 0 && shared.bus_speed > 0) {
 
 		bitrate = shared.bus_speed;
 		node_id = shared.node_id;
@@ -858,23 +859,19 @@ extern "C" int uavcannode_start(int argc, char *argv[])
 		}
 	}
 
-	// Use a static node ID if the parameter is set and in range
+	// CANNODE_NODE_ID == 0 (default) keeps dynamic node ID allocation, reusing an ID the
+	// bootloader may have already allocated. 1..125 sets a static node ID, overriding
+	// anything the bootloader negotiated. The bootloader never sees this parameter: it
+	// learns our node ID only through the firmware update handoff in cb_beginfirmware_update.
 	int32_t cannode_node_id = 0;
 	param_get(param_find("CANNODE_NODE_ID"), &cannode_node_id);
 
-	if (cannode_node_id < 0 || cannode_node_id > uavcan::NodeID::Max) {
-		PX4_ERR("Invalid static node ID %ld, using dynamic allocation", cannode_node_id);
-		node_id = 0;
+	if (cannode_node_id < 0 || cannode_node_id > uavcan::NodeID::MaxRecommendedForRegularNodes) {
+		PX4_ERR("Invalid CANNODE_NODE_ID %" PRId32 ", using dynamic node ID allocation", cannode_node_id);
 
-	} else {
+	} else if (cannode_node_id > 0) {
 		node_id = cannode_node_id;
 	}
-
-	// Persist the node ID for the bootloader
-	bootloader_app_shared_t shared_write = {};
-	shared_write.node_id = node_id;
-	shared_write.bus_speed = 0; // we always want to autobaud
-	bootloader_app_shared_write(&shared_write, BootLoader);
 
 	if (
 #if defined(SUPPORT_ALT_CAN_BOOTLOADER)

--- a/src/drivers/uavcannode/uavcannode_params.yaml
+++ b/src/drivers/uavcannode/uavcannode_params.yaml
@@ -5,10 +5,14 @@ parameters:
     CANNODE_NODE_ID:
       description:
         short: UAVCAN CAN node ID (0 for dynamic allocation)
+        long: |-
+          Set to 0 (default) to use dynamic node ID allocation (DNA).
+          Set to 1-125 to use a static node ID, which must be unique on the bus.
       type: int32
       default: 0
       min: 0
-      max: 127
+      max: 125
+      reboot_required: true
     CANNODE_BITRATE:
       description:
         short: UAVCAN CAN bus bitrate


### PR DESCRIPTION
Follow-up to #25669. The static node ID logic had two problems. The startup `bootloader_app_shared_write(..., BootLoader)` never reaches the bootloader: the bootloader only accepts App-signed data and unconditionally invalidates the shared region on every boot. Its only real consumer was uavcannode itself on a restart without a reset (`uavcannode stop`/`start`), where the persisted `bus_speed = 0` fails CAN driver init and leaves the node off the bus. Second, the parameter unconditionally overwrote the node ID handed over by the bootloader, so with the default value the node ran dynamic allocation twice on every boot (once in the bootloader, again in the app).

This makes the parameter the single source of node ID policy:

- 1-125 sets a static node ID, overriding anything the bootloader negotiated; 0 (default) keeps DNA and reuses the bootloader-allocated ID again instead of allocating twice
- the startup shared-memory write is removed; the app now writes shared memory only in `cb_beginfirmware_update`, which is how the bootloader inherits the static ID during firmware updates — no bootloader changes needed, fielded bootloaders are unaffected
- the bootloader handoff is ignored unless it carries a valid bitrate, healing shared regions written by firmware running the previous code
- param max is now 125 since 126/127 are conventionally reserved for debug tools (matches `UAVCAN_NODE_ID`); English docs updated to match

Compile-tested with `make ark_can-rtk-gps_default`, `make px4_fmu-v6x`, `make px4_sitl`. The boot/update/recovery flows were traced against the canbootloader sources; bench testing on a CAN node against a flight controller (static ID set, DNA default, and a firmware update with a static ID) is recommended.