### PR TITLE
feat(gps): frame UBX AssistNow MGA and harden the correction injection path

### DIFF
--- a/boards/ark/can-rtk-gps/init/rc.board_defaults
+++ b/boards/ark/can-rtk-gps/init/rc.board_defaults
@@ -7,6 +7,7 @@ param set-default CBRK_IO_SAFETY 0
 param set-default CANNODE_SUB_MBD 1
 param set-default CANNODE_SUB_RTCM 1
 param set-default GPS_1_GNSS 63
+param set-default GPS_UBX_BAUD1 921600
 param set-default MBE_ENABLE 0
 param set-default SENS_IMU_CLPNOTI 0
 

--- a/boards/ark/x20-gps/init/rc.board_defaults
+++ b/boards/ark/x20-gps/init/rc.board_defaults
@@ -7,6 +7,7 @@ param set-default CBRK_IO_SAFETY 0
 param set-default CANNODE_SUB_MBD 1
 param set-default CANNODE_SUB_RTCM 1
 param set-default GPS_1_GNSS 47
+param set-default GPS_UBX_BAUD1 921600
 param set-default SENS_IMU_CLPNOTI 0
 
 safety_button start

--- a/docs/en/dronecan/ark_rtk_gps.md
+++ b/docs/en/dronecan/ark_rtk_gps.md
@@ -96,6 +96,8 @@ You may need to [configure the following parameters](../dronecan/index.md#qgc-ca
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-125 to use a static node ID. |
 | <a id="CANNODE_TERM"></a>[CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM)          | CAN built-in bus termination. Set to `1` if this is the last node on the CAN bus.                                                     |
+| <a id="GPS_UBX_BAUD1"></a>[GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1)       | UART1 target baudrate after auto-detect. Board default is `921600` (short on-module MCU↔F9P link). Lower only if UART1 is rewired over a long serial cable. |
+| <a id="GPS_UBX_BAUD2"></a>[GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2)       | UART2 baudrate (default `230400`). Used when two modules exchange RTCM over UART2 ([GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) 1/2). |
 
 ### Setting Up Rover and Fixed Base
 
@@ -137,6 +139,7 @@ Setup via CAN:
 - On the _Moving Base_, set the following:
   - [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) to `4`.
   - [CANNODE_PUB_MBD](../advanced_config/parameter_reference.md#CANNODE_PUB_MBD) to `1`.
+- Leave [GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1) at the board default (`921600`) on both nodes unless UART1 has been rewired off-board.
 - On the _Flight Controller_, set [SENS_GPS_PRIME](../advanced_config/parameter_reference.md#SENS_GPS_PRIME) to the CAN node ID of the _Moving Base_ (see [PX4 Configuration](#px4-configuration)).
 
 Setup via UART:
@@ -156,6 +159,7 @@ Setup via UART:
   - [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) to `0` if your _Rover_ is in front of your _Moving Base_, `90` if _Rover_ is right of _Moving Base_, `180` if _Rover_ is behind _Moving Base_, or `270` if _Rover_ is left of _Moving Base_.
 - On the _Moving Base_, set the following:
   - [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) to `2`.
+- Optionally set [GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2) on both nodes if the UART2 link needs a rate other than the default `230400`.
 - On the _Flight Controller_, set [SENS_GPS_PRIME](../advanced_config/parameter_reference.md#SENS_GPS_PRIME) to the CAN node ID of the _Moving Base_ (see [PX4 Configuration](#px4-configuration)).
 
 For more information see [Rover and Moving Base](../dronecan/index.md#rover-and-moving-base) in the DroneCAN guide.

--- a/docs/en/dronecan/ark_rtk_gps.md
+++ b/docs/en/dronecan/ark_rtk_gps.md
@@ -96,8 +96,8 @@ You may need to [configure the following parameters](../dronecan/index.md#qgc-ca
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-125 to use a static node ID. |
 | <a id="CANNODE_TERM"></a>[CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM)          | CAN built-in bus termination. Set to `1` if this is the last node on the CAN bus.                                                     |
-| <a id="GPS_UBX_BAUD1"></a>[GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1)       | UART1 target baudrate after auto-detect. Board default is `921600` (short on-module MCU↔F9P link). Lower only if UART1 is rewired over a long serial cable. |
-| <a id="GPS_UBX_BAUD2"></a>[GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2)       | UART2 baudrate (default `230400`). Used when two modules exchange RTCM over UART2 ([GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) 1/2). |
+| <a id="GPS_UBX_BAUD1"></a>[GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1)       | UART1 baudrate after the link is auto-detected. Board default is `921600`.                                                            |
+| <a id="GPS_UBX_BAUD2"></a>[GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2)       | UART2 baudrate (default `230400`).                                                                                                    |
 
 ### Setting Up Rover and Fixed Base
 
@@ -139,7 +139,6 @@ Setup via CAN:
 - On the _Moving Base_, set the following:
   - [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) to `4`.
   - [CANNODE_PUB_MBD](../advanced_config/parameter_reference.md#CANNODE_PUB_MBD) to `1`.
-- Leave [GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1) at the board default (`921600`) on both nodes unless UART1 has been rewired off-board.
 - On the _Flight Controller_, set [SENS_GPS_PRIME](../advanced_config/parameter_reference.md#SENS_GPS_PRIME) to the CAN node ID of the _Moving Base_ (see [PX4 Configuration](#px4-configuration)).
 
 Setup via UART:
@@ -159,7 +158,6 @@ Setup via UART:
   - [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) to `0` if your _Rover_ is in front of your _Moving Base_, `90` if _Rover_ is right of _Moving Base_, `180` if _Rover_ is behind _Moving Base_, or `270` if _Rover_ is left of _Moving Base_.
 - On the _Moving Base_, set the following:
   - [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) to `2`.
-- Optionally set [GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2) on both nodes if the UART2 link needs a rate other than the default `230400`.
 - On the _Flight Controller_, set [SENS_GPS_PRIME](../advanced_config/parameter_reference.md#SENS_GPS_PRIME) to the CAN node ID of the _Moving Base_ (see [PX4 Configuration](#px4-configuration)).
 
 For more information see [Rover and Moving Base](../dronecan/index.md#rover-and-moving-base) in the DroneCAN guide.

--- a/docs/en/dronecan/ark_x20_rtk_gps.md
+++ b/docs/en/dronecan/ark_x20_rtk_gps.md
@@ -98,8 +98,8 @@ You may need to [configure the following parameters](../dronecan/index.md#qgc-ca
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-125 to use a static node ID. |
 | <a id="CANNODE_TERM"></a>[CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM)          | CAN built-in bus termination. Set to `1` if this is the last node on the CAN bus.                                                     |
-| <a id="GPS_UBX_BAUD1"></a>[GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1)       | UART1 target baudrate after auto-detect. Board default is `921600` (short on-module MCU↔X20P link). Lower only if UART1 is rewired over a long serial cable. |
-| <a id="GPS_UBX_BAUD2"></a>[GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2)       | UART2 baudrate (default `230400`). Used when UART2 carries RTCM or other serial traffic. |
+| <a id="GPS_UBX_BAUD1"></a>[GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1)       | UART1 baudrate after the link is auto-detected. Board default is `921600`.                                                            |
+| <a id="GPS_UBX_BAUD2"></a>[GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2)       | UART2 baudrate (default `230400`).                                                                                                    |
 
 ### Setting Up Rover and Fixed Base
 

--- a/docs/en/dronecan/ark_x20_rtk_gps.md
+++ b/docs/en/dronecan/ark_x20_rtk_gps.md
@@ -98,6 +98,8 @@ You may need to [configure the following parameters](../dronecan/index.md#qgc-ca
 | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | <a id="CANNODE_NODE_ID"></a>[CANNODE_NODE_ID](../advanced_config/parameter_reference.md#CANNODE_NODE_ID) | CAN node ID (0 for dynamic allocation). If set to 0 (default), dynamic node allocation is used. Set to 1-125 to use a static node ID. |
 | <a id="CANNODE_TERM"></a>[CANNODE_TERM](../advanced_config/parameter_reference.md#CANNODE_TERM)          | CAN built-in bus termination. Set to `1` if this is the last node on the CAN bus.                                                     |
+| <a id="GPS_UBX_BAUD1"></a>[GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1)       | UART1 target baudrate after auto-detect. Board default is `921600` (short on-module MCU↔X20P link). Lower only if UART1 is rewired over a long serial cable. |
+| <a id="GPS_UBX_BAUD2"></a>[GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2)       | UART2 baudrate (default `230400`). Used when UART2 carries RTCM or other serial traffic. |
 
 ### Setting Up Rover and Fixed Base
 

--- a/docs/en/gps_compass/u-blox_f9p_heading.md
+++ b/docs/en/gps_compass/u-blox_f9p_heading.md
@@ -33,13 +33,14 @@ Ideally the two antennas should be identical, on the same level/horizontal plane
 
 ### UART Setup
 
-- The UART2 of the GPS devices need to be connected together (TXD2 of the "Moving Base" to RXD2 of the "Rover").
-- Connect UART1 on each of the GPS to (separate) unused UARTs on the autopilot, and configure both of them as GPS with the serial port baudrate set to `Auto` (the driver probes the link, then moves the receiver to [GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1)).
+- The UART2 of the GPS devices need to be connected together (TXD2 of the "Moving Base" to RXD2 of the "Rover")
+- Connect UART1 on each of the GPS to (separate) unused UART's on the autopilot, and configure both of them as GPS with baudrate set to `Auto`.
   The mapping is as follows:
   - Main GPS = Rover
   - Secondary GPS = Moving Base
-- Set [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) to `Heading` (1).
-- Configure [GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1) / [GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2) as needed (see [u-blox UART baudrates](#u-blox-uart-baudrates)).
+- Set [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) to `Heading` (1)
+- Set [GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1) if a UART1 rate other than the default is required (0 keeps 115200). Use a higher rate for high update rates or when RTCM is sent on UART1 ([GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) 3/4), and a lower rate on long serial cables.
+- Set [GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2) if a UART2 rate other than the default (230400) is required. UART2 carries RTCM between the modules in this setup.
 - [EKF2_GPS_CTRL](../advanced_config/parameter_reference.md#EKF2_GPS_CTRL) parameter bit 3 must be set (see [RTK GPS > GPS as Yaw/Heading Source](../gps_compass/rtk_gps.md#configuring-gps-as-yaw-heading-source)).
 - [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) may need to be set (see [RTK GPS > GPS as Yaw/Heading Source](../gps_compass/rtk_gps.md#configuring-gps-as-yaw-heading-source)).
 - Reboot and wait until both devices have GPS reception.
@@ -47,28 +48,11 @@ Ideally the two antennas should be identical, on the same level/horizontal plane
 
 ### CAN Setup
 
-Refer to the CAN RTK GPS documentation for each specific device for the setup instructions (such as [ARK RTK GPS > Setting Up Moving Baseline & GPS Heading](../dronecan/ark_rtk_gps.md#setting-up-moving-baseline-gps-heading)).
-Set [GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1) / [GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2) on each CAN GPS node (see [u-blox UART baudrates](#u-blox-uart-baudrates)).
+Refer to the CAN RTK GPS documentation for each specific device for the setup instructions (such as [ARK RTK GPS > Setting Up Moving Baseline & GPS Heading](../dronecan/ark_rtk_gps.md#setting-up-moving-baseline-gps-heading))
 
 ::: info
 If using RTK with a fixed base station the secondary GPS will show the RTK state w.r.t. the base station.
 :::
-
-### u-blox UART baudrates
-
-The GPS driver auto-detects the UART1 link, then moves the receiver to a target rate. That target is set by parameters — not by the flight-controller serial-port baud (keep that at `Auto` so probing still works).
-
-| Parameter | Port | Default | When to change |
-| --- | --- | --- | --- |
-| [GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1) | UART1 (to FC or CAN-node MCU) | `0` → 115200 | Raise for high nav rates or when RTCM shares UART1 ([GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) 3/4). Keep lower on long or unreliable serial cables. |
-| [GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2) | UART2 (between modules, or corrections) | 230400 | Used when UART2 carries RTCM (modes 1/2 and similar). Lower if attaching a telemetry radio to UART2. |
-
-Notes:
-
-- `GPS_UBX_BAUD1` is the UART1 target in every mode (heading modes do not hard-code a baudrate).
-- On ARK DroneCAN GPS modules the MCU↔receiver link is on-board and short; firmware board defaults set `GPS_UBX_BAUD1` to `921600`. Only lower it if you rewire UART1 over a long off-board cable.
-- For dual serial F9P with RTCM on UART2 (mode 1), the default UART1 rate is usually enough; raise `GPS_UBX_BAUD1` if you enable a high [GPS_UBX_RATE](../advanced_config/parameter_reference.md#GPS_UBX_RATE) and see dropouts.
-- On a flight controller these parameters apply to the vehicle GPS driver(s). On a DroneCAN GPS they are set on the **node** ([QGC Component parameters](../dronecan/index.md#qgc-cannode-parameter-configuration)).
 
 ## Further Information
 

--- a/docs/en/gps_compass/u-blox_f9p_heading.md
+++ b/docs/en/gps_compass/u-blox_f9p_heading.md
@@ -33,12 +33,13 @@ Ideally the two antennas should be identical, on the same level/horizontal plane
 
 ### UART Setup
 
-- The UART2 of the GPS devices need to be connected together (TXD2 of the "Moving Base" to RXD2 of the "Rover")
-- Connect UART1 on each of the GPS to (separate) unused UART's on the autopilot, and configure both of them as GPS with baudrate set to `Auto`.
+- The UART2 of the GPS devices need to be connected together (TXD2 of the "Moving Base" to RXD2 of the "Rover").
+- Connect UART1 on each of the GPS to (separate) unused UARTs on the autopilot, and configure both of them as GPS with the serial port baudrate set to `Auto` (the driver probes the link, then moves the receiver to [GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1)).
   The mapping is as follows:
   - Main GPS = Rover
   - Secondary GPS = Moving Base
-- Set [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) to `Heading` (1)
+- Set [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) to `Heading` (1).
+- Configure [GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1) / [GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2) as needed (see [u-blox UART baudrates](#u-blox-uart-baudrates)).
 - [EKF2_GPS_CTRL](../advanced_config/parameter_reference.md#EKF2_GPS_CTRL) parameter bit 3 must be set (see [RTK GPS > GPS as Yaw/Heading Source](../gps_compass/rtk_gps.md#configuring-gps-as-yaw-heading-source)).
 - [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) may need to be set (see [RTK GPS > GPS as Yaw/Heading Source](../gps_compass/rtk_gps.md#configuring-gps-as-yaw-heading-source)).
 - Reboot and wait until both devices have GPS reception.
@@ -46,11 +47,28 @@ Ideally the two antennas should be identical, on the same level/horizontal plane
 
 ### CAN Setup
 
-Refer to the CAN RTK GPS documentation for each specific device for the setup instructions (such as [ARK RTK GPS > Setting Up Moving Baseline & GPS Heading](../dronecan/ark_rtk_gps.md#setting-up-moving-baseline-gps-heading))
+Refer to the CAN RTK GPS documentation for each specific device for the setup instructions (such as [ARK RTK GPS > Setting Up Moving Baseline & GPS Heading](../dronecan/ark_rtk_gps.md#setting-up-moving-baseline-gps-heading)).
+Set [GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1) / [GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2) on each CAN GPS node (see [u-blox UART baudrates](#u-blox-uart-baudrates)).
 
 ::: info
 If using RTK with a fixed base station the secondary GPS will show the RTK state w.r.t. the base station.
 :::
+
+### u-blox UART baudrates
+
+The GPS driver auto-detects the UART1 link, then moves the receiver to a target rate. That target is set by parameters — not by the flight-controller serial-port baud (keep that at `Auto` so probing still works).
+
+| Parameter | Port | Default | When to change |
+| --- | --- | --- | --- |
+| [GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1) | UART1 (to FC or CAN-node MCU) | `0` → 115200 | Raise for high nav rates or when RTCM shares UART1 ([GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) 3/4). Keep lower on long or unreliable serial cables. |
+| [GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2) | UART2 (between modules, or corrections) | 230400 | Used when UART2 carries RTCM (modes 1/2 and similar). Lower if attaching a telemetry radio to UART2. |
+
+Notes:
+
+- `GPS_UBX_BAUD1` is the UART1 target in every mode (heading modes do not hard-code a baudrate).
+- On ARK DroneCAN GPS modules the MCU↔receiver link is on-board and short; firmware board defaults set `GPS_UBX_BAUD1` to `921600`. Only lower it if you rewire UART1 over a long off-board cable.
+- For dual serial F9P with RTCM on UART2 (mode 1), the default UART1 rate is usually enough; raise `GPS_UBX_BAUD1` if you enable a high [GPS_UBX_RATE](../advanced_config/parameter_reference.md#GPS_UBX_RATE) and see dropouts.
+- On a flight controller these parameters apply to the vehicle GPS driver(s). On a DroneCAN GPS they are set on the **node** ([QGC Component parameters](../dronecan/index.md#qgc-cannode-parameter-configuration)).
 
 ## Further Information
 

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -786,9 +786,13 @@ void GPS::injectRtcmFrames(gnss::CorrectionFramer &framer, perf_counter_t inject
 				(*rtcm_frames_in_window)++;
 			}
 
-		} else if (spartn_frames_in_window != nullptr) {
-			(*spartn_frames_in_window)++;
+		} else if (protocol == gnss::CorrectionProtocol::Spartn) {
+			if (spartn_frames_in_window != nullptr) {
+				(*spartn_frames_in_window)++;
+			}
 		}
+
+		// UBX (AssistNow MGA) is injected the same way; no rate window counter yet.
 	}
 }
 

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -290,6 +290,7 @@ private:
 	static px4::atomic<GPS *> _secondary_instance;
 
 	px4::atomic<int> _scheduled_reset{(int)GPSRestartType::None};
+	bool _reset_performed{false};	///< a reset we issued dropped the receiver, so _mode is still known good
 
 	/**
 	 * Publish the gps struct
@@ -1393,7 +1394,13 @@ GPS::run()
 #endif
 		}
 
-		if (_mode_auto) {
+		// Dropping out of the receive loop normally means the protocol guess was
+		// wrong, but a reset we issued is a receiver we already had talking:
+		// keep the mode and wait for it to come back on it.
+		const bool keep_mode = _reset_performed;
+		_reset_performed = false;
+
+		if (_mode_auto && !keep_mode) {
 			size_t i = 0;
 
 			while (kAutoDetectModes[i] != _mode && kAutoDetectModes[i] != gps_driver_mode_t::None) {
@@ -1548,6 +1555,7 @@ GPS::reset_if_scheduled()
 			PX4_INFO("Reset failed.");
 
 		} else {
+			_reset_performed = true;
 			PX4_INFO("Reset succeeded.");
 		}
 	}

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -788,9 +788,13 @@ void GPS::injectRtcmFrames(gnss::CorrectionFramer &framer, perf_counter_t inject
 				(*rtcm_frames_in_window)++;
 			}
 
-		} else if (spartn_frames_in_window != nullptr) {
-			(*spartn_frames_in_window)++;
+		} else if (protocol == gnss::CorrectionProtocol::Spartn) {
+			if (spartn_frames_in_window != nullptr) {
+				(*spartn_frames_in_window)++;
+			}
 		}
+
+		// UBX (AssistNow MGA) is injected the same way; no rate window counter yet.
 	}
 }
 

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -331,9 +331,11 @@ private:
 
 	/**
 	 * Drain the multi-instance rtcm_corrections subscription into its RTCM parser, selecting an
-	 * active instance if the current one goes stale.
+	 * active instance if the current one goes stale. With inject false the messages are dropped
+	 * rather than framed, which keeps the subscription current while the receiver cannot be
+	 * written to.
 	 */
-	void drainRtcmCorrections();
+	void drainRtcmCorrections(bool inject);
 
 	/**
 	 * Drain the single-publisher rtcm_moving_baseline subscription into its RTCM parser.
@@ -647,7 +649,7 @@ int GPS::pollOrRead(uint8_t *buf, size_t buf_length, int timeout)
 	return ret;
 }
 
-void GPS::drainRtcmCorrections()
+void GPS::drainRtcmCorrections(bool inject)
 {
 	// rtcm_corrections may have several sources (MAVLink plus CAN nodes), one uORB instance each.
 	rtcm_data_s msg;
@@ -681,7 +683,7 @@ void GPS::drainRtcmCorrections()
 			num_injections++;
 
 			// Prevent injection of data from self
-			if (msg.device_id != get_device_id()) {
+			if (inject && msg.device_id != get_device_id()) {
 				// Add data to the framer buffer for frame reassembly
 				if (_rtcm_corrections_framer.addData(msg.data, msg.len) < msg.len) {
 					perf_count(_correction_buffer_full_perf);
@@ -736,8 +738,15 @@ void GPS::drainMovingBaseline()
 void GPS::handleInjectDataTopic()
 {
 	// receiverReady() is false until the receiver is configured, which keeps us from writing to the
-	// device mid-configuration.
-	if (!_helper->receiverReady()) {
+	// device mid-configuration. Keep draining regardless: rtcm_corrections is queued, and letting
+	// a burst pile up deeper than the queue means the first read after it silently discards the
+	// oldest messages. That is fatal for a one-shot AssistNow burst, whose leading UBX-MGA-INI
+	// carries the time base the ephemeris behind it is useless without.
+	const bool receiver_ready = _helper->receiverReady();
+
+	drainRtcmCorrections(receiver_ready);
+
+	if (!receiver_ready) {
 		return;
 	}
 
@@ -745,7 +754,6 @@ void GPS::handleInjectDataTopic()
 	// SPARTN framed from one buffer in arrival order. Every configured receiver can use these -
 	// including a UART2 moving-base rover, whose baseline arrives in hardware but which still wants
 	// fixed-base corrections over its main link.
-	drainRtcmCorrections();
 	injectRtcmFrames(_rtcm_corrections_framer, _rtcm_corrections_injection_perf,
 			 &_rtcm_frames_in_rate_window, &_spartn_frames_in_rate_window);
 

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -806,7 +806,7 @@ void GPS::injectRtcmFrames(gnss::CorrectionFramer &framer, perf_counter_t inject
 
 		} else if (protocol == gnss::CorrectionProtocol::Ubx && frame_len >= 4) {
 			// One-shot billed burst: name each message as it goes to the receiver.
-			PX4_INFO("injected UBX-%02X-%02X, %u bytes", frame_ptr[2], frame_ptr[3], (unsigned)frame_len);
+			PX4_DEBUG("injected UBX-%02X-%02X, %u bytes", frame_ptr[2], frame_ptr[3], (unsigned)frame_len);
 		}
 	}
 }

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -1019,6 +1019,13 @@ GPS::run()
 		}
 	}
 
+	handle = param_find("GPS_UBX_BAUD1");
+	int32_t ubx_uart1_baudrate = 0;
+
+	if (handle != PARAM_INVALID) {
+		param_get(handle, &ubx_uart1_baudrate);
+	}
+
 	handle = param_find("GPS_UBX_BAUD2");
 	int32_t f9p_uart2_baudrate = 57600;
 
@@ -1142,6 +1149,7 @@ GPS::run()
 					.min_elev = (int8_t)gps_ubx_min_elev,
 					.output_rate = (uint8_t)gps_ubx_rate,
 					.heading_offset = heading_offset,
+					.uart1_baudrate = ubx_uart1_baudrate,
 					.uart2_baudrate = f9p_uart2_baudrate,
 					.ppk_output = ppk_output > 0,
 					.jam_det_sensitivity_hi = jam_det_sensitivity_hi > 0,

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -677,10 +677,8 @@ void GPS::drainRtcmCorrections(bool inject)
 	bool have_msg = already_copied;
 	size_t num_injections = 0;
 
-	// Limit maximum number of injections per call so a burst can't starve the driver loop. The
-	// budget is checked before reading, never after: a message taken off the queue and then left
-	// behind by the loop exit is gone, and one missing frame can invalidate a whole assistance
-	// burst.
+	// Cap injections per call so a burst can't starve the loop. Checked before
+	// reading, never after: a message taken off the queue and left behind is gone.
 	while (num_injections < rtcm_data_s::ORB_QUEUE_LENGTH) {
 		if (!have_msg) {
 			auto &sub = _rtcm_corrections_sub[_selected_rtcm_instance];
@@ -743,11 +741,9 @@ void GPS::drainMovingBaseline()
 
 void GPS::handleInjectDataTopic()
 {
-	// receiverReady() is false until the receiver is configured, which keeps us from writing to the
-	// device mid-configuration. Keep draining regardless: rtcm_corrections is queued, and letting
-	// a burst pile up deeper than the queue means the first read after it silently discards the
-	// oldest messages. That is fatal for a one-shot AssistNow burst, whose leading UBX-MGA-INI
-	// carries the time base the ephemeris behind it is useless without.
+	// receiverReady() is false mid-configuration, so no writing to the device —
+	// but keep draining: a burst piling past the uORB queue depth silently
+	// drops the oldest messages.
 	const bool receiver_ready = _helper->receiverReady();
 
 	drainRtcmCorrections(receiver_ready);
@@ -809,8 +805,7 @@ void GPS::injectRtcmFrames(gnss::CorrectionFramer &framer, perf_counter_t inject
 			}
 
 		} else if (protocol == gnss::CorrectionProtocol::Ubx && frame_len >= 4) {
-			// AssistNow (MGA) arrives once per caster connection and a single missing
-			// message can invalidate the rest, so name each one as it goes to the receiver.
+			// One-shot billed burst: name each message as it goes to the receiver.
 			PX4_INFO("injected UBX-%02X-%02X, %u bytes", frame_ptr[2], frame_ptr[3], (unsigned)frame_len);
 		}
 	}
@@ -1420,8 +1415,7 @@ GPS::run()
 		}
 
 		// Dropping out of the receive loop normally means the protocol guess was
-		// wrong, but a reset we issued is a receiver we already had talking:
-		// keep the mode and wait for it to come back on it.
+		// wrong; after a reset we issued, keep the known-good mode.
 		const bool keep_mode = _reset_performed;
 		_reset_performed = false;
 

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -674,35 +674,41 @@ void GPS::drainRtcmCorrections(bool inject)
 		}
 	}
 
-	bool updated = already_copied;
+	bool have_msg = already_copied;
 	size_t num_injections = 0;
 
-	// Limit maximum number of injections per call so a burst can't starve the driver loop.
-	do {
-		if (updated) {
-			num_injections++;
+	// Limit maximum number of injections per call so a burst can't starve the driver loop. The
+	// budget is checked before reading, never after: a message taken off the queue and then left
+	// behind by the loop exit is gone, and one missing frame can invalidate a whole assistance
+	// burst.
+	while (num_injections < rtcm_data_s::ORB_QUEUE_LENGTH) {
+		if (!have_msg) {
+			auto &sub = _rtcm_corrections_sub[_selected_rtcm_instance];
+			const unsigned last_generation = sub.get_last_generation();
 
-			// Prevent injection of data from self
-			if (inject && msg.device_id != get_device_id()) {
-				// Add data to the framer buffer for frame reassembly
-				if (_rtcm_corrections_framer.addData(msg.data, msg.len) < msg.len) {
-					perf_count(_correction_buffer_full_perf);
-				}
+			if (!sub.update(&msg)) {
+				break;
+			}
 
-				_last_rtcm_injection_time = hrt_absolute_time();
+			if (sub.get_last_generation() != last_generation + 1) {
+				PX4_WARN("%s lost, generation %u -> %u", sub.get_topic()->o_name,
+					 last_generation, sub.get_last_generation());
 			}
 		}
 
-		auto &sub = _rtcm_corrections_sub[_selected_rtcm_instance];
-		const unsigned last_generation = sub.get_last_generation();
+		have_msg = false;
+		num_injections++;
 
-		updated = sub.update(&msg);
+		// Prevent injection of data from self
+		if (inject && msg.device_id != get_device_id()) {
+			// Add data to the framer buffer for frame reassembly
+			if (_rtcm_corrections_framer.addData(msg.data, msg.len) < msg.len) {
+				perf_count(_correction_buffer_full_perf);
+			}
 
-		if (updated && sub.get_last_generation() != last_generation + 1) {
-			PX4_WARN("%s lost, generation %u -> %u", sub.get_topic()->o_name,
-				 last_generation, sub.get_last_generation());
+			_last_rtcm_injection_time = hrt_absolute_time();
 		}
-	} while (updated && num_injections < rtcm_data_s::ORB_QUEUE_LENGTH);
+	}
 }
 
 void GPS::drainMovingBaseline()
@@ -801,9 +807,12 @@ void GPS::injectRtcmFrames(gnss::CorrectionFramer &framer, perf_counter_t inject
 			if (spartn_frames_in_window != nullptr) {
 				(*spartn_frames_in_window)++;
 			}
-		}
 
-		// UBX (AssistNow MGA) is injected the same way; no rate window counter yet.
+		} else if (protocol == gnss::CorrectionProtocol::Ubx && frame_len >= 4) {
+			// AssistNow (MGA) arrives once per caster connection and a single missing
+			// message can invalidate the rest, so name each one as it goes to the receiver.
+			PX4_INFO("injected UBX-%02X-%02X, %u bytes", frame_ptr[2], frame_ptr[3], (unsigned)frame_len);
+		}
 	}
 }
 

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -1539,6 +1539,20 @@ GPS::print_status()
 	perf_print_counter(_rtcm_corrections_injection_perf);
 	perf_print_counter(_rtcm_moving_baseline_injection_perf);
 
+	const gnss::CorrectionFramerStats corrections_stats = _rtcm_corrections_framer.getStats();
+	PX4_INFO("corrections framed: %u RTCM3, %u SPARTN, %u UBX, %u CRC errors, %u bytes discarded",
+		 (unsigned)corrections_stats.rtcm3_messages, (unsigned)corrections_stats.spartn_messages,
+		 (unsigned)corrections_stats.ubx_messages, (unsigned)corrections_stats.crc_errors,
+		 (unsigned)corrections_stats.bytes_discarded);
+
+	const gnss::CorrectionFramerStats mb_stats = _rtcm_moving_baseline_framer.getStats();
+
+	if (mb_stats.messages_parsed > 0 || mb_stats.crc_errors > 0 || mb_stats.bytes_discarded > 0) {
+		PX4_INFO("moving baseline framed: %u RTCM3, %u CRC errors, %u bytes discarded",
+			 (unsigned)mb_stats.rtcm3_messages, (unsigned)mb_stats.crc_errors,
+			 (unsigned)mb_stats.bytes_discarded);
+	}
+
 	if (_instance == Instance::Main && _secondary_instance.load()) {
 		GPS *secondary_instance = _secondary_instance.load();
 		secondary_instance->print_status();

--- a/src/drivers/gps/params.yaml
+++ b/src/drivers/gps/params.yaml
@@ -128,6 +128,21 @@ parameters:
       min: 0
       max: 6
       reboot_required: true
+    GPS_UBX_BAUD1:
+      description:
+        short: u-blox UART1 target baudrate
+        long: |-
+          Baudrate the receiver's UART1 is configured to after the driver
+          connects. The link is auto-detected first, so unlike a fixed
+          baudrate (gps start -b) this cannot lock the driver out of a
+          receiver at its power-on default. 0 keeps the driver default
+          (115200; heading modes use 921600).
+      type: int32
+      default: 0
+      min: 0
+      max: 3000000
+      unit: B/s
+      reboot_required: true
     GPS_UBX_BAUD2:
       description:
         short: u-blox F9P UART2 Baudrate

--- a/src/drivers/gps/params.yaml
+++ b/src/drivers/gps/params.yaml
@@ -132,11 +132,10 @@ parameters:
       description:
         short: u-blox UART1 target baudrate
         long: |-
-          Baudrate the receiver's UART1 is configured to after the driver
-          connects. The link is auto-detected first, so unlike a fixed
-          baudrate (gps start -b) this cannot lock the driver out of a
-          receiver at its power-on default. 0 keeps the driver default
-          (115200; heading modes use 921600).
+          Baudrate the receiver's UART1 is moved to after the link is
+          auto-detected, so a receiver at its power-on default always connects
+          (unlike a fixed baudrate). 0 keeps the driver default (115200;
+          heading modes use 921600).
       type: int32
       default: 0
       min: 0

--- a/src/drivers/gps/params.yaml
+++ b/src/drivers/gps/params.yaml
@@ -118,9 +118,8 @@ parameters:
         1: Heading (Rover With Moving Base UART1 Connected To Autopilot, UART2 Connected
           To Moving Base)
         2: Moving Base (UART1 Connected To Autopilot, UART2 Connected To Rover)
-        3: Heading (Rover With Moving Base UART1 Connected to Autopilot Or Can Node
-          At 921600)
-        4: Moving Base (Moving Base UART1 Connected to Autopilot Or Can Node At 921600)
+        3: Heading (Rover With Moving Base UART1 Connected to Autopilot Or Can Node)
+        4: Moving Base (Moving Base UART1 Connected to Autopilot Or Can Node)
         5: Rover with Static Base on UART2 (similar to Default, except coming in on
           UART2)
         6: Ground Control Station (UART2 outputs NMEA)
@@ -132,10 +131,9 @@ parameters:
       description:
         short: u-blox UART1 target baudrate
         long: |-
-          Baudrate the receiver's UART1 is moved to after the link is
-          auto-detected, so a receiver at its power-on default always connects
-          (unlike a fixed baudrate). 0 keeps the driver default (115200;
-          heading modes use 921600).
+          Baudrate applied to the receiver UART1 after the link is auto-detected.
+          0 keeps the driver default (115200). Modes that share UART1 with RTCM
+          (GPS_UBX_MODE 3/4) may need a higher rate on short/reliable links.
       type: int32
       default: 0
       min: 0
@@ -144,11 +142,8 @@ parameters:
       reboot_required: true
     GPS_UBX_BAUD2:
       description:
-        short: u-blox F9P UART2 Baudrate
-        long: |-
-          Select a baudrate for the F9P's UART2 port.
-          In GPS_UBX_MODE 1, 2, and 3, the F9P's UART2 port is configured to send/receive RTCM corrections.
-          Set this to 57600 if you want to attach a telemetry radio on UART2.
+        short: u-blox UART2 baudrate
+        long: Baudrate for the receiver UART2 port.
       type: int32
       default: 230400
       min: 0

--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -76,7 +76,9 @@ UavcanGnssBridge::~UavcanGnssBridge()
 {
 	delete [] _channel_using_fix2;
 	perf_free(_rtcm_stream_pub_perf);
+	perf_free(_rtcm_stream_pub_failed_perf);
 	perf_free(_moving_baseline_data_pub_perf);
+	perf_free(_moving_baseline_data_pub_failed_perf);
 	perf_free(_moving_baseline_data_sub_perf);
 }
 
@@ -119,6 +121,7 @@ UavcanGnssBridge::init()
 		_publish_rtcm_stream = true;
 		_pub_rtcm_stream.setPriority(uavcan::TransferPriority::NumericallyMax);
 		_rtcm_stream_pub_perf = perf_alloc(PC_INTERVAL, "uavcan: gnss: rtcm stream pub");
+		_rtcm_stream_pub_failed_perf = perf_alloc(PC_COUNT, "uavcan: gnss: rtcm stream pub failed");
 	}
 
 	// UAVCAN_PUB_MBD
@@ -129,6 +132,7 @@ UavcanGnssBridge::init()
 		_publish_moving_baseline_data = true;
 		_pub_moving_baseline_data.setPriority(uavcan::TransferPriority::NumericallyMax);
 		_moving_baseline_data_pub_perf = perf_alloc(PC_INTERVAL, "uavcan: gnss: moving baseline data rtcm stream pub");
+		_moving_baseline_data_pub_failed_perf = perf_alloc(PC_COUNT, "uavcan: gnss: moving baseline data rtcm stream pub failed");
 	}
 
 	// UAVCAN_SUB_MBD
@@ -749,6 +753,13 @@ bool UavcanGnssBridge::PublishRTCMStream(const uint8_t *const data, const size_t
 
 		result = _pub_rtcm_stream.broadcast(msg) >= 0;
 		perf_count(_rtcm_stream_pub_perf);
+
+		if (!result) {
+			// TX queue / pool exhaustion drops the rest of this message silently -
+			// the receiver-side framer sees a partial frame and fails its CRC.
+			perf_count(_rtcm_stream_pub_failed_perf);
+		}
+
 		msg.data.clear();
 	}
 
@@ -777,6 +788,11 @@ bool UavcanGnssBridge::PublishMovingBaselineData(const uint8_t *data, size_t dat
 
 		result = _pub_moving_baseline_data.broadcast(msg) >= 0;
 		perf_count(_moving_baseline_data_pub_perf);
+
+		if (!result) {
+			perf_count(_moving_baseline_data_pub_failed_perf);
+		}
+
 		msg.data.clear();
 	}
 
@@ -787,6 +803,8 @@ void UavcanGnssBridge::print_status() const
 {
 	UavcanSensorBridgeBase::print_status();
 	perf_print_counter(_rtcm_stream_pub_perf);
+	perf_print_counter(_rtcm_stream_pub_failed_perf);
 	perf_print_counter(_moving_baseline_data_pub_perf);
+	perf_print_counter(_moving_baseline_data_pub_failed_perf);
 	perf_print_counter(_moving_baseline_data_sub_perf);
 }

--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -647,27 +647,33 @@ void UavcanGnssBridge::drainRtcmCorrections()
 		}
 	}
 
-	bool updated = already_copied;
+	bool have_msg = already_copied;
 	size_t num_injections = 0;
 
-	do {
-		if (updated) {
-			num_injections++;
-			PublishRTCMStream(msg.data, msg.len);
-			_rtcm_injection_rate_message_count++;
-			_last_rtcm_injection_time = hrt_absolute_time();
+	// The budget is checked before reading, never after: a message taken off the queue and then
+	// left behind by the loop exit is gone, and one missing frame can invalidate a whole
+	// assistance burst.
+	while (num_injections < rtcm_data_s::ORB_QUEUE_LENGTH) {
+		if (!have_msg) {
+			auto &sub = _rtcm_corrections_sub[_selected_rtcm_instance];
+			const unsigned last_generation = sub.get_last_generation();
+
+			if (!sub.update(&msg)) {
+				break;
+			}
+
+			if (sub.get_last_generation() != last_generation + 1) {
+				PX4_WARN("%s lost, generation %u -> %u", sub.get_topic()->o_name,
+					 last_generation, sub.get_last_generation());
+			}
 		}
 
-		auto &sub = _rtcm_corrections_sub[_selected_rtcm_instance];
-		const unsigned last_generation = sub.get_last_generation();
-
-		updated = sub.update(&msg);
-
-		if (updated && sub.get_last_generation() != last_generation + 1) {
-			PX4_WARN("%s lost, generation %u -> %u", sub.get_topic()->o_name,
-				 last_generation, sub.get_last_generation());
-		}
-	} while (updated && num_injections < rtcm_data_s::ORB_QUEUE_LENGTH);
+		have_msg = false;
+		num_injections++;
+		PublishRTCMStream(msg.data, msg.len);
+		_rtcm_injection_rate_message_count++;
+		_last_rtcm_injection_time = hrt_absolute_time();
+	}
 }
 
 // Drains rtcm_moving_baseline (moving-base RTCM 4072 from a peer GPS) to

--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -650,9 +650,8 @@ void UavcanGnssBridge::drainRtcmCorrections()
 	bool have_msg = already_copied;
 	size_t num_injections = 0;
 
-	// The budget is checked before reading, never after: a message taken off the queue and then
-	// left behind by the loop exit is gone, and one missing frame can invalidate a whole
-	// assistance burst.
+	// Budget checked before reading, never after: a message taken off the queue
+	// and left behind is gone.
 	while (num_injections < rtcm_data_s::ORB_QUEUE_LENGTH) {
 		if (!have_msg) {
 			auto &sub = _rtcm_corrections_sub[_selected_rtcm_instance];

--- a/src/drivers/uavcan/sensors/gnss.hpp
+++ b/src/drivers/uavcan/sensors/gnss.hpp
@@ -179,7 +179,9 @@ private:
 	bool _rel_heading_valid{false};
 
 	perf_counter_t _rtcm_stream_pub_perf{nullptr};
+	perf_counter_t _rtcm_stream_pub_failed_perf{nullptr};
 	perf_counter_t _moving_baseline_data_pub_perf{nullptr};
+	perf_counter_t _moving_baseline_data_pub_failed_perf{nullptr};
 	perf_counter_t _moving_baseline_data_sub_perf{nullptr};
 
 	hrt_abstime _last_rate_measurement{0};

--- a/src/lib/gnss/correction_framer.cpp
+++ b/src/lib/gnss/correction_framer.cpp
@@ -50,6 +50,10 @@ bool CorrectionFramer::isPreamble(uint8_t byte)
 		return true;
 	}
 
+	if (byte == UBX_SYNC1) {
+		return true;
+	}
+
 #if defined(CONFIG_GPS_SPARTN)
 
 	if (byte == SPARTN_PREAMBLE) {
@@ -96,6 +100,49 @@ CorrectionFramer::Probe CorrectionFramer::probeRtcm3(size_t *frame_len) const
 				      _buffer[len - 1];
 
 	if (calculated_crc != received_crc) {
+		return Probe::CrcError;
+	}
+
+	*frame_len = len;
+	return Probe::Complete;
+}
+
+CorrectionFramer::Probe CorrectionFramer::probeUbx(size_t *frame_len) const
+{
+	// Need sync1 + sync2 at minimum to reject a false preamble quickly
+	if (_buffer_len < 2) {
+		return Probe::NeedMoreData;
+	}
+
+	if (_buffer[1] != UBX_SYNC2) {
+		return Probe::InvalidHeader;
+	}
+
+	if (_buffer_len < UBX_HEADER_LEN) {
+		return Probe::NeedMoreData;
+	}
+
+	const size_t payload_len = static_cast<size_t>(_buffer[4]) |
+				   (static_cast<size_t>(_buffer[5]) << 8);
+
+	// Protocol allows larger payloads; reject beyond the injection cap so a
+	// garbage length cannot pin the buffer waiting for thousands of bytes.
+	if (payload_len > UBX_MAX_PAYLOAD_LEN) {
+		return Probe::InvalidHeader;
+	}
+
+	const size_t len = UBX_HEADER_LEN + payload_len + UBX_CK_LEN;
+
+	if (_buffer_len < len) {
+		return Probe::NeedMoreData;
+	}
+
+	// CK_A/CK_B cover Class..end of payload (not the sync bytes)
+	uint8_t ck_a = 0;
+	uint8_t ck_b = 0;
+	ubx_checksum(&_buffer[2], UBX_HEADER_LEN - 2 + payload_len, &ck_a, &ck_b);
+
+	if ((ck_a != _buffer[len - 2]) || (ck_b != _buffer[len - 1])) {
 		return Probe::CrcError;
 	}
 
@@ -174,7 +221,7 @@ CorrectionFramer::Probe CorrectionFramer::probeSpartn(size_t *frame_len) const
 const uint8_t *CorrectionFramer::getNextMessage(size_t *out_len, CorrectionProtocol *out_protocol)
 {
 	while (_buffer_len > 0) {
-		// Drop everything that cannot start a frame of either protocol
+		// Drop everything that cannot start a frame of any supported protocol
 		size_t to_drop = 0;
 
 		while ((to_drop < _buffer_len) && !isPreamble(_buffer[to_drop])) {
@@ -194,19 +241,23 @@ const uint8_t *CorrectionFramer::getNextMessage(size_t *out_len, CorrectionProto
 		CorrectionProtocol protocol = CorrectionProtocol::Rtcm3;
 		Probe result;
 
+		if (_buffer[0] == UBX_SYNC1) {
+			protocol = CorrectionProtocol::Ubx;
+			result = probeUbx(&frame_len);
+
 #if defined(CONFIG_GPS_SPARTN)
 
-		if (_buffer[0] == SPARTN_PREAMBLE) {
+		} else if (_buffer[0] == SPARTN_PREAMBLE) {
 			protocol = CorrectionProtocol::Spartn;
 			result = probeSpartn(&frame_len);
 
+#endif
+
 		} else {
+			// RTCM3 preamble (isPreamble already filtered other bytes)
+			protocol = CorrectionProtocol::Rtcm3;
 			result = probeRtcm3(&frame_len);
 		}
-
-#else
-		result = probeRtcm3(&frame_len);
-#endif
 
 		switch (result) {
 		case Probe::NeedMoreData:
@@ -243,11 +294,18 @@ void CorrectionFramer::consumeMessage(size_t len)
 	_messages_parsed++;
 	_total_frame_bytes += len;
 
-	if (_pending_protocol == CorrectionProtocol::Rtcm3) {
+	switch (_pending_protocol) {
+	case CorrectionProtocol::Rtcm3:
 		_rtcm3_messages++;
+		break;
 
-	} else {
+	case CorrectionProtocol::Spartn:
 		_spartn_messages++;
+		break;
+
+	case CorrectionProtocol::Ubx:
+		_ubx_messages++;
+		break;
 	}
 }
 

--- a/src/lib/gnss/correction_framer.h
+++ b/src/lib/gnss/correction_framer.h
@@ -34,13 +34,15 @@
 /**
  * @file correction_framer.h
  *
- * Frame parser for GNSS correction streams: RTCM3, plus SPARTN when
- * CONFIG_GPS_SPARTN is enabled.
+ * Frame parser for GNSS correction streams: RTCM3, UBX (AssistNow MGA),
+ * plus SPARTN when CONFIG_GPS_SPARTN is enabled.
  *
- * Corrections arrive as arbitrary byte chunks (uORB gps_inject_data, serial),
- * so frame boundaries have to be recovered from the byte stream. Both protocols
+ * Corrections arrive as arbitrary byte chunks (uORB rtcm_corrections, serial),
+ * so frame boundaries have to be recovered from the byte stream. All protocols
  * share one buffer: whichever preamble appears first is framed, and a valid
- * frame consumes its own payload.
+ * frame consumes its own payload. There is no sticky protocol selection — an
+ * MGA (UBX) burst followed by SPARTN or RTCM3 is framed frame-by-frame in
+ * arrival order.
  *
  * That sharing is what makes the framing safe. A separate framer per protocol
  * fed the same bytes would each scan inside the other's payloads, and SPARTN's
@@ -70,6 +72,7 @@
 #include <cstddef>
 
 #include "rtcm.h"
+#include "ubx.h"
 
 #if defined(CONFIG_GPS_SPARTN)
 # include "spartn.h"
@@ -81,25 +84,29 @@ namespace gnss
 enum class CorrectionProtocol : uint8_t {
 	Rtcm3,
 	Spartn,
+	Ubx,
 };
 
 struct CorrectionFramerStats {
 	uint32_t messages_parsed;   ///< Frames successfully parsed and consumed
-	uint32_t crc_errors;        ///< Frames rejected by their CRC
+	uint32_t crc_errors;        ///< Frames rejected by their CRC / checksum
 	uint32_t bytes_discarded;   ///< Bytes discarded while searching for a frame
 	uint32_t total_frame_bytes; ///< Total bytes in successfully parsed frames
 	uint32_t rtcm3_messages;    ///< Subset of messages_parsed that were RTCM3
 	uint32_t spartn_messages;   ///< Subset of messages_parsed that were SPARTN
+	uint32_t ubx_messages;      ///< Subset of messages_parsed that were UBX
 };
 
 class CorrectionFramer
 {
 public:
-#if defined(CONFIG_GPS_SPARTN)
 	static constexpr size_t MAX_FRAME_LEN =
-		(SPARTN_MAX_FRAME_LEN > RTCM3_MAX_FRAME_LEN) ? SPARTN_MAX_FRAME_LEN : RTCM3_MAX_FRAME_LEN;
+#if defined(CONFIG_GPS_SPARTN)
+		(SPARTN_MAX_FRAME_LEN > RTCM3_MAX_FRAME_LEN)
+		? ((SPARTN_MAX_FRAME_LEN > UBX_MAX_FRAME_LEN) ? SPARTN_MAX_FRAME_LEN : UBX_MAX_FRAME_LEN)
+		: ((RTCM3_MAX_FRAME_LEN > UBX_MAX_FRAME_LEN) ? RTCM3_MAX_FRAME_LEN : UBX_MAX_FRAME_LEN);
 #else
-	static constexpr size_t MAX_FRAME_LEN = RTCM3_MAX_FRAME_LEN;
+		(RTCM3_MAX_FRAME_LEN > UBX_MAX_FRAME_LEN) ? RTCM3_MAX_FRAME_LEN : UBX_MAX_FRAME_LEN;
 #endif
 
 	// Enough for 2 max-size frames to handle overlap
@@ -142,20 +149,21 @@ public:
 	CorrectionFramerStats getStats() const
 	{
 		return {_messages_parsed, _crc_errors, _bytes_discarded, _total_frame_bytes,
-			_rtcm3_messages, _spartn_messages};
+			_rtcm3_messages, _spartn_messages, _ubx_messages};
 	}
 
 private:
 	enum class Probe {
 		NeedMoreData,  ///< Could still become a valid frame, wait for more bytes
 		InvalidHeader, ///< Cannot be a frame start
-		CrcError,      ///< Frame is complete but failed its CRC
+		CrcError,      ///< Frame is complete but failed its CRC / checksum
 		Complete,
 	};
 
 	static bool isPreamble(uint8_t byte);
 
 	Probe probeRtcm3(size_t *frame_len) const;
+	Probe probeUbx(size_t *frame_len) const;
 #if defined(CONFIG_GPS_SPARTN)
 	Probe probeSpartn(size_t *frame_len) const;
 #endif
@@ -176,6 +184,7 @@ private:
 	uint32_t _total_frame_bytes {0};
 	uint32_t _rtcm3_messages {0};
 	uint32_t _spartn_messages {0};
+	uint32_t _ubx_messages {0};
 };
 
 } // namespace gnss

--- a/src/lib/gnss/test/CMakeLists.txt
+++ b/src/lib/gnss/test/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_unit_gtest(SRC RtcmCrcTest.cpp LINKLIBS gnss)
 px4_add_unit_gtest(SRC RtcmParserTest.cpp LINKLIBS gnss)
 px4_add_unit_gtest(SRC RtcmBustedSenderTest.cpp LINKLIBS gnss)
 px4_add_unit_gtest(SRC RtcmStressTest.cpp LINKLIBS gnss)
+px4_add_unit_gtest(SRC UbxFramerTest.cpp LINKLIBS gnss)
 
 if(CONFIG_GPS_SPARTN)
 	px4_add_unit_gtest(SRC SpartnFramerTest.cpp LINKLIBS gnss)

--- a/src/lib/gnss/test/UbxFramerTest.cpp
+++ b/src/lib/gnss/test/UbxFramerTest.cpp
@@ -1,0 +1,398 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file UbxFramerTest.cpp
+ *
+ * UBX framing tests for CorrectionFramer (AssistNow MGA pass-through), including
+ * interleaved UBX then RTCM3/SPARTN streams that mirror PointPerfect -MGA
+ * mountpoints.
+ */
+
+#include <gtest/gtest.h>
+#include "correction_framer.h"
+
+#include <vector>
+#include <cstring>
+#include <random>
+
+using namespace gnss;
+
+class UbxTest : public ::testing::Test
+{
+protected:
+	CorrectionFramer parser;
+
+	// Build a valid UBX frame (class/id arbitrary; content not decoded).
+	std::vector<uint8_t> buildUbxFrame(uint8_t msg_class, uint8_t msg_id,
+					   const std::vector<uint8_t> &payload)
+	{
+		const size_t payload_len = payload.size();
+		std::vector<uint8_t> frame;
+		frame.push_back(UBX_SYNC1);
+		frame.push_back(UBX_SYNC2);
+		frame.push_back(msg_class);
+		frame.push_back(msg_id);
+		frame.push_back(static_cast<uint8_t>(payload_len & 0xFF));
+		frame.push_back(static_cast<uint8_t>((payload_len >> 8) & 0xFF));
+		frame.insert(frame.end(), payload.begin(), payload.end());
+
+		uint8_t ck_a = 0;
+		uint8_t ck_b = 0;
+		ubx_checksum(&frame[2], UBX_HEADER_LEN - 2 + payload_len, &ck_a, &ck_b);
+		frame.push_back(ck_a);
+		frame.push_back(ck_b);
+		return frame;
+	}
+
+	std::vector<uint8_t> buildRtcmFrame(std::mt19937 &rng, size_t payload_len)
+	{
+		std::vector<uint8_t> frame;
+		frame.push_back(RTCM3_PREAMBLE);
+		frame.push_back(static_cast<uint8_t>((payload_len >> 8) & 0x03));
+		frame.push_back(static_cast<uint8_t>(payload_len & 0xFF));
+
+		std::uniform_int_distribution<int> byte(0, 255);
+
+		for (size_t i = 0; i < payload_len; i++) {
+			frame.push_back(static_cast<uint8_t>(byte(rng)));
+		}
+
+		const uint32_t crc = rtcm3_crc24q(frame.data(), frame.size());
+		frame.push_back((crc >> 16) & 0xFF);
+		frame.push_back((crc >> 8) & 0xFF);
+		frame.push_back(crc & 0xFF);
+		return frame;
+	}
+
+#if defined(CONFIG_GPS_SPARTN)
+	std::vector<uint8_t> buildSpartnFrame(uint8_t msg_type, const std::vector<uint8_t> &payload,
+					      uint8_t crc_type = 0)
+	{
+		const size_t payload_len = payload.size();
+		std::vector<uint8_t> frame;
+		frame.push_back(SPARTN_PREAMBLE);
+
+		uint8_t b1 = static_cast<uint8_t>(((msg_type & 0x7F) << 1) | ((payload_len >> 9) & 0x01));
+		uint8_t b2 = static_cast<uint8_t>((payload_len >> 1) & 0xFF);
+		uint8_t b3 = static_cast<uint8_t>(((payload_len & 0x01) << 7) | ((crc_type & 0x03) << 4));
+		frame.push_back(b1);
+		frame.push_back(b2);
+		frame.push_back(b3);
+
+		// 4-byte description, 16-bit time tag
+		frame.push_back(0x00);
+		frame.push_back(0x00);
+		frame.push_back(0x00);
+		frame.push_back(0x00);
+
+		frame.insert(frame.end(), payload.begin(), payload.end());
+
+		const uint32_t crc = spartn_message_crc(&frame[1], frame.size() - 1, crc_type);
+		const size_t crc_bytes = static_cast<size_t>(crc_type) + 1;
+
+		for (int i = static_cast<int>(crc_bytes) - 1; i >= 0; i--) {
+			frame.push_back(static_cast<uint8_t>((crc >>(8 * i)) & 0xFF));
+		}
+
+		return frame;
+	}
+#endif
+};
+
+// =============================================================================
+// Checksum
+// =============================================================================
+
+// Empty ACK-ACK (class=0x05, id=0x01, length=0): covered bytes 05 01 00 00.
+// 8-bit Fletcher: a runs 5,6,6,6 and b runs 5,11,17,23 → CK_A=0x06, CK_B=0x17.
+TEST_F(UbxTest, ChecksumKnownVector)
+{
+	const uint8_t covered[] = {0x05, 0x01, 0x00, 0x00};
+	uint8_t ck_a = 0;
+	uint8_t ck_b = 0;
+	ubx_checksum(covered, sizeof(covered), &ck_a, &ck_b);
+	EXPECT_EQ(ck_a, 0x06u);
+	EXPECT_EQ(ck_b, 0x17u);
+}
+
+// =============================================================================
+// Framing
+// =============================================================================
+
+TEST_F(UbxTest, SingleMinimalFrame)
+{
+	// UBX-MGA class is 0x13; any class/id is fine for framing
+	auto frame = buildUbxFrame(0x13, 0x00, {0xAA, 0xBB});
+	parser.addData(frame.data(), frame.size());
+
+	size_t len = 0;
+	CorrectionProtocol protocol = CorrectionProtocol::Rtcm3;
+	const uint8_t *msg = parser.getNextMessage(&len, &protocol);
+	ASSERT_NE(msg, nullptr);
+	EXPECT_EQ(protocol, CorrectionProtocol::Ubx);
+	EXPECT_EQ(len, frame.size());
+	EXPECT_EQ(0, memcmp(msg, frame.data(), frame.size()));
+	parser.consumeMessage(len);
+	EXPECT_EQ(parser.getStats().messages_parsed, 1u);
+	EXPECT_EQ(parser.getStats().ubx_messages, 1u);
+	EXPECT_EQ(parser.getStats().crc_errors, 0u);
+}
+
+TEST_F(UbxTest, EmptyPayloadFrame)
+{
+	auto frame = buildUbxFrame(0x05, 0x01, {});
+	parser.addData(frame.data(), frame.size());
+
+	size_t len = 0;
+	ASSERT_NE(parser.getNextMessage(&len), nullptr);
+	EXPECT_EQ(len, UBX_HEADER_LEN + UBX_CK_LEN);
+	parser.consumeMessage(len);
+	EXPECT_EQ(parser.getStats().ubx_messages, 1u);
+}
+
+TEST_F(UbxTest, MultipleFrames)
+{
+	auto f1 = buildUbxFrame(0x13, 0x00, {0x01});
+	auto f2 = buildUbxFrame(0x13, 0x02, {0x02, 0x03, 0x04});
+	std::vector<uint8_t> stream;
+	stream.insert(stream.end(), f1.begin(), f1.end());
+	stream.insert(stream.end(), f2.begin(), f2.end());
+	parser.addData(stream.data(), stream.size());
+
+	int count = 0;
+	size_t len = 0;
+
+	while (parser.getNextMessage(&len) != nullptr) {
+		parser.consumeMessage(len);
+		count++;
+	}
+
+	EXPECT_EQ(count, 2);
+	EXPECT_EQ(parser.getStats().ubx_messages, 2u);
+}
+
+TEST_F(UbxTest, ChunkedArrival)
+{
+	auto frame = buildUbxFrame(0x13, 0x01, {0x10, 0x20, 0x30, 0x40});
+
+	for (size_t i = 0; i < frame.size(); i++) {
+		parser.addData(&frame[i], 1);
+		// No complete frame until the last byte
+	}
+
+	size_t len = 0;
+	ASSERT_NE(parser.getNextMessage(&len), nullptr);
+	EXPECT_EQ(len, frame.size());
+}
+
+TEST_F(UbxTest, NoiseBeforeFrame)
+{
+	auto frame = buildUbxFrame(0x13, 0x00, {0x55});
+	std::vector<uint8_t> stream = {0x00, 0xFF, 0x01};
+	stream.insert(stream.end(), frame.begin(), frame.end());
+	parser.addData(stream.data(), stream.size());
+
+	size_t len = 0;
+	ASSERT_NE(parser.getNextMessage(&len), nullptr);
+	EXPECT_GT(parser.getStats().bytes_discarded, 0u);
+	parser.consumeMessage(len);
+	EXPECT_EQ(parser.getStats().ubx_messages, 1u);
+}
+
+TEST_F(UbxTest, BadSync2)
+{
+	// 0xB5 followed by something other than 0x62 is not a frame start
+	std::vector<uint8_t> stream = {UBX_SYNC1, 0x00, 0x11, 0x22};
+	auto frame = buildUbxFrame(0x13, 0x00, {0x01});
+	stream.insert(stream.end(), frame.begin(), frame.end());
+	parser.addData(stream.data(), stream.size());
+
+	size_t len = 0;
+	CorrectionProtocol protocol = CorrectionProtocol::Rtcm3;
+	ASSERT_NE(parser.getNextMessage(&len, &protocol), nullptr);
+	EXPECT_EQ(protocol, CorrectionProtocol::Ubx);
+	parser.consumeMessage(len);
+	EXPECT_EQ(parser.getStats().ubx_messages, 1u);
+	EXPECT_GT(parser.getStats().bytes_discarded, 0u);
+}
+
+TEST_F(UbxTest, BadChecksum)
+{
+	auto frame = buildUbxFrame(0x13, 0x00, {0x11, 0x22});
+	frame.back() ^= 0xFF;
+	parser.addData(frame.data(), frame.size());
+
+	size_t len = 0;
+	EXPECT_EQ(parser.getNextMessage(&len), nullptr);
+	EXPECT_GE(parser.getStats().crc_errors, 1u);
+	EXPECT_EQ(parser.getStats().ubx_messages, 0u);
+}
+
+TEST_F(UbxTest, RejectsOversizedPayload)
+{
+	// Length field claims UBX_MAX_PAYLOAD_LEN + 1 — must not pin the buffer
+	std::vector<uint8_t> header = {
+		UBX_SYNC1, UBX_SYNC2,
+		0x13, 0x00,
+		static_cast<uint8_t>((UBX_MAX_PAYLOAD_LEN + 1) & 0xFF),
+		static_cast<uint8_t>(((UBX_MAX_PAYLOAD_LEN + 1) >> 8) & 0xFF),
+	};
+	auto good = buildUbxFrame(0x13, 0x00, {0xAB});
+	header.insert(header.end(), good.begin(), good.end());
+	parser.addData(header.data(), header.size());
+
+	size_t len = 0;
+	CorrectionProtocol protocol = CorrectionProtocol::Rtcm3;
+	ASSERT_NE(parser.getNextMessage(&len, &protocol), nullptr);
+	EXPECT_EQ(protocol, CorrectionProtocol::Ubx);
+	EXPECT_EQ(len, good.size());
+	parser.consumeMessage(len);
+	EXPECT_EQ(parser.getStats().ubx_messages, 1u);
+}
+
+// =============================================================================
+// Cross-protocol: MGA then corrections (the PointPerfect -MGA case)
+// =============================================================================
+
+// PointPerfect -MGA mountpoints deliver a UBX-MGA burst once on connect, then
+// the normal correction stream (RTCM3 or SPARTN). The framer must not lock onto
+// UBX and reject everything after — each complete frame is consumed and the next
+// preamble (of any protocol) starts the next frame.
+TEST_F(UbxTest, MgaThenRtcm3)
+{
+	std::mt19937 rng(42);
+	auto mga1 = buildUbxFrame(0x13, 0x00, {0x01, 0x02, 0x03});
+	auto mga2 = buildUbxFrame(0x13, 0x02, {0x10, 0x20});
+	auto rtcm = buildRtcmFrame(rng, 40);
+
+	std::vector<uint8_t> stream;
+	stream.insert(stream.end(), mga1.begin(), mga1.end());
+	stream.insert(stream.end(), mga2.begin(), mga2.end());
+	stream.insert(stream.end(), rtcm.begin(), rtcm.end());
+	parser.addData(stream.data(), stream.size());
+
+	std::vector<CorrectionProtocol> seen;
+	size_t len = 0;
+	CorrectionProtocol protocol = CorrectionProtocol::Rtcm3;
+
+	while (parser.getNextMessage(&len, &protocol) != nullptr) {
+		seen.push_back(protocol);
+		parser.consumeMessage(len);
+	}
+
+	ASSERT_EQ(seen.size(), 3u);
+	EXPECT_EQ(seen[0], CorrectionProtocol::Ubx);
+	EXPECT_EQ(seen[1], CorrectionProtocol::Ubx);
+	EXPECT_EQ(seen[2], CorrectionProtocol::Rtcm3);
+	EXPECT_EQ(parser.getStats().ubx_messages, 2u);
+	EXPECT_EQ(parser.getStats().rtcm3_messages, 1u);
+	EXPECT_EQ(parser.getStats().crc_errors, 0u);
+}
+
+#if defined(CONFIG_GPS_SPARTN)
+TEST_F(UbxTest, MgaThenSpartn)
+{
+	auto mga = buildUbxFrame(0x13, 0x00, {0xDE, 0xAD});
+	auto spartn = buildSpartnFrame(0, {0xAA, 0xBB});
+
+	std::vector<uint8_t> stream;
+	stream.insert(stream.end(), mga.begin(), mga.end());
+	stream.insert(stream.end(), spartn.begin(), spartn.end());
+	// Another MGA mid-stream should also work (reconnect-style)
+	auto mga2 = buildUbxFrame(0x13, 0x01, {0x01});
+	stream.insert(stream.end(), mga2.begin(), mga2.end());
+	parser.addData(stream.data(), stream.size());
+
+	std::vector<CorrectionProtocol> seen;
+	size_t len = 0;
+	CorrectionProtocol protocol = CorrectionProtocol::Rtcm3;
+
+	while (parser.getNextMessage(&len, &protocol) != nullptr) {
+		seen.push_back(protocol);
+		parser.consumeMessage(len);
+	}
+
+	ASSERT_EQ(seen.size(), 3u);
+	EXPECT_EQ(seen[0], CorrectionProtocol::Ubx);
+	EXPECT_EQ(seen[1], CorrectionProtocol::Spartn);
+	EXPECT_EQ(seen[2], CorrectionProtocol::Ubx);
+	EXPECT_EQ(parser.getStats().ubx_messages, 2u);
+	EXPECT_EQ(parser.getStats().spartn_messages, 1u);
+}
+#endif
+
+// A complete RTCM3 frame consumes its payload, so a 0xB5 that happens to sit
+// inside that payload is never considered as a UBX start.
+TEST_F(UbxTest, RtcmPayloadStrayB5IsNotFramedAsUbx)
+{
+	// Craft an RTCM3 frame whose payload contains a UBX-looking prefix.
+	// buildRtcmFrame randomizes payload; force a 0xB5 0x62 sequence in raw form.
+	std::vector<uint8_t> payload(32, 0x00);
+	payload[4] = UBX_SYNC1;
+	payload[5] = UBX_SYNC2;
+	payload[6] = 0x13;
+	payload[7] = 0x00;
+	payload[8] = 0x02; // fake length
+	payload[9] = 0x00;
+
+	std::vector<uint8_t> frame;
+	frame.push_back(RTCM3_PREAMBLE);
+	frame.push_back(0x00);
+	frame.push_back(static_cast<uint8_t>(payload.size()));
+	frame.insert(frame.end(), payload.begin(), payload.end());
+	const uint32_t crc = rtcm3_crc24q(frame.data(), frame.size());
+	frame.push_back((crc >> 16) & 0xFF);
+	frame.push_back((crc >> 8) & 0xFF);
+	frame.push_back(crc & 0xFF);
+
+	// Follow with a real UBX so we know the framer still works after
+	auto ubx = buildUbxFrame(0x13, 0x00, {0x99});
+	std::vector<uint8_t> stream = frame;
+	stream.insert(stream.end(), ubx.begin(), ubx.end());
+	parser.addData(stream.data(), stream.size());
+
+	size_t len = 0;
+	CorrectionProtocol protocol = CorrectionProtocol::Ubx;
+	ASSERT_NE(parser.getNextMessage(&len, &protocol), nullptr);
+	EXPECT_EQ(protocol, CorrectionProtocol::Rtcm3);
+	parser.consumeMessage(len);
+
+	ASSERT_NE(parser.getNextMessage(&len, &protocol), nullptr);
+	EXPECT_EQ(protocol, CorrectionProtocol::Ubx);
+	parser.consumeMessage(len);
+
+	EXPECT_EQ(parser.getStats().rtcm3_messages, 1u);
+	EXPECT_EQ(parser.getStats().ubx_messages, 1u);
+	EXPECT_EQ(parser.getStats().crc_errors, 0u);
+}

--- a/src/lib/gnss/ubx.h
+++ b/src/lib/gnss/ubx.h
@@ -1,0 +1,96 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file ubx.h
+ *
+ * UBX transport-layer definitions used to locate frame boundaries.
+ * Payload content is not decoded. Framing lives in CorrectionFramer.
+ *
+ * Used for AssistNow MGA (UBX-MGA-*) delivered ahead of RTCM3/SPARTN
+ * corrections on PointPerfect -MGA NTRIP mountpoints.
+ *
+ * Frame layout (u-blox UBX protocol):
+ *   Byte 0:     Sync1 (0xB5)
+ *   Byte 1:     Sync2 (0x62)
+ *   Byte 2:     Class
+ *   Byte 3:     ID
+ *   Byte 4-5:   Payload length (uint16 little-endian)
+ *   Byte 6..N:  Payload
+ *   Last 2:     CK_A, CK_B (8-bit Fletcher over class..end of payload)
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+namespace gnss
+{
+
+static constexpr uint8_t  UBX_SYNC1            = 0xB5;
+static constexpr uint8_t  UBX_SYNC2            = 0x62;
+static constexpr size_t   UBX_HEADER_LEN       = 6;   // sync1, sync2, class, id, len_lo, len_hi
+static constexpr size_t   UBX_CK_LEN           = 2;
+// Protocol allows up to 65535 payload bytes; cap for correction injection so the
+// shared framer buffer stays comparable to RTCM3/SPARTN. AssistNow MGA ephemeris
+// messages are well under this.
+static constexpr size_t   UBX_MAX_PAYLOAD_LEN  = 1024;
+static constexpr size_t   UBX_MAX_FRAME_LEN    = UBX_HEADER_LEN + UBX_MAX_PAYLOAD_LEN + UBX_CK_LEN;
+
+/**
+ * 8-bit Fletcher checksum used by UBX (CK_A, CK_B).
+ *
+ * Covers every byte from Class through the end of the payload (not the sync
+ * bytes and not the two checksum bytes themselves).
+ *
+ * @param data Pointer to Class (first covered byte)
+ * @param len  Number of covered bytes (class + id + length field + payload)
+ * @param ck_a Out: CK_A
+ * @param ck_b Out: CK_B
+ */
+inline void ubx_checksum(const uint8_t *data, size_t len, uint8_t *ck_a, uint8_t *ck_b)
+{
+	uint8_t a = 0;
+	uint8_t b = 0;
+
+	for (size_t i = 0; i < len; i++) {
+		a = static_cast<uint8_t>(a + data[i]);
+		b = static_cast<uint8_t>(b + a);
+	}
+
+	*ck_a = a;
+	*ck_b = b;
+}
+
+} // namespace gnss

--- a/src/lib/gnss/ubx.h
+++ b/src/lib/gnss/ubx.h
@@ -62,9 +62,8 @@ static constexpr uint8_t  UBX_SYNC1            = 0xB5;
 static constexpr uint8_t  UBX_SYNC2            = 0x62;
 static constexpr size_t   UBX_HEADER_LEN       = 6;   // sync1, sync2, class, id, len_lo, len_hi
 static constexpr size_t   UBX_CK_LEN           = 2;
-// Protocol allows up to 65535 payload bytes; cap for correction injection so the
-// shared framer buffer stays comparable to RTCM3/SPARTN. AssistNow MGA ephemeris
-// messages are well under this.
+// Cap below the protocol's 65535 payload bytes so a garbage length cannot pin
+// the shared framer buffer; MGA messages are well under this.
 static constexpr size_t   UBX_MAX_PAYLOAD_LEN  = 1024;
 static constexpr size_t   UBX_MAX_FRAME_LEN    = UBX_HEADER_LEN + UBX_MAX_PAYLOAD_LEN + UBX_CK_LEN;
 


### PR DESCRIPTION
## Summary

Extend `CorrectionFramer` so AssistNow MGA (UBX) delivered on PointPerfect `-MGA` NTRIP mountpoints is framed and injected instead of discarded as noise. Framing remains per-frame with no sticky protocol selection, so an MGA burst followed by RTCM3 or SPARTN continues to work in arrival order. Also hardens the injection path against one-shot data loss found while bench-validating the burst end-to-end, and adds configurable u-blox UART baud targets.

## Problem

After the shared RTCM3/SPARTN correction framer landed, the inject path only accepted those preambles. PointPerfect `NEAR-*-MGA` mountpoints send a one-shot UBX-MGA ephemeris burst on connect before corrections. Those bytes already traverse MAVLink `GPS_RTCM_DATA` as opaque payload, but the framer dropped every `0xB5` while searching for RTCM3/SPARTN, so MGA never reached the receiver on current main.

Bench-validating a 58-message AssistNow burst end-to-end on an ARK X20 CAN node surfaced three ways the injection path loses one-shot data: corrections written into a receiver mid-reset are discarded, the drain stopped while unconfigured so the 16-deep queue overflowed and dropped the leading MGA-INI, and both drains read one message past their per-pass budget and threw it away. A commanded reset also restarted protocol auto-detection.

Heading modes 3/4 also forced UART1 to 921600 independently of configuration, which is unreliable on long GPS-to-FC serial runs once a configurable UART1 target exists.

## Solution

- Add UBX transport definitions (`ubx.h`): sync `B5 62`, little-endian length, Fletcher CK_A/CK_B. Payload content is not decoded.
- Teach `CorrectionFramer` a third protocol (`CorrectionProtocol::Ubx`), always enabled, with a 1024-byte payload cap so the shared buffer stays comparable to RTCM3/SPARTN.
- Inject complete UBX frames the same way as RTCM3/SPARTN; stop counting non-RTCM frames as SPARTN in the GPS driver rate windows.
- Unit tests cover framing edge cases and interleaved MGA→RTCM3 / MGA→SPARTN streams.
- Gate injection on receiver readiness but keep draining (dropping) so the subscription stays current; hold the driver mode across a reset we issued (PX4/PX4-GPSDrivers#220 clears `_configured` on reset).
- Check the injection budget before reading instead of after, in the GPS driver and the UAVCAN bridge.
- Add `GPS_UBX_BAUD1` as the post-detect UART1 target in all modes (PX4/PX4-GPSDrivers#224 removes the heading-mode hardcode). Board defaults set 921600 on ark x20-gps and ark can-rtk-gps. Trim `GPS_UBX_BAUD2` description and document both params in the dual-F9P / ARK setup docs.