### PR TITLE
test(mathlib): cover FilteredDerivative ramp and reset

### DIFF
--- a/src/lib/mathlib/CMakeLists.txt
+++ b/src/lib/mathlib/CMakeLists.txt
@@ -42,6 +42,7 @@ px4_add_library(mathlib
 
 px4_add_unit_gtest(SRC math/test/LowPassFilter2pVector3fTest.cpp LINKLIBS mathlib)
 px4_add_unit_gtest(SRC math/test/AlphaFilterTest.cpp)
+px4_add_unit_gtest(SRC math/test/FilteredDerivativeTest.cpp)
 px4_add_unit_gtest(SRC math/test/MedianFilterTest.cpp)
 px4_add_unit_gtest(SRC math/test/NotchFilterTest.cpp)
 px4_add_unit_gtest(SRC math/test/second_order_reference_model_test.cpp)

--- a/src/lib/mathlib/math/test/FilteredDerivativeTest.cpp
+++ b/src/lib/mathlib/math/test/FilteredDerivativeTest.cpp
@@ -53,7 +53,6 @@ TEST(FilteredDerivative, resetClearsInitializedPath)
 	// after reset, first sample only primes; next three stay low for flat signal
 	(void)fd.update(0.f);
 	float out = fd.update(0.f);
-	out =
-fd.update(0.f);
+	out = fd.update(0.f);
 	EXPECT_NEAR(out, 0.f, 0.15f);
 }

--- a/src/lib/mathlib/math/test/FilteredDerivativeTest.cpp
+++ b/src/lib/mathlib/math/test/FilteredDerivativeTest.cpp
@@ -1,0 +1,59 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2026 PX4 Development Team. All rights reserved.
+ *
+ ****************************************************************************/
+
+/**
+ * make tests TESTFILTER=FilteredDerivative
+ */
+
+#include <gtest/gtest.h>
+#include <cmath>
+
+#include <lib/mathlib/math/filter/FilteredDerivative.hpp>
+
+TEST(FilteredDerivative, constantSignalYieldsNearZeroDerivative)
+{
+	FilteredDerivative<float> fd;
+	fd.setParameters(0.01f, 0.05f);
+	float out = 0.f;
+
+	for (int i = 0; i < 50; i++) {
+		out = fd.update(5.f);
+	}
+
+	EXPECT_NEAR(out, 0.f, 0.2f);
+}
+
+TEST(FilteredDerivative, linearRampApproachesSlope)
+{
+	FilteredDerivative<float> fd;
+	const float dt = 0.01f;
+	const float slope = 2.5f;
+	fd.setParameters(dt, 0.02f);
+	float out = 0.f;
+	float s = 0.f;
+
+	for (int i = 0; i < 200; i++) {
+		s = slope * (i * dt);
+		out = fd.update(s);
+	}
+
+	EXPECT_NEAR(out, slope, 0.35f);
+}
+
+TEST(FilteredDerivative, resetClearsInitializedPath)
+{
+	FilteredDerivative<float> fd;
+	fd.setParameters(0.01f, 0.05f);
+	(void)fd.update(0.f);
+	(void)fd.update(1.f);
+	fd.reset(0.f);
+	// after reset, first sample only primes; next three stay low for flat signal
+	(void)fd.update(0.f);
+	float out = fd.update(0.f);
+	out =
+fd.update(0.f);
+	EXPECT_NEAR(out, 0.f, 0.15f);
+}


### PR DESCRIPTION
## Summary
Unit tests for `FilteredDerivative`: flat signal → ~0 rate, linear ramp → filtered slope, reset re-primes.

## Verification
Unit Tests CI / TESTFILTER=FilteredDerivative

Tests only; human-authored.