### PR TITLE
fix(ekf2): hard reset external position estimate while position aiding active

### DIFF
--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -336,11 +336,11 @@ bool Ekf::resetGlobalPosToExternalObservation(const double latitude, const doubl
 
 		const bool innov_rejected = (test_ratio > 1.f);
 
-		if (!_control_status.flags.in_air || (eph > 0.f && eph < 1.f) || innov_rejected) {
+		if (!_control_status.flags.in_air || (eph > 0.f && eph < 1.f) || innov_rejected
+		    || isHorizontalPositionAidingActive()) {
 			// When on ground or accuracy chosen to be very low, we hard reset position
 			// this allows the user to still send hard resets at any time
-			// Also reset when another position source is active as it it would otherwise have almost no
-			// visible effect to the position estimate.
+			// Also hard reset when a position aiding source is active
 			ECL_INFO("reset position to external observation");
 			_information_events.flags.reset_pos_to_ext_obs = true;
 


### PR DESCRIPTION



### Solved Problem
Since #25223, `MAV_CMD_EXTERNAL_POSITION_ESTIMATE` is also executed while a horizontal position source (GNSS, EV, AGP, beacon) is being fused. In that case the command takes the reset-by-fusion path introduced in #25885, which applies the innovation with an artificially high Kalman gain and deliberately pushes it into the correlated states.

This is correct during dead reckoning (large position variance, innovation reflects accumulated state error), but harmful with an active position source: the position variance is small, so the gain into correlated states is large, and the innovation is typically caused by a bias of the aiding source rather than by state error. In a real flight this yanked the velocity state by ~18 m/s from an 83 m position innovation, which then caused airspeed and position fusion to be gate-rejected.

### Solution
Route the command to the hard-reset branch whenever `isHorizontalPositionAidingActive()` is true. The hard reset translates the position, keeps velocity (minus wind), and zeroes wind with inflated variance. Reset-by-fusion remains in place for its intended dead-reckoning use case.

### Changelog Entry
For release notes:
```
Bugfix: MAV_CMD_EXTERNAL_POSITION_ESTIMATE now performs a hard position reset instead of reset-by-fusion while a horizontal position aiding source (GNSS, EV, AGP, beacon) is active, preventing large velocity/wind/heading corruption from the forced fusion
```

### Test coverage
Tested in SITL
