### PR TITLE
Draft: feat(ekf2): airspeed fusion for wind estimation in rotary-wing flight

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/airspeed/airspeed_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/airspeed/airspeed_fusion.cpp
@@ -66,9 +66,10 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 		_external_wind_init = false;
 	}
 
-#if defined(CONFIG_EKF2_GNSS)
+	const bool fixed_wing_or_transition = _control_status.flags.fixed_wing || _control_status.flags.in_transition;
 
-	// clear yaw estimator airspeed (updated later with true airspeed if airspeed fusion is active)
+#if defined(CONFIG_EKF2_GNSS)
+	// EKF-GSF airspeed compensation assumes fixed-wing dynamics.
 	if (_control_status.flags.fixed_wing) {
 		if (_control_status.flags.in_air && !_control_status.flags.vehicle_at_rest) {
 			if (!_control_status.flags.fuse_aspd) {
@@ -78,6 +79,9 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 		} else {
 			_yawEstimator.setTrueAirspeed(0.f);
 		}
+
+	} else if (!_control_status.flags.in_transition) {
+		_yawEstimator.setTrueAirspeed(NAN);
 	}
 
 #endif // CONFIG_EKF2_GNSS
@@ -95,11 +99,7 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 
 		updateAirspeed(airspeed_sample, _aid_src_airspeed);
 
-		const bool fixed_wing_or_transition = _control_status.flags.fixed_wing || _control_status.flags.in_transition;
-
-		// in rotary-wing flight the airspeed and synthetic sideslip observations are only valid when
-		// the airflow is aligned with the body X axis (zero sideslip): a significant low-passed
-		// lateral specific force indicates a lateral relative airflow, i.e. misalignment
+		// Use lateral specific force to check the zero-sideslip assumption in MC mode.
 		const bool mc_airflow_aligned = (_params.ekf2_aspd_mc_lim <= 0.f)
 						|| (fabsf(_aspd_mc_lat_accel_lpf.getState()) < _params.ekf2_aspd_mc_lim);
 		const bool mc_aspd_allowed = (_params.ekf2_aspd_mc == 1) && mc_airflow_aligned;
@@ -122,8 +122,6 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 
 #if defined(CONFIG_EKF2_GNSS)
 
-				// don't feed the yaw estimator in rotary-wing flight as its motion model
-				// assumes fixed-wing flight dynamics
 				if (fixed_wing_or_transition) {
 					_yawEstimator.setTrueAirspeed(airspeed_sample.true_airspeed);
 				}
@@ -141,7 +139,7 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 			}
 
 		} else if (starting_conditions_passing) {
-			// in rotary-wing flight airspeed must never correct the navigation states
+			// Never reset navigation states from airspeed in MC mode.
 			const bool do_vel_reset = (_horizontal_deadreckon_time_exceeded
 						   || (_control_status.flags.inertial_dead_reckoning && !is_airspeed_consistent))
 						  && fixed_wing_or_transition;
@@ -209,8 +207,7 @@ void Ekf::fuseAirspeed(const airspeedSample &airspeed_sample, estimator_aid_sour
 		return;
 	}
 
-	// determine if we need the fusion to correct states other than wind;
-	// in rotary-wing flight only ever update the wind states
+	// Airspeed never corrects navigation states in MC mode.
 	const bool update_wind_only = !_control_status.flags.wind_dead_reckoning
 				      || !(_control_status.flags.fixed_wing || _control_status.flags.in_transition);
 

--- a/src/modules/ekf2/EKF/aid_sources/airspeed/airspeed_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/airspeed/airspeed_fusion.cpp
@@ -95,8 +95,17 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 
 		updateAirspeed(airspeed_sample, _aid_src_airspeed);
 
-		const bool continuing_conditions_passing = _control_status.flags.in_air && (_control_status.flags.fixed_wing
-				|| _control_status.flags.in_transition)
+		const bool fixed_wing_or_transition = _control_status.flags.fixed_wing || _control_status.flags.in_transition;
+
+		// in rotary-wing flight the airspeed and synthetic sideslip observations are only valid when
+		// the airflow is aligned with the body X axis (zero sideslip): a significant low-passed
+		// lateral specific force indicates a lateral relative airflow, i.e. misalignment
+		const bool mc_airflow_aligned = (_params.ekf2_aspd_mc_lim <= 0.f)
+						|| (fabsf(_aspd_mc_lat_accel_lpf.getState()) < _params.ekf2_aspd_mc_lim);
+		const bool mc_aspd_allowed = (_params.ekf2_aspd_mc == 1) && mc_airflow_aligned;
+
+		const bool continuing_conditions_passing = _control_status.flags.in_air
+				&& (fixed_wing_or_transition || mc_aspd_allowed)
 				&& !_control_status.flags.fake_pos;
 
 		const bool is_airspeed_significant = airspeed_sample.true_airspeed > _params.ekf2_arsp_thr;
@@ -112,7 +121,13 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 				}
 
 #if defined(CONFIG_EKF2_GNSS)
