### PR TITLE
fix(parameters): save resets synchronously and scope caldata repair

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -179,19 +179,19 @@ else
 	# Load param file location from kconfig
 	. ${R}etc/init.d/rc.filepaths
 
-	# Check if /fs/mtd_params is a valid BSON file
-	if ! bsondump docsize /fs/mtd_caldata
-	then
-		echo "New /fs/mtd_caldata size is:"
-		bsondump docsize /fs/mtd_caldata
-	fi
-
 	#
 	# Load parameters.
 	#
 	# if the board has a storage for (factory) calibration data
 	if mft query -q -k MTD -s MTD_CALDATA -v /fs/mtd_caldata
 	then
+		# repair the caldata BSON document size field if it was left zeroed
+		if ! bsondump docsize /fs/mtd_caldata
+		then
+			echo "New /fs/mtd_caldata size is:"
+			bsondump docsize /fs/mtd_caldata
+		fi
+
 		param load /fs/mtd_caldata
 	fi
 

--- a/src/modules/commander/worker_thread.cpp
+++ b/src/modules/commander/worker_thread.cpp
@@ -176,7 +176,7 @@ void WorkerThread::threadEntry()
 
 	case Request::ParamResetAll:
 		param_reset_all();
-		_ret_value = 0;
+		_ret_value = param_save_default(true);
 		break;
 
 	case Request::ParamResetSensorFactory: {
@@ -196,7 +196,7 @@ void WorkerThread::threadEntry()
 				"COM_FLIGHT_UUID"
 			};
 			param_reset_excludes(exclude_list, sizeof(exclude_list) / sizeof(exclude_list[0]));
-			_ret_value = 0;
+			_ret_value = param_save_default(true);
 			break;
 		}
 	}


### PR DESCRIPTION
QGC's "Reset all to firmware's defaults" (MAV_CMD_PREFLIGHT_STORAGE param1=2) and the full reset (param1=4) only reset parameters in RAM and leave persistence to the deferred autosave (300 ms delay, rate-limited to 2 s). A reboot or power cycle in that window silently undoes the reset. The factory sensor reset (param1=3) already saves synchronously.

- `commander`: `ParamResetAll` and `ParamResetAllConfig` now call `param_save_default(true)`, same as `ParamResetSensorFactory`. Verified in SITL over MAVLink: `parameters.bson` and `parameters_backup.bson` are rewritten ~5 ms after the command ack (previously ≥300 ms), and a follow-up PREFLIGHT_STORAGE command is still accepted afterwards.
- `rcS`: the `bsondump docsize` block from #23088 repairs a zeroed BSON document size field in `/fs/mtd_caldata`, but ran unconditionally (with a comment claiming it checks `/fs/mtd_params`), printing failed-bsondump noise on every boot for boards without a caldata partition. Move it inside the `MTD_CALDATA` gate next to the `param load` it protects.

Built `px4_fmu-v4_default` and `px4_sitl_default`.