### PR TITLE
docs(test_cards): add MC_11 companion computer ROS 2 external mode

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -909,6 +909,7 @@
         - [Test MC_08 - DSHOT ESC](test_cards/mc_08_dshot.md)
         - [Test MC_09 - VIO (Visual-Inertial Odometry)](test_cards/mc_09_vio.md)
         - [Test MC_10 - Optical Flow / GPS Mixed](test_cards/mc_10_optical_flow_gps_mixed.md)
+        - [Test MC_11 - Companion Computer (ROS 2 External Mode)](test_cards/mc_11_companion_ros2_external_mode.md)
       - [Fixed Wing](test_and_ci/test_flights.md#fixed-wing)
         - [Test FW_01 - Manual Modes](test_cards/fw_01_manual_modes.md)
         - [Test FW_02 - Full Autonomous](test_cards/fw_02_full_autonomous.md)

--- a/docs/en/_sidebar.md
+++ b/docs/en/_sidebar.md
@@ -902,6 +902,7 @@
         - [Test MC_08 - DSHOT ESC](/test_cards/mc_08_dshot.md)
         - [Test MC_09 - VIO (Visual-Inertial Odometry)](/test_cards/mc_09_vio.md)
         - [Test MC_10 - Optical Flow / GPS Mixed](/test_cards/mc_10_optical_flow_gps_mixed.md)
+        - [Test MC_11 - Companion Computer (ROS 2 External Mode)](/test_cards/mc_11_companion_ros2_external_mode.md)
       - [Fixed Wing](/test_and_ci/test_flights.md#fixed-wing)
         - [Test FW_01 - Manual Modes](/test_cards/fw_01_manual_modes.md)
         - [Test FW_02 - Full Autonomous](/test_cards/fw_02_full_autonomous.md)

--- a/docs/en/test_and_ci/test_flights.md
+++ b/docs/en/test_and_ci/test_flights.md
@@ -34,6 +34,7 @@ These are run by the test team as part of release testing, and for more signific
 - [MC_08 - DSHOT ESC](../test_cards/mc_08_dshot.md)
 - [MC_09 - VIO (Visual-Inertial Odometry)](../test_cards/mc_09_vio.md)
 - [MC_10 - Optical Flow / GPS Mixed](../test_cards/mc_10_optical_flow_gps_mixed.md)
+- [MC_11 - Companion Computer (ROS 2 External Mode)](../test_cards/mc_11_companion_ros2_external_mode.md)
 
 ### Fixed Wing
 

--- a/docs/en/test_cards/mc_11_companion_ros2_external_mode.md
+++ b/docs/en/test_cards/mc_11_companion_ros2_external_mode.md
@@ -1,0 +1,76 @@
+# Test MC_11 - Companion Computer (ROS 2 External Mode)
+
+## Objective
+
+To test autonomous flight commanded from a companion computer using the [PX4 ROS 2 Interface Library](../ros2/px4_ros2_interface_lib.md) over the [uXRCE-DDS](../middleware/uxrce_dds.md) or [Zenoh](../middleware/zenoh.md) bridge.
+
+The test runs the library's [go-to example](https://github.com/Auterion/px4-ros2-interface-lib/tree/main/examples/cpp/modes/goto), which registers an external flight mode named _Go-to Example_ and flies a fixed triangular pattern (about 20 m x 30 m) relative to the position where the mode is engaged, at constant altitude.
+This exercises external mode registration, setpoint configuration, go-to setpoint streaming, and mode completion signalling across the bridge.
+
+## Preflight
+
+Companion computer setup (once):
+
+- Connect a companion computer to the flight controller and start the bridge:
+  - [uXRCE-DDS](../middleware/uxrce_dds.md): run the micro XRCE-DDS agent on the companion computer, or
+  - [Zenoh](../middleware/zenoh.md): follow the ROS 2 Zenoh bring-up on the companion computer
+- Set up a ROS 2 workspace on the companion computer with `px4_msgs` and the interface library, following steps 1 to 3 of [PX4 ROS 2 Control Interface > Installation and First Test](../ros2/px4_ros2_control_interface.md#installation-and-first-test) (skip the SITL steps).
+  The go-to example is built as part of the workspace (package `example_mode_goto_cpp`).
+- Use a recent QGroundControl (Daily), which supports dynamically updating the list of flight modes.
+
+Before flight:
+
+- Start the example on the companion computer:
+
+  ```sh
+  ros2 run example_mode_goto_cpp example_mode_goto
+  ```
+
+- Confirm the console shows the registration succeeding (`Registering 'Go-to Example'` followed by `Got RegisterExtComponentReply`)
+- Confirm _Go-to Example_ shows up in the QGC flight mode list
+- Confirm the airspace is clear roughly 20 m north and 30 m east of the planned engage position (the pattern is flown from wherever the mode is engaged)
+
+## Flight Tests
+
+❏ Mode registration
+
+&nbsp;&nbsp;&nbsp;&nbsp;❏ With the vehicle disarmed, stop and restart the example node
+
+&nbsp;&nbsp;&nbsp;&nbsp;❏ _Go-to Example_ disappears from and reappears in the QGC mode list
+
+❏ Go-to Example mode
+
+&nbsp;&nbsp;&nbsp;&nbsp;❏ Arm and take off in Position mode, climb to a safe altitude (10 m or more)
+
+&nbsp;&nbsp;&nbsp;&nbsp;❏ Select _Go-to Example_ in QGC (mode must engage on first attempt, no rejection message)
+
+&nbsp;&nbsp;&nbsp;&nbsp;❏ Vehicle settles at the engage position, then flies north facing the direction of travel
+
+&nbsp;&nbsp;&nbsp;&nbsp;❏ Vehicle flies the east leg while spinning around yaw, slowing down as it approaches the corner
+
+&nbsp;&nbsp;&nbsp;&nbsp;❏ Vehicle returns to the engage position with the heading fixed on the first corner
+
+&nbsp;&nbsp;&nbsp;&nbsp;❏ On completion the vehicle holds position; switch back to Position or Hold mode
+
+❏ Re-engagement
+
+&nbsp;&nbsp;&nbsp;&nbsp;❏ Fly to a different location and engage _Go-to Example_ again
+
+&nbsp;&nbsp;&nbsp;&nbsp;❏ The same pattern is flown relative to the new engage position
+
+❏ Companion loss failsafe
+
+&nbsp;&nbsp;&nbsp;&nbsp;❏ Engage _Go-to Example_ once more and stop the example node (Ctrl-C) mid-pattern
+
+&nbsp;&nbsp;&nbsp;&nbsp;❏ Vehicle triggers a failsafe and switches to Hold; QGC shows a corresponding warning
+
+❏ Land and disarm
+
+## Expected Results
+
+- The external mode appears in QGC while the node is running and can be engaged on the first attempt
+- Transitions into and out of the mode are smooth, with no twitches or setpoint jumps
+- The triangular pattern is tracked accurately at constant altitude
+- Stopping the node while the mode is active triggers a failsafe into Hold
+- The log shows the pattern portion of the flight in the external mode (check in [Flight Review](../log/flight_review.md))
+- Attach the flight log and the example's console output to the test report


### PR DESCRIPTION
Adds a flight test card for autonomous flight commanded from a companion computer through the PX4 ROS 2 Interface Library over the uXRCE-DDS or Zenoh bridge. This came out of the discussion in #27683: the test team currently has no card covering a companion computer running external modes, and @bkueng suggested the interface library's [go-to example](https://github.com/Auterion/px4-ros2-interface-lib/tree/main/examples/cpp/modes/goto) since it can be engaged from any location and flies a fixed pattern.

The go-to example exercises the paths #27683 touched: external mode registration with the API version check, the setpoint configuration request/reply, continuous go-to setpoint streaming, and mode completion signalling. Engaging and leaving the mode switches setpoint types, which is the transition where the topic drops were seen, so the card includes a re-engagement step. It also includes stopping the ROS 2 node mid-pattern to verify the failsafe into Hold.

Companion setup steps are not duplicated; the card links to the uXRCE-DDS and Zenoh bridge pages and to the workspace setup steps in the [control interface docs](https://docs.px4.io/main/en/ros2/px4_ros2_control_interface.html#installation-and-first-test).

- New card: `docs/en/test_cards/mc_11_companion_ros2_external_mode.md`
- Listed in `SUMMARY.md`, `_sidebar.md`, and the test flights page

Not yet flown by the test team; review of the steps by @bkueng and @mahima-yoga would be appreciated before it goes into the release test rotation.