### PR TITLE
ci(flash-analysis): skip PR comment when flash delta is zero

### DIFF
--- a/.github/workflows/flash_analysis.yml
+++ b/.github/workflows/flash_analysis.yml
@@ -155,12 +155,26 @@ jobs:
       V6X-SUMMARY-MAP-PERC: ${{ fromJSON(fromJSON(needs.analyze_flash.outputs.px4_fmu-v6x-bloaty-summary-map).vm-percentage) }}
     if: github.event.pull_request
     steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v4
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- pr-comment-poster:flash-analysis -->'
+
       - name: Set Build Time
         id: bt
         run: |
           echo "timestamp=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
 
       - name: Write pr-comment artifact
+        # Skip only when the diff is exactly 0 bytes on all targets and no comment exists yet.
+        # This can't be moved to the job-level conditions, as GH actions don't allow a job-level if condition to access the env.
+        if: |
+          steps.fc.outputs.comment-id != '' ||
+          env.V5X-SUMMARY-MAP-ABS != 0 ||
+          env.V6X-SUMMARY-MAP-ABS != 0
         run: |
           mkdir -p pr-comment
           cat > pr-comment/manifest.json <<EOF
@@ -193,6 +207,10 @@ jobs:
           PR_COMMENT_BODY_EOF
 
       - name: Upload pr-comment artifact
+        if: |
+          steps.fc.outputs.comment-id != '' ||
+          env.V5X-SUMMARY-MAP-ABS != 0 ||
+          env.V6X-SUMMARY-MAP-ABS != 0
         uses: actions/upload-artifact@v7
         with:
           name: pr-comment


### PR DESCRIPTION
#27473 made the flash-analysis workflow always post a PR comment because the ±50 byte threshold was hiding small-but-real deltas. That swung too far the other way: PRs with zero flash impact now get a comment too. This restores the suppression, but only when the VM diff is exactly 0 bytes on all targets — any non-zero delta still posts. The `Find Comment` step is restored as well, so once a comment exists it is always updated (e.g. when a later push brings the delta back to 0) and never goes stale.