### PR TITLE
test(matrix): cover wrap_pi at multi-turn boundaries

### DIFF
--- a/src/lib/matrix/test/MatrixHelperTest.cpp
+++ b/src/lib/matrix/test/MatrixHelperTest.cpp
@@ -123,3 +123,15 @@ TEST(MatrixHelperTest, Helper)
 	EXPECT_TRUE(isEqual(c, c));
 	EXPECT_TRUE(isEqual(d, d));
 }
+
+
+TEST(MatrixHelperTest, WrapPiRange)
+{
+	EXPECT_NEAR(wrap_pi(0.f), 0.f, 1e-6f);
+	EXPECT_NEAR(wrap_pi(float(M_PI)), float(M_PI), 1e-5f);
+	EXPECT_NEAR(wrap_pi(-float(M_PI)), -float(M_PI), 1e-5f);
+	EXPECT_NEAR(wrap_pi(3.f * float(M_PI)), float(M_PI), 1e-4f);
+	EXPECT_NEAR(wrap_pi(-3.f * float(M_PI)), -float(M_PI), 1e-4f);
+	EXPECT_NEAR(wrap_pi(2.f * float(M_PI) + 0.1f), 0.1f, 1e-4f);
+}
+

--- a/src/lib/matrix/test/MatrixHelperTest.cpp
+++ b/src/lib/matrix/test/MatrixHelperTest.cpp
@@ -127,11 +127,11 @@ TEST(MatrixHelperTest, Helper)
 
 TEST(MatrixHelperTest, WrapPiRange)
 {
+	// wrap_pi uses wrap(x, -pi, pi) => half-open [-pi, pi); +pi folds to -pi
 	EXPECT_NEAR(wrap_pi(0.f), 0.f, 1e-6f);
-	EXPECT_NEAR(wrap_pi(float(M_PI)), float(M_PI), 1e-5f);
+	EXPECT_NEAR(wrap_pi(float(M_PI)), -float(M_PI), 1e-5f);
 	EXPECT_NEAR(wrap_pi(-float(M_PI)), -float(M_PI), 1e-5f);
-	EXPECT_NEAR(wrap_pi(3.f * float(M_PI)), float(M_PI), 1e-4f);
+	EXPECT_NEAR(wrap_pi(3.f * float(M_PI)), -float(M_PI), 1e-4f);
 	EXPECT_NEAR(wrap_pi(-3.f * float(M_PI)), -float(M_PI), 1e-4f);
 	EXPECT_NEAR(wrap_pi(2.f * float(M_PI) + 0.1f), 0.1f, 1e-4f);
 }
-


### PR DESCRIPTION
### Summary
Adds `wrap_pi` multi-turn boundary cases to MatrixHelperTest.

### Verification
Unit test only. AI-assisted; human-reviewed.