### PR TITLE
fix(ROMFS): Safe flash pruning more unnecessary characters from ROMFS

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
@@ -48,20 +48,20 @@ param set-default SENS_GPS0_DELAY 0
 param set-default SENS_GPS1_DELAY 0
 
 # Rate controllers
-param set-default FW_RR_P 0.0500
-param set-default FW_RR_I 2.0000
-param set-default FW_RR_D 0.0000
-param set-default FW_RR_FF 0.0000
-param set-default FW_RR_IMAX 1.0000
+param set-default FW_RR_P 0.05
+param set-default FW_RR_I 2
+param set-default FW_RR_D 0
+param set-default FW_RR_FF 0
+param set-default FW_RR_IMAX 1
 
-param set-default FW_PR_P 0.0800
-param set-default FW_PR_I 2.5000
-param set-default FW_PR_D 0.0000
-param set-default FW_PR_FF 0.0000
-param set-default FW_PR_IMAX 1.0000
+param set-default FW_PR_P 0.08
+param set-default FW_PR_I 2.5
+param set-default FW_PR_D 0
+param set-default FW_PR_FF 0
+param set-default FW_PR_IMAX 1
 
-param set-default FW_YR_P 0.0500
-param set-default FW_YR_I 3.0000
-param set-default FW_YR_D 0.0000
-param set-default FW_YR_FF 0.0000
-param set-default FW_YR_IMAX 1.0000
+param set-default FW_YR_P 0.05
+param set-default FW_YR_I 3
+param set-default FW_YR_D 0
+param set-default FW_YR_FF 0
+param set-default FW_YR_IMAX 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
@@ -24,8 +24,8 @@ param set-default SIH_IZZ 0.0177
 param set-default SIH_IXZ 0.00046
 param set-default SIH_KDV 0.2
 
-param set-default SIH_VEHICLE_TYPE 1 	# sih as fixed wing
-param set-default RWTO_TKOFF 1  # enable takeoff from runway (as opposed to launched)
+param set-default SIH_VEHICLE_TYPE 1 # sih as fixed wing
+param set-default RWTO_TKOFF 1 # enable takeoff from runway (as opposed to launched)
 
 param set-default CA_ROTOR_COUNT 1
 param set-default CA_ROTOR0_PX 0.3
@@ -33,11 +33,11 @@ param set-default CA_ROTOR0_PX 0.3
 # SIH for now hardcodes this configuration which we need to match in the airframe files.
 param set-default CA_SV_CS_COUNT 3
 param set-default CA_SV_CS0_TRQ_R 1
-param set-default CA_SV_CS0_TYPE 15  # single channel aileron
+param set-default CA_SV_CS0_TYPE 15 # single channel aileron
 param set-default CA_SV_CS1_TRQ_P 1
-param set-default CA_SV_CS1_TYPE 3  # elevator
+param set-default CA_SV_CS1_TYPE 3 # elevator
 param set-default CA_SV_CS2_TRQ_Y 1
-param set-default CA_SV_CS2_TYPE 4  # rudder
+param set-default CA_SV_CS2_TYPE 4 # rudder
 
 param set-default PWM_MAIN_FUNC1 201
 param set-default PWM_MAIN_FUNC2 202

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
@@ -35,7 +35,7 @@ param set-default SIH_MASS 0.2
 # IXX and IZZ are inverted from the thesis as the body frame is pitched by 90 deg
 param set-default SIH_IXX 0.00354
 param set-default SIH_IYY 0.000625
-param set-default SIH_IZZ 0.00300
+param set-default SIH_IZZ 0.003
 param set-default SIH_IXZ 0
 param set-default SIH_KDV 0.2
 param set-default SIH_L_ROLL 0.145

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10043_sihsim_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10043_sihsim_standard_vtol
@@ -82,13 +82,13 @@ param set-default MAV_TYPE 22
 
 param set-default SENS_DPRES_OFF 0.001
 
-param set SIH_T_MAX 2.0
+param set SIH_T_MAX 2
 param set SIH_Q_MAX 0.0165
 param set SIH_MASS 0.2
 # IXX and IZZ are inverted from the thesis as the body frame is pitched by 90 deg
 param set SIH_IXX 0.00354
 param set SIH_IYY 0.000625
-param set SIH_IZZ 0.00300
+param set SIH_IZZ 0.003
 param set SIH_IXZ 0
 param set SIH_KDV 0.2
 param set SIH_L_ROLL 0.2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10043_sihsim_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10043_sihsim_standard_vtol
@@ -56,11 +56,11 @@ param set-default CA_ROTOR4_AZ 0
 # SIH for now hardcodes this configuration which we need to match in the airframe files.
 param set-default CA_SV_CS_COUNT 3
 param set-default CA_SV_CS0_TRQ_R 1
-param set-default CA_SV_CS0_TYPE 15  # single channel aileron
+param set-default CA_SV_CS0_TYPE 15 # single channel aileron
 param set-default CA_SV_CS1_TRQ_P 1
-param set-default CA_SV_CS1_TYPE 3  # elevator
+param set-default CA_SV_CS1_TYPE 3 # elevator
 param set-default CA_SV_CS2_TRQ_Y 1
-param set-default CA_SV_CS2_TYPE 4  # rudder
+param set-default CA_SV_CS2_TYPE 4 # rudder
 
 param set-default FW_AIRSPD_MIN 7
 param set-default FW_AIRSPD_TRIM 10

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10045_sihsim_rover_ackermann
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10045_sihsim_rover_ackermann
@@ -6,10 +6,10 @@
 . ${R}etc/init.d/rc.rover_ackermann_defaults
 
 set VEHICLE_TYPE rover_ackermann
-param set-default CA_AIRFRAME 5         # Rover (Ackermann)
-param set-default CA_R_REV 1            # Motor is assumed to be reversible
-param set-default EKF2_MAG_TYPE 1       # Make sure magnetometer is fused even when not driving
-param set-default NAV_ACC_RAD 0.5       # Waypoint acceptance radius
+param set-default CA_AIRFRAME 5 # Rover (Ackermann)
+param set-default CA_R_REV 1 # Motor is assumed to be reversible
+param set-default EKF2_MAG_TYPE 1 # Make sure magnetometer is fused even when not driving
+param set-default NAV_ACC_RAD 0.5 # Waypoint acceptance radius
 param set-default EKF2_GBIAS_INIT 0.01
 param set-default EKF2_ANGERR_INIT 0.01
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1033_jsbsim_rascal
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1033_jsbsim_rascal
@@ -12,12 +12,12 @@ param set-default FW_LND_FLALT 5
 
 param set-default NPFG_PERIOD 25
 
-param set-default FW_PR_FF 0.40
+param set-default FW_PR_FF 0.4
 param set-default FW_PR_I 0.05
 param set-default FW_PR_P 0.05
 
 param set-default FW_R_TC 0.45
-param set-default FW_RR_FF 0.40
+param set-default FW_RR_FF 0.4
 param set-default FW_RR_I 0.132
 param set-default FW_RR_P 0.085
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1034_flightgear_rascal-electric
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1034_flightgear_rascal-electric
@@ -12,12 +12,12 @@ param set-default FW_LND_FLALT 5
 
 param set-default NPFG_PERIOD 25
 
