### PR TITLE
feat(failure_injection): make SYS_FAIL_RC_INST a bitmask for instance selection

### DIFF
--- a/docs/en/debug/failure_injection.md
+++ b/docs/en/debug/failure_injection.md
@@ -110,7 +110,7 @@ A failure can also be injected from an RC switch, without a console or telemetry
 - [SYS_FAIL_RC_SRC](../advanced_config/parameter_reference.md#SYS_FAIL_RC_SRC): the auxiliary RC input that triggers the failure — `0` disables it, `1`–`6` select AUX1–AUX6 (mapped via `RC_MAP_AUXn`).
 - [SYS_FAIL_RC_UNIT](../advanced_config/parameter_reference.md#SYS_FAIL_RC_UNIT): the affected component (the `FAILURE_UNIT` value; e.g. `101` = motor).
 - [SYS_FAIL_RC_MODE](../advanced_config/parameter_reference.md#SYS_FAIL_RC_MODE): the failure type (the `FAILURE_TYPE` value; e.g. `1` = off).
-- [SYS_FAIL_RC_INST](../advanced_config/parameter_reference.md#SYS_FAIL_RC_INST): the affected instance (1-based; `0` = all instances).
+- [SYS_FAIL_RC_INST](../advanced_config/parameter_reference.md#SYS_FAIL_RC_INST): the affected instances, as a bitmask (bit 0 = instance 1, e.g. `5` = instances 1 and 3; `0` = all instances).
 
 While the selected aux switch is on the configured failure is injected; switching it back off clears the failure. The injection goes through the same path as the console/MAVLink commands, so for a motor it stops the motor exactly as `failure motor off` does (which also requires [CA_FAILURE_MODE](../advanced_config/parameter_reference.md#CA_FAILURE_MODE)).
 

--- a/docs/en/debug/failure_injection.md
+++ b/docs/en/debug/failure_injection.md
@@ -117,7 +117,7 @@ A failure can also be injected from an RC switch, without a console or telemetry
 - [SYS_FAIL_RC_SRC](../advanced_config/parameter_reference.md#SYS_FAIL_RC_SRC): the auxiliary RC input that triggers the failure — `0` disables it, `1`–`6` select AUX1–AUX6 (mapped via `RC_MAP_AUXn`).
 - [SYS_FAIL_RC_UNIT](../advanced_config/parameter_reference.md#SYS_FAIL_RC_UNIT): the affected component (the `FAILURE_UNIT` value; e.g. `101` = motor).
 - [SYS_FAIL_RC_MODE](../advanced_config/parameter_reference.md#SYS_FAIL_RC_MODE): the failure type (the `FAILURE_TYPE` value; e.g. `1` = off).
-- [SYS_FAIL_RC_INST](../advanced_config/parameter_reference.md#SYS_FAIL_RC_INST): the affected instance (1-based; `0` = all instances).
+- [SYS_FAIL_RC_INST](../advanced_config/parameter_reference.md#SYS_FAIL_RC_INST): the affected instances, as a bitmask (bit 0 = instance 1, e.g. `5` = instances 1 and 3; `0` = all instances).
 
 While the selected aux switch is on the configured failure is injected; switching it back off clears the failure. The injection goes through the same path as the console/MAVLink commands, so for a motor it stops the motor exactly as `failure motor off` does (which also requires [CA_FAILURE_MODE](../advanced_config/parameter_reference.md#CA_FAILURE_MODE)).
 

--- a/src/modules/failure_injection_manager/FailureInjectionManager.cpp
+++ b/src/modules/failure_injection_manager/FailureInjectionManager.cpp
@@ -127,14 +127,16 @@ void FailureInjectionManager::evaluateRcInjection()
 		const bool triggered = value > 0.5f;
 
 		if (triggered && !_rc_active) {
+			const int32_t raw = _param_sys_fail_rc_inst.get();
 			_rc_active_unit = static_cast<uint8_t>(_param_sys_fail_rc_unit.get());
-			_rc_active_instance = static_cast<uint8_t>(_param_sys_fail_rc_inst.get());
+			// SYS_FAIL_RC_INST is an instance bitmask (bit 0 = instance 1); 0 = all instances.
+			_rc_active_mask = (raw == 0) ? 0xFFFF : static_cast<uint16_t>(raw);
 			_rc_active = true;
 
-			_table.inject(_rc_active_unit, static_cast<uint8_t>(_param_sys_fail_rc_mode.get()), _rc_active_instance);
+			_table.injectMask(_rc_active_unit, static_cast<uint8_t>(_param_sys_fail_rc_mode.get()), _rc_active_mask);
 
 		} else if (!triggered && _rc_active) {
-			_table.inject(_rc_active_unit, failure_injection_s::FAILURE_TYPE_OK, _rc_active_instance);
+			_table.injectMask(_rc_active_unit, failure_injection_s::FAILURE_TYPE_OK, _rc_active_mask);
 			_rc_active = false;
 		}
 	}

--- a/src/modules/failure_injection_manager/FailureInjectionManager.cpp
+++ b/src/modules/failure_injection_manager/FailureInjectionManager.cpp
@@ -128,21 +128,22 @@ void FailureInjectionManager::evaluateRcInjection()
 		const bool triggered = value > 0.5f;
 
 		if (triggered && !_rc_active) {
+			const int32_t raw = _param_sys_fail_rc_inst.get();
 			_rc_active_unit = static_cast<uint8_t>(_param_sys_fail_rc_unit.get());
-			_rc_active_instance = static_cast<uint8_t>(_param_sys_fail_rc_inst.get());
+			// SYS_FAIL_RC_INST is an instance bitmask (bit 0 = instance 1); 0 = all instances.
+			_rc_active_mask = (raw == 0) ? 0xFFFF : static_cast<uint16_t>(raw);
 			_rc_active = true;
 
 			const uint8_t type = static_cast<uint8_t>(_param_sys_fail_rc_mode.get());
 
-			if (_table.inject(_rc_active_unit, type, _rc_active_instance) == failure_injection::FailureTable::AckResult::Accepted) {
-				announceFailure(_rc_active_unit, type, failure_injection::FailureTable::instanceToMask(_rc_active_instance));
+			if (_table.injectMask(_rc_active_unit, type, _rc_active_mask) == failure_injection::FailureTable::AckResult::Accepted) {
+				announceFailure(_rc_active_unit, type, _rc_active_mask);
 			}
 
 		} else if (!triggered && _rc_active) {
-			if (_table.inject(_rc_active_unit, failure_injection_s::FAILURE_TYPE_OK,
-					  _rc_active_instance) == failure_injection::FailureTable::AckResult::Accepted) {
-				announceFailure(_rc_active_unit, failure_injection_s::FAILURE_TYPE_OK,
-						failure_injection::FailureTable::instanceToMask(_rc_active_instance));
+			if (_table.injectMask(_rc_active_unit, failure_injection_s::FAILURE_TYPE_OK,
+					      _rc_active_mask) == failure_injection::FailureTable::AckResult::Accepted) {
+				announceFailure(_rc_active_unit, failure_injection_s::FAILURE_TYPE_OK, _rc_active_mask);
 			}
 
 			_rc_active = false;

--- a/src/modules/failure_injection_manager/FailureInjectionManager.hpp
+++ b/src/modules/failure_injection_manager/FailureInjectionManager.hpp
@@ -90,9 +90,9 @@ private:
 
 	failure_injection::FailureTable _table;
 
-	bool    _rc_active{false};
-	uint8_t _rc_active_unit{0};
-	uint8_t _rc_active_instance{0};
+	bool     _rc_active{false};
+	uint8_t  _rc_active_unit{0};
+	uint16_t _rc_active_mask{0};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::SYS_FAIL_RC_SRC>) _param_sys_fail_rc_src,

--- a/src/modules/failure_injection_manager/FailureInjectionManager.hpp
+++ b/src/modules/failure_injection_manager/FailureInjectionManager.hpp
@@ -94,9 +94,9 @@ private:
 
 	orb_advert_t _mavlink_log_pub{nullptr};
 
-	bool    _rc_active{false};
-	uint8_t _rc_active_unit{0};
-	uint8_t _rc_active_instance{0};
+	bool     _rc_active{false};
+	uint8_t  _rc_active_unit{0};
+	uint16_t _rc_active_mask{0};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::SYS_FAIL_RC_SRC>) _param_sys_fail_rc_src,

--- a/src/modules/failure_injection_manager/failure_injection_manager_params.yaml
+++ b/src/modules/failure_injection_manager/failure_injection_manager_params.yaml
@@ -72,14 +72,31 @@ parameters:
           7: Intermittent
       SYS_FAIL_RC_INST:
         description:
-          short: Instance failed by the RC switch
+          short: Instances failed by the RC switch
           long: |-
-            Which instance of SYS_FAIL_RC_UNIT the SYS_FAIL_RC_SRC trigger affects.
-            1-based, or 0 for all instances (motor number for motors).
-        type: int32
-        min: 0
-        max: 16
+            Bitmask of instances of SYS_FAIL_RC_UNIT that the SYS_FAIL_RC_SRC trigger
+            affects (bit 0 = instance 1, motor number for motors). 0 = all instances.
+        type: bitmask
+        bit:
+          0: Instance 1
+          1: Instance 2
+          2: Instance 3
+          3: Instance 4
+          4: Instance 5
+          5: Instance 6
+          6: Instance 7
+          7: Instance 8
+          8: Instance 9
+          9: Instance 10
+          10: Instance 11
+          11: Instance 12
+          12: Instance 13
+          13: Instance 14
+          14: Instance 15
+          15: Instance 16
         default: 1
+        min: 0
+        max: 65535
         reboot_required: true
       SYS_FAIL_BAT_LVL:
         description:

--- a/src/modules/failure_injection_manager/failure_injection_manager_params.yaml
+++ b/src/modules/failure_injection_manager/failure_injection_manager_params.yaml
@@ -72,14 +72,31 @@ parameters:
           7: Intermittent
       SYS_FAIL_RC_INST:
         description:
-          short: Instance failed by the RC switch
+          short: Instances failed by the RC switch
           long: |-
-            Which instance of SYS_FAIL_RC_UNIT the SYS_FAIL_RC_SRC trigger affects.
-            1-based, or 0 for all instances (motor number for motors).
-        type: int32
-        min: 0
-        max: 16
+            Bitmask of instances of SYS_FAIL_RC_UNIT that the SYS_FAIL_RC_SRC trigger
+            affects (bit 0 = instance 1, motor number for motors). 0 = all instances.
+        type: bitmask
+        bit:
+          0: Instance 1
+          1: Instance 2
+          2: Instance 3
+          3: Instance 4
+          4: Instance 5
+          5: Instance 6
+          6: Instance 7
+          7: Instance 8
+          8: Instance 9
+          9: Instance 10
+          10: Instance 11
+          11: Instance 12
+          12: Instance 13
+          13: Instance 14
+          14: Instance 15
+          15: Instance 16
         default: 1
+        min: 0
+        max: 65535
         reboot_required: true
       SYS_FAIL_GPS_WRG:
         description:


### PR DESCRIPTION
Changes `SYS_FAIL_RC_INST` from a single 1-based instance index to an
instance bitmask, so an RC-triggered failure can hit several instances at
once (e.g. `5` = instances 1 and 3). `0` still means all instances.

- Param type switched `int32` → `bitmask` (bits 0–15 = instances 1–16), max 65535.
- RC injection path now uses `injectMask()` with a `uint16_t` mask;
  `_rc_active_instance` (uint8) replaced by `_rc_active_mask` (uint16).
- Docs updated to describe the bitmask semantics.