### PR TITLE
fix(FlightTaskAuto): Corner cases moving platform auto-takeoff

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -79,8 +79,6 @@ bool FlightTaskAuto::activate(const trajectory_setpoint_s &last_setpoint)
 	_is_emergency_braking_active = false;
 	_time_last_cruise_speed_override = 0;
 	_lock_position_xy.setNaN();
-	_takeoff_locked_xy.setNaN();
-	_takeoff_liftoff_z = NAN;
 
 	return ret;
 }
@@ -91,8 +89,6 @@ void FlightTaskAuto::reActivate()
 
 	// On ground, reset acceleration and velocity to zero
 	_position_smoothing.reset({0.f, 0.f, 0.f}, {0.f, 0.f, 0.7f}, _position);
-	_takeoff_locked_xy.setNaN();
-	_takeoff_liftoff_z = NAN;
 }
 
 bool FlightTaskAuto::updateInitialize()
@@ -151,24 +147,35 @@ bool FlightTaskAuto::update()
 		_velocity_setpoint(2) = NAN;
 		break;
 
-	case WaypointType::loiter:
 	case WaypointType::takeoff:
+		_position_setpoint = _triplet_current;
+		_velocity_setpoint.setNaN();
+
+		if (_type_previous != WaypointType::takeoff) {
+			_takeoff_liftoff_position.setNaN();
+		}
+
+		if (_takeoff_status_sub.get().takeoff_state < takeoff_status_s::TAKEOFF_STATE_FLIGHT) {
+			_takeoff_liftoff_position = _position;
+			_position_smoothing.forceSetPosition({_position(0), _position(1), NAN});
+		}
+
+		if (Vector2f(_takeoff_liftoff_position).isAllFinite()) {
+			_position_setpoint.xy() = _takeoff_liftoff_position.xy();
+		}
+
+		if (PX4_ISFINITE(_takeoff_liftoff_position(2)) && (_takeoff_liftoff_position(2) - _position(2)) < 1.f) {
+			_position_smoothing.forceSetVelocity({_velocity(0), _velocity(1), NAN});
+		}
+
+		break;
+
+	case WaypointType::loiter:
 	case WaypointType::position:
 	default:
 		// Simple waypoint navigation: go to xyz target, with standard limitations
 		_position_setpoint = _triplet_current;
 		_velocity_setpoint.setNaN();
-
-		if (_type == WaypointType::takeoff) {
-			if (_takeoff_status_sub.get().takeoff_state < takeoff_status_s::TAKEOFF_STATE_FLIGHT) {
-				_takeoff_locked_xy = Vector2f(_position);
-			}
-
-			if (_takeoff_locked_xy.isAllFinite()) {
-				_position_setpoint.xy() = _takeoff_locked_xy;
-			}
-		}
-
 		break;
 	}
 
@@ -184,18 +191,6 @@ bool FlightTaskAuto::update()
 					       && !_yaw_sp_aligned;
 	const bool force_zero_velocity_setpoint = should_wait_for_yaw_align || _is_emergency_braking_active;
 	_updateTrajConstraints();
