### PR TITLE
fix(bench): retry shell wake writes and require pymavlink >= 2.4.42

### DIFF
--- a/Tools/bench_test/README.md
+++ b/Tools/bench_test/README.md
@@ -70,7 +70,8 @@ pip install -e "Tools/bench_test[ulog]"  # + pyulog for deep ULog verification
 ## Requirements
 
 - Python 3.8+.
-- Required: `pymavlink`, `pyserial` (`pip3 install --user pymavlink pyserial`).
+- Required: `pymavlink` >= 2.4.42 (ships the `mavftp` module), `pyserial`
+  (`pip3 install --user 'pymavlink>=2.4.42' pyserial`).
 - Optional: `pyulog` (deep .ulg verification; a magic-byte check is the
   fallback).
 

--- a/Tools/bench_test/bench/boot_health.py
+++ b/Tools/bench_test/bench/boot_health.py
@@ -144,8 +144,9 @@ def run_capture(args, report):
     report.ok('connect', 'heartbeat from {}'.format(args.connection))
 
     shell = px4bench.MavlinkShell(mav)
-    if not shell.open(timeout=5):
-        report.fail('shell open', 'no nsh output on SERIAL_CONTROL within 5s')
+    if not shell.open():
+        report.fail('shell open', 'no nsh output on SERIAL_CONTROL within {:.0f}s'.format(
+            px4bench.SHELL_OPEN_TIMEOUT))
         shell.close()
         mav.close()
         return report_dir

--- a/Tools/bench_test/bench/link_forwarding.py
+++ b/Tools/bench_test/bench/link_forwarding.py
@@ -29,8 +29,9 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from px4bench import (Reporter, MavlinkShell, add_connection_args, connect,
-                      parse_mavlink_status, send_heartbeat)
+from px4bench import (Reporter, MavlinkShell, SHELL_OPEN_TIMEOUT,
+                      add_connection_args, connect, parse_mavlink_status,
+                      send_heartbeat)
 
 
 HEARTBEAT_INTERVAL = 1.0        # GCS -> autopilot heartbeat cadence, seconds
