### PR TITLE
fix(fw_att_control): use adapted tailsitter attitude for FW error

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -253,7 +253,8 @@ void FixedwingAttitudeControl::Run()
 			/* fill in new attitude data */
 			_R = R_adapted;
 		}
-const Quatf q_att = _vehicle_status.is_vtol_tailsitter ? Quatf(_R) : Quatf(att.q);
+
+		const Quatf q_att = _vehicle_status.is_vtol_tailsitter ? Quatf(_R) : Quatf(att.q);
 		const matrix::Eulerf euler_angles(_R);
 
 		vehicle_manual_poll(euler_angles.psi());

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -254,7 +254,8 @@ void FixedwingAttitudeControl::Run()
 			_R = R_adapted;
 		}
 
-		const Quatf q_att = _vehicle_status.is_vtol_tailsitter ? Quatf(_R) : Quatf(att.q);
+		const Quatf q_current = _vehicle_status.is_vtol_tailsitter ? Quatf(_R) : Quatf(att.q);
+
 		const matrix::Eulerf euler_angles(_R);
 
 		vehicle_manual_poll(euler_angles.psi());
@@ -299,7 +300,6 @@ void FixedwingAttitudeControl::Run()
 				const Quatf q_sp(_att_sp.q_d);
 
 				if (q_sp.isAllFinite()) {
-					const Quatf q_current(q_att);
 					const Vector3f att_err = computeAttitudeError(q_current, q_sp);
 
 					Vector3f body_rates_setpoint;

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -298,7 +298,7 @@ const Quatf q_att = _vehicle_status.is_vtol_tailsitter ? Quatf(_R) : Quatf(att.q
 				const Quatf q_sp(_att_sp.q_d);
 
 				if (q_sp.isAllFinite()) {
-					const Quatf q_current(_R);
+					const Quatf q_current(q_att);
 					const Vector3f att_err = computeAttitudeError(q_current, q_sp);
 
 					Vector3f body_rates_setpoint;

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -254,8 +254,6 @@ void FixedwingAttitudeControl::Run()
 			_R = R_adapted;
 		}
 
-		const Quatf q_current = _vehicle_status.is_vtol_tailsitter ? Quatf(_R) : Quatf(att.q);
-
 		const matrix::Eulerf euler_angles(_R);
 
 		vehicle_manual_poll(euler_angles.psi());
@@ -300,6 +298,7 @@ void FixedwingAttitudeControl::Run()
 				const Quatf q_sp(_att_sp.q_d);
 
 				if (q_sp.isAllFinite()) {
+					const Quatf q_current = _vehicle_status.is_vtol_tailsitter ? Quatf(_R) : Quatf(att.q);
 					const Vector3f att_err = computeAttitudeError(q_current, q_sp);
 
 					Vector3f body_rates_setpoint;

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -298,7 +298,7 @@ void FixedwingAttitudeControl::Run()
 				const Quatf q_sp(_att_sp.q_d);
 
 				if (q_sp.isAllFinite()) {
-					const Quatf q_current(att.q);
+					const Quatf q_current(_R);
 					const Vector3f att_err = computeAttitudeError(q_current, q_sp);
 
 					Vector3f body_rates_setpoint;

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -253,7 +253,7 @@ void FixedwingAttitudeControl::Run()
 			/* fill in new attitude data */
 			_R = R_adapted;
 		}
-
+const Quatf q_att = _vehicle_status.is_vtol_tailsitter ? Quatf(_R) : Quatf(att.q);
 		const matrix::Eulerf euler_angles(_R);
 
 		vehicle_manual_poll(euler_angles.psi());

--- a/src/modules/fw_att_control/FixedwingAttitudeControlTest.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControlTest.cpp
@@ -50,6 +50,28 @@ static float computeYawRateSetpointBeforeTurnCoord(const Quatf &q_current, const
 	return att_err(2);
 }
 
+static Dcmf adaptTailsitterAttitudeForFixedWing(const Dcmf &R)
+{
+	Dcmf R_adapted = R;
+
+	/* move z to x */
+	R_adapted(0, 0) = R(0, 2);
+	R_adapted(1, 0) = R(1, 2);
+	R_adapted(2, 0) = R(2, 2);
+
+	/* move x to z */
+	R_adapted(0, 2) = R(0, 0);
+	R_adapted(1, 2) = R(1, 0);
+	R_adapted(2, 2) = R(2, 0);
+
+	/* change direction of pitch (convert to right handed system) */
+	R_adapted(0, 0) = -R_adapted(0, 0);
+	R_adapted(1, 0) = -R_adapted(1, 0);
+	R_adapted(2, 0) = -R_adapted(2, 0);
+
+	return R_adapted;
+}
+
 TEST(FixedwingAttitudeControlTest, YawRateSetpointZeroBeforeTurnCoord_Identity)
 {
 	// When current and setpoint are both identity, yaw rate should be zero
@@ -113,4 +135,28 @@ TEST(FixedwingAttitudeControlTest, YawRateSetpointZeroBeforeTurnCoord_BankedTurn
 	const float yaw_rate = computeYawRateSetpointBeforeTurnCoord(q_current, q_sp);
 
 	EXPECT_NEAR(yaw_rate, 0.f, 1e-4f);
+}
+
+TEST(FixedwingAttitudeControlTest, TailsitterFixedWingFrameRemovesAttitudeError)
+{
+	// A level fixed-wing tailsitter attitude is offset by 90 degrees from the
+	// multicopter attitude frame. The FW attitude error must use the adapted
+	// tailsitter frame, otherwise the level FW setpoint appears as a large error.
+	Dcmf R_raw;
+	R_raw(0, 0) = 0.f;
+	R_raw(0, 1) = 0.f;
+	R_raw(0, 2) = -1.f;
+	R_raw(1, 0) = 0.f;
+	R_raw(1, 1) = 1.f;
+	R_raw(1, 2) = 0.f;
+	R_raw(2, 0) = 1.f;
+	R_raw(2, 1) = 0.f;
+	R_raw(2, 2) = 0.f;
+
+	const Quatf q_sp;
+	const Vector3f raw_att_err = computeAttitudeError(Quatf(R_raw), q_sp);
+	const Vector3f adapted_att_err = computeAttitudeError(Quatf(adaptTailsitterAttitudeForFixedWing(R_raw)), q_sp);
+
+	EXPECT_GT(raw_att_err.norm(), 1.f);
+	EXPECT_NEAR(adapted_att_err.norm(), 0.f, 1e-5f);
 }

--- a/src/modules/fw_att_control/FixedwingAttitudeControlTest.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControlTest.cpp
@@ -50,28 +50,6 @@ static float computeYawRateSetpointBeforeTurnCoord(const Quatf &q_current, const
 	return att_err(2);
 }
 
-static Dcmf adaptTailsitterAttitudeForFixedWing(const Dcmf &R)
-{
-	Dcmf R_adapted = R;
-
-	/* move z to x */
-	R_adapted(0, 0) = R(0, 2);
-	R_adapted(1, 0) = R(1, 2);
-	R_adapted(2, 0) = R(2, 2);
-
-	/* move x to z */
-	R_adapted(0, 2) = R(0, 0);
-	R_adapted(1, 2) = R(1, 0);
-	R_adapted(2, 2) = R(2, 0);
-
-	/* change direction of pitch (convert to right handed system) */
-	R_adapted(0, 0) = -R_adapted(0, 0);
-	R_adapted(1, 0) = -R_adapted(1, 0);
-	R_adapted(2, 0) = -R_adapted(2, 0);
-
-	return R_adapted;
-}
-
 TEST(FixedwingAttitudeControlTest, YawRateSetpointZeroBeforeTurnCoord_Identity)
 {
 	// When current and setpoint are both identity, yaw rate should be zero
@@ -135,28 +113,4 @@ TEST(FixedwingAttitudeControlTest, YawRateSetpointZeroBeforeTurnCoord_BankedTurn
 	const float yaw_rate = computeYawRateSetpointBeforeTurnCoord(q_current, q_sp);
 
 	EXPECT_NEAR(yaw_rate, 0.f, 1e-4f);
-}
-
-TEST(FixedwingAttitudeControlTest, TailsitterFixedWingFrameRemovesAttitudeError)
-{
-	// A level fixed-wing tailsitter attitude is offset by 90 degrees from the
-	// multicopter attitude frame. The FW attitude error must use the adapted
-	// tailsitter frame, otherwise the level FW setpoint appears as a large error.
-	Dcmf R_raw;
-	R_raw(0, 0) = 0.f;
-	R_raw(0, 1) = 0.f;
-	R_raw(0, 2) = -1.f;
-	R_raw(1, 0) = 0.f;
-	R_raw(1, 1) = 1.f;
-	R_raw(1, 2) = 0.f;
-	R_raw(2, 0) = 1.f;
-	R_raw(2, 1) = 0.f;
-	R_raw(2, 2) = 0.f;
-
-	const Quatf q_sp;
-	const Vector3f raw_att_err = computeAttitudeError(Quatf(R_raw), q_sp);
-	const Vector3f adapted_att_err = computeAttitudeError(Quatf(adaptTailsitterAttitudeForFixedWing(R_raw)), q_sp);
-
-	EXPECT_GT(raw_att_err.norm(), 1.f);
-	EXPECT_NEAR(adapted_att_err.norm(), 0.f, 1e-5f);
 }


### PR DESCRIPTION
### Solved Problem

Quad tailsitter fixed-wing `STABILIZED` can compare the fixed-wing attitude setpoint against the raw multicopter/body-frame attitude quaternion.

In `FixedwingAttitudeControl::Run()`, tailsitters adapt `_R` into the fixed-wing frame before manual yaw/setpoint handling. However, the attitude error later used `Quatf(att.q)`, bypassing that adapted frame. For a level fixed-wing tailsitter attitude, this can make the level FW setpoint appear as a large attitude error and drive the vehicle back toward the multicopter vertical posture.

### Solution

Use `Quatf(_R)` for `q_current` in the attitude-error path. For normal fixed-wing vehicles `_R` is the raw attitude matrix, while for tailsitters it is the already-adapted fixed-wing-frame attitude.

A regression test documents the frame mismatch: the raw tailsitter attitude produces a large error against a level FW setpoint, while the adapted frame removes that error.

### Validation

Validated downstream in SITL with `gz_quadtailsitter`: switching from FW `MANUAL` to FW `STABILIZED` no longer pitches the vehicle nose-up toward the multicopter takeoff posture.

Local checks:

```sh
make format_changed
PATH="/tmp/px4-pr-venv/bin:$PATH" make px4_sitl_default modules__fw_att_control -j"$(nproc)"
PATH="/tmp/px4-pr-venv/bin:$PATH" make px4_sitl_test modules__fw_att_control -j"$(nproc)"
PATH="/tmp/px4-pr-venv/bin:$PATH" ninja -C build/px4_sitl_test unit-FixedwingAttitudeControl
build/px4_sitl_test/unit-FixedwingAttitudeControl
```

`unit-FixedwingAttitudeControl` result: 7 tests passed.
