### PR TITLE
fix(cyphal): release node mutex before clearing _instance

### DIFF
--- a/src/drivers/cyphal/Cyphal.cpp
+++ b/src/drivers/cyphal/Cyphal.cpp
@@ -222,6 +222,8 @@ void CyphalNode::Run()
 
 	perf_end(_cycle_perf);
 
+	bool exiting = false;
+
 	if (_instance && _task_should_exit.load()) {
 		ScheduleClear();
 
@@ -229,10 +231,16 @@ void CyphalNode::Run()
 			_initialized = false;
 		}
 
-		_instance = nullptr;
+		exiting = true;
 	}
 
 	pthread_mutex_unlock(&_node_mutex);
+
+	// clear _instance only after releasing the mutex: ~CyphalNode() waits on _instance
+	// and then frees this object, including _node_mutex
+	if (exiting) {
+		_instance = nullptr;
+	}
 }
 
 template <typename As, typename F>


### PR DESCRIPTION
## Summary

Fix a use-after-free in the Cyphal (UAVCANv1) driver shutdown path: the work-queue thread can unlock the node mutex after the object has already been freed.

## Problem

`CyphalNode::Run()` clears `_instance = nullptr` while still holding `_node_mutex`, then unlocks it. `~CyphalNode()` (run on the shell thread by `cyphal stop`) spins on `while (_instance)` and, the moment it observes null, proceeds to destroy the object — including `_node_mutex`. The worker thread can then call `pthread_mutex_unlock(&_node_mutex)` on freed memory.

## Solution

Release `_node_mutex` before clearing `_instance`, so that clearing `_instance` is the last access the worker makes to the object. This matches the ordering already used by `UavcanNode::Run()`. Reachable via the runtime `cyphal stop` command.
