### PR TITLE
docs(boards): fix returns/Successful typos in board_common and ModalAI HITL

### DIFF
--- a/boards/modalai/voxl2/src/drivers/qurt/dsp_hitl/dsp_hitl.cpp
+++ b/boards/modalai/voxl2/src/drivers/qurt/dsp_hitl/dsp_hitl.cpp
@@ -312,7 +312,7 @@ void send_actuator_data()
 
 				actuator_sent_counter++;
 
-				if (_debug) { PX4_INFO("Succesful write of actuator back to jMAVSim: %d at %llu", writeRetval, hrt_absolute_time()); }
+				if (_debug) { PX4_INFO("Successful write of actuator back to jMAVSim: %d at %llu", writeRetval, hrt_absolute_time()); }
 
 				first_sent = true;
 
@@ -327,7 +327,7 @@ void send_actuator_data()
 
 			actuator_sent_counter++;
 
-			if (_debug) { PX4_INFO("Succesful write of actuator back to jMAVSim: %d at %llu", writeRetval, hrt_absolute_time()); }
+			if (_debug) { PX4_INFO("Successful write of actuator back to jMAVSim: %d at %llu", writeRetval, hrt_absolute_time()); }
 
 			send_esc_status(hil_act_control);
 		}
@@ -532,7 +532,7 @@ handle_message_command_long_dsp(mavlink_message_t *msg)
 	acknewBufLen = mavlink_msg_to_send_buffer(acknewBuf, &ack_message);
 	int writeRetval = writeResponse(&acknewBuf, acknewBufLen);
 
-	if (_debug) { PX4_INFO("Succesful write of ACK back over UART: %d at %llu", writeRetval, hrt_absolute_time()); }
+	if (_debug) { PX4_INFO("Successful write of ACK back over UART: %d at %llu", writeRetval, hrt_absolute_time()); }
 }
 
 int	flow_debug_counter = 0;

--- a/platforms/common/include/px4_platform_common/board_common.h
+++ b/platforms/common/include/px4_platform_common/board_common.h
@@ -496,7 +496,7 @@ static inline bool board_rc_singlewire(const char *device) { return false; }
  *
  *    RC_SERIAL_SWAP_USING_SINGLEWIRE   is defined
  *    RC_SERIAL_SWAP_RXTX               is defined
- *    TIOCSSWAP                         is defined and retuns !OK
+ *    TIOCSSWAP                         is defined and returns !OK
  *    TIOCSSINGLEWIRE                   is defined
  *
  * Input Parameters:


### PR DESCRIPTION
## Summary
- `board_common.h`: **retuns** → **returns** in TIOCSSWAP docs comment
- ModalAI VOXL2 HITL: **Succesful** → **Successful** in three debug log format strings

## Motivation
Docs/debug hygiene only (HITL debug path; no flight control change).

## Verification
- Comment + debug string only
- No arming/geofence/altitude changes

## Aerial campaign
Spec `2026-07-14-5.md`. Cursor cloud not mid-wired; Grok-scope + Bartok review.