### PR TITLE
fix(fw_att_control): Correct tailsitter attitude conversion

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -211,8 +211,6 @@ void FixedwingAttitudeControl::Run()
 		if (_att_sub.copy(&att)) {
 			dt = math::constrain((att.timestamp_sample - _last_run) * 1e-6f, DT_MIN, DT_MAX);
 			_last_run = att.timestamp_sample;
-
-			_R = matrix::Quatf(att.q);
 		}
 
 		if (dt < DT_MIN || dt > DT_MAX) {
@@ -221,45 +219,11 @@ void FixedwingAttitudeControl::Run()
 			_last_run = time_now_us;
 		}
 
-		if (_vehicle_status.is_vtol_tailsitter) {
-			/* vehicle is a tailsitter, we need to modify the estimated attitude for fw mode
-			 *
-			 * Since the VTOL airframe is initialized as a multicopter we need to
-			 * modify the estimated attitude for the fixed wing operation.
-			 * Since the neutral position of the vehicle in fixed wing mode is -90 degrees rotated around
-			 * the pitch axis compared to the neutral position of the vehicle in multicopter mode
-			 * we need to swap the roll and the yaw axis (1st and 3rd column) in the rotation matrix.
-			 * Additionally, in order to get the correct sign of the pitch, we need to multiply
-			 * the new x axis of the rotation matrix with -1
-			 *
-			 * original:			modified:
-			 *
-			 * Rxx  Ryx  Rzx		-Rzx  Ryx  Rxx
-			 * Rxy	Ryy  Rzy		-Rzy  Ryy  Rxy
-			 * Rxz	Ryz  Rzz		-Rzz  Ryz  Rxz
-			 * */
-			matrix::Dcmf R_adapted = _R;		//modified rotation matrix
+		// Tailsitter: rotate measurement from MC to FW frame (controller is in FW frame, interface in MC).
+		// The attitude is world-from-body, so it composes on the right with the body rotation FW -> MC.
+		const Quatf q_current = _vehicle_status.is_vtol_tailsitter ? Quatf(att.q) * _q_mc_to_fw.inversed() : Quatf(att.q);
 
-			/* move z to x */
-			R_adapted(0, 0) = _R(0, 2);
-			R_adapted(1, 0) = _R(1, 2);
-			R_adapted(2, 0) = _R(2, 2);
-
-			/* move x to z */
-			R_adapted(0, 2) = _R(0, 0);
-			R_adapted(1, 2) = _R(1, 0);
-			R_adapted(2, 2) = _R(2, 0);
-
-			/* change direction of pitch (convert to right handed system) */
-			R_adapted(0, 0) = -R_adapted(0, 0);
-			R_adapted(1, 0) = -R_adapted(1, 0);
-			R_adapted(2, 0) = -R_adapted(2, 0);
-
-			/* fill in new attitude data */
-			_R = R_adapted;
-		}
-
-		const matrix::Eulerf euler_angles(_R);
+		const matrix::Eulerf euler_angles(q_current);
 
 		vehicle_manual_poll(euler_angles.psi());
 
@@ -303,7 +267,6 @@ void FixedwingAttitudeControl::Run()
 				const Quatf q_sp(_att_sp.q_d);
 
 				if (q_sp.isAllFinite()) {
-					const Quatf q_current = _vehicle_status.is_vtol_tailsitter ? Quatf(_R) : Quatf(att.q);
 					const Vector3f att_err = computeAttitudeError(q_current, q_sp);
 
 					Vector3f body_rates_setpoint;
@@ -351,9 +314,9 @@ void FixedwingAttitudeControl::Run()
 									  -radians(_param_fw_y_rmax.get()), radians(_param_fw_y_rmax.get()));
 					}
 
