### PR TITLE
docs(params): fix parameter/threshold typos in FW control, follow-me, and batmon

### DIFF
--- a/src/drivers/smart_battery/batmon/batmon.cpp
+++ b/src/drivers/smart_battery/batmon/batmon.cpp
@@ -195,7 +195,7 @@ void Batmon::RunImpl()
 		new_report.cell_count = _cell_count;
 		new_report.state_of_health = _state_of_health;
 
-		// TODO: This critical setting should be set with BMS info or through a paramter
+		// TODO: This critical setting should be set with BMS info or through a parameter
 		// Setting a hard coded BATT_CELL_VOLTAGE_THRESHOLD_FAILED may not be appropriate
 		//if (_lifetime_max_delta_cell_voltage > BATT_CELL_VOLTAGE_THRESHOLD_FAILED) {
 		//	new_report.warning = battery_status_s::WARNING_CRITICAL;

--- a/src/modules/flight_mode_manager/tasks/AutoFollowTarget/FlightTaskAutoFollowTarget.cpp
+++ b/src/modules/flight_mode_manager/tasks/AutoFollowTarget/FlightTaskAutoFollowTarget.cpp
@@ -51,7 +51,7 @@ using matrix::Quatf;
 using matrix::Eulerf;
 
 // Call the constructor of _sticks to establish Follow Target class as a parent as ModuleParams class
-// which enables chained paramter update sequence, which keeps the parameters in _sticks up to date.
+// which enables chained parameter update sequence, which keeps the parameters in _sticks up to date.
 FlightTaskAutoFollowTarget::FlightTaskAutoFollowTarget() : _sticks(this)
 {
 	_target_estimator.Start();

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -45,7 +45,7 @@ using matrix::Vector2f;
 
 ModuleBase::Descriptor FwLateralLongitudinalControl::desc{task_spawn, custom_command, print_usage};
 
-// [m/s] maximum reference altitude rate threshhold
+// [m/s] maximum reference altitude rate threshold
 static constexpr float MAX_ALT_REF_RATE_FOR_LEVEL_FLIGHT = 0.1f;
 // [us] time after which the wind estimate is disabled if no longer updating
 static constexpr hrt_abstime WIND_EST_TIMEOUT = 10_s;


### PR DESCRIPTION
## Summary
- FW lat/lon control: **threshhold** → **threshold** in altitude-rate comment
- AutoFollowTarget: **paramter** → **parameter** in stick update comment
- batmon: **paramter** → **parameter** in TODO comment

## Motivation
Comment hygiene; no behavior change.

## Verification
- Comments/TODO only

## Aerial campaign
Spec `2026-07-14-4.md`. Overlapping paths with NEW-3 avoided (this PR is modules/drivers only).