### PR TITLE
fix(drivers/bmi270): correct FIFO watermark byte calculation (salvage #27875)

### DIFF
--- a/src/drivers/imu/bosch/bmi270/BMI270.cpp
+++ b/src/drivers/imu/bosch/bmi270/BMI270.cpp
@@ -530,7 +530,8 @@ void BMI270::ConfigureFIFOWatermark(uint8_t samples)
 {
 	// FIFO_WTM: 13 bit FIFO watermark level value
 	// unit of the fifo watermark is one byte
-	const uint16_t fifo_watermark_threshold = samples * sizeof(FIFO::Data);
+	// each combined accel+gyro frame is 1 header byte + 6 gyro bytes + 6 accel bytes
+	const uint16_t fifo_watermark_threshold = samples * (2 * sizeof(FIFO::Data) + FIFO::HEADER_SIZE);
 
 	for (auto &r : _register_cfg) {
 		if (r.reg == Register::FIFO_WTM_0) {

--- a/src/drivers/imu/bosch/bmi270/Bosch_BMI270_registers.hpp
+++ b/src/drivers/imu/bosch/bmi270/Bosch_BMI270_registers.hpp
@@ -181,6 +181,7 @@ enum ACC_PWR_CTRL_BIT : uint8_t {
 namespace FIFO
 {
 static constexpr size_t SIZE = 1024;
+static constexpr size_t HEADER_SIZE = 1; // one header byte precedes each accel+gyro frame
 
 struct Data {
 	uint8_t x_lsb;


### PR DESCRIPTION
## Summary
**salvage:** rebase of #27875 by @IgorKolesnikov onto current `main`.

Corrects BMI270 FIFO watermark byte calculation (register + driver path). Original author credit: **@IgorKolesnikov**.

## Why salvage
Original PR was useful and small but risked going stale against moving `main`; rebased cleanly (ort) with no conflict.

## Verification
Scan / board CI (driver path)

## Spec
`specs/px4-autopilot/2026-07-22-salvage-27875.md`


<sub>Claim: bartok · Operator: bartok · Campaign: aerial-drone</sub>

AI-assisted; human-reviewed.