### PR TITLE
fix(zenoh): allow CDR padding margin in subscriber payload guard

### DIFF
--- a/src/lib/cdrstream/dds_serializer.h
+++ b/src/lib/cdrstream/dds_serializer.h
@@ -40,12 +40,9 @@
 extern const struct dds_cdrstream_allocator dds_allocator;
 extern const uint8_t ros2_header[4];
 
-// Upper bound on how many bytes XCDR1 serialization can exceed the in-memory
-// uORB struct size (o_size). The struct layout is sorted by field size to
-// minimize padding, while CDR serializes in declaration order and inserts more
-// alignment padding, so the wire size can be larger than o_size. Used both to
-// size outbound serialization buffers and to bound inbound payloads before
-// stack allocation.
+// Max bytes the XCDR1 wire size can exceed the in-memory uORB struct (o_size):
+// CDR pads in declaration order while the struct is packed sorted-by-size.
+// Sizes outbound buffers and bounds inbound payloads before stack allocation.
 #define CDR_SAFETY_MARGIN 24
 
 #endif //DDS_CDRSTREAM_SERDER_H

--- a/src/lib/cdrstream/dds_serializer.h
+++ b/src/lib/cdrstream/dds_serializer.h
@@ -40,4 +40,12 @@
 extern const struct dds_cdrstream_allocator dds_allocator;
 extern const uint8_t ros2_header[4];
 
+// Upper bound on how many bytes XCDR1 serialization can exceed the in-memory
+// uORB struct size (o_size). The struct layout is sorted by field size to
+// minimize padding, while CDR serializes in declaration order and inserts more
+// alignment padding, so the wire size can be larger than o_size. Used both to
+// size outbound serialization buffers and to bound inbound payloads before
+// stack allocation.
+#define CDR_SAFETY_MARGIN 24
+
 #endif //DDS_CDRSTREAM_SERDER_H

--- a/src/modules/zenoh/publishers/uorb_publisher.hpp
+++ b/src/modules/zenoh/publishers/uorb_publisher.hpp
@@ -45,8 +45,6 @@
 #include <uORB/Subscription.hpp>
 #include <dds_serializer.h>
 
