### PR TITLE
fix(mavsdk_tests): don't wait for Land mode on mission GPS loss

### DIFF
--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -298,8 +298,8 @@ void AutopilotTester::execute_mission_and_lose_gps()
 
 	CHECK(_failure->inject(Failure::FailureUnit::SensorGps, Failure::FailureType::Off, 0) == Failure::Result::Success);
 
-	// We expect that a blind land is performed.
-	wait_for_flight_mode(Telemetry::FlightMode::Land, std::chrono::seconds(30));
+	// With no position aiding left, a blind descend is performed. MAVSDK has no
+	// Descend flight mode, so the caller just waits for the disarm after landing.
 }
 
 void AutopilotTester::execute_mission_and_lose_mag()


### PR DESCRIPTION
## Summary

Restores the SITL Tests on `main`, red for every PR since #27918. The multicopter "Land on GPS lost during mission" cases wait for the `Land` flight mode, but a blind descend is now reported as the distinct `Descend` mode.

## Problem

#27918 gave `NAVIGATION_STATE_DESCEND` its own MAVLink `custom_mode` instead of reusing `AUTO_LAND`. In SIH the only horizontal-position source is GPS, so injecting a GPS failure mid-mission removes all aiding and the vehicle performs a blind descend — a controlled `AUTO_LAND` is never entered. The test previously passed only because Descend masqueraded as Land; MAVSDK v3.17.1 has no Descend flight mode, so `wait_for_flight_mode(Land)` now times out and the quadx job fails (both the baro- and GPS-height cases).

## Solution

Drop the obsolete `Land` mode assertion in `execute_mission_and_lose_gps()`. Both GPS-loss cases already wait for the automatic disarm after landing, which is the meaningful end-to-end check and is unaffected by the mode-reporting change.
