### PR TITLE
fix(ekf2): correct initialize spelling in magnetometer fusion param

### DIFF
--- a/src/modules/ekf2/params_magnetometer.yaml
+++ b/src/modules/ekf2/params_magnetometer.yaml
@@ -14,7 +14,7 @@ parameters:
           If set to 'None' the magnetometer will not be used under any circumstance.
           If no external source of yaw is available, it is possible to use post-takeoff
           horizontal movement combined with GNSS velocity measurements to align the yaw angle.
-          If set to 'Init' the magnetometer is only used to initalize the heading.
+          If set to 'Init' the magnetometer is only used to initialize the heading.
       type: enum
       values:
         0: Automatic


### PR DESCRIPTION
### Summary
Corrects \`initalize\` → \`initialize\` in EKF2 magnetometer fusion long description (\`params_magnetometer.yaml\`).

### Motivation
GCS/param UI shows this text to operators.

### Verification
Metadata-only; no runtime logic change.

AI-assisted; human-reviewed.