### PR TITLE
feat(build): support firmware upload from WSL2

### DIFF
--- a/Tools/px4_uploader.py
+++ b/Tools/px4_uploader.py
@@ -1512,6 +1512,14 @@ class PortDetector:
         elif self.platform == "darwin":
             patterns = self.MACOS_PATTERNS
         elif self.platform.startswith("win") or self.platform == "cygwin":
+            try:
+                detected_ports = [
+                    port_info.device for port_info in serial.tools.list_ports.comports()
+                ]
+                if detected_ports:
+                    return detected_ports
+            except Exception as e:
+                logger.debug(f"Windows COM port detection failed: {e}")
             patterns = self.WINDOWS_PATTERNS
         else:
             patterns = []
@@ -1834,7 +1842,8 @@ class Uploader:
         last_error = None
         for port in ports:
             try:
-                return self._upload_to_port(port, firmwares)
+                if self._upload_to_port(port, firmwares):
+                    return True
             except BoardMismatchError as e:
                 logger.warning(f"Board mismatch on {port}: {e}")
                 last_error = e

--- a/platforms/nuttx/cmake/upload.cmake
+++ b/platforms/nuttx/cmake/upload.cmake
@@ -33,9 +33,26 @@
 
 # Uploader script auto-detects PX4 devices by USB VID/PID
 set(PX4_UPLOADER_SCRIPT "${PX4_SOURCE_DIR}/Tools/px4_uploader.py")
+set(PX4_UPLOADER_PYTHON ${PYTHON_EXECUTABLE})
+
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND EXISTS "/proc/sys/kernel/osrelease")
+	file(READ "/proc/sys/kernel/osrelease" PX4_HOST_OS_RELEASE)
+	string(FIND "${PX4_HOST_OS_RELEASE}" "microsoft-standard-WSL2" PX4_WSL2_INDEX)
+
+	if(NOT PX4_WSL2_INDEX EQUAL -1)
+		find_program(PX4_WINDOWS_PYTHON_EXECUTABLE python.exe)
+
+		if(PX4_WINDOWS_PYTHON_EXECUTABLE)
+			# Windows Python can access COM<N> ports directly,
+			# while WSL2 often cannot expose high-numbered COM
+			# ports as working /dev/ttyS<N> nodes.
+			set(PX4_UPLOADER_PYTHON ${PX4_WINDOWS_PYTHON_EXECUTABLE} -u)
+		endif()
+	endif()
+endif()
 
 add_custom_target(upload
-	COMMAND ${PYTHON_EXECUTABLE} ${PX4_UPLOADER_SCRIPT} ${fw_package}
+	COMMAND ${PX4_UPLOADER_PYTHON} ${PX4_UPLOADER_SCRIPT} ${fw_package}
 	DEPENDS ${fw_package}
 	COMMENT "uploading px4"
 	VERBATIM
@@ -44,7 +61,7 @@ add_custom_target(upload
 )
 
 add_custom_target(force-upload
-	COMMAND ${PYTHON_EXECUTABLE} ${PX4_UPLOADER_SCRIPT} --force ${fw_package}
+	COMMAND ${PX4_UPLOADER_PYTHON} ${PX4_UPLOADER_SCRIPT} --force ${fw_package}
 	DEPENDS ${fw_package}
 	COMMENT "uploading px4 with --force"
 	VERBATIM
@@ -53,7 +70,7 @@ add_custom_target(force-upload
 )
 
 add_custom_target(upload-verbose
-	COMMAND ${PYTHON_EXECUTABLE} ${PX4_UPLOADER_SCRIPT} --verbose ${fw_package}
+	COMMAND ${PX4_UPLOADER_PYTHON} ${PX4_UPLOADER_SCRIPT} --verbose ${fw_package}
 	DEPENDS ${fw_package}
 	COMMENT "uploading px4 with verbose output"
 	VERBATIM


### PR DESCRIPTION
### Solved Problem
Fixes #27668 
When CMake detects that the host is WSL2, run the existing PX4 uploader with the Windows Python interpreter:

python.exe -u Tools/px4_uploader.py <firmware>
Running the uploader with Windows Python allows pyserial to enumerate and access the Windows COM ports directly, including after the flight controller re-enumerates in bootloader mode.

Native Linux, macOS and Windows behavior would remain unchanged.