### PR TITLE
feat(drivers/pwm_out,platforms): Prevent sudden PWM output pulse cutoff during system shutdown/reboot

### DIFF
--- a/platforms/nuttx/src/px4/espressif/esp32/io_pins/pwm_servo.c
+++ b/platforms/nuttx/src/px4/espressif/esp32/io_pins/pwm_servo.c
@@ -226,6 +226,11 @@ void up_pwm_servo_deinit(uint32_t channel_mask)
 
 int up_pwm_servo_set_rate_group_update(unsigned group, unsigned rate)
 {
+	// Oneshot and timer max modes not supported.
+	if (PWM_RATE_ONESHOT == rate || PWM_RATE_TIMER_MAX) {
+		return ERROR;
+	}
+
 	if (group == 0 || group == 1 || group == 2 || group == 3) {
 		irqstate_t flags;
 		shift = 0;

--- a/platforms/nuttx/src/px4/nxp/imxrt/io_pins/io_timer.c
+++ b/platforms/nuttx/src/px4/nxp/imxrt/io_pins/io_timer.c
@@ -423,7 +423,7 @@ static int allocate_channel(unsigned channel, io_timer_channel_mode_t mode)
 	return rv;
 }
 
-static int timer_set_rate(unsigned timer, unsigned rate)
+static int timer_set_val(unsigned timer, uint16_t val)
 {
 	int channels = get_timer_channels(timer);
 
@@ -433,7 +433,7 @@ static int timer_set_rate(unsigned timer, unsigned rate)
 		if ((1 << channel) & channels) {
 			rMCTRL(channels_timer(channel)) |= (timer_io_channels[channel].sub_module_bits >> MCTRL_LDOK_SHIFT) << MCTRL_CLDOK_SHIFT
 							   ;
-			rVAL1(channels_timer(channel), timer_io_channels[channel].sub_module) = (BOARD_PWM_FREQ / rate) - 1;
+			rVAL1(channels_timer(channel), timer_io_channels[channel].sub_module) = val;
 			rMCTRL(channels_timer(channel)) |= timer_io_channels[channel].sub_module_bits;
 
 		}
@@ -441,6 +441,16 @@ static int timer_set_rate(unsigned timer, unsigned rate)
 
 	px4_leave_critical_section(flags);
 	return 0;
+}
+
+static int timer_set_max_timer_rate(unsigned timer)
+{
+	return timer_set_val(timer, UINT16_MAX);
+}
+
+static int timer_set_rate(unsigned timer, unsigned rate)
+{
+	return timer_set_val(timer, (BOARD_PWM_FREQ / rate) - 1);
 }
 
 static inline void io_timer_set_oneshot_mode(unsigned timer)
@@ -658,7 +668,12 @@ int io_timer_set_pwm_rate(unsigned timer, unsigned rate)
 			io_timer_set_PWM_mode(timer);
 		}
 
-		timer_set_rate(timer, rate);
+		if (PWM_RATE_TIMER_MAX == rate) {
+			timer_set_max_timer_rate(timer);
+
+		} else {
+			timer_set_rate(timer, rate);
+		}
 	}
 
 	return OK;

--- a/platforms/nuttx/src/px4/nxp/imxrt/io_pins/pwm_servo.c
+++ b/platforms/nuttx/src/px4/nxp/imxrt/io_pins/pwm_servo.c
@@ -126,9 +126,9 @@ int up_pwm_servo_set_rate_group_update(unsigned channel, unsigned rate)
 		return ERROR;
 	}
 
-	/* Allow a rate of 0 to enter oneshot mode */
+	/* Allow specific rates to enter oneshot or timer max rate mode */
 
-	if (rate != 0) {
+	if (rate != PWM_RATE_ONESHOT && rate != PWM_RATE_TIMER_MAX) {
 
 		/* limit update rate to 1..10000Hz; somewhat arbitrary but safe */
 

--- a/platforms/nuttx/src/px4/nxp/kinetis/io_pins/io_timer.c
+++ b/platforms/nuttx/src/px4/nxp/kinetis/io_pins/io_timer.c
@@ -670,6 +670,11 @@ int io_timer_set_pwm_rate(unsigned timer, unsigned rate)
 			io_timer_set_PWM_mode(timer);
 		}
 
+		// Comments in timer_set_rate says that rate change requires counter reset so there is no result to do that online.
+		if (PWM_RATE_TIMER_MAX == rate) {
+			return -EINVAL;
+		}
+
 		timer_set_rate(timer, rate);
 	}
 

