### PR TITLE
feat(ManualControl): Disable sticks when executing gestures

### DIFF
--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -121,16 +121,20 @@ void ManualControl::processInput(hrt_abstime now)
 	if (_selector.setpoint().valid) {
 		_published_invalid_once = false;
 
-		IgnoreStick ignore_stick = processStickArming(_selector.setpoint());
+		processStickArming(_selector.setpoint());
+		bool kill_gesture_active = processStickKillGesture(_selector.setpoint());
 
-		if (ignore_stick == IgnoreStick::LEFT || ignore_stick == IgnoreStick::ALL) {
-			_selector.setpoint().throttle = -1.0f;
-			_selector.setpoint().yaw = 0.f;
-		}
+		if (kill_gesture_active) {
+			// Zero sticks and set min throttle to prevent extreme setpoints
+			// while waiting for the kill hysteresis to trigger.
 
-		if (ignore_stick == IgnoreStick::ALL) {
+			// Note: Arm/Disarm gestures dont require stick centering because
+			// they aren't active during flight
+
 			_selector.setpoint().roll = 0.f;
 			_selector.setpoint().pitch = 0.f;
+			_selector.setpoint().throttle = -1.0f;
+			_selector.setpoint().yaw = 0.f;
 		}
 
 		// User override by stick
@@ -398,7 +402,7 @@ void ManualControl::updateParams()
 	}
 }
 
-ManualControl::IgnoreStick ManualControl::processStickArming(const manual_control_setpoint_s &input)
+void ManualControl::processStickArming(const manual_control_setpoint_s &input)
 {
 	// Arm gesture
 	const bool right_stick_centered = (fabsf(input.pitch) < 0.1f) && (fabsf(input.roll) < 0.1f);
@@ -420,34 +424,26 @@ ManualControl::IgnoreStick ManualControl::processStickArming(const manual_contro
 	if (_param_man_arm_gesture.get() && !previous_stick_disarm_hysteresis && _stick_disarm_hysteresis.get_state()) {
 		sendActionRequest(action_request_s::ACTION_DISARM, action_request_s::SOURCE_STICK_GESTURE);
 	}
+}
 
-	// Kill gesture
-	const bool right_stick_lower_right = (input.pitch < -0.9f) && (input.roll > 0.9f);
-
+bool ManualControl::processStickKillGesture(const manual_control_setpoint_s &input)
+{
 	if (_param_man_kill_gest_t.get() > 0.f) {
+		const bool right_stick_lower_right = (input.pitch < -0.9f) && (input.roll > 0.9f);
+		const bool left_stick_lower_left = (input.throttle < -0.8f) && (input.yaw < -0.9f);
+		const bool kill_gesture = right_stick_lower_right && left_stick_lower_left;
+
 		const bool previous_stick_kill_hysteresis = _stick_kill_hysteresis.get_state();
-		_stick_kill_hysteresis.set_state_and_update(left_stick_lower_left && right_stick_lower_right, input.timestamp);
+		_stick_kill_hysteresis.set_state_and_update(kill_gesture, input.timestamp);
 
 		if (!previous_stick_kill_hysteresis && _stick_kill_hysteresis.get_state()) {
 			sendActionRequest(action_request_s::ACTION_KILL, action_request_s::SOURCE_STICK_GESTURE);
 		}
 
+		return kill_gesture;
 	}
 
-	// Disable sticks state machine
-	const bool disable_left_stick = _param_man_arm_gesture.get() && right_stick_centered && (left_stick_lower_left
-					|| left_stick_lower_right);
-	const bool disable_all_sticks = _param_man_kill_gest_t.get() > 0.f && right_stick_lower_right && left_stick_lower_left;
-
-	if (disable_all_sticks) {
-		return IgnoreStick::ALL;
-
-	} else if (disable_left_stick) {
-		return IgnoreStick::LEFT;
-
-	}
-
-	return IgnoreStick::NONE;
+	return false;
 }
 
 void ManualControl::evaluateModeSlot(uint8_t mode_slot)

--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -121,7 +121,17 @@ void ManualControl::processInput(hrt_abstime now)
 	if (_selector.setpoint().valid) {
 		_published_invalid_once = false;
 
-		processStickArming(_selector.setpoint());
+		IgnoreStick ignore_stick = processStickArming(_selector.setpoint());
+
+		if (ignore_stick == IgnoreStick::LEFT || ignore_stick == IgnoreStick::ALL) {
+			_selector.setpoint().throttle = -1.0f;
+			_selector.setpoint().yaw = 0.f;
+		}
+
+		if (ignore_stick == IgnoreStick::ALL) {
+			_selector.setpoint().roll = 0.f;
+			_selector.setpoint().pitch = 0.f;
+		}
 
 		// User override by stick
 		const float dt_s = (now - _timestamp_last_loop) / 1e6f;
@@ -388,7 +398,7 @@ void ManualControl::updateParams()
 	}
 }
 
