### PR TITLE
fix(params): use celsius unit token instead of celcius

### DIFF
--- a/src/drivers/heater/module.yaml
+++ b/src/drivers/heater/module.yaml
@@ -35,7 +35,7 @@ parameters:
             reboot_required: true
             num_instances: *max_num_config_instances
             instance_start: 1
-            unit: celcius
+            unit: celsius
             min: 0
             max: 85.0
             default: [55.0, 55.0, 55.0]
@@ -134,7 +134,7 @@ parameters:
                     e.g. 5 to only start heating once the temperature drops below 5°C.
 
             type: float
-            unit: celcius
+            unit: celsius
             min: -100.0
             max: 200.0
             decimal: 1

--- a/src/modules/commander/HealthAndArmingChecks/esc_check_params.yaml
+++ b/src/modules/commander/HealthAndArmingChecks/esc_check_params.yaml
@@ -61,6 +61,6 @@ parameters:
       default: 90.0
       min: -1
       max: 150
-      unit: celcius
+      unit: celsius
       decimal: 1
       increment: 1

--- a/src/modules/commander/commander_params.yaml
+++ b/src/modules/commander/commander_params.yaml
@@ -617,7 +617,7 @@ parameters:
       max: 127
       decimal: 0
       increment: 1
-      unit: celcius
+      unit: celsius
     COM_WIND_WARN:
       description:
         short: Wind speed warning threshold

--- a/src/modules/simulation/sensor_baro_sim/parameters.yaml
+++ b/src/modules/simulation/sensor_baro_sim/parameters.yaml
@@ -25,4 +25,4 @@ parameters:
         short: simulated barometer temperature offset
       type: float
       default: 0.0
-      unit: celcius
+      unit: celsius


### PR DESCRIPTION
### Summary
Replace unit token \`celcius\` with \`celsius\` in parameter YAML used by heater, sensor_baro_sim, ESC checks, and commander.

### Motivation
GCS unit display / export consistency.

### Verification
four YAML files; no value changes.

AI-assisted; human-reviewed.