--- a/platforms/nuttx/src/px4/nxp/kinetis/io_pins/pwm_servo.c
+++ b/platforms/nuttx/src/px4/nxp/kinetis/io_pins/pwm_servo.c
@@ -125,9 +125,9 @@ int up_pwm_servo_set_rate_group_update(unsigned group, unsigned rate)
 		return ERROR;
 	}
 
-	/* Allow a rate of 0 to enter oneshot mode */
+	/* Allow specific rates to enter oneshot or timer max rate mode */
 
-	if (rate != 0) {
+	if (rate != PWM_RATE_ONESHOT && rate != PWM_RATE_TIMER_MAX) {
 
 		/* limit update rate to 1..10000Hz; somewhat arbitrary but safe */
 

--- a/platforms/nuttx/src/px4/nxp/s32k1xx/io_pins/io_timer.c
+++ b/platforms/nuttx/src/px4/nxp/s32k1xx/io_pins/io_timer.c
@@ -674,6 +674,11 @@ int io_timer_set_pwm_rate(unsigned timer, unsigned rate)
 			io_timer_set_PWM_mode(timer);
 		}
 
+		// Comments in timer_set_rate says that rate change invokes counter reset so won't work online.
+		if (PWM_RATE_TIMER_MAX == rate) {
+			return -EINVAL;
+		}
+
 		timer_set_rate(timer, rate);
 	}
 

--- a/platforms/nuttx/src/px4/nxp/s32k1xx/io_pins/pwm_servo.c
+++ b/platforms/nuttx/src/px4/nxp/s32k1xx/io_pins/pwm_servo.c
@@ -124,9 +124,9 @@ int up_pwm_servo_set_rate_group_update(unsigned group, unsigned rate)
 		return ERROR;
 	}
 
-	/* Allow a rate of 0 to enter oneshot mode */
+	/* Allow specific rates to enter oneshot or timer max rate mode */
 
-	if (rate != 0) {
+	if (rate != PWM_RATE_ONESHOT && rate != PWM_RATE_TIMER_MAX) {
 
 		/* limit update rate to 1..10000Hz; somewhat arbitrary but safe */
 

--- a/platforms/nuttx/src/px4/nxp/s32k3xx/io_pins/io_timer.c
+++ b/platforms/nuttx/src/px4/nxp/s32k3xx/io_pins/io_timer.c
@@ -430,17 +430,14 @@ static int allocate_channel(unsigned channel, io_timer_channel_mode_t mode)
 	return rv;
 }
 
-static int timer_set_rate(unsigned channel, unsigned rate)
+static int timer_set_prediv4_and_b(unsigned channel, bool prediv4, uint16_t b)
 {
 
 	irqstate_t flags = px4_enter_critical_section();
 
-	int prediv = 1;
-
-	if (rate < 500) {
+	if (prediv4) {
 		rC(channels_timer(channel), channel) = (rC(channels_timer(channel), channel) & ~EMIOS_C_UCPRE_MASK)
 						       | EMIOS_C_UCPRE_DIV4;
-		prediv = 4;
 
 	} else {
 		rC(channels_timer(channel), channel) = (rC(channels_timer(channel), channel) & ~EMIOS_C_UCPRE_MASK)
@@ -449,11 +446,22 @@ static int timer_set_rate(unsigned channel, unsigned rate)
 
 
 	/* configure the timer to update at the desired rate */
-	rB(channels_timer(channel), channel) = ((BOARD_PWM_FREQ / prediv) / rate) - 1;
+	rB(channels_timer(channel), channel) = b;
 
 	px4_leave_critical_section(flags);
 
 	return 0;
+}
+
+static int timer_set_max_timer_rate(unsigned channel)
+{
+	return timer_set_prediv4_and_b(channel, true, UINT16_MAX);
+}
+
+static int timer_set_rate(unsigned channel, unsigned rate)
+{
+	int prediv = rate < 500 ? 4 : 1;
+	return timer_set_prediv4_and_b(channel, 4 == prediv, ((BOARD_PWM_FREQ / prediv) / rate) - 1);
 }
 
 static inline uint32_t div2psc(int div)
@@ -661,7 +669,12 @@ int io_timer_set_pwm_rate(unsigned timer, unsigned rate)
 			io_timer_set_PWM_mode(timer);
 		}
 
-		timer_set_rate(timer, rate);
+		if (PWM_RATE_TIMER_MAX == rate) {
+			timer_set_max_timer_rate(timer);
+
+		} else {
+			timer_set_rate(timer, rate);
+		}
 	}
 
 	return OK;

--- a/platforms/nuttx/src/px4/nxp/s32k3xx/io_pins/pwm_servo.c
+++ b/platforms/nuttx/src/px4/nxp/s32k3xx/io_pins/pwm_servo.c
@@ -124,9 +124,9 @@ int up_pwm_servo_set_rate_group_update(unsigned channel, unsigned rate)
 		return ERROR;
 	}
 
