### PR TITLE
fix(simulation): wind_info topic takes precedence over the wind entity

### DIFF
--- a/src/modules/simulation/gz_plugins/airspeed/AirSpeed.cpp
+++ b/src/modules/simulation/gz_plugins/airspeed/AirSpeed.cpp
@@ -123,15 +123,18 @@ void AirSpeed::PreUpdate(const gz::sim::UpdateInfo &_info,
 	// Calculate differential pressure + noise in hPa
 	const float diff_pressure_noise = standard_normal_distribution_(random_generator_) * diff_pressure_stddev_;
 
-	// Read the wind from the ECM: the wind_info topic is only published on wind changes,
-	// which the subscription misses when the model spawns after the world was loaded
-	const gz::sim::Entity wind_entity = _ecm.EntityByComponents(gz::sim::components::Wind());
+	// Default the wind to the world wind entity: the wind_info topic is only published on
+	// wind changes, which the subscription misses when the model spawns after the world was
+	// loaded. Once wind is received from the topic the topic takes precedence.
+	if (!_wind_received_from_topic) {
+		const gz::sim::Entity wind_entity = _ecm.EntityByComponents(gz::sim::components::Wind());
 
-	if (wind_entity != gz::sim::kNullEntity) {
-		const auto wind_linear_velocity = _ecm.Component<gz::sim::components::WorldLinearVelocity>(wind_entity);
+		if (wind_entity != gz::sim::kNullEntity) {
+			const auto wind_linear_velocity = _ecm.Component<gz::sim::components::WorldLinearVelocity>(wind_entity);
 
-		if (wind_linear_velocity) {
-			_wind_velocity = wind_linear_velocity->Data();
+			if (wind_linear_velocity) {
+				_wind_velocity = wind_linear_velocity->Data();
+			}
 		}
 	}
 
@@ -148,5 +151,6 @@ void AirSpeed::PreUpdate(const gz::sim::UpdateInfo &_info,
 
 void AirSpeed::windCallback(const gz::msgs::Wind &msg)
 {
+	_wind_received_from_topic = true;
 	_wind_velocity = gz::math::Vector3d(msg.linear_velocity().x(), msg.linear_velocity().y(), msg.linear_velocity().z());
 }

--- a/src/modules/simulation/gz_plugins/airspeed/AirSpeed.hpp
+++ b/src/modules/simulation/gz_plugins/airspeed/AirSpeed.hpp
@@ -87,6 +87,10 @@ private:
 	gz::math::Vector3d _vehicle_position{0., 0., 0.};
 	gz::math::Vector3d _wind_velocity{0., 0., 0.};
 
+	// once wind is received from the topic, it takes
+	// precedence over the world wind entity
+	bool _wind_received_from_topic{false};
+
 	std::default_random_engine random_generator_;
 	std::normal_distribution<float> standard_normal_distribution_;
 


### PR DESCRIPTION
Follow-up to #28042: the ECM wind entity read ran every step and would overwrite wind published on the wind_info topic. Only default to the wind entity until the first wind_info message is received, from then on the topic value is used exclusively.


Tested: start the simulation without specifying anything. Then overwrite it. 
[Screencast from 07-22-2026 04:14:31 PM.webm](https://github.com/user-attachments/assets/60feb559-24a3-4d47-aca9-a9b338c6264e)

