### PR TITLE
fix(pga460): fix occurred spelling in thermal shutdown log

### DIFF
--- a/src/drivers/distance_sensor/pga460/pga460.cpp
+++ b/src/drivers/distance_sensor/pga460/pga460.cpp
@@ -415,7 +415,7 @@ void PGA460::print_device_status()
 		}
 
 		if (status_flags2 & 1 << 6) {
-			PX4_INFO("Thermal shutdown has occured");
+			PX4_INFO("Thermal shutdown has occurred");
 		}
 	}
 }


### PR DESCRIPTION
### Summary
pga460 PX4_INFO: occured → occurred on thermal shutdown.

### Verification
Logging-only; AI-assisted; human-reviewed.