-	/* Allow a rate of 0 to enter oneshot mode */
+	/* Allow specific rates to enter oneshot or timer max rate mode */
 
-	if (rate != 0) {
+	if (rate != PWM_RATE_ONESHOT && rate != PWM_RATE_TIMER_MAX) {
 
 		/* limit update rate to 1..20000Hz; somewhat arbitrary but safe */
 

--- a/platforms/nuttx/src/px4/rpi/rpi_common/io_pins/io_timer.c
+++ b/platforms/nuttx/src/px4/rpi/rpi_common/io_pins/io_timer.c
@@ -409,12 +409,23 @@ static int allocate_channel(unsigned channel, io_timer_channel_mode_t mode)
 	return rv;
 }
 
-static int timer_set_rate(unsigned timer, unsigned rate)
+
+static int timer_set_top(unsigned timer, uint32_t top)
 {
 	// RP2040 has a buffer for rTOP, so there shouldn't be any need to turn the timer off to change rTOP value
-	rTOP(timer) = (BOARD_PWM_FREQ / rate) - 1;
+	rTOP(timer) = top;
 
 	return 0;
+}
+
+static int timer_set_max_timer_rate(unsigned timer)
+{
+	return timer_set_top(timer, UINT32_MAX);
+}
+
+static int timer_set_rate(unsigned timer, unsigned rate)
+{
+	return timer_set_top(timer, (BOARD_PWM_FREQ / rate) - 1);
 }
 
 static inline uint32_t freq2div(uint32_t freq)
@@ -562,7 +573,12 @@ int io_timer_set_rate(unsigned timer, unsigned rate)
 				io_timer_set_PWM_mode(timer);
 			}
 
-			timer_set_rate(timer, rate);
+			if (rate == PWM_RATE_TIMER_MAX) {
+				timer_set_max_timer_rate(timer);
+
+			} else {
+				timer_set_rate(timer, rate);
+			}
 		}
 
 		rv = OK;

--- a/platforms/nuttx/src/px4/rpi/rpi_common/io_pins/pwm_servo.c
+++ b/platforms/nuttx/src/px4/rpi/rpi_common/io_pins/pwm_servo.c
@@ -113,9 +113,9 @@ int up_pwm_servo_set_rate_group_update(unsigned group, unsigned rate)
 		return ERROR;
 	}
 
-	/* Allow a rate of 0 to enter oneshot mode */
+	/* Allow specific rates to enter oneshot or timer max rate mode */
 
-	if (rate != 0) {
+	if (rate != PWM_RATE_ONESHOT && rate != PWM_RATE_TIMER_MAX) {
 
 		/* limit update rate to 1..10000Hz; somewhat arbitrary but safe */
 

--- a/platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c
@@ -492,16 +492,22 @@ static int allocate_channel(unsigned channel, io_timer_channel_mode_t mode)
 	return rv;
 }
 
-static int timer_set_rate(unsigned timer, unsigned rate)
+static int timer_set_arr(unsigned timer, uint32_t arr)
 {
-	/* configure the timer to update at the desired rate */
-
-	rARR(timer) = (BOARD_PWM_FREQ / rate) - 1;
-
+	rARR(timer) = arr;
 	return 0;
 }
 
+static int timer_set_max_timer_rate(unsigned timer)
+{
+	return timer_set_arr(timer, UINT32_MAX);
+}
 
+static int timer_set_rate(unsigned timer, unsigned rate)
+{
+	/* configure the timer to update at the desired rate */
+	return timer_set_arr(timer, (BOARD_PWM_FREQ / rate) - 1);
+}
 
 static inline void io_timer_set_oneshot_mode(unsigned timer)
 {
@@ -844,7 +850,12 @@ int io_timer_set_pwm_rate(unsigned timer, unsigned rate)
 			io_timer_set_PWM_mode(timer);
 		}
 
-		timer_set_rate(timer, rate);
+		if (PWM_RATE_TIMER_MAX == rate) {
+			timer_set_max_timer_rate(timer);
+
+		} else {
+			timer_set_rate(timer, rate);
+		}
 	}
 
 	return OK;

--- a/platforms/nuttx/src/px4/stm/stm32_common/io_pins/pwm_servo.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/io_pins/pwm_servo.c
@@ -127,9 +127,9 @@ int up_pwm_servo_set_rate_group_update(unsigned group, unsigned rate)
 		return ERROR;
 	}
 
