### PR TITLE
fix(mavlink): update TransponderReport flag bitmask

### DIFF
--- a/msg/TransponderReport.msg
+++ b/msg/TransponderReport.msg
@@ -1,36 +1,21 @@
-uint64 timestamp	# time since system start (microseconds)
-uint32 icao_address 	# ICAO address
-float64 lat 		# Latitude, expressed as degrees
-float64 lon 		# Longitude, expressed as degrees
-uint8 altitude_type	# Type from ADSB_ALTITUDE_TYPE enum
-float32 altitude 	# Altitude(ASL) in meters
-float32 heading 	# Course over ground in radians, 0 to 2pi, 0 is north
-float32 hor_velocity	# The horizontal velocity in m/s
-float32 ver_velocity 	# The vertical velocity in m/s, positive is up
-char[9] callsign	# The callsign, 8+null
-uint8 emitter_type 	# Type from ADSB_EMITTER_TYPE enum
-uint8 tslc 		# Time since last communication in seconds
-uint16 flags 		# Flags to indicate various statuses including valid data fields
-uint16 squawk 		# Squawk code
-uint8[18] uas_id	# Unique UAS ID
+# Transponder report
+#
+# ADSB report closely matching MAVLink's ADSB_VEHICLE (246) message with few internal extra fields at the end.
+# Populated by ADSB receivers, processed for user messaging and navigator, logging and republishing ADSB information.
 
-# ADSB flags, bit values match MAVLink's ADSB_FLAGS enum (common.xml)
-uint16 PX4_ADSB_FLAGS_VALID_COORDS = 1
-uint16 PX4_ADSB_FLAGS_VALID_ALTITUDE = 2
-uint16 PX4_ADSB_FLAGS_VALID_HEADING = 4
-uint16 PX4_ADSB_FLAGS_VALID_VELOCITY = 8
-uint16 PX4_ADSB_FLAGS_VALID_CALLSIGN = 16
-uint16 PX4_ADSB_FLAGS_VALID_SQUAWK = 32
-uint16 PX4_ADSB_FLAGS_SIMULATED = 64
-uint16 PX4_ADSB_FLAGS_VERTICAL_VELOCITY_VALID = 128
-uint16 PX4_ADSB_FLAGS_BARO_VALID = 256
-uint16 PX4_ADSB_FLAGS_SOURCE_UAT = 32768
+uint64 timestamp # [us] Time since system start
 
-# PX4-internal flag, not part of the MAVLink ADSB_FLAGS bitmask: uses a bit MAVLink leaves unused
-uint16 PX4_ADSB_FLAGS_RETRANSLATE = 512
+uint32 icao_address # [-] ICAO address
+float64 lat # [deg] Latitude, validity flag: PX4_ADSB_FLAGS_VALID_COORDS
+float64 lon # [deg] Longitude, validity flag: PX4_ADSB_FLAGS_VALID_COORDS
+uint8 altitude_type # Type from ADSB_ALTITUDE_TYPE enum
+float32 altitude # [m] Altitude (ASL), validity flag: PX4_ADSB_FLAGS_VALID_ALTITUDE
+float32 heading # [rad] Course over ground, 0 to 2pi, 0 is north, validity flag: PX4_ADSB_FLAGS_VALID_HEADING
+float32 hor_velocity # [m/s] Horizontal velocity, validity flag: PX4_ADSB_FLAGS_VALID_VELOCITY
+float32 ver_velocity # [m/s] Vertical velocity, positive is up, validity flag: PX4_ADSB_FLAGS_VALID_VELOCITY
+char[9] callsign # The callsign, 8+null, validity flag: PX4_ADSB_FLAGS_VALID_CALLSIGN
 
-#ADSB Emitter Data:
-#from mavlink/v2.0/common/common.h
+uint8 emitter_type # [@enum ADSB_EMITTER_TYPE] Type matching MAVLink's ADSB_EMITTER_TYPE enum
 uint16 ADSB_EMITTER_TYPE_NO_INFO=0
 uint16 ADSB_EMITTER_TYPE_LIGHT=1
 uint16 ADSB_EMITTER_TYPE_SMALL=2
