### PR TITLE
fix(simulation): remove redundant random normal generator

### DIFF
--- a/src/modules/simulation/sensor_baro_sim/SensorBaroSim.cpp
+++ b/src/modules/simulation/sensor_baro_sim/SensorBaroSim.cpp
@@ -125,35 +125,8 @@ void SensorBaroSim::Run()
 			const float pressure_msl = 101325.0f; // pressure at MSL
 			const float absolute_pressure = pressure_msl / pressure_ratio;
 
-			// generate Gaussian noise sequence using polar form of Box-Muller transformation
-			float y1;
-			{
-				float x1;
-				float x2;
-				float w;
-
-				if (!_baro_rnd_use_last) {
-					do {
-						x1 = 2.f * generate_wgn() - 1.f;
-						x2 = 2.f * generate_wgn() - 1.f;
-						w = x1 * x1 + x2 * x2;
-					} while (w >= 1.0f);
-
-					w = sqrtf((-2.f * logf(w)) / w);
-					// calculate two values - the second value can be used next time because it is uncorrelated
-					y1 = x1 * w;
-					_baro_rnd_y2 = x2 * w;
-					_baro_rnd_use_last = true;
-
-				} else {
-					// no need to repeat the calculation - use the second value from last update
-					y1 = _baro_rnd_y2;
-					_baro_rnd_use_last = false;
-				}
-			}
-
 			// Apply noise and drift
-			const float abs_pressure_noise = 1.f * (float)y1;  // 1 Pa RMS noise
+			const float abs_pressure_noise = 1.f * generate_wgn();  // 1 Pa RMS noise
 			_baro_drift_pa += _baro_drift_pa_per_sec * dt;
 			const float absolute_pressure_noisy = absolute_pressure + abs_pressure_noise + _baro_drift_pa;
 

--- a/src/modules/simulation/sensor_baro_sim/SensorBaroSim.cpp
+++ b/src/modules/simulation/sensor_baro_sim/SensorBaroSim.cpp
@@ -126,20 +126,20 @@ void SensorBaroSim::Run()
 			const float absolute_pressure = pressure_msl / pressure_ratio;
 
 			// generate Gaussian noise sequence using polar form of Box-Muller transformation
-			double y1;
+			float y1;
 			{
-				double x1;
-				double x2;
-				double w;
+				float x1;
+				float x2;
+				float w;
 
 				if (!_baro_rnd_use_last) {
 					do {
-						x1 = 2. * (double)generate_wgn() - 1.;
-						x2 = 2. * (double)generate_wgn() - 1.;
+						x1 = 2.f * generate_wgn() - 1.f;
+						x2 = 2.f * generate_wgn() - 1.f;
 						w = x1 * x1 + x2 * x2;
-					} while (w >= 1.0);
+					} while (w >= 1.0f);
 
-					w = sqrt((-2.0 * log(w)) / w);
+					w = sqrtf((-2.f * logf(w)) / w);
 					// calculate two values - the second value can be used next time because it is uncorrelated
 					y1 = x1 * w;
 					_baro_rnd_y2 = x2 * w;

--- a/src/modules/simulation/sensor_baro_sim/SensorBaroSim.hpp
+++ b/src/modules/simulation/sensor_baro_sim/SensorBaroSim.hpp
@@ -75,8 +75,6 @@ private:
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 	uORB::Subscription _vehicle_global_position_sub{ORB_ID(vehicle_global_position_groundtruth)};
 
-	bool _baro_rnd_use_last{false};
-	double _baro_rnd_y2{0.0};
 	float _baro_drift_pa_per_sec{0.0};
 	float _baro_drift_pa{0.0};
 


### PR DESCRIPTION
### Solved Problem

The Box-Muller noise generator ran in double precision, pulling in the double `log()` implementation and its `__log_data` table (~2.2 KB). The module is included in builds for SIH. 

### Solution

Noise generation does not need double precision; converting the block to float drops the last double `log()` caller on the target. Cherrypicked from https://github.com/PX4/PX4-Autopilot/pull/27816. 

### Test coverage

Check simulated baro data from `sihsim_standard_vtol` before and after, to sanity check the RNG. 


Log from `main`: https://review.px4.io/plot_app?log=1100c16f-9a73-4429-af6c-b71cd767233e
<img width="1387" height="648" alt="image" src="https://github.com/user-attachments/assets/dcfa3977-14f5-45fc-ab29-6ec67f1bb7f6" />

Log from PR: https://review.px4.io/plot_app?log=4a0286a0-f437-4dfd-900e-3217f668a055
<img width="1387" height="648" alt="image" src="https://github.com/user-attachments/assets/b3f8a0af-3ef6-410e-989c-dbc53f3857b4" />

### Context / Alternative

The RNG is currently repeated in a lot of places. I have a WIP version of the [unification](https://github.com/PX4/PX4-Autopilot/tree/pr-refactor-generate-wgn), which saves a tiny bit of flash too but is mainly a code cleanliness benefit. Will pick up later unless related refactors make that idea obsolete. 
