### PR TITLE
fix(collision_prevention): bound body-frame obstacle loop to BIN_COUNT

### DIFF
--- a/src/lib/collision_prevention/CollisionPrevention.cpp
+++ b/src/lib/collision_prevention/CollisionPrevention.cpp
@@ -278,7 +278,7 @@ void CollisionPrevention::_addObstacleSensorData(const obstacle_distance_s &obst
 		// Obstacle message arrives in body frame (front aligned)
 		// corresponding data index (shift by msg offset)
 		for (int i = 0; i < BIN_COUNT; i++) {
-			for (int j = 0; j < 360 / obstacle.increment; j++) {
+			for (int j = 0; (j < 360 / obstacle.increment) && (j < BIN_COUNT); j++) {
 				float bin_lower_angle = ObstacleMath::get_lower_bound_angle(i, _obstacle_map_body_frame.increment,
 							_obstacle_map_body_frame.angle_offset);
 				float bin_upper_angle = ObstacleMath::get_lower_bound_angle(i + 1, _obstacle_map_body_frame.increment,

--- a/src/lib/collision_prevention/CollisionPreventionTest.cpp
+++ b/src/lib/collision_prevention/CollisionPreventionTest.cpp
@@ -1370,3 +1370,38 @@ TEST_F(CollisionPreventionTest, enterData)
 	EXPECT_TRUE(cp.test_enterData(16, 30.f, 1.5f)); //longer range, reading in range
 	EXPECT_TRUE(cp.test_enterData(16, 30.f, 31.f)); //longer range, reading out of range
 }
+
+TEST_F(CollisionPreventionTest, addObstacleSensorData_smallIncrementNoOverflow)
+{
+	// GIVEN: a body-frame obstacle message whose increment is smaller than BIN_SIZE (5 deg).
+	// The distances[] array is a fixed 72 elements, but the BODY_FRD ingest loop bounds its
+	// message index by 360/increment. With increment < 5 that exceeds 72 and reads past the
+	// end of distances[] (the sibling GLOBAL/LOCAL_NED branch guards this with j < BIN_COUNT).
+	TestCollisionPrevention cp;
+	obstacle_distance_s obstacle_msg {};
+	obstacle_msg.frame = obstacle_msg.MAV_FRAME_BODY_FRD; // vehicle front aligned
+	obstacle_msg.increment = 1.f;                         // 360 / 1 = 360 >> 72-element array
+	obstacle_msg.min_distance = 20;
+	obstacle_msg.max_distance = 2000;
+	obstacle_msg.angle_offset = 0.f;
+
+	// fill the whole valid array: a few close bins, the rest "no obstacle"
+	memset(&obstacle_msg.distances[0], UINT16_MAX, sizeof(obstacle_msg.distances));
+
+	for (int i = 2; i <= 6; i++) {
+		obstacle_msg.distances[i] = 500;
+	}
+
+	// WHEN: we ingest it. Before the fix this reads obstacle_msg.distances[j] for j up to 359,
+	// i.e. far past the end of the array (AddressSanitizer aborts here).
+	cp.test_addObstacleSensorData(obstacle_msg, 0.f);
+
+	// THEN: every resulting map bin holds either "no obstacle" or one of the values we supplied.
+	// A value outside {UINT16_MAX, 500} means out-of-bounds memory leaked into the obstacle map.
+	const int map_size = sizeof(cp.getObstacleMap().distances) / sizeof(cp.getObstacleMap().distances[0]);
+
+	for (int i = 0; i < map_size; i++) {
+		const uint16_t d = cp.getObstacleMap().distances[i];
+		EXPECT_TRUE(d == UINT16_MAX || d == 500) << "bin " << i << " leaked value " << d;
+	}
+}


### PR DESCRIPTION
### Solved Problem

`CollisionPrevention::_addObstacleSensorData()` maps an incoming `obstacle_distance`
message into the internal 72-bin obstacle map in two branches. The
`MAV_FRAME_GLOBAL` / `MAV_FRAME_LOCAL_NED` branch bounds its inner loop with
`(j < 360 / obstacle.increment) && (j < BIN_COUNT)`, but the `MAV_FRAME_BODY_FRD`
branch bounds it only with `j < 360 / obstacle.increment`.

`obstacle.increment` is only validated to be `> 0` upstream. A body-frame message
with `increment < BIN_SIZE` (5°) — e.g. `increment = 1` — makes `j` run up to 359 and
index `obstacle.distances[j]` past the end of the fixed 72-element `distances[]` array.
This is an out-of-bounds read that leaks adjacent memory into the obstacle map as
fabricated obstacle readings, which can affect braking/steering.

Found by code inspection while auditing the module; no existing issue.

### Solution

Add the same `j < BIN_COUNT` guard the sibling GLOBAL/LOCAL_NED branch already uses:

```diff
-for (int j = 0; j < 360 / obstacle.increment; j++) {
+for (int j = 0; (j < 360 / obstacle.increment) && (j < BIN_COUNT); j++) {
```

### Changelog Entry

```
Bugfix: collision_prevention: fix out-of-bounds read when ingesting body-frame
(MAV_FRAME_BODY_FRD) obstacle_distance messages whose increment is smaller than the
5-degree bin size
```

### Test coverage

Added `CollisionPreventionTest.addObstacleSensorData_smallIncrementNoOverflow`, which
ingests a `MAV_FRAME_BODY_FRD` message with `increment = 1`. Built with
`-DCMAKE_BUILD_TYPE=AddressSanitizer`, the test triggers a `stack-buffer-overflow` in
`_addObstacleSensorData` **without** this fix and passes **with** it. The full
`CollisionPrevention` suite (24 tests) passes under ASan with no regressions.

### Context

The GLOBAL/LOCAL_NED branch already carries the `j < BIN_COUNT` guard — this simply
brings the body-frame branch in line with it.