### PR TITLE
fix(muorb): correct initialize spelling in protobuf channel logs

### DIFF
--- a/src/modules/muorb/apps/uORBAppsProtobufChannel.cpp
+++ b/src/modules/muorb/apps/uORBAppsProtobufChannel.cpp
@@ -269,10 +269,10 @@ bool uORB::AppsProtobufChannel::Initialize(bool enable_debug)
 				  };
 
 		if (fc_sensor_initialize(enable_debug, &cb) != 0) {
-			if (enable_debug) { PX4_INFO("Warning: muorb protobuf initalize method failed"); }
+			if (enable_debug) { PX4_INFO("Warning: muorb protobuf initialize method failed"); }
 
 		} else {
-			PX4_INFO("muorb protobuf initalize method succeeded");
+			PX4_INFO("muorb protobuf initialize method succeeded");
 
 			_task_handle = px4_task_spawn_cmd("muorb_keepalive",
 							  SCHED_DEFAULT,


### PR DESCRIPTION
### Summary
Fix \`initalize\` → \`initialize\` in muorb protobuf initialize success/failure log lines.

### Verification
String-only; VOXL/muorb path.

AI-assisted; human-reviewed.