### PR TITLE
feat(rallyPointCheck): allow arming when RTL_TYPE=5 & no rally point

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/rallyPointCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/rallyPointCheck.cpp
@@ -55,18 +55,19 @@ void RallyPointChecks::checkAndReport(const Context &context, Report &reporter)
 	if (!_rtl_status_sub.copy(&rtl_status) || rtl_status.safe_point_index == UINT8_MAX) {
 		/* EVENT
 		 * @description
-		 * Upload at least one rally point before arming, or change <param>RTL_TYPE</param>.
+		 * No rally point is configured. Return will fall back to the current position when RTL is triggered.
+		 * Upload at least one rally point, or change <param>RTL_TYPE</param> to silence this warning.
 		 *
 		 * <profile name="dev">
-		 * This check is active when RTL_TYPE is set to 5 (safe points only).
+		 * This warning is active when RTL_TYPE is set to 5 (safe points only).
 		 * </profile>
 		 */
-		reporter.armingCheckFailure(NavModes::All, health_component_t::system,
+		reporter.armingCheckFailure(NavModes::None, health_component_t::system,
 					    events::ID("check_rally_point_missing"),
-					    events::Log::Error, "No rally point available");
+					    events::Log::Warning, "No rally point configured");
 
 		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: No rally point available\t");
+			mavlink_log_warning(reporter.mavlink_log_pub(), "No rally point configured\t");
 		}
 	}
 }


### PR DESCRIPTION
### Solved Problem
When RTL_TYPE=5 and no rally point is set, arming is denied. This is quite strict, and can be reduced to a warning instead to inform the operator. 

### Solution

Allow arming when rally point is not set, but warn the user that it's missing. 

### Changelog Entry
For release notes:
```
Feature/Bugfix warn user if no rally point is set when RTL_TYPE=5, but don't deny arming. 
```
### Test coverage

Tested in SITL. `RTL_TTYPE = 5` and no rally point set. Arming allowed and warning displayed in orange: 

<img width="1580" height="476" alt="image" src="https://github.com/user-attachments/assets/6087aa95-a1e2-416f-91aa-539f756e88be" />

