### PR TITLE
feat(tecs): expose max jerk as parameter

### DIFF
--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -139,14 +139,14 @@ void TECSAltitudeReferenceModel::update(const float dt, const AltitudeReferenceS
 
 	const float current_alt = PX4_ISFINITE(altitude) ? altitude : 0.f;
 
-	_velocity_control_traj_generator.setMaxJerk(param.jerk_max);
+	_velocity_control_traj_generator.setMaxJerk(param.vert_jerk_limit);
 	_velocity_control_traj_generator.setMaxAccelUp(param.vert_accel_limit);
 	_velocity_control_traj_generator.setMaxAccelDown(param.vert_accel_limit);
 	_velocity_control_traj_generator.setMaxVelUp(param.max_sink_rate); // different convention for FW than for MC
 	_velocity_control_traj_generator.setMaxVelDown(param.max_climb_rate); // different convention for FW than for MC
 
 	// Altitude setpoint reference
-	_alt_control_traj_generator.setMaxJerk(param.jerk_max);
+	_alt_control_traj_generator.setMaxJerk(param.vert_jerk_limit);
 	_alt_control_traj_generator.setMaxAccel(param.vert_accel_limit);
 	_alt_control_traj_generator.setMaxVel(fmax(param.max_climb_rate, param.max_sink_rate));
 
@@ -184,7 +184,7 @@ void TECSAltitudeReferenceModel::update(const float dt, const AltitudeReferenceS
 
 		float height_rate_target = math::signNoZero<float>(delta_trajectory_to_target_m) *
 					   math::trajectory::computeMaxSpeedFromDistance(
-						   param.jerk_max, param.vert_accel_limit, fabsf(delta_trajectory_to_target_m), 0.f);
+						   param.vert_jerk_limit, param.vert_accel_limit, fabsf(delta_trajectory_to_target_m), 0.f);
 
 		height_rate_target = math::constrain(height_rate_target, -target_sinkrate_m_s, target_climbrate_m_s);
 

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -157,7 +157,7 @@ public:
 	struct Param {
 		float target_climbrate;	///< The target climbrate in [m/s].
 		float target_sinkrate;	///< The target sinkrate in [m/s].
-		float jerk_max;		///< Magnitude of the maximum jerk allowed [m/s³].
+		float vert_jerk_limit;	///< Magnitude of the maximum jerk allowed [m/s³].
 		float vert_accel_limit;	///< Magnitude of the maximum vertical acceleration allowed [m/s²].
 		float max_climb_rate;	///< Climb rate produced by max allowed throttle [m/s].
 		float max_sink_rate;	///< Maximum sink rate (with min throttle, max speed) [m/s].
@@ -221,6 +221,7 @@ public:
 		float max_sink_rate;			///< Maximum sink rate (with min throttle and max speed) [m/s].
 		float min_sink_rate;			///< Minimum sink rate (with min throttle and trim speed) [m/s].
 		float max_climb_rate;			///< Climb rate produced by max allowed throttle [m/s].
+		float vert_jerk_limit;			///< Magnitude of the maximum vertical jerk allowed [m/s²].
 		float vert_accel_limit;			///< Magnitude of the maximum vertical acceleration allowed [m/s²].
 		float equivalent_airspeed_trim;		///< Equivalent cruise airspeed for airspeed less mode [m/s].
 		float tas_min;				///< True airspeed demand lower limit [m/s].
@@ -640,6 +641,7 @@ public:
 	void set_equivalent_airspeed_trim(float airspeed) { _control_param.equivalent_airspeed_trim = airspeed; _airspeed_filter_param.equivalent_airspeed_trim = airspeed; }
 
 	void set_pitch_damping(float damping) { _control_param.pitch_damping_gain = damping; }
+	void set_vertical_jerk_limit(float limit) { _reference_param.vert_jerk_limit = limit; _control_param.vert_jerk_limit = limit; };
 	void set_vertical_accel_limit(float limit) { _reference_param.vert_accel_limit = limit; _control_param.vert_accel_limit = limit; };
 
 	void set_speed_weight(float weight) { _control_param.pitch_speed_weight = weight; };
@@ -718,7 +720,7 @@ private:
 
 	float _equivalent_airspeed_min{10.0f};				///< equivalent airspeed demand lower limit (m/sec)
 	float _equivalent_airspeed_max{20.0f};				///< equivalent airspeed demand upper limit (m/sec)
-	float _fast_descend_alt_err{-1.f};	 				///< Altitude difference between current altitude to altitude setpoint needed to descend with higher airspeed [m].
+	float _fast_descend_alt_err{-1.f};	 			///< Altitude difference between current altitude to altitude setpoint needed to descend with higher airspeed [m].
 	float _fast_descend{0.f};					///< Value for fast descend in [0,1]. continuous value used to flatten the high speed value out when close to target altitude.
 	hrt_abstime _enabled_fast_descend_timestamp{0U};		///< timestamp at activation of fast descend mode
 
@@ -737,7 +739,7 @@ private:
 	TECSAltitudeReferenceModel::Param _reference_param{
 		.target_climbrate = 2.0f,
 		.target_sinkrate = 2.0f,
-		.jerk_max = 1000.0f,
+		.vert_jerk_limit = 1000.0f,
 		.vert_accel_limit = 0.0f,
 		.max_climb_rate = 2.0f,
 		.max_sink_rate = 2.0f,
@@ -747,6 +749,7 @@ private:
 		.max_sink_rate = 5.0f,
 		.min_sink_rate = 2.0f,
 		.max_climb_rate = 5.0f,
+		.vert_jerk_limit = 10.0f,
 		.vert_accel_limit = 0.0f,
 		.equivalent_airspeed_trim = 15.0f,
 		.tas_min = 10.0f,

--- a/src/lib/tecs/TECSTest.cpp
+++ b/src/lib/tecs/TECSTest.cpp
@@ -48,6 +48,7 @@ TECSControl::Param makeParam()
 	param.max_sink_rate = 5.f;
 	param.min_sink_rate = 2.f;
 	param.max_climb_rate = 5.f;
+	param.vert_jerk_limit = 10.f;
 	param.vert_accel_limit = 10.f;
 	param.equivalent_airspeed_trim = 15.f;
 	param.tas_min = 10.f;

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -103,6 +103,7 @@ FwLateralLongitudinalControl::parameters_update()
 	_tecs.set_integrator_gain_throttle(_param_fw_t_thr_integ.get());
 	_tecs.set_integrator_gain_pitch(_param_fw_t_I_gain_pit.get());
 	_tecs.set_throttle_slewrate(_param_fw_thr_slew_max.get());
+	_tecs.set_vertical_jerk_limit(_param_fw_t_vert_jerk.get());
 	_tecs.set_vertical_accel_limit(_param_fw_t_vert_acc.get());
 	_tecs.set_roll_throttle_compensation(_param_fw_t_rll2thr.get());
 	_tecs.set_pitch_damping(_param_fw_t_ptch_damp.get());

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.hpp
@@ -156,6 +156,7 @@ private:
 		(ParamFloat<px4::params::FW_T_SINK_MAX>) _param_fw_t_sink_max,
 		(ParamFloat<px4::params::FW_T_TAS_TC>) _param_fw_t_tas_error_tc,
 		(ParamFloat<px4::params::FW_T_THR_DAMPING>) _param_fw_t_thr_damping,
+		(ParamFloat<px4::params::FW_T_VERT_JERK>) _param_fw_t_vert_jerk,
 		(ParamFloat<px4::params::FW_T_VERT_ACC>) _param_fw_t_vert_acc,
 		(ParamFloat<px4::params::FW_T_STE_R_TC>) _param_ste_rate_time_const,
 		(ParamFloat<px4::params::FW_T_SEB_R_FF>) _param_seb_rate_ff,

--- a/src/modules/fw_lateral_longitudinal_control/fw_lat_long_params.yaml
+++ b/src/modules/fw_lateral_longitudinal_control/fw_lat_long_params.yaml
@@ -89,6 +89,20 @@ parameters:
       max: 2.0
       decimal: 2
       increment: 0.05
+    FW_T_VERT_JERK:
+      description:
+        short: Maximum vertical jerk
+        long: |-
+          This is the maximum vertical jerk
+          either up or down that the controller will use to correct speed
+          or height errors.
+      type: float
+      default: 7.0
+      unit: m/s^3
+      min: 1.0
+      max: 1000.0
+      decimal: 1
+      increment: 0.5
     FW_T_VERT_ACC:
       description:
         short: Maximum vertical acceleration


### PR DESCRIPTION
### Solved Problem
The start and end of climbs in TECS are quite abrupt. It uses the jerk-limited trajectory smoothing algorithm but is hardcoded to use a very high jerk. Being able to configure the max jerk allows to smooth the desired trajectory. And having a trajectory generator that really outputs what you want to fly allows for a higher value of FW_T_HRATE_FF and less altitude deviation during climbs and descents. Ideally you would fly with FW_T_HRATE_FF = 1 (at least when using mission mode): If your flight plan requires to climb at 3m/s, you know that you want a height rate setpoint of 3m/s.

### Solution
Expose the max jerk as a parameter called FW_T_VERT_JERK, analogous to FW_T_VERT_ACC:

### Changelog Entry
For release notes:
```
Feature New parameter FW_T_VERT_JERK to allow smoother climbs and descends
```

### Context
During a TECS tuning campaign on our (outdated) branch of PX4, we have found it limiting to not be able to limit the jerk in the trajectory generator.

Unfortunately I don't have access to a FW/VTOL drone currently that I could fly on upstream... So here are some screenshots showing how it behaves on SITL:
Jerk = 1000 m/s³ : (current behaviour) The height rate reference is almost immediately at max speed (square profile)
<img width="1983" height="1414" alt="image" src="https://github.com/user-attachments/assets/2b6d3fec-c4b5-416a-abbf-9066fe37902a" />

Jerk = 7 m/s³ : (approximate value that I think would make sense as default based on first tests, so that you get to default max acceleration in 1s) The height rate reference is noticeably smoother.
<img width="1983" height="1414" alt="image" src="https://github.com/user-attachments/assets/7f56a88d-c894-4cf9-93c0-3555938cb98d" />

Going lower (I also tested with 3 m/s³) is too extreme for most platforms I think.

Route:
[climb flight Zurich.zip](https://github.com/user-attachments/files/30081395/climb.flight.Zurich.zip)

Flight logs are too big to attach all three, I can provide them individually if desired. But can be repeated with a fresh build and then running `make px4_sitl gazebo-classic_standard_vtol`