### PR TITLE
fix(ekf2): stop AGP source when fusion is disabled at runtime

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position_control.cpp
@@ -106,6 +106,7 @@ bool AgpSource::update(Ekf &ekf, const estimator::imuSample &imu_delayed)
 	if (_buffer.pop_first_older_than(imu_delayed.time_us, &sample)) {
 
 		if (!ekf._fc.agp[_slot].intended()) {
+			_state = State::kStopped;
 			return true;
 		}
 


### PR DESCRIPTION
### Solved Problem
`AgpSource::update()` returned early when the source was no longer intended (AGP disabled via `EKF2_SENS_EN`) without changing its state. As long as AGP data kept arriving, the buffer kept popping and the 5 s "data stopped" timeout never fired, so a source that had reached `kActive` stayed latched there indefinitely.

Effects of the zombie kActive source:
 - cs_aux_gpos stays 1 with no actual fusion
 - it counts as an active horizontal aiding source, so `isHorizontalAidingActive()` is true and the on-ground valid_fake_pos position lock can never engage
 - in GNSS-denied flight the horizontal estimate then dead-reckons to `EKF2_NOAID_TOUT` and triggers a position-invalid failsafe

### Solution
Explicitly set `_state = kStopped` when the source is not intended, so disabling AGP releases the aiding slot regardless of whether data is still flowing.