### PR TITLE
docs(mc_pos_control): fix MPC_ACC_HOR_MAX description for MPC_POS_MODE

### DIFF
--- a/src/modules/mc_pos_control/multicopter_position_mode_params.yaml
+++ b/src/modules/mc_pos_control/multicopter_position_mode_params.yaml
@@ -63,13 +63,8 @@ parameters:
       description:
         short: Maximum horizontal acceleration
         long: |-
-          Maximum horizontal acceleration limit.
-
-          With MPC_POS_MODE Direct velocity (0): used for the deceleration
-          limit when slowing down.
-
-          With MPC_POS_MODE Acceleration based (4): not used; use MPC_ACC_HOR
-          instead.
+          With MPC_POS_MODE=0 it limits deceleration.
+          With MPC_POS_MODE=4 it is unused (see MPC_ACC_HOR).
       type: float
       default: 5.0
       unit: m/s^2

--- a/src/modules/mc_pos_control/multicopter_position_mode_params.yaml
+++ b/src/modules/mc_pos_control/multicopter_position_mode_params.yaml
@@ -63,9 +63,13 @@ parameters:
       description:
         short: Maximum horizontal acceleration
         long: |-
-          MPC_POS_MODE
-          1 just deceleration
-          4 not used, use MPC_ACC_HOR instead
+          Maximum horizontal acceleration limit.
+
+          With MPC_POS_MODE Direct velocity (0): used for the deceleration
+          limit when slowing down.
+
+          With MPC_POS_MODE Acceleration based (4): not used; use MPC_ACC_HOR
+          instead.
       type: float
       default: 5.0
       unit: m/s^2


### PR DESCRIPTION
## Summary
- Correct the `MPC_ACC_HOR_MAX` long description so it matches live `MPC_POS_MODE` values (0 = Direct velocity, 4 = Acceleration based).
- Remove the obsolete “mode 1” wording that no longer exists in the enum.

## Motivation
Parameter metadata currently documents a non-existent `MPC_POS_MODE` value (`1 just deceleration`), which confuses QGC/docs consumers. This was also flagged as a pre-existing description issue in the bulk trim discussion (#27758) — shipping a tiny targeted fix.

## Verification
- Diff limited to one param block in `src/modules/mc_pos_control/multicopter_position_mode_params.yaml`.
- Cross-checked enum `values:` for `MPC_POS_MODE` in the same file (0 / 4 only).
- No control-law, default, min/max, or flash layout changes.
- `Tools/validate_yaml.py` needs `cerberus` (not installed in this environment); YAML indentation/keys unchanged structurally.

## Context
Aerial/drone OSS campaign micro-docs PR (tier-4 PX4 — docs only, safe).