@@ -52,5 +37,23 @@ uint16 ADSB_EMITTER_TYPE_EMERGENCY_SURFACE=17
 uint16 ADSB_EMITTER_TYPE_SERVICE_SURFACE=18
 uint16 ADSB_EMITTER_TYPE_POINT_OBSTACLE=19
 uint16 ADSB_EMITTER_TYPE_ENUM_END=20
+
+uint8 tslc # [s] Time since last communication
+
+uint16 flags # [@enum PX4_ADSB_FLAGS] Flags matching MAVLink's ADSB_FLAGS bitmask
+uint16 PX4_ADSB_FLAGS_VALID_COORDS = 1
+uint16 PX4_ADSB_FLAGS_VALID_ALTITUDE = 2
+uint16 PX4_ADSB_FLAGS_VALID_HEADING = 4
+uint16 PX4_ADSB_FLAGS_VALID_VELOCITY = 8
+uint16 PX4_ADSB_FLAGS_VALID_CALLSIGN = 16
+uint16 PX4_ADSB_FLAGS_VALID_SQUAWK = 32
+uint16 PX4_ADSB_FLAGS_SIMULATED = 64
+uint16 PX4_ADSB_FLAGS_VERTICAL_VELOCITY_VALID = 128
+uint16 PX4_ADSB_FLAGS_BARO_VALID = 256
+uint16 PX4_ADSB_FLAGS_SOURCE_UAT = 32768
+
+uint16 squawk # [-] Squawk code, validity flag: PX4_ADSB_FLAGS_VALID_SQUAWK
+
+uint8[18] uas_id # [-] Unique UAS ID, not part of ADSB_VEHICLE MAVLink message
 
 uint8 ORB_QUEUE_LENGTH = 16

--- a/msg/TransponderReport.msg
+++ b/msg/TransponderReport.msg
@@ -14,14 +14,20 @@ uint16 flags 		# Flags to indicate various statuses including valid data fields
 uint16 squawk 		# Squawk code
 uint8[18] uas_id	# Unique UAS ID
 
-# ADSB flags
+# ADSB flags, bit values match MAVLink's ADSB_FLAGS enum (common.xml)
 uint16 PX4_ADSB_FLAGS_VALID_COORDS = 1
 uint16 PX4_ADSB_FLAGS_VALID_ALTITUDE = 2
 uint16 PX4_ADSB_FLAGS_VALID_HEADING = 4
 uint16 PX4_ADSB_FLAGS_VALID_VELOCITY = 8
 uint16 PX4_ADSB_FLAGS_VALID_CALLSIGN = 16
 uint16 PX4_ADSB_FLAGS_VALID_SQUAWK = 32
-uint16 PX4_ADSB_FLAGS_RETRANSLATE = 256
+uint16 PX4_ADSB_FLAGS_SIMULATED = 64
+uint16 PX4_ADSB_FLAGS_VERTICAL_VELOCITY_VALID = 128
+uint16 PX4_ADSB_FLAGS_BARO_VALID = 256
+uint16 PX4_ADSB_FLAGS_SOURCE_UAT = 32768
+
+# PX4-internal flag, not part of the MAVLink ADSB_FLAGS bitmask: uses a bit MAVLink leaves unused
+uint16 PX4_ADSB_FLAGS_RETRANSLATE = 512
 
 #ADSB Emitter Data:
 #from mavlink/v2.0/common/common.h

--- a/src/drivers/transponder/sagetech_mxs/SagetechMXS.cpp
+++ b/src/drivers/transponder/sagetech_mxs/SagetechMXS.cpp
@@ -588,7 +588,6 @@ void SagetechMXS::handle_svr(sg_svr_t svr)
 
 	t.timestamp = hrt_absolute_time();
 	t.flags &= ~transponder_report_s::PX4_ADSB_FLAGS_VALID_SQUAWK;
