### PR TITLE
fix(boards/micoair-h743-v2): drive PWM/DShot output pins low on reset…

### DIFF
--- a/boards/micoair/h743-v2/src/init.c
+++ b/boards/micoair/h743-v2/src/init.c
@@ -95,7 +95,7 @@ __EXPORT void board_peripheral_reset(int ms)
 __EXPORT void board_on_reset(int status)
 {
 	for (int i = 0; i < DIRECT_PWM_OUTPUT_CHANNELS; ++i) {
-		px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
+		px4_arch_configgpio(PX4_MAKE_GPIO_OUTPUT_CLEAR(io_timer_channel_get_as_pwm_input(i)));
 	}
 
 	/*


### PR DESCRIPTION
… instead of floating them as inputs

board_on_reset configured the PWM timer channels as GPIO inputs, letting them float high before DShot output is initialized. ESCs sample the output line at power-up and interpret a floating/high signal as a bootloader-entry request, so motors could unexpectedly enter ESC bootloader mode instead of arming normally.

Configuring the pins as GPIO outputs driven low keeps them at a defined low level through reset until DShot takes over, matching what the ESCs expect on power-up.

Tested on MicoAir743v2-AIO-45A: ESCs no longer enter bootloader mode on boot, motors arm and respond to DShot normally.

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
