### PR TITLE
fix(qurt): implement px4_task_join

### DIFF
--- a/platforms/qurt/src/px4/tasks.cpp
+++ b/platforms/qurt/src/px4/tasks.cpp
@@ -273,6 +273,40 @@ px4_task_t px4_task_spawn_cmd(const char *name, int scheduler, int priority, int
 	return px4_task_spawn_internal(name, priority, entry, argv);
 }
 
+int px4_task_join(px4_task_t id)
+{
+	if (id < 0 || id >= PX4_MAX_TASKS) {
+		return -EINVAL;
+	}
+
+	if (!task_mutex_initialized) {
+		return -EINVAL;
+	}
+
+	pthread_mutex_lock(&task_mutex);
+	pthread_t pid = taskmap[id].tid;
+	pthread_mutex_unlock(&task_mutex);
+
+	if (pid == 0 || pthread_self() == pid) {
+		return -EINVAL;
+	}
+
+	int rv = pthread_join(pid, nullptr);
+
+	if (rv == 0) {
+		pthread_mutex_lock(&task_mutex);
+
+		if (taskmap[id].isused && taskmap[id].tid == pid) {
+			pthread_attr_destroy(&taskmap[id].attr);
+			taskmap[id].isused = false;
+		}
+
+		pthread_mutex_unlock(&task_mutex);
+	}
+
+	return rv;
+}
+
 int px4_task_delete(px4_task_t id)
 {
 	int rv = 0;


### PR DESCRIPTION
  ### Solved Problem

  The common PX4 task API exports `px4_task_join()`, and modules such as `dataman` now call it during shutdown.
  The qurt platform task layer did not provide an implementation, leaving `libpx4.so` with an unresolved symbol
  on target load.


  ### Solution

  Add a qurt implementation of `px4_task_join()` in `platforms/qurt/src/px4/tasks.cpp`.

  The implementation maps the PX4 task id back to the stored `pthread_t`, avoids joining the current thread,
  performs `pthread_join()` outside the task mutex, and clears the qurt task slot after a successful join.

  ### Changelog Entry

  For release notes:


  Bugfix: Add missing qurt px4_task_join implementation


  ### Alternatives

  A stub implementation or unresolved-symbol shim would avoid the loader error but would not preserve the
  intended task shutdown behavior. Implementing the platform task API directly keeps qurt aligned with the POSIX
  task abstraction.

  ### Test coverage

  Built for qurt in the ModalAI docker environment. Verified that the voxl2 target loads successfully and PX4 runs
  without the previous missing-symbol loader error.

  Also checked formatting with:


  git diff --check

  ### Context

  `px4_task_join()` was added to the common task API in PX4-Autopilot PR #27606, `fix(many): TSAN fixes towards
  stable SIH CI`:

  https://github.com/PX4/PX4-Autopilot/pull/27606

  Specifically, commit `2c599bf5cf07d5dc44d9544f8e124436fcf8a39f` added the exported declaration in `platforms/
  common/include/px4_platform_common/tasks.h` and a POSIX implementation, but qurt already had its own task
  implementation in `platforms/qurt/src/px4/tasks.cpp` and was not updated in that PR.

