### PR TITLE
docs(mavlink): update mavlink temperature conversion example

### DIFF
--- a/docs/en/mavlink/receiving_messages.md
+++ b/docs/en/mavlink/receiving_messages.md
@@ -57,7 +57,8 @@ MavlinkReceiver::handle_message_battery_status_demo(mavlink_message_t *msg)
 	battery_status.timestamp = hrt_absolute_time();
 
 	battery_status.remaining = (float)battery_mavlink.battery_remaining / 100.0f;
-	battery_status.temperature = (float)battery_mavlink.temperature;
+	battery_status.temperature = (battery_mavlink.temperature == INT16_MAX) ?
+				     NAN : (float)battery_mavlink.temperature / 100.0f;
 	battery_status.connected = true;
 
 	_battery_pub.publish(battery_status);

--- a/docs/ko/mavlink/receiving_messages.md
+++ b/docs/ko/mavlink/receiving_messages.md
@@ -57,7 +57,8 @@ MavlinkReceiver::handle_message_battery_status_demo(mavlink_message_t *msg)
 	battery_status.timestamp = hrt_absolute_time();
 
 	battery_status.remaining = (float)battery_mavlink.battery_remaining / 100.0f;
-	battery_status.temperature = (float)battery_mavlink.temperature;
+	battery_status.temperature = (battery_mavlink.temperature == INT16_MAX) ?
+				     NAN : (float)battery_mavlink.temperature / 100.0f;
 	battery_status.connected = true;
 
 	_battery_pub.publish(battery_status);

--- a/docs/uk/mavlink/receiving_messages.md
+++ b/docs/uk/mavlink/receiving_messages.md
@@ -57,7 +57,8 @@ MavlinkReceiver::handle_message_battery_status_demo(mavlink_message_t *msg)
 	battery_status.timestamp = hrt_absolute_time();
 
 	battery_status.remaining = (float)battery_mavlink.battery_remaining / 100.0f;
-	battery_status.temperature = (float)battery_mavlink.temperature;
+	battery_status.temperature = (battery_mavlink.temperature == INT16_MAX) ?
+				     NAN : (float)battery_mavlink.temperature / 100.0f;
 	battery_status.connected = true;
 
 	_battery_pub.publish(battery_status);

--- a/docs/zh/mavlink/receiving_messages.md
+++ b/docs/zh/mavlink/receiving_messages.md
@@ -57,7 +57,8 @@ MavlinkReceiver::handle_message_battery_status_demo(mavlink_message_t *msg)
 	battery_status.timestamp = hrt_absolute_time();
 
 	battery_status.remaining = (float)battery_mavlink.battery_remaining / 100.0f;
-	battery_status.temperature = (float)battery_mavlink.temperature;
+	battery_status.temperature = (battery_mavlink.temperature == INT16_MAX) ?
+				     NAN : (float)battery_mavlink.temperature / 100.0f;
 	battery_status.connected = true;
 
 	_battery_pub.publish(battery_status);


### PR DESCRIPTION
Update the mavlink receiving example to match the current behavior from b52464059e patch.

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
