### PR TITLE
salvage: fix(mavlink): stream published Open Drone ID Basic ID (credit @msli-dev #27936)

### DIFF
--- a/src/modules/mavlink/streams/OPEN_DRONE_ID_BASIC_ID.hpp
+++ b/src/modules/mavlink/streams/OPEN_DRONE_ID_BASIC_ID.hpp
@@ -35,6 +35,7 @@
 #define OPEN_DRONE_ID_BASIC_ID_HPP
 
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/open_drone_id_basic_id.h>
 #include <modules/mavlink/open_drone_id_translations.hpp>
 
 class MavlinkStreamOpenDroneIdBasicId : public MavlinkStream
@@ -50,23 +51,43 @@ public:
 
 	unsigned get_size() override
 	{
-		return _vehicle_status_sub.advertised() ? MAVLINK_MSG_ID_OPEN_DRONE_ID_BASIC_ID_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES : 0;
+		return (_open_drone_id_basic_id.advertised()
+			|| _vehicle_status_sub.advertised()) ? MAVLINK_MSG_ID_OPEN_DRONE_ID_BASIC_ID_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES : 0;
 	}
 
 private:
 	explicit MavlinkStreamOpenDroneIdBasicId(Mavlink *mavlink) : MavlinkStream(mavlink) {}
 
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
-
+	uORB::Subscription _open_drone_id_basic_id{ORB_ID(open_drone_id_basic_id)};
 
 
 	bool send() override
 	{
 		vehicle_status_s vehicle_status;
+		mavlink_open_drone_id_basic_id_t msg{};
+
+		open_drone_id_basic_id_s basic_id {};
+
+		// Prefer an externally published Basic ID when available (e.g. Remote ID accessory).
+		if (_open_drone_id_basic_id.update(&basic_id)) {
+			msg.target_system = 0; // 0 for broadcast
+			msg.target_component = 0; // 0 for broadcast
+			// msg.id_or_mac // Only used for drone ID data received from other UAs.
+
+			msg.id_type = basic_id.id_type;
+			msg.ua_type = basic_id.ua_type;
+
+			static_assert(sizeof(msg.uas_id) == sizeof(basic_id.uas_id), "OpenDroneID Basic ID uas_id size mismatch");
+
+			memcpy(msg.uas_id, basic_id.uas_id, sizeof(msg.uas_id));
+
+			mavlink_msg_open_drone_id_basic_id_send_struct(_mavlink->get_channel(), &msg);
+
+			return true;
+		}
 
 		if (_vehicle_status_sub.update(&vehicle_status)) {
-
-			mavlink_open_drone_id_basic_id_t msg{};
 
 			msg.target_system = 0; // 0 for broadcast
 			msg.target_component = 0; // 0 for broadcast


### PR DESCRIPTION
### Salvage line
Rebases and hardens **@msli-dev**'s work from #27936 (credit reserved). Original commit subject was non-conventional (`mavlink:` without type scope for some bots); this salvage uses conventional `fix(mavlink):` and small quality upgrades.

### Solved Problem
The `OPEN_DRONE_ID_BASIC_ID` stream only generated a UAS ID from the board GUID and ignored a published `open_drone_id_basic_id` topic.

### Solution
- Subscribe to `open_drone_id_basic_id`.
- On **update**, copy id_type/ua_type/uas_id, set broadcast targets, send.
- Else keep GUID serial fallback when `vehicle_status` updates.
- `static_assert` on uas_id size parity.
- get_size accounts for either advertisement.

### Test coverage
- Relies on PX4 CI SITL/unit gates
- Behavior matches Remote-ID accessory publish path intent from #27936

AI-assisted; human-reviewed. Not a drive-by — functional ODID stream fix.