-param set-default FW_PR_FF 0.40
+param set-default FW_PR_FF 0.4
 param set-default FW_PR_I 0.05
 param set-default FW_PR_P 0.05
 
 param set-default FW_R_TC 0.45
-param set-default FW_RR_FF 0.40
+param set-default FW_RR_FF 0.4
 param set-default FW_RR_I 0.132
 param set-default FW_RR_P 0.085
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1035_gazebo-classic_techpod
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1035_gazebo-classic_techpod
@@ -10,12 +10,12 @@
 param set-default FW_LND_ANG 8
 
 param set-default FW_P_TC 0.5
-param set-default FW_PR_FF 0.40
+param set-default FW_PR_FF 0.4
 param set-default FW_PR_I 0.05
 param set-default FW_PR_P 0.05
 
 param set-default FW_R_TC 0.7
-param set-default FW_RR_FF 0.20
+param set-default FW_RR_FF 0.2
 param set-default FW_RR_I 0.02
 param set-default FW_RR_P 0.22
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1036_jsbsim_malolo
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1036_jsbsim_malolo
@@ -12,12 +12,12 @@ param set-default FW_LND_FLALT 5
 
 param set-default NPFG_PERIOD 25
 
-param set-default FW_PR_FF 0.40
+param set-default FW_PR_FF 0.4
 param set-default FW_PR_I 0.05
 param set-default FW_PR_P 0.05
 
 param set-default FW_R_TC 0.45
-param set-default FW_RR_FF 0.40
+param set-default FW_RR_FF 0.4
 param set-default FW_RR_I 0.132
 param set-default FW_RR_P 0.085
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1038_gazebo-classic_glider
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1038_gazebo-classic_glider
@@ -67,4 +67,4 @@ param set-default PWM_MAIN_FUNC8 203
 param set-default PWM_MAIN_FUNC9 206
 param set-default PWM_MAIN_REV 256
 
-param set-default FW_THR_TRIM 0.0
+param set-default FW_THR_TRIM 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1039_flightgear_rascal
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1039_flightgear_rascal
@@ -12,12 +12,12 @@ param set-default FW_LND_FLALT 5
 
 param set-default NPFG_PERIOD 25
 
-param set-default FW_PR_FF 0.40
+param set-default FW_PR_FF 0.4
 param set-default FW_PR_I 0.05
 param set-default FW_PR_P 0.05
 
 param set-default FW_R_TC 0.45
-param set-default FW_RR_FF 0.40
+param set-default FW_RR_FF 0.4
 param set-default FW_RR_I 0.132
 param set-default FW_RR_P 0.085
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
@@ -50,7 +50,7 @@ param set-default SENS_IMU_MODE 1
 
 param set-default FW_P_TC 0.6
 
-param set-default FW_PR_FF 0.0
+param set-default FW_PR_FF 0
 param set-default FW_PSP_OFF 2
 param set-default FW_RR_FF 0.1
 param set-default FW_RR_I 0.2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500
@@ -21,7 +21,7 @@ param set-default CA_ROTOR0_PY 0.22
 param set-default CA_ROTOR0_KM  0.05
 
 param set-default CA_ROTOR1_PX -0.13
-param set-default CA_ROTOR1_PY -0.20
+param set-default CA_ROTOR1_PY -0.2
 param set-default CA_ROTOR1_KM  0.05
 
 param set-default CA_ROTOR2_PX 0.13
@@ -29,7 +29,7 @@ param set-default CA_ROTOR2_PY -0.22
 param set-default CA_ROTOR2_KM -0.05
 
 param set-default CA_ROTOR3_PX -0.13
-param set-default CA_ROTOR3_PY 0.20
+param set-default CA_ROTOR3_PY 0.2
 param set-default CA_ROTOR3_KM -0.05
 
 param set-default SIM_GZ_EC_FUNC1 101
@@ -47,5 +47,5 @@ param set-default SIM_GZ_EC_MAX2 1000
 param set-default SIM_GZ_EC_MAX3 1000
 param set-default SIM_GZ_EC_MAX4 1000
 
-param set-default MPC_THR_HOVER 0.60
+param set-default MPC_THR_HOVER 0.6
 param set-default NAV_DLL_ACT 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500
@@ -18,11 +18,11 @@ param set-default CA_ROTOR_COUNT 4
 
 param set-default CA_ROTOR0_PX 0.13
 param set-default CA_ROTOR0_PY 0.22
-param set-default CA_ROTOR0_KM  0.05
+param set-default CA_ROTOR0_KM 0.05
 
 param set-default CA_ROTOR1_PX -0.13
 param set-default CA_ROTOR1_PY -0.2
-param set-default CA_ROTOR1_KM  0.05
+param set-default CA_ROTOR1_KM 0.05
 
 param set-default CA_ROTOR2_PX 0.13
 param set-default CA_ROTOR2_PY -0.22

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
@@ -29,11 +29,11 @@ param set-default RO_MAX_THR_SPEED 2.7
 
 # Rover Rate Control Parameters
 param set-default RO_YAW_RATE_I 0.2
-param set-default RO_YAW_RATE_P 1.0
+param set-default RO_YAW_RATE_P 1
 param set-default RO_YAW_RATE_LIM 60
 param set-default RO_YAW_ACCEL_LIM 50
 param set-default RO_YAW_DECEL_LIM 1000
-param set-default RO_YAW_RATE_CORR 1.0
+param set-default RO_YAW_RATE_CORR 1
 
 # Rover Attitude Control Parameters
 param set-default RO_YAW_P 5
@@ -42,7 +42,7 @@ param set-default RO_YAW_P 5
 param set-default RO_SPEED_LIM 2.1
 param set-default RO_SPEED_I 0.01
 param set-default RO_SPEED_P 0.1
-param set-defatul RO_SPEED_RED 1.0
+param set-defatul RO_SPEED_RED 1
 
 # Pure pursuit parameters
 param set-default PP_LOOKAHD_GAIN 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
@@ -42,7 +42,7 @@ param set-default RO_YAW_P 5
 param set-default RO_SPEED_LIM 2.1
 param set-default RO_SPEED_I 0.01
 param set-default RO_SPEED_P 0.1
-param set-defatul RO_SPEED_RED 1
+param set-default RO_SPEED_RED 1
 
 # Pure pursuit parameters
 param set-default PP_LOOKAHD_GAIN 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/60002_gz_uuv_bluerov2_heavy
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/60002_gz_uuv_bluerov2_heavy
@@ -46,7 +46,7 @@ param set-default CA_ROTOR0_AY -1
 param set-default CA_ROTOR0_AZ 0
 param set-default CA_ROTOR0_KM 0
 param set-default CA_ROTOR0_PX 0.14
-param set-default CA_ROTOR0_PY 0.10
+param set-default CA_ROTOR0_PY 0.1
 param set-default CA_ROTOR0_PZ 0.06
 
 param set-default CA_ROTOR1_AX 1
