### PR TITLE
docs(rover_differential): fix threshhold typo in RD_TRANS_* short descriptions

### DIFF
--- a/src/modules/rover_differential/module.yaml
+++ b/src/modules/rover_differential/module.yaml
@@ -17,7 +17,7 @@ parameters:
 
       RD_TRANS_TRN_DRV:
         description:
-            short: Yaw error threshhold to switch from spot turning to driving
+            short: Yaw error threshold to switch from spot turning to driving
             long: |
               This threshold is used for the state machine to switch from turning to driving based on the
               error between the desired and actual yaw.
@@ -31,7 +31,7 @@ parameters:
 
       RD_TRANS_DRV_TRN:
         description:
-            short: Yaw error threshhold to switch from driving to spot turning
+            short: Yaw error threshold to switch from driving to spot turning
             long: |
               This threshold is used for the state machine to switch from driving to turning based on the
               error between the desired and actual yaw. It is also used as the threshold whether the rover should come


### PR DESCRIPTION
## Summary
- Fix misspelled **threshhold** → **threshold** in short descriptions for `RD_TRANS_TRN_DRV` and `RD_TRANS_DRV_TRN` in `src/modules/rover_differential/module.yaml`.
- Long descriptions already said "threshold"; shorts were wrong and feed the generated parameter reference.

## Motivation
Spelling fix for QGC/param UI short labels. No numeric or behavior change.

## Verification
- Path-limited to rover differential module YAML
- YAML structure unchanged (units/min/max/defaults untouched)
- Conventional docs commit

## Aerial campaign
Dual-agent: Grok scoped (`specs/px4-autopilot/2026-07-14-1.md`); Cursor Composer 2.5 Standard cloud not mid-wired — micro-diff applied + Bartok 10/10 review (same posture as other aerial nightlies).