### PR TITLE
fix(simulation): make wind affect the airspeed sensor in gz

### DIFF
--- a/src/modules/simulation/gz_bridge/server.config
+++ b/src/modules/simulation/gz_bridge/server.config
@@ -8,6 +8,7 @@
     <plugin entity_name="*" entity_type="world" filename="gz-sim-air-pressure-system" name="gz::sim::systems::AirPressure"/>
     <plugin entity_name="*" entity_type="world" filename="gz-sim-air-speed-system" name="gz::sim::systems::AirSpeed"/>
     <plugin entity_name="*" entity_type="world" filename="gz-sim-apply-link-wrench-system" name="gz::sim::systems::ApplyLinkWrench"/>
+    <plugin entity_name="*" entity_type="world" filename="gz-sim-wind-effects-system" name="gz::sim::systems::WindEffects"/>
     <plugin entity_name="*" entity_type="world" filename="gz-sim-navsat-system" name="gz::sim::systems::NavSat"/>
     <plugin entity_name="*" entity_type="world" filename="gz-sim-magnetometer-system" name="gz::sim::systems::Magnetometer"/>
     <plugin entity_name="*" entity_type="world" filename="gz-sim-sensors-system" name="gz::sim::systems::Sensors">

--- a/src/modules/simulation/gz_plugins/airspeed/AirSpeed.cpp
+++ b/src/modules/simulation/gz_plugins/airspeed/AirSpeed.cpp
@@ -35,6 +35,8 @@
 
 #include <gz/plugin/Register.hh>
 #include <gz/msgs/air_speed.pb.h>
+#include <gz/sim/components/LinearVelocity.hh>
+#include <gz/sim/components/Wind.hh>
 
 using namespace px4;
 
@@ -120,6 +122,19 @@ void AirSpeed::PreUpdate(const gz::sim::UpdateInfo &_info,
 
 	// Calculate differential pressure + noise in hPa
 	const float diff_pressure_noise = standard_normal_distribution_(random_generator_) * diff_pressure_stddev_;
+
+	// Read the wind from the ECM: the wind_info topic is only published on wind changes,
+	// which the subscription misses when the model spawns after the world was loaded
+	const gz::sim::Entity wind_entity = _ecm.EntityByComponents(gz::sim::components::Wind());
+
+	if (wind_entity != gz::sim::kNullEntity) {
+		const auto wind_linear_velocity = _ecm.Component<gz::sim::components::WorldLinearVelocity>(wind_entity);
+
+		if (wind_linear_velocity) {
+			_wind_velocity = wind_linear_velocity->Data();
+		}
+	}
+
 	// Body-relateive air velocity
 	gz::math::Vector3d air_relative_velocity = _vehicle_velocity - _wind_velocity;
 	gz::math::Vector3d body_velocity = _vehicle_attitude.RotateVectorReverse(air_relative_velocity);


### PR DESCRIPTION
### Solved Problem
Wind defined in a gz world (for example windy.sdf) had no effect on the measured airspeed. The airspeed plugin gets the wind from the wind_info topic, which is only published when the wind changes. A model that spawns after the world has loaded misses that message. As a result the EKF wind estimate always stayed near zero.

There was also no publisher for wind_info at all, because the WindEffects system was not loaded anywhere.

### Solution
- Load the gz WindEffects system globally via the server config. Putting it in the world files instead would disable the default systems, since gz ignores the server config for worlds that define their own plugin list.
- Read the wind directly from the ECM in the airspeed plugin on every step, so there is no dependency on message timing. 

### Changelog Entry
For release notes:
```
Bugfix make wind affect the airspeed sensor in gz
```

### Test coverage

- Tested with the windy world (`PX4_GZ_WORLD=windy make px4_sitl gz_advanced_plane`) : measured airspeed and ground speed now differ by the wind component, and the EKF wind estimate converges to the world wind after a few turns.
- Tested that without windy world there is no regression. 
