### PR TITLE
fix(jsbsim): build bridge after MAVLink headers are generated

### DIFF
--- a/src/modules/simulation/simulator_mavlink/sitl_targets_jsbsim.cmake
+++ b/src/modules/simulation/simulator_mavlink/sitl_targets_jsbsim.cmake
@@ -21,10 +21,14 @@ if(JSBSIM_INCLUDE_DIR)
 	include(ExternalProject)
 	ExternalProject_Add(jsbsim_bridge
 		SOURCE_DIR ${PX4_SOURCE_DIR}/Tools/simulation/jsbsim/jsbsim_bridge
-		CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+		CMAKE_ARGS
+			-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+			-D_MAVLINK_INCLUDE_DIR=${PX4_BINARY_DIR}/mavlink
 		BINARY_DIR ${PX4_BINARY_DIR}/build_jsbsim_bridge
 		INSTALL_COMMAND ""
-		DEPENDS git_jsbsim_bridge
+		DEPENDS
+			git_jsbsim_bridge
+			mavlink_c_generate
 		USES_TERMINAL_CONFIGURE true
 		USES_TERMINAL_BUILD true
 		EXCLUDE_FROM_ALL true


### PR DESCRIPTION
## Solved Problem

The `jsbsim_bridge` external project compiles against the generated MAVLink C headers, but its target has no dependency on `mavlink_c_generate`. On a clean `make px4_sitl jsbsim_<model>` build the bridge can configure/compile before header generation finishes and fail with missing `mavlink/...` includes; whether it succeeds depends on build scheduling.

## Solution

- Add `mavlink_c_generate` to the `jsbsim_bridge` external-project dependencies.
- Pass the generated include path (`${PX4_BINARY_DIR}/mavlink`) into the bridge CMake configure step so the bridge builds against the headers generated by this PX4 build rather than whatever happens to be on the system.

## Test coverage

We have carried this as a local patch across PX4 v1.16.2 and v1.17.0 for a JSBSim fixed-wing SITL pipeline; clean-tree `px4_sitl jsbsim_*` builds are reliable with it applied, including in CI-style from-scratch bootstraps.