### PR TITLE
fix(navigator): silence geofence RTL error without geofences

### DIFF
--- a/src/modules/navigator/RTLPlanner/GeofenceAvoidancePlannerTest.cpp
+++ b/src/modules/navigator/RTLPlanner/GeofenceAvoidancePlannerTest.cpp
@@ -95,6 +95,7 @@ TEST_F(GeofenceAvoidancePlannerTest, DirectPathNoFence)
 	const int num_waypoints = _planner.updateStartAndFillPath(start);
 
 	ASSERT_EQ(num_waypoints, 0);
+	EXPECT_FALSE(_planner.needsStraightLineFallback());
 }
 
 TEST_F(GeofenceAvoidancePlannerTest, PathAroundExclusionZone)

--- a/src/modules/navigator/RTLPlanner/geofence_avoidance_planner.cpp
+++ b/src/modules/navigator/RTLPlanner/geofence_avoidance_planner.cpp
@@ -295,7 +295,8 @@ int GeofenceAvoidancePlanner::updateStartAndFillPath(matrix::Vector2d start)
 	if (!_polygons_healthy || !_destination_healthy) {
 		_path_length = 0;
 		_path_cursor = 0;
-		_straight_line_fallback = true;
+		// Without any fence there is nothing to avoid, so flying directly is not a fallback.
+		_straight_line_fallback = (_status != Status::NoFence);
 		return 0;
 	}
 

--- a/src/modules/navigator/RTLPlanner/geofence_avoidance_planner.h
+++ b/src/modules/navigator/RTLPlanner/geofence_avoidance_planner.h
@@ -73,6 +73,7 @@ public:
 	/**
 	 * True if the latest updateStartAndFillPath() found neither a routed path nor a direct
 	 * line to the destination -- the caller will fly directly and ignore geofences.
+	 * Stays false when no fence is loaded (Status::NoFence), as there is nothing to avoid.
 	 */
 	bool needsStraightLineFallback() const { return _straight_line_fallback; }
 


### PR DESCRIPTION
### Problem

In `navigator_main` we use `needsStraightLineFallback()` do determine whether or not to show the error "RTL: no geofence avoidance path; flying directly".

Without any geofences that is not an error but expected behaviour.

### Solution

When there are no geofences, do not declare `needsStraightLineFallback()`. Behaviour is otherwise the same - the geofence avoidance path is empty, `hasMore()` always false, and we return directly. 

### Test coverage

Verified in sim that the error is gone