### PR TITLE
feat(hardfault): add SRAM hardfault/watchdog DroneCAN logging

### DIFF
--- a/ROMFS/cannode/init.d/rcS
+++ b/ROMFS/cannode/init.d/rcS
@@ -116,5 +116,10 @@ param set-default SENS_MAG_RATE 100
 
 sensors start
 
+task_watchdog start
+
 uavcannode start
+
+hardfault_stream start
+
 unset R

--- a/ROMFS/cannode/init.d/rcS
+++ b/ROMFS/cannode/init.d/rcS
@@ -116,10 +116,5 @@ param set-default SENS_MAG_RATE 100
 
 sensors start
 
-task_watchdog start
-
 uavcannode start
-
-hardfault_stream start
-
 unset R

--- a/Tools/hardfaults_rawhex_decode.py
+++ b/Tools/hardfaults_rawhex_decode.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, Auterion AG
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Decode a NuttX hardfault info_s hex dump into postmortem debug artifacts.
+
+Accepts a plain hex file, a tab-separated data_streamer log, or a chunked
+hardfault_stream log (offset-prefixed chunks + CRC line).
+
+Typical usage:
+
+    python3 scripts/hardfaults_decode.py dump.dmp
+    python3 scripts/hardfaults_decode.py dump.dmp --cpu m7
+
+Output files:
+  coredump_<name>.txt  - CrashDebug-compatible memory + register dump
+                         (pass directly via --coredump to emdbg.bench.fmu)
+  <name>.hardfault.log - PX4-style human-readable fault log; also loadable
+                         via --coredump (goes through emdbg.analyze.hardfault)
+
+Supported --cpu values: M4 (default), M7.
+
+Porting: the fullcontext_s struct layout is identical across all NuttX ARMv7-M
+targets. Only task_name_size and filename_size in _L are board-specific
+(CONFIG_TASK_NAME_SIZE / MAX_FILE_PATH_LENGTH); update _L if they differ.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+_HEX_TOKEN = re.compile(r"[0-9a-fA-F]+")
+
+
+# ---------------------------------------------------------------------------
+# Struct layout - ARMv7-M with FPU (NuttX XCPTCONTEXT_REGS = 53)
+#
+# SW-saved:  R13, BASEPRI, R4-R11, EXC_RETURN, S16-S31  (27 words)
+# HW-saved:  R0-R3, R12, LR, PC, XPSR, S0-S15, FPSCR, reserved  (26 words)
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class _Layout:
+    reg_count: int
+    # fault_reg_count=7 for Cortex-M4: the struct only has 6 fault registers
+    # (cfsr/hfsr/dfsr/mmfsr/bfar/afsr); the 7th read deliberately "steals"
+    # stacks.user.sp so that fault_regs[6] == user.sp, which _parse() then
+    # uses as user_sp.  The remaining 5 stack words (user.top/size +
+    # interrupt.sp/top/size) are consumed by the 3*4 + 2*4 block below.
+    fault_reg_count: int
+    task_name_size: int      # CONFIG_TASK_NAME_SIZE + 1  (includes null terminator)
+    filename_size: int       # MAX_FILE_PATH_LENGTH
+    struct_padding: int      # trailing padding bytes in info_s so sizeof(info_s) is a multiple of 4
+    idx_sp: int
+    idx_basepri: int
+    idx_r4: int; idx_r5: int; idx_r6: int; idx_r7: int
+    idx_r8: int; idx_r9: int; idx_r10: int; idx_r11: int
+    idx_exc_return: int
+    idx_r0: int; idx_r1: int; idx_r2: int; idx_r3: int
+    idx_r12: int; idx_lr: int; idx_pc: int; idx_xpsr: int
+
+    @property
+    def total_size(self) -> int:
+        # Must equal sizeof(info_s): raw field bytes (341) + struct_padding (3) = 344.
+        # C rounds struct size to the largest member's alignment (uint32_t = 4 bytes).
+        return (4 * 4                          # flags, current_regs, lineno, pid
+                + self.reg_count * 4
+                + self.fault_reg_count * 4     # includes stolen user.sp word
+                + 3 * 4                        # user.top, user.size, interrupt.sp
+                + 2 * 4                        # interrupt.top, interrupt.size
+                + self.task_name_size
+                + self.filename_size
+                + self.struct_padding)         # trailing alignment pad
+
+# Cortex-M4:
+#   CONFIG_TASK_NAME_SIZE      = 24  → name buffer = 25 bytes (includes null terminator)
+#   MAX_FILE_PATH_LENGTH       = 40
+#   sizeof(info_s) field bytes = 341; sizeof(info_s) = 344 (3-byte trailing pad for 4-byte alignment)
+#   iStack-size and uStack-size are read from the dump itself
+#   (irq_stack.size / payload size)
+_L = _Layout(
+    reg_count=53, fault_reg_count=7, task_name_size=25, filename_size=40, struct_padding=3,
+    idx_sp=0, idx_basepri=1,
+    idx_r4=2, idx_r5=3, idx_r6=4, idx_r7=5,
+    idx_r8=6, idx_r9=7, idx_r10=8, idx_r11=9,
+    idx_exc_return=10,
+    # 11-26: S16-S31
+    idx_r0=27, idx_r1=28, idx_r2=29, idx_r3=30,
+    idx_r12=31, idx_lr=32, idx_pc=33, idx_xpsr=34,
+    # 35-50: S0-S15  51: FPSCR  52: reserved
+)
+
+# Stack arrays appended after info_s.  istack and ustack have DIFFERENT sizes
+# (CONFIG_ARCH_INTERRUPTSTACK / 4 vs ustack).
+# Each array is center-indexed: array[CENTER] is the word at SP.
+# array[CENTER + k] → address SP - k*4   (below SP, deeper in call stack)
+# array[CENTER - k] → address SP + k*4   (above SP, toward stack top)
+
+
+# ---------------------------------------------------------------------------
+# Input: hex extraction
+# ---------------------------------------------------------------------------
+
+_CHUNK_OFFSET_RE = re.compile(r"^([0-9a-fA-F]{4})\s(.*)$")
+_CRC_LINE_RE     = re.compile(r"^crc\s+([0-9a-fA-F]{8})$")
+
+
+def _crc32part(data: bytes, crc: int = 0) -> int:
+    """NuttX crc32part: reflected CRC32, no init/final XOR."""
+    for b in data:
+        crc ^= b
+        for _ in range(8):
+            crc = (crc >> 1) ^ 0xEDB88320 if crc & 1 else crc >> 1
+    return crc & 0xFFFFFFFF
+
+
+def _load_payload(path: Path) -> tuple[bytes, list[str]]:
+    """
+    Parse *path* and return (payload_bytes, warnings).
+
+    Handles 3 file-formats:
+    - hardfault_stream log  - tab-separated, column after module-name is ``XXXX <hex>``
+                              with a trailing ``crc XXXXXXXX`` line
+    - data_streamer log     - tab-separated, column after module-name is raw hex
+    - plain hex file        - just hex tokens, no module marker
+
+    For hardfault_stream the chunks are assembled by their byte offset so gaps
+    are detected. The CRC is verified over the original ASCII hex lines.
+    """
+    chunks: dict[int, bytes] = {} # offset → data  (hardfault_stream)
+    plain_parts: list[str]   = [] # simple token accumulation (others)
+    expected_crc: int | None = None
+    crc_acc = 0xFFFFFFFF
+    is_chunked = False
+
+    for line in path.read_text().splitlines():
+        module_name = "hardfault_stream"
+        if module_name in line:
+            seg = line.split(module_name, maxsplit=1)[1].strip()
+
+            # CRC line: "crc XXXXXXXX"
+            m_crc = _CRC_LINE_RE.match(seg)
+            if m_crc:
+                expected_crc = int(m_crc.group(1), 16)
+                break
+
+            # Chunk line: "XXXX <hexdata>"
+            m_off = _CHUNK_OFFSET_RE.match(seg)
+            if m_off:
+                is_chunked = True
+                offset   = int(m_off.group(1), 16)
+                hex_part = "".join(
+                    t.group() for t in _HEX_TOKEN.finditer(m_off.group(2))
+                    if len(t.group()) % 2 == 0
+                )
+                data = bytes.fromhex(hex_part)
+                chunks[offset] = data
+                ascii_line = f"{offset:04x} {hex_part}"
+                crc_acc = _crc32part(ascii_line.encode(), crc_acc)
+                continue
+
+            # data_streamer: raw hex after marker
+            for t in _HEX_TOKEN.finditer(seg):
+                if len(t.group()) % 2 == 0:
+                    plain_parts.append(t.group())
+
+        else:
+            # Plain hex file (no marker found)
+            for t in _HEX_TOKEN.finditer(line):
+                if len(t.group()) % 2 == 0:
+                    plain_parts.append(t.group())
+
+    warnings: list[str] = []
+
+    if is_chunked:
+        if not chunks:
+            raise SystemExit("No hardfault_stream chunks found")
+
+        offsets = sorted(chunks)
+        # Detect chunk size from the first gap
+        chunk_size = (offsets[1] - offsets[0]) if len(offsets) > 1 else len(chunks[offsets[0]])
+        total      = offsets[-1] + len(chunks[offsets[-1]])
+
+        missing = [off for off in range(0, total, chunk_size) if off not in chunks]
+        if missing:
+            warnings.append(
+                f"WARN: {len(missing)} missing chunk(s) at offsets: "
+                + ", ".join(f"0x{o:04x}" for o in missing)
+            )
+
+        buf = bytearray(total)
+        for off, data in chunks.items():
+            buf[off:off + len(data)] = data
+        payload = bytes(buf)
+
+        # CRC verification
+        if expected_crc is not None:
+            computed = crc_acc ^ 0xFFFFFFFF
+            if computed != expected_crc:
+                warnings.append(
+                    f"WARN: CRC mismatch - expected 0x{expected_crc:08x}, "
+                    f"got 0x{computed:08x} (possible bit-flip in stream)"
+                )
+        else:
+            warnings.append("WARN: no CRC line found in stream")
+
+    else:
+        payload = bytes.fromhex("".join(plain_parts))
+
+    if len(payload) < _L.total_size:
+        raise SystemExit(f"Payload too short: {len(payload)} B, need ≥{_L.total_size} B")
+
+    return payload, warnings
+
+
+# ---------------------------------------------------------------------------
+# Struct parsing
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class StackRegion:
+    top: int   # high address of allocated region (base + size)
+    size: int  # total allocated bytes
+
+    @property
+    def base(self) -> int:
+        return (self.top - self.size) & 0xFFFFFFFF
+
+
+@dataclass(frozen=True)
+class ParsedHardfault:
+    flags: int
+    current_regs: int
+    lineno: int
+    pid: int
+    regs: list[int]
+    fault_regs: list[int]
+    user_stack: StackRegion
+    user_sp: int          # PSP at fault time (from fault_regs[6])
+    irq_stack: StackRegion
+    irq_sp: int           # MSP at fault time (from user_stack field 2)
+    istack_bytes: int     # = irq_stack.size = CONFIG_ARCH_INTERRUPTSTACK
+    ustack_bytes: int     # = payload_size - total_size - istack_bytes
+    task_name: str
+    filename: str
+    raw: bytes
+
+
+def _parse(raw: bytes) -> ParsedHardfault:
+    def u32(off: int) -> int:
+        return int.from_bytes(raw[off: off + 4], "little")
+
+    off = 0
+    flags      = u32(off); off += 4
+    cur_regs   = u32(off); off += 4
+    lineno     = u32(off); off += 4
+    pid        = u32(off); off += 4
+
+    regs       = [u32(off + i * 4) for i in range(_L.reg_count)];       off += _L.reg_count * 4
+    fault_regs = [u32(off + i * 4) for i in range(_L.fault_reg_count)]; off += _L.fault_reg_count * 4
+
+    user_top  = u32(off); user_size = u32(off + 4); irq_sp = u32(off + 8); off += 12
+    irq_top   = u32(off); irq_size  = u32(off + 4);                        off += 8
+    user_stack = StackRegion(user_top, user_size)
+    irq_stack  = StackRegion(irq_top,  irq_size)
+    user_sp    = fault_regs[6] if len(fault_regs) > 6 else 0
+
+    # Scan the remaining string region for the two null-terminated fields.
+    # Skipping inter-field null padding makes this robust across different
+    # CONFIG_TASK_NAME_SIZE / filename-buffer-size build configurations.
+    strings = [s.decode("ascii", errors="replace")
+               for s in raw[off: off + _L.task_name_size + _L.filename_size].split(b"\x00")
+               if s]
+    task_name = strings[0] if strings else ""
+    filename  = strings[1] if len(strings) > 1 else ""
+
+    istack_bytes = irq_stack.size
+    ustack_bytes = max(0, len(raw) - _L.total_size - istack_bytes)
+
+    return ParsedHardfault(
+        flags=flags, current_regs=cur_regs, lineno=lineno, pid=pid,
+        regs=regs, fault_regs=fault_regs,
+        user_stack=user_stack, user_sp=user_sp,
+        irq_stack=irq_stack, irq_sp=irq_sp,
+        istack_bytes=istack_bytes, ustack_bytes=ustack_bytes,
+        task_name=task_name, filename=filename, raw=raw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+_ADDR_RANGES = [
+    (0x2000_0000, 0x80000),
+    (0x2400_0000, 0x80000),
+    (0x3000_0000, 0x48000),
+    (0x3800_0000, 0x10000),
+    (0x3880_0000, 0x01000),
+    (0xE004_2000, 4),
+    (0x5C00_1000, 4),
+    (0xE000_E000, 0xFFF),
+]
+
+_UNKNOWN = 0xFEEDC0DE
+_CPUIDS = {
+    "m4": 0x410FC240,  # Cortex-M4 r0p0 (STM32F412)
+    "m7": 0x411FC271,  # Cortex-M7 r1p1 (STM32H7)
+}
+
+_REG_NAMES = [
+    "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7",
+    "r8", "r9", "r10", "r11", "r12", "sp", "lr", "pc",
+    "xpsr", "msp", "psp", "primask", "basepri", "faultmask", "control", "fpscr",
+    "s0",  "s1",  "s2",  "s3",  "s4",  "s5",  "s6",  "s7",
+    "s8",  "s9",  "s10", "s11", "s12", "s13", "s14", "s15", "s16",
+    "s17", "s18", "s19", "s20", "s21", "s22", "s23",
+    "s24", "s25", "s26", "s27", "s28", "s29", "s30", "s31",
+    "d0",  "d1",  "d2",  "d3",  "d4",  "d5",  "d6",  "d7",
+    "d8",  "d9",  "d10", "d11", "d12", "d13", "d14", "d15",
+]
+
+
+def format_coredump(p: ParsedHardfault, cpuid: int) -> str:
+    base = p.current_regs - (_L.idx_r0 * 4) - 16
+
+    # Map the struct bytes at their base address in SRAM
+    mems: dict[int, int] = {
+        base + i: int.from_bytes(p.raw[i: i + 4], "little")
+        for i in range(0, _L.total_size, 4)
+    }
+
+    # Map istack and ustack using center-based addressing.
+    # array[CENTER + k] → SP - k*4  (below SP)
+    # array[CENTER - k] → SP + k*4  (above SP)
+    irq_dump  = p.raw[_L.total_size:                          _L.total_size + p.istack_bytes]
+    user_dump = p.raw[_L.total_size + p.istack_bytes:         _L.total_size + p.istack_bytes + p.ustack_bytes]
+    irq_words   = p.istack_bytes // 4
+    user_words  = p.ustack_bytes // 4
+    irq_center  = irq_words  // 2
+    user_center = user_words // 2
+    for idx in range(irq_words):
+        addr = (p.irq_sp  + (irq_center  - idx) * 4) & 0xFFFFFFFF
+        mems[addr] = int.from_bytes(irq_dump[idx * 4: idx * 4 + 4],  "little")
+    for idx in range(user_words):
+        addr = (p.user_sp + (user_center - idx) * 4) & 0xFFFFFFFF
+        mems[addr] = int.from_bytes(user_dump[idx * 4: idx * 4 + 4], "little")
+
+    r = p.regs
+    regs = {n: _UNKNOWN for n in _REG_NAMES}
+    regs.update({
+        "r0": r[_L.idx_r0], "r1": r[_L.idx_r1], "r2": r[_L.idx_r2], "r3": r[_L.idx_r3],
+        "r4": r[_L.idx_r4], "r5": r[_L.idx_r5], "r6": r[_L.idx_r6], "r7": r[_L.idx_r7],
+        "r8": r[_L.idx_r8], "r9": r[_L.idx_r9], "r10": r[_L.idx_r10], "r11": r[_L.idx_r11],
+        "r12": r[_L.idx_r12], "sp": r[_L.idx_sp], "lr": r[_L.idx_lr], "pc": r[_L.idx_pc],
+        "xpsr": r[_L.idx_xpsr], "msp": r[_L.idx_sp], "psp": r[_L.idx_sp],
+        "basepri": r[_L.idx_basepri], "control": 0,
+    })
+
+    cfsr  = p.fault_regs[0]
+    hfsr  = p.fault_regs[1]
+    dfsr  = p.fault_regs[2]
+    mmfar = p.fault_regs[3]
+    bfar  = p.fault_regs[4]
+    afsr  = p.fault_regs[5]
+    mems[0x5C00_1000] = 0x10030450
+    mems[0xE004_2000] = 0x10030451
+    mems[0xE000_ED00] = cpuid
+    mems[0xE000_ED28] = cfsr
+    mems[0xE000_ED2C] = hfsr
+    mems[0xE000_ED30] = dfsr
+    mems[0xE000_ED34] = mmfar
+    mems[0xE000_ED38] = bfar
+    mems[0xE000_ED3C] = afsr
+
+    out = []
+    for start, size in _ADDR_RANGES:
+        for addr in range(start, start + size, 16):
+            out.append("{:#8x}:\t{:#8x}\t{:#8x}\t{:#8x}\t{:#8x}".format(
+                addr,
+                mems.get(addr,      _UNKNOWN),
+                mems.get(addr + 4,  _UNKNOWN),
+                mems.get(addr + 8,  _UNKNOWN),
+                mems.get(addr + 12, _UNKNOWN),
+            ))
+    for name, val in regs.items():
+        out.append(f"{name:15} {val:#20x} {val:20}")
+    return "\n".join(out)
+
+
+def format_hardfault_log(p: ParsedHardfault, cpuid: int) -> str:
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%d-%H:%M:%S")
+    r = p.regs
+    lines = [
+        f"[data_streamer] -- {ts} Begin Fault Log --",
+        f"System fault Occurred on: {ts}",
+        f" Type:Hard Fault in file:{p.filename} at line: {p.lineno} running task: {p.task_name}",
+        " FW git-hash: unknown",
+        " Build datetime: unknown unknown",
+        " Build url: unknown ",
+    ]
+
+    if p.flags & (0x01 | 0x40):
+        lines += [
+            f" Processor registers: from 0x{p.current_regs:08x}",
+            (f" r0:0x{r[_L.idx_r0]:08x} r1:0x{r[_L.idx_r1]:08x}"
+             f"  r2:0x{r[_L.idx_r2]:08x}  r3:0x{r[_L.idx_r3]:08x}"
+             f"  r4:0x{r[_L.idx_r4]:08x}  r5:0x{r[_L.idx_r5]:08x}"
+             f" r6:0x{r[_L.idx_r6]:08x} r7:0x{r[_L.idx_r7]:08x}"),
+            (f" r8:0x{r[_L.idx_r8]:08x} r9:0x{r[_L.idx_r9]:08x}"
+             f" r10:0x{r[_L.idx_r10]:08x} r11:0x{r[_L.idx_r11]:08x}"
+             f" r12:0x{r[_L.idx_r12]:08x}  sp:0x{r[_L.idx_sp]:08x}"
+             f" lr:0x{r[_L.idx_lr]:08x} pc:0x{r[_L.idx_pc]:08x}"),
+            f" xpsr:0x{r[_L.idx_xpsr]:08x} basepri:0x{r[_L.idx_basepri]:08x} control:0x00000000",
+            f" exe return:0x{r[_L.idx_exc_return]:08x}",
+        ]
+
+    if p.flags & 0x08 and p.flags & 0x01:
+        cfsr = p.fault_regs[0]
+        hfsr = p.fault_regs[1]
+        dfsr = p.fault_regs[2]
+        bfar = p.fault_regs[4]
+        afsr = p.fault_regs[5]
+        lines += [
+            " Fault status registers: from NVIC",
+            f"  CFSR: {cfsr:08x} HFSR: {hfsr:08x} DFSR: {dfsr:08x} BFAR: {bfar:08x} AFSR: {afsr:08x}",
+        ]
+
+    def _stackdump(dump: bytes, sp: int, top: int) -> list[str]:
+        """Format 8-words-per-line using center-based addressing.
+
+        dump[CENTER*4 + sp - addr] is the word at `addr`.
+        Prints from (sp & ~0x1F) up to top.
+        """
+        result = []
+        center_off = (len(dump) // 4 // 2) * 4   # stack_center * 4
+        addr = sp & ~0x1F
+        end  = (top + 3) & ~3
+        while addr < end:
+            words = []
+            for i in range(0, 32, 4):
+                byte_off = center_off + sp - (addr + i)
+                if 0 <= byte_off <= len(dump) - 4:
+                    words.append(f"0x{int.from_bytes(dump[byte_off:byte_off+4], 'little'):08x}")
+                else:
+                    break
+            if words:
+                result.append(f"0x{addr:08x} {' '.join(words)}")
+            addr += 32
+        return result
+
+    def _stack_region(name: str, sp: int, region: StackRegion, dump: bytes) -> list[str]:
+        out = [
+            f" {name} Stack:",
+            f" sp:     {sp:08x}",
+            f"   base: {region.base:08x}",
+            f"   size: {region.size:08x}",
+        ]
+        if region.base <= sp < region.top:
+            out += _stackdump(dump, sp, region.top)
+        else:
+            out.append(f" ERROR: {name} Stack pointer is not within the stack")
+        return out
+
+    irq_dump  = p.raw[_L.total_size:                          _L.total_size + p.istack_bytes]
+    user_dump = p.raw[_L.total_size + p.istack_bytes:         _L.total_size + p.istack_bytes + p.ustack_bytes]
+
+    if p.flags & (0x04 | 0x08):
+        lines += _stack_region("IRQ",  p.irq_sp,  p.irq_stack,  irq_dump)
+    if p.flags & 0x02:
+        lines += _stack_region("User", p.user_sp, p.user_stack, user_dump)
+
+    lines.append(f"0xe000ed00 {cpuid:#010x}") # expected by emdbg - CrashDebug for Cortex-M4/M7
+    lines.append(f"[data_streamer] -- {ts} END Fault Log --")
+    return "\n".join(lines) + "\n"
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Decode a NuttX hardfault hex dump for postmortem debugging"
+    )
+    parser.add_argument("blob", type=Path,
+                        help="Hex dump file: plain hex string or data_streamer log")
+    parser.add_argument("--cpu", choices=list(_CPUIDS), default="m4",
+                        help="Target CPU (default: m4)")
+    args = parser.parse_args()
+
+    payload, warnings = _load_payload(args.blob)
+    p = _parse(payload)
+    cpuid = _CPUIDS[args.cpu]
+
+    out_log = args.blob.with_suffix(".hardfault.log")
+    out_coredump = args.blob.parent / f"coredump_{args.blob.stem}.txt"
+
+    out_coredump.write_text(format_coredump(p, cpuid))
+    out_log.write_text(format_hardfault_log(p, cpuid))
+
+    for w in warnings:
+        print(w)
+    print(f"Size:  total={len(payload)} B  istack={p.istack_bytes} B  ustack={p.ustack_bytes} B")
+    print(f"Task:  {p.task_name!r}  pid={p.pid}  line={p.lineno}")
+    print(f"File:  {p.filename!r}")
+    print(f"PC:    0x{p.regs[_L.idx_pc]:08x}  LR: 0x{p.regs[_L.idx_lr]:08x}  SP: 0x{p.regs[_L.idx_sp]:08x}")
+    print(f"Wrote: {out_log}")
+    print(f"Wrote: {out_coredump}")
+
+    return 1 if any(w.startswith("WARN: CRC") for w in warnings) else 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/hardfaults_rawhex_decode.py
+++ b/Tools/hardfaults_rawhex_decode.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import zlib
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -105,18 +106,10 @@ _L = _Layout(
 # ---------------------------------------------------------------------------
 # Input: hex extraction
 # ---------------------------------------------------------------------------
-
-_CHUNK_OFFSET_RE = re.compile(r"^([0-9a-fA-F]{4})\s(.*)$")
-_CRC_LINE_RE     = re.compile(r"^crc\s+([0-9a-fA-F]{8})$")
-
-
-def _crc32part(data: bytes, crc: int = 0) -> int:
-    """NuttX crc32part: reflected CRC32, no init/final XOR."""
-    for b in data:
-        crc ^= b
-        for _ in range(8):
-            crc = (crc >> 1) ^ 0xEDB88320 if crc & 1 else crc >> 1
-    return crc & 0xFFFFFFFF
+# Search for chunk-pattern "hardfault_stream<sep>xxxx <hexdata>" in different variations.
+_CHUNK_RE = re.compile(r"hardfault_stream\W*?([0-9a-fA-F]{4})\s+([0-9a-fA-F]+)\s*$")
+# Search for crc-pattern "hardfault_stream<sep>crc XXXXXXXX" in different variations.
+_CRC_RE   = re.compile(r"hardfault_stream\W*?crc\s+([0-9a-fA-F]{8})\b")
 
 
 def _load_payload(path: Path) -> tuple[bytes, list[str]]:
@@ -124,9 +117,9 @@ def _load_payload(path: Path) -> tuple[bytes, list[str]]:
     Parse *path* and return (payload_bytes, warnings).
 
     Handles 3 file-formats:
-    - hardfault_stream log  - tab-separated, column after module-name is ``XXXX <hex>``
-                              with a trailing ``crc XXXXXXXX`` line
-    - data_streamer log     - tab-separated, column after module-name is raw hex
+    - hardfault_stream log  - any line containing "hardfault_stream" with an
+                              ``XXXX <hex>`` chunk or trailing ``crc XXXXXXXX``
+    - data_streamer log     - column after module-name is raw hex, no offset
     - plain hex file        - just hex tokens, no module marker
 
     For hardfault_stream the chunks are assembled by their byte offset so gaps
@@ -135,45 +128,42 @@ def _load_payload(path: Path) -> tuple[bytes, list[str]]:
     chunks: dict[int, bytes] = {} # offset → data  (hardfault_stream)
     plain_parts: list[str]   = [] # simple token accumulation (others)
     expected_crc: int | None = None
-    crc_acc = 0xFFFFFFFF
+    crc_acc = 0
     is_chunked = False
+    module_name = "hardfault_stream"
 
     for line in path.read_text().splitlines():
-        module_name = "hardfault_stream"
-        if module_name in line:
-            seg = line.split(module_name, maxsplit=1)[1].strip()
-
-            # CRC line: "crc XXXXXXXX"
-            m_crc = _CRC_LINE_RE.match(seg)
-            if m_crc:
-                expected_crc = int(m_crc.group(1), 16)
-                break
-
-            # Chunk line: "XXXX <hexdata>"
-            m_off = _CHUNK_OFFSET_RE.match(seg)
-            if m_off:
-                is_chunked = True
-                offset   = int(m_off.group(1), 16)
-                hex_part = "".join(
-                    t.group() for t in _HEX_TOKEN.finditer(m_off.group(2))
-                    if len(t.group()) % 2 == 0
-                )
-                data = bytes.fromhex(hex_part)
-                chunks[offset] = data
-                ascii_line = f"{offset:04x} {hex_part}"
-                crc_acc = _crc32part(ascii_line.encode(), crc_acc)
-                continue
-
-            # data_streamer: raw hex after marker
-            for t in _HEX_TOKEN.finditer(seg):
-                if len(t.group()) % 2 == 0:
-                    plain_parts.append(t.group())
-
-        else:
+        if module_name not in line:
             # Plain hex file (no marker found)
             for t in _HEX_TOKEN.finditer(line):
                 if len(t.group()) % 2 == 0:
                     plain_parts.append(t.group())
+            continue
+
+        # CRC line: whatever precedes "crc XXXXXXXX" is discarded.
+        m_crc = _CRC_RE.search(line)
+        if m_crc:
+            expected_crc = int(m_crc.group(1), 16)
+            break
+
+        # Chunk line: whatever precedes "XXXX <hexdata>" is discarded.
+        m_off = _CHUNK_RE.search(line)
+        if m_off:
+            is_chunked = True
+            offset   = int(m_off.group(1), 16)
+            hex_part = m_off.group(2)
+            data = bytes.fromhex(hex_part)
+            chunks[offset] = data
+            ascii_line = f"{offset:04x} {hex_part}"
+            crc_acc = zlib.crc32(ascii_line.encode(), crc_acc)
+            continue
+
+        # data_streamer: raw hex after marker, no offset present
+        seg = line.split(module_name, maxsplit=1)[1]
+
+        for t in _HEX_TOKEN.finditer(seg):
+            if len(t.group()) % 2 == 0:
+                plain_parts.append(t.group())
 
     warnings: list[str] = []
 
@@ -200,7 +190,7 @@ def _load_payload(path: Path) -> tuple[bytes, list[str]]:
 
         # CRC verification
         if expected_crc is not None:
-            computed = crc_acc ^ 0xFFFFFFFF
+            computed = crc_acc
             if computed != expected_crc:
                 warnings.append(
                     f"WARN: CRC mismatch - expected 0x{expected_crc:08x}, "

--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -845,6 +845,7 @@
       - [STLink Probe](debug/probe_stlink.md)
       - [MCU-Link Probe](debug/probe_mculink.md)
       - [Hardfault Debugging](debug/gdb_hardfault.md)
+    - [Hardfault Logging on Boards Without Non-Volatile Memory](debug/hardfault_no_nvram.md)
     - [Debugging with Eclipse](debug/eclipse_jlink.md)
     - [Failure Injection](debug/failure_injection.md)
     - [Plotting uORB Topic Data in Real Time](debug/plotting_realtime_uorb_data.md)

--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -845,7 +845,7 @@
       - [STLink Probe](debug/probe_stlink.md)
       - [MCU-Link Probe](debug/probe_mculink.md)
       - [Hardfault Debugging](debug/gdb_hardfault.md)
-    - [Hardfault Logging on Boards Without Usable Non-Volatile Memory](debug/hardfault_no_nvram.md)
+    - [Hardfault Logging (FC w/o usable Non-Volatile Memory](debug/hardfault_no_nvram.md)
     - [Debugging with Eclipse](debug/eclipse_jlink.md)
     - [Failure Injection](debug/failure_injection.md)
     - [Plotting uORB Topic Data in Real Time](debug/plotting_realtime_uorb_data.md)

--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -845,7 +845,7 @@
       - [STLink Probe](debug/probe_stlink.md)
       - [MCU-Link Probe](debug/probe_mculink.md)
       - [Hardfault Debugging](debug/gdb_hardfault.md)
-    - [Hardfault Logging on Boards Without Non-Volatile Memory](debug/hardfault_no_nvram.md)
+    - [Hardfault Logging on Boards Without Usable Non-Volatile Memory](debug/hardfault_no_nvram.md)
     - [Debugging with Eclipse](debug/eclipse_jlink.md)
     - [Failure Injection](debug/failure_injection.md)
     - [Plotting uORB Topic Data in Real Time](debug/plotting_realtime_uorb_data.md)

--- a/docs/en/debug/hardfault_no_nvram.md
+++ b/docs/en/debug/hardfault_no_nvram.md
@@ -1,0 +1,101 @@
+# Hardfault Logging on Boards Without Non-Volatile Memory
+
+This Section introduce how to setup a board-config to persist a hardfault over warm-reset (power-cycle not covered)
+on boards without a non-volatile storage (sd-card, BBSRAM, PROGMEM, SSARC, …).
+The Hardfault is provided via uORB-log-msg topic after warm-reset.
+
+## Overview
+
+Changes needed:
+
+- \#DEFINES in `src/board_config.h`:
+  - `BOARD_HAS_RAM_HARDFAULT_DUMP`
+  - `BOARD_RAM_HARDFAULT_USTACK_BYTES`
+- Memory region in the board's linker script: That survives a warm reset (not zero-initialized) and is big enough for the dump buffer:
+  `sizeof(px4_ram_hardfault_dump_s)` (`sizeof(uint32_t)` + `sizeof(fullcontext_s)`, which depends on `BOARD_RAM_HARDFAULT_USTACK_BYTES`)
+- Setup module Hardfault_Stream:
+  - `CONFIG_MODULES_HARDFAULT_STREAM=y`
+  - `hardfault_stream start` in startup script
+- Optional: `CONFIG_MODULES_TASK_WATCHDOG=y` to also stream live task/CPU-load dumps through the same path on CPU starvation (unrelated feature, same mechanism).
+- Optional: `cmake/linker_preprocess.cmake` to keep the linker-script region size and `BOARD_RAM_HARDFAULT_USTACK_BYTES` in sync automatically, instead of hand-sizing the region.
+
+## Examples Configuration
+
+#### `src/board_config.h`
+
+```c
+#define BOARD_HAS_RAM_HARDFAULT_DUMP
+#define BOARD_RAM_HARDFAULT_USTACK_BYTES 4096 // bytes of user stack to capture, check actual usage with `top`
+// IRAM can be taken from `CONFIG_ARCH_INTERRUPTSTACK`
+```
+#### `nuttx-config/scripts/script.ld`
+
+```ld
+MEMORY
+{
+    ...
+    noinit (rwx) : ORIGIN = ...,
+    		   LENGTH = 8K /* generously-sized, no need to compute exactly */
+}
+...
+.noinit (NOLOAD) : {
+	*(.noinit .noinit.*)
+} > noinit
+
+/* optional to check it's actual size with `nm` */
+_noinit_size = SIZEOF(.noinit);
+```
+
+#### `<board>.px4board` And Startup Script
+
+```sh
+CONFIG_MODULES_HARDFAULT_STREAM=y
+```
+
+```sh
+# in the board's rcS, after the log transport is up
+hardfault_stream start
+```
+
+### Optional:
+##### Keep the linker-script size in sync (`cmake/linker_preprocess.cmake`)
+
+Instead of hand-sizing the `noinit` region, a preprocessor-script `${PX4_BOARD_DIR}/cmake/linker_preprocess.cmake` can be used compute and inject the region-size into `script.ld`:
+
+```cmake
+# >> Values can differ from board to board <<
+#
+# For <fixed header overhead> compute:
+# `src/lib/systemlib/hardfault_log.h`
+# BOARD_RAM_HARDFAULT_OVERHEAD at worst-case
+# sizeof(uint32_t magic) + sizeof(info_s), chosen from CONFIG_ARCH_FPU:
+#   no FPU: XCPTCONTEXT_REGS=19 → sizeof(info_s)=208 → overhead=212
+#   FPU:    XCPTCONTEXT_REGS=53 → sizeof(info_s)=344 → overhead=348
+#
+
+set(BOARD_RAM_HARDFAULT_USTACK_BYTES 4096) // check for board at runtime eg. `top`
+math(EXPR _dump_size "${CONFIG_ARCH_INTERRUPTSTACK} + ${BOARD_RAM_HARDFAULT_USTACK_BYTES} + <fixed header overhead>")
+
+# preprocess script.ld with -DPX4_NOINIT_DUMP_SIZE=${_dump_size}, use PX4_NOINIT_DUMP_SIZE for the noinit region's LENGTH in script.ld
+add_custom_command(
+    OUTPUT  "${_ld_script_pp}"
+    COMMAND "${CMAKE_C_COMPILER}"
+        -E -P -x c
+        -DPX4_NOINIT_DUMP_SIZE=${_px4_noinit_dump_size}
+        "${_ld_script_src}"
+        -o "${_ld_script_pp}"
+    DEPENDS "${_ld_script_src}"
+    COMMENT "Preprocessing script.ld (PX4_NOINIT_DUMP_SIZE=${_px4_noinit_dump_size})"
+)
+add_custom_target(px4_ld_script_pp DEPENDS "${_ld_script_pp}")
+add_dependencies(px4 px4_ld_script_pp)
+
+set(_ld_script_flag "-Wl,--script=${_ld_script_pp}")
+```
+
+##### `task_watchdog`
+
+`task_watchdog` (`CONFIG_MODULES_TASK_WATCHDOG=y`)
+
+## What Happens
+On hardfault, `the board_crashdump()` stashes the fault-context to the `.noinit` region and resets; on the next boot the [hardfault_stream](../modules/modules_system.md#hardfault-stream) checks for valid hadfault-log and streams it out as a hex dump over `PX4_INFO`/`PX4_ERR` (picked up by `ORB_ID(log_message)`. From there by whatever transport the board forwards log messages over, e.g. DroneCAN). [Tools/hardfaults_rawhex_decode.py](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/hardfaults_rawhex_decode.py) turns a captured hex dump back into a CrashDebug-compatible coredump or a PX4-style fault log.

--- a/docs/en/debug/hardfault_no_nvram.md
+++ b/docs/en/debug/hardfault_no_nvram.md
@@ -6,8 +6,9 @@ The Hardfault is provided via uORB-log-msg topic after warm-reset.
 
 ## Overview
 
-Changes needed:
+Configuration needed:
 
+- `CONFIG_BOARD_CRASHDUMP=y`
 - \#DEFINES in `src/board_config.h`:
   - `BOARD_HAS_RAM_HARDFAULT_DUMP`
   - `BOARD_RAM_HARDFAULT_USTACK_BYTES`
@@ -16,19 +17,25 @@ Changes needed:
 - Setup module Hardfault_Stream:
   - `CONFIG_MODULES_HARDFAULT_STREAM=y`
   - `hardfault_stream start` in startup script
-- Optional: `CONFIG_MODULES_TASK_WATCHDOG=y` to also stream live task/CPU-load dumps through the same path on CPU starvation (unrelated feature, same mechanism).
-- Optional: `cmake/linker_preprocess.cmake` to keep the linker-script region size and `BOARD_RAM_HARDFAULT_USTACK_BYTES` in sync automatically, instead of hand-sizing the region.
+- Optional: `CONFIG_MODULES_TASK_WATCHDOG=y` to also stream live task/CPU-load dumps through the same path (unrelated feature, same mechanism).
+- Optional: `cmake/linker_preprocess.cmake` to keep the linker-script region-size and `BOARD_RAM_HARDFAULT_USTACK_BYTES` in sync automatically, instead of hand-sizing the region. (see example for reference)
 
 ## Examples Configuration
 
-#### `src/board_config.h`
+#### nuttx-config/<config>/defconfig
+
+```sh
+CONFIG_BOARD_CRASHDUMP=y
+```
+
+#### src/board_config.h
 
 ```c
 #define BOARD_HAS_RAM_HARDFAULT_DUMP
 #define BOARD_RAM_HARDFAULT_USTACK_BYTES 4096 // bytes of user stack to capture, check actual usage with `top`
 // IRAM can be taken from `CONFIG_ARCH_INTERRUPTSTACK`
 ```
-#### `nuttx-config/scripts/script.ld`
+#### nuttx-config/scripts/script.ld
 
 ```ld
 MEMORY
@@ -58,7 +65,7 @@ hardfault_stream start
 ```
 
 ### Optional:
-##### Keep the linker-script size in sync (`cmake/linker_preprocess.cmake`)
+##### keep the linker-script size in sync (`cmake/linker_preprocess.cmake`)
 
 Instead of hand-sizing the `noinit` region, a preprocessor-script `${PX4_BOARD_DIR}/cmake/linker_preprocess.cmake` can be used compute and inject the region-size into `script.ld`:
 
@@ -73,19 +80,20 @@ Instead of hand-sizing the `noinit` region, a preprocessor-script `${PX4_BOARD_D
 #   FPU:    XCPTCONTEXT_REGS=53 → sizeof(info_s)=344 → overhead=348
 #
 
-set(BOARD_RAM_HARDFAULT_USTACK_BYTES 4096) // check for board at runtime eg. `top`
+set(BOARD_RAM_HARDFAULT_USTACK_BYTES 4096) # check for board at runtime eg. `top`
 math(EXPR _dump_size "${CONFIG_ARCH_INTERRUPTSTACK} + ${BOARD_RAM_HARDFAULT_USTACK_BYTES} + <fixed header overhead>")
 
+# _ld_script_src/_ld_script_pp: paths to your script.ld and its preprocessed output, set earlier
 # preprocess script.ld with -DPX4_NOINIT_DUMP_SIZE=${_dump_size}, use PX4_NOINIT_DUMP_SIZE for the noinit region's LENGTH in script.ld
 add_custom_command(
     OUTPUT  "${_ld_script_pp}"
     COMMAND "${CMAKE_C_COMPILER}"
         -E -P -x c
-        -DPX4_NOINIT_DUMP_SIZE=${_px4_noinit_dump_size}
+        -DPX4_NOINIT_DUMP_SIZE=${_dump_size}
         "${_ld_script_src}"
         -o "${_ld_script_pp}"
     DEPENDS "${_ld_script_src}"
-    COMMENT "Preprocessing script.ld (PX4_NOINIT_DUMP_SIZE=${_px4_noinit_dump_size})"
+    COMMENT "Preprocessing script.ld (PX4_NOINIT_DUMP_SIZE=${_dump_size})"
 )
 add_custom_target(px4_ld_script_pp DEPENDS "${_ld_script_pp}")
 add_dependencies(px4 px4_ld_script_pp)
@@ -93,7 +101,7 @@ add_dependencies(px4 px4_ld_script_pp)
 set(_ld_script_flag "-Wl,--script=${_ld_script_pp}")
 ```
 
-##### `task_watchdog`
+##### task_watchdog
 
 `task_watchdog` (`CONFIG_MODULES_TASK_WATCHDOG=y`)
 

--- a/docs/en/debug/hardfault_no_nvram.md
+++ b/docs/en/debug/hardfault_no_nvram.md
@@ -1,37 +1,40 @@
-# Hardfault Logging on Boards Without Usable Non-Volatile Memory
+# Hardfault Logging on Boards without Usable Non-Volatile Memory
 
-This section shows how to setup a board to save a hardfault persistently over warm-reset (only), on boards without usable non-volatile storage.  
-The Hardfault is provided via the uORB-topic `log_message` on reset.  
-Some settings and instructions are already provided by px4-common-files and only mentioned for completness.
+<Badge type="tip" text="PX4 main (v1.19)" />
+
+This topic shows how to setup a flight controller board to persist hardfaults over warm-reset (only) on boards without usable non-volatile storage.
+The same mechanism can optionally be used to provide CPU starvation information.
 
 ## Overview
 
-Configuration needed:
+Flight controller boards typically log hardfaults to persistent memory, such as Battery-Backed SRAM (BBSRAM), Program memory/on-chip flash (PROGMEM), or Standby SRAM Controller (SSARC).
 
-- `CONFIG_BOARD_CRASHDUMP=y`
-- \#DEFINES in `src/board_config.h`:
-  - `BOARD_HAS_RAM_HARDFAULT_DUMP`
-  - `BOARD_RAM_HARDFAULT_USTACK_BYTES`
-- Memory region in the board's linker script, that survives a warm reset (not zero-initialized) and is big enough for the dump buffer:  
-  `sizeof(px4_ram_hardfault_dump_s)` = `sizeof(uint32_t)` + `sizeof(fullcontext_s)`  
-`fullcontext_s` depends on `BOARD_RAM_HARDFAULT_USTACK_BYTES`
-- Setup module Hardfault_Stream:
-  - `CONFIG_MODULES_HARDFAULT_STREAM=y`
-  - `hardfault_stream start`
-- Optional: `CONFIG_MODULES_TASK_WATCHDOG=y`  
-To also stream live task/CPU-load dumps through the same path (unrelated feature, same mechanism).
-- Optional: `cmake/linker_preprocess.cmake`  
-To keep the linker-script region-size and `BOARD_RAM_HARDFAULT_USTACK_BYTES` in sync automatically, instead of hand-sizing the region. (see [example](#example-implementation-and-configuration) for reference).
+Boards that don't have this memory can still be configured to persist the fault to a `.noinit` SRAM region that survives warm resets.
+On hardfault, `board_crashdump()` then stashes the fault-context to the `.noinit` region and resets.
+On the next boot, the [hardfault_stream](../modules/modules_system.md#hardfault-stream) checks for a valid hardfault log and streams it out as a hex dump with a CRC32 over `PX4_INFO`/`PX4_ERR` (picked up by `ORB_ID(log_message)`).
+The [`log_message`](../msg_docs/LogMessage.md) is forwarded by the configured logging tool (e.g. DroneCAN).
+The captured hex-dump can be parsed into a CrashDebug-compatible coredump or a PX4-style fault log using [Tools/hardfaults_rawhex_decode.py](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/hardfaults_rawhex_decode.py).
 
-## Example Implementation And Configuration
+The following sections show how to configure the board.
+Some settings and instructions are already provided by px4-common-files and are mentioned here only for completeness.
 
-#### defconfig
+## Configuration
 
-```sh
+### Hardfault Dumps
+
+The following configuration changes are required to enable crash dumps.
+
+#### KConfig
+
+The [KConfig board configuration](../hardware/porting_guide_config.md) must include:
+
+```txt
 CONFIG_BOARD_CRASHDUMP=y
 ```
 
 #### board_config.h
+
+Set these `#DEFINES` in `src/board_config.h`:
 
 ```c
 #define BOARD_HAS_RAM_HARDFAULT_DUMP
@@ -40,22 +43,13 @@ CONFIG_BOARD_CRASHDUMP=y
 // ISTACK is taken from `CONFIG_ARCH_INTERRUPTSTACK`
 ```
 
-#### `<board>.px4board` And Startup Script
+#### Linker script
 
-```sh
-CONFIG_MODULES_HARDFAULT_STREAM=y
-```
+Define a memory region in the board's linker script, that survives a warm reset (not zero-initialized) and is big enough for the dump buffer:
+`sizeof(px4_ram_hardfault_dump_s)` = `sizeof(uint32_t)` + `sizeof(fullcontext_s)`  
+(`fullcontext_s` depends on `BOARD_RAM_HARDFAULT_USTACK_BYTES`), e.g. in `script.ld`:
 
-```sh
-# in the board's rcS, after the log transport is up
-hardfault_stream start
-# <optional> to also log task-starvation
-task_watchdog start
-```
-
-#### script.ld
-
-```ld
+```txt
 MEMORY
 {
     ...
@@ -71,8 +65,7 @@ MEMORY
 _noinit_size = SIZEOF(.noinit);
 ```
 
-### Optional:
-##### keep the linker-script size in sync (`cmake/linker_preprocess.cmake`)
+#### Optional: keep the linker-script size in sync (`cmake/linker_preprocess.cmake`)
 
 Instead of hand-sizing the `noinit` region, a preprocessor-script `${PX4_BOARD_DIR}/cmake/linker_preprocess.cmake`  
 can be used to compute and inject the region-size into `script.ld`:
@@ -109,11 +102,33 @@ add_dependencies(px4 px4_ld_script_pp)
 set(_ld_script_flag "-Wl,--script=${_ld_script_pp}")
 ```
 
-##### task_watchdog
+### Setup the hardfault_stream Module
 
-`task_watchdog` (`CONFIG_MODULES_TASK_WATCHDOG=y`)
+The [KConfig board configuration](../hardware/porting_guide_config.md) must include the [hardfault-stream](../modules/modules_system.md#hardfault-stream) module:
 
-## What Happens
-On hardfault, the `board_crashdump()` stashes the fault-context to the `.noinit` region and resets.  
-On the next boot, the [hardfault_stream](../modules/modules_system.md#hardfault-stream) checks for valid hadfault-log and streams it out as a hex dump over `PX4_INFO`/`PX4_ERR` (picked up by `ORB_ID(log_message)`. The log_message is forwarded by the configured tool (e.g. DroneCAN).  
-The captured hex-dump can be parsed into a CrashDebug-compatible coredump or a PX4-style fault log by using [Tools/hardfaults_rawhex_decode.py](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/hardfaults_rawhex_decode.py).
+```txt
+CONFIG_MODULES_HARDFAULT_STREAM=y
+```
+
+The board's `rcS` must also include the following line to start the module.
+This should be placed after the log transport is started.
+
+```sh
+hardfault_stream start
+```
+
+### Task/CPU-load streaming (Optional)
+
+Live task/CPU-load dumps can also be published through the same path (unrelated feature, same mechanism) using the [task-watchdog](http://localhost:5173/px4_user_guide/en/modules/modules_system#task-watchdog) module:
+
+The [KConfig board configuration](../hardware/porting_guide_config.md) must include the module:
+
+```txt
+CONFIG_MODULES_TASK_WATCHDOG=y
+```
+
+The board's `rcS` must include the following line to start the module.
+
+```sh
+task_watchdog start
+```

--- a/docs/en/debug/hardfault_no_nvram.md
+++ b/docs/en/debug/hardfault_no_nvram.md
@@ -22,7 +22,7 @@ Some settings and instructions are already provided by px4-common-files and are 
 
 ### Hardfault Dumps
 
-The following configuration changes are required to enable crash dumps.
+The following configuration changes are required to enable crash dumps and streaming.
 
 #### KConfig
 
@@ -30,6 +30,13 @@ The [KConfig board configuration](../hardware/porting_guide_config.md) must incl
 
 ```txt
 CONFIG_BOARD_CRASHDUMP=y
+CONFIG_MODULES_HARDFAULT_STREAM=y
+```
+
+The board's `rcS` needs to start the [hardfault-stream](../modules/modules_system.md#hardfault-stream) module.
+
+```sh
+hardfault_stream start
 ```
 
 #### board_config.h
@@ -100,21 +107,6 @@ add_custom_target(px4_ld_script_pp DEPENDS "${_ld_script_pp}")
 add_dependencies(px4 px4_ld_script_pp)
 
 set(_ld_script_flag "-Wl,--script=${_ld_script_pp}")
-```
-
-### Setup the hardfault_stream Module
-
-The [KConfig board configuration](../hardware/porting_guide_config.md) must include the [hardfault-stream](../modules/modules_system.md#hardfault-stream) module:
-
-```txt
-CONFIG_MODULES_HARDFAULT_STREAM=y
-```
-
-The board's `rcS` must also include the following line to start the module.
-This should be placed after the log transport is started.
-
-```sh
-hardfault_stream start
 ```
 
 ### Task/CPU-load streaming (Optional)

--- a/docs/en/debug/hardfault_no_nvram.md
+++ b/docs/en/debug/hardfault_no_nvram.md
@@ -1,8 +1,8 @@
-# Hardfault Logging on Boards Without Non-Volatile Memory
+# Hardfault Logging on Boards Without Usable Non-Volatile Memory
 
-This Section introduce how to setup a board-config to persist a hardfault over warm-reset (power-cycle not covered)
-on boards without a non-volatile storage (sd-card, BBSRAM, PROGMEM, SSARC, …).
-The Hardfault is provided via uORB-log-msg topic after warm-reset.
+This section shows how to setup a board to save a hardfault persistently over warm-reset (only), on boards without usable non-volatile storage.  
+The Hardfault is provided via the uORB-topic `log_message` on reset.  
+Some settings and instructions are already provided by px4-common-files and only mentioned for completness.
 
 ## Overview
 
@@ -12,30 +12,48 @@ Configuration needed:
 - \#DEFINES in `src/board_config.h`:
   - `BOARD_HAS_RAM_HARDFAULT_DUMP`
   - `BOARD_RAM_HARDFAULT_USTACK_BYTES`
-- Memory region in the board's linker script: That survives a warm reset (not zero-initialized) and is big enough for the dump buffer:
-  `sizeof(px4_ram_hardfault_dump_s)` (`sizeof(uint32_t)` + `sizeof(fullcontext_s)`, which depends on `BOARD_RAM_HARDFAULT_USTACK_BYTES`)
+- Memory region in the board's linker script, that survives a warm reset (not zero-initialized) and is big enough for the dump buffer:  
+  `sizeof(px4_ram_hardfault_dump_s)` = `sizeof(uint32_t)` + `sizeof(fullcontext_s)`  
+`fullcontext_s` depends on `BOARD_RAM_HARDFAULT_USTACK_BYTES`
 - Setup module Hardfault_Stream:
   - `CONFIG_MODULES_HARDFAULT_STREAM=y`
-  - `hardfault_stream start` in startup script
-- Optional: `CONFIG_MODULES_TASK_WATCHDOG=y` to also stream live task/CPU-load dumps through the same path (unrelated feature, same mechanism).
-- Optional: `cmake/linker_preprocess.cmake` to keep the linker-script region-size and `BOARD_RAM_HARDFAULT_USTACK_BYTES` in sync automatically, instead of hand-sizing the region. (see example for reference)
+  - `hardfault_stream start`
+- Optional: `CONFIG_MODULES_TASK_WATCHDOG=y`  
+To also stream live task/CPU-load dumps through the same path (unrelated feature, same mechanism).
+- Optional: `cmake/linker_preprocess.cmake`  
+To keep the linker-script region-size and `BOARD_RAM_HARDFAULT_USTACK_BYTES` in sync automatically, instead of hand-sizing the region. (see [example](#example-implementation-and-configuration) for reference).
 
-## Examples Configuration
+## Example Implementation And Configuration
 
-#### nuttx-config/<config>/defconfig
+#### defconfig
 
 ```sh
 CONFIG_BOARD_CRASHDUMP=y
 ```
 
-#### src/board_config.h
+#### board_config.h
 
 ```c
 #define BOARD_HAS_RAM_HARDFAULT_DUMP
-#define BOARD_RAM_HARDFAULT_USTACK_BYTES 4096 // bytes of user stack to capture, check actual usage with `top`
-// IRAM can be taken from `CONFIG_ARCH_INTERRUPTSTACK`
+// bytes of user stack to capture, check actual usage with `top`
+#define BOARD_RAM_HARDFAULT_USTACK_BYTES 4096
+// ISTACK is taken from `CONFIG_ARCH_INTERRUPTSTACK`
 ```
-#### nuttx-config/scripts/script.ld
+
+#### `<board>.px4board` And Startup Script
+
+```sh
+CONFIG_MODULES_HARDFAULT_STREAM=y
+```
+
+```sh
+# in the board's rcS, after the log transport is up
+hardfault_stream start
+# <optional> to also log task-starvation
+task_watchdog start
+```
+
+#### script.ld
 
 ```ld
 MEMORY
@@ -53,21 +71,11 @@ MEMORY
 _noinit_size = SIZEOF(.noinit);
 ```
 
-#### `<board>.px4board` And Startup Script
-
-```sh
-CONFIG_MODULES_HARDFAULT_STREAM=y
-```
-
-```sh
-# in the board's rcS, after the log transport is up
-hardfault_stream start
-```
-
 ### Optional:
 ##### keep the linker-script size in sync (`cmake/linker_preprocess.cmake`)
 
-Instead of hand-sizing the `noinit` region, a preprocessor-script `${PX4_BOARD_DIR}/cmake/linker_preprocess.cmake` can be used compute and inject the region-size into `script.ld`:
+Instead of hand-sizing the `noinit` region, a preprocessor-script `${PX4_BOARD_DIR}/cmake/linker_preprocess.cmake`  
+can be used to compute and inject the region-size into `script.ld`:
 
 ```cmake
 # >> Values can differ from board to board <<
@@ -106,4 +114,6 @@ set(_ld_script_flag "-Wl,--script=${_ld_script_pp}")
 `task_watchdog` (`CONFIG_MODULES_TASK_WATCHDOG=y`)
 
 ## What Happens
-On hardfault, `the board_crashdump()` stashes the fault-context to the `.noinit` region and resets; on the next boot the [hardfault_stream](../modules/modules_system.md#hardfault-stream) checks for valid hadfault-log and streams it out as a hex dump over `PX4_INFO`/`PX4_ERR` (picked up by `ORB_ID(log_message)`. From there by whatever transport the board forwards log messages over, e.g. DroneCAN). [Tools/hardfaults_rawhex_decode.py](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/hardfaults_rawhex_decode.py) turns a captured hex dump back into a CrashDebug-compatible coredump or a PX4-style fault log.
+On hardfault, the `board_crashdump()` stashes the fault-context to the `.noinit` region and resets.  
+On the next boot, the [hardfault_stream](../modules/modules_system.md#hardfault-stream) checks for valid hadfault-log and streams it out as a hex dump over `PX4_INFO`/`PX4_ERR` (picked up by `ORB_ID(log_message)`. The log_message is forwarded by the configured tool (e.g. DroneCAN).  
+The captured hex-dump can be parsed into a CrashDebug-compatible coredump or a PX4-style fault log by using [Tools/hardfaults_rawhex_decode.py](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/hardfaults_rawhex_decode.py).

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -362,6 +362,12 @@ else()
 	target_link_libraries(nuttx_xx INTERFACE nuttx_c)
 	target_link_libraries(nuttx_fs INTERFACE nuttx_c nuttx_mm)
 
+	# Provide the possibility to preprocess linker by providing cmake/linker_preprocess.cmake
+	set(_ld_script_flag "-Wl,--script=${NUTTX_CONFIG_DIR_CYG}/scripts/${SCRIPT_PREFIX}script.ld")
+	if(EXISTS "${PX4_BOARD_DIR}/cmake/linker_preprocess.cmake")
+		include(${PX4_BOARD_DIR}/cmake/linker_preprocess.cmake)
+	endif()
+
 	target_link_libraries(px4 PRIVATE
 
 		-nostartfiles
@@ -371,7 +377,7 @@ else()
 
 		-fno-exceptions
 		-fno-rtti
-		-Wl,--script=${NUTTX_CONFIG_DIR_CYG}/scripts/${SCRIPT_PREFIX}script.ld
+		${_ld_script_flag}
 		-L${NUTTX_CONFIG_DIR_CYG}/scripts
 		-Wl,-Map=${PX4_CONFIG}.map
 		-Wl,--warn-common

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -362,9 +362,9 @@ else()
 	target_link_libraries(nuttx_xx INTERFACE nuttx_c)
 	target_link_libraries(nuttx_fs INTERFACE nuttx_c nuttx_mm)
 
-	# Provide the possibility to preprocess linker by providing cmake/linker_preprocess.cmake
+	# Provide the possibility to preprocess linker by providing cmake/linker_preprocess.cmake.
 	set(_ld_script_flag "-Wl,--script=${NUTTX_CONFIG_DIR_CYG}/scripts/${SCRIPT_PREFIX}script.ld")
-	if(EXISTS "${PX4_BOARD_DIR}/cmake/linker_preprocess.cmake")
+	if(NOT SCRIPT_PREFIX AND EXISTS "${PX4_BOARD_DIR}/cmake/linker_preprocess.cmake")
 		include(${PX4_BOARD_DIR}/cmake/linker_preprocess.cmake)
 	endif()
 

--- a/platforms/nuttx/src/px4/common/board_crashdump.c
+++ b/platforms/nuttx/src/px4/common/board_crashdump.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2017-2021 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2017-2026 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -75,7 +75,7 @@ int board_hardfault_init(int display_to_console, bool allow_prompt)
 {
 
 	int hadCrash = -1;
-#if defined(HAS_BBSRAM)
+#if HAS_BBSRAM
 
 	/* NB. the use of the console requires the hrt running
 	 * to poll the DMA
@@ -256,6 +256,14 @@ static void copy_reverse(stack_word_t *dest, stack_word_t *src, int size)
 	}
 }
 
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+
+/* The persistent dump buffer - placed in .noinit.hardfault_dump so it is never zeroed by the
+ * C runtime on a warm reset.*/
+px4_ram_hardfault_dump_s g_px4_ram_hardfault __attribute__((section(".noinit.hardfault_dump")));
+
+
+#else /* no BOARD_HAS_RAM_HARDFAULT_DUMP */
 #ifdef BOARD_CRASHDUMP_BSS
 
 static uint32_t *__attribute__((noinline)) __ebss_addr(void)
@@ -271,6 +279,7 @@ static uint32_t *__attribute__((noinline)) __sdata_addr(void)
 }
 
 #endif
+#endif /* BOARD_HAS_RAM_HARDFAULT_DUMP */
 
 
 __EXPORT void board_crashdump(uintptr_t currentsp, FAR void *tcb, FAR const char *filename, int lineno)
@@ -283,7 +292,12 @@ __EXPORT void board_crashdump(uintptr_t currentsp, FAR void *tcb, FAR const char
 	 * Unfortunately this is hard to test. See dead below
 	 */
 
-#ifdef BOARD_CRASHDUMP_BSS
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+	/* .noinit.hardfault_dump RAM dump: invalidate magic now so a concurrent reader never sees a
+	 * half-written context.  It will be restamped at the end*/
+	g_px4_ram_hardfault.magic = 0u;
+	fullcontext_s *pdump = &g_px4_ram_hardfault.context;
+#elif defined(BOARD_CRASHDUMP_BSS)
 	fullcontext_s *pdump = (fullcontext_s *)(__ebss_addr() - sizeof(fullcontext_s));
 #else
 	fullcontext_s *pdump = (fullcontext_s *)__sdata_addr();
@@ -411,6 +425,10 @@ __EXPORT void board_crashdump(uintptr_t currentsp, FAR void *tcb, FAR const char
 		pdump->info.flags |= eInvalidUserStackPtr;
 	}
 
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+	/* Stamp magic to mark dump as valid */
+	g_px4_ram_hardfault.magic = BOARD_RAM_HARDFAULT_MAGIC;
+#else
 	int rv = px4_savepanic(HARDFAULT_FILENO, (uint8_t *)pdump, sizeof(fullcontext_s));
 
 	/* Test if memory got wiped because of using _sdata */
@@ -428,6 +446,8 @@ __EXPORT void board_crashdump(uintptr_t currentsp, FAR void *tcb, FAR const char
 
 		up_putc('!');
 	}
+
+#endif /* BOARD_HAS_RAM_HARDFAULT_DUMP */
 
 #endif /* BOARD_CRASHDUMP_RESET_ONLY */
 

--- a/platforms/nuttx/src/px4/common/board_crashdump.c
+++ b/platforms/nuttx/src/px4/common/board_crashdump.c
@@ -293,7 +293,7 @@ __EXPORT void board_crashdump(uintptr_t currentsp, FAR void *tcb, FAR const char
 	 */
 
 #ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
-	/* .noinit.hardfault_dump RAM dump: invalidate magic now so a concurrent reader never sees a
+	/* invalidate magic now, so a concurrent reader never sees a
 	 * half-written context.  It will be restamped at the end*/
 	g_px4_ram_hardfault.magic = 0u;
 	fullcontext_s *pdump = &g_px4_ram_hardfault.context;

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -525,7 +525,6 @@ class RestartRequestHandler: public uavcan::IRestartRequestHandler
 
 void UavcanNode::Run()
 {
-	static  hrt_abstime up_time{0};
 	pthread_mutex_lock(&_node_mutex);
 
 	// Bootloader started it.
@@ -593,7 +592,7 @@ void UavcanNode::Run()
 	case  Allocated:
 		if (_node.getNodeID() != 0) {
 
-			up_time = hrt_absolute_time();
+			_up_time = hrt_absolute_time();
 			get_node().setRestartRequestHandler(&restart_request_handler);
 			_param_server.start(&_param_manager);
 
@@ -692,10 +691,12 @@ void UavcanNode::Run()
 
 	_node.spinOnce();
 
+	publish_node_status();
+
 	// This is done only once to signify the node has run 30 seconds
 
-	if (up_time && hrt_elapsed_time(&up_time) > 30_s) {
-		up_time = 0;
+	if (_up_time && hrt_elapsed_time(&_up_time) > 30_s) {
+		_up_time = 0;
 		board_configure_reset(BOARD_RESET_MODE_RTC_BOOT_FWOK, 0);
 	}
 
@@ -784,6 +785,29 @@ void UavcanNode::PrintInfo()
 	perf_print_counter(_interval_perf);
 
 	pthread_mutex_unlock(&_node_mutex);
+}
+
+void UavcanNode::publish_node_status()
+{
+	constexpr hrt_abstime status_pub_interval = 1_s;
+	const hrt_abstime now = hrt_absolute_time();
+
+	if (now - _last_node_status_pub < status_pub_interval) {
+		return;
+	}
+
+	_last_node_status_pub = now;
+
+	const auto &status_provider = _node.getNodeStatusProvider();
+
+	dronecan_node_status_s status{};
+	status.timestamp = now;
+	status.node_id = _node.getNodeID().get();
+	status.uptime_sec = _up_time ? (now - _up_time) / 1_s : 0;
+	status.health = status_provider.getHealth();
+	status.mode = status_provider.getMode();
+
+	_node_status_pub.publish(status);
 }
 
 void UavcanNode::shrink()

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -634,7 +634,8 @@ void UavcanNode::Run()
 		publisher->BroadcastAnyUpdates();
 	}
 
-	if (_log_message_sub.updated()) {
+	// Don't drain log_message until the node has a valid ID and can actually broadcast on the bus,
+	if ((_init_state == Done) && _log_message_sub.updated()) {
 		log_message_s log_message;
 
 		if (_log_message_sub.copy(&log_message)) {

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -633,8 +633,7 @@ void UavcanNode::Run()
 		publisher->BroadcastAnyUpdates();
 	}
 
-	// Don't drain log_message until the node has a valid ID and can actually broadcast on the bus,
-	if ((_init_state == Done) && _log_message_sub.updated()) {
+	if (_log_message_sub.updated()) {
 		log_message_s log_message;
 
 		if (_log_message_sub.copy(&log_message)) {

--- a/src/drivers/uavcannode/UavcanNode.hpp
+++ b/src/drivers/uavcannode/UavcanNode.hpp
@@ -54,7 +54,6 @@
 #include <uavcan/protocol/global_time_sync_slave.hpp>
 #include <uavcan/protocol/file/BeginFirmwareUpdate.hpp>
 #include <uavcan/node/timer.hpp>
-#include <uavcan/protocol/node_status_monitor.hpp>
 #include <uavcan/protocol/param/GetSet.hpp>
 #include <uavcan/protocol/param/ExecuteOpcode.hpp>
 #include <uavcan/protocol/RestartNode.hpp>
@@ -65,9 +64,11 @@
 #include <lib/parameters/param.h>
 #include <lib/perf/perf_counter.h>
 
+#include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/SubscriptionInterval.hpp>
+#include <uORB/topics/dronecan_node_status.h>
 #include <uORB/topics/log_message.h>
 #include <uORB/topics/parameter_update.h>
 
@@ -148,6 +149,7 @@ private:
 	void Run() override;
 
 	void fill_node_info();
+	void publish_node_status();
 	int init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events);
 
 	px4::atomic_bool	_task_should_exit{false};	///< flag to indicate to tear down the CAN driver
@@ -177,6 +179,10 @@ private:
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 	uORB::SubscriptionCallbackWorkItem _log_message_sub{this, ORB_ID(log_message)};
+
+	uORB::Publication<dronecan_node_status_s> _node_status_pub{ORB_ID(dronecan_node_status)};
+	hrt_abstime _last_node_status_pub{0};
+	hrt_abstime _up_time{0};
 
 	UavcanNodeParamManager _param_manager;
 	uavcan::ParamServer _param_server;

--- a/src/lib/systemlib/hardfault_log.h
+++ b/src/lib/systemlib/hardfault_log.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2015 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2015-2026 PX4 Development Team. All rights reserved.
  *   Author: @author David Sidrane <david_s5@nscdg.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,7 +44,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#if defined(HAS_BBSRAM)
+#if HAS_BBSRAM
 
 #include <stm32_bbsram.h>
 typedef struct bbsramd_s dump_s;
@@ -198,7 +198,24 @@ typedef struct ssarc_s dump_s;
 		SSARC_DUMP_SIZE_FN4,   /* For the Panic Log use rest of space */  \
 		0                  /* End of table marker */                  \
 	}
-#else /* HAS_SSARC */
+#elif defined(BOARD_HAS_RAM_HARDFAULT_DUMP)
+
+/* .noinit RAM dump backend (no BBSRAM/progmem/SSARC).
+ * Stack capture fills the noinit region after the magic word and info_s. */
+#include <time.h>
+/* Minimal dump descriptor - only the timestamp field is used during formatting */
+typedef struct { struct timespec lastwrite; } dump_s;
+
+#define BOARD_RAM_HARDFAULT_MAGIC 0xDEADA1B2U
+
+#if CONFIG_ARCH_INTERRUPTSTACK <= 3
+#  define CONFIG_ISTACK_SIZE  0U
+#else
+#  define CONFIG_ISTACK_SIZE  (CONFIG_ARCH_INTERRUPTSTACK / sizeof(stack_word_t))
+#endif
+#define CONFIG_USTACK_SIZE  (BOARD_RAM_HARDFAULT_USTACK_BYTES / sizeof(stack_word_t))
+
+#else
 
 #define CONFIG_ISTACK_SIZE 0
 #define CONFIG_USTACK_SIZE 0
@@ -382,18 +399,30 @@ typedef struct {
 } info_s;
 
 typedef struct {
-	info_s    info;                       /* The info */
+	info_s    info;                 /* The info */
 #if CONFIG_ARCH_INTERRUPTSTACK > 3      /* The amount of stack data is compile time
-									 * sized backed on what is left after the
-									 * other BBSRAM files are defined
-									 * The order is such that only the
-									 * ustack should be truncated
-									 */
-	stack_word_t istack[CONFIG_USTACK_SIZE];
+					* sized backed on what is left after the
+					* other BBSRAM files are defined
+					* The order is such that only the
+					* ustack should be truncated
+					*/
+	stack_word_t istack[CONFIG_ISTACK_SIZE];
 #endif
-	stack_word_t ustack[CONFIG_ISTACK_SIZE];
+	stack_word_t ustack[CONFIG_USTACK_SIZE];
 } fullcontext_s;
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+/**
+ * Generic .noinit RAM hardfault dump buffer for boards with BOARD_HAS_RAM_HARDFAULT_DUMP.
+ *
+ * Boards opting into this mechanism must define BOARD_HAS_RAM_HARDFAULT_DUMP
+ */
+typedef struct {
+	uint32_t      magic;    /* BOARD_RAM_HARDFAULT_MAGIC when context is valid */
+	fullcontext_s context;
+} px4_ram_hardfault_dump_s;
 
+extern px4_ram_hardfault_dump_s g_px4_ram_hardfault;
+#endif /* BOARD_HAS_RAM_HARDFAULT_DUMP */
 __BEGIN_DECLS
 /****************************************************************************
  * Name: hardfault_check_status

--- a/src/lib/systemlib/hardfault_log.h
+++ b/src/lib/systemlib/hardfault_log.h
@@ -200,7 +200,7 @@ typedef struct ssarc_s dump_s;
 	}
 #elif defined(BOARD_HAS_RAM_HARDFAULT_DUMP)
 
-/* .noinit RAM dump backend (no BBSRAM/progmem/SSARC).
+/* .noinit RAM dump backend
  * Stack capture fills the noinit region after the magic word and info_s. */
 #include <time.h>
 /* Minimal dump descriptor - only the timestamp field is used during formatting */
@@ -417,7 +417,7 @@ typedef struct {
  * Boards opting into this mechanism must define BOARD_HAS_RAM_HARDFAULT_DUMP
  */
 typedef struct {
-	uint32_t      magic;    /* BOARD_RAM_HARDFAULT_MAGIC when context is valid */
+	volatile uint32_t magic; /* BOARD_RAM_HARDFAULT_MAGIC when context is valid */
 	fullcontext_s context;
 } px4_ram_hardfault_dump_s;
 

--- a/src/modules/hardfault_stream/CMakeLists.txt
+++ b/src/modules/hardfault_stream/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2016-2025 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2016-2026 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,11 +34,15 @@ px4_add_module(
 	MODULE modules__hardfault_stream
 	MAIN hardfault_stream
 	COMPILE_FLAGS
+		-DUAVCAN_CPP_VERSION=UAVCAN_CPP03
 	SRCS
 		HardfaultStream.cpp
 		HardfaultStream.hpp
 	MODULE_CONFIG
 		params.yaml
+	INCLUDES
+		${PX4_SOURCE_DIR}/src/drivers/uavcan/libdronecan/libuavcan/include
+		${PX4_SOURCE_DIR}/src/drivers/uavcan/libdronecan/libuavcan/include/dsdlc_generated
 	DEPENDS
 		px4_work_queue
 )

--- a/src/modules/hardfault_stream/HardfaultStream.cpp
+++ b/src/modules/hardfault_stream/HardfaultStream.cpp
@@ -135,7 +135,7 @@ void HardfaultStream::stream_hardfault()
 			return;
 		}
 
-		PX4_INFO("Streaming hardfault log: %s", _hardfault_file_path);
+		PX4_ERR("Streaming hardfault log: %s", _hardfault_file_path);
 	}
 
 	static constexpr int chunk_size = sizeof(mavlink_log_s::text) - 1;
@@ -160,9 +160,22 @@ void HardfaultStream::Run()
 	}
 
 	switch (_state) {
-	case State::SearchFile:
+	case State::SearchHardFault:
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+		if (g_px4_ram_hardfault.magic == BOARD_RAM_HARDFAULT_MAGIC) {
+			_ram_off = 0;
+			_ram_crc = 0xFFFFFFFFu;
+			_state = State::StreamRAM;
+
+		} else {
+			_state = State::RequestStop;
+		}
+
+#else
 		search_hardfault_file();
 		_state = State::WaitMavlink;
+#endif
+
 		ScheduleNow();
 		break;
 
@@ -183,6 +196,44 @@ void HardfaultStream::Run()
 		}
 
 		break;
+
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+
+	case State::StreamRAM: {
+			using LogTextField = uavcan::protocol::debug::LogMessage::FieldTypes::text;
+			static constexpr size_t kLogTextMax    = LogTextField::MaxSize;       // uint8[<=90]
+			static constexpr size_t kHexPfxLen     = 5;                           // "%04x "
+			static constexpr size_t kBytesPerChunk = (kLogTextMax - kHexPfxLen) / 2;
+
+			const uint8_t *ptr   = reinterpret_cast<const uint8_t *>(&g_px4_ram_hardfault.context);
+			const size_t   total = sizeof(fullcontext_s);
+
+			if (_ram_off < total) {
+				size_t n = total - _ram_off;
+
+				if (n > kBytesPerChunk) { n = kBytesPerChunk; }
+
+				char hexline[kLogTextMax];
+				int  pos = snprintf(hexline, sizeof(hexline), "%04x ", (unsigned)_ram_off);
+
+				for (size_t i = 0; i < n; i++) {
+					pos += snprintf(hexline + pos, sizeof(hexline) - pos, "%02x", ptr[_ram_off + i]);
+				}
+
+				_ram_crc = crc32part((const uint8_t *)hexline, strlen(hexline), _ram_crc);
+				PX4_ERR("%s", hexline);
+				_ram_off += n;
+
+			} else {
+				PX4_ERR("crc %08" PRIx32, _ram_crc ^ 0xFFFFFFFFu);
+				g_px4_ram_hardfault.magic = 0u;
+				_state = State::RequestStop;
+			}
+
+			break;
+		}
+
+#endif
 
 	case State::RequestStop:
 		request_stop();

--- a/src/modules/hardfault_stream/HardfaultStream.cpp
+++ b/src/modules/hardfault_stream/HardfaultStream.cpp
@@ -78,6 +78,24 @@ void HardfaultStream::start()
 	ScheduleOnInterval(150_ms);
 }
 
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+bool HardfaultStream::is_transport_ready()
+{
+#ifdef CONFIG_DRIVERS_UAVCANNODE
+	dronecan_node_status_s status;
+
+	if (_dronecan_node_status_sub.copy(&status)) {
+		return status.mode == dronecan_node_status_s::MODE_OPERATIONAL;
+	}
+
+	return false;
+#else
+	// No known transport to wait for - don't block.
+	return true;
+#endif
+}
+#endif // BOARD_HAS_RAM_HARDFAULT_DUMP
+
 bool HardfaultStream::mavlink_gcs_up()
 {
 	for (auto &telemetry_status : _telemetry_status_subs) {
@@ -165,7 +183,7 @@ void HardfaultStream::Run()
 		if (g_px4_ram_hardfault.magic == BOARD_RAM_HARDFAULT_MAGIC) {
 			_ram_off = 0;
 			_ram_crc = 0xFFFFFFFFu;
-			_state = State::StreamRAM;
+			_state = State::WaitTransportReady;
 
 		} else {
 			_state = State::RequestStop;
@@ -198,6 +216,15 @@ void HardfaultStream::Run()
 		break;
 
 #ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+
+	case State::WaitTransportReady:
+
+		// Don't stream before the log transport is ready, otherwise part of dump gets lost
+		if (is_transport_ready()) {
+			_state = State::StreamRAM;
+		}
+
+		break;
 
 	case State::StreamRAM: {
 			using LogTextField = uavcan::protocol::debug::LogMessage::FieldTypes::text;

--- a/src/modules/hardfault_stream/HardfaultStream.cpp
+++ b/src/modules/hardfault_stream/HardfaultStream.cpp
@@ -84,7 +84,7 @@ bool HardfaultStream::is_transport_ready()
 #ifdef CONFIG_DRIVERS_UAVCANNODE
 	dronecan_node_status_s status;
 
-	if (_dronecan_node_status_sub.copy(&status)) {
+	if (_dronecan_node_status_sub.update(&status)) {
 		return status.mode == dronecan_node_status_s::MODE_OPERATIONAL;
 	}
 
@@ -228,9 +228,9 @@ void HardfaultStream::Run()
 
 	case State::StreamRAM: {
 			using LogTextField = uavcan::protocol::debug::LogMessage::FieldTypes::text;
-			static constexpr size_t kLogTextMax    = LogTextField::MaxSize;       // uint8[<=90]
-			static constexpr size_t kHexPfxLen     = 5;                           // "%04x "
-			static constexpr size_t kBytesPerChunk = (kLogTextMax - kHexPfxLen) / 2;
+			static constexpr size_t kLogTextMax    = LogTextField::MaxSize;          // uint8[<=90]
+			static constexpr size_t kHexPfxLen     = 5;                              // "%04x "
+			static constexpr size_t kBytesPerChunk = (kLogTextMax - kHexPfxLen) / 2; // 2 hex chars per byte
 
 			const uint8_t *ptr   = reinterpret_cast<const uint8_t *>(&g_px4_ram_hardfault.context);
 			const size_t   total = sizeof(fullcontext_s);

--- a/src/modules/hardfault_stream/HardfaultStream.hpp
+++ b/src/modules/hardfault_stream/HardfaultStream.hpp
@@ -37,6 +37,8 @@
 #include <string.h>
 #include <sys/stat.h>
 
+#include <board_config.h>
+
 #include <px4_platform_common/defines.h>
 #include <px4_platform_common/module.h>
 #include <px4_platform_common/module_params.h>
@@ -48,6 +50,13 @@
 #include <uORB/topics/telemetry_status.h>
 
 #include <systemlib/mavlink_log.h>
+
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+# include <inttypes.h>
+# include <systemlib/hardfault_log.h>
+# include <crc32.h>
+# include <uavcan/protocol/debug/LogMessage.hpp>
+#endif
 
 namespace hardfault_stream
 {
@@ -75,9 +84,12 @@ public:
 
 private:
 	enum class State {
-		SearchFile,
+		SearchHardFault,
 		WaitMavlink,
 		StreamFile,
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+		StreamRAM,
+#endif
 		RequestStop,
 		WaitStop,
 	};
@@ -89,7 +101,7 @@ private:
 	void search_hardfault_file();
 	void stream_hardfault();
 
-	State _state {State::SearchFile};
+	State _state {State::SearchHardFault};
 
 	bool _stream_finished {false};
 	bool _hardfault_file_present {false};
@@ -99,6 +111,11 @@ private:
 
 	orb_advert_t _mavlink_log_pub {nullptr};
 	uORB::SubscriptionMultiArray<telemetry_status_s> _telemetry_status_subs{ORB_ID::telemetry_status};
+
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+	size_t   _ram_off {0};
+	uint32_t _ram_crc{0xFFFFFFFFu};
+#endif
 };
 
 } // namespace hardfault_stream

--- a/src/modules/hardfault_stream/HardfaultStream.hpp
+++ b/src/modules/hardfault_stream/HardfaultStream.hpp
@@ -56,6 +56,7 @@
 # include <systemlib/hardfault_log.h>
 # include <crc32.h>
 # include <uavcan/protocol/debug/LogMessage.hpp>
+# include <uORB/topics/dronecan_node_status.h>
 #endif
 
 namespace hardfault_stream
@@ -88,6 +89,7 @@ private:
 		WaitMavlink,
 		StreamFile,
 #ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+		WaitTransportReady,
 		StreamRAM,
 #endif
 		RequestStop,
@@ -100,6 +102,9 @@ private:
 	bool mavlink_gcs_up();
 	void search_hardfault_file();
 	void stream_hardfault();
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+	bool is_transport_ready();
+#endif
 
 	State _state {State::SearchHardFault};
 
@@ -115,6 +120,7 @@ private:
 #ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
 	size_t   _ram_off {0};
 	uint32_t _ram_crc{0xFFFFFFFFu};
+	uORB::Subscription _dronecan_node_status_sub {ORB_ID(dronecan_node_status)};
 #endif
 };
 

--- a/src/modules/task_watchdog/CMakeLists.txt
+++ b/src/modules/task_watchdog/CMakeLists.txt
@@ -34,8 +34,13 @@
 px4_add_module(
 	MODULE modules__task_watchdog
 	MAIN task_watchdog
+	COMPILE_FLAGS
+		-DUAVCAN_CPP_VERSION=UAVCAN_CPP03
 	SRCS
 		TaskWatchdog.cpp
+	INCLUDES
+		${PX4_SOURCE_DIR}/src/drivers/uavcan/libdronecan/libuavcan/include
+		${PX4_SOURCE_DIR}/src/drivers/uavcan/libdronecan/libuavcan/include/dsdlc_generated
 	DEPENDS
 		version
 )

--- a/src/modules/task_watchdog/Kconfig
+++ b/src/modules/task_watchdog/Kconfig
@@ -3,4 +3,13 @@ menuconfig MODULES_TASK_WATCHDOG
 	default n
 	depends on PLATFORM_NUTTX
 	---help---
-		Detect tasks running too long and dump their register/stack state and cpuload to files
+		Detect tasks running too long and dump their register/stack state and cpuload
+
+if MODULES_TASK_WATCHDOG
+config TASK_WATCHDOG_MAX_DUMP_TASKS
+	int "Max number of tasks captured in a starvation dump"
+	default -1
+	---help---
+		On boards with minimal RAM, configure how many tasks will be logged on task starvation.
+		If TASK_WATCHDOG_MAX_DUMP_TASKS == -1, the config_variable CONFIG_FS_PROCFS_MAX_TASKS is used instead.
+endif

--- a/src/modules/task_watchdog/TaskWatchdog.cpp
+++ b/src/modules/task_watchdog/TaskWatchdog.cpp
@@ -249,6 +249,20 @@ void TaskWatchdog::run()
 	hrt_cancel(&_hrt_call);
 }
 
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+void TaskWatchdog::wait_for_transport_ready()
+{
+#ifdef CONFIG_DRIVERS_UAVCANNODE
+	dronecan_node_status_s status;
+
+	while (!(_dronecan_node_status_sub.copy(&status) && status.mode == dronecan_node_status_s::MODE_OPERATIONAL)) {
+		px4_usleep(100_ms);
+	}
+
+#endif
+}
+#endif // BOARD_HAS_RAM_HARDFAULT_DUMP
+
 void TaskWatchdog::capture_and_write_dump()
 {
 	for (int i = 0; i < MAX_DUMP_TASKS; i++) { _dumps[i] = task_dump_s{}; }
@@ -297,6 +311,8 @@ void TaskWatchdog::capture_and_write_dump()
 	char line[90];
 
 #ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+	wait_for_transport_ready();
+
 	uint32_t crc = 0xFFFFFFFFu;
 
 	auto emit = [&](const char *s) {
@@ -422,6 +438,8 @@ void TaskWatchdog::capture_and_write_dump()
 void TaskWatchdog::write_cpuload_file()
 {
 #ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+	wait_for_transport_ready();
+
 	char buf[90];
 	print_load_buffer(buf, sizeof(buf),
 	[](void *user) {

--- a/src/modules/task_watchdog/TaskWatchdog.cpp
+++ b/src/modules/task_watchdog/TaskWatchdog.cpp
@@ -46,6 +46,10 @@
 #include <errno.h>
 #include <sys/stat.h>
 
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+# include <crc32.h>
+#endif
+
 #ifndef CONFIG_BUILD_FLAT
 # error Task Watchdog requires flat build, please enable it to use this module
 #endif
@@ -110,7 +114,7 @@ void TaskWatchdog::start()
 
 	sched_lock();
 
-	for (int i = 0; i < CONFIG_FS_PROCFS_MAX_TASKS; i++) {
+	for (int i = 0; i < MAX_DUMP_TASKS; i++) {
 		if (system_load.tasks[i].valid && system_load.tasks[i].tcb->pid == my_pid) {
 			_shared.monitored_task_index = i;
 			break;
@@ -145,7 +149,7 @@ void TaskWatchdog::isr_callback(void *arg)
 		return;
 	}
 
-	// Already triggered — wait for the task side to process
+	// Already triggered - wait for the task side to process
 	if (shared->triggered.load()) {
 		// Wake the task, otherwise it can get stuck when starved before entering the sem wait
 		px4_sem_post(shared->sem);
@@ -247,34 +251,14 @@ void TaskWatchdog::run()
 
 void TaskWatchdog::capture_and_write_dump()
 {
-	mkdir(LOG_PATH_BASE, S_IRWXU | S_IRWXG | S_IRWXO);
-
-	char path[64];
-	int ret = format_file_path(LOG_WDG, path, sizeof(path));
-
-	if (ret != PX4_OK) {
-		PX4_ERR("Could not create watchdog dump file: %d", ret);
-		return;
-	}
-
-	int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
-
-	if (fd < 0) {
-		PX4_ERR("failed to create %s: %d", path, errno);
-		return;
-	}
-
-	dprintf(fd, "Task Watchdog Dump\n");
-	dprintf(fd, "FW git-hash: %s\n", px4_firmware_version_string());
-	dprintf(fd, "Build datetime: %s %s\n", __DATE__, __TIME__);
-	dprintf(fd, "Build url: %s \n", px4_build_uri());
+	for (int i = 0; i < MAX_DUMP_TASKS; i++) { _dumps[i] = task_dump_s{}; }
 
 	const hrt_abstime now = hrt_absolute_time();
 
 	/* Loop 1: capture under sched_lock */
 	sched_lock();
 
-	for (int i = 0; i < CONFIG_FS_PROCFS_MAX_TASKS; i++) {
+	for (int i = 0; i < MAX_DUMP_TASKS; i++) {
 		const system_load_taskinfo_s &task = system_load.tasks[i];
 
 		if (!task.valid || !task.tcb || task.tcb->pid == 0) {
@@ -310,71 +294,142 @@ void TaskWatchdog::capture_and_write_dump()
 
 	sched_unlock();
 
-	/* Loop 2: write to file — no locks held */
-	for (int i = 0; i < CONFIG_FS_PROCFS_MAX_TASKS; i++) {
+	char line[90];
+
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+	uint32_t crc = 0xFFFFFFFFu;
+
+	auto emit = [&](const char *s) {
+		crc = crc32part((const uint8_t *)s, strlen(s), crc);
+		PX4_ERR("%s", s);
+		px4_usleep(150_ms);
+	};
+
+#else /* !BOARD_HAS_RAM_HARDFAULT_DUMP */
+	mkdir(LOG_PATH_BASE, S_IRWXU | S_IRWXG | S_IRWXO);
+
+	char path[64];
+	int ret = format_file_path(LOG_WDG, path, sizeof(path));
+
+	if (ret != PX4_OK) {
+		PX4_ERR("Could not create watchdog dump file: %d", ret);
+		return;
+	}
+
+	int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+
+	if (fd < 0) {
+		PX4_ERR("failed to create %s: %d", path, errno);
+		return;
+	}
+
+	auto emit = [&](const char *s) { dprintf(fd, "%s\n", s); };
+
+#endif /* BOARD_HAS_RAM_HARDFAULT_DUMP */
+
+	snprintf(line, sizeof(line), "WDG fw:%.60s", px4_firmware_version_string());
+	emit(line);
+	snprintf(line, sizeof(line), "build: %s %s", __DATE__, __TIME__);
+	emit(line);
+	snprintf(line, sizeof(line), "url: %.70s", px4_build_uri());
+	emit(line);
+
+	/* Loop 2: output - no locks held */
+	for (int i = 0; i < MAX_DUMP_TASKS; i++) {
 		const task_dump_s &d = _dumps[i];
 
 		if (!d.valid) {
 			continue;
 		}
 
-		dprintf(fd, "T:%" PRIu64 " %s(%d) state:%d",
-			now,
+		snprintf(line, sizeof(line), "T:%" PRIu64 " %s(%d) state:%d",
+			 now,
 #if CONFIG_TASK_NAME_SIZE > 0
-			d.name,
+			 d.name,
 #else
-			"?",
+			 "?",
 #endif
-			(int)d.pid,
-			(int)d.state);
+			 (int)d.pid,
+			 (int)d.state);
+		emit(line);
 
 		if (d.has_regs) {
-			dprintf(fd, "\n r0:%08" PRIx32 " r1:%08" PRIx32 "  r2:%08" PRIx32 "  r3:%08" PRIx32
-				"  r4:%08" PRIx32 "  r5:%08" PRIx32 " r6:%08" PRIx32 " r7:%08" PRIx32 "\n",
-				d.regs[REG_R0],  d.regs[REG_R1],
-				d.regs[REG_R2],  d.regs[REG_R3],
-				d.regs[REG_R4],  d.regs[REG_R5],
-				d.regs[REG_R6],  d.regs[REG_R7]);
-			dprintf(fd, " r8:%08" PRIx32 " r9:%08" PRIx32 " r10:%08" PRIx32 " r11:%08" PRIx32
-				" r12:%08" PRIx32 "  sp:%08" PRIx32 " lr:%08" PRIx32 " pc:%08" PRIx32 "\n",
-				d.regs[REG_R8],  d.regs[REG_R9],
-				d.regs[REG_R10], d.regs[REG_R11],
-				d.regs[REG_R12], d.regs[REG_R13],
-				d.regs[REG_R14], d.regs[REG_R15]);
+			snprintf(line, sizeof(line),
+				 " r0:%08" PRIx32 " r1:%08" PRIx32 " r2:%08" PRIx32 " r3:%08" PRIx32,
+				 d.regs[REG_R0],  d.regs[REG_R1],
+				 d.regs[REG_R2],  d.regs[REG_R3]);
+			emit(line);
+
+			snprintf(line, sizeof(line),
+				 " r4:%08" PRIx32 " r5:%08" PRIx32 " r6:%08" PRIx32 " r7:%08" PRIx32,
+				 d.regs[REG_R4],  d.regs[REG_R5],
+				 d.regs[REG_R6],  d.regs[REG_R7]);
+			emit(line);
+
+			snprintf(line, sizeof(line),
+				 " r8:%08" PRIx32 " r9:%08" PRIx32 " r10:%08" PRIx32 " r11:%08" PRIx32,
+				 d.regs[REG_R8],  d.regs[REG_R9],
+				 d.regs[REG_R10], d.regs[REG_R11]);
+			emit(line);
+
+			snprintf(line, sizeof(line),
+				 " r12:%08" PRIx32 " sp:%08" PRIx32 " lr:%08" PRIx32 " pc:%08" PRIx32,
+				 d.regs[REG_R12], d.regs[REG_R13],
+				 d.regs[REG_R14], d.regs[REG_R15]);
+			emit(line);
+
 #ifdef CONFIG_ARMV7M_USEBASEPRI
-			dprintf(fd, " xpsr:%08" PRIx32 " basepri:%08" PRIx32 "\n",
-				d.regs[REG_XPSR], d.regs[REG_BASEPRI]);
+			snprintf(line, sizeof(line), " xpsr:%08" PRIx32 " basepri:%08" PRIx32,
+				 d.regs[REG_XPSR], d.regs[REG_BASEPRI]);
 #else
-			dprintf(fd, " xpsr:%08" PRIx32 " primask:%08" PRIx32 "\n",
-				d.regs[REG_XPSR], d.regs[REG_PRIMASK]);
+			snprintf(line, sizeof(line), " xpsr:%08" PRIx32 " primask:%08" PRIx32,
+				 d.regs[REG_XPSR], d.regs[REG_PRIMASK]);
 #endif
+			emit(line);
 
 			if (d.stack_words > 0) {
-				dprintf(fd, "STK(%u@%08" PRIx32 "):", d.stack_words, d.regs[REG_R13]);
+				int pos = snprintf(line, sizeof(line), "STK(%u@%08" PRIx32 "):", d.stack_words,
+						   d.regs[REG_R13]);
 
 				for (unsigned j = 0; j < d.stack_words; j++) {
 					if (j > 0 && (j % 8) == 0) {
-						dprintf(fd, "\n");
+						emit(line);
+						pos = snprintf(line, sizeof(line), "STK+%u:", j);
 					}
 
-					dprintf(fd, " %08" PRIx32, d.stack[j]);
+					pos += snprintf(line + pos, sizeof(line) - pos, " %08" PRIx32, d.stack[j]);
 				}
 
-				dprintf(fd, "\n");
+				emit(line);
 			}
 
 		} else {
-			dprintf(fd, " [no saved regs]\n");
+			snprintf(line, sizeof(line), " [no saved regs]");
+			emit(line);
 		}
 	}
 
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+	snprintf(line, sizeof(line), "crc %08" PRIx32, crc ^ 0xFFFFFFFFu);
+	PX4_ERR("%s", line);
+#else
 	fsync(fd);
 	close(fd);
-	PX4_INFO("dump written to %s", path);
+	PX4_ERR("dump written to %s", path);
+#endif
 }
 
 void TaskWatchdog::write_cpuload_file()
 {
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+	char buf[90];
+	print_load_buffer(buf, sizeof(buf),
+	[](void *user) {
+		PX4_ERR("%s", static_cast<char *>(user));
+		px4_usleep(150_ms);
+	},
+	buf, &_load);
+#else
 	mkdir(LOG_PATH_BASE, S_IRWXU | S_IRWXG | S_IRWXO);
 
 	char path[64];
@@ -396,7 +451,8 @@ void TaskWatchdog::write_cpuload_file()
 
 	fsync(fd);
 	close(fd);
-	PX4_INFO("cpuload written to %s", path);
+	PX4_ERR("cpuload written to %s", path);
+#endif
 }
 
 int TaskWatchdog::format_file_path(log_type_t type, char *buf, size_t bufsz)

--- a/src/modules/task_watchdog/TaskWatchdog.cpp
+++ b/src/modules/task_watchdog/TaskWatchdog.cpp
@@ -114,7 +114,7 @@ void TaskWatchdog::start()
 
 	sched_lock();
 
-	for (int i = 0; i < MAX_DUMP_TASKS; i++) {
+	for (int i = 0; i < CONFIG_FS_PROCFS_MAX_TASKS; i++) {
 		if (system_load.tasks[i].valid && system_load.tasks[i].tcb->pid == my_pid) {
 			_shared.monitored_task_index = i;
 			break;
@@ -255,8 +255,8 @@ void TaskWatchdog::wait_for_transport_ready()
 #ifdef CONFIG_DRIVERS_UAVCANNODE
 	dronecan_node_status_s status;
 
-	while (!(_dronecan_node_status_sub.copy(&status) && status.mode == dronecan_node_status_s::MODE_OPERATIONAL)) {
-		px4_usleep(100_ms);
+	while (!(_dronecan_node_status_sub.update(&status) && status.mode == dronecan_node_status_s::MODE_OPERATIONAL)) {
+		px4_usleep(1_s);
 	}
 
 #endif
@@ -313,13 +313,7 @@ void TaskWatchdog::capture_and_write_dump()
 #ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
 	wait_for_transport_ready();
 
-	uint32_t crc = 0xFFFFFFFFu;
-
-	auto emit = [&](const char *s) {
-		crc = crc32part((const uint8_t *)s, strlen(s), crc);
-		PX4_ERR("%s", s);
-		px4_usleep(150_ms);
-	};
+	_dump_crc = 0xFFFFFFFFu;
 
 #else /* !BOARD_HAS_RAM_HARDFAULT_DUMP */
 	mkdir(LOG_PATH_BASE, S_IRWXU | S_IRWXG | S_IRWXO);
@@ -332,23 +326,23 @@ void TaskWatchdog::capture_and_write_dump()
 		return;
 	}
 
-	int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	_dump_fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 
-	if (fd < 0) {
+	if (_dump_fd < 0) {
 		PX4_ERR("failed to create %s: %d", path, errno);
 		return;
 	}
 
-	auto emit = [&](const char *s) { dprintf(fd, "%s\n", s); };
-
 #endif /* BOARD_HAS_RAM_HARDFAULT_DUMP */
 
-	snprintf(line, sizeof(line), "WDG fw:%.60s", px4_firmware_version_string());
-	emit(line);
-	snprintf(line, sizeof(line), "build: %s %s", __DATE__, __TIME__);
-	emit(line);
-	snprintf(line, sizeof(line), "url: %.70s", px4_build_uri());
-	emit(line);
+	snprintf(line, sizeof(line), "Task Watchdog Dump");
+	emit_line(line);
+	snprintf(line, sizeof(line), "FW git-hash: %s", px4_firmware_version_string());
+	emit_line(line);
+	snprintf(line, sizeof(line), "Build datetime: %s %s", __DATE__, __TIME__);
+	emit_line(line);
+	snprintf(line, sizeof(line), "Build url: %s", px4_build_uri());
+	emit_line(line);
 
 	/* Loop 2: output - no locks held */
 	for (int i = 0; i < MAX_DUMP_TASKS; i++) {
@@ -367,32 +361,32 @@ void TaskWatchdog::capture_and_write_dump()
 #endif
 			 (int)d.pid,
 			 (int)d.state);
-		emit(line);
+		emit_line(line);
 
 		if (d.has_regs) {
 			snprintf(line, sizeof(line),
 				 " r0:%08" PRIx32 " r1:%08" PRIx32 " r2:%08" PRIx32 " r3:%08" PRIx32,
 				 d.regs[REG_R0],  d.regs[REG_R1],
 				 d.regs[REG_R2],  d.regs[REG_R3]);
-			emit(line);
+			emit_line(line);
 
 			snprintf(line, sizeof(line),
 				 " r4:%08" PRIx32 " r5:%08" PRIx32 " r6:%08" PRIx32 " r7:%08" PRIx32,
 				 d.regs[REG_R4],  d.regs[REG_R5],
 				 d.regs[REG_R6],  d.regs[REG_R7]);
-			emit(line);
+			emit_line(line);
 
 			snprintf(line, sizeof(line),
 				 " r8:%08" PRIx32 " r9:%08" PRIx32 " r10:%08" PRIx32 " r11:%08" PRIx32,
 				 d.regs[REG_R8],  d.regs[REG_R9],
 				 d.regs[REG_R10], d.regs[REG_R11]);
-			emit(line);
+			emit_line(line);
 
 			snprintf(line, sizeof(line),
 				 " r12:%08" PRIx32 " sp:%08" PRIx32 " lr:%08" PRIx32 " pc:%08" PRIx32,
 				 d.regs[REG_R12], d.regs[REG_R13],
 				 d.regs[REG_R14], d.regs[REG_R15]);
-			emit(line);
+			emit_line(line);
 
 #ifdef CONFIG_ARMV7M_USEBASEPRI
 			snprintf(line, sizeof(line), " xpsr:%08" PRIx32 " basepri:%08" PRIx32,
@@ -401,7 +395,7 @@ void TaskWatchdog::capture_and_write_dump()
 			snprintf(line, sizeof(line), " xpsr:%08" PRIx32 " primask:%08" PRIx32,
 				 d.regs[REG_XPSR], d.regs[REG_PRIMASK]);
 #endif
-			emit(line);
+			emit_line(line);
 
 			if (d.stack_words > 0) {
 				int pos = snprintf(line, sizeof(line), "STK(%u@%08" PRIx32 "):", d.stack_words,
@@ -409,44 +403,59 @@ void TaskWatchdog::capture_and_write_dump()
 
 				for (unsigned j = 0; j < d.stack_words; j++) {
 					if (j > 0 && (j % 8) == 0) {
-						emit(line);
+						emit_line(line);
 						pos = snprintf(line, sizeof(line), "STK+%u:", j);
 					}
 
 					pos += snprintf(line + pos, sizeof(line) - pos, " %08" PRIx32, d.stack[j]);
 				}
 
-				emit(line);
+				emit_line(line);
 			}
 
 		} else {
 			snprintf(line, sizeof(line), " [no saved regs]");
-			emit(line);
+			emit_line(line);
 		}
 	}
 
 #ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
-	snprintf(line, sizeof(line), "crc %08" PRIx32, crc ^ 0xFFFFFFFFu);
+	snprintf(line, sizeof(line), "crc %08" PRIx32, _dump_crc ^ 0xFFFFFFFFu);
 	PX4_ERR("%s", line);
 #else
-	fsync(fd);
-	close(fd);
+	fsync(_dump_fd);
+	close(_dump_fd);
 	PX4_ERR("dump written to %s", path);
 #endif
 }
+
+void TaskWatchdog::emit_line(const char *s)
+{
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+	_dump_crc = crc32part((const uint8_t *)s, strlen(s), _dump_crc);
+	PX4_ERR("%s", s);
+	px4_usleep(UAVCAN_DUMP_INTERVAL);
+#else
+	dprintf(_dump_fd, "%s\n", s);
+#endif
+}
+
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+void TaskWatchdog::print_load_line_callback(void *user)
+{
+	PX4_ERR("%s", static_cast<char *>(user));
+	px4_usleep(UAVCAN_DUMP_INTERVAL);
+}
+#endif // BOARD_HAS_RAM_HARDFAULT_DUMP
 
 void TaskWatchdog::write_cpuload_file()
 {
 #ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
 	wait_for_transport_ready();
 
-	char buf[90];
-	print_load_buffer(buf, sizeof(buf),
-	[](void *user) {
-		PX4_ERR("%s", static_cast<char *>(user));
-		px4_usleep(150_ms);
-	},
-	buf, &_load);
+	using LogTextField = uavcan::protocol::debug::LogMessage::FieldTypes::text;
+	char buf[LogTextField::MaxSize];
+	print_load_buffer(buf, sizeof(buf), print_load_line_callback, buf, &_load);
 #else
 	mkdir(LOG_PATH_BASE, S_IRWXU | S_IRWXG | S_IRWXO);
 

--- a/src/modules/task_watchdog/TaskWatchdog.hpp
+++ b/src/modules/task_watchdog/TaskWatchdog.hpp
@@ -42,6 +42,7 @@
 #include <px4_platform_common/atomic.h>
 #include <px4_platform_common/sem.h>
 #include <nuttx/sched.h>
+#include <board_config.h>
 
 #define LOG_PATH_BASE       CONFIG_BOARD_ROOT_PATH "/task_watchdog"
 #define LOG_WDG_NAME_FMT    "wdg_%s.log"
@@ -54,6 +55,13 @@ namespace task_watchdog
 {
 
 static constexpr unsigned STACK_DUMP_WORDS = 16;
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+static constexpr int MAX_DUMP_TASKS = 24; /* RAM-constrained boards: cap to avoid heap exhaustion */
+#elif defined(CONFIG_FS_PROCFS_MAX_TASKS)
+static constexpr int MAX_DUMP_TASKS = CONFIG_FS_PROCFS_MAX_TASKS;
+#else
+static constexpr int MAX_DUMP_TASKS = 24;
+#endif
 
 struct task_dump_s {
 	pid_t pid{0};
@@ -103,10 +111,11 @@ public:
 private:
 	void start();
 
-	/* Capture all tasks and write register+stack dump to a file. Called from task context at boosted priority. */
+	/* Capture all tasks and output register+stack dump. Writes to file on storage boards,
+	 * streams via PX4_ERR on RAM-dump boards. Called at boosted priority. */
 	void capture_and_write_dump();
 
-	/* Write cpuload snapshot to a file. Called from task context. */
+	/* Output cpuload snapshot. Writes to file on storage boards, streams via PX4_ERR on RAM-dump boards. */
 	void write_cpuload_file();
 
 	int format_file_path(log_type_t type, char *buf, size_t bufsz);
@@ -117,7 +126,7 @@ private:
 	hrt_call _hrt_call{};
 	watchdog_shared_s _shared{};
 	px4_sem_t _sem;
-	task_dump_s _dumps[CONFIG_FS_PROCFS_MAX_TASKS] {};
+	task_dump_s _dumps[MAX_DUMP_TASKS] {};
 	print_load_s _load{};
 
 	bool _cpuload_pending{false};

--- a/src/modules/task_watchdog/TaskWatchdog.hpp
+++ b/src/modules/task_watchdog/TaskWatchdog.hpp
@@ -44,6 +44,11 @@
 #include <nuttx/sched.h>
 #include <board_config.h>
 
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+# include <uORB/Subscription.hpp>
+# include <uORB/topics/dronecan_node_status.h>
+#endif
+
 #define LOG_PATH_BASE       CONFIG_BOARD_ROOT_PATH "/task_watchdog"
 #define LOG_WDG_NAME_FMT    "wdg_%s.log"
 #define LOG_LOAD_NAME_FMT   "load_%s.log"
@@ -122,6 +127,13 @@ private:
 
 	/* HRT ISR callback which monitors whether this task is being starved. */
 	static void isr_callback(void *arg);
+
+#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
+	/* Block so streamed lines are not dropped in queue. */
+	void wait_for_transport_ready();
+
+	uORB::Subscription _dronecan_node_status_sub{ORB_ID(dronecan_node_status)};
+#endif
 
 	hrt_call _hrt_call{};
 	watchdog_shared_s _shared{};

--- a/src/modules/task_watchdog/TaskWatchdog.hpp
+++ b/src/modules/task_watchdog/TaskWatchdog.hpp
@@ -47,6 +47,7 @@
 #ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
 # include <uORB/Subscription.hpp>
 # include <uORB/topics/dronecan_node_status.h>
+# include <uavcan/protocol/debug/LogMessage.hpp>
 #endif
 
 #define LOG_PATH_BASE       CONFIG_BOARD_ROOT_PATH "/task_watchdog"
@@ -60,12 +61,13 @@ namespace task_watchdog
 {
 
 static constexpr unsigned STACK_DUMP_WORDS = 16;
-#ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
-static constexpr int MAX_DUMP_TASKS = 24; /* RAM-constrained boards: cap to avoid heap exhaustion */
-#elif defined(CONFIG_FS_PROCFS_MAX_TASKS)
+
+#if CONFIG_TASK_WATCHDOG_MAX_DUMP_TASKS < 0
 static constexpr int MAX_DUMP_TASKS = CONFIG_FS_PROCFS_MAX_TASKS;
 #else
-static constexpr int MAX_DUMP_TASKS = 24;
+static_assert(CONFIG_TASK_WATCHDOG_MAX_DUMP_TASKS <= CONFIG_FS_PROCFS_MAX_TASKS,
+	      "CONFIG_TASK_WATCHDOG_MAX_DUMP_TASKS must be less than or equal to CONFIG_FS_PROCFS_MAX_TASKS");
+static constexpr int MAX_DUMP_TASKS = CONFIG_TASK_WATCHDOG_MAX_DUMP_TASKS;
 #endif
 
 struct task_dump_s {
@@ -128,11 +130,20 @@ private:
 	/* HRT ISR callback which monitors whether this task is being starved. */
 	static void isr_callback(void *arg);
 
+	/* Emit one line of a dump: streamed via PX4_ERR on RAM-dump boards, written to _dump_fd otherwise. */
+	void emit_line(const char *s);
+
 #ifdef BOARD_HAS_RAM_HARDFAULT_DUMP
 	/* Block so streamed lines are not dropped in queue. */
 	void wait_for_transport_ready();
 
+	/* print_load_buffer() callback: streams one cpuload line via PX4_ERR. */
+	static void print_load_line_callback(void *user);
+
 	uORB::Subscription _dronecan_node_status_sub{ORB_ID(dronecan_node_status)};
+	uint32_t _dump_crc{0};
+#else
+	int _dump_fd {-1};
 #endif
 
 	hrt_call _hrt_call{};
@@ -145,6 +156,11 @@ private:
 
 	static constexpr hrt_abstime TRIGGER_THRESHOLD = 2_s; ///< time in ready to run to trigger watchdog
 	static constexpr hrt_abstime CPULOAD_ACCUMULATE_TIME = 300_ms;   ///< how long to accumulate cpuload data
+	// Task_watchdog has a boosted priority (higher than uavcannode) for 1500_ms.
+	// - CPU-load is 1 line per task, + header / footer
+	// - Task_Dump is 8 lines per task
+	// to not flood the canbus, we use 200Hz (5ms) which allows up to 30 tasks to be dumped in 1500ms.
+	static constexpr hrt_abstime UAVCAN_DUMP_INTERVAL = 5_ms; ///< how long to wait between UAVCAN messages
 };
 
 } // namespace task_watchdog


### PR DESCRIPTION
### Solved Problem
On boards without a usable persistant memory (filesystem, BBSRAM, PROGMEM, SSARC, …), there is no possibility to save the full-hardfault-context (registers + interrupt/user stack).
Neither does the task_watchdog log starvation via dronecan.
There is currently no possibility to preprocess the linker-file.

UAVcan-Node does not publish its status.
If a critical task (like hardfault_streamer) does publish its log-msgs to early (before an ID was assigned),
log-msgs get lost

### Solution
**Hardfault-Dump:**
This PR introduces a _.noinit_ SRAM region, that survives warm resets.
On the next boot, the _hardfault_stream_ streams the raw hex dump with a CRC32 via PX4_ERR so it is forwarded over DroneCAN LogMessage.

**Task_Watchdog**
    The same streaming path is used by task_watchdog: when CPU-starvation is
    detected the task dump and a cpuload snapshot are emitted via PX4_ERR.

### Changes:
    - introduce BOARD_HAS_RAM_HARDFAULT_DUMP to tell the system, that there is no persistent storage (filesystem, BBSRAM, PROGMEM, SSARC, …) available
    - hardfault_log.h: add BOARD_HAS_RAM_HARDFAULT_DUMP branch with px4_ram_hardfault_dump_s; fix #if HAS_BBSRAM (was #if defined()) so STM32F4 boards without BBSRAM fall through to the RAM dump path
    - nuttx/CMakeLists.txt: add logic to inject custom cmake-files
    - board_crashdump.c: save hardfault to SRAM (.noinit) and stamp magic
    - hardfault_stream: stream hardfault-hex dump + CRC via DroneCAN if configured
    - task_watchdog: stream dump + cpuload via PX4_INFO if configured

**UAVcan_node**
Does now publish it status via uORB
This status is used by hardfault-streamer and task_watchdog.

### Test:
1. trigger a hardfault on a board
2. collect it via dronecan and save it. (eg hardfault_dump.dmp) it should look like:

``` shell
125	14:54:47.217	ERROR	hardfault_stream	0000 0f000000fcb80120ad000000d6000000d0b90120f0000000efffffffac20002003000000a8b201200000
125	14:54:47.367	ERROR	hardfault_stream	002a 0000000000000000000000000000e9ffffff000000000000000000000000000000000000000000000000
125	14:54:47.517	ERROR	hardfault_stream	0054 000000000000000000000000000000000000000000000000000000000000000000000000000000000000
125	14:55:02.518	ERROR	hardfault_stream	10bc efbeaddeefbeaddeefbeaddeefbeaddeefbeaddeefbeaddeefbeaddeefbeaddeefbeaddeefbeaddeefbe
…
125	14:55:05.367	ERROR	hardfault_stream	13da 0000000000003d000000486a01200000000000000000801b00208870012084d709080000000000000000
125	14:55:05.517	ERROR	hardfault_stream	1404 586a0120dcd70908efd9ef7df203000010b10120c4d70908810000008000000000000000940009080000
125	14:55:05.668	ERROR	hardfault_stream	142e 000000000000c1e5040890b1012000000000b0b10120c1e50408a0b10120319e0000486b0120486a0120
125	14:55:05.815	ERROR	hardfault_stream	crc b2f8ddd0
```

4. used the provided python-script to convert the hex-blob into a [emdbg](https://auterion.github.io/embedded-debug-tools/emdbg.html#embedded-debug-tools)-compatible file-format
``` shell
python3 Tools/hardfaults_rawhex_decode.py memcpy_to_null/dump.dmp
WARN: 1 missing chunk(s) at offsets: 0x0516
WARN: CRC mismatch - expected 0xb2f8ddd0, got 0x23c5d065 (possible bit-flip in stream)
Size:  total=5208 B  istack=768 B  ustack=4096 B
Task:  'task_watchdog'  pid=214  line=173
File:  'armv7-m/arm_hardfault.c'
PC:    0x0805b41e  LR: 0x08010e20  SP: 0x2001b9d0
Wrote: memcpy_to_null/dump.hardfault.log
Wrote: memcpy_to_null/coredump_dump.txt
```
5. call postmortem-dbg
``` shell
python3 -m emdbg.bench.fmu --target TARGET \
  --coredump PATH/TO/DUMP/memcpy_to_null/coredump_dump.txt

Reading symbols from …

515	int TaskWatchdog::print_usage(const char *reason)
   0x0805b414 <_ZN13task_watchdog12TaskWatchdog14custom_commandEiPPc+76>:	2280    	movs	r2, #128	@ 0x80
   0x0805b416 <_ZN13task_watchdog12TaskWatchdog14custom_commandEiPPc+78>:	4669    	mov	r1, sp
  …

(gdb) bt
#0  0x0805b41e in task_watchdog::TaskWatchdog::custom_command (argc=<optimized out>, argv=<optimized out>)
    at px4/src/modules/task_watchdog/TaskWatchdog.cpp:515
#1  0x0807f1b4 in ModuleBase::main (desc=..., argc=3, argv=0x2001b2a8)
    at px4/platforms/common/module_base.cpp:82
#2  0x08018b42 in nxtask_startup (entrypt=0x805bb15 <task_watchdog_main(int, char**)>, entrypt@entry=0x3, argc=3, argv=0x2001b2a8)
    at px4/platforms/nuttx/NuttX/nuttx/libs/libc/sched/task_startup.c:70
#3  0x08012bd2 in nxtask_start ()
    at px4/platforms/nuttx/NuttX/nuttx/sched/task/task_start.c:134
#4  0x00000000 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
(gdb)
```