### PR TITLE
feat(commander): add failsafe for traffic avoidance system

### DIFF
--- a/docs/en/advanced_features/detect_and_avoid.md
+++ b/docs/en/advanced_features/detect_and_avoid.md
@@ -409,7 +409,7 @@ That means DAA will not automatically switch a manually flown vehicle into Hold,
 The commander health check reads [`detect_and_avoid_most_urgent`](../msg_docs/DetectAndAvoidMostUrgent.md) and applies the result only while the vehicle is disarmed.
 
 This section covers conflict-based DAA behavior when traffic is already present.
-The separate traffic-system-presence arming check is configured by [COM_ARM_TRAFF](../advanced_config/parameter_reference.md#COM_ARM_TRAFF) and described in [ADS-B/FLARM/UTM Receivers > Arming Check](../peripherals/adsb_flarm.md#arming-check).
+The separate traffic-system-presence arming check and failsafe is configured by [COM_TRAFF_AVOID](../advanced_config/parameter_reference.md#COM_TRAFF_AVOID) and described in [ADS-B/FLARM/UTM Receivers > Arming Check and Failsafe](../peripherals/adsb_flarm.md#arming-check-and-failsafe).
 
 Preflight behavior:
 

--- a/docs/en/peripherals/adsb_flarm.md
+++ b/docs/en/peripherals/adsb_flarm.md
@@ -176,21 +176,21 @@ These parameters use the same action scale:
 Most users can start with the default F3442 volume parameters and tune them only if needed.
 See [Detect and Avoid > F3442 Mode](../advanced_features/detect_and_avoid.md#f3442-mode), which also includes the zone-computation equations.
 
-### Arming Check
+### Arming Check and Failsafe
 
-PX4 can be configured to check for the presence of a traffic avoidance system (for example an ADS-B or FLARM receiver) before arming.
-This ensures that a traffic avoidance system is connected and functioning before flight.
+PX4 can be configured to warn about, or require, a traffic avoidance system (for example an ADS-B or FLARM receiver), and to trigger a failsafe if the system stops sending MAVLink heartbeats in flight.
 
 This check only verifies that a traffic source is present. It is separate from DAA rejecting arming because active traffic already requires an automatic action; that behavior is described in [Detect and Avoid > Arming, Preflight, and Ground Behavior](../advanced_features/detect_and_avoid.md#arming-preflight-and-ground-behavior).
 
-The check is configured using the [COM_ARM_TRAFF](../advanced_config/parameter_reference.md#COM_ARM_TRAFF) parameter:
+The behavior is configured using the [COM_TRAFF_AVOID](../advanced_config/parameter_reference.md#COM_TRAFF_AVOID) parameter:
 
-| Value | Description                                                                                                                |
-| ----- | -------------------------------------------------------------------------------------------------------------------------- |
-| 0     | Disabled (default). No check is performed.                                                                                 |
-| 1     | Warning only. A warning is issued if no traffic avoidance system is detected, but arming is allowed.                       |
-| 2     | Enforce for all modes. Arming is denied if no traffic avoidance system is detected, regardless of flight mode.             |
-| 3     | Enforce for mission modes only. Arming is denied if no traffic avoidance system is detected and a mission mode is planned. |
+| Value | Description                                                                                                                    |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------- |
+| 0     | Disabled (default). No check is performed.                                                                                     |
+| 1     | Warning (allow arming). Arming is allowed even if no traffic avoidance system is detected; a warning is issued if it is missing or lost in flight. |
+| 2     | Error (block arming). Arming is denied while no traffic avoidance system is detected, and a warning is issued if it is lost in flight. |
+| 3     | Return. Arming is denied while no traffic avoidance system is detected, and the vehicle returns if it is lost in flight.       |
+| 4     | Land. Arming is denied while no traffic avoidance system is detected, and the vehicle lands if it is lost in flight.           |
 
 When a traffic avoidance system is detected, the system tracks its presence with a 3-second timeout.
 If the system is lost or regained, corresponding events are logged ("Traffic avoidance system lost" / "Traffic avoidance system regained").

--- a/docs/en/peripherals/adsb_flarm.md
+++ b/docs/en/peripherals/adsb_flarm.md
@@ -184,13 +184,13 @@ This check only verifies that a traffic source is present. It is separate from D
 
 The behavior is configured using the [COM_TRAFF_AVOID](../advanced_config/parameter_reference.md#COM_TRAFF_AVOID) parameter:
 
-| Value | Description                                                                                                                    |
-| ----- | -------------------------------------------------------------------------------------------------------------------------------- |
-| 0     | Disabled (default). No check is performed.                                                                                     |
+| Value | Description|
+| ----- | ---------- |
+| 0     | Disabled (default). No check is performed.|
 | 1     | Warning (allow arming). Arming is allowed even if no traffic avoidance system is detected; a warning is issued if it is missing or lost in flight. |
 | 2     | Error (block arming). Arming is denied while no traffic avoidance system is detected, and a warning is issued if it is lost in flight. |
-| 3     | Return. Arming is denied while no traffic avoidance system is detected, and the vehicle returns if it is lost in flight.       |
-| 4     | Land. Arming is denied while no traffic avoidance system is detected, and the vehicle lands if it is lost in flight.           |
+| 3     | Return. Arming is denied while no traffic avoidance system is detected, and the vehicle returns if it is lost in flight.|
+| 4     | Land. Arming is denied while no traffic avoidance system is detected, and the vehicle lands if it is lost in flight.|
 
 When a traffic avoidance system is detected, the system tracks its presence with a 3-second timeout.
 If the system is lost or regained, corresponding events are logged ("Traffic avoidance system lost" / "Traffic avoidance system regained").

--- a/docs/en/releases/main.md
+++ b/docs/en/releases/main.md
@@ -30,6 +30,8 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 ## Upgrade Guide
 
+- `COM_ARM_TRAFF` has been replaced by `COM_TRAFF_AVOID`. The old value 3 ("enforce for mission modes only") is migrated to `COM_TRAFF_AVOID=2`, which blocks arming in all modes, not just mission modes. If you relied on being able to arm manually with traffic detected, set `COM_TRAFF_AVOID=1` (warning only) instead.
+
 ## Other changes
 
 - Fast mission Return modes ([RTL_TYPE](../advanced_config/parameter_reference.md#RTL_TYPE) = 2 and 4) now skip `DO_JUMP` commands (loops) while following the mission path. ([PX4-Autopilot#26993: fix(navigator): goToNextPositionItem skip loops when required](https://github.com/PX4/PX4-Autopilot/pull/26993))

--- a/msg/FailsafeFlags.msg
+++ b/msg/FailsafeFlags.msg
@@ -60,5 +60,6 @@ bool flight_time_limit_exceeded       # Maximum flight time exceeded
 bool position_accuracy_low            # Position estimate has dropped below threshold, but is currently still declared valid
 bool navigator_failure        	      # Navigator failed to execute a mode
 bool parachute_unhealthy              # Parachute system missing or unhealthy
+bool traffic_avoidance_unhealthy      # Traffic avoidance (ADS-B/FLARM) system missing or unhealthy
 bool remote_id_unhealthy              # Remote ID (Open Drone ID) system missing or unhealthy
 bool gnss_lost                        # Active GNSS count dropped below SYS_HAS_NUM_GNSS, or two receivers report inconsistent positions

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -286,5 +286,25 @@ param_modify_on_import_ret param_modify_on_import(bson_node_t node)
 		}
 	}
 
+	// 2026-07-13: translate COM_ARM_TRAFF (arming check only) to COM_TRAFF_AVOID (arming check + failsafe action)
+	{
+		if ((node->type == bson_type_t::BSON_INT32) && (strcmp("COM_ARM_TRAFF", node->name) == 0)) {
+			// old: 0 Disabled, 1 Warning only (arming allowed), 2 Enforce all modes, 3 Enforce mission only
+			// new: 0 Disabled, 1 Warning (arming allowed), 2 Error (arming blocked)
+			// COM_ARM_TRAFF never triggered an in-flight failsafe action, so the new failsafe
+			// action defaults to Warning either way; only the arming behavior is preserved.
+			if (node->i32 == 1) {
+				node->i32 = 1;
+
+			} else if (node->i32 >= 2) {
+				node->i32 = 2;
+			}
+
+			strcpy(node->name, "COM_TRAFF_AVOID");
+			PX4_INFO("migrating %s -> %s", "COM_ARM_TRAFF", "COM_TRAFF_AVOID");
+			return param_modify_on_import_ret::PARAM_MODIFIED;
+		}
+	}
+
 	return param_modify_on_import_ret::PARAM_NOT_MODIFIED;
 }

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -291,6 +291,8 @@ param_modify_on_import_ret param_modify_on_import(bson_node_t node)
 		if ((node->type == bson_type_t::BSON_INT32) && (strcmp("COM_ARM_TRAFF", node->name) == 0)) {
 			// old: 0 Disabled, 1 Warning only (arming allowed), 2 Enforce all modes, 3 Enforce mission only
 			// new: 0 Disabled, 1 Warning (arming allowed), 2 Error (arming blocked)
+			// Old value 3 (mission-only enforcement) is intentionally mapped to 2 (all modes): mode-scoped
+			// arming enforcement is no longer supported, so we err on the restrictive side.
 			// COM_ARM_TRAFF never triggered an in-flight failsafe action, so the new failsafe
 			// action defaults to Warning either way; only the arming behavior is preserved.
 			if (node->i32 == 1) {

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3072,7 +3072,7 @@ void Commander::dataLinkCheck()
 	}
 
 	// Traffic avoidance system (ADSB/FLARM)
-	if ((_param_com_arm_traff.get() > 0) && (hrt_elapsed_time(&_datalink_last_heartbeat_traffic_avoidance_system) > 3_s)
+	if ((hrt_elapsed_time(&_datalink_last_heartbeat_traffic_avoidance_system) > 3_s)
 	    && !_traffic_avoidance_system_lost) {
 		mavlink_log_critical(&_mavlink_log_pub, "Traffic avoidance system lost\t");
 		events::send(events::ID("commander_traffic_avoidance_lost"), events::Log::Critical, "Traffic avoidance system lost");

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -350,7 +350,6 @@ private:
 		(ParamFloat<px4::params::COM_CPU_MAX>)      _param_com_cpu_max,
 		(ParamBool<px4::params::COM_ARM_ON_BOOT>)   _param_com_arm_on_boot,
 		(ParamInt<px4::params::COM_FLTMODE_BOOT>)   _param_com_fltmode_boot,
-		(ParamInt<px4::params::COM_ARM_TRAFF>)      _param_com_arm_traff,
 		(ParamInt<px4::params::NAV_RCL_ACT>)        _param_nav_rcl_act
 	)
 };

--- a/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
+++ b/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
@@ -90,3 +90,5 @@ px4_add_functional_gtest(SRC HealthAndArmingChecksTest.cpp
 	)
 
 px4_add_functional_gtest(SRC gnssRedundancyChecksTest.cpp LINKLIBS health_and_arming_checks mode_util)
+
+px4_add_functional_gtest(SRC trafficAvoidanceCheckTest.cpp LINKLIBS health_and_arming_checks mode_util)

--- a/src/modules/commander/HealthAndArmingChecks/checks/trafficAvoidanceCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/trafficAvoidanceCheck.cpp
@@ -36,36 +36,44 @@
 
 void TrafficAvoidanceChecks::checkAndReport(const Context &context, Report &reporter)
 {
-	NavModes affected_modes{NavModes::None}; // COM_ARM_TRAFF 1 - warning only, arming allowed, affected_modes stays None
+	const int param_value = _param_com_traff_avoid.get();
 
-	switch (_param_com_arm_traff.get()) {
-	case 0:
-		return; // Check disabled
-
-	case 2:
-		affected_modes = NavModes::All; // Disallow arming for all modes
-		break;
-
-	case 3:
-		affected_modes = NavModes::Mission; // Disallow arming for mission
-		break;
+	if (param_value < 1) { // COM_TRAFF_AVOID 0 disables the check
+		return;
 	}
 
+	reporter.failsafeFlags().traffic_avoidance_unhealthy = !context.status().traffic_avoidance_system_present;
+
 	if (!context.status().traffic_avoidance_system_present) {
+		// 2 is failsafe::traffic_avoidance_unhealthy_failsafe_mode::Error (failsafe.h)
+		// keep this threshold in sync with that enum and with COM_TRAFF_AVOID's values in commander_params.yaml.
+		const bool block_arming = param_value >= 2;
+		const NavModes nav_modes = block_arming ? NavModes::All : NavModes::None;
+		const events::Log log_level = block_arming ? events::Log::Error : events::Log::Warning;
+
 		/* EVENT
 		 * @description
 		 * Traffic avoidance system (ADSB/FLARM) failed to report. Make sure it is setup and connected properly.
 		 *
 		 * <profile name="dev">
-		 * This check can be configured via <param>COM_ARM_TRAFF</param> parameter.
+		 * Configured by <param>COM_TRAFF_AVOID</param> parameter.
 		 * </profile>
 		 */
-		reporter.armingCheckFailure(affected_modes, health_component_t::traffic_avoidance,
-					    events::ID("check_traffic_avoidance_missing"),
-					    events::Log::Error, "Traffic avoidance system missing");
+		reporter.healthFailure(nav_modes, health_component_t::traffic_avoidance,
+				       events::ID("check_traffic_avoidance_missing"),
+				       log_level, "Traffic avoidance system missing");
 
 		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Traffic avoidance system missing");
+			if (block_arming) {
+				mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Traffic avoidance system missing");
+
+			} else {
+				mavlink_log_warning(reporter.mavlink_log_pub(), "Traffic avoidance system missing");
+			}
 		}
+	}
+
+	if (context.status().traffic_avoidance_system_present) {
+		reporter.setIsPresent(health_component_t::traffic_avoidance);
 	}
 }

--- a/src/modules/commander/HealthAndArmingChecks/checks/trafficAvoidanceCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/trafficAvoidanceCheck.cpp
@@ -38,12 +38,15 @@
 void TrafficAvoidanceChecks::checkAndReport(const Context &context, Report &reporter)
 {
 	const auto mode = static_cast<traffic_avoidance::FailsafeMode>(_param_com_traff_avoid.get());
+	const bool enabled = traffic_avoidance::isEnabled(mode);
 
-	if (!traffic_avoidance::isEnabled(mode)) {
+	// Always update the flag, so that disabling the check also clears a previously-set flag
+	reporter.failsafeFlags().traffic_avoidance_unhealthy = enabled
+			&& !context.status().traffic_avoidance_system_present;
+
+	if (!enabled) {
 		return;
 	}
-
-	reporter.failsafeFlags().traffic_avoidance_unhealthy = !context.status().traffic_avoidance_system_present;
 
 	if (!context.status().traffic_avoidance_system_present) {
 		const bool block_arming = traffic_avoidance::blocksArming(mode);

--- a/src/modules/commander/HealthAndArmingChecks/checks/trafficAvoidanceCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/trafficAvoidanceCheck.cpp
@@ -33,7 +33,7 @@
 
 #include "trafficAvoidanceCheck.hpp"
 
-#include "../../failsafe/failsafe_mode_params.h"
+#include "../../failsafe/failsafe_action_modes.h"
 
 void TrafficAvoidanceChecks::checkAndReport(const Context &context, Report &reporter)
 {

--- a/src/modules/commander/HealthAndArmingChecks/checks/trafficAvoidanceCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/trafficAvoidanceCheck.hpp
@@ -45,6 +45,6 @@ public:
 
 private:
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
-					(ParamInt<px4::params::COM_ARM_TRAFF>) _param_com_arm_traff
+					(ParamInt<px4::params::COM_TRAFF_AVOID>) _param_com_traff_avoid
 				       )
 };

--- a/src/modules/commander/HealthAndArmingChecks/trafficAvoidanceCheckTest.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/trafficAvoidanceCheckTest.cpp
@@ -1,0 +1,131 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "checks/trafficAvoidanceCheck.hpp"
+
+#include <px4_platform_common/param.h>
+
+// to run: make tests TESTFILTER=trafficAvoidanceCheck
+
+/* EVENT
+ * @skip-file
+ */
+
+class TrafficAvoidanceChecksTest : public ::testing::Test
+{
+public:
+	void SetUp() override
+	{
+		param_control_autosave(false);
+		param_reset(param_find("COM_TRAFF_AVOID"));
+	}
+
+	// Run the check and store results in _failsafe_flags and the health/arming result caches.
+	void runCheck(bool system_present)
+	{
+		vehicle_status_s status{};
+		status.traffic_avoidance_system_present = system_present;
+
+		_check.updateParams();
+		Context context{status};
+		_failsafe_flags = {};
+		Report reporter{_failsafe_flags, 0};
+		_check.checkAndReport(context, reporter);
+		_health_error_traffic_avoidance = (bool)(reporter.healthResults().error & health_component_t::traffic_avoidance);
+		_health_warning_traffic_avoidance = (bool)(reporter.healthResults().warning & health_component_t::traffic_avoidance);
+		_is_present_traffic_avoidance = (bool)(reporter.healthResults().is_present & health_component_t::traffic_avoidance);
+		_can_arm_all_modes = reporter.armingCheckResults().can_arm == NavModes::All;
+	}
+
+	void setParam(int com_traff_avoid)
+	{
+		param_set(param_find("COM_TRAFF_AVOID"), &com_traff_avoid);
+	}
+
+	failsafe_flags_s  _failsafe_flags{};
+	bool              _health_error_traffic_avoidance{false};
+	bool              _health_warning_traffic_avoidance{false};
+	bool              _is_present_traffic_avoidance{false};
+	bool              _can_arm_all_modes{false};
+	TrafficAvoidanceChecks _check;
+};
+
+// COM_TRAFF_AVOID = 0 (Disabled): missing system is ignored entirely, arming unaffected.
+TEST_F(TrafficAvoidanceChecksTest, DisabledIgnoresMissingSystem)
+{
+	setParam(0);
+
+	runCheck(false);
+	EXPECT_FALSE(_failsafe_flags.traffic_avoidance_unhealthy);
+	EXPECT_FALSE(_health_error_traffic_avoidance);
+	EXPECT_FALSE(_health_warning_traffic_avoidance);
+	EXPECT_TRUE(_can_arm_all_modes);
+}
+
+// COM_TRAFF_AVOID = 1 (Warning): missing system sets unhealthy + a warning, but does NOT block arming.
+TEST_F(TrafficAvoidanceChecksTest, WarningMissingSystemDoesNotBlockArming)
+{
+	setParam(1);
+
+	runCheck(false);
+	EXPECT_TRUE(_failsafe_flags.traffic_avoidance_unhealthy);
+	EXPECT_TRUE(_health_warning_traffic_avoidance);
+	EXPECT_FALSE(_health_error_traffic_avoidance);
+	EXPECT_TRUE(_can_arm_all_modes);
+}
+
+// COM_TRAFF_AVOID = 2 (WarningBlockArming): missing system sets unhealthy + an error, and blocks arming.
+TEST_F(TrafficAvoidanceChecksTest, WarningBlockArmingMissingSystemBlocksArming)
+{
+	setParam(2);
+
+	runCheck(false);
+	EXPECT_TRUE(_failsafe_flags.traffic_avoidance_unhealthy);
+	EXPECT_TRUE(_health_error_traffic_avoidance);
+	EXPECT_FALSE(_can_arm_all_modes);
+}
+
+// COM_TRAFF_AVOID >= 1 and system present -> healthy, present, arming unaffected.
+TEST_F(TrafficAvoidanceChecksTest, PresentSystemIsHealthy)
+{
+	setParam(2);
+
+	runCheck(true);
+	EXPECT_FALSE(_failsafe_flags.traffic_avoidance_unhealthy);
+	EXPECT_FALSE(_health_error_traffic_avoidance);
+	EXPECT_FALSE(_health_warning_traffic_avoidance);
+	EXPECT_TRUE(_is_present_traffic_avoidance);
+	EXPECT_TRUE(_can_arm_all_modes);
+}

--- a/src/modules/commander/HealthAndArmingChecks/trafficAvoidanceCheckTest.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/trafficAvoidanceCheckTest.cpp
@@ -62,7 +62,7 @@ public:
 
 		_check.updateParams();
 		Context context{status};
-		_failsafe_flags = {};
+		// _failsafe_flags deliberately persists across calls, like commander's failsafe_flags in production
 		Report reporter{_failsafe_flags, 0};
 		_check.checkAndReport(context, reporter);
 		_health_error_traffic_avoidance = (bool)(reporter.healthResults().error & health_component_t::traffic_avoidance);
@@ -118,6 +118,19 @@ TEST_F(TrafficAvoidanceChecksTest, ErrorMissingSystemBlocksArming)
 	EXPECT_TRUE(_failsafe_flags.traffic_avoidance_unhealthy);
 	EXPECT_TRUE(_health_error_traffic_avoidance);
 	EXPECT_FALSE(_can_arm_all_modes);
+}
+
+// Disabling the check (e.g. in flight, to allow arming) clears a previously-set unhealthy flag.
+TEST_F(TrafficAvoidanceChecksTest, DisablingClearsStaleUnhealthyFlag)
+{
+	setParam(traffic_avoidance::FailsafeMode::Warning);
+	runCheck(false);
+	EXPECT_TRUE(_failsafe_flags.traffic_avoidance_unhealthy);
+
+	setParam(traffic_avoidance::FailsafeMode::Disabled);
+	runCheck(false);
+	EXPECT_FALSE(_failsafe_flags.traffic_avoidance_unhealthy);
+	EXPECT_TRUE(_can_arm_all_modes);
 }
 
 // COM_TRAFF_AVOID >= 1 and system present -> healthy, present, arming unaffected.

--- a/src/modules/commander/HealthAndArmingChecks/trafficAvoidanceCheckTest.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/trafficAvoidanceCheckTest.cpp
@@ -35,6 +35,8 @@
 
 #include "checks/trafficAvoidanceCheck.hpp"
 
+#include "../failsafe/failsafe_mode_params.h"
+
 #include <px4_platform_common/param.h>
 
 // to run: make tests TESTFILTER=trafficAvoidanceCheck
@@ -69,8 +71,9 @@ public:
 		_can_arm_all_modes = reporter.armingCheckResults().can_arm == NavModes::All;
 	}
 
-	void setParam(int com_traff_avoid)
+	void setParam(traffic_avoidance::FailsafeMode mode)
 	{
+		int32_t com_traff_avoid = static_cast<int32_t>(mode);
 		param_set(param_find("COM_TRAFF_AVOID"), &com_traff_avoid);
 	}
 
@@ -85,7 +88,7 @@ public:
 // COM_TRAFF_AVOID = 0 (Disabled): missing system is ignored entirely, arming unaffected.
 TEST_F(TrafficAvoidanceChecksTest, DisabledIgnoresMissingSystem)
 {
-	setParam(0);
+	setParam(traffic_avoidance::FailsafeMode::Disabled);
 
 	runCheck(false);
 	EXPECT_FALSE(_failsafe_flags.traffic_avoidance_unhealthy);
@@ -97,7 +100,7 @@ TEST_F(TrafficAvoidanceChecksTest, DisabledIgnoresMissingSystem)
 // COM_TRAFF_AVOID = 1 (Warning): missing system sets unhealthy + a warning, but does NOT block arming.
 TEST_F(TrafficAvoidanceChecksTest, WarningMissingSystemDoesNotBlockArming)
 {
-	setParam(1);
+	setParam(traffic_avoidance::FailsafeMode::Warning);
 
 	runCheck(false);
 	EXPECT_TRUE(_failsafe_flags.traffic_avoidance_unhealthy);
@@ -106,10 +109,10 @@ TEST_F(TrafficAvoidanceChecksTest, WarningMissingSystemDoesNotBlockArming)
 	EXPECT_TRUE(_can_arm_all_modes);
 }
 
-// COM_TRAFF_AVOID = 2 (WarningBlockArming): missing system sets unhealthy + an error, and blocks arming.
-TEST_F(TrafficAvoidanceChecksTest, WarningBlockArmingMissingSystemBlocksArming)
+// COM_TRAFF_AVOID = 2 (Error): missing system sets unhealthy + an error, and blocks arming.
+TEST_F(TrafficAvoidanceChecksTest, ErrorMissingSystemBlocksArming)
 {
-	setParam(2);
+	setParam(traffic_avoidance::FailsafeMode::Error);
 
 	runCheck(false);
 	EXPECT_TRUE(_failsafe_flags.traffic_avoidance_unhealthy);
@@ -120,7 +123,7 @@ TEST_F(TrafficAvoidanceChecksTest, WarningBlockArmingMissingSystemBlocksArming)
 // COM_TRAFF_AVOID >= 1 and system present -> healthy, present, arming unaffected.
 TEST_F(TrafficAvoidanceChecksTest, PresentSystemIsHealthy)
 {
-	setParam(2);
+	setParam(traffic_avoidance::FailsafeMode::Error);
 
 	runCheck(true);
 	EXPECT_FALSE(_failsafe_flags.traffic_avoidance_unhealthy);

--- a/src/modules/commander/HealthAndArmingChecks/trafficAvoidanceCheckTest.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/trafficAvoidanceCheckTest.cpp
@@ -35,7 +35,7 @@
 
 #include "checks/trafficAvoidanceCheck.hpp"
 
-#include "../failsafe/failsafe_mode_params.h"
+#include "../failsafe/failsafe_action_modes.h"
 
 #include <px4_platform_common/param.h>
 

--- a/src/modules/commander/commander_params.yaml
+++ b/src/modules/commander/commander_params.yaml
@@ -572,19 +572,20 @@ parameters:
         4: Land
         5: Terminate
       default: 0
-    COM_ARM_TRAFF:
+    COM_TRAFF_AVOID:
       description:
-        short: Enable Traffic Avoidance system detection check
+        short: Traffic avoidance system requirement and failsafe
         long: |-
-          This check detects if a traffic avoidance system (ADSB/FLARM transponder)
-          is missing. Depending on the value of the parameter, the check can be
-          disabled, warn only, or deny arming.
+          Warn about, and optionally require, a traffic avoidance system (ADS-B/FLARM
+          transponder, detected via MAVLink heartbeats with a 3 second timeout), and
+          trigger a failsafe action when it is missing or lost in flight.
       type: enum
       values:
         0: Disabled
-        1: Warning only
-        2: Enforce for all modes
-        3: Enforce for mission modes only
+        1: Warning
+        2: Error
+        3: Return
+        4: Land
       default: 0
     COM_SPOOLUP_TIME:
       description:
@@ -606,8 +607,8 @@ parameters:
       description:
         short: Companion computer high-temperature warning threshold
         long: |-
-          
-          
+
+
           Arming is not prevented as the temperature typically drops in flight.
 
           Set to -1 to disable.

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -443,6 +443,36 @@ FailsafeBase::ActionOptions Failsafe::fromParachuteActParam(int param_value)
 	return options;
 }
 
+FailsafeBase::ActionOptions Failsafe::fromTrafficAvoidanceActParam(int param_value)
+{
+	ActionOptions options{};
+
+	switch (traffic_avoidance_unhealthy_failsafe_mode(param_value)) {
+	case traffic_avoidance_unhealthy_failsafe_mode::Disabled:
+	default:
+		options.action = Action::None;
+		break;
+
+	case traffic_avoidance_unhealthy_failsafe_mode::Warning:
+	case traffic_avoidance_unhealthy_failsafe_mode::Error:
+		options.action = Action::Warn;
+		options.clear_condition = ClearCondition::WhenConditionClears;
+		break;
+
+	case traffic_avoidance_unhealthy_failsafe_mode::Return:
+		options.action = Action::RTL;
+		options.clear_condition = ClearCondition::OnModeChangeOrDisarm;
+		break;
+
+	case traffic_avoidance_unhealthy_failsafe_mode::Land:
+		options.action = Action::Land;
+		options.clear_condition = ClearCondition::OnModeChangeOrDisarm;
+		break;
+	}
+
+	return options;
+}
+
 FailsafeBase::ActionOptions Failsafe::fromRemainingFlightTimeLowActParam(int param_value)
 {
 	ActionOptions options{};
@@ -639,6 +669,9 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 
 	// Parachute system health failsafe
 	CHECK_FAILSAFE(status_flags, parachute_unhealthy, ActionOptions(fromParachuteActParam(_param_com_parachute.get())));
+
+	// Traffic avoidance system health failsafe
+	CHECK_FAILSAFE(status_flags, traffic_avoidance_unhealthy, ActionOptions(fromTrafficAvoidanceActParam(_param_com_traff_avoid.get())));
 
 	// Remote ID (Open Drone ID) loss failsafe
 	if (state.armed && _param_com_arm_odid.get() >= int32_t(open_drone_id_failsafe_mode::Return_mode)) {

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 #include "failsafe.h"
-#include "failsafe_mode_params.h"
+#include "failsafe_action_modes.h"
 
 #include <px4_platform_common/log.h>
 #include <uORB/topics/vehicle_status.h>

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -32,6 +32,7 @@
  ****************************************************************************/
 
 #include "failsafe.h"
+#include "failsafe_mode_params.h"
 
 #include <px4_platform_common/log.h>
 #include <uORB/topics/vehicle_status.h>
@@ -447,24 +448,24 @@ FailsafeBase::ActionOptions Failsafe::fromTrafficAvoidanceActParam(int param_val
 {
 	ActionOptions options{};
 
-	switch (traffic_avoidance_unhealthy_failsafe_mode(param_value)) {
-	case traffic_avoidance_unhealthy_failsafe_mode::Disabled:
+	switch (static_cast<traffic_avoidance::FailsafeMode>(param_value)) {
+	case traffic_avoidance::FailsafeMode::Disabled:
 	default:
 		options.action = Action::None;
 		break;
 
-	case traffic_avoidance_unhealthy_failsafe_mode::Warning:
-	case traffic_avoidance_unhealthy_failsafe_mode::Error:
+	case traffic_avoidance::FailsafeMode::Warning:
+	case traffic_avoidance::FailsafeMode::Error:
 		options.action = Action::Warn;
 		options.clear_condition = ClearCondition::WhenConditionClears;
 		break;
 
-	case traffic_avoidance_unhealthy_failsafe_mode::Return:
+	case traffic_avoidance::FailsafeMode::Return:
 		options.action = Action::RTL;
 		options.clear_condition = ClearCondition::OnModeChangeOrDisarm;
 		break;
 
-	case traffic_avoidance_unhealthy_failsafe_mode::Land:
+	case traffic_avoidance::FailsafeMode::Land:
 		options.action = Action::Land;
 		options.clear_condition = ClearCondition::OnModeChangeOrDisarm;
 		break;

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -167,6 +167,14 @@ private:
 		Land = 3,
 	};
 
+	enum class traffic_avoidance_unhealthy_failsafe_mode : int32_t {
+		Disabled = 0,
+		Warning = 1,
+		Error = 2,
+		Return = 3,
+		Land = 4,
+	};
+
 	enum class gps_redundancy_failsafe_mode : int32_t {
 		Warning = 0,
 		Return_mode = 1,
@@ -186,6 +194,7 @@ private:
 	static ActionOptions fromRemainingFlightTimeLowActParam(int param_value);
 	static ActionOptions fromOdidFailActParam(int param_value);
 	static ActionOptions fromParachuteActParam(int param_value);
+	static ActionOptions fromTrafficAvoidanceActParam(int param_value);
 	static ActionOptions fromGnssLossActParam(int param_value);
 
 	static bool isFailsafeIgnored(uint8_t user_intended_mode, int32_t exception_mask_parameter);
@@ -231,6 +240,7 @@ private:
 					(ParamInt<px4::params::COM_POS_LOW_ACT>) _param_com_pos_low_act,
 					(ParamInt<px4::params::COM_ARM_ODID>) _param_com_arm_odid,
 					(ParamInt<px4::params::COM_PARACHUTE>) _param_com_parachute,
+					(ParamInt<px4::params::COM_TRAFF_AVOID>) _param_com_traff_avoid,
 					(ParamInt<px4::params::COM_GNSSLOSS_ACT>) _param_com_gnssloss_act
 				       );
 

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -167,14 +167,6 @@ private:
 		Land = 3,
 	};
 
-	enum class traffic_avoidance_unhealthy_failsafe_mode : int32_t {
-		Disabled = 0,
-		Warning = 1,
-		Error = 2,
-		Return = 3,
-		Land = 4,
-	};
-
 	enum class gps_redundancy_failsafe_mode : int32_t {
 		Warning = 0,
 		Return_mode = 1,

--- a/src/modules/commander/failsafe/failsafe_action_modes.h
+++ b/src/modules/commander/failsafe/failsafe_action_modes.h
@@ -35,10 +35,11 @@
 
 #include <stdint.h>
 
-// Mode enums for failsafe action parameters (values must match the
-// parameter metadata in commander_params.yaml), one namespace per
-// failsafe. Shared between the failsafe state machine and the
-// HealthAndArmingChecks.
+// Failsafe action-mode enums (values must match the parameter metadata
+// in commander_params.yaml), one namespace per failsafe. Kept in this
+// dependency-free header so the enum and its severity predicates can be
+// shared between the failsafe state machine and the HealthAndArmingChecks
+// without the latter pulling in the failsafe framework.
 
 namespace traffic_avoidance
 {

--- a/src/modules/commander/failsafe/failsafe_mode_params.h
+++ b/src/modules/commander/failsafe/failsafe_mode_params.h
@@ -31,48 +31,29 @@
  *
  ****************************************************************************/
 
-#include "trafficAvoidanceCheck.hpp"
+#pragma once
 
-#include "../../failsafe/failsafe_mode_params.h"
+#include <stdint.h>
 
-void TrafficAvoidanceChecks::checkAndReport(const Context &context, Report &reporter)
+// Mode enums for failsafe action parameters (values must match the
+// parameter metadata in commander_params.yaml), one namespace per
+// failsafe. Shared between the failsafe state machine and the
+// HealthAndArmingChecks.
+
+namespace traffic_avoidance
 {
-	const auto mode = static_cast<traffic_avoidance::FailsafeMode>(_param_com_traff_avoid.get());
 
-	if (!traffic_avoidance::isEnabled(mode)) {
-		return;
-	}
+// COM_TRAFF_AVOID parameter values.
+enum class FailsafeMode : int32_t {
+	Disabled = 0,
+	Warning = 1, // arming allowed, in-flight warning
+	Error = 2, // arming blocked, in-flight warning
+	Return = 3, // arming blocked, in-flight RTL
+	Land = 4, // arming blocked, in-flight Land
+};
 
-	reporter.failsafeFlags().traffic_avoidance_unhealthy = !context.status().traffic_avoidance_system_present;
+// Increasing order of severity in enum is assumed.
+constexpr bool isEnabled(FailsafeMode mode) { return mode >= FailsafeMode::Warning; }
+constexpr bool blocksArming(FailsafeMode mode) { return mode >= FailsafeMode::Error; }
 
-	if (!context.status().traffic_avoidance_system_present) {
-		const bool block_arming = traffic_avoidance::blocksArming(mode);
-		const NavModes nav_modes = block_arming ? NavModes::All : NavModes::None;
-		const events::Log log_level = block_arming ? events::Log::Error : events::Log::Warning;
-
-		/* EVENT
-		 * @description
-		 * Traffic avoidance system (ADSB/FLARM) failed to report. Make sure it is setup and connected properly.
-		 *
-		 * <profile name="dev">
-		 * Configured by <param>COM_TRAFF_AVOID</param> parameter.
-		 * </profile>
-		 */
-		reporter.healthFailure(nav_modes, health_component_t::traffic_avoidance,
-				       events::ID("check_traffic_avoidance_missing"),
-				       log_level, "Traffic avoidance system missing");
-
-		if (reporter.mavlink_log_pub()) {
-			if (block_arming) {
-				mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Traffic avoidance system missing");
-
-			} else {
-				mavlink_log_warning(reporter.mavlink_log_pub(), "Traffic avoidance system missing");
-			}
-		}
-	}
-
-	if (context.status().traffic_avoidance_system_present) {
-		reporter.setIsPresent(health_component_t::traffic_avoidance);
-	}
-}
+} // namespace traffic_avoidance

--- a/src/modules/commander/failsafe/failsafe_test.cpp
+++ b/src/modules/commander/failsafe/failsafe_test.cpp
@@ -728,6 +728,39 @@ TEST_F(FailsafeTest, FallbackAltitudeUsesNavRclActParam)
 	EXPECT_EQ(failsafe.selectedAction(), FailsafeBase::Action::Terminate);
 }
 
+TEST_F(FailsafeTest, TrafficAvoidanceUnhealthyUsesTrafficAvoidActParam)
+{
+	// Each param value is exercised on its own fresh Failsafe instance, to avoid
+	// action hysteresis/clear-conditions from one value leaking into the next.
+	auto selectedActionFor = [](int com_traff_avoid) {
+		param_set(param_handle(px4::params::COM_TRAFF_AVOID), &com_traff_avoid);
+
+		// Disable the generic user-takeover hold delay (set to 5s in SetUp()) so a newly
+		// triggered RTL/Land is selected immediately instead of Hold-then-RTL/Land.
+		float com_fail_act_t = 0.f;
+		param_set(param_handle(px4::params::COM_FAIL_ACT_T), &com_fail_act_t);
+
+		Failsafe failsafe(nullptr);
+
+		failsafe_flags_s failsafe_flags{};
+		mode_util::getModeRequirements(vehicle_status_s::VEHICLE_TYPE_ROTARY_WING, failsafe_flags);
+		failsafe_flags.traffic_avoidance_unhealthy = true;
+
+		FailsafeBase::State state{};
+		state.armed = true;
+		state.vehicle_type = vehicle_status_s::VEHICLE_TYPE_ROTARY_WING;
+
+		failsafe.update(5_s, state, false, false, failsafe_flags);
+		return failsafe.selectedAction();
+	};
+
+	EXPECT_EQ(selectedActionFor(0), FailsafeBase::Action::None); // Disabled
+	EXPECT_EQ(selectedActionFor(1), FailsafeBase::Action::Warn); // Warning (arming allowed)
+	EXPECT_EQ(selectedActionFor(2), FailsafeBase::Action::Warn); // Warning (block arming) -- same in-flight action as 1
+	EXPECT_EQ(selectedActionFor(3), FailsafeBase::Action::RTL);  // Return
+	EXPECT_EQ(selectedActionFor(4), FailsafeBase::Action::Land); // Land
+}
+
 TEST_F(FailsafeTest, FallbackStabilizedRequiresManualControl)
 {
 	int nav_rcl_act = 2;

--- a/src/modules/commander/failsafe/failsafe_test.cpp
+++ b/src/modules/commander/failsafe/failsafe_test.cpp
@@ -34,6 +34,7 @@
 #include <gtest/gtest.h>
 
 #include "failsafe.h"
+#include "failsafe_mode_params.h"
 #include <uORB/topics/vehicle_status.h>
 #include "../ModeUtil/mode_requirements.hpp"
 
@@ -732,7 +733,8 @@ TEST_F(FailsafeTest, TrafficAvoidanceUnhealthyUsesTrafficAvoidActParam)
 {
 	// Each param value is exercised on its own fresh Failsafe instance, to avoid
 	// action hysteresis/clear-conditions from one value leaking into the next.
-	auto selectedActionFor = [](int com_traff_avoid) {
+	auto selectedActionFor = [](traffic_avoidance::FailsafeMode mode) {
+		int32_t com_traff_avoid = static_cast<int32_t>(mode);
 		param_set(param_handle(px4::params::COM_TRAFF_AVOID), &com_traff_avoid);
 
 		// Disable the generic user-takeover hold delay (set to 5s in SetUp()) so a newly
@@ -754,11 +756,11 @@ TEST_F(FailsafeTest, TrafficAvoidanceUnhealthyUsesTrafficAvoidActParam)
 		return failsafe.selectedAction();
 	};
 
-	EXPECT_EQ(selectedActionFor(0), FailsafeBase::Action::None); // Disabled
-	EXPECT_EQ(selectedActionFor(1), FailsafeBase::Action::Warn); // Warning (arming allowed)
-	EXPECT_EQ(selectedActionFor(2), FailsafeBase::Action::Warn); // Warning (block arming) -- same in-flight action as 1
-	EXPECT_EQ(selectedActionFor(3), FailsafeBase::Action::RTL);  // Return
-	EXPECT_EQ(selectedActionFor(4), FailsafeBase::Action::Land); // Land
+	EXPECT_EQ(selectedActionFor(traffic_avoidance::FailsafeMode::Disabled), FailsafeBase::Action::None);
+	EXPECT_EQ(selectedActionFor(traffic_avoidance::FailsafeMode::Warning), FailsafeBase::Action::Warn);
+	EXPECT_EQ(selectedActionFor(traffic_avoidance::FailsafeMode::Error), FailsafeBase::Action::Warn); // same as Warning in-flight
+	EXPECT_EQ(selectedActionFor(traffic_avoidance::FailsafeMode::Return), FailsafeBase::Action::RTL);
+	EXPECT_EQ(selectedActionFor(traffic_avoidance::FailsafeMode::Land), FailsafeBase::Action::Land);
 }
 
 TEST_F(FailsafeTest, FallbackStabilizedRequiresManualControl)

--- a/src/modules/commander/failsafe/failsafe_test.cpp
+++ b/src/modules/commander/failsafe/failsafe_test.cpp
@@ -34,7 +34,7 @@
 #include <gtest/gtest.h>
 
 #include "failsafe.h"
-#include "failsafe_mode_params.h"
+#include "failsafe_action_modes.h"
 #include <uORB/topics/vehicle_status.h>
 #include "../ModeUtil/mode_requirements.hpp"
 


### PR DESCRIPTION
### Solved Problem
`COM_ARM_TRAFF` only ever gated arming. It didn't have a way to trigger an in-flight failsafe (Warn/RTL/Land) if a previously-detected ADS-B/FLARM traffic avoidance system stopped reporting mid-flight.

### Solution
Replaced `COM_ARM_TRAFF` with `COM_TRAFF_AVOID`, a single parameter that drives both the arming check and a new in-flight failsafe. Adds `traffic_avoidance_unhealthy` to `FailsafeFlags.msg`, wires `Failsafe::fromTrafficAvoidanceActParam()` in failsafe.cpp/.h, updates `trafficAvoidanceCheck.cpp` to report both the health/arming result and the failsafe flag, and migrates existing `COM_ARM_TRAFF` values via `param_translation.cpp`. Unit tests cover both the health-check boundary (arming block at value 2) and the failsafe action mapping (all 5 values).
- **Value**: 0, **Arming**: Allowed, **In-flight-action**: None
- **Value**: 1, **Arming**: Allowed, **In-flight-action**: Warn
- **Value**: 2, **Arming**: Blocked, **In-flight-action**: Warn
- **Value**: 3, **Arming**: Blocked, **In-flight-action**: RTL
- **Value**: 4, **Arming**: Blocked, **In-flight-action**: Land

### Changelog Entry
For release notes:
```
Feature: Traffic avoidance (ADS-B/FLARM) system loss now triggers a configurable in-flight failsafe (Warn/RTL/Land), not just an arming check.
New parameter: COM_TRAFF_AVOID (replaces COM_ARM_TRAFF, migrated automatically on upgrade)
Documentation: docs/en/peripherals/adsb_flarm.md updated with the new parameter table.
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video
