### PR TITLE
docs(offboard): clarify BODY_NED velocity/acceleration-only support

### DIFF
--- a/docs/en/flight_modes/offboard.md
+++ b/docs/en/flight_modes/offboard.md
@@ -253,7 +253,7 @@ The following MAVLink messages and their particular fields and field values are 
 ### Copter/VTOL
 
 - [SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED)
-  - The following input combinations are supported: <!-- https://github.com/PX4/PX4-Autopilot/blob/main/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp#L166-L170 -->
+  - The following input combinations are supported: <!-- https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_receiver.cpp (handle_message_set_position_target_local_ned) -->
     - Position setpoint (only `x`, `y`, `z`)
     - Velocity setpoint (only `vx`, `vy`, `vz`)
     - Acceleration setpoint (only `afx`, `afy`, `afz`)
@@ -262,8 +262,13 @@ The following MAVLink messages and their particular fields and field values are 
 
   - PX4 supports the following `coordinate_frame` values (only): [MAV_FRAME_LOCAL_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_LOCAL_NED) and [MAV_FRAME_BODY_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_BODY_NED).
 
+    ::: info
+    `MAV_FRAME_BODY_NED` can only be used with velocity and acceleration setpoints, which are rotated from body to local frame using the vehicle heading.
+    Position setpoints are ignored (set to `NAN`) in this frame, because a position in a body-fixed frame is ambiguous; position setpoints must use `MAV_FRAME_LOCAL_NED`.
+    :::
+
 - [SET_POSITION_TARGET_GLOBAL_INT](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_GLOBAL_INT)
-  - The following input combinations are supported: <!-- https://github.com/PX4/PX4-Autopilot/blob/main/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp#L166-L170 -->
+  - The following input combinations are supported: <!-- https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_receiver.cpp (handle_message_set_position_target_global_int) -->
     - Position setpoint (only `lat_int`, `lon_int`, `alt`)
     - Velocity setpoint (only `vx`, `vy`, `vz`)
     - _Thrust_ setpoint (only `afx`, `afy`, `afz`)
@@ -284,7 +289,7 @@ The following MAVLink messages and their particular fields and field values are 
 ### Fixed-wing
 
 - [SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED)
-  - The following input combinations are supported (via `type_mask`): <!-- https://github.com/PX4/PX4-Autopilot/blob/main/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp#L166-L170 -->
+  - The following input combinations are supported (via `type_mask`): <!-- https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_receiver.cpp (handle_message_set_position_target_local_ned) -->
     - Position setpoint (`x`, `y`, `z` only; velocity and acceleration setpoints are ignored).
       - Specify the _type_ of the setpoint in `type_mask` (if these bits are not set the vehicle will fly in a flower-like pattern):
         ::: info
@@ -300,10 +305,11 @@ The following MAVLink messages and their particular fields and field values are 
         - 12288: Loiter setpoint (fly a circle centred on setpoint).
         - 16384: Idle setpoint (zero throttle, zero roll / pitch).
 
-  - PX4 supports the coordinate frames (`coordinate_frame` field): [MAV_FRAME_LOCAL_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_LOCAL_NED) and [MAV_FRAME_BODY_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_BODY_NED).
+  - PX4 supports the coordinate frame (`coordinate_frame` field): [MAV_FRAME_LOCAL_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_LOCAL_NED).
+    [MAV_FRAME_BODY_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_BODY_NED) only applies to velocity and acceleration setpoints, which are ignored for fixed-wing, so it cannot be used.
 
 - [SET_POSITION_TARGET_GLOBAL_INT](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_GLOBAL_INT)
-  - The following input combinations are supported (via `type_mask`): <!-- https://github.com/PX4/PX4-Autopilot/blob/main/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp#L166-L170 -->
+  - The following input combinations are supported (via `type_mask`): <!-- https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_receiver.cpp (handle_message_set_position_target_global_int) -->
     - Position setpoint (only `lat_int`, `lon_int`, `alt`)
       - Specify the _type_ of the setpoint in `type_mask` (if these bits are not set the vehicle will fly in a flower-like pattern):
 


### PR DESCRIPTION
The offboard docs list the supported SET_POSITION_TARGET_LOCAL_NED input combinations and the supported coordinate frames as two independent lists, which reads as if every combination works in every frame. It doesn't: BODY_NED position setpoints have never been supported. The receiver rotates velocity and acceleration setpoints into the local frame and sets position to NAN, a behavior that predates the v1.12 offboard rework (#16739) and was kept there deliberately. This mismatch misled the reporter of #27617 into filing the works-as-designed behavior as a firmware bug.

- Copter/VTOL: add an info block stating BODY_NED only applies to velocity and acceleration setpoints and that position setpoints must use LOCAL_NED.
- Fixed-wing: remove BODY_NED from the supported frames, since fixed-wing offboard only accepts position setpoints, which that frame cannot carry.
- Update stale code links still pointing at FlightTaskOffboard.cpp, removed in 2021.

The rover section already scopes BODY_NED to velocity setpoints correctly and is unchanged.