### PR TITLE
feat(dynamic-notch-filter): support for RPM input for notch filter

### DIFF
--- a/src/drivers/rpm/rpm_simulator/rpm_simulator.cpp
+++ b/src/drivers/rpm/rpm_simulator/rpm_simulator.cpp
@@ -36,14 +36,19 @@
  * @file rpm_simulator.cpp
  * Simple app for publishing RPM messages with custom value.
  *
- * Usage: rpm_simulator <rpm_value>
+ * Usage: rpm_simulator <rpm_value> [duration_s]
  *  rpm_simulator 344.2
+ *  rpm_simulator 344.2 10   # keep republishing for 10s (uORB::Publication
+ *                           # unadvertises on destruction, so a single-shot
+ *                           # publish disappears again as soon as this
+ *                           # command returns)
  *
  * @author ThunderFly s.r.o., Roman Dvorak <dvorakroman@thunderfly.cz>
  */
 
 #include <px4_platform_common/px4_config.h>
 #include <drivers/drv_hrt.h>
+#include <px4_platform_common/posix.h>
 
 #include <uORB/Publication.hpp>
 #include <uORB/topics/rpm.h>
@@ -52,8 +57,8 @@ extern "C" __EXPORT int rpm_simulator_main(int argc, char *argv[]);
 int rpm_simulator_main(int argc, char *argv[])
 {
 	// check input
-	if (argc != 2) {
-		PX4_INFO("Usage: rpm_simulator <published RPM>");
+	if (argc < 2) {
+		PX4_INFO("Usage: rpm_simulator <published RPM> [duration_s]");
 		PX4_INFO("Exit. Without publishing any message.");
 		return 0;
 	}
@@ -61,16 +66,26 @@ int rpm_simulator_main(int argc, char *argv[])
 	rpm_s rpm{};
 
 	uORB::Publication<rpm_s> rpm_pub{ORB_ID(rpm)};
-	uint64_t timestamp_us = hrt_absolute_time();
 	float frequency = atof(argv[1]);
+	float duration_s = (argc >= 3) ? (float)atof(argv[2]) : 0.f;
 
 	// prpepare RPM data message
-	rpm.timestamp = timestamp_us;
+	rpm.timestamp = hrt_absolute_time();
 	rpm.rpm_estimate = frequency;
 
 	// Publish data and let the user know what was published
 	rpm_pub.publish(rpm);
 	print_message(ORB_ID(rpm), rpm);
+
+	if (duration_s > 0.f) {
+		const hrt_abstime end = hrt_absolute_time() + (hrt_abstime)(duration_s * 1e6f);
+
+		while (hrt_absolute_time() < end) {
+			px4_usleep(100000);
+			rpm.timestamp = hrt_absolute_time();
+			rpm_pub.publish(rpm);
+		}
+	}
 
 	return 0;
 }

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -659,13 +659,14 @@ void VehicleAngularVelocity::UpdateDynamicNotchIceRpm(const hrt_abstime &time_no
 		const float bandwidth_hz = _param_imu_gyro_dnf_bw.get();
 		const float freq_min = math::max(_param_imu_gyro_dnf_min.get(), bandwidth_hz);
 
-		for (unsigned i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
+		for (unsigned i = 0; i < MAX_NUM_ICE_ENGINES; i++) {
 			internal_combustion_engine_status_s ice_status{};
 
 			if (_ice_status_sub[i].copy(&ice_status) &&
 			    (time_now_us < ice_status.timestamp + DYNAMIC_NOTCH_FITLER_TIMEOUT)) {
 
-				const bool engine_running = (ice_status.state == internal_combustion_engine_status_s::STATE_RUNNING);
+				const bool engine_running = (ice_status.state == internal_combustion_engine_status_s::STATE_RUNNING
+							     || ice_status.state == internal_combustion_engine_status_s::STATE_STARTING);
 
 				if (engine_running && ice_status.engine_speed_rpm > 0.f) {
 					const float engine_hz = fabsf(ice_status.engine_speed_rpm) / 60.f;
@@ -702,7 +703,7 @@ void VehicleAngularVelocity::UpdateDynamicNotchIceRpm(const hrt_abstime &time_no
 		}
 
 		// timeout handling
-		for (unsigned i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
+		for (unsigned i = 0; i < MAX_NUM_ICE_ENGINES; i++) {
 			if (_ice_available[i] && (time_now_us > _last_ice_rpm_notch_update[i] + DYNAMIC_NOTCH_FITLER_TIMEOUT)) {
 				bool all_disabled = true;
 

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -59,9 +59,13 @@ VehicleAngularVelocity::~VehicleAngularVelocity()
 
 #if !defined(CONSTRAINED_FLASH)
 	delete[] _dynamic_notch_filter_esc_rpm;
+	delete[] _dynamic_notch_filter_ice_rpm;
 	perf_free(_dynamic_notch_filter_esc_rpm_disable_perf);
 	perf_free(_dynamic_notch_filter_esc_rpm_init_perf);
 	perf_free(_dynamic_notch_filter_esc_rpm_update_perf);
+	perf_free(_dynamic_notch_filter_ice_rpm_disable_perf);
+	perf_free(_dynamic_notch_filter_ice_rpm_init_perf);
+	perf_free(_dynamic_notch_filter_ice_rpm_update_perf);
 
 	perf_free(_dynamic_notch_filter_fft_disable_perf);
 	perf_free(_dynamic_notch_filter_fft_update_perf);
@@ -195,6 +199,7 @@ void VehicleAngularVelocity::ResetFilters(const hrt_abstime &time_now_us)
 
 		// force reset notch filters on any scale change
 		UpdateDynamicNotchEscRpm(time_now_us, true);
+		UpdateDynamicNotchIceRpm(time_now_us, true);
 		UpdateDynamicNotchFFT(time_now_us, true);
 
 		_angular_velocity_raw_prev = angular_velocity_uncalibrated;
@@ -492,6 +497,56 @@ void VehicleAngularVelocity::ParametersUpdate(bool force)
 			DisableDynamicNotchEscRpm();
 		}
 
+		// ICE dynamic notches: use same harmonics parameter for now
+		if (_param_imu_gyro_dnf_en.get() & DynamicNotch::IceRpm) {
+
+			const int32_t ice_rpm_harmonics = math::constrain(_param_imu_gyro_dnf_hmc.get(), (int32_t)1, (int32_t)10);
+
+			if (_dynamic_notch_filter_ice_rpm && (ice_rpm_harmonics != _ice_rpm_harmonics)) {
+				delete[] _dynamic_notch_filter_ice_rpm;
+				_dynamic_notch_filter_ice_rpm = nullptr;
+				_ice_rpm_harmonics = 0;
+			}
+
+			if (_dynamic_notch_filter_ice_rpm == nullptr) {
+
+				_dynamic_notch_filter_ice_rpm = new NotchFilterIceHarmonic[ice_rpm_harmonics];
+
+				if (_dynamic_notch_filter_ice_rpm) {
+					_ice_rpm_harmonics = ice_rpm_harmonics;
+
+					if (_dynamic_notch_filter_ice_rpm_disable_perf == nullptr) {
+						_dynamic_notch_filter_ice_rpm_disable_perf = perf_alloc(PC_COUNT,
+								MODULE_NAME": gyro dynamic notch filter ICE disable");
+					}
+
+					if (_dynamic_notch_filter_ice_rpm_init_perf == nullptr) {
+						_dynamic_notch_filter_ice_rpm_init_perf = perf_alloc(PC_COUNT,
+								MODULE_NAME": gyro dynamic notch filter ICE init");
+					}
+
+					if (_dynamic_notch_filter_ice_rpm_update_perf == nullptr) {
+						_dynamic_notch_filter_ice_rpm_update_perf = perf_alloc(PC_COUNT,
+								MODULE_NAME": gyro dynamic notch filter ICE update");
+					}
+
+				} else {
+					_ice_rpm_harmonics = 0;
+
+					perf_free(_dynamic_notch_filter_ice_rpm_disable_perf);
+					perf_free(_dynamic_notch_filter_ice_rpm_init_perf);
+					perf_free(_dynamic_notch_filter_ice_rpm_update_perf);
+
+					_dynamic_notch_filter_ice_rpm_disable_perf = nullptr;
+					_dynamic_notch_filter_ice_rpm_init_perf = nullptr;
+					_dynamic_notch_filter_ice_rpm_update_perf = nullptr;
+				}
+			}
+
+		} else {
+			DisableDynamicNotchIceRpm();
+		}
+
 		if (_param_imu_gyro_dnf_en.get() & DynamicNotch::FFT) {
 			if (_dynamic_notch_filter_fft_disable_perf == nullptr) {
 				_dynamic_notch_filter_fft_disable_perf = perf_alloc(PC_COUNT, MODULE_NAME": gyro dynamic notch filter FFT disable");
@@ -568,6 +623,112 @@ void VehicleAngularVelocity::DisableDynamicNotchFFT()
 		}
 
 		_dynamic_notch_fft_available = false;
+	}
+
+#endif // !CONSTRAINED_FLASH
+}
+
+void VehicleAngularVelocity::DisableDynamicNotchIceRpm()
+{
+#if !defined(CONSTRAINED_FLASH)
+
+	if (_dynamic_notch_filter_ice_rpm) {
+		for (int harmonic = 0; harmonic < _ice_rpm_harmonics; harmonic++) {
+			for (int axis = 0; axis < 3; axis++) {
+				for (int engine = 0; engine < MAX_NUM_ICE_ENGINES; engine++) {
+					_dynamic_notch_filter_ice_rpm[harmonic][axis][engine].disable();
+					_ice_available.set(engine, false);
+					perf_count(_dynamic_notch_filter_ice_rpm_disable_perf);
+				}
+			}
+		}
+	}
+
+#endif // !CONSTRAINED_FLASH
+}
+
+
+void VehicleAngularVelocity::UpdateDynamicNotchIceRpm(const hrt_abstime &time_now_us, bool force)
+{
+#if !defined(CONSTRAINED_FLASH)
+	const bool enabled = _dynamic_notch_filter_ice_rpm && (_param_imu_gyro_dnf_en.get() & DynamicNotch::IceRpm);
+
+	if (enabled) {
+		bool axis_init[3] {false, false, false};
+
+		const float bandwidth_hz = _param_imu_gyro_dnf_bw.get();
+		const float freq_min = math::max(_param_imu_gyro_dnf_min.get(), bandwidth_hz);
+
+		for (unsigned i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
+			internal_combustion_engine_status_s ice_status{};
+
+			if (_ice_status_sub[i].copy(&ice_status) &&
+			    (time_now_us < ice_status.timestamp + DYNAMIC_NOTCH_FITLER_TIMEOUT)) {
+
+				const bool engine_running = (ice_status.state == internal_combustion_engine_status_s::STATE_RUNNING);
+
+				if (engine_running && ice_status.engine_speed_rpm > 0.f) {
+					const float engine_hz = fabsf(ice_status.engine_speed_rpm) / 60.f;
+					const bool force_update = force || !_ice_available[i];
+
+					for (int harmonic = 0; harmonic < _ice_rpm_harmonics; harmonic++) {
+						const float frequency_hz = math::max(engine_hz * (harmonic + 1),
+										     freq_min + (harmonic * 0.5f * bandwidth_hz));
+
+						for (int axis = 0; axis < 3; axis++) {
+							auto &nf = _dynamic_notch_filter_ice_rpm[harmonic][axis][i];
+
+							const float notch_freq_delta = fabsf(nf.getNotchFreq() - frequency_hz);
+							const bool notch_freq_changed = (notch_freq_delta > 0.1f);
+							const bool allow_update = !axis_init[axis] || (nf.initialized() && notch_freq_delta < nf.getBandwidth());
+
+							if ((force_update || notch_freq_changed) && allow_update) {
+								if (nf.setParameters(_filter_sample_rate_hz, frequency_hz, bandwidth_hz)) {
+									perf_count(_dynamic_notch_filter_ice_rpm_update_perf);
+
+									if (!nf.initialized()) {
+										perf_count(_dynamic_notch_filter_ice_rpm_init_perf);
+										axis_init[axis] = true;
+									}
+								}
+							}
+						}
+					}
+
+					_ice_available.set(i, true);
+					_last_ice_rpm_notch_update[i] = ice_status.timestamp;
+				}
+			}
+		}
+
+		// timeout handling
+		for (unsigned i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
+			if (_ice_available[i] && (time_now_us > _last_ice_rpm_notch_update[i] + DYNAMIC_NOTCH_FITLER_TIMEOUT)) {
+				bool all_disabled = true;
+
+				for (int harmonic = _ice_rpm_harmonics - 1; harmonic >= 0; harmonic--) {
+					for (int axis = 0; axis < 3; axis++) {
+						auto &nf = _dynamic_notch_filter_ice_rpm[harmonic][axis][i];
+
+						if (nf.getNotchFreq() > 0.f) {
+							if (nf.initialized() && !axis_init[axis]) {
+								nf.disable();
+								perf_count(_dynamic_notch_filter_ice_rpm_disable_perf);
+								axis_init[axis] = true;
+							}
+						}
+
+						if (nf.getNotchFreq() > 0.f) {
+							all_disabled = false;
+						}
+					}
+				}
+
+				if (all_disabled) {
+					_ice_available.set(i, false);
+				}
+			}
+		}
 	}
 
 #endif // !CONSTRAINED_FLASH
@@ -746,6 +907,19 @@ float VehicleAngularVelocity::FilterAngularVelocity(int axis, float data[], int 
 		}
 	}
 
+	// Apply dynamic notch filter from ICE RPM (separate filters)
+	if (_dynamic_notch_filter_ice_rpm) {
+		for (int inst = 0; inst < MAX_NUM_ESCS; inst++) {
+			if (_ice_available[inst]) {
+				for (int harmonic = 0; harmonic < _ice_rpm_harmonics; harmonic++) {
+					if (_dynamic_notch_filter_ice_rpm[harmonic][axis][inst].getNotchFreq() > 0.f) {
+						_dynamic_notch_filter_ice_rpm[harmonic][axis][inst].applyArray(data, N);
+					}
+				}
+			}
+		}
+	}
+
 	// Apply dynamic notch filter from FFT
 	if (_dynamic_notch_fft_available) {
 		for (int peak = MAX_NUM_FFT_PEAKS - 1; peak >= 0; peak--) {
@@ -825,6 +999,7 @@ void VehicleAngularVelocity::Run()
 	}
 
 	UpdateDynamicNotchEscRpm(time_now_us);
+	UpdateDynamicNotchIceRpm(time_now_us);
 	UpdateDynamicNotchFFT(time_now_us);
 
 	if (_fifo_available) {
@@ -972,6 +1147,10 @@ void VehicleAngularVelocity::PrintStatus()
 	perf_print_counter(_dynamic_notch_filter_esc_rpm_disable_perf);
 	perf_print_counter(_dynamic_notch_filter_esc_rpm_init_perf);
 	perf_print_counter(_dynamic_notch_filter_esc_rpm_update_perf);
+
+	perf_print_counter(_dynamic_notch_filter_ice_rpm_disable_perf);
+	perf_print_counter(_dynamic_notch_filter_ice_rpm_init_perf);
+	perf_print_counter(_dynamic_notch_filter_ice_rpm_update_perf);
 
 	perf_print_counter(_dynamic_notch_filter_fft_disable_perf);
 	perf_print_counter(_dynamic_notch_filter_fft_update_perf);

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -59,13 +59,15 @@ VehicleAngularVelocity::~VehicleAngularVelocity()
 
 #if !defined(CONSTRAINED_FLASH)
 	delete[] _dynamic_notch_filter_esc_rpm;
-	delete[] _dynamic_notch_filter_ice_rpm;
 	perf_free(_dynamic_notch_filter_esc_rpm_disable_perf);
 	perf_free(_dynamic_notch_filter_esc_rpm_init_perf);
 	perf_free(_dynamic_notch_filter_esc_rpm_update_perf);
-	perf_free(_dynamic_notch_filter_ice_rpm_disable_perf);
-	perf_free(_dynamic_notch_filter_ice_rpm_init_perf);
-	perf_free(_dynamic_notch_filter_ice_rpm_update_perf);
+
+	delete[] _dynamic_notch_filter_rotor_rpm;
+	perf_free(_dynamic_notch_filter_rotor_rpm_disable_perf);
+	perf_free(_dynamic_notch_filter_rotor_rpm_init_perf);
+	perf_free(_dynamic_notch_filter_rotor_rpm_update_perf);
+
 
 	perf_free(_dynamic_notch_filter_fft_disable_perf);
 	perf_free(_dynamic_notch_filter_fft_update_perf);
@@ -199,7 +201,7 @@ void VehicleAngularVelocity::ResetFilters(const hrt_abstime &time_now_us)
 
 		// force reset notch filters on any scale change
 		UpdateDynamicNotchEscRpm(time_now_us, true);
-		UpdateDynamicNotchIceRpm(time_now_us, true);
+		UpdateDynamicNotchRotorRpm(time_now_us, true);
 		UpdateDynamicNotchFFT(time_now_us, true);
 
 		_angular_velocity_raw_prev = angular_velocity_uncalibrated;
@@ -497,56 +499,6 @@ void VehicleAngularVelocity::ParametersUpdate(bool force)
 			DisableDynamicNotchEscRpm();
 		}
 
-		// ICE dynamic notches: use same harmonics parameter for now
-		if (_param_imu_gyro_dnf_en.get() & DynamicNotch::IceRpm) {
-
-			const int32_t ice_rpm_harmonics = math::constrain(_param_imu_gyro_dnf_hmc.get(), (int32_t)1, (int32_t)10);
-
-			if (_dynamic_notch_filter_ice_rpm && (ice_rpm_harmonics != _ice_rpm_harmonics)) {
-				delete[] _dynamic_notch_filter_ice_rpm;
-				_dynamic_notch_filter_ice_rpm = nullptr;
-				_ice_rpm_harmonics = 0;
-			}
-
-			if (_dynamic_notch_filter_ice_rpm == nullptr) {
-
-				_dynamic_notch_filter_ice_rpm = new NotchFilterIceHarmonic[ice_rpm_harmonics];
-
-				if (_dynamic_notch_filter_ice_rpm) {
-					_ice_rpm_harmonics = ice_rpm_harmonics;
-
-					if (_dynamic_notch_filter_ice_rpm_disable_perf == nullptr) {
-						_dynamic_notch_filter_ice_rpm_disable_perf = perf_alloc(PC_COUNT,
-								MODULE_NAME": gyro dynamic notch filter ICE disable");
-					}
-
-					if (_dynamic_notch_filter_ice_rpm_init_perf == nullptr) {
-						_dynamic_notch_filter_ice_rpm_init_perf = perf_alloc(PC_COUNT,
-								MODULE_NAME": gyro dynamic notch filter ICE init");
-					}
-
-					if (_dynamic_notch_filter_ice_rpm_update_perf == nullptr) {
-						_dynamic_notch_filter_ice_rpm_update_perf = perf_alloc(PC_COUNT,
-								MODULE_NAME": gyro dynamic notch filter ICE update");
-					}
-
-				} else {
-					_ice_rpm_harmonics = 0;
-
-					perf_free(_dynamic_notch_filter_ice_rpm_disable_perf);
-					perf_free(_dynamic_notch_filter_ice_rpm_init_perf);
-					perf_free(_dynamic_notch_filter_ice_rpm_update_perf);
-
-					_dynamic_notch_filter_ice_rpm_disable_perf = nullptr;
-					_dynamic_notch_filter_ice_rpm_init_perf = nullptr;
-					_dynamic_notch_filter_ice_rpm_update_perf = nullptr;
-				}
-			}
-
-		} else {
-			DisableDynamicNotchIceRpm();
-		}
-
 		if (_param_imu_gyro_dnf_en.get() & DynamicNotch::FFT) {
 			if (_dynamic_notch_filter_fft_disable_perf == nullptr) {
 				_dynamic_notch_filter_fft_disable_perf = perf_alloc(PC_COUNT, MODULE_NAME": gyro dynamic notch filter FFT disable");
@@ -555,6 +507,56 @@ void VehicleAngularVelocity::ParametersUpdate(bool force)
 
 		} else {
 			DisableDynamicNotchFFT();
+		}
+
+		// Rotor RPM dynamic notches: use same harmonics parameter for now
+		if (_param_imu_gyro_dnf_en.get() & DynamicNotch::RotorRpm) {
+
+			const int32_t rotor_rpm_harmonics = math::constrain(_param_imu_gyro_dnf_hmc.get(), (int32_t)1, (int32_t)10);
+
+			if (_dynamic_notch_filter_rotor_rpm && (rotor_rpm_harmonics != _rotor_rpm_harmonics)) {
+				delete[] _dynamic_notch_filter_rotor_rpm;
+				_dynamic_notch_filter_rotor_rpm = nullptr;
+				_rotor_rpm_harmonics = 0;
+			}
+
+			if (_dynamic_notch_filter_rotor_rpm == nullptr) {
+
+				_dynamic_notch_filter_rotor_rpm = new NotchFilterRotorRpmHarmonic[rotor_rpm_harmonics];
+
+				if (_dynamic_notch_filter_rotor_rpm) {
+					_rotor_rpm_harmonics = rotor_rpm_harmonics;
+
+					if (_dynamic_notch_filter_rotor_rpm_disable_perf == nullptr) {
+						_dynamic_notch_filter_rotor_rpm_disable_perf = perf_alloc(PC_COUNT,
+								MODULE_NAME": gyro dynamic notch filter Rotor RPM disable");
+					}
+
+					if (_dynamic_notch_filter_rotor_rpm_init_perf == nullptr) {
+						_dynamic_notch_filter_rotor_rpm_init_perf = perf_alloc(PC_COUNT,
+								MODULE_NAME": gyro dynamic notch filter Rotor RPM init");
+					}
+
+					if (_dynamic_notch_filter_rotor_rpm_update_perf == nullptr) {
+						_dynamic_notch_filter_rotor_rpm_update_perf = perf_alloc(PC_COUNT,
+								MODULE_NAME": gyro dynamic notch filter Rotor RPM update");
+					}
+
+				} else {
+					_rotor_rpm_harmonics = 0;
+
+					perf_free(_dynamic_notch_filter_rotor_rpm_disable_perf);
+					perf_free(_dynamic_notch_filter_rotor_rpm_init_perf);
+					perf_free(_dynamic_notch_filter_rotor_rpm_update_perf);
+
+					_dynamic_notch_filter_rotor_rpm_disable_perf = nullptr;
+					_dynamic_notch_filter_rotor_rpm_init_perf = nullptr;
+					_dynamic_notch_filter_rotor_rpm_update_perf = nullptr;
+				}
+			}
+
+		} else {
+			DisableDynamicNotchRotorRpm();
 		}
 
 #endif // !CONSTRAINED_FLASH
@@ -628,105 +630,17 @@ void VehicleAngularVelocity::DisableDynamicNotchFFT()
 #endif // !CONSTRAINED_FLASH
 }
 
-void VehicleAngularVelocity::DisableDynamicNotchIceRpm()
+void VehicleAngularVelocity::DisableDynamicNotchRotorRpm()
 {
 #if !defined(CONSTRAINED_FLASH)
 
-	if (_dynamic_notch_filter_ice_rpm) {
-		for (int harmonic = 0; harmonic < _ice_rpm_harmonics; harmonic++) {
+	if (_dynamic_notch_filter_rotor_rpm) {
+		for (int harmonic = 0; harmonic < _rotor_rpm_harmonics; harmonic++) {
 			for (int axis = 0; axis < 3; axis++) {
-				for (int engine = 0; engine < MAX_NUM_ICE_ENGINES; engine++) {
-					_dynamic_notch_filter_ice_rpm[harmonic][axis][engine].disable();
-					_ice_available.set(engine, false);
-					perf_count(_dynamic_notch_filter_ice_rpm_disable_perf);
-				}
-			}
-		}
-	}
-
-#endif // !CONSTRAINED_FLASH
-}
-
-
-void VehicleAngularVelocity::UpdateDynamicNotchIceRpm(const hrt_abstime &time_now_us, bool force)
-{
-#if !defined(CONSTRAINED_FLASH)
-	const bool enabled = _dynamic_notch_filter_ice_rpm && (_param_imu_gyro_dnf_en.get() & DynamicNotch::IceRpm);
-
-	if (enabled) {
-		bool axis_init[3] {false, false, false};
-
-		const float bandwidth_hz = _param_imu_gyro_dnf_bw.get();
-		const float freq_min = math::max(_param_imu_gyro_dnf_min.get(), bandwidth_hz);
-
-		for (unsigned i = 0; i < MAX_NUM_ICE_ENGINES; i++) {
-			internal_combustion_engine_status_s ice_status{};
-
-			if (_ice_status_sub[i].copy(&ice_status) &&
-			    (time_now_us < ice_status.timestamp + DYNAMIC_NOTCH_FITLER_TIMEOUT)) {
-
-				const bool engine_running = (ice_status.state == internal_combustion_engine_status_s::STATE_RUNNING
-							     || ice_status.state == internal_combustion_engine_status_s::STATE_STARTING);
-
-				if (engine_running && ice_status.engine_speed_rpm > 0.f) {
-					const float engine_hz = fabsf(ice_status.engine_speed_rpm) / 60.f;
-					const bool force_update = force || !_ice_available[i];
-
-					for (int harmonic = 0; harmonic < _ice_rpm_harmonics; harmonic++) {
-						const float frequency_hz = math::max(engine_hz * (harmonic + 1),
-										     freq_min + (harmonic * 0.5f * bandwidth_hz));
-
-						for (int axis = 0; axis < 3; axis++) {
-							auto &nf = _dynamic_notch_filter_ice_rpm[harmonic][axis][i];
-
-							const float notch_freq_delta = fabsf(nf.getNotchFreq() - frequency_hz);
-							const bool notch_freq_changed = (notch_freq_delta > 0.1f);
-							const bool allow_update = !axis_init[axis] || (nf.initialized() && notch_freq_delta < nf.getBandwidth());
-
-							if ((force_update || notch_freq_changed) && allow_update) {
-								if (nf.setParameters(_filter_sample_rate_hz, frequency_hz, bandwidth_hz)) {
-									perf_count(_dynamic_notch_filter_ice_rpm_update_perf);
-
-									if (!nf.initialized()) {
-										perf_count(_dynamic_notch_filter_ice_rpm_init_perf);
-										axis_init[axis] = true;
-									}
-								}
-							}
-						}
-					}
-
-					_ice_available.set(i, true);
-					_last_ice_rpm_notch_update[i] = ice_status.timestamp;
-				}
-			}
-		}
-
-		// timeout handling
-		for (unsigned i = 0; i < MAX_NUM_ICE_ENGINES; i++) {
-			if (_ice_available[i] && (time_now_us > _last_ice_rpm_notch_update[i] + DYNAMIC_NOTCH_FITLER_TIMEOUT)) {
-				bool all_disabled = true;
-
-				for (int harmonic = _ice_rpm_harmonics - 1; harmonic >= 0; harmonic--) {
-					for (int axis = 0; axis < 3; axis++) {
-						auto &nf = _dynamic_notch_filter_ice_rpm[harmonic][axis][i];
-
-						if (nf.getNotchFreq() > 0.f) {
-							if (nf.initialized() && !axis_init[axis]) {
-								nf.disable();
-								perf_count(_dynamic_notch_filter_ice_rpm_disable_perf);
-								axis_init[axis] = true;
-							}
-						}
-
-						if (nf.getNotchFreq() > 0.f) {
-							all_disabled = false;
-						}
-					}
-				}
-
-				if (all_disabled) {
-					_ice_available.set(i, false);
+				for (int sensor = 0; sensor < MAX_NUM_ROTOR_RPM_SENSORS; sensor++) {
+					_dynamic_notch_filter_rotor_rpm[harmonic][axis][sensor].disable();
+					_rotor_rpm_available.set(sensor, false);
+					perf_count(_dynamic_notch_filter_rotor_rpm_disable_perf);
 				}
 			}
 		}
@@ -891,6 +805,91 @@ void VehicleAngularVelocity::UpdateDynamicNotchFFT(const hrt_abstime &time_now_u
 #endif // !CONSTRAINED_FLASH
 }
 
+void VehicleAngularVelocity::UpdateDynamicNotchRotorRpm(const hrt_abstime &time_now_us, bool force)
+{
+#if !defined(CONSTRAINED_FLASH)
+	const bool enabled = _dynamic_notch_filter_rotor_rpm && (_param_imu_gyro_dnf_en.get() & DynamicNotch::RotorRpm);
+
+	if (enabled) {
+		bool axis_init[3] {false, false, false};
+
+		const float bandwidth_hz = _param_imu_gyro_dnf_bw.get();
+		const float freq_min = math::max(_param_imu_gyro_dnf_min.get(), bandwidth_hz);
+
+		for (unsigned i = 0; i < MAX_NUM_ROTOR_RPM_SENSORS; i++) {
+			rpm_s rpm_status{};
+
+			if (_rpm_sub[i].copy(&rpm_status) &&
+			    (time_now_us < rpm_status.timestamp + DYNAMIC_NOTCH_FITLER_TIMEOUT)) {
+
+				// rpm_estimate of 0 means no movement measured within the driver's own timeout
+				if (rpm_status.rpm_estimate > FLT_EPSILON) {
+					const float rotor_hz = rpm_status.rpm_estimate / 60.f;
+					const bool force_update = force || !_rotor_rpm_available[i];
+
+					for (int harmonic = 0; harmonic < _rotor_rpm_harmonics; harmonic++) {
+						const float frequency_hz = math::max(rotor_hz * (harmonic + 1),
+										      freq_min + (harmonic * 0.5f * bandwidth_hz));
+
+						for (int axis = 0; axis < 3; axis++) {
+							auto &nf = _dynamic_notch_filter_rotor_rpm[harmonic][axis][i];
+
+							const float notch_freq_delta = fabsf(nf.getNotchFreq() - frequency_hz);
+							const bool notch_freq_changed = (notch_freq_delta > 0.1f);
+							const bool allow_update = !axis_init[axis] || (nf.initialized() && notch_freq_delta < nf.getBandwidth());
+
+							if ((force_update || notch_freq_changed) && allow_update) {
+								if (nf.setParameters(_filter_sample_rate_hz, frequency_hz, bandwidth_hz)) {
+									perf_count(_dynamic_notch_filter_rotor_rpm_update_perf);
+
+									if (!nf.initialized()) {
+										perf_count(_dynamic_notch_filter_rotor_rpm_init_perf);
+										axis_init[axis] = true;
+									}
+								}
+							}
+						}
+					}
+
+					_rotor_rpm_available.set(i, true);
+					_last_rotor_rpm_notch_update[i] = rpm_status.timestamp;
+				}
+			}
+		}
+
+		// timeout handling
+		for (unsigned i = 0; i < MAX_NUM_ROTOR_RPM_SENSORS; i++) {
+			if (_rotor_rpm_available[i] && (time_now_us > _last_rotor_rpm_notch_update[i] + DYNAMIC_NOTCH_FITLER_TIMEOUT)) {
+				bool all_disabled = true;
+
+				for (int harmonic = _rotor_rpm_harmonics - 1; harmonic >= 0; harmonic--) {
+					for (int axis = 0; axis < 3; axis++) {
+						auto &nf = _dynamic_notch_filter_rotor_rpm[harmonic][axis][i];
+
+						if (nf.getNotchFreq() > 0.f) {
+							if (nf.initialized() && !axis_init[axis]) {
+								nf.disable();
+								perf_count(_dynamic_notch_filter_rotor_rpm_disable_perf);
+								axis_init[axis] = true;
+							}
+						}
+
+						if (nf.getNotchFreq() > 0.f) {
+							all_disabled = false;
+						}
+					}
+				}
+
+				if (all_disabled) {
+					_rotor_rpm_available.set(i, false);
+				}
+			}
+		}
+	}
+
+#endif // !CONSTRAINED_FLASH
+}
+
 float VehicleAngularVelocity::FilterAngularVelocity(int axis, float data[], int N)
 {
 #if !defined(CONSTRAINED_FLASH)
@@ -908,13 +907,13 @@ float VehicleAngularVelocity::FilterAngularVelocity(int axis, float data[], int 
 		}
 	}
 
-	// Apply dynamic notch filter from ICE RPM (separate filters)
-	if (_dynamic_notch_filter_ice_rpm) {
-		for (int inst = 0; inst < MAX_NUM_ESCS; inst++) {
-			if (_ice_available[inst]) {
-				for (int harmonic = 0; harmonic < _ice_rpm_harmonics; harmonic++) {
-					if (_dynamic_notch_filter_ice_rpm[harmonic][axis][inst].getNotchFreq() > 0.f) {
-						_dynamic_notch_filter_ice_rpm[harmonic][axis][inst].applyArray(data, N);
+	// Apply dynamic notch filter from Rotor RPM
+	if (_dynamic_notch_filter_rotor_rpm) {
+		for (int inst = 0; inst < MAX_NUM_ROTOR_RPM_SENSORS; inst++) {
+			if (_rotor_rpm_available[inst]) {
+				for (int harmonic = 0; harmonic < _rotor_rpm_harmonics; harmonic++) {
+					if (_dynamic_notch_filter_rotor_rpm[harmonic][axis][inst].getNotchFreq() > 0.f) {
+						_dynamic_notch_filter_rotor_rpm[harmonic][axis][inst].applyArray(data, N);
 					}
 				}
 			}
@@ -1000,8 +999,8 @@ void VehicleAngularVelocity::Run()
 	}
 
 	UpdateDynamicNotchEscRpm(time_now_us);
-	UpdateDynamicNotchIceRpm(time_now_us);
 	UpdateDynamicNotchFFT(time_now_us);
+	UpdateDynamicNotchRotorRpm(time_now_us);
 
 	if (_fifo_available) {
 		// process all outstanding fifo messages
@@ -1149,12 +1148,12 @@ void VehicleAngularVelocity::PrintStatus()
 	perf_print_counter(_dynamic_notch_filter_esc_rpm_init_perf);
 	perf_print_counter(_dynamic_notch_filter_esc_rpm_update_perf);
 
-	perf_print_counter(_dynamic_notch_filter_ice_rpm_disable_perf);
-	perf_print_counter(_dynamic_notch_filter_ice_rpm_init_perf);
-	perf_print_counter(_dynamic_notch_filter_ice_rpm_update_perf);
-
 	perf_print_counter(_dynamic_notch_filter_fft_disable_perf);
 	perf_print_counter(_dynamic_notch_filter_fft_update_perf);
+
+	perf_print_counter(_dynamic_notch_filter_rotor_rpm_disable_perf);
+	perf_print_counter(_dynamic_notch_filter_rotor_rpm_init_perf);
+	perf_print_counter(_dynamic_notch_filter_rotor_rpm_update_perf);
 #endif // CONSTRAINED_FLASH
 }
 

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -829,7 +829,7 @@ void VehicleAngularVelocity::UpdateDynamicNotchRotorRpm(const hrt_abstime &time_
 
 					for (int harmonic = 0; harmonic < _rotor_rpm_harmonics; harmonic++) {
 						const float frequency_hz = math::max(rotor_hz * (harmonic + 1),
-										      freq_min + (harmonic * 0.5f * bandwidth_hz));
+										     freq_min + (harmonic * 0.5f * bandwidth_hz));
 
 						for (int axis = 0; axis < 3; axis++) {
 							auto &nf = _dynamic_notch_filter_rotor_rpm[harmonic][axis][i];

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -111,8 +111,6 @@ private:
 	uORB::Subscription _esc_status_sub {ORB_ID(esc_status)};
 	uORB::Subscription _sensor_gyro_fft_sub {ORB_ID(sensor_gyro_fft)};
 	uORB::SubscriptionMultiArray<internal_combustion_engine_status_s> _ice_status_sub{ORB_ID::internal_combustion_engine_status};
-
-	uORB::Subscription _sensor_gyro_fft_sub {ORB_ID(sensor_gyro_fft)};
 #endif // !CONSTRAINED_FLASH
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -109,6 +109,7 @@ private:
 	uORB::Subscription _estimator_sensor_bias_sub{ORB_ID(estimator_sensor_bias)};
 #if !defined(CONSTRAINED_FLASH)
 	uORB::Subscription _esc_status_sub {ORB_ID(esc_status)};
+	uORB::Subscription _sensor_gyro_fft_sub {ORB_ID(sensor_gyro_fft)};
 	uORB::SubscriptionMultiArray<internal_combustion_engine_status_s> _ice_status_sub{ORB_ID::internal_combustion_engine_status};
 
 	uORB::Subscription _sensor_gyro_fft_sub {ORB_ID(sensor_gyro_fft)};
@@ -144,8 +145,8 @@ private:
 
 	enum DynamicNotch {
 		EscRpm = 1,
-		FFT    = 2,
-		IceRpm = 4,
+		IceRpm = 2,
+		FFT    = 4,
 	};
 
 	static constexpr hrt_abstime DYNAMIC_NOTCH_FITLER_TIMEOUT = 3_s;
@@ -156,24 +157,23 @@ private:
 	using NotchFilterHarmonic = math::NotchFilter<float>[3][MAX_NUM_ESCS];
 	NotchFilterHarmonic *_dynamic_notch_filter_esc_rpm{nullptr};
 
-	// Internal Combustion Engine (ICE) dynamic notch filters (separate storage)
-	static constexpr int MAX_NUM_ICE_ENGINES = 5;
-	using NotchFilterIceHarmonic = math::NotchFilter<float>[3][MAX_NUM_ICE_ENGINES];
-	NotchFilterIceHarmonic *_dynamic_notch_filter_ice_rpm{nullptr};
-
 	int _esc_rpm_harmonics{0};
-
-	int _ice_rpm_harmonics{0};
 	px4::Bitset<MAX_NUM_ESCS> _esc_available{};
 	hrt_abstime _last_esc_rpm_notch_update[MAX_NUM_ESCS] {};
-
-	// ICE availability/timeouts (separate from ESC)
-	px4::Bitset<MAX_NUM_ICE_ENGINES> _ice_available{};
-	hrt_abstime _last_ice_rpm_notch_update[MAX_NUM_ICE_ENGINES] {};
 
 	perf_counter_t _dynamic_notch_filter_esc_rpm_disable_perf{nullptr};
 	perf_counter_t _dynamic_notch_filter_esc_rpm_init_perf{nullptr};
 	perf_counter_t _dynamic_notch_filter_esc_rpm_update_perf{nullptr};
+
+	// ICE RPM
+	static constexpr int MAX_NUM_ICE_ENGINES = ORB_MULTI_MAX_INSTANCES;
+
+	using NotchFilterIceHarmonic = math::NotchFilter<float>[3][MAX_NUM_ICE_ENGINES];
+	NotchFilterIceHarmonic *_dynamic_notch_filter_ice_rpm{nullptr};
+
+	int _ice_rpm_harmonics{0};
+	px4::Bitset<MAX_NUM_ICE_ENGINES> _ice_available{};
+	hrt_abstime _last_ice_rpm_notch_update[MAX_NUM_ICE_ENGINES] {};
 
 	perf_counter_t _dynamic_notch_filter_ice_rpm_disable_perf{nullptr};
 	perf_counter_t _dynamic_notch_filter_ice_rpm_init_perf{nullptr};

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -46,8 +46,8 @@
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
-#include <uORB/SubscriptionMultiArray.hpp>
 #include <uORB/SubscriptionCallback.hpp>
+#include <uORB/SubscriptionMultiArray.hpp>
 #include <uORB/topics/esc_status.h>
 #include <uORB/topics/estimator_selector_status.h>
 #include <uORB/topics/estimator_sensor_bias.h>
@@ -57,7 +57,7 @@
 #include <uORB/topics/sensor_gyro_fifo.h>
 #include <uORB/topics/sensor_selection.h>
 #include <uORB/topics/vehicle_angular_velocity.h>
-#include <uORB/topics/internal_combustion_engine_status.h>
+#include <uORB/topics/rpm.h>
 
 using namespace time_literals;
 
@@ -84,17 +84,16 @@ private:
 	inline float FilterAngularAcceleration(int axis, float inverse_dt_s, float data[], int N = 1);
 
 	void DisableDynamicNotchEscRpm();
-	void DisableDynamicNotchIceRpm();
 	void DisableDynamicNotchFFT();
+	void DisableDynamicNotchRotorRpm();
 	void ParametersUpdate(bool force = false);
 
 	void ResetFilters(const hrt_abstime &time_now_us);
 	void SensorBiasUpdate(bool force = false);
 	bool SensorSelectionUpdate(const hrt_abstime &time_now_us, bool force = false);
 	void UpdateDynamicNotchEscRpm(const hrt_abstime &time_now_us, bool force = false);
-	void UpdateDynamicNotchIceRpm(const hrt_abstime &time_now_us, bool force = false);
-
 	void UpdateDynamicNotchFFT(const hrt_abstime &time_now_us, bool force = false);
+	void UpdateDynamicNotchRotorRpm(const hrt_abstime &time_now_us, bool force = false);
 	bool UpdateSampleRate();
 
 	// scaled appropriately for current sensor
@@ -110,7 +109,7 @@ private:
 #if !defined(CONSTRAINED_FLASH)
 	uORB::Subscription _esc_status_sub {ORB_ID(esc_status)};
 	uORB::Subscription _sensor_gyro_fft_sub {ORB_ID(sensor_gyro_fft)};
-	uORB::SubscriptionMultiArray<internal_combustion_engine_status_s> _ice_status_sub{ORB_ID::internal_combustion_engine_status};
+	uORB::SubscriptionMultiArray<rpm_s> _rpm_sub{ORB_ID::rpm};
 #endif // !CONSTRAINED_FLASH
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
@@ -142,9 +141,10 @@ private:
 #if !defined(CONSTRAINED_FLASH)
 
 	enum DynamicNotch {
+		// Power of two for bitwise comparison
 		EscRpm = 1,
-		IceRpm = 2,
-		FFT    = 4,
+		FFT    = 2,
+		RotorRpm = 4,
 	};
 
 	static constexpr hrt_abstime DYNAMIC_NOTCH_FITLER_TIMEOUT = 3_s;
@@ -163,20 +163,6 @@ private:
 	perf_counter_t _dynamic_notch_filter_esc_rpm_init_perf{nullptr};
 	perf_counter_t _dynamic_notch_filter_esc_rpm_update_perf{nullptr};
 
-	// ICE RPM
-	static constexpr int MAX_NUM_ICE_ENGINES = ORB_MULTI_MAX_INSTANCES;
-
-	using NotchFilterIceHarmonic = math::NotchFilter<float>[3][MAX_NUM_ICE_ENGINES];
-	NotchFilterIceHarmonic *_dynamic_notch_filter_ice_rpm{nullptr};
-
-	int _ice_rpm_harmonics{0};
-	px4::Bitset<MAX_NUM_ICE_ENGINES> _ice_available{};
-	hrt_abstime _last_ice_rpm_notch_update[MAX_NUM_ICE_ENGINES] {};
-
-	perf_counter_t _dynamic_notch_filter_ice_rpm_disable_perf{nullptr};
-	perf_counter_t _dynamic_notch_filter_ice_rpm_init_perf{nullptr};
-	perf_counter_t _dynamic_notch_filter_ice_rpm_update_perf{nullptr};
-
 	// FFT
 	static constexpr int MAX_NUM_FFT_PEAKS = sizeof(sensor_gyro_fft_s::peak_frequencies_x)
 			/ sizeof(sensor_gyro_fft_s::peak_frequencies_x[0]);
@@ -187,6 +173,21 @@ private:
 	perf_counter_t _dynamic_notch_filter_fft_update_perf{nullptr};
 
 	bool _dynamic_notch_fft_available{false};
+
+	// Rotor RPM (dedicated tachometer, eg autorotating gyrocopter main rotor)
+	static constexpr int MAX_NUM_ROTOR_RPM_SENSORS = ORB_MULTI_MAX_INSTANCES;
+
+	using NotchFilterRotorRpmHarmonic = math::NotchFilter<float>[3][MAX_NUM_ROTOR_RPM_SENSORS];
+	NotchFilterRotorRpmHarmonic *_dynamic_notch_filter_rotor_rpm{nullptr};
+
+	int _rotor_rpm_harmonics{0};
+	px4::Bitset<MAX_NUM_ROTOR_RPM_SENSORS> _rotor_rpm_available{};
+	hrt_abstime _last_rotor_rpm_notch_update[MAX_NUM_ROTOR_RPM_SENSORS] {};
+
+	perf_counter_t _dynamic_notch_filter_rotor_rpm_disable_perf{nullptr};
+	perf_counter_t _dynamic_notch_filter_rotor_rpm_init_perf{nullptr};
+	perf_counter_t _dynamic_notch_filter_rotor_rpm_update_perf{nullptr};
+
 #endif // !CONSTRAINED_FLASH
 
 	// angular acceleration filter

--- a/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.yaml
+++ b/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.yaml
@@ -138,9 +138,10 @@ parameters:
       bit:
         0: ESC RPM
         1: FFT
+        2: Rotor RPM
       default: 0
       min: 0
-      max: 3
+      max: 7
     IMU_GYRO_DNF_BW:
       description:
         short: IMU gyro ESC notch filter bandwidth


### PR DESCRIPTION
### Solved Problem
This PR is a 2nd attempt to implement a dynamic notch filter based on `RPM.msg`. A work first started by @mahima-yoga in [this PR](https://github.com/PX4/PX4-Autopilot/pull/25752).

### Solution
As Mahima stated, this PR adds filters for RPM feedback from `Rpm.msg` (applying the change @sfuhrer suggested, to use `Rpm.msg` instead of `InternalCombustionEngineStatus.msg`):

* Identical to ESC RPM filter implementation
* Can be disabled/enabled through existing bitmask param [IMU_GYRO_DNF_EN](https://docs.px4.io/main/en/advanced_config/parameter_reference#IMU_GYRO_DNF_EN)
* Supports multiple engines (up to 10. Limited by ORB_MULTI_MAX_INSTANCES).

### Changelog Entry
For release notes:
```
Feature: Extend dynamic notch filter to accept RPM feedback
```

### Test coverage
Still to be tested on hardware. Tested with SITL together with rpm_simulator.cpp, verifying that the filters were activated based on the data coming in from the simulator (OFC, when IMU_GYRO_DNF_EN == 4).