### PR TITLE
docs(cyphal): fix succes→success in socket/CAN return comments

### DIFF
--- a/src/drivers/cyphal/CanardNuttXCDev.hpp
+++ b/src/drivers/cyphal/CanardNuttXCDev.hpp
@@ -48,7 +48,7 @@ public:
 	/// Creates a SocketCAN socket for corresponding iface can_iface_name
 	/// Also sets up the message structures required for socketcanTransmit & socketcanReceive
 	/// can_fd determines to use CAN FD frame when is 1, and classical CAN frame when is 0
-	/// The return value is 0 on succes and -1 on error
+	/// The return value is 0 on success and -1 on error
 	int init();
 
 	/// Send a CanardTxQueueItem to the CanardSocketInstance socket

--- a/src/drivers/cyphal/CanardSocketCAN.hpp
+++ b/src/drivers/cyphal/CanardSocketCAN.hpp
@@ -59,7 +59,7 @@ public:
 	/// Creates a SocketCAN socket for corresponding iface can_iface_name
 	/// Also sets up the message structures required for socketcanTransmit & socketcanReceive
 	/// can_fd determines to use CAN FD frame when is 1, and classical CAN frame when is 0
-	/// The return value is 0 on succes and -1 on error
+	/// The return value is 0 on success and -1 on error
 	int init();
 
 	/// Close socket connection


### PR DESCRIPTION
## Summary
Comment and doc-comment spelling: "0 on succes" → "0 on success" in CanardSocketCAN / CanardNuttXCDev headers.

## Scope
Comments only. Spec: `specs/px4-autopilot/2026-07-15-2.md`.