### PR TITLE
test(mathlib): cover isFinite float and Vector2f overloads

### DIFF
--- a/src/lib/mathlib/math/FunctionsTest.cpp
+++ b/src/lib/mathlib/math/FunctionsTest.cpp
@@ -250,3 +250,18 @@ TEST(FunctionsTest, isFiniteVector3f)
 	EXPECT_FALSE(isFinite(matrix::Vector3f(NAN, NAN, 0.f)));
 	EXPECT_FALSE(isFinite(matrix::Vector3f(NAN, NAN, NAN)));
 }
+
+TEST(FunctionsTest, isFiniteFloatAndVector2f)
+{
+	EXPECT_TRUE(isFinite(0.f));
+	EXPECT_TRUE(isFinite(1.f));
+	EXPECT_FALSE(isFinite(NAN));
+	EXPECT_FALSE(isFinite(INFINITY));
+	EXPECT_FALSE(isFinite(-INFINITY));
+
+	EXPECT_TRUE(isFinite(matrix::Vector2f()));
+	EXPECT_TRUE(isFinite(matrix::Vector2f(0.f, 1.f)));
+	EXPECT_FALSE(isFinite(matrix::Vector2f(NAN, 0.f)));
+	EXPECT_FALSE(isFinite(matrix::Vector2f(0.f, INFINITY)));
+	EXPECT_FALSE(isFinite(matrix::Vector2f(NAN, NAN)));
+}


### PR DESCRIPTION
### Solved Problem
`math::isFinite` overloads for scalar float and `Vector2f` lacked unit tests (`Vector3f` already covered).

### Solution
Add focused gtest cases for finite/NaN/Inf float and Vector2f.

### Test coverage
FunctionsTest only.

AI-assisted; human-reviewed.