### PR TITLE
fix(navigator): gate DO_CHANGE_ALTITUDE setpoint updates by mode

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -900,7 +900,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 
 	case vehicle_command_s::VEHICLE_CMD_DO_CHANGE_ALTITUDE: {
 			// Accept only in modes where the navigator handles altitude changes in-place.
-			// No mode switching: if the current mode doesn't support it, deny.
+			// No mode switching: if the current mode doesn't support it, temporarily reject.
 			const uint8_t nav_state = _vehicle_status.nav_state;
 
 			if (nav_state == vehicle_status_s::NAVIGATION_STATE_GUIDED_COURSE
@@ -908,7 +908,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 				cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED;
 
 			} else {
-				cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_DENIED;
+				cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED;
 			}
 		}
 		break;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -430,9 +430,11 @@ void Navigator::run()
 				// CMD_DO_REPOSITION is acknowledged by commander
 
 			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_CHANGE_ALTITUDE
-				   && _vstatus.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
-				// only update the setpoint if armed, as it otherwise won't get executed until the vehicle switches to loiter,
-				// which can lead to dangerous and unexpected behaviors (see loiter.cpp, there is an if(armed) in there too)
+				   && _vstatus.arming_state == vehicle_status_s::ARMING_STATE_ARMED
+				   && (_navigation_mode == &_course
+				       || _vstatus.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER)) {
+				// Only update the setpoint if armed and already in a mode that consumes it. Otherwise a later
+				// switch into Hold could execute a stale setpoint (loiter.cpp applies it within a 500ms window).
 
 				if (_navigation_mode == &_course) {
 					// In course mode, update altitude directly (after geofence check)


### PR DESCRIPTION
### Solved Problem
`MAV_CMD_DO_CHANGE_ALTITUDE` could update Navigator's `reposition_triplet` while the vehicle was armed but not in a mode that consumes that setpoint immediately, for example Mission or RTL.

If the vehicle switched to Hold within Loiter's 500 ms freshness window, the stale altitude setpoint could be consumed even though Commander denies `DO_CHANGE_ALTITUDE` outside Guided Course and Hold.

### Solution
Gate Navigator handling of `MAV_CMD_DO_CHANGE_ALTITUDE` to the modes that can consume it immediately:

- Guided Course: update the course altitude directly.
- Hold/Loiter: update the Hold reposition setpoint.

This mirrors the stale-setpoint protection already applied to `DO_REPOSITION`.

### Changelog Entry
For release notes:
```text
Bugfix: prevent stale DO_CHANGE_ALTITUDE setpoints from being applied when switching to Hold
```

### Test coverage

Reproduced in SITL by sending `MAV_CMD_DO_CHANGE_ALTITUDE` while armed in RTL, then switching to Hold within 500 ms and observing that the stale altitude setpoint was applied before the fix.

reproduction script:
https://gist.github.com/AkaiEurus/a4ae0a8cdaf257926a1c59e9522dc677

log before patch:
https://logs.px4.io/plot_app?log=6f0b4a55-5c9f-43bc-8331-2ae4ee3f036c

log after patch:
https://logs.px4.io/plot_app?log=38135ebd-9ded-47cc-b497-a03aa7ab605e