### PR TITLE
docs(docs): serial passthrough

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -508,6 +508,7 @@
       - [I2C Bus](sensor_bus/i2c_development.md)
       - [UART/Serial Ports](uart/index.md)
         - [Port-Configurable Serial Drivers](uart/user_configurable_serial_driver.md)
+        - [Serial Passthrough (MAVLink SERIAL_CONTROL)](uart/serial_passthrough.md)
     - [RTK GPS (Integration)](advanced/rtk_gps.md)
     - [PPS Time Synchronization](advanced/pps_time_sync.md)
   - [Middleware](middleware/index.md)

--- a/docs/en/mavlink/security_hardening.md
+++ b/docs/en/mavlink/security_hardening.md
@@ -17,7 +17,7 @@ When MAVLink signing is not enabled, an attacker within communication range can:
 | Capability                   | MAVLink mechanism                                |
 | ---------------------------- | ------------------------------------------------ |
 | Execute shell commands       | `SERIAL_CONTROL` with `SERIAL_CONTROL_DEV_SHELL` |
-| Read/write arbitrary UART or ESC signal pin | `SERIAL_CONTROL` with [Serial Passthrough](../uart/serial_passthrough.md) |
+| Read/write arbitrary UART pin| `SERIAL_CONTROL`                                 |
 | Read, write, or delete files | MAVLink FTP protocol                             |
 | Change any flight parameter  | `PARAM_SET` / `PARAM_EXT_SET`                    |
 | Upload or overwrite missions | Mission protocol                                 |

--- a/docs/en/mavlink/security_hardening.md
+++ b/docs/en/mavlink/security_hardening.md
@@ -17,6 +17,7 @@ When MAVLink signing is not enabled, an attacker within communication range can:
 | Capability                   | MAVLink mechanism                                |
 | ---------------------------- | ------------------------------------------------ |
 | Execute shell commands       | `SERIAL_CONTROL` with `SERIAL_CONTROL_DEV_SHELL` |
+| Read/write arbitrary UART or ESC signal pin | `SERIAL_CONTROL` with [Serial Passthrough](../uart/serial_passthrough.md) |
 | Read, write, or delete files | MAVLink FTP protocol                             |
 | Change any flight parameter  | `PARAM_SET` / `PARAM_EXT_SET`                    |
 | Upload or overwrite missions | Mission protocol                                 |

--- a/docs/en/mavlink/security_hardening.md
+++ b/docs/en/mavlink/security_hardening.md
@@ -14,17 +14,17 @@ Without message signing enabled, any device that can send MAVLink messages to th
 
 When MAVLink signing is not enabled, an attacker within communication range can:
 
-| Capability                   | MAVLink mechanism                                |
-| ---------------------------- | ------------------------------------------------ |
-| Execute shell commands       | `SERIAL_CONTROL` with `SERIAL_CONTROL_DEV_SHELL` |
-| Read/write arbitrary UART pin| `SERIAL_CONTROL`                                 |
-| Read, write, or delete files | MAVLink FTP protocol                             |
-| Change any flight parameter  | `PARAM_SET` / `PARAM_EXT_SET`                    |
-| Upload or overwrite missions | Mission protocol                                 |
-| Arm or disarm motors         | `MAV_CMD_COMPONENT_ARM_DISARM`                   |
-| Terminate flight (crash)     | `MAV_CMD_DO_FLIGHTTERMINATION`                   |
-| Trigger emergency landing    | Spoofed `BATTERY_STATUS`                         |
-| Reboot the vehicle           | `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN`              |
+| Capability                    | MAVLink mechanism                                |
+| ----------------------------- | ------------------------------------------------ |
+| Execute shell commands        | `SERIAL_CONTROL` with `SERIAL_CONTROL_DEV_SHELL` |
+| Read/write arbitrary UART pin | `SERIAL_CONTROL`                                 |
+| Read, write, or delete files  | MAVLink FTP protocol                             |
+| Change any flight parameter   | `PARAM_SET` / `PARAM_EXT_SET`                    |
+| Upload or overwrite missions  | Mission protocol                                 |
+| Arm or disarm motors          | `MAV_CMD_COMPONENT_ARM_DISARM`                   |
+| Terminate flight (crash)      | `MAV_CMD_DO_FLIGHTTERMINATION`                   |
+| Trigger emergency landing     | Spoofed `BATTERY_STATUS`                         |
+| Reboot the vehicle            | `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN`              |
 
 All of these are standard MAVLink capabilities used by ground control stations.
 Without signing, there is no distinction between a legitimate GCS and an unauthorized sender.

--- a/docs/en/peripherals/dshot.md
+++ b/docs/en/peripherals/dshot.md
@@ -144,3 +144,15 @@ PX4 can read and write AM32 ESC firmware settings (EEPROM) via a ground station,
 PX4 automatically reads the full EEPROM from each ESC on boot.
 The ground station can then display individual settings and allow the user to modify them.
 Changes are written back to the ESC one byte at a time using the DShot programming protocol.
+
+## ESC Serial Passthrough (Bitbang UART)
+
+PX4 supports direct UART communication through an ESC signal pin using a software bit-bang UART.
+This allows a ground station or companion computer to talk to ESC configuration tools (e.g. BLHeli Suite, AM32 configurator) over MAVLink, without any additional wiring.
+
+::: warning
+The `PASSTHRU_EN` parameter must be set to `1` (and the vehicle rebooted) before using ESC bitbang passthrough.
+This **disables DShot and PWM output** at boot.
+:::
+
+See [Serial Passthrough (MAVLink SERIAL_CONTROL)](../uart/serial_passthrough.md) for full configuration details.

--- a/docs/en/peripherals/dshot.md
+++ b/docs/en/peripherals/dshot.md
@@ -145,14 +145,18 @@ PX4 automatically reads the full EEPROM from each ESC on boot.
 The ground station can then display individual settings and allow the user to modify them.
 Changes are written back to the ESC one byte at a time using the DShot programming protocol.
 
