### PR TITLE
Limited airmode: continuous MC_AIRMODE_LIM / MC_AIRMODE_YLIM

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1040_gazebo-classic_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1040_gazebo-classic_standard_vtol
@@ -63,7 +63,7 @@ param set-default FW_T_CLMB_MAX 8
 param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
 
-param set-default MC_AIRMODE 1
+param set-default MC_AIRMODE_LIM 1.0
 param set-default MC_ROLL_P 4
 param set-default MC_ROLLRATE_P 0.3
 param set-default MC_YAW_P 1.6

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
@@ -63,7 +63,7 @@ param set-default FW_T_HRATE_FF 0.5
 param set-default FW_T_SINK_MAX 3
 param set-default FW_T_SINK_MIN 1.6
 
-param set-default MC_AIRMODE 1
+param set-default MC_AIRMODE_LIM 1.0
 param set-default MC_ROLL_P 3
 param set-default MC_PITCH_P 3
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1042_gazebo-classic_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1042_gazebo-classic_tiltrotor
@@ -60,7 +60,7 @@ param set-default FW_T_CLMB_MAX 8
 param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
 
-param set-default MC_AIRMODE 1
+param set-default MC_AIRMODE_LIM 1.0
 param set-default MC_YAWRATE_P 0.3
 param set-default MC_YAWRATE_I 0.3
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
@@ -57,7 +57,8 @@ param set-default FW_AIRSPD_MIN 14
 param set-default FW_AIRSPD_TRIM 18
 param set-default FW_AIRSPD_MAX 22
 
-param set-default MC_AIRMODE 2
+param set-default MC_AIRMODE_LIM 1.0
+param set-default MC_AIRMODE_YLIM 1.0
 param set-default MAN_ARM_GESTURE 0 # required for yaw airmode
 param set-default MC_ROLL_P 3
 param set-default MC_PITCH_P 3

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
@@ -86,7 +86,7 @@ param set-default FW_T_CLMB_MAX 8
 param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
 
-param set-default MC_AIRMODE 1
+param set-default MC_AIRMODE_LIM 1.0
 param set-default MC_ROLLRATE_P 0.3
 param set-default MC_YAW_P 1.6
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4018_gz_quadtailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4018_gz_quadtailsitter
@@ -72,7 +72,8 @@ param set-default FW_AIRSPD_MIN 14
 param set-default FW_AIRSPD_TRIM 18
 param set-default FW_AIRSPD_MAX 22
 
-param set-default MC_AIRMODE 2
+param set-default MC_AIRMODE_LIM 1.0
+param set-default MC_AIRMODE_YLIM 1.0
 param set-default MAN_ARM_GESTURE 0 # required for yaw airmode
 param set-default MC_ROLL_P 3
 param set-default MC_PITCH_P 3

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4020_gz_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4020_gz_tiltrotor
@@ -91,7 +91,7 @@ param set-default FW_T_CLMB_MAX 8
 param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
 
-param set-default MC_AIRMODE 1
+param set-default MC_AIRMODE_LIM 1.0
 param set-default MC_YAWRATE_P 0.4
 param set-default MC_YAWRATE_I 0.1
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
@@ -28,7 +28,7 @@ param set-default CBRK_SUPPLY_CHK 894281
 param set-default IMU_GYRO_CUTOFF 100
 param set-default IMU_DGYRO_CUTOFF 60
 
-param set-default MC_AIRMODE 2
+param set-default MC_AIRMODE_LIM 1.0
 param set-default MC_PITCHRATE_D 0.001
 param set-default MC_PITCHRATE_I 0.5
 param set-default MC_PITCHRATE_MAX 600

--- a/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
@@ -23,7 +23,7 @@ param set-default BAT1_N_CELLS 4
 param set-default IMU_GYRO_CUTOFF 120
 param set-default IMU_DGYRO_CUTOFF 45
 
-param set-default MC_AIRMODE 1
+param set-default MC_AIRMODE_LIM 1.0
 param set-default MC_PITCHRATE_D 0.0012
 param set-default MC_PITCHRATE_I 0.35
 param set-default MC_PITCHRATE_MAX 1200

--- a/ROMFS/px4fmu_common/init.d/airframes/4053_holybro_kopis2
+++ b/ROMFS/px4fmu_common/init.d/airframes/4053_holybro_kopis2
@@ -51,7 +51,7 @@ param set-default THR_MDL_FAC 0.35
 param set-default MPC_THR_CURVE 1
 param set-default MPC_THR_HOVER 0.12
 
-param set-default MC_AIRMODE 1
+param set-default MC_AIRMODE_LIM 1.0
 
 param set-default EV_TSK_RC_LOSS 1
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4901_crazyflie21
+++ b/ROMFS/px4fmu_common/init.d/airframes/4901_crazyflie21
@@ -33,7 +33,7 @@ param set-default COM_RC_IN_MODE 1
 param set-default IMU_GYRO_CUTOFF 100
 param set-default IMU_ACCEL_CUTOFF 30
 
-param set-default MC_AIRMODE 1
+param set-default MC_AIRMODE_LIM 1.0
 param set-default IMU_DGYRO_CUTOFF 70
 param set-default MC_PITCHRATE_D 0.002
 param set-default MC_PITCHRATE_P 0.07

--- a/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.cpp
@@ -51,15 +51,15 @@ ControlAllocationSequentialDesaturation::allocate()
 
 	switch (_param_mc_airmode.get()) {
 	case 1:
-		mixAirmodeRP();
+		mix(/*airmode_rp=*/ true, /*airmode_yaw=*/ false);
 		break;
 
 	case 2:
-		mixAirmodeRPY();
+		mix(/*airmode_rp=*/ true, /*airmode_yaw=*/ true);
 		break;
 
 	default:
-		mixAirmodeDisabled();
+		mix(/*airmode_rp=*/ false, /*airmode_yaw=*/ false);
 		break;
 	}
 }
@@ -119,112 +119,60 @@ float ControlAllocationSequentialDesaturation::computeDesaturationGain(const Act
 }
 
 void