-				_yawEstimator.setTrueAirspeed(airspeed_sample.true_airspeed);
+
+				// don't feed the yaw estimator in rotary-wing flight as its motion model
+				// assumes fixed-wing flight dynamics
+				if (fixed_wing_or_transition) {
+					_yawEstimator.setTrueAirspeed(airspeed_sample.true_airspeed);
+				}
+
 #endif // CONFIG_EKF2_GNSS
 
 				const bool is_fusion_failing = isTimedOut(_aid_src_airspeed.time_last_fuse, (uint64_t)10e6);
@@ -126,8 +141,10 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 			}
 
 		} else if (starting_conditions_passing) {
-			const bool do_vel_reset = _horizontal_deadreckon_time_exceeded
-						  || (_control_status.flags.inertial_dead_reckoning && !is_airspeed_consistent);
+			// in rotary-wing flight airspeed must never correct the navigation states
+			const bool do_vel_reset = (_horizontal_deadreckon_time_exceeded
+						   || (_control_status.flags.inertial_dead_reckoning && !is_airspeed_consistent))
+						  && fixed_wing_or_transition;
 
 			const Vector2f wind_vel_var = getWindVelocityVariance();
 			const bool do_wind_reset = (!_control_status.flags.wind || ((wind_vel_var(0) + wind_vel_var(1)) > sq(_params.initial_wind_uncertainty)))
@@ -192,8 +209,10 @@ void Ekf::fuseAirspeed(const airspeedSample &airspeed_sample, estimator_aid_sour
 		return;
 	}
 
-	// determine if we need the airspeed fusion to correct states other than wind
-	const bool update_wind_only = !_control_status.flags.wind_dead_reckoning;
+	// determine if we need the fusion to correct states other than wind;
+	// in rotary-wing flight only ever update the wind states
+	const bool update_wind_only = !_control_status.flags.wind_dead_reckoning
+				      || !(_control_status.flags.fixed_wing || _control_status.flags.in_transition);
 
 	const float innov_var = aid_src.innovation_variance;
 

--- a/src/modules/ekf2/EKF/aid_sources/sideslip/sideslip_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/sideslip/sideslip_fusion.cpp
@@ -97,8 +97,10 @@ bool Ekf::fuseSideslip(estimator_aid_source1d_s &sideslip)
 		return false;
 	}
 
-	// determine if we need the sideslip fusion to correct states other than wind
-	bool update_wind_only = !_control_status.flags.wind_dead_reckoning;
+	// determine if we need the fusion to correct states other than wind;
+	// in rotary-wing flight only ever update the wind states
+	bool update_wind_only = !_control_status.flags.wind_dead_reckoning
+				|| !(_control_status.flags.fixed_wing || _control_status.flags.in_transition);
 
 	// Reset covariance and states if the calculation is badly conditioned
 	if ((sideslip.innovation_variance < sideslip.observation_variance)

--- a/src/modules/ekf2/EKF/aid_sources/sideslip/sideslip_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/sideslip/sideslip_fusion.cpp
@@ -97,10 +97,9 @@ bool Ekf::fuseSideslip(estimator_aid_source1d_s &sideslip)
 		return false;
 	}
 
