### PR TITLE
fix(i2c_spi): prevent use-after-free when stopping driver instances

### DIFF
--- a/platforms/common/i2c_spi_buses.cpp
+++ b/platforms/common/i2c_spi_buses.cpp
@@ -747,8 +747,6 @@ int I2CSPIDriverBase::module_stop(BusInstanceIterator &iterator)
 				delete instance;
 
 			} else {
-				// the module did not stop: it may still be referenced by its work queue,
-				// so leave it allocated and listed rather than risk a use-after-free
 				stop_failed = true;
 			}
 		}

--- a/platforms/common/i2c_spi_buses.cpp
+++ b/platforms/common/i2c_spi_buses.cpp
@@ -733,14 +733,24 @@ int I2CSPIDriverBase::module_start(const BusCLIArguments &cli, BusInstanceIterat
 int I2CSPIDriverBase::module_stop(BusInstanceIterator &iterator)
 {
 	bool is_running = false;
+	bool stop_failed = false;
 
 	while (iterator.next()) {
 		if (iterator.instance()) {
-			I2CSPIDriverBase *instance = (I2CSPIDriverBase *)iterator.instance();
-			instance->request_stop_and_wait();
-			delete iterator.instance();
-			iterator.removeInstance();
 			is_running = true;
+			I2CSPIDriverBase *instance = (I2CSPIDriverBase *)iterator.instance();
+
+			if (instance->request_stop_and_wait()) {
+				// the instance is the list node, so unlink it before freeing - otherwise
+				// removeInstance() operates on freed memory and can corrupt the list
+				iterator.removeInstance();
+				delete instance;
+
+			} else {
+				// the module did not stop: it may still be referenced by its work queue,
+				// so leave it allocated and listed rather than risk a use-after-free
+				stop_failed = true;
+			}
 		}
 	}
 
@@ -749,7 +759,7 @@ int I2CSPIDriverBase::module_stop(BusInstanceIterator &iterator)
 		return -1;
 	}
 
-	return 0;
+	return stop_failed ? -1 : 0;
 }
 
 int I2CSPIDriverBase::module_status(BusInstanceIterator &iterator)
@@ -826,7 +836,7 @@ void I2CSPIDriverBase::print_status()
 #endif // CONFIG_SPI
 }
 
-void I2CSPIDriverBase::request_stop_and_wait()
+bool I2CSPIDriverBase::request_stop_and_wait()
 {
 	_task_should_exit.store(true);
 	ScheduleNow(); // wake up the task (in case it is not scheduled anymore or just to be faster)
@@ -837,7 +847,11 @@ void I2CSPIDriverBase::request_stop_and_wait()
 		// wait at most 2 sec
 	} while (++i < 100 && !_task_exited.load());
 
-	if (i >= 100) {
+	const bool exited = _task_exited.load();
+
+	if (!exited) {
 		PX4_ERR("Module did not respond to stop request");
 	}
+
+	return exited;
 }

--- a/platforms/common/i2c_spi_buses.cpp
+++ b/platforms/common/i2c_spi_buses.cpp
@@ -741,8 +741,6 @@ int I2CSPIDriverBase::module_stop(BusInstanceIterator &iterator)
 			I2CSPIDriverBase *instance = (I2CSPIDriverBase *)iterator.instance();
 
 			if (instance->request_stop_and_wait()) {
-				// the instance is the list node, so unlink it before freeing - otherwise
-				// removeInstance() operates on freed memory and can corrupt the list
 				iterator.removeInstance();
 				delete instance;
 

--- a/platforms/common/include/px4_platform_common/i2c_spi_buses.h
+++ b/platforms/common/include/px4_platform_common/i2c_spi_buses.h
@@ -314,7 +314,7 @@ protected:
 private:
 	static void custom_method_trampoline(void *argument);
 
-	void request_stop_and_wait();
+	bool request_stop_and_wait();
 
 	px4::atomic_bool _task_should_exit{false};
 	px4::atomic_bool _task_exited{false};


### PR DESCRIPTION
## Summary

Fix a sporadic use-after-free in the I2C/SPI driver framework's `stop` path that can corrupt the running-instance list — sometimes leaving a driver running after `stop` (a later `start` then reports "already running"), or hard-faulting. Surfaces when stopping multiple instances of one driver on separate buses, e.g. three `iis2mdc` on I2C1/2/3.

_**Seen regularly on our test fixtures**_

## Problem

`I2CSPIDriverBase::module_stop()` deleted each instance *before* unlinking it from the global `i2c_spi_module_instances` list. The instance *is* the intrusive list node, so `removeInstance()` / `List::remove()` then dereferenced the freed node to repair the links. If another thread reused that heap block in the window, the list got relinked through a stale pointer — dropping the not-yet-stopped instances (which keep polling on their per-bus work queues) or faulting. The window is widest with several instances on separate work queues, since the others are concurrently active during the `delete`.

Separately, `module_stop()` freed the instance even when `request_stop_and_wait()` timed out — i.e. when the work queue may still reference it — a second use-after-free.

## Solution

- Unlink each instance (`removeInstance()`) *before* `delete`, so the unlink runs on live memory.
- Only delete/unlink when the task actually exited; on a stop timeout, leave it allocated and listed rather than freeing it out from under its work queue. `request_stop_and_wait()` now returns whether the module exited, and `module_stop()` returns `-1` when an instance fails to stop.
