### PR TITLE
fix(fw_latlon_control): do not reset alt err time constant on every param update

### DIFF
--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -78,6 +78,10 @@ FwLateralLongitudinalControl::FwLateralLongitudinalControl(bool is_vtol) :
 	_fixed_wing_lateral_status_pub.advertise();
 	parameters_update();
 	_airspeed_slew_rate_controller.setSlewRate(ASPD_SP_SLEW_RATE);
+
+	_tecs_alt_time_const_slew_rate.setSlewRate(TECS_ALT_TIME_CONST_SLEW_RATE);
+	_tecs_alt_time_const_slew_rate.setForcedValue(_param_fw_t_h_error_tc.get() * _param_fw_thrtc_sc.get());
+
 }
 
 FwLateralLongitudinalControl::~FwLateralLongitudinalControl()
@@ -111,9 +115,6 @@ FwLateralLongitudinalControl::parameters_update()
 	_tecs.set_seb_rate_ff_gain(_param_seb_rate_ff.get());
 
 	_roll_slew_rate.setSlewRate(radians(_param_fw_pn_r_slew_max.get()));
-
-	_tecs_alt_time_const_slew_rate.setSlewRate(TECS_ALT_TIME_CONST_SLEW_RATE);
-	_tecs_alt_time_const_slew_rate.setForcedValue(_param_fw_t_h_error_tc.get() * _param_fw_thrtc_sc.get());
 
 	_airspeed_direction_control.setPGainFromPeriodAndDamping(_param_npfg_damping.get(), _param_npfg_period.get());
 }

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -81,7 +81,6 @@ FwLateralLongitudinalControl::FwLateralLongitudinalControl(bool is_vtol) :
 
 	_tecs_alt_time_const_slew_rate.setSlewRate(TECS_ALT_TIME_CONST_SLEW_RATE);
 	_tecs_alt_time_const_slew_rate.setForcedValue(_param_fw_t_h_error_tc.get() * _param_fw_thrtc_sc.get());
-
 }
 
 FwLateralLongitudinalControl::~FwLateralLongitudinalControl()


### PR DESCRIPTION
### Problem

 - https://github.com/PX4/PX4-Autopilot/pull/23519 introduced this reset using `setForcedValue` in the constructor of `FixedwingPositionControl`. This is the interface expected by `SlewRate` as indicated by its [tests](https://github.com/PX4/PX4-Autopilot/blob/main/src/lib/slew_rate/SlewRateTest.cpp).
 - https://github.com/PX4/PX4-Autopilot/pull/24056 accidentally moved it from the constructor to the `parameters_update`.

This means that now the time constant is reset to the tighter low-altitude value (intended for use below `FW_T_THR_LOW_HGT` by https://github.com/PX4/PX4-Autopilot/pull/23519) even though we could be arbitrarily high.

<img width="844" height="518" alt="image" src="https://github.com/user-attachments/assets/08e1620e-fa34-4923-9874-d4401db60b00" />


### Solution

Move both slew rate (given by a static constexpr) and initial reset to constructor.

