### PR TITLE
refactor(sih): remove local variable to save stack

### DIFF
--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -368,8 +368,10 @@ uint8_t Sih::num_motors() const
 
 void Sih::publish_esc_status()
 {
-	esc_status_s esc_status{};
+	esc_status_s &esc_status = _esc_status_pub.get();
 	esc_status.timestamp = hrt_absolute_time();
+	esc_status.esc_online_flags = 0;
+	esc_status.esc_armed_flags = 0;
 	int motor_idx = 0;
 	bool any_motor_running = false;
 	float max_rpm = 10000.f;
@@ -404,7 +406,7 @@ void Sih::publish_esc_status()
 		esc_status.esc_armed_flags = (1u << motor_idx) - 1;
 	}
 
-	_esc_status_pub.publish(esc_status);
+	_esc_status_pub.update();
 }
 
 void Sih::generate_force_and_torques(const float dt)

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -368,10 +368,9 @@ uint8_t Sih::num_motors() const
 
 void Sih::publish_esc_status()
 {
-	esc_status_s &esc_status = _esc_status_pub.get();
-	esc_status.timestamp = hrt_absolute_time();
-	esc_status.esc_online_flags = 0;
-	esc_status.esc_armed_flags = 0;
+	_esc_status.timestamp = hrt_absolute_time();
+	_esc_status.esc_online_flags = 0;
+	_esc_status.esc_armed_flags = 0;
 	int motor_idx = 0;
 	bool any_motor_running = false;
 	float max_rpm = 10000.f;
@@ -387,11 +386,11 @@ void Sih::publish_esc_status()
 			continue; // control surface / steering channel, not a motor
 		}
 
-		esc_status.esc[motor_idx].timestamp = hrt_absolute_time();
-		esc_status.esc[motor_idx].actuator_function = esc_report_s::ACTUATOR_FUNCTION_MOTOR1 + motor_idx;
-		esc_status.esc[motor_idx].esc_temperature = 50.f;
-		esc_status.esc[motor_idx].esc_rpm = (int32_t)roundf(Thruster::throttle_to_rpm(_u[i], max_rpm));
-		esc_status.esc_online_flags |= 1u << motor_idx;
+		_esc_status.esc[motor_idx].timestamp = hrt_absolute_time();
+		_esc_status.esc[motor_idx].actuator_function = esc_report_s::ACTUATOR_FUNCTION_MOTOR1 + motor_idx;
+		_esc_status.esc[motor_idx].esc_temperature = 50.f;
+		_esc_status.esc[motor_idx].esc_rpm = (int32_t)roundf(Thruster::throttle_to_rpm(_u[i], max_rpm));
+		_esc_status.esc_online_flags |= 1u << motor_idx;
 
 		if (_u[i] > FLT_EPSILON) {
 			any_motor_running = true;
@@ -400,13 +399,13 @@ void Sih::publish_esc_status()
 		motor_idx++;
 	}
 
-	esc_status.esc_count = motor_idx;
+	_esc_status.esc_count = motor_idx;
 
 	if (any_motor_running) {
-		esc_status.esc_armed_flags = (1u << motor_idx) - 1;
+		_esc_status.esc_armed_flags = (1u << motor_idx) - 1;
 	}
 
-	_esc_status_pub.update();
+	_esc_status_pub.publish(_esc_status);
 }
 
 void Sih::generate_force_and_torques(const float dt)

--- a/src/modules/simulation/simulator_sih/sih.hpp
+++ b/src/modules/simulation/simulator_sih/sih.hpp
@@ -132,7 +132,7 @@ private:
 	PX4Rangefinder   _px4_rangefinder{10092548}; // 10092548: DRV_DIST_DEVTYPE_SIM, BUS: 0, ADDR: 0, TYPE: SIMULATION
 	uORB::Publication<airspeed_s>         _airspeed_pub{ORB_ID(airspeed)};
 	uORB::Publication<ranging_beacon_s>   _ranging_beacon_pub{ORB_ID(ranging_beacon)};
-	uORB::PublicationData<esc_status_s>   _esc_status_pub{ORB_ID(esc_status)};
+	uORB::Publication<esc_status_s>       _esc_status_pub{ORB_ID(esc_status)};
 
 	// groundtruth
 	uORB::Publication<vehicle_angular_velocity_s> _angular_velocity_ground_truth_pub{ORB_ID(vehicle_angular_velocity_groundtruth)};
@@ -302,6 +302,8 @@ private:
 	matrix::Matrix3f _Im1;  // inverse of the inertia matrix
 
 	float _distance_snsr_min, _distance_snsr_max, _distance_snsr_override;
+
+	esc_status_s _esc_status{};
 
 	// parameters defined in sih_params.c
 	DEFINE_PARAMETERS(

--- a/src/modules/simulation/simulator_sih/sih.hpp
+++ b/src/modules/simulation/simulator_sih/sih.hpp
@@ -132,7 +132,7 @@ private:
 	PX4Rangefinder   _px4_rangefinder{10092548}; // 10092548: DRV_DIST_DEVTYPE_SIM, BUS: 0, ADDR: 0, TYPE: SIMULATION
 	uORB::Publication<airspeed_s>         _airspeed_pub{ORB_ID(airspeed)};
 	uORB::Publication<ranging_beacon_s>   _ranging_beacon_pub{ORB_ID(ranging_beacon)};
-	uORB::Publication<esc_status_s>       _esc_status_pub{ORB_ID(esc_status)};
+	uORB::PublicationData<esc_status_s>   _esc_status_pub{ORB_ID(esc_status)};
 
 	// groundtruth
 	uORB::Publication<vehicle_angular_velocity_s> _angular_velocity_ground_truth_pub{ORB_ID(vehicle_angular_velocity_groundtruth)};


### PR DESCRIPTION
### Problem

A recent SIH log (V6X) was full of:

```
WARNING: [px4] [load_mon] sih low on stack! (144 bytes left)
```

### Solution

Using `PublicationData` (which holds the `esc_status_s` in heap rather than stack) fixes them and adheres to the philosophy from the module description: "Most of the variables are declared global in the .hpp file to avoid stack overflow"

### Alternative

Just bump the stack size...