@@ -54,7 +54,7 @@ param set-default CA_ROTOR1_AY 1
 param set-default CA_ROTOR1_AZ 0
 param set-default CA_ROTOR1_KM 0
 param set-default CA_ROTOR1_PX 0.14
-param set-default CA_ROTOR1_PY -0.10
+param set-default CA_ROTOR1_PY -0.1
 param set-default CA_ROTOR1_PZ 0.06
 
 param set-default CA_ROTOR2_AX 1
@@ -62,7 +62,7 @@ param set-default CA_ROTOR2_AY 1
 param set-default CA_ROTOR2_AZ 0
 param set-default CA_ROTOR2_KM 0
 param set-default CA_ROTOR2_PX -0.14
-param set-default CA_ROTOR2_PY 0.10
+param set-default CA_ROTOR2_PY 0.1
 param set-default CA_ROTOR2_PZ 0.06
 
 param set-default CA_ROTOR3_AX 1
@@ -70,7 +70,7 @@ param set-default CA_ROTOR3_AY -1
 param set-default CA_ROTOR3_AZ 0
 param set-default CA_ROTOR3_KM 0
 param set-default CA_ROTOR3_PX -0.14
-param set-default CA_ROTOR3_PY -0.10
+param set-default CA_ROTOR3_PY -0.1
 param set-default CA_ROTOR3_PZ 0.06
 
 param set-default CA_ROTOR4_AX 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/60002_gz_uuv_bluerov2_heavy
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/60002_gz_uuv_bluerov2_heavy
@@ -25,7 +25,7 @@ param set-default MAV_TYPE 12
 param set-default SENS_EN_GPSSIM 1
 param set-default SENS_EN_BAROSIM 1
 param set-default SENS_EN_MAGSIM 1
-param set-default COM_ARM_CHK_ESCS 0  # We don't have ESCs
+param set-default COM_ARM_CHK_ESCS 0 # We don't have ESCs
 
 # Set proper failsafes
 param set-default COM_ACT_FAIL_ACT 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/70000_gz_atmos
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/70000_gz_atmos
@@ -51,67 +51,67 @@ param set-default FD_FAIL_R 0
 
 param set-default CA_ROTOR0_PX -0.12
 param set-default CA_ROTOR0_PY -0.12
-param set-default CA_ROTOR0_PZ 0.0
+param set-default CA_ROTOR0_PZ 0
 param set-default CA_ROTOR0_CT 1.4
-param set-default CA_ROTOR0_AX 1.0
-param set-default CA_ROTOR0_AY 0.0
-param set-default CA_ROTOR0_AZ 0.0
+param set-default CA_ROTOR0_AX 1
+param set-default CA_ROTOR0_AY 0
+param set-default CA_ROTOR0_AZ 0
 
 param set-default CA_ROTOR1_PX 0.12
 param set-default CA_ROTOR1_PY -0.12
-param set-default CA_ROTOR1_PZ 0.0
+param set-default CA_ROTOR1_PZ 0
 param set-default CA_ROTOR1_CT 1.4
-param set-default CA_ROTOR1_AX -1.0
-param set-default CA_ROTOR1_AY 0.0
-param set-default CA_ROTOR1_AZ 0.0
+param set-default CA_ROTOR1_AX -1
+param set-default CA_ROTOR1_AY 0
+param set-default CA_ROTOR1_AZ 0
 
 param set-default CA_ROTOR2_PX -0.12
 param set-default CA_ROTOR2_PY 0.12
-param set-default CA_ROTOR2_PZ 0.0
+param set-default CA_ROTOR2_PZ 0
 param set-default CA_ROTOR2_CT 1.4
-param set-default CA_ROTOR2_AX 1.0
-param set-default CA_ROTOR2_AY 0.0
-param set-default CA_ROTOR2_AZ 0.0
+param set-default CA_ROTOR2_AX 1
+param set-default CA_ROTOR2_AY 0
+param set-default CA_ROTOR2_AZ 0
 
 param set-default CA_ROTOR3_PX 0.12
 param set-default CA_ROTOR3_PY 0.12
-param set-default CA_ROTOR3_PZ 0.0
+param set-default CA_ROTOR3_PZ 0
 param set-default CA_ROTOR3_CT 1.4
-param set-default CA_ROTOR3_AX -1.0
-param set-default CA_ROTOR3_AY 0.0
-param set-default CA_ROTOR3_AZ 0.0
+param set-default CA_ROTOR3_AX -1
+param set-default CA_ROTOR3_AY 0
+param set-default CA_ROTOR3_AZ 0
 
 param set-default CA_ROTOR4_PX 0.12
 param set-default CA_ROTOR4_PY -0.12
-param set-default CA_ROTOR4_PZ 0.0
+param set-default CA_ROTOR4_PZ 0
 param set-default CA_ROTOR4_CT 1.4
-param set-default CA_ROTOR4_AX 0.0
-param set-default CA_ROTOR4_AY 1.0
-param set-default CA_ROTOR4_AZ 0.0
+param set-default CA_ROTOR4_AX 0
+param set-default CA_ROTOR4_AY 1
+param set-default CA_ROTOR4_AZ 0
 
 param set-default CA_ROTOR5_PX 0.12
 param set-default CA_ROTOR5_PY 0.12
-param set-default CA_ROTOR5_PZ 0.0
+param set-default CA_ROTOR5_PZ 0
 param set-default CA_ROTOR5_CT 1.4
-param set-default CA_ROTOR5_AX 0.0
-param set-default CA_ROTOR5_AY -1.0
-param set-default CA_ROTOR5_AZ 0.0
+param set-default CA_ROTOR5_AX 0
+param set-default CA_ROTOR5_AY -1
+param set-default CA_ROTOR5_AZ 0
 
 param set-default CA_ROTOR6_PX -0.12
 param set-default CA_ROTOR6_PY -0.12
-param set-default CA_ROTOR6_PZ 0.0
+param set-default CA_ROTOR6_PZ 0
 param set-default CA_ROTOR6_CT 1.4
-param set-default CA_ROTOR6_AX 0.0
-param set-default CA_ROTOR6_AY 1.0
-param set-default CA_ROTOR6_AZ 0.0
+param set-default CA_ROTOR6_AX 0
+param set-default CA_ROTOR6_AY 1
+param set-default CA_ROTOR6_AZ 0
 
 param set-default CA_ROTOR7_PX -0.12
 param set-default CA_ROTOR7_PY 0.12
-param set-default CA_ROTOR7_PZ 0.0
+param set-default CA_ROTOR7_PZ 0
 param set-default CA_ROTOR7_CT 1.4
-param set-default CA_ROTOR7_AX 0.0
-param set-default CA_ROTOR7_AY -1.0
-param set-default CA_ROTOR7_AZ 0.0
+param set-default CA_ROTOR7_AX 0
+param set-default CA_ROTOR7_AY -1
+param set-default CA_ROTOR7_AZ 0
 
 param set-default SIM_GZ_EC_FUNC1 101
 param set-default SIM_GZ_EC_FUNC2 102
