### PR TITLE
fix(mavlink): handle unknown battery time remaining

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2009,6 +2009,7 @@ MavlinkReceiver::handle_message_battery_status(mavlink_message_t *msg)
 	battery_status.temperature = (battery_mavlink.temperature == INT16_MAX) ?
 				     NAN : (float)battery_mavlink.temperature / 100.0f;
 	battery_status.connected = true;
+	battery_status.time_remaining_s = (battery_mavlink.time_remaining > 0) ? static_cast<float>(battery_mavlink.time_remaining) : NAN;
 
 	// Set the battery warning based on remaining charge, if available.
 	//  Note: Smallest values must come first in evaluation.


### PR DESCRIPTION
### Description

Convert an unavailable MAVLink `BATTERY_STATUS.time_remaining` value to `NAN`
when publishing `battery_status`.

MAVLink uses `0` to indicate that the remaining battery time estimate is not
provided, while the uORB `battery_status.time_remaining_s` field uses `NAN` as
its invalid value.

Previously, `battery_status_s` was zero-initialized and
`time_remaining_s` was not explicitly assigned. This left the field at
`0.0f`, which was treated as a valid estimate by battery checks. It was also
converted back to a MAVLink value of `1` second by the `BATTERY_STATUS` stream.

This change maps:

- Positive `time_remaining` values to `time_remaining_s`
- Zero or invalid values to `NAN`

### Impact

This prevents an unavailable battery time estimate from being interpreted as
zero or one second remaining, which could incorrectly affect RTL battery-time
checks and downstream MAVLink consumers.

### Test coverage

- Verified that an incoming `BATTERY_STATUS` with `time_remaining = 0`
  publishes `battery_status.time_remaining_s = NAN`.
- Verified that a positive `time_remaining` value is preserved in uORB.
- Verified that the outgoing MAVLink `BATTERY_STATUS.time_remaining` remains
  `0` when no estimate is available.