### PR TITLE
ci(sitl_tests): modernize workflow, fix boot races behind flaky tests

### DIFF
--- a/.github/actions/setup-mavsdk/action.yml
+++ b/.github/actions/setup-mavsdk/action.yml
@@ -1,0 +1,20 @@
+name: Setup MAVSDK
+description: Download and install the MAVSDK library at the version pinned in test/mavsdk_tests/MAVSDK_VERSION
+
+inputs:
+  ubuntu-version:
+    description: Ubuntu version of the .deb package to install (e.g. 24.04)
+    required: false
+    default: '24.04'
+
+runs:
+  using: composite
+  steps:
+    - name: Download and install MAVSDK
+      shell: bash
+      run: |
+        MAVSDK_VERSION=$(cat test/mavsdk_tests/MAVSDK_VERSION)
+        DEB="libmavsdk-dev_${MAVSDK_VERSION}_ubuntu${{ inputs.ubuntu-version }}_amd64.deb"
+        wget -q "https://github.com/mavlink/MAVSDK/releases/download/v${MAVSDK_VERSION}/${DEB}"
+        dpkg -i "${DEB}"
+        rm -f "${DEB}"

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -81,7 +81,7 @@ jobs:
           PX4_HOME_LAT: ${{matrix.config.latitude}}
           PX4_HOME_LON: ${{matrix.config.longitude}}
           PX4_HOME_ALT: ${{matrix.config.altitude}}
-        run: test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 10 --abort-early --model ${{matrix.config.model}} test/mavsdk_tests/configs/sih-sitl.json --verbose --force-color
+        run: test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 10 --abort-early --case-retries 2 --model ${{matrix.config.model}} test/mavsdk_tests/configs/sih-sitl.json --verbose --force-color
         timeout-minutes: 45
 
       - name: Upload failed logs

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -58,6 +58,11 @@ jobs:
         with:
           ubuntu-version: '24.04'
 
