### PR TITLE
docs(docs): Ubuntu EOL/LTS

### DIFF
--- a/docs/en/dev_setup/dev_env_linux_ubuntu.md
+++ b/docs/en/dev_setup/dev_env_linux_ubuntu.md
@@ -10,8 +10,11 @@ The environment includes:
 The build toolchain for other flight controllers, simulators, and working with ROS are discussed in the [Other Targets](#other-targets) section below.
 
 ::: info
-PX4 targets the **current Ubuntu LTS** (24.04) for CI and release builds, with the **previous LTS** (22.04) also supported.
-Older Ubuntu versions are not supported and may not work.
+The current CI and release target is **Ubuntu 24.04**, with build tests also run on **Ubuntu 22.04**.
+Ubuntu 26.04 is not yet supported.
+
+More generally, PX4 supports all currently active Ubuntu LTS releases, dropping versions when they reach end-of-life.
+Support for a new LTS release is added once it provides the toolchain packages required by CI — including the ability to build for hardware targets and run SIH-based integration tests.
 :::
 
 ## Simulation and NuttX (Pixhawk) Targets


### PR DESCRIPTION
This updates docs to make it clear that we support last three LTS Ubuntu versions, and when we support a new version.

Falls out of discussion in #27086