-	// determine if we need the fusion to correct states other than wind;
-	// in rotary-wing flight only ever update the wind states
-	bool update_wind_only = !_control_status.flags.wind_dead_reckoning
-				|| !(_control_status.flags.fixed_wing || _control_status.flags.in_transition);
+	// Synthetic sideslip never corrects navigation states in MC mode.
+	const bool update_wind_only = !_control_status.flags.wind_dead_reckoning
+				      || !(_control_status.flags.fixed_wing || _control_status.flags.in_transition);
 
 	// Reset covariance and states if the calculation is badly conditioned
 	if ((sideslip.innovation_variance < sideslip.observation_variance)

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -424,6 +424,8 @@ struct parameters {
 	float ekf2_tas_gate{5.0f};              ///< True Airspeed innovation consistency gate size (STD)
 	float ekf2_eas_noise{1.4f};             ///< EAS measurement noise standard deviation used for airspeed fusion (m/s)
 	float ekf2_arsp_thr{2.0f};              ///< Airspeed fusion threshold. A value of zero will deactivate airspeed fusion
+	int32_t ekf2_aspd_mc{0};                ///< set to 1 to allow airspeed fusion for wind estimation in rotary-wing flight (wind states only)
+	float ekf2_aspd_mc_lim{1.0f};           ///< low-passed lateral specific force magnitude above which rotary-wing airspeed fusion is inhibited (m/sec**2). A value of zero disables the check
 #endif // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_SIDESLIP)

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -424,8 +424,8 @@ struct parameters {
 	float ekf2_tas_gate{5.0f};              ///< True Airspeed innovation consistency gate size (STD)
 	float ekf2_eas_noise{1.4f};             ///< EAS measurement noise standard deviation used for airspeed fusion (m/s)
 	float ekf2_arsp_thr{2.0f};              ///< Airspeed fusion threshold. A value of zero will deactivate airspeed fusion
-	int32_t ekf2_aspd_mc{0};                ///< set to 1 to allow airspeed fusion for wind estimation in rotary-wing flight (wind states only)
-	float ekf2_aspd_mc_lim{1.0f};           ///< low-passed lateral specific force magnitude above which rotary-wing airspeed fusion is inhibited (m/sec**2). A value of zero disables the check
+	int32_t ekf2_aspd_mc{0};                ///< Enable airspeed fusion for wind estimation in MC mode
+	float ekf2_aspd_mc_lim{1.0f};           ///< MC airspeed fusion lateral specific force limit (m/sec**2); 0 disables
 #endif // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_SIDESLIP)

--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -277,8 +277,6 @@ void Ekf::predictState(const imuSample &imu_delayed)
 	_accel_horiz_lpf.update(corrected_delta_vel_ef.xy() / imu_delayed.delta_vel_dt, imu_delayed.delta_vel_dt);
 
 #if defined(CONFIG_EKF2_AIRSPEED)
-	// low-pass the body Y specific force used by the rotary-wing airspeed fusion alignment check;
-	// the signed value is filtered so that zero-mean vibration averages out instead of accumulating
 	_aspd_mc_lat_accel_lpf.update(corrected_delta_vel(1) / imu_delayed.delta_vel_dt, imu_delayed.delta_vel_dt);
 #endif // CONFIG_EKF2_AIRSPEED
 }

--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -275,6 +275,12 @@ void Ekf::predictState(const imuSample &imu_delayed)
 
 	// calculate a filtered horizontal acceleration this are used for manoeuvre detection elsewhere
 	_accel_horiz_lpf.update(corrected_delta_vel_ef.xy() / imu_delayed.delta_vel_dt, imu_delayed.delta_vel_dt);
+
+#if defined(CONFIG_EKF2_AIRSPEED)
+	// low-pass the body Y specific force used by the rotary-wing airspeed fusion alignment check;
+	// the signed value is filtered so that zero-mean vibration averages out instead of accumulating
+	_aspd_mc_lat_accel_lpf.update(corrected_delta_vel(1) / imu_delayed.delta_vel_dt, imu_delayed.delta_vel_dt);
+#endif // CONFIG_EKF2_AIRSPEED
 }
 
 bool Ekf::resetGlobalPosToExternalObservation(const double latitude, const double longitude, const float altitude,

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -550,6 +550,11 @@ private:
 	static constexpr float _kAccelHorizLpfTimeConstant = 1.f;
 	AlphaFilter<Vector2f> _accel_horiz_lpf{_kAccelHorizLpfTimeConstant}; ///< Low pass filtered horizontal earth frame acceleration (m/sec**2)
 
+#if defined(CONFIG_EKF2_AIRSPEED)
+	static constexpr float _kAspdMcLatAccelLpfTimeConstant = 1.f;
+	AlphaFilter<float> _aspd_mc_lat_accel_lpf{_kAspdMcLatAccelLpfTimeConstant}; ///< Low pass filtered body Y specific force used for the rotary-wing airspeed fusion alignment check (m/sec**2)
+#endif // CONFIG_EKF2_AIRSPEED
+
 #if defined(CONFIG_EKF2_WIND)
 	static constexpr float _kHeightRateLpfTimeConstant = 10.f;
 	AlphaFilter<float> _height_rate_lpf{_kHeightRateLpfTimeConstant};

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -552,7 +552,7 @@ private:
 
 #if defined(CONFIG_EKF2_AIRSPEED)
 	static constexpr float _kAspdMcLatAccelLpfTimeConstant = 1.f;
-	AlphaFilter<float> _aspd_mc_lat_accel_lpf{_kAspdMcLatAccelLpfTimeConstant}; ///< Low pass filtered body Y specific force used for the rotary-wing airspeed fusion alignment check (m/sec**2)
+	AlphaFilter<float> _aspd_mc_lat_accel_lpf{_kAspdMcLatAccelLpfTimeConstant}; ///< Filtered body-Y specific force (m/sec**2)
 #endif // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_WIND)

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -843,7 +843,10 @@ void Ekf::updateHorizontalDeadReckoningstatus()
 #if defined(CONFIG_EKF2_AIRSPEED)
 
 	// air data aiding active
-	if ((_control_status.flags.fuse_aspd && isRecent(_aid_src_airspeed.time_last_fuse, _params.no_aid_timeout_max))
+	// airspeed and sideslip fusion only correct the navigation states in fixed-wing flight,
+	// otherwise the updates are limited to the wind states and cannot be used for dead-reckoning
+	if ((_control_status.flags.fixed_wing || _control_status.flags.in_transition)
+	    && (_control_status.flags.fuse_aspd && isRecent(_aid_src_airspeed.time_last_fuse, _params.no_aid_timeout_max))
 	    && (_control_status.flags.fuse_beta && isRecent(_aid_src_sideslip.time_last_fuse, _params.no_aid_timeout_max))
 	   ) {
 		// wind_dead_reckoning: no other aiding but air data

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -842,9 +842,7 @@ void Ekf::updateHorizontalDeadReckoningstatus()
 
 #if defined(CONFIG_EKF2_AIRSPEED)
 
-	// air data aiding active
-	// airspeed and sideslip fusion only correct the navigation states in fixed-wing flight,
-	// otherwise the updates are limited to the wind states and cannot be used for dead-reckoning
+	// MC air data cannot provide dead-reckoning aiding.
 	if ((_control_status.flags.fixed_wing || _control_status.flags.in_transition)
 	    && (_control_status.flags.fuse_aspd && isRecent(_aid_src_airspeed.time_last_fuse, _params.no_aid_timeout_max))
 	    && (_control_status.flags.fuse_beta && isRecent(_aid_src_sideslip.time_last_fuse, _params.no_aid_timeout_max))

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1761,7 +1761,7 @@ void EKF2::PublishLocalPosition(const hrt_abstime &timestamp)
 
 #if defined(CONFIG_EKF2_TERRAIN)
 	// Distance to bottom surface (ground) in meters, must be positive
-	lpos.dist_bottom_valid = _ekf.isTerrainEstimateValid() || (_ekf.getHeightSensorRef() == HeightSensor::RANGE);
+	lpos.dist_bottom_valid = _ekf.isHeightAboveGroundEstimateValid();
 	lpos.dist_bottom = math::max(_ekf.getHagl(), 0.f);
 	lpos.dist_bottom_var = _ekf.getHaglVariance();
 	_ekf.get_hagl_reset(&lpos.delta_dist_bottom, &lpos.dist_bottom_reset_counter);

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -118,6 +118,8 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_tas_gate(_params->ekf2_tas_gate),
 	_param_ekf2_eas_noise(_params->ekf2_eas_noise),
 	_param_ekf2_arsp_thr(_params->ekf2_arsp_thr),
+	_param_ekf2_aspd_mc(_params->ekf2_aspd_mc),
+	_param_ekf2_aspd_mc_lim(_params->ekf2_aspd_mc_lim),
 #endif // CONFIG_EKF2_AIRSPEED
 #if defined(CONFIG_EKF2_SIDESLIP)
 	_param_ekf2_beta_gate(_params->ekf2_beta_gate),
@@ -1759,7 +1761,7 @@ void EKF2::PublishLocalPosition(const hrt_abstime &timestamp)
 
 #if defined(CONFIG_EKF2_TERRAIN)
 	// Distance to bottom surface (ground) in meters, must be positive
-	lpos.dist_bottom_valid = _ekf.isHeightAboveGroundEstimateValid();
+	lpos.dist_bottom_valid = _ekf.isTerrainEstimateValid() || (_ekf.getHeightSensorRef() == HeightSensor::RANGE);
 	lpos.dist_bottom = math::max(_ekf.getHagl(), 0.f);
 	lpos.dist_bottom_var = _ekf.getHaglVariance();
 	_ekf.get_hagl_reset(&lpos.delta_dist_bottom, &lpos.dist_bottom_reset_counter);

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -610,6 +610,10 @@ private:
 		// control of airspeed fusion
 		(ParamExtFloat<px4::params::EKF2_ARSP_THR>)
 		_param_ekf2_arsp_thr, ///< A value of zero will disabled airspeed fusion. Any positive value sets the minimum airspeed which will be used (m/sec)
+		(ParamExtInt<px4::params::EKF2_ASPD_MC>)
+		_param_ekf2_aspd_mc, ///< airspeed fusion for wind estimation in rotary-wing flight
+		(ParamExtFloat<px4::params::EKF2_ASPD_MC_LIM>)
+		_param_ekf2_aspd_mc_lim, ///< lateral specific force limit for rotary-wing airspeed fusion (m/s^2)
 #endif // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_SIDESLIP)

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -611,9 +611,9 @@ private:
 		(ParamExtFloat<px4::params::EKF2_ARSP_THR>)
 		_param_ekf2_arsp_thr, ///< A value of zero will disabled airspeed fusion. Any positive value sets the minimum airspeed which will be used (m/sec)
 		(ParamExtInt<px4::params::EKF2_ASPD_MC>)
-		_param_ekf2_aspd_mc, ///< airspeed fusion for wind estimation in rotary-wing flight
+		_param_ekf2_aspd_mc, ///< Airspeed fusion for wind estimation in MC mode
 		(ParamExtFloat<px4::params::EKF2_ASPD_MC_LIM>)
-		_param_ekf2_aspd_mc_lim, ///< lateral specific force limit for rotary-wing airspeed fusion (m/s^2)
+		_param_ekf2_aspd_mc_lim, ///< MC airspeed fusion lateral specific force limit (m/s^2)
 #endif // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_SIDESLIP)

--- a/src/modules/ekf2/params_airspeed.yaml
+++ b/src/modules/ekf2/params_airspeed.yaml
@@ -8,12 +8,38 @@ parameters:
         long: Airspeed data is fused for wind estimation if above this threshold.
           Set to 0 to disable airspeed fusion. For reliable wind estimation both sideslip
           (see EKF2_FUSE_BETA) and airspeed fusion should be enabled. Only applies
-          to fixed-wing vehicles (or VTOLs in fixed-wing mode).
+          to fixed-wing vehicles (or VTOLs in fixed-wing mode), unless EKF2_ASPD_MC
+          is enabled.
       type: float
       default: 0.0
       min: 0.0
       unit: m/s
       decimal: 1
+    EKF2_ASPD_MC:
+      description:
+        short: Airspeed fusion for wind estimation in rotary-wing flight
+        long: When enabled, true airspeed may also be fused in rotary-wing flight
+          (e.g. a VTOL in multicopter mode with pusher-assisted forward flight) if
+          the vehicle is airborne, the airspeed is above EKF2_ARSP_THR and the
+          filtered lateral specific force is below EKF2_ASPD_MC_LIM (zero-sideslip
+          assumption). In rotary-wing flight these measurements only ever correct
+          the wind states, never the navigation states.
+      type: boolean
+      default: 0
+    EKF2_ASPD_MC_LIM:
+      description:
+        short: Lateral specific force limit for rotary-wing airspeed fusion
+        long: The airspeed and synthetic sideslip observations assume the airflow
+          is aligned with the body X axis (zero sideslip). A sustained low-passed
+          lateral specific force indicates a lateral relative airflow, i.e. misalignment,
+          and inhibits airspeed fusion in rotary-wing flight. Set to zero to disable
+          this check.
+      type: float
+      default: 1.0
+      min: 0.0
+      max: 5.0
+      unit: m/s^2
+      decimal: 2
     EKF2_ASP_DELAY:
       description:
         short: Airspeed measurement delay relative to IMU measurements

--- a/src/modules/ekf2/params_airspeed.yaml
+++ b/src/modules/ekf2/params_airspeed.yaml
@@ -17,23 +17,18 @@ parameters:
       decimal: 1
     EKF2_ASPD_MC:
       description:
-        short: Airspeed fusion for wind estimation in rotary-wing flight
-        long: When enabled, true airspeed may also be fused in rotary-wing flight
-          (e.g. a VTOL in multicopter mode with pusher-assisted forward flight) if
-          the vehicle is airborne, the airspeed is above EKF2_ARSP_THR and the
-          filtered lateral specific force is below EKF2_ASPD_MC_LIM (zero-sideslip
-          assumption). In rotary-wing flight these measurements only ever correct
-          the wind states, never the navigation states.
+        short: Airspeed fusion in multicopter mode
+        long: Allow true airspeed fusion for wind estimation in multicopter mode.
+          Only the wind states are corrected. Fusion stops when lateral specific force
+          exceeds EKF2_ASPD_MC_LIM.
       type: boolean
       default: 0
     EKF2_ASPD_MC_LIM:
       description:
-        short: Lateral specific force limit for rotary-wing airspeed fusion
-        long: The airspeed and synthetic sideslip observations assume the airflow
-          is aligned with the body X axis (zero sideslip). A sustained low-passed
-          lateral specific force indicates a lateral relative airflow, i.e. misalignment,
-          and inhibits airspeed fusion in rotary-wing flight. Set to zero to disable
-          this check.
+        short: Multicopter lateral specific force limit
+        long: Maximum low-pass filtered body-Y specific force for airspeed fusion in
+          multicopter mode. Fusion stops above this value because the airspeed and
+          sideslip models assume zero sideslip. Set to 0 to disable the check.
       type: float
       default: 1.0
       min: 0.0

--- a/src/modules/ekf2/test/sensor_simulator/airspeed.h
+++ b/src/modules/ekf2/test/sensor_simulator/airspeed.h
@@ -51,7 +51,7 @@ public:
 	Airspeed(std::shared_ptr<Ekf> ekf);
 	~Airspeed();
 
-	void setData(float true_airspeed, float eas2tas);
+	void setData(float true_airspeed, float indicated_airspeed);
 
 private:
 	float _true_airspeed_data{0.0f};

--- a/src/modules/ekf2/test/test_EKF_airspeed.cpp
+++ b/src/modules/ekf2/test/test_EKF_airspeed.cpp
@@ -83,7 +83,7 @@ public:
 		_sensor_simulator._vio.setVelocityFrameToLocalNED();
 		_sensor_simulator.startExternalVision();
 
-		// Let the EV fusion start first to reset the velocity estimate
+		// Allow EV fusion to reset velocity.
 		_sensor_simulator.runSeconds(0.5);
 	}
 
@@ -99,7 +99,7 @@ public:
 		_ekf->set_vehicle_at_rest(false);
 		_ekf->set_is_fixed_wing(false);
 		_sensor_simulator.startAirspeedSensor();
-		_sensor_simulator._airspeed.setData(true_airspeed, 1.f);
+		_sensor_simulator._airspeed.setData(true_airspeed, true_airspeed);
 	}
 };
 
@@ -391,7 +391,6 @@ TEST_F(EkfAirspeedTest, testMulticopterWindVelocityEstimation)
 	startExternalVisionVelocity(simulated_velocity_earth);
 	startMulticopterAirspeedFusionScenario(true, airspeed_body(0));
 
-	// Wind estimation is rather slow
 	_sensor_simulator.runSeconds(15);
 
 	EXPECT_TRUE(_ekf_wrapper.isIntendingAirspeedFusion());
@@ -415,14 +414,14 @@ TEST_F(EkfAirspeedTest, testMulticopterAirspeedFusionStopsWhenMisaligned)
 	_sensor_simulator.runSeconds(2);
 	EXPECT_TRUE(_ekf_wrapper.isIntendingAirspeedFusion());
 
-	// a sustained lateral specific force indicates lateral airflow: fusion has to stop
+	// Exceed the lateral specific force limit.
 	_sensor_simulator._imu.setAccelData(Vector3f(0.0f, 3.0f, -CONSTANTS_ONE_G));
 	_sensor_simulator.runSeconds(2);
 
 	EXPECT_FALSE(_ekf_wrapper.isIntendingAirspeedFusion());
 	EXPECT_FALSE(_ekf_wrapper.isIntendingBetaFusion());
 
-	// once realigned, fusion restarts (the wind estimate is still valid and consistent)
+	// Fusion restarts once the specific force drops below the limit.
 	_sensor_simulator._imu.setAccelData(Vector3f(0.0f, 0.0f, -CONSTANTS_ONE_G));
 	_sensor_simulator.runSeconds(5);
 
@@ -439,9 +438,7 @@ TEST_F(EkfAirspeedTest, testMulticopterAirspeedNoDeadReckoning)
 	EXPECT_TRUE(_ekf_wrapper.isIntendingAirspeedFusion());
 	EXPECT_TRUE(_ekf_wrapper.isIntendingBetaFusion());
 
-	// stop velocity aiding: in rotary-wing flight airspeed and sideslip only update the wind
-	// states, so they must not count as dead-reckoning aiding and the position estimate
-	// has to become invalid
+	// MC air data must not count as dead-reckoning aiding.
 	_sensor_simulator.stopExternalVision();
 	_sensor_simulator.runSeconds(3);
 

--- a/src/modules/ekf2/test/test_EKF_airspeed.cpp
+++ b/src/modules/ekf2/test/test_EKF_airspeed.cpp
@@ -75,6 +75,32 @@ public:
 	void TearDown() override
 	{
 	}
+
+	void startExternalVisionVelocity(const Vector3f &velocity)
+	{
+		_ekf_wrapper.enableExternalVisionVelocityFusion();
+		_sensor_simulator._vio.setVelocity(velocity);
+		_sensor_simulator._vio.setVelocityFrameToLocalNED();
+		_sensor_simulator.startExternalVision();
+
+		// Let the EV fusion start first to reset the velocity estimate
+		_sensor_simulator.runSeconds(0.5);
+	}
+
+	void startMulticopterAirspeedFusionScenario(bool mc_airspeed_enabled, float true_airspeed)
+	{
+		parameters *params = _ekf->getParamHandle();
+		params->ekf2_arsp_thr = 2.0f;
+		params->ekf2_aspd_mc = mc_airspeed_enabled ? 1 : 0;
+		params->ekf2_aspd_mc_lim = 1.0f;
+		_ekf_wrapper.enableBetaFusion();
+
+		_ekf->set_in_air_status(true);
+		_ekf->set_vehicle_at_rest(false);
+		_ekf->set_is_fixed_wing(false);
+		_sensor_simulator.startAirspeedSensor();
+		_sensor_simulator._airspeed.setData(true_airspeed, 1.f);
+	}
 };
 
 TEST_F(EkfAirspeedTest, testWindVelocityEstimation)
@@ -345,4 +371,83 @@ TEST_F(EkfAirspeedTest, testExternalWindResetOnGround)
 	EXPECT_TRUE(_ekf_wrapper.isIntendingAirspeedFusion());
 	EXPECT_TRUE(_ekf_wrapper.isIntendingBetaFusion());
 	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
+}
+
+TEST_F(EkfAirspeedTest, testMulticopterAirspeedFusionRequiresParam)
+{
+	startExternalVisionVelocity(Vector3f(0.0f, 1.5f, 0.0f));
+	startMulticopterAirspeedFusionScenario(false, 2.4f);
+
+	_sensor_simulator.runSeconds(2);
+
+	EXPECT_FALSE(_ekf_wrapper.isIntendingAirspeedFusion());
+	EXPECT_FALSE(_ekf_wrapper.isWindVelocityEstimated());
+}
+
+TEST_F(EkfAirspeedTest, testMulticopterWindVelocityEstimation)
+{
+	const Vector3f simulated_velocity_earth(0.0f, 1.5f, 0.0f);
+	const Vector2f airspeed_body(2.4f, 0.0f);
+	startExternalVisionVelocity(simulated_velocity_earth);
+	startMulticopterAirspeedFusionScenario(true, airspeed_body(0));
+
+	// Wind estimation is rather slow
+	_sensor_simulator.runSeconds(15);
+
+	EXPECT_TRUE(_ekf_wrapper.isIntendingAirspeedFusion());
+	EXPECT_TRUE(_ekf_wrapper.isIntendingBetaFusion());
+	EXPECT_TRUE(_ekf_wrapper.isWindVelocityEstimated());
+
+	const Dcmf R_to_earth_sim(_quat_sim);
+	const Vector2f vel_wind_earth = _ekf->getWindVelocity();
+	const Vector3f vel_wind_expected = simulated_velocity_earth - R_to_earth_sim * Vector3f(airspeed_body(0),
+					   airspeed_body(1), 0.0f);
+
+	EXPECT_NEAR(vel_wind_earth(0), vel_wind_expected(0), 1e-1f);
+	EXPECT_NEAR(vel_wind_earth(1), vel_wind_expected(1), 1e-1f);
+}
+
+TEST_F(EkfAirspeedTest, testMulticopterAirspeedFusionStopsWhenMisaligned)
+{
+	startExternalVisionVelocity(Vector3f(0.0f, 1.5f, 0.0f));
+	startMulticopterAirspeedFusionScenario(true, 2.4f);
+
+	_sensor_simulator.runSeconds(2);
+	EXPECT_TRUE(_ekf_wrapper.isIntendingAirspeedFusion());
+
+	// a sustained lateral specific force indicates lateral airflow: fusion has to stop
+	_sensor_simulator._imu.setAccelData(Vector3f(0.0f, 3.0f, -CONSTANTS_ONE_G));
+	_sensor_simulator.runSeconds(2);
+
+	EXPECT_FALSE(_ekf_wrapper.isIntendingAirspeedFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingBetaFusion());
+
+	// once realigned, fusion restarts (the wind estimate is still valid and consistent)
+	_sensor_simulator._imu.setAccelData(Vector3f(0.0f, 0.0f, -CONSTANTS_ONE_G));
+	_sensor_simulator.runSeconds(5);
+
+	EXPECT_TRUE(_ekf_wrapper.isIntendingAirspeedFusion());
+	EXPECT_TRUE(_ekf_wrapper.isWindVelocityEstimated());
+}
+
+TEST_F(EkfAirspeedTest, testMulticopterAirspeedNoDeadReckoning)
+{
+	startExternalVisionVelocity(Vector3f(0.0f, 1.5f, 0.0f));
+	startMulticopterAirspeedFusionScenario(true, 8.0f);
+
+	_sensor_simulator.runSeconds(5);
+	EXPECT_TRUE(_ekf_wrapper.isIntendingAirspeedFusion());
+	EXPECT_TRUE(_ekf_wrapper.isIntendingBetaFusion());
+
+	// stop velocity aiding: in rotary-wing flight airspeed and sideslip only update the wind
+	// states, so they must not count as dead-reckoning aiding and the position estimate
+	// has to become invalid
+	_sensor_simulator.stopExternalVision();
+	_sensor_simulator.runSeconds(3);
+
+	EXPECT_FALSE(_ekf->control_status_flags().wind_dead_reckoning);
+	EXPECT_TRUE(_ekf->control_status_flags().inertial_dead_reckoning);
+
+	_sensor_simulator.runSeconds(5);
+	EXPECT_FALSE(_ekf->isLocalHorizontalPositionValid());
 }