-ControlAllocationSequentialDesaturation::mixAirmodeRP()
+ControlAllocationSequentialDesaturation::mix(bool airmode_rp, bool airmode_yaw)
 {
-	// Airmode for roll and pitch, but not yaw
-
-	// Mix without yaw
 	ActuatorVector thrust_z;
-
-	for (int i = 0; i < _num_actuators; i++) {
-		_actuator_sp(i) = _actuator_trim(i) +
-				  _mix(i, ControlAxis::ROLL) * (_control_sp(ControlAxis::ROLL) - _control_trim(ControlAxis::ROLL)) +
-				  _mix(i, ControlAxis::PITCH) * (_control_sp(ControlAxis::PITCH) - _control_trim(ControlAxis::PITCH)) +
-				  _mix(i, ControlAxis::THRUST_X) * (_control_sp(ControlAxis::THRUST_X) - _control_trim(ControlAxis::THRUST_X)) +
-				  _mix(i, ControlAxis::THRUST_Y) * (_control_sp(ControlAxis::THRUST_Y) - _control_trim(ControlAxis::THRUST_Y)) +
-				  _mix(i, ControlAxis::THRUST_Z) * (_control_sp(ControlAxis::THRUST_Z) - _control_trim(ControlAxis::THRUST_Z));
-		thrust_z(i) = _mix(i, ControlAxis::THRUST_Z);
-	}
-
-	desaturateActuators(_actuator_sp, thrust_z);
-
-	// Mix yaw independently
-	mixYaw();
-}
-
-void
-ControlAllocationSequentialDesaturation::mixAirmodeRPY()
-{
-	// Airmode for roll, pitch and yaw
-
-	// Do full mixing
-	ActuatorVector thrust_z;
+	ActuatorVector roll;
+	ActuatorVector pitch;
 	ActuatorVector yaw;
 
 	for (int i = 0; i < _num_actuators; i++) {
 		_actuator_sp(i) = _actuator_trim(i) +
 				  _mix(i, ControlAxis::ROLL) * (_control_sp(ControlAxis::ROLL) - _control_trim(ControlAxis::ROLL)) +
 				  _mix(i, ControlAxis::PITCH) * (_control_sp(ControlAxis::PITCH) - _control_trim(ControlAxis::PITCH)) +
-				  _mix(i, ControlAxis::YAW) * (_control_sp(ControlAxis::YAW) - _control_trim(ControlAxis::YAW)) +
-				  _mix(i, ControlAxis::THRUST_X) * (_control_sp(ControlAxis::THRUST_X) - _control_trim(ControlAxis::THRUST_X)) +
-				  _mix(i, ControlAxis::THRUST_Y) * (_control_sp(ControlAxis::THRUST_Y) - _control_trim(ControlAxis::THRUST_Y)) +
-				  _mix(i, ControlAxis::THRUST_Z) * (_control_sp(ControlAxis::THRUST_Z) - _control_trim(ControlAxis::THRUST_Z));
-		thrust_z(i) = _mix(i, ControlAxis::THRUST_Z);
-		yaw(i) = _mix(i, ControlAxis::YAW);
-	}
-
-	desaturateActuators(_actuator_sp, thrust_z);
-
-	// Unsaturate yaw (in case upper and lower bounds are exceeded)
-	// to prioritize roll/pitch over yaw.
-	desaturateActuators(_actuator_sp, yaw);
-}
-
-void
-ControlAllocationSequentialDesaturation::mixAirmodeDisabled()
-{
-	// Airmode disabled: never allow to increase the thrust to unsaturate a motor
-
-	// Mix without yaw
-	ActuatorVector thrust_z;
-	ActuatorVector roll;
-	ActuatorVector pitch;
-
-	for (int i = 0; i < _num_actuators; i++) {
-		_actuator_sp(i) = _actuator_trim(i) +
-				  _mix(i, ControlAxis::ROLL) * (_control_sp(ControlAxis::ROLL) - _control_trim(ControlAxis::ROLL)) +
-				  _mix(i, ControlAxis::PITCH) * (_control_sp(ControlAxis::PITCH) - _control_trim(ControlAxis::PITCH)) +
+				  (airmode_yaw
+				   ? _mix(i, ControlAxis::YAW) * (_control_sp(ControlAxis::YAW) - _control_trim(ControlAxis::YAW))
+				   : 0.f) +
 				  _mix(i, ControlAxis::THRUST_X) * (_control_sp(ControlAxis::THRUST_X) - _control_trim(ControlAxis::THRUST_X)) +
 				  _mix(i, ControlAxis::THRUST_Y) * (_control_sp(ControlAxis::THRUST_Y) - _control_trim(ControlAxis::THRUST_Y)) +
 				  _mix(i, ControlAxis::THRUST_Z) * (_control_sp(ControlAxis::THRUST_Z) - _control_trim(ControlAxis::THRUST_Z));
 		thrust_z(i) = _mix(i, ControlAxis::THRUST_Z);
 		roll(i) = _mix(i, ControlAxis::ROLL);
 		pitch(i) = _mix(i, ControlAxis::PITCH);
-	}
-
-	// only reduce thrust
-	desaturateActuators(_actuator_sp, thrust_z, true);
-
-	// Reduce roll/pitch acceleration if needed to unsaturate
-	desaturateActuators(_actuator_sp, roll);
-	desaturateActuators(_actuator_sp, pitch);
-
-	// Mix yaw independently
-	mixYaw();
-}
-
-void
-ControlAllocationSequentialDesaturation::mixYaw()
-{
-	// Add yaw to outputs
-	ActuatorVector yaw;
-	ActuatorVector thrust_z;
-
-	for (int i = 0; i < _num_actuators; i++) {
-		_actuator_sp(i) += _mix(i, ControlAxis::YAW) * (_control_sp(ControlAxis::YAW) - _control_trim(ControlAxis::YAW));
 		yaw(i) = _mix(i, ControlAxis::YAW);
-		thrust_z(i) = _mix(i, ControlAxis::THRUST_Z);
 	}
 
-	// Change yaw acceleration to unsaturate the outputs if needed (do not change roll/pitch),
-	// and allow some yaw response at maximum thrust
-	ActuatorVector max_prev = _actuator_max;
-	_actuator_max += (_actuator_max - _actuator_min) * MINIMUM_YAW_MARGIN;
-	desaturateActuators(_actuator_sp, yaw);
-	_actuator_max = max_prev;
+	// Slide thrust to unsaturate roll/pitch (and yaw when in the sum).
+	// Without airmode_rp, thrust may only decrease.
+	desaturateActuators(_actuator_sp, thrust_z, !airmode_rp);
 
-	// reduce thrust only
-	desaturateActuators(_actuator_sp, thrust_z, true);
+	if (!airmode_rp) {
+		// Reduce roll/pitch acceleration if needed to unsaturate.
+		desaturateActuators(_actuator_sp, roll);
+		desaturateActuators(_actuator_sp, pitch);
+	}
+
+	if (airmode_yaw) {
+		// Yaw is already in the sum; deprioritize it relative to roll/pitch by
+		// desaturating bidirectionally without the MINIMUM_YAW_MARGIN inflation.
+		desaturateActuators(_actuator_sp, yaw);
+
+	} else {
+		// Add yaw to outputs.
+		for (int i = 0; i < _num_actuators; i++) {
+			_actuator_sp(i) += _mix(i, ControlAxis::YAW) * (_control_sp(ControlAxis::YAW) - _control_trim(ControlAxis::YAW));
+		}
+
+		// Inflate the upper bound by MINIMUM_YAW_MARGIN so yaw retains some authority
+		// near maximum thrust, then desaturate yaw against the inflated bound.
+		const ActuatorVector max_prev = _actuator_max;
+		_actuator_max += (_actuator_max - _actuator_min) * MINIMUM_YAW_MARGIN;
+		desaturateActuators(_actuator_sp, yaw);
+		_actuator_max = max_prev;
+
+		// Reduce thrust only to clean up any overshoot the inflation allowed.
+		desaturateActuators(_actuator_sp, thrust_z, true);
+	}
 }
 
 void

--- a/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.cpp
@@ -131,10 +131,43 @@ float ControlAllocationSequentialDesaturation::computeDesaturationGain(const Act
 	return k_min + k_max;
 }
 
