### PR TITLE
ci(release): upload release assets sequentially to avoid rate limit

### DIFF
--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -293,12 +293,15 @@ jobs:
 
       # Create a draft GitHub Release for all version tags
       # Pre-releases are automatically marked as such
+      # preserve_order uploads assets sequentially: the default parallel
+      # upload of hundreds of assets trips GitHub's secondary rate limit
       - name: Upload Artifacts to GitHub Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           draft: true
           prerelease: ${{ steps.upload-location.outputs.is_prerelease == 'true' }}
+          preserve_order: true
           files: |
             artifacts/*.px4
             artifacts/*.deb


### PR DESCRIPTION
The v1.18.0-beta1 tag build failed twice in the "Upload Artifacts to GitHub Release" step with GitHub secondary rate limit errors, leaving the draft release partially populated (469 of 522 assets; the gaps were recovered manually). Root cause: softprops/action-gh-release uploads all matched files in parallel via `Promise.all`, and the per-board SBOMs introduced in #26731 roughly doubled the asset count to ~522, so the tag push fired ~522 concurrent asset uploads. That is exactly the burst shape GitHub's secondary rate limit rejects ([softprops/action-gh-release#239](https://github.com/softprops/action-gh-release/issues/239)), and re-runs don't converge because previously uploaded assets are deleted and re-uploaded first.

Fix: set `preserve_order: true` on the release step, which switches the action from parallel to sequential upload. This is the upstream-recommended remedy and is available in the pinned `@v2` line, no version bump needed. All assets, including the per-board SBOM files, remain individually downloadable on the release page; the upload just no longer fires as one concurrent burst. Draft and re-run semantics are unchanged (`overwrite_files` stays at its default), and branch pushes and PR builds are unaffected.

This needs to be cherry-picked to `release/1.18` so the v1.18.0-beta2/rc/stable tags get it.