### PR TITLE
fix(mavlink): use published Open Drone ID Basic ID

### DIFF
--- a/src/modules/mavlink/streams/OPEN_DRONE_ID_BASIC_ID.hpp
+++ b/src/modules/mavlink/streams/OPEN_DRONE_ID_BASIC_ID.hpp
@@ -35,6 +35,7 @@
 #define OPEN_DRONE_ID_BASIC_ID_HPP
 
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/open_drone_id_basic_id.h>
 #include <modules/mavlink/open_drone_id_translations.hpp>
 
 class MavlinkStreamOpenDroneIdBasicId : public MavlinkStream
@@ -50,23 +51,42 @@ public:
 
 	unsigned get_size() override
 	{
-		return _vehicle_status_sub.advertised() ? MAVLINK_MSG_ID_OPEN_DRONE_ID_BASIC_ID_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES : 0;
+		return (_open_drone_id_basic_id.advertised()
+			|| _vehicle_status_sub.advertised()) ? MAVLINK_MSG_ID_OPEN_DRONE_ID_BASIC_ID_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES : 0;
 	}
 
 private:
 	explicit MavlinkStreamOpenDroneIdBasicId(Mavlink *mavlink) : MavlinkStream(mavlink) {}
 
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
-
+	uORB::Subscription _open_drone_id_basic_id{ORB_ID(open_drone_id_basic_id)};
 
 
 	bool send() override
 	{
 		vehicle_status_s vehicle_status;
+		mavlink_open_drone_id_basic_id_t msg{};
+
+		if (_open_drone_id_basic_id.advertised()) {
+			open_drone_id_basic_id_s basic_id {};
+
+			if (_open_drone_id_basic_id.copy(&basic_id)) {
+				msg.id_type = basic_id.id_type;
+				msg.ua_type = basic_id.ua_type;
+				// msg.id_or_mac // Only used for drone ID data received from other UAs.
+
+				static_assert(sizeof(msg.uas_id) == sizeof(basic_id.uas_id), "OpenDroneID Basic ID uas_id size mismatch");
+
+				memcpy(msg.uas_id, basic_id.uas_id, sizeof(msg.uas_id));
+
+				mavlink_msg_open_drone_id_basic_id_send_struct(_mavlink->get_channel(), &msg);
+
+				return true;
+
+			}
+		}
 
 		if (_vehicle_status_sub.update(&vehicle_status)) {
-
-			mavlink_open_drone_id_basic_id_t msg{};
 
 			msg.target_system = 0; // 0 for broadcast
 			msg.target_component = 0; // 0 for broadcast


### PR DESCRIPTION
### Solved Problem

The `OPEN_DRONE_ID_BASIC_ID` MAVLink stream always generates the UAS ID from the PX4 board GUID.

It does not use an `open_drone_id_basic_id` message already published through uORB, preventing an externally provided Basic ID from being sent over MAVLink.

### Solution

Subscribe the MAVLink stream to the `open_drone_id_basic_id` uORB topic.

When the topic is advertised:

- Copy `id_type`, `ua_type`, and `uas_id` from the published Basic ID.
- Send the published Basic ID through the MAVLink stream.
- Verify at compile time that the uORB and MAVLink `uas_id` fields have matching sizes.

If no published Basic ID is available, retain the existing behavior of generating a serial-number ID from the PX4 board GUID.

The stream size calculation now accounts for both the Basic ID and vehicle status subscriptions.

### Changelog Entry

Feature: Allow the MAVLink Open Drone ID Basic ID stream to use an ID provided through uORB.

### Alternatives

Always generating the UAS ID from the PX4 board GUID was considered insufficient because it prevents external Remote ID implementations from providing the Basic ID.

The implemented behavior follows the existing UAVCAN Remote ID Basic ID handling.

### Test coverage

- Build test: `[make px4_sitl_default]`
- Verified that the existing PX4 GUID fallback remains available when no `open_drone_id_basic_id` topic is published.
- Verified that a published `open_drone_id_basic_id` is copied into the outgoing MAVLink message.