### PR TITLE
docs(temperature_compensation): fix calulate typo in thermal offset comments

### DIFF
--- a/src/modules/temperature_compensation/TemperatureCompensation.cpp
+++ b/src/modules/temperature_compensation/TemperatureCompensation.cpp
@@ -322,7 +322,7 @@ bool TemperatureCompensation::calc_thermal_offsets_1D(SensorCalData1D &coef, flo
 
 	}
 
-	// calulate the offset
+	// calculate the offset
 	float temp_var = delta_temp;
 	offset = coef.x0 + coef.x1 * temp_var;
 	temp_var *= delta_temp;
@@ -358,7 +358,7 @@ bool TemperatureCompensation::calc_thermal_offsets_3D(const SensorCalData3D &coe
 
 	}
 
-	// calulate the offsets
+	// calculate the offsets
 	float delta_temp_2 = delta_temp * delta_temp;
 	float delta_temp_3 = delta_temp_2 * delta_temp;
 


### PR DESCRIPTION
## Summary
- Fix comment typo **calulate** → **calculate** in `TemperatureCompensation.cpp` (2 sites).

## Motivation
Comment hygiene only; no formula/control changes.

## Verification
- Diff is two comment lines
- No runtime change

## Aerial campaign
Spec: `specs/px4-autopilot/2026-07-14-2.md`. Cursor cloud not mid-wired; Grok-scope + Bartok review micro-diff.