### PR TITLE
docs(hardware): expand USB VID/PID options in board support guide

### DIFF
--- a/docs/en/hardware/board_support_guide.md
+++ b/docs/en/hardware/board_support_guide.md
@@ -70,12 +70,20 @@ The pair must be unique to your product.
 Each board needs its own identity.
 :::
 
-You have two ways to get a valid pair:
+There are several ways to get a valid pair, listed in order of preference:
 
-- **Provide your own.** As the hardware manufacturer, the VID/PID identify _your_ company and product, and you are expected to obtain them yourself.
-- **Use the Dronecode VID.** [Dronecode Foundation members](https://dronecode.org/membership/) can request a PID allocated under the Dronecode USB VID.
-  This is one of the membership benefits, alongside access to the Pixhawk FMU reference schematics.
-  If you would like to use the Dronecode VID, [become a member](https://dronecode.org/membership/) first.
+1. **Buy your own VID from USB-IF (preferred).** As a serious hardware manufacturer, the cleanest option is to purchase your own Vendor ID directly from the [USB Implementers Forum](https://www.usb.org/getting-vendor-id).
+   The VID/PID then unambiguously identify _your_ company and product.
+2. **Obtain a free VID/PID.** If purchasing your own is not an option, you can get a free VID/PID pair from one of several community registries or chip-vendor programs, for example [pid.codes](https://pid.codes/) (VID `0x1209`) or the [Openmoko registry](https://github.com/openmoko/openmoko-usb-oui) (VID `0x1d50`) for open-source hardware, or a sub-PID from your MCU/USB-bridge vendor (e.g. Microchip, FTDI).
+   PX4 takes no position on how you source a free pair and assumes no responsibility for it.
+   The only requirement is that your VID/PID pair is unique and does not conflict with anything already in the PX4 codebase.
+3. **Use the Dronecode VID.** [Dronecode Foundation members](https://dronecode.org/membership/) can request a PID allocated under the Dronecode USB VID.
+   This is one of the membership benefits, alongside access to the Pixhawk FMU reference schematics.
+
+::: info
+Membership is **not** required to get your board supported in PX4.
+The Dronecode VID is a convenience for members; any unique, non-conflicting VID/PID pair from the options above is equally acceptable for a board support pull request.
+:::
 
 ### 4. Fly it and Capture Logs
 


### PR DESCRIPTION
Expands the "Sort Out your USB VID/PID" section of the manufacturer board support guide. The section previously listed only two ways to get a VID/PID pair (provide your own, or use the Dronecode VID), which left a gap for manufacturers who can't immediately buy a Vendor ID from USB-IF and incorrectly implied that the Dronecode VID was the only fallback.

The options are now ordered by preference: buy your own VID from USB-IF (preferred for serious manufacturers), obtain a free VID/PID pair from a community registry or chip-vendor program (pid.codes, Openmoko, or an MCU/USB-bridge vendor sub-PID), or request a PID under the Dronecode VID as a member. The free-pair option states clearly that PX4 takes no position on how you source it and the only requirement is that the pair is unique and doesn't conflict with anything already in the codebase.

A note also makes explicit that Dronecode membership is not required to get a board supported in PX4. The Dronecode VID is a convenience for members, not a gate on board support.
