### PR TITLE
docs(ko): point MAVSDK SITL tests at sih-sitl.json

### DIFF
--- a/docs/ko/test_and_ci/integration_testing_mavsdk.md
+++ b/docs/ko/test_and_ci/integration_testing_mavsdk.md
@@ -45,10 +45,10 @@ The tests need the MAVSDK C++ library installed system-wide (e.g. in `/usr/lib` 
 
 ## 모든 PX4 테스트 실행
 
-To run all SITL tests as defined in [sitl.json](https://github.com/PX4/PX4-Autopilot/blob/main/test/mavsdk_tests/configs/sitl.json), do:
+To run all SITL tests using the SIH simulator as defined in [sih-sitl.json](https://github.com/PX4/PX4-Autopilot/blob/main/test/mavsdk_tests/configs/sih-sitl.json), do:
 
 ```sh
-test/mavsdk_tests/mavsdk_test_runner.py test/mavsdk_tests/configs/sitl.json --speed-factor 10
+test/mavsdk_tests/mavsdk_test_runner.py test/mavsdk_tests/configs/sih-sitl.json --speed-factor 10
 ```
 
 This will list all the tests and then run them sequentially.
@@ -90,7 +90,7 @@ Run a single test by specifying the `model` and test `case` as command line opti
 예를 들어, 임무에서 테일시터 비행을 테스트하려면, 다음을 실행합니다.
 
 ```sh
-test/mavsdk_tests/mavsdk_test_runner.py test/mavsdk_tests/configs/sitl.json --speed-factor 10 --model tailsitter --case 'Fly square Multicopter Missions including RTL'
+test/mavsdk_tests/mavsdk_test_runner.py test/mavsdk_tests/configs/sih-sitl.json --speed-factor 10 --model quadx --case 'Fly square Multicopter Missions including RTL'
 ```
 
 The easiest way to find out the current set of models and their associated test cases is to run all PX4 tests [as shown above](#run-all-px4-tests) (note, you can then cancel the build if you wish to test just one).


### PR DESCRIPTION
### Solved Problem
After `sitl.json` was replaced by `sih-sitl.json` / `gazebo-classic-sitl.json`, the **ko** MAVSDK integration testing page still linked and invoked the removed config path (404 on GitHub blob links).

### Solution
- Point examples at `test/mavsdk_tests/configs/sih-sitl.json` (matches EN + CI workflow default SIH path).
- Align the single-test example model/case with SIH-supported `quadx` multicopter mission (tailsitter remains under gazebo-classic config).

### Test coverage
- [x] Link target exists in tree
- [x] Matches `.github/workflows/sitl_tests.yml` SIH config path

AI-assisted; human-reviewed.