### PR TITLE
feat(boards/3dr/ctrl-n1): configure barometer as DPS368

### DIFF
--- a/boards/3dr/ctrl-n1/init/rc.board_sensors
+++ b/boards/3dr/ctrl-n1/init/rc.board_sensors
@@ -9,8 +9,8 @@ board_adc start
 iim42653 -R 14 -s -b 1 start
 iim42653 -R 14 -s -b 2 start
 
-# Internal DPS310 (barometer)
-dps310 -s -b 6 start
+# Internal DPS368 (barometer)
+dps310 -s -b 6 -8 start
 
 # Internal AK09940A magnetometer
 ak09940a -I -b 1 -R 4 start

--- a/boards/3dr/ctrl-n1/src/spi.cpp
+++ b/boards/3dr/ctrl-n1/src/spi.cpp
@@ -47,7 +47,7 @@ constexpr px4_spi_bus_t px4_spi_buses[SPI_BUS_MAX_BUS_ITEMS] = {
 	}),
 	initSPIBus(SPI::Bus::SPI6, {
 		initSPIDevice(SPIDEV_FLASH(0), SPI::CS{GPIO::PortC, GPIO::Pin13}),
-		initSPIDevice(DRV_BARO_DEVTYPE_DPS310, SPI::CS{GPIO::PortE, GPIO::Pin3}),
+		initSPIDevice(DRV_BARO_DEVTYPE_DPS368, SPI::CS{GPIO::PortE, GPIO::Pin3}),
 	}),
 };
 


### PR DESCRIPTION
<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->

3DR Control-N1 uses the DPS368 barometer variant (not DPS310) on the internal SPI6 bus. Wire the existing dps310 driver's DPS368 mode so the device is probed and registered with the correct device type.

- `rc.board_sensors`: pass `-8` to `dps310 start` to select the DPS368 variant
- `spi.cpp`: change the SPI6 baro device type from `DRV_BARO_DEVTYPE_DPS310` to `DRV_BARO_DEVTYPE_DPS368` so the bus scan matches the driver's request

Verified on hardware: boot log shows `dps310 #0 on SPI bus 6`, and `listener sensor_baro` reports `device_id: 0x77` = DPS368, bus 6) with valid pressure/temperature readings. Also confirmed the compiled `px4_spi_buses` table in the built ELF carries `devtype_driver = 0x77` rather than the old `0x68` (DPS310).