-void ManualControl::processStickArming(const manual_control_setpoint_s &input)
+ManualControl::IgnoreStick ManualControl::processStickArming(const manual_control_setpoint_s &input)
 {
 	// Arm gesture
 	const bool right_stick_centered = (fabsf(input.pitch) < 0.1f) && (fabsf(input.roll) < 0.1f);
@@ -412,16 +422,32 @@ void ManualControl::processStickArming(const manual_control_setpoint_s &input)
 	}
 
 	// Kill gesture
-	if (_param_man_kill_gest_t.get() > 0.f) {
-		const bool right_stick_lower_right = (input.pitch < -0.9f) && (input.roll > 0.9f);
+	const bool right_stick_lower_right = (input.pitch < -0.9f) && (input.roll > 0.9f);
 
+	if (_param_man_kill_gest_t.get() > 0.f) {
 		const bool previous_stick_kill_hysteresis = _stick_kill_hysteresis.get_state();
 		_stick_kill_hysteresis.set_state_and_update(left_stick_lower_left && right_stick_lower_right, input.timestamp);
 
 		if (!previous_stick_kill_hysteresis && _stick_kill_hysteresis.get_state()) {
 			sendActionRequest(action_request_s::ACTION_KILL, action_request_s::SOURCE_STICK_GESTURE);
 		}
+
 	}
+
+	// Disable sticks state machine
+	const bool disable_left_stick = _param_man_arm_gesture.get() && right_stick_centered && (left_stick_lower_left
+					|| left_stick_lower_right);
+	const bool disable_all_sticks = _param_man_kill_gest_t.get() > 0.f && right_stick_lower_right && left_stick_lower_left;
+
+	if (disable_all_sticks) {
+		return IgnoreStick::ALL;
+
+	} else if (disable_left_stick) {
+		return IgnoreStick::LEFT;
+
+	}
+
+	return IgnoreStick::NONE;
 }
 
 void ManualControl::evaluateModeSlot(uint8_t mode_slot)

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -86,8 +86,14 @@ private:
 
 	void Run() override;
 	void updateParams() override;
-	void processStickArming(const manual_control_setpoint_s &input);
 	void processSwitches(hrt_abstime &now);
+
+	enum class IgnoreStick {
+		NONE,
+		LEFT,
+		ALL
+	};
+	IgnoreStick processStickArming(const manual_control_setpoint_s &input);
 
 	void evaluateModeSlot(uint8_t mode_slot);
 	void sendActionRequest(int8_t action, int8_t source, int8_t mode = 0);

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -87,13 +87,10 @@ private:
 	void Run() override;
 	void updateParams() override;
 	void processSwitches(hrt_abstime &now);
+	void processStickArming(const manual_control_setpoint_s &input);
 
-	enum class IgnoreStick {
-		NONE,
-		LEFT,
-		ALL
-	};
-	IgnoreStick processStickArming(const manual_control_setpoint_s &input);
+	// Return true if kill switch gesture is detected, false otherwise
+	bool processStickKillGesture(const manual_control_setpoint_s &input);
 
 	void evaluateModeSlot(uint8_t mode_slot);
 	void sendActionRequest(int8_t action, int8_t source, int8_t mode = 0);

