### PR TITLE
fix(sensors): disable SENS_MAG_AUTOCAL by default, keep for CAN nodes

### DIFF
--- a/ROMFS/cannode/init.d/rcS
+++ b/ROMFS/cannode/init.d/rcS
@@ -107,6 +107,8 @@ then
 	# conservative mag bias estimation
 	param set-default MBE_LEARN_GAIN 5
 	param set-default IMU_GYRO_CUTOFF 20
+	# nodes have no GCS calibration flow, persist the estimated bias
+	param set-default SENS_MAG_AUTOCAL 1
 	mag_bias_estimator start
 fi
 

--- a/src/modules/sensors/sensor_params_mag.yaml
+++ b/src/modules/sensors/sensor_params_mag.yaml
@@ -78,7 +78,9 @@ parameters:
       description:
         short: Magnetometer auto calibration
         long: Automatically initialize magnetometer calibration from bias estimate
-          if available.
+          if available. The estimate only captures hard-iron offsets, so a full
+          calibration is still recommended. Mainly intended for remote nodes
+          (e.g. CAN GPS units) that cannot be calibrated from a ground station.
       category: System
       type: boolean
-      default: 1
+      default: 0


### PR DESCRIPTION
With `SENS_MAG_AUTOCAL=1`, an uncalibrated mag saves an "initial calibration" — including `CAL_MAGn_ID` — about 30 s after the disarmed bias estimator stabilizes. A brand-new board marks itself compass-calibrated just from being handled on the bench, so ground stations that detect "compass calibration required" from `CAL_MAG0_ID` (QGC does) silently stop prompting, and the first flight happens on a hard-iron-only estimate: scale is saved as identity, and an uncalibrated external mag gets `ROT=0` persisted — a mount rotation guess that a full calibration would have auto-detected. Reported by @DonLakeFlyer.

Some history:
- #18421 added the initial-cal save. The review raised exactly this concern ("a user would not be aware of that feature if there is no feedback on QGC") and it was deliberately merged disabled: *"Merging with `SENS_MAG_AUTOCAL = 0` as the default until the parameter system concerns can be addressed."*
- #19818 (CAN GPS nodes) flipped the global default to 1 as an undiscussed side change. It shipped in v1.14.0, and every vehicle since self-claims mag calibration.

This restores the disabled default and re-enables it via `param set-default` in the cannode rcS, since CAN GPS/compass nodes are the case that genuinely needs it (no GCS calibration flow, no EKF for in-flight refinement). `MBE_ENABLE` is untouched — the bias estimator still runs and corrects everywhere; only the automatic persisting of an initial calibration is off by default. Vehicles already auto-calibrated keep their saved `CAL_` params on upgrade; fresh setups are prompted for compass calibration again.

Built `px4_sitl_default`, `px4_fmu-v4_default`, and `ark_can-gps_default` (verified the `set-default` line survives ROMFS pruning and the param exists in the cannode build).