-	t.flags |= transponder_report_s::PX4_ADSB_FLAGS_RETRANSLATE;
 
 	//Set data from svr message
 	if (svr.validity.position) {
@@ -649,7 +648,6 @@ void SagetechMXS::handle_msr(sg_msr_t msr)
 	}
 
 	t.timestamp = hrt_absolute_time();
-	t.flags |= transponder_report_s::PX4_ADSB_FLAGS_RETRANSLATE;
 
 	if (strlen(msr.callsign)) {
 		snprintf(t.callsign, sizeof(t.callsign), "%-8s", msr.callsign);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2885,6 +2885,14 @@ MavlinkReceiver::handle_message_adsb_vehicle(mavlink_message_t *msg)
 
 	if (adsb.flags & ADSB_FLAGS_VALID_SQUAWK) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_VALID_SQUAWK; }
 
+	if (adsb.flags & ADSB_FLAGS_SIMULATED) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_SIMULATED; }
+
+	if (adsb.flags & ADSB_FLAGS_VERTICAL_VELOCITY_VALID) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_VERTICAL_VELOCITY_VALID; }
+
+	if (adsb.flags & ADSB_FLAGS_BARO_VALID) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_BARO_VALID; }
+
+	if (adsb.flags & ADSB_FLAGS_SOURCE_UAT) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_SOURCE_UAT; }
+
 	//PX4_INFO("code: %d callsign: %s, vel: %8.4f, tslc: %d", (int)t.ICAO_address, t.callsign, (double)t.hor_velocity, (int)t.tslc);
 
 	_transponder_report_pub.publish(t);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2871,27 +2871,17 @@ MavlinkReceiver::handle_message_adsb_vehicle(mavlink_message_t *msg)
 	t.tslc = adsb.tslc;
 	t.squawk = adsb.squawk;
 
-	t.flags = transponder_report_s::PX4_ADSB_FLAGS_RETRANSLATE;  //Unset in receiver already broadcast its messages
-
-	if (adsb.flags & ADSB_FLAGS_VALID_COORDS) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_VALID_COORDS; }
-
-	if (adsb.flags & ADSB_FLAGS_VALID_ALTITUDE) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_VALID_ALTITUDE; }
-
-	if (adsb.flags & ADSB_FLAGS_VALID_HEADING) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_VALID_HEADING; }
-
-	if (adsb.flags & ADSB_FLAGS_VALID_VELOCITY) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_VALID_VELOCITY; }
-
-	if (adsb.flags & ADSB_FLAGS_VALID_CALLSIGN) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_VALID_CALLSIGN; }
-
-	if (adsb.flags & ADSB_FLAGS_VALID_SQUAWK) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_VALID_SQUAWK; }
-
-	if (adsb.flags & ADSB_FLAGS_SIMULATED) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_SIMULATED; }
-
-	if (adsb.flags & ADSB_FLAGS_VERTICAL_VELOCITY_VALID) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_VERTICAL_VELOCITY_VALID; }
-
-	if (adsb.flags & ADSB_FLAGS_BARO_VALID) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_BARO_VALID; }
-
-	if (adsb.flags & ADSB_FLAGS_SOURCE_UAT) { t.flags |= transponder_report_s::PX4_ADSB_FLAGS_SOURCE_UAT; }
+	t.flags = adsb.flags; // The PX4_ADSB_FLAGS_* bit values are defined to be identical to MAVLink's ADSB_FLAGS bitmask (see TransponderReport.msg),
+	static_assert(transponder_report_s::PX4_ADSB_FLAGS_VALID_COORDS == ADSB_FLAGS_VALID_COORDS);
+	static_assert(transponder_report_s::PX4_ADSB_FLAGS_VALID_ALTITUDE == ADSB_FLAGS_VALID_ALTITUDE);
+	static_assert(transponder_report_s::PX4_ADSB_FLAGS_VALID_HEADING == ADSB_FLAGS_VALID_HEADING);
+	static_assert(transponder_report_s::PX4_ADSB_FLAGS_VALID_VELOCITY == ADSB_FLAGS_VALID_VELOCITY);
+	static_assert(transponder_report_s::PX4_ADSB_FLAGS_VALID_CALLSIGN == ADSB_FLAGS_VALID_CALLSIGN);
+	static_assert(transponder_report_s::PX4_ADSB_FLAGS_VALID_SQUAWK == ADSB_FLAGS_VALID_SQUAWK);
+	static_assert(transponder_report_s::PX4_ADSB_FLAGS_SIMULATED == ADSB_FLAGS_SIMULATED);
+	static_assert(transponder_report_s::PX4_ADSB_FLAGS_VERTICAL_VELOCITY_VALID == ADSB_FLAGS_VERTICAL_VELOCITY_VALID);
+	static_assert(transponder_report_s::PX4_ADSB_FLAGS_BARO_VALID == ADSB_FLAGS_BARO_VALID);
+	static_assert(transponder_report_s::PX4_ADSB_FLAGS_SOURCE_UAT == ADSB_FLAGS_SOURCE_UAT);
 
 	//PX4_INFO("code: %d callsign: %s, vel: %8.4f, tslc: %d", (int)t.ICAO_address, t.callsign, (double)t.hor_velocity, (int)t.tslc);
 

