### PR TITLE
fix(uavcan): publish non-valid range readings with quality 0

### DIFF
--- a/src/drivers/uavcan/sensors/rangefinder.cpp
+++ b/src/drivers/uavcan/sensors/rangefinder.cpp
@@ -110,7 +110,10 @@ void UavcanRangefinderBridge::range_sub_cb(const
 		_inited = true;
 	}
 
-	int8_t quality = -1;
+	// TOO_CLOSE, TOO_FAR and UNDEFINED readings do not carry a usable range
+	// value: publish them as invalid (0) rather than unknown (-1), which
+	// consumers like the EKF would otherwise accept and fuse.
+	int8_t quality = 0;
 
 	if (msg.reading_type == uavcan::equipment::range_sensor::Measurement::READING_TYPE_VALID_RANGE) {
 		quality = 100;


### PR DESCRIPTION
## Summary
The DroneCAN rangefinder bridge now publishes TOO_CLOSE, TOO_FAR and UNDEFINED readings with signal_quality 0 (invalid) instead of -1 (unknown), so downstream consumers reject them.

## Problem
DroneCAN rangefinder nodes report an out-of-range sentinel in the range field for non-valid reading types (commonly max_distance + 1 for TOO_FAR). The bridge passed that raw range through with signal_quality -1, which consumers treat as usable. With UAVCAN_RNG_MIN/MAX at their defaults there is no other gate, and flight logs from an AFBR-S50 based CAN node show the EKF fusing the node's 101 m TOO_FAR sentinel as terrain distance for most of a climb between 45 and 113 m AGL.

## Solution
Map every reading type other than VALID_RANGE to signal_quality 0, which the distance_sensor uORB convention defines as invalid signal and consumers such as the EKF reject.