### PR TITLE
refactor(navigator): replace FeasibilityChecker bitfield union with struct

### DIFF
--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
@@ -46,7 +46,7 @@ FeasibilityChecker::FeasibilityChecker() :
 
 void FeasibilityChecker::reset()
 {
-	_checks_failed.value = 0;
+	_checks_failed = ChecksFailed{};
 
 	_found_item_with_position = false;
 	_has_vtol_takeoff = false;
@@ -150,11 +150,11 @@ bool FeasibilityChecker::processNextItem(mission_item_s &mission_item, const int
 		updateData();
 	}
 
-	if (!_checks_failed.flags.mission_validity_failed) {
-		_checks_failed.flags.mission_validity_failed = !checkMissionItemValidity(mission_item, current_index);
+	if (!_checks_failed.mission_validity_failed) {
+		_checks_failed.mission_validity_failed = !checkMissionItemValidity(mission_item, current_index);
 	}
 
-	if (_checks_failed.flags.mission_validity_failed) {
+	if (_checks_failed.mission_validity_failed) {
 		// if a mission item is not valid then abort the other checks
 		return false;
 	}
@@ -172,7 +172,7 @@ bool FeasibilityChecker::processNextItem(mission_item_s &mission_item, const int
 	}
 
 	if (current_index == total_count - 1) {
-		_checks_failed.flags.takeoff_land_available_failed = !checkTakeoffLandAvailable();
+		_checks_failed.takeoff_land_available_failed = !checkTakeoffLandAvailable();
 	}
 
 	_mission_item_previous = mission_item;
@@ -183,39 +183,39 @@ bool FeasibilityChecker::processNextItem(mission_item_s &mission_item, const int
 void FeasibilityChecker::doCommonChecks(mission_item_s &mission_item, const int current_index)
 {
 
-	if (!_checks_failed.flags.distance_between_waypoints_failed) {
-		_checks_failed.flags.distance_between_waypoints_failed = !checkDistancesBetweenWaypoints(mission_item);
+	if (!_checks_failed.distance_between_waypoints_failed) {
+		_checks_failed.distance_between_waypoints_failed = !checkDistancesBetweenWaypoints(mission_item);
 	}
 
 	if (!_first_waypoint_found) {
 		checkHorizontalDistanceToFirstWaypoint(mission_item);
 	}
 
-	if (!_checks_failed.flags.takeoff_failed) {
-		_checks_failed.flags.takeoff_failed = !checkTakeoff(mission_item);
+	if (!_checks_failed.takeoff_failed) {
+		_checks_failed.takeoff_failed = !checkTakeoff(mission_item);
 	}
 
-	if (!_checks_failed.flags.items_fit_to_vehicle_type_failed) {
-		_checks_failed.flags.items_fit_to_vehicle_type_failed = !checkItemsFitToVehicleType(mission_item);
+	if (!_checks_failed.items_fit_to_vehicle_type_failed) {
+		_checks_failed.items_fit_to_vehicle_type_failed = !checkItemsFitToVehicleType(mission_item);
 	}
 }
 
 void FeasibilityChecker::doVtolChecks(mission_item_s &mission_item, const int current_index, const int last_index)
 {
-	if (!_checks_failed.flags.land_pattern_validity_failed) {
-		_checks_failed.flags.land_pattern_validity_failed = !checkLandPatternValidity(mission_item, current_index, last_index);
+	if (!_checks_failed.land_pattern_validity_failed) {
+		_checks_failed.land_pattern_validity_failed = !checkLandPatternValidity(mission_item, current_index, last_index);
 	}
 
 }
 
 void FeasibilityChecker::doFixedWingChecks(mission_item_s &mission_item, const int current_index, const int last_index)
 {
-	if (!_checks_failed.flags.land_pattern_validity_failed) {
-		_checks_failed.flags.land_pattern_validity_failed = !checkLandPatternValidity(mission_item, current_index, last_index);
+	if (!_checks_failed.land_pattern_validity_failed) {
+		_checks_failed.land_pattern_validity_failed = !checkLandPatternValidity(mission_item, current_index, last_index);
 	}
 
-	if (!_checks_failed.flags.fixed_wing_land_approach_failed) {
-		_checks_failed.flags.fixed_wing_land_approach_failed = !checkFixedWingLandApproach(mission_item, current_index);
+	if (!_checks_failed.fixed_wing_land_approach_failed) {
+		_checks_failed.fixed_wing_land_approach_failed = !checkFixedWingLandApproach(mission_item, current_index);
 	}
 
 }
@@ -231,8 +231,6 @@ bool FeasibilityChecker::checkMissionItemValidity(mission_item_s &mission_item, 
 	/* reject relative alt without home set */
 	if (mission_item.altitude_is_relative && !PX4_ISFINITE(_home_alt_msl)
 	    && mission_item_contains_position(mission_item)) {
-
-
 
 		mavlink_log_critical(_mavlink_log_pub, "Mission rejected: No home pos, WP %d uses rel alt\t", current_index + 1);
 		events::send<int16_t>(events::ID("navigator_mis_no_home_rel_alt"), {events::Log::Error, events::LogInternal::Info},

--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
@@ -77,7 +77,13 @@ public:
 	*/
 	bool someCheckFailed()
 	{
-		return _checks_failed.value != 0;
+		return _checks_failed.mission_validity_failed
+		       || _checks_failed.takeoff_failed
+		       || _checks_failed.land_pattern_validity_failed
+		       || _checks_failed.distance_between_waypoints_failed
+		       || _checks_failed.fixed_wing_land_approach_failed
+		       || _checks_failed.takeoff_land_available_failed
+		       || _checks_failed.items_fit_to_vehicle_type_failed;
 	}
 
 	/**
@@ -105,17 +111,14 @@ private:
 	matrix::Vector2d _home_lat_lon = matrix::Vector2d((double)NAN, (double)NAN);
 	VehicleType _vehicle_type{VehicleType::RotaryWing};
 
-	union checks_failed_u {
-		struct {
-			bool mission_validity_failed : 1;
-			bool takeoff_failed : 1;
-			bool land_pattern_validity_failed : 1;
-			bool distance_between_waypoints_failed : 1;
-			bool fixed_wing_land_approach_failed : 1;
-			bool takeoff_land_available_failed : 1;
-			bool items_fit_to_vehicle_type_failed : 1;
-		} flags;
-		uint16_t value {0};
+	struct ChecksFailed {
+		bool mission_validity_failed{false};
+		bool takeoff_failed{false};
+		bool land_pattern_validity_failed{false};
+		bool distance_between_waypoints_failed{false};
+		bool fixed_wing_land_approach_failed{false};
+		bool takeoff_land_available_failed{false};
+		bool items_fit_to_vehicle_type_failed{false};
 	} _checks_failed{};
 
 	// internal checkTakeoff related variables


### PR DESCRIPTION
### Solved Problem

We saw instances where an uploaded mission, which had previously passed feasibility checks, is dropped mid flight for no apparent reason. No event was emitted, just the message that the mission is unfeasible.
This change is meant to harden the relevant code as there was not other explanation found (yet) how the above situation can occur and why.

_checks_failed was a union overlaying a bitfield struct of 1-bit flags with a uint16_t value. The flags were written individually (_checks_failed.flags.takeoff_failed = ...) while pass/fail was read back through the aliased integer (_checks_failed.value != 0).

Writing one member of a union and reading a different one is undefined behavior in C++ (only one union member is "active" at a time; type punning through a union is not permitted by the standard). In practice every mainstream compiler supports this pattern, so it works today — but relying on UB is fragile and better avoided outright.

### Solution
Use a struct ChecksFailed with named, default-initialized bool members. someCheckFailed() now ORs the members explicitly and reset() assigns a fresh ChecksFailed{}. Behavior is unchanged; the code no longer depends on union type punning.
### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video
