### PR TITLE
fix(boards/px4/fmu-v6x) Add 1s delay during boot after periph power enable for proper can gps initialisation.

### DIFF
--- a/boards/px4/fmu-v6x/src/init.cpp
+++ b/boards/px4/fmu-v6x/src/init.cpp
@@ -75,6 +75,8 @@
 #include <px4_platform/board_determine_hw_info.h>
 #include <px4_platform/board_dma_alloc.h>
 
+using namespace time_literals;
+
 /****************************************************************************
  * Pre-Processor Definitions
  ****************************************************************************/
@@ -221,6 +223,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	VDD_5V_HIPOWER_EN(true);
 	VDD_3V3_SENSORS_EN(true);
 	VDD_3V3_SPEKTRUM_POWER_EN(true);
+
+	usleep(1_s);
 
 	/* Need hrt running before using the ADC */
 


### PR DESCRIPTION
### Solved Problem
Fixes https://github.com/PX4/PX4-Autopilot/issues/27092 and maybe https://github.com/PX4/PX4-Autopilot/issues/27152. 

### Changelog Entry
TODO