### PR TITLE
feat(driver/heater): Add activation threshold

### DIFF
--- a/msg/HeaterStatus.msg
+++ b/msg/HeaterStatus.msg
@@ -4,6 +4,7 @@ uint32 device_id
 
 bool heater_on
 bool temperature_target_met
+bool temperature_threshold_met
 
 float32 temperature_sensor
 float32 temperature_target

--- a/msg/HeaterStatus.msg
+++ b/msg/HeaterStatus.msg
@@ -4,7 +4,7 @@ uint32 device_id
 
 bool heater_on
 bool temperature_target_met
-bool temperature_threshold_met
+bool temperature_activation_threshold_met
 
 float32 temperature_sensor
 float32 temperature_target

--- a/src/drivers/heater/heater.cpp
+++ b/src/drivers/heater/heater.cpp
@@ -440,20 +440,20 @@ void Heater::Run()
 			}
 		}
 
+		if (PX4_ISFINITE(current_temp)) {
+			temperature_delta = _params.temp - current_temp;
+			_temperature_last = current_temp;
+			temperature_updated = true;
+#ifdef CONFIG_HEATER_FAST_UPDATE_MODE
+			_temperature_last_update_time = hrt_absolute_time();
+#endif
+		}
+
 		// Latch heating on once the temperature threshold is crossed; stays on until reset.
 		if (_temperature_threshold_met
 		    || (PX4_ISFINITE(current_temp) && current_temp < _params.temp_threshold)) {
 
 			_temperature_threshold_met = true;
-
-			if (PX4_ISFINITE(current_temp)) {
-				temperature_delta = _params.temp - current_temp;
-				_temperature_last = current_temp;
-				temperature_updated = true;
-#ifdef CONFIG_HEATER_FAST_UPDATE_MODE
-				_temperature_last_update_time = hrt_absolute_time();
-#endif
-			}
 
 #ifdef CONFIG_HEATER_FAST_UPDATE_MODE
 
@@ -512,20 +512,21 @@ void Heater::Run()
 void Heater::publish_status()
 {
 	heater_status_s status{};
-	status.device_id               = _sensor_device_id;
-	status.heater_on               = _heater_on;
-	status.temperature_sensor      = _temperature_last;
-	status.temperature_target      = _params.temp;
-	status.temperature_target_met  = _temperature_target_met;
-	status.controller_period_usec  = CONTROLLER_PERIOD_DEFAULT;
-	status.controller_time_on_usec = _controller_time_on_usec;
-	status.proportional_value      = _proportional_value;
-	status.integrator_value        = _integrator_value;
-	status.feed_forward_value      = _params.temp_ff;
-	status.supply_voltage          = _supply_voltage;
-	status.heater_current          = _heater_current;
-	status.nominal_multiplier      = _nominal_multiplier;
-	status.temperature_source      = _params.temp_src;
+	status.device_id                 = _sensor_device_id;
+	status.heater_on                 = _heater_on;
+	status.temperature_sensor        = _temperature_last;
+	status.temperature_target        = _params.temp;
+	status.temperature_target_met    = _temperature_target_met;
+	status.controller_period_usec    = CONTROLLER_PERIOD_DEFAULT;
+	status.controller_time_on_usec   = _controller_time_on_usec;
+	status.proportional_value        = _proportional_value;
+	status.integrator_value          = _integrator_value;
+	status.feed_forward_value        = _params.temp_ff;
+	status.supply_voltage            = _supply_voltage;
+	status.heater_current            = _heater_current;
+	status.nominal_multiplier        = _nominal_multiplier;
+	status.temperature_threshold_met = _temperature_threshold_met;
+	status.temperature_source        = _params.temp_src;
 
 #ifdef HEATER_PX4IO
 	status.mode = heater_status_s::MODE_PX4IO;

--- a/src/drivers/heater/heater.cpp
+++ b/src/drivers/heater/heater.cpp
@@ -133,8 +133,8 @@ Heater::Heater(uint8_t instance) :
 	snprintf(name, sizeof(name), "HEATER%u_TEMP_SRC", (unsigned)_instance);
 	_param_handles.temp_src = param_find(name);
 
-	snprintf(name, sizeof(name), "HEATER%u_TEMP_TH", (unsigned)_instance);
-	_param_handles.temp_threshold = param_find(name);
+	snprintf(name, sizeof(name), "HEATER%u_TEMP_ACT", (unsigned)_instance);
+	_param_handles.temp_activation_threshold = param_find(name);
 
 	snprintf(name, sizeof(name), "HEATER%u_NOM_V", (unsigned)_instance);
 	_param_handles.nom_v = param_find(name);
@@ -450,10 +450,10 @@ void Heater::Run()
 		}
 
 		// Latch heating on once the temperature threshold is crossed; stays on until reset.
-		if (_temperature_threshold_met
-		    || (PX4_ISFINITE(current_temp) && current_temp < _params.temp_threshold)) {
+		if (_temperature_activation_threshold_met
+		    || (PX4_ISFINITE(current_temp) && current_temp < _params.temp_activation_threshold)) {
 
-			_temperature_threshold_met = true;
+			_temperature_activation_threshold_met = true;
 
 #ifdef CONFIG_HEATER_FAST_UPDATE_MODE
 
@@ -512,21 +512,21 @@ void Heater::Run()
 void Heater::publish_status()
 {
 	heater_status_s status{};
-	status.device_id                 = _sensor_device_id;
-	status.heater_on                 = _heater_on;
-	status.temperature_sensor        = _temperature_last;
-	status.temperature_target        = _params.temp;
-	status.temperature_target_met    = _temperature_target_met;
-	status.controller_period_usec    = CONTROLLER_PERIOD_DEFAULT;
-	status.controller_time_on_usec   = _controller_time_on_usec;
-	status.proportional_value        = _proportional_value;
-	status.integrator_value          = _integrator_value;
-	status.feed_forward_value        = _params.temp_ff;
-	status.supply_voltage            = _supply_voltage;
-	status.heater_current            = _heater_current;
-	status.nominal_multiplier        = _nominal_multiplier;
-	status.temperature_threshold_met = _temperature_threshold_met;
-	status.temperature_source        = _params.temp_src;
+	status.device_id                 	    = _sensor_device_id;
+	status.heater_on                 	    = _heater_on;
+	status.temperature_sensor        	    = _temperature_last;
+	status.temperature_target        	    = _params.temp;
+	status.temperature_target_met    	    = _temperature_target_met;
+	status.controller_period_usec    	    = CONTROLLER_PERIOD_DEFAULT;
+	status.controller_time_on_usec   	    = _controller_time_on_usec;
+	status.proportional_value        	    = _proportional_value;
+	status.integrator_value          	    = _integrator_value;
+	status.feed_forward_value        	    = _params.temp_ff;
+	status.supply_voltage            	    = _supply_voltage;
+	status.heater_current            	    = _heater_current;
+	status.nominal_multiplier        	    = _nominal_multiplier;
+	status.temperature_activation_threshold_met = _temperature_activation_threshold_met;
+	status.temperature_source                   = _params.temp_src;
 
 #ifdef HEATER_PX4IO
 	status.mode = heater_status_s::MODE_PX4IO;
@@ -708,8 +708,8 @@ void Heater::update_params(const bool force)
 			param_get(_param_handles.temp_src, &_params.temp_src);
 		}
 
-		if (_param_handles.temp_threshold != PARAM_INVALID) {
-			param_get(_param_handles.temp_threshold, &_params.temp_threshold);
+		if (_param_handles.temp_activation_threshold != PARAM_INVALID) {
+			param_get(_param_handles.temp_activation_threshold, &_params.temp_activation_threshold);
 		}
 
 		if (_param_handles.nom_v != PARAM_INVALID) {

--- a/src/drivers/heater/heater.cpp
+++ b/src/drivers/heater/heater.cpp
@@ -133,6 +133,9 @@ Heater::Heater(uint8_t instance) :
 	snprintf(name, sizeof(name), "HEATER%u_TEMP_SRC", (unsigned)_instance);
 	_param_handles.temp_src = param_find(name);
 
+	snprintf(name, sizeof(name), "HEATER%u_TEMP_TH", (unsigned)_instance);
+	_param_handles.temp_threshold = param_find(name);
+
 	snprintf(name, sizeof(name), "HEATER%u_NOM_V", (unsigned)_instance);
 	_param_handles.nom_v = param_find(name);
 
@@ -401,6 +404,7 @@ void Heater::Run()
 
 	float temperature_delta {0.f};
 	bool temperature_updated = false;
+	uint32_t schedule_delay = CONTROLLER_PERIOD_DEFAULT;
 
 	// Update input voltage/current monitoring
 	battery_status_s battery_status;
@@ -415,7 +419,7 @@ void Heater::Run()
 		// Turn the heater off.
 		_heater_on = false;
 		heater_off();
-		ScheduleDelayed(CONTROLLER_PERIOD_DEFAULT - _controller_time_on_usec);
+		schedule_delay = CONTROLLER_PERIOD_DEFAULT - _controller_time_on_usec;
 
 	} else {
 		float current_temp = NAN;
@@ -436,74 +440,72 @@ void Heater::Run()
 			}
 		}
 
-		if (PX4_ISFINITE(current_temp)) {
-			temperature_delta = _params.temp - current_temp;
-			_temperature_last = current_temp;
-			temperature_updated = true;
+		// Latch heating on once the temperature threshold is crossed; stays on until reset.
+		if (_temperature_threshold_met
+		    || (PX4_ISFINITE(current_temp) && current_temp < _params.temp_threshold)) {
+
+			_temperature_threshold_met = true;
+
+			if (PX4_ISFINITE(current_temp)) {
+				temperature_delta = _params.temp - current_temp;
+				_temperature_last = current_temp;
+				temperature_updated = true;
 #ifdef CONFIG_HEATER_FAST_UPDATE_MODE
-			_temperature_last_update_time = hrt_absolute_time();
+				_temperature_last_update_time = hrt_absolute_time();
 #endif
-		}
+			}
 
 #ifdef CONFIG_HEATER_FAST_UPDATE_MODE
 
-		// No fresh sensor update: use cached temperature if still within a certain window.
-		if (!temperature_updated
-		    && _temperature_last_update_time != 0
-		    && hrt_elapsed_time(&_temperature_last_update_time) < 500_ms) {
-			temperature_delta = _params.temp - _temperature_last;
-			temperature_updated = true;
-		}
+			// No fresh sensor update: use cached temperature if still within a certain window.
+			if (!temperature_updated
+			    && _temperature_last_update_time != 0
+			    && hrt_elapsed_time(&_temperature_last_update_time) < 500_ms) {
+				temperature_delta = _params.temp - _temperature_last;
+				temperature_updated = true;
+			}
 
 #endif
 
-		if (temperature_updated) {
-			_proportional_value = temperature_delta * _params.temp_p;
+			if (temperature_updated) {
+				_proportional_value = temperature_delta * _params.temp_p;
 
-			_integrator_value += temperature_delta * _params.temp_i;
+				_integrator_value += temperature_delta * _params.temp_i;
 
-			_integrator_value = math::constrain(_integrator_value, -_params.temp_imax, _params.temp_imax);
+				_integrator_value = math::constrain(_integrator_value, -_params.temp_imax, _params.temp_imax);
 
-			_controller_time_on_usec = static_cast<int>((_params.temp_ff + _proportional_value +
-						   _integrator_value) * static_cast<float>(CONTROLLER_PERIOD_DEFAULT));
+				_controller_time_on_usec = static_cast<int>((_params.temp_ff + _proportional_value +
+							   _integrator_value) * static_cast<float>(CONTROLLER_PERIOD_DEFAULT));
 
-			_controller_time_on_usec = math::constrain(_controller_time_on_usec, 0, CONTROLLER_PERIOD_DEFAULT);
+				_controller_time_on_usec = math::constrain(_controller_time_on_usec, 0, CONTROLLER_PERIOD_DEFAULT);
 
-			const float nom_v = _params.nom_v;
+				const float nom_v = _params.nom_v;
 
-			if (nom_v > 0.f) {
-				if (_battery_status_last_update_time == 0 || hrt_elapsed_time(&_battery_status_last_update_time) > 500_ms) {
-					_controller_time_on_usec = 0;
+				if (nom_v > 0.f) {
+					if (_battery_status_last_update_time == 0 || hrt_elapsed_time(&_battery_status_last_update_time) > 500_ms) {
+						_controller_time_on_usec = 0;
 
-				} else if (PX4_ISFINITE(_supply_voltage) && _supply_voltage > nom_v) {
-					// Scale duty cycle by (V_nom/V)^2 so delivered power is the same regardless of supply voltage.
-					const float ratio = nom_v / _supply_voltage;
-					_nominal_multiplier = ratio * ratio;
-					_controller_time_on_usec = static_cast<int>(_controller_time_on_usec * _nominal_multiplier);
+					} else if (PX4_ISFINITE(_supply_voltage) && _supply_voltage > nom_v) {
+						// Scale duty cycle by (V_nom/V)^2 so delivered power is the same regardless of supply voltage.
+						const float ratio = nom_v / _supply_voltage;
+						_nominal_multiplier = ratio * ratio;
+						_controller_time_on_usec = static_cast<int>(_controller_time_on_usec * _nominal_multiplier);
+					}
+				}
+
+				_temperature_target_met = fabsf(temperature_delta) < TEMPERATURE_TARGET_THRESHOLD;
+
+				if (_controller_time_on_usec > 0) {
+					_heater_on = true;
+					heater_on();
+					schedule_delay = _controller_time_on_usec;
 				}
 			}
 
-			if (fabsf(temperature_delta) < TEMPERATURE_TARGET_THRESHOLD) {
-				_temperature_target_met = true;
-
-			} else {
-				_temperature_target_met = false;
-			}
-
-			if (_controller_time_on_usec > 0) {
-				_heater_on = true;
-				heater_on();
-				ScheduleDelayed(_controller_time_on_usec);
-
-			} else {
-				ScheduleDelayed(CONTROLLER_PERIOD_DEFAULT);
-			}
-
-		} else {
-			ScheduleDelayed(CONTROLLER_PERIOD_DEFAULT);
 		}
 	}
 
+	ScheduleDelayed(schedule_delay);
 	publish_status();
 }
 
@@ -703,6 +705,10 @@ void Heater::update_params(const bool force)
 
 		if (_param_handles.temp_src != PARAM_INVALID) {
 			param_get(_param_handles.temp_src, &_params.temp_src);
+		}
+
+		if (_param_handles.temp_threshold != PARAM_INVALID) {
+			param_get(_param_handles.temp_threshold, &_params.temp_threshold);
 		}
 
 		if (_param_handles.nom_v != PARAM_INVALID) {

--- a/src/drivers/heater/heater.h
+++ b/src/drivers/heater/heater.h
@@ -171,7 +171,7 @@ private:
 	float _temperature_last{NAN};
 	float _supply_voltage{NAN};
 	float _heater_current{NAN};
-	bool _temperature_threshold_met{false};
+	bool _temperature_activation_threshold_met{false};
 	const uint8_t _instance; //! 1-based
 
 	volatile bool _should_exit{false};
@@ -183,7 +183,7 @@ private:
 		param_t temp_ff;
 		param_t temp_imax;
 		param_t temp_src;
-		param_t temp_threshold;
+		param_t temp_activation_threshold;
 		param_t nom_v;
 	} _param_handles;
 
@@ -195,7 +195,7 @@ private:
 		float   temp_ff;
 		float   temp_imax;
 		int32_t temp_src; // 0 = IMU, 1 = hygrometer
-		float   temp_threshold; // start heating once the temperature drops below this value
+		float   temp_activation_threshold; // start heating once the temperature drops below this value
 		float   nom_v;    // nominal supply voltage for power limiting (0 = disabled)
 	} _params;
 

--- a/src/drivers/heater/heater.h
+++ b/src/drivers/heater/heater.h
@@ -171,7 +171,7 @@ private:
 	float _temperature_last{NAN};
 	float _supply_voltage{NAN};
 	float _heater_current{NAN};
-
+	bool _temperature_threshold_met{false};
 	const uint8_t _instance; //! 1-based
 
 	volatile bool _should_exit{false};
@@ -183,6 +183,7 @@ private:
 		param_t temp_ff;
 		param_t temp_imax;
 		param_t temp_src;
+		param_t temp_threshold;
 		param_t nom_v;
 	} _param_handles;
 
@@ -194,6 +195,7 @@ private:
 		float   temp_ff;
 		float   temp_imax;
 		int32_t temp_src; // 0 = IMU, 1 = hygrometer
+		float   temp_threshold; // temperature threshold to start heating
 		float   nom_v;    // nominal supply voltage for power limiting (0 = disabled)
 	} _params;
 

--- a/src/drivers/heater/heater.h
+++ b/src/drivers/heater/heater.h
@@ -195,7 +195,7 @@ private:
 		float   temp_ff;
 		float   temp_imax;
 		int32_t temp_src; // 0 = IMU, 1 = hygrometer
-		float   temp_threshold; // temperature threshold to start heating
+		float   temp_threshold; // start heating once the temperature drops below this value
 		float   nom_v;    // nominal supply voltage for power limiting (0 = disabled)
 	} _params;
 

