### PR TITLE
feat(uavcan): add HobbyWing ESC driver (com.hobbywing.esc)

### DIFF
--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -162,6 +162,7 @@ px4_add_module(
 
 		# Actuators
 		actuators/esc.cpp
+		$<$<BOOL:${CONFIG_UAVCAN_HOBBYWING_ESC}>:actuators/esc_hobbywing.cpp>
 		actuators/hardpoint.cpp
 		actuators/servo.cpp
 

--- a/src/drivers/uavcan/Kconfig
+++ b/src/drivers/uavcan/Kconfig
@@ -18,6 +18,11 @@ if DRIVERS_UAVCAN
         bool "Include servo & ESC controller"
         default y
 
+    config UAVCAN_HOBBYWING_ESC
+        bool "Include HobbyWing ESC support (com.hobbywing.esc)"
+        default y
+        depends on UAVCAN_OUTPUTS_CONTROLLER
+
     config UAVCAN_HARDPOINT_CONTROLLER
         bool "Include hardpoint controller"
         default y

--- a/src/drivers/uavcan/actuators/esc_hobbywing.cpp
+++ b/src/drivers/uavcan/actuators/esc_hobbywing.cpp
@@ -1,0 +1,311 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2024-2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file esc_hobbywing.cpp
+ *
+ * DroneCAN driver for HobbyWing ESCs (com.hobbywing.esc namespace).
+ *
+ * Protocol overview:
+ *   Discovery (disarmed only):
+ *     FC broadcasts GetEscID (DTID 20013) with payload[0]=0 every 1 second.
+ *     Each ESC responds with payload[0]=its_node_id, payload[1]=throttle_channel (1-based).
+ *     The node_id -> motor_slot table is built from these responses.
+ *
+ *   Command:
+ *     com.hobbywing.esc.RawCommand (DTID 20100), int14[<=8] per-ESC commands.
+ *     All ESCs receive the same broadcast; each takes the command at its
+ *     throttle_channel index.
+ *
+ *   Telemetry:
+ *     StatusMsg1 (DTID 20050): rpm, pwm, status
+ *     StatusMsg2 (DTID 20051): input_voltage (0.1V), current (0.1A), temperature (degC)
+ *     StatusMsg3 (DTID 20052): MOS_T, CAP_T, Motor_T (all degC)
+ */
+
+#include <px4_platform_common/px4_config.h>
+
+#ifdef CONFIG_UAVCAN_HOBBYWING_ESC
+
+#include "esc_hobbywing.hpp"
+#include <systemlib/err.h>
+#include <parameters/param.h>
+#include <drivers/drv_hrt.h>
+#include <cmath>
+
+using namespace time_literals;
+
+UavcanHobbyWingEscController::UavcanHobbyWingEscController(uavcan::INode &node) :
+	_node(node),
+	_pub_raw_cmd(node),
+	_pub_get_esc_id(node),
+	_sub_get_esc_id(node),
+	_sub_status_msg1(node),
+	_sub_status_msg2(node),
+	_sub_status_msg3(node),
+	_get_esc_id_timer(node)
+{
+	memset(_node_id_to_slot, SLOT_UNMAPPED, sizeof(_node_id_to_slot));
+	_pub_raw_cmd.setPriority(uavcan::TransferPriority::NumericallyMin);  // Highest priority
+}
+
+int UavcanHobbyWingEscController::init()
+{
+	// Subscribe to GetEscID — handles both our own echoed requests (len=1, ignored)
+	// and ESC responses (len=2: [node_id, throttle_channel])
+	int res = _sub_get_esc_id.start(GetEscIDCbBinder(this, &UavcanHobbyWingEscController::handle_GetEscID));
+
+	if (res < 0) {
+		PX4_ERR("HobbyWing: GetEscID sub failed %i", res);
+		return res;
+	}
+
+	res = _sub_status_msg1.start(StatusMsg1CbBinder(this, &UavcanHobbyWingEscController::handle_StatusMsg1));
+
+	if (res < 0) {
+		PX4_ERR("HobbyWing: StatusMsg1 sub failed %i", res);
+		return res;
+	}
+
+	res = _sub_status_msg2.start(StatusMsg2CbBinder(this, &UavcanHobbyWingEscController::handle_StatusMsg2));
+
+	if (res < 0) {
+		PX4_ERR("HobbyWing: StatusMsg2 sub failed %i", res);
+		return res;
+	}
+
+	res = _sub_status_msg3.start(StatusMsg3CbBinder(this, &UavcanHobbyWingEscController::handle_StatusMsg3));
+
+	if (res < 0) {
+		PX4_ERR("HobbyWing: StatusMsg3 sub failed %i", res);
+		return res;
+	}
+
+	// Apply CAN interface mask from parameter (same as standard ESC driver)
+	int32_t iface_mask{0xFF};
+
+	if (param_get(param_find("UAVCAN_ESC_IFACE"), &iface_mask) == OK) {
+		_pub_raw_cmd.getTransferSender().setIfaceMask(iface_mask);
+		_pub_get_esc_id.getTransferSender().setIfaceMask(iface_mask);
+	}
+
+	// Start 1 Hz GetEscID discovery timer. The callback skips broadcasting
+	// while the vehicle is armed to prevent mid-flight ESC stutter.
+	_get_esc_id_timer.setCallback(TimerCbBinder(this, &UavcanHobbyWingEscController::get_esc_id_timer_cb));
+	_get_esc_id_timer.startPeriodic(uavcan::MonotonicDuration::fromMSec(1000));
+
+	_esc_status_pub.advertise();
+
+	_initialized = true;
+	return 0;
+}
+
+// ---------------------------------------------------------------------------
+// GetEscID discovery
+// ---------------------------------------------------------------------------
+
+void UavcanHobbyWingEscController::get_esc_id_timer_cb(const uavcan::TimerEvent &)
+{
+	// Stop discovery broadcasts while armed — avoids any transient command glitch
+	actuator_armed_s armed{};
+
+	if (_actuator_armed_sub.copy(&armed) && armed.armed) {
+		return;
+	}
+
+	com::hobbywing::esc::GetEscID msg{};
+	msg.payload.push_back(0);  // 1-byte request; ESC replies with [node_id, channel]
+	_pub_get_esc_id.broadcast(msg);
+}
+
+void UavcanHobbyWingEscController::handle_GetEscID(
+	const uavcan::ReceivedDataStructure<com::hobbywing::esc::GetEscID> &msg)
+{
+	// ESC responses have 2 bytes: [node_id, throttle_channel (1-based)]
+	// Our own broadcast requests echo back with 1 byte — ignore those
+	if (msg.payload.size() != 2) {
+		return;
+	}
+
+	const uint8_t esc_node_id      = msg.getSrcNodeID().get();
+	const uint8_t throttle_channel = msg.payload[1];
+
+	if (esc_node_id == 0 || esc_node_id >= sizeof(_node_id_to_slot)) {
+		return;
+	}
+
+	if (throttle_channel == 0 || throttle_channel > MAX_ACTUATORS) {
+		PX4_WARN("HobbyWing: node %u reported invalid throttle_channel %u",
+			 esc_node_id, throttle_channel);
+		return;
+	}
+
+	const uint8_t slot = throttle_channel - 1;  // convert to 0-based motor slot
+
+	if (_node_id_to_slot[esc_node_id] != slot) {
+		PX4_INFO("HobbyWing: ESC node %u -> motor slot %u", esc_node_id, slot);
+		_node_id_to_slot[esc_node_id] = slot;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Command output
+// ---------------------------------------------------------------------------
+
+void UavcanHobbyWingEscController::update_outputs(float outputs[MAX_ACTUATORS], uint8_t output_array_size)
+{
+	const auto timestamp = _node.getMonotonicTime();
+
+	if ((timestamp - _prev_cmd_pub).toUSec() < (1000000 / MAX_RATE_HZ)) {
+		return;
+	}
+
+	_prev_cmd_pub = timestamp;
+
+	com::hobbywing::esc::RawCommand msg{};
+
+	for (unsigned i = 0; i < output_array_size; i++) {
+		msg.command.push_back(static_cast<int>(lroundf(outputs[i])));
+	}
+
+	_pub_raw_cmd.broadcast(msg);
+}
+
+void UavcanHobbyWingEscController::set_rotor_count(uint8_t count)
+{
+	_rotor_count = count;
+}
+
+// ---------------------------------------------------------------------------
+// Node ID -> slot helper
+// ---------------------------------------------------------------------------
+
+int8_t UavcanHobbyWingEscController::node_id_to_slot_idx(uint8_t node_id) const
+{
+	if (node_id == 0 || node_id >= sizeof(_node_id_to_slot)) {
+		return -1;
+	}
+
+	const uint8_t slot = _node_id_to_slot[node_id];
+
+	return (slot == SLOT_UNMAPPED || slot >= MAX_ACTUATORS) ? -1 : static_cast<int8_t>(slot);
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry callbacks
+// ---------------------------------------------------------------------------
+
+void UavcanHobbyWingEscController::handle_StatusMsg1(
+	const uavcan::ReceivedDataStructure<com::hobbywing::esc::StatusMsg1> &msg)
+{
+	const int8_t slot = node_id_to_slot_idx(msg.getSrcNodeID().get());
+
+	if (slot < 0) {
+		return;  // ESC not yet discovered via GetEscID
+	}
+
+	esc_report_s &ref = _esc_status.esc[slot];
+	ref.timestamp   = hrt_absolute_time();
+	ref.esc_rpm     = static_cast<int32_t>(msg.rpm);
+	// HobbyWing 'pwm' is a throttle echo, nominally 0-1000; scale to esc_power [0-100%]
+	ref.esc_power   = static_cast<int8_t>(msg.pwm > 1000u ? 100 : msg.pwm / 10u);
+
+	_esc_status.esc_count          = _rotor_count;
+	_esc_status.counter            += 1;
+	_esc_status.esc_connectiontype  = esc_status_s::ESC_CONNECTION_TYPE_CAN;
+	_esc_status.esc_online_flags    = check_escs_status();
+	_esc_status.esc_armed_flags     = 0;  // Not encoded in HobbyWing protocol
+	_esc_status.timestamp           = ref.timestamp;
+	_esc_status_pub.publish(_esc_status);
+}
+
+void UavcanHobbyWingEscController::handle_StatusMsg2(
+	const uavcan::ReceivedDataStructure<com::hobbywing::esc::StatusMsg2> &msg)
+{
+	const int8_t slot = node_id_to_slot_idx(msg.getSrcNodeID().get());
+
+	if (slot < 0) {
+		return;
+	}
+
+	esc_report_s &ref   = _esc_status.esc[slot];
+	ref.timestamp       = hrt_absolute_time();
+	ref.esc_voltage     = msg.input_voltage * 0.1f;        // 0.1V units -> Volts
+	ref.esc_current     = msg.current * 0.1f;              // 0.1A units -> Amps
+	ref.esc_temperature = static_cast<float>(msg.temperature);  // degC (direct, no conversion)
+
+	_esc_status.esc_count          = _rotor_count;
+	_esc_status.counter            += 1;
+	_esc_status.esc_connectiontype  = esc_status_s::ESC_CONNECTION_TYPE_CAN;
+	_esc_status.esc_online_flags    = check_escs_status();
+	_esc_status.timestamp           = ref.timestamp;
+	_esc_status_pub.publish(_esc_status);
+}
+
+void UavcanHobbyWingEscController::handle_StatusMsg3(
+	const uavcan::ReceivedDataStructure<com::hobbywing::esc::StatusMsg3> &msg)
+{
+	const int8_t slot = node_id_to_slot_idx(msg.getSrcNodeID().get());
+
+	if (slot < 0) {
+		return;
+	}
+
+	esc_report_s &ref     = _esc_status.esc[slot];
+	ref.timestamp         = hrt_absolute_time();
+	// Use the highest temperature among MOSFET and capacitor as the ESC temperature
+	ref.esc_temperature   = static_cast<float>(msg.MOS_T > msg.CAP_T ? msg.MOS_T : msg.CAP_T);
+	ref.motor_temperature = static_cast<int16_t>(msg.Motor_T);
+
+	// Timestamp update keeps the freshness checker happy; StatusMsg1 drives the publish cycle.
+}
+
+// ---------------------------------------------------------------------------
+// Online check
+// ---------------------------------------------------------------------------
+
+uint16_t UavcanHobbyWingEscController::check_escs_status()
+{
+	uint16_t online_flags = 0;
+	const hrt_abstime now = hrt_absolute_time();
+
+	for (int i = 0; i < MAX_ACTUATORS; i++) {
+		if (_esc_status.esc[i].timestamp > 0 && now - _esc_status.esc[i].timestamp < 1200_ms) {
+			online_flags |= (1 << i);
+		}
+	}
+
+	return online_flags;
+}
+
+#endif // CONFIG_UAVCAN_HOBBYWING_ESC

--- a/src/drivers/uavcan/actuators/esc_hobbywing.cpp
+++ b/src/drivers/uavcan/actuators/esc_hobbywing.cpp
@@ -244,7 +244,9 @@ void UavcanHobbyWingEscController::handle_StatusMsg1(
 	_esc_status.counter            += 1;
 	_esc_status.esc_connectiontype  = esc_status_s::ESC_CONNECTION_TYPE_CAN;
 	_esc_status.esc_online_flags    = check_escs_status();
-	_esc_status.esc_armed_flags     = 0;  // Not encoded in HobbyWing protocol
+	// HobbyWing protocol does not encode arming state; assume all configured ESCs are
+	// armed so commander's EscChecks ((1<<esc_count)-1) does not false-trip a failsafe.
+	_esc_status.esc_armed_flags     = (1 << _rotor_count) - 1;
 	_esc_status.timestamp           = ref.timestamp;
 	_esc_status_pub.publish(_esc_status);
 }
@@ -264,12 +266,7 @@ void UavcanHobbyWingEscController::handle_StatusMsg2(
 	ref.esc_current     = msg.current * 0.1f;              // 0.1A units -> Amps
 	ref.esc_temperature = static_cast<float>(msg.temperature);  // degC (direct, no conversion)
 
-	_esc_status.esc_count          = _rotor_count;
-	_esc_status.counter            += 1;
-	_esc_status.esc_connectiontype  = esc_status_s::ESC_CONNECTION_TYPE_CAN;
-	_esc_status.esc_online_flags    = check_escs_status();
-	_esc_status.timestamp           = ref.timestamp;
-	_esc_status_pub.publish(_esc_status);
+	// Update per-ESC fields only; StatusMsg1 drives the publish cycle (matches StatusMsg3).
 }
 
 void UavcanHobbyWingEscController::handle_StatusMsg3(

--- a/src/drivers/uavcan/actuators/esc_hobbywing.hpp
+++ b/src/drivers/uavcan/actuators/esc_hobbywing.hpp
@@ -1,0 +1,155 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2024-2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file esc_hobbywing.hpp
+ *
+ * DroneCAN driver for HobbyWing ESCs (com.hobbywing.esc namespace).
+ *
+ * HobbyWing ESCs do not include an esc_index field in their status messages.
+ * Instead, a GetEscID discovery protocol maps CAN node IDs to motor slots
+ * before arming. While disarmed, the FC broadcasts GetEscID (DTID 20013)
+ * every 1 second; each ESC responds with [node_id, throttle_channel].
+ *
+ * Default ESC settings: CAN node ID = 1, bitrate = 500 kbps.
+ * Change via SetID (DTID 210) and SetBaud (DTID 211) services using the
+ * DroneCAN GUI Tool, or use the HobbyWing PC configuration software.
+ */
+
+#pragma once
+
+#ifdef CONFIG_UAVCAN_HOBBYWING_ESC
+
+#include <uavcan/uavcan.hpp>
+#include <com/hobbywing/esc/RawCommand.hpp>
+#include <com/hobbywing/esc/GetEscID.hpp>
+#include <com/hobbywing/esc/StatusMsg1.hpp>
+#include <com/hobbywing/esc/StatusMsg2.hpp>
+#include <com/hobbywing/esc/StatusMsg3.hpp>
+#include <uORB/PublicationMulti.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/esc_status.h>
+#include <uORB/topics/esc_report.h>
+#include <uORB/topics/actuator_armed.h>
+#include <lib/mixer_module/mixer_module.hpp>
+#include <drivers/drv_hrt.h>
+#include "../node_info.hpp"
+
+/**
+ * DroneCAN ESC controller for HobbyWing ESCs.
+ *
+ * Exposes the same public interface as UavcanEscController so it can be
+ * used interchangeably by UavcanMixingInterfaceHobbyWingESC.
+ */
+class UavcanHobbyWingEscController
+{
+public:
+	static constexpr int     MAX_ACTUATORS = esc_status_s::CONNECTED_ESC_MAX;
+	static constexpr unsigned MAX_RATE_HZ  = 200;
+	static constexpr uint8_t  SLOT_UNMAPPED = 0xFF;
+
+	UavcanHobbyWingEscController(uavcan::INode &node);
+	~UavcanHobbyWingEscController() = default;
+
+	int  init();
+	bool initialized() const { return _initialized; }
+
+	void update_outputs(float outputs[MAX_ACTUATORS], uint8_t output_array_size);
+	void set_rotor_count(uint8_t count);
+	void set_node_info_publisher(NodeInfoPublisher *publisher) { _node_info_publisher = publisher; }
+
+	static int max_output_value() { return 8191; }  ///< int14 max
+
+	esc_status_s &esc_status() { return _esc_status; }
+
+private:
+	void handle_GetEscID(const uavcan::ReceivedDataStructure<com::hobbywing::esc::GetEscID> &msg);
+	void handle_StatusMsg1(const uavcan::ReceivedDataStructure<com::hobbywing::esc::StatusMsg1> &msg);
+	void handle_StatusMsg2(const uavcan::ReceivedDataStructure<com::hobbywing::esc::StatusMsg2> &msg);
+	void handle_StatusMsg3(const uavcan::ReceivedDataStructure<com::hobbywing::esc::StatusMsg3> &msg);
+	void get_esc_id_timer_cb(const uavcan::TimerEvent &);
+
+	uint16_t check_escs_status();
+	int8_t   node_id_to_slot_idx(uint8_t node_id) const;
+
+	typedef uavcan::MethodBinder<UavcanHobbyWingEscController *,
+		void (UavcanHobbyWingEscController::*)(const uavcan::ReceivedDataStructure<com::hobbywing::esc::GetEscID> &)>
+		GetEscIDCbBinder;
+
+	typedef uavcan::MethodBinder<UavcanHobbyWingEscController *,
+		void (UavcanHobbyWingEscController::*)(const uavcan::ReceivedDataStructure<com::hobbywing::esc::StatusMsg1> &)>
+		StatusMsg1CbBinder;
+
+	typedef uavcan::MethodBinder<UavcanHobbyWingEscController *,
+		void (UavcanHobbyWingEscController::*)(const uavcan::ReceivedDataStructure<com::hobbywing::esc::StatusMsg2> &)>
+		StatusMsg2CbBinder;
+
+	typedef uavcan::MethodBinder<UavcanHobbyWingEscController *,
+		void (UavcanHobbyWingEscController::*)(const uavcan::ReceivedDataStructure<com::hobbywing::esc::StatusMsg3> &)>
+		StatusMsg3CbBinder;
+
+	typedef uavcan::MethodBinder<UavcanHobbyWingEscController *,
+		void (UavcanHobbyWingEscController::*)(const uavcan::TimerEvent &)>
+		TimerCbBinder;
+
+	bool _initialized{false};
+
+	/// CAN node ID -> 0-based motor slot (SLOT_UNMAPPED until GetEscID discovery)
+	uint8_t _node_id_to_slot[128];
+
+	esc_status_s _esc_status{};
+	uORB::PublicationMulti<esc_status_s> _esc_status_pub{ORB_ID(esc_status)};
+	uORB::Subscription _actuator_armed_sub{ORB_ID(actuator_armed)};
+
+	uint8_t           _rotor_count{0};
+	uavcan::MonotonicTime _prev_cmd_pub;
+
+	uavcan::INode &_node;
+
+	// Publishers
+	uavcan::Publisher<com::hobbywing::esc::RawCommand> _pub_raw_cmd;
+	uavcan::Publisher<com::hobbywing::esc::GetEscID>   _pub_get_esc_id;
+
+	// Subscribers
+	uavcan::Subscriber<com::hobbywing::esc::GetEscID,   GetEscIDCbBinder>   _sub_get_esc_id;
+	uavcan::Subscriber<com::hobbywing::esc::StatusMsg1, StatusMsg1CbBinder> _sub_status_msg1;
+	uavcan::Subscriber<com::hobbywing::esc::StatusMsg2, StatusMsg2CbBinder> _sub_status_msg2;
+	uavcan::Subscriber<com::hobbywing::esc::StatusMsg3, StatusMsg3CbBinder> _sub_status_msg3;
+
+	/// Periodic timer: broadcasts GetEscID at 1 Hz while disarmed
+	uavcan::TimerEventForwarder<TimerCbBinder> _get_esc_id_timer;
+
+	NodeInfoPublisher *_node_info_publisher{nullptr};
+};
+
+#endif // CONFIG_UAVCAN_HOBBYWING_ESC

--- a/src/drivers/uavcan/actuators/esc_hobbywing.hpp
+++ b/src/drivers/uavcan/actuators/esc_hobbywing.hpp
@@ -63,7 +63,6 @@
 #include <uORB/topics/actuator_armed.h>
 #include <lib/mixer_module/mixer_module.hpp>
 #include <drivers/drv_hrt.h>
-#include "../node_info.hpp"
 
 /**
  * DroneCAN ESC controller for HobbyWing ESCs.
@@ -86,7 +85,6 @@ public:
 
 	void update_outputs(float outputs[MAX_ACTUATORS], uint8_t output_array_size);
 	void set_rotor_count(uint8_t count);
-	void set_node_info_publisher(NodeInfoPublisher *publisher) { _node_info_publisher = publisher; }
 
 	static int max_output_value() { return 8191; }  ///< int14 max
 
@@ -148,8 +146,6 @@ private:
 
 	/// Periodic timer: broadcasts GetEscID at 1 Hz while disarmed
 	uavcan::TimerEventForwarder<TimerCbBinder> _get_esc_id_timer;
-
-	NodeInfoPublisher *_node_info_publisher{nullptr};
 };
 
 #endif // CONFIG_UAVCAN_HOBBYWING_ESC

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -27,6 +27,21 @@ parameters:
       min: 1
       max: 255
       reboot_required: true
+    UAVCAN_ESC_TYPE:
+      description:
+        short: ESC protocol type for UAVCAN output.
+        long: |
+          Selects which DroneCAN ESC protocol to use.
+          0 = Standard UAVCAN ESC (uavcan.equipment.esc.RawCommand).
+          1 = HobbyWing ESC (com.hobbywing.esc.RawCommand). Requires
+          ESCs to have unique node IDs and throttle channels assigned
+          via the SetID service before use. Reboot required.
+      type: enum
+      values:
+        0: Standard UAVCAN ESC
+        1: HobbyWing ESC
+      default: 0
+      reboot_required: true
     UAVCAN_LGT_NUM:
       description:
         short: Number of UAVCAN lights to configure

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -89,6 +89,9 @@ UavcanNode::UavcanNode(uavcan::ICanDriver &can_driver, uavcan::ISystemClock &sys
 #if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
 	_esc_controller(_node),
 	_servo_controller(_node),
+#if defined(CONFIG_UAVCAN_HOBBYWING_ESC)
+	_esc_hobbywing_controller(_node),
+#endif
 #endif
 #if defined(CONFIG_UAVCAN_HARDPOINT_CONTROLLER)
 	_hardpoint_controller(_node),
@@ -121,6 +124,9 @@ UavcanNode::UavcanNode(uavcan::ICanDriver &can_driver, uavcan::ISystemClock &sys
 
 #if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
 	_mixing_interface_esc.mixingOutput().setMaxTopicUpdateRate(1000000 / UavcanEscController::MAX_RATE_HZ);
+#if defined(CONFIG_UAVCAN_HOBBYWING_ESC)
+	_mixing_interface_hobbywing_esc.mixingOutput().setMaxTopicUpdateRate(1000000 / UavcanHobbyWingEscController::MAX_RATE_HZ);
+#endif
 	_mixing_interface_servo.mixingOutput().setMaxTopicUpdateRate(1000000 / UavcanServoController::MAX_RATE_HZ);
 #endif
 }
@@ -415,6 +421,9 @@ UavcanNode::update_params()
 {
 #if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
 	_mixing_interface_esc.updateParams();
+#if defined(CONFIG_UAVCAN_HOBBYWING_ESC)
+	_mixing_interface_hobbywing_esc.updateParams();
+#endif
 	_mixing_interface_servo.updateParams();
 #endif
 }
@@ -451,7 +460,21 @@ UavcanNode::start(uavcan::NodeID node_id, uint32_t bitrate)
 	_instance->ScheduleOnInterval(ScheduleIntervalMs * 1000);
 
 #if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
+#if defined(CONFIG_UAVCAN_HOBBYWING_ESC)
+	{
+		int32_t esc_type = 0;
+		(void)param_get(param_find("UAVCAN_ESC_TYPE"), &esc_type);
+
+		if (esc_type == 1) {
+			_instance->_mixing_interface_hobbywing_esc.ScheduleNow();
+
+		} else {
+			_instance->_mixing_interface_esc.ScheduleNow();
+		}
+	}
+#else
 	_instance->_mixing_interface_esc.ScheduleNow();
+#endif
 	_instance->_mixing_interface_servo.ScheduleNow();
 #endif
 
@@ -534,8 +557,18 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 	(void)param_get(param_find("UAVCAN_ENABLE"), &uavcan_enable);
 
 	if (uavcan_enable > 2) {
+#if defined(CONFIG_UAVCAN_HOBBYWING_ESC)
+		int32_t esc_type = 0;
+		(void)param_get(param_find("UAVCAN_ESC_TYPE"), &esc_type);
 
-		ret = _esc_controller.init();
+		if (esc_type == 1) {
+			ret = _esc_hobbywing_controller.init();
+
+		} else
+#endif
+		{
+			ret = _esc_controller.init();
+		}
 
 		if (ret < 0) {
 			return ret;
@@ -610,7 +643,17 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 	}
 
 #if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
-	_esc_controller.set_node_info_publisher(&_node_info_publisher);
+#if defined(CONFIG_UAVCAN_HOBBYWING_ESC)
+
+	if (_esc_hobbywing_controller.initialized()) {
+		_esc_hobbywing_controller.set_node_info_publisher(&_node_info_publisher);
+
+	} else
+#endif
+	{
+		_esc_controller.set_node_info_publisher(&_node_info_publisher);
+	}
+
 #endif
 
 	/* Set up shared service clients */
@@ -970,7 +1013,11 @@ UavcanNode::Run()
 	}
 
 #if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
-	_arming_status_controller.setActuatorTestRunning(_mixing_interface_esc.isActuatorTestRunning());
+	bool actuator_test_running = _mixing_interface_esc.isActuatorTestRunning();
+#if defined(CONFIG_UAVCAN_HOBBYWING_ESC)
+	actuator_test_running = actuator_test_running || _mixing_interface_hobbywing_esc.isActuatorTestRunning();
+#endif
+	_arming_status_controller.setActuatorTestRunning(actuator_test_running);
 #endif
 
 	perf_end(_cycle_perf);
@@ -982,6 +1029,11 @@ UavcanNode::Run()
 #if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
 		_mixing_interface_esc.mixingOutput().unregister();
 		_mixing_interface_esc.ScheduleClear();
+
+#if defined(CONFIG_UAVCAN_HOBBYWING_ESC)
+		_mixing_interface_hobbywing_esc.mixingOutput().unregister();
+		_mixing_interface_hobbywing_esc.ScheduleClear();
+#endif
 
 		_mixing_interface_servo.mixingOutput().unregister();
 		_mixing_interface_servo.ScheduleClear();
@@ -1147,6 +1199,51 @@ void UavcanMixingInterfaceServo::Run()
 	_mixing_output.updateSubscriptions(false);
 	pthread_mutex_unlock(&_node_mutex);
 }
+
+#if defined(CONFIG_UAVCAN_HOBBYWING_ESC)
+bool UavcanMixingInterfaceHobbyWingESC::updateOutputs(float outputs[MAX_ACTUATORS], unsigned num_outputs,
+		unsigned num_control_groups_updated)
+{
+	if (_esc_controller.initialized()) {
+		uint8_t output_array_size = 0;
+
+		for (int i = MAX_ACTUATORS - 1; i >= 0; i--) {
+			if (mixingOutput().isFunctionSet(i)) {
+				output_array_size = i + 1;
+				break;
+			}
+		}
+
+		_esc_controller.update_outputs(outputs, output_array_size);
+	}
+
+	return true;
+}
+
+void UavcanMixingInterfaceHobbyWingESC::Run()
+{
+	pthread_mutex_lock(&_node_mutex);
+	_mixing_output.update();
+	_mixing_output.updateSubscriptions(false);
+	pthread_mutex_unlock(&_node_mutex);
+}
+
+void UavcanMixingInterfaceHobbyWingESC::mixerChanged()
+{
+	int rotor_count = 0;
+
+	for (unsigned i = 0; i < MAX_ACTUATORS; ++i) {
+		rotor_count += _mixing_output.isFunctionSet(i);
+
+		if (i < esc_status_s::CONNECTED_ESC_MAX) {
+			_esc_controller.esc_status().esc[i].actuator_function = (uint8_t)_mixing_output.outputFunction(i);
+		}
+	}
+
+	_esc_controller.set_rotor_count(rotor_count);
+}
+#endif // CONFIG_UAVCAN_HOBBYWING_ESC
+
 #endif
 
 void

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -643,17 +643,7 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 	}
 
 #if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
-#if defined(CONFIG_UAVCAN_HOBBYWING_ESC)
-
-	if (_esc_hobbywing_controller.initialized()) {
-		_esc_hobbywing_controller.set_node_info_publisher(&_node_info_publisher);
-
-	} else
-#endif
-	{
-		_esc_controller.set_node_info_publisher(&_node_info_publisher);
-	}
-
+	_esc_controller.set_node_info_publisher(&_node_info_publisher);
 #endif
 
 	/* Set up shared service clients */

--- a/src/drivers/uavcan/uavcan_main.hpp
+++ b/src/drivers/uavcan/uavcan_main.hpp
@@ -50,6 +50,9 @@
 #if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
 #include "actuators/esc.hpp"
 #include "actuators/servo.hpp"
+#if defined(CONFIG_UAVCAN_HOBBYWING_ESC)
+#include "actuators/esc_hobbywing.hpp"
+#endif
 #endif
 
 #if defined(CONFIG_UAVCAN_HARDPOINT_CONTROLLER)
@@ -173,6 +176,39 @@ private:
 	UavcanServoController &_servo_controller;
 	MixingOutput _mixing_output{"UAVCAN_SV", UavcanServoController::MAX_ACTUATORS, *this, MixingOutput::SchedulingPolicy::Auto, false, false};
 };
+
+#if defined(CONFIG_UAVCAN_HOBBYWING_ESC)
+/**
+ * UAVCAN mixing class for HobbyWing ESCs.
+ * Uses the same UAVCAN_EC parameter namespace as UavcanMixingInterfaceESC so
+ * motor function assignments are shared between ESC protocol variants.
+ */
+class UavcanMixingInterfaceHobbyWingESC : public OutputModuleInterface
+{
+public:
+	UavcanMixingInterfaceHobbyWingESC(pthread_mutex_t &node_mutex, UavcanHobbyWingEscController &esc_controller)
+		: OutputModuleInterface(MODULE_NAME "-actuators-esc-hw", px4::wq_configurations::uavcan),
+		  _node_mutex(node_mutex),
+		  _esc_controller(esc_controller) {}
+
+	bool updateOutputs(float outputs[MAX_ACTUATORS], unsigned num_outputs, unsigned num_control_groups_updated) override;
+
+	void mixerChanged() override;
+
+	MixingOutput &mixingOutput() { return _mixing_output; }
+
+	bool isActuatorTestRunning() const { return _mixing_output.isActuatorTestRunning(); }
+
+protected:
+	void Run() override;
+private:
+	friend class UavcanNode;
+	pthread_mutex_t &_node_mutex;
+	UavcanHobbyWingEscController &_esc_controller;
+	// Shares UAVCAN_EC parameter namespace with UavcanMixingInterfaceESC
+	MixingOutput _mixing_output{"UAVCAN_EC", UavcanHobbyWingEscController::MAX_ACTUATORS, *this, MixingOutput::SchedulingPolicy::Auto, false, false};
+};
+#endif // CONFIG_UAVCAN_HOBBYWING_ESC
 #endif
 
 /**
@@ -271,6 +307,10 @@ private:
 
 	UavcanServoController		_servo_controller;
 	UavcanMixingInterfaceServo 	_mixing_interface_servo{_node_mutex, _servo_controller};
+#if defined(CONFIG_UAVCAN_HOBBYWING_ESC)
+	UavcanHobbyWingEscController		_esc_hobbywing_controller;
+	UavcanMixingInterfaceHobbyWingESC	_mixing_interface_hobbywing_esc{_node_mutex, _esc_hobbywing_controller};
+#endif
 #endif
 #if defined(CONFIG_UAVCAN_HARDPOINT_CONTROLLER)
 	UavcanHardpointController	_hardpoint_controller;


### PR DESCRIPTION
Continues #26838 (thanks @notYourUsername) with @dakejahl's review feedback applied on top, as suggested there. @notYourUsername's original commit is kept intact; one commit on top addresses the three review items:

- **`esc_armed_flags`** → `(1 << _rotor_count) - 1` instead of `0`, so commander's `EscChecks` doesn't false-trip a "not all ESCs armed" failsafe while armed.
- **`handle_StatusMsg2`** no longer publishes `esc_status` or touches the aggregate fields — `StatusMsg1` is now the sole publish point (matching `StatusMsg3`), avoiding a double publish and a stale single-sensor temperature overwrite.
- Removed the unused **`_node_info_publisher`** member/setter (dead code). Happy to instead wire `registerDeviceCapability()` like the standard driver if you'd prefer capability reporting — just let me know.

### Testing
Hardware-validated on a **Pixhawk 6X** with **HobbyWing H8M** ESCs (I backported this to v1.17 for our aircraft; driver code identical):
- GetEscID discovery maps node ID → throttle channel
- `esc_status` decodes voltage / current / temperature / RPM
- `actuator_test` drives the commanded motor's ESC (and only that one) via `RawCommand`

**Flight-tested** (2026-07-02): successful flight on the same vehicle. The only extra setup was configuring each ESC output's Minimum Value on the `RawCommand` 0–8191 scale — see [this comment](https://github.com/PX4/PX4-Autopilot/pull/27779#issuecomment-4873514421) for details.

Supersedes #26838. Refs #24176.

Field note for H8M users: units ship at 500 kbit and `SetBaud` only applies after a power-cycle; the bus must run one uniform rate (we use 1 Mbit).

