### PR TITLE
fix(iis2mdc): data-ready flag, sensitivity, and sample rate

### DIFF
--- a/src/drivers/magnetometer/st/iis2mdc/iis2mdc.cpp
+++ b/src/drivers/magnetometer/st/iis2mdc/iis2mdc.cpp
@@ -66,7 +66,9 @@ int IIS2MDC::init()
 
 	_px4_mag.set_scale(0.0015f); // 1.5 mGauss/LSB (datasheet)
 
-	ScheduleDelayed(20_ms);
+	// Poll at the 100 Hz ODR on a fixed interval so the rate does not drift with
+	// the time spent reading the sensor.
+	ScheduleOnInterval(10_ms);
 
 	return PX4_OK;
 }
@@ -95,11 +97,9 @@ void IIS2MDC::RunImpl()
 		}
 
 	} else {
+		// No new sample yet; expected occasionally when polling at the data rate.
 		PX4_DEBUG("not ready: %u", status);
-		perf_count(_comms_errors);
 	}
-
-	ScheduleDelayed(10_ms);
 }
 
 uint8_t IIS2MDC::read_register_block(SensorData *data)

--- a/src/drivers/magnetometer/st/iis2mdc/iis2mdc.cpp
+++ b/src/drivers/magnetometer/st/iis2mdc/iis2mdc.cpp
@@ -64,7 +64,7 @@ int IIS2MDC::init()
 	write_register(IIS2MDC_ADDR_CFG_REG_B, OFF_CANC);
 	write_register(IIS2MDC_ADDR_CFG_REG_C, BDU);
 
-	_px4_mag.set_scale(100.f / 65535.f); // +/- 50 Gauss, 16bit
+	_px4_mag.set_scale(0.0015f); // 1.5 mGauss/LSB (datasheet)
 
 	ScheduleDelayed(20_ms);
 

--- a/src/drivers/magnetometer/st/iis2mdc/iis2mdc.h
+++ b/src/drivers/magnetometer/st/iis2mdc/iis2mdc.h
@@ -46,7 +46,7 @@
 
 // IIS2MDC Definitions
 #define IIS2MDC_WHO_AM_I         0b01000000
-#define IIS2MDC_STATUS_REG_READY 0b00001111
+#define IIS2MDC_STATUS_REG_READY 0b00001000 // Zyxda: X, Y and Z all have new data
 // CFG_REG_A
 #define COMP_TEMP_EN    (1 << 7)
 #define MD_CONTINUOUS   (0 << 0)


### PR DESCRIPTION
## Summary

Three small correctness fixes to the IIS2MDC magnetometer driver: wait for the combined data-ready flag, use the datasheet sensitivity, and poll on a fixed interval so the output holds the 100 Hz ODR.

## Problem

The data-ready mask covered the per-axis flags (STATUS_REG bits 0-2) in addition to Zyxda (bit 3), so a sample could be read when only one axis had refreshed.

The sensitivity used `100/65535`, which assumes the ±50 Gauss range maps exactly onto the 16-bit output. The datasheet value is 1.5 mGauss/LSB, so the reading was about 1.7% high.

`RunImpl()` rescheduled with `ScheduleDelayed(10ms)` after reading the sensor, so the period was 10 ms plus the read time. The effective rate fell below the 100 Hz ODR and dropped samples.

## Solution

Mask STATUS_REG with Zyxda (bit 3) only, so a sample is taken when X, Y and Z all have new data.

Set the scale to 0.0015 Gauss/LSB.

Drive the work item from `ScheduleOnInterval(10ms)` so the period is independent of the read time. A not-ready poll is now expected occasionally and no longer counts as a comms error.
