### PR TITLE
feat(modules): uxrce_dds, add vtx and input_rc to DDS publications

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -110,6 +110,14 @@ publications:
     type: px4_msgs::msg::GimbalDeviceAttitudeStatus
     rate_limit: 20.
 
+  - topic: /fmu/out/vtx
+    type: px4_msgs::msg::Vtx
+    rate_limit: 1.
+
+  - topic: /fmu/out/input_rc
+    type: px4_msgs::msg::InputRc
+    rate_limit: 10.
+
 # Create uORB::Publication
 subscriptions:
   - topic: /fmu/in/register_ext_component_request


### PR DESCRIPTION
### Solved Problem

To create an OSD app on the companion computer one needs the vtx data as well as `InputRc`. The VTX driver was merged in January 2026 but `dds_topics.yaml` was not updated as part of that PR.

### Solution

Add two publish entries to `dds_topics.yaml`:

- `/fmu/out/vtx` (`px4_msgs::msg::Vtx`, 1 Hz) — VTX status telemetry (band, channel, frequency, power, protocol). Rate-limited to 1 Hz as VTX config changes are infrequent.
- `/fmu/out/input_rc` (`px4_msgs::msg::InputRc`, 10 Hz) — Raw RC input channels from hardware RC drivers including link data. Rate-limited to 10 Hz to avoid flooding the DDS bus.

The `InputRc` is especially useful for displaying the following attributes:
```
input_rc->link_quality
input_rc->rssi_dbm
input_rc->rc_frame_rate
input_rc->link_snr
input_rc->rssi
```