### PR TITLE
fix(macos): trust osrf/simulation tap in --sim-tools block

### DIFF
--- a/Tools/setup/macos.sh
+++ b/Tools/setup/macos.sh
@@ -121,6 +121,14 @@ if [[ $INSTALL_SIM == "--sim-tools" ]]; then
 	# osrf/simulation: gz-harmonic (Gazebo Harmonic meta-formula)
 	brew tap osrf/simulation
 
+	# Homebrew 6.0+ refuses to load formulae from untrusted third-party
+	# taps (see the toolchain trust block above). Without this, the
+	# gz-harmonic install aborts and the script still exits successfully,
+	# leaving the simulation stack silently missing.
+	if brew trust --help &> /dev/null; then
+		brew trust osrf/simulation
+	fi
+
 	PX4_SIM_BREW_PACKAGES=(
 		exiftool
 		glog


### PR DESCRIPTION
Homebrew 6.0+ refuses to load formulae from third-party taps unless they are explicitly trusted. `Tools/setup/macos.sh` already handles this for the toolchain taps (`osx-cross/arm`, `PX4/px4`, `discoteq/discoteq`), but the `--sim-tools` block taps `osrf/simulation` without a matching `brew trust`. As a result, `brew install osrf/simulation/gz-harmonic` aborts with:

```
Error: Refusing to load formula osrf/simulation/gz-cmake3 from untrusted tap osrf/simulation.
```

and the script still finishes "successfully", leaving the Gazebo simulation stack silently missing.

This adds the same guarded `brew trust` call used for the toolchain taps (skipped on Homebrew < 6.0, which has no `brew trust` and doesn't gate untrusted taps).

Verified on macOS (Apple Silicon, Homebrew 6.0.10): after trusting the tap, `./Tools/setup/macos.sh --sim-tools` installs gz-harmonic, and `make px4_sitl gz_x500` builds and boots to "Ready for takeoff".