### PR TITLE
fix(vectornav): free temporary buffer in libvnc VnSearcher_discardData

### DIFF
--- a/src/drivers/ins/vectornav/libvnc/src/vn/sensors/searcher.c
+++ b/src/drivers/ins/vectornav/libvnc/src/vn/sensors/searcher.c
@@ -84,6 +84,7 @@ void VnSearcher_discardData(char inputData[], size_t dataLength, size_t discardL
 		memset(inputData, 0, dataLength);
 		/*memcpy_s(inputData, tmpSize, tmp, tmpSize);*/
 		memcpy(inputData, tmp, tmpSize);
+		free(tmp);
 	}
 }
 

--- a/src/drivers/ins/vectornav/libvnc/src/vn/sensors/searcher.c
+++ b/src/drivers/ins/vectornav/libvnc/src/vn/sensors/searcher.c
@@ -74,17 +74,9 @@ void VnSearcher_discardData(char inputData[], size_t dataLength, size_t discardL
 	else
 	{
 		/* Move the data to the front of the array and zero out everything else */
-		/* Size of the data to move */
-		size_t tmpSize = dataLength - discardLength;
-		/* Temporary swap buffer */
-		char* tmp = (char*)malloc(sizeof(char) * tmpSize);
-		/* And the swap operations */
-		/*memcpy_s(tmp, tmpSize, inputData + discardLength, tmpSize);*/
-		memcpy(tmp, inputData + discardLength, tmpSize);
-		memset(inputData, 0, dataLength);
-		/*memcpy_s(inputData, tmpSize, tmp, tmpSize);*/
-		memcpy(inputData, tmp, tmpSize);
-		free(tmp);
+		const size_t newSize = dataLength - discardLength;
+		memmove(inputData, inputData + discardLength, newSize);
+		memset(inputData + newSize, 0, discardLength);
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix a memory leak in the vendored VectorNav vnproglib library.

## Problem

`VnSearcher_discardData()` in `src/drivers/ins/vectornav/libvnc` allocates a temporary swap buffer with `malloc()` and never frees it, leaking once per call. Reported by Martin Strunz via email.

## Solution

Free the buffer after the swap. Upstream vnproglib is frozen with no public repository, so the fix is carried in the vendored copy.