### PR TITLE
fix(simulation): fix Gazebo gimbal ROI yaw frame and tracking

### DIFF
--- a/src/modules/gimbal/output_mavlink.cpp
+++ b/src/modules/gimbal/output_mavlink.cpp
@@ -160,10 +160,10 @@ void OutputMavlinkV2::update(const ControlData &control_data, bool new_setpoints
 		if (new_setpoints) {
 			//got new command
 			_set_angle_setpoints(control_data);
-
-			_handle_position_update(control_data);
 			_last_update = now;
 		}
+
+		_handle_position_update(control_data);
 
 		gimbal_device_id = _gimbal_device_found ? _gimbal_device_id : 0;
 

--- a/src/modules/simulation/gz_bridge/GZGimbal.cpp
+++ b/src/modules/simulation/gz_bridge/GZGimbal.cpp
@@ -145,7 +145,23 @@ bool GZGimbal::pollSetpoint()
 		gimbal_device_set_attitude_s msg;
 
 		if (_gimbal_device_set_attitude_sub.copy(&msg)) {
-			const matrix::Eulerf gimbal_att_stp(matrix::Quatf(msg.q));
+			matrix::Quatf attitude_setpoint(msg.q);
+			const bool yaw_in_vehicle_frame = msg.flags
+							  & gimbal_device_set_attitude_s::GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME;
+			const bool yaw_in_earth_frame = msg.flags
+							& gimbal_device_set_attitude_s::GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME;
+			const bool legacy_yaw_lock = !yaw_in_vehicle_frame && !yaw_in_earth_frame
+						     && (msg.flags & gimbal_device_set_attitude_s::GIMBAL_DEVICE_FLAGS_YAW_LOCK);
+
+			if ((yaw_in_earth_frame && !yaw_in_vehicle_frame) || legacy_yaw_lock) {
+				vehicle_attitude_s vehicle_attitude{};
+
+				if (_vehicle_attitude_sub.copy(&vehicle_attitude)) {
+					attitude_setpoint = matrix::Quatf(vehicle_attitude.q).inversed() * attitude_setpoint;
+				}
+			}
+
+			const matrix::Eulerf gimbal_att_stp(attitude_setpoint);
 			_roll_stp = gimbal_att_stp.phi();
 			_pitch_stp = gimbal_att_stp.theta();
 			_yaw_stp = gimbal_att_stp.psi();

--- a/src/modules/simulation/gz_bridge/GZGimbal.hpp
+++ b/src/modules/simulation/gz_bridge/GZGimbal.hpp
@@ -10,6 +10,7 @@
 #include <uORB/topics/vehicle_command_ack.h>
 #include <uORB/topics/gimbal_controls.h>
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/vehicle_attitude.h>
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
@@ -41,6 +42,7 @@ private:
 
 	uORB::Subscription _gimbal_device_set_attitude_sub{ORB_ID(gimbal_device_set_attitude)};
 	uORB::Subscription _gimbal_controls_sub{ORB_ID(gimbal_controls)};
+	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::SubscriptionCallbackWorkItem _vehicle_command_sub{this, ORB_ID(vehicle_command)};
 
 	uORB::Publication<gimbal_device_attitude_status_s> _gimbal_device_attitude_status_pub{ORB_ID(gimbal_device_attitude_status)};


### PR DESCRIPTION
## Summary

fixes #26178

Convert Earth-frame gimbal attitude setpoints into vehicle-relative Gazebo joint targets, and recompute geographic ROI bearings as the vehicle moves.

## Problem

Gazebo gimbal joints consume vehicle-relative angles, but PX4 could send an Earth-frame ROI quaternion directly to those joints, applying the vehicle heading twice. In addition, the MAVLink v2 output recalculated a geographic ROI bearing only when a new ROI command arrived, so the gimbal setpoint froze while the vehicle translated.

## Solution

The Gazebo bridge now respects the yaw-frame flags (including the legacy yaw-lock flag) and rotates Earth-frame attitudes into the vehicle frame with the inverse vehicle attitude before commanding the joints. The MAVLink v2 output now refreshes position-based setpoints on every update cycle, matching the v1 output.

Validated in SITL with `gz_x500_gimbal` and `MIS_MNT_YAW_CTL=1`: vehicle yaw and Earth-frame gimbal yaw remain independent, and the gimbal keeps tracking a fixed ROI as the vehicle moves.

<img width="584" height="340" alt="image" src="https://github.com/user-attachments/assets/ea8643de-026d-45c6-86a7-eb8ccd0a43c9" />
<img width="499" height="341" alt="image" src="https://github.com/user-attachments/assets/8b14a4b2-e961-4a87-8c97-2a444e23a194" />
<img width="513" height="373" alt="image" src="https://github.com/user-attachments/assets/648d370c-ff74-4e47-83fe-ba148e306541" />