-	/* Allow a rate of 0 to enter oneshot mode */
+	/* Allow specific rates to enter oneshot or timer max rate mode */
 
-	if (rate != PWM_RATE_ONESHOT) {
+	if (rate != PWM_RATE_ONESHOT && rate != PWM_RATE_TIMER_MAX) {
 
 		/* limit update rate to 1..10000Hz; somewhat arbitrary but safe */
 

--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -88,6 +88,7 @@ __BEGIN_DECLS
 #define	PWM_RATE_ONESHOT			0u
 #define	PWM_RATE_LOWER_LIMIT		1u
 #define	PWM_RATE_UPPER_LIMIT		10000u
+#define	PWM_RATE_TIMER_MAX		UINT16_MAX
 
 /*
  * Low-level PWM output interface.

--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -153,9 +153,42 @@ bool PWMOut::updateOutputs(float outputs[MAX_ACTUATORS], unsigned num_outputs, u
 	return true;
 }
 
+void PWMOut::set_max_timers_rate()
+{
+	for (int timer = 0; timer < MAX_IO_TIMERS; ++timer) {
+		uint32_t channels = _pwm_mask & up_pwm_servo_get_rate_group(timer);
+
+		if (channels == 0) {
+			continue;
+		}
+
+		int ret = up_pwm_servo_set_rate_group_update(timer, PWM_RATE_TIMER_MAX);
+
+		if (ret != 0) {
+			PX4_ERR("up_pwm_servo_set_rate_group_update failed for timer %i, rate %i (%i)", timer, _timer_rates[timer], ret);
+			_timer_rates[timer] = -1;
+			_pwm_mask &= ~channels;
+		}
+	}
+}
+
 void PWMOut::Run()
 {
 	if (should_exit()) {
+		hrt_abstime now = hrt_absolute_time();
+
+		if (shutdown_request_time == 0) {
+			shutdown_request_time = now;
+
+			if (pwm_shutdown_period) {
+				set_max_timers_rate();
+			}
+		}
+
+		if (now < shutdown_request_time + pwm_shutdown_period) {
+			return;
+		}
+
 		ScheduleClear();
 		_mixing_output.unregister();
 

--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -34,8 +34,19 @@
 #include "PWMOut.hpp"
 
 #include <px4_platform_common/sem.hpp>
+#include <px4_platform_common/shutdown.h>
 
 ModuleBase::Descriptor PWMOut::desc{task_spawn, custom_command, print_usage};
+
+bool PWMOut::request_stop_static()
+{
+	if (is_running(desc)) {
+		get_instance<PWMOut>(desc)->request_stop();
+		return false;
+	}
+
+	return true;
+}
 
 PWMOut::PWMOut() :
 	OutputModuleInterface(MODULE_NAME, px4::wq_configurations::hp_default)
@@ -51,6 +62,10 @@ PWMOut::~PWMOut()
 {
 	/* make sure servos are off */
 	up_pwm_servo_deinit(_pwm_mask);
+
+	if (_shutdown_hook_registered) {
+		px4_unregister_shutdown_hook(&PWMOut::request_stop_static);
+	}
 
 	perf_free(_cycle_perf);
 	perf_free(_interval_perf);
@@ -182,6 +197,7 @@ void PWMOut::Run()
 
 			if (pwm_shutdown_period) {
 				set_max_timers_rate();
+				PX4_INFO("Gracefully stopping PWM outputs");
 			}
 		}
 
@@ -238,6 +254,11 @@ int PWMOut::task_spawn(int argc, char *argv[])
 
 	desc.object.store(instance);
 	desc.task_id = task_id_is_work_queue;
+
+	if (px4_register_shutdown_hook(&PWMOut::request_stop_static) == 0) {
+		instance->_shutdown_hook_registered = true;
+	}
+
 	instance->ScheduleNow();
 	return 0;
 }

