### PR TITLE
fix(navigator): fix FW takeoff loiter with negative coordinates

### DIFF
--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -82,9 +82,14 @@ Takeoff::on_active()
 					_mission_item.altitude = _loiter_altitude_msl;
 
 					mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
-					pos_sp_triplet->current.lat = PX4_ISFINITE(_loiter_position_lat_lon(0)) ?
+					const bool loiter_lat_valid = PX4_ISFINITE(_loiter_position_lat_lon(0))
+								      && fabs(_loiter_position_lat_lon(0)) > DBL_EPSILON;
+					const bool loiter_lon_valid = PX4_ISFINITE(_loiter_position_lat_lon(1))
+								      && fabs(_loiter_position_lat_lon(1)) > DBL_EPSILON;
+
+					pos_sp_triplet->current.lat = loiter_lat_valid ?
 								      _loiter_position_lat_lon(0) : _navigator->get_global_position()->lat;
-					pos_sp_triplet->current.lon = PX4_ISFINITE(_loiter_position_lat_lon(1)) ?
+					pos_sp_triplet->current.lon = loiter_lon_valid ?
 								      _loiter_position_lat_lon(1) : _navigator->get_global_position()->lon;
 					pos_sp_triplet->current.type = position_setpoint_s::SETPOINT_TYPE_LOITER;
 					pos_sp_triplet->current.cruising_speed = -1.f;

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -82,9 +82,9 @@ Takeoff::on_active()
 					_mission_item.altitude = _loiter_altitude_msl;
 
 					mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
-					pos_sp_triplet->current.lat = _loiter_position_lat_lon(0) > DBL_EPSILON ?
+					pos_sp_triplet->current.lat = PX4_ISFINITE(_loiter_position_lat_lon(0)) ?
 								      _loiter_position_lat_lon(0) : _navigator->get_global_position()->lat;
-					pos_sp_triplet->current.lon = _loiter_position_lat_lon(1) > DBL_EPSILON ?
+					pos_sp_triplet->current.lon = PX4_ISFINITE(_loiter_position_lat_lon(1)) ?
 								      _loiter_position_lat_lon(1) : _navigator->get_global_position()->lon;
 					pos_sp_triplet->current.type = position_setpoint_s::SETPOINT_TYPE_LOITER;
 					pos_sp_triplet->current.cruising_speed = -1.f;


### PR DESCRIPTION
### Solved Problem
Fixed-wing `MAV_CMD_NAV_TAKEOFF` stores the requested post-takeoff loiter latitude/longitude in a `NaN`-initialized vector, but validated it with `> DBL_EPSILON`. This incorrectly rejected valid negative coordinates, causing takeoff loiter targets in the southern or western hemisphere to be replaced with the current vehicle position.

### Solution
Use `PX4_ISFINITE()` to validate the stored loiter latitude and longitude, matching the `NaN` sentinel used by the member initialization and allowing valid negative coordinates.

### Changelog Entry
For release notes:
```
Bugfix: Fixed-wing takeoff loiter now correctly accepts negative latitude/longitude targets.
```

### Test coverage
Tested with fixed-wing SITL:

1. Start fixed-wing SITL:
   ```sh
   HEADLESS=1 make px4_sitl gz_rc_cessna
   ```

2. Send `MAV_CMD_NAV_TAKEOFF` with negative `param5` latitude and/or negative `param6` longitude.

3. Verify that after climbout, the fixed-wing loiter target keeps the requested negative latitude/longitude instead of falling back to the current vehicle position.

log before patch:
https://logs.px4.io/plot_app?log=3a5b3b52-7923-471a-b218-77b3c0ec77d1

log after patch:
https://logs.px4.io/plot_app?log=d5dc322c-1fb2-4a59-9aaa-5448cfb467b2