### PR TITLE
fix(mavlink): pthread_once init for command_sender, try_lock in check [Backport 1.17]

### DIFF
--- a/src/modules/mavlink/mavlink_command_sender.cpp
+++ b/src/modules/mavlink/mavlink_command_sender.cpp
@@ -48,9 +48,8 @@ px4_sem_t MavlinkCommandSender::_lock;
 
 void MavlinkCommandSender::initialize()
 {
-	px4_sem_init(&_lock, 1, 1);
-
 	if (_instance == nullptr) {
+		px4_sem_init(&_lock, 1, 1);
 		_instance = new MavlinkCommandSender();
 	}
 }

--- a/src/modules/mavlink/mavlink_command_sender.cpp
+++ b/src/modules/mavlink/mavlink_command_sender.cpp
@@ -40,18 +40,33 @@
 
 #include "mavlink_command_sender.h"
 #include <px4_platform_common/log.h>
+#include <pthread.h>
 
 #define CMD_DEBUG(FMT, ...) PX4_LOG_NAMED_COND("cmd sender", _debug_enabled, FMT, ##__VA_ARGS__)
 
 MavlinkCommandSender *MavlinkCommandSender::_instance = nullptr;
 px4_sem_t MavlinkCommandSender::_lock;
 
+static pthread_once_t mavlink_command_sender_init_once = PTHREAD_ONCE_INIT;
+
+void MavlinkCommandSender::do_initialize()
+{
+	px4_sem_init(&_lock, 1, 1);
+	_instance = new MavlinkCommandSender();
+
+	if (_instance == nullptr) {
+		PX4_ERR("MavlinkCommandSender alloc failed");
+	}
+}
+
 void MavlinkCommandSender::initialize()
 {
-	if (_instance == nullptr) {
-		px4_sem_init(&_lock, 1, 1);
-		_instance = new MavlinkCommandSender();
-	}
+	// Multiple Mavlink instances can call start() concurrently, each of which
+	// hits initialize(). Only the first call may set up the shared lock and
+	// singleton — otherwise we'd re-init a semaphore another thread is already
+	// using (classic race that TSan flags). pthread_once is portable across
+	// POSIX and NuttX.
+	pthread_once(&mavlink_command_sender_init_once, do_initialize);
 }
 
 MavlinkCommandSender &MavlinkCommandSender::instance()
@@ -141,7 +156,14 @@ void MavlinkCommandSender::handle_mavlink_command_ack(const mavlink_command_ack_
 
 void MavlinkCommandSender::check_timeout(mavlink_channel_t channel)
 {
-	lock();
+	// Use try_lock: check_timeout is called very frequently (every MAVLink
+	// main loop iteration on every instance). If another instance is already
+	// holding the lock, skip this cycle — we'll retry on the next update.
+	// This prevents lock convoys that can stall the MAVLink sender and
+	// receiver threads, causing heartbeat loss under high load.
+	if (!try_lock()) {
+		return;
+	}
 
 	_commands.reset_to_start();
 

--- a/src/modules/mavlink/mavlink_command_sender.h
+++ b/src/modules/mavlink/mavlink_command_sender.h
@@ -93,10 +93,17 @@ private:
 		do {} while (px4_sem_wait(&_lock) != 0);
 	}
 
+	static bool try_lock()
+	{
+		return px4_sem_trywait(&_lock) == 0;
+	}
+
 	static void unlock()
 	{
 		px4_sem_post(&_lock);
 	}
+
+	static void do_initialize(); ///< called exactly once via pthread_once from initialize()
 
 	static MavlinkCommandSender *_instance;
 	static px4_sem_t _lock;


### PR DESCRIPTION
Backport of https://github.com/PX4/PX4-Autopilot/commit/b1a17ac355b4925eedb38e9809f655c78fbcc4c8.

Related to #27879.