@@ -145,10 +145,10 @@ param set SC_YAWRATE_P 3.335
 param set SC_YAWRATE_I 0.87
 param set SC_YAWRATE_D 0.15
 param set SC_YR_INT_LIM 0.2
-param set SC_YAW_P 3.0
+param set SC_YAW_P 3
 
-param set SPC_POS_P 0.20
+param set SPC_POS_P 0.2
 param set SPC_VEL_P 6.55
-param set SPC_VEL_I 0.0
-param set SPC_VEL_D 0.0
-param set SPC_VEL_MAX 12.0
+param set SPC_VEL_I 0
+param set SPC_VEL_D 0
+param set SPC_VEL_MAX 12

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/70000_gz_atmos
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/70000_gz_atmos
@@ -27,7 +27,7 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=atmos}
 param set-default SIM_GZ_EN 1
 
 param set-default SENS_EN_MAGSIM 1
-param set-default COM_ARM_CHK_ESCS 0  # We don't have ESCs
+param set-default COM_ARM_CHK_ESCS 0 # We don't have ESCs
 
 param set-default CA_AIRFRAME 14
 param set-default MAV_TYPE 45

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/70001_gz_atmos_dual
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/70001_gz_atmos_dual
@@ -51,67 +51,67 @@ param set-default FD_FAIL_R 0
 
 param set-default CA_ROTOR0_PX -0.12
 param set-default CA_ROTOR0_PY -0.12
-param set-default CA_ROTOR0_PZ 0.0
+param set-default CA_ROTOR0_PZ 0
 param set-default CA_ROTOR0_CT 1.4
-param set-default CA_ROTOR0_AX 1.0
-param set-default CA_ROTOR0_AY 0.0
-param set-default CA_ROTOR0_AZ 0.0
+param set-default CA_ROTOR0_AX 1
+param set-default CA_ROTOR0_AY 0
+param set-default CA_ROTOR0_AZ 0
 
 param set-default CA_ROTOR1_PX 0.12
 param set-default CA_ROTOR1_PY -0.12
-param set-default CA_ROTOR1_PZ 0.0
+param set-default CA_ROTOR1_PZ 0
 param set-default CA_ROTOR1_CT 1.4
-param set-default CA_ROTOR1_AX -1.0
-param set-default CA_ROTOR1_AY 0.0
-param set-default CA_ROTOR1_AZ 0.0
+param set-default CA_ROTOR1_AX -1
+param set-default CA_ROTOR1_AY 0
+param set-default CA_ROTOR1_AZ 0
 
 param set-default CA_ROTOR2_PX -0.12
 param set-default CA_ROTOR2_PY 0.12
-param set-default CA_ROTOR2_PZ 0.0
+param set-default CA_ROTOR2_PZ 0
 param set-default CA_ROTOR2_CT 1.4
-param set-default CA_ROTOR2_AX 1.0
-param set-default CA_ROTOR2_AY 0.0
-param set-default CA_ROTOR2_AZ 0.0
+param set-default CA_ROTOR2_AX 1
+param set-default CA_ROTOR2_AY 0
+param set-default CA_ROTOR2_AZ 0
 
 param set-default CA_ROTOR3_PX 0.12
 param set-default CA_ROTOR3_PY 0.12
-param set-default CA_ROTOR3_PZ 0.0
+param set-default CA_ROTOR3_PZ 0
 param set-default CA_ROTOR3_CT 1.4
-param set-default CA_ROTOR3_AX -1.0
-param set-default CA_ROTOR3_AY 0.0
-param set-default CA_ROTOR3_AZ 0.0
+param set-default CA_ROTOR3_AX -1
+param set-default CA_ROTOR3_AY 0
+param set-default CA_ROTOR3_AZ 0
 
 param set-default CA_ROTOR4_PX 0.12
 param set-default CA_ROTOR4_PY -0.12
-param set-default CA_ROTOR4_PZ 0.0
+param set-default CA_ROTOR4_PZ 0
 param set-default CA_ROTOR4_CT 1.4
-param set-default CA_ROTOR4_AX 0.0
-param set-default CA_ROTOR4_AY 1.0
-param set-default CA_ROTOR4_AZ 0.0
+param set-default CA_ROTOR4_AX 0
+param set-default CA_ROTOR4_AY 1
+param set-default CA_ROTOR4_AZ 0
 
 param set-default CA_ROTOR5_PX 0.12
 param set-default CA_ROTOR5_PY 0.12
-param set-default CA_ROTOR5_PZ 0.0
+param set-default CA_ROTOR5_PZ 0
 param set-default CA_ROTOR5_CT 1.4
-param set-default CA_ROTOR5_AX 0.0
-param set-default CA_ROTOR5_AY -1.0
-param set-default CA_ROTOR5_AZ 0.0
+param set-default CA_ROTOR5_AX 0
+param set-default CA_ROTOR5_AY -1
+param set-default CA_ROTOR5_AZ 0
 
 param set-default CA_ROTOR6_PX -0.12
 param set-default CA_ROTOR6_PY -0.12
-param set-default CA_ROTOR6_PZ 0.0
+param set-default CA_ROTOR6_PZ 0
 param set-default CA_ROTOR6_CT 1.4
-param set-default CA_ROTOR6_AX 0.0
-param set-default CA_ROTOR6_AY 1.0
-param set-default CA_ROTOR6_AZ 0.0
+param set-default CA_ROTOR6_AX 0
+param set-default CA_ROTOR6_AY 1
+param set-default CA_ROTOR6_AZ 0
 
 param set-default CA_ROTOR7_PX -0.12
 param set-default CA_ROTOR7_PY 0.12
-param set-default CA_ROTOR7_PZ 0.0
+param set-default CA_ROTOR7_PZ 0
 param set-default CA_ROTOR7_CT 1.4
-param set-default CA_ROTOR7_AX 0.0
-param set-default CA_ROTOR7_AY -1.0
-param set-default CA_ROTOR7_AZ 0.0
+param set-default CA_ROTOR7_AX 0
+param set-default CA_ROTOR7_AY -1
+param set-default CA_ROTOR7_AZ 0
 
 param set-default SIM_GZ_EC_FUNC1 101
 param set-default SIM_GZ_EC_FUNC2 102
@@ -157,10 +157,10 @@ param set SC_YAWRATE_P 3.335
 param set SC_YAWRATE_I 0.87
 param set SC_YAWRATE_D 0.15
 param set SC_YR_INT_LIM 0.2
-param set SC_YAW_P 3.0
+param set SC_YAW_P 3
 
-param set SPC_POS_P 0.20
+param set SPC_POS_P 0.2
 param set SPC_VEL_P 6.55
-param set SPC_VEL_I 0.0
-param set SPC_VEL_D 0.0
-param set SPC_VEL_MAX 12.0
+param set SPC_VEL_I 0
+param set SPC_VEL_D 0
+param set SPC_VEL_MAX 12

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/70001_gz_atmos_dual
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/70001_gz_atmos_dual
@@ -27,7 +27,7 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=atmos_dual}
 param set-default SIM_GZ_EN 1
 
 param set-default SENS_EN_MAGSIM 1
