### PR TITLE
fix(airship_att_control): gate manual passthrough on control mode

### DIFF
--- a/src/modules/airship_att_control/airship_att_control.hpp
+++ b/src/modules/airship_att_control/airship_att_control.hpp
@@ -36,7 +36,7 @@
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
-#include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/vehicle_angular_velocity.h>
@@ -82,7 +82,7 @@ private:
 	void publishThrustSetpoint(const hrt_abstime &timestamp_sample);
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
-	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 
 	uORB::SubscriptionCallbackWorkItem _vehicle_angular_velocity_sub{this, ORB_ID(vehicle_angular_velocity)};
@@ -91,7 +91,7 @@ private:
 	uORB::Publication<vehicle_torque_setpoint_s>    _vehicle_torque_setpoint_pub{ORB_ID(vehicle_torque_setpoint)};
 
 	manual_control_setpoint_s       _manual_control_setpoint{};
-	vehicle_status_s                _vehicle_status{};
+	vehicle_control_mode_s          _vehicle_control_mode{};
 
 	perf_counter_t _loop_perf;
 

--- a/src/modules/airship_att_control/airship_att_control_main.cpp
+++ b/src/modules/airship_att_control/airship_att_control_main.cpp
@@ -87,8 +87,8 @@ void AirshipAttitudeControl::publishTorqueSetpoint(const hrt_abstime &timestamp_
 	v_torque_sp.timestamp = hrt_absolute_time();
 	v_torque_sp.timestamp_sample = timestamp_sample;
 
-	// zero actuators if not armed
-	if (_vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
+	// zero actuators unless armed and in a manual flight mode
+	if (_vehicle_control_mode.flag_armed && _vehicle_control_mode.flag_control_manual_enabled) {
 		v_torque_sp.xyz[0] = 0.f;
 		v_torque_sp.xyz[1] = _manual_control_setpoint.pitch;
 		v_torque_sp.xyz[2] = _manual_control_setpoint.yaw;
@@ -103,8 +103,8 @@ void AirshipAttitudeControl::publishThrustSetpoint(const hrt_abstime &timestamp_
 	v_thrust_sp.timestamp = hrt_absolute_time();
 	v_thrust_sp.timestamp_sample = timestamp_sample;
 
-	// zero actuators if not armed
-	if (_vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
+	// zero actuators unless armed and in a manual flight mode
+	if (_vehicle_control_mode.flag_armed && _vehicle_control_mode.flag_control_manual_enabled) {
 		v_thrust_sp.xyz[0] = (_manual_control_setpoint.throttle + 1.f) * .5f;
 	}
 
@@ -127,15 +127,13 @@ AirshipAttitudeControl::Run()
 
 	if (_vehicle_angular_velocity_sub.update(&angular_velocity)) {
 
-		/* run the rate controller immediately after a gyro update */
+		/* refresh manual control and control mode before publishing */
+		_manual_control_setpoint_sub.update(&_manual_control_setpoint);
+		_vehicle_control_mode_sub.update(&_vehicle_control_mode);
+
+		/* run the controller immediately after a gyro update */
 		publishThrustSetpoint(angular_velocity.timestamp_sample);
 		publishTorqueSetpoint(angular_velocity.timestamp_sample);
-
-		/* check for updates in manual control topic */
-		_manual_control_setpoint_sub.update(&_manual_control_setpoint);
-
-		/* check for updates in vehicle status topic */
-		_vehicle_status_sub.update(&_vehicle_status);
 
 		parameter_update_poll();
 	}


### PR DESCRIPTION
### Solved Problem
`airship_att_control` feeds `manual_control_setpoint` straight into the actuator setpoints, gated only on the arming state. On RC loss the vehicle stays armed while the flight mode switches to a non-manual failsafe (e.g. Land). Because the gate checks only arming, the module keeps republishing the last (frozen) stick values to the thrusters and surfaces — ignoring the failsafe, unlike the other controllers, which gate manual authority on the flight mode.

### Solution
Also gate the passthrough on `vehicle_control_mode.flag_control_manual_enabled`, so the sticks drive the actuators only in a manual flight mode (e.g. Manual or Acro) and the publishers emit zero otherwise. Both flags now come from `vehicle_control_mode` (`flag_armed`), letting the redundant `vehicle_status` subscription be dropped; subscriptions are refreshed before publishing so the gate uses the current cycle. Matches the contract in `mc_rate_control`/`fw_rate_control`.

### Changelog Entry
```
Bugfix: airship_att_control drives actuator outputs to zero outside manual flight modes (e.g. RC-loss failsafe) instead of holding the last stick values.
```

### Test coverage
Bench-tested on Cube Orange / Cloudship (2507), props off, watching `vehicle_thrust_setpoint`/`vehicle_torque_setpoint`:
- Manual: passthrough works in both builds.
- RC loss → Land (still armed): without the change outputs hold the last sticks; with it they go to zero.
