### PR TITLE
test(atmosphere): pressure/altitude roundtrip across altitudes

### DIFF
--- a/src/lib/atmosphere/test_atmosphere.cpp
+++ b/src/lib/atmosphere/test_atmosphere.cpp
@@ -124,3 +124,24 @@ TEST(TestAtmosphere, StandardTemperature)
 	// THEN expect standard temperature at 3000m
 	EXPECT_NEAR(temperature, -4.5f, 0.001f);
 }
+
+
+TEST(TestAtmosphere, PressureAltitudeRoundtrip)
+{
+	const float p0 = 101325.f;
+	for (float alt : {0.f, 500.f, 1500.f, 5000.f, 8000.f}) {
+		const float p = getPressureFromAltitude(alt);
+		const float alt_back = getAltitudeFromPressure(p, p0);
+		EXPECT_NEAR(alt_back, alt, 1.0f) << "alt=" << alt;
+	}
+}
+
+TEST(TestAtmosphere, StandardTemperatureMonotonic)
+{
+	const float t0 = getStandardTemperatureAtAltitude(0.f);
+	const float t1 = getStandardTemperatureAtAltitude(1000.f);
+	const float t3 = getStandardTemperatureAtAltitude(3000.f);
+	EXPECT_GT(t0, t1);
+	EXPECT_GT(t1, t3);
+}
+

--- a/src/lib/atmosphere/test_atmosphere.cpp
+++ b/src/lib/atmosphere/test_atmosphere.cpp
@@ -129,6 +129,7 @@ TEST(TestAtmosphere, StandardTemperature)
 TEST(TestAtmosphere, PressureAltitudeRoundtrip)
 {
 	const float p0 = 101325.f;
+
 	for (float alt : {0.f, 500.f, 1500.f, 5000.f, 8000.f}) {
 		const float p = getPressureFromAltitude(alt);
 		const float alt_back = getAltitudeFromPressure(p, p0);
@@ -144,4 +145,3 @@ TEST(TestAtmosphere, StandardTemperatureMonotonic)
 	EXPECT_GT(t0, t1);
 	EXPECT_GT(t1, t3);
 }
-


### PR DESCRIPTION
### What
Adds multi-altitude pressure→altitude roundtrip checks (0–8000 m) and monotonic standard temperature with height.

### Why
Existing tests only hit sea level and 3000 m; small regressions in ISA helpers could slip.

### How verified
Unit gtest file only. AI-assisted; human-reviewed. No runtime module changes.