+bool ControlAllocationSequentialDesaturation::yawReducesAirmodeThrust()
+{
+	ActuatorVector thrust_z;
+	ActuatorVector mixed_no_yaw;
+	ActuatorVector mixed_with_yaw;
+
+	for (int i = 0; i < _num_actuators; i++) {
+		const float base = _actuator_trim(i) +
+				   _mix(i, ControlAxis::ROLL) * (_control_sp(ControlAxis::ROLL) - _control_trim(ControlAxis::ROLL)) +
+				   _mix(i, ControlAxis::PITCH) * (_control_sp(ControlAxis::PITCH) - _control_trim(ControlAxis::PITCH)) +
+				   _mix(i, ControlAxis::THRUST_X) * (_control_sp(ControlAxis::THRUST_X) - _control_trim(ControlAxis::THRUST_X)) +
+				   _mix(i, ControlAxis::THRUST_Y) * (_control_sp(ControlAxis::THRUST_Y) - _control_trim(ControlAxis::THRUST_Y)) +
+				   _mix(i, ControlAxis::THRUST_Z) * (_control_sp(ControlAxis::THRUST_Z) - _control_trim(ControlAxis::THRUST_Z));
+		mixed_no_yaw(i) = base;
+		mixed_with_yaw(i) = base + _mix(i, ControlAxis::YAW) * (_control_sp(ControlAxis::YAW) - _control_trim(ControlAxis::YAW));
+		thrust_z(i) = _mix(i, ControlAxis::THRUST_Z);
+	}
+
+	// Yaw helps iff the roll/pitch+yaw mix needs a strictly smaller thrust shift to unsaturate.
+	const float gain_no_yaw = computeDesaturationGain(thrust_z, mixed_no_yaw);
+	const float gain_with_yaw = computeDesaturationGain(thrust_z, mixed_with_yaw);
+
+	return fabsf(gain_with_yaw) < fabsf(gain_no_yaw);
+}
+
 void
 ControlAllocationSequentialDesaturation::mix(float roll_pitch_limit, float yaw_limit)
 {
-	const bool yaw_in_sum = (yaw_limit > 0.f);
+	bool yaw_in_sum = (yaw_limit > 0.f);
+
+	// In the deferred-yaw regime (yaw airmode off, roll/pitch airmode on), fold yaw into the
+	// pre-thrust sum when it relieves the saturating actuator, so the collective-thrust step can
+	// credit that relief instead of over-adding thrust. Delivers the same attitude with less or
+	// equal collective; when yaw does not help it stays deferred (legacy).
+	if (!yaw_in_sum && roll_pitch_limit > 0.f) {
+		yaw_in_sum = yawReducesAirmodeThrust();
+	}
 
 	ActuatorVector thrust_z;
 	ActuatorVector roll;
@@ -170,22 +203,23 @@ ControlAllocationSequentialDesaturation::mix(float roll_pitch_limit, float yaw_l
 
 	if (yaw_in_sum) {
 		// Yaw is already in the sum; deprioritize it relative to roll/pitch by desaturating
-		// against the original bounds, capping any upward gain at yaw_limit.
+		// without the MINIMUM_YAW_MARGIN inflation, capping any upward gain at yaw_limit.
 		desaturateActuators(_actuator_sp, yaw, yaw_limit);
 
 	} else {
-		// Legacy deferred-yaw path: add yaw after roll/pitch resolve, inflate the upper bound
-		// by MINIMUM_YAW_MARGIN to grant a fixed 15% yaw authority near max thrust, then pull
-		// thrust back down to clean up any overshoot.
+		// Add yaw to outputs.
 		for (int i = 0; i < _num_actuators; i++) {
 			_actuator_sp(i) += _mix(i, ControlAxis::YAW) * (_control_sp(ControlAxis::YAW) - _control_trim(ControlAxis::YAW));
 		}
 
+		// Inflate the upper bound by MINIMUM_YAW_MARGIN so yaw retains some authority
+		// near maximum thrust, then desaturate yaw against the inflated bound.
 		const ActuatorVector max_prev = _actuator_max;
 		_actuator_max += (_actuator_max - _actuator_min) * MINIMUM_YAW_MARGIN;
 		desaturateActuators(_actuator_sp, yaw);
 		_actuator_max = max_prev;
 
+		// Reduce thrust only to clean up any overshoot the inflation allowed.
 		desaturateActuators(_actuator_sp, thrust_z, 0.f);
 	}
 }

--- a/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.cpp
@@ -49,36 +49,49 @@ ControlAllocationSequentialDesaturation::allocate()
 
 	_prev_actuator_sp = _actuator_sp;
 
-	switch (_param_mc_airmode.get()) {
-	case 1:
-		mix(/*airmode_rp=*/ true, /*airmode_yaw=*/ false);
-		break;
-
-	case 2:
-		mix(/*airmode_rp=*/ true, /*airmode_yaw=*/ true);
-		break;
-
-	default:
-		mix(/*airmode_rp=*/ false, /*airmode_yaw=*/ false);
-		break;
-	}
+	mix(_param_mc_airmode_lim.get(), _param_mc_airmode_yaw_lim.get());
 }
 
 void ControlAllocationSequentialDesaturation::desaturateActuators(
 	ActuatorVector &actuator_sp,
-	const ActuatorVector &desaturation_vector, bool increase_only)
+	const ActuatorVector &desaturation_vector, float increase_limit)
 {
 	float gain = computeDesaturationGain(desaturation_vector, actuator_sp);
 
-	if (increase_only && gain < 0.f) {
-		return;
+	// Negative gain raises actuator setpoints (for thrust_z desat_vec, that's raising thrust).
+	// At increase_limit == 0 we forbid that entirely (legacy "no airmode"); between 0 and 1 we cap
+	// the TOTAL upward excursion (both passes) at the requested fraction; at >= 1 the gain is left
+	// unbounded so the endpoint is identical to legacy full airmode regardless of effectiveness scaling.
+	if (gain < 0.f) {
+		if (increase_limit <= 0.f) {
+			return;
+		}
+
+		if (increase_limit < 1.f && gain < -increase_limit) {
+			gain = -increase_limit;
+		}
 	}
 
 	for (int i = 0; i < _num_actuators; i++) {
 		actuator_sp(i) += gain * desaturation_vector(i);
 	}
 
+	// The refinement pass must respect the same upward budget, otherwise the effective thrust
+	// excursion exceeds increase_limit and the limit saturates well before 1.
+	const float raised = (gain < 0.f) ? -gain : 0.f;
+
 	gain = 0.5f * computeDesaturationGain(desaturation_vector, actuator_sp);
+
+	if (gain < 0.f && increase_limit > 0.f && increase_limit < 1.f) {
+		const float budget = increase_limit - raised;
+
+		if (budget <= 0.f) {
+			gain = 0.f;
+
+		} else if (gain < -budget) {
+			gain = -budget;
+		}
+	}
 
 	for (int i = 0; i < _num_actuators; i++) {
 		actuator_sp(i) += gain * desaturation_vector(i);
@@ -119,8 +132,10 @@ float ControlAllocationSequentialDesaturation::computeDesaturationGain(const Act
 }
 
 void
-ControlAllocationSequentialDesaturation::mix(bool airmode_rp, bool airmode_yaw)
+ControlAllocationSequentialDesaturation::mix(float roll_pitch_limit, float yaw_limit)
 {
+	const bool yaw_in_sum = (yaw_limit > 0.f);
+
 	ActuatorVector thrust_z;
 	ActuatorVector roll;
 	ActuatorVector pitch;
@@ -130,7 +145,7 @@ ControlAllocationSequentialDesaturation::mix(bool airmode_rp, bool airmode_yaw)
 		_actuator_sp(i) = _actuator_trim(i) +
 				  _mix(i, ControlAxis::ROLL) * (_control_sp(ControlAxis::ROLL) - _control_trim(ControlAxis::ROLL)) +
 				  _mix(i, ControlAxis::PITCH) * (_control_sp(ControlAxis::PITCH) - _control_trim(ControlAxis::PITCH)) +
-				  (airmode_yaw
+				  (yaw_in_sum
 				   ? _mix(i, ControlAxis::YAW) * (_control_sp(ControlAxis::YAW) - _control_trim(ControlAxis::YAW))
 				   : 0.f) +
 				  _mix(i, ControlAxis::THRUST_X) * (_control_sp(ControlAxis::THRUST_X) - _control_trim(ControlAxis::THRUST_X)) +
@@ -142,36 +157,36 @@ ControlAllocationSequentialDesaturation::mix(bool airmode_rp, bool airmode_yaw)
 		yaw(i) = _mix(i, ControlAxis::YAW);
 	}
 
-	// Slide thrust to unsaturate roll/pitch (and yaw when in the sum).
-	// Without airmode_rp, thrust may only decrease.
-	desaturateActuators(_actuator_sp, thrust_z, !airmode_rp);
+	// Slide thrust to unsaturate roll/pitch (and yaw when in the sum); the upward gain is
+	// bounded by roll_pitch_limit.
+	desaturateActuators(_actuator_sp, thrust_z, roll_pitch_limit);
 
-	if (!airmode_rp) {
-		// Reduce roll/pitch acceleration if needed to unsaturate.
+	if (roll_pitch_limit < 1.f) {
+		// Reduce roll/pitch acceleration if any saturation remains; legacy bit-equivalence at
+		// roll_pitch_limit == 1 requires skipping these passes.
 		desaturateActuators(_actuator_sp, roll);
 		desaturateActuators(_actuator_sp, pitch);
 	}
 
-	if (airmode_yaw) {
-		// Yaw is already in the sum; deprioritize it relative to roll/pitch by
-		// desaturating bidirectionally without the MINIMUM_YAW_MARGIN inflation.
-		desaturateActuators(_actuator_sp, yaw);
+	if (yaw_in_sum) {
+		// Yaw is already in the sum; deprioritize it relative to roll/pitch by desaturating
+		// against the original bounds, capping any upward gain at yaw_limit.
+		desaturateActuators(_actuator_sp, yaw, yaw_limit);
 
 	} else {
-		// Add yaw to outputs.
+		// Legacy deferred-yaw path: add yaw after roll/pitch resolve, inflate the upper bound
+		// by MINIMUM_YAW_MARGIN to grant a fixed 15% yaw authority near max thrust, then pull
+		// thrust back down to clean up any overshoot.
 		for (int i = 0; i < _num_actuators; i++) {
 			_actuator_sp(i) += _mix(i, ControlAxis::YAW) * (_control_sp(ControlAxis::YAW) - _control_trim(ControlAxis::YAW));
 		}
 
-		// Inflate the upper bound by MINIMUM_YAW_MARGIN so yaw retains some authority
-		// near maximum thrust, then desaturate yaw against the inflated bound.
 		const ActuatorVector max_prev = _actuator_max;
 		_actuator_max += (_actuator_max - _actuator_min) * MINIMUM_YAW_MARGIN;
 		desaturateActuators(_actuator_sp, yaw);
 		_actuator_max = max_prev;
 
-		// Reduce thrust only to clean up any overshoot the inflation allowed.
-		desaturateActuators(_actuator_sp, thrust_z, true);
+		desaturateActuators(_actuator_sp, thrust_z, 0.f);
 	}
 }
 

--- a/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.hpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.hpp
@@ -76,10 +76,13 @@ private:
 	 *
 	 * @param actuator_sp Actuator setpoint, vector that is modified
 	 * @param desaturation_vector vector that is added to the outputs, e.g. thrust_scale
-	 * @param increase_only if true, only allow to increase (add) a fraction of desaturation_vector
+	 * @param increase_limit fraction in [0,1] of the desaturation gain that is allowed to RAISE
+	 *                       the actuator setpoint. 0 forbids any upward adjustment (legacy "no
+	 *                       airmode"); 1 allows the full unsaturating gain (legacy full airmode).
+	 *                       Intermediate values cap the upward excursion proportionally.
 	 */
 	void desaturateActuators(ActuatorVector &actuator_sp, const ActuatorVector &desaturation_vector,
-				 bool increase_only = false);
+				 float increase_limit = 1.f);
 
 	/**
 	 * Computes the gain k by which desaturation_vector has to be multiplied
@@ -92,19 +95,25 @@ private:
 	/**
 	 * Mix roll, pitch, yaw, thrust and set the actuator setpoint.
 	 *
-	 * @param airmode_rp  If true, allow thrust increases to satisfy roll/pitch.
-	 * @param airmode_yaw If true, mix yaw into the initial accumulation and desaturate
-	 *                    yaw bidirectionally with the same priority structure as roll/pitch.
-	 *                    If false, yaw is added after roll/pitch resolution and desaturated
-	 *                    against an upper bound inflated by MINIMUM_YAW_MARGIN.
+	 * @param roll_pitch_limit fraction in [0,1] of per-actuator headroom the
+	 *                         desaturator may consume to raise thrust in order
+	 *                         to preserve roll/pitch authority.
+	 * @param yaw_limit        fraction in [0,1] for the analogous yaw budget.
+	 *                         When 0, yaw is added after roll/pitch resolution
+	 *                         and desaturated against an upper bound inflated
+	 *                         by MINIMUM_YAW_MARGIN (legacy deferred-yaw path).
+	 *                         When > 0, yaw is mixed into the initial
+	 *                         accumulation and the desaturator's upward gain
+	 *                         is capped by yaw_limit (legacy RPY path at 1).
 	 *
-	 * Legacy equivalence: (false,false) = airmode disabled,
-	 *                     (true, false) = roll/pitch airmode,
-	 *                     (true, true)  = roll/pitch/yaw airmode.
+	 * Legacy equivalence: (0, 0) = airmode disabled,
+	 *                     (1, 0) = roll/pitch airmode,
+	 *                     (1, 1) = roll/pitch/yaw airmode.
 	 */
-	void mix(bool airmode_rp, bool airmode_yaw);
+	void mix(float roll_pitch_limit, float yaw_limit);
 
 	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::MC_AIRMODE>) _param_mc_airmode   ///< air-mode
+		(ParamFloat<px4::params::MC_AIRMODE_LIM>) _param_mc_airmode_lim,         ///< roll/pitch airmode authority limit
+		(ParamFloat<px4::params::MC_AIRMODE_YLIM>) _param_mc_airmode_yaw_lim  ///< yaw airmode authority limit
 	);
 };

--- a/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.hpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.hpp
@@ -93,6 +93,17 @@ private:
 	float computeDesaturationGain(const ActuatorVector &desaturation_vector, const ActuatorVector &actuator_sp);
 
 	/**
+	 * Decide whether folding the yaw demand into the pre-thrust mix reduces the airmode thrust
+	 * bump. When true, yaw is folded into the initial sum so the collective-thrust desaturation
+	 * can credit yaw relieving the saturating actuator, instead of deferring yaw until after the
+	 * thrust step (which over-adds thrust). Compares the unconstrained thrust desaturation gain
+	 * of the roll/pitch-only mix against the roll/pitch+yaw mix.
+	 *
+	 * @return true if including yaw needs a strictly smaller thrust shift to unsaturate.
+	 */
+	bool yawReducesAirmodeThrust();
+
+	/**
 	 * Mix roll, pitch, yaw, thrust and set the actuator setpoint.
 	 *
 	 * @param roll_pitch_limit fraction in [0,1] of per-actuator headroom the

--- a/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.hpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.hpp
@@ -92,39 +92,17 @@ private:
 	/**
 	 * Mix roll, pitch, yaw, thrust and set the actuator setpoint.
 	 *
-	 * Desaturation behavior: airmode for roll/pitch:
-	 * thrust is increased/decreased as much as required to meet the demanded roll/pitch.
-	 * Yaw is not allowed to increase the thrust, @see mix_yaw() for the exact behavior.
-	 */
-	void mixAirmodeRP();
-
-	/**
-	 * Mix roll, pitch, yaw, thrust and set the actuator setpoint.
+	 * @param airmode_rp  If true, allow thrust increases to satisfy roll/pitch.
+	 * @param airmode_yaw If true, mix yaw into the initial accumulation and desaturate
+	 *                    yaw bidirectionally with the same priority structure as roll/pitch.
+	 *                    If false, yaw is added after roll/pitch resolution and desaturated
+	 *                    against an upper bound inflated by MINIMUM_YAW_MARGIN.
 	 *
-	 * Desaturation behavior: full airmode for roll/pitch/yaw:
-	 * thrust is increased/decreased as much as required to meet demanded the roll/pitch/yaw,
-	 * while giving priority to roll and pitch over yaw.
+	 * Legacy equivalence: (false,false) = airmode disabled,
+	 *                     (true, false) = roll/pitch airmode,
+	 *                     (true, true)  = roll/pitch/yaw airmode.
 	 */
-	void mixAirmodeRPY();
-
-	/**
-	 * Mix roll, pitch, yaw, thrust and set the actuator setpoint.
-	 *
-	 * Desaturation behavior: no airmode, thrust is NEVER increased to meet the demanded
-	 * roll/pitch/yaw. Instead roll/pitch/yaw is reduced as much as needed.
-	 * Thrust can be reduced to unsaturate the upper side.
-	 * @see mixYaw() for the exact yaw behavior.
-	 */
-	void mixAirmodeDisabled();
-
-	/**
-	 * Mix yaw by updating the actuator setpoint (that already contains roll/pitch/thrust).
-	 *
-	 * Desaturation behavior: thrust is allowed to be decreased up to 15% in order to allow
-	 * some yaw control on the upper end. On the lower end thrust will never be increased,
-	 * but yaw is decreased as much as required.
-	 */
-	void mixYaw();
+	void mix(bool airmode_rp, bool airmode_yaw);
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::MC_AIRMODE>) _param_mc_airmode   ///< air-mode

--- a/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturationTest.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturationTest.cpp
@@ -563,3 +563,143 @@ TEST_F(ControlAllocationSequentialDesaturationTestQuadX, PreviousMixingTestsAirm
 	EXPECT_EQ(allocate(-1.000f, 0.900f, 0.000f, -0.900f), Vector4f(1.000000f, 0.550000f, 0.050000f, 0.500000f)); // 64
 	EXPECT_EQ(allocate(-1.000f, 0.900f, 0.000f, -1.000f), Vector4f(1.000000f, 0.550000f, 0.050000f, 0.500000f)); // 65
 }
+
+
+// Hex fixture covers the QuadX blind spot: with 6 motors at 60-degree intervals the roll/pitch
+// mix matrix is no longer ±0.25 like QuadX, so the 0.2 effectiveness-cutoff inside
+// computeDesaturationGain interacts differently with the per-axis desat passes. Motor failure on
+// hex is also one of the strongest motivations for limited airmode (PR #25138 description).
+class ControlAllocationSequentialDesaturationTestHex : public ::testing::Test
+{
+public:
+	static constexpr uint8_t NUM_ROTORS = 6;
+	using HexVector = Vector<float, NUM_ROTORS>;
+
+	ControlAllocationSequentialDesaturation _control_allocation;
+
+	void SetUp() override
+	{
+		param_control_autosave(false);
+		setAirmodeLimits(0.f, 0.f);
+
+		// Hex geometry: 6 motors at 30, 90, 150, 210, 270, 330 degrees measured clockwise from
+		// +X (forward) toward +Y (right), normalized unit arm length. Alternating moment ratios.
+		// Numbering goes clockwise starting from the front-right sextant.
+		const float positions[NUM_ROTORS][2] = {
+			{ 0.866025f,  0.5f},     // M0  30 deg — front-right
+			{ 0.f,        1.f},      // M1  90 deg — right
+			{-0.866025f,  0.5f},     // M2 150 deg — back-right
+			{-0.866025f, -0.5f},     // M3 210 deg — back-left
+			{ 0.f,       -1.f},      // M4 270 deg — left
+			{ 0.866025f, -0.5f},     // M5 330 deg — front-left
+		};
+
+		ActuatorEffectivenessRotors::Geometry hex_geometry{};
+		hex_geometry.num_rotors = NUM_ROTORS;
+
+		for (int i = 0; i < NUM_ROTORS; ++i) {
+			hex_geometry.rotors[i].position = {positions[i][0], positions[i][1], 0.f};
+			hex_geometry.rotors[i].moment_ratio = (i % 2 == 0) ? 1.f : -1.f;
+			hex_geometry.rotors[i].axis = Vector3f(0.f, 0.f, -1.f);
+			hex_geometry.rotors[i].thrust_coef = 1.f;
+			hex_geometry.rotors[i].tilt_index = -1;
+		}
+
+		ActuatorEffectiveness::Configuration actuator_configuration{};
+		int num_actuators = ActuatorEffectivenessRotors::computeEffectivenessMatrix(
+					    hex_geometry,
+					    actuator_configuration.effectiveness_matrices[0],
+					    actuator_configuration.num_actuators_matrix[0]);
+		EXPECT_EQ(num_actuators, NUM_ROTORS);
+		actuator_configuration.actuatorsAdded(ActuatorType::MOTORS, num_actuators);
+
+		_control_allocation.setEffectivenessMatrix(
+			actuator_configuration.effectiveness_matrices[0],
+			actuator_configuration.trim[0],
+			actuator_configuration.linearization_point[0],
+			actuator_configuration.num_actuators_matrix[0],
+			true);
+	}
+
+	void setAirmodeLimits(const float lim, const float yaw_lim)
+	{
+		param_set(param_find("MC_AIRMODE_LIM"),     &lim);
+		param_set(param_find("MC_AIRMODE_YLIM"), &yaw_lim);
+		_control_allocation.updateParameters();
+	}
+
+	HexVector allocate(float roll, float pitch, float yaw, float thrust)
+	{
+		Vector<float, ControlAllocation::NUM_AXES> control_setpoint{};
+		control_setpoint(ControlAllocation::ControlAxis::ROLL) = roll;
+		control_setpoint(ControlAllocation::ControlAxis::PITCH) = pitch;
+		control_setpoint(ControlAllocation::ControlAxis::YAW) = yaw;
+		control_setpoint(ControlAllocation::ControlAxis::THRUST_Z) = thrust;
+		_control_allocation.setControlSetpoint(control_setpoint);
+		_control_allocation.allocate();
+		return HexVector(_control_allocation.getActuatorSetpoint().slice<NUM_ROTORS, 1>(0, 0));
+	}
+};
+
+constexpr uint8_t ControlAllocationSequentialDesaturationTestHex::NUM_ROTORS;
+
+TEST_F(ControlAllocationSequentialDesaturationTestHex, CollectiveThrust)
+{
+	HexVector expected;
+
+	for (int i = 0; i < NUM_ROTORS; ++i) { expected(i) = 0.5f; }
+
+	EXPECT_EQ(allocate(0.f, 0.f, 0.f, -0.5f), expected);
+}
+
+// Sweep MC_AIRMODE_LIM on a saturating-low input and verify monotonicity. Mirrors the QuadX
+// monotonicity test but with the different mix matrix that hex produces, so a regression in the
+// desaturator that depends on the 0.2 effectiveness cutoff would show here even if QuadX passes.
+TEST_F(ControlAllocationSequentialDesaturationTestHex, AirmodeLimMonotonicity)
+{
+	const float sweep[] = {0.f, 0.05f, 0.10f, 0.15f, 1.f};
+	HexVector prev{};
+
+	for (size_t i = 0; i < sizeof(sweep) / sizeof(sweep[0]); ++i) {
+		setAirmodeLimits(sweep[i], 0.f);
+		HexVector out = allocate(0.5f, 0.f, 0.f, -0.1f);
+
+		if (i > 0) {
+			for (int m = 0; m < NUM_ROTORS; ++m) {
+				EXPECT_GE(out(m), prev(m))
+						<< "non-monotonic at MC_AIRMODE_LIM=" << sweep[i] << " motor=" << m;
+			}
+		}
+
+		prev = out;
+	}
+}
+
+// At yaw_limit=0 with saturating yaw input, the deferred-yaw path uses MINIMUM_YAW_MARGIN to
+// retain some yaw authority near max thrust. Sanity check that the path works on hex (different
+// yaw mix sign pattern than QuadX).
+TEST_F(ControlAllocationSequentialDesaturationTestHex, YawAtFullThrustDisabledHasMargin)
+{
+	setAirmodeLimits(0.f, 0.f);
+	const HexVector out = allocate(0.f, 0.f, 1.f, -1.f);
+
+	// All motors clamped to [0, 1].
+	for (int i = 0; i < NUM_ROTORS; ++i) {
+		EXPECT_GE(out(i), 0.f) << "motor " << i << " below min";
+		EXPECT_LE(out(i), 1.f) << "motor " << i << " above max";
+	}
+
+	// Yaw differential must be non-zero: at least one CW motor must differ from at least one
+	// CCW motor. Otherwise yaw authority is dead and the 15% margin trick failed.
+	float ccw_avg = 0.f; // moment_ratio = +1 → indices 0, 2, 4
+	float cw_avg = 0.f;  // moment_ratio = -1 → indices 1, 3, 5
+
+	for (int i = 0; i < NUM_ROTORS; i += 2) { ccw_avg += out(i); }
+
+	for (int i = 1; i < NUM_ROTORS; i += 2) { cw_avg += out(i); }
+
+	ccw_avg /= 3.f;
+	cw_avg /= 3.f;
+	EXPECT_GT(fabsf(ccw_avg - cw_avg), 0.05f) << "yaw authority lost at full thrust (ccw_avg="
+			<< ccw_avg << " cw_avg=" << cw_avg << ")";
+}

--- a/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturationTest.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturationTest.cpp
@@ -354,6 +354,31 @@ TEST_F(ControlAllocationSequentialDesaturationTestQuadX, YawLimitDiscontinuityAt
 	EXPECT_FALSE(deferred_path == sum_path) << "yaw_limit=0 and yaw_limit>0 must differ";
 }
 
+// Roll/pitch airmode (YLIM=0) folds yaw into the thrust desaturation when yaw relieves the
+// saturating actuator, removing the collective over-command of pure sequential allocation (the
+// "#16" case). Roll, pitch and yaw are still delivered exactly; only the unnecessary extra
+// collective is dropped, so the result matches full roll/pitch/yaw airmode for this command.
+TEST_F(ControlAllocationSequentialDesaturationTestQuadX, DeferredYawFoldedWhenItReducesThrust)
+{
+	setAirmodeLimits(1.f, 0.f);
+	const Vector4f folded = allocate(0.05f, 0.05f, -0.025f, 0.f);
+	EXPECT_EQ(folded, Vector4f(0.0125f, 0.f, 0.0125f, 0.05f));
+
+	// Strictly less total collective than the old deferred-yaw allocation (0.01875,...,0.05625).
+	EXPECT_LT(folded(0) + folded(1) + folded(2) + folded(3), 0.1f);
+
+	// Equals what full roll/pitch/yaw airmode (yaw already in the sum) produces for this command.
+	setAirmodeLimits(1.f, 1.f);
+	EXPECT_EQ(allocate(0.05f, 0.05f, -0.025f, 0.f), folded);
+}
+
+// When yaw would worsen the saturating actuator it stays deferred (legacy deprioritized yaw).
+TEST_F(ControlAllocationSequentialDesaturationTestQuadX, DeferredYawKeptWhenYawWorsens)
+{
+	setAirmodeLimits(1.f, 0.f);
+	EXPECT_EQ(allocate(0.05f, 0.05f, 0.025f, 0.f), Vector4f(0.025f, 0.f, 0.025f, 0.05f));
+}
+
 TEST_F(ControlAllocationSequentialDesaturationTestQuadX, PreviousMixingTestsNoAirmode)
 {
 	setAirmode(0); // No airmode
@@ -424,6 +449,11 @@ TEST_F(ControlAllocationSequentialDesaturationTestQuadX, PreviousMixingTestsNoAi
 	EXPECT_EQ(allocate(-1.000f, 0.900f, 0.000f, -1.000f), Vector4f(1.000000f, 0.550000f, 0.050000f, 0.500000f)); // 65
 }
 
+// Rows tagged "yaw folded" (16, 30, 51, 52, 59, 60) differ from the historical multirotor-mixer
+// values because the deferred-yaw path now folds yaw into the collective-thrust desaturation when
+// that relieves the saturating actuator, yielding exactly the full roll/pitch/yaw-airmode
+// allocation for the command: roll, pitch and yaw are delivered at least as well (never worse),
+// while collective thrust may shift to make room for the yaw torque.
 TEST_F(ControlAllocationSequentialDesaturationTestQuadX, PreviousMixingTestsAirmodeRP)
 {
 	setAirmode(1); // Roll and pitch airmode
@@ -442,7 +472,7 @@ TEST_F(ControlAllocationSequentialDesaturationTestQuadX, PreviousMixingTestsAirm
 	EXPECT_EQ(allocate(0.050f, -0.050f, 0.000f, -0.450f), Vector4f(0.425000f, 0.450000f, 0.475000f, 0.450000f)); // 13
 	EXPECT_EQ(allocate(0.050f, -0.050f, 0.000f, -0.900f), Vector4f(0.875000f, 0.900000f, 0.925000f, 0.900000f)); // 14
 	EXPECT_EQ(allocate(0.050f, -0.050f, 0.000f, -1.000f), Vector4f(0.950000f, 0.975000f, 1.000000f, 0.975000f)); // 15
-	EXPECT_EQ(allocate(0.050f, 0.050f, -0.025f, -0.000f), Vector4f(0.018750f, 0.006250f, 0.018750f, 0.056250f)); // 16
+	EXPECT_EQ(allocate(0.050f, 0.050f, -0.025f, -0.000f), Vector4f(0.012500f, 0.000000f, 0.012500f, 0.050000f)); // 16 yaw folded
 	EXPECT_EQ(allocate(0.050f, 0.050f, -0.025f, -0.100f), Vector4f(0.093750f, 0.081250f, 0.093750f, 0.131250f)); // 17
 	EXPECT_EQ(allocate(0.050f, 0.050f, -0.025f, -0.450f), Vector4f(0.443750f, 0.431250f, 0.443750f, 0.481250f)); // 18
 	EXPECT_EQ(allocate(0.050f, 0.050f, -0.025f, -0.900f), Vector4f(0.893750f, 0.881250f, 0.893750f, 0.931250f)); // 19
@@ -456,7 +486,7 @@ TEST_F(ControlAllocationSequentialDesaturationTestQuadX, PreviousMixingTestsAirm
 	EXPECT_EQ(allocate(0.200f, 0.050f, 0.090f, -0.100f), Vector4f(0.085000f, 0.015000f, 0.160000f, 0.140000f)); // 27
 	EXPECT_EQ(allocate(0.200f, 0.050f, 0.090f, -0.450f), Vector4f(0.435000f, 0.365000f, 0.510000f, 0.490000f)); // 28
 	EXPECT_EQ(allocate(0.200f, 0.050f, 0.090f, -0.900f), Vector4f(0.885000f, 0.815000f, 0.960000f, 0.940000f)); // 29
-	EXPECT_EQ(allocate(0.200f, 0.050f, 0.090f, -1.000f), Vector4f(0.922500f, 0.852500f, 0.997500f, 0.977500f)); // 30
+	EXPECT_EQ(allocate(0.200f, 0.050f, 0.090f, -1.000f), Vector4f(0.925000f, 0.855000f, 1.000000f, 0.980000f)); // 30 yaw folded
 	EXPECT_EQ(allocate(-0.125f, 0.020f, 0.040f, -0.000f), Vector4f(0.082500f, 0.052500f, 0.010000f, 0.000000f)); // 31
 	EXPECT_EQ(allocate(-0.125f, 0.020f, 0.040f, -0.100f), Vector4f(0.146250f, 0.116250f, 0.073750f, 0.063750f)); // 32
 	EXPECT_EQ(allocate(-0.125f, 0.020f, 0.040f, -0.450f), Vector4f(0.496250f, 0.466250f, 0.423750f, 0.413750f)); // 33
@@ -477,16 +507,16 @@ TEST_F(ControlAllocationSequentialDesaturationTestQuadX, PreviousMixingTestsAirm
 	EXPECT_EQ(allocate(0.000f, 0.000f, 1.000f, -0.450f), Vector4f(0.700000f, 0.200000f, 0.700000f, 0.200000f)); // 48
 	EXPECT_EQ(allocate(0.000f, 0.000f, 1.000f, -0.900f), Vector4f(1.000000f, 0.500000f, 1.000000f, 0.500000f)); // 49
 	EXPECT_EQ(allocate(0.000f, 0.000f, 1.000f, -1.000f), Vector4f(1.000000f, 0.700000f, 1.000000f, 0.700000f)); // 50
-	EXPECT_EQ(allocate(1.000f, 1.000f, -1.000f, -0.000f), Vector4f(0.200000f, 0.000000f, 0.200000f, 1.000000f)); // 51
-	EXPECT_EQ(allocate(1.000f, 1.000f, -1.000f, -0.100f), Vector4f(0.200000f, 0.000000f, 0.200000f, 1.000000f)); // 52
+	EXPECT_EQ(allocate(1.000f, 1.000f, -1.000f, -0.000f), Vector4f(0.000000f, 0.000000f, 0.000000f, 1.000000f)); // 51 yaw folded
+	EXPECT_EQ(allocate(1.000f, 1.000f, -1.000f, -0.100f), Vector4f(0.000000f, 0.000000f, 0.000000f, 1.000000f)); // 52 yaw folded
 	EXPECT_EQ(allocate(1.000f, 1.000f, -1.000f, -0.450f), Vector4f(0.200000f, 0.000000f, 0.200000f, 1.000000f)); // 53
 	EXPECT_EQ(allocate(1.000f, 1.000f, -1.000f, -0.900f), Vector4f(0.200000f, 0.000000f, 0.200000f, 1.000000f)); // 54
 	EXPECT_EQ(allocate(1.000f, 1.000f, -1.000f, -1.000f), Vector4f(0.200000f, 0.000000f, 0.200000f, 1.000000f)); // 55
 	EXPECT_EQ(allocate(-1.000f, 0.900f, -0.900f, -0.000f), Vector4f(0.950000f, 0.500000f, 0.000000f, 0.450000f)); // 56
 	EXPECT_EQ(allocate(-1.000f, 0.900f, -0.900f, -0.100f), Vector4f(0.950000f, 0.500000f, 0.000000f, 0.450000f)); // 57
 	EXPECT_EQ(allocate(-1.000f, 0.900f, -0.900f, -0.450f), Vector4f(0.950000f, 0.500000f, 0.000000f, 0.450000f)); // 58
-	EXPECT_EQ(allocate(-1.000f, 0.900f, -0.900f, -0.900f), Vector4f(0.950000f, 0.600000f, 0.000000f, 0.550000f)); // 59
-	EXPECT_EQ(allocate(-1.000f, 0.900f, -0.900f, -1.000f), Vector4f(0.950000f, 0.600000f, 0.000000f, 0.550000f)); // 60
+	EXPECT_EQ(allocate(-1.000f, 0.900f, -0.900f, -0.900f), Vector4f(1.000000f, 1.000000f, 0.050000f, 0.950000f)); // 59 yaw folded
+	EXPECT_EQ(allocate(-1.000f, 0.900f, -0.900f, -1.000f), Vector4f(1.000000f, 1.000000f, 0.050000f, 0.950000f)); // 60 yaw folded
 	EXPECT_EQ(allocate(-1.000f, 0.900f, 0.000f, -0.000f), Vector4f(0.950000f, 0.500000f, 0.000000f, 0.450000f)); // 61
 	EXPECT_EQ(allocate(-1.000f, 0.900f, 0.000f, -0.100f), Vector4f(0.950000f, 0.500000f, 0.000000f, 0.450000f)); // 62
 	EXPECT_EQ(allocate(-1.000f, 0.900f, 0.000f, -0.450f), Vector4f(0.950000f, 0.500000f, 0.000000f, 0.450000f)); // 63

--- a/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturationTest.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturationTest.cpp
@@ -100,8 +100,24 @@ public:
 
 	void setAirmode(const int32_t mode)
 	{
-		param_t param = param_find("MC_AIRMODE");
-		param_set(param, &mode);
+		float lim = 0.f;
+		float yaw_lim = 0.f;
+
+		switch (mode) {
+		case 1: lim = 1.f; yaw_lim = 0.f; break;
+
+		case 2: lim = 1.f; yaw_lim = 1.f; break;
+
+		default: lim = 0.f; yaw_lim = 0.f; break;
+		}
+
+		setAirmodeLimits(lim, yaw_lim);
+	}
+
+	void setAirmodeLimits(const float lim, const float yaw_lim)
+	{
+		param_set(param_find("MC_AIRMODE_LIM"),     &lim);
+		param_set(param_find("MC_AIRMODE_YLIM"), &yaw_lim);
 		_control_allocation.updateParameters();
 	}
 
@@ -263,6 +279,79 @@ TEST_F(ControlAllocationSequentialDesaturationTestQuadX, AirmodeDisabledReducedT
 TEST_F(ControlAllocationSequentialDesaturationTestQuadX, AirmodeDisabledReducedThrustAndPitch)
 {
 	EXPECT_EQ(allocate(0.f, 2.f, 0.f, -3.f), Vector4f(1.f, 0.f, 0.f, 1.f));
+}
+
+// MC_AIRMODE_LIM = 0 (set directly, not via the legacy MC_AIRMODE wrapper) must reproduce the
+// legacy "no airmode" outputs bit-exactly. Cross-checks the float-only API path.
+TEST_F(ControlAllocationSequentialDesaturationTestQuadX, AirmodeLimZeroMatchesLegacyDisabled)
+{
+	setAirmodeLimits(0.f, 0.f);
+	EXPECT_EQ(allocate(1.000f, 0.000f, 0.000f, -0.100f), Vector4f(0.f, 0.f, 0.2f, 0.2f));   // legacy row 37
+	EXPECT_EQ(allocate(0.000f, -1.000f, 0.000f, -0.100f), Vector4f(0.f, 0.2f, 0.2f, 0.f));  // legacy row 42
+	EXPECT_EQ(allocate(0.000f, 0.000f, 1.000f, -1.000f), Vector4f(1.f, 0.7f, 1.f, 0.7f));   // legacy row 50
+}
+
+// MC_AIRMODE_LIM = 1 (set directly) must reproduce legacy roll/pitch airmode.
+TEST_F(ControlAllocationSequentialDesaturationTestQuadX, AirmodeLimOneMatchesLegacyRP)
+{
+	setAirmodeLimits(1.f, 0.f);
+	EXPECT_EQ(allocate(1.000f, 0.000f, 0.000f, -0.100f), Vector4f(0.f, 0.f, 0.5f, 0.5f));   // legacy row 37
+	EXPECT_EQ(allocate(0.000f, -1.000f, 0.000f, -0.100f), Vector4f(0.f, 0.5f, 0.5f, 0.f));  // legacy row 42
+}
+
+// MC_AIRMODE_LIM = 1, MC_AIRMODE_YLIM = 1 must reproduce legacy roll/pitch/yaw airmode.
+TEST_F(ControlAllocationSequentialDesaturationTestQuadX, AirmodeLimAndYlimOneMatchLegacyRPY)
+{
+	setAirmodeLimits(1.f, 1.f);
+	EXPECT_EQ(allocate(1.000f, 1.000f, -1.000f, -0.000f), Vector4f(0.f, 0.f, 0.f, 1.f));    // legacy row 51 RPY
+	EXPECT_EQ(allocate(0.000f, 0.000f, 1.000f, -0.000f), Vector4f(0.5f, 0.f, 0.5f, 0.f));   // legacy row 46 RPY
+}
+
+// Sweep MC_AIRMODE_LIM ∈ {0, 0.05, 0.10, 0.15, 1.0} for the saturating input
+// (roll=1, thrust=-0.1) and verify each motor's output is non-decreasing in the
+// limit. Endpoints match the legacy NoAirmode and AirmodeRP row 37 values.
+TEST_F(ControlAllocationSequentialDesaturationTestQuadX, AirmodeLimMonotonicity)
+{
+	const float sweep[] = {0.f, 0.05f, 0.10f, 0.15f, 1.f};
+	Vector4f prev{};
+
+	for (size_t i = 0; i < sizeof(sweep) / sizeof(sweep[0]); ++i) {
+		setAirmodeLimits(sweep[i], 0.f);
+		Vector4f out = allocate(1.f, 0.f, 0.f, -0.1f);
+
+		if (i == 0) {
+			EXPECT_EQ(out, Vector4f(0.f, 0.f, 0.2f, 0.2f)); // legacy disabled
+		}
+
+		if (i + 1 == sizeof(sweep) / sizeof(sweep[0])) {
+			EXPECT_EQ(out, Vector4f(0.f, 0.f, 0.5f, 0.5f)); // legacy RP
+		}
+
+		if (i > 0) {
+			for (int m = 0; m < 4; ++m) {
+				EXPECT_GE(out(m), prev(m)) << "non-monotonic at MC_AIRMODE_LIM=" << sweep[i] << " motor=" << m;
+			}
+		}
+
+		prev = out;
+	}
+}
+
+// The yaw path is structurally different at yaw_limit==0 (legacy deferred path with the hidden
+// 15% MINIMUM_YAW_MARGIN) vs yaw_limit>0 (yaw mixed into the initial accumulation). This is a
+// designed discontinuity — pin both sides to detect anyone "smoothing" them together in a way
+// that breaks either endpoint.
+TEST_F(ControlAllocationSequentialDesaturationTestQuadX, YawLimitDiscontinuityAtZero)
+{
+	setAirmodeLimits(1.f, 0.f);
+	const Vector4f deferred_path = allocate(0.f, 0.f, 1.f, -1.f);
+	EXPECT_EQ(deferred_path, Vector4f(1.f, 0.7f, 1.f, 0.7f)); // 30% yaw via 15% margin trick
+
+	setAirmodeLimits(1.f, FLT_EPSILON);
+	const Vector4f sum_path = allocate(0.f, 0.f, 1.f, -1.f);
+	EXPECT_EQ(sum_path, Vector4f(1.f, 0.5f, 1.f, 0.5f));      // 50% yaw via priority sum
+
+	EXPECT_FALSE(deferred_path == sum_path) << "yaw_limit=0 and yaw_limit>0 must differ";
 }
 
 TEST_F(ControlAllocationSequentialDesaturationTestQuadX, PreviousMixingTestsNoAirmode)

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -298,7 +298,6 @@ private:
 
 
 	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::MC_AIRMODE>) _param_mc_airmode,   ///< multicopter air-mode
 		(ParamFloat<px4::params::THR_MDL_FAC>) _param_thr_mdl_fac ///< thrust to motor control signal modelling factor
 	)
 };

--- a/src/lib/mixer_module/params.yaml
+++ b/src/lib/mixer_module/params.yaml
@@ -4,18 +4,68 @@ parameters:
   definitions:
     MC_AIRMODE:
       description:
-        short: Multicopter air-mode
+        short: '[DEPRECATED] Multicopter air-mode (use MC_AIRMODE_LIM / MC_AIRMODE_YLIM)'
         long: |-
-          The air-mode enables the mixer to increase the total thrust of the multirotor
-          in order to keep attitude and rate control even at low and high throttle.
-
-          This function should be disabled during tuning as it will help the controller
-          to diverge if the closed-loop is unstable (i.e. the vehicle is not tuned yet).
-
-          Enabling air-mode for yaw requires the use of an arming switch.
+          Deprecated. On first boot the value is migrated to MC_AIRMODE_LIM and
+          MC_AIRMODE_YLIM:
+            0 -> (MC_AIRMODE_LIM=0, MC_AIRMODE_YLIM=0)
+            1 -> (MC_AIRMODE_LIM=1, MC_AIRMODE_YLIM=0)
+            2 -> (MC_AIRMODE_LIM=1, MC_AIRMODE_YLIM=1)
+          Will be removed in a future release.
       type: enum
       values:
         0: Disabled
         1: Roll/Pitch
         2: Roll/Pitch/Yaw
       default: 0
+
+    MC_AIRMODE_LIM:
+      description:
+        short: Roll/pitch airmode authority limit
+        long: |-
+          Fraction in [0,1] of per-actuator headroom that the control allocator
+          may consume to raise collective thrust in order to satisfy a roll or
+          pitch demand that would otherwise saturate the actuators.
+
+          0 reproduces the legacy "no airmode" behavior: thrust is never increased
+          to preserve attitude, so attitude commands get cut near minimum thrust.
+
+          1 reproduces full legacy roll/pitch airmode: thrust is increased as much
+          as needed to maintain roll/pitch authority.
+
+          Intermediate values cap the upward thrust excursion at
+          MC_AIRMODE_LIM * (actuator_max - actuator_min) per actuator. Useful
+          for tuning a new airframe (start low, raise as the loop proves stable)
+          and for bounding recovery behavior on faults like a reversed motor.
+      type: float
+      default: 0.0
+      min: 0.0
+      max: 1.0
+      decimal: 2
+      increment: 0.05
+
+    MC_AIRMODE_YLIM:
+      description:
+        short: Yaw airmode authority limit
+        long: |-
+          Fraction in [0,1] of per-actuator headroom that the control allocator
+          may consume to satisfy a yaw demand that would otherwise saturate the
+          actuators.
+
+          0 routes yaw through the legacy deferred path (a fixed 15% margin
+          applies near maximum thrust to keep some yaw response). This is the
+          safe default that preserves the arming-stick-gesture interlock.
+
+          Greater than 0 routes yaw through the priority-sum path with this
+          value as the upward-thrust cap. 1 reproduces full legacy
+          roll/pitch/yaw airmode.
+
+          Yaw airmode > 0 is incompatible with the throttle-and-yaw arming
+          gesture (MAN_ARM_GESTURE = 1) and the safety check will refuse to
+          enable yaw airmode while the gesture is configured.
+      type: float
+      default: 0.0
+      min: 0.0
+      max: 1.0
+      decimal: 2
+      increment: 0.05

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -244,5 +244,27 @@ param_modify_on_import_ret param_modify_on_import(bson_node_t node)
 		}
 	}
 
+	// 2026-05-28: translate MC_AIRMODE enum to MC_AIRMODE_LIM/MC_AIRMODE_YLIM floats
+	{
+		if ((node->type == bson_type_t::BSON_INT32) && (strcmp("MC_AIRMODE", node->name) == 0)) {
+			float lim = 0.f;
+			float yaw_lim = 0.f;
+
+			switch (node->i32) {
+			case 1: lim = 1.f; yaw_lim = 0.f; break;
+
+			case 2: lim = 1.f; yaw_lim = 1.f; break;
+
+			default: lim = 0.f; yaw_lim = 0.f; break;
+			}
+
+			param_set(param_find("MC_AIRMODE_LIM"),     &lim);
+			param_set(param_find("MC_AIRMODE_YLIM"), &yaw_lim);
+			PX4_INFO("migrating MC_AIRMODE=%" PRId32 " -> MC_AIRMODE_LIM=%.2f, MC_AIRMODE_YLIM=%.2f",
+				 node->i32, (double)lim, (double)yaw_lim);
+			return param_modify_on_import_ret::PARAM_SKIP_IMPORT;
+		}
+	}
+
 	return param_modify_on_import_ret::PARAM_NOT_MODIFIED;
 }

--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -363,22 +363,24 @@ void ManualControl::updateParams()
 			}
 		}
 
