### PR TITLE
feat(FWModeManager): runway takeoff set yaw setpoint to bearing to takeoff waypoint

### DIFF
--- a/docs/assets/flight_modes/fw_runway_takeoff_wheel_steering.svg
+++ b/docs/assets/flight_modes/fw_runway_takeoff_wheel_steering.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 482" width="720" height="482" font-family="Helvetica, Arial, sans-serif">
+  <rect width="720" height="482" fill="#ffffff"/>
+
+  <!-- ================= Panel 1: centered and aligned ================= -->
+  <text x="20" y="28" font-size="14" font-weight="bold" fill="#212529">1 — Centered and aligned: the ground roll follows the runway</text>
+
+  <rect x="60" y="48" width="600" height="120" rx="6" fill="#f1f0ec" stroke="#ced4da"/>
+  <text x="72" y="68" font-size="11" fill="#868e96">Runway</text>
+
+  <line x1="80" y1="118" x2="645" y2="118" stroke="#adb5bd" stroke-width="2" stroke-dasharray="14 10"/>
+  <text x="95" y="142" font-size="11" fill="#868e96">Runway centerline</text>
+
+  <circle cx="600" cy="118" r="7" fill="#ffffff" stroke="#4c6ef5" stroke-width="2"/>
+  <line x1="600" y1="127" x2="600" y2="174" stroke="#4c6ef5" stroke-width="1" stroke-dasharray="3 3"/>
+  <text x="563" y="190" font-size="11" fill="#4c6ef5">Takeoff waypoint</text>
+
+  <!-- vehicle at the start of the takeoff, aligned with the runway -->
+  <path d="M 118 118 L 100 107 L 106 118 L 100 129 Z" fill="#fff4e6" stroke="#d9480f" stroke-width="2"/>
+  <text x="86" y="100" font-size="11" fill="#868e96">Start</text>
+
+  <!-- commanded ground roll direction -->
+  <line x1="128" y1="118" x2="575" y2="118" stroke="#d9480f" stroke-width="2.5"/>
+  <path d="M 575 112 L 589 118 L 575 124 Z" fill="#d9480f"/>
+  <text x="170" y="96" font-size="12" fill="#d9480f">Yaw setpoint = bearing to the takeoff waypoint</text>
+
+  <!-- ================= Panel 2: offset from the centerline ================= -->
+  <text x="20" y="238" font-size="14" font-weight="bold" fill="#212529">2 — Offset from the centerline: the ground roll cuts across the runway</text>
+
+  <rect x="60" y="258" width="600" height="162" rx="6" fill="#f1f0ec" stroke="#ced4da"/>
+  <text x="72" y="278" font-size="11" fill="#868e96">Runway</text>
+
+  <line x1="80" y1="310" x2="645" y2="310" stroke="#adb5bd" stroke-width="2" stroke-dasharray="14 10"/>
+  <text x="95" y="334" font-size="11" fill="#868e96">Runway centerline</text>
+
+  <circle cx="600" cy="310" r="7" fill="#ffffff" stroke="#4c6ef5" stroke-width="2"/>
+  <line x1="600" y1="319" x2="600" y2="428" stroke="#4c6ef5" stroke-width="1" stroke-dasharray="3 3"/>
+  <text x="563" y="444" font-size="11" fill="#4c6ef5">Takeoff waypoint</text>
+
+  <!-- vehicle at the start of the takeoff, offset from the centerline -->
+  <path d="M 145 372 L 124 363 L 131 373 L 126 385 Z" fill="#fff4e6" stroke="#d9480f" stroke-width="2"/>
+  <text x="72" y="394" font-size="11" fill="#868e96">Start, off the</text>
+  <text x="72" y="406" font-size="11" fill="#868e96">centerline</text>
+
+  <!-- direction parallel to the runway, for reference -->
+  <line x1="155" y1="376" x2="298" y2="376" stroke="#868e96" stroke-width="1.5" stroke-dasharray="6 5"/>
+  <path d="M 298 372.5 L 308 376 L 298 379.5 Z" fill="#868e96"/>
+  <text x="196" y="393" font-size="11" fill="#868e96">runway direction</text>
+
+  <!-- commanded ground roll direction -->
+  <line x1="155" y1="371" x2="573" y2="314.6" stroke="#d9480f" stroke-width="2.5"/>
+  <path d="M 572.9 320.8 L 586 313 L 571.3 309 Z" fill="#d9480f"/>
+  <text x="170" y="296" font-size="12" fill="#d9480f">Ground roll: straight line towards the takeoff waypoint</text>
+</svg>

