### PR TITLE
docs(simulation): fix GPS sinstance typo in SENS_EN_GPSSIM short

### DIFF
--- a/src/modules/simulation/sensor_gps_sim/parameters.yaml
+++ b/src/modules/simulation/sensor_gps_sim/parameters.yaml
@@ -4,7 +4,7 @@ parameters:
   definitions:
     SENS_EN_GPSSIM:
       description:
-        short: Enable simulated GPS sinstance
+        short: Enable simulated GPS instance
       type: enum
       values:
         0: Disabled


### PR DESCRIPTION
## Summary
`SENS_EN_GPSSIM` short description: "GPS sinstance" → "GPS instance". Param name and default unchanged.

## Scope
Param YAML metadata only. Spec: `specs/px4-autopilot/2026-07-15-3.md`.