-#define CDR_SAFETY_MARGIN 24
-
 class uORB_Zenoh_Publisher : public Zenoh_Publisher
 {
 public:

--- a/src/modules/zenoh/subscribers/uorb_subscriber.hpp
+++ b/src/modules/zenoh/subscribers/uorb_subscriber.hpp
@@ -45,6 +45,7 @@
 #include <uORB/topics/input_rc.h>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/actuator_outputs.h>
+#include <perf/perf_counter.h>
 
 class uORB_Zenoh_Subscriber : public Zenoh_Subscriber
 {
@@ -68,6 +69,7 @@ public:
 	{
 		undeclare_subscriber();
 		orb_unadvertise(_uorb_pub_handle);
+		perf_free(_payload_drop_perf);
 	}
 
 	// Update the uORB Subscription and broadcast a Zenoh ROS2 message
@@ -79,13 +81,12 @@ public:
 		const z_loaned_bytes_t *payload = z_sample_payload(sample);
 		size_t len = z_bytes_len(payload);
 
-		// Validate payload size to prevent stack overflow from untrusted input.
-		// CDR payload = 4-byte header + serialized data. CDR alignment padding can make
-		// the serialized data larger than the in-memory struct, so allow the same
-		// CDR_SAFETY_MARGIN the publisher budgets for (see dds_serializer.h).
+		// Bound payload before stack allocation to reject oversized/truncated input.
+		// Allow the CDR_SAFETY_MARGIN the publisher budgets for padding (see dds_serializer.h).
 		const size_t max_payload_size = _uorb_meta->o_size + 4 + CDR_SAFETY_MARGIN;
 
 		if (len > max_payload_size || len < 4) {
+			perf_count(_payload_drop_perf);
 			return;
 		}
 
@@ -96,7 +97,7 @@ public:
 		if (z_bytes_get_contiguous_view(payload, &view) == Z_OK) {
 			const uint8_t *ptr = z_slice_data(z_loan(view));
 
-			dds_istream_t is = {.m_buffer = (unsigned char *)(ptr + 4), .m_size = static_cast<int>(len),
+			dds_istream_t is = {.m_buffer = (unsigned char *)(ptr + 4), .m_size = static_cast<int>(len - 4),
 					    .m_index = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_1
 					   };
 			dds_stream_read(&is, data, &dds_allocator, _cdr_ops);
@@ -108,7 +109,7 @@ public:
 			z_bytes_reader_t reader = z_bytes_get_reader(payload);
 			z_bytes_reader_read(&reader, reassembled_payload, len);
 
-			dds_istream_t is = {.m_buffer = &reassembled_payload[4], .m_size = static_cast<int>(len),
+			dds_istream_t is = {.m_buffer = &reassembled_payload[4], .m_size = static_cast<int>(len - 4),
 					    .m_index = 0, .m_xcdr_version = DDSI_RTPS_CDR_ENC_VERSION_1
 					   };
 			dds_stream_read(&is, data, &dds_allocator, _cdr_ops);
@@ -148,4 +149,5 @@ private:
 	const orb_metadata *_uorb_meta;
 	orb_advert_t _uorb_pub_handle;
 	const uint32_t *_cdr_ops;
+	perf_counter_t _payload_drop_perf{perf_alloc(PC_COUNT, "zenoh: rx invalid size")};
 };

--- a/src/modules/zenoh/subscribers/uorb_subscriber.hpp
+++ b/src/modules/zenoh/subscribers/uorb_subscriber.hpp
@@ -80,8 +80,10 @@ public:
 		size_t len = z_bytes_len(payload);
 
 		// Validate payload size to prevent stack overflow from untrusted input.
-		// CDR payload = 4-byte header + serialized data, which should not exceed o_size + 4.
-		const size_t max_payload_size = _uorb_meta->o_size + 4;
+		// CDR payload = 4-byte header + serialized data. CDR alignment padding can make
+		// the serialized data larger than the in-memory struct, so allow the same
+		// CDR_SAFETY_MARGIN the publisher budgets for (see dds_serializer.h).
+		const size_t max_payload_size = _uorb_meta->o_size + 4 + CDR_SAFETY_MARGIN;
 
 		if (len > max_payload_size || len < 4) {
 			return;

--- a/src/modules/zenoh/subscribers/uorb_subscriber.hpp
+++ b/src/modules/zenoh/subscribers/uorb_subscriber.hpp
@@ -75,7 +75,7 @@ public:
 	// Update the uORB Subscription and broadcast a Zenoh ROS2 message
 	void data_handler(const z_loaned_sample_t *sample)
 	{
-		char data[_uorb_meta->o_size];
+		char data[_uorb_meta->o_size + CDR_SAFETY_MARGIN];
 
 		// TODO process rmw_zenoh attachment
 		const z_loaned_bytes_t *payload = z_sample_payload(sample);


### PR DESCRIPTION
### Solved Problem

The inbound payload size guard added in 2d79b9ea38 rejects any Zenoh/CDR payload larger than `o_size + 4`, on the assumption that the CDR-serialized data is never larger than the in-memory uORB struct. That assumption is wrong.

uORB structs are laid out with their fields **sorted by size** to minimize padding, while XCDR1 serializes fields in **declaration order** and inserts alignment padding accordingly. The serialized wire size can therefore legitimately exceed `o_size`, and the guard silently drops valid `/fmu/in` messages.

Measuring the actual wire size against `o_size` for every message type, several subscribed `/fmu/in` topics are wrongly dropped:

| topic | type | o_size | wire len | old limit (`o_size+4`) |
|---|---|---|---|---|
| vehicle_visual_odometry / vehicle_mocap_odometry | VehicleOdometry | 112 | 120 | 116 |
| goto_setpoint | GotoSetpoint | 40 | 56 | 44 |
| sensor_optical_flow | SensorOpticalFlow | 72 | 84 | 76 |
| distance_sensor | DistanceSensor | 56 | 64 | 60 |

### Solution

The publisher side already handles this correctly: it sizes its serialization buffer as `o_size + 4 + CDR_SAFETY_MARGIN` (margin `24`), which matches the measured maximum overhead across all types (`max(len - o_size) = 28 = 4 + 24`). The subscriber guard simply omitted that margin.

- Move `CDR_SAFETY_MARGIN` into the shared `dds_serializer.h` (which already holds `ros2_header[4]` and `dds_allocator`) so the publisher and subscriber share one definition.
- Change the subscriber guard from `o_size + 4` to `o_size + 4 + CDR_SAFETY_MARGIN`.
- Fix the now-incorrect comment.

The guard still bounds the stack allocation against untrusted input (at most `o_size + 28`); oversized and truncated payloads are still rejected.

### Test coverage

- Computed the CDR wire size for the affected types and confirmed all four now pass the guard while remaining bounded; oversized (`len = 10000`), boundary `+1`, and truncated (`len = 3`) payloads are still dropped.
- `make px4_sitl_zenoh` builds cleanly.
- End-to-end before/after in SITL below.

### Context

Regression introduced in 2d79b9ea38 ("fix(zenoh): validate payload size before stack allocation").

**Before fix** — a valid message on an affected `/fmu/in` topic never reaches uORB (dropped by the guard):

<img width="1772" height="1394" alt="Screenshot from 2026-06-20 21-11-47" src="https://github.com/user-attachments/assets/dd1f5357-1873-4d3d-ba00-949964b61a27" />

**After fix** — the same message is received and published to uORB:

<img width="1772" height="1394" alt="Screenshot from 2026-06-20 21-10-18" src="https://github.com/user-attachments/assets/84c85824-2d62-4bcc-91d1-d101287cc408" />

Setup: SITL (px4_sitl_zenoh) bridged to ROS 2 via a Zenoh router.

  [Top] `ros2 run rmw_zenoh_cpp rmw_zenohd`
        Zenoh router bridging ROS 2 (rmw_zenoh) and PX4 (zenoh-pico). "Started Zenoh router".

  [Middle] `ros2 topic pub /fmu/in/vehicle_visual_odometry px4_msgs/msg/VehicleOdometry "{...}"`
        A ROS 2 node publishing VehicleOdometry (position [11, 22, 33]) at 10 Hz.

  [Bottom] PX4 console: `zenoh start` then `listener vehicle_visual_odometry`