--- a/src/modules/mavlink/streams/ADSB_VEHICLE.hpp
+++ b/src/modules/mavlink/streams/ADSB_VEHICLE.hpp
@@ -99,6 +99,14 @@ private:
 
 			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_SQUAWK) { msg.flags |= ADSB_FLAGS_VALID_SQUAWK; }
 
+			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_SIMULATED) { msg.flags |= ADSB_FLAGS_SIMULATED; }
+
+			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_VERTICAL_VELOCITY_VALID) { msg.flags |= ADSB_FLAGS_VERTICAL_VELOCITY_VALID; }
+
+			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_BARO_VALID) { msg.flags |= ADSB_FLAGS_BARO_VALID; }
+
+			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_SOURCE_UAT) { msg.flags |= ADSB_FLAGS_SOURCE_UAT; }
+
 			mavlink_msg_adsb_vehicle_send_struct(_mavlink->get_channel(), &msg);
 			sent = true;
 		}

--- a/src/modules/mavlink/streams/ADSB_VEHICLE.hpp
+++ b/src/modules/mavlink/streams/ADSB_VEHICLE.hpp
@@ -67,7 +67,7 @@ private:
 
 		while ((_mavlink->get_free_tx_buf() >= get_size()) && _transponder_report_sub.update(&pos)) {
 
-			if (!(pos.flags & transponder_report_s::PX4_ADSB_FLAGS_RETRANSLATE)) {
+			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_SIMULATED) {
 				continue;
 			}
 
@@ -84,28 +84,7 @@ private:
 			msg.emitter_type = pos.emitter_type;
 			msg.tslc = pos.tslc;
 			msg.squawk = pos.squawk;
-
-			msg.flags = 0;
-
-			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_COORDS) { msg.flags |= ADSB_FLAGS_VALID_COORDS; }
-
-			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_ALTITUDE) { msg.flags |= ADSB_FLAGS_VALID_ALTITUDE; }
-
-			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_HEADING) { msg.flags |= ADSB_FLAGS_VALID_HEADING; }
-
-			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_VELOCITY) { msg.flags |= ADSB_FLAGS_VALID_VELOCITY; }
-
-			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_CALLSIGN) { msg.flags |= ADSB_FLAGS_VALID_CALLSIGN; }
-
-			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_SQUAWK) { msg.flags |= ADSB_FLAGS_VALID_SQUAWK; }
-
-			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_SIMULATED) { msg.flags |= ADSB_FLAGS_SIMULATED; }
-
-			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_VERTICAL_VELOCITY_VALID) { msg.flags |= ADSB_FLAGS_VERTICAL_VELOCITY_VALID; }
-
-			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_BARO_VALID) { msg.flags |= ADSB_FLAGS_BARO_VALID; }
-
-			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_SOURCE_UAT) { msg.flags |= ADSB_FLAGS_SOURCE_UAT; }
+			msg.flags = pos.flags;
 
 			mavlink_msg_adsb_vehicle_send_struct(_mavlink->get_channel(), &msg);
 			sent = true;

