### PR TITLE
fix(simulation): clamp simulated FIFO accel/gyro samples to int16

### DIFF
--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
@@ -220,9 +220,10 @@ void SimulatorMavlink::update_sensors(const hrt_abstime &time, const mavlink_hil
 			accel_fifo.samples = 1;
 			accel_fifo.dt = time - _last_accel_fifo_timestamp;
 			accel_fifo.timestamp_sample = time;
-			accel_fifo.x[0] = sensors.xacc / ACCEL_FIFO_SCALE;
-			accel_fifo.y[0] = sensors.yacc / ACCEL_FIFO_SCALE;
-			accel_fifo.z[0] = sensors.zacc / ACCEL_FIFO_SCALE;
+			// Constrain to FIFO int16 range: beyond full-scale saturates (clip) instead of wrapping.
+			accel_fifo.x[0] = math::constrainFloatToInt16(sensors.xacc / ACCEL_FIFO_SCALE);
+			accel_fifo.y[0] = math::constrainFloatToInt16(sensors.yacc / ACCEL_FIFO_SCALE);
+			accel_fifo.z[0] = math::constrainFloatToInt16(sensors.zacc / ACCEL_FIFO_SCALE);
 			_last_accel_fifo_timestamp = time;
 
 			_px4_accel[sensors.id].updateFIFO(accel_fifo);
@@ -253,9 +254,10 @@ void SimulatorMavlink::update_sensors(const hrt_abstime &time, const mavlink_hil
 			gyro_fifo.samples = 1;
 			gyro_fifo.dt = time - _last_gyro_fifo_timestamp;
 			gyro_fifo.timestamp_sample = time;
-			gyro_fifo.x[0] = sensors.xgyro / GYRO_FIFO_SCALE;
-			gyro_fifo.y[0] = sensors.ygyro / GYRO_FIFO_SCALE;
-			gyro_fifo.z[0] = sensors.zgyro / GYRO_FIFO_SCALE;
+			// Constrain to FIFO int16 range: rates beyond full-scale saturates instead of wrapping.
+			gyro_fifo.x[0] = math::constrainFloatToInt16(sensors.xgyro / GYRO_FIFO_SCALE);
+			gyro_fifo.y[0] = math::constrainFloatToInt16(sensors.ygyro / GYRO_FIFO_SCALE);
+			gyro_fifo.z[0] = math::constrainFloatToInt16(sensors.zgyro / GYRO_FIFO_SCALE);
 			_last_gyro_fifo_timestamp = time;
 
 			_px4_gyro[sensors.id].updateFIFO(gyro_fifo);


### PR DESCRIPTION
### Summary
Salvage of draft CONFLICTING #27864 by @farhangnaderi. Clamp simulated FIFO accel/gyro samples with math::constrainFloatToInt16 so float→int16 saturates instead of wrapping (inverted gyro at high rates).

### Motivation
#27864 useful but CONFLICTING after SimulatorMavlink FIFO refactor. Rebased on main with stock math helper.

### Related
Fixes #23469. Salvages #27864 (credit @farhangnaderi).

### Verification
Simulation HIL FIFO id==0 only; no flight safety path changes. AI-assisted rebase; human-reviewed.

Co-authored-by: Farhang Naderi <farhangnaderi@users.noreply.github.com>