### PR TITLE
fix(cyphal): fix successful spelling in Set portID log

### DIFF
--- a/src/drivers/cyphal/NodeManager.cpp
+++ b/src/drivers/cyphal/NodeManager.cpp
@@ -163,7 +163,7 @@ void NodeManager::HandleListResponse(const CanardRxTransfer &receive)
 		}
 
 		if (_access_request.setPortId(receive.metadata.remote_node_id, msg.name, NULL)) { //FIXME confirm handler
-			PX4_INFO("Set portID succesfull");
+			PX4_INFO("Set portID successful");
 
 		} else {
 			PX4_INFO("Register not found %.*s",


### PR DESCRIPTION
### Summary
PX4_INFO Set portID succesfull → successful (user-visible log).

### Verification
Logging-only; AI-assisted; human-reviewed.