### PR TITLE
refactor(uORB): out-line more methods to save flash

### DIFF
--- a/platforms/common/uORB/Publication.cpp
+++ b/platforms/common/uORB/Publication.cpp
@@ -45,6 +45,16 @@
 namespace uORB
 {
 
+PublicationBase::~PublicationBase()
+{
+	if (_handle != nullptr) {
+		// don't automatically unadvertise queued publications (eg vehicle_command)
+		if (Manager::orb_get_queue_size(_handle) == 1) {
+			unadvertise();
+		}
+	}
+}
+
 bool PublicationBase::advertise()
 {
 	if (!advertised()) {

--- a/platforms/common/uORB/Publication.cpp
+++ b/platforms/common/uORB/Publication.cpp
@@ -40,6 +40,7 @@
  */
 
 #include "Publication.hpp"
+#include "PublicationMulti.hpp"
 
 namespace uORB
 {
@@ -60,6 +61,35 @@ bool PublicationBase::publish(const void *data)
 	}
 
 	return (Manager::orb_publish(get_topic(), _handle, data) == PX4_OK);
+}
+
+bool PublicationMultiBase::advertise()
+{
+	if (!advertised()) {
+		int instance = 0;
+		_handle = orb_advertise_multi(get_topic(), nullptr, &instance);
+	}
+
+	return advertised();
+}
+
+bool PublicationMultiBase::publish(const void *data)
+{
+	if (!advertised()) {
+		advertise();
+	}
+
+	return (orb_publish(get_topic(), _handle, data) == PX4_OK);
+}
+
+int PublicationMultiBase::get_instance()
+{
+	// advertise if not already advertised
+	if (advertise()) {
+		return Manager::orb_get_instance(_handle);
+	}
+
+	return -1;
 }
 
 } // namespace uORB

--- a/platforms/common/uORB/Publication.hpp
+++ b/platforms/common/uORB/Publication.hpp
@@ -64,15 +64,7 @@ protected:
 
 	PublicationBase(ORB_ID id) : _orb_id(id) {}
 
-	~PublicationBase()
-	{
-		if (_handle != nullptr) {
-			// don't automatically unadvertise queued publications (eg vehicle_command)
-			if (Manager::orb_get_queue_size(_handle) == 1) {
-				unadvertise();
-			}
-		}
-	}
+	~PublicationBase();
 
 	// type-independent publish; data points to a message of the topic's type
 	bool publish(const void *data);

--- a/platforms/common/uORB/PublicationMulti.hpp
+++ b/platforms/common/uORB/PublicationMulti.hpp
@@ -51,8 +51,27 @@ namespace uORB
 /**
  * Base publication multi wrapper class
  */
+class PublicationMultiBase : public PublicationBase
+{
+public:
+	bool advertise();
+
+	int get_instance();
+
+protected:
+	PublicationMultiBase(ORB_ID id) :
+		PublicationBase(id)
+	{}
+
+	// type-independent publish; data points to a message of the topic's type
+	bool publish(const void *data);
+};
+
+/**
+ * Publication multi wrapper class
+ */
 template<typename T>
-class PublicationMulti : public PublicationBase
+class PublicationMulti : public PublicationMultiBase
 {
 public:
 
@@ -62,45 +81,18 @@ public:
 	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
 	 */
 	PublicationMulti(ORB_ID id) :
-		PublicationBase(id)
+		PublicationMultiBase(id)
 	{}
 
 	PublicationMulti(const orb_metadata *meta) :
-		PublicationBase(static_cast<ORB_ID>(meta->o_id))
+		PublicationMultiBase(static_cast<ORB_ID>(meta->o_id))
 	{}
-
-	bool advertise()
-	{
-		if (!advertised()) {
-			int instance = 0;
-			_handle = orb_advertise_multi(get_topic(), nullptr, &instance);
-		}
-
-		return advertised();
-	}
 
 	/**
 	 * Publish the struct
 	 * @param data The uORB message struct we are updating.
 	 */
-	bool publish(const T &data)
-	{
-		if (!advertised()) {
-			advertise();
-		}
-
-		return (orb_publish(get_topic(), _handle, &data) == PX4_OK);
-	}
-
-	int get_instance()
-	{
-		// advertise if not already advertised
-		if (advertise()) {
-			return Manager::orb_get_instance(_handle);
-		}
-
-		return -1;
-	}
+	bool publish(const T &data) { return PublicationMultiBase::publish(&data); }
 };
 
 /**


### PR DESCRIPTION
### Solved Problem
Flash scarcity. 

### Solution
Out-line `PublicationBase` destructor and `PublicationMulti` methods, which still ended up repeatedly in the binary. Cherrypicked from https://github.com/PX4/PX4-Autopilot/pull/27816.

### Test coverage

Perf test on V6S (`cpuload` stats):
```
AUTERION_FMU_V6S at 909dbc9a6cd2 (PR): μ=0.3336, σ=0.0016, median=0.3332 (n=168)
AUTERION_FMU_V6S at d448e3f5b0 (main): μ=0.3386, σ=0.0010, median=0.3388 (n=122)
```

Same script used to compute cpuload stats as https://github.com/PX4/PX4-Autopilot/pull/27581 - it ignores the large deviations right after boot and only takes samples between 0.32 and 0.34, which contains the steady state in both cases. 

Similarly to that PR we expect it to be perf neutral, at least compared to measurement noise. 
