### PR TITLE
fix(gz_bridge): respect gimbal setpoint frame

### DIFF
--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -68,6 +68,7 @@ if (gz-transport_FOUND)
 			GZMixingInterfaceWheel.hpp
 			GZGimbal.cpp
 			GZGimbal.hpp
+			GZGimbalSetpoint.hpp
 		DEPENDS
 			drivers_accelerometer
 			drivers_gyroscope
@@ -89,6 +90,8 @@ if (gz-transport_FOUND)
 
 	target_include_directories(modules__simulation__gz_bridge PUBLIC px4_gz_msgs)
 	target_link_libraries(modules__simulation__gz_bridge PUBLIC px4_gz_msgs)
+
+	px4_add_unit_gtest(SRC GZGimbalSetpointTest.cpp)
 
 	include(ExternalProject)
 	ExternalProject_Add(gz

--- a/src/modules/simulation/gz_bridge/GZGimbal.cpp
+++ b/src/modules/simulation/gz_bridge/GZGimbal.cpp
@@ -1,5 +1,6 @@
 // #define DEBUG_BUILD
 #include "GZGimbal.hpp"
+#include "GZGimbalSetpoint.hpp"
 
 bool GZGimbal::init(const std::string &world_name, const std::string &model_name)
 {
@@ -140,7 +141,15 @@ bool GZGimbal::pollSetpoint()
 		gimbal_device_set_attitude_s msg;
 
 		if (_gimbal_device_set_attitude_sub.copy(&msg)) {
-			const matrix::Eulerf gimbal_att_stp(matrix::Quatf(msg.q));
+			matrix::Quatf attitude_setpoint(msg.q);
+			vehicle_attitude_s vehicle_attitude{};
+
+			if (_vehicle_attitude_sub.copy(&vehicle_attitude)) {
+				attitude_setpoint = gz_gimbal::attitudeSetpointInVehicleFrame(matrix::Quatf(vehicle_attitude.q),
+						    attitude_setpoint, msg.flags);
+			}
+
+			const matrix::Eulerf gimbal_att_stp(attitude_setpoint);
 			_roll_stp = gimbal_att_stp.phi();
 			_pitch_stp = gimbal_att_stp.theta();
 			_yaw_stp = gimbal_att_stp.psi();

--- a/src/modules/simulation/gz_bridge/GZGimbal.hpp
+++ b/src/modules/simulation/gz_bridge/GZGimbal.hpp
@@ -10,6 +10,7 @@
 #include <uORB/topics/vehicle_command_ack.h>
 #include <uORB/topics/gimbal_controls.h>
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/vehicle_attitude.h>
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
@@ -41,6 +42,7 @@ private:
 
 	uORB::Subscription _gimbal_device_set_attitude_sub{ORB_ID(gimbal_device_set_attitude)};
 	uORB::Subscription _gimbal_controls_sub{ORB_ID(gimbal_controls)};
+	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::SubscriptionCallbackWorkItem _vehicle_command_sub{this, ORB_ID(vehicle_command)};
 
 	uORB::Publication<gimbal_device_attitude_status_s> _gimbal_device_attitude_status_pub{ORB_ID(gimbal_device_attitude_status)};

--- a/src/modules/simulation/gz_bridge/GZGimbalSetpoint.hpp
+++ b/src/modules/simulation/gz_bridge/GZGimbalSetpoint.hpp
@@ -1,0 +1,59 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <lib/matrix/matrix/Quaternion.hpp>
+#include <uORB/topics/gimbal_device_set_attitude.h>
+
+namespace gz_gimbal
+{
+
+inline matrix::Quatf attitudeSetpointInVehicleFrame(const matrix::Quatf &vehicle_attitude,
+		const matrix::Quatf &attitude_setpoint, const uint16_t device_flags)
+{
+	const bool yaw_in_vehicle_frame = device_flags
+					  & gimbal_device_set_attitude_s::GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME;
+	const bool yaw_in_earth_frame = device_flags
+					& gimbal_device_set_attitude_s::GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME;
+	const bool legacy_yaw_lock = !yaw_in_vehicle_frame && !yaw_in_earth_frame
+				     && (device_flags & gimbal_device_set_attitude_s::GIMBAL_DEVICE_FLAGS_YAW_LOCK);
+
+	if ((yaw_in_earth_frame && !yaw_in_vehicle_frame) || legacy_yaw_lock) {
+		return vehicle_attitude.inversed() * attitude_setpoint;
+	}
+
+	return attitude_setpoint;
+}
+
+} // namespace gz_gimbal

--- a/src/modules/simulation/gz_bridge/GZGimbalSetpointTest.cpp
+++ b/src/modules/simulation/gz_bridge/GZGimbalSetpointTest.cpp
@@ -1,0 +1,84 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <lib/matrix/matrix/math.hpp>
+
+#include "GZGimbalSetpoint.hpp"
+
+using matrix::Eulerf;
+using matrix::Quatf;
+
+TEST(GZGimbalSetpoint, ConvertsEarthFrameToVehicleFrame)
+{
+	const Quatf vehicle_attitude(Eulerf(0.f, 0.f, M_PI_2_F));
+	const Quatf earth_frame_setpoint(Eulerf(0.f, 0.f, 0.f));
+	const Quatf vehicle_frame_setpoint = gz_gimbal::attitudeSetpointInVehicleFrame(
+			vehicle_attitude, earth_frame_setpoint,
+			gimbal_device_set_attitude_s::GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME);
+
+	EXPECT_NEAR(Eulerf(vehicle_frame_setpoint).psi(), -M_PI_2_F, 1e-5f);
+}
+
+TEST(GZGimbalSetpoint, PreservesVehicleFrame)
+{
+	const Quatf vehicle_attitude(Eulerf(0.f, 0.f, M_PI_2_F));
+	const Quatf vehicle_frame_input(Eulerf(0.f, 0.f, 0.2f));
+	const Quatf vehicle_frame_setpoint = gz_gimbal::attitudeSetpointInVehicleFrame(
+			vehicle_attitude, vehicle_frame_input,
+			gimbal_device_set_attitude_s::GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME);
+
+	EXPECT_NEAR(Eulerf(vehicle_frame_setpoint).psi(), 0.2f, 1e-5f);
+}
+
+TEST(GZGimbalSetpoint, ConvertsLegacyYawLockToVehicleFrame)
+{
+	const Quatf vehicle_attitude(Eulerf(0.f, 0.f, M_PI_2_F));
+	const Quatf earth_frame_setpoint(Eulerf(0.f, 0.f, 0.f));
+	const Quatf vehicle_frame_setpoint = gz_gimbal::attitudeSetpointInVehicleFrame(
+			vehicle_attitude, earth_frame_setpoint,
+			gimbal_device_set_attitude_s::GIMBAL_DEVICE_FLAGS_YAW_LOCK);
+
+	EXPECT_NEAR(Eulerf(vehicle_frame_setpoint).psi(), -M_PI_2_F, 1e-5f);
+}
+
+TEST(GZGimbalSetpoint, PreservesLegacyYawFollow)
+{
+	const Quatf vehicle_attitude(Eulerf(0.f, 0.f, M_PI_2_F));
+	const Quatf vehicle_frame_input(Eulerf(0.f, 0.f, 0.2f));
+	const Quatf vehicle_frame_setpoint = gz_gimbal::attitudeSetpointInVehicleFrame(
+			vehicle_attitude, vehicle_frame_input, 0);
+
+	EXPECT_NEAR(Eulerf(vehicle_frame_setpoint).psi(), 0.2f, 1e-5f);
+}


### PR DESCRIPTION
This converts earth-referenced gimbal device setpoints into the vehicle-relative joint frame used by Gazebo. Without the conversion, ROI yaw commands applied the vehicle heading a second time.

- Honor explicit `YAW_IN_EARTH_FRAME` commands and the legacy `YAW_LOCK` fallback.
- Preserve explicit and legacy vehicle-frame yaw commands.
- Add focused unit coverage for all four frame-selection cases.

Tested with QGroundControl 5.0.3 and Gazebo Sim 8.14.0 using `gz_x500_gimbal` on current `upstream/main`. Before the change, north/east setpoints of 0.0/89.9 degrees produced 90.0/179.9 degrees feedback; after the change they produced -6.0/84.0 degrees, removing the vehicle-heading addition. `make px4_sitl` and `make check_format` pass, and all four isolated gtest cases pass. The full macOS `make tests` path is blocked by an unrelated existing `sprintf` deprecation in `test_uart_send.c`.

