### PR TITLE
fix(temperature_compensation): correct success spelling in API comment

### DIFF
--- a/src/modules/temperature_compensation/TemperatureCompensation.h
+++ b/src/modules/temperature_compensation/TemperatureCompensation.h
@@ -213,7 +213,7 @@ private:
 
 	/**
 	 * initialize ParameterHandles struct
-	 * @return 0 on succes, <0 on error
+	 * @return 0 on success, <0 on error
 	 */
 	static int initialize_parameter_handles(ParameterHandles &parameter_handles);
 


### PR DESCRIPTION
### Summary
\`on succes\` → \`on success\` in TemperatureCompensation header \@return docs.

### Motivation
Consistency with sibling calibration APIs already using success.

AI-assisted; human-reviewed.