### PR TITLE
test(mathlib): cover max distance to circle far-side hit

### DIFF
--- a/src/lib/mathlib/math/MaxDistanceToCircleTest.cpp
+++ b/src/lib/mathlib/math/MaxDistanceToCircleTest.cpp
@@ -120,3 +120,16 @@ TEST(MaxDistanceToCircle, onCircle)
 	distance = trajectory::getMaxDistanceToCircle(pos, circle_center, radius, direction);
 	EXPECT_FLOAT_EQ(distance, 2.f * radius);
 }
+
+
+TEST(MaxDistanceToCircle, unitDirectionFromOutsideHitsFarSide)
+{
+	// Due east of circle looking west should hit far rim at center_x - radius from pos_x perspective
+	Vector2f pos(5.f, 0.f);
+	Vector2f circle_center(0.f, 0.f);
+	float radius = 2.f;
+	Vector2f direction(-1.f, 0.f);
+	float distance = trajectory::getMaxDistanceToCircle(pos, circle_center, radius, direction);
+	EXPECT_FLOAT_EQ(distance, 5.f + 2.f);
+}
+

--- a/src/lib/mathlib/math/MaxDistanceToCircleTest.cpp
+++ b/src/lib/mathlib/math/MaxDistanceToCircleTest.cpp
@@ -132,4 +132,3 @@ TEST(MaxDistanceToCircle, unitDirectionFromOutsideHitsFarSide)
 	float distance = trajectory::getMaxDistanceToCircle(pos, circle_center, radius, direction);
 	EXPECT_FLOAT_EQ(distance, 5.f + 2.f);
 }
-


### PR DESCRIPTION
Extends trajectory max-distance-to-circle unit coverage for an outside point looking through the center.

gtest-only. AI-assisted; human-reviewed.