### PR TITLE
docs(mc_hover_thrust_estimator): fix HTE_HT_ERR_INIT description

### DIFF
--- a/src/modules/mc_hover_thrust_estimator/hover_thrust_estimator_params.yaml
+++ b/src/modules/mc_hover_thrust_estimator/hover_thrust_estimator_params.yaml
@@ -31,8 +31,9 @@ parameters:
       description:
         short: 1-sigma initial hover thrust uncertainty
         long: |-
-          Sets the number of standard deviations used
-          by the innovation consistency test.
+          Initial standard deviation of the hover thrust state estimate.
+          Larger values allow the estimate to move farther from the initial
+          hover thrust before process noise takes over.
       type: float
       default: 0.1
       decimal: 3


### PR DESCRIPTION
## Summary
- Fix the copy-pasted long description on `HTE_HT_ERR_INIT`.
- It previously repeated the `HTE_ACC_GATE` innovation-consistency-gate wording; the parameter is actually the initial 1-σ hover thrust uncertainty (`normalized_thrust`).

## Motivation
Wrong metadata confuses tuning. Independently noted as a pre-existing error in #27758’s audit; this PR applies the small correct fix without the bulk flash trim.

## Verification
- Single-file / single-parameter description edit.
- Defaults, min/max, unit, and estimator code untouched.
- No flight-behavior change.

## Context
Aerial campaign micro-docs (safe, flash-neutral beyond string content).