### PR TITLE
fix(fw): reset TECS on altitude reference changes

### DIFF
--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -179,20 +179,36 @@ void FwLateralLongitudinalControl::Run()
 
 		update_control_state(now);
 
-		if (_control_mode_sub.get().flag_control_manual_enabled && _control_mode_sub.get().flag_control_altitude_enabled
-		    && _local_pos.z_reset_counter != _z_reset_counter) {
-			if (_control_mode_sub.get().flag_control_altitude_enabled && _local_pos.z_reset_counter != _z_reset_counter) {
-				// make TECS accept step in altitude and demanded altitude
-				_tecs.handle_alt_step(_long_control_state.altitude_msl, _long_control_state.height_rate);
-			}
-		}
-
 		const bool should_run = (_control_mode_sub.get().flag_control_position_enabled ||
 					 _control_mode_sub.get().flag_control_velocity_enabled ||
 					 _control_mode_sub.get().flag_control_altitude_enabled ||
 					 _control_mode_sub.get().flag_control_climb_rate_enabled) &&
 					(_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING
 					 || _vehicle_status_sub.get().in_transition_mode);
+
+		const bool tecs_should_run = should_run
+					     && !(_vehicle_status_sub.get().is_vtol
+						  && (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
+						      || _vehicle_status_sub.get().in_transition_mode));
+
+		if (tecs_should_run) {
+			const bool altitude_frame_valid = _local_pos.z_global && PX4_ISFINITE(_local_pos.ref_alt);
+			const bool altitude_frame_changed = altitude_frame_valid
+							    && (!_altitude_frame_valid
+								|| _local_pos.ref_timestamp != _altitude_frame_ref_timestamp);
+			const bool altitude_reset = _local_pos.z_reset_counter != _z_reset_counter;
+
+			if (altitude_frame_changed || altitude_reset) {
+				_tecs.handle_alt_step(_long_control_state.altitude_msl, _long_control_state.height_rate);
+			}
+
+			_altitude_frame_valid = altitude_frame_valid;
+			_altitude_frame_ref_timestamp = altitude_frame_valid ? _local_pos.ref_timestamp : UINT64_C(0);
+
+		} else {
+			_altitude_frame_valid = false;
+			_altitude_frame_ref_timestamp = UINT64_C(0);
+		}
 
 		if (should_run) {
 

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
@@ -175,6 +175,8 @@ private:
 
 	hrt_abstime _last_time_loop_ran{};
 	uint8_t _z_reset_counter{UINT8_C(0)};
+	bool _altitude_frame_valid{false};
+	uint64_t _altitude_frame_ref_timestamp{UINT64_C(0)};
 	uint64_t _time_airspeed_last_valid{UINT64_C(0)};
 	float _air_density{atmosphere::kAirDensitySeaLevelStandardAtmos};
 	// Smooths changes in the altitude tracking error time constant value


### PR DESCRIPTION
### Solved Problem

TECS keeps internal altitude-reference state. If the local-position altitude frame becomes valid or changes after TECS has already initialized, the controller can continue tracking the old reference. On high-elevation SITL airports this is very visible: after fixed-wing climbout finishes, the TECS altitude reference can remain hundreds of meters away from the actual AMSL altitude and the aircraft commands a long controlled descent instead of holding the mission altitude.

The same class of problem is already close to existing TECS/local-altitude-reference work in #23057 and #25473. In this case the reproduced failure was fixed-wing auto takeoff/mission after the FW high-level-control rework (#24056), where TECS may enter before the final local altitude frame has been consumed.

This is fixed-wing TECS scope. It does not affect normal multicopter position control. VTOL vehicles are affected only when they are actually in fixed-wing TECS control; the reset intentionally does not run in VTOL rotary-wing mode or transition.

### Solution

Track the local altitude frame consumed by TECS and call `handle_alt_step()` when:

- the local altitude reference first becomes valid,
- the local altitude reference timestamp changes, or
- the local `z_reset_counter` changes.

The reset uses the current measured altitude and height rate, and is gated by the same VTOL rotary/transition exclusion used by `tecs_update_pitch_throttle()`, so it only applies when TECS is actually active.

### Changelog Entry

For release notes:
```
Bugfix: Fixed-wing: reset TECS altitude state when the local altitude reference changes.
```

### Test coverage

- `make px4_sitl_default`
- Local Cessna 172 and TB2 X-Plane SITL validation at non-sea-level airports: without this reset, post-climbout TECS held a stale altitude reference and descended; with this reset, TECS stayed aligned with the mission altitude after climbout.
