### PR TITLE
test(circuit_breaker): cover enabled_by_val magic match

### DIFF
--- a/src/lib/circuit_breaker/CMakeLists.txt
+++ b/src/lib/circuit_breaker/CMakeLists.txt
@@ -33,3 +33,5 @@
 
 px4_add_library(circuit_breaker circuit_breaker.cpp)
 set_property(GLOBAL APPEND PROPERTY PX4_MODULE_CONFIG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/circuit_breaker_params.yaml)
+
+px4_add_unit_gtest(SRC CircuitBreakerValTest.cpp)

--- a/src/lib/circuit_breaker/CircuitBreakerValTest.cpp
+++ b/src/lib/circuit_breaker/CircuitBreakerValTest.cpp
@@ -1,0 +1,30 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2026 PX4 Development Team. All rights reserved.
+ *
+ ****************************************************************************/
+
+/**
+ * Unit tests for circuit_breaker_enabled_by_val magic match.
+ * make tests TESTFILTER=CircuitBreakerVal
+ */
+
+#include <gtest/gtest.h>
+#include "circuit_breaker.h"
+
+TEST(CircuitBreakerVal, MatchesMagic)
+{
+	EXPECT_TRUE(circuit_breaker_enabled_by_val(CBRK_BUZZER_KEY, CBRK_BUZZER_KEY));
+	EXPECT_TRUE(circuit_breaker_enabled_by_val(CBRK_IO_SAFETY_KEY, CBRK_IO_SAFETY_KEY));
+	EXPECT_FALSE(circuit_breaker_enabled_by_val(0, CBRK_BUZZER_KEY));
+	EXPECT_FALSE(circuit_breaker_enabled_by_val(CBRK_BUZZER_KEY, CBRK_IO_SAFETY_KEY));
+	EXPECT_FALSE(circuit_breaker_enabled_by_val(-1, CBRK_USB_CHK_KEY));
+}
+
+TEST(CircuitBreakerVal, PublishedKeysDistinct)
+{
+	// Spot-check keys stay unique so a wrong match cannot silent-enable another breakers
+	EXPECT_NE(CBRK_BUZZER_KEY, CBRK_SUPPLY_CHK_KEY);
+	EXPECT_NE(CBRK_IO_SAFETY_KEY, CBRK_FLIGHTTERM_KEY);
+	EXPECT_NE(CBRK_USB_CHK_KEY, CBRK_VTOLARMING_KEY);
+}


### PR DESCRIPTION
## Summary
Adds unit coverage for `circuit_breaker_enabled_by_val` magic equality and basic key uniqueness. Tests only; no behavior change to flight checks.

## Verification
Unit Tests CI

## Spec
`specs/px4-autopilot/2026-07-22-1.md`

<sub>Claim: bartok · Operator: bartok · Campaign: aerial-drone</sub>

AI-assisted; human-reviewed.