### PR TITLE
fix(motion_planning): stop auto setpoint drifting past an unreached waypoint

### DIFF
--- a/src/lib/motion_planning/PositionSmoothing.cpp
+++ b/src/lib/motion_planning/PositionSmoothing.cpp
@@ -155,14 +155,16 @@ const Vector3f PositionSmoothing::_getL1Point(const Vector3f &position, const Ve
 {
 	const Vector3f pos_traj(_trajectory[0].getCurrentPosition(), _trajectory[1].getCurrentPosition(),
 				_trajectory[2].getCurrentPosition());
-	const Vector3f u_prev_to_target = (waypoints[1] - waypoints[0]).unit_or_zero();
+	const Vector3f prev_to_target = waypoints[1] - waypoints[0];
+	const float leg_length = prev_to_target.length();
+	const Vector3f u_prev_to_target = (leg_length > FLT_EPSILON) ? prev_to_target / leg_length : Vector3f();
 	const Vector3f prev_to_pos(pos_traj - waypoints[0]);
 	const float along_track = prev_to_pos * u_prev_to_target;
 
 	// If the trajectory has already passed the target, aim straight at it instead of
 	// projecting the look-ahead point further along the (extended) leg. Otherwise an
 	// overshoot of a not-yet-accepted waypoint marches the setpoint away from it forever.
-	if (along_track >= (waypoints[1] - waypoints[0]).length()) {
+	if (along_track >= leg_length) {
 		return waypoints[1];
 	}
 

--- a/src/lib/motion_planning/PositionSmoothing.cpp
+++ b/src/lib/motion_planning/PositionSmoothing.cpp
@@ -157,8 +157,16 @@ const Vector3f PositionSmoothing::_getL1Point(const Vector3f &position, const Ve
 				_trajectory[2].getCurrentPosition());
 	const Vector3f u_prev_to_target = (waypoints[1] - waypoints[0]).unit_or_zero();
 	const Vector3f prev_to_pos(pos_traj - waypoints[0]);
-	const Vector3f prev_to_closest(u_prev_to_target * (prev_to_pos * u_prev_to_target));
-	const Vector3f closest_pt = waypoints[0] + prev_to_closest;
+	const float along_track = prev_to_pos * u_prev_to_target;
+
+	// If the trajectory has already passed the target, aim straight at it instead of
+	// projecting the look-ahead point further along the (extended) leg. Otherwise an
+	// overshoot of a not-yet-accepted waypoint marches the setpoint away from it forever.
+	if (along_track >= (waypoints[1] - waypoints[0]).length()) {
+		return waypoints[1];
+	}
+
+	const Vector3f closest_pt = waypoints[0] + u_prev_to_target * along_track;
 
 	// Compute along-track error using L1 distance and cross-track error
 	const float crosstrack_error = (closest_pt - pos_traj).length();

--- a/src/lib/motion_planning/PositionSmoothingTest.cpp
+++ b/src/lib/motion_planning/PositionSmoothingTest.cpp
@@ -193,3 +193,56 @@ TEST_F(PositionSmoothingTest, reachesTargetInitialVelocity)
 	EXPECT_LT(fabsf(position(2) - TARGET(2)), Z_ACC_RAD);
 	EXPECT_LT(iteration, N_ITER) << "Took too long to converge\n";
 }
+
+
+// Fly through a waypoint whose triplet never advances (e.g. an overshoot the navigator
+// can't accept). The look-ahead point must not keep marching down the extended leg: the
+// vehicle has to brake and come back to the target instead of drifting away forever.
+TEST_F(PositionSmoothingTest, doesNotDriftPastUnreachedWaypoint)
+{
+	const int N_ITER = 3000; // 60 s at 50 Hz
+	const float DELTA_T = 0.02f;
+
+	const Vector3f PREV{0.f, 0.f, 0.f};
+	const Vector3f TARGET{20.f, 0.f, 0.f};
+	const Vector3f NEXT{40.f, 2.f, 0.f}; // near-collinear next leg -> high corner speed -> clear fly-through
+
+	// Triplet stays fixed for the whole run: the navigator never advances past TARGET.
+	Vector3f waypoints[3] = {PREV, TARGET, NEXT};
+
+	const Vector3f u_leg = (TARGET - PREV).unit_or_zero();
+	const float leg_length = (TARGET - PREV).length();
+
+	Vector3f position{0.f, 0.f, 0.f};
+	PositionSmoothing::PositionSmoothingSetpoints out;
+
+	bool reached_target = false;
+	bool came_back = false;
+	float max_distance_past_target = 0.f;
+
+	for (int i = 0; i < N_ITER; i++) {
+		_position_smoothing.generateSetpoints(position, waypoints, Vector3f{}, DELTA_T, false, out);
+		position = out.position;
+		expectDynamicsLimitsRespected(out);
+
+		const float along_track = Vector3f(position - PREV) * u_leg;
+
+		if (Vector3f(position - TARGET).length() < 1.f) {
+			reached_target = true;
+		}
+
+		if (reached_target) {
+			max_distance_past_target = fmaxf(max_distance_past_target, along_track - leg_length);
+
+			// Once the vehicle has gone past the target, the fix must turn it around.
+			if (along_track > leg_length + 1.f && out.velocity * u_leg < -0.1f) {
+				came_back = true;
+			}
+		}
+	}
+
+	EXPECT_TRUE(reached_target) << "Vehicle never reached the target waypoint\n";
+	EXPECT_TRUE(came_back) << "Vehicle never turned back toward the unreached waypoint (it drifted away)\n";
+	// Without the fix the look-ahead marches down the extended leg and this grows unbounded.
+	EXPECT_LT(max_distance_past_target, 10.f) << "Vehicle drifted too far past the unreached waypoint\n";
+}


### PR DESCRIPTION
## Summary

Part of #27730. Prevents the multicopter auto flight task from driving the position setpoint indefinitely past a waypoint that has not been accepted, which otherwise makes the vehicle drift away with no failsafe.

## Problem

`PositionSmoothing::_getL1Point` builds the look-ahead carrot as `closest_pt + alongtrack_error * u_prev_to_target` — a forward projection along the prev→target line with no upper bound. Once the smoothed trajectory passes the target (for example the vehicle overshoots a waypoint the navigator has not advanced past), the carrot sits beyond the target and the velocity setpoint keeps pointing down the extended leg, so the vehicle coasts away at the corner speed instead of holding on the waypoint.

## Solution

When the trajectory's along-track position reaches the leg length (i.e. it has passed the target), aim straight at the target instead of projecting further along the leg. The smoother then decelerates and holds on the waypoint. While still approaching, the function is unchanged, so normal cornering and the fly-through look-ahead are preserved — in healthy flight the navigator advances the triplet before the trajectory crosses the waypoint.

**Note:** this changes trajectory generation for all multicopter auto flight, so it needs a SITL mission fly-through (normal cornering stays smooth, and an overshot/un-accepted waypoint brakes-and-holds instead of drifting) before being marked ready for review.