--- a/src/drivers/heater/module.yaml
+++ b/src/drivers/heater/module.yaml
@@ -123,19 +123,25 @@ parameters:
 
         HEATER${i}_TEMP_TH:
             description:
-                short: Temperature threshold for heater ${i} to start heating
+                short: Threshold; If heater ${i} drops below this value, it starts heating
                 long: |
-                    Used to prevent the heater from always heating. It only starts heating if the temperature drops below this threshold, and continues until reset.
+                    The heater starts heating once the temperature drops below this threshold, and keeps
+                    heating until reset.
+
+                    The default (200) effectively keeps the heater always on (fmu), since ambient temperature never
+                    reaches that high.
+                    Lower this for heaters that should only run when actually needed (e.g. a pitot-tube heater to save power)
+                    e.g. 5 to only start heating once the temperature drops below 5°C.
 
             type: float
-            unit: us/C
-            min: -1000.0
-            max: 1000.0
+            unit: celcius
+            min: -100.0
+            max: 200.0
             decimal: 1
-            reboot_required: true
+            reboot_required: false
             num_instances: *max_num_config_instances
             instance_start: 1
-            default: [1000.0, 1000.0, 1000.0]
+            default: [200.0, 200.0, 200.0]
 
         HEATER${i}_NOM_V:
             description:

