### PR TITLE
fix(mavlink): accept NAV_TAKEOFF param1 on multicopters

### DIFF
--- a/src/modules/mavlink/mavlink_command_params.hpp
+++ b/src/modules/mavlink/mavlink_command_params.hpp
@@ -197,8 +197,9 @@ struct VehicleOverride {
 
 // When adding vehicle-specific param differences, add entries here.
 static constexpr VehicleOverride VehicleParamOverrides[] = {
-	// NAV_TAKEOFF: p1 (minimum pitch angle) is used by FW and VTOL-FW; not applicable to MC.
-	{ 22, VEHICLE_FW | VEHICLE_VTOL, 0x01, 0x01 },
+	// NAV_TAKEOFF: p1 (minimum pitch angle) is used by FW and VTOL-FW; MC ignores it, but
+	// GCS (e.g. QGC) send p1=-1 on MC takeoff, so accept p1 for MC too instead of denying.
+	{ 22, VEHICLE_FW | VEHICLE_VTOL | VEHICLE_MC, 0x01, 0x01 },
 };
 
 // Binary search + vehicle override lookup. Returns the adjusted mask, or -1 if cmd not in table.


### PR DESCRIPTION
Strict command-parameter validation added in #27541 rejects MAV_CMD_NAV_TAKEOFF when an unsupported param is set. QGroundControl sends param1 (minimum pitch) = -1 on multicopter takeoff, which is non-zero/non-NaN, so commands were silently denied (MAV_RESULT_DENIED with no log) on MC airframes and QGC guided takeoff stopped working.

Extend the NAV_TAKEOFF override to include VEHICLE_MC so param1 is accepted and ignored on multicopters, matching FW/VTOL handling.


<img width="2562" height="1440" alt="Screenshot from 2026-07-09 15-10-20" src="https://github.com/user-attachments/assets/a36c6ece-7cb8-40ce-9bbb-6f15c84b229a" />