### PR TITLE
fix(rover): reuse offboard control timestamp

### DIFF
--- a/src/modules/rover_ackermann/AckermannDriveModes/AckermannOffboardMode/AckermannOffboardMode.cpp
+++ b/src/modules/rover_ackermann/AckermannDriveModes/AckermannOffboardMode/AckermannOffboardMode.cpp
@@ -56,9 +56,11 @@ void AckermannOffboardMode::offboardControl()
 	trajectory_setpoint_s trajectory_setpoint{};
 	_trajectory_setpoint_sub.copy(&trajectory_setpoint);
 
+	const hrt_abstime timestamp = hrt_absolute_time();
+
 	if (offboard_control_mode.position) {
 		rover_position_setpoint_s rover_position_setpoint{};
-		rover_position_setpoint.timestamp = hrt_absolute_time();
+		rover_position_setpoint.timestamp = timestamp;
 		rover_position_setpoint.position_ned[0] = trajectory_setpoint.position[0];
 		rover_position_setpoint.position_ned[1] = trajectory_setpoint.position[1];
 		rover_position_setpoint.start_ned[0] = NAN;
@@ -71,11 +73,11 @@ void AckermannOffboardMode::offboardControl()
 	} else if (offboard_control_mode.velocity) {
 		const Vector2f velocity_ned(trajectory_setpoint.velocity[0], trajectory_setpoint.velocity[1]);
 		rover_speed_setpoint_s rover_speed_setpoint{};
-		rover_speed_setpoint.timestamp = hrt_absolute_time();
+		rover_speed_setpoint.timestamp = timestamp;
 		rover_speed_setpoint.speed_body_x = velocity_ned.norm();
 		_rover_speed_setpoint_pub.publish(rover_speed_setpoint);
 		rover_attitude_setpoint_s rover_attitude_setpoint{};
-		rover_attitude_setpoint.timestamp = hrt_absolute_time();
+		rover_attitude_setpoint.timestamp = timestamp;
 		rover_attitude_setpoint.yaw_setpoint = atan2f(velocity_ned(1), velocity_ned(0));
 		_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
 	}

--- a/src/modules/rover_differential/DifferentialDriveModes/DifferentialOffboardMode/DifferentialOffboardMode.cpp
+++ b/src/modules/rover_differential/DifferentialDriveModes/DifferentialOffboardMode/DifferentialOffboardMode.cpp
@@ -57,9 +57,11 @@ void DifferentialOffboardMode::offboardControl()
 	trajectory_setpoint_s trajectory_setpoint{};
 	_trajectory_setpoint_sub.copy(&trajectory_setpoint);
 
+	const hrt_abstime timestamp = hrt_absolute_time();
+
 	if (offboard_control_mode.position) {
 		rover_position_setpoint_s rover_position_setpoint{};
-		rover_position_setpoint.timestamp = hrt_absolute_time();
+		rover_position_setpoint.timestamp = timestamp;
 		rover_position_setpoint.position_ned[0] = trajectory_setpoint.position[0];
 		rover_position_setpoint.position_ned[1] = trajectory_setpoint.position[1];
 		rover_position_setpoint.start_ned[0] = NAN;
@@ -72,23 +74,23 @@ void DifferentialOffboardMode::offboardControl()
 	} else if (offboard_control_mode.velocity) {
 		const Vector2f velocity_ned(trajectory_setpoint.velocity[0], trajectory_setpoint.velocity[1]);
 		rover_speed_setpoint_s rover_speed_setpoint{};
-		rover_speed_setpoint.timestamp = hrt_absolute_time();
+		rover_speed_setpoint.timestamp = timestamp;
 		rover_speed_setpoint.speed_body_x = velocity_ned.norm();
 		_rover_speed_setpoint_pub.publish(rover_speed_setpoint);
 		rover_attitude_setpoint_s rover_attitude_setpoint{};
-		rover_attitude_setpoint.timestamp = hrt_absolute_time();
+		rover_attitude_setpoint.timestamp = timestamp;
 		rover_attitude_setpoint.yaw_setpoint = atan2f(velocity_ned(1), velocity_ned(0));
 		_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
 
 	} else if (offboard_control_mode.attitude) {
 		rover_attitude_setpoint_s rover_attitude_setpoint{};
-		rover_attitude_setpoint.timestamp = hrt_absolute_time();
+		rover_attitude_setpoint.timestamp = timestamp;
 		rover_attitude_setpoint.yaw_setpoint = trajectory_setpoint.yaw;
 		_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
 
 	} else if (offboard_control_mode.body_rate) {
 		rover_rate_setpoint_s rover_rate_setpoint{};
-		rover_rate_setpoint.timestamp = hrt_absolute_time();
+		rover_rate_setpoint.timestamp = timestamp;
 		rover_rate_setpoint.yaw_rate_setpoint = trajectory_setpoint.yawspeed;
 		_rover_rate_setpoint_pub.publish(rover_rate_setpoint);
 	}

