### PR TITLE
fix(mc_autotune): keep module scheduled so autotune can re-trigger

### DIFF
--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
@@ -598,7 +598,6 @@ void McAutotuneAttitudeControl::saveGainsToParams()
 void McAutotuneAttitudeControl::stopAutotune()
 {
 	_vehicle_cmd_start_autotune = false;
-	_vehicle_torque_setpoint_sub.unregisterCallback();
 }
 
 const Vector3f McAutotuneAttitudeControl::getIdentificationSignal()


### PR DESCRIPTION

## Summary

MC autotune could only run once per power cycle; a second `VEHICLE_CMD_DO_AUTOTUNE_ENABLE` was ignored until reboot. This restores re-triggering.

## Problem

Commit ca83b8330d moved the module's only persistent wakeup from the `parameter_update` callback onto the `vehicle_torque_setpoint` callback, but `stopAutotune()` still unregisters that callback on return to idle. With no callback left, `Run()` is never scheduled again and the module never polls `vehicle_command`. Most visible with `MC_AT_APPLY=0` (logging), which returns to idle while still flying. Fixed-wing is unaffected.

## Solution

Don't unregister the `vehicle_torque_setpoint` callback in `stopAutotune()`, so the module stays scheduled and keeps polling `vehicle_command` — same pattern as fixed-wing. Still torn down on module shutdown.