### PR TITLE
docs(uuv_att_control): fix Yawh→Yaw in UUV_YAW_P short

### DIFF
--- a/src/modules/uuv_att_control/uuv_att_control_params.yaml
+++ b/src/modules/uuv_att_control/uuv_att_control_params.yaml
@@ -28,7 +28,7 @@ parameters:
       decimal: 2
     UUV_YAW_P:
       description:
-        short: Yawh proportional gain
+        short: Yaw proportional gain
       type: float
       default: 4.0
       decimal: 2


### PR DESCRIPTION
## Summary
UUV yaw P-gain short: "Yawh proportional gain" → "Yaw proportional gain". Param `UUV_YAW_P` name unchanged.

## Scope
YAML short only. Spec: `specs/px4-autopilot/2026-07-15-4.md`.