### PR TITLE
test(mathlib): cover radians/degrees conversion helpers

### DIFF
--- a/src/lib/mathlib/math/FunctionsTest.cpp
+++ b/src/lib/mathlib/math/FunctionsTest.cpp
@@ -33,6 +33,7 @@
 
 #include <gtest/gtest.h>
 #include "Functions.hpp"
+#include "Limits.hpp"
 
 using namespace math;
 
@@ -249,4 +250,14 @@ TEST(FunctionsTest, isFiniteVector3f)
 	EXPECT_FALSE(isFinite(matrix::Vector3f(NAN, 0.f, NAN)));
 	EXPECT_FALSE(isFinite(matrix::Vector3f(NAN, NAN, 0.f)));
 	EXPECT_FALSE(isFinite(matrix::Vector3f(NAN, NAN, NAN)));
+}
+
+TEST(FunctionsTest, RadiansDegrees)
+{
+	EXPECT_FLOAT_EQ(radians(0.f), 0.f);
+	EXPECT_FLOAT_EQ(radians(180.f), static_cast<float>(MATH_PI));
+	EXPECT_FLOAT_EQ(degrees(0.f), 0.f);
+	EXPECT_FLOAT_EQ(degrees(static_cast<float>(MATH_PI)), 180.f);
+	EXPECT_NEAR(degrees(radians(45.f)), 45.f, 1e-5f);
+	EXPECT_NEAR(radians(degrees(1.2f)), 1.2f, 1e-5f);
 }


### PR DESCRIPTION
### Solved Problem
`math::radians` / `math::degrees` lacked direct unit tests.

### Solution
Add round-trip and known-value cases in `FunctionsTest`.

AI-assisted; human-reviewed.