### PR TITLE
fix(simulation): clamp simulated FIFO accel/gyro samples to int16 range

### DIFF
--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
@@ -224,9 +224,11 @@ void SimulatorMavlink::update_sensors(const hrt_abstime &time, const mavlink_hil
 				_last_accel_fifo.samples = 1;
 				_last_accel_fifo.dt = time - _last_accel_fifo.timestamp_sample;
 				_last_accel_fifo.timestamp_sample = time;
-				_last_accel_fifo.x[0] = sensors.xacc / ACCEL_FIFO_SCALE;
-				_last_accel_fifo.y[0] = sensors.yacc / ACCEL_FIFO_SCALE;
-				_last_accel_fifo.z[0] = sensors.zacc / ACCEL_FIFO_SCALE;
+				// constrain to the FIFO int16 range: values beyond full scale saturate
+				// (and get reported as clipping) instead of wrapping around
+				_last_accel_fifo.x[0] = math::constrain(sensors.xacc / ACCEL_FIFO_SCALE, (float)INT16_MIN, (float)INT16_MAX);
+				_last_accel_fifo.y[0] = math::constrain(sensors.yacc / ACCEL_FIFO_SCALE, (float)INT16_MIN, (float)INT16_MAX);
+				_last_accel_fifo.z[0] = math::constrain(sensors.zacc / ACCEL_FIFO_SCALE, (float)INT16_MIN, (float)INT16_MAX);
 
 				_px4_accel[sensors.id].updateFIFO(_last_accel_fifo);
 			}
@@ -267,9 +269,11 @@ void SimulatorMavlink::update_sensors(const hrt_abstime &time, const mavlink_hil
 				_last_gyro_fifo.samples = 1;
 				_last_gyro_fifo.dt = time - _last_gyro_fifo.timestamp_sample;
 				_last_gyro_fifo.timestamp_sample = time;
-				_last_gyro_fifo.x[0] = sensors.xgyro / GYRO_FIFO_SCALE;
-				_last_gyro_fifo.y[0] = sensors.ygyro / GYRO_FIFO_SCALE;
-				_last_gyro_fifo.z[0] = sensors.zgyro / GYRO_FIFO_SCALE;
+				// constrain to the FIFO int16 range: rates beyond full scale saturate
+				// (and get reported as clipping) instead of wrapping around
+				_last_gyro_fifo.x[0] = math::constrain(sensors.xgyro / GYRO_FIFO_SCALE, (float)INT16_MIN, (float)INT16_MAX);
+				_last_gyro_fifo.y[0] = math::constrain(sensors.ygyro / GYRO_FIFO_SCALE, (float)INT16_MIN, (float)INT16_MAX);
+				_last_gyro_fifo.z[0] = math::constrain(sensors.zgyro / GYRO_FIFO_SCALE, (float)INT16_MIN, (float)INT16_MAX);
 
 				_px4_gyro[sensors.id].updateFIFO(_last_gyro_fifo);
 			}


### PR DESCRIPTION
Fixes #23469.

The simulated FIFO emulation in `SimulatorMavlink::update_sensors()` converts SI sensor values to raw counts and assigns them to the `int16` sample fields of `sensor_accel_fifo` / `sensor_gyro_fifo`. Beyond the emulated full-scale range (16 g for accel 0, 2000 °/s ≈ 34.9 rad/s for gyro 0) the float-to-`int16` conversion overflows and wraps, so a fast-spinning vehicle (e.g. the monocopter at ~50 rad/s) sees its gyro data flip sign instead of saturating — the "inverted gyro at fast rates" reported in the issue.

This change constrains the raw counts to `[INT16_MIN, INT16_MAX]` before the assignment, for both the accel and gyro FIFO paths, so out-of-range values saturate at full scale. Since `PX4Accelerometer`/`PX4Gyroscope` already flag FIFO samples at the int16 rails as clipped, the saturation is now correctly reported as clipping to downstream consumers (EKF2, vibration metrics), matching real IMU behavior and the expected behavior described in the issue.

Tested by building `px4_sitl_default`; the change is limited to the SITL MAVLink simulator sensor path and does not affect hardware targets.

---
