### PR TITLE
refactor(timesync): swap exp -> expf to save flash

### DIFF
--- a/src/lib/timesync/Timesync.cpp
+++ b/src/lib/timesync/Timesync.cpp
@@ -76,8 +76,8 @@ void Timesync::update(const uint64_t now_us, const int64_t remote_timestamp_ns, 
 				// Filter gain scheduling
 				if (!sync_converged()) {
 					// Interpolate with a sigmoid function
-					double progress = (double)_sequence / (double)CONVERGENCE_WINDOW;
-					double p = 1.0 - exp(0.5 * (1.0 - 1.0 / (1.0 - progress)));
+					const float progress = (float) _sequence / (float) CONVERGENCE_WINDOW;
+					double p = (double)(1.f - expf(0.5f * (1.f - 1.f / (1.f - progress))));
 					_filter_alpha = p * ALPHA_GAIN_FINAL + (1.0 - p) * ALPHA_GAIN_INITIAL;
 					_filter_beta = p * BETA_GAIN_FINAL + (1.0 - p) * BETA_GAIN_INITIAL;
 


### PR DESCRIPTION
### Problem

This is the only double-precision `exp` in the codebase, and occupies a hefty chunk of flash.

### Context

Relevant history:
 - https://github.com/PX4/PX4-Autopilot/pull/9365 / 39bb65ffd7 
   - Timesync algorithm is initially added with this "sigmoid" function calculated completely in float 
   - but `_filter_alpha` / `_filter_beta` are double, presumably to be compatible with adjusting `_time_offset` in `add_sample` which is a double (which it needs to be to represent large offsets coming from `int64_t`)
 - https://github.com/PX4/PX4-Autopilot/pull/9809 / cf74166801
     - To fix the implicit promotion, the entire calculation is switched to double

### Solution

I would say the better fix is to keep the sigmoid function in float (precision not needed) and cast to double right after, to not accidentally change anything depending on double.

Cherrypicked from https://github.com/PX4/PX4-Autopilot/pull/27816.

For reference this is the "sigmoid" function, different from the [typical one](https://en.wikipedia.org/wiki/Sigmoid_function), Not sure where it comes from and what the benefit is over linear interpolation, but left it unchanged to not risk anything. 

<img width="951" height="466" alt="image" src="https://github.com/user-attachments/assets/57863c8c-15b9-49ef-9b55-8b664e9510a9" />
