### PR TITLE
ci(macos): trust PX4 brew taps for Homebrew 6.0

### DIFF
--- a/Tools/setup/macos.sh
+++ b/Tools/setup/macos.sh
@@ -51,6 +51,18 @@ brew tap osx-cross/arm
 brew tap PX4/px4
 brew tap discoteq/discoteq
 
+# Homebrew 6.0+ refuses to load formulae from third-party taps unless they
+# are explicitly trusted ("Refusing to load formula ... from untrusted tap").
+# Trust each tap non-interactively before installing from it. Without this,
+# `brew install` aborts before pouring any package (including ccache).
+# `brew trust` only exists on Homebrew 6.0+; guard it so older versions,
+# which don't gate untrusted taps, skip it silently.
+if brew trust --help &> /dev/null; then
+	brew trust osx-cross/arm
+	brew trust PX4/px4
+	brew trust discoteq/discoteq
+fi
+
 # Package list. This replaces the px4-dev meta-formula, which is kept
 # as a deprecated no-op upstream. See PX4/homebrew-px4 for history.
 PX4_BREW_PACKAGES=(


### PR DESCRIPTION
Homebrew 6.0 (released 2026-06-11) makes tap-trust mandatory and refuses to load formulae from untrusted third-party taps. As of today this is breaking every macOS build, including pushes to `main`. The `setup` step runs `Tools/setup/macos.sh`, which taps `osx-cross/arm`, `PX4/px4`, and `discoteq/discoteq`, then `brew install` aborts with `Refusing to load formula px4/px4/fastdds from untrusted tap px4/px4` before pouring any package. Because `macos.sh` has no `set -e`, the setup step still reports success, so the failure only surfaces later as `ccache: command not found` (exit 127) in `setup-ccache`, which is the first step to actually invoke a brewed tool.

This trusts the three required taps non-interactively before installing from them, which is the migration path Homebrew documents. It is guarded behind a `brew trust` capability check so older Homebrew versions (which have no trust gate) skip it cleanly.

Verified the root cause against run 28192097486 and today's `main` push runs, all of which fail with the same untrusted-tap error in the setup step.