-param set-default COM_ARM_CHK_ESCS 0  # We don't have ESCs
+param set-default COM_ARM_CHK_ESCS 0 # We don't have ESCs
 
 param set-default CA_AIRFRAME 14
 param set-default MAV_TYPE 45

--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
@@ -42,6 +42,6 @@ if [ "$PX4_SIMULATOR" = "sihsim" ]; then
 	udp_sihsim_port_local=$((19450+px4_instance))
 	udp_sihsim_port_remote=$((19410+px4_instance))
 	mavlink start -x -u $udp_sihsim_port_local -r 400000 -m custom -o $udp_sihsim_port_remote $mavlink_network_interface_arg
-	mavlink stream -r 200 -s HIL_ACTUATOR_CONTROLS -u  $udp_sihsim_port_local
-	mavlink stream -r 25 -s HIL_STATE_QUATERNION -u  $udp_sihsim_port_local
+	mavlink stream -r 200 -s HIL_ACTUATOR_CONTROLS -u $udp_sihsim_port_local
+	mavlink stream -r 25 -s HIL_STATE_QUATERNION -u $udp_sihsim_port_local
 fi

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -26,11 +26,11 @@ then
 fi
 
 # initialize script variables
-set VEHICLE_TYPE                none
-set LOGGER_ARGS                 ""
-set LOGGER_BUF                  1000
+set VEHICLE_TYPE none
+set LOGGER_ARGS ""
+set LOGGER_BUF 1000
 
-set RUN_MINIMAL_SHELL           no
+set RUN_MINIMAL_SHELL no
 
 set SYS_AUTOSTART=0
 
@@ -136,11 +136,11 @@ if [ $AUTOCNF = yes ]
 then
 	param set SYS_AUTOSTART $SYS_AUTOSTART
 
-	param set CAL_ACC0_ID  1310988 # 1310988: DRV_IMU_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
+	param set CAL_ACC0_ID 1310988 # 1310988: DRV_IMU_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
 	param set CAL_GYRO0_ID 1310988 # 1310988: DRV_IMU_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
-	param set CAL_ACC1_ID  1310996 # 1310996: DRV_IMU_DEVTYPE_SIM, BUS: 2, ADDR: 1, TYPE: SIMULATION
+	param set CAL_ACC1_ID 1310996 # 1310996: DRV_IMU_DEVTYPE_SIM, BUS: 2, ADDR: 1, TYPE: SIMULATION
 	param set CAL_GYRO1_ID 1310996 # 1310996: DRV_IMU_DEVTYPE_SIM, BUS: 2, ADDR: 1, TYPE: SIMULATION
-	param set CAL_ACC2_ID  1311004 # 1311004: DRV_IMU_DEVTYPE_SIM, BUS: 3, ADDR: 1, TYPE: SIMULATION
+	param set CAL_ACC2_ID 1311004 # 1311004: DRV_IMU_DEVTYPE_SIM, BUS: 3, ADDR: 1, TYPE: SIMULATION
 	param set CAL_GYRO2_ID 1311004 # 1311004: DRV_IMU_DEVTYPE_SIM, BUS: 3, ADDR: 1, TYPE: SIMULATION
 
 	param set CAL_MAG0_ID 197388
@@ -182,7 +182,7 @@ param set-default SYS_FAILURE_EN 1
 param set-default COM_LOW_BAT_ACT 3
 
 # set default IP to localhost
-param set-default UXRCE_DDS_AG_IP 2130706433  # 127.0.0.1
+param set-default UXRCE_DDS_AG_IP 2130706433 # 127.0.0.1
 
 
 # Adapt timeout parameters if simulation runs faster or slower than realtime.

--- a/ROMFS/px4fmu_common/init.d/airframes/1101_rc_plane_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1101_rc_plane_sih.hil
@@ -21,11 +21,11 @@ param set-default CA_ROTOR0_PX 0.3
 # SIH for now hardcodes this configuration which we need to match in the airframe files.
 param set-default CA_SV_CS_COUNT 3
 param set-default CA_SV_CS0_TRQ_R 1
-param set-default CA_SV_CS0_TYPE 15  # single channel aileron
+param set-default CA_SV_CS0_TYPE 15 # single channel aileron
 param set-default CA_SV_CS1_TRQ_P 1
-param set-default CA_SV_CS1_TYPE 3  # elevator
+param set-default CA_SV_CS1_TYPE 3 # elevator
 param set-default CA_SV_CS2_TRQ_Y 1
-param set-default CA_SV_CS2_TYPE 4  # rudder
+param set-default CA_SV_CS2_TYPE 4 # rudder
 
 param set HIL_ACT_FUNC1 201
 param set HIL_ACT_FUNC2 202
@@ -46,8 +46,8 @@ param set SIH_IZZ 0.0177
 param set SIH_IXZ 0.00046
 param set SIH_KDV 0.2
 
-param set SIH_VEHICLE_TYPE 1 	# sih as fixed wing
-param set RWTO_TKOFF 1  # enable takeoff from runway (as opposed to launched)
+param set SIH_VEHICLE_TYPE 1 # sih as fixed wing
+param set RWTO_TKOFF 1 # enable takeoff from runway (as opposed to launched)
 
 # pusher propeller model with advance ratio, model from UIUC APC 8x6"
 param set SIH_F_T_MAX 6

--- a/ROMFS/px4fmu_common/init.d/airframes/1102_tailsitter_duo_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1102_tailsitter_duo_sih.hil
@@ -73,7 +73,7 @@ param set SIH_MASS 0.2
 # IXX and IZZ are inverted from the thesis as the body frame is pitched by 90 deg
 param set SIH_IXX 0.00354
 param set SIH_IYY 0.000625
-param set SIH_IZZ 0.00300
+param set SIH_IZZ 0.003
 param set SIH_IXZ 0
 param set SIH_KDV 0.2
 param set SIH_L_ROLL 0.145

--- a/ROMFS/px4fmu_common/init.d/airframes/1103_standard_vtol_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1103_standard_vtol_sih.hil
@@ -79,13 +79,13 @@ param set-default CBRK_SUPPLY_CHK 894281
 param set-default SENS_DPRES_OFF 0.001
 
 # quadrotor propellers
-param set SIH_T_MAX 2.0
+param set SIH_T_MAX 2
 param set SIH_Q_MAX 0.0165
 param set SIH_MASS 0.2
 # IXX and IZZ are inverted from the thesis as the body frame is pitched by 90 deg
 param set SIH_IXX 0.00354
 param set SIH_IYY 0.000625
-param set SIH_IZZ 0.00300
+param set SIH_IZZ 0.003
 param set SIH_IXZ 0
 param set SIH_KDV 0.2
 param set SIH_L_ROLL 0.2

--- a/ROMFS/px4fmu_common/init.d/airframes/1103_standard_vtol_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1103_standard_vtol_sih.hil
@@ -47,11 +47,11 @@ param set-default CA_ROTOR4_AZ 0
 # SIH for now hardcodes this configuration which we need to match in the airframe files.
 param set-default CA_SV_CS_COUNT 3
 param set-default CA_SV_CS0_TRQ_R 1
