### PR TITLE
docs(test): document gazebo-classic-sitl.json for MAVSDK integration tests

### DIFF
--- a/docs/en/test_and_ci/integration_testing_mavsdk.md
+++ b/docs/en/test_and_ci/integration_testing_mavsdk.md
@@ -51,6 +51,8 @@ To run all SITL tests using the SIH simulator as defined in [sih-sitl.json](http
 test/mavsdk_tests/mavsdk_test_runner.py test/mavsdk_tests/configs/sih-sitl.json --speed-factor 10
 ```
 
+For Gazebo Classic SITL suites (iris, tailsitter, typhoon, etc.), use [gazebo-classic-sitl.json](https://github.com/PX4/PX4-Autopilot/blob/main/test/mavsdk_tests/configs/gazebo-classic-sitl.json) instead of the SIH config.
+
 This will list all the tests and then run them sequentially.
 
 To see all possible command line arguments use the `-h` argument:


### PR DESCRIPTION
### Solved Problem
MAVSDK SITL configs were split into SIH vs Gazebo Classic JSON files. EN docs cover SIH but do not point authors at `gazebo-classic-sitl.json` for iris/tailsitter/etc.

### Solution
Add a short pointer next to the SIH runner example.

AI-assisted; human-reviewed.