@@ -206,8 +207,10 @@ def phase3_nested_hammer(report, mav1, mav2, global_deadline):
     """
     report.info('Phase 3: nested-send hammer (param download on link2, shell on link1)')
     shell = MavlinkShell(mav1)
-    if not shell.open(timeout=5):
-        report.fail('phase3_shell_open', 'nsh shell over link1 did not respond within 5s')
+    if not shell.open():
+        report.fail('phase3_shell_open',
+                    'nsh shell over link1 did not respond within {:.0f}s'.format(
+                        SHELL_OPEN_TIMEOUT))
         return False
 
     downloader = ParamDownloader(mav2)
@@ -281,7 +284,7 @@ def phase4_post_liveness(report, mav1, mav2, global_deadline):
         report.ok('phase4_heartbeat_{}'.format(label), 'link alive after stress')
 
     shell = MavlinkShell(mav1)
-    if not shell.open(timeout=5):
+    if not shell.open():
         report.fail('phase4_shell_open', 'nsh shell over link1 did not respond after stress')
         return False
     try:

--- a/Tools/bench_test/bench/log_transfer.py
+++ b/Tools/bench_test/bench/log_transfer.py
@@ -24,8 +24,9 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from px4bench import (Reporter, MavlinkShell, add_connection_args, connect,
-                      make_report_dir, send_heartbeat)
+from px4bench import (Reporter, MavlinkShell, SHELL_OPEN_TIMEOUT,
+                      add_connection_args, connect, make_report_dir,
+                      send_heartbeat)
 from px4bench.ftp import LOG_ROOT, ULOG_MAGIC7, ftp_list, ftp_download
 
 from pymavlink import mavftp
@@ -60,8 +61,9 @@ def main():
         # no early exit leaks the firmware nsh task. The FTP phase below uses
         # no shell, so the shell is closed as soon as the logging is flushed.
         shell = MavlinkShell(mav)
-        if not shell.open(timeout=5):
-            report.fail('shell_open', 'nsh shell did not respond within 5s')
+        if not shell.open():
+            report.fail('shell_open', 'nsh shell did not respond within {:.0f}s'.format(
+                SHELL_OPEN_TIMEOUT))
             sys.exit(report.finish())
 
         # logger status: confirm the module is running before we tell it to log

--- a/Tools/bench_test/bench/log_transfer.py
+++ b/Tools/bench_test/bench/log_transfer.py
@@ -27,9 +27,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from px4bench import (Reporter, MavlinkShell, SHELL_OPEN_TIMEOUT,
                       add_connection_args, connect, make_report_dir,
                       send_heartbeat)
-from px4bench.ftp import LOG_ROOT, ULOG_MAGIC7, ftp_list, ftp_download
-
-from pymavlink import mavftp
+from px4bench.ftp import LOG_ROOT, ULOG_MAGIC7, ftp_list, ftp_download, mavftp
 
 SHELL_TIMEOUT = 10.0
 MIN_LOG_SIZE = 1024            # a real ULog is more than 1 KB

--- a/Tools/bench_test/bench/param_stress.py
+++ b/Tools/bench_test/bench/param_stress.py
@@ -206,7 +206,7 @@ def phase_persistence(report, mav, param, conn_str, baud, original_value):
     #    wrong value means save did not persist the marker; retry once, then
     #    fail without rebooting on an unsaved marker.
     shell = px4bench.MavlinkShell(mav)
-    if not shell.open(timeout=5):
+    if not shell.open():
         report.fail('persistence_shell', 'could not open nsh shell for param save')
         return mav
     try:

--- a/Tools/bench_test/bench/param_stress.py
+++ b/Tools/bench_test/bench/param_stress.py
@@ -302,8 +302,11 @@ def main():
         # Guard: a typo must not silently thrash the wrong (or no) param.
         if args.param not in by_name:
             report.fail('param_exists',
-                        '{} not found in downloaded set; aborting before any set'.format(
-                            args.param))
+                        '{} not in the {} downloaded params (the autopilot lists '
+                        'used params only; a booted board reports hundreds, so a '
+                        'tiny set means a degraded param session, not a missing '
+                        'param); aborting before any set'.format(
+                            args.param, len(by_name)))
             sys.exit(report.finish())
 
         original_value, _ = read_param(mav, args.param, READ_TIMEOUT_S)

--- a/Tools/bench_test/bench/reboot_loop.py
+++ b/Tools/bench_test/bench/reboot_loop.py
@@ -66,9 +66,10 @@ def main():
 
         # prove the shell (and thus the running system) is responsive
         shell = px4bench.MavlinkShell(mav)
-        if not shell.open(timeout=5):
+        if not shell.open():
             report.fail('cycle {} shell'.format(i),
-                        'no nsh output on SERIAL_CONTROL within 5s')
+                        'no nsh output on SERIAL_CONTROL within {:.0f}s'.format(
+                            px4bench.SHELL_OPEN_TIMEOUT))
             shell.close()
             report.info('aborting remaining {} cycle(s)'.format(args.iterations - i))
             sys.exit(report.finish())

--- a/Tools/bench_test/bench/serial_loopback.py
+++ b/Tools/bench_test/bench/serial_loopback.py
@@ -68,8 +68,9 @@ def main():
     report.ok('connect', 'heartbeat from {}'.format(args.connection))
 
     shell = px4bench.MavlinkShell(mav)
-    if not shell.open(timeout=5):
-        report.fail('shell open', 'no nsh output on SERIAL_CONTROL within 5s')
+    if not shell.open():
+        report.fail('shell open', 'no nsh output on SERIAL_CONTROL within {:.0f}s'.format(
+            px4bench.SHELL_OPEN_TIMEOUT))
         mav.close()
         sys.exit(report.finish())
 

--- a/Tools/bench_test/bench/storage_stress.py
+++ b/Tools/bench_test/bench/storage_stress.py
@@ -152,8 +152,9 @@ def main():
     report.ok('connect', 'heartbeat from {}'.format(args.connection))
 
     shell = px4bench.MavlinkShell(mav)
-    if not shell.open(timeout=5):
-        report.fail('shell open', 'no nsh output on SERIAL_CONTROL within 5s')
+    if not shell.open():
+        report.fail('shell open', 'no nsh output on SERIAL_CONTROL within {:.0f}s'.format(
+            px4bench.SHELL_OPEN_TIMEOUT))
         mav.close()
         sys.exit(report.finish())
 

--- a/Tools/bench_test/bench/usb_replug.py
+++ b/Tools/bench_test/bench/usb_replug.py
@@ -134,8 +134,9 @@ def main():
     report.ok('baseline connect', 'heartbeat from {}'.format(device))
 
     shell = px4bench.MavlinkShell(mav)
-    if not shell.open(timeout=5):
-        report.fail('baseline shell', 'no nsh output on SERIAL_CONTROL within 5s')
+    if not shell.open():
+        report.fail('baseline shell', 'no nsh output on SERIAL_CONTROL within {:.0f}s'.format(
+            px4bench.SHELL_OPEN_TIMEOUT))
         shell.close()
         mav.close()
         sys.exit(report.finish())
@@ -194,9 +195,10 @@ def main():
                   'reconnected on {}'.format(device))
 
         shell = px4bench.MavlinkShell(mav)
-        if not shell.open(timeout=5):
+        if not shell.open():
             report.fail('cycle {} shell'.format(i),
-                        'no nsh output on SERIAL_CONTROL within 5s')
+                        'no nsh output on SERIAL_CONTROL within {:.0f}s'.format(
+                            px4bench.SHELL_OPEN_TIMEOUT))
             shell.close()
             mav.close()
             continue

--- a/Tools/bench_test/px4bench/__init__.py
+++ b/Tools/bench_test/px4bench/__init__.py
@@ -53,6 +53,11 @@ mavutil.add_message = _safe_add_message
 
 SERIAL_CONTROL_DEV_SHELL = 10  # SERIAL_CONTROL_DEV_SHELL (see Tools/mavlink_shell.py)
 DEFAULT_BAUD = 57600
+# Default budget for MavlinkShell.open(). Opening spawns the nsh task on the
+# firmware side and older releases (v1.17, #27840) failed a 5s single-write
+# open right after a previous session closed, so the budget is generous and
+# open() re-sends its wake write until the shell answers.
+SHELL_OPEN_TIMEOUT = 10.0
 USB_DEVICE_GLOB_DARWIN = '/dev/tty.usbmodem*'
 USB_DEVICE_GLOB_LINUX = '/dev/serial/by-id/*PX4*'
 
@@ -254,7 +259,7 @@ class MavlinkShell:
         if m is not None:
             self.buf += ''.join(chr(x) for x in m.data[:m.count])
 
-    def open(self, timeout: float = 5):
+    def open(self, timeout: float = SHELL_OPEN_TIMEOUT):
         """Wake the shell and confirm a live prompt. Returns True on success.
 
         The firmware spawns a fresh nsh task plus two pipes on the first
