### PR TITLE
build(msg): silence uORB IDL codegen build noise

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -555,7 +555,7 @@ if(CONFIG_LIB_CDRSTREAM)
                   FILES ${uorb_cdr_idl}
                   INCLUDES ${idl_include_path}
                   BASE_DIR ${idl_include_path}
-                  WARNINGS no-implicit-extensibility)
+                  WARNINGS no-implicit-extensibility no-unsupported-annotations)
 	target_link_libraries(uorb_cdrstream INTERFACE cdr)
 
 	# Generate and overwrite IDL header with custom headers for uORB operatability

--- a/src/lib/cdrstream/msg2idl.py
+++ b/src/lib/cdrstream/msg2idl.py
@@ -34,6 +34,7 @@
 ############################################################################
 
 import argparse
+import builtins
 import pathlib
 import sys
 
@@ -47,11 +48,26 @@ if __name__ == '__main__':
         help='The interface files to convert')
     args = parser.parse_args(sys.argv[1:])
 
-    for interface_file in args.interface_files:
-        interface_file = pathlib.Path(interface_file)
-        package_dir = interface_file.parent.absolute()
+    # convert_msg_to_idl prints a Reading/Writing line per file. Filter those
+    # via builtins.print instead of redirecting stdout, which the empy template
+    # engine relies on and breaks if replaced. Errors still surface on stderr.
+    real_print = builtins.print
 
-        convert_msg_to_idl(
-            package_dir, 'px4_msgs',
-            interface_file.absolute().relative_to(package_dir),
-            interface_file.parent)
+    def quiet_print(*pargs, **kwargs):
+        if pargs and isinstance(pargs[0], str) and \
+                pargs[0].startswith(('Reading input file:', 'Writing output file:')):
+            return
+        real_print(*pargs, **kwargs)
+
+    builtins.print = quiet_print
+    try:
+        for interface_file in args.interface_files:
+            interface_file = pathlib.Path(interface_file)
+            package_dir = interface_file.parent.absolute()
+
+            convert_msg_to_idl(
+                package_dir, 'px4_msgs',
+                interface_file.absolute().relative_to(package_dir),
+                interface_file.parent)
+    finally:
+        builtins.print = real_print


### PR DESCRIPTION
## Summary

Silence two sources of uORB IDL codegen build-log noise that carry no signal, so real warnings stay visible. Affects any target that enables the cdrstream IDL codegen (uXRCE-DDS, Zenoh).

## Problem

CycloneDDS `idlc` prints `@verbatim is currently not supported, and will be skipped in parsing` once for every doc comment carried from a `.msg` into its generated `.idl` — `VehicleCommand` alone produces 153 lines, repeated across every topic. Separately, `rosidl_adapter` prints a `Reading input file` / `Writing output file` pair for every message `msg2idl.py` converts. Together they bury the build output under thousands of lines of noise.

## Solution

Add `no-unsupported-annotations` to the existing `idlc_generate(... WARNINGS ...)` list in `msg/CMakeLists.txt`; it maps to idlc's `-Wno-unsupported-annotations` and suppresses the (already-skipped) `@verbatim` warnings. Filter the two chatty lines in `msg2idl.py` by wrapping `builtins.print` — not by redirecting `sys.stdout`, which breaks the empy template engine that installs its own stdout proxy. Real errors still raise and surface on stderr in both paths.
