### PR TITLE
fix(barometer): update i2c speed for bmp581 to 400khz

### DIFF
--- a/src/drivers/barometer/bmp581/bmp581_main.cpp
+++ b/src/drivers/barometer/bmp581/bmp581_main.cpp
@@ -94,7 +94,7 @@ extern "C" int bmp581_main(int argc, char *argv[])
 	using ThisDriver = BMP581;
 	BusCLIArguments cli{true, true};
 	cli.i2c_address = 0x46;
-	cli.default_i2c_frequency = 100 * 1000;
+	cli.default_i2c_frequency = 400 * 1000;
 	cli.default_spi_frequency = 10 * 1000 * 1000;
 
 	const char *verb = cli.parseDefaultArguments(argc, argv);


### PR DESCRIPTION


### Solved Problem
Update speed to 400khz. The previous 100khz may have been carried over/copied from a previous gen bosch baro driver.

### Solution
Increase to 400khz to match with other devices at 400khz on the same I2C bus (such as the v6x sensors board mags, e.g. BMM350 or EEPROM)

### Changelog Entry

For release notes:
```
Fix: update i2c speed for bosch bmp581 barometer

```

### Alternatives
Leave as-is
### Test coverage

### Context



