### PR TITLE
build(nuttx): use and enforce the supported arm-none-eabi-gcc

### DIFF
--- a/docs/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/docs/en/dev_setup/dev_env_linux_ubuntu.md
@@ -63,6 +63,15 @@ These notes are provided "for information only":
   warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
   ```
 
+- PX4 NuttX firmware must be built with exactly the GCC version used by CI so that firmware binaries are reproducible. The build checks `arm-none-eabi-gcc` at configure time and stops with an error if it is a different version. If you have more than one `arm-none-eabi-gcc` installed and the required one is not first on `PATH`, point the build at it:
+
+  ```sh
+  # directory that contains the required arm-none-eabi-gcc
+  export PX4_ARM_TOOLCHAIN_DIR=/usr/bin
+  ```
+
+  Export it (e.g. in your shell profile) rather than setting it for a single command, so it applies to the whole build including the IO firmware and other sub-builds. To build with a different compiler on purpose, set `PX4_ARM_TOOLCHAIN_VERSION` to that version (or to `any` to disable the version check).
+
 - You're going to need the PX4 source code anyway.
   But if you just wanted to set up the development environment without getting all the source code you could instead just download [ubuntu.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/ubuntu.sh) and [requirements.txt](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/setup/requirements.txt) and then run **ubuntu.sh**:
 

--- a/platforms/nuttx/cmake/Toolchain-arm-none-eabi.cmake
+++ b/platforms/nuttx/cmake/Toolchain-arm-none-eabi.cmake
@@ -7,27 +7,100 @@ set(triple arm-none-eabi)
 set(CMAKE_LIBRARY_ARCHITECTURE ${triple})
 set(TOOLCHAIN_PREFIX ${triple})
 
-set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+# The supported arm-none-eabi-gcc version. PX4 NuttX firmware is built and tested
+# with exactly this compiler so release binaries are reproducible. Bump this together
+# with the CI toolchain. Override with PX4_ARM_TOOLCHAIN_VERSION.
+set(PX4_ARM_GCC_VERSION_REQUIRED "13.2.1")
+
+if(NOT PX4_ARM_TOOLCHAIN_VERSION AND DEFINED ENV{PX4_ARM_TOOLCHAIN_VERSION})
+	set(PX4_ARM_TOOLCHAIN_VERSION "$ENV{PX4_ARM_TOOLCHAIN_VERSION}")
+endif()
+if(NOT PX4_ARM_TOOLCHAIN_VERSION)
+	set(PX4_ARM_TOOLCHAIN_VERSION "${PX4_ARM_GCC_VERSION_REQUIRED}")
+endif()
+string(TOLOWER "${PX4_ARM_TOOLCHAIN_VERSION}" PX4_ARM_TOOLCHAIN_VERSION_LOWER)
+if(PX4_ARM_TOOLCHAIN_VERSION_LOWER MATCHES "^(any|none|off|0|false)$")
+	set(PX4_ARM_TOOLCHAIN_ENFORCE FALSE)
+else()
+	set(PX4_ARM_TOOLCHAIN_ENFORCE TRUE)
+endif()
+
+# Locate the toolchain:
+#   1. PX4_ARM_TOOLCHAIN_DIR - explicit override.
+#   2. a standard install dir holding the required version (e.g. /usr/bin for the distro package).
+#   3. arm-none-eabi-gcc from PATH.
+# Pinning to a directory takes the compiler and every binutil from that one place.
+if(NOT PX4_ARM_TOOLCHAIN_DIR AND DEFINED ENV{PX4_ARM_TOOLCHAIN_DIR})
+	set(PX4_ARM_TOOLCHAIN_DIR "$ENV{PX4_ARM_TOOLCHAIN_DIR}")
+endif()
+
+if(NOT PX4_ARM_TOOLCHAIN_DIR AND PX4_ARM_TOOLCHAIN_ENFORCE)
+	foreach(_dir /usr/bin /usr/local/bin /opt/homebrew/bin)
+		if(EXISTS "${_dir}/${TOOLCHAIN_PREFIX}-gcc")
+			execute_process(COMMAND "${_dir}/${TOOLCHAIN_PREFIX}-gcc" -dumpfullversion
+				OUTPUT_VARIABLE _dir_gcc_version OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+			if(_dir_gcc_version VERSION_EQUAL PX4_ARM_TOOLCHAIN_VERSION)
+				set(PX4_ARM_TOOLCHAIN_DIR "${_dir}")
+				break()
+			endif()
+		endif()
+	endforeach()
+endif()
+
+if(PX4_ARM_TOOLCHAIN_DIR)
+	get_filename_component(PX4_ARM_TOOLCHAIN_DIR "${PX4_ARM_TOOLCHAIN_DIR}" ABSOLUTE)
+	if(NOT EXISTS "${PX4_ARM_TOOLCHAIN_DIR}/${TOOLCHAIN_PREFIX}-gcc")
+		message(FATAL_ERROR "PX4_ARM_TOOLCHAIN_DIR='${PX4_ARM_TOOLCHAIN_DIR}' does not contain ${TOOLCHAIN_PREFIX}-gcc")
+	endif()
+	set(TOOLCHAIN_BIN_PREFIX "${PX4_ARM_TOOLCHAIN_DIR}/${TOOLCHAIN_PREFIX}-")
+else()
+	set(TOOLCHAIN_BIN_PREFIX "${TOOLCHAIN_PREFIX}-")
+endif()
+
+set(CMAKE_C_COMPILER ${TOOLCHAIN_BIN_PREFIX}gcc)
 set(CMAKE_C_COMPILER_TARGET ${triple})
 
-set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_BIN_PREFIX}g++)
 set(CMAKE_CXX_COMPILER_TARGET ${triple})
 
-set(CMAKE_ASM_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_ASM_COMPILER ${TOOLCHAIN_BIN_PREFIX}gcc)
 
 # needed for test compilation
 set(CMAKE_EXE_LINKER_FLAGS_INIT "--specs=nosys.specs")
 
 # compiler tools
-find_program(CMAKE_AR ${TOOLCHAIN_PREFIX}-gcc-ar)
-find_program(CMAKE_GDB ${TOOLCHAIN_PREFIX}-gdb)
-find_program(CMAKE_LD ${TOOLCHAIN_PREFIX}-ld)
-find_program(CMAKE_LINKER ${TOOLCHAIN_PREFIX}-ld)
-find_program(CMAKE_NM ${TOOLCHAIN_PREFIX}-gcc-nm)
-find_program(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}-objcopy)
-find_program(CMAKE_OBJDUMP ${TOOLCHAIN_PREFIX}-objdump)
-find_program(CMAKE_RANLIB ${TOOLCHAIN_PREFIX}-gcc-ranlib)
-find_program(CMAKE_STRIP ${TOOLCHAIN_PREFIX}-strip)
+find_program(CMAKE_AR ${TOOLCHAIN_BIN_PREFIX}gcc-ar)
+find_program(CMAKE_GDB ${TOOLCHAIN_BIN_PREFIX}gdb)
+find_program(CMAKE_LD ${TOOLCHAIN_BIN_PREFIX}ld)
+find_program(CMAKE_LINKER ${TOOLCHAIN_BIN_PREFIX}ld)
+find_program(CMAKE_NM ${TOOLCHAIN_BIN_PREFIX}gcc-nm)
+find_program(CMAKE_OBJCOPY ${TOOLCHAIN_BIN_PREFIX}objcopy)
+find_program(CMAKE_OBJDUMP ${TOOLCHAIN_BIN_PREFIX}objdump)
+find_program(CMAKE_RANLIB ${TOOLCHAIN_BIN_PREFIX}gcc-ranlib)
+find_program(CMAKE_STRIP ${TOOLCHAIN_BIN_PREFIX}strip)
+
+# Enforce the resolved compiler version (fail loud on mismatch) unless disabled.
+execute_process(
+	COMMAND ${CMAKE_C_COMPILER} -dumpfullversion
+	OUTPUT_VARIABLE GCC_VERSION
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+	ERROR_QUIET
+	RESULT_VARIABLE GCC_VERSION_RESULT)
+
+if(NOT GCC_VERSION_RESULT EQUAL 0)
+	message(FATAL_ERROR "could not run '${CMAKE_C_COMPILER}' to determine its version (is the arm-none-eabi toolchain installed / on PATH / PX4_ARM_TOOLCHAIN_DIR correct?)")
+elseif(NOT PX4_ARM_TOOLCHAIN_ENFORCE)
+	message(STATUS "arm-none-eabi-gcc ${GCC_VERSION} (version enforcement disabled)")
+elseif(GCC_VERSION VERSION_EQUAL PX4_ARM_TOOLCHAIN_VERSION)
+	message(STATUS "arm-none-eabi-gcc ${GCC_VERSION}")
+else()
+	message(FATAL_ERROR
+		"arm-none-eabi-gcc ${GCC_VERSION} is not the supported version ${PX4_ARM_TOOLCHAIN_VERSION} (resolved '${CMAKE_C_COMPILER}').\n"
+		"PX4 NuttX firmware must be built with exactly ${PX4_ARM_TOOLCHAIN_VERSION}, the same toolchain used by CI)."
+		"If the right version is installed but not first on PATH, point the build at it:\n"
+		"    export PX4_ARM_TOOLCHAIN_DIR=/path/to/toolchain/bin\n"
+		"To build with a different compiler anyway, set PX4_ARM_TOOLCHAIN_VERSION=<version> (or =any to disable the check).")
+endif()
 
 set(CMAKE_FIND_ROOT_PATH get_file_component(${CMAKE_C_COMPILER} PATH))
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
## Summary

Make the NuttX build prefer the supported `arm-none-eabi-gcc` (13.2.1, matching CI) from a standard install location instead of whichever copy is first on `PATH`, and fail with a clear error if a different version is used, so firmware binaries are reproducible.

## Problem

The arm-none-eabi toolchain file set `CMAKE_C_COMPILER` to the bare name `arm-none-eabi-gcc`, so `PATH` order alone decided which compiler built PX4, silently. On a machine with a second `arm-none-eabi-gcc` installed for another project (for example under `/opt`), whichever copy is earlier on `PATH` wins and quietly changes the resulting binary — and nothing reported or checked which version was actually used.

## Solution

The toolchain file resolves the compiler with an explicit precedence: `PX4_ARM_TOOLCHAIN_DIR` (explicit override), then a standard install directory (`/usr/bin`, `/usr/local/bin`, `/opt/homebrew/bin`) whose `arm-none-eabi-gcc` matches the required version, then `PATH` as before. The resolved version is reported at configure time and a mismatch is fatal; `PX4_ARM_TOOLCHAIN_VERSION` overrides the required version (or `any` disables the check). The standard-directory lookup is version-matched so a wrong-version `/usr/bin` cannot shadow a correct compiler elsewhere on `PATH`.
