### PR TITLE
docs(middleware): update 1.18 release notes for uXRCE-DDS and Zenoh

### DIFF
--- a/docs/en/releases/1.18.md
+++ b/docs/en/releases/1.18.md
@@ -291,13 +291,38 @@ For users upgrading from v1.17, please take a moment to review the following bef
 
 ### uXRCE-DDS
 
-- uXRCE-DDS, add support for DDS `v3`, ROS 2 Lyrical and Rolling ([PX4-Autopilot#27597](https://github.com/PX4/PX4-Autopilot/pull/27597))
-- uXRCE-DDS topic bridging gained per-topic drain and unlimited-rate options, letting a topic be published as fast as it updates instead of at a fixed interval. ([PX4-Autopilot#27688](https://github.com/PX4/PX4-Autopilot/pull/27688))
+- [DDS version selection](../middleware/uxrce_dds.md#version-selection).
+Added support for DDS `v3`, ROS 2 Lyrical and Rolling ([PX4-Autopilot#27597](https://github.com/PX4/PX4-Autopilot/pull/27597))
+- Topic bridging gained per-topic drain and unlimited-rate options, letting a topic be published as fast as it updates instead of at a fixed interval.
+([PX4-Autopilot#27688](https://github.com/PX4/PX4-Autopilot/pull/27688))
+- Added rate limiter to `vehicle_attitude` and `vehicle_odometry` topic publishers.
+([PX4-Autopilot#25792](https://github.com/PX4/PX4-Autopilot/pull/25792))
+- New uORB topic bridged.
+([PX4-Autopilot#27681](https://github.com/PX4/PX4-Autopilot/pull/27681))
+
+  | uORB | ROS 2 | DIRECTION | INSTANCE | MAX RATE [Hz]
+  | - | - | - | - | - |
+  | `vtx` | `/fmu/out/vtx` | PX4 to ROS 2| `0` | 1 |
+  | `input_rc` | `/fmu/out/input_rc` | PX4 to ROS 2| `0` | 10 |
+
+
+
+- [Multi instace publication](../middleware/uxrce_dds.md#dds-topics-yaml).
+Added `instance` field to the `publications` section of `dds_topics.yaml` to control which uORB instance shall be published to ROS 2.
+Defaults to instance zero.
+([PX4-Autopilot#22350](https://github.com/PX4/PX4-Autopilot/pull/22350))
+- Added support for hardware flow control when using serial communication.
+**Note:** [Custom Micro XRCE DDS Agent](https://github.com/eProsima/Micro-XRCE-DDS-Agent/pull/407) build is required.
+([PX4-Autopilot#26209](https://github.com/PX4/PX4-Autopilot/pull/26209))
+- ROS 2 subscribriptions can be demuxed into diffenent uORB topic instances.
+([PX4-Autopilot#26305](https://github.com/PX4/PX4-Autopilot/pull/26305))
 
 ### Zenoh
 
 - Zenoh publisher options (reliability, priority, congestion control, express) are now configurable, both as common defaults and per-publisher overrides gated by the `ZENOH_PUB_OPTION_OVERRIDE` build option. ([PX4-Autopilot#27157](https://github.com/PX4/PX4-Autopilot/pull/27157))
 - Added a Zenoh build variant (`zenoh.px4board`) for the ARKV6X flight controller. ([PX4-Autopilot#25887](https://github.com/PX4/PX4-Autopilot/pull/25887))
+- Added support for ROS 2 humble and earlier.
+([PX4-Autopilot#26619](https://github.com/PX4/PX4-Autopilot/pull/26619))
 
 ## Simulation
 

--- a/docs/en/releases/1.18.md
+++ b/docs/en/releases/1.18.md
@@ -292,37 +292,35 @@ For users upgrading from v1.17, please take a moment to review the following bef
 ### uXRCE-DDS
 
 - [DDS version selection](../middleware/uxrce_dds.md#version-selection).
-Added support for DDS `v3`, ROS 2 Lyrical and Rolling ([PX4-Autopilot#27597](https://github.com/PX4/PX4-Autopilot/pull/27597))
+  Added support for DDS v3, ROS 2 Lyrical Luth and Rolling Ridley ([PX4-Autopilot#27597](https://github.com/PX4/PX4-Autopilot/pull/27597))
 - Topic bridging gained per-topic drain and unlimited-rate options, letting a topic be published as fast as it updates instead of at a fixed interval.
-([PX4-Autopilot#27688](https://github.com/PX4/PX4-Autopilot/pull/27688))
-- Added rate limiter to `vehicle_attitude` and `vehicle_odometry` topic publishers.
-([PX4-Autopilot#25792](https://github.com/PX4/PX4-Autopilot/pull/25792))
-- New uORB topic bridged.
-([PX4-Autopilot#27681](https://github.com/PX4/PX4-Autopilot/pull/27681))
+  ([PX4-Autopilot#27688](https://github.com/PX4/PX4-Autopilot/pull/27688))
+- Added rate limiter to [`vehicle_attitude`](../msg_docs/VehicleAttitude.md) and [`vehicle_odometry`](../msg_docs/VehicleOdometry.md) topic publishers.
+  ([PX4-Autopilot#25792](https://github.com/PX4/PX4-Autopilot/pull/25792))
+- New uORB topics bridged.
+  ([PX4-Autopilot#27681](https://github.com/PX4/PX4-Autopilot/pull/27681))
 
-  | uORB | ROS 2 | DIRECTION | INSTANCE | MAX RATE [Hz]
-  | - | - | - | - | - |
-  | `vtx` | `/fmu/out/vtx` | PX4 to ROS 2| `0` | 1 |
-  | `input_rc` | `/fmu/out/input_rc` | PX4 to ROS 2| `0` | 10 |
+  | uORB       | ROS 2               | Direction    | Instance | Max Rate [Hz] |
+  | ---------- | ------------------- | ------------ | -------- | ------------- |
+  | `vtx`      | `/fmu/out/vtx`      | PX4 to ROS 2 | `0`      | 1             |
+  | `input_rc` | `/fmu/out/input_rc` | PX4 to ROS 2 | `0`      | 10            |
 
-
-
-- [Multi instace publication](../middleware/uxrce_dds.md#dds-topics-yaml).
-Added `instance` field to the `publications` section of `dds_topics.yaml` to control which uORB instance shall be published to ROS 2.
-Defaults to instance zero.
-([PX4-Autopilot#22350](https://github.com/PX4/PX4-Autopilot/pull/22350))
+- [Multi instance publication](../middleware/uxrce_dds.md#dds-topics-yaml).
+  Added `instance` field to the `publications` section of `dds_topics.yaml` to control which uORB instance is published to ROS 2.
+  Defaults to instance zero.
+  ([PX4-Autopilot#22350](https://github.com/PX4/PX4-Autopilot/pull/22350))
 - Added support for hardware flow control when using serial communication.
-**Note:** [Custom Micro XRCE DDS Agent](https://github.com/eProsima/Micro-XRCE-DDS-Agent/pull/407) build is required.
-([PX4-Autopilot#26209](https://github.com/PX4/PX4-Autopilot/pull/26209))
-- ROS 2 subscribriptions can be demuxed into diffenent uORB topic instances.
-([PX4-Autopilot#26305](https://github.com/PX4/PX4-Autopilot/pull/26305))
+  **Note:** [Custom Micro XRCE DDS Agent](https://github.com/eProsima/Micro-XRCE-DDS-Agent/pull/407) build is required.
+  ([PX4-Autopilot#26209](https://github.com/PX4/PX4-Autopilot/pull/26209))
+- ROS 2 subscriptions can be demuxed into different uORB topic instances.
+  ([PX4-Autopilot#26305](https://github.com/PX4/PX4-Autopilot/pull/26305))
 
 ### Zenoh
 
 - Zenoh publisher options (reliability, priority, congestion control, express) are now configurable, both as common defaults and per-publisher overrides gated by the `ZENOH_PUB_OPTION_OVERRIDE` build option. ([PX4-Autopilot#27157](https://github.com/PX4/PX4-Autopilot/pull/27157))
 - Added a Zenoh build variant (`zenoh.px4board`) for the ARKV6X flight controller. ([PX4-Autopilot#25887](https://github.com/PX4/PX4-Autopilot/pull/25887))
-- Added support for ROS 2 humble and earlier.
-([PX4-Autopilot#26619](https://github.com/PX4/PX4-Autopilot/pull/26619))
+- Added support for ROS 2 Humble and earlier.
+  ([PX4-Autopilot#26619](https://github.com/PX4/PX4-Autopilot/pull/26619))
 
 ## Simulation
 


### PR DESCRIPTION
Updates uXRCE-DDS and Zenoh 1.18 release notes.

It will require backport to `release/1.18`