--- a/src/modules/manual_control/ManualControlTest.cpp
+++ b/src/modules/manual_control/ManualControlTest.cpp
@@ -36,6 +36,8 @@
 
 static constexpr uint64_t SOME_TIME = 12345678;
 
+static constexpr uint8_t ACTION_ARM = action_request_s::ACTION_ARM;
+static constexpr uint8_t ACTION_DISARM = action_request_s::ACTION_DISARM;
 static constexpr uint8_t ACTION_KILL = action_request_s::ACTION_KILL;
 static constexpr uint8_t ACTION_UNKILL = action_request_s::ACTION_UNKILL;
 static constexpr uint8_t ACTION_VTOL_TRANSITION_TO_FIXEDWING = action_request_s::ACTION_VTOL_TRANSITION_TO_FIXEDWING;
@@ -326,4 +328,180 @@ TEST_F(SwitchTest, ModeSwitchInitializationArmed)
 	EXPECT_TRUE(_action_request_sub.update());
 	EXPECT_EQ(_action_request_sub.get().action, ACTION_SWITCH_MODE);
 	EXPECT_EQ(_action_request_sub.get().mode, TestManualControl::navStateFromParam(NAVIGATION_STATE_MANUAL));
+}
+
+class GestureTest : public SwitchTest
+{
+public:
+	void SetUp() override
+	{
+		SwitchTest::SetUp();
+
+		// Set gesture parameters
+		float man_kill_gest_t = .5f;
+		param_set(param_find("MAN_KILL_GEST_T"), &man_kill_gest_t);
+
+		int man_arm_gesture = 1;
+		param_set(param_find("MAN_ARM_GESTURE"), &man_arm_gesture);
+	}
+
+	void publishArmGesture(hrt_abstime time_step)
+	{
+		_timestamp += time_step;
+		_manual_control_input_pub.publish({.timestamp_sample = _timestamp, .roll = 0.0f, .pitch = 0.0f, .yaw = 1.0f, .throttle = -0.9f, .valid = true, .data_source = manual_control_setpoint_s::SOURCE_RC,});
+	}
+
+	void publishKillGesture(hrt_abstime time_step)
+	{
+		_timestamp += time_step;
+		_manual_control_input_pub.publish({.timestamp_sample = _timestamp, .roll = 1.0f, .pitch = -1.0f, .yaw = -1.0f, .throttle = -0.9f, .valid = true, .data_source = manual_control_setpoint_s::SOURCE_RC,});
+	}
+
+	void publishDisarmGesture(hrt_abstime time_step)
+	{
+		_timestamp += time_step;
+		_manual_control_input_pub.publish({.timestamp_sample = _timestamp, .roll = 0.0f, .pitch = 0.0f, .yaw = -1.0f, .throttle = -0.9f, .valid = true, .data_source = manual_control_setpoint_s::SOURCE_RC,});
+	}
+
+	void publishValidInput(hrt_abstime time_step)
+	{
+		_timestamp += time_step;
+		// Must be some value to distinguish from ignored sticks
+		_manual_control_input_pub.publish({.timestamp_sample = _timestamp, .roll = 0.5f, .pitch = 0.5f, .yaw = 0.5f, .throttle = 0.5f, .valid = true, .data_source = manual_control_setpoint_s::SOURCE_RC,});
+	}
+};
+
+TEST_F(GestureTest, NoGestureNoIgnore)
+{
+	publishValidInput(100_ms);
+	_manual_control.processInput(_timestamp);
+
+	// THEN: the stick input is published for use
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+
+	// Stick inputs are not ignored
+	auto setpoint = _manual_control_setpoint_sub.get();
+	EXPECT_TRUE(setpoint.valid);
+	EXPECT_GT(fabs(setpoint.roll), FLT_EPSILON);
+	EXPECT_GT(fabs(setpoint.pitch), FLT_EPSILON);
+	EXPECT_GT(fabs(setpoint.yaw), FLT_EPSILON);
+	EXPECT_GT(fabs(setpoint.throttle), FLT_EPSILON);
+
+	// no action requested
+	EXPECT_FALSE(_action_request_sub.update());
+}
+
+TEST_F(GestureTest, ArmingGesture)
+{
+	// ─── Gesture Start ───────────────────────────────────────────────────
+	publishArmGesture(100_ms);
+	_manual_control.processInput(_timestamp);
+
+	// Left stick is ignored during gesture attempt (set to safe default)
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	auto setpoint = _manual_control_setpoint_sub.get();
+
+	EXPECT_TRUE(setpoint.valid);
+	EXPECT_NEAR(setpoint.yaw, 0.0F, FLT_EPSILON);
+	EXPECT_NEAR(setpoint.throttle, -1.0F, FLT_EPSILON);
+
+	// No kill action requested yet because of hysteresis
+	EXPECT_FALSE(_action_request_sub.update());
+
+
+	// ─── Gesture Hysterisis ──────────────────────────────────────────────
+	// Hysteresis is 1_s but COM_RC_LOSS_T is 0.5s, so using 2 updated at 0.5s
+	publishArmGesture(500_ms);
+	_manual_control.processInput(_timestamp);
+	publishArmGesture(500_ms);
+	_manual_control.processInput(_timestamp);
+
+	// Left stick is still ignored
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	setpoint = _manual_control_setpoint_sub.get();
+
+	EXPECT_TRUE(setpoint.valid);
+	EXPECT_NEAR(setpoint.yaw, 0.0F, FLT_EPSILON);
+	EXPECT_NEAR(setpoint.throttle, -1.0F, FLT_EPSILON);
+
+	EXPECT_TRUE(_action_request_sub.update());
+	EXPECT_EQ(_action_request_sub.get().action, ACTION_ARM);
+}
+
+TEST_F(GestureTest, DisarmGesture)
+{
+	// ─── Gesture Start ───────────────────────────────────────────────────
+	publishDisarmGesture(100_ms);
+	_manual_control.processInput(_timestamp);
+
+	// Left stick is ignored during gesture attempt (set to safe default)
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	auto setpoint = _manual_control_setpoint_sub.get();
+
+	EXPECT_TRUE(setpoint.valid);
+	EXPECT_NEAR(setpoint.yaw, 0.0F, FLT_EPSILON);
+	EXPECT_NEAR(setpoint.throttle, -1.0F, FLT_EPSILON);
+
+	// No kill action requested yet because of hysteresis
+	EXPECT_FALSE(_action_request_sub.update());
+
+
+	// ─── Gesture Hysterisis ──────────────────────────────────────────────
+	publishDisarmGesture(500_ms);
+	_manual_control.processInput(_timestamp);
+	publishDisarmGesture(500_ms);
+	_manual_control.processInput(_timestamp);
+
+	// Left stick is still ignored
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	setpoint = _manual_control_setpoint_sub.get();
+
+	EXPECT_TRUE(setpoint.valid);
+	EXPECT_NEAR(setpoint.yaw, 0.0F, FLT_EPSILON);
+	EXPECT_NEAR(setpoint.throttle, -1.0F, FLT_EPSILON);
+
+	EXPECT_TRUE(_action_request_sub.update());
+	EXPECT_EQ(_action_request_sub.get().action, ACTION_DISARM);
+}
+
+TEST_F(GestureTest, KillGesture)
+{
+	// ─── Gesture Start ───────────────────────────────────────────────────
+	publishKillGesture(100_ms);
+	_manual_control.processInput(_timestamp);
+
+	// Both Sticks ignored during kill gesture attempt
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	auto setpoint = _manual_control_setpoint_sub.get();
+	EXPECT_TRUE(setpoint.valid);
+
+	// LEFT
+	EXPECT_NEAR(setpoint.yaw, 0.0F, FLT_EPSILON);
+	EXPECT_NEAR(setpoint.throttle, -1.0F, FLT_EPSILON);
+	// RIGHT
+	EXPECT_NEAR(setpoint.roll, 0.0F, FLT_EPSILON);
+	EXPECT_NEAR(setpoint.pitch, 0.0F, FLT_EPSILON);
+
+	// No kill action requested yet because of hysteresis
+	EXPECT_FALSE(_action_request_sub.update());
+
+
+	// ─── Gesture Hysterisis ──────────────────────────────────────────────
+	publishKillGesture(500_ms);
+	_manual_control.processInput(_timestamp);
+
+	// Left stick is still ignored
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	setpoint = _manual_control_setpoint_sub.get();
+	EXPECT_TRUE(setpoint.valid);
+
+	// LEFT
+	EXPECT_NEAR(setpoint.yaw, 0.0F, FLT_EPSILON);
+	EXPECT_NEAR(setpoint.throttle, -1.0F, FLT_EPSILON);
+	// RIGHT
+	EXPECT_NEAR(setpoint.roll, 0.0F, FLT_EPSILON);
+	EXPECT_NEAR(setpoint.pitch, 0.0F, FLT_EPSILON);
+
+	EXPECT_TRUE(_action_request_sub.update());
+	EXPECT_EQ(_action_request_sub.get().action, ACTION_KILL);
 }