-		// MC_AIRMODE & MAN_ARM_GESTURE: check for unsafe Airmode settings: yaw airmode requires disabling the stick arm gesture
+		// MC_AIRMODE_YLIM & MAN_ARM_GESTURE: yaw airmode is incompatible with the yaw-stick arm
+		// gesture because the gesture itself commands max yaw at zero throttle. Disable yaw
+		// airmode in that case; roll/pitch airmode (MC_AIRMODE_LIM) is left untouched.
 		if ((_param_man_arm_gesture.get() == 1) && (_rotary_wing || _vtol)) {
-			param_t param_mc_airmode = param_find("MC_AIRMODE");
+			param_t param_mc_airmode_ylim = param_find("MC_AIRMODE_YLIM");
 
-			if (param_mc_airmode != PARAM_INVALID) {
-				int32_t airmode = 0;
-				param_get(param_mc_airmode, &airmode);
+			if (param_mc_airmode_ylim != PARAM_INVALID) {
+				float ylim = 0.f;
+				param_get(param_mc_airmode_ylim, &ylim);
 
-				if (airmode == 2) {
-					airmode = 1; // change to roll/pitch airmode
-					param_set(param_mc_airmode, &airmode);
+				if (ylim > 0.f) {
+					ylim = 0.f;
+					param_set(param_mc_airmode_ylim, &ylim);
 
 					orb_advert_t mavlink_log_pub = nullptr;
 					mavlink_log_critical(&mavlink_log_pub, "Yaw Airmode requires disabling the stick arm gesture\t")
 					/* EVENT
-					* @description <param>MC_AIRMODE</param> is now set to roll/pitch airmode.
+					* @description <param>MC_AIRMODE_YLIM</param> is now set to 0 (yaw airmode disabled).
 					*/
 					events::send(events::ID("commander_airmode_requires_no_arm_gesture"), {events::Log::Error, events::LogInternal::Disabled},
 						     "Yaw Airmode requires disabling the stick arm gesture");

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -149,7 +149,7 @@ private:
 	uint8_t _quat_reset_counter{0};
 
 	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::MC_AIRMODE>)         _param_mc_airmode,
+		(ParamFloat<px4::params::MC_AIRMODE_YLIM>)  _param_mc_airmode_ylim,
 		(ParamFloat<px4::params::MC_MAN_TILT_TAU>)  _param_mc_man_tilt_tau,
 
 		(ParamFloat<px4::params::MC_ROLL_P>)        _param_mc_roll_p,

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -141,8 +141,10 @@ MulticopterAttitudeControl::generate_attitude_setpoint(const Quatf &q, float dt)
 {
 	vehicle_attitude_setpoint_s attitude_setpoint{};
 
-	// Avoid accumulating absolute yaw error with arming stick gesture
-	const bool arming_gesture = (_manual_control_setpoint.throttle < -.9f) && (_param_mc_airmode.get() != 2);
+	// Avoid accumulating absolute yaw error with arming stick gesture.
+	// Active when yaw airmode is off (yaw stick to corner is the arm gesture; with yaw airmode
+	// on the yaw stick would command thrust too, defeating the gesture).
+	const bool arming_gesture = (_manual_control_setpoint.throttle < -.9f) && (_param_mc_airmode_ylim.get() <= 0.f);
 
 	if (arming_gesture) {
 		_yaw_setpoint_stabilized = NAN;

--- a/src/modules/mc_pos_control/multicopter_position_control_limits_params.yaml
+++ b/src/modules/mc_pos_control/multicopter_position_control_limits_params.yaml
@@ -74,8 +74,8 @@ parameters:
         short: Minimum collective thrust in climb rate controlled modes
         long: |-
           Too low thrust leads to loss of roll/pitch/yaw torque control authority.
-          With airmode enabled this parameters can be set to 0
-          while still keeping torque authority (see MC_AIRMODE).
+          With airmode enabled this parameter can be set to 0
+          while still keeping torque authority (see MC_AIRMODE_LIM).
       type: float
       default: 0.12
       unit: norm

--- a/src/modules/mc_pos_control/multicopter_stabilized_mode_params.yaml
+++ b/src/modules/mc_pos_control/multicopter_stabilized_mode_params.yaml
@@ -29,7 +29,7 @@ parameters:
           The value is mapped to the lowest throttle stick position in Stabilized mode.
 
           Too low collective thrust leads to loss of roll/pitch/yaw torque control authority.
-          Airmode is used to keep torque authority with zero thrust (see MC_AIRMODE).
+          Airmode is used to keep torque authority with zero thrust (see MC_AIRMODE_LIM).
       type: float
       default: 0.08
       unit: norm


### PR DESCRIPTION
**Draft / WIP — full description and documentation to follow once the implementation is settled.**

Generalizes multicopter airmode from the three-value `MC_AIRMODE` enum into two continuous, per-axis
authority limits — `MC_AIRMODE_LIM` (roll/pitch) and `MC_AIRMODE_YLIM` (yaw) — each a ceiling in `[0,1]`
on how much collective thrust the allocator may inject to preserve that axis when the actuators saturate.

Endpoints reproduce the legacy modes bit-exactly: `(0,0)` = disabled, `(1,0)` = roll/pitch,
`(1,1)` = roll/pitch/yaw, with automatic migration of the old `MC_AIRMODE` param and `default 0`
(no behavior change out of the box).

Reimplements the concept from #22706.
