### PR TITLE
feat(gz_bridge): Make IMU and Mag subscription optional for gz_bridge

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -83,15 +83,19 @@ int GZBridge::init()
 		return PX4_ERROR;
 	}
 
-	if (!subscribeImu(true)) {
-		return PX4_ERROR;
-	}
-
-	if (!subscribeMag(true)) {
-		return PX4_ERROR;
-	}
-
 	// OPTIONAL:
+	if (_sim_gz_en_imu.get()) {
+		if (!subscribeImu(false)) {
+			return PX4_ERROR;
+		}
+	}
+
+	if (_sim_gz_en_mag.get()) {
+		if (!subscribeMag(false)) {
+			return PX4_ERROR;
+		}
+	}
+
 	if (_sim_gz_en_gps.get()) {
 		if (!subscribeNavsat(false)) {
 			return PX4_ERROR;

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -204,6 +204,8 @@ private:
 		(ParamInt<px4::params::SIM_GZ_EN_ASPD>) _sim_gz_en_aspd,
 		(ParamInt<px4::params::SIM_GZ_EN_BARO>) _sim_gz_en_baro,
 		(ParamInt<px4::params::SIM_GZ_EN_ODOM>) _sim_gz_en_odom,
-		(ParamInt<px4::params::SIM_GZ_EN_GPS>) _sim_gz_en_gps
+		(ParamInt<px4::params::SIM_GZ_EN_GPS>) _sim_gz_en_gps,
+		(ParamInt<px4::params::SIM_GZ_EN_IMU>) _sim_gz_en_imu,
+		(ParamInt<px4::params::SIM_GZ_EN_MAG>) _sim_gz_en_mag
 	)
 };

--- a/src/modules/simulation/gz_bridge/parameters.yaml
+++ b/src/modules/simulation/gz_bridge/parameters.yaml
@@ -56,6 +56,24 @@ parameters:
         1: Enabled
       default: 1
       reboot_required: true
+    SIM_GZ_EN_IMU:
+      description:
+        short: Enable IMU sensor in Gazebo bridge
+      type: enum
+      values:
+        0: Disabled
+        1: Enabled
+      default: 1
+      reboot_required: true
+    SIM_GZ_EN_MAG:
+      description:
+        short: Enable magnetometer sensor in Gazebo bridge
+      type: enum
+      values:
+        0: Disabled
+        1: Enabled
+      default: 1
+      reboot_required: true
 - group: UAVCAN
   definitions:
     SIM_GZ_EN:


### PR DESCRIPTION
### Solved Problem
Previously, it was not possible to not subscribe to the imu topics in gz sim. This is because the `gz_bridge` treats imu and mag differently from other sensors. However, it maybe useful that we would want to test the system against a more general setup.

For example, when running an external estimator with `EKF_EN=0`.

### Solution
Treat IMU like other sensors, such that all sensors are treated the same way. 

### Changelog Entry
For release notes:
```
Feature(gz_bridge): Make imu subscription optional for gz_bridge
New parameter: `SIM_GZ_EN_IMU`, `SIM_GZ_EN_MAG`
Documentation: Need to clarify page in Gz simulation
```

### Alternatives
- We can always require an imu on a vehicle. However, not sure what value this brings :smile: 

### Test coverage

### Context
Related links, screenshot before/after, video
