### PR TITLE
fix(navigator): keep course setpoint NaN outside Course mode

### DIFF
--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -574,8 +574,7 @@ FixedWingModeManager::control_auto(const float control_interval, const Vector2d 
 	move_position_setpoint_for_vtol_transition(current_sp);
 
 	// Course setpoints are handled directly to avoid entering hold mode
-	if (PX4_ISFINITE(current_sp.course)
-	    && _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_GUIDED_COURSE) {
+	if (PX4_ISFINITE(current_sp.course)) {
 		control_auto_position(control_interval, curr_pos, ground_speed, pos_sp_prev, current_sp);
 		return;
 	}
@@ -779,8 +778,7 @@ FixedWingModeManager::control_auto_position(const float control_interval, const 
 		const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr)
 {
 	// Course Hold: if a course is explicitly set, navigate along that bearing (ground track)
-	if (PX4_ISFINITE(pos_sp_curr.course)
-	    && _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_GUIDED_COURSE) {
+	if (PX4_ISFINITE(pos_sp_curr.course)) {
 		const float target_airspeed = pos_sp_curr.cruising_speed > FLT_EPSILON ? pos_sp_curr.cruising_speed : NAN;
 
 		const Vector2f curr_pos_local{_local_pos.x, _local_pos.y};

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -164,12 +164,14 @@ Loiter::reposition()
 		pos_sp_triplet->previous.lon = _navigator->get_global_position()->lon;
 		pos_sp_triplet->previous.alt = _navigator->get_global_position()->alt;
 		memcpy(&pos_sp_triplet->current, &rep->current, sizeof(rep->current));
-		pos_sp_triplet->current.course = NAN;
 		pos_sp_triplet->next.valid = false;
 
 		_navigator->set_position_setpoint_triplet_updated();
 
-		// mark this as done
-		memset(rep, 0, sizeof(*rep));
+		// mark this as done: reset instead of zeroing so unset fields (yaw, course)
+		// stay NaN when the triplet is repopulated by a partial reposition command
+		_navigator->reset_position_setpoint(rep->previous);
+		_navigator->reset_position_setpoint(rep->current);
+		_navigator->reset_position_setpoint(rep->next);
 	}
 }

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -614,6 +614,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 	sp->lon = item.lon;
 	sp->alt = get_absolute_altitude_for_item(item);
 	sp->yaw = item.yaw;
+	sp->course = NAN; // mission items never command a course, only Course mode sets it
 	sp->loiter_radius = (fabsf(item.loiter_radius) > FLT_EPSILON) ? fabsf(item.loiter_radius) :
 			    _navigator->get_default_loiter_rad();
 	sp->loiter_direction_counter_clockwise = item.loiter_radius < 0;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -163,6 +163,12 @@ void Navigator::run()
 
 	params_update();
 
+	// the reposition triplet is only partially populated by reposition commands,
+	// reset it so unset fields (yaw, course) are NaN instead of zero
+	reset_position_setpoint(_reposition_triplet.previous);
+	reset_position_setpoint(_reposition_triplet.current);
+	reset_position_setpoint(_reposition_triplet.next);
+
 	/* wakeup source(s) */
 	px4_pollfd_struct_t fds[3] {};
 


### PR DESCRIPTION
Follow-up to #27537 and #27487, fixing the course initialization issue at the source so the hotfix guard can be removed.

The `PositionSetpoint.course` field could end up finite (and get consumed as a course guidance command) in two ways: the reposition triplet was zero-initialized at boot and `memset` after consumption while none of the reposition command handlers write `course`, and `mission_item_to_position_setpoint()` updates the current setpoint in place without ever touching `course`, so a stale value set by Course mode survived a switch to Hold, RTL, or Mission.

- `mission_item_to_position_setpoint()` now clears `course` to NaN; mission items never command a course.
- `Loiter::reposition()` resets the consumed reposition triplet with `reset_position_setpoint()` instead of `memset`, and the navigator resets it once at startup, so unset fields (`yaw`, `course`) are NaN rather than zero. This replaces the consumer-side clear from #27537.
- Reverts the `GUIDED_COURSE` nav state guard from #27487: with the navigator guaranteeing NaN semantics, `PX4_ISFINITE(course)` is again a sufficient trigger in the FW mode manager.

Verified in SIH SITL (airplane) at the uORB level: entering Course mode publishes a finite `course`, switching back to Hold publishes a LOITER setpoint with `course = NaN` (previously stale finite), and repeated `DO_REPOSITION` commands produce loiter setpoints with `course`/`yaw` = NaN on both the first-use and post-consumption paths. Built for px4_sitl_sih and px4_fmu-v6x.

Log of the SITL session (the `position_setpoint_triplet.current.course` transitions are visible in Flight Review; ground roll only, the SIH airplane cannot reach rotation speed): https://logs.px4.io/plot_app?log=d89b1ec6-4cc4-4e92-b115-55a90623052c

### Changelog Entry

```
Bugfix: initialize unused course setpoint to NaN so GCS repositions and mode switches out of Course mode never trigger course guidance
```

@mahima-yoga this should be the "remaining corner cases" hunt from #27537: the stale-course-after-Course-mode path via `mission_item_to_position_setpoint()` was the one left, covered here along with the revert of your guard.