### PR TITLE
fix(logging): consolidate user-visible log/doc spelling fixes

### DIFF
--- a/docs/en/modules/modules_driver_camera.md
+++ b/docs/en/modules/modules_driver_camera.md
@@ -11,7 +11,7 @@ Camera trigger driver.
 This module triggers cameras that are connected to the flight-controller outputs,
 or simple MAVLink cameras that implement the MAVLink trigger protocol.
 
-The driver responds to the following MAVLink trigger commands being found in missions or recieved over MAVLink:
+The driver responds to the following MAVLink trigger commands being found in missions or received over MAVLink:
 
 - `MAV_CMD_DO_TRIGGER_CONTROL`
 - `MAV_CMD_DO_DIGICAM_CONTROL`

--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -934,7 +934,7 @@ Camera trigger driver.
 This module triggers cameras that are connected to the flight-controller outputs,
 or simple MAVLink cameras that implement the MAVLink trigger protocol.
 
-The driver responds to the following MAVLink trigger commands being found in missions or recieved over MAVLink:
+The driver responds to the following MAVLink trigger commands being found in missions or received over MAVLink:
 
 - `MAV_CMD_DO_TRIGGER_CONTROL`
 - `MAV_CMD_DO_DIGICAM_CONTROL`

--- a/src/drivers/cyphal/NodeManager.cpp
+++ b/src/drivers/cyphal/NodeManager.cpp
@@ -163,7 +163,7 @@ void NodeManager::HandleListResponse(const CanardRxTransfer &receive)
 		}
 
 		if (_access_request.setPortId(receive.metadata.remote_node_id, msg.name, NULL)) { //FIXME confirm handler
-			PX4_INFO("Set portID succesfull");
+			PX4_INFO("Set portID successful");
 
 		} else {
 			PX4_INFO("Register not found %.*s",

--- a/src/drivers/distance_sensor/pga460/pga460.cpp
+++ b/src/drivers/distance_sensor/pga460/pga460.cpp
@@ -415,7 +415,7 @@ void PGA460::print_device_status()
 		}
 
 		if (status_flags2 & 1 << 6) {
-			PX4_INFO("Thermal shutdown has occured");
+			PX4_INFO("Thermal shutdown has occurred");
 		}
 	}
 }

--- a/src/modules/muorb/apps/uORBAppsProtobufChannel.cpp
+++ b/src/modules/muorb/apps/uORBAppsProtobufChannel.cpp
@@ -186,22 +186,22 @@ bool uORB::AppsProtobufChannel::Test(MUORBTestType test_type)
 	switch (test_type) {
 	case ADVERTISE_TEST_TYPE:
 		rc = topic_advertised(muorb_test_topic_name);
-		PX4_INFO("succesfully did ADVERTISE_TEST_TYPE");
+		PX4_INFO("successfully did ADVERTISE_TEST_TYPE");
 		break;
 
 	case SUBSCRIBE_TEST_TYPE:
 		rc = add_subscription(muorb_test_topic_name, 1000);
-		PX4_INFO("succesfully did SUBSCRIBE_TEST_TYPE");
+		PX4_INFO("successfully did SUBSCRIBE_TEST_TYPE");
 		break;
 
 	case TOPIC_TEST_TYPE:
 		rc = fc_sensor_send_data(muorb_test_topic_name, test_data, MUORB_TEST_DATA_LEN);
-		PX4_INFO("succesfully did TOPIC_TEST_TYPE");
+		PX4_INFO("successfully did TOPIC_TEST_TYPE");
 		break;
 
 	case UNSUBSCRIBE_TEST_TYPE:
 		rc = remove_subscription(muorb_test_topic_name);
-		PX4_INFO("succesfully did UNSUBSCRIBE_TEST_TYPE");
+		PX4_INFO("successfully did UNSUBSCRIBE_TEST_TYPE");
 		break;
 
 	default:


### PR DESCRIPTION
### Summary
Per @farhangnaderi's feedback on #27924, consolidating the individual typo fixes into a single PR with one clean commit. Replaces #27922, #27924, #27925, #27926 (all closed in favor of this).

Fixes user-visible spelling in:
- `cyphal/NodeManager`: "succesfull" → "successful" (Set portID log)
- `muorb/apps`: "succesfully" → "successfully" (protobuf test logs)
- `pga460`: "occured" → "occurred" (thermal shutdown log)
- `camera_trigger` + docs: "recieved" → "received" (module help)

### Verification
Logging/docs-only, no behavior change. AI-assisted; human-reviewed.