### PR TITLE
test(matrix): cover unwrap_pi multi-crossing walks

### DIFF
--- a/src/lib/matrix/test/MatrixUnwrapTest.cpp
+++ b/src/lib/matrix/test/MatrixUnwrapTest.cpp
@@ -66,11 +66,13 @@ TEST(MatrixUnwrapTest, UnwrapPiMultipleCrossings)
 	// Staircase of wrap_pi samples that should reconstruct monotone increasing angle
 	float last = 0.f;
 	float walked = 0.f;
+
 	for (int i = 0; i < 20; i++) {
 		walked += 0.7f; // rad per step
 		const float wrapped = matrix::wrap_pi(walked);
 		last = matrix::unwrap_pi(last, wrapped);
 	}
+
 	EXPECT_NEAR(last, 0.7f * 20.f, 1e-3f);
 }
 
@@ -78,10 +80,12 @@ TEST(MatrixUnwrapTest, UnwrapPiNegativeWalk)
 {
 	float last = 0.f;
 	float walked = 0.f;
+
 	for (int i = 0; i < 15; i++) {
 		walked -= 0.8f;
 		const float wrapped = matrix::wrap_pi(walked);
 		last = matrix::unwrap_pi(last, wrapped);
 	}
+
 	EXPECT_NEAR(last, -0.8f * 15.f, 1e-3f);
 }

--- a/src/lib/matrix/test/MatrixUnwrapTest.cpp
+++ b/src/lib/matrix/test/MatrixUnwrapTest.cpp
@@ -60,3 +60,28 @@ TEST(MatrixUnwrapTest, UnwrapDoubles)
 		EXPECT_DOUBLE_EQ(last_angle, -unwrapped_angles[i]);
 	}
 }
+
+TEST(MatrixUnwrapTest, UnwrapPiMultipleCrossings)
+{
+	// Staircase of wrap_pi samples that should reconstruct monotone increasing angle
+	float last = 0.f;
+	float walked = 0.f;
+	for (int i = 0; i < 20; i++) {
+		walked += 0.7f; // rad per step
+		const float wrapped = matrix::wrap_pi(walked);
+		last = matrix::unwrap_pi(last, wrapped);
+	}
+	EXPECT_NEAR(last, 0.7f * 20.f, 1e-3f);
+}
+
+TEST(MatrixUnwrapTest, UnwrapPiNegativeWalk)
+{
+	float last = 0.f;
+	float walked = 0.f;
+	for (int i = 0; i < 15; i++) {
+		walked -= 0.8f;
+		const float wrapped = matrix::wrap_pi(walked);
+		last = matrix::unwrap_pi(last, wrapped);
+	}
+	EXPECT_NEAR(last, -0.8f * 15.f, 1e-3f);
+}


### PR DESCRIPTION
## Summary
Extends MatrixUnwrapTest with multi-crossing positive/negative unwrap_pi walks.

## Verification
Unit Tests CI

## Spec
`specs/px4-autopilot/2026-07-22-7.md`

<sub>Claim: bartok · Operator: bartok · Campaign: aerial-drone</sub>

AI-assisted; human-reviewed.