### PR TITLE
docs(lib): fix threshhold/paramter typos in pure_pursuit and sensor_calibration

### DIFF
--- a/src/lib/pure_pursuit/PurePursuit.hpp
+++ b/src/lib/pure_pursuit/PurePursuit.hpp
@@ -49,7 +49,7 @@
  * The lookahead distance is defined as v * k.
  * 	v: Vehicle ground speed [m/s]
  * 	k: Tuning parameter
- * The lookahead distance is further constrained between an upper and lower threshhold.
+ * The lookahead distance is further constrained between an upper and lower threshold.
  * 							C
  * 		  				       /
  * 						    __/__

--- a/src/lib/sensor_calibration/Utilities.hpp
+++ b/src/lib/sensor_calibration/Utilities.hpp
@@ -74,7 +74,7 @@ int32_t GetCalibrationParamInt32(const char *sensor_type, const char *cal_type, 
 float GetCalibrationParamFloat(const char *sensor_type, const char *cal_type, uint8_t instance);
 
 /**
- * @brief Set a single calibration paramter.
+ * @brief Set a single calibration parameter.
  *
  * @param sensor_type Calibration parameter abbreviated sensor string ("ACC", "GYRO", "MAG")
  * @param cal_type Calibration parameter abbreviated type ("OFF", "SCALE", "ROT", "PRIO")


### PR DESCRIPTION
## Summary
- `PurePursuit.hpp`: **threshhold** → **threshold** in lookahead prose
- `sensor_calibration/Utilities.hpp`: **paramter** → **parameter** in `@brief`

## Motivation
Header documentation spelling; no API change.

## Verification
- Comments/docs only

## Aerial campaign
Spec `2026-07-14-3.md`. Cursor cloud not mid-wired; reviewed micro-diff.