### PR TITLE
fix(fw_att_control): use tailsitter attitude frame for FW quaternion error

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -298,7 +298,11 @@ void FixedwingAttitudeControl::Run()
 				const Quatf q_sp(_att_sp.q_d);
 
 				if (q_sp.isAllFinite()) {
-					const Quatf q_current(att.q);
+					// _R is adapted above for tailsitters so the quaternion attitude
+					// error is computed in the same fixed-wing frame used by the
+					// previous Euler attitude controller. The resulting FW body rates
+					// are transformed back to the hover/body frame below.
+					const Quatf q_current(_R);
 					const Vector3f att_err = computeAttitudeError(q_current, q_sp);
 
 					Vector3f body_rates_setpoint;

--- a/src/modules/fw_att_control/FixedwingAttitudeControlTest.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControlTest.cpp
@@ -50,6 +50,28 @@ static float computeYawRateSetpointBeforeTurnCoord(const Quatf &q_current, const
 	return att_err(2);
 }
 
+static matrix::Dcmf adaptTailsitterAttitudeForFixedWing(const matrix::Dcmf &R)
+{
+	matrix::Dcmf R_adapted = R;
+
+	/* move z to x */
+	R_adapted(0, 0) = R(0, 2);
+	R_adapted(1, 0) = R(1, 2);
+	R_adapted(2, 0) = R(2, 2);
+
+	/* move x to z */
+	R_adapted(0, 2) = R(0, 0);
+	R_adapted(1, 2) = R(1, 0);
+	R_adapted(2, 2) = R(2, 0);
+
+	/* change direction of pitch (convert to right handed system) */
+	R_adapted(0, 0) = -R_adapted(0, 0);
+	R_adapted(1, 0) = -R_adapted(1, 0);
+	R_adapted(2, 0) = -R_adapted(2, 0);
+
+	return R_adapted;
+}
+
 TEST(FixedwingAttitudeControlTest, YawRateSetpointZeroBeforeTurnCoord_Identity)
 {
 	// When current and setpoint are both identity, yaw rate should be zero
@@ -113,4 +135,20 @@ TEST(FixedwingAttitudeControlTest, YawRateSetpointZeroBeforeTurnCoord_BankedTurn
 	const float yaw_rate = computeYawRateSetpointBeforeTurnCoord(q_current, q_sp);
 
 	EXPECT_NEAR(yaw_rate, 0.f, 1e-4f);
+}
+
+TEST(FixedwingAttitudeControlTest, TailsitterAttitudeErrorUsesFixedWingFrame)
+{
+	// A tailsitter in normal fixed-wing flight is pitched about -90 deg in the
+	// multicopter body frame. The fixed-wing attitude controller must compare
+	// setpoints against the adapted fixed-wing frame, not the raw hover frame.
+	const Quatf q_current_raw(Eulerf(0.f, -math::radians(88.f), 0.f));
+	const Quatf q_current_fw(adaptTailsitterAttitudeForFixedWing(matrix::Dcmf(q_current_raw)));
+	const Quatf q_sp(Eulerf(0.f, math::radians(2.f), 0.f));
+
+	const Vector3f raw_error = computeAttitudeError(q_current_raw, q_sp);
+	const Vector3f fixed_wing_error = computeAttitudeError(q_current_fw, q_sp);
+
+	EXPECT_GT(fabsf(raw_error(1)), math::radians(80.f));
+	EXPECT_NEAR(fixed_wing_error(1), 0.f, math::radians(1.f));
 }


### PR DESCRIPTION
### Solved Problem

`FixedwingAttitudeControl` adapts `_R` into the fixed-wing frame for tailsitters before running the fixed-wing attitude controller. The quaternion error path still built `q_current` from the raw vehicle attitude quaternion, so tailsitters could compute the FW quaternion error in a different frame than the Euler/PID path.

This showed up during QuadTailsitter SITL validation after transition to fixed-wing: the vehicle could alternate between large pitch errors depending on the active attitude-control path, even though the fixed-wing-frame Euler attitude was already being prepared correctly.

### Solution

Use the already-adapted `_R` matrix to build the current quaternion for the FW quaternion error calculation. For non-tailsitters `_R` is the normal attitude rotation matrix, so behavior is unchanged. For tailsitters this keeps quaternion control in the same frame that the surrounding FW attitude-controller code already uses, and the existing rate-setpoint transform back to the vehicle body frame remains unchanged.

A unit test was added to exercise the tailsitter frame conversion and verify that a level fixed-wing attitude does not produce a spurious pitch demand.

### Changelog Entry

For release notes:
```
Bugfix: Fixed-wing: use the tailsitter fixed-wing attitude frame for quaternion attitude error calculation.
```

### Test coverage

- `make tests TESTFILTER=FixedwingAttitudeControl`
- Local QuadTailsitter X-Plane SITL validation with the guard applied on top of the X-Plane SITL branch.
