### PR TITLE
fix(math): add countTrailingZeros with unit tests also use compiler builtin function for countSetBits

### DIFF
--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -275,14 +275,13 @@ constexpr int16_t negate<int16_t>(int16_t value)
 template<typename T>
 int countSetBits(T n)
 {
-	int count = 0;
+	return __builtin_popcount(n);
+}
 
-	while (n) {
-		count += n & 1;
-		n >>= 1;
-	}
-
-	return count;
+template<typename T>
+int countTrailingZeros(T n)
+{
+	return n == 0 ? (int)(sizeof(T) * 8) : __builtin_ctz(n);
 }
 
 inline bool isFinite(const float &value)

--- a/src/lib/mathlib/math/FunctionsTest.cpp
+++ b/src/lib/mathlib/math/FunctionsTest.cpp
@@ -225,6 +225,18 @@ TEST(FunctionsTest, countSetBits)
 	EXPECT_EQ(countSetBits(754323), 9);
 }
 
+TEST(FunctionsTest, countTrailingZeros)
+{
+	EXPECT_EQ(countTrailingZeros(1u), 0);
+	EXPECT_EQ(countTrailingZeros(2u), 1);
+	EXPECT_EQ(countTrailingZeros(8u), 3);
+	EXPECT_EQ(countTrailingZeros(256u), 8);
+	EXPECT_EQ(countTrailingZeros(0xffffffffu), 0);
+	EXPECT_EQ(countTrailingZeros(0x80000000u), 31);
+	EXPECT_EQ(countTrailingZeros(0u), 32);
+	EXPECT_EQ(countTrailingZeros((uint8_t)0u), 8);
+}
+
 TEST(FunctionsTest, isFiniteVector3f)
 {
 	EXPECT_TRUE(isFinite(matrix::Vector3f()));


### PR DESCRIPTION
### Solved Problem
We need `countTrailingZeros()` to get the index of the first bit set in a mask separately from this. I thought I'd add the function to the library ahead of time.

 Thanks to Claude we discovered `__builtin_popcount()` and `__builtin_ctz()` are functions that the compiler can optimize to a single machine instruction on the given architecture. It's fully supported by GCC and Clang but remind me if we have other compiler dependencies which don't support these.

### Solution
Add `countTrailingZeros()` and use builtin functions.

### Test coverage
I added unit tests also for explicitly handling the undefined behavior of counting trailing zeros in the value zero.