### PR TITLE
fix(vtol_att_control): correct tailsitter quadchute attitude frame

### DIFF
--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -56,6 +56,48 @@ Tailsitter::parameters_update()
 
 }
 
+Eulerf Tailsitter::getFixedWingAttitudeEuler() const
+{
+	// Tailsitter attitude is estimated in MC frame; rotate it to FW frame before checking FW limits.
+	return Eulerf(Quatf(_v_att->q) * Quatf(Eulerf(0.f, M_PI_2_F, 0.f)));
+}
+
+bool Tailsitter::isPitchExceeded()
+{
+	if (_common_vtol_mode != mode::FIXED_WING) {
+		return false;
+	}
+
+	// fixed-wing maximum pitch angle
+	if (_param_vt_fw_qc_p.get() > 0) {
+		const Eulerf euler = getFixedWingAttitudeEuler();
+
+		if (fabsf(euler.theta()) > fabsf(math::radians(static_cast<float>(_param_vt_fw_qc_p.get())))) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool Tailsitter::isRollExceeded()
+{
+	if (_common_vtol_mode != mode::FIXED_WING) {
+		return false;
+	}
+
+	// fixed-wing maximum roll angle
+	if (_param_vt_fw_qc_r.get() > 0) {
+		const Eulerf euler = getFixedWingAttitudeEuler();
+
+		if (fabsf(euler.phi()) > fabsf(math::radians(static_cast<float>(_param_vt_fw_qc_r.get())))) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void Tailsitter::update_vtol_state()
 {
 	/* simple logic using a two way switch to perform transitions.

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -59,7 +59,7 @@ Tailsitter::parameters_update()
 Eulerf Tailsitter::getFixedWingAttitudeEuler() const
 {
 	// Tailsitter attitude is estimated in MC frame; rotate it to FW frame before checking FW limits.
-	return Eulerf(Quatf(_v_att->q) * Quatf(Eulerf(0.f, M_PI_2_F, 0.f)));
+	return Eulerf(Quatf(_v_att->q) * _q_fw_to_mc);
 }
 
 bool Tailsitter::isPitchExceeded()

--- a/src/modules/vtol_att_control/tailsitter.h
+++ b/src/modules/vtol_att_control/tailsitter.h
@@ -88,6 +88,8 @@ private:
 	matrix::Quatf _q_trans_sp;
 	matrix::Vector3f _trans_rot_axis;
 
+	inline static const matrix::Quatf _q_fw_to_mc{matrix::Eulerf{0.f, M_PI_2_F, 0.f}};
+
 	void parameters_update() override;
 
 	bool isFrontTransitionCompletedBase() override;

--- a/src/modules/vtol_att_control/tailsitter.h
+++ b/src/modules/vtol_att_control/tailsitter.h
@@ -91,6 +91,10 @@ private:
 	void parameters_update() override;
 
 	bool isFrontTransitionCompletedBase() override;
+	bool isPitchExceeded() override;
+	bool isRollExceeded() override;
+
+	matrix::Eulerf getFixedWingAttitudeEuler() const;
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(VtolType,
 					(ParamFloat<px4::params::FW_PSP_OFF>) _param_fw_psp_off

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -182,14 +182,14 @@ public:
 	 *
 	 * @return     true if exeeded
 	 */
-	bool isPitchExceeded();
+	virtual bool isPitchExceeded();
 
 	/**
 	 *  @brief Indicates if the absolute value of the vehicle roll angle exceeds the threshold defined by VT_FW_QC_R
 	 *
 	 * @return     true if exeeded
 	 */
-	bool isRollExceeded();
+	virtual bool isRollExceeded();
 
 	/**
 	 *  @brief Indicates if the front transition duration has exceeded the timeout definded by VT_TRANS_TIMEOUT


### PR DESCRIPTION
### Solved Problem
Fixes false quadchute triggers on tailsitters when `VT_FW_QC_P` or `VT_FW_QC_R` is enabled.

Tailsitters report attitude in the multicopter body frame, where level fixed-wing flight appears close to +/-90 deg pitch. The VTOL quadchute pitch/roll checks used that raw attitude directly, so enabling fixed-wing attitude limits could immediately trigger an incorrect quadchute.

### Solution
Make the VTOL pitch/roll quadchute checks overridable and add tailsitter-specific handling.

For tailsitters, the attitude is rotated into the fixed-wing frame before evaluating `VT_FW_QC_P/R`. The fixed-wing attitude-limit checks are skipped during transition to avoid evaluating intentional transition attitudes as fixed-wing limit violations.

### Changelog Entry
For release notes:
```text
Bugfix: Fix false tailsitter quadchute triggers from fixed-wing pitch/roll attitude limits
```
### Test coverage
log before patch:
https://logs.px4.io/plot_app?log=af901b7f-7097-4759-a459-36864ac1d49f

log after patch:
https://logs.px4.io/plot_app?log=1bf886e0-128b-49a0-b4f8-19615849dfb0