### PR TITLE
fix(ekf/mavlink): fix logging and mavlink stream of fusion-control-status

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -239,6 +239,7 @@ void EKF2::AdvertiseTopics()
 	_estimator_sensor_bias_pub.advertise();
 	_estimator_status_pub.advertise();
 	_estimator_status_flags_pub.advertise();
+	_estimator_fc_pub.advertise();
 
 	if (_multi_mode) {
 		// only force advertise these in multi mode to ensure consistent uORB instance numbering

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2006,6 +2006,9 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("CAMERA_IMAGE_CAPTURED", unlimited_rate);
 		configure_stream_local("CURRENT_MODE", 0.5f);
 		configure_stream_local("ESTIMATOR_STATUS", 1.0f);
+#if defined(MAVLINK_MSG_ID_ESTIMATOR_SENSOR_FUSION_STATUS)
+		configure_stream_local("ESTIMATOR_SENSOR_FUSION_STATUS", 1.0f);
+#endif
 		configure_stream_local("EXTENDED_SYS_STATE", 1.0f);
 		configure_stream_local("GLOBAL_POSITION_SENSOR", 10.0f);
 		configure_stream_local("GLOBAL_POSITION_INT", 10.0f);
@@ -2073,6 +2076,9 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("CAMERA_IMAGE_CAPTURED", 2.0f);
 		configure_stream_local("CURRENT_MODE", 0.5f);
 		configure_stream_local("ESTIMATOR_STATUS", 1.0f);
+#if defined(MAVLINK_MSG_ID_ESTIMATOR_SENSOR_FUSION_STATUS)
+		configure_stream_local("ESTIMATOR_SENSOR_FUSION_STATUS", 1.0f);
+#endif
 		configure_stream_local("EXTENDED_SYS_STATE", 0.5f);
 		configure_stream_local("GLOBAL_POSITION_INT", 2.0f);
 		configure_stream_local("GLOBAL_POSITION_SENSOR", 2.0f);


### PR DESCRIPTION

### Solved Problem & Solution
Currently, the `estimator_fusion_control` uORB topic wasn't being logged correctly. This change advertises it immediately.

Additionally, `ESTIMATOR_SENSOR_FUSION_STATUS` wasn't included in any low-bandwidth logging profile. Since this is a system-critical stream for the new fusion control logic over MAVLink, it has now been added.



### Changelog Entry
For release notes:
```
Bugfix: fixed `estimator_fusion_control` logging and `ESTIMATOR_SENSOR_FUSION_STATUS` streaming
```

### Test coverage
Tested in SITL.