-
-	if (_type == WaypointType::takeoff) {
-		if (_takeoff_status_sub.get().takeoff_state < takeoff_status_s::TAKEOFF_STATE_FLIGHT) {
-			_takeoff_liftoff_z = _position(2);
-			_position_smoothing.forceSetPosition({_position(0), _position(1), NAN});
-		}
-
-		if (!PX4_ISFINITE(_takeoff_liftoff_z)
-		    || (_takeoff_liftoff_z - _position(2)) < 1.f) {
-			_position_smoothing.forceSetVelocity({_velocity(0), _velocity(1), NAN});
-		}
-	}
 
 	PositionSmoothing::PositionSmoothingSetpoints smoothed_setpoints;
 	_position_smoothing.generateSetpoints(
@@ -674,8 +669,8 @@ void FlightTaskAuto::_ekfResetHandlerPositionXY(const matrix::Vector2f &delta_xy
 {
 	_position_smoothing.forceSetPosition({_position(0), _position(1), NAN});
 
-	if (_takeoff_locked_xy.isAllFinite()) {
-		_takeoff_locked_xy += delta_xy;
+	if (Vector2f(_takeoff_liftoff_position).isAllFinite()) {
+		_takeoff_liftoff_position.xy() += delta_xy;
 	}
 }
 
@@ -688,8 +683,8 @@ void FlightTaskAuto::_ekfResetHandlerPositionZ(const float delta_z)
 {
 	_position_smoothing.forceSetPosition({NAN, NAN, _position(2)});
 
-	if (PX4_ISFINITE(_takeoff_liftoff_z)) {
-		_takeoff_liftoff_z += delta_z;
+	if (PX4_ISFINITE(_takeoff_liftoff_position(2))) {
+		_takeoff_liftoff_position(2) += delta_z;
 	}
 }
 

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -40,9 +40,6 @@
 
 using namespace matrix;
 
-// First meter after lift-off prioritises altitude over horizontal tracking.
-static constexpr float kTakeoffClimbPriorityHeight = 1.0f; // [m]
-
 bool FlightTaskAuto::activate(const trajectory_setpoint_s &last_setpoint)
 {
 	bool ret = FlightTask::activate(last_setpoint);
@@ -81,6 +78,7 @@ bool FlightTaskAuto::activate(const trajectory_setpoint_s &last_setpoint)
 	_updateTrajConstraints();
 	_is_emergency_braking_active = false;
 	_time_last_cruise_speed_override = 0;
+	_lock_position_xy.setNaN();
 	_takeoff_locked_xy.setNaN();
 	_takeoff_liftoff_z = NAN;
 
@@ -167,8 +165,7 @@ bool FlightTaskAuto::update()
 			}
 
 			if (_takeoff_locked_xy.isAllFinite()) {
-				_position_setpoint(0) = _takeoff_locked_xy(0);
-				_position_setpoint(1) = _takeoff_locked_xy(1);
+				_position_setpoint.xy() = _takeoff_locked_xy;
 			}
 		}
 
@@ -195,7 +192,7 @@ bool FlightTaskAuto::update()
 		}
 
 		if (!PX4_ISFINITE(_takeoff_liftoff_z)
-		    || (_takeoff_liftoff_z - _position(2)) < kTakeoffClimbPriorityHeight) {
+		    || (_takeoff_liftoff_z - _position(2)) < 1.f) {
 			_position_smoothing.forceSetVelocity({_velocity(0), _velocity(1), NAN});
 		}
 	}
@@ -423,8 +420,7 @@ bool FlightTaskAuto::_evaluatePositionSetpointTriplet()
 	// Temporary target variable where we save the local reprojection of the latest navigator current triplet.
 	Vector3f tmp_target;
 
-	if (!PX4_ISFINITE(position_setpoint_triplet.current.lat)
-	    || !PX4_ISFINITE(position_setpoint_triplet.current.lon)) {
+	if (!PX4_ISFINITE(position_setpoint_triplet.current.lat) || !PX4_ISFINITE(position_setpoint_triplet.current.lon)) {
 		// No position provided in xy. Lock position
 		if (!_lock_position_xy.isAllFinite()) {
 			tmp_target(0) = _lock_position_xy(0) = _position(0);
@@ -436,12 +432,11 @@ bool FlightTaskAuto::_evaluatePositionSetpointTriplet()
 		}
 
 	} else {
-		// reset locked position if current lon and lat are valid
-		_lock_position_xy.setAll(NAN);
+		// reset locked position if current coordinates are valid
+		_lock_position_xy.setNaN();
 
 		// Convert from global to local frame.
-		_reference_position.project(position_setpoint_triplet.current.lat, position_setpoint_triplet.current.lon,
-					    tmp_target(0), tmp_target(1));
+		_reference_position.project(position_setpoint_triplet.current.lat, position_setpoint_triplet.current.lon, tmp_target(0), tmp_target(1));
 	}
 
 	tmp_target(2) = -(position_setpoint_triplet.current.alt - _reference_altitude);

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -678,6 +678,10 @@ bool FlightTaskAuto::_compute_heading_from_2D_vector(float &heading, Vector2f v)
 void FlightTaskAuto::_ekfResetHandlerPositionXY(const matrix::Vector2f &delta_xy)
 {
 	_position_smoothing.forceSetPosition({_position(0), _position(1), NAN});
+
+	if (_takeoff_locked_xy.isAllFinite()) {
+		_takeoff_locked_xy += delta_xy;
+	}
 }
 
 void FlightTaskAuto::_ekfResetHandlerVelocityXY(const matrix::Vector2f &delta_vxy)
@@ -688,6 +692,10 @@ void FlightTaskAuto::_ekfResetHandlerVelocityXY(const matrix::Vector2f &delta_vx
 void FlightTaskAuto::_ekfResetHandlerPositionZ(const float delta_z)
 {
 	_position_smoothing.forceSetPosition({NAN, NAN, _position(2)});
+
+	if (PX4_ISFINITE(_takeoff_liftoff_z)) {
+		_takeoff_liftoff_z += delta_z;
+	}
 }
 
 void FlightTaskAuto::_ekfResetHandlerVelocityZ(const float delta_vz)

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -174,8 +174,7 @@ protected:
 
 private:
 	matrix::Vector2f _lock_position_xy; /**< if no valid triplet is received, lock positition to current position */
-	matrix::Vector2f _takeoff_locked_xy; /**< lift-off XY tracked during the takeoff ramp and frozen at FLIGHT to keep the climb vertical */
-	float _takeoff_liftoff_z{NAN}; /**< lift-off altitude (NED z), frozen at FLIGHT */
+	matrix::Vector3f _takeoff_liftoff_position; /**< tracks the position state during the takeoff ramp and is frozen at FLIGHT */
 	bool _yaw_lock{false}; /**< if within acceptance radius, lock yaw to current yaw */
 
 	matrix::Vector3f _triplet_previous; ///< previous waypoint in triplet from navigator

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -121,9 +121,9 @@ protected:
 	WaypointType _type{WaypointType::idle}; /**< Type of current target triplet. */
 
 	uORB::SubscriptionData<position_setpoint_triplet_s> _position_setpoint_triplet_sub{ORB_ID(position_setpoint_triplet)};
-	uORB::SubscriptionData<home_position_s>			_sub_home_position {ORB_ID(home_position)};
-	uORB::SubscriptionData<vehicle_status_s>		_sub_vehicle_status{ORB_ID(vehicle_status)};
-	uORB::SubscriptionData<takeoff_status_s>		_takeoff_status_sub{ORB_ID(takeoff_status)};
+	uORB::SubscriptionData<home_position_s> _sub_home_position{ORB_ID(home_position)};
+	uORB::SubscriptionData<vehicle_status_s> _sub_vehicle_status{ORB_ID(vehicle_status)};
+	uORB::SubscriptionData<takeoff_status_s> _takeoff_status_sub{ORB_ID(takeoff_status)};
 
 	float _target_acceptance_radius{0.0f}; /**< Acceptances radius of the target */
 
@@ -173,8 +173,8 @@ protected:
 				       );
 
 private:
-	matrix::Vector2f _lock_position_xy{NAN, NAN}; /**< if no valid triplet is received, lock positition to current position */
-	matrix::Vector2f _takeoff_locked_xy{NAN, NAN}; /**< lift-off XY tracked during the takeoff ramp and frozen at FLIGHT to keep the climb vertical */
+	matrix::Vector2f _lock_position_xy; /**< if no valid triplet is received, lock positition to current position */
+	matrix::Vector2f _takeoff_locked_xy; /**< lift-off XY tracked during the takeoff ramp and frozen at FLIGHT to keep the climb vertical */
 	float _takeoff_liftoff_z{NAN}; /**< lift-off altitude (NED z), frozen at FLIGHT */
 	bool _yaw_lock{false}; /**< if within acceptance radius, lock yaw to current yaw */
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -341,9 +341,9 @@ private:
 	orb_sub_t _mission_sub{ORB_SUB_INVALID};
 	orb_sub_t _vehicle_status_sub{ORB_SUB_INVALID};
 
-	uORB::SubscriptionData<position_controller_status_s>	_position_controller_status_sub{ORB_ID(position_controller_status)};
+	uORB::SubscriptionData<position_controller_status_s> _position_controller_status_sub{ORB_ID(position_controller_status)};
 	uORB::SubscriptionData<fixed_wing_lateral_guidance_status_s> _fw_lateral_guidance_status_sub{ORB_ID(fixed_wing_lateral_guidance_status)};
-	uORB::SubscriptionData<takeoff_status_s>		_takeoff_status_sub{ORB_ID(takeoff_status)};
+	uORB::SubscriptionData<takeoff_status_s> _takeoff_status_sub{ORB_ID(takeoff_status)};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 


### PR DESCRIPTION
### Solved Problem
I was late reviewing https://github.com/PX4/PX4-Autopilot/pull/27559 and didn't communicate that clearly.

### Solution
1. Some refactor like spacing, different use of Matrix library
2. Handle position estimate reset during takeoff
3. Move as much as possible into the `case WaypointType::takeoff:` case to make it obvious what belongs together and can later move into a takeoff flight task. This changes behavior ever so slightly because the reset to current state happens before the emergency break check. But I'm arguing that's if you ever take off while being faster than the maximum speed an improved outcome.
4. Initialize the 3D takeoff location with NAN when switching to a takeoff type (`_type_previous != WaypointType::takeoff`) to rule out using any previous state e.g. when the takeoff state machine is skipped which is currently probably only the case for throw launch.

### Changelog Entry
```
Corner cases moving platform auto-takeoff
```

### Test coverage
Ideally we make an integration test (in SIH) for this. I was testing manually with 5m/s win from north in SIH and let Claude check that I don't change behavior from the original intent.

I haven't analyzed the expected timing of
1. "want takeoff"
2. "takeoff ramp done"
3. "1 meter higher than takeoff ramp done"
with default configuration and typical vehicle (yet). I think that would be useful to know.

I also noticed that the takeoff position (also x,y) was and still is locked when the takeoff ramp is done but the velocity is reset until 1 meter off the ground. I assume that's intentional based on the real world testing but it makes the drone fly back to where the takeoff ramp was done and I'd consider resetting horizontal position until 1 meter off the ground...