--- a/src/modules/rover_mecanum/MecanumDriveModes/MecanumOffboardMode/MecanumOffboardMode.cpp
+++ b/src/modules/rover_mecanum/MecanumDriveModes/MecanumOffboardMode/MecanumOffboardMode.cpp
@@ -57,9 +57,11 @@ void MecanumOffboardMode::offboardControl()
 	trajectory_setpoint_s trajectory_setpoint{};
 	_trajectory_setpoint_sub.copy(&trajectory_setpoint);
 
+	const hrt_abstime timestamp = hrt_absolute_time();
+
 	if (offboard_control_mode.position) {
 		rover_position_setpoint_s rover_position_setpoint{};
-		rover_position_setpoint.timestamp = hrt_absolute_time();
+		rover_position_setpoint.timestamp = timestamp;
 		rover_position_setpoint.position_ned[0] = trajectory_setpoint.position[0];
 		rover_position_setpoint.position_ned[1] = trajectory_setpoint.position[1];
 		rover_position_setpoint.start_ned[0] = NAN;
@@ -79,12 +81,12 @@ void MecanumOffboardMode::offboardControl()
 		const Vector3f velocity_ned(trajectory_setpoint.velocity[0], trajectory_setpoint.velocity[1], 0.f);
 		const Vector3f velocity_in_body_frame = _vehicle_attitude_quaternion.rotateVectorInverse(velocity_ned);
 		rover_speed_setpoint_s rover_speed_setpoint{};
-		rover_speed_setpoint.timestamp = hrt_absolute_time();
+		rover_speed_setpoint.timestamp = timestamp;
 		rover_speed_setpoint.speed_body_x = velocity_in_body_frame(0);
 		rover_speed_setpoint.speed_body_y = velocity_in_body_frame(1);
 		_rover_speed_setpoint_pub.publish(rover_speed_setpoint);
 		rover_attitude_setpoint_s rover_attitude_setpoint{};
-		rover_attitude_setpoint.timestamp = hrt_absolute_time();
+		rover_attitude_setpoint.timestamp = timestamp;
 		rover_attitude_setpoint.yaw_setpoint = atan2f(velocity_ned(1), velocity_ned(0));
 		_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
 
@@ -93,13 +95,13 @@ void MecanumOffboardMode::offboardControl()
 	// For Mecanum wheel systems, attitude and position control can be decoupled
 	if (offboard_control_mode.attitude) {
 		rover_attitude_setpoint_s rover_attitude_setpoint{};
-		rover_attitude_setpoint.timestamp = hrt_absolute_time();
+		rover_attitude_setpoint.timestamp = timestamp;
 		rover_attitude_setpoint.yaw_setpoint = trajectory_setpoint.yaw;
 		_rover_attitude_setpoint_pub.publish(rover_attitude_setpoint);
 
 	} else if (offboard_control_mode.body_rate) {
 		rover_rate_setpoint_s rover_rate_setpoint{};
-		rover_rate_setpoint.timestamp = hrt_absolute_time();
+		rover_rate_setpoint.timestamp = timestamp;
 		rover_rate_setpoint.yaw_rate_setpoint = trajectory_setpoint.yawspeed;
 		_rover_rate_setpoint_pub.publish(rover_rate_setpoint);
 	}


### PR DESCRIPTION
Setpoints published from the same offboardControl() call come from the same offboard input update.

Use one timestamp for all of them so messages from the same update do not get slightly different timestamps.

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
