### PR TITLE
docs(contribute): add AI coding assistant policy

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -17,7 +17,9 @@ Create a git commit in conventional-commit format: `type(scope): description`.
   `.github/workflows/` → `ci`).
 - **description:** imperative, concise, ≥5 chars.
 
-**NEVER add Co-Authored-By Claude Code. No Claude attribution.**
+**The user is the author. Never add `Co-Authored-By` naming an AI. End the
+commit body with the disclosure trailer `Assisted-by: Claude:<model-id>`
+(e.g. `Assisted-by: Claude:claude-fable-5`).**
 
 ## Steps
 
@@ -28,7 +30,9 @@ Create a git commit in conventional-commit format: `type(scope): description`.
 3. Run `make format` (or `./Tools/astyle/fix_code_style.sh <file>`) on changed
    C/C++ files.
 4. Body (if needed): explain **why**, not what.
-5. Check GPG signing: `git config --get user.signingkey`. If set,
-   `git commit -S -s`; else `git commit -s`.
+5. Commit with `git commit -s`. Do not pass `-S`: GPG signing is the user's
+   git config decision (`commit.gpgsign`), not the skill's. The `-s` sign-off
+   is the user's DCO certification of changes they have reviewed: never
+   commit with `-s` work the user has not seen.
 
 If the user provided arguments, use them as context: $ARGUMENTS

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -7,7 +7,9 @@ allowed-tools: Bash, Read, Glob, Grep
 
 # PX4 Pull Request
 
-**No Claude attribution anywhere (no Co-Authored-By, no "Generated with Claude").**
+**The user is the author: no `Co-Authored-By`, no "Generated with Claude"
+footers. AI disclosure lives in the commit trailers (`Assisted-by:`), not in
+the PR body.**
 
 ## Steps
 
@@ -22,7 +24,7 @@ allowed-tools: Bash, Read, Glob, Grep
 4. PR **title:** `type(scope): description` — under 72 chars, covers the
    overall change across all commits. This becomes the squash-merge commit
    message.
