### PR TITLE
fix(gps): correct overridden spelling in GPS config param long

### DIFF
--- a/src/drivers/gps/params.yaml
+++ b/src/drivers/gps/params.yaml
@@ -178,7 +178,7 @@ parameters:
         long: |-
           Some UBX modules have a FLASH that allows to store persistent configuration that will be loaded on start.
           PX4 does override all configuration parameters it needs in RAM, which takes precedence over the values in FLASH.
-          However, configuration parameters that are not overriden by PX4 can still cause unexpected problems during flight.
+          However, configuration parameters that are not overridden by PX4 can still cause unexpected problems during flight.
           To avoid these kind of problems a clean config can be reached by wiping the FLASH on boot.
 
           Note: Currently only supported on UBX.


### PR DESCRIPTION
### Solved Problem
GPS driver parameter long description used "overriden" instead of "overridden".

### Solution
Fix the spelling in user-facing YAML metadata.

AI-assisted; human-reviewed.