### PR TITLE
fix(simulation): use nvautogpuh264enc for GStreamer NVENC encoding

### DIFF
--- a/src/modules/simulation/gz_plugins/gstreamer/GstCameraSystem.cpp
+++ b/src/modules/simulation/gz_plugins/gstreamer/GstCameraSystem.cpp
@@ -352,7 +352,7 @@ void CameraStream::gstThreadFunc()
 	GstElement *encoder;
 
 	if (_useCuda) {
-		encoder = gst_element_factory_make("nvh264enc", nullptr);
+		encoder = gst_element_factory_make("nvautogpuh264enc", nullptr);
 
 		if (encoder) {
 			// Higher quality NVIDIA encoder settings


### PR DESCRIPTION
### Summary

Related to #27296

The Gazebo GStreamer camera plugin currently uses `nvh264enc` when CUDA is enabled.

On my system (Ubuntu 24.04, NVIDIA Driver 595.71.05, RTX 3050 Laptop GPU), `nvh264enc` consistently fails to initialize with:

```
Selected preset not supported
```

While investigating issue #27296, I observed that the RAM growth on my system coincided with repeated failures to initialize the GStreamer pipeline using `nvh264enc`.

Replacing `nvh264enc` with `nvautogpuh264enc` allows the hardware encoder to initialize successfully on my system and prevents the RAM growth observed during camera-enabled SITL runs.

---

### Solution

Replace

```cpp
gst_element_factory_make("nvh264enc", nullptr);
```

with

```cpp
gst_element_factory_make("nvautogpuh264enc", nullptr);
```

`nvautogpuh264enc` automatically selects the appropriate NVENC implementation for the current GPU and driver configuration while preserving hardware acceleration.

---

### Investigation

To isolate the issue, I performed the following:

- Reproduced the memory growth during PX4 SITL with the Gazebo camera plugin.
- Compared the behavior with another machine where the issue could not be reproduced.
- Reproduced the encoder failure outside PX4 using a standalone `gst-launch-1.0` pipeline, indicating that the problem is not specific to PX4 itself.
- Verified that setting `useCuda=false` alone did not eliminate the RAM growth. Removing the GStreamer camera plugin eliminated the issue.
- Confirmed that `nvh264enc` failed with the error `Selected preset not supported`.
- Verified that replacing `nvh264enc` with `nvautogpuh264enc` allowed the pipeline to initialize correctly.
- Rebuilt PX4 and confirmed that RAM usage remained stable while hardware encoding was still used.

---

### Testing

**Test platform**

- Ubuntu 24.04
- NVIDIA Driver 595.71.05
- NVIDIA RTX 3050 Laptop GPU
- Gazebo Harmonic
- PX4 commit: `eddc929db37f4a488cbccd7d6629b0a0e09459a9`

**Test command**

```bash
make px4_sitl gz_x500_mono_cam
```

**Results**

- `nvh264enc` → pipeline initialization failed with `Selected preset not supported`, accompanied by continuous RAM growth.
- `nvautogpuh264enc` → hardware encoding initialized successfully and RAM usage remained stable.

---

### Notes

This change has been tested on a single hardware/software configuration (Ubuntu 24.04, NVIDIA Driver 595.71.05, RTX 3050 Laptop GPU). Feedback from users with different NVIDIA GPUs or driver versions would be appreciated to verify the behavior across additional systems.