--- a/src/drivers/heater/module.yaml
+++ b/src/drivers/heater/module.yaml
@@ -121,6 +121,22 @@ parameters:
             instance_start: 1
             default: [0, 0, 0]
 
+        HEATER${i}_TEMP_TH:
+            description:
+                short: Temperature threshold for heater ${i} to start heating
+                long: |
+                    Used to prevent the heater from always heating. It only starts heating if the temperature drops below this threshold, and continues until reset.
+
+            type: float
+            unit: us/C
+            min: -1000.0
+            max: 1000.0
+            decimal: 1
+            reboot_required: true
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: [1000.0, 1000.0, 1000.0]
+
         HEATER${i}_NOM_V:
             description:
                 short: Nominal supply voltage for heater ${i}

--- a/src/drivers/heater/module.yaml
+++ b/src/drivers/heater/module.yaml
@@ -121,15 +121,15 @@ parameters:
             instance_start: 1
             default: [0, 0, 0]
 
-        HEATER${i}_TEMP_TH:
+        HEATER${i}_TEMP_ACT:
             description:
-                short: Threshold; If heater ${i} drops below this value, it starts heating
+                short: If temperature drops below Activation_Threshold, it starts heating
                 long: |
-                    The heater starts heating once the temperature drops below this threshold, and keeps
+                    The heater starts heating once the temperature drops below this activation threshold, and keeps
                     heating until reset.
 
