### PR TITLE
fix(lockstep_scheduler): fix flaky test_multiple_semaphores_waiting

### DIFF
--- a/platforms/posix/src/px4/common/lockstep_scheduler/test/src/lockstep_scheduler_test.cpp
+++ b/platforms/posix/src/px4/common/lockstep_scheduler/test/src/lockstep_scheduler_test.cpp
@@ -159,6 +159,18 @@ public:
 		});
 	}
 
+	void wait_until_ready()
+	{
+		// Block until the worker thread has locked its mutex and is about to wait
+		// on the condition. Otherwise advancing virtual time could pass this case's
+		// timeout before the thread even starts, so check() (which early-returns on
+		// !_thread_ready) would never complete it and its thread would be left
+		// joinable at destruction.
+		while (!_thread_ready) {
+			std::this_thread::yield();
+		}
+	}
+
 	void check()
 	{
 		if (_is_done || !_thread_ready) {
@@ -258,6 +270,12 @@ void test_multiple_semaphores_waiting()
 		test_case->run();
 	}
 
+	// Make sure every thread has started and is waiting before we advance virtual
+	// time, so the loop below can't skip past a case's timeout before it registers.
+	for (auto &test_case : test_cases) {
+		test_case->wait_until_ready();
+	}
+
 	const int min_step_size = 1;
 	const int max_step_size = 100;
 
@@ -321,7 +339,7 @@ void test_usleep()
 TEST(LockstepScheduler, All)
 {
 	for (unsigned iteration = 1; iteration <= 100; ++iteration) {
-		std::cout << "Test iteration: " << iteration << "\n";
+		//std::cout << "Test iteration: " << iteration << "\n";
 		test_absolute_time();
 		test_condition_timing_out();
 		test_locked_semaphore_getting_unlocked();


### PR DESCRIPTION
TLDR: should fix a unit test failure introduced in https://github.com/PX4/PX4-Autopilot/pull/27606.

---

`functional-lockstep_scheduler_test` is flaky and intermittently aborts CI (e.g. failing ~50% of the time locally, and more under CI load). `test_multiple_semaphores_waiting()` spawns one worker thread per `TestCase`, then advances virtual time in a loop, completing each case in `check()`. Because `check()` early-returns while `!_thread_ready`, a worker thread that is slow to start can be skipped entirely: the loop advances past that case's timeout before the thread registers, so the case is never completed. `~TestCase()` then fails `EXPECT_TRUE(_is_done)` and destroys a still-joinable `std::thread`, which calls `std::terminate()` and aborts the process.

This regressed in 162cce35d8, which added the `!_thread_ready` gate to `check()` (correctly, to avoid broadcasting before the thread waits) but without ensuring the threads are actually ready before virtual time is advanced.

Fix by waiting for every worker thread to reach its wait point before stepping time. Also re-comment the per-iteration `std::cout` that the same commit left enabled.

Verified by running the test 30x in a row with no failures (was ~5/10 before).