@@ -268,14 +273,22 @@ class MavlinkShell:
         seeing that sentinel echoed back proves nsh is up and processing our
         input. The sentinel round-trip also covers builds whose prompt token
         differs or is suppressed.
+
+        The wake write is re-sent every second until the deadline: the write
+        that spawns the shell task can be consumed before the nsh pipes are
+        reading (seen on v1.17 right after a prior session closed, #27840),
+        and a single write turns that dropped line into a bogus open failure.
         """
         self._seq += 1
         sentinel = 'BENCHOPEN{}'.format(self._seq)
         self.buf = ''
-        self._write('\n')
-        self._write('echo {}\n'.format(sentinel))
         deadline = time.monotonic() + timeout
+        next_wake = 0.0
         while time.monotonic() < deadline:
+            if time.monotonic() >= next_wake:
+                self._write('\n')
+                self._write('echo {}\n'.format(sentinel))
+                next_wake = time.monotonic() + 1.0
             self._pump()
             if 'nsh>' in self.buf or re.search(
                     r'^{}\s*$'.format(re.escape(sentinel)), self.buf, re.MULTILINE):
@@ -314,11 +327,16 @@ class MavlinkShell:
 
         Strips ANY BENCHDONE sentinel, not just the current one: the second
         safety echo of the previous command often arrives after run() already
-        returned and would otherwise leak into this command's output.
+        returned and would otherwise leak into this command's output. Same
+        for BENCHOPEN: open() re-sends its wake echo until the shell answers,
+        so queued wake lines can execute (echo command and its output) after
+        open() already returned.
         """
         lines = []
         for line in self.buf.splitlines():
             if sentinel in line or re.match(r'BENCHDONE\d+\s*$', line.strip()):
+                continue
+            if 'BENCHOPEN' in line:
                 continue
             if cmd in line and 'echo' in line:
                 continue

--- a/Tools/bench_test/px4bench/firmware.py
+++ b/Tools/bench_test/px4bench/firmware.py
@@ -33,7 +33,8 @@ import sys
 import threading
 import time
 
-from . import (DEFAULT_BAUD, MavlinkShell, is_serial_device, wait_reconnect)
+from . import (DEFAULT_BAUD, SHELL_OPEN_TIMEOUT, MavlinkShell,
+               is_serial_device, wait_reconnect)
 
 GITHUB_REPO = 'PX4/PX4-Autopilot'
 FLASH_TIMEOUT_S = 600.0
@@ -107,8 +108,8 @@ def board_identity(mav, timeout=15):
     output.
     """
     shell = MavlinkShell(mav)
-    if not shell.open(timeout=5):
-        return None, 'nsh shell did not respond within 5s'
+    if not shell.open():
+        return None, 'nsh shell did not respond within {:.0f}s'.format(SHELL_OPEN_TIMEOUT)
     try:
         out, timed_out = shell.run('ver all', timeout=timeout)
     finally:

--- a/Tools/bench_test/px4bench/ftp.py
+++ b/Tools/bench_test/px4bench/ftp.py
@@ -6,9 +6,23 @@ bounded slices with its own budget and stall detection: a transfer that
 stops mid-file becomes an error naming the byte count, never a hang.
 """
 
+import sys
 import time
 
 from . import send_heartbeat
+
+MAVFTP_INSTALL_HINT = """\
+Failed to import pymavlink.mavftp: {err}
+
+The mavftp module ships with pymavlink >= 2.4.42. Upgrade with:
+    pip3 install --user --upgrade pymavlink
+"""
+
+try:
+    from pymavlink import mavftp
+except ImportError as e:
+    print(MAVFTP_INSTALL_HINT.format(err=e))
+    sys.exit(2)
 
 LOG_ROOT = '/fs/microsd/log'
 # ULog file header magic: 'U' 'L' 'o' 'g' 0x01 0x12 0x35, then a file-version

--- a/Tools/bench_test/pyproject.toml
+++ b/Tools/bench_test/pyproject.toml
@@ -10,7 +10,9 @@ readme = "README.md"
 license = { text = "BSD-3-Clause" }
 requires-python = ">=3.8"
 dependencies = [
-    "pymavlink>=2.4.40",
+    # 2.4.42 is the first release that ships pymavlink.mavftp (log_transfer,
+    # flight_mission log download)
+    "pymavlink>=2.4.42",
     "pyserial",
 ]
 

--- a/Tools/bench_test/sih/flight_mission.py
+++ b/Tools/bench_test/sih/flight_mission.py
@@ -309,7 +309,7 @@ def download_flight_log(report, mav, report_dir):
     truth for post-flight verification, so fetch it on failure too (it is
     the post-mortem). Best effort; a missing log is a FAIL, not a crash.
     """
-    from pymavlink import mavftp
+    from px4bench.ftp import mavftp
     try:
         ftp = mavftp.MAVFTP(mav, target_system=mav.target_system,
                             target_component=1)

--- a/Tools/bench_test/sih/flight_mission.py
+++ b/Tools/bench_test/sih/flight_mission.py
@@ -124,7 +124,7 @@ def save_params(report, mav, label):
     and the board came back on the SIH airframe).
     """
     shell = MavlinkShell(mav)
-    if not shell.open(timeout=5):
+    if not shell.open():
         report.fail(label, 'could not open nsh shell for param save')
         return False
     try:
@@ -392,8 +392,9 @@ def main():
     # a firmware nsh task plus its two pipes). enter_sih() reboots the board
     # below, so this session cannot be reused past the probe anyway.
     probe_shell = MavlinkShell(mav)
-    if not probe_shell.open(timeout=5):
-        report.fail('sih_probe', 'nsh shell did not respond within 5s')
+    if not probe_shell.open():
+        report.fail('sih_probe', 'nsh shell did not respond within {:.0f}s'.format(
+            px4bench.SHELL_OPEN_TIMEOUT))
         return report.finish()
     try:
         present, probe_out = px4bench.shell_command_exists(
@@ -429,7 +430,7 @@ def main():
         # One shell session for the whole flight, torn down in finally so an
         # error path never leaks the firmware nsh task.
         shell = MavlinkShell(mav)
-        if not shell.open(timeout=5):
+        if not shell.open():
             report.fail('shell', 'could not open nsh shell')
             return report.finish()
         try:

--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -17,7 +17,7 @@ pkgconfig
 psutil
 pycryptodome
 pygments
-pymavlink
+pymavlink>=2.4.42
 pynacl
 pyros-genmsg
 pyserial


### PR DESCRIPTION
Follow-up to the release/1.17 run in #27840. Digging into that log, the shell failures are not the 5s-vs-8.8s boot timing suggested there: preflight opened the same shell seconds after the flash boot, reboot_loop passed the identical 5s open 10/10, and flight_mission failed its probe moments after reboot_loop had just verified the shell on the same boot. The pattern is that the session immediately following a closed one fails, meaning the single wake write gets consumed before the firmware nsh pipes are reading, and no amount of waiting recovers a dropped write.

- `MavlinkShell.open()` now re-sends its newline plus sentinel wake write every second until the deadline, and stale `BENCHOPEN` echoes are stripped from subsequent command output. The timeout hardcoded at every call site is now a single `px4bench.SHELL_OPEN_TIMEOUT` (10s).
- pymavlink 2.4.42 is the first release shipping the `mavftp` module, so the floor is raised in `pyproject.toml`, `Tools/setup/requirements.txt` and the README, and the import is guarded in `px4bench.ftp` so an old install prints an upgrade hint instead of the raw traceback seen in the issue.
- The `param_exists` failure now reports the downloaded count and that the autopilot lists used params only. `SDLOG_UTC_OFFSET` does exist on release/1.17; the real anomaly in that run was a 19-param download (plus heartbeats from system 0), which points at a degraded MAVLink session, not a missing parameter.

Verified with a mock SERIAL_CONTROL endpoint that drops writes for 2.5s: the old single-write open fails, the retrying open succeeds, and the timeout path stays bounded. The missing-mavftp path was tested by blocking the module import.

@farhangnaderi could you re-run the suite from this branch against your 1.17 FMUv6X-RT bench? boot_health, flight_mission and log_transfer should now pass or at least fail with a clearer story. If param_stress still reports a tiny download, please grab `param status` and `mavlink status` from the nsh console on that boot; the 19-param set and the sysid 0 heartbeats are worth their own investigation.