### PR TITLE
fix(parameters): fix param_value_is_default float comparisoin

### DIFF
--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -377,7 +377,7 @@ bool param_value_is_default(param_t param)
 			}
 
 		case PARAM_TYPE_FLOAT: {
-				return user_config_value.f - runtime_default_value.f < FLT_EPSILON;
+				return fabsf(user_config_value.f - runtime_default_value.f) < FLT_EPSILON;
 			}
 		}
 	}


### PR DESCRIPTION
### Solved Problem

Approximate float equality was evaluated without wrapping in `fabsf`, so effectively it becomes `lhs < rhs`, completely the wrong semantics for comparing parameters to defaults. 

This went unnoticed for quite long because it affects only display: `param_value_is_default` is only used in a handful of places to decide whether or not to put a `+` before the param in console output to indicate that it differs from default. 

### Solution

`fabsf`

### Changelog Entry

```
Fix: Display issue where + was not always printed in front of float params that differ from default
```