--- a/src/drivers/pwm_out/PWMOut.hpp
+++ b/src/drivers/pwm_out/PWMOut.hpp
@@ -76,6 +76,13 @@ public:
 	bool updateOutputs(float outputs[MAX_ACTUATORS], unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:
+	// 20 ms is biggest allowed pwm period (50Hz) so use 2.5x20ms.
+	static constexpr hrt_abstime pwm_shutdown_period = 50_ms;
+	// Timestamp when exit request was received and PWM outputs where configurated in PWM_RATE_TIMER_MAX. Module will exit in pwm_shutdown_period since then.
+	hrt_abstime shutdown_request_time = 0;
+
+	void set_max_timers_rate();
+
 	void Run() override;
 
 	void update_params();

--- a/src/drivers/pwm_out/PWMOut.hpp
+++ b/src/drivers/pwm_out/PWMOut.hpp
@@ -75,7 +75,11 @@ public:
 
 	bool updateOutputs(float outputs[MAX_ACTUATORS], unsigned num_outputs, unsigned num_control_groups_updated) override;
 
+	static bool request_stop_static();
+
 private:
+	bool _shutdown_hook_registered{false};
+
 	// 20 ms is biggest allowed pwm period (50Hz) so use 2.5x20ms.
 	static constexpr hrt_abstime pwm_shutdown_period = 50_ms;
 	// Timestamp when exit request was received and PWM outputs where configurated in PWM_RATE_TIMER_MAX. Module will exit in pwm_shutdown_period since then.


### PR DESCRIPTION
### Solved Problem

I experienced unexpected servo movements. Sometimes, when a PX4 reboot is triggered, the servos move all the way to their lower limit position, corresponding to PWM = 800us(not configurated by `PWM_xxx_MINn`). This could damage the servo or the structure if the movement range is physically limited, or it could trigger a mechanism, for example a parachute.

### Cause

I discovered that the problem is caused by a sudden PWM signal cutoff when the MCU shuts down. If it turns off while the PWM line is low, everything is fine. However, if it happens while the line is high, the signal immediately goes low. The servo interprets this as a low PWM value and moves to a lower position than the one actually expected at the moment of shutdown.

### Reproduce

I observed this problem on a Holybro V6X, using AUX outputs, and on an ARK CANnode. You can easily reproduce this behavior by connecting a servo to a PWM output configured with a center value of >=1500, and then periodically stopping and starting the `pwm_out` module from NSH. Sometimes, when the module stops, the servo moves toward the lower position. The expected behavior is that the servo should not move. Set the PWM frequency to 400 Hz to increase the chance of triggering this event.

### Solution

For the STM32 platform, a possible workaround for this problem is to set a very high PWM rate shortly before shutdown, in a similar way to how OneShot mode is implemented in [io_timer.c](https://github.com/PX4/PX4-Autopilot/blob/c890d9db0a300795594fd5ba6c045be9ebd71c09/platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c#L517). This way, the last high PWM pulse is followed by a long low-level period before the signal is cut off.

What I implemented and tested:
1. 9656c58145e8b60353f509980814098b8c029557 - when the `pwm_out` module stops, it tries to switch the PWM outputs to the new `PWM_RATE_TIMER_MAX` mode and waits 50 ms before exiting.
2. 0a9a8ea247138cd27b680fdf1aa35890724f4922 - added support for this `PWM_RATE_TIMER_MAX` mode on the STM32 platform by setting the timer register `ARR = UINT32_MAX`.
3. ef7b5df1d589afcb708df476b8a54ab1e0128d53 - added a graceful stop for the `pwm_out` module when the whole system shuts down, in a similar way to how it is done in the [logger](https://github.com/PX4/PX4-Autopilot/blob/c890d9db0a300795594fd5ba6c045be9ebd71c09/src/modules/logger/logger.cpp#L661) module.

What I implemented but have not tested:
4. 62003e3c7f8b5e623f8696adf643048e5a89a000, 0eecffabe717c2cbdc21529a596aeb4ba66a84f5, 4653eddd18d95bbe06ed7c646e75db36bca297de — added support for `PWM_RATE_TIMER_MAX` mode on the `rpi`, `nxp/s32k3xx`, and `nxp/imxrt` platforms.

What I did not implement:
5. 2b32008050e3a1a936d67fb4b8ef83d8ce5dfeb9, 4604aa7c16f2e8695ffc6a0f84d65fca683c7966, 313857391490ea02b3220fcd805470ba623f2c29 — support for `PWM_RATE_TIMER_MAX` mode on the `nxp/s32k1xx`, `nxp/kinetis`, and `espressif` platforms.


### Test status
At the moment I tested changes for STM32 platform on Holybro V6X and ARK CANnode on table. I will do in-air test soon for them.

I have no possibility to do tests for other platforms.

### Context

Before-after visualization: 
<img width="2499" height="1242" alt="image" src="https://github.com/user-attachments/assets/d77d9b87-6fbf-453b-b07e-8b2b082829a8" />

Reproduce helpful script for debug console:
```bash
#!/usr/bin/env bash
set -euo pipefail

PORT="${1:-/dev/ttyUSB0}"
BAUD="${2:-57600}"
DELAY="${3:-1}"

while true; do
    printf 'pwm_out stop\r\n'
    sleep "$DELAY"

    printf 'pwm_out start\r\n'
    sleep "$DELAY"
done | picocom "$PORT" -b "$BAUD"

```

### Changelog Entry
TODO
