### PR TITLE
docs(camera_trigger): fix received spelling in module help

### DIFF
--- a/docs/en/modules/modules_driver_camera.md
+++ b/docs/en/modules/modules_driver_camera.md
@@ -11,7 +11,7 @@ Camera trigger driver.
 This module triggers cameras that are connected to the flight-controller outputs,
 or simple MAVLink cameras that implement the MAVLink trigger protocol.
 
-The driver responds to the following MAVLink trigger commands being found in missions or recieved over MAVLink:
+The driver responds to the following MAVLink trigger commands being found in missions or received over MAVLink:
 
 - `MAV_CMD_DO_TRIGGER_CONTROL`
 - `MAV_CMD_DO_DIGICAM_CONTROL`

--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -934,7 +934,7 @@ Camera trigger driver.
 This module triggers cameras that are connected to the flight-controller outputs,
 or simple MAVLink cameras that implement the MAVLink trigger protocol.
 
-The driver responds to the following MAVLink trigger commands being found in missions or recieved over MAVLink:
+The driver responds to the following MAVLink trigger commands being found in missions or received over MAVLink:
 
 - `MAV_CMD_DO_TRIGGER_CONTROL`
 - `MAV_CMD_DO_DIGICAM_CONTROL`


### PR DESCRIPTION
### Summary
Fix recieved → received in camera_trigger PRINT_MODULE_DESCRIPTION and mirrored docs/en/modules/modules_driver_camera.md (operator-facing help).

### Motivation
Maintainer guidance: user-facing help/docs OK (not comment-only thrash).

### Verification
Spelling-only; AI-assisted; human-reviewed.