### PR TITLE
fix(mc_defaults): remove 2m instead of 10m acceptance radius

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -15,8 +15,6 @@ then
 	param set-default IMU_GYRO_RATEMAX 800
 fi
 
-param set-default NAV_ACC_RAD 2
-
 param set-default RTL_RETURN_ALT 30
 param set-default RTL_DESCEND_ALT 10
 


### PR DESCRIPTION
This setting comes from a time where takeoff was accepted immediately if the acceptance radius was too big and also the mission behavior was completely different:

95a8414895d0f93bf92b8339ad15a1b3b4d1a7f2

### Solved Problem
This setting comes from a time where the takeoff was immediately accepted if the acceptance radius was larger than the takeoff altitude and the line between two waypoints never reached if waypoints were accepted too early. This all got fixed and the default 10 meters make sense with rounded corners.

I suggest to change this since when I use missions e.g. surveys in production the first thing I do is resetting the acceptance radius.

### Solution
Remove mc_defaults override for the acceptance radius `NAV_ACC_RAD`.

### Changelog Entry
```
Use default 10m acceptance radius for multicopters instead of 2m override
```

### Test coverage
Like I wrote I use the default all the time, here's how it looks in simulation:
<img width="958" height="862" alt="image" src="https://github.com/user-attachments/assets/ef01a57b-3c67-4dc6-b84d-f263e8b80040" />


