### PR TITLE
fix(mc_pos_control): correct initial spelling in MPC_TILTMAX_LND short

### DIFF
--- a/src/modules/mc_pos_control/multicopter_position_control_limits_params.yaml
+++ b/src/modules/mc_pos_control/multicopter_position_control_limits_params.yaml
@@ -60,7 +60,7 @@ parameters:
       increment: 1
     MPC_TILTMAX_LND:
       description:
-        short: Maximum tilt during inital takeoff ramp
+        short: Maximum tilt during initial takeoff ramp
         long: Tighter tilt limit during takeoff to avoid tip over.
       type: float
       default: 12.0


### PR DESCRIPTION
### Solved Problem
`MPC_TILTMAX_LND` short description said "inital" instead of "initial". Operators see this string in QGC / parameter metadata.

### Solution
One-word fix in the module params YAML.

### Changelog Entry
fix: correct spelling in MPC_TILTMAX_LND short description

### Test coverage
- [x] N/A string-only metadata
- validate_module_configs via CI

AI-assisted; human-reviewed.