### PR TITLE
fix(cellular_status): reorder fields to match MAVLink, correct status enum

### DIFF
--- a/msg/CellularStatus.msg
+++ b/msg/CellularStatus.msg
@@ -1,23 +1,23 @@
 # Cellular status
 #
-# This is currently used only for logging cell status from MAVLink.
+# This is currently used only for logging cell status from MAVLink 1:1.
 
 uint64 timestamp # [us] Time since system start
 
-uint16 status # [@enum STATUS_FLAG] Status bitmap
-uint16 STATUS_FLAG_UNKNOWN = 1 # State unknown or not reportable
-uint16 STATUS_FLAG_FAILED = 2 # Modem is unusable
-uint16 STATUS_FLAG_INITIALIZING = 4 # Modem is being initialized
-uint16 STATUS_FLAG_LOCKED = 8 # Modem is locked
-uint16 STATUS_FLAG_DISABLED = 16 # Modem is not enabled and is powered down
-uint16 STATUS_FLAG_DISABLING = 32 # Modem is currently transitioning to the STATUS_FLAG_DISABLED state
-uint16 STATUS_FLAG_ENABLING = 64 # Modem is currently transitioning to the STATUS_FLAG_ENABLED state
-uint16 STATUS_FLAG_ENABLED = 128 # Modem is enabled and powered on but not registered with a network provider and not available for data connections
-uint16 STATUS_FLAG_SEARCHING = 256 # Modem is searching for a network provider to register
-uint16 STATUS_FLAG_REGISTERED = 512 # Modem is registered with a network provider, and data connections and messaging may be available for use
-uint16 STATUS_FLAG_DISCONNECTING = 1024 # Modem is disconnecting and deactivating the last active packet data bearer. This state will not be entered if more than one packet data bearer is active and one of the active bearers is deactivated
-uint16 STATUS_FLAG_CONNECTING = 2048 # Modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered
-uint16 STATUS_FLAG_CONNECTED = 4096 # One or more packet data bearers is active and connected
+uint8 status # [@enum STATUS_FLAG] Status
+uint8 STATUS_FLAG_UNKNOWN = 0 # State unknown or not reportable
+uint8 STATUS_FLAG_FAILED = 1 # Modem is unusable
+uint8 STATUS_FLAG_INITIALIZING = 2 # Modem is being initialized
+uint8 STATUS_FLAG_LOCKED = 3 # Modem is locked
+uint8 STATUS_FLAG_DISABLED = 4 # Modem is not enabled and is powered down
+uint8 STATUS_FLAG_DISABLING = 5 # Modem is currently transitioning to the STATUS_FLAG_DISABLED state
+uint8 STATUS_FLAG_ENABLING = 6 # Modem is currently transitioning to the STATUS_FLAG_ENABLED state
+uint8 STATUS_FLAG_ENABLED = 7 # Modem is enabled and powered on but not registered with a network provider and not available for data connections
+uint8 STATUS_FLAG_SEARCHING = 8 # Modem is searching for a network provider to register
+uint8 STATUS_FLAG_REGISTERED = 9 # Modem is registered with a network provider, and data connections and messaging may be available for use
+uint8 STATUS_FLAG_DISCONNECTING = 10 # Modem is disconnecting and deactivating the last active packet data bearer. This state will not be entered if more than one packet data bearer is active and one of the active bearers is deactivated
+uint8 STATUS_FLAG_CONNECTING = 11 # Modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered
+uint8 STATUS_FLAG_CONNECTED = 12 # One or more packet data bearers is active and connected
 
 uint8 failure_reason # [@enum FAILURE_REASON] Failure reason
 uint8 FAILURE_REASON_NONE = 0 # No error
@@ -37,14 +37,14 @@ uint16 mcc # [@invalid UINT16_MAX] Mobile country code
 uint16 mnc # [@invalid UINT16_MAX] Mobile network code
 uint16 lac # [@invalid 0] Location area code
 
+uint8 id # [-] Cellular instance number. Indexed from 1. A value of 0 indicates the sender does not support reporting of multiple modems
+uint32 link_tx_rate # [KiB/s] [@invalid 0] Download rate
+uint32 link_rx_rate # [KiB/s] [@invalid 0] Upload rate
+char[9] cell_tower_id # [@invalid 0] ID of the currently connected cell tower. Must be NULL terminated if the length is less than 9 human-readable characters, and without NULL termination character if the length is exactly 9 characters
 uint8 band_number # [-] [@invalid 0] LTE frequency band number
 float32 band_frequency # [MHz] [@invalid 0] LTE radio frequency
 uint32 channel_number # [@invalid 0] Channel Number (CN), Absolute radio-frequency (ARFCN) / E-UTRA (EARFCN) / UTRA (UARFCN) / New radio (NR_CH)
 float32 rx_level # [dBm] [@invalid 0] Receiver signal level. On 3G is Received Signal Code Power (RSCP). On LTE Reference Signal Received Power (RSRP). On 5G is New Radio Reference Signal Received Power (NR_RSRP)
 float32 tx_level # [dBm] [@invalid 0] Transmitter signal absolute level
 float32 rx_quality # [dBm] [@invalid 0] Received signal quality. On 3G is Receiver Quality (RxQual). On LTE is Reference Signal Received Quality (RSRQ). On 5G is New Radio Reference Signal Received Quality (NR_RSRQ)
-uint32 link_tx_rate # [KiB/s] [@invalid 0] Download rate
-uint32 link_rx_rate # [KiB/s] [@invalid 0] Upload rate
-uint8 id # [-] Cellular instance number. Indexed from 1. A value of 0 indicates the sender does not support reporting of multiple modems
-char[9] cell_tower_id # [@invalid 0] ID of the currently connected cell tower. Must be NULL terminated if the length is less than 9 human-readable characters, and without NULL termination character if the length is exactly 9 characters
 float32 sinr # [dB] [@invalid 0] Signal to Interference plus Noise Ratio


### PR DESCRIPTION
### Solved Problem
I saw https://github.com/PX4/PX4-Autopilot/pull/27760 but was too slow to review but had two comments:
- Since it's 1:1 reflecting a MAVLink message we better also keep the order to make it simple to follow.
- The "flags" title in the status enum is misleading. Those aren't flags, there can only be one status at a time a uint8 would not even have 12 bits to set and there's no remapping to the power of two values just a copy of the field.

Can you check I'm not writing ** @anilkir ?