### PR TITLE
docs(docs): Subscription handle is orb_sub_t type in example

### DIFF
--- a/docs/en/modules/hello_sky.md
+++ b/docs/en/modules/hello_sky.md
@@ -311,7 +311,7 @@ Subscribing to a topic is straightforward:
 ```cpp
 #include <uORB/topics/vehicle_acceleration.h>
 ..
-int sensor_sub_fd = orb_subscribe(ORB_ID(vehicle_acceleration));
+orb_sub_t sensor_sub_fd = orb_subscribe(ORB_ID(vehicle_acceleration));
 ```
 
 The `sensor_sub_fd` is a topic handle and can be used to very efficiently perform a blocking wait for new data.
@@ -324,7 +324,7 @@ Adding `poll()` to the subscription looks like (_pseudocode, look for the full i
 #include <poll.h>
 #include <uORB/topics/vehicle_acceleration.h>
 ..
-int sensor_sub_fd = orb_subscribe(ORB_ID(vehicle_acceleration));
+orb_sub_t sensor_sub_fd = orb_subscribe(ORB_ID(vehicle_acceleration));
 
 /* one could wait for multiple topics with this technique, just using one here */
 px4_pollfd_struct_t fds[] = {
@@ -469,7 +469,7 @@ int px4_simple_app_main(int argc, char *argv[])
 	PX4_INFO("Hello Sky!");
 
 	/* subscribe to vehicle_acceleration topic */
-	int sensor_sub_fd = orb_subscribe(ORB_ID(vehicle_acceleration));
+	orb_sub_t sensor_sub_fd = orb_subscribe(ORB_ID(vehicle_acceleration));
 	/* limit the update rate to 5 Hz */
 	orb_set_interval(sensor_sub_fd, 200);
 


### PR DESCRIPTION
https://github.com/PX4/PX4-Autopilot/pull/27457 updated the basic example to use orb_sub_t instead of `int` for the handle type. This updates the example in the docs.

There might be other places we need to say this, but I don't think so, as our uorb howto docs point to the source code for this level of info.