-param set-default CA_SV_CS0_TYPE 15  # single channel aileron
+param set-default CA_SV_CS0_TYPE 15 # single channel aileron
 param set-default CA_SV_CS1_TRQ_P 1
-param set-default CA_SV_CS1_TYPE 3  # elevator
+param set-default CA_SV_CS1_TYPE 3 # elevator
 param set-default CA_SV_CS2_TRQ_Y 1
-param set-default CA_SV_CS2_TYPE 4  # rudder
+param set-default CA_SV_CS2_TYPE 4 # rudder
 
 param set-default FW_AIRSPD_MIN 7
 param set-default FW_AIRSPD_TRIM 10

--- a/ROMFS/px4fmu_common/init.d/airframes/1104_standard_ackermann_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1104_standard_ackermann_sih.hil
@@ -6,10 +6,10 @@
 . ${R}etc/init.d/rc.rover_ackermann_defaults
 
 set VEHICLE_TYPE rover_ackermann
-param set-default CA_AIRFRAME 5         # Rover (Ackermann)
-param set-default CA_R_REV 1            # Motor is assumed to be reversible
-param set-default EKF2_MAG_TYPE 1       # Make sure magnetometer is fused even when not driving
-param set-default NAV_ACC_RAD 0.5       # Waypoint acceptance radius
+param set-default CA_AIRFRAME 5 # Rover (Ackermann)
+param set-default CA_R_REV 1 # Motor is assumed to be reversible
+param set-default EKF2_MAG_TYPE 1 # Make sure magnetometer is fused even when not driving
+param set-default NAV_ACC_RAD 0.5 # Waypoint acceptance radius
 param set-default EKF2_GBIAS_INIT 0.01
 param set-default EKF2_ANGERR_INIT 0.01
 

--- a/ROMFS/px4fmu_common/init.d/airframes/18001_TF-B1
+++ b/ROMFS/px4fmu_common/init.d/airframes/18001_TF-B1
@@ -15,7 +15,7 @@
 
 . ${R}etc/init.d/rc.balloon_defaults
 
-param set-default COM_PREARM_MODE 2  # always in prearm state
+param set-default COM_PREARM_MODE 2 # always in prearm state
 param set-default SDLOG_PROFILE 17
 param set-default SDLOG_MODE 2
 param set-default MAV_0_MODE 1

--- a/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
@@ -45,5 +45,5 @@ param set-default CA_ROTOR3_PX -1
 param set-default CA_ROTOR3_PY 1
 param set-default CA_ROTOR3_KM -0.05
 
-param set-default MPC_Z_VEL_MAX_UP 3.0
-param set-default MPC_Z_VEL_MAX_DN 3.0
+param set-default MPC_Z_VEL_MAX_UP 3
+param set-default MPC_Z_VEL_MAX_DN 3

--- a/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
+++ b/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
@@ -17,7 +17,7 @@
 . ${R}etc/init.d/rc.mc_defaults
 
 # Battery settings
-param set-default BAT_CRIT_THR 0.20
+param set-default BAT_CRIT_THR 0.2
 param set-default BAT_LOW_THR 0.25
 
 param set-default BAT1_CAPACITY 2800

--- a/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
+++ b/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
@@ -31,12 +31,12 @@ param set-default CBRK_SUPPLY_CHK 894281
 param set-default COM_DISARM_LAND 0.1
 param set-default COM_DISARM_PRFLT 3
 param set-default COM_DL_LOSS_T 10
-param set-default COM_FLTMODE1  2
+param set-default COM_FLTMODE1 2
 param set-default COM_FLTMODE2 -1
 param set-default COM_FLTMODE3 -1
 param set-default COM_FLTMODE4 -1
 param set-default COM_FLTMODE5 -1
-param set-default COM_FLTMODE6  1
+param set-default COM_FLTMODE6 1
 param set-default COM_RC_LOSS_T 3
 
 # ekf2
@@ -132,22 +132,22 @@ param set-default MNT_MAN_PITCH 2
 param set-default MNT_RATE_PITCH 30
 
 # RC
-param set-default RC_CHAN_CNT       12
+param set-default RC_CHAN_CNT 12
 
-param set-default RC_MAP_THROTTLE   1
-param set-default RC_MAP_YAW        2
-param set-default RC_MAP_PITCH      3
-param set-default RC_MAP_ROLL       4
-param set-default RC_MAP_AUX2       5
-param set-default RC_MAP_AUX3       10
-param set-default RC_MAP_AUX4       8
-param set-default RC_MAP_FLTMODE    6
-param set-default RC_MAP_RETURN_SW  7
+param set-default RC_MAP_THROTTLE 1
+param set-default RC_MAP_YAW 2
+param set-default RC_MAP_PITCH 3
+param set-default RC_MAP_ROLL 4
+param set-default RC_MAP_AUX2 5
+param set-default RC_MAP_AUX3 10
+param set-default RC_MAP_AUX4 8
+param set-default RC_MAP_FLTMODE 6
+param set-default RC_MAP_RETURN_SW 7
 
-param set-default RC1_TRIM          1000
+param set-default RC1_TRIM 1000
 
 # optical flow
-param set-default SENS_FLOW_MAXR   7.4
+param set-default SENS_FLOW_MAXR 7.4
 param set-default SENS_FLOW_MINHGT 0.15
 param set-default SENS_FLOW_MAXHGT 5
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4601_droneblocks_dexi_5
+++ b/ROMFS/px4fmu_common/init.d/airframes/4601_droneblocks_dexi_5
@@ -51,8 +51,8 @@ param set-default EKF2_OF_POS_X 0.043
 param set-default EKF2_OF_POS_Y 0.011
 param set-default EKF2_OF_QMIN_GND 1
 param set-default EKF2_RNG_POS_X 0.043
-param set-default EKF2_RNG_POS_Y 0.0
-param set-default EKF2_RNG_A_HMAX 25.0
+param set-default EKF2_RNG_POS_Y 0
+param set-default EKF2_RNG_A_HMAX 25
 
 param set-default IMU_GYRO_DNF_EN 2
 
@@ -60,7 +60,7 @@ param set-default MC_PITCHRATE_D 0.0013
 param set-default MC_PITCHRATE_I 0.185
 param set-default MC_PITCHRATE_P 0.105
 param set-default MC_PITCH_P 7.5
-param set-default MC_ROLLRATE_D 0.0010
+param set-default MC_ROLLRATE_D 0.001
 param set-default MC_ROLLRATE_I 0.165
 param set-default MC_ROLLRATE_P 0.095
 param set-default MC_ROLL_P 7.5
@@ -70,15 +70,15 @@ param set-default MC_YAWRATE_P 0.13
 param set-default MPC_THR_HOVER 0.22
 param set-default MPC_THR_MAX 0.5
 param set-default MPC_THR_MIN 0.025
-param set-default MPC_VEL_MANUAL 5.0
-param set-default MPC_XY_VEL_MAX 8.0
+param set-default MPC_VEL_MANUAL 5
+param set-default MPC_XY_VEL_MAX 8
 
 param set-default RC_CRSF_PRT_CFG 300
 param set-default RC_CRSF_TEL_EN 1
 
 param set-default RTL_RETURN_ALT 15
 