--- a/src/modules/manual_control/ManualControlTest.cpp
+++ b/src/modules/manual_control/ManualControlTest.cpp
@@ -397,15 +397,10 @@ TEST_F(GestureTest, ArmingGesture)
 	publishArmGesture(100_ms);
 	_manual_control.processInput(_timestamp);
 
-	// Left stick is ignored during gesture attempt (set to safe default)
 	EXPECT_TRUE(_manual_control_setpoint_sub.update());
-	auto setpoint = _manual_control_setpoint_sub.get();
+	EXPECT_TRUE(_manual_control_setpoint_sub.get().valid);
 
-	EXPECT_TRUE(setpoint.valid);
-	EXPECT_NEAR(setpoint.yaw, 0.0F, FLT_EPSILON);
-	EXPECT_NEAR(setpoint.throttle, -1.0F, FLT_EPSILON);
-
-	// No kill action requested yet because of hysteresis
+	// No action requested yet because of hysteresis
 	EXPECT_FALSE(_action_request_sub.update());
 
 
@@ -416,13 +411,8 @@ TEST_F(GestureTest, ArmingGesture)
 	publishArmGesture(500_ms);
 	_manual_control.processInput(_timestamp);
 
-	// Left stick is still ignored
 	EXPECT_TRUE(_manual_control_setpoint_sub.update());
