### PR TITLE
fix(navigator): publish geofence result also if GF_ACTION==0

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/geofenceCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/geofenceCheck.cpp
@@ -45,7 +45,7 @@ void GeofenceChecks::checkAndReport(const Context &context, Report &reporter)
 					    geofence_result.geofence_max_alt_triggered ||
 					    geofence_result.geofence_custom_fence_triggered;
 
-	reporter.failsafeFlags().geofence_breached = any_geofence_triggered;
+	reporter.failsafeFlags().geofence_breached = geofence_result.geofence_action != geofence_result_s::GF_ACTION_NONE && any_geofence_triggered;
 
 	if (geofence_result.geofence_action != geofence_result_s::GF_ACTION_NONE && any_geofence_triggered) {
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/systemCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/systemCheck.hpp
@@ -53,7 +53,6 @@ private:
 					(ParamInt<px4::params::CBRK_VTOLARMING>) _param_cbrk_vtolarming,
 					(ParamInt<px4::params::CBRK_USB_CHK>) _param_cbrk_usb_chk,
 					(ParamBool<px4::params::COM_ARM_WO_GPS>) _param_com_arm_wo_gps,
-					(ParamInt<px4::params::COM_ARM_AUTH_REQ>) _param_com_arm_auth_req,
-					(ParamInt<px4::params::GF_ACTION>) _param_gf_action
+					(ParamInt<px4::params::COM_ARM_AUTH_REQ>) _param_com_arm_auth_req
 				       )
 };

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1007,8 +1007,7 @@ void Navigator::geofence_breach_check()
 		_time_loitering_after_gf_breach = 0;
 	}
 
-	if ((_geofence.getGeofenceAction() != geofence_result_s::GF_ACTION_NONE) &&
-	    (hrt_elapsed_time(&_last_geofence_check) > GEOFENCE_CHECK_INTERVAL_US)) {
+	if (hrt_elapsed_time(&_last_geofence_check) > GEOFENCE_CHECK_INTERVAL_US) {
 
 		double current_latitude = _global_pos.lat;
 		double current_longitude = _global_pos.lon;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1043,9 +1043,11 @@ void Navigator::geofence_breach_check()
 					current_longitude, current_altitude);
 		}
 
-		_last_geofence_check = hrt_absolute_time();
+		const auto now = hrt_absolute_time();
 
-		_geofence_result.timestamp = hrt_absolute_time();
+		_last_geofence_check = now;
+
+		_geofence_result.timestamp = now;
 		_geofence_result.geofence_action = _geofence.getGeofenceAction();
 
 		const bool breach = _geofence_result.geofence_max_dist_triggered
@@ -1058,7 +1060,7 @@ void Navigator::geofence_breach_check()
 
 				// loiter at the current position; we no longer predict ahead of the vehicle
 				position_setpoint_triplet_s *rep = get_reposition_triplet();
-				rep->current.timestamp = hrt_absolute_time();
+				rep->current.timestamp = now;
 				rep->current.yaw = NAN;
 				rep->current.lat = current_latitude;
 				rep->current.lon = current_longitude;
@@ -1071,7 +1073,7 @@ void Navigator::geofence_breach_check()
 				rep->current.cruising_speed = get_cruising_speed();
 
 				_geofence_reposition_sent = true;
-				_time_loitering_after_gf_breach = hrt_absolute_time();
+				_time_loitering_after_gf_breach = now;
 			}
 
 		} else {


### PR DESCRIPTION
### Problem

Currently there is the this bug:
 - Set `GF_ACTION=2`, breach a geofence
 - While the breach is still occurring, set `GF_ACTION=0`
 - Fly out of the geofence
 - The warning from `GeofenceChecks::checkAndReport` sticks around

This is because the entire section is gated by `GF_ACTION != 0`, so if it is changed to 0, no `geofence_result` message is published again. All consumers are then left with stale data.

### Solution 

Do not gate on `GF_ACTION != 0`. We regularly send `geofence_result` with the configured action in `geofence_action`. The individual `geofence_*_triggered` flags are still populated - consumers ignore them if `GF_ACTION` is 0.

Half related cleanup:
 - consolidate `hrt_absolute_time` calls to save some CPU cycles
 - clean up unused instance of parameter

### Testing

Verified with `sihsim_quadx` that the issue is resolved. 