### PR TITLE
fix(mavlink): init mutexes before argument parsing

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2152,6 +2152,11 @@ Mavlink::task_main(int argc, char *argv[])
 		}
 	}
 
+	pthread_mutex_init(&_tstatus_mutex, nullptr);
+	pthread_mutex_init(&_radio_status_mutex, nullptr);
+	pthread_mutex_init(&_message_buffer_mutex, nullptr);
+	pthread_mutex_init(&_mavlink_shell_mutex, nullptr);
+
 	int ch;
 	_baudrate = 57600;
 	_datarate = 0;
@@ -2492,11 +2497,6 @@ Mavlink::task_main(int argc, char *argv[])
 	}
 
 	_sign_control.start(get_instance_id(), get_status(), &accept_unsigned_callback);
-
-	pthread_mutex_init(&_mavlink_shell_mutex, nullptr);
-	pthread_mutex_init(&_message_buffer_mutex, nullptr);
-	pthread_mutex_init(&_radio_status_mutex, nullptr);
-	pthread_mutex_init(&_tstatus_mutex, nullptr);
 
 	/* if we are passing on mavlink messages, we need to prepare a buffer for this instance */
 	if (get_forwarding_on()) {


### PR DESCRIPTION
<!--


### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->

### Solved Problem
On NuttX, zero-initializing a `pthread_mutex_t` leaves the underlying semaphore count at 0 (locked). `set_telemetry_status_type()` locks `_tstatus_mutex` during argument parsing, before the `pthread_mutex_init()` calls that were placed after `set_instance_id()`,  causing a silent deadlock at startup on those link types. UART instances should remain unaffected.

### Solution 
- Move mutex init to the top of task_main(), before argument parsing.

Tested on 3DR Control-N1 over USB with QGroundControl.