-5. PR **body:** concise and terse — do not restate what the diff already shows (no file-changed lists, no code snippets that reproduce the diff). Use exactly three sections, in order: `## Summary`, `## Problem`, `## Solution`. If the PR closes a GitHub issue, the first line of `## Summary` must be `fixes #<N>`, then a blank line, then the summary text. No `## Test plan` section, no boilerplate, no Claude attribution. Use markdown (links, code blocks, lists) only when warranted.
+5. PR **body:** concise and terse — do not restate what the diff already shows (no file-changed lists, no code snippets that reproduce the diff). Use exactly three sections, in order: `## Summary`, `## Problem`, `## Solution`. If the PR closes a GitHub issue, the first line of `## Summary` must be `fixes #<N>`, then a blank line, then the summary text. No `## Test plan` section, no boilerplate, no Claude attribution. Use markdown (links, code blocks, lists) only when warranted. Never state testing that did not happen: ask the user what they actually ran beyond the builds in step 3, report exactly that, and say so plainly when something is untested.
 
 6. Push with `-u` if needed, then `gh pr create`. Default base is `main`
    unless user says otherwise.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,14 @@ git rebase -i HEAD~N
 git push --force-with-lease
 ```
 
+## AI-assisted contributions
+
+AI coding assistants are welcome, under the [AI coding assistants policy](docs/en/contribute/ai_assistants.md):
+
+- You are the author. You must understand, and be able to defend, every line you submit. An AI tool is never an author or co-author, and never appears in a `Signed-off-by` tag.
+- Disclosure is required. Every commit with AI-generated or AI-assisted content must carry an `Assisted-by: NAME:MODEL` trailer in the commit body (for example `Assisted-by: Claude:claude-fable-5`).
+- All licensing, testing, and review requirements apply unchanged. Never claim testing that did not happen.
+
 ## Test your changes
 
 PX4 is safety-critical software. All contributions must include adequate testing where practical:

--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -951,6 +951,7 @@
   - [Support](contribute/support.md)
   - [Source Code Management](contribute/code.md)
     - [GIT Examples](contribute/git_examples.md)
+  - [AI Coding Assistants](contribute/ai_assistants.md)
   - [Documentation](contribute/docs.md)
   - [Translation](contribute/translation.md)
   - [Terminology/Notation](contribute/notation.md)

--- a/docs/en/contribute/ai_assistants.md
+++ b/docs/en/contribute/ai_assistants.md
@@ -1,0 +1,79 @@
+# AI Coding Assistants
+
+AI-assisted contributions are welcome in PX4.
+AI coding assistants are development tools, like compilers and static analyzers, and contributions made with their help are held to exactly the same standard as any other contribution: the [coding standards](../contribute/code.md), [commit conventions](https://github.com/PX4/PX4-Autopilot/blob/main/CONTRIBUTING.md), testing requirements, and review process apply unchanged.
+
+This page defines the additional rules that apply when AI tools are used.
+They exist to keep authorship, accountability, and licensing unambiguous, and to keep review manageable for maintainers.
+
+::: info
+Using AI tools is optional.
+Disclosing their use is not.
+:::
+
+## Authorship and Accountability
+
+The human submitter is the author of the contribution.
+
+- You must understand every line you submit, be able to explain it, and be prepared to defend it in review.
+- Responsibility for correctness, safety, licensing, and testing never transfers to a tool.
+  PX4 is safety-critical software that flies real vehicles; "the AI wrote it" is never an acceptable answer in review.
+- An AI tool is never an author or co-author.
+  Do not add `Co-Authored-By` tags naming an AI tool.
+
+## Signed-off-by and the Developer Certificate of Origin
+
+A `Signed-off-by` tag is the human author's certification under the [Developer Certificate of Origin](https://developercertificate.org/).
+
+- An AI tool is never the author of a contribution and must never appear in a `Signed-off-by` tag.
+- Tooling acting on your instruction, including an AI agent, may apply your sign-off mechanically, the same way `git commit -s` does.
+  The certification remains yours.
+- By signing off you certify that you have personally reviewed the contribution and have the right to submit it under the project license.
+  Never allow your sign-off to be applied to changes you have not reviewed.
+
+## Licensing
+
+All code contributions must be compatible with the [BSD 3-clause license](../contribute/licenses.md) and must not impose any further constraints.
+
+When using AI tools you are additionally responsible for the conditions of the [Linux Foundation Generative AI Policy](https://www.linuxfoundation.org/legal/generative-ai):
+
+- The terms of service of the AI tool you use must not conflict with the project license.
+- If the tool's output includes pre-existing copyrighted material from a third party, you must have the right to submit it, and must include the required notice, attribution, and license information.
+
+## Disclosure (Required)
+
+Every commit that contains AI-generated or AI-assisted content (code, documentation, or commit message text) must carry a disclosure trailer in the commit message body:
+
+```
+Assisted-by: NAME:MODEL
+```
+
+`NAME` identifies the tool and `MODEL` the specific model used, for example:
+
+```
+Assisted-by: Claude:claude-fable-5
+Assisted-by: Copilot:gpt-5
+```
+
+- Conventional development tooling does not need to be disclosed: compilers, formatters (`make format`), linters, git, and classic editor autocomplete are not AI assistance in this sense.
+- Like the sign-off, disclosure operates on good faith: reviewers cannot reliably detect AI usage and will not try to.
+  Undisclosed AI use discovered after the fact is treated as a misrepresentation and is grounds for reverting the contribution.
+
+## Expectations
+
+These rules keep review sustainable.
+Contributions that ignore them may be closed by maintainers without detailed review.
+
+- **Test claims must be real.**
+  The [testing requirements](https://github.com/PX4/PX4-Autopilot/blob/main/CONTRIBUTING.md#test-your-changes) apply unchanged: state exactly what you ran (SITL, bench test, flight test) and provide logs where they apply.
+  Never let a tool describe testing that did not happen.
+  An AI cannot have flown your vehicle.
+- **No unsolicited bulk changes.**
+  Do not submit large AI-generated refactors, style sweeps, or "cleanup" pull requests that nobody asked for.
+  Discuss the idea in an issue or on the [dev call](../contribute/dev_call.md) first.
+- **Issues and security reports must be human-verified.**
+  Reproduce the problem yourself before filing.
+  Unverified AI-generated findings cost maintainers real time and erode trust.
+- **Review discussion is between humans.**
+  Using an AI tool to help you understand a review comment is fine; posting model output you do not understand as your reply is not.
+  AI-assisted review is acceptable when clearly labeled as such; presenting undisclosed AI review as your own reading is not.

--- a/docs/en/contribute/index.md
+++ b/docs/en/contribute/index.md
@@ -23,6 +23,7 @@ This section contains information about how you can meet with the community and 
 - [Maintainers](./maintainers.md) - Maintainer roles, types, and how to become one
 - [Support](../contribute/support.md) - Get help and raise issues
 - [Source Code Management](../contribute/code.md) - Work with PX4 code
+- [AI Coding Assistants](../contribute/ai_assistants.md) - Rules for contributing with AI coding tools
 - [Documentation](../contribute/docs.md) - Improve the docs
 - [Translation](../contribute/translation.md) - Translate using Crowdin
 - [Terminology/Notation](../contribute/notation.md) - Terms and symbols used in the docs


### PR DESCRIPTION
## Summary

Adds a project policy for AI-assisted contributions, modeled on the Linux kernel's [coding-assistants](https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst) document, and wires it into the contributor docs and the in-repo agent tooling.

## Problem

AI-assisted contributions are arriving in volume and PX4 has no stated rules for them. Contributors don't know what is expected, and maintainers have no reference to point to when authorship, licensing, testing claims, or disclosure are unclear. The project position is that AI tools are welcome, but the human in the loop is the author and the responsible entity, and that needs to be written down.

## Solution

New docs page [`contribute/ai_assistants.md`](https://docs.px4.io/main/en/contribute/ai_assistants) defining the policy:

- The human submitter is the author, accountable for every line; an AI tool never appears as author, co-author, or in a `Signed-off-by` tag. Sign-off is the author's certification of changes they have personally reviewed.
- Licensing follows the BSD 3-clause requirements and the [Linux Foundation Generative AI Policy](https://www.linuxfoundation.org/legal/generative-ai).
- Disclosure is required: commits with AI-generated or AI-assisted content carry an `Assisted-by: NAME:MODEL` trailer (kernel format).
- Maintainer expectations: test claims must be real, no unsolicited bulk AI changes, issues and security reports human-verified, AI-assisted review clearly labeled. Non-compliant contributions may be closed without detailed review.

The policy is summarized in CONTRIBUTING.md and enforced by default in the in-repo agent tooling: new `AGENTS.md` with the agent-facing short form (imported by `CLAUDE.md`), and the commit/pr/review skills updated to add the disclosure trailer, protect the sign-off rule, and never fabricate test claims.

This commit was written with AI assistance and discloses it per the policy it introduces.