### PR TITLE
feat(drivers/imu/analog_devices): adis16607 support sync clock input

### DIFF
--- a/boards/cuav/x25-mega/init/rc.board_sensors
+++ b/boards/cuav/x25-mega/init/rc.board_sensors
@@ -48,7 +48,7 @@ then
 	fi
 fi
 
-adis16607 -s -b 1 start
+adis16607 -s -b 1 -C 8000 start
 iim42652 -s -b 2 -R 2 -C 32768 start
 iim42653 -s -b 5 -R 12 start
 

--- a/src/drivers/imu/analog_devices/adis16607/ADIS16607.cpp
+++ b/src/drivers/imu/analog_devices/adis16607/ADIS16607.cpp
@@ -42,7 +42,7 @@ ADIS16607::ADIS16607(const I2CSPIDriverConfig &config) :
 	_px4_accel(get_device_id(), config.rotation),
 	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (config.custom1 != 0) {
+	if (config.custom1 > 0) {
 		_enable_clock_input = true;
 		_input_clock_freq = config.custom1;
 		ConfigureCLKIN();
@@ -93,7 +93,7 @@ void ADIS16607::print_status()
 	I2CSPIDriverBase::print_status();
 
 	PX4_INFO("FIFO empty interval: %d us (%.1f Hz)", _fifo_empty_interval_us, 1e6 / _fifo_empty_interval_us);
-	PX4_INFO("Clock input: %s", _enable_clock_input ? "enabled" : "disabled");
+	PX4_INFO("Clock input: %s (%.1f Hz)", _enable_clock_input ? "enabled" : "disabled", (double)_input_clock_freq);
 
 	perf_print_counter(_reset_perf);
 	perf_print_counter(_bad_transfer_perf);
@@ -218,7 +218,13 @@ void ADIS16607::RunImpl()
 			//  Read status
 			const uint16_t diag_stat = RegisterRead(Register::DIAG_STAT);
 
-			if ((diag_stat & ~DIAG_STAT_BIT::FIFO_Threshold_Met) != 0) {
+			if ((diag_stat & DIAG_STAT_BIT::SYNC_LOST) || (diag_stat & DIAG_STAT_BIT::DPLL_UnLocked)) {
+				// DPLL Has lost its sync input
+				DisableCLKIN();
+				Reset();
+				return;
+
+			} else if ((diag_stat & ~DIAG_STAT_BIT::FIFO_Threshold_Met) != 0) {
 				// Reset the sensor if any error other than FIFO overflow occurs.
 				Reset();
 				return;
@@ -240,7 +246,7 @@ void ADIS16607::RunImpl()
 
 				// tolerate minor jitter, leave sample to next iteration if behind by only 1
 				if (samples == _fifo_samples + 1) {
-					timestamp_sample -= static_cast<int>(FIFO_SAMPLE_DT);
+					timestamp_sample -= static_cast<int>(_sample_dt_us);
 					samples--;
 				}
 
@@ -269,6 +275,8 @@ void ADIS16607::RunImpl()
 
 				// full reset if things are failing consistently
 				if (_failure_count > 10) {
+					// Disable external clock on repeated failures
+					DisableCLKIN();
 					Reset();
 					return;
 				}
@@ -281,23 +289,20 @@ void ADIS16607::RunImpl()
 
 void ADIS16607::ConfigureSampleRate(int sample_rate)
 {
-	float min_interval = 0.f;
-	float max_rate = 0.f;
-
 	if (_enable_clock_input) {
-		min_interval = 1e6f / _input_clock_freq;
-		max_rate = _input_clock_freq;
+		_sample_dt_us = 1e6f / _input_clock_freq;
+		_sample_rate_hz = _input_clock_freq;
 
 	} else {
-		min_interval = FIFO_SAMPLE_DT;
-		max_rate = RATE;
+		_sample_dt_us = FIFO_SAMPLE_DT;
+		_sample_rate_hz = RATE;
 	}
 
-	_fifo_empty_interval_us = math::max(roundf((1e6f / (float)sample_rate) / min_interval) * min_interval, min_interval);
+	_fifo_empty_interval_us = math::max(roundf((1e6f / (float)sample_rate) / _sample_dt_us) * _sample_dt_us, _sample_dt_us);
 
-	_fifo_samples = roundf(math::min((float)_fifo_empty_interval_us / (1e6f / max_rate), (float)FIFO_MAX_SAMPLES));
+	_fifo_samples = roundf(math::min((float)_fifo_empty_interval_us / (1e6f / _sample_rate_hz), (float)FIFO_MAX_SAMPLES));
 
-	_fifo_empty_interval_us = _fifo_samples * (1e6f / max_rate);
+	_fifo_empty_interval_us = _fifo_samples * (1e6f / _sample_rate_hz);
 
 	ConfigureFIFOWatermark(_fifo_samples);
 }
@@ -311,6 +316,21 @@ void ADIS16607::ConfigureFIFOWatermark(uint8_t samples)
 		if (r.reg == Register::USER_FIFO_CFG) {
 			r.set_bits = r.set_bits | fifo_watermark_threshold;
 		}
+	}
+}
+
+void ADIS16607::DisableCLKIN()
+{
+	if (_enable_clock_input) {
+		_enable_clock_input = false;
+
+		for (auto &r : _register_cfg) {
+			if (r.reg == Register::USER_GPIO_CFG1) {
+				r.set_bits = r.set_bits & (~USER_GPIO_CFG1_BIT::GPIO2_SYNC);
+			}
+		}
+
+		ConfigureSampleRate(_px4_gyro.get_max_rate_hz());
 	}
 }
 
@@ -437,13 +457,7 @@ void ADIS16607::ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DA
 	sensor_accel_fifo_s accel{};
 	accel.timestamp_sample = timestamp_sample;
 	accel.samples = samples;
-
-	if (_enable_clock_input) {
-		accel.dt = 1e6f / _input_clock_freq;
-
-	} else {
-		accel.dt = FIFO_SAMPLE_DT;
-	}
+	accel.dt = _sample_dt_us;
 
 	for (uint8_t i = 0; i < samples; i++) {
 		// sensor's frame is +x forward, +y left, +z up
@@ -467,13 +481,7 @@ void ADIS16607::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DAT
 	sensor_gyro_fifo_s gyro{};
 	gyro.timestamp_sample = timestamp_sample;
 	gyro.samples = samples;
-
-	if (_enable_clock_input) {
-		gyro.dt = 1e6f / _input_clock_freq;
-
-	} else {
-		gyro.dt = FIFO_SAMPLE_DT;
-	}
+	gyro.dt = _sample_dt_us;
 
 	for (uint8_t i = 0; i < samples; i++) {
 		// sensor's frame is +x forward, +y left, +z up

--- a/src/drivers/imu/analog_devices/adis16607/ADIS16607.cpp
+++ b/src/drivers/imu/analog_devices/adis16607/ADIS16607.cpp
@@ -42,6 +42,15 @@ ADIS16607::ADIS16607(const I2CSPIDriverConfig &config) :
 	_px4_accel(get_device_id(), config.rotation),
 	_px4_gyro(get_device_id(), config.rotation)
 {
+	if (config.custom1 != 0) {
+		_enable_clock_input = true;
+		_input_clock_freq = config.custom1;
+		ConfigureCLKIN();
+
+	} else {
+		_enable_clock_input = false;
+	}
+
 	ConfigureSampleRate(_px4_gyro.get_max_rate_hz());
 }
 
@@ -84,6 +93,7 @@ void ADIS16607::print_status()
 	I2CSPIDriverBase::print_status();
 
 	PX4_INFO("FIFO empty interval: %d us (%.1f Hz)", _fifo_empty_interval_us, 1e6 / _fifo_empty_interval_us);
+	PX4_INFO("Clock input: %s", _enable_clock_input ? "enabled" : "disabled");
 
 	perf_print_counter(_reset_perf);
 	perf_print_counter(_bad_transfer_perf);
@@ -271,12 +281,23 @@ void ADIS16607::RunImpl()
 
 void ADIS16607::ConfigureSampleRate(int sample_rate)
 {
-	const float min_interval = FIFO_SAMPLE_DT;
+	float min_interval = 0.f;
+	float max_rate = 0.f;
+
+	if (_enable_clock_input) {
+		min_interval = 1e6f / _input_clock_freq;
+		max_rate = _input_clock_freq;
+
+	} else {
+		min_interval = FIFO_SAMPLE_DT;
+		max_rate = RATE;
+	}
+
 	_fifo_empty_interval_us = math::max(roundf((1e6f / (float)sample_rate) / min_interval) * min_interval, min_interval);
 
-	_fifo_samples = roundf(math::min((float)_fifo_empty_interval_us / (1e6f / RATE), (float)FIFO_MAX_SAMPLES));
+	_fifo_samples = roundf(math::min((float)_fifo_empty_interval_us / (1e6f / max_rate), (float)FIFO_MAX_SAMPLES));
 
-	_fifo_empty_interval_us = _fifo_samples * (1e6f / RATE);
+	_fifo_empty_interval_us = _fifo_samples * (1e6f / max_rate);
 
 	ConfigureFIFOWatermark(_fifo_samples);
 }
@@ -289,6 +310,15 @@ void ADIS16607::ConfigureFIFOWatermark(uint8_t samples)
 	for (auto &r : _register_cfg) {
 		if (r.reg == Register::USER_FIFO_CFG) {
 			r.set_bits = r.set_bits | fifo_watermark_threshold;
+		}
+	}
+}
+
+void ADIS16607::ConfigureCLKIN()
+{
+	for (auto &r : _register_cfg) {
+		if (r.reg == Register::USER_GPIO_CFG1) {
+			r.set_bits = r.set_bits | USER_GPIO_CFG1_BIT::GOIO2_SYNC;
 		}
 	}
 }
@@ -407,7 +437,13 @@ void ADIS16607::ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DA
 	sensor_accel_fifo_s accel{};
 	accel.timestamp_sample = timestamp_sample;
 	accel.samples = samples;
-	accel.dt = FIFO_SAMPLE_DT;
+
+	if (_enable_clock_input) {
+		accel.dt = 1e6f / _input_clock_freq;
+
+	} else {
+		accel.dt = FIFO_SAMPLE_DT;
+	}
 
 	for (uint8_t i = 0; i < samples; i++) {
 		// sensor's frame is +x forward, +y left, +z up
@@ -431,7 +467,13 @@ void ADIS16607::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DAT
 	sensor_gyro_fifo_s gyro{};
 	gyro.timestamp_sample = timestamp_sample;
 	gyro.samples = samples;
-	gyro.dt = FIFO_SAMPLE_DT;
+
+	if (_enable_clock_input) {
+		gyro.dt = 1e6f / _input_clock_freq;
+
+	} else {
+		gyro.dt = FIFO_SAMPLE_DT;
+	}
 
 	for (uint8_t i = 0; i < samples; i++) {
 		// sensor's frame is +x forward, +y left, +z up

--- a/src/drivers/imu/analog_devices/adis16607/ADIS16607.cpp
+++ b/src/drivers/imu/analog_devices/adis16607/ADIS16607.cpp
@@ -318,7 +318,7 @@ void ADIS16607::ConfigureCLKIN()
 {
 	for (auto &r : _register_cfg) {
 		if (r.reg == Register::USER_GPIO_CFG1) {
-			r.set_bits = r.set_bits | USER_GPIO_CFG1_BIT::GOIO2_SYNC;
+			r.set_bits = r.set_bits | USER_GPIO_CFG1_BIT::GPIO2_SYNC;
 		}
 	}
 }

--- a/src/drivers/imu/analog_devices/adis16607/ADIS16607.hpp
+++ b/src/drivers/imu/analog_devices/adis16607/ADIS16607.hpp
@@ -97,6 +97,8 @@ private:
 	void ConfigureFIFOWatermark(uint8_t samples);
 	void ConfigureCLKIN();
 
+	void DisableCLKIN();
+
 	bool RegisterCheck(const register_config_t &reg_cfg);
 
 	uint16_t RegisterRead(Register reg);
@@ -137,6 +139,8 @@ private:
 
 	uint16_t _fifo_empty_interval_us{1250}; // default 1250 us / 800 Hz transfer interval
 	int32_t _fifo_samples{static_cast<int32_t>(_fifo_empty_interval_us / (1000000 / RATE))};
+	float _sample_dt_us{0.f};
+	float _sample_rate_hz{0.f};
 
 	register_config_t _register_cfg[4] {
 		// Register | Set bits, Clear bits

--- a/src/drivers/imu/analog_devices/adis16607/ADIS16607.hpp
+++ b/src/drivers/imu/analog_devices/adis16607/ADIS16607.hpp
@@ -95,6 +95,7 @@ private:
 	bool Configure();
 	void ConfigureSampleRate(int sample_rate);
 	void ConfigureFIFOWatermark(uint8_t samples);
+	void ConfigureCLKIN();
 
 	bool RegisterCheck(const register_config_t &reg_cfg);
 
@@ -121,6 +122,9 @@ private:
 	hrt_abstime _reset_timestamp{0};
 	int _failure_count{0};
 
+	bool _enable_clock_input{false};
+	float _input_clock_freq{0.f};
+
 	bool _self_test_passed{false};
 
 	enum class STATE : uint8_t {
@@ -134,8 +138,9 @@ private:
 	uint16_t _fifo_empty_interval_us{1250}; // default 1250 us / 800 Hz transfer interval
 	int32_t _fifo_samples{static_cast<int32_t>(_fifo_empty_interval_us / (1000000 / RATE))};
 
-	register_config_t _register_cfg[3] {
+	register_config_t _register_cfg[4] {
 		// Register | Set bits, Clear bits
+		{Register::USER_GPIO_CFG1, 0, 0},
 		{
 			Register::USER_DATA_CFG, 0, USER_DATA_CFG_BIT::Z_DELTANG_EN | USER_DATA_CFG_BIT::Y_DELTANG_EN | USER_DATA_CFG_BIT::X_DELTANG_EN |
 			USER_DATA_CFG_BIT::Z_DELTVEL_EN | USER_DATA_CFG_BIT::Y_DELTVEL_EN | USER_DATA_CFG_BIT::X_DELTVEL_EN

--- a/src/drivers/imu/analog_devices/adis16607/Analog_Devices_ADIS16607_registers.hpp
+++ b/src/drivers/imu/analog_devices/adis16607/Analog_Devices_ADIS16607_registers.hpp
@@ -102,7 +102,7 @@ enum DIAG_STAT_BIT : uint16_t {
 // USER_GPIO_CFG1
 enum USER_GPIO_CFG1_BIT : uint16_t {
 	GPIO3_DR = Bit9, // Configure GPIO pins(GPIO3 as DR)
-	GOIO2_SYNC = Bit6, // Configure GPIO pins(GPIO2 as SYNC)
+	GPIO2_SYNC = Bit6, // Configure GPIO pins(GPIO2 as SYNC)
 };
 
 // USER_DATA_CFG

--- a/src/drivers/imu/analog_devices/adis16607/Analog_Devices_ADIS16607_registers.hpp
+++ b/src/drivers/imu/analog_devices/adis16607/Analog_Devices_ADIS16607_registers.hpp
@@ -102,6 +102,7 @@ enum DIAG_STAT_BIT : uint16_t {
 // USER_GPIO_CFG1
 enum USER_GPIO_CFG1_BIT : uint16_t {
 	GPIO3_DR = Bit9, // Configure GPIO pins(GPIO3 as DR)
+	GOIO2_SYNC = Bit6, // Configure GPIO pins(GPIO2 as SYNC)
 };
 
 // USER_DATA_CFG

--- a/src/drivers/imu/analog_devices/adis16607/adis16607_main.cpp
+++ b/src/drivers/imu/analog_devices/adis16607/adis16607_main.cpp
@@ -53,8 +53,12 @@ extern "C" int adis16607_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "C:R:")) != EOF) {
 		switch (ch) {
+		case 'C':
+			cli.custom1 = atoi(cli.optArg());
+			break;
+
 		case 'R':
 			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;

--- a/src/drivers/imu/analog_devices/adis16607/adis16607_main.cpp
+++ b/src/drivers/imu/analog_devices/adis16607/adis16607_main.cpp
@@ -43,6 +43,7 @@ void ADIS16607::print_usage()
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
+	PRINT_MODULE_USAGE_PARAM_INT('C', 0, 0, 8000, "Input clock frequency (Hz)", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 


### PR DESCRIPTION
Using a synchronous clock input enables more consistent sampling frequency.

External 8KHz clock input:
<img width="1497" height="853" alt="image" src="https://github.com/user-attachments/assets/7ad8688a-8732-4a13-8b92-d2d780a53c35" />

Internal 9.56 kHz:
<img width="1510" height="839" alt="image" src="https://github.com/user-attachments/assets/c27d97a2-b03b-489d-8c1a-4eb19ce000e4" />

