### PR TITLE
fix(ekf2): correct Minimum spelling in range validity param short

### DIFF
--- a/src/modules/ekf2/params_range_finder.yaml
+++ b/src/modules/ekf2/params_range_finder.yaml
@@ -85,7 +85,7 @@ parameters:
       unit: m
     EKF2_RNG_QLTY_T:
       description:
-        short: Minumum range validity period
+        short: Minimum range validity period
         long: Minimum duration during which the reported range finder signal quality
           needs to be non-zero in order to be declared valid (s)
       type: float


### PR DESCRIPTION
### Solved Problem
An EKF2 range-finder parameter short description used "Minumum" instead of "Minimum" (visible in QGC / param metadata).

### Solution
Correct the spelling in `params_range_finder.yaml`.

### Changelog Entry
fix: correct spelling in EKF2 range validity parameter short description

AI-assisted; human-reviewed.