### PR DESCRIPTION
Estimating the wind in MC mode is important to avoid flying out of specs as soon as possible to prevent flying out of specs and attempting a front transition. (There is not always an anemometer on site, and wind can change with altitude).  

There is a multicopter wind estimator: https://docs.px4.io/main/en/advanced_config/tuning_the_ecl_ekf#mc_wind_estimation_using_drag, however, it did not work for our VTOL platform, the wind estimated was not precise enough.

## Solution

Allow **airspeed** fusion for wind estimation in multicopter mode, mainly for VTOL flight with pusher. Fusion is gated by lateral specific force (must be aligned with the wind) and only updates the wind states, so it cannot act as navigation aiding. 

Params: 
- `EKF2_ASPD_MC` enable MC wind estimation
- `EKF2_ASPD_MC_LIM` Lateral specific force limit for multicopter airspeed fusion

## Tests 

Added tests for parameter gating, wind convergence, alignment rejection, and dead-reckoning behavior.

## To discuss: 

How do we know that the UAV is aligned with the wind (zero sideslip assumption)?  

Sideslip fusion assumes that the UAV is aligned with the wind and sets the observation to zero. This works well in FW but in MC we need a way to know whether the uav is aligned with the wind or not. This PR reuses the lateral specific force as defined in the drag-based MC wind estimator https://docs.px4.io/main/en/advanced_config/tuning_the_ecl_ekf#mc_wind_estimation_using_drag. One limitation is when flying sideways in the direction of the wind, in that case the y-specific force is small.

@bresch could you have a look please? Do you think there is a better way to determine whether the UAV is aligned with the wind?