--- a/src/modules/navigator/DetectAndAvoid/detect_and_avoid.cpp
+++ b/src/modules/navigator/DetectAndAvoid/detect_and_avoid.cpp
@@ -624,14 +624,13 @@ void DetectAndAvoid::debug_print_transponder_report(const transponder_report_s &
 		  uas_id_char);
 
 	// Log which flags are enabled in one line using printf
-	PX4_DEBUG("ADSB_IN: Flags missing: %s%s%s%s%s%s%s",
+	PX4_DEBUG("ADSB_IN: Flags missing: %s%s%s%s%s%s",
 		  (transponder_report.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_COORDS) ? "" : "coord ",
 		  (transponder_report.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_ALTITUDE) ? "" : "alt ",
 		  (transponder_report.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_HEADING) ? "" : "hdg ",
 		  (transponder_report.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_VELOCITY) ? "" : "vel ",
 		  (transponder_report.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_CALLSIGN) ? "" : "callsign ",
-		  (transponder_report.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_SQUAWK) ? "" : "squawk ",
-		  (transponder_report.flags & transponder_report_s::PX4_ADSB_FLAGS_RETRANSLATE) ? "" : "Retranslate ");
+		  (transponder_report.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_SQUAWK) ? "" : "squawk ");
 
 	PX4_DEBUG("ADSB_IN: lat %.2f, lon %.2f, alt %.2f, hdg %.d, vel hor %.1f, vel vert %.1f \n",
 		  (double)transponder_report.lat,

--- a/src/modules/navigator/DetectAndAvoid/detect_and_avoid.h
+++ b/src/modules/navigator/DetectAndAvoid/detect_and_avoid.h
@@ -86,7 +86,8 @@ public:
 			transponder_report_s::PX4_ADSB_FLAGS_VALID_HEADING |
 			transponder_report_s::PX4_ADSB_FLAGS_VALID_VELOCITY |
 			transponder_report_s::PX4_ADSB_FLAGS_VALID_ALTITUDE |
-			transponder_report_s::PX4_ADSB_FLAGS_VALID_CALLSIGN;
+			transponder_report_s::PX4_ADSB_FLAGS_VALID_CALLSIGN |
+			transponder_report_s::PX4_ADSB_FLAGS_SIMULATED;
 
 	// Fake traffic scripts used for manual DAA validation from the navigator shell.
 	enum class FakeTraffMode : uint8_t {

--- a/src/modules/navigator/DetectAndAvoid/detect_and_avoid_fake_traffic.cpp
+++ b/src/modules/navigator/DetectAndAvoid/detect_and_avoid_fake_traffic.cpp
@@ -52,16 +52,8 @@ namespace
 // stores the selected mode and an ownship position snapshot; `process_fake_traffic()`
 // later publishes the scripted reports that are due from the navigator update loop.
 static constexpr uint16_t kDefaultFakeTrafficFlags = DetectAndAvoid::kFakeTrafficDefaultFlags;
-
-static constexpr uint16_t kCallsignNotValidFlags = transponder_report_s::PX4_ADSB_FLAGS_VALID_COORDS |
-		transponder_report_s::PX4_ADSB_FLAGS_VALID_HEADING |
-		transponder_report_s::PX4_ADSB_FLAGS_VALID_VELOCITY |
-		transponder_report_s::PX4_ADSB_FLAGS_VALID_ALTITUDE;
-
-static constexpr uint16_t kVelocityNotValidFlags = transponder_report_s::PX4_ADSB_FLAGS_VALID_COORDS |
-		transponder_report_s::PX4_ADSB_FLAGS_VALID_HEADING |
-		transponder_report_s::PX4_ADSB_FLAGS_VALID_ALTITUDE |
-		transponder_report_s::PX4_ADSB_FLAGS_VALID_CALLSIGN;
+static constexpr uint16_t kCallsignNotValidFlags = kDefaultFakeTrafficFlags & ~transponder_report_s::PX4_ADSB_FLAGS_VALID_CALLSIGN;
+static constexpr uint16_t kVelocityNotValidFlags = kDefaultFakeTrafficFlags & ~transponder_report_s::PX4_ADSB_FLAGS_VALID_VELOCITY;
 
 // Publish one final far-away sample to clear the same traffic entry cleanly.
 static constexpr float kFakeTrafficResolveDistance = 5000.f;
@@ -184,8 +176,7 @@ static constexpr fake_traffic_script_step_s kFlagsScript[] {
 };
 
 template <size_t N>
-bool get_script_step(const fake_traffic_script_step_s(&script)[N], const uint8_t step_idx,
-		     fake_traffic_script_step_s &step)
+bool get_script_step(const fake_traffic_script_step_s(&script)[N], const uint8_t step_idx, fake_traffic_script_step_s &step)
 {
 	if (step_idx >= N) {
 		return false;
@@ -282,8 +273,7 @@ const char *fake_traffic_mode_to_string(const DetectAndAvoid::FakeTraffMode mode
 	}
 }
 
-bool get_fake_traffic_step(const DetectAndAvoid::FakeTraffMode mode, const uint8_t step_idx,
-			   fake_traffic_script_step_s &step)
+bool get_fake_traffic_step(const DetectAndAvoid::FakeTraffMode mode, const uint8_t step_idx, fake_traffic_script_step_s &step)
 {
 	switch (mode) {
 	case DetectAndAvoid::FakeTraffMode::kUniqueIds:

--- a/src/modules/navigator/DetectAndAvoid/detect_and_avoid_fake_traffic.cpp
+++ b/src/modules/navigator/DetectAndAvoid/detect_and_avoid_fake_traffic.cpp
@@ -445,7 +445,7 @@ void DetectAndAvoid::fake_traffic(const SyntheticTrafficReport &report)
 	tr.callsign[sizeof(tr.callsign) - 1] = 0;
 	tr.emitter_type = report.emitter_type;
 	tr.tslc = 2; // seconds since last communication
-	tr.flags = report.flags;
+	tr.flags = report.flags | transponder_report_s::PX4_ADSB_FLAGS_SIMULATED;
 	tr.squawk = 6667;
 
 #ifndef BOARD_HAS_NO_UUID


### PR DESCRIPTION
### Solved Problem
`TransponderReport.msg` is missing MAVLink's `SIMULATED`, `VERTICAL_VELOCITY_VALID`, `BARO_VALID`, and `SOURCE_UAT` flags entirely ([mavlink msg definition](https://github.com/mavlink/mavlink/blob/f9cb1f9e482977446c3dd953a16368d4834c6aa5/message_definitions/v1.0/common.xml#L3654)). The `PX4_ADSB_FLAGS_RETRANSLATE` bit (256) also collides with MAVLink's `ADSB_FLAGS_BARO_VALID` bit at the same value.

### Solution
- Moved `PX4_ADSB_FLAGS_RETRANSLATE` to bit 512 (unused by MAVLink's `ADSB_FLAGS` enum), resolving the collision
- Added the missing flags with correct bit values.
- Forwarded the new flags in both directions: (uORB → MAVLink) and (MAVLink → uORB).

### Changelog Entry
For release notes:
```
Fix TransponderReport ADS-B flag bitmask to match MAVLink ADSB_FLAGS.
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video