### PR TITLE
feat(drivers): add DPS368 variant support via -8 flag

### DIFF
--- a/src/drivers/barometer/dps310/dps310_main.cpp
+++ b/src/drivers/barometer/dps310/dps310_main.cpp
@@ -58,6 +58,7 @@ DPS310::print_usage()
 #else
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 #endif
+	PRINT_MODULE_USAGE_PARAM_FLAG('8', "Drive DPS368", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
@@ -116,14 +117,25 @@ extern "C" int dps310_main(int argc, char *argv[])
 
 	cli.default_spi_frequency = 10 * 1000 * 1000;
 
-	const char *verb = cli.parseDefaultArguments(argc, argv);
+	int ch;
+
+	while ((ch = cli.getOpt(argc, argv, "8")) != EOF) {
+		switch (ch) {
+		case '8':
+			cli.custom1 = DRV_BARO_DEVTYPE_DPS368;
+			break;
+		}
+	}
+
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();
 		return -1;
 	}
 
-	BusInstanceIterator iterator(MODULE_NAME, cli, DRV_BARO_DEVTYPE_DPS310);
+	BusInstanceIterator iterator(MODULE_NAME, cli,
+				     cli.custom1 ? DRV_BARO_DEVTYPE_DPS368 : DRV_BARO_DEVTYPE_DPS310);
 
 	if (!strcmp(verb, "start")) {
 		return ThisDriver::module_start(cli, iterator);

--- a/src/drivers/barometer/dps310/dps310_main.cpp
+++ b/src/drivers/barometer/dps310/dps310_main.cpp
@@ -88,6 +88,9 @@ I2CSPIDriverBase *DPS310::instantiate(const I2CSPIDriverConfig &config, int runt
 		return nullptr;
 	}
 
+	// device_id must reflect the requested variant, since DPS310_I2C/SPI hardcode DPS310
+	interface->set_device_type(config.devid_driver_index);
+
 	DPS310 *dev = new DPS310(config, interface);
 
 	if (dev == nullptr) {

--- a/src/drivers/drv_sensor.h
+++ b/src/drivers/drv_sensor.h
@@ -154,6 +154,7 @@
 #define DRV_GYR_DEVTYPE_BMI088          0x66
 #define DRV_BARO_DEVTYPE_BMP388         0x67
 #define DRV_BARO_DEVTYPE_DPS310         0x68
+#define DRV_BARO_DEVTYPE_DPS368         0x77
 #define DRV_PWM_DEVTYPE_PCA9685         0x69
 #define DRV_ACC_DEVTYPE_BMI088          0x6a
 #define DRV_OSD_DEVTYPE_ATXXXX          0x6b


### PR DESCRIPTION
Register DRV_BARO_DEVTYPE_DPS368 (0x77) and extend the dps310 driver entry point with a -8 flag to select the DPS368 devtype at startup. The DPS368 is the same silicon as the DPS310, with the hardware bug fix already applied at manufacture. Without the flag, the driver defaults to DPS310, so no existing boards are affected.

### Solved Problem
No proper identification for DPS368 barometer.

### Solution
Follows the same flag pattern as `icm42688p -6` for the ICM-42686P variant:
- Added `DRV_BARO_DEVTYPE_DPS368 0x77` to `drv_sensor.h`
- Added `-8` flag to `dps310_main.cpp` via `getOpt`, selecting the DPS368 devtype through a single iterator ternary

### Changelog Entry
Feature: DPS368 barometer support in dps310 driver via -8 flag

### Test coverage
Tested on 3DR Control N1 (STM32H7, SPI6) with a DPS368; correct pressure and temperature readings confirmed on hardware.
