### PR TITLE
fix(mavlink): Timestamp missing from HIL_STATE_QUATERION stream

### DIFF
--- a/src/modules/mavlink/streams/HIL_STATE_QUATERNION.hpp
+++ b/src/modules/mavlink/streams/HIL_STATE_QUATERNION.hpp
@@ -80,6 +80,7 @@ private:
 			mavlink_hil_state_quaternion_t msg{};
 
 			// vehicle_attitude -> hil_state_quaternion
+			msg.time_usec = att.timestamp;
 			msg.attitude_quaternion[0] = att.q[0];
 			msg.attitude_quaternion[1] = att.q[1];
 			msg.attitude_quaternion[2] = att.q[2];


### PR DESCRIPTION
### Solved Problem

When attempting to read [ground truth](https://mavsdk.mavlink.io/main/en/cpp/api_reference/structmavsdk_1_1_telemetry_1_1_ground_truth.html#mavsdk-telemetry-groundtruth-struct-reference) via MavSDK it was noticed that timestamp field is always empty:

> GroundTruth(latitude_deg=<lat>, longitude_deg=<long>, absolute_altitude_m=<alt>, timestamp_us=0)

For my application, timestamps are required for establishing ground truth at a given point in time.

### Solution

I traced this issue down to `time_usec` field not being set in `mavlink_hil_state_quaternion_t`, causing `timestamp_us` on MavSDK side to get default-initialized to 0. Setting the timestamp resolves my issue.

### Changelog Entry
Bugfix: `time_usec` field of `mavlink_hil_state_quaternion_t` in `MavlinkStreamHILStateQuaternion` was not being set.
