### PR TITLE
feat(docs): sort dds topics, fix formatting

### DIFF
--- a/Tools/msg/generate_msg_docs.py
+++ b/Tools/msg/generate_msg_docs.py
@@ -867,14 +867,14 @@ Topic | Type| Rate Limit
 --- | --- | ---
 """
 
-        for message in data["publications"]:
+        for message in sorted(data["publications"], key=lambda elem: elem['topic']):
             type = message['type']
             px4Type=type.split("::")[-1]
             dds_markdown += f"`{message['topic']}` | [{type}](../msg_docs/{px4Type}.md) | {message.get('rate_limit','')}\n"
 
         dds_markdown += "\n## Subscriptions\n\nTopic | Type\n--- | ---\n"
 
-        for message in data["subscriptions"]:
+        for message in sorted(data["subscriptions"], key=lambda elem: elem['topic']):
             type = message['type']
             px4Type=type.split("::")[-1]
             dds_markdown += f"{message['topic']} | [{type}](../msg_docs/{px4Type}.md)\n"

--- a/Tools/msg/generate_msg_docs.py
+++ b/Tools/msg/generate_msg_docs.py
@@ -877,7 +877,7 @@ Topic | Type| Rate Limit
         for message in sorted(data["subscriptions"], key=lambda elem: elem['topic']):
             type = message['type']
             px4Type=type.split("::")[-1]
-            dds_markdown += f"{message['topic']} | [{type}](../msg_docs/{px4Type}.md)\n"
+            dds_markdown += f"`{message['topic']}` | [{type}](../msg_docs/{px4Type}.md)\n"
 
         dds_markdown += "\n## Subscriptions Multi\n\n"
 

--- a/Tools/msg/generate_msg_docs.py
+++ b/Tools/msg/generate_msg_docs.py
@@ -897,7 +897,7 @@ Topic | Type| Rate Limit
             # Print the topics that are not exported to DDS
             dds_markdown += "\n## Not Exported\n\nThese messages are not listed in the yaml file.\nThey are not build into the module, and hence are neither published or subscribed."
             dds_markdown += "\n\n::: details See messages\n"
-            for item in  messagesNotExported:
+            for item in sorted(messagesNotExported):
                 dds_markdown += f"\n- [{item}](../msg_docs/{item}.md)"
             dds_markdown += "\n:::\n" # End of details block
 


### PR DESCRIPTION
To remove the unnecessarily large diff in each `docs: auto-sync metadata [skip ci]` commit. Example: https://github.com/PX4/PX4-Autopilot/commit/692d624670871f721ee3ed82a432fdb9c6129862

While we're at it, also sort the dds topics themselves and render consistently in monospace. 