### PR TITLE
fix(ekf2): wait for Run() to exit before deleting instances

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -444,11 +444,31 @@ int EKF2::print_status(bool verbose)
 	return 0;
 }
 
+bool EKF2::request_stop_and_wait()
+{
+	request_stop();
+
+	// wait for the work-queue thread to run Run() once more and exit
+	for (int i = 0; i < 100 && !_task_exited.load(); i++) {
+		px4_usleep(20000); // 20 ms, up to 2 s
+	}
+
+	const bool exited = _task_exited.load();
+
+	if (!exited) {
+		PX4_ERR("ekf2 instance did not stop");
+	}
+
+	return exited;
+}
+
 void EKF2::Run()
 {
 	if (should_exit()) {
 		_sensor_combined_sub.unregisterCallback();
 		_vehicle_imu_sub.unregisterCallback();
+		ScheduleClear();
+		_task_exited.store(true);
 
 		return;
 	}
@@ -3269,10 +3289,10 @@ extern "C" __EXPORT int ekf2_main(int argc, char *argv[])
 				EKF2 *inst = _objects[instance].load();
 
 				if (inst) {
-					inst->request_stop();
-					px4_usleep(20000); // 20 ms
-					delete inst;
-					_objects[instance].store(nullptr);
+					if (inst->request_stop_and_wait()) {
+						delete inst;
+						_objects[instance].store(nullptr);
+					}
 				}
 			} else {
 				PX4_ERR("invalid instance %d", instance);
@@ -3285,10 +3305,12 @@ extern "C" __EXPORT int ekf2_main(int argc, char *argv[])
 #if defined(CONFIG_EKF2_MULTI_INSTANCE)
 			if (_ekf2_selector.load()) {
 				PX4_INFO("stopping ekf2 selector");
-				_ekf2_selector.load()->Stop();
-				delete _ekf2_selector.load();
-				_ekf2_selector.store(nullptr);
 				was_running = true;
+
+				if (_ekf2_selector.load()->Stop()) {
+					delete _ekf2_selector.load();
+					_ekf2_selector.store(nullptr);
+				}
 			}
 #endif // CONFIG_EKF2_MULTI_INSTANCE
 
@@ -3298,10 +3320,11 @@ extern "C" __EXPORT int ekf2_main(int argc, char *argv[])
 				if (inst) {
 					PX4_INFO("stopping ekf2 instance %d", i);
 					was_running = true;
-					inst->request_stop();
-					px4_usleep(20000); // 20 ms
-					delete inst;
-					_objects[i].store(nullptr);
+
+					if (inst->request_stop_and_wait()) {
+						delete inst;
+						_objects[i].store(nullptr);
+					}
 				}
 			}
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -150,7 +150,11 @@ public:
 
 	bool should_exit() const { return _task_should_exit.load(); }
 
-	void request_stop() { _task_should_exit.store(true); }
+	void request_stop() { _task_should_exit.store(true); ScheduleNow(); }
+
+	// request a stop and wait until Run() has exited on the work queue, so the
+	// instance can be safely deleted; returns false if it did not exit in time
+	bool request_stop_and_wait();
 
 	static void lock_module() { pthread_mutex_lock(&ekf2_module_mutex); }
 	static bool trylock_module() { return (pthread_mutex_trylock(&ekf2_module_mutex) == 0); }
@@ -281,6 +285,7 @@ private:
 	int _instance{0};
 
 	px4::atomic_bool _task_should_exit{false};
+	px4::atomic_bool _task_exited{false};
 
 	// time slip monitoring
 	uint64_t _integrated_time_us = 0;	///< integral of gyro delta time from start (uSec)

--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -57,14 +57,28 @@ EKF2Selector::~EKF2Selector()
 	Stop();
 }
 
-void EKF2Selector::Stop()
+bool EKF2Selector::Stop()
 {
-	for (int i = 0; i < EKF2_MAX_INSTANCES; i++) {
-		_instance[i].estimator_attitude_sub.unregisterCallback();
-		_instance[i].estimator_status_sub.unregisterCallback();
+	if (_task_exited.load()) {
+		// already stopped (Stop() is also called from the destructor)
+		return true;
 	}
 
-	ScheduleClear();
+	_task_should_exit.store(true);
+	ScheduleNow();
+
+	// wait for the work-queue thread to run Run() once more and exit
+	for (int i = 0; i < 100 && !_task_exited.load(); i++) {
+		px4_usleep(20000); // 20 ms, up to 2 s
+	}
+
+	const bool exited = _task_exited.load();
+
+	if (!exited) {
+		PX4_ERR("ekf2 selector did not stop");
+	}
+
+	return exited;
 }
 
 void EKF2Selector::PrintInstanceChange(const uint8_t old_instance, uint8_t new_instance)
@@ -699,6 +713,17 @@ void EKF2Selector::PublishWindEstimate()
 
 void EKF2Selector::Run()
 {
+	if (_task_should_exit.load()) {
+		for (int i = 0; i < EKF2_MAX_INSTANCES; i++) {
+			_instance[i].estimator_attitude_sub.unregisterCallback();
+			_instance[i].estimator_status_sub.unregisterCallback();
+		}
+
+		ScheduleClear();
+		_task_exited.store(true);
+		return;
+	}
+
 	// check for parameter updates
 	if (_parameter_update_sub.updated()) {
 		// clear update

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -70,7 +70,7 @@ public:
 	EKF2Selector();
 	~EKF2Selector() override;
 
-	void Stop();
+	bool Stop();
 
 	void PrintStatus();
 
@@ -183,6 +183,9 @@ private:
 	uint8_t _available_instances{0};
 	uint8_t _selected_instance{INVALID_INSTANCE};
 	px4::atomic<uint8_t> _request_instance{INVALID_INSTANCE};
+
+	px4::atomic_bool _task_should_exit{false};
+	px4::atomic_bool _task_exited{false};
 
 	uint32_t _instance_changed_count{0};
 	hrt_abstime _last_instance_change{0};


### PR DESCRIPTION
## Summary

Fix a use-after-free in the runtime `ekf2 stop` path: an EKF2 instance — or the multi-EKF selector — could be freed while its work-queue thread was still executing `Run()`.

## Problem

`ekf2 stop` set `_task_should_exit` and then slept a fixed 20 ms before `delete`-ing each instance, with no confirmation that the work queue had exited. EKF2 instances are `ScheduledWorkItem`s driven by IMU/sensor_combined callbacks, and `Run()` on `should_exit()` only unregistered its callbacks and returned. If the EKF2 work queue was starved or busy for longer than 20 ms — plausible, since EKF2 is heavy and shares a work queue — the object was freed while its `Run()` was still executing on the work-queue thread. `EKF2Selector::Stop()` had the same gap: it cleared the schedule but could not stop an in-progress `Run()`.

## Solution

Add a `_task_exited` handshake. On `should_exit()`, `Run()` now unregisters its callbacks, calls `ScheduleClear()`, and sets `_task_exited` before returning. The stop path uses `request_stop_and_wait()`, which polls `_task_exited` and deletes the instance only once the work queue has exited; on timeout it leaves the instance allocated rather than risk the use-after-free. `request_stop()` also calls `ScheduleNow()` so the item processes the exit promptly. The selector gets the same handshake, with its cleanup moved into `Run()`'s exit path and `Stop()` returning whether it stopped.
