### PR TITLE
fix(sensor_baro_sim): update barometer timestamp handling in simulation

### DIFF
--- a/src/modules/simulation/sensor_baro_sim/SensorBaroSim.cpp
+++ b/src/modules/simulation/sensor_baro_sim/SensorBaroSim.cpp
@@ -165,7 +165,7 @@ void SensorBaroSim::Run()
 
 			// publish
 			_px4_baro.set_temperature(temperature);
-			_px4_baro.update(hrt_absolute_time(), pressure);
+			_px4_baro.update(gpos.timestamp, pressure);
 
 			_last_update_time = gpos.timestamp;
 		}


### PR DESCRIPTION
Short follow up to https://github.com/PX4/PX4-Autopilot/pull/27580

saw that it makes more sense to use the global position timestamp than the current time, as this is what baro is derived from. overlooked it in the original PR