-param set-default SENS_FLOW_MINHGT 0.0
+param set-default SENS_FLOW_MINHGT 0
 
 param set-default SER_TEL2_BAUD 3000000
 

--- a/ROMFS/px4fmu_common/init.d/airframes/60002_uuv_bluerov2_heavy
+++ b/ROMFS/px4fmu_common/init.d/airframes/60002_uuv_bluerov2_heavy
@@ -61,7 +61,7 @@ param set-default CA_ROTOR0_AY -1
 param set-default CA_ROTOR0_AZ 0
 param set-default CA_ROTOR0_KM 0
 param set-default CA_ROTOR0_PX 0.14
-param set-default CA_ROTOR0_PY 0.10
+param set-default CA_ROTOR0_PY 0.1
 param set-default CA_ROTOR0_PZ 0.06
 
 param set-default CA_ROTOR1_AX 1
@@ -69,7 +69,7 @@ param set-default CA_ROTOR1_AY 1
 param set-default CA_ROTOR1_AZ 0
 param set-default CA_ROTOR1_KM 0
 param set-default CA_ROTOR1_PX 0.14
-param set-default CA_ROTOR1_PY -0.10
+param set-default CA_ROTOR1_PY -0.1
 param set-default CA_ROTOR1_PZ 0.06
 
 param set-default CA_ROTOR2_AX 1
@@ -77,7 +77,7 @@ param set-default CA_ROTOR2_AY 1
 param set-default CA_ROTOR2_AZ 0
 param set-default CA_ROTOR2_KM 0
 param set-default CA_ROTOR2_PX -0.14
-param set-default CA_ROTOR2_PY 0.10
+param set-default CA_ROTOR2_PY 0.1
 param set-default CA_ROTOR2_PZ 0.06
 
 param set-default CA_ROTOR3_AX 1
@@ -85,7 +85,7 @@ param set-default CA_ROTOR3_AY -1
 param set-default CA_ROTOR3_AZ 0
 param set-default CA_ROTOR3_KM 0
 param set-default CA_ROTOR3_PX -0.14
-param set-default CA_ROTOR3_PY -0.10
+param set-default CA_ROTOR3_PY -0.1
 param set-default CA_ROTOR3_PZ 0.06
 
 param set-default CA_ROTOR4_AX 0

--- a/ROMFS/px4fmu_common/init.d/airframes/70000_atmos
+++ b/ROMFS/px4fmu_common/init.d/airframes/70000_atmos
@@ -49,67 +49,67 @@ param set-default FD_FAIL_R 0
 
 param set-default CA_ROTOR0_PX -0.12
 param set-default CA_ROTOR0_PY -0.12
-param set-default CA_ROTOR0_PZ 0.0
+param set-default CA_ROTOR0_PZ 0
 param set-default CA_ROTOR0_CT 1.4
-param set-default CA_ROTOR0_AX 1.0
-param set-default CA_ROTOR0_AY 0.0
-param set-default CA_ROTOR0_AZ 0.0
+param set-default CA_ROTOR0_AX 1
+param set-default CA_ROTOR0_AY 0
+param set-default CA_ROTOR0_AZ 0
 
 param set-default CA_ROTOR1_PX 0.12
 param set-default CA_ROTOR1_PY -0.12
-param set-default CA_ROTOR1_PZ 0.0
+param set-default CA_ROTOR1_PZ 0
 param set-default CA_ROTOR1_CT 1.4
-param set-default CA_ROTOR1_AX -1.0
-param set-default CA_ROTOR1_AY 0.0
-param set-default CA_ROTOR1_AZ 0.0
+param set-default CA_ROTOR1_AX -1
+param set-default CA_ROTOR1_AY 0
+param set-default CA_ROTOR1_AZ 0
 
 param set-default CA_ROTOR2_PX -0.12
 param set-default CA_ROTOR2_PY 0.12
-param set-default CA_ROTOR2_PZ 0.0
+param set-default CA_ROTOR2_PZ 0
 param set-default CA_ROTOR2_CT 1.4
-param set-default CA_ROTOR2_AX 1.0
-param set-default CA_ROTOR2_AY 0.0
-param set-default CA_ROTOR2_AZ 0.0
+param set-default CA_ROTOR2_AX 1
+param set-default CA_ROTOR2_AY 0
+param set-default CA_ROTOR2_AZ 0
 
 param set-default CA_ROTOR3_PX 0.12
 param set-default CA_ROTOR3_PY 0.12
-param set-default CA_ROTOR3_PZ 0.0
+param set-default CA_ROTOR3_PZ 0
 param set-default CA_ROTOR3_CT 1.4
-param set-default CA_ROTOR3_AX -1.0
-param set-default CA_ROTOR3_AY 0.0
-param set-default CA_ROTOR3_AZ 0.0
+param set-default CA_ROTOR3_AX -1
+param set-default CA_ROTOR3_AY 0
+param set-default CA_ROTOR3_AZ 0
 
 param set-default CA_ROTOR4_PX 0.12
 param set-default CA_ROTOR4_PY -0.12
-param set-default CA_ROTOR4_PZ 0.0
+param set-default CA_ROTOR4_PZ 0
 param set-default CA_ROTOR4_CT 1.4
-param set-default CA_ROTOR4_AX 0.0
-param set-default CA_ROTOR4_AY 1.0
-param set-default CA_ROTOR4_AZ 0.0
+param set-default CA_ROTOR4_AX 0
+param set-default CA_ROTOR4_AY 1
+param set-default CA_ROTOR4_AZ 0
 
 param set-default CA_ROTOR5_PX 0.12
 param set-default CA_ROTOR5_PY 0.12
-param set-default CA_ROTOR5_PZ 0.0
+param set-default CA_ROTOR5_PZ 0
 param set-default CA_ROTOR5_CT 1.4
-param set-default CA_ROTOR5_AX 0.0
-param set-default CA_ROTOR5_AY -1.0
-param set-default CA_ROTOR5_AZ 0.0
+param set-default CA_ROTOR5_AX 0
+param set-default CA_ROTOR5_AY -1
+param set-default CA_ROTOR5_AZ 0
 
 param set-default CA_ROTOR6_PX -0.12
 param set-default CA_ROTOR6_PY -0.12
-param set-default CA_ROTOR6_PZ 0.0
+param set-default CA_ROTOR6_PZ 0
 param set-default CA_ROTOR6_CT 1.4
-param set-default CA_ROTOR6_AX 0.0
-param set-default CA_ROTOR6_AY 1.0
-param set-default CA_ROTOR6_AZ 0.0
+param set-default CA_ROTOR6_AX 0
+param set-default CA_ROTOR6_AY 1
+param set-default CA_ROTOR6_AZ 0
 
 param set-default CA_ROTOR7_PX -0.12
 param set-default CA_ROTOR7_PY 0.12
-param set-default CA_ROTOR7_PZ 0.0
+param set-default CA_ROTOR7_PZ 0
 param set-default CA_ROTOR7_CT 1.4
