### PR TITLE
fix(mavlink): retune low_bandwidth stream rates for manual fixed-wing flight

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1930,10 +1930,9 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 
 	case MAVLINK_MODE_LOW_BANDWIDTH:
 		// Note: streams requiring low latency come first
-		configure_stream_local("TIMESYNC", 10.0f);
 		configure_stream_local("CAMERA_TRIGGER", 2.0f);
 		configure_stream_local("LOCAL_POSITION_NED", 1.0f);
-		configure_stream_local("ATTITUDE_QUATERNION", 2.0f);
+		configure_stream_local("ATTITUDE_QUATERNION", 4.0f);
 		configure_stream_local("ALTITUDE", 1.0f);
 		configure_stream_local("DISTANCE_SENSOR", 1.0f);
 		configure_stream_local("MOUNT_ORIENTATION", 2.0f);
@@ -1942,23 +1941,23 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("GIMBAL_MANAGER_STATUS", 0.5f);
 		configure_stream_local("GIMBAL_DEVICE_SET_ATTITUDE", 2.0f);
 		configure_stream_local("ESC_INFO", 1.0f);
-		configure_stream_local("ESC_STATUS", 2.0f);
+		configure_stream_local("ESC_STATUS", 1.0f);
 #if defined(MAVLINK_MSG_ID_ESC_EEPROM)
 		configure_stream_local("ESC_EEPROM", unlimited_rate);
 #endif
 		configure_stream_local("ADSB_VEHICLE", 1.0f);
 		configure_stream_local("ATTITUDE_TARGET", 0.5f);
 		configure_stream_local("AVAILABLE_MODES", 0.3f);
-		configure_stream_local("BATTERY_STATUS", 0.5f);
+		configure_stream_local("BATTERY_STATUS", 1.0f);
 		configure_stream_local("CAMERA_IMAGE_CAPTURED", 2.0f);
 		configure_stream_local("CURRENT_MODE", 0.5f);
 		configure_stream_local("ESTIMATOR_STATUS", 1.0f);
 		configure_stream_local("EXTENDED_SYS_STATE", 0.5f);
 		configure_stream_local("GLOBAL_POSITION_INT", 2.0f);
 		configure_stream_local("GLOBAL_POSITION_SENSOR", 2.0f);
-		configure_stream_local("GPS_GLOBAL_ORIGIN", 1.0f);
-		configure_stream_local("GPS2_RAW", 2.0f);
-		configure_stream_local("GPS_RAW_INT", 2.0f);
+		configure_stream_local("GPS_GLOBAL_ORIGIN", 0.1f);
+		configure_stream_local("GPS2_RAW", 1.0f);
+		configure_stream_local("GPS_RAW_INT", 1.0f);
 		configure_stream_local("HOME_POSITION", 0.5f);
 		configure_stream_local("NAV_CONTROLLER_OUTPUT", 0.1f);
 		configure_stream_local("OPTICAL_FLOW_RAD", 0.1f);
@@ -1966,13 +1965,13 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("PING", 0.1f);
 		configure_stream_local("POSITION_TARGET_GLOBAL_INT", 0.5f);
 		configure_stream_local("POSITION_TARGET_LOCAL_NED", 0.5f);
-		configure_stream_local("RAW_RPM", 1.0f);
-		configure_stream_local("RC_CHANNELS", 5.0f);
+		configure_stream_local("RAW_RPM", 2.0f);
+		configure_stream_local("RC_CHANNELS", 1.0f);
 		configure_stream_local("SERVO_OUTPUT_RAW_0", 0.1f);
 		configure_stream_local("SYS_STATUS", 0.5f);
-		configure_stream_local("SYSTEM_TIME", 2.0f);
+		configure_stream_local("SYSTEM_TIME", 0.5f);
 		configure_stream_local("TIME_ESTIMATE_TO_TARGET", 0.5f);
-		configure_stream_local("VFR_HUD", 1.5f);
+		configure_stream_local("VFR_HUD", 4.0f);
 		configure_stream_local("VIBRATION", 0.1f);
 		configure_stream_local("WIND_COV", 0.1f);
 #if defined(MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS)


### PR DESCRIPTION
The low_bandwidth MAVLink mode (`mavlink start -m low_bandwidth`) is meant for telemetry over constrained RF links, but as currently tuned it wastes bandwidth on high-rate redundant streams (e.g. `TIMESYNC` at 10 Hz, which normal mode doesn't stream at all) while updating the flight instruments too slowly to fly fixed-wing by reference. This retunes the per-stream rates in the `MAVLINK_MODE_LOW_BANDWIDTH` case so flight-critical messages update faster and redundant/low-value traffic goes slower or away, for a net bandwidth decrease.

Faster, for manual instrument flight and to catch transient states:
- `ATTITUDE_QUATERNION` 2 → 4 Hz — artificial horizon responsiveness
- `VFR_HUD` 1.5 → 4 Hz — primary instrument; matches normal mode
- `BATTERY_STATUS` 0.5 → 1 Hz — catch transient states
- `RAW_RPM` 1 → 2 Hz — catch transient states; matches normal mode

Slower or removed, for bandwidth savings:
- `TIMESYNC` removed — mirrors normal mode, which doesn't stream it at all. `onboard_low_bandwidth`, which keeps `TIMESYNC` at 10 Hz and is untouched.
- `SYSTEM_TIME` 2 → 0.5 Hz — kept low for vehicle/GCS clock alignment (the GCS uses the vehicle `time_unix_usec` to align log timestamps); PX4 still consumes an incoming `SYSTEM_TIME` to set its RTC regardless of this stream.
- `RC_CHANNELS` 5 → 1 Hz — vehicle→GCS echo of RC input, not the control uplink
- `GPS_RAW_INT` 2 → 1 Hz — fix type / sat count, 1 Hz is fine
- `GPS2_RAW` 2 → 1 Hz — was above normal mode's 1 Hz
- `ESC_STATUS` 2 → 1 Hz — was above normal mode's 1 Hz
- `GPS_GLOBAL_ORIGIN` 1 → 0.1 Hz — EKF origin is set once at init and is ~static

`ALTITUDE` stays at 1 Hz since `VFR_HUD` at 4 Hz already carries altitude and climb rate and normal mode also keeps it at 1 Hz. Only the `MAVLINK_MODE_LOW_BANDWIDTH` case is changed; `onboard_low_bandwidth` and all other modes are unaffected.
