### PR TITLE
feat(fw_mode_manager): add ETA-based height-rate modulation

### DIFF
--- a/docs/en/flight_modes_fw/mission.md
+++ b/docs/en/flight_modes_fw/mission.md
@@ -234,6 +234,20 @@ Any remaining altitude error is then removed by climbing or sinking once the veh
 The ramp is (re)started whenever the target altitude changes; consecutive waypoints at the same altitude are held level.
 :::
 
+## ETA-Based Height-Rate Modulation
+
+By default, fixed-wing missions generate an altitude setpoint along the active mission leg and let the
+longitudinal controller track that setpoint. If the aircraft reaches the waypoint laterally with remaining altitude
+error, it may need to loiter until the target altitude is reached.
+
+When [ETA_CLMB_MOD](../advanced_config/parameter_reference.md#ETA_CLMB_MOD) is enabled, PX4 estimates the time of
+arrival at the active waypoint from the current horizontal distance and ground speed. It then commands the climb or
+sink rate required to remove the remaining altitude error by that estimated arrival time.
+
+This modulation applies to fixed-wing mission waypoint tracking. The internally calculated height-rate setpoint is
+limited symmetrically by [ETA_HR_SAT](../advanced_config/parameter_reference.md#ETA_HR_SAT). If a valid arrival-time
+estimate is unavailable, PX4 falls back to the normal altitude setpoint.
+
 ## Mission Takeoff
 
 Starting flights with mission takeoff (and landing using a mission landing) is the recommended way of operating a plane autonomously.

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -811,10 +811,13 @@ FixedWingModeManager::control_auto_position(const float control_interval, const 
 	const float position_sp_alt = calculateFirstOrderHoldAltitude(pos_sp_curr.lat, pos_sp_curr.lon, pos_sp_curr.alt,
 				      _current_latitude, _current_longitude, _current_altitude, acc_rad, _foh_altitude_state);
 
+	const float height_rate_setpoint = _param_eta_based_climbrate_enable.get() ?
+					   getHeightRateSetpointThroughETA(curr_pos, ground_speed, pos_sp_curr) : NAN;
+
 	const fixed_wing_longitudinal_setpoint_s fw_longitudinal_control_sp = {
 		.timestamp = hrt_absolute_time(),
 		.altitude = position_sp_alt,
-		.height_rate = NAN,
+		.height_rate = height_rate_setpoint,
 		.equivalent_airspeed = target_airspeed,
 		.pitch_direct = NAN,
 		.throttle_direct = NAN
@@ -2417,6 +2420,30 @@ float FixedWingModeManager::getMaxRollAngleNearGround(const float altitude, cons
 
 	return  math::constrain(2.f * height_above_ground / _param_fw_wing_span.get(), 0.f,
 				math::radians(_param_fw_r_lim.get()));
+}
+
+float FixedWingModeManager::getHeightRateSetpointThroughETA(const Vector2d &curr_pos, const Vector2f &ground_speed,
+		const position_setpoint_s &pos_sp_curr) const
+{
+	const float ground_speed_magnitude = ground_speed.norm();
+
+	if (!PX4_ISFINITE(ground_speed_magnitude) || ground_speed_magnitude <= FLT_EPSILON
+	    || !PX4_ISFINITE(pos_sp_curr.alt) || !PX4_ISFINITE(_current_altitude)) {
+		return NAN;
+	}
+
+	const float distance_to_waypoint = get_distance_to_next_waypoint(pos_sp_curr.lat, pos_sp_curr.lon,
+					   curr_pos(0), curr_pos(1));
+
+	if (!PX4_ISFINITE(distance_to_waypoint) || distance_to_waypoint <= FLT_EPSILON) {
+		return NAN;
+	}
+
+	const float approach_time = distance_to_waypoint / ground_speed_magnitude;
+	const float height_rate_setpoint = (pos_sp_curr.alt - _current_altitude) / approach_time;
+	const float height_rate_saturation = _param_eta_height_rate_saturation.get();
+
+	return math::constrain(height_rate_setpoint, -height_rate_saturation, height_rate_saturation);
 }
 
 

--- a/src/modules/fw_mode_manager/FixedWingModeManager.hpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.hpp
@@ -678,6 +678,8 @@ private:
 	void publishOrbitStatus(const position_setpoint_s &pos_sp);
 
 	float getMaxRollAngleNearGround(const float altitude, const float terrain_altitude) const;
+	float getHeightRateSetpointThroughETA(const Vector2d &curr_pos, const Vector2f &ground_speed,
+			const position_setpoint_s &pos_sp_curr) const;
 
 	/**
 	 * @brief Calculates the touchdown position for landing with optional manual lateral adjustments.
@@ -845,6 +847,8 @@ private:
 		(ParamFloat<px4::params::NPFG_PERIOD>) _param_npfg_period,
 		(ParamFloat<px4::params::NPFG_DAMPING>) _param_npfg_damping,
 		(ParamBool<px4::params::NPFG_LB_PERIOD>) _param_npfg_en_period_lb,
+		(ParamBool<px4::params::ETA_CLMB_MOD>) _param_eta_based_climbrate_enable,
+		(ParamFloat<px4::params::ETA_HR_SAT>) _param_eta_height_rate_saturation,
 		(ParamBool<px4::params::NPFG_UB_PERIOD>) _param_npfg_en_period_ub,
 		(ParamFloat<px4::params::NPFG_ROLL_TC>) _param_npfg_roll_time_const,
 		(ParamFloat<px4::params::NPFG_SW_DST_MLT>) _param_npfg_switch_distance_multiplier,

--- a/src/modules/fw_mode_manager/FixedWingModeManager.hpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.hpp
@@ -679,7 +679,7 @@ private:
 
 	float getMaxRollAngleNearGround(const float altitude, const float terrain_altitude) const;
 	float getHeightRateSetpointThroughETA(const Vector2d &curr_pos, const Vector2f &ground_speed,
-			const position_setpoint_s &pos_sp_curr) const;
+					      const position_setpoint_s &pos_sp_curr) const;
 
 	/**
 	 * @brief Calculates the touchdown position for landing with optional manual lateral adjustments.

--- a/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
+++ b/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
@@ -474,6 +474,25 @@ parameters:
           If false, also disables upper bound NPFG_PERIOD_UB.
       type: boolean
       default: 1
+    ETA_CLMB_MOD:
+      description:
+        short: Enable ETA-based height-rate modulation
+        long: |-
+          Commands the climb or sink rate required to reach the active mission waypoint altitude at the
+          estimated time of arrival. The estimate uses the horizontal distance and current ground speed.
+      type: boolean
+      default: 0
+    ETA_HR_SAT:
+      description:
+        short: ETA height-rate saturation
+        long: Maximum absolute climb or sink rate commanded by ETA-based height-rate modulation.
+      type: float
+      default: 5.0
+      unit: m/s
+      min: 0.1
+      max: 20.0
+      decimal: 1
+      increment: 0.1
     NPFG_UB_PERIOD:
       description:
         short: Enable automatic upper bound on the NPFG period


### PR DESCRIPTION
## Description

Add optional ETA-based height-rate modulation for fixed-wing mission waypoint tracking.

When enabled with `ETA_CLMB_MOD`, the fixed-wing mode manager estimates time to the active waypoint from horizontal distance and ground speed, then commands the height rate required to remove the remaining altitude error by arrival. The command is symmetrically constrained by the new `ETA_HR_SAT` parameter.

If the ETA inputs are invalid, the controller falls back to the existing altitude-setpoint behavior.

## Changes

- Add `ETA_CLMB_MOD` to enable ETA-based height-rate modulation.
- Add `ETA_HR_SAT` to constrain the internally generated climb/sink-rate command.
- Feed the bounded height-rate setpoint into fixed-wing longitudinal control during mission waypoint tracking.
- Document the behavior and parameters.

## Testing

- Built the `modules__fw_mode_manager` SITL target successfully against current PX4 `main`.
- Validated ETA modulation and saturation behavior in the experimental branch.

## Results 
- Tested through Gazebo based SITL. Vehicle : `gz_rc_cessna` 
<img width="1536" height="1024" alt="resutls_for_PR" src="https://github.com/user-attachments/assets/4e47aa21-e1b8-4080-a53e-d3e4b68598db" />