-	setpoint = _manual_control_setpoint_sub.get();
-
-	EXPECT_TRUE(setpoint.valid);
-	EXPECT_NEAR(setpoint.yaw, 0.0F, FLT_EPSILON);
-	EXPECT_NEAR(setpoint.throttle, -1.0F, FLT_EPSILON);
+	EXPECT_TRUE(_manual_control_setpoint_sub.get().valid);;
 
 	EXPECT_TRUE(_action_request_sub.update());
 	EXPECT_EQ(_action_request_sub.get().action, ACTION_ARM);
@@ -434,15 +424,10 @@ TEST_F(GestureTest, DisarmGesture)
 	publishDisarmGesture(100_ms);
 	_manual_control.processInput(_timestamp);
 
-	// Left stick is ignored during gesture attempt (set to safe default)
 	EXPECT_TRUE(_manual_control_setpoint_sub.update());
-	auto setpoint = _manual_control_setpoint_sub.get();
+	EXPECT_TRUE(_manual_control_setpoint_sub.get().valid);
 
-	EXPECT_TRUE(setpoint.valid);
-	EXPECT_NEAR(setpoint.yaw, 0.0F, FLT_EPSILON);
-	EXPECT_NEAR(setpoint.throttle, -1.0F, FLT_EPSILON);
-
-	// No kill action requested yet because of hysteresis
+	// No action requested yet because of hysteresis
 	EXPECT_FALSE(_action_request_sub.update());
 
 
