### PR TITLE
fix(navigator): enforce NAV_MIN_LTR_ALT in MC braking loiter

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -730,7 +730,14 @@ MissionBlock::setLoiterItemFromCurrentPositionWithBraking(struct mission_item_s 
 
 	_navigator->preproject_stop_point(item->lat, item->lon);
 
-	item->altitude = _navigator->get_global_position()->alt;
+	float loiter_altitude_amsl = _navigator->get_global_position()->alt;
+
+	if (_navigator->get_loiter_min_alt() > FLT_EPSILON) {
+		loiter_altitude_amsl = math::max(loiter_altitude_amsl,
+						 _navigator->get_home_position()->alt + _navigator->get_loiter_min_alt());
+	}
+
+	item->altitude = loiter_altitude_amsl;
 	item->loiter_radius = _navigator->get_default_loiter_rad();
 	item->yaw = NAN;
 }


### PR DESCRIPTION
Multicopter Hold/AUTO.LOITER silently ignores `NAV_MIN_LTR_ALT` when entered below the configured altitude, contradicting the [documented behavior](https://docs.px4.io/main/en/flight_modes_mc/hold#technical-summary). The min-altitude clamp was added to `MissionBlock::setLoiterItemFromCurrentPosition` in 2022 but never applied to the sibling `setLoiterItemFromCurrentPositionWithBraking`, which is the multicopter Hold path selected at `loiter.cpp:131` (`vehicle_type == ROTARY_WING`). Fixed-wing keeps working because it takes the non-braking branch.

This PR copies the same four-line clamp into the braking variant so the rotary-wing path matches.

Reproduced and verified in SITL (jMAVSim x500):

- before fix: `NAV_MIN_LTR_ALT=20`, Hold entered at ~5 m → vehicle held at 5 m for 30 s.
- after fix: same setup → vehicle climbs from 5 m to 20 m on Hold entry.

Local sanity:

- [x] `make px4_sitl` builds clean
- [ ] `make px4_fmu-v6x` not built locally (no arm toolchain on this machine — CI covers it)

Fixes #27578