### PR TITLE
test(mathlib): cover WelfordMean constant and empty cases

### DIFF
--- a/src/lib/mathlib/math/WelfordMeanTest.cpp
+++ b/src/lib/mathlib/math/WelfordMeanTest.cpp
@@ -62,3 +62,23 @@ TEST(WelfordMeanTest, NoisySignal)
 	EXPECT_NEAR(var, var_real, 0.1f);
 
 }
+
+TEST(WelfordMeanTest, ConstantSignal)
+{
+	WelfordMean<float> welford{};
+
+	for (int i = 0; i < 50; i++) {
+		welford.update(2.5f);
+	}
+
+	EXPECT_TRUE(welford.valid());
+	EXPECT_NEAR(welford.mean(), 2.5f, 1e-5f);
+	EXPECT_NEAR(welford.variance(), 0.f, 1e-5f);
+}
+
+TEST(WelfordMeanTest, InvalidBeforeSamples)
+{
+	WelfordMean<float> welford{};
+	EXPECT_FALSE(welford.valid());
+}
+

--- a/src/lib/mathlib/math/WelfordMeanTest.cpp
+++ b/src/lib/mathlib/math/WelfordMeanTest.cpp
@@ -81,4 +81,3 @@ TEST(WelfordMeanTest, InvalidBeforeSamples)
 	WelfordMean<float> welford{};
 	EXPECT_FALSE(welford.valid());
 }
-


### PR DESCRIPTION
## Summary
Extends `WelfordMeanTest` with a constant-signal path (mean pinned, variance ~0) and a pre-sample `valid()` false check.

## Why
Noisy Monte-Carlo coverage alone does not lock easy edge cases used by online filter estimators.

## Verification
- File-only extension to existing unit gtest
- Human-reviewed micro-diff; AI-assisted drafting

No flight-control path changes.