@@ -452,13 +437,8 @@ TEST_F(GestureTest, DisarmGesture)
 	publishDisarmGesture(500_ms);
 	_manual_control.processInput(_timestamp);
 
-	// Left stick is still ignored
 	EXPECT_TRUE(_manual_control_setpoint_sub.update());
-	setpoint = _manual_control_setpoint_sub.get();
-
-	EXPECT_TRUE(setpoint.valid);
-	EXPECT_NEAR(setpoint.yaw, 0.0F, FLT_EPSILON);
-	EXPECT_NEAR(setpoint.throttle, -1.0F, FLT_EPSILON);
+	EXPECT_TRUE(_manual_control_setpoint_sub.get().valid);
 
 	EXPECT_TRUE(_action_request_sub.update());
 	EXPECT_EQ(_action_request_sub.get().action, ACTION_DISARM);

--- a/src/modules/manual_control/ManualControlTest.cpp
+++ b/src/modules/manual_control/ManualControlTest.cpp
@@ -404,7 +404,7 @@ TEST_F(GestureTest, ArmingGesture)
 	EXPECT_FALSE(_action_request_sub.update());
 
 
-	// ─── Gesture Hysterisis ──────────────────────────────────────────────
+	// ─── Gesture Hysteresis ──────────────────────────────────────────────
 	// Hysteresis is 1_s but COM_RC_LOSS_T is 0.5s, so using 2 updated at 0.5s
 	publishArmGesture(500_ms);
 	_manual_control.processInput(_timestamp);
@@ -412,7 +412,7 @@ TEST_F(GestureTest, ArmingGesture)
 	_manual_control.processInput(_timestamp);
 
 	EXPECT_TRUE(_manual_control_setpoint_sub.update());
-	EXPECT_TRUE(_manual_control_setpoint_sub.get().valid);;
+	EXPECT_TRUE(_manual_control_setpoint_sub.get().valid);
 
 	EXPECT_TRUE(_action_request_sub.update());
 	EXPECT_EQ(_action_request_sub.get().action, ACTION_ARM);
@@ -431,7 +431,7 @@ TEST_F(GestureTest, DisarmGesture)
 	EXPECT_FALSE(_action_request_sub.update());
 
 
-	// ─── Gesture Hysterisis ──────────────────────────────────────────────
+	// ─── Gesture Hysteresis ──────────────────────────────────────────────
 	publishDisarmGesture(500_ms);
 	_manual_control.processInput(_timestamp);
 	publishDisarmGesture(500_ms);
@@ -466,7 +466,7 @@ TEST_F(GestureTest, KillGesture)
 	EXPECT_FALSE(_action_request_sub.update());
 
 
-	// ─── Gesture Hysterisis ──────────────────────────────────────────────
+	// ─── Gesture Hysteresis ──────────────────────────────────────────────
 	publishKillGesture(500_ms);
 	_manual_control.processInput(_timestamp);
 


### PR DESCRIPTION
### Solved Problem
When doing gestures (eg. Kill gesture) The stick input of the gesture was passed on along the control stack. This seems undesirable because the gestures are all very aggressive maneuvers.

### Solution
Returns an IgnoreStick enum from processStickArming which is used to set rpyt to safe default values if the sticks are in a gesture position.

during Disarm/Arm gesture the left stick is ignored:
- throttle = -1.0
- yaw = 0.0

during Kill gesture left and right stick are ignored:
- throttle = -1.0
- yaw = 0.0
- roll = 0.0
- pitch = 0.0

### Changelog Entry
For release notes:
```
Feature: Stick input ignored during gestures
Documentation: Would need to document change to https://docs.px4.io/main/en/config/safety#kill-gesture  / not-done, 
```

### Test coverage
Functional tests for Kill, Disarm, and Arm gesture. Covering disabling sticks and gestures
