### PR TITLE
fix(navigator): prevent multicopter mission stall at waypoints

### DIFF
--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -523,6 +523,9 @@ MissionBase::set_mission_items()
 
 			setActiveMissionItems();
 
+			// anchor the altitude reference for home-change handling to the freshly set item
+			_mission_alt_reference_amsl = get_absolute_altitude_for_item(_mission_item);
+
 		} else {
 			set_end_of_mission = true;
 		}
@@ -1546,21 +1549,28 @@ void MissionBase::updateMissionAltAfterHomeChanged()
 
 		if (mission_item_contains_position(_mission_item)) {
 			const float new_alt = get_absolute_altitude_for_item(_mission_item);
-			const float altitude_diff = new_alt - _navigator->get_position_setpoint_triplet()->current.alt;
 
-			if (_navigator->get_position_setpoint_triplet()->previous.valid
-			    && PX4_ISFINITE(_navigator->get_position_setpoint_triplet()->previous.alt)) {
-				_navigator->get_position_setpoint_triplet()->previous.alt += altitude_diff;
+			// Shift the other legs to track the corrected home, but leave the leg we are
+			// currently flying untouched so its altitude is not yanked mid-approach. Anchor
+			// the delta on the last synced reference (not current.alt, which we no longer
+			// move) so repeated home corrections do not accumulate on the other legs.
+			if (PX4_ISFINITE(_mission_alt_reference_amsl)) {
+				const float altitude_diff = new_alt - _mission_alt_reference_amsl;
+
+				if (_navigator->get_position_setpoint_triplet()->previous.valid
+				    && PX4_ISFINITE(_navigator->get_position_setpoint_triplet()->previous.alt)) {
+					_navigator->get_position_setpoint_triplet()->previous.alt += altitude_diff;
+				}
+
+				if (_navigator->get_position_setpoint_triplet()->next.valid
+				    && PX4_ISFINITE(_navigator->get_position_setpoint_triplet()->next.alt)) {
+					_navigator->get_position_setpoint_triplet()->next.alt += altitude_diff;
+				}
+
+				_navigator->set_position_setpoint_triplet_updated();
 			}
 
-			_navigator->get_position_setpoint_triplet()->current.alt += altitude_diff;
-
-			if (_navigator->get_position_setpoint_triplet()->next.valid
-			    && PX4_ISFINITE(_navigator->get_position_setpoint_triplet()->next.alt)) {
-				_navigator->get_position_setpoint_triplet()->next.alt += altitude_diff;
-			}
-
-			_navigator->set_position_setpoint_triplet_updated();
+			_mission_alt_reference_amsl = new_alt;
 		}
 
 		_home_update_counter = _navigator->get_home_position()->update_count;

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -587,6 +587,7 @@ private:
 	bool canRunMissionFeasibility();
 
 	uint32_t _home_update_counter = 0; /**< Variable to store the previous value for home change detection.*/
+	float _mission_alt_reference_amsl{NAN}; /**< resolved AMSL of the current item at the last home-alt sync */
 
 	bool _align_heading_necessary{false}; // if true, heading of vehicle needs to be aligned with heading of next waypoint. Used to create new mission items for heading alignment.
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -169,12 +169,18 @@ MissionBlock::is_mission_item_reached_or_completed()
 
 		const float mission_item_altitude_amsl = get_absolute_altitude_for_item(_mission_item);
 
+		// Check acceptance against the commanded setpoint altitude, not the live home-relative
+		// item altitude, so acceptance stays consistent when the active leg altitude is held.
+		const position_setpoint_s &current_setpoint = _navigator->get_position_setpoint_triplet()->current;
+		const float acceptance_altitude_amsl = (current_setpoint.valid && PX4_ISFINITE(current_setpoint.alt)) ?
+						       current_setpoint.alt : mission_item_altitude_amsl;
+
 		// consider mission_item.loiter_radius invalid if NAN or 0, use default value in this case.
 		const float mission_item_loiter_radius_abs = (PX4_ISFINITE(_mission_item.loiter_radius)
 				&& fabsf(_mission_item.loiter_radius) > FLT_EPSILON) ? fabsf(_mission_item.loiter_radius) :
 				_navigator->get_default_loiter_rad();
 
-		dist = get_distance_to_point_global_wgs84(_mission_item.lat, _mission_item.lon, mission_item_altitude_amsl,
+		dist = get_distance_to_point_global_wgs84(_mission_item.lat, _mission_item.lon, acceptance_altitude_amsl,
 				_navigator->get_global_position()->lat,
 				_navigator->get_global_position()->lon,
 				_navigator->get_global_position()->alt,
@@ -200,14 +206,14 @@ MissionBlock::is_mission_item_reached_or_completed()
 
 			/* require only altitude for takeoff for multicopter */
 			if (_navigator->get_global_position()->alt >
-			    mission_item_altitude_amsl - altitude_acceptance_radius) {
+			    acceptance_altitude_amsl - altitude_acceptance_radius) {
 				_waypoint_position_reached = true;
 			}
 
 		} else if (_mission_item.nav_cmd == NAV_CMD_TAKEOFF
 			   && _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
 			/* fixed-wing takeoff is reached once the vehicle has exceeded the takeoff altitude */
-			if (_navigator->get_global_position()->alt > mission_item_altitude_amsl) {
+			if (_navigator->get_global_position()->alt > acceptance_altitude_amsl) {
 				_waypoint_position_reached = true;
 			}
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -340,14 +340,17 @@ MissionBlock::is_mission_item_reached_or_completed()
 
 			bool passed_curr_wp = false;
 
-			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+			// Fixed-wing and multicopter fly through waypoints, so also accept the waypoint once the
+			// vehicle has passed it along the leg (multicopter has a tight radius it can blow through).
+			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING
+			    || _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
 
 				const float dist_prev_to_curr = get_distance_to_next_waypoint(_navigator->get_position_setpoint_triplet()->previous.lat,
 								_navigator->get_position_setpoint_triplet()->previous.lon, _navigator->get_position_setpoint_triplet()->current.lat,
 								_navigator->get_position_setpoint_triplet()->current.lon);
 
 				if (dist_prev_to_curr > 1.0e-6f && _navigator->get_position_setpoint_triplet()->previous.valid) {
-					// Fixed-wing guidance interprets this condition as line segment following
+					// line segment following: accept the waypoint once it has been passed
 
 					// vector from previous waypoint to current waypoint
 					float vector_prev_to_curr_north;


### PR DESCRIPTION
## Summary

Part of #27730. Stops a multicopter auto mission from stalling at a waypoint and drifting away when it overshoots a tight acceptance radius on a fast leg, or when the leg altitude shifts during the approach.

## Problem

A multicopter accepts a normal waypoint only when it is inside both the horizontal radius and the altitude window in the same cycle — there is no "passed the waypoint" fallback (that path is fixed-wing only). On fast, short legs with a small `NAV_ACC_RAD` the vehicle can cross the waypoint in under a cycle without ever satisfying both conditions at once, so the mission never advances. Separately, the acceptance check measures altitude against the live home-relative item altitude, so a home-altitude correction that lands mid-approach (for example the post-takeoff correction shifting relative legs) moves the target out from under the vehicle and it misses the altitude window.

## Solution

- Extend the existing `passed_curr_wp` line-segment-passed acceptance to multicopters (still gated on altitude), so a fly-through advances once the vehicle has passed the waypoint.
- Evaluate the acceptance altitude against the commanded setpoint instead of re-deriving it from live home; this is behaviour-neutral while the setpoint tracks the item, and `NAV_CMD_LOITER_TO_ALT` keeps using the item altitude for its staged climb.
- In `updateMissionAltAfterHomeChanged`, leave the leg currently being flown untouched and shift only the previous/next legs, anchored on a tracked reference so repeated home corrections stay correct. A home correction is then absorbed gradually on the next leg instead of yanking the active one.
