### PR TITLE
fix(mavlink): reject unsupported CONDITION_DISTANCE missions

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1644,7 +1644,6 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 		case MAV_CMD_NAV_RETURN_TO_LAUNCH:
 		case MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET:
 		case MAV_CMD_DO_SET_ROI_NONE:
-		case MAV_CMD_CONDITION_DISTANCE:
 		case MAV_CMD_DO_SET_ACTUATOR:
 		case MAV_CMD_DO_AUTOTUNE_ENABLE:
 		case MAV_CMD_COMPONENT_ARM_DISARM:


### PR DESCRIPTION
### Solved Problem

`MAV_CMD_CONDITION_DISTANCE` was accepted on mission upload but PX4 has no navigator support for it, causing a later `unsupported cmd: 114` rejection.

Introduced in [`ed8cb1c5a7`](https://github.com/PX4/PX4-Autopilot/commit/ed8cb1c5a7458e774556b98ed624b36ea323008f); unlike the related gate support in [`b405c7e9b`](https://github.com/PX4/PX4-Autopilot/commit/b405c7e9bd8e773041582b5c0d72ec053b7e2e79), `CONDITION_DISTANCE` was never implemented.

### Changelog Entry

For release notes:
```text
Bugfix: Reject unsupported MAV_CMD_CONDITION_DISTANCE mission items during upload
```