--- a/docs/en/flight_modes_fw/takeoff.md
+++ b/docs/en/flight_modes_fw/takeoff.md
@@ -123,9 +123,38 @@ The _runway takeoff mode_ has the following phases:
 2. **Clamped to runway**: Pitch fixed, no roll and takeoff path controlled until the rotation airspeed ([RWTO_ROT_AIRSPD](../advanced_config/parameter_reference.md#RWTO_ROT_AIRSPD)) is reached. The operator is able to nudge the vehicle left/right via yaw stick.
 3. **Climbout**: Increase pitch setpoint and climb to takeoff altitude. To prevent wingstrikes, the controller will keep the roll setpoint locked to 0 when close to the ground, and then gradually allow more roll while climbing. It is based on the vehicle geometry as configured in [FW_WING_SPAN](#FW_WING_SPAN) and [FW_WING_HEIGHT](#FW_WING_HEIGHT).
 
+### Wheel Controller {#wheel_controller}
+
+The wheel controller steers the vehicle on the ground using the steerable nose/tail wheel.
+It is enabled with [FW_W_EN](#FW_W_EN) and only runs in automatic modes during runway takeoff and during the landing rollout.
+Whenever it is not active (in all manual modes, or if it is disabled), the yaw stick is mapped directly to the wheel.
+
+The controller is cascaded:
+
+1. **Heading controller**: The heading (yaw) error is converted into a yaw rate setpoint with a fixed time constant of 0.1s, limited to [FW_W_RMAX](#FW_W_RMAX).
+2. **Rate controller**: A P-I-FF controller ([FW_WR_P](#FW_WR_P), [FW_WR_I](#FW_WR_I), [FW_WR_FF](#FW_WR_FF), integrator limited by [FW_WR_IMAX](#FW_WR_IMAX)) turns the yaw rate setpoint into a normalized wheel steering command in the range [-1, 1].
+
+The heading setpoint during the ground roll is the bearing from the takeoff position to the takeoff waypoint, so the nose is kept aligned with the intended runway direction.
+If no navigation reference is available (takeoff without takeoff waypoint), and during the landing rollout, the controller instead holds the heading that was captured at the moment the wheel steering engaged.
+
+![Wheel steering heading setpoint during the ground roll](../../assets/flight_modes/fw_runway_takeoff_wheel_steering.svg)
+
+Operator yaw stick input is added on top of the controller output to "nudge" the vehicle (enabled with [RWTO_NUDGE](#RWTO_NUDGE) for takeoff, and [FW_LND_NUDGE](../advanced_config/parameter_reference.md#FW_LND_NUDGE) for landing).
+
 ::: info
-For a smooth takeoff, the runway wheel controller possibly needs to be tuned.
-It consists of a rate controller (P-I-FF-controller with the parameters [FW_WR_P](../advanced_config/parameter_reference.md#FW_WR_P), [FW_WR_I](../advanced_config/parameter_reference.md#FW_WR_I), [FW_WR_FF](../advanced_config/parameter_reference.md#FW_WR_FF)).
+The gains are scaled with groundspeed (using [FW_AIRSPD_STALL](../advanced_config/parameter_reference.md#FW_AIRSPD_STALL) as the reference speed) so that the steering becomes less aggressive as the vehicle accelerates.
+This means the controller should be tuned at low speed, around stall airspeed.
+:::
+
+For a smooth takeoff the wheel controller usually needs to be tuned:
+
+1. Start with [FW_WR_P](#FW_WR_P) and [FW_WR_FF](#FW_WR_FF) only (set [FW_WR_I](#FW_WR_I) to 0) and taxi/roll the vehicle in _Mission mode_ with active Takeoff waypoint item at low speed.
+2. Increase the gains until the vehicle tracks the runway heading without noticeable oscillation of the nose.
+3. Add [FW_WR_I](#FW_WR_I) to remove a remaining constant heading offset (e.g. caused by wheel misalignment or crosswind).
+
+::: warning
+Excessive gains lead to oscillations of the nose during the ground roll, which can quickly become dangerous at higher groundspeed.
+Always test with increasing speed step by step.
 :::
 
 ### Parameters (Runway Takeoff)
@@ -144,6 +173,19 @@ Runway takeoff is affected by the following parameters:
 | <a id="RWTO_NUDGE"></a>[RWTO_NUDGE](../advanced_config/parameter_reference.md#RWTO_NUDGE)                | Enable wheel controller nudging while on the runway                                                                          |
 | <a id="FW_WING_SPAN"></a>[FW_WING_SPAN](../advanced_config/parameter_reference.md#FW_WING_SPAN)          | The wingspan of the vehicle. Used to prevent wingstrikes.                                                                    |
 | <a id="FW_WING_HEIGHT"></a>[FW_WING_HEIGHT](../advanced_config/parameter_reference.md#FW_WING_HEIGHT)    | The height of the wings above ground (ground clearance). Used to prevent wingstrikes.                                        |
+
+### Parameters (Wheel Controller)
+
+The [wheel controller](#wheel_controller) is affected by the following parameters:
+
+| Parameter                                                                                 | Description                                                          |
+| ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [FW_W_EN](#FW_W_EN)                                                                       | Enable wheel controller                                              |
+| <a id="FW_W_RMAX"></a>[FW_W_RMAX](../advanced_config/parameter_reference.md#FW_W_RMAX)    | Maximum yaw rate setpoint the heading controller outputs             |
+| <a id="FW_WR_P"></a>[FW_WR_P](../advanced_config/parameter_reference.md#FW_WR_P)          | Yaw rate controller proportional gain                                |
+| <a id="FW_WR_I"></a>[FW_WR_I](../advanced_config/parameter_reference.md#FW_WR_I)          | Yaw rate controller integrator gain (trims a constant heading error) |
+| <a id="FW_WR_IMAX"></a>[FW_WR_IMAX](../advanced_config/parameter_reference.md#FW_WR_IMAX) | Yaw rate controller integrator limit                                 |
+| <a id="FW_WR_FF"></a>[FW_WR_FF](../advanced_config/parameter_reference.md#FW_WR_FF)       | Yaw rate controller feed forward gain                                |
 
 ## See Also
 

--- a/msg/FixedWingRunwayControl.msg
+++ b/msg/FixedWingRunwayControl.msg
@@ -12,4 +12,5 @@ uint8 STATE_FLYING = 3			# navigate freely
 uint8 runway_takeoff_state		# Current state of runway takeoff state machine
 
 bool wheel_steering_enabled		# Flag that enables the wheel steering.
+float32 wheel_steering_yaw_setpoint	# [rad] [@range -pi, pi] For the wheel controller to track. NAN means hold the heading captured when steering engaged.
 float32 wheel_steering_nudging_rate	# [norm] [@range -1, 1] [FRD] Manual wheel nudging, added to controller output. NAN is interpreted as 0.

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -359,8 +359,12 @@ void FixedwingAttitudeControl::Run()
 
 			}
 
-			// set now yaw setpoint once we're entering the first time
-			if (!PX4_ISFINITE(_steering_wheel_yaw_setpoint)) {
+			// track the heading commanded by the mode manager (e.g. the runway bearing towards the
+			// takeoff waypoint); if none is provided, hold the heading captured when steering engaged
+			if (PX4_ISFINITE(runway_control.wheel_steering_yaw_setpoint)) {
+				_steering_wheel_yaw_setpoint = runway_control.wheel_steering_yaw_setpoint;
+
+			} else if (!PX4_ISFINITE(_steering_wheel_yaw_setpoint)) {
 				_steering_wheel_yaw_setpoint = euler_angles.psi();
 			}
 

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -1195,6 +1195,8 @@ FixedWingModeManager::control_auto_takeoff(const hrt_abstime &now, const float c
 		fw_runway_control.timestamp = now;
 		fw_runway_control.runway_takeoff_state = _runway_takeoff.getState();
 		fw_runway_control.wheel_steering_enabled = true;
+		// keep the nose aligned with the runway bearing towards the takeoff waypoint during the ground roll
+		fw_runway_control.wheel_steering_yaw_setpoint = takeoff_bearing;
 		fw_runway_control.wheel_steering_nudging_rate = _param_rwto_nudge.get() ? _sticks.getYaw() : 0.f;
 
 		_fixed_wing_runway_control_pub.publish(fw_runway_control);
@@ -1373,6 +1375,8 @@ FixedWingModeManager::control_auto_takeoff_no_nav(const hrt_abstime &now, const 
 		fw_runway_control.timestamp = now;
 		fw_runway_control.runway_takeoff_state = _runway_takeoff.getState();
 		fw_runway_control.wheel_steering_enabled = true;
+		// no navigation reference available: hold the heading captured when steering engaged
+		fw_runway_control.wheel_steering_yaw_setpoint = NAN;
 		fw_runway_control.wheel_steering_nudging_rate = _param_rwto_nudge.get() ? _sticks.getYaw() : 0.f;
 
 		_fixed_wing_runway_control_pub.publish(fw_runway_control);
@@ -1622,6 +1626,8 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 	fw_runway_control.timestamp = now;
 	fw_runway_control.runway_takeoff_state = fixed_wing_runway_control_s::STATE_FLYING; // not in takeoff, use FLYING as default
 	fw_runway_control.wheel_steering_enabled = true;
+	// during landing rollout hold the heading captured at touchdown
+	fw_runway_control.wheel_steering_yaw_setpoint = NAN;
 	fw_runway_control.wheel_steering_nudging_rate = _param_fw_lnd_nudge.get() > LandingNudgingOption::kNudgingDisabled ?
 			_sticks.getYaw() : 0.f;
 
@@ -1795,6 +1801,8 @@ FixedWingModeManager::control_auto_landing_circular(const hrt_abstime &now, cons
 	fw_runway_control.timestamp = now;
 	fw_runway_control.runway_takeoff_state = fixed_wing_runway_control_s::STATE_FLYING; // not in takeoff, use FLYING as default
 	fw_runway_control.wheel_steering_enabled = true;
+	// during landing rollout hold the heading captured at touchdown
+	fw_runway_control.wheel_steering_yaw_setpoint = NAN;
 	fw_runway_control.wheel_steering_nudging_rate = _param_fw_lnd_nudge.get() > LandingNudgingOption::kNudgingDisabled ?
 			_sticks.getYaw() : 0.f;
 


### PR DESCRIPTION

### Solved Problem
In older PX4 versions we used to steer the vehicle towards the takeoff waypoint with the wheel controller. This got removed in https://github.com/PX4/PX4-Autopilot/pull/24056. Since then the wheel controller just tracks the heading it was initialized with. When the vehicle is well aligned with runway center line it may get off the runway during the takeoff.

### Solution
Set the wheel controller heading setpoint to the bearing from "takeoff start" point (measurement) to  "takeoff waypoint" (planned). 
<img width="680" height="400" alt="case1_off_centerline_bearing" src="https://github.com/user-attachments/assets/16d38e9d-6d8f-4c70-b580-3ed3d6810456" />

### Changelog Entry
For release notes:
```
Feature: Runway takeoff set yaw setpoint to bearing to takeoff waypoint
```

### Alternatives
- We used to have a param (`RWTO_HDG`) to chose between 0 = hold initial airframe heading, 1 = track heading towards the takeoff waypoint. I would prefer to avoid adding back a setting that few people really ever cared about.
- Instead of doing simple bearing tracking, we could do "line tracking". The controller would then use `DirectionalGuidance::guideToPath()`
<img width="680" height="400" alt="case2_displaced_bearing" src="https://github.com/user-attachments/assets/ee45404b-eb7e-4617-8f6d-11dc2fbf3d39" />


### Test coverage
Untested. 

### Context
Related links, screenshot before/after, video
