### PR TITLE
fix(drivers): handle AS-DT1 Max Distance Bins

### DIFF
--- a/src/drivers/distance_sensor/sony/sony_asdt1.cpp
+++ b/src/drivers/distance_sensor/sony/sony_asdt1.cpp
@@ -1332,6 +1332,8 @@ int AS_DT1::process_frame(const uint8_t *frame, size_t length)
 		_obstacle_distance.distances[i] = UINT16_MAX;
 	}
 
+	const uint16_t no_obstacle_cm = _obstacle_distance.max_distance + 1;
+
 	// Only publish the rows that cover the horizontal band used by obstacle_distance.
 	for (size_t sample = 0; sample < sample_count; sample++) {
 		const int layout_index = sample_to_layout_index(sample, _range_mode);
@@ -1352,6 +1354,10 @@ int AS_DT1::process_frame(const uint8_t *frame, size_t length)
 			continue;
 		}
 
+		if (_obstacle_distance.distances[bin] == UINT16_MAX) {
+			_obstacle_distance.distances[bin] = no_obstacle_cm;
+		}
+
 		const uint32_t z_raw = decode_20bit_raw(frame, sample);
 
 		if (z_raw == 0) {
@@ -1370,7 +1376,7 @@ int AS_DT1::process_frame(const uint8_t *frame, size_t length)
 						      _obstacle_distance.max_distance + 1 : distance_cm;
 
 		if (obstacle_distance_cm < _obstacle_distance.distances[bin]) {
-			if (_obstacle_distance.distances[bin] == UINT16_MAX) {
+			if (_obstacle_distance.distances[bin] > _obstacle_distance.max_distance) {
 				_last_valid_bins++;
 			}
 


### PR DESCRIPTION
### Solved Problem

Fixes an edge case in the Sony AS-DT1 distance sensor driver where valid frames with no in-range returns left covered obstacle bins as `UINT16_MAX`.

PX4 collision prevention interprets `UINT16_MAX` as unknown/no data, so open-field operation could be treated as missing obstacle data even though the AS-DT1 was publishing valid frames.

### Solution

For each valid AS-DT1 frame, bins covered by the selected Sony FOV now default to `max_distance + 1`, matching the `obstacle_distance` definition for "no obstacle present".

Measured returns still overwrite those bins with the closest detected distance. Bins outside the Sony FOV remain `UINT16_MAX`.

This does not change startup, parsing, scheduling, or serial behavior.

### Changelog Entry

Bugfix: Sony AS-DT1 publishes clear in-FOV obstacle bins as no-obstacle instead of unknown.

### Test coverage

Tested on hardware with Sony AS-DT1 and PX4 collision prevention enabled.

Evidence/logs:
Flight Log 1: https://review.px4.io/plot_app?log=29fa57cb-0ddf-41ad-aab2-742077301cd9
Flight Log 2: https://review.px4.io/plot_app?log=b39a1198-4539-46c2-b353-bcb0140fdc7a

### Context

This is a follow-up fix for the Sony AS-DT1 driver added in #27769.