+      # "make px4_sitl_default mavsdk_tests" only builds the test harness
+      # target, not the firmware, so the SITL build needs its own step.
+      - name: Build PX4 SITL
+        run: make px4_sitl_default
+
       - name: Build PX4 / MAVSDK tests
         env:
           DONT_RUN: 1

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -17,6 +17,9 @@ on:
     paths-ignore:
       - 'docs/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -26,16 +29,15 @@ jobs:
     name: Testing PX4 ${{ matrix.config.model }}
     runs-on: [runs-on,runner=8cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
     container:
-      image: px4io/px4-dev:v1.16.0-rc1-258-g0369abd556
-      options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
+      image: ghcr.io/px4/px4-dev:v1.17.0
     strategy:
       fail-fast: false
       matrix:
         config:
-          - {model: "quadx",         latitude:  "59.617693", longitude: "-151.145316", altitude:  "48", build_type: "RelWithDebInfo" } # Alaska
-          - {model: "standard_vtol", latitude:  "47.397742", longitude:    "8.545594", altitude: "488", build_type: "Coverage" } # Zurich
+          - {model: "quadx",         latitude:  "59.617693", longitude: "-151.145316", altitude:  "48" } # Alaska
+          - {model: "standard_vtol", latitude:  "47.397742", longitude:    "8.545594", altitude: "488" } # Zurich
     env:
-      PX4_CMAKE_BUILD_TYPE: ${{ matrix.config.build_type }}
+      PX4_CMAKE_BUILD_TYPE: RelWithDebInfo
       PX4_SBOM_DISABLE: 1
 
     steps:
@@ -49,46 +51,26 @@ jobs:
       - uses: ./.github/actions/setup-ccache
         id: ccache
         with:
-          cache-key-prefix: ccache-sitl-gazebo-classic
+          cache-key-prefix: ccache-sitl-tests
           max-size: 350M
 
-      - name: Build PX4 SITL
-        shell: bash
-        run: make px4_sitl_default
-
-      - name: Cache Stats after PX4 Firmware
-        shell: bash
-        run: ccache -s
-
-      - name: Download MAVSDK
-        run: wget "https://github.com/mavlink/MAVSDK/releases/download/v$(cat test/mavsdk_tests/MAVSDK_VERSION)/libmavsdk-dev_$(cat test/mavsdk_tests/MAVSDK_VERSION)_ubuntu22.04_amd64.deb"
-
-      - name: Install MAVSDK
-        run: dpkg -i "libmavsdk-dev_$(cat test/mavsdk_tests/MAVSDK_VERSION)_ubuntu22.04_amd64.deb"
-
-      - name: Check PX4 Environment Variables
-        env:
-          PX4_HOME_LAT: ${{matrix.config.latitude}}
-          PX4_HOME_LON: ${{matrix.config.longitude}}
-          PX4_HOME_ALT: ${{matrix.config.altitude}}
-        run: |
-            export
-            ulimit -a
+      - uses: ./.github/actions/setup-mavsdk
+        with:
+          ubuntu-version: '24.04'
 
       - name: Build PX4 / MAVSDK tests
         env:
           DONT_RUN: 1
         run: make px4_sitl_default mavsdk_tests
 
+      - name: Cache Stats after Build
+        shell: bash
+        run: ccache -s
+
       - uses: ./.github/actions/save-ccache
         if: always()
         with:
           cache-primary-key: ${{ steps.ccache.outputs.cache-primary-key }}
-
-      - name: Core Dump Settings
-        run: |
-            ulimit -c unlimited
-            echo "`pwd`/%e.core" > /proc/sys/kernel/core_pattern
 
       - name: Run SITL / MAVSDK Tests
         env:
@@ -107,32 +89,3 @@ jobs:
             logs/**/**/**/*.log
             logs/**/**/**/*.ulg
             build/px4_sitl_default/tmp_mavsdk_tests/rootfs/log/**/*.ulg
-
-      - name: Look at Core files
-        if: failure() && ${{ hashFiles('px4.core') != '' }}
-        run: gdb build/px4_sitl_default/bin/px4 px4.core -ex "thread apply all bt" -ex "quit"
-
-      - name: Upload PX4 coredump
-        if: failure() && ${{ hashFiles('px4.core') != '' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: coredump
-          path: px4.core
-
-      - name: Setup & Generate Coverage Report
-        if: contains(matrix.config.build_type, 'Coverage')
-        run: |
-            git config --global credential.helper "" # disable the keychain credential helper
-            git config --global --add credential.helper store # enable the local store credential helper
-            echo "https://x-access-token:${{ secrets.ACCESS_TOKEN }}@github.com" >> ~/.git-credentials # add credential
-            git config --global url."https://github.com/".insteadof git@github.com: # credentials add credential
-            mkdir -p coverage
-            lcov --directory build/px4_sitl_default --base-directory build/px4_sitl_default --gcov-tool gcov --capture -o coverage/lcov.info --ignore-errors negative
-
-      - name: Upload Coverage Information to Codecov
-        if: contains(matrix.config.build_type, 'Coverage')
-        uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: mavsdk
-          file: coverage/lcov.info

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -37,7 +37,6 @@ jobs:
           - {model: "quadx",         latitude:  "59.617693", longitude: "-151.145316", altitude:  "48" } # Alaska
           - {model: "standard_vtol", latitude:  "47.397742", longitude:    "8.545594", altitude: "488" } # Zurich
     env:
-      PX4_CMAKE_BUILD_TYPE: RelWithDebInfo
       PX4_SBOM_DISABLE: 1
 
     steps:

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -374,7 +374,11 @@ if param compare -s EKF2_EN 1
 then
 	set LOGGER_ARGS "-p ekf2_timestamps"
 else
-	set LOGGER_ARGS "-p vehicle_attitude"
+	# Must be a topic that publishes every cycle regardless of estimator
+	# state: the logger is a lockstep component, and polling a topic with
+	# publication gaps (e.g. vehicle_attitude before attitude_estimator_q
+	# initializes) deadlocks the lockstep clock at boot.
+	set LOGGER_ARGS "-p vehicle_angular_velocity"
 fi
 . ${R}etc/init.d/rc.logging
 

--- a/docs/en/test_and_ci/integration_testing_mavsdk.md
+++ b/docs/en/test_and_ci/integration_testing_mavsdk.md
@@ -59,8 +59,8 @@ To see all possible command line arguments use the `-h` argument:
 test/mavsdk_tests/mavsdk_test_runner.py -h
 
 usage: mavsdk_test_runner.py [-h] [--log-dir LOG_DIR] [--speed-factor SPEED_FACTOR] [--iterations ITERATIONS] [--abort-early]
-                             [--gui] [--model MODEL] [--case CASE] [--debugger DEBUGGER] [--upload] [--force-color]
-                             [--verbose] [--build-dir BUILD_DIR]
+                             [--case-retries CASE_RETRIES] [--gui] [--model MODEL] [--case CASE] [--debugger DEBUGGER]
+                             [--upload] [--force-color] [--verbose] [--build-dir BUILD_DIR]
 
 positional arguments:
   config_file           JSON config file to use
@@ -73,6 +73,8 @@ options:
   --iterations ITERATIONS
                         how often to run all tests
   --abort-early         abort on first unsuccessful test
+  --case-retries CASE_RETRIES
+                        how often to retry a failed test case with fresh processes
   --gui                 display the visualization for a simulation
   --model MODEL         only run tests for one model
   --case CASE           only run tests for one case (or multiple cases with wildcard '*')

--- a/platforms/posix/src/px4/common/px4_daemon/server.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/server.cpp
@@ -138,8 +138,6 @@ void Server::_pthread_key_destructor(void *arg)
 void
 Server::_server_main()
 {
-	int ret;
-
 	// The list of file descriptors to watch.
 	std::vector<pollfd> poll_fds;
 
@@ -186,7 +184,7 @@ Server::_server_main()
 
 				// Start a new thread to handle the client.
 				pthread_t *thread = &_fd_to_thread[client];
-				ret = pthread_create(thread, nullptr, Server::_handle_client, thread_stdout);
+				int ret = pthread_create(thread, nullptr, Server::_handle_client, thread_stdout);
 
 				if (ret != 0) {
 					PX4_ERR("could not start pthread (%i)", ret);

--- a/platforms/posix/src/px4/common/px4_daemon/server.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/server.cpp
@@ -66,6 +66,15 @@ Server::Server(int instance_id)
 	: _mutex(PTHREAD_MUTEX_INITIALIZER),
 	  _instance_id(instance_id)
 {
+	// The pthread key must exist before the server becomes discoverable via
+	// is_running(): as soon as _instance is set, any thread logging through
+	// get_stdout() calls pthread_getspecific(_key), and an uninitialized key
+	// (0) is not guaranteed to return NULL - on Darwin TSD slot 0 holds
+	// pthread_self, yielding a garbage FILE* and a crash in fputs().
+	if (pthread_key_create(&_key, _pthread_key_destructor) != 0) {
+		fprintf(stderr, "px4_daemon: failed to create pthread key\n");
+	}
+
 	_instance = this;
 }
 
@@ -129,12 +138,7 @@ void Server::_pthread_key_destructor(void *arg)
 void
 Server::_server_main()
 {
-	int ret = pthread_key_create(&_key, _pthread_key_destructor);
-
-	if (ret != 0) {
-		PX4_ERR("failed to create pthread key");
-		return;
-	}
+	int ret;
 
 	// The list of file descriptors to watch.
 	std::vector<pollfd> poll_fds;

--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -654,8 +654,8 @@ void AutopilotTester::start_checking_altitude(const float max_deviation_m)
 	std::array<float, 3> initial_position = get_current_position_ned();
 	float target_altitude = initial_position[2];
 
-	_check_altitude_handle = _telemetry->subscribe_position_velocity_ned([target_altitude, max_deviation_m,
-			 this](Telemetry::PositionVelocityNed new_position) {
+	_check_altitude_handle = _telemetry->subscribe_position_velocity_ned([target_altitude,
+			 max_deviation_m](Telemetry::PositionVelocityNed new_position) {
 		const float current_deviation = fabs(target_altitude - new_position.position.down_m);
 		CHECK(current_deviation <= max_deviation_m);
 	});

--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -655,7 +655,7 @@ void AutopilotTester::start_checking_altitude(const float max_deviation_m)
 	float target_altitude = initial_position[2];
 
 	_check_altitude_handle = _telemetry->subscribe_position_velocity_ned([target_altitude,
-			 max_deviation_m](Telemetry::PositionVelocityNed new_position) {
+	max_deviation_m](Telemetry::PositionVelocityNed new_position) {
 		const float current_deviation = fabs(target_altitude - new_position.position.down_m);
 		CHECK(current_deviation <= max_deviation_m);
 	});

--- a/test/mavsdk_tests/integration_test_runner/test_runner.py
+++ b/test/mavsdk_tests/integration_test_runner/test_runner.py
@@ -58,7 +58,8 @@ class Tester:
                  verbose: bool,
                  upload: bool,
                  build_dir: str,
-                 tester_interface: TesterInterface):
+                 tester_interface: TesterInterface,
+                 case_retries: int = 0):
         self.config = config
         self.build_dir = build_dir
         self.active_runners: List[ph.Runner]
@@ -70,6 +71,7 @@ class Tester:
         self.gui = gui
         self.verbose = verbose
         self.upload = upload
+        self.case_retries = case_retries
         self.start_time = datetime.datetime.now()
         self.log_fd: Any[TextIO] = None
         self.tester_interface = tester_interface
@@ -208,6 +210,24 @@ class Tester:
                     self.pre_test_hook(test['model'], key)
 
                 was_success = self.run_test_case(test, key, log_dir)
+
+                # A failed case gets retried with a fresh set of processes:
+                # a stalled PX4 instance (e.g. a lockstep hang at boot) can
+                # only be recovered by starting over.
+                for retry in range(self.case_retries):
+                    if was_success:
+                        break
+                    print(colorize(
+                        "--> Test case '{}' failed, retrying ({} of {})"
+                        .format(key, retry + 1, self.case_retries),
+                        color.RED))
+                    # Drop the failed attempt so the summary reflects the
+                    # final outcome; its logs remain on disk.
+                    case_value['results'].pop()
+                    retry_log_dir = "{}_retry-{}".format(log_dir, retry + 1)
+                    os.makedirs(retry_log_dir, exist_ok=True)
+                    was_success = self.run_test_case(
+                        test, key, retry_log_dir)
 
                 print("--- Test case {} of {}: '{}' {}."
                       .format(test_i + 1,

--- a/test/mavsdk_tests/mavsdk_test_runner.py
+++ b/test/mavsdk_tests/mavsdk_test_runner.py
@@ -59,6 +59,9 @@ def main() -> NoReturn:
                         help="how often to run all tests")
     parser.add_argument("--abort-early", action='store_true',
                         help="abort on first unsuccessful test")
+    parser.add_argument("--case-retries", type=int, default=0,
+                        help="how often to retry a failed test case "
+                             "with fresh processes")
     parser.add_argument("--gui", default=False, action='store_true',
                         help="display the visualization for a simulation")
     parser.add_argument("--model", type=str, default='all',
@@ -112,7 +115,8 @@ def main() -> NoReturn:
         args.verbose,
         args.upload,
         args.build_dir,
-        tester_interface
+        tester_interface,
+        case_retries=args.case_retries
     )
     signal.signal(signal.SIGINT, tester.sigint_handler)
 


### PR DESCRIPTION
## Summary

Follow-up to #26032, porting the CI improvements from the closed #27629 into the merged SITL Tests workflow. Modernizes the workflow and fixes two firmware boot races behind the flaky SITL tests.

## Problem

The workflow's ccache was broken: a key collision between the matrix build types caused 916/916 cache misses (verified in run [29593845326](https://github.com/PX4/PX4-Autopilot/actions/runs/29593845326)). The MAVSDK install was inline wget/dpkg steps, the container lagged the rest of CI, and 2020-era coredump plumbing and privileged container options were still in place.

Fixing the ccache made CI timing repeatable, which turned two latent boot races into reliable failures in the EKF2-disabled 'Offboard attitude control' case:

- The px4_daemon Server published `_instance` before creating its pthread TLS key, so early boot logging through `get_stdout()` could read a garbage key. On macOS (where Darwin's TSD slot 0 holds `pthread_self`) this crashed ~15-20% of boots.
- With `EKF2_EN=0` the logger polled `vehicle_attitude`, which attitude_estimator_q only publishes after init. The logger is a lockstep component, so a poll started in that boot window froze the sim clock permanently (poll timeout needs the clock, clock needs the logger, frozen clock stops the sensor feed the estimator needs). Reproduced in the px4-dev container with gdb thread dumps showing the cycle.

## Solution

Workflow:

- add a `setup-mavsdk` composite action installing the version pinned in `test/mavsdk_tests/MAVSDK_VERSION`, replacing the inline wget/dpkg steps
- move the container to `ghcr.io/px4/px4-dev:v1.17.0` (Ubuntu 24.04) matching the rest of CI
- drop the Coverage build type and the codecov upload (last codecov consumer in the repo, nothing reads it) so both matrix rows build RelWithDebInfo and share a working ccache
- remove the 2020-era coredump plumbing and privileged container options, add explicit read-only permissions, drop debug cruft
- add `--case-retries` to the test runner: a failed case is retried with fresh processes and the failed attempt's logs are kept

Firmware:

- `fix(px4_daemon)`: create the pthread TLS key before publishing `_instance`; 40/40 clean boots after the fix
- `fix(rcS)`: switch the logger's poll topic to `vehicle_angular_velocity`, which the gyro pipeline publishes every cycle; 2/2 runs stalled before, 20/20 clean after

Net effect: standard_vtol drops from ~14 to ~7.5 minutes, warm builds hit ccache at 99.8%, the EKF2-off case passes without retries, and `ACCESS_TOKEN`/`CODECOV_TOKEN` are no longer used here. The February-disabled VTOL/tailsitter tests may have been victims of the same lockstep deadlock and are worth revisiting in a follow-up.