-                    The default (200) effectively keeps the heater always on (fmu), since ambient temperature never
-                    reaches that high.
+                    The default (200): Since ambient temperature never reaches that high, on heater-start the temperature
+                    is always below the activation threshold and thus turn on the heater immediately.
                     Lower this for heaters that should only run when actually needed (e.g. a pitot-tube heater to save power)
                     e.g. 5 to only start heating once the temperature drops below 5°C.
 


### PR DESCRIPTION
### Solved Problem
The heater responsible for heating up the pitot-tube starts heating as soon as it has a reference-temperature and never stops.
This leads to unnecessary high power-consumption (in case no heating is needed).

### Solution
This PR introduces a parameter HEATER{i}_TEMP_ACT (Temperature_Activation_Threshold).
If the Activation_Threshold is reached once, the heater starts heating up to the specified heater-temperature and stays on until reset/reboot.

This allows 3 possible configuration options:
**1. Always off:**  If set to an "impossible" low value like (-100C) the temperature never falls below the Activation_Threshold  and thus is always off
**2. Start with Activation_Threshold:** If set to an appropriate temperature eg. 5C, once the temperature drops below the specified Activation_Threshold, the heater starts heating
**3. Always on (default):**  If set to an "impossible" high value like (200C) the temperature exceeds the Activation_Threshold immediately and the heater starts heating