-## ESC Serial Passthrough (Bitbang UART)
+## ESC Serial Passthrough
+
+<Badge type="tip" text="PX4 v1.18" />
 
 PX4 supports direct UART communication through an ESC signal pin using a software bit-bang UART.
-This enables ESC configuration tools (e.g. *BLHeli Suite*, *AM32 configurator*) to communicate with the ESC using UART over Mavlink - provided a MAVLink↔UART bridge is available on the ground station or companion computer side.
+This enables ESC configuration tools, such as _BLHeli Suite_ and the _AM32 configurator_, to communicate with the ESC using UART over MAVLink.
+Note that a MAVLink-to-UART bridge is required on the ground station or companion computer side (you'll need to write your own).
 
 ::: warning
 The `PASSTHRU_EN` parameter must be set to `1` (and the vehicle rebooted) before using ESC bitbang passthrough.
-This **disables DShot and PWM output** at boot. After the next reboot, `PASSTHRU_EN` automatically resets to `0` thereby restoring normal DShot/PWM operation.
+This **disables DShot and PWM output** at boot.
+After the next reboot, `PASSTHRU_EN` automatically resets to `0`, thereby restoring normal DShot/PWM operation.
 :::
 
 See [Serial Passthrough (MAVLink SERIAL_CONTROL)](../uart/serial_passthrough.md) for full configuration details.

--- a/docs/en/peripherals/dshot.md
+++ b/docs/en/peripherals/dshot.md
@@ -51,7 +51,7 @@ The ESCs should initialize and the motors turn in the correct directions.
 ## ESC Commands {#commands}
 
 Commands can be sent to the ESC via the [MAVLink shell](../debug/mavlink_shell.md).
-See [here](../modules/modules_driver.md#dshot) for a full reference of the supported commands.
+See the [`dshot` module](../modules/modules_driver.md#dshot) for a full reference of the supported commands.
 
 ## ESC Telemetry
 
@@ -145,6 +145,8 @@ PX4 automatically reads the full EEPROM from each ESC on boot.
 The ground station can then display individual settings and allow the user to modify them.
 Changes are written back to the ESC one byte at a time using the DShot programming protocol.
 
+<!-- Section below commented out until serial passthrough bridge productised: https://github.com/PX4/PX4-Autopilot/pull/27654#discussion_r3434404781 -->
+<!--
 ## ESC Serial Passthrough
 
 <Badge type="tip" text="PX4 v1.18" />
@@ -160,3 +162,4 @@ After the next reboot, `PASSTHRU_EN` automatically resets to `0`, thereby restor
 :::
 
 See [Serial Passthrough (MAVLink SERIAL_CONTROL)](../uart/serial_passthrough.md) for full configuration details.
+-->

--- a/docs/en/peripherals/dshot.md
+++ b/docs/en/peripherals/dshot.md
@@ -148,11 +148,11 @@ Changes are written back to the ESC one byte at a time using the DShot programmi
 ## ESC Serial Passthrough (Bitbang UART)
 
 PX4 supports direct UART communication through an ESC signal pin using a software bit-bang UART.
-This allows a ground station or companion computer to talk to ESC configuration tools (e.g. BLHeli Suite, AM32 configurator) over MAVLink, without any additional wiring.
+This enables ESC configuration tools (e.g. *BLHeli Suite*, *AM32 configurator*) to communicate with the ESC using UART over Mavlink - provided a MAVLink↔UART bridge is available on the ground station or companion computer side.
 
 ::: warning
 The `PASSTHRU_EN` parameter must be set to `1` (and the vehicle rebooted) before using ESC bitbang passthrough.
-This **disables DShot and PWM output** at boot.
+This **disables DShot and PWM output** at boot. After the next reboot, `PASSTHRU_EN` automatically resets to `0` thereby restoring normal DShot/PWM operation.
 :::
 
 See [Serial Passthrough (MAVLink SERIAL_CONTROL)](../uart/serial_passthrough.md) for full configuration details.

--- a/docs/en/releases/1.18.md
+++ b/docs/en/releases/1.18.md
@@ -60,7 +60,9 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
   | `COM_OBC_LOSS_T`   | Timeout for missing heartbeats from the onboard computer is always 5 seconds (was the default). ([PX4-Autopilot#27261](https://github.com/PX4/PX4-Autopilot/pull/27261))                                                                          |
   | `COM_LKDOWN_TKO`   | Takeoff failure detection always runs for 3 seconds (was the default). ([PX4-Autopilot#27262](https://github.com/PX4/PX4-Autopilot/pull/27262))                                                                                                   |
 
-- [Serial Passthrough (MAVLink SERIAL_CONTROL)](../uart/serial_passthrough.md): new `serialpassthrough` driver enables MAVLink clients to read from and write to FC serial ports (TEL1/2, GPS1/2, TEL3/4) and, on STM32F7/H7 boards, ESC signal pins via a software bit-bang UART (device IDs 20–27). To use this with an ESC configuration tool (e.g. *BLHeli Suite*, *AM32 configurator*), a bridge application is required on the ground station or companion computer side — it connects over MAVLink, exposes a virtual serial port to the tool, and translates traffic bidirectionally. Set `PASSTHRU_EN=1` and reboot before using ESC bitbang mode; the parameter auto-resets after the following reboot to restore normal DShot/PWM output.
+- [Serial Passthrough (MAVLink SERIAL_CONTROL)](../uart/serial_passthrough.md): new `serialpassthrough` driver enables MAVLink clients to read from and write to FC serial ports (TEL1/2, GPS1/2, TEL3/4).
+  On STM32F7/H7 boards, ESC signal pins can also be written via a software bit-bang UART (device IDs 20–27): note that a bridge application is also required, so this functionality is not usable out of the box.
+  ([PX4-Autopilot#27605: feat(drivers): implemented serial passthrough](https://github.com/PX4/PX4-Autopilot/pull/27605)).
 
 ### Control
 

--- a/docs/en/releases/1.18.md
+++ b/docs/en/releases/1.18.md
@@ -60,6 +60,8 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
   | `COM_OBC_LOSS_T`   | Timeout for missing heartbeats from the onboard computer is always 5 seconds (was the default). ([PX4-Autopilot#27261](https://github.com/PX4/PX4-Autopilot/pull/27261))                                                                          |
   | `COM_LKDOWN_TKO`   | Takeoff failure detection always runs for 3 seconds (was the default). ([PX4-Autopilot#27262](https://github.com/PX4/PX4-Autopilot/pull/27262))                                                                                                   |
 
+- [Serial Passthrough (MAVLink SERIAL_CONTROL)](../uart/serial_passthrough.md): new `serialpassthrough` driver enables MAVLink clients to read from and write to FC serial ports (TEL1/2, GPS1/2, TEL3/4) and, on STM32F7/H7 boards, ESC signal pins via a software bit-bang UART (device IDs 20–27). To use this with an ESC configuration tool (e.g. *BLHeli Suite*, *AM32 configurator*), a bridge application is required on the ground station or companion computer side — it connects over MAVLink, exposes a virtual serial port to the tool, and translates traffic bidirectionally. Set `PASSTHRU_EN=1` and reboot before using ESC bitbang mode; the parameter auto-resets after the following reboot to restore normal DShot/PWM output.
+
 ### Control
 
 - Added new flight mode(s): [Altitude Cruise (MC)](../flight_modes_mc/altitude_cruise.md), Altitude Cruise (FW).

--- a/docs/en/uart/index.md
+++ b/docs/en/uart/index.md
@@ -3,3 +3,4 @@
 This section contains topics about the serial bus and serial drivers:
 
 - [Making Serial Port Drivers User-Configurable](../uart/user_configurable_serial_driver.md)
+- [Serial Passthrough (MAVLink SERIAL_CONTROL)](../uart/serial_passthrough.md)

--- a/docs/en/uart/serial_passthrough.md
+++ b/docs/en/uart/serial_passthrough.md
@@ -1,46 +1,28 @@
 # Serial Passthrough (MAVLink SERIAL_CONTROL)
 
-Serial Passthrough is a driver that bridges a MAVLink link to a hardware UART or an ESC signal pin,
-using the MAVLink [SERIAL_CONTROL](https://mavlink.io/en/messages/common.html#SERIAL_CONTROL) message.
-It allows a GCS, companion computer, or any MAVLink-speaking client to transparently read from and write to a serial device on the flight controller without any additional infrastructure.
+Serial Passthrough allows a MAVLink client to read from and write to selected FC serial interfaces using [SERIAL_CONTROL](https://mavlink.io/en/messages/common.html#SERIAL_CONTROL).
+It can be used with normal UART ports and, on supported boards, ESC signal pins.
 
-## How It Works
+Typical use cases include ESC configuration tools and debugging serial peripherals over a telemetry link.
 
-The driver maintains two thread-safe byte buffers and one dedicated OS task per device.
+## Overview
 
-Data flow:
-
-```
-GCS ──SERIAL_CONTROL──► MavlinkReceiver ──pushFromMavlink()──► [rx buffer] ──► UART / ESC pin
-GCS ◄─SERIAL_CONTROL(REPLY)─ Mavlink loop ◄─popToMavlink()─── [tx buffer] ◄── UART / ESC pin
-```
-
-1. When a `SERIAL_CONTROL` message arrives on any MAVLink channel the receiver
-   calls `SerialPassthrough::startForDevice()` to lazily start a task for that
-   device if none is running yet, then pushes the payload bytes into the
-   driver's receive buffer.
-2. The driver task drains the receive buffer to the UART (or ESC pin) and
-   reads any reply bytes back into its transmit buffer.
-3. The MAVLink main loop drains the transmit buffer and sends back a
-   `SERIAL_CONTROL` message with the `FLAG_REPLY` flag set, directed at the
-   original sender.
-
-Up to 8 passthrough instances can run simultaneously, one per device.
-Only a single sender per instance is supported at a time.
-Simultaneous `SERIAL_CONTROL` messages from different senders produce undefined behaviour.
+For most users, passthrough is automatic.
+When SERIAL_CONTROL traffic is sent to a supported target, PX4 starts handling that target and returns reply data over MAVLink.
+You can also start and stop passthrough manually from the PX4 shell.
 
 ## Device IDs
 
 The `device` field of `SERIAL_CONTROL` selects the target:
 
-| Device ID | Target |
-| --------- | ------ |
-| `0`       | TEL1   |
-| `1`       | TEL2   |
-| `2`       | GPS1   |
-| `3`       | GPS2   |
-| `4`       | TEL3   |
-| `5`       | TEL4   |
+| Device ID | Target                  |
+| --------- | ----------------------- |
+| `0`       | TEL1                    |
+| `1`       | TEL2                    |
+| `2`       | GPS1                    |
+| `3`       | GPS2                    |
+| `4`       | TEL3                    |
+| `5`       | TEL4                    |
 | `20`      | ESC channel 0 (bitbang) |
 | `21`      | ESC channel 1 (bitbang) |
 | `22`      | ESC channel 2 (bitbang) |
@@ -95,34 +77,14 @@ the bitbang driver and the DShot/PWM driver cannot share the same ESC signal pin
 Setting `PASSTHRU_EN=1` disables motor control.
 :::
 
-## Usage
 
-The driver starts automatically on the first `SERIAL_CONTROL` message received for a given device.
-Manual control is available via the PX4 shell:
+## Bridge Application
 
-```sh
-# Start manually on a UART at 115200 baud
-serialpassthrough start -d /dev/ttyS1 -b 115200
-
-# Start on ESC channel 0 via bitbang at 19200 baud
-serialpassthrough start -e 0 -b 19200
-
-# Show all running instances
-serialpassthrough status
-
-# Stop all instances
-serialpassthrough stop
-```
-
-### Options
-
-| Flag | Argument | Description |
-| ---- | -------- | ----------- |
-| `-d` | `<path>` | Serial device path (e.g. `/dev/ttyS1`) |
-| `-b` | `<baud>` | Baud rate (default 115200) |
-| `-e` | `0`–`7`  | ESC bitbang channel, instead of `-d` |
-| `-x` |          | Swap RX/TX pins |
-| `-s` |          | Single-wire (half-duplex) mode |
+PX4 does not yet ship a ready-made tool for using Serial Passthrough with common ESC configuration or firmware flashing tools.
+To integrate it, a bridge application connects to the vehicle over MAVLink, exposes a virtual serial port (e.g. a Unix PTY) to the tool on the host, and translates traffic bidirectionally: data written to the PTY is sent as `SERIAL_CONTROL` messages with `SERIAL_CONTROL_FLAG_RESPOND | SERIAL_CONTROL_FLAG_EXCLUSIVE` set, and incoming `SERIAL_CONTROL` reply messages (with `FLAG_REPLY` set) are written back to the PTY.
+To initialise the passthrough, the bridge should send one `SERIAL_CONTROL` message with the target device ID, the desired UART baud rate in the `baudrate` field, and `count=0` (no payload), then wait approximately 2 seconds for PX4 to spawn the passthrough task before sending real traffic.
+For ESC bitbang mode (device IDs 20–27), the bridge must first set `PASSTHRU_EN=1` via `PARAM_SET`, confirm the `PARAM_VALUE` acknowledgement, send `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN`, and wait for the FMU heartbeat to return before sending the init message — this ensures the DShot/PWM drivers are not running when the bitbang driver takes over the ESC signal pins.
+We developed such a bridge internally and may upstream it in a future release.
 
 ## Limitations
 

--- a/docs/en/uart/serial_passthrough.md
+++ b/docs/en/uart/serial_passthrough.md
@@ -69,12 +69,13 @@ When `PASSTHRU_EN` is set to `1` (and the vehicle rebooted), the normal motor ou
 This is required when you intend to use the ESC bitbang passthrough mode, because
 the bitbang driver and the DShot/PWM driver cannot share the same ESC signal pins.
 
-| Parameter    | Description |
-| ------------ | ----------- |
-| `PASSTHRU_EN` | Set to `1` to suppress normal ESC output drivers at boot. Requires reboot. |
+| Parameter     | Description |
+| ------------- | ----------- |
+| `PASSTHRU_EN` | Set to `1` to suppress normal ESC output drivers at boot. Requires reboot. Automatically resets to `0` after the next reboot, restoring normal DShot/PWM operation. |
 
 ::: warning
 Setting `PASSTHRU_EN=1` disables motor control.
+The parameter auto-resets to `0` on the following reboot, so DShot/PWM output is automatically restored after power cycling.
 :::
 
 
@@ -88,7 +89,7 @@ We developed such a bridge internally and may upstream it in a future release.
 
 ## Limitations
 
-- **One sender at a time:** only the MAVLink channel that sent the most recent `SERIAL_CONTROL` message receives replies.
+- **Single sender:** only one MAVLink sender is supported at a time. A single sender can communicate with multiple ports simultaneously, but replies are always routed back to the MAVLink channel that sent the most recent `SERIAL_CONTROL` message, so concurrent senders could interfere with each other's replies.
 - **ESC bitbang baud rate:** maximum reliable baud rate is 19200.
   Higher rates may work but are not guaranteed.
 - **ESC channel exclusivity:** only one ESC bitbang channel can be active at a time.

--- a/docs/en/uart/serial_passthrough.md
+++ b/docs/en/uart/serial_passthrough.md
@@ -2,20 +2,23 @@
 
 <Badge type="tip" text="PX4 v1.18" />
 
-Serial Passthrough allows a MAVLink client to read from and write to selected FC serial interfaces using [SERIAL_CONTROL](https://mavlink.io/en/messages/common.html#SERIAL_CONTROL).
-It can be used with normal UART ports and, on supported boards, ESC signal pins.
-
+Serial Passthrough allows a MAVLink client to read from and write to selected flight controller serial interfaces using the [SERIAL_CONTROL](https://mavlink.io/en/messages/common.html#SERIAL_CONTROL) message.
 Typical use cases include: providing a direct serial channel for ESC configuration tools, and debugging serial peripherals over a telemetry link.
 
-## Overview
+Two cases are supported:
 
-For most users, passthrough is automatic.
-When `SERIAL_CONTROL` traffic is sent to a supported target, PX4 starts handling that target and returns reply data over MAVLink.
+- Control of normal ports, such as telemetry or GPS ports.
+  This works automatically as long as the [`serialpassthrough` driver](../modules/modules_driver.md#serialpassthrough) is present in firmware.
+- Control of ESC signal pins on STM32F7/H7 boards via a bit-bang UART implemented in software.
+  This requires additional configuration.
+
+When serial control is enabled/supported, passthrough is automatic.
+If `SERIAL_CONTROL` traffic is sent to a supported target, PX4 starts handling that target and returns reply data over MAVLink.
 You can also start and stop passthrough manually from the PX4 shell.
 
 ## Device IDs
 
-The `SERIAL_CONTROL.device` selects the target UART.
+The `SERIAL_CONTROL.device` field selects the target UART that is to be controlled.
 The following device IDs are allowed (note that this is a subset of the IDs specified in [SERIAL_CONTROL_DEV](https://mavlink.io/en/messages/common.html#SERIAL_CONTROL_DEV)):
 
 | Device ID | Target                              |
@@ -38,10 +41,22 @@ The following device IDs are allowed (note that this is a subset of the IDs spec
 The UART device path for each port (e.g. `/dev/ttyS1`) is taken from the board's corresponding Kconfig symbols, such as `CONFIG_BOARD_SERIAL_TEL1`, `CONFIG_BOARD_SERIAL_GPS1`, and so on.
 If the used device ID is not configured on the board, the driver logs a warning and rejects the message.
 
+## UART Control
+
+Normal UARTs such as those for telemetry and GPS are targeted using device IDs 0 to 5.
+
+This feature requires only that the [`serialpassthrough` driver](../modules/modules_driver.md#serialpassthrough) is present in firmware (the KConfig key `CONFIG_DRIVERS_SERIALPASSTHROUGH=y` must be set).
+Note that the `PASSTHRU_EN` parameter need not be set.
+
 ## ESC Channel Mode (Bitbang UART) {#bitbang}
 
+::: tip
+This feature is not yet useful because PX4 does not ship a ready-made tool for using serial passthrough with common ESC configuration or firmware flashing tools.
+Information on how such a tool might be developed is given below in [Bridge Application](#bridge-application).
+:::
+
 Device IDs 20–27 route through a software bit-bang UART on the ESC signal pin rather than a hardware UART.
-This is useful for communicating with ESCs that expose a UART telemetry or configuration port on their signal wire (e.g. BLHeli_32 passthrough, AM32, or ESC configuration tools).
+This is useful for communicating with ESCs that expose a UART telemetry or configuration port on their signal wire (such as BLHeli_32 passthrough, AM32, or ESC configuration tools).
 
 Bitbang UART is implemented using a hardware timer and direct GPIO toggling.
 Due to interrupt latency, reliable operation is only guaranteed up to **19200 baud**.
@@ -49,35 +64,10 @@ Due to interrupt latency, reliable operation is only guaranteed up to **19200 ba
 Because only one hardware timer is used, only one ESC channel can be active at a time.
 When a request arrives for a different ESC channel, the driver stops the current instance and waits up to 100 ms for it to exit before starting the new one.
 
-Bitbang UART support requires `CONFIG_SERIALPASSTHROUGH_BITBANG=y` and the timer is selected at build time with `CONFIG_UART_BITBANG_TIMER` (default TIM13).
+Bitbang UART support requires that both `CONFIG_DRIVERS_SERIALPASSTHROUGH=y` and `CONFIG_SERIALPASSTHROUGH_BITBANG=y` are set before building (the timer is selected with `CONFIG_UART_BITBANG_TIMER`, and defaults to `TIM13`).
+The `PASSTHRU_EN` parameter must be set to `1` and the device rebooted in order to enable this mode.
 
-## Configuration
-
-### Firmware Configuration (Build-Time)
-
-The driver is enabled via [Kconfig](../hardware/porting_guide_config.md).
-You will need to set the following keys in your board and then rebuild the firmware.
-
-```text
-CONFIG_DRIVERS_SERIALPASSTHROUGH=y # Enable the driver
-CONFIG_SERIALPASSTHROUGH_BITBANG=y # Optional: ESC channel support (NuttX & STM32 only)
-CONFIG_UART_BITBANG_TIMER=13       # Optional: timer instance (default TIM13)
-```
-
-### PX4 Configuration
-
-Set [PASSTHRU_EN](../advanced_config/parameter_reference.md#PASSTHRU_EN) to `1` and reboot the vehicle.
-
-This disables motor control after the reboot (the motor output drivers `dshot` and `pwm_out` are not started).
-This is required when you intend to use the ESC bitbang passthrough mode, because the bitbang driver and the DShot/PWM driver cannot share the same ESC signal pins.
-
-::: tip
-The parameter auto-resets to `0` on the following reboot, so DShot/PWM output is automatically restored after power cycling.
-:::
-
-## Bridge Application
-
-PX4 does not yet ship a ready-made tool for using Serial Passthrough with common ESC configuration or firmware flashing tools.
+### Bridge Application
 
 Developers can create their own bridge application if needed.
 This would connect to the vehicle over MAVLink, expose a virtual serial port (e.g. a Unix PTY) to the tool on the host, and translate traffic bidirectionally.
@@ -85,6 +75,37 @@ Data written to the PTY would be sent as `SERIAL_CONTROL` messages with `SERIAL_
 
 To initialise the passthrough, the bridge should send one `SERIAL_CONTROL` message with the target device ID, the desired UART baud rate in the `baudrate` field, and `count=0` (no payload), then wait approximately 2 seconds for PX4 to spawn the passthrough task before sending real traffic.
 For ESC bitbang mode (device IDs 20–27), the bridge must first set `PASSTHRU_EN=1` via `PARAM_SET`, confirm the `PARAM_VALUE` acknowledgement, send `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN`, and wait for the FMU heartbeat to return before sending the init message — this ensures the DShot/PWM drivers are not running when the bitbang driver takes over the ESC signal pins.
+
+## Configuration
+
+### Firmware Configuration (Build-Time)
+
+The driver is enabled via [Kconfig](../hardware/porting_guide_config.md).
+You will need to set the following key in your board:
+
+```text
+CONFIG_DRIVERS_SERIALPASSTHROUGH=y # Include the driver
+```
+
+If you want to use ESC channel targets you must also set the following keys:
+
+```text
+CONFIG_SERIALPASSTHROUGH_BITBANG=y # ESC channel support (NuttX & STM32 only)
+CONFIG_UART_BITBANG_TIMER=13       # Timer instance (default TIM13)
+```
+
+Then rebuild the firmware.
+
+### PX4 Configuration (ESC targets)
+
+For ESC channel targets (only) you must also set [PASSTHRU_EN](../advanced_config/parameter_reference.md#PASSTHRU_EN) to `1` and reboot the vehicle.
+
+This disables motor control after the reboot (the motor output drivers `dshot` and `pwm_out` are not started).
+This is required when you intend to use the ESC bitbang passthrough mode, because the bitbang driver and the DShot/PWM driver cannot share the same ESC signal pins.
+
+::: tip
+The parameter auto-resets to `0` on the following reboot, so DShot/PWM output is automatically restored after power cycling.
+:::
 
 ## Limitations
 

--- a/docs/en/uart/serial_passthrough.md
+++ b/docs/en/uart/serial_passthrough.md
@@ -1,0 +1,136 @@
+# Serial Passthrough (MAVLink SERIAL_CONTROL)
+
+Serial Passthrough is a driver that bridges a MAVLink link to a hardware UART or an ESC signal pin,
+using the MAVLink [SERIAL_CONTROL](https://mavlink.io/en/messages/common.html#SERIAL_CONTROL) message.
+It allows a GCS, companion computer, or any MAVLink-speaking client to transparently read from and write to a serial device on the flight controller without any additional infrastructure.
+
+## How It Works
+
+The driver maintains two thread-safe byte buffers and one dedicated OS task per device.
+
+Data flow:
+
+```
+GCS ──SERIAL_CONTROL──► MavlinkReceiver ──pushFromMavlink()──► [rx buffer] ──► UART / ESC pin
+GCS ◄─SERIAL_CONTROL(REPLY)─ Mavlink loop ◄─popToMavlink()─── [tx buffer] ◄── UART / ESC pin
+```
+
+1. When a `SERIAL_CONTROL` message arrives on any MAVLink channel the receiver
+   calls `SerialPassthrough::startForDevice()` to lazily start a task for that
+   device if none is running yet, then pushes the payload bytes into the
+   driver's receive buffer.
+2. The driver task drains the receive buffer to the UART (or ESC pin) and
+   reads any reply bytes back into its transmit buffer.
+3. The MAVLink main loop drains the transmit buffer and sends back a
+   `SERIAL_CONTROL` message with the `FLAG_REPLY` flag set, directed at the
+   original sender.
+
+Up to 8 passthrough instances can run simultaneously, one per device.
+Only a single sender per instance is supported at a time.
+Simultaneous `SERIAL_CONTROL` messages from different senders produce undefined behaviour.
+
+## Device IDs
+
+The `device` field of `SERIAL_CONTROL` selects the target:
+
+| Device ID | Target |
+| --------- | ------ |
+| `0`       | TEL1   |
+| `1`       | TEL2   |
+| `2`       | GPS1   |
+| `3`       | GPS2   |
+| `4`       | TEL3   |
+| `5`       | TEL4   |
+| `20`      | ESC channel 0 (bitbang) |
+| `21`      | ESC channel 1 (bitbang) |
+| `22`      | ESC channel 2 (bitbang) |
+| `23`      | ESC channel 3 (bitbang) |
+| `24`      | ESC channel 4 (bitbang) |
+| `25`      | ESC channel 5 (bitbang) |
+| `26`      | ESC channel 6 (bitbang) |
+| `27`      | ESC channel 7 (bitbang) |
+
+The UART device path for each port (e.g. `/dev/ttyS1`) is taken from the board's
+`CONFIG_BOARD_SERIAL_TEL1` / `CONFIG_BOARD_SERIAL_GPS1` / … Kconfig symbols.
+If a device ID is not configured on the board the driver logs a warning and rejects the request.
+
+## ESC Channel Mode (Bitbang UART)
+
+Device IDs 20–27 route through a software bit-bang UART on the ESC signal pin rather than a hardware UART.
+This is useful for communicating with ESCs that expose a UART telemetry or configuration port on their signal wire (e.g. BLHeli_32 passthrough, AM32, or ESC configuration tools).
+
+Bitbang UART is implemented using a hardware timer and direct GPIO toggling.
+Due to interrupt latency, reliable operation is only guaranteed up to **19200 baud**.
+
+Because only one hardware timer is used, only one ESC channel can be active at a time.
+When a request arrives for a different ESC channel the driver stops the current instance and waits up to 100 ms for it to exit before starting the new one.
+
+Bitbang UART support requires `CONFIG_SERIALPASSTHROUGH_BITBANG=y` and the timer
+is selected at build time with `CONFIG_UART_BITBANG_TIMER` (default TIM13).
+
+## Configuration
+
+### Build-Time
+
+The driver is enabled via Kconfig:
+
+```
+CONFIG_DRIVERS_SERIALPASSTHROUGH=y          # Enable the driver
+CONFIG_SERIALPASSTHROUGH_BITBANG=y          # Optional: ESC channel support (NuttX & STM32 only)
+CONFIG_UART_BITBANG_TIMER=13                # Optional: timer instance (default TIM13)
+```
+
+### PASSTHRU_EN Parameter
+
+When `PASSTHRU_EN` is set to `1` (and the vehicle rebooted), the normal motor output drivers
+(`dshot`, `pwm_out`) are **not started** at boot.
+This is required when you intend to use the ESC bitbang passthrough mode, because
+the bitbang driver and the DShot/PWM driver cannot share the same ESC signal pins.
+
+| Parameter    | Description |
+| ------------ | ----------- |
+| `PASSTHRU_EN` | Set to `1` to suppress normal ESC output drivers at boot. Requires reboot. |
+
+::: warning
+Setting `PASSTHRU_EN=1` disables motor control.
+:::
+
+## Usage
+
+The driver starts automatically on the first `SERIAL_CONTROL` message received for a given device.
+Manual control is available via the PX4 shell:
+
+```sh
+# Start manually on a UART at 115200 baud
+serialpassthrough start -d /dev/ttyS1 -b 115200
+
+# Start on ESC channel 0 via bitbang at 19200 baud
+serialpassthrough start -e 0 -b 19200
+
+# Show all running instances
+serialpassthrough status
+
+# Stop all instances
+serialpassthrough stop
+```
+
+### Options
+
+| Flag | Argument | Description |
+| ---- | -------- | ----------- |
+| `-d` | `<path>` | Serial device path (e.g. `/dev/ttyS1`) |
+| `-b` | `<baud>` | Baud rate (default 115200) |
+| `-e` | `0`–`7`  | ESC bitbang channel, instead of `-d` |
+| `-x` |          | Swap RX/TX pins |
+| `-s` |          | Single-wire (half-duplex) mode |
+
+## Limitations
+
+- **One sender at a time:** only the MAVLink channel that sent the most recent `SERIAL_CONTROL` message receives replies.
+- **ESC bitbang baud rate:** maximum reliable baud rate is 19200.
+  Higher rates may work but are not guaranteed.
+- **ESC channel exclusivity:** only one ESC bitbang channel can be active at a time.
+- **Platform:** bitbang UART is only available on NuttX with STM32F7/H7.
+  Requesting ESC bitbang on an unsupported platform returns an error.
+- **Buffer size:** each instance has a 1 kB receive and 1 kB transmit buffer.
+  Frames larger than 1 kB will be truncated with a warning logged.

--- a/docs/en/uart/serial_passthrough.md
+++ b/docs/en/uart/serial_passthrough.md
@@ -1,42 +1,44 @@
 # Serial Passthrough (MAVLink SERIAL_CONTROL)
 
+<Badge type="tip" text="PX4 v1.18" />
+
 Serial Passthrough allows a MAVLink client to read from and write to selected FC serial interfaces using [SERIAL_CONTROL](https://mavlink.io/en/messages/common.html#SERIAL_CONTROL).
 It can be used with normal UART ports and, on supported boards, ESC signal pins.
 
-Typical use cases include ESC configuration tools and debugging serial peripherals over a telemetry link.
+Typical use cases include: providing a direct serial channel for ESC configuration tools, and debugging serial peripherals over a telemetry link.
 
 ## Overview
 
 For most users, passthrough is automatic.
-When SERIAL_CONTROL traffic is sent to a supported target, PX4 starts handling that target and returns reply data over MAVLink.
+When `SERIAL_CONTROL` traffic is sent to a supported target, PX4 starts handling that target and returns reply data over MAVLink.
 You can also start and stop passthrough manually from the PX4 shell.
 
 ## Device IDs
 
-The `device` field of `SERIAL_CONTROL` selects the target:
+The `SERIAL_CONTROL.device` selects the target UART.
+The following device IDs are allowed (note that this is a subset of the IDs specified in [SERIAL_CONTROL_DEV](https://mavlink.io/en/messages/common.html#SERIAL_CONTROL_DEV)):
 
-| Device ID | Target                  |
-| --------- | ----------------------- |
-| `0`       | TEL1                    |
-| `1`       | TEL2                    |
-| `2`       | GPS1                    |
-| `3`       | GPS2                    |
-| `4`       | TEL3                    |
-| `5`       | TEL4                    |
-| `20`      | ESC channel 0 (bitbang) |
-| `21`      | ESC channel 1 (bitbang) |
-| `22`      | ESC channel 2 (bitbang) |
-| `23`      | ESC channel 3 (bitbang) |
-| `24`      | ESC channel 4 (bitbang) |
-| `25`      | ESC channel 5 (bitbang) |
-| `26`      | ESC channel 6 (bitbang) |
-| `27`      | ESC channel 7 (bitbang) |
+| Device ID | Target                              |
+| --------- | ----------------------------------- |
+| `0`       | TEL1                                |
+| `1`       | TEL2                                |
+| `2`       | GPS1                                |
+| `3`       | GPS2                                |
+| `4`       | TEL3                                |
+| `5`       | TEL4                                |
+| `20`      | ESC channel 0 ([bitbang](#bitbang)) |
+| `21`      | ESC channel 1 (bitbang)             |
+| `22`      | ESC channel 2 (bitbang)             |
+| `23`      | ESC channel 3 (bitbang)             |
+| `24`      | ESC channel 4 (bitbang)             |
+| `25`      | ESC channel 5 (bitbang)             |
+| `26`      | ESC channel 6 (bitbang)             |
+| `27`      | ESC channel 7 (bitbang)             |
 
-The UART device path for each port (e.g. `/dev/ttyS1`) is taken from the board's
-`CONFIG_BOARD_SERIAL_TEL1` / `CONFIG_BOARD_SERIAL_GPS1` / … Kconfig symbols.
-If a device ID is not configured on the board the driver logs a warning and rejects the request.
+The UART device path for each port (e.g. `/dev/ttyS1`) is taken from the board's corresponding Kconfig symbols, such as `CONFIG_BOARD_SERIAL_TEL1`, `CONFIG_BOARD_SERIAL_GPS1`, and so on.
+If the used device ID is not configured on the board, the driver logs a warning and rejects the message.
 
-## ESC Channel Mode (Bitbang UART)
+## ESC Channel Mode (Bitbang UART) {#bitbang}
 
 Device IDs 20–27 route through a software bit-bang UART on the ESC signal pin rather than a hardware UART.
 This is useful for communicating with ESCs that expose a UART telemetry or configuration port on their signal wire (e.g. BLHeli_32 passthrough, AM32, or ESC configuration tools).
@@ -45,55 +47,54 @@ Bitbang UART is implemented using a hardware timer and direct GPIO toggling.
 Due to interrupt latency, reliable operation is only guaranteed up to **19200 baud**.
 
 Because only one hardware timer is used, only one ESC channel can be active at a time.
-When a request arrives for a different ESC channel the driver stops the current instance and waits up to 100 ms for it to exit before starting the new one.
+When a request arrives for a different ESC channel, the driver stops the current instance and waits up to 100 ms for it to exit before starting the new one.
 
-Bitbang UART support requires `CONFIG_SERIALPASSTHROUGH_BITBANG=y` and the timer
-is selected at build time with `CONFIG_UART_BITBANG_TIMER` (default TIM13).
+Bitbang UART support requires `CONFIG_SERIALPASSTHROUGH_BITBANG=y` and the timer is selected at build time with `CONFIG_UART_BITBANG_TIMER` (default TIM13).
 
 ## Configuration
 
-### Build-Time
+### Firmware Configuration (Build-Time)
 
-The driver is enabled via Kconfig:
+The driver is enabled via [Kconfig](../hardware/porting_guide_config.md).
+You will need to set the following keys in your board and then rebuild the firmware.
 
+```text
+CONFIG_DRIVERS_SERIALPASSTHROUGH=y # Enable the driver
+CONFIG_SERIALPASSTHROUGH_BITBANG=y # Optional: ESC channel support (NuttX & STM32 only)
+CONFIG_UART_BITBANG_TIMER=13       # Optional: timer instance (default TIM13)
 ```
-CONFIG_DRIVERS_SERIALPASSTHROUGH=y          # Enable the driver
-CONFIG_SERIALPASSTHROUGH_BITBANG=y          # Optional: ESC channel support (NuttX & STM32 only)
-CONFIG_UART_BITBANG_TIMER=13                # Optional: timer instance (default TIM13)
-```
 
-### PASSTHRU_EN Parameter
+### PX4 Configuration
 
-When `PASSTHRU_EN` is set to `1` (and the vehicle rebooted), the normal motor output drivers
-(`dshot`, `pwm_out`) are **not started** at boot.
-This is required when you intend to use the ESC bitbang passthrough mode, because
-the bitbang driver and the DShot/PWM driver cannot share the same ESC signal pins.
+Set [PASSTHRU_EN](../advanced_config/parameter_reference.md#PASSTHRU_EN) to `1` and reboot the vehicle.
 
-| Parameter     | Description |
-| ------------- | ----------- |
-| `PASSTHRU_EN` | Set to `1` to suppress normal ESC output drivers at boot. Requires reboot. Automatically resets to `0` after the next reboot, restoring normal DShot/PWM operation. |
+This disables motor control after the reboot (the motor output drivers `dshot` and `pwm_out` are not started).
+This is required when you intend to use the ESC bitbang passthrough mode, because the bitbang driver and the DShot/PWM driver cannot share the same ESC signal pins.
 
-::: warning
-Setting `PASSTHRU_EN=1` disables motor control.
+::: tip
 The parameter auto-resets to `0` on the following reboot, so DShot/PWM output is automatically restored after power cycling.
 :::
-
 
 ## Bridge Application
 
 PX4 does not yet ship a ready-made tool for using Serial Passthrough with common ESC configuration or firmware flashing tools.
-To integrate it, a bridge application connects to the vehicle over MAVLink, exposes a virtual serial port (e.g. a Unix PTY) to the tool on the host, and translates traffic bidirectionally: data written to the PTY is sent as `SERIAL_CONTROL` messages with `SERIAL_CONTROL_FLAG_RESPOND | SERIAL_CONTROL_FLAG_EXCLUSIVE` set, and incoming `SERIAL_CONTROL` reply messages (with `FLAG_REPLY` set) are written back to the PTY.
+
+Developers can create their own bridge application if needed.
+This would connect to the vehicle over MAVLink, expose a virtual serial port (e.g. a Unix PTY) to the tool on the host, and translate traffic bidirectionally.
+Data written to the PTY would be sent as `SERIAL_CONTROL` messages with `SERIAL_CONTROL_FLAG_RESPOND | SERIAL_CONTROL_FLAG_EXCLUSIVE` set, and incoming `SERIAL_CONTROL` reply messages (with `FLAG_REPLY` set) would be written back to the PTY.
+
 To initialise the passthrough, the bridge should send one `SERIAL_CONTROL` message with the target device ID, the desired UART baud rate in the `baudrate` field, and `count=0` (no payload), then wait approximately 2 seconds for PX4 to spawn the passthrough task before sending real traffic.
 For ESC bitbang mode (device IDs 20–27), the bridge must first set `PASSTHRU_EN=1` via `PARAM_SET`, confirm the `PARAM_VALUE` acknowledgement, send `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN`, and wait for the FMU heartbeat to return before sending the init message — this ensures the DShot/PWM drivers are not running when the bitbang driver takes over the ESC signal pins.
-We developed such a bridge internally and may upstream it in a future release.
 
 ## Limitations
 
-- **Single sender:** only one MAVLink sender is supported at a time. A single sender can communicate with multiple ports simultaneously, but replies are always routed back to the MAVLink channel that sent the most recent `SERIAL_CONTROL` message, so concurrent senders could interfere with each other's replies.
+- **Single sender:** only one MAVLink sender is supported at a time.
+  A single sender can communicate with multiple ports simultaneously, but replies are always routed back to the MAVLink channel that sent the most recent `SERIAL_CONTROL` message.
+  This means that concurrent senders could interfere with each other's replies.
 - **ESC bitbang baud rate:** maximum reliable baud rate is 19200.
   Higher rates may work but are not guaranteed.
 - **ESC channel exclusivity:** only one ESC bitbang channel can be active at a time.
 - **Platform:** bitbang UART is only available on NuttX with STM32F7/H7.
-  Requesting ESC bitbang on an unsupported platform returns an error.
+  Requesting ESC bitbang on an unsupported platform logs an error.
 - **Buffer size:** each instance has a 1 kB receive and 1 kB transmit buffer.
   Frames larger than 1 kB will be truncated with a warning logged.


### PR DESCRIPTION
### Solved Problem

Documents the new `serialpassthrough` driver introduced in the companion
implementation PR: 
- https://github.com/PX4/PX4-Autopilot/pull/27605

### Solution

Added a new page `docs/en/uart/serial_passthrough.md` covering:

- What Serial Passthrough is and typical use cases
- The full `SERIAL_CONTROL` device ID mapping (TEL1–TEL4, GPS1/2, ESC channels 0–7)
- ESC signal pin (bitbang UART) mode: baud rate limit, single-channel exclusivity, STM32 platform requirement
- Build-time Kconfig options (`DRIVERS_SERIALPASSTHROUGH`, `SERIALPASSTHROUGH_BITBANG`, `UART_BITBANG_TIMER`)
- `PASSTHRU_EN` parameter and the safety requirement to remove propellers before enabling it
- Shell usage (`serialpassthrough start / stop / status`)
- A developer-facing note on how to implement a MAVLink-to-virtual-serial bridge, including the `count=0` init handshake and the ESC bitbang pre-flight sequence (`PASSTHRU_EN=1` → reboot → wait for heartbeat)
- Limitations (one sender, 19200 baud cap, single ESC channel, platform restriction, buffer size)

Also:
- Added page to `docs/en/SUMMARY.md` under *UART/Serial Ports*
- Added page link to `docs/en/uart/index.md`
- Added a cross-reference in `docs/en/peripherals/dshot.md` under *ESC Serial Passthrough (Bitbang UART)*
- Added `SERIAL_CONTROL` serial passthrough to the threat table in `docs/en/mavlink/security_hardening.md`

### Changelog Entry
Documentation: New page [serial_passthrough.md]  -  Serial Passthrough via MAVLink SERIAL_CONTROL (UART ports and ESC bitbang mode)
New parameter: PASSTHRU_EN


### Alternatives

N/A — this is purely additive documentation for an already-merged feature.

### Test coverage

Documentation only. The implementation is tested in the companion PR.

### Context

Companion implementation PR: https://github.com/PX4/PX4-Autopilot/pull/27605