-					// Tailsitter: transform from FW to hover frame (all interfaces are in hover (body) frame)
+					// Tailsitter: rotate setpoint back from FW to MC frame (controller is in FW frame, interface in MC).
 					if (_vehicle_status.is_vtol_tailsitter) {
-						body_rates_setpoint = Vector3f(body_rates_setpoint(2), body_rates_setpoint(1), -body_rates_setpoint(0));
+						body_rates_setpoint = _q_mc_to_fw.rotateVectorInverse(body_rates_setpoint);
 					}
 
 					/* Publish the rate setpoint for analysis once available */

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -303,7 +303,7 @@ void FixedwingAttitudeControl::Run()
 				const Quatf q_sp(_att_sp.q_d);
 
 				if (q_sp.isAllFinite()) {
-					const Quatf q_current(att.q);
+					const Quatf q_current = _vehicle_status.is_vtol_tailsitter ? Quatf(_R) : Quatf(att.q);
 					const Vector3f att_err = computeAttitudeError(q_current, q_sp);
 
 					Vector3f body_rates_setpoint;

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -109,6 +109,11 @@ public:
 
 	bool init();
 
+	// Tailsitter body frame conversion:
+	// vector in FW body frame = _q_mc_to_fw.rotateVector(vector in MC body frame);
+	// (public so we can use it in FixedwingAttitudeControlTest)
+	inline static const matrix::Quatf _q_mc_to_fw{matrix::Eulerf{0.f, -M_PI_2_F, 0.f}};
+
 private:
 	void Run() override;
 
@@ -138,8 +143,6 @@ private:
 	vehicle_rates_setpoint_s		_rates_sp{};
 	vehicle_status_s			_vehicle_status{};
 	landing_gear_wheel_s			_landing_gear_wheel{};
-
-	matrix::Dcmf _R{matrix::eye<float, 3>()};
 
 	perf_counter_t _loop_perf;
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControlTest.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControlTest.cpp
@@ -114,3 +114,33 @@ TEST(FixedwingAttitudeControlTest, YawRateSetpointZeroBeforeTurnCoord_BankedTurn
 
 	EXPECT_NEAR(yaw_rate, 0.f, 1e-4f);
 }
+
+TEST(FixedwingAttitudeControlTest, TailsitterFrameRotation)
+{
+	// NOTE: this test cannot guard against breaking the conversion in Run()
+	// (while keeping the quaternion the same). This only sanity checks the
+	// underlying math. We rely on integration tests to test the actual
+	// implementation in Run().
+
+	const Quatf &q_mc_to_fw = FixedwingAttitudeControl::_q_mc_to_fw;
+
+	// The rotation maps the MC body axes onto the FW body axes: MC x -> FW z, MC z -> FW -x.
+	const Vector3f x_fw = q_mc_to_fw.rotateVector(Vector3f(1.f, 0.f, 0.f));
+	const Vector3f z_fw = q_mc_to_fw.rotateVector(Vector3f(0.f, 0.f, 1.f));
+	EXPECT_NEAR(x_fw(0), 0.f, 1e-6f);
+	EXPECT_NEAR(x_fw(2), 1.f, 1e-6f);
+	EXPECT_NEAR(z_fw(0), -1.f, 1e-6f);
+	EXPECT_NEAR(z_fw(2), 0.f, 1e-6f);
+
+	// Attitude of level FW flight in MC frame
+	const Quatf q_ned_mc(Eulerf(0.f, -M_PI_2_F, 0.f));
+	// level fixed-wing setpoint = unit quaternion
+	const Quatf q_sp;
+
+	// The raw hover-frame attitude appears as a large error against the level FW setpoint.
+	EXPECT_GT(computeAttitudeError(q_ned_mc, q_sp).norm(), 1.f);
+
+	// Adapting it exactly as Run() does (att.q * _q_mc_to_fw.inversed()) removes the error.
+	const Quatf q_adapted = q_ned_mc * q_mc_to_fw.inversed();
+	EXPECT_NEAR(computeAttitudeError(q_adapted, q_sp).norm(), 0.f, 1e-5f);
+}


### PR DESCRIPTION
### Solved Problem

Tailsitters have a body frame corresponding to multicopter convention, and the fixed-wing controllers have to convert incoming data to the FW convention, and outgoing data back to the MC convention. This was recently broken, and fixes have been proposed here:
 - https://github.com/PX4/PX4-Autopilot/pull/27719
 - https://github.com/PX4/PX4-Autopilot/pull/27669
 - https://github.com/PX4/PX4-Autopilot/pull/27448

The fix works but keeps a lot of unnecessary things around: We convert to a rotation matrix, then manipulate that manually to rotate, and then convert back to a quaternion (the last step is currently missing on main and introduced by the fixes).

### Solution

Remove the rotation matrix entirely and do everything with quaternions. Cleaner and less error prone, while reclaiming about 400B in flash. 
 - Define `const matrix::Quatf _q_mc_to_fw` 
 - Use consistently, replacing previous ad-hoc conversions
 - Standardise and clarify wording in comments
 - Add a unit test that guards against changing `_q_mc_to_fw`
   - It cannot ensure correct _usage_ of the quaternion (see note in test)
   - we could make a functional test in the style of e.g. `ManualControl` (separating `Run` from an inner `processInput`, which still contains basically the entire logic but can neatly be tested)

(previously I changed the rate controller similarly but reverted it as it provides a small benefit but measurable performance hit https://github.com/PX4/PX4-Autopilot/pull/27793#issuecomment-4873904033) 

### Changelog Entry
```
Fix: Correct tailsitter attitude conversion in FW attitude controller
```
(related cleanup irrelevant to end user)

### Test coverage

Sim flights with `gz_quadtailsitter`: 

 - before: https://review.px4.io/plot_app?log=da02b08d-9401-4eeb-bec7-48fa8a337507
 - after: https://review.px4.io/plot_app?log=391dceed-7f0a-48fd-a684-ca52c7610272