### PR TITLE
feat(param): add bitset and bitclear commands

### DIFF
--- a/docs/en/advanced/parameters_and_configurations.md
+++ b/docs/en/advanced/parameters_and_configurations.md
@@ -13,7 +13,7 @@ It covers how to list, save and load parameters, and how to define them and make
 
 The PX4 [system console](../debug/system_console.md) offers the [param](../modules/modules_command.md#param) tool, which can be used to set parameters, read their value, save them, and export and restore to/from files.
 
-### Getting and Setting Parameters
+### Getting Parameters
 
 The `param show` command lists all system parameters:
 
@@ -41,6 +41,22 @@ param show -c
 ```
 
 You can use `param show-for-airframe` to show all parameters that have changed from their defaults for just the current airframe's definition file (and defaults it imports).
+
+### Setting Parameters
+
+Use `param set` to change a specific parameter:
+
+```sh
+param set SYS_AUTOSTART 1103   # Load airframe 1103 on next boot if SYS_AUTOCONFIG==1
+param set FW_T_F_ALT_ERR 20    # Enable TECS fast descend if >20m above altitude setpoint
+```
+
+Use `param bitset` and `param bitclear` to modify individual bits of a parameter (only for `INT32`):
+
+```sh
+param bitclear EKF2_SENS_EN 3  # Disable GPS fusion (lowest 2 bits -> 0b11), leaving other settings intact
+param bitset PWM_MAIN_REV 24   # Set output range for main PWM 4 and 5 to reversed (0b11000), leaving others intact
+```
 
 ### Exporting and Loading Parameters
 

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -88,6 +88,7 @@ static int	do_show_index(const char *index, bool used_index);
 static void	do_show_print(void *arg, param_t param);
 static void	do_show_print_for_airframe(void *arg, param_t param);
 static int	do_set(const char *name, const char *val, bool fail_on_not_found);
+static int	do_bitop(const char *name, const char *mask_str, bool set_bits, bool fail_on_not_found);
 static int	do_set_custom_default(const char *name, const char *val, bool silent_fail = false);
 static int	do_compare(const char *name, char *vals[], unsigned comparisons, enum COMPARE_OPERATOR cmd_op,
 			   enum COMPARE_ERROR_LEVEL err_level);
@@ -153,6 +154,14 @@ $ reboot
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("set", "Set parameter to a value");
 	PRINT_MODULE_USAGE_ARG("<param_name> <value>", "Parameter name and value to set", false);
+	PRINT_MODULE_USAGE_ARG("fail", "If provided, let the command fail if param is not found", true);
+
+	PRINT_MODULE_USAGE_COMMAND_DESCR("bitset", "Set bits of an int32 parameter (param |= mask)");
+	PRINT_MODULE_USAGE_ARG("<param_name> <mask>", "Parameter name and bitmask (decimal or 0x hex)", false);
+	PRINT_MODULE_USAGE_ARG("fail", "If provided, let the command fail if param is not found", true);
+
+	PRINT_MODULE_USAGE_COMMAND_DESCR("bitclear", "Clear bits of an int32 parameter (param &= ~mask)");
+	PRINT_MODULE_USAGE_ARG("<param_name> <mask>", "Parameter name and bitmask (decimal or 0x hex)", false);
 	PRINT_MODULE_USAGE_ARG("fail", "If provided, let the command fail if param is not found", true);
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("set-default", "Set parameter default to a value");
@@ -324,6 +333,20 @@ param_main(int argc, char *argv[])
 
 			} else {
 				PX4_ERR("not enough arguments.\nTry 'param set %s 3 [fail]'", (argc > 2) ? argv[2] : "PARAM_NAME");
+				return 1;
+			}
+		}
+
+		if (!strcmp(argv[1], "bitset") || !strcmp(argv[1], "bitclear")) {
+			bool set_bits = !strcmp(argv[1], "bitset");
+
+			if (argc >= 4) {
+				bool fail = (argc >= 5) && !strcmp(argv[4], "fail");
+
+				return do_bitop(argv[2], argv[3], set_bits, fail);
+
+			} else {
+				PX4_ERR("not enough arguments.\nTry 'param %s %s 3 [fail]'", argv[1], (argc > 2) ? argv[2] : "PARAM_NAME");
 				return 1;
 			}
 		}
@@ -969,6 +992,51 @@ do_set(const char *name, const char *val, bool fail_on_not_found)
 	default:
 		PX4_ERR("<unknown / unsupported type %d>\n", 0 + param_type(param));
 		return 1;
+	}
+
+	return 0;
+}
+
+static int
+do_bitop(const char *name, const char *mask_str, bool set_bits, bool fail_on_not_found)
+{
+	param_t param = param_find(name);
+
+	if (param == PARAM_INVALID) {
+		/* param not found - fail silently in scripts as it prevents booting */
+		PX4_ERR("Parameter %s not found.", name);
+		return (fail_on_not_found) ? 1 : 0;
+	}
+
+	if (param_type(param) != PARAM_TYPE_INT32) {
+		PX4_ERR("Parameter %s is not of type int32.", name);
+		return 1;
+	}
+
+	char *end;
+	int32_t mask = strtol(mask_str, &end, 0);
+
+	if (end == mask_str || *end != '\0') {
+		PX4_ERR("Invalid bitmask '%s'.", mask_str);
+		return 1;
+	}
+
+	int32_t val;
+
+	if (param_get(param, &val) != 0) {
+		PX4_ERR("Failed to get parameter %s.", name);
+		return 1;
+	}
+
+	int32_t newval = set_bits ? (val | mask) : (val & ~mask);
+
+	if (val != newval) {
+		PX4_INFO_RAW("%c %s: ",
+			     param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
+			     param_name(param));
+		PX4_INFO_RAW("curr: %ld", (long)val);
+		param_set(param, &newval);
+		PX4_INFO_RAW(" -> new: %ld\n", (long)newval);
 	}
 
 	return 0;


### PR DESCRIPTION
Credit goes to @mbjd, I'm just the executor.

Currently we can only set such parameters to specific values, but we cannot toggle on and off individual bits programmatically.

This allows us to modify only some bits of a param, while leaving others the same. This is essential for parameters which:
 - are an int32 bitset
 - have some bits which should persist
 - have some bits which should take on a specified value

Motivating example here is EKF2_SENS_EN. With this we can replace the current

    param set EKF2_GPS_CTRL 0  # Disable GPS Aiding on every boot

in airframes that expect spoofing by

    param bitclear EKF2_SENS_EN 3

This accomodates for the change in parameter semantics from https://github.com/PX4/PX4-Autopilot/pull/26739 - see here: 
https://github.com/PX4/PX4-Autopilot/blob/3d853a2c11530a0b251623faeff2dd52e3ae2479/src/modules/ekf2/EKF/common.h#L290-L294

and the one we want to disable on every boot to escape spoofing is enabled, not available.
