### PR TITLE
fix(airframes/10042): correct sihsim_xvert sign error

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
@@ -58,8 +58,8 @@ param set-default CA_SV_CS0_TYPE 5
 param set-default CA_SV_CS0_TRQ_P 0.5
 param set-default CA_SV_CS0_TRQ_Y -0.5
 param set-default CA_SV_CS1_TYPE 6
-param set-default CA_SV_CS1_TRQ_P 0.5
-param set-default CA_SV_CS1_TRQ_Y 0.5
+param set-default CA_SV_CS1_TRQ_P -0.5
+param set-default CA_SV_CS1_TRQ_Y -0.5
 
 param set-default PWM_MAIN_FUNC1 101
 param set-default PWM_MAIN_FUNC2 102


### PR DESCRIPTION
### Problem

The `sihsim_xvert` currently tumbles immediately on takeoff. Here is how the simulation maps servo deflections to torques:

[`generate_ts_aerodynamics`](https://github.com/PX4/PX4-Autopilot/blob/0b47f41d7c42f841e61914fd3353dfa1462a2fe7/src/modules/simulation/simulator_sih/sih.cpp#L513-L523) in `sih.cpp` calculates elevon torques. everything is rotated into the fixed-wing body frame, in which
 - positive `_u[4]` (configured as `CA_SV_CS0`) generates positive roll torque (left wing pushed up)
 - positive `_u[5]` (configured as `CA_SV_CS1`) generates positive roll torque (right wing pushed down, note the additional minus)

So in the FW frame, they work like this:
 - positive `_u[4] + _u[5]` -> positive FW roll torque
 - positive `_u[4] - _u[5]` -> positive FW pitch torque

The airframe file however configures all of these in the multicopter frame. So accounting for the frame conversion, we have:
 - MC yaw = -FW roll = `-_u[4] - _u[5]` 
   - Minus because FW x points towards the nose while MC z points against the nose
 - MC pitch = FW pitch = `_u[4] - _u[5]`

or in matrix form:

```
[  MC yaw  ]   [ -1  -1 ] [ _u[4] ]
[ MC pitch ] = [ 1   -1 ] [ _u[5] ]
```

### Solution 

As the matrix above is basically (up to scaling)

```
[ CS0_TRQ_Y CS1_TRQ_Y ]
[ CS0_TRQ_P CS1_TRQ_P ]
```

we have to change the `CS1_TRQ_*` coefficients to be negative.


### Context

I don't know when / if this ever worked. First I searched the history for an easy obvious error to revert but found none. I had to conclude that this airframe just never flew. 

It is still very clunky:
 - front transition times out
 - MC roll loop is somewhat underdamped
 - there is a ~20Hz pitch oscillation but only when giving full pitch up (flying backward)  
 - it almost crashed just by giving large commands in altitude mode 

But let's address that in a separate step.

### Testing

 - before https://review.px4.io/plot_app?log=9019765f-de1f-410f-9236-786b5a194859
 - after https://review.px4.io/plot_app?log=983492da-37f9-4d38-8d5b-e277d3803d66

### Alternatives

 - change the simulation to fit the airframe?