### PR TITLE
fix(matrix): clamp asin domain in Euler(Dcm) near gimbal lock

### DIFF
--- a/src/lib/matrix/matrix/Euler.hpp
+++ b/src/lib/matrix/matrix/Euler.hpp
@@ -15,6 +15,10 @@
 
 #pragma once
 
+#include <cmath>
+
+#include "Matrix.hpp"
+
 namespace matrix
 {
 
@@ -83,7 +87,17 @@ public:
 	*/
 	Euler(const Dcm<Type> &dcm)
 	{
-		theta() = std::asin(-dcm(2, 0));
+		// Clamp the asin() argument to its valid [-1, 1] domain. In exact
+		// arithmetic -dcm(2, 0) is always within this range for a proper
+		// rotation matrix, but floating point rounding (e.g. from quaternion
+		// normalization) can push it a ULP or two outside, which would
+		// otherwise make asin() return NaN and silently corrupt theta() --
+		// most likely to occur near the +-90 degree pitch singularity, which
+		// e.g. tailsitter VTOL vehicles fly through during every transition.
+		// This mirrors the equivalent acos() guard already used for the same
+		// reason in MapProjection::project() (src/lib/geo/geo.cpp).
+		const Type sin_theta = typeFunction::constrain(-dcm(2, 0), Type(-1), Type(1));
+		theta() = std::asin(sin_theta);
 
 		if ((std::fabs(theta() - Type(M_PI / 2))) < Type(1.0e-3)) {
 			phi() = 0;

--- a/src/lib/matrix/test/MatrixAttitudeTest.cpp
+++ b/src/lib/matrix/test/MatrixAttitudeTest.cpp
@@ -494,3 +494,26 @@ TEST(MatrixAttitudeTest, Attitude)
 	R = Dcmf(q);
 	EXPECT_EQ(q, Quatf(R));
 }
+
+TEST(MatrixAttitudeTest, EulerFromDcmAsinDomainNearGimbalLock)
+{
+	// Regression test: in exact arithmetic the asin() argument in
+	// Euler(const Dcm<Type>&) (-dcm(2, 0)) is always within [-1, 1], but
+	// floating point rounding can push it a ULP or two outside that range
+	// for quaternions near the +-90 degree pitch singularity -- which e.g. a
+	// tailsitter VTOL flies through on every transition. Before the fix this
+	// made asin() return NaN and silently corrupted theta(). This mirrors
+	// the equivalent acos() guard already used for the same reason in
+	// MapProjection::project() (src/lib/geo/geo.cpp).
+	Quatf q(0.70719326f, -3.2680862e-05f, 0.7070204f, -8.065616e-05f);
+	q.normalize();
+
+	Dcmf dcm(q);
+	// Confirm this quaternion actually exercises the asin() domain edge;
+	// otherwise the test would pass vacuously.
+	ASSERT_GT(std::fabs((double)(-dcm(2, 0))), 1.0);
+
+	Eulerf euler(dcm);
+	EXPECT_TRUE(std::isfinite(euler.theta()));
+	EXPECT_NEAR((double)euler.theta(), M_PI_2, 1e-3);
+}


### PR DESCRIPTION
### Solved Problem
`Euler(const Dcm&)` can feed `asin()` a value slightly outside `[-1,1]` after float normalization near ±90° pitch, producing NaN pitch (failure detector / airspeed paths).

### Solution
salvage of **#27872** by **@94xhn** (full credit). Rebased onto current `main`, keep `typeFunction::constrain` + regression test `EulerFromDcmAsinDomainNearGimbalLock`.

### Test coverage
- Matrix attitude unit test near gimbal-lock DCM domain edge

### Context
AI-assisted; human-reviewed. No arm/geofence changes.

<sub>Claim: bartok · Operator: bartok · Campaign: aerial-drone</sub>