### PR TITLE
fix(rcS): FMU output pins not working when serial passthrough is not compiled for a board

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -539,12 +539,14 @@ else
 	else
 		commander start
 
-		if param compare -s PASSTHRU_EN 0
+		if param greater -s PASSTHRU_EN 0
 		then
+			# serial passthrough requested: leave the ESC lines free and
+			# reset so the next boot starts the outputs normally
+			param set PASSTHRU_EN 0
+		else
 			dshot start
 			pwm_out start
-		else
-			param set PASSTHRU_EN 0
 		fi
 	fi
 


### PR DESCRIPTION
  ### Problem
  After #27605 (serial passthrough), the FMU outputs (`pwm_out`/`dshot`) fail to
  start on boards that don't compile the serialpassthrough driver — e.g. fmu-v5x.
  Symptom: the PWM AUX output group disappears from the QGC Actuators screen and
  motors wired to the FMU pins won't arm. SITL is unaffected.

  ### Root cause
  `PASSTHRU_EN` is owned by `src/drivers/serialpassthrough/module.yaml`, so it is
  only registered when that driver is built in — which it isn't on most boards.
  When the param is absent, `param_find()` fails and `do_compare()` returns 1
  ("no match"), so the `else` branch runs and the FMU outputs are never started.
  The failure is silent (`-s`), so nothing appears in the boot log. SITL boots
  from `init.d-posix/rcS`, which doesn't contain this guard — hence CI didn't
  catch it.

  ### Fix
  Use the start-unless-explicitly-enabled idiom already used elsewhere in rcS
  (`param greater -s`): only skip the outputs when `PASSTHRU_EN` is explicitly
  `> 0`. A missing or zero parameter starts the outputs, restoring pre-#27605
  behaviour. Behaviour for the `0` and `>0` cases is unchanged.

  ### Testing
  Hardware-verified on fmu-v5x (Skynode): before the fix `pwm_out`/`dshot` report
  "not running" and `PWM_AUX_*` are unregistered; after the fix `pwm_out` runs with
  `Param prefix: PWM_AUX`, the AUX group returns, and the motors arm.

