### PR TITLE
test(mathlib): cover negate including int16 extremes

### DIFF
--- a/src/lib/mathlib/math/FunctionsTest.cpp
+++ b/src/lib/mathlib/math/FunctionsTest.cpp
@@ -33,6 +33,7 @@
 
 #include <gtest/gtest.h>
 #include "Functions.hpp"
+#include <cstdint>
 
 using namespace math;
 
@@ -249,4 +250,17 @@ TEST(FunctionsTest, isFiniteVector3f)
 	EXPECT_FALSE(isFinite(matrix::Vector3f(NAN, 0.f, NAN)));
 	EXPECT_FALSE(isFinite(matrix::Vector3f(NAN, NAN, 0.f)));
 	EXPECT_FALSE(isFinite(matrix::Vector3f(NAN, NAN, NAN)));
+}
+
+TEST(FunctionsTest, negate)
+{
+	EXPECT_FLOAT_EQ(negate(1.5f), -1.5f);
+	EXPECT_FLOAT_EQ(negate(-2.25f), 2.25f);
+	EXPECT_FLOAT_EQ(negate(0.f), 0.f);
+
+	EXPECT_EQ(negate(static_cast<int16_t>(5)), static_cast<int16_t>(-5));
+	EXPECT_EQ(negate(static_cast<int16_t>(-5)), static_cast<int16_t>(5));
+	// int16_t extremal values swap as documented
+	EXPECT_EQ(negate(INT16_MAX), INT16_MIN);
+	EXPECT_EQ(negate(INT16_MIN), INT16_MAX);
 }

--- a/src/lib/mathlib/math/FunctionsTest.cpp
+++ b/src/lib/mathlib/math/FunctionsTest.cpp
@@ -260,7 +260,7 @@ TEST(FunctionsTest, negate)
 
 	EXPECT_EQ(negate(static_cast<int16_t>(5)), static_cast<int16_t>(-5));
 	EXPECT_EQ(negate(static_cast<int16_t>(-5)), static_cast<int16_t>(5));
-	// int16_t extremal values swap as documented
-	EXPECT_EQ(negate(INT16_MAX), INT16_MIN);
-	EXPECT_EQ(negate(INT16_MIN), INT16_MAX);
+	// Cast required: INT16_* macros are int-ranked; bare value skips int16 specialization
+	EXPECT_EQ(negate(static_cast<int16_t>(INT16_MAX)), static_cast<int16_t>(INT16_MIN));
+	EXPECT_EQ(negate(static_cast<int16_t>(INT16_MIN)), static_cast<int16_t>(INT16_MAX));
 }


### PR DESCRIPTION
### Solved Problem
`math::negate` int16 special cases (INT16_MIN/MAX swap) had no unit lock.

### Solution
Gtest for float and int16_t including extremes.

### Test coverage
FunctionsTest.

AI-assisted; human-reviewed.