-param set-default CA_ROTOR7_AX 0.0
-param set-default CA_ROTOR7_AY -1.0
-param set-default CA_ROTOR7_AZ 0.0
+param set-default CA_ROTOR7_AX 0
+param set-default CA_ROTOR7_AY -1
+param set-default CA_ROTOR7_AZ 0
 
 
 param set-default PWM_AUX_TIM0 10
@@ -159,4 +159,4 @@ param set-default SC_PITCHRATE_P 0.14
 param set-default SC_ROLLRATE_I 0.3
 param set-default SC_PITCHRATE_I 0.3
 param set-default SC_ROLLRATE_D 0.004
-param set-default SC_PITCHRATE_D 0.00
+param set-default SC_PITCHRATE_D 0

--- a/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -19,4 +19,4 @@ param set-default RTL_RETURN_ALT 30
 param set-default RTL_DESCEND_ALT 10
 
 # lower RNG_FOG since MC are expected to fly closer over obstacles
-param set-default EKF2_RNG_FOG 1.0
+param set-default EKF2_RNG_FOG 1

--- a/ROMFS/px4fmu_common/init.d/rc.rover_ackermann_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.rover_ackermann_defaults
@@ -2,10 +2,10 @@
 # Ackermann rover parameters.
 
 set VEHICLE_TYPE rover_ackermann
-param set-default MAV_TYPE 10           # MAV_TYPE_GROUND_ROVER
-param set-default CA_AIRFRAME 5         # Rover (Ackermann)
-param set-default CA_R_REV 1            # Motor is assumed to be reversible
-param set-default EKF2_MAG_TYPE 1       # Make sure magnetometer is fused even when not flying
-param set-default NAV_ACC_RAD 0.5       # Waypoint acceptance radius
+param set-default MAV_TYPE 10 # MAV_TYPE_GROUND_ROVER
+param set-default CA_AIRFRAME 5 # Rover (Ackermann)
+param set-default CA_R_REV 1 # Motor is assumed to be reversible
+param set-default EKF2_MAG_TYPE 1 # Make sure magnetometer is fused even when not flying
+param set-default NAV_ACC_RAD 0.5 # Waypoint acceptance radius
 param set-default EKF2_GBIAS_INIT 0.01
 param set-default EKF2_ANGERR_INIT 0.01

--- a/ROMFS/px4fmu_common/init.d/rc.rover_differential_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.rover_differential_defaults
@@ -2,10 +2,10 @@
 # Differential rover parameters.
 
 set VEHICLE_TYPE rover_differential
-param set-default MAV_TYPE 10           # MAV_TYPE_GROUND_ROVER
-param set-default CA_AIRFRAME 6         # Rover (Differential)
-param set-default CA_R_REV 3            # Right and left motors reversible
-param set-default EKF2_MAG_TYPE 1       # Make sure magnetometer is fused even when not flying
-param set-default NAV_ACC_RAD 0.5       # Waypoint acceptance radius
+param set-default MAV_TYPE 10 # MAV_TYPE_GROUND_ROVER
+param set-default CA_AIRFRAME 6 # Rover (Differential)
+param set-default CA_R_REV 3 # Right and left motors reversible
+param set-default EKF2_MAG_TYPE 1 # Make sure magnetometer is fused even when not flying
+param set-default NAV_ACC_RAD 0.5 # Waypoint acceptance radius
 param set-default EKF2_GBIAS_INIT 0.01
 param set-default EKF2_ANGERR_INIT 0.01

--- a/ROMFS/px4fmu_common/init.d/rc.rover_mecanum_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.rover_mecanum_defaults
@@ -2,9 +2,9 @@
 # Mecanum rover parameters.
 
 set VEHICLE_TYPE rover_mecanum
-param set-default MAV_TYPE 10     # MAV_TYPE_GROUND_ROVER
-param set-default CA_AIRFRAME 13  # Rover (Mecanum)
-param set-default CA_R_REV 15     # Right and left motors reversible
+param set-default MAV_TYPE 10 # MAV_TYPE_GROUND_ROVER
+param set-default CA_AIRFRAME 13 # Rover (Mecanum)
+param set-default CA_R_REV 15 # Right and left motors reversible
 param set-default EKF2_MAG_TYPE 1 # make sure magnetometer is fused even when not flying
 param set-default NAV_ACC_RAD 0.5 # Waypoint acceptance radius
 param set-default EKF2_GBIAS_INIT 0.01

--- a/ROMFS/px4fmu_common/init.d/rc.sc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.sc_defaults
@@ -14,7 +14,7 @@ param set-default CBRK_SUPPLY_CHK 894281
 param set-default COM_ARM_HFLT_CHK 0
 
 #Missing params
-param set-default CP_DIST -1.0
+param set-default CP_DIST -1
 
 # Default to MoCap fusion
 param set-default ATT_EXT_HDG_M 2

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -16,7 +16,7 @@ fi
 # Start batmon driver if enabled using BATMON_DRIVER_EN
 if param compare -s BATMON_DRIVER_EN 1
 then
-	batmon start -X  #start on external bus
+	batmon start -X # start on external bus
 fi
 
 # Sensors on the PWM interface bank

--- a/ROMFS/px4fmu_common/init.d/rc.uuv_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.uuv_defaults
@@ -16,7 +16,7 @@ param set-default CBRK_SUPPLY_CHK 894281
 param set-default COM_ARM_HFLT_CHK 0
 
 #Missing params
-param set-default CP_DIST -1.0
+param set-default CP_DIST -1
 
 # Default to MoCap fusion
 param set-default ATT_EXT_HDG_M 2

--- a/Tools/px_romfs_pruner.py
+++ b/Tools/px_romfs_pruner.py
@@ -108,7 +108,9 @@ def main():
 
                     if not line.isspace() \
                             and not line.strip().startswith("#"):
-                        pruned_content += line.strip() + "\n"
+                        stripped = re.sub(r'[ \t]+#.*$', '', line.strip())
+                        if stripped:
+                            pruned_content += stripped + "\n"
             # delete the file if it doesn't contain the architecture
             # write out the pruned content else
             if not board_excluded:

--- a/Tools/px_romfs_pruner.py
+++ b/Tools/px_romfs_pruner.py
@@ -109,6 +109,7 @@ def main():
                     if not line.isspace() \
                             and not line.strip().startswith("#"):
                         stripped = re.sub(r'[ \t]+#.*$', '', line.strip())
+                        stripped = re.sub(r' {2,}', ' ', stripped)
                         if stripped:
                             pruned_content += stripped + "\n"
             # delete the file if it doesn't contain the architecture


### PR DESCRIPTION
### Solved Problem
Save flash wasted to useless ROMFS characters.

### Solution
- Remove trailing zeroes in parameter values from ROMFS
- Remove alignment whitespace from ROMFS scripts
- Strip end of line comments in romfs_pruner  (by far biggest saving)
- Strip inline multi-whitespace in romfs_pruner

### Changelog Entry
```
Safe flash pruning more unnecessary characters from ROMFS
```

### Test coverage
Haven't tested this in depth yet.