### PR TITLE
fix(uavcan/rangefinder): rangefinder does track init-variables now for all instances

### DIFF
--- a/src/drivers/uavcan/sensors/rangefinder.cpp
+++ b/src/drivers/uavcan/sensors/rangefinder.cpp
@@ -82,7 +82,9 @@ void UavcanRangefinderBridge::range_sub_cb(const
 		return;
 	}
 
-	if (!_inited) {
+	const int8_t channel_idx = get_channel_index_for_node(msg.getSrcNodeID().get());
+
+	if (channel_idx >= 0 && !_channel_initialized[channel_idx]) {
 
 		uint8_t rangefinder_type = 0;
 
@@ -107,7 +109,7 @@ void UavcanRangefinderBridge::range_sub_cb(const
 		rangefinder->set_min_distance(_range_min_m);
 		rangefinder->set_max_distance(_range_max_m);
 
-		_inited = true;
+		_channel_initialized[channel_idx] = true;
 	}
 
 	// TOO_CLOSE, TOO_FAR and UNDEFINED readings do not carry a usable range

--- a/src/drivers/uavcan/sensors/rangefinder.hpp
+++ b/src/drivers/uavcan/sensors/rangefinder.hpp
@@ -70,6 +70,6 @@ private:
 	float _range_min_m{0.0f};
 	float _range_max_m{0.0f};
 
-	bool _inited{false};
+	bool _channel_initialized[DEFAULT_MAX_CHANNELS] {};
 
 };


### PR DESCRIPTION
### Solved Problem
if multible instances of range_finders are been used  the variables

``` c++
rangefinder->set_rangefinder_type(rangefinder_type);
rangefinder->set_fov(msg.field_of_view);
rangefinder->set_min_distance(_range_min_m);
rangefinder->set_max_distance(_range_max_m);
```
are only applied to the first instance showing up

``` shell
TOPIC: distance_sensor 3 instances

Instance 0:
…

Instance 1:
 distance_sensor
    timestamp: 19740394 (0.008352 seconds ago)
    device_id: 8993803 (Type: 0x89, UAVCAN:1 (0x3C))
    min_distance: 3.00000                     <<<<<<<<<<<<<<<<<<<<<<<<<<< SET
    max_distance: 999.00000                <<<<<<<<<<<<<<<<<<<<<<<<<<< SET
    current_distance: 256.00000
…

Instance 2:
 distance_sensor
    timestamp: 19739107 (0.018010 seconds ago)
    device_id: 9010435 (Type: 0x89, UAVCAN:0 (0x7D))
    min_distance: 0.00000                    <<<<<<<<<<<<<<<<<<<<<<<<<<< NOT SET
    max_distance: 0.00000                   <<<<<<<<<<<<<<<<<<<<<<<<<<< NOT SET
    current_distance: 0.04400
…
```
### Solution
Use same approach as gnss and create a bool-list based on `_max_channels` 
and apply the `_inited`-logic on each channel

### Alternatives

### Test

``` shell
TOPIC: distance_sensor 3 instances

Instance 0:
…

Instance 1:
 distance_sensor
    timestamp: 399297053 (0.017911 seconds ago)
    device_id: 9010435 (Type: 0x89, UAVCAN:0 (0x7D))
    min_distance: 3.00000                    <<<<<<<<<<<<<<<<<<<<<<<<<<< SET
    max_distance: 999.00000               <<<<<<<<<<<<<<<<<<<<<<<<<<< SET
    current_distance: 0.04199
…

Instance 2:
 distance_sensor
    timestamp: 399318076 (0.005594 seconds ago)
    device_id: 8993803 (Type: 0x89, UAVCAN:1 (0x3C))
    min_distance: 3.00000                    <<<<<<<<<<<<<<<<<<<<<<<<<<< SET
    max_distance: 999.00000               <<<<<<<<<<<<<<<<<<<<<<<<<<< SET
    current_distance: 2.00000
…
```