### PR TITLE
[BACKPORT 1.17]fix(crsf_rc): guard against packet_size underflow in CRSF parse

### DIFF
--- a/src/drivers/rc/crsf_rc/CrsfParser.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfParser.cpp
@@ -275,6 +275,18 @@ bool CrsfParser_TryParseCrsfPacket(CrsfPacket_t *const new_packet, CrsfParserSta
 			QueueBuffer_Peek(&rx_queue, working_index++, &packet_size);
 			QueueBuffer_Peek(&rx_queue, working_index++, &packet_type);
 
+			// Discard packets with packet_size too small to contain type + CRC.
+			// Without this guard, (packet_size - PACKET_SIZE_TYPE_SIZE) underflows
+			// the uint32_t working_segment_size, permanently stalling the parser.
+			if (packet_size < PACKET_SIZE_TYPE_SIZE) {
+				parser_statistics->invalid_unknown_packet_sizes++;
+				parser_state = PARSER_STATE_HEADER;
+				working_segment_size = HEADER_SIZE;
+				working_index = 0;
+				buffer_count = QueueBuffer_Count(&rx_queue);
+				continue;
+			}
+
 			working_descriptor = FindCrsfDescriptor((enum CRSF_PACKET_TYPE)packet_type);
 
 			// If we know what this packet is...


### PR DESCRIPTION
Backport of #26792 to `release/1.17`. Clean cherry-pick of 05cc1687.

### Solved Problem

A CRSF frame with `packet_size < 2` underflows `working_segment_size`
via `packet_size - PACKET_SIZE_TYPE_SIZE`. The existing bounds check
also wraps and passes. Since `working_segment_size` is static, the
parser is permanently stalled and RC is lost until reboot.

The fix merged to `main` in March but was never picked to the release
branch, so it is missing from v1.17.0. Reported in flight in #27916.

Related: #27916

### Solution

Validate `packet_size >= PACKET_SIZE_TYPE_SIZE` early in
`PARSER_STATE_SIZE_TYPE`, before any subtraction. Identical to 05cc1687
on `main`.

### Changelog Entry

​```
Bugfix: CRSF parser no longer permanently stalls (loss of RC until reboot) on a malformed frame
​```

### Test coverage

Same as #26792: inject `0xC8 0x01 0x13` and `0xC8 0x00 0x14`, confirm
the parser recovers and keeps processing valid frames.