### PR TITLE
fix(navigator): report correct number of geofence polygon vertices

### DIFF
--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -705,15 +705,16 @@ void Geofence::printStatus()
 	int num_inclusion_circles = 0, num_exclusion_circles = 0;
 
 	for (int i = 0; i < _num_polygons; ++i) {
-		total_num_vertices += _polygons[i].vertex_count;
 
 		switch (_polygons[i].fence_type) {
 		case NAV_CMD_FENCE_POLYGON_VERTEX_INCLUSION:
 			++num_inclusion_polygons;
+			total_num_vertices += _polygons[i].vertex_count;
 			break;
 
 		case NAV_CMD_FENCE_POLYGON_VERTEX_EXCLUSION:
 			++num_exclusion_polygons;
+			total_num_vertices += _polygons[i].vertex_count;
 			break;
 
 		case NAV_CMD_FENCE_CIRCLE_INCLUSION:
@@ -730,7 +731,6 @@ void Geofence::printStatus()
 		}
 	}
 
-	PX4_INFO("Geofence: %i inclusion, %i exclusion polygons, %i inclusion circles, %i exclusion circles, %i total vertices",
-		 num_inclusion_polygons, num_exclusion_polygons, num_inclusion_circles, num_exclusion_circles,
-		 total_num_vertices);
+	PX4_INFO("Geofence: polygons: %i inclusion, %i exclusion, %i vertices; circles: %i inclusion, %i exclusion",
+		 num_inclusion_polygons, num_exclusion_polygons, total_num_vertices, num_inclusion_circles, num_exclusion_circles);
 }


### PR DESCRIPTION
### Problem

Currently, this bogus number of vertices is reported:

```
nsh> navigator status
INFO  [navigator] Running
INFO  [navigator] Geofence: 1 inclusion, 6 exclusion polygons, 0 inclusion circles, 2 exclusion circles, 83345 total vertices
```

The code that reports it accumulates `_polygons[i].vertex_count`. But for circles, that field is a `float` (union), so we get a random large integer from casing it implicitly.

https://github.com/PX4/PX4-Autopilot/blob/3b9a5a6adac9b22bbc400f1faf898b70dcc8b7e4/src/modules/navigator/geofence.h#L163-L170

### Solution

Only add `vertex_count` if we are dealing with a polygon.

Also shorten the overall string slightly, and reorder to make it clear the vertices belong to the polygons rather than the circles.

### Alternatives

Given that apparently this did not bother anybody for 9 years (printing added here 401d6a1a6f67c8397d46fa34e74bf03d2c216ef1, circles added here ed478f40fdf69b1f779f4154f50b835dd1102cbb) we could probably also remove the printout entirely...