### PR TITLE
refactor(lat_lon_alt): replace pow by cbrt to save flash

### DIFF
--- a/src/lib/lat_lon_alt/lat_lon_alt.cpp
+++ b/src/lib/lat_lon_alt/lat_lon_alt.cpp
@@ -72,8 +72,7 @@ Vector3d LatLonAlt::toEcef() const
 	const double cos_lon = cos(_longitude_rad);
 	const double sin_lon = sin(_longitude_rad);
 
-	const double ecc_sin_lat = Wgs84::eccentricity * sin_lat;
-	const double r_e = Wgs84::equatorial_radius / sqrt(1.0 - ecc_sin_lat * ecc_sin_lat);
+	const double r_e = Wgs84::equatorial_radius / sqrt(1.0 - std::pow(Wgs84::eccentricity * sin_lat, 2.0));
 	const double r_total = r_e + static_cast<double>(_altitude);
 
 	return Vector3d(r_total * cos_lat * cos_lon,
@@ -106,8 +105,7 @@ Vector2d LatLonAlt::deltaLatLonToDeltaXY(const double latitude, const float alti
 void LatLonAlt::computeRadiiOfCurvature(const double latitude, double &meridian_radius_of_curvature,
 					double &transverse_radius_of_curvature)
 {
-	const double ecc_sin_lat = Wgs84::eccentricity * sin(latitude);
-	const double tmp = 1.0 - ecc_sin_lat * ecc_sin_lat;
+	const double tmp = 1.0 - pow(Wgs84::eccentricity * sin(latitude), 2);
 	const double sqrt_tmp = std::sqrt(tmp);
 	meridian_radius_of_curvature = Wgs84::meridian_radius_of_curvature_numerator / (tmp * tmp * sqrt_tmp);
 	transverse_radius_of_curvature = Wgs84::equatorial_radius / sqrt_tmp;

--- a/src/lib/lat_lon_alt/lat_lon_alt.cpp
+++ b/src/lib/lat_lon_alt/lat_lon_alt.cpp
@@ -50,7 +50,7 @@ LatLonAlt LatLonAlt::fromEcef(const Vector3d &p_ecef)
 	const double P = 4.0 / 3.0 * (E * F + 1);
 	const double Q = 2 * (E * E - F * F);
 	const double D = P * P * P + Q * Q;
-	const double V = pow(sqrt(D) - Q, 1.0 / 3.0) - pow(sqrt(D) + Q, 1.0 / 3.0);
+	const double V = cbrt(sqrt(D) - Q) - cbrt(sqrt(D) + Q);
 	const double G = 0.5 * (sqrt(E * E + V) + E);
 	const double T = sqrt(G * G + (F - V * G) / (2 * G - E)) - G;
 
@@ -72,7 +72,8 @@ Vector3d LatLonAlt::toEcef() const
 	const double cos_lon = cos(_longitude_rad);
 	const double sin_lon = sin(_longitude_rad);
 
-	const double r_e = Wgs84::equatorial_radius / sqrt(1.0 - std::pow(Wgs84::eccentricity * sin_lat, 2.0));
+	const double ecc_sin_lat = Wgs84::eccentricity * sin_lat;
+	const double r_e = Wgs84::equatorial_radius / sqrt(1.0 - ecc_sin_lat * ecc_sin_lat);
 	const double r_total = r_e + static_cast<double>(_altitude);
 
 	return Vector3d(r_total * cos_lat * cos_lon,
@@ -105,7 +106,8 @@ Vector2d LatLonAlt::deltaLatLonToDeltaXY(const double latitude, const float alti
 void LatLonAlt::computeRadiiOfCurvature(const double latitude, double &meridian_radius_of_curvature,
 					double &transverse_radius_of_curvature)
 {
-	const double tmp = 1.0 - pow(Wgs84::eccentricity * sin(latitude), 2);
+	const double ecc_sin_lat = Wgs84::eccentricity * sin(latitude);
+	const double tmp = 1.0 - ecc_sin_lat * ecc_sin_lat;
 	const double sqrt_tmp = std::sqrt(tmp);
 	meridian_radius_of_curvature = Wgs84::meridian_radius_of_curvature_numerator / (tmp * tmp * sqrt_tmp);
 	transverse_radius_of_curvature = Wgs84::equatorial_radius / sqrt_tmp;


### PR DESCRIPTION
### Solved Problem

`lat_lon_alt` uses the generic `pow` to compute squares and cube roots, which eats up a bit of flash (when built with SIH, the only place where `LatLonAlt::fromEcef` is used).

### Solution

Replace it with lighter alternatives:
 - Square: `x*x`
 - Cube root: `cbrt`

Apparently `cbrt` works a bit like the legendary [fast inverse sqrt](https://en.wikipedia.org/wiki/Fast_inverse_square_root). Here are the two implementations for reference:
 - https://github.com/mirror/newlib-cygwin/blob/master/newlib/libm/common/s_cbrt.c
 - https://github.com/mirror/newlib-cygwin/blob/master/newlib/libm/common/pow.c

Cherrypicked from https://github.com/PX4/PX4-Autopilot/pull/27816.

### Test coverage

LLA is self-contained and well unit tested which should rule out correctness regressions. 

However `cbrt` is otherwise never used by us, so maybe we should at least make an additional test like [this](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/ekf2/test/test_EKF_utils.cpp)? 