### PR TITLE
fix(sih): correct particles spelling in drag coefficient descriptions

### DIFF
--- a/src/modules/simulation/simulator_sih/sih_params.yaml
+++ b/src/modules/simulation/simulator_sih/sih_params.yaml
@@ -145,7 +145,7 @@ parameters:
       description:
         short: First order drag coefficient
         long: |-
-          Physical coefficient representing the friction with air particules.
+          Physical coefficient representing the friction with air particles.
           The greater this value, the slower the quad will move.
 
           Drag force function of velocity: D=-KDV*V.
@@ -160,7 +160,7 @@ parameters:
       description:
         short: First order angular damper coefficient
         long: |-
-          Physical coefficient representing the friction with air particules during rotations.
+          Physical coefficient representing the friction with air particles during rotations.
           The greater this value, the slower the quad will rotate.
 
           Aerodynamic moment function of body rate: Ma=-KDW*W_B.


### PR DESCRIPTION
### Summary
Replace French/typo \`particules\` with \`particles\` in SIH linear/angular drag long descriptions.

### Motivation
Param docs shown in QGC/parameter reference for hardware-in-the-loop SIH.

### Verification
YAML strings only.

AI-assisted; human-reviewed.