### PR TITLE
docs(rtk): note SPARTN on the GPS inject path

### DIFF
--- a/docs/en/advanced/rtk_gps.md
+++ b/docs/en/advanced/rtk_gps.md
@@ -35,6 +35,10 @@ The PX4 GPS stack automatically sets up the GPS modules to send and receive the 
 As soon as the autopilot receives `GPS_RTCM_DATA` MAVLink messages, it reassembles fragmented packets when needed and then forwards the RTCM data to the attached GPS module over existing data channels (a dedicated channel for correction data is not required).
 
 ::: info
+Firmware built with `CONFIG_GPS_SPARTN` (default off; enabled on selected targets such as ARK GNSS nodes and SITL) also frames [SPARTN](https://www.spartnformat.org/) corrections on that same inject path — for example u-blox PointPerfect streams carried in `GPS_RTCM_DATA` / `rtcm_corrections`. PX4 does not provision SPARTN decryption keys; those must already be configured on the receiver.
+:::
+
+::: info
 The u-blox U-Center RTK module configuration tool is not needed/used!
 :::
 


### PR DESCRIPTION
Document that firmware with `CONFIG_GPS_SPARTN` can frame SPARTN (e.g. PointPerfect) on the existing `GPS_RTCM_DATA` / `rtcm_corrections` inject path, and that PX4 does not provision decryption keys.

Follow-up to #27919.