### PR TITLE
feat(fw-mission): do not return to line when large position reset occurs

### DIFF
--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -2110,6 +2110,16 @@ FixedWingModeManager::Run()
 							     _local_pos.ref_timestamp);
 		}
 
+		const float max_reset_dist = _param_fw_wp_rst_dist.get();
+
+		if (_control_mode.flag_control_auto_enabled
+		    && (_local_pos.xy_reset_counter != _xy_reset_counter)
+		    && (max_reset_dist > FLT_EPSILON)
+		    && (Vector2f(_local_pos.delta_xy).longerThan(max_reset_dist))) {
+			// Large position reset, directly go to destination to avoid strange path corrections
+			_go_direct_to_destination = true;
+		}
+
 		if (_control_mode.flag_control_offboard_enabled) {
 			trajectory_setpoint_s trajectory_setpoint;
 
@@ -2183,6 +2193,8 @@ FixedWingModeManager::Run()
 
 				// reset the altitude foh (first order hold) logic
 				_min_current_sp_distance_xy = FLT_MAX;
+
+				_go_direct_to_destination = false;
 			}
 		}
 
@@ -2630,6 +2642,10 @@ DirectionalGuidanceOutput FixedWingModeManager::navigateWaypoints(const Vector2f
 		// end waypoint. however this included here as a safety precaution if any navigator (module) switch condition
 		// is missed for any reason. in the future this logic should all be handled in one place in a dedicated
 		// flight mode state machine.
+		return navigateWaypoint(end_waypoint, vehicle_pos, ground_vel, wind_vel);
+	}
+
+	if (_go_direct_to_destination) {
 		return navigateWaypoint(end_waypoint, vehicle_pos, ground_vel, wind_vel);
 	}
 

--- a/src/modules/fw_mode_manager/FixedWingModeManager.hpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.hpp
@@ -385,6 +385,7 @@ private:
 	uint64_t _time_last_xy_reset{0};
 
 	// LATERAL-DIRECTIONAL GUIDANCE
+	bool _go_direct_to_destination{false};
 
 	// CLosest point on path to track
 	matrix::Vector2f _closest_point_on_path;
@@ -845,6 +846,8 @@ private:
 		(ParamFloat<px4::params::NPFG_ROLL_TC>) _param_npfg_roll_time_const,
 		(ParamFloat<px4::params::NPFG_SW_DST_MLT>) _param_npfg_switch_distance_multiplier,
 		(ParamFloat<px4::params::NPFG_PERIOD_SF>) _param_npfg_period_safety_factor,
+
+		(ParamFloat<px4::params::FW_WP_RST_DIST>) _param_fw_wp_rst_dist,
 
 		(ParamFloat<px4::params::FW_LND_AIRSPD>) _param_fw_lnd_airspd,
 		(ParamFloat<px4::params::FW_LND_ANG>) _param_fw_lnd_ang,

--- a/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
+++ b/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
@@ -517,3 +517,17 @@ parameters:
       max: 10.0
       decimal: 1
       increment: 0.1
+    FW_WP_RST_DIST:
+      description:
+        short: Max position reset distance
+        long: |-
+          If a horizontal position reset larger than this occurs while flying between two
+          waypoints, fly directly to the current waypoint instead of rejoining the line.
+          -1 to disable.
+      type: float
+      default: -1.0
+      unit: m
+      min: -1.0
+      max: 10000.0
+      decimal: 0
+      increment: 1


### PR DESCRIPTION
### Solved Problem
If a position reset occurs when a fixedwing vehicle is flying a mission, it will always maneuver to go back to the line segment defined by the previous and next waypoints. This is sometimes undesired as the vehicles starts to make a strong path correction while it could just correct its course towards the next waypoint.

### Solution
While flying a leg between two waypoints, if a position reset (e.g. manual reset, GNSS position reset) shifts the estimate by more than FW_WP_RST_DIST, the aircraft heads straight to the current waypoint for the remainder of that leg instead of turning back to rejoin the prev->next line.
By default, the param is set to -1, which makes the current behavior unchanged. We'll see if the future if we can just enable it for every one with a good default value.

Example test where the plane flies with airspeed dead-reckoning in a mission
<img width="1017" height="733" alt="Screenshot from 2026-06-23 12-17-58" src="https://github.com/user-attachments/assets/7171ae3e-26b1-46c9-a222-2b7abeeb3915" />

After a manual position reset, the plane directly flies to the waypoint instead of rejoining the line segment (param was set to `FW_WP_RST_DIST` = 10m).
<img width="1017" height="733" alt="Screenshot from 2026-06-23 12-18-19" src="https://github.com/user-attachments/assets/f4c5b77b-7e52-4f41-8111-62cb6e3172fe" />

### Changelog Entry
For release notes:
```
feat(fw-mission): do not return to line when large position reset occurs
New parameter: FW_WP_RST_DIST
Documentation: -
```

### Alternatives
I initially wanted to add the logic into navigator to invalidate the previous waypoint, but this could have unwanted side effects e.g.: during landing while the previous wp validity is required to know if a straight or circular landing should be done.

### Test coverage
SIH in SITL

