### PR TITLE
feat(airframes): add generic airship

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/2500_generic_airship
+++ b/ROMFS/px4fmu_common/init.d/airframes/2500_generic_airship
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# @name Generic Airship
+# @type Airship
+# @class Airship
+# @maintainer Hyunduk Shin <hyunduk@icarus-airship.com>
+#
+# @output Motor1 starboard thruster
+# @output Motor2 port thruster
+# @output Servo1 right elevator
+# @output Servo2 left elevator
+# @output Servo3 upper rudder
+# @output Servo4 lower rudder
+#
+# @board px4_fmu-v2 exclude
+# @board bitcraze_crazyflie exclude
+#
+
+. ${R}etc/init.d/rc.airship_defaults
+
+param set-default COM_PREARM_MODE 2
+
+param set-default CA_AIRFRAME 9
+
+# Thrusters offset starboard/port but driven collectively
+param set-default CA_ROTOR_COUNT 2
+param set-default CA_ROTOR0_AX 1
+param set-default CA_ROTOR0_AZ 0
+param set-default CA_ROTOR0_KM 0
+param set-default CA_ROTOR0_PY 0
+param set-default CA_ROTOR1_AX 1
+param set-default CA_ROTOR1_AZ 0
+param set-default CA_ROTOR1_KM 0
+param set-default CA_ROTOR1_PY 0
+
+param set-default CA_SV_CS_COUNT 4
+param set-default CA_SV_CS0_TYPE 3
+param set-default CA_SV_CS0_TRQ_P 0.5
+param set-default CA_SV_CS1_TYPE 3
+param set-default CA_SV_CS1_TRQ_P 0.5
+param set-default CA_SV_CS2_TYPE 4
+param set-default CA_SV_CS2_TRQ_Y 0.5
+param set-default CA_SV_CS3_TYPE 4
+param set-default CA_SV_CS3_TRQ_Y 0.5

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -127,6 +127,7 @@ endif()
 
 if(CONFIG_MODULES_AIRSHIP_ATT_CONTROL)
 	px4_add_romfs_files(
+		2500_generic_airship
 		2507_cloudship
 	)
 endif()

--- a/docs/en/frames_airship/index.md
+++ b/docs/en/frames_airship/index.md
@@ -7,5 +7,9 @@ Support for airships is [experimental](../airframes/index.md#experimental-vehicl
 Maintainer volunteers, [contribution](../contribute/index.md) of new features, new frame configurations, or other improvements would all be very welcome!
 :::
 
-PX4 supports a single airship geometry with starboard, port and tail thrusters, and a thrust tilt server.
-The frame configuration is shown in [Airframes Reference > Airship](../airframes/airframe_reference.md#airship).
+PX4 supports two airship geometries:
+
+- **Generic airship:** <Badge type="tip" text="PX4 v1.18" /> two forward thrusters and a cruciform tail with elevators and rudders.
+- **Cloudship:** starboard, port and tail thrusters with a thrust tilt servo.
+
+The frame configurations are shown in [Airframes Reference > Airship](../airframes/airframe_reference.md#airship).


### PR DESCRIPTION
Adds a generic non-rigid airship airframe — a second airship geometry alongside the existing Cloudship — on PX4's experimental manual-passthrough airship stack. Unlike Cloudship (tiltable side thrusters plus a tail thruster), this is a conventional cruciform-tail airship: two forward fixed thrusters for propulsion and aerodynamic control surfaces for steering. It is config-only (no C++ changes) and reuses the existing `airship_att_control` manual passthrough and `rc.airship_defaults`.

- 2 forward fixed gondola thrusters (collective forward thrust)
- cruciform tail allocated as control surfaces: 2 elevators (pitch) and 2 rudders (yaw)
- `CA_AIRFRAME=9` (Custom), composing rotors and control surfaces

Manual passthrough only, consistent with the current experimental airship support; autonomous flight, a SITL model, and board enablement are intentionally out of scope.

Bench-verified on a Cube Orange: the pitch stick drives the elevator outputs, yaw the rudders, and throttle both thrusters, all producing valid servo PWM (measured on MAIN OUT with a logic analyzer). The control-allocation matrix was also checked in SITL with `control_allocator status`.
