### PR TITLE
fix(mavsdk_tests): stabilize takeoff-and-hold altitude check

### DIFF
--- a/test/mavsdk_tests/test_multicopter_basics.cpp
+++ b/test/mavsdk_tests/test_multicopter_basics.cpp
@@ -40,6 +40,9 @@
 TEST_CASE("Takeoff and hold position", "[multicopter][vtol]")
 {
 	const float takeoff_altitude = 10.f;
+	// Takeoff overshoot plus the slow VTOL settle can drift the hold altitude by
+	// ~0.1 m; keep the tolerance above that so a normal hover doesn't trip it.
+	const float altitude_hold_tolerance = 0.2f;
 
 	AutopilotTester tester;
 	tester.connect(connection_url);
@@ -60,8 +63,13 @@ TEST_CASE("Takeoff and hold position", "[multicopter][vtol]")
 	tester.wait_until_hovering();
 	tester.wait_until_altitude(ground_altitude + takeoff_altitude, std::chrono::seconds(15), 0.1f);
 
+	// wait_until_altitude() returns on the first touch of the target band, while
+	// the vehicle is still climbing. Let the takeoff overshoot damp out so the
+	// hold reference is captured at the settled hover altitude, not mid-climb.
+	tester.sleep_for(std::chrono::seconds(5));
+
 	// Monitor altitude and fail if it exceeds the tolerance
-	tester.start_checking_altitude(0.15);
+	tester.start_checking_altitude(altitude_hold_tolerance);
 
 	tester.sleep_for(std::chrono::seconds(15));
 }


### PR DESCRIPTION
## Summary

Fixes intermittent failures of the `standard_vtol` "Takeoff and hold position" SITL test.

## Problem

`wait_until_altitude(target, …, 0.1f)` returns the instant altitude first enters the ±0.1 m band, while the vehicle is still climbing. `start_checking_altitude()` then latches that transient altitude as the hold reference. The normal takeoff overshoot (peak ~10.20 m against a reference captured at ~9.96 m → ~0.24 m in the failing ulog) plus the slow VTOL settle exceed the 0.15 m tolerance, producing hundreds of failed altitude CHECKs. The vehicle's actual hold precision is fine — steady-state hover is ~0.05 m peak-to-peak. Commit (#26106) had already raised this tolerance for the same reason; the later switch to the SIH simulator tightened it back to 0.15 m.

## Solution

Let the overshoot damp out before capturing the hold reference (short settle wait), and restore the 0.2 m tolerance. With the reference taken at the settled hover, the observed check-window deviation drops to ~0.10 m — roughly 2× margin — while the check stays sensitive to real altitude-hold regressions (which are meter-scale).
