### PR TITLE
feat(fw_performance_model): scale vehicle weight by remaining fuel

### DIFF
--- a/docs/en/config_fw/weight_and_altitude_tuning.md
+++ b/docs/en/config_fw/weight_and_altitude_tuning.md
@@ -1,6 +1,6 @@
 # Advanced TECS Tuning (Weight and Altitude)
 
-This topic shows how you can compensate for changes to the [weight of the vehicle](#vehicle-weight-compensation) and the [air density](#air-density-compensation), along with information about the [algorithms](#weight-and-density-compensation-algorithms) that are used.
+This topic shows how you can compensate for changes to the [mass of the vehicle](#vehicle-weight-compensation) and the [air density](#air-density-compensation), along with information about the [algorithms](#weight-and-density-compensation-algorithms) that are used.
 
 :::warning
 This topic requires that you have already performed [basic TECS tuning](../config_fw/position_tuning_guide_fixedwing.md#tecs-tuning-altitude-and-airspeed).
@@ -9,25 +9,49 @@ This topic requires that you have already performed [basic TECS tuning](../confi
 [Basic TECS tuning](../config_fw/position_tuning_guide_fixedwing.md#tecs-tuning-altitude-and-airspeed) established the key performance limitations of the vehicle that are required for the altitude and airspeed controller to function properly.
 
 While those limitations are specified using constant parameters, in reality vehicle performance is not constant and is affected by various factors.
-If changes in weight and air density are not taken into account, altitude and airspeed tracking will likely deteriorate in the case where the configuration (air density and weight) deviate significantly from the configuration at which the vehicle was tuned.
+If changes in vehicle mass and air density are not taken into account, altitude and airspeed tracking will likely deteriorate in the case where the configuration (air density and mass) deviate significantly from the configuration at which the vehicle was tuned.
 
 ## Vehicle Weight Compensation
 
-Set (both) the following parameters to scale the maximum climb rate, minimum sink rate, and adjust airspeed limits for weight:
+Set (both) the following parameters to scale the maximum climb rate, minimum sink rate, and adjust airspeed limits for the vehicle mass:
 
-- [WEIGHT_BASE](../advanced_config/parameter_reference.md#WEIGHT_BASE) — the weight of the vehicle at which the [Basic TECS tuning](../config_fw/position_tuning_guide_fixedwing.md#tecs-tuning-altitude-and-airspeed) was performed.
-- [WEIGHT_GROSS](../advanced_config/parameter_reference.md#WEIGHT_BASE) — the actual weight of the vehicle at any given time, for example when using a larger battery, or with a payload that was not present during tuning.
+- [WEIGHT_BASE](../advanced_config/parameter_reference.md#WEIGHT_BASE) — the mass of the vehicle at which the [Basic TECS tuning](../config_fw/position_tuning_guide_fixedwing.md#tecs-tuning-altitude-and-airspeed) was performed.
+- [WEIGHT_GROSS](../advanced_config/parameter_reference.md#WEIGHT_GROSS) — the actual mass of the vehicle at any given time, for example when using a larger battery, or with a payload that was not present during tuning.
 
-You can determine the values by measuring the weight of the vehicle using a scale in the tuning configuration and when flying with a payload.
+You can determine the values by measuring the mass of the vehicle using a scale in the tuning configuration and when flying with a payload.
+
+::: info
+The `WEIGHT_*` parameters are masses in kilograms; the parameter names and the derived _weight ratio_ (the ratio of the current vehicle mass to `WEIGHT_BASE`) use "weight" following common aviation usage.
+:::
 
 Scaling is performed when _both_ `WEIGHT_BASE` and `WEIGHT_GROSS` are greater than `0`, and will have no effect if the values are the same.
 See the [algorithms](#weight-and-density-compensation-algorithms) section below for more information.
+
+### Fuel Burn Compensation
+
+On combustion-engine vehicles a significant proportion of the takeoff mass is fuel, so the vehicle mass decreases considerably over the course of a flight.
+If a fuel tank sensor is present (publishing to the [FuelTankStatus](../msg_docs/FuelTankStatus.md) message, for example from a [DroneCAN](../dronecan/index.md) engine ECU), PX4 can continuously estimate the current vehicle mass from the amount of burned fuel.
+
+To enable this, additionally set:
+
+- [WEIGHT_FUEL](../advanced_config/parameter_reference.md#WEIGHT_FUEL) — the mass of a full fuel load (tank capacity multiplied by fuel density).
+
+When `WEIGHT_FUEL` is greater than `0`, `WEIGHT_GROSS` must be set to the takeoff mass with a _full_ tank.
+The current mass is then computed from the measured fraction of fuel remaining, so no parameter update is needed when taking off with a partially filled tank.
+The measured fuel level is low-pass filtered to reject fuel slosh.
+
+If no fuel data is available (no sensor, or the sensor fails before boot), any mass-based scaling makes the conservative assumption that the vehicle is at the full gross mass (including fuel).
+If fuel data is lost mid-flight, the last known fuel state is kept.
+
+Fuel-consumption compensation is only applied to the fuel tank with id `0` (the default id for single-tank systems).
+Multi-tank vehicles should publish the aggregated total fuel state as tank `0`.
+A warning is shown if fuel data is not received from id `0` but is received for other tank ids.
 
 ## Air Density Compensation
 
 ### Specify a Service Ceiling
 
-In PX4 the service ceiling [FW_SERVICE_CEIL](../advanced_config/parameter_reference.md#FW_SERVICE_CEIL) specifies the altitude in standard atmospheric conditions at which the vehicle is still able to achieve a maximum climb rate of 0.5 m/s at maximum throttle and weight equal to [WEIGHT_BASE](../advanced_config/parameter_reference.md#WEIGHT_BASE).
+In PX4 the service ceiling [FW_SERVICE_CEIL](../advanced_config/parameter_reference.md#FW_SERVICE_CEIL) specifies the altitude in standard atmospheric conditions at which the vehicle is still able to achieve a maximum climb rate of 0.5 m/s at maximum throttle and a vehicle mass equal to [WEIGHT_BASE](../advanced_config/parameter_reference.md#WEIGHT_BASE).
 By default this parameter is disabled and no compensation will take place.
 
 This parameter needs to be determined experimentally.
@@ -61,11 +85,11 @@ This is provided for interest only, and may be of interest to developers who wan
 ### Notation
 
 In the following sections we will use the notation $\hat X$ to specify that this value is a calibrated value of the variable $X$.
-By calibrated we mean the value of that variable measured at sea level in standard atmospheric conditions, and when vehicle weight was equal to [WEIGHT_BASE](../advanced_config/parameter_reference.md#WEIGHT_BASE).
+By calibrated we mean the value of that variable measured at sea level in standard atmospheric conditions, and when the vehicle mass was equal to [WEIGHT_BASE](../advanced_config/parameter_reference.md#WEIGHT_BASE).
 
 E.g. by $\hat{\dot{h}}_{\text{max}}$ we specify the maximum climb rate the vehicle can achieve at [WEIGHT_BASE](../advanced_config/parameter_reference.md#WEIGHT_BASE) at sea level in standard atmospheric conditions.
 
-### Effect of Weight on Maximum Climb Rate
+### Effect of Mass on Maximum Climb Rate
 
 The maximum climb rate ([FW_T_CLMB_MAX](../advanced_config/parameter_reference.md#FW_T_CLMB_MAX)) is scaled as a function of the weight ratio.
 
@@ -76,7 +100,7 @@ $$\dot{h}_{\text{max}} = \frac{V \cdot (\text{Thrust} - \text{Drag})}{m \cdot g}
 where `V` is the true airspeed and `m` is the vehicle mass.
 From this equation we see that the maximum climb rates scales with vehicle mass.
 
-### Effect of Weight on Minimum Sink Rate
+### Effect of Mass on Minimum Sink Rate
 
 The minimum sink rate ([FW_T_SINK_MIN](../advanced_config/parameter_reference.md#FW_T_SINK_MIN)) is scaled as a function of weight ratio
 
@@ -88,7 +112,7 @@ where $\rho$ is the air density, S is the wing surface reference area and $f(C_L
 
 From this equation we see that the minimum sink rate scales with the square root of the weight ratio.
 
-### Effect of Weight on Airspeed Limits
+### Effect of Mass on Airspeed Limits
 
 The minimum airspeed ([FW_AIRSPD_MIN](../advanced_config/parameter_reference.md#FW_AIRSPD_MIN)), the stall airspeed ([FW_AIRSPD_STALL](../advanced_config/parameter_reference.md#FW_AIRSPD_STALL)) and trim airspeed ([FW_AIRSPD_TRIM](../advanced_config/parameter_reference.md#FW_AIRSPD_TRIM)) are adjusted based on the weight ratio specified by [WEIGHT_BASE](../advanced_config/parameter_reference.md#WEIGHT_BASE) and [WEIGHT_GROSS](../advanced_config/parameter_reference.md#WEIGHT_GROSS).
 
@@ -100,12 +124,12 @@ rearranging this equation for airspeed gives:
 
 $$V = \sqrt{\frac{2mg}{\rho S C_L}}$$
 
-From this equation we see that if we assume a constant angle of attack (which we generally desire), the vehicle weight affects airspeed with a square root relation.
+From this equation we see that if we assume a constant angle of attack (which we generally desire), the vehicle mass affects airspeed with a square root relation.
 Therefore, the airspeed limits mentioned above are all scaled using the square root of the weight ratio.
 
 ### Effect of Bank Angle on Airspeed Limits
 
-Flying a coordinated, level turn at bank angle $\phi$ increases the load factor by $\frac{1}{\cos{\phi}}$. This is similar to the added load factor due to weight (section above), and thus the stall and minimum airspeeds are increased by an additional factor of $\sqrt{\frac{1}{\cos{\phi}}}$.
+Flying a coordinated, level turn at bank angle $\phi$ increases the load factor by $\frac{1}{\cos{\phi}}$. This is similar to the added load factor due to increased mass (section above), and thus the stall and minimum airspeeds are increased by an additional factor of $\sqrt{\frac{1}{\cos{\phi}}}$.
 
 The maximum airspeed ([FW_AIRSPD_MAX](../advanced_config/parameter_reference.md#FW_AIRSPD_MAX)) is _not_ compensated in this way, as it can represent structural limits of the airframe.
 

--- a/msg/TecsStatus.msg
+++ b/msg/TecsStatus.msg
@@ -29,3 +29,5 @@ float32 throttle_trim			# estimated throttle value [0,1] required to fly level a
 
 float32 underspeed_ratio		# 0: no underspeed, 1: maximal underspeed. Controller takes measures to avoid stall proportional to ratio if >0.
 float32 fast_descend_ratio 		#  value indicating if fast descend mode is enabled with ramp up and ramp down [0-1]
+
+float32 weight_ratio			# Ratio of estimated vehicle weight to WEIGHT_BASE, accounting for burned fuel if fuel-based weight compensation is enabled [-]

--- a/msg/TecsStatus.msg
+++ b/msg/TecsStatus.msg
@@ -29,3 +29,5 @@ float32 throttle_trim			# estimated throttle value [0,1] required to fly level a
 
 float32 underspeed_ratio		# 0: no underspeed, 1: maximal underspeed. Controller takes measures to avoid stall proportional to ratio if >0.
 float32 fast_descend_ratio 		#  value indicating if fast descend mode is enabled with ramp up and ramp down [0-1]
+
+float32 weight_ratio # [-] Ratio of estimated vehicle weight to WEIGHT_BASE. Accounts for burned fuel if fuel-based weight compensation is enabled.

--- a/src/lib/fw_performance_model/CMakeLists.txt
+++ b/src/lib/fw_performance_model/CMakeLists.txt
@@ -34,4 +34,7 @@
 px4_add_library(performance_model
         PerformanceModel.cpp
 )
+target_link_libraries(performance_model PRIVATE atmosphere geo)
 set_property(GLOBAL APPEND PROPERTY PX4_MODULE_CONFIG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/performance_model_params.yaml)
+
+px4_add_functional_gtest(SRC PerformanceModelTest.cpp LINKLIBS performance_model)

--- a/src/lib/fw_performance_model/PerformanceModel.cpp
+++ b/src/lib/fw_performance_model/PerformanceModel.cpp
@@ -58,12 +58,42 @@ PerformanceModel::PerformanceModel(): ModuleParams(nullptr)
 {
 	updateParams();
 }
+void PerformanceModel::setFuelFractionRemaining(float fuel_fraction_remaining)
+{
+	if (PX4_ISFINITE(fuel_fraction_remaining)) {
+		_fuel_fraction_remaining = fuel_fraction_remaining;
+	}
+}
+
+float PerformanceModel::getFuelFractionRemaining(const fuel_tank_status_s &fuel_tank_status)
+{
+	float fraction = NAN;
+
+	if (PX4_ISFINITE(fuel_tank_status.remaining_fuel) && fuel_tank_status.maximum_fuel_capacity > FLT_EPSILON) {
+		fraction = fuel_tank_status.remaining_fuel / fuel_tank_status.maximum_fuel_capacity;
+
+	} else if (fuel_tank_status.percent_remaining <= 100) {
+		fraction = fuel_tank_status.percent_remaining * 0.01f;
+
+	} else if (PX4_ISFINITE(fuel_tank_status.consumed_fuel) && fuel_tank_status.maximum_fuel_capacity > FLT_EPSILON) {
+		fraction = 1.f - fuel_tank_status.consumed_fuel / fuel_tank_status.maximum_fuel_capacity;
+	}
+
+	return PX4_ISFINITE(fraction) ? math::constrain(fraction, 0.f, 1.f) : NAN;
+}
+
 float PerformanceModel::getWeightRatio() const
 {
 	float weight_factor = 1.0f;
 
 	if (_param_weight_base.get() > FLT_EPSILON && _param_weight_gross.get() > FLT_EPSILON) {
-		weight_factor = math::constrain(_param_weight_gross.get() / _param_weight_base.get(), kMinWeightRatio,
+		float weight = _param_weight_gross.get();
+
+		if (_param_weight_fuel.get() > FLT_EPSILON && PX4_ISFINITE(_fuel_fraction_remaining)) {
+			weight -= (1.f - math::constrain(_fuel_fraction_remaining, 0.f, 1.f)) * _param_weight_fuel.get();
+		}
+
+		weight_factor = math::constrain(weight / _param_weight_base.get(), kMinWeightRatio,
 						kMaxWeightRatio);
 	}
 

--- a/src/lib/fw_performance_model/PerformanceModel.cpp
+++ b/src/lib/fw_performance_model/PerformanceModel.cpp
@@ -61,7 +61,7 @@ PerformanceModel::PerformanceModel(): ModuleParams(nullptr)
 void PerformanceModel::setFuelFractionRemaining(float fuel_fraction_remaining)
 {
 	if (PX4_ISFINITE(fuel_fraction_remaining)) {
-		_fuel_fraction_remaining = fuel_fraction_remaining;
+		_fuel_fraction_remaining = math::constrain(fuel_fraction_remaining, 0.f, 1.f);
 	}
 }
 
@@ -90,7 +90,7 @@ float PerformanceModel::getWeightRatio() const
 		float weight = _param_weight_gross.get();
 
 		if (_param_weight_fuel.get() > FLT_EPSILON && PX4_ISFINITE(_fuel_fraction_remaining)) {
-			weight -= (1.f - math::constrain(_fuel_fraction_remaining, 0.f, 1.f)) * _param_weight_fuel.get();
+			weight -= (1.f - _fuel_fraction_remaining) * _param_weight_fuel.get();
 		}
 
 		weight_factor = math::constrain(weight / _param_weight_base.get(), kMinWeightRatio,

--- a/src/lib/fw_performance_model/PerformanceModel.cpp
+++ b/src/lib/fw_performance_model/PerformanceModel.cpp
@@ -58,12 +58,42 @@ PerformanceModel::PerformanceModel(): ModuleParams(nullptr)
 {
 	updateParams();
 }
+void PerformanceModel::setFuelFractionRemaining(float fuel_fraction_remaining)
+{
+	if (PX4_ISFINITE(fuel_fraction_remaining)) {
+		_fuel_fraction_remaining = math::constrain(fuel_fraction_remaining, 0.f, 1.f);
+	}
+}
+
+float PerformanceModel::getFuelFractionRemaining(const fuel_tank_status_s &fuel_tank_status)
+{
+	float fraction = NAN;
+
+	if (fuel_tank_status.percent_remaining <= 100) {
+		fraction = fuel_tank_status.percent_remaining * 0.01f;
+
+	} else if (PX4_ISFINITE(fuel_tank_status.remaining_fuel) && fuel_tank_status.maximum_fuel_capacity > FLT_EPSILON) {
+		fraction = fuel_tank_status.remaining_fuel / fuel_tank_status.maximum_fuel_capacity;
+
+	} else if (PX4_ISFINITE(fuel_tank_status.consumed_fuel) && fuel_tank_status.maximum_fuel_capacity > FLT_EPSILON) {
+		fraction = 1.f - fuel_tank_status.consumed_fuel / fuel_tank_status.maximum_fuel_capacity;
+	}
+
+	return PX4_ISFINITE(fraction) ? math::constrain(fraction, 0.f, 1.f) : NAN;
+}
+
 float PerformanceModel::getWeightRatio() const
 {
 	float weight_factor = 1.0f;
 
 	if (_param_weight_base.get() > FLT_EPSILON && _param_weight_gross.get() > FLT_EPSILON) {
-		weight_factor = math::constrain(_param_weight_gross.get() / _param_weight_base.get(), kMinWeightRatio,
+		float weight = _param_weight_gross.get();
+
+		if (_param_weight_fuel.get() > FLT_EPSILON && PX4_ISFINITE(_fuel_fraction_remaining)) {
+			weight -= (1.f - _fuel_fraction_remaining) * _param_weight_fuel.get();
+		}
+
+		weight_factor = math::constrain(weight / _param_weight_base.get(), kMinWeightRatio,
 						kMaxWeightRatio);
 	}
 

--- a/src/lib/fw_performance_model/PerformanceModel.hpp
+++ b/src/lib/fw_performance_model/PerformanceModel.hpp
@@ -37,7 +37,9 @@
  * Performance model.
  */
 
+#include <math.h>
 #include <px4_platform_common/module_params.h>
+#include <uORB/topics/fuel_tank_status.h>
 
 #ifndef PX4_SRC_MODULES_FW_POS_CONTROL_PERFORMANCEMODEL_H_
 #define PX4_SRC_MODULES_FW_POS_CONTROL_PERFORMANCEMODEL_H_
@@ -69,6 +71,23 @@ public:
 	 * @return weight ratio
 	 */
 	float getWeightRatio() const;
+
+	/**
+	 * Set the fraction of fuel remaining, used to reduce the vehicle weight by the burned fuel mass
+	 * if fuel-based weight compensation is enabled (WEIGHT_FUEL > 0).
+	 * Non-finite input is ignored and the last known fuel fraction is kept.
+	 * @param fuel_fraction_remaining fraction of fuel remaining in range [0,1]
+	 */
+	void setFuelFractionRemaining(float fuel_fraction_remaining);
+
+	/**
+	 * Extract the fraction of fuel remaining from a fuel tank status message, preferring the
+	 * measured remaining fuel over the remaining percentage over the consumed fuel.
+	 * The consumed fuel fallback assumes the tank was full at boot.
+	 * @param fuel_tank_status fuel tank status message
+	 * @return fraction of fuel remaining in range [0,1], NAN if not available
+	 */
+	static float getFuelFractionRemaining(const fuel_tank_status_s &fuel_tank_status);
 
 	/**
 	 * Get the trim throttle for the current airspeed setpoint as well as air density and weight.
@@ -131,6 +150,7 @@ private:
 		(ParamFloat<px4::params::FW_T_SINK_MIN>) _param_fw_t_sink_min,
 		(ParamFloat<px4::params::WEIGHT_BASE>) _param_weight_base,
 		(ParamFloat<px4::params::WEIGHT_GROSS>) _param_weight_gross,
+		(ParamFloat<px4::params::WEIGHT_FUEL>) _param_weight_fuel,
 		(ParamFloat<px4::params::FW_SERVICE_CEIL>) _param_service_ceiling,
 		(ParamFloat<px4::params::FW_THR_TRIM>) _param_fw_thr_trim,
 		(ParamFloat<px4::params::FW_THR_MAX>) _param_fw_thr_max,
@@ -150,6 +170,8 @@ private:
 
 
 	static float sanitiseAirDensity(float air_density);
+
+	float _fuel_fraction_remaining{NAN}; ///< fraction of fuel remaining in range [0,1], NAN if unknown
 };
 
 #endif //PX4_SRC_MODULES_FW_POS_CONTROL_PERFORMANCEMODEL_H_

--- a/src/lib/fw_performance_model/PerformanceModel.hpp
+++ b/src/lib/fw_performance_model/PerformanceModel.hpp
@@ -37,7 +37,10 @@
  * Performance model.
  */
 
+#include <float.h>
+#include <math.h>
 #include <px4_platform_common/module_params.h>
+#include <uORB/topics/fuel_tank_status.h>
 
 #ifndef PX4_SRC_MODULES_FW_POS_CONTROL_PERFORMANCEMODEL_H_
 #define PX4_SRC_MODULES_FW_POS_CONTROL_PERFORMANCEMODEL_H_
@@ -69,6 +72,29 @@ public:
 	 * @return weight ratio
 	 */
 	float getWeightRatio() const;
+
+	/**
+	 * Set the fraction of fuel remaining, used to reduce the vehicle weight by the burned fuel mass
+	 * if fuel-based weight compensation is enabled (WEIGHT_FUEL > 0).
+	 * Non-finite input is ignored and the last known fuel fraction is kept.
+	 * @param fuel_fraction_remaining fraction of fuel remaining in range [0,1]
+	 */
+	void setFuelFractionRemaining(float fuel_fraction_remaining);
+
+	/**
+	 * Check if fuel-based weight compensation is enabled.
+	 * @return true if WEIGHT_FUEL is set to a valid fuel weight
+	 */
+	bool isFuelCompensationEnabled() const { return _param_weight_fuel.get() > FLT_EPSILON; }
+
+	/**
+	 * Extract the fraction of fuel remaining from a fuel tank status message, preferring the
+	 * remaining percentage over the measured remaining fuel over the consumed fuel.
+	 * The consumed fuel fallback assumes the tank was full at boot.
+	 * @param fuel_tank_status fuel tank status message
+	 * @return fraction of fuel remaining in range [0,1], NAN if not available
+	 */
+	static float getFuelFractionRemaining(const fuel_tank_status_s &fuel_tank_status);
 
 	/**
 	 * Get the trim throttle for the current airspeed setpoint as well as air density and weight.
@@ -131,6 +157,7 @@ private:
 		(ParamFloat<px4::params::FW_T_SINK_MIN>) _param_fw_t_sink_min,
 		(ParamFloat<px4::params::WEIGHT_BASE>) _param_weight_base,
 		(ParamFloat<px4::params::WEIGHT_GROSS>) _param_weight_gross,
+		(ParamFloat<px4::params::WEIGHT_FUEL>) _param_weight_fuel,
 		(ParamFloat<px4::params::FW_SERVICE_CEIL>) _param_service_ceiling,
 		(ParamFloat<px4::params::FW_THR_TRIM>) _param_fw_thr_trim,
 		(ParamFloat<px4::params::FW_THR_MAX>) _param_fw_thr_max,
@@ -150,6 +177,8 @@ private:
 
 
 	static float sanitiseAirDensity(float air_density);
+
+	float _fuel_fraction_remaining{NAN}; ///< fraction of fuel remaining in range [0,1], NAN if unknown
 };
 
 #endif //PX4_SRC_MODULES_FW_POS_CONTROL_PERFORMANCEMODEL_H_

--- a/src/lib/fw_performance_model/PerformanceModelTest.cpp
+++ b/src/lib/fw_performance_model/PerformanceModelTest.cpp
@@ -1,0 +1,181 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+#include "PerformanceModel.hpp"
+
+// to run: make tests TESTFILTER=PerformanceModel
+
+class PerformanceModelTest : public ::testing::Test
+{
+public:
+	void SetUp() override
+	{
+		param_control_autosave(false);
+		param_reset_all();
+	}
+
+	void setWeightParams(float base, float gross, float fuel)
+	{
+		param_set(param_handle(px4::params::WEIGHT_BASE), &base);
+		param_set(param_handle(px4::params::WEIGHT_GROSS), &gross);
+		param_set(param_handle(px4::params::WEIGHT_FUEL), &fuel);
+		_model.updateParameters();
+	}
+
+	PerformanceModel _model;
+};
+
+TEST_F(PerformanceModelTest, weightRatioDefaultsToOne)
+{
+	// GIVEN: default parameters (weight compensation disabled)
+	// THEN: the weight ratio is 1
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.0f);
+}
+
+TEST_F(PerformanceModelTest, weightRatioWithoutFuelCompensation)
+{
+	// GIVEN: base and gross weight set, fuel compensation disabled
+	setWeightParams(10.0f, 12.0f, -1.0f);
+
+	// THEN: the weight ratio is gross/base, independent of any fuel fraction
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.2f);
+
+	_model.setFuelFractionRemaining(0.5f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.2f);
+}
+
+TEST_F(PerformanceModelTest, weightRatioScalesWithFuelFraction)
+{
+	// GIVEN: base and gross weight set, 4kg full fuel load
+	setWeightParams(10.0f, 12.0f, 4.0f);
+
+	// THEN: with unknown fuel fraction the full-tank gross weight is assumed
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.2f);
+
+	// AND: the weight ratio scales linearly with the burned fuel mass
+	_model.setFuelFractionRemaining(1.0f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.2f);
+
+	_model.setFuelFractionRemaining(0.5f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.0f);
+
+	_model.setFuelFractionRemaining(0.0f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 0.8f);
+}
+
+TEST_F(PerformanceModelTest, fuelFractionKeptOnNonFiniteInput)
+{
+	// GIVEN: base and gross weight set, 4kg full fuel load, and a known fuel fraction
+	setWeightParams(10.0f, 12.0f, 4.0f);
+	_model.setFuelFractionRemaining(0.5f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.0f);
+
+	// WHEN: the fuel fraction input becomes non-finite (e.g. sensor failure)
+	_model.setFuelFractionRemaining(NAN);
+
+	// THEN: the last known fuel fraction is kept
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.0f);
+}
+
+TEST_F(PerformanceModelTest, fuelFractionIsConstrained)
+{
+	// GIVEN: base and gross weight set, 4kg full fuel load
+	setWeightParams(10.0f, 12.0f, 4.0f);
+
+	// THEN: out-of-range fuel fractions are constrained to [0, 1]
+	_model.setFuelFractionRemaining(-0.5f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 0.8f);
+
+	_model.setFuelFractionRemaining(1.5f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.2f);
+}
+
+TEST_F(PerformanceModelTest, weightRatioIsConstrained)
+{
+	// GIVEN: a fuel weight larger than the gross weight (misconfiguration)
+	setWeightParams(10.0f, 12.0f, 12.0f);
+
+	// THEN: the weight ratio is constrained to its lower bound
+	_model.setFuelFractionRemaining(0.0f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 0.5f);
+}
+
+TEST_F(PerformanceModelTest, fuelFractionFromTankStatusFallbackChain)
+{
+	// GIVEN: a fuel tank status with no measurements
+	fuel_tank_status_s status{};
+	status.maximum_fuel_capacity = NAN;
+	status.remaining_fuel = NAN;
+	status.consumed_fuel = NAN;
+	status.percent_remaining = UINT8_MAX;
+
+	// THEN: no fuel fraction is available
+	EXPECT_TRUE(std::isnan(PerformanceModel::getFuelFractionRemaining(status)));
+
+	// AND: the consumed fuel is the last fallback, assuming a full tank at boot
+	status.maximum_fuel_capacity = 2000.f;
+	status.consumed_fuel = 500.f;
+	EXPECT_FLOAT_EQ(PerformanceModel::getFuelFractionRemaining(status), 0.75f);
+
+	// AND: a valid remaining percentage takes precedence over the consumed fuel
+	status.percent_remaining = 40;
+	EXPECT_FLOAT_EQ(PerformanceModel::getFuelFractionRemaining(status), 0.4f);
+
+	// AND: the measured remaining fuel takes precedence over everything else
+	status.remaining_fuel = 1000.f;
+	EXPECT_FLOAT_EQ(PerformanceModel::getFuelFractionRemaining(status), 0.5f);
+}
+
+TEST_F(PerformanceModelTest, fuelFractionFromTankStatusIsConstrained)
+{
+	// GIVEN: a remaining fuel measurement exceeding the maximum capacity
+	fuel_tank_status_s status{};
+	status.maximum_fuel_capacity = 2000.f;
+	status.remaining_fuel = 3000.f;
+	status.consumed_fuel = NAN;
+	status.percent_remaining = UINT8_MAX;
+
+	// THEN: the fuel fraction is constrained to 1
+	EXPECT_FLOAT_EQ(PerformanceModel::getFuelFractionRemaining(status), 1.0f);
+
+	// AND: more consumed fuel than the maximum capacity results in a fraction of 0
+	status.remaining_fuel = NAN;
+	status.consumed_fuel = 3000.f;
+	EXPECT_FLOAT_EQ(PerformanceModel::getFuelFractionRemaining(status), 0.0f);
+
+	// AND: a remaining fuel measurement without a valid maximum capacity is unusable
+	status.maximum_fuel_capacity = 0.f;
+	status.remaining_fuel = 1000.f;
+	EXPECT_TRUE(std::isnan(PerformanceModel::getFuelFractionRemaining(status)));
+}

--- a/src/lib/fw_performance_model/PerformanceModelTest.cpp
+++ b/src/lib/fw_performance_model/PerformanceModelTest.cpp
@@ -1,0 +1,181 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+#include "PerformanceModel.hpp"
+
+// to run: make tests TESTFILTER=PerformanceModel
+
+class PerformanceModelTest : public ::testing::Test
+{
+public:
+	void SetUp() override
+	{
+		param_control_autosave(false);
+		param_reset_all();
+	}
+
+	void setWeightParams(float base, float gross, float fuel)
+	{
+		param_set(param_handle(px4::params::WEIGHT_BASE), &base);
+		param_set(param_handle(px4::params::WEIGHT_GROSS), &gross);
+		param_set(param_handle(px4::params::WEIGHT_FUEL), &fuel);
+		_model.updateParameters();
+	}
+
+	PerformanceModel _model;
+};
+
+TEST_F(PerformanceModelTest, weightRatioDefaultsToOne)
+{
+	// GIVEN: default parameters (weight compensation disabled)
+	// THEN: the weight ratio is 1
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.0f);
+}
+
+TEST_F(PerformanceModelTest, weightRatioWithoutFuelCompensation)
+{
+	// GIVEN: base and gross weight set, fuel compensation disabled
+	setWeightParams(10.0f, 12.0f, -1.0f);
+
+	// THEN: the weight ratio is gross/base, independent of any fuel fraction
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.2f);
+
+	_model.setFuelFractionRemaining(0.5f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.2f);
+}
+
+TEST_F(PerformanceModelTest, weightRatioScalesWithFuelFraction)
+{
+	// GIVEN: base and gross weight set, 4kg full fuel load
+	setWeightParams(10.0f, 12.0f, 4.0f);
+
+	// THEN: with unknown fuel fraction the full-tank gross weight is assumed
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.2f);
+
+	// AND: the weight ratio scales linearly with the burned fuel mass
+	_model.setFuelFractionRemaining(1.0f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.2f);
+
+	_model.setFuelFractionRemaining(0.5f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.0f);
+
+	_model.setFuelFractionRemaining(0.0f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 0.8f);
+}
+
+TEST_F(PerformanceModelTest, fuelFractionKeptOnNonFiniteInput)
+{
+	// GIVEN: base and gross weight set, 4kg full fuel load, and a known fuel fraction
+	setWeightParams(10.0f, 12.0f, 4.0f);
+	_model.setFuelFractionRemaining(0.5f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.0f);
+
+	// WHEN: the fuel fraction input becomes non-finite (e.g. sensor failure)
+	_model.setFuelFractionRemaining(NAN);
+
+	// THEN: the last known fuel fraction is kept
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.0f);
+}
+
+TEST_F(PerformanceModelTest, fuelFractionIsConstrained)
+{
+	// GIVEN: base and gross weight set, 4kg full fuel load
+	setWeightParams(10.0f, 12.0f, 4.0f);
+
+	// THEN: out-of-range fuel fractions are constrained to [0, 1]
+	_model.setFuelFractionRemaining(-0.5f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 0.8f);
+
+	_model.setFuelFractionRemaining(1.5f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 1.2f);
+}
+
+TEST_F(PerformanceModelTest, weightRatioIsConstrained)
+{
+	// GIVEN: a fuel weight larger than the gross weight (misconfiguration)
+	setWeightParams(10.0f, 12.0f, 12.0f);
+
+	// THEN: the weight ratio is constrained to its lower bound
+	_model.setFuelFractionRemaining(0.0f);
+	EXPECT_FLOAT_EQ(_model.getWeightRatio(), 0.5f);
+}
+
+TEST_F(PerformanceModelTest, fuelFractionFromTankStatusFallbackChain)
+{
+	// GIVEN: a fuel tank status with no measurements
+	fuel_tank_status_s status{};
+	status.maximum_fuel_capacity = NAN;
+	status.remaining_fuel = NAN;
+	status.consumed_fuel = NAN;
+	status.percent_remaining = UINT8_MAX;
+
+	// THEN: no fuel fraction is available
+	EXPECT_TRUE(std::isnan(PerformanceModel::getFuelFractionRemaining(status)));
+
+	// AND: the consumed fuel is the last fallback, assuming a full tank at boot
+	status.maximum_fuel_capacity = 2000.f;
+	status.consumed_fuel = 500.f;
+	EXPECT_FLOAT_EQ(PerformanceModel::getFuelFractionRemaining(status), 0.75f);
+
+	// AND: the measured remaining fuel takes precedence over the consumed fuel
+	status.remaining_fuel = 1000.f;
+	EXPECT_FLOAT_EQ(PerformanceModel::getFuelFractionRemaining(status), 0.5f);
+
+	// AND: a valid remaining percentage takes precedence over everything else
+	status.percent_remaining = 40;
+	EXPECT_FLOAT_EQ(PerformanceModel::getFuelFractionRemaining(status), 0.4f);
+}
+
+TEST_F(PerformanceModelTest, fuelFractionFromTankStatusIsConstrained)
+{
+	// GIVEN: a remaining fuel measurement exceeding the maximum capacity
+	fuel_tank_status_s status{};
+	status.maximum_fuel_capacity = 2000.f;
+	status.remaining_fuel = 3000.f;
+	status.consumed_fuel = NAN;
+	status.percent_remaining = UINT8_MAX;
+
+	// THEN: the fuel fraction is constrained to 1
+	EXPECT_FLOAT_EQ(PerformanceModel::getFuelFractionRemaining(status), 1.0f);
+
+	// AND: more consumed fuel than the maximum capacity results in a fraction of 0
+	status.remaining_fuel = NAN;
+	status.consumed_fuel = 3000.f;
+	EXPECT_FLOAT_EQ(PerformanceModel::getFuelFractionRemaining(status), 0.0f);
+
+	// AND: a remaining fuel measurement without a valid maximum capacity is unusable
+	status.maximum_fuel_capacity = 0.f;
+	status.remaining_fuel = 1000.f;
+	EXPECT_TRUE(std::isnan(PerformanceModel::getFuelFractionRemaining(status)));
+}

--- a/src/lib/fw_performance_model/performance_model_params.yaml
+++ b/src/lib/fw_performance_model/performance_model_params.yaml
@@ -71,6 +71,21 @@ parameters:
           This is the actual weight of the vehicle at any time. This value will differ from WEIGHT_BASE in case weight was added
           or removed from the base weight. Examples are the addition of payloads or larger batteries. A zero or negative value
           disables trim throttle and minimum airspeed compensation based on weight.
+          If fuel-based weight compensation is enabled (WEIGHT_FUEL), set this to the takeoff weight with a full fuel load.
+      type: float
+      default: -1.0
+      unit: kg
+      decimal: 1
+      increment: 0.1
+    WEIGHT_FUEL:
+      description:
+        short: Weight of a full fuel load
+        long: |-
+          Mass of the fuel at maximum fuel tank capacity. If set, together with WEIGHT_BASE
+          and WEIGHT_GROSS, the vehicle weight used for performance scaling is reduced by the burned fuel mass derived from
+          the fuel tank status. WEIGHT_GROSS then corresponds to the takeoff weight with a full fuel load. A zero or negative
+          value disables fuel-based weight compensation.
+          Only a single fuel tank is supported: reports from additional tank ids are ignored.
       type: float
       default: -1.0
       unit: kg

--- a/src/lib/fw_performance_model/performance_model_params.yaml
+++ b/src/lib/fw_performance_model/performance_model_params.yaml
@@ -81,11 +81,9 @@ parameters:
       description:
         short: Weight of a full fuel load
         long: |-
-          Mass of the fuel at maximum fuel tank capacity. If set, together with WEIGHT_BASE
-          and WEIGHT_GROSS, the vehicle weight used for performance scaling is reduced by the burned fuel mass derived from
-          the fuel tank status. WEIGHT_GROSS then corresponds to the takeoff weight with a full fuel load. A zero or negative
-          value disables fuel-based weight compensation.
-          Only a single fuel tank is supported: reports from additional tank ids are ignored.
+          Mass of a full fuel load. If set together with WEIGHT_BASE and WEIGHT_GROSS, the weight used for
+          performance scaling is reduced by the burned fuel reported in the fuel tank status.
+          Only a single fuel tank is supported. A zero or negative value disables fuel-based weight compensation.
       type: float
       default: -1.0
       unit: kg

--- a/src/lib/fw_performance_model/performance_model_params.yaml
+++ b/src/lib/fw_performance_model/performance_model_params.yaml
@@ -71,6 +71,19 @@ parameters:
           This is the actual weight of the vehicle at any time. This value will differ from WEIGHT_BASE in case weight was added
           or removed from the base weight. Examples are the addition of payloads or larger batteries. A zero or negative value
           disables trim throttle and minimum airspeed compensation based on weight.
+          If fuel-based weight compensation is enabled (WEIGHT_FUEL), set this to the takeoff weight with a full fuel load.
+      type: float
+      default: -1.0
+      unit: kg
+      decimal: 1
+      increment: 0.1
+    WEIGHT_FUEL:
+      description:
+        short: Mass of a full fuel load
+        long: |-
+          If set together with WEIGHT_BASE and WEIGHT_GROSS, the weight used for
+          performance scaling is reduced by the burned fuel reported in the fuel tank status.
+          Only a single fuel tank is supported. A zero or negative value disables fuel-based weight compensation.
       type: float
       default: -1.0
       unit: kg

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -66,6 +66,12 @@ static constexpr float ROLL_WARNING_CAN_RUN_THRESHOLD = 0.9f;
 // [m/s/s] slew rate limit for airspeed setpoint changes
 static constexpr float ASPD_SP_SLEW_RATE = 1.f;
 
+// [s] time constant of the fuel fraction filter, needs to be slow enough to reject fuel sloshing
+static constexpr float FUEL_FRACTION_FILTER_TIME_CONST = 30.f;
+
+// [s] maximum time step used to advance the fuel fraction filter on a new sample
+static constexpr float FUEL_FRACTION_FILTER_MAX_DT = 10.f;
+
 FwLateralLongitudinalControl::FwLateralLongitudinalControl(bool is_vtol) :
 	ModuleParams(nullptr),
 	WorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers),
@@ -76,6 +82,9 @@ FwLateralLongitudinalControl::FwLateralLongitudinalControl(bool is_vtol) :
 	_tecs_status_pub.advertise();
 	_flight_phase_estimation_pub.advertise();
 	_fixed_wing_lateral_status_pub.advertise();
+
+	_fuel_fraction_filter.setParameters(0.f, FUEL_FRACTION_FILTER_TIME_CONST);
+
 	parameters_update();
 	_airspeed_slew_rate_controller.setSlewRate(ASPD_SP_SLEW_RATE);
 
@@ -159,6 +168,8 @@ void FwLateralLongitudinalControl::Run()
 			_tecs.set_max_climb_rate(_performance_model.getMaximumClimbRate(_air_density));
 			_tecs.set_min_sink_rate(_performance_model.getMinimumSinkRate(_air_density));
 		}
+
+		updateFuelState();
 
 		if (_vehicle_landed_sub.updated()) {
 			vehicle_land_detected_s landed{};
@@ -443,6 +454,47 @@ FwLateralLongitudinalControl::tecs_update_pitch_throttle(const float control_int
 	return flight_phase_estimation_s::FLIGHT_PHASE_UNKNOWN;
 }
 
+void FwLateralLongitudinalControl::updateFuelState()
+{
+	fuel_tank_status_s fuel_tank_status;
+
+	if (_fuel_tank_status_sub.update(&fuel_tank_status)) {
+		// only a single fuel tank is supported: use the first reported tank id and ignore all others
+		if (_fuel_tank_id < 0) {
+			_fuel_tank_id = fuel_tank_status.fuel_tank_id;
+		}
+
+		if (fuel_tank_status.fuel_tank_id != _fuel_tank_id) {
+			return;
+		}
+
+		const float fuel_fraction_remaining = PerformanceModel::getFuelFractionRemaining(fuel_tank_status);
+
+		if (PX4_ISFINITE(fuel_fraction_remaining)) {
+			if (_time_last_fuel_fraction_update == 0) {
+				_fuel_fraction_filter.reset(fuel_fraction_remaining);
+
+			} else if (fuel_tank_status.timestamp > _time_last_fuel_fraction_update) {
+				const float dt = math::min((fuel_tank_status.timestamp - _time_last_fuel_fraction_update) * 1e-6f,
+							   FUEL_FRACTION_FILTER_MAX_DT);
+				_fuel_fraction_filter.update(fuel_fraction_remaining, dt);
+
+			} else {
+				// out-of-order sample
+				return;
+			}
+
+			_time_last_fuel_fraction_update = fuel_tank_status.timestamp;
+
+			_performance_model.setFuelFractionRemaining(_fuel_fraction_filter.getState());
+
+			_tecs.set_max_climb_rate(_performance_model.getMaximumClimbRate(_air_density));
+			_tecs.set_min_sink_rate(_performance_model.getMinimumSinkRate(_air_density));
+			_tecs.set_equivalent_airspeed_trim(_performance_model.getCalibratedTrimAirspeed());
+		}
+	}
+}
+
 void
 FwLateralLongitudinalControl::tecs_status_publish(float alt_sp, float equivalent_airspeed_sp,
 		float true_airspeed_derivative_raw, float throttle_trim, hrt_abstime timestamp)
@@ -475,6 +527,7 @@ FwLateralLongitudinalControl::tecs_status_publish(float alt_sp, float equivalent
 	tecs_status.throttle_trim = throttle_trim;
 	tecs_status.underspeed_ratio = _tecs.get_underspeed_ratio();
 	tecs_status.fast_descend_ratio = debug_output.fast_descend;
+	tecs_status.weight_ratio = _performance_model.getWeightRatio();
 
 	tecs_status.timestamp = timestamp;
 

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -488,8 +488,6 @@ void FwLateralLongitudinalControl::updateFuelState()
 
 			_performance_model.setFuelFractionRemaining(_fuel_fraction_filter.getState());
 
-			_tecs.set_max_climb_rate(_performance_model.getMaximumClimbRate(_air_density));
-			_tecs.set_min_sink_rate(_performance_model.getMinimumSinkRate(_air_density));
 			_tecs.set_equivalent_airspeed_trim(_performance_model.getCalibratedTrimAirspeed());
 		}
 	}

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -66,6 +66,12 @@ static constexpr float ROLL_WARNING_CAN_RUN_THRESHOLD = 0.9f;
 // [m/s/s] slew rate limit for airspeed setpoint changes
 static constexpr float ASPD_SP_SLEW_RATE = 1.f;
 
+// [s] time constant of the fuel fraction filter, needs to be slow enough to reject fuel sloshing
+static constexpr float FUEL_FRACTION_FILTER_TIME_CONST = 30.f;
+
+// [s] maximum time step used to advance the fuel fraction filter on a new sample
+static constexpr float FUEL_FRACTION_FILTER_MAX_DT = 10.f;
+
 FwLateralLongitudinalControl::FwLateralLongitudinalControl(bool is_vtol) :
 	ModuleParams(nullptr),
 	WorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers),
@@ -76,6 +82,9 @@ FwLateralLongitudinalControl::FwLateralLongitudinalControl(bool is_vtol) :
 	_tecs_status_pub.advertise();
 	_flight_phase_estimation_pub.advertise();
 	_fixed_wing_lateral_status_pub.advertise();
+
+	_fuel_fraction_filter.setParameters(0.f, FUEL_FRACTION_FILTER_TIME_CONST);
+
 	parameters_update();
 	_airspeed_slew_rate_controller.setSlewRate(ASPD_SP_SLEW_RATE);
 
@@ -159,6 +168,8 @@ void FwLateralLongitudinalControl::Run()
 			_tecs.set_max_climb_rate(_performance_model.getMaximumClimbRate(_air_density));
 			_tecs.set_min_sink_rate(_performance_model.getMinimumSinkRate(_air_density));
 		}
+
+		updateFuelState();
 
 		if (_vehicle_landed_sub.updated()) {
 			vehicle_land_detected_s landed{};
@@ -443,6 +454,54 @@ FwLateralLongitudinalControl::tecs_update_pitch_throttle(const float control_int
 	return flight_phase_estimation_s::FLIGHT_PHASE_UNKNOWN;
 }
 
+void FwLateralLongitudinalControl::updateFuelState()
+{
+	fuel_tank_status_s fuel_tank_status;
+
+	for (auto &sub : _fuel_tank_status_subs) {
+		if (!sub.update(&fuel_tank_status)) {
+			continue;
+		}
+
+		// only the tank with id 0 is used for weight compensation, multi-tank systems
+		// are expected to publish an aggregated total as tank 0
+		if (fuel_tank_status.fuel_tank_id != 0) {
+			if (!_ignored_fuel_tank_reported && _performance_model.isFuelCompensationEnabled()) {
+				PX4_WARN("Ignoring fuel tank status with tank id %d, only tank 0 is used for weight compensation",
+					 fuel_tank_status.fuel_tank_id);
+				_ignored_fuel_tank_reported = true;
+			}
+
+			continue;
+		}
+
+		const float fuel_fraction_remaining = PerformanceModel::getFuelFractionRemaining(fuel_tank_status);
+
+		if (!PX4_ISFINITE(fuel_fraction_remaining)) {
+			continue;
+		}
+
+		if (_time_last_fuel_fraction_update == 0) {
+			_fuel_fraction_filter.reset(fuel_fraction_remaining);
+
+		} else if (fuel_tank_status.timestamp > _time_last_fuel_fraction_update) {
+			const float dt = math::min((fuel_tank_status.timestamp - _time_last_fuel_fraction_update) * 1e-6f,
+						   FUEL_FRACTION_FILTER_MAX_DT);
+			_fuel_fraction_filter.update(fuel_fraction_remaining, dt);
+
+		} else {
+			// out-dated sample
+			continue;
+		}
+
+		_time_last_fuel_fraction_update = fuel_tank_status.timestamp;
+
+		_performance_model.setFuelFractionRemaining(_fuel_fraction_filter.getState());
+
+		_tecs.set_equivalent_airspeed_trim(_performance_model.getCalibratedTrimAirspeed());
+	}
+}
+
 void
 FwLateralLongitudinalControl::tecs_status_publish(float alt_sp, float equivalent_airspeed_sp,
 		float true_airspeed_derivative_raw, float throttle_trim, hrt_abstime timestamp)
@@ -478,6 +537,7 @@ FwLateralLongitudinalControl::tecs_status_publish(float alt_sp, float equivalent
 	tecs_status.throttle_trim = throttle_trim;
 	tecs_status.underspeed_ratio = _tecs.get_underspeed_ratio();
 	tecs_status.fast_descend_ratio = debug_output.fast_descend;
+	tecs_status.weight_ratio = _performance_model.getWeightRatio();
 
 	tecs_status.timestamp = timestamp;
 

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
@@ -48,6 +48,7 @@
 #include <lib/npfg/AirspeedDirectionController.hpp>
 #include <lib/tecs/TECS.hpp>
 #include <lib/mathlib/mathlib.h>
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
 #include <lib/perf/perf_counter.h>
 #include <px4_platform_common/px4_config.h>
 #include <px4_platform_common/defines.h>
@@ -66,6 +67,7 @@
 #include <uORB/topics/fixed_wing_lateral_setpoint.h>
 #include <uORB/topics/fixed_wing_lateral_status.h>
 #include <uORB/topics/fixed_wing_longitudinal_setpoint.h>
+#include <uORB/topics/fuel_tank_status.h>
 #include <uORB/topics/normalized_unsigned_setpoint.h>
 #include <uORB/topics/flight_phase_estimation.h>
 #include <uORB/topics/lateral_control_configuration.h>
@@ -114,6 +116,7 @@ private:
 
 	uORB::Subscription _airspeed_validated_sub{ORB_ID(airspeed_validated)};
 	uORB::Subscription _flaps_setpoint_sub{ORB_ID(flaps_setpoint)};
+	uORB::Subscription _fuel_tank_status_sub{ORB_ID(fuel_tank_status)};
 	uORB::Subscription _wind_sub{ORB_ID(wind)};
 	uORB::SubscriptionData<vehicle_control_mode_s> _control_mode_sub{ORB_ID(vehicle_control_mode)};
 	uORB::SubscriptionData<vehicle_air_data_s> _vehicle_air_data_sub{ORB_ID(vehicle_air_data)};
@@ -204,6 +207,10 @@ private:
 	float _load_factor_from_bank_angle{1.f};
 	SlewRate<float> _airspeed_slew_rate_controller;
 
+	AlphaFilter<float> _fuel_fraction_filter;
+	hrt_abstime _time_last_fuel_fraction_update{0};
+	int _fuel_tank_id{-1}; ///< id of the tracked fuel tank, -1 until the first fuel tank status is received
+
 	perf_counter_t _loop_perf; // loop performance counter
 
 	PerformanceModel _performance_model;
@@ -234,6 +241,8 @@ private:
 	float mapLateralAccelerationToRollAngle(float lateral_acceleration_sp) const;
 
 	void updateWind(hrt_abstime now);
+
+	void updateFuelState();
 
 	void updateTECSAltitudeTimeConstant(const bool is_low_height, const float dt);
 

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
@@ -48,6 +48,7 @@
 #include <lib/npfg/AirspeedDirectionController.hpp>
 #include <lib/tecs/TECS.hpp>
 #include <lib/mathlib/mathlib.h>
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
 #include <lib/perf/perf_counter.h>
 #include <px4_platform_common/px4_config.h>
 #include <px4_platform_common/defines.h>
@@ -62,10 +63,12 @@
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
+#include <uORB/SubscriptionMultiArray.hpp>
 #include <uORB/topics/airspeed_validated.h>
 #include <uORB/topics/fixed_wing_lateral_setpoint.h>
 #include <uORB/topics/fixed_wing_lateral_status.h>
 #include <uORB/topics/fixed_wing_longitudinal_setpoint.h>
+#include <uORB/topics/fuel_tank_status.h>
 #include <uORB/topics/normalized_unsigned_setpoint.h>
 #include <uORB/topics/flight_phase_estimation.h>
 #include <uORB/topics/lateral_control_configuration.h>
@@ -114,6 +117,7 @@ private:
 
 	uORB::Subscription _airspeed_validated_sub{ORB_ID(airspeed_validated)};
 	uORB::Subscription _flaps_setpoint_sub{ORB_ID(flaps_setpoint)};
+	uORB::SubscriptionMultiArray<fuel_tank_status_s> _fuel_tank_status_subs{ORB_ID::fuel_tank_status};
 	uORB::Subscription _wind_sub{ORB_ID(wind)};
 	uORB::SubscriptionData<vehicle_control_mode_s> _control_mode_sub{ORB_ID(vehicle_control_mode)};
 	uORB::SubscriptionData<vehicle_air_data_s> _vehicle_air_data_sub{ORB_ID(vehicle_air_data)};
@@ -204,6 +208,10 @@ private:
 	float _load_factor_from_bank_angle{1.f};
 	SlewRate<float> _airspeed_slew_rate_controller;
 
+	AlphaFilter<float> _fuel_fraction_filter;
+	hrt_abstime _time_last_fuel_fraction_update{0};
+	bool _ignored_fuel_tank_reported{false}; ///< true if the warning about an ignored fuel tank id was already sent
+
 	perf_counter_t _loop_perf; // loop performance counter
 
 	PerformanceModel _performance_model;
@@ -234,6 +242,8 @@ private:
 	float mapLateralAccelerationToRollAngle(float lateral_acceleration_sp) const;
 
 	void updateWind(hrt_abstime now);
+
+	void updateFuelState();
 
 	void updateTECSAltitudeTimeConstant(const bool is_low_height, const float dt);
 


### PR DESCRIPTION
### Solved Problem

The FW performance model scales trim throttle, min/stall airspeed, and climb/sink rates from the static `WEIGHT_GROSS` parameter. For combustion vehicles a large share of the takeoff weight is fuel, so these limits become increasingly wrong
as fuel burns off during flight - which leads to inefficient flight.

### Solution

Add an optional `WEIGHT_FUEL` parameter (mass of a full fuel load). When set, the weight used by the performance model is reduced by the burned fuel mass derived from `fuel_tank_status` (percentage preferred, then remaining fuel preferred, then consumed fuel), low-pass filtered to reject sloshing. 

Also adds `weight_ratio` to `TecsStatus` (appended field, uLog-compatible) for log analysis.

### Test coverage

- Needs to be tested. 

- Unit tests for the weight-ratio math and the fuel-fraction fallback chain
  (`make tests TESTFILTER=PerformanceModel`)
  
 
### Some points / limitations: 

1. Currently only supports a single fuel tank. 
2. Filter parameters haven't been tested / verified. 

