### PR TITLE
fix(mavlink): DO_SET_GLOBAL_ORIGIN - enable in release

### DIFF
--- a/src/modules/mavlink/mavlink_command_params.hpp
+++ b/src/modules/mavlink/mavlink_command_params.hpp
@@ -110,6 +110,7 @@ static constexpr Entry SupportedCommandParams[] = {
 	{  530, 0x03, 0x03 }, // SET_CAMERA_MODE:             p1:camera_id,p2:mode
 	{  532, 0x07, 0x07 }, // SET_CAMERA_FOCUS:            p1:focus_type,p2:value,p3:camera_id
 	{  534, 0x07, 0x07 }, // SET_CAMERA_SOURCE:           p1:camera_id,p2:primary,p3:secondary
+	{  611, 0x00, 0x70 }, // DO_SET_GLOBAL_ORIGIN:        cmd:p5-7:lat/lon/alt (not a mission item)
 	{ 2000, 0x0F, 0x0F }, // IMAGE_START_CAPTURE:         p1:camera_id,p2:interval,p3:total,p4:seq
 	{ 2001, 0x01, 0x01 }, // IMAGE_STOP_CAPTURE:          p1:camera_id
 	{ 2003, 0x0F, 0x0F }, // DO_TRIGGER_CONTROL:          p1:enable,p2:reset,p3:pause,p4:camera_id

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -551,9 +551,7 @@ MavlinkReceiver::command_has_location(uint16_t command)
 	case MAV_CMD_DO_SET_ROI:                             // 201
 	case MAV_CMD_PAYLOAD_PREPARE_DEPLOY:                 // 30001
 	case MAV_CMD_EXTERNAL_POSITION_ESTIMATE:             // 43003
-#ifdef MAVLINK_ENABLED_DEVELOPMENT
 	case MAV_CMD_DO_SET_GLOBAL_ORIGIN:                   // 611
-#endif
 		return true;
 
 	// Not supported by PX4 as COMMAND_INT (mission items or unimplemented)


### PR DESCRIPTION
We just added support for MAV_CMD_DO_SET_GLOBAL_ORIGIN in https://github.com/PX4/PX4-Autopilot/pull/24697. Next step is to move it into common and update params.

Before merging:
- [x] Move message to common.xml in mavlink - https://github.com/mavlink/mavlink/pull/2536
- [x] Enable in common (here)
- [x] Add to invalid parameter checking list:
- [x] Get mavlink that has this (here)

