### PR TITLE
fix(preflt-mag): warning msg without "Fail" when configured as warning

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -203,12 +203,14 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 	}
 
 
-	if ((_param_com_arm_mag_str.get() >= 1)
+	if (_param_com_arm_mag_str.get()
 	    && (!context.isArmed() && estimator_status.pre_flt_fail_mag_field_disturbed)) {
+
+		const MagArmingCheck mag_arming_check = static_cast<MagArmingCheck>(_param_com_arm_mag_str.get());
 
 		NavModes required_groups_mag = required_groups;
 
-		if (_param_com_arm_mag_str.get() != 1) {
+		if (mag_arming_check != MagArmingCheck::DenyArming) {
 			required_groups_mag = NavModes::None; // optional
 		}
 
@@ -228,7 +230,14 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 				estimator_status.mag_inclination_deg, estimator_status.mag_inclination_ref_deg);
 
 		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Strong magnetic interference");
+			const char *message = "Preflight%s: Strong magnetic interference";
+
+			if (mag_arming_check == MagArmingCheck::DenyArming) {
+				mavlink_log_critical(reporter.mavlink_log_pub(), message, " Fail");
+
+			} else {
+				mavlink_log_warning(reporter.mavlink_log_pub(), message, "");
+			}
 		}
 	}
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
@@ -65,6 +65,12 @@ private:
 		Disabled = 2
 	};
 
+	enum class MagArmingCheck : uint8_t {
+		Disabled = 0,
+		DenyArming = 1,
+		WarningOnly = 2
+	};
+
 	void checkEstimatorStatus(const Context &context, Report &reporter, const estimator_status_s &estimator_status,
 				  NavModes required_groups);
 	void checkSensorBias(const Context &context, Report &reporter, NavModes required_groups);


### PR DESCRIPTION
### Solved Problem
`Preflight Fail: Strong magnetic interference` is always sent in a `mavlink_log_critical`, even if configured as "warning" in `COM_ARM_MAG_STR`

### Solution
If `COM_ARM_MAG_STR` == "warning" send `Preflight: Strong magnetic interference` (no `Fail`) in a mavlink_log_warning message.
