### PR TITLE
test(mathlib): cover MedianFilter finite majority with NaN

### DIFF
--- a/src/lib/mathlib/CMakeLists.txt
+++ b/src/lib/mathlib/CMakeLists.txt
@@ -43,6 +43,7 @@ px4_add_library(mathlib
 px4_add_unit_gtest(SRC math/test/LowPassFilter2pVector3fTest.cpp LINKLIBS mathlib)
 px4_add_unit_gtest(SRC math/test/AlphaFilterTest.cpp)
 px4_add_unit_gtest(SRC math/test/MedianFilterTest.cpp)
+px4_add_unit_gtest(SRC math/test/MedianFilterNanTest.cpp)
 px4_add_unit_gtest(SRC math/test/NotchFilterTest.cpp)
 px4_add_unit_gtest(SRC math/test/second_order_reference_model_test.cpp)
 px4_add_unit_gtest(SRC math/FunctionsTest.cpp)

--- a/src/lib/mathlib/math/test/MedianFilterNanTest.cpp
+++ b/src/lib/mathlib/math/test/MedianFilterNanTest.cpp
@@ -1,0 +1,40 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2026 PX4 Development Team. All rights reserved.
+ *
+ ****************************************************************************/
+
+/**
+ * make tests TESTFILTER=MedianFilterNan
+ */
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <limits>
+
+#include <lib/mathlib/math/filter/MedianFilter.hpp>
+
+using math::MedianFilter;
+
+TEST(MedianFilterNan, finiteSamplesMedian)
+{
+	MedianFilter<float, 3> mf;
+	EXPECT_FLOAT_EQ(mf.apply(3.f), 3.f); // buffer start partially zero-filled by default
+	// Fill a clear window
+	mf.apply(1.f);
+	mf.apply(5.f);
+	const float m = mf.apply(3.f);
+	EXPECT_FLOAT_EQ(m, 3.f);
+}
+
+TEST(MedianFilterNan, nanPushedAsideVersusFinite)
+{
+	MedianFilter<float, 3> mf;
+	const float nan = std::numeric_limits<float>::quiet_NaN();
+	mf.insert(1.f);
+	mf.insert(2.f);
+	mf.insert(nan);
+	const float m = mf.median();
+	// non-finite sorts after finite in cmp → median tends finite when majority finite
+	EXPECT_TRUE(std::isfinite(m));
+}

--- a/src/lib/mathlib/math/test/MedianFilterNanTest.cpp
+++ b/src/lib/mathlib/math/test/MedianFilterNanTest.cpp
@@ -19,11 +19,10 @@ using math::MedianFilter;
 TEST(MedianFilterNan, finiteSamplesMedian)
 {
 	MedianFilter<float, 3> mf;
-	EXPECT_FLOAT_EQ(mf.apply(3.f), 3.f); // buffer start partially zero-filled by default
-	// Fill a clear window
-	mf.apply(1.f);
-	mf.apply(5.f);
-	const float m = mf.apply(3.f);
+	// cold start is zero-filled; load a full clear window first
+	(void)mf.apply(1.f);
+	(void)mf.apply(5.f);
+	const float m = mf.apply(3.f); // window {1,5,3} -> median 3
 	EXPECT_FLOAT_EQ(m, 3.f);
 }
 


### PR DESCRIPTION
## Summary
Covers MedianFilter float path when a NaN is present alongside finite samples (sort comparator favors finite).

## Verification
Unit Tests CI

Tests only; human-authored.