### PR TITLE
fix(flight_mode_manager): initialize smoothing with current acceleration

### DIFF
--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
@@ -52,7 +52,12 @@ bool FlightTaskManualAcceleration::activate(const trajectory_setpoint_s &last_se
 		_stick_acceleration_xy.resetVelocity(_velocity.xy());
 	}
 
-	_stick_acceleration_xy.resetAcceleration(Vector2f(last_setpoint.acceleration));
+	if (Vector2f(last_setpoint.acceleration).isAllFinite()) {
+		_stick_acceleration_xy.resetAcceleration(Vector2f(last_setpoint.acceleration));
+
+	} else {
+		_stick_acceleration_xy.resetAcceleration(_acceleration.xy());
+	}
 
 	return ret;
 }

--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
@@ -53,8 +53,8 @@ bool FlightTaskManualAltitudeSmoothVel::activate(const trajectory_setpoint_s &la
 	// If the velocity setpoint is unknown, set to the current velocity
 	float vz_sp_last = PX4_ISFINITE(last_setpoint.velocity[2]) ? last_setpoint.velocity[2] : _velocity(2);
 
-	// No acceleration estimate available, set to zero if the setpoint is NAN
-	float az_sp_last = PX4_ISFINITE(last_setpoint.acceleration[2]) ? last_setpoint.acceleration[2] : 0.f;
+	// If accel setpoint unknown, set to the current accel
+	float az_sp_last = PX4_ISFINITE(last_setpoint.acceleration[2]) ? last_setpoint.acceleration[2] : _acceleration(2);
 
 	_smoothing.reset(az_sp_last, vz_sp_last, z_sp_last);
 

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -197,8 +197,8 @@ bool FlightTaskOrbit::activate(const trajectory_setpoint_s &last_setpoint)
 		// If the velocity setpoint is unknown, set to the current velocity
 		if (!PX4_ISFINITE(vel_prev(i))) { vel_prev(i) = _velocity(i); }
 
-		// No acceleration estimate available, set to zero if the setpoint is NAN
-		if (!PX4_ISFINITE(accel_prev(i))) { accel_prev(i) = 0.f; }
+		// If accel setpoint unknown, set to the current accel
+		if (!PX4_ISFINITE(accel_prev(i))) { accel_prev(i) = _acceleration(i); }
 	}
 
 	_position_smoothing.reset(accel_prev, vel_prev, pos_prev);
@@ -219,7 +219,7 @@ bool FlightTaskOrbit::update()
 			_in_circle_approach = false;
 			_slew_rate_velocity.setForcedValue(0.f); // reset the slew rate when moving between orbits.
 			FlightTaskManualAltitudeSmoothVel::_smoothing.reset(
-				PX4_ISFINITE(_acceleration_setpoint(2)) ? _acceleration_setpoint(2) : 0.f,
+				PX4_ISFINITE(_acceleration_setpoint(2)) ? _acceleration_setpoint(2) : _acceleration(2),
 				PX4_ISFINITE(_velocity_setpoint(2)) ? _velocity_setpoint(2) : _velocity(2),
 				PX4_ISFINITE(_position_setpoint(2)) ? _position_setpoint(2) : _position(2));
 		}


### PR DESCRIPTION
### Solved Problem

#26254 introduced `_acceleration` and updated `FlightTaskAuto`, but other flight tasks still fell back to zero acceleration.

### Solution

Use `_acceleration` as the fallback in Orbit, ManualAltitudeSmoothVel, and ManualAcceleration.

### Changelog Entry

```text
Bugfix: Align flight task acceleration fallback with #26254
```

### Test Coverage

Validated in multicopter SITL with before/after ULogs. For each case I compared `trajectory_setpoint.acceleration[*]` with `vehicle_local_position.ax/ay/az` around the FlightTask switch point.

1. `ManualAltitudeSmoothVel::activate()`
   - Set `MPC_POS_MODE=4`.
   - Took off to a stable hover, switched to `STABILIZED`, applied vertical stick input to create a non-zero `vehicle_local_position.az`, then switched to `ALTCTL`.
   
  log before patch: https://logs.px4.io/plot_app?log=4a9e955e-e9a5-4942-a72a-18624371d7da
  
  log after patch: https://logs.px4.io/plot_app?log=94daeb66-81ec-4616-828d-ea0f48fac17f

2. `ManualAcceleration::activate()`
   - Set `MPC_POS_MODE=4`.
   - Took off to a stable hover, switched to `STABILIZED`, applied pitch/roll stick input to create non-zero `vehicle_local_position.ax/ay`, then switched to `POSCTL` while the vehicle was still accelerating horizontally.

  log before patch: https://logs.px4.io/plot_app?log=3a5a6161-e2d5-4069-bb83-1aa30ce34d5d
  
  log after patch: https://logs.px4.io/plot_app?log=096e588f-4e8a-4649-99ec-5e8bc799ffe8

3. `FlightTaskOrbit::activate()`
   - Set `MPC_POS_MODE=0`.
   - Took off to a stable hover in `POSCTL`, applied a short horizontal stick input/vertical stick input, then sent `MAV_CMD_DO_ORBIT`.

horizontal input:

log before patch: https://logs.px4.io/plot_app?log=50deadae-9f72-4813-be58-a23dda815d76

log after patch: https://logs.px4.io/plot_app?log=9bb01426-a4e7-4684-a4cd-0cadc0b67e7c

vertical input:

log before patch: https://logs.px4.io/plot_app?log=fcd86b5c-1935-4c0a-abc5-df788f6773fc

log after patch: https://logs.px4.io/plot_app?log=7a6163e4-5f71-4cbe-8ad4-2c1444462f41