### PR TITLE
fix(mavlink): correct BODY_NED position setpoint parsing and bitmasks

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1165,48 +1165,71 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 		} else if (target_local_ned.coordinate_frame == MAV_FRAME_BODY_NED) {
 
 			vehicle_attitude_s vehicle_attitude{};
-			_vehicle_attitude_sub.copy(&vehicle_attitude);
-			const matrix::Dcmf R{matrix::Quatf{vehicle_attitude.q}};
+                        _vehicle_attitude_sub.copy(&vehicle_attitude);
+                        const matrix::Dcmf R{matrix::Quatf{vehicle_attitude.q}};
+                        const float yaw = matrix::Eulerf{R}(2);
 
-			const bool ignore_velocity = type_mask & (POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE |
-						     POSITION_TARGET_TYPEMASK_VZ_IGNORE);
+                        // 1. FIX THE POSITION LOGIC
+                        const bool ignore_position = (type_mask & POSITION_TARGET_TYPEMASK_X_IGNORE) &&
+                                                     (type_mask & POSITION_TARGET_TYPEMASK_Y_IGNORE) &&
+                                                     (type_mask & POSITION_TARGET_TYPEMASK_Z_IGNORE);
 
-			if (!ignore_velocity) {
-				const matrix::Vector3f velocity_body_sp{
-					(type_mask & POSITION_TARGET_TYPEMASK_VX_IGNORE) ? 0.f : target_local_ned.vx,
-					(type_mask & POSITION_TARGET_TYPEMASK_VY_IGNORE) ? 0.f : target_local_ned.vy,
-					(type_mask & POSITION_TARGET_TYPEMASK_VZ_IGNORE) ? 0.f : target_local_ned.vz
-				};
+                        if (!ignore_position) {
+                                uORB::Subscription local_pos_sub{ORB_ID(vehicle_local_position)};
+                                vehicle_local_position_s local_pos{};
+                                local_pos_sub.copy(&local_pos); // Grab current position from the OS
 
+                                const matrix::Vector3f position_body_sp{
+                                        (type_mask & POSITION_TARGET_TYPEMASK_X_IGNORE) ? 0.f : target_local_ned.x,
+                                        (type_mask & POSITION_TARGET_TYPEMASK_Y_IGNORE) ? 0.f : target_local_ned.y,
+                                        (type_mask & POSITION_TARGET_TYPEMASK_Z_IGNORE) ? 0.f : target_local_ned.z
+                                };
 
-				const float yaw = matrix::Eulerf{R}(2);
+                                // Rotate the offset and add it to the current position
+                                setpoint.position[0] = local_pos.x + cosf(yaw) * position_body_sp(0) - sinf(yaw) * position_body_sp(1);
+                                setpoint.position[1] = local_pos.y + sinf(yaw) * position_body_sp(0) + cosf(yaw) * position_body_sp(1);
+                                setpoint.position[2] = local_pos.z + position_body_sp(2);
+                        } else {
+                                matrix::Vector3f(NAN, NAN, NAN).copyTo(setpoint.position);
+                        }
 
-				setpoint.velocity[0] = cosf(yaw) * velocity_body_sp(0) - sinf(yaw) * velocity_body_sp(1);
-				setpoint.velocity[1] = sinf(yaw) * velocity_body_sp(0) + cosf(yaw) * velocity_body_sp(1);
-				setpoint.velocity[2] = velocity_body_sp(2);
+                        // 2. FIX THE VELOCITY BITMASK LOGIC (Changed | to &&)
+                        const bool ignore_velocity = (type_mask & POSITION_TARGET_TYPEMASK_VX_IGNORE) &&
+                                                     (type_mask & POSITION_TARGET_TYPEMASK_VY_IGNORE) &&
+                                                     (type_mask & POSITION_TARGET_TYPEMASK_VZ_IGNORE);
 
-			} else {
-				matrix::Vector3f(NAN, NAN, NAN).copyTo(setpoint.velocity);
-			}
+                        if (!ignore_velocity) {
+                                const matrix::Vector3f velocity_body_sp{
+                                        (type_mask & POSITION_TARGET_TYPEMASK_VX_IGNORE) ? 0.f : target_local_ned.vx,
+                                        (type_mask & POSITION_TARGET_TYPEMASK_VY_IGNORE) ? 0.f : target_local_ned.vy,
+                                        (type_mask & POSITION_TARGET_TYPEMASK_VZ_IGNORE) ? 0.f : target_local_ned.vz
+                                };
 
-			const bool ignore_acceleration = type_mask & (POSITION_TARGET_TYPEMASK_AX_IGNORE | POSITION_TARGET_TYPEMASK_AY_IGNORE |
-							 POSITION_TARGET_TYPEMASK_AZ_IGNORE);
+                                setpoint.velocity[0] = cosf(yaw) * velocity_body_sp(0) - sinf(yaw) * velocity_body_sp(1);
+                                setpoint.velocity[1] = sinf(yaw) * velocity_body_sp(0) + cosf(yaw) * velocity_body_sp(1);
+                                setpoint.velocity[2] = velocity_body_sp(2);
+                        } else {
+                                matrix::Vector3f(NAN, NAN, NAN).copyTo(setpoint.velocity);
+                        }
 
-			if (!ignore_acceleration) {
-				const matrix::Vector3f acceleration_body_sp{
-					(type_mask & POSITION_TARGET_TYPEMASK_AX_IGNORE) ? 0.f : target_local_ned.afx,
-					(type_mask & POSITION_TARGET_TYPEMASK_AY_IGNORE) ? 0.f : target_local_ned.afy,
-					(type_mask & POSITION_TARGET_TYPEMASK_AZ_IGNORE) ? 0.f : target_local_ned.afz
-				};
+                        // 3. FIX THE ACCEL BITMASK LOGIC (Changed | to &&)
+                        const bool ignore_acceleration = (type_mask & POSITION_TARGET_TYPEMASK_AX_IGNORE) &&
+                                                         (type_mask & POSITION_TARGET_TYPEMASK_AY_IGNORE) &&
+                                                         (type_mask & POSITION_TARGET_TYPEMASK_AZ_IGNORE);
 
-				const matrix::Vector3f acceleration_setpoint{R * acceleration_body_sp};
-				acceleration_setpoint.copyTo(setpoint.acceleration);
+                        if (!ignore_acceleration) {
+                                const matrix::Vector3f acceleration_body_sp{
+                                        (type_mask & POSITION_TARGET_TYPEMASK_AX_IGNORE) ? 0.f : target_local_ned.afx,
+                                        (type_mask & POSITION_TARGET_TYPEMASK_AY_IGNORE) ? 0.f : target_local_ned.afy,
+                                        (type_mask & POSITION_TARGET_TYPEMASK_AZ_IGNORE) ? 0.f : target_local_ned.afz
+                                };
 
-			} else {
-				matrix::Vector3f(NAN, NAN, NAN).copyTo(setpoint.acceleration);
-			}
+                                const matrix::Vector3f acceleration_setpoint{R * acceleration_body_sp};
+                                acceleration_setpoint.copyTo(setpoint.acceleration);
 
-			matrix::Vector3f(NAN, NAN, NAN).copyTo(setpoint.position);
+                        } else {
+                                matrix::Vector3f(NAN, NAN, NAN).copyTo(setpoint.acceleration);
+                        }
 
 		} else {
 			mavlink_log_critical(&_mavlink_log_pub, "SET_POSITION_TARGET_LOCAL_NED coordinate frame %" PRIu8 " unsupported\t",

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1165,71 +1165,71 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 		} else if (target_local_ned.coordinate_frame == MAV_FRAME_BODY_NED) {
 
 			vehicle_attitude_s vehicle_attitude{};
-                        _vehicle_attitude_sub.copy(&vehicle_attitude);
-                        const matrix::Dcmf R{matrix::Quatf{vehicle_attitude.q}};
-                        const float yaw = matrix::Eulerf{R}(2);
+			_vehicle_attitude_sub.copy(&vehicle_attitude);
+			const matrix::Dcmf R{matrix::Quatf{vehicle_attitude.q}};
+			const float yaw = matrix::Eulerf{R}(2);
 
-                        // 1. FIX THE POSITION LOGIC
-                        const bool ignore_position = (type_mask & POSITION_TARGET_TYPEMASK_X_IGNORE) &&
-                                                     (type_mask & POSITION_TARGET_TYPEMASK_Y_IGNORE) &&
-                                                     (type_mask & POSITION_TARGET_TYPEMASK_Z_IGNORE);
+			// 1. FIX THE POSITION LOGIC
+			const bool ignore_position =	(type_mask & POSITION_TARGET_TYPEMASK_X_IGNORE) &&
+							(type_mask & POSITION_TARGET_TYPEMASK_Y_IGNORE) &&
+							(type_mask & POSITION_TARGET_TYPEMASK_Z_IGNORE);
 
-                        if (!ignore_position) {
-                                uORB::Subscription local_pos_sub{ORB_ID(vehicle_local_position)};
-                                vehicle_local_position_s local_pos{};
-                                local_pos_sub.copy(&local_pos); // Grab current position from the OS
+				if (!ignore_position) {
+				uORB::Subscription local_pos_sub{ORB_ID(vehicle_local_position)};
+				vehicle_local_position_s local_pos{};
+				local_pos_sub.copy(&local_pos); // Grab current position from the OS
 
-                                const matrix::Vector3f position_body_sp{
-                                        (type_mask & POSITION_TARGET_TYPEMASK_X_IGNORE) ? 0.f : target_local_ned.x,
-                                        (type_mask & POSITION_TARGET_TYPEMASK_Y_IGNORE) ? 0.f : target_local_ned.y,
-                                        (type_mask & POSITION_TARGET_TYPEMASK_Z_IGNORE) ? 0.f : target_local_ned.z
-                                };
+				const matrix::Vector3f position_body_sp{
+					(type_mask & POSITION_TARGET_TYPEMASK_X_IGNORE) ? 0.f : target_local_ned.x,
+					(type_mask & POSITION_TARGET_TYPEMASK_Y_IGNORE) ? 0.f : target_local_ned.y,
+					(type_mask & POSITION_TARGET_TYPEMASK_Z_IGNORE) ? 0.f : target_local_ned.z
+				};
 
-                                // Rotate the offset and add it to the current position
-                                setpoint.position[0] = local_pos.x + cosf(yaw) * position_body_sp(0) - sinf(yaw) * position_body_sp(1);
-                                setpoint.position[1] = local_pos.y + sinf(yaw) * position_body_sp(0) + cosf(yaw) * position_body_sp(1);
-                                setpoint.position[2] = local_pos.z + position_body_sp(2);
-                        } else {
-                                matrix::Vector3f(NAN, NAN, NAN).copyTo(setpoint.position);
-                        }
+				// Rotate the offset and add it to the current position
+				setpoint.position[0] = local_pos.x + cosf(yaw) * position_body_sp(0) - sinf(yaw) * position_body_sp(1);
+				setpoint.position[1] = local_pos.y + sinf(yaw) * position_body_sp(0) + cosf(yaw) * position_body_sp(1);
+				setpoint.position[2] = local_pos.z + position_body_sp(2);
+			} else {
+				matrix::Vector3f(NAN, NAN, NAN).copyTo(setpoint.position);
+			}
 
-                        // 2. FIX THE VELOCITY BITMASK LOGIC (Changed | to &&)
-                        const bool ignore_velocity = (type_mask & POSITION_TARGET_TYPEMASK_VX_IGNORE) &&
-                                                     (type_mask & POSITION_TARGET_TYPEMASK_VY_IGNORE) &&
-                                                     (type_mask & POSITION_TARGET_TYPEMASK_VZ_IGNORE);
+			// 2. FIX THE VELOCITY BITMASK LOGIC (Changed | to &&)
+			const bool ignore_velocity =	(type_mask & POSITION_TARGET_TYPEMASK_VX_IGNORE) &&
+							(type_mask & POSITION_TARGET_TYPEMASK_VY_IGNORE) &&
+							(type_mask & POSITION_TARGET_TYPEMASK_VZ_IGNORE);
 
-                        if (!ignore_velocity) {
-                                const matrix::Vector3f velocity_body_sp{
-                                        (type_mask & POSITION_TARGET_TYPEMASK_VX_IGNORE) ? 0.f : target_local_ned.vx,
-                                        (type_mask & POSITION_TARGET_TYPEMASK_VY_IGNORE) ? 0.f : target_local_ned.vy,
-                                        (type_mask & POSITION_TARGET_TYPEMASK_VZ_IGNORE) ? 0.f : target_local_ned.vz
-                                };
+			if (!ignore_velocity) {
+				const matrix::Vector3f velocity_body_sp{
+					(type_mask & POSITION_TARGET_TYPEMASK_VX_IGNORE) ? 0.f : target_local_ned.vx,
+					(type_mask & POSITION_TARGET_TYPEMASK_VY_IGNORE) ? 0.f : target_local_ned.vy,
+					(type_mask & POSITION_TARGET_TYPEMASK_VZ_IGNORE) ? 0.f : target_local_ned.vz
+				};
 
-                                setpoint.velocity[0] = cosf(yaw) * velocity_body_sp(0) - sinf(yaw) * velocity_body_sp(1);
-                                setpoint.velocity[1] = sinf(yaw) * velocity_body_sp(0) + cosf(yaw) * velocity_body_sp(1);
-                                setpoint.velocity[2] = velocity_body_sp(2);
-                        } else {
-                                matrix::Vector3f(NAN, NAN, NAN).copyTo(setpoint.velocity);
-                        }
+				setpoint.velocity[0] = cosf(yaw) * velocity_body_sp(0) - sinf(yaw) * velocity_body_sp(1);
+				setpoint.velocity[1] = sinf(yaw) * velocity_body_sp(0) + cosf(yaw) * velocity_body_sp(1);
+				setpoint.velocity[2] = velocity_body_sp(2);
+			} else {
+				matrix::Vector3f(NAN, NAN, NAN).copyTo(setpoint.velocity);
+			}
 
-                        // 3. FIX THE ACCEL BITMASK LOGIC (Changed | to &&)
-                        const bool ignore_acceleration = (type_mask & POSITION_TARGET_TYPEMASK_AX_IGNORE) &&
-                                                         (type_mask & POSITION_TARGET_TYPEMASK_AY_IGNORE) &&
-                                                         (type_mask & POSITION_TARGET_TYPEMASK_AZ_IGNORE);
+			// 3. FIX THE ACCEL BITMASK LOGIC (Changed | to &&)
+			const bool ignore_acceleration = (type_mask & POSITION_TARGET_TYPEMASK_AX_IGNORE) &&
+							 (type_mask & POSITION_TARGET_TYPEMASK_AY_IGNORE) &&
+							 (type_mask & POSITION_TARGET_TYPEMASK_AZ_IGNORE);
 
-                        if (!ignore_acceleration) {
-                                const matrix::Vector3f acceleration_body_sp{
-                                        (type_mask & POSITION_TARGET_TYPEMASK_AX_IGNORE) ? 0.f : target_local_ned.afx,
-                                        (type_mask & POSITION_TARGET_TYPEMASK_AY_IGNORE) ? 0.f : target_local_ned.afy,
-                                        (type_mask & POSITION_TARGET_TYPEMASK_AZ_IGNORE) ? 0.f : target_local_ned.afz
-                                };
+			if (!ignore_acceleration) {
+				const matrix::Vector3f acceleration_body_sp{
+					(type_mask & POSITION_TARGET_TYPEMASK_AX_IGNORE) ? 0.f : target_local_ned.afx,
+					(type_mask & POSITION_TARGET_TYPEMASK_AY_IGNORE) ? 0.f : target_local_ned.afy,
+					(type_mask & POSITION_TARGET_TYPEMASK_AZ_IGNORE) ? 0.f : target_local_ned.afz
+				};
 
-                                const matrix::Vector3f acceleration_setpoint{R * acceleration_body_sp};
-                                acceleration_setpoint.copyTo(setpoint.acceleration);
+				const matrix::Vector3f acceleration_setpoint{R * acceleration_body_sp};
+				acceleration_setpoint.copyTo(setpoint.acceleration);
 
-                        } else {
-                                matrix::Vector3f(NAN, NAN, NAN).copyTo(setpoint.acceleration);
-                        }
+			} else {
+				matrix::Vector3f(NAN, NAN, NAN).copyTo(setpoint.acceleration);
+			}
 
 		} else {
 			mavlink_log_critical(&_mavlink_log_pub, "SET_POSITION_TARGET_LOCAL_NED coordinate frame %" PRIu8 " unsupported\t",

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1174,7 +1174,7 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 							(type_mask & POSITION_TARGET_TYPEMASK_Y_IGNORE) &&
 							(type_mask & POSITION_TARGET_TYPEMASK_Z_IGNORE);
 
-				if (!ignore_position) {
+			if (!ignore_position) {
 				uORB::Subscription local_pos_sub{ORB_ID(vehicle_local_position)};
 				vehicle_local_position_s local_pos{};
 				local_pos_sub.copy(&local_pos); // Grab current position from the OS

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1189,6 +1189,7 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 				setpoint.position[0] = local_pos.x + cosf(yaw) * position_body_sp(0) - sinf(yaw) * position_body_sp(1);
 				setpoint.position[1] = local_pos.y + sinf(yaw) * position_body_sp(0) + cosf(yaw) * position_body_sp(1);
 				setpoint.position[2] = local_pos.z + position_body_sp(2);
+
 			} else {
 				matrix::Vector3f(NAN, NAN, NAN).copyTo(setpoint.position);
 			}
@@ -1208,6 +1209,7 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 				setpoint.velocity[0] = cosf(yaw) * velocity_body_sp(0) - sinf(yaw) * velocity_body_sp(1);
 				setpoint.velocity[1] = sinf(yaw) * velocity_body_sp(0) + cosf(yaw) * velocity_body_sp(1);
 				setpoint.velocity[2] = velocity_body_sp(2);
+
 			} else {
 				matrix::Vector3f(NAN, NAN, NAN).copyTo(setpoint.velocity);
 			}


### PR DESCRIPTION
Previously, 'SET_POSITION_TARGET_LOCAL_NED' messages using 'MAV_FRAME_BODY_NED' with position-only or partial-velocity bitmasks were incorrectly rejected. This fix properly rotates body-position offsets to local Earth coordinates and replaces the bitwise OR with AND for the velocity/acceleration ignore masks.

### Solved Problem
Fixes #27617

The current implementation of 'MavlinkReceiver::handle_message_set_position_target_local_ned' incorrectly rejects valid 'MAV_FRAME_BODY_NED' messages from companion computers. 
1. It forcefully sets the position to 'NAN', failing position-only setpoints.
2. It uses a bitwise 'OR' ('|') for velocity and acceleration ignore masks, causing the entire message to be rejected if even a single axis is masked out.

### Solution
* **Bitmask Logic:** Replaced the bitwise '|' with '&&' when evaluating the 'ignore_velocity' and 'ignore_acceleration' booleans to perfectly match the 'LOCAL_NED' parsing behavior.
* **Position Transformation:** Added logic to handle body-frame position setpoints. The receiver now creates a 'uORB::Subscription' to 'vehicle_local_position', rotates the requested body-frame offsets by the vehicle's current yaw, and applies them to the current local position to generate a valid 'LOCAL_NED' target.

### Changelog Entry
Bugfix: MavlinkReceiver now correctly parses position-only and partial-velocity `SET_POSITION_TARGET_LOCAL_NED` messages in the `BODY_NED` frame.

### Alternatives
N/A. Without this fix, offboard companion computers cannot reliably use the BODY_NED frame for targeted positional movements or partial velocity vectors.

### Test coverage
Tested locally in PX4 SITL (Gazebo gz_x500). Wrote a custom PyMAVLink script to send position-only MAV_FRAME_BODY_NED messages with a type_mask ignoring velocity and acceleration.

Before: Firmware rejected the command with WARN [mavlink] SET_POSITION_TARGET_LOCAL_NED invalid.

After: Firmware successfully parsed the bitmask, transformed the position coordinates, and accepted the command silently without throwing warnings.

Context
This is highly relevant for edge-AI companion computers (such as the Jetson Nano) that attempt to send relative coordinate movements to the flight controller via MAVLink.