### PR TITLE
perf(dataman): Speed up DatamanCache lookups with a search hint

### DIFF
--- a/src/lib/dataman_client/DatamanClient.cpp
+++ b/src/lib/dataman_client/DatamanClient.cpp
@@ -600,13 +600,17 @@ bool DatamanCache::loadWait(dm_item_t item, uint32_t index, uint8_t *buffer, uin
 	bool item_found = false;
 
 	if (_items) {
-		for (uint32_t i = 0; i < _num_items; ++i) {
+		// Start scanning at the last hit
+		for (uint32_t n = 0; n < _num_items; ++n) {
+			const uint32_t i = (_search_hint + n) % _num_items;
+
 			if ((_items[i].response.item == item) &&
 			    (_items[i].response.index == index)) {
 				item_found = true;
 
 				if (_items[i].cache_state == State::ResponseReceived) {
 					memcpy(buffer, _items[i].response.data, length);
+					_search_hint = i;
 					success = true;
 					break;
 				}
@@ -731,6 +735,7 @@ void DatamanCache::resetCacheState()
 	_update_index = 0;
 	_item_counter = 0;
 	_load_index = 0;
+	_search_hint = 0;
 }
 
 void DatamanCache::invalidate()

--- a/src/lib/dataman_client/DatamanClient.hpp
+++ b/src/lib/dataman_client/DatamanClient.hpp
@@ -303,6 +303,7 @@ private:
 	uint32_t _update_index{0};	///< index for tracking last index used by update function
 	uint32_t _item_counter{0};	///< number of items to process with update function
 	uint32_t _num_items{0};		///< number of items that cache can store
+	uint32_t _search_hint{0};	///< slot of the last loadWait hit, speeds up sequential lookups
 
 	DatamanClient _client{};
 


### PR DESCRIPTION
This PR changes `DatamanCache::loadWait()` to scan from the last successful cache hit instead of always starting at slot 0.

This keeps sequential and repeated mission item reads close to O(1) in the common case while preserving the same fallback behavior on cache misses.

Linked to https://github.com/PX4/PX4-Autopilot/pull/27707 where the plan is to have the full route in the cache. In this case starting from the last hit can become significant.