### PR TITLE
fix(boards): canhubk3 SD card config & initialization on LPSPI2 instead of LPSPI1

### DIFF
--- a/boards/nxp/mr-canhubk3/src/init.c
+++ b/boards/nxp/mr-canhubk3/src/init.c
@@ -46,7 +46,7 @@
 #include <px4_platform_common/init.h>
 #include <px4_platform/board_determine_hw_info.h>
 
-#if defined(CONFIG_S32K3XX_LPSPI1) && defined(CONFIG_MMCSD)
+#if defined(CONFIG_S32K3XX_LPSPI2) && defined(CONFIG_MMCSD)
 #include <nuttx/mmcsd.h>
 #endif
 
@@ -100,23 +100,23 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	board_determine_hw_info();
 
 
-#if defined(CONFIG_S32K3XX_LPSPI1) && defined(CONFIG_MMCSD)
-	/* LPSPI1 *****************************************************************/
+#if defined(CONFIG_S32K3XX_LPSPI2) && defined(CONFIG_MMCSD)
+	/* LPSPI2 *****************************************************************/
 
-	/* Configure LPSPI1 peripheral chip select */
+	/* Configure LPSPI2 peripheral chip select */
 
-	s32k3xx_pinconfig(PIN_LPSPI1_PCS);
+	s32k3xx_pinconfig(PIN_LPSPI2_PCS);
 
-	/* Initialize the SPI driver for LPSPI1 */
+	/* Initialize the SPI driver for LPSPI2 */
 
-	struct spi_dev_s *g_lpspi1 = s32k3xx_lpspibus_initialize(1);
+	struct spi_dev_s *g_lpspi2 = s32k3xx_lpspibus_initialize(2);
 
-	if (g_lpspi1 == NULL) {
-		spierr("ERROR: FAILED to initialize LPSPI1\n");
+	if (g_lpspi2 == NULL) {
+		spierr("ERROR: FAILED to initialize LPSPI2\n");
 		return -ENODEV;
 	}
 
-	rv = mmcsd_spislotinitialize(0, 0, g_lpspi1);
+	rv = mmcsd_spislotinitialize(0, 0, g_lpspi2);
 
 	if (rv < 0) {
 		mcerr("ERROR: Failed to bind SPI port %d to SD slot %d\n",


### PR DESCRIPTION


### Solved Problem
SD card not detected on the MR-CANHUBK3 with ADAP board (connected the SPI port on the ADAP to [P1B -SPI2 ](https://nxp.gitbook.io/mobilerobotics/flashing-guide/mr-canhubk3/connectors)on the MR-CANHUBK3)
<img width="768" height="276" alt="image" src="https://github.com/user-attachments/assets/5453eeb2-ecee-40da-9f01-a2066f4c475d" />

init.c assumes MMC is on LPSPI1, but the board definitions explicitly define it on LPSPI2
### Solution
Change init.c to initialize LPSPI2 instead of LPSPI1 for MMC
### Changelog Entry
For release notes:
```
Bugfix: Fix MMC detection on MRCANHUBK3 FMU with ADAP board

```

### Alternatives

### Test coverage

### Context

