### PR TITLE
docs(rtk_gps): fix received spelling in RTCM fragment note

### DIFF
--- a/docs/en/advanced/rtk_gps.md
+++ b/docs/en/advanced/rtk_gps.md
@@ -51,7 +51,7 @@ If you are sending RTCM corrections to PX4 yourself, follow the MAVLink [`GPS_RT
 - If the RTCM payload exceeds 180 bytes, split it across up to 4 packets using the Fragment ID and Sequence ID (encoded in `GPS_RTCM_DATA.flags`).
   Every packet except the last one must be filled to its maximum 180-byte capacity; only the final packet may be partially filled.
 - PX4 reassembles fragmented packets according to the MAVLink rules and supports out-of-order delivery for one in-progress fragmented message at a time.
-- A fragmented message is considered complete when either 4 fragments with the same Sequence ID have been received, or when you receive a partial fragment and you have already recieved all the fully-packed fragments that precede it (by Fragment ID) in the current sequence.
+- A fragmented message is considered complete when either 4 fragments with the same Sequence ID have been received, or when you receive a partial fragment and you have already received all the fully-packed fragments that precede it (by Fragment ID) in the current sequence.
 - If the RTCM payload length is an exact multiple of 180 bytes and uses fewer than 4 fragments, the sender must still send a final zero-length fragment to mark completion. A 720-byte payload (all 4 fragments full) is complete after the last fragment is received.
 - As a compatibility fallback for older QGroundControl builds that omit that final zero-length fragment, PX4 also flushes a buffered RTCM message to the GNSS when a `GPS_RTCM_DATA` message with a different Sequence ID arrives, but only if the buffered fragments are a gap-free run of full 180-byte fragments starting at fragment 0.
 


### PR DESCRIPTION
### Summary
docs/en/advanced/rtk_gps.md: recieved → received in RTCM fragment note.

### Verification
Single token; AI-assisted; human-reviewed.