### PR TITLE
feat(fw_mode_manager): parachute landing on mission landing approach  

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2514,6 +2514,7 @@ bool Commander::handleModeIntentionAndFailsafe()
 	state.mission_finished = _mission_result_sub.get().finished;
 	state.user_intended_mode = _user_mode_intention.get();
 	state.vehicle_type = _vehicle_status.vehicle_type;
+	state.parachute_deployed = _failure_detector.parachuteDeployed();
 
 	// There might have been a mode change request without changing the user intended mode.
 	// If a failsafe is active we must pass the request along as it might lead to a user-takeover.

--- a/src/modules/commander/HealthAndArmingChecks/checks/parachuteCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/parachuteCheck.cpp
@@ -35,6 +35,27 @@
 
 void ParachuteChecks::checkAndReport(const Context &context, Report &reporter)
 {
+	int32_t fw_lnd_para_en = 0;
+
+	if (_param_fw_lnd_para_en_handle != PARAM_INVALID) {
+		param_get(_param_fw_lnd_para_en_handle, &fw_lnd_para_en);
+	}
+
+	if (fw_lnd_para_en == 1 && _param_com_parachute.get() < 1 && !_parachute_sub.advertised()) {
+		// Parachute landing is enabled, but neither a monitored external parachute system is
+		// configured nor is the parachute module present to release a local parachute output:
+		// nothing can act on the release command.
+		/* EVENT
+		 * @description
+		 * FW_LND_PARA_EN is set but no monitored parachute system is configured
+		 * (COM_PARACHUTE) and the parachute module is not part of the firmware, so the
+		 * parachute release on the landing approach would have no effect.
+		 */
+		reporter.armingCheckFailure(NavModes::None, health_component_t::parachute,
+					    events::ID("check_parachute_landing_no_consumer"),
+					    events::Log::Warning, "Parachute landing enabled but no parachute system found");
+	}
+
 	if (_param_com_parachute.get() < 1) { // COM_PARACHUTE 0 disables the check
 		return;
 	}

--- a/src/modules/commander/HealthAndArmingChecks/checks/parachuteCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/parachuteCheck.hpp
@@ -35,15 +35,23 @@
 
 #include "../Common.hpp"
 
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/parachute.h>
+
 class ParachuteChecks : public HealthAndArmingCheckBase
 {
 public:
-	ParachuteChecks() = default;
+	ParachuteChecks() : _param_fw_lnd_para_en_handle(param_find("FW_LND_PARA_EN")) {}
 	~ParachuteChecks() = default;
 
 	void checkAndReport(const Context &context, Report &reporter) override;
 
 private:
+	// only exists on builds with the fixed-wing mode manager
+	const param_t _param_fw_lnd_para_en_handle{PARAM_INVALID};
+
+	uORB::Subscription _parachute_sub{ORB_ID(parachute)};
+
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
 					(ParamInt<px4::params::COM_PARACHUTE>) _param_com_parachute
 				       )

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -555,6 +555,11 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 	const bool ignore_any_link_loss_vtol_takeoff_fixedwing = (state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF)
 			&& in_forward_flight && !state.mission_finished;
 
+	// While descending under a deployed parachute the vehicle has no control authority left to
+	// execute a failsafe reaction; ignore the failsafes whose only effect would be a mode change
+	// and continue the descent. Failsafes acting on the current state (e.g. termination) stay active.
+	const bool parachute_descent = state.parachute_deployed;
+
 	// Manual control (RC or joystick) loss
 	if (!status_flags.manual_control_signal_lost) {
 		// If manual control was lost and arming was allowed, consider it optional until we regain manual control
@@ -562,7 +567,8 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 	}
 
 	const bool rc_loss_ignored = isFailsafeIgnored(state.user_intended_mode, _param_com_rcl_except.get())
-				     || ignore_any_link_loss_vtol_takeoff_fixedwing || _manual_control_lost_at_arming;
+				     || ignore_any_link_loss_vtol_takeoff_fixedwing || _manual_control_lost_at_arming
+				     || parachute_descent;
 
 	if (_param_com_rc_in_mode.get() != int32_t(RcInMode::DisableManualControl) && !rc_loss_ignored) {
 		CHECK_FAILSAFE(status_flags, manual_control_signal_lost,
@@ -574,7 +580,8 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 					   || state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND;
 
 	const bool dll_loss_ignored = isFailsafeIgnored(state.user_intended_mode, _param_com_dll_except.get())
-				      || ignore_any_link_loss_vtol_takeoff_fixedwing || dll_loss_ignored_land || !state.armed;
+				      || ignore_any_link_loss_vtol_takeoff_fixedwing || dll_loss_ignored_land || !state.armed
+				      || parachute_descent;
 
 	if (_param_nav_dll_act.get() != int32_t(gcs_connection_loss_failsafe_mode::Disabled) && !dll_loss_ignored) {
 		CHECK_FAILSAFE(status_flags, gcs_connection_lost, fromNavDllOrRclActParam(_param_nav_dll_act.get()).causedBy(Cause::GCSConnectionLoss));
@@ -603,13 +610,15 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 		}
 	}
 
-	CHECK_FAILSAFE(status_flags, wind_limit_exceeded,
-		       ActionOptions(fromHighWindLimitActParam(_param_com_wind_max_act.get()).cannotBeDeferred()));
-	CHECK_FAILSAFE(status_flags, flight_time_limit_exceeded, ActionOptions(Action::RTL).cannotBeDeferred());
+	if (!parachute_descent) {
+		CHECK_FAILSAFE(status_flags, wind_limit_exceeded,
+			       ActionOptions(fromHighWindLimitActParam(_param_com_wind_max_act.get()).cannotBeDeferred()));
+		CHECK_FAILSAFE(status_flags, flight_time_limit_exceeded, ActionOptions(Action::RTL).cannotBeDeferred());
+	}
 
 	// trigger Low Position Accuracy Failsafe (only in auto mission and auto loiter)
-	if (state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION ||
-	    state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER) {
+	if ((state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION ||
+	     state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER) && !parachute_descent) {
 		CHECK_FAILSAFE(status_flags, position_accuracy_low, fromPosLowActParam(_param_com_pos_low_act.get()));
 	}
 

--- a/src/modules/commander/failsafe/framework.h
+++ b/src/modules/commander/failsafe/framework.h
@@ -124,6 +124,7 @@ public:
 		uint8_t vehicle_type;
 		bool vtol_in_transition_mode{false};
 		bool mission_finished{false};
+		bool parachute_deployed{false};
 	};
 
 	FailsafeBase(ModuleParams *parent);

--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -52,11 +52,27 @@ bool FailureDetector::update(const vehicle_status_s &vehicle_status, const vehic
 {
 	_failure_injector.update();
 
+	updateParachuteStatus(vehicle_status);
+
 	failure_detector_status_u status_prev = _failure_detector_status;
 
-	if (vehicle_control_mode.flag_control_attitude_enabled) {
+	if (vehicle_control_mode.flag_control_attitude_enabled && !_parachute_deployed) {
 		updateAttitudeStatus(vehicle_status);
 		updateAltitudeStatus(vehicle_status, vehicle_control_mode);
+
+		if (_param_fd_ext_ats_en.get()) {
+			updateExternalAtsStatus();
+		}
+
+	} else if (_parachute_deployed) {
+		// hanging under the canopy exceeds the attitude limits and descends on purpose:
+		// suppress the attitude and altitude loss triggers to not escalate a controlled
+		// parachute descent into flight termination. the external ATS is an independent
+		// trigger system and stays active.
+		_failure_detector_status.flags.roll = false;
+		_failure_detector_status.flags.pitch = false;
+		_failure_detector_status.flags.alt = false;
+		_alt_loss_ref_z = NAN;
 
 		if (_param_fd_ext_ats_en.get()) {
 			updateExternalAtsStatus();
@@ -95,6 +111,22 @@ void FailureDetector::publishStatus(bool esc_arm_status, uint16_t motor_failure_
 	failure_detector_status.motor_stop_mask = _failure_injector.getMotorStopMask();
 	failure_detector_status.timestamp = hrt_absolute_time();
 	_failure_detector_status_pub.publish(failure_detector_status);
+}
+
+void FailureDetector::updateParachuteStatus(const vehicle_status_s &vehicle_status)
+{
+	if (vehicle_status.arming_state != vehicle_status_s::ARMING_STATE_ARMED) {
+		_parachute_deployed = false;
+		return;
+	}
+
+	parachute_s parachute;
+
+	while (_parachute_sub.update(&parachute)) {
+		if (parachute.command == parachute_s::COMMAND_RELEASE) {
+			_parachute_deployed = true;
+		}
+	}
 }
 
 void FailureDetector::updateAttitudeStatus(const vehicle_status_s &vehicle_status)

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -54,6 +54,7 @@
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/failure_detector_status.h>
+#include <uORB/topics/parachute.h>
 #include <uORB/topics/pwm_input.h>
 #include <uORB/topics/sensor_selection.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
@@ -87,9 +88,13 @@ public:
 	bool update(const vehicle_status_s &vehicle_status, const vehicle_control_mode_s &vehicle_control_mode);
 	const failure_detector_status_u &getStatus() const { return _failure_detector_status; }
 
+	// true while the parachute has been released and the vehicle is still armed
+	bool parachuteDeployed() const { return _parachute_deployed; }
+
 	void publishStatus(bool esc_arm_status, uint16_t motor_failure_mask);
 
 private:
+	void updateParachuteStatus(const vehicle_status_s &vehicle_status);
 	void updateAttitudeStatus(const vehicle_status_s &vehicle_status);
 	void updateAltitudeStatus(const vehicle_status_s &vehicle_status,
 				  const vehicle_control_mode_s &vehicle_control_mode);
@@ -106,12 +111,15 @@ private:
 	float _alt_loss_ref_z{NAN}; // ratcheting NED-z reference for altitude loss detection
 	uint8_t _alt_loss_z_reset_counter{0}; // tracks EKF z resets to avoid false altitude loss triggers
 
+	bool _parachute_deployed{false};
+
 	static constexpr float _imbalanced_prop_lpf_time_constant{5.f};
 	AlphaFilter<float> _imbalanced_prop_lpf{};
 	uint32_t _selected_accel_device_id{0};
 	hrt_abstime _imu_status_timestamp_prev{0};
 
 
+	uORB::Subscription _parachute_sub{ORB_ID(parachute)};
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _vehicle_local_position_setpoint_sub{ORB_ID(vehicle_local_position_setpoint)};

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -1485,18 +1485,12 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 	const bool parachute_landing_active = _param_fw_lnd_para_en.get() && !_parachute_release_commanded
 					      && !_vehicle_status.is_vtol;
 
+	// minimum release altitude, below which the canopy cannot fully open before touchdown
+	const float parachute_release_floor = _param_fw_lnd_para_sink.get() * _param_fw_lnd_para_time.get();
+
 	// release altitude, constrained to the altitude lost while the parachute deploys so that the
 	// canopy is fully open before touchdown
-	const float parachute_release_alt = math::max(_param_fw_lnd_para_alt.get(),
-					    _param_fw_lnd_para_sink.get() * _param_fw_lnd_para_time.get());
-
-	if (parachute_landing_active && _wind_valid) {
-		// compensate the crosswind drift component by aiming upwind of the landing point
-		const Vector2f approach_direction = landing_approach_vector.unit_or_zero();
-		const Vector2f drift = _wind_vel * parachute_release_alt / math::max(_param_fw_lnd_para_sink.get(), 0.5f);
-		const Vector2f cross_drift = drift - approach_direction * drift.dot(approach_direction);
-		local_land_point -= cross_drift;
-	}
+	const float parachute_release_alt = math::max(_param_fw_lnd_para_alt.get(), parachute_release_floor);
 
 	// calculate the altitude setpoint based on the landing glide slope
 	const float along_track_dist_to_touchdown = -landing_approach_vector.unit_or_zero().dot(
@@ -1519,6 +1513,18 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 				  abort_on_terrain_timeout);
 	const float glide_slope_reference_alt = (_param_fw_lnd_useter.get() ==
 						TerrainEstimateUseOnLanding::kFollowTerrainRelativeLandingGlideSlope) ? terrain_alt : pos_sp_curr.alt;
+
+	if (parachute_landing_active && _wind_valid) {
+		// compensate the crosswind drift under canopy by aiming upwind of the landing point.
+		// the drift is predicted from the altitude the release is expected to happen at: the
+		// release altitude, or lower if the vehicle cannot hold it (e.g. a motor-less glider).
+		const float release_alt_predicted = math::constrain(_current_altitude - terrain_alt,
+						    parachute_release_floor, parachute_release_alt);
+		const Vector2f approach_direction = landing_approach_vector.unit_or_zero();
+		const Vector2f drift = _wind_vel * release_alt_predicted / math::max(_param_fw_lnd_para_sink.get(), 0.5f);
+		const Vector2f cross_drift = drift - approach_direction * drift.dot(approach_direction);
+		local_land_point -= cross_drift;
+	}
 
 	float altitude_setpoint;
 
@@ -1546,12 +1552,12 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 
 		const float altitude_above_ground = math::max(_current_altitude - terrain_alt, 0.f);
 
-		// only release in the altitude band around the level-off: this makes the release
-		// altitude deterministic, and leaves the canopy room to open when arriving below
 		const bool at_release_altitude = altitude_above_ground < parachute_release_alt + kParachuteReleaseAltitudeMargin
-						 && altitude_above_ground > _param_fw_lnd_para_sink.get() * _param_fw_lnd_para_time.get();
+						 && altitude_above_ground > parachute_release_floor;
 
 		if (at_release_altitude) {
+			_parachute_release_band_entered = true;
+
 			const Vector2f approach_direction = landing_approach_vector.unit_or_zero();
 			const float ground_speed_along_track = math::max(ground_speed.dot(approach_direction), 0.f);
 			const float wind_along_track = _wind_valid ? _wind_vel.dot(approach_direction) : 0.f;
@@ -1564,6 +1570,15 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 				releaseParachute(now);
 				_parachute_release_commanded = true;
 			}
+
+		} else if (_parachute_release_band_entered && altitude_above_ground <= parachute_release_floor) {
+			// a vehicle that cannot hold the release altitude (e.g. a motor-less glider) can sink
+			// through the band before reaching the release point. Release now
+			releaseParachute(now);
+			_parachute_release_commanded = true;
+
+			events::send(events::ID("fw_mode_manager_parachute_release_floor"), events::Log::Warning,
+				     "Releasing parachute at minimum altitude");
 		}
 	}
 
@@ -2513,6 +2528,7 @@ FixedWingModeManager::reset_landing_state()
 	_lateral_touchdown_position_offset = 0.0f;
 
 	_parachute_release_commanded = false;
+	_parachute_release_band_entered = false;
 
 	_last_time_terrain_alt_was_valid = 0;
 

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -1537,7 +1537,10 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 	// parachute landing: release once the predicted touchdown point under canopy reaches the landing
 	// point. the vehicle is carried forward by its ground speed while the parachute deploys, and
 	// drifts with the wind while descending under canopy.
+	// not supported on VTOL: an MC failsafe (e.g. quadchute) during the descent would spool up the
+	// hover motors into the parachute lines.
 	if (_param_fw_lnd_para_en.get() && !_parachute_release_commanded && !_flare_states.flaring
+	    && !_vehicle_status.is_vtol
 	    && _landing_abort_status == position_controller_landing_status_s::NOT_ABORTED) {
 
 		const float altitude_above_ground = math::max(_current_altitude - terrain_alt, 0.f);

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -158,6 +158,18 @@ FixedWingModeManager::vehicle_command_poll()
 }
 
 void
+FixedWingModeManager::parachute_poll()
+{
+	parachute_s parachute;
+
+	while (_parachute_sub.update(&parachute)) {
+		if (parachute.command == parachute_s::COMMAND_RELEASE && !_landed) {
+			_parachute_released = true;
+		}
+	}
+}
+
+void
 FixedWingModeManager::airspeed_poll()
 {
 	airspeed_validated_s airspeed_validated;
@@ -380,6 +392,19 @@ FixedWingModeManager::set_control_mode_current(const hrt_abstime &now)
 	}
 
 	const FW_POSCTRL_MODE previous_position_control_mode = _control_mode_current;
+
+	if (_parachute_released && _control_mode.flag_armed) {
+		// A parachute release was detected in air. Regardless of the commanded mode, keep the motor
+		// off and hold attitude: there is no meaningful control authority under canopy, and any
+		// spooled-up motor risks entangling the parachute lines.
+		if (previous_position_control_mode != FW_POSCTRL_MODE_AUTO_LANDING_PARACHUTE) {
+			events::send(events::ID("fw_mode_manager_parachute_descent"), events::Log::Warning,
+				     "Descending under parachute, motor off");
+		}
+
+		_control_mode_current = FW_POSCTRL_MODE_AUTO_LANDING_PARACHUTE;
+		return;
+	}
 
 	_skipping_takeoff_detection = false;
 	const bool doing_backtransition = _vehicle_status.in_transition_mode && !_vehicle_status.in_transition_to_fw;
@@ -1815,6 +1840,28 @@ FixedWingModeManager::control_auto_landing_circular(const hrt_abstime &now, cons
 }
 
 void
+FixedWingModeManager::control_auto_landing_parachute(const hrt_abstime &now)
+{
+	// The aerodynamic controllers have no authority under canopy. Command the attitude
+	// open-loop: level pitch directly, wings level via zero lateral acceleration.
+	fixed_wing_longitudinal_setpoint_s longitudinal_ctrl_sp{empty_longitudinal_control_setpoint};
+	longitudinal_ctrl_sp.timestamp = now;
+	longitudinal_ctrl_sp.pitch_direct = 0.f;
+	longitudinal_ctrl_sp.throttle_direct = 0.f;
+	_longitudinal_ctrl_sp_pub.publish(longitudinal_ctrl_sp);
+
+	fixed_wing_lateral_setpoint_s lateral_ctrl_sp{empty_lateral_control_setpoint};
+	lateral_ctrl_sp.timestamp = now;
+	lateral_ctrl_sp.lateral_acceleration = 0.f;
+	_lateral_ctrl_sp_pub.publish(lateral_ctrl_sp);
+
+	// Keep the motor off, and keep TECS underspeed protection from spooling it back up
+	_ctrl_configuration_handler.setThrottleMin(0.f);
+	_ctrl_configuration_handler.setThrottleMax(0.f);
+	_ctrl_configuration_handler.setDisableUnderspeedProtection(true);
+}
+
+void
 FixedWingModeManager::control_manual_altitude(const float control_interval, const Vector2d &curr_pos,
 		const Vector2f &ground_speed)
 {
@@ -2207,6 +2254,8 @@ FixedWingModeManager::Run()
 			}
 		}
 
+		parachute_poll();
+
 		if (!_vehicle_status.in_transition_mode) {
 			// reset position of backtransition start if not in transition
 			_lpos_where_backtrans_started = Vector2f(NAN, NAN);
@@ -2282,6 +2331,11 @@ FixedWingModeManager::Run()
 
 		case FW_POSCTRL_MODE_AUTO_LANDING_CIRCULAR: {
 				control_auto_landing_circular(now, control_interval, ground_speed, _pos_sp_triplet.current);
+				break;
+			}
+
+		case FW_POSCTRL_MODE_AUTO_LANDING_PARACHUTE: {
+				control_auto_landing_parachute(now);
 				break;
 			}
 

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -1480,13 +1480,17 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 	local_land_point = calculateTouchdownPosition(control_interval, local_land_point);
 	const Vector2f landing_approach_vector = calculateLandingApproachVector();
 
-	// release altitude, floored to the altitude lost while the parachute deploys so that the
+	// parachute landing is not supported on VTOL: an MC failsafe (e.g. quadchute) during the
+	// descent would spool up the hover motors into the parachute lines.
+	const bool parachute_landing_active = _param_fw_lnd_para_en.get() && !_parachute_release_commanded
+					      && !_vehicle_status.is_vtol;
+
+	// release altitude, constrained to the altitude lost while the parachute deploys so that the
 	// canopy is fully open before touchdown
 	const float parachute_release_alt = math::max(_param_fw_lnd_para_alt.get(),
 					    _param_fw_lnd_para_sink.get() * _param_fw_lnd_para_time.get());
 
-	if (_param_fw_lnd_para_en.get() && !_parachute_release_commanded && !_vehicle_status.is_vtol && _wind_valid) {
-		// the release timing below only corrects the touchdown drift along the approach:
+	if (parachute_landing_active && _wind_valid) {
 		// compensate the crosswind drift component by aiming upwind of the landing point
 		const Vector2f approach_direction = landing_approach_vector.unit_or_zero();
 		const Vector2f drift = _wind_vel * parachute_release_alt / math::max(_param_fw_lnd_para_sink.get(), 0.5f);
@@ -1527,7 +1531,7 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 		altitude_setpoint = _current_altitude;
 	}
 
-	if (_param_fw_lnd_para_en.get() && !_parachute_release_commanded) {
+	if (parachute_landing_active) {
 		// follow the normal landing approach down to the release altitude, then continue level
 		// towards the landing point until the release condition below is met
 		altitude_setpoint = math::max(altitude_setpoint, terrain_alt + parachute_release_alt);
@@ -1537,10 +1541,7 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 	// parachute landing: release once the predicted touchdown point under canopy reaches the landing
 	// point. the vehicle is carried forward by its ground speed while the parachute deploys, and
 	// drifts with the wind while descending under canopy.
-	// not supported on VTOL: an MC failsafe (e.g. quadchute) during the descent would spool up the
-	// hover motors into the parachute lines.
-	if (_param_fw_lnd_para_en.get() && !_parachute_release_commanded && !_flare_states.flaring
-	    && !_vehicle_status.is_vtol
+	if (parachute_landing_active && !_flare_states.flaring
 	    && _landing_abort_status == position_controller_landing_status_s::NOT_ABORTED) {
 
 		const float altitude_above_ground = math::max(_current_altitude - terrain_alt, 0.f);

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -1901,7 +1901,7 @@ FixedWingModeManager::releaseParachute(const hrt_abstime &now)
 	vehicle_command.command = vehicle_command_s::VEHICLE_CMD_DO_PARACHUTE;
 	vehicle_command.param1 = vehicle_command_s::PARACHUTE_ACTION_RELEASE;
 	vehicle_command.target_system = _vehicle_status.system_id;
-	vehicle_command.target_component = 161; // MAV_COMP_ID_PARACHUTE, forwarded to external parachute systems
+	vehicle_command.target_component = 0; // MAV_COMP_ID_ALL: handled by the parachute module, forwarded to external parachute systems
 	vehicle_command.source_system = _vehicle_status.system_id;
 	vehicle_command.source_component = _vehicle_status.component_id;
 	_vehicle_command_pub.publish(vehicle_command);
@@ -1910,8 +1910,8 @@ FixedWingModeManager::releaseParachute(const hrt_abstime &now)
 void
 FixedWingModeManager::control_auto_landing_parachute(const hrt_abstime &now)
 {
-	// The aerodynamic controllers have no authority under canopy. Command the attitude
-	// open-loop: level pitch directly, wings level via zero lateral acceleration.
+	// The aerodynamic controllers have no authority under canopy.
+	// level pitch directly, wings level via zero lateral acceleration.
 	fixed_wing_longitudinal_setpoint_s longitudinal_ctrl_sp{empty_longitudinal_control_setpoint};
 	longitudinal_ctrl_sp.timestamp = now;
 	longitudinal_ctrl_sp.pitch_direct = 0.f;

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -1480,6 +1480,20 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 	local_land_point = calculateTouchdownPosition(control_interval, local_land_point);
 	const Vector2f landing_approach_vector = calculateLandingApproachVector();
 
+	// release altitude, floored to the altitude lost while the parachute deploys so that the
+	// canopy is fully open before touchdown
+	const float parachute_release_alt = math::max(_param_fw_lnd_para_alt.get(),
+					    _param_fw_lnd_para_sink.get() * _param_fw_lnd_para_time.get());
+
+	if (_param_fw_lnd_para_en.get() && !_parachute_release_commanded && !_vehicle_status.is_vtol && _wind_valid) {
+		// the release timing below only corrects the touchdown drift along the approach:
+		// compensate the crosswind drift component by aiming upwind of the landing point
+		const Vector2f approach_direction = landing_approach_vector.unit_or_zero();
+		const Vector2f drift = _wind_vel * parachute_release_alt / math::max(_param_fw_lnd_para_sink.get(), 0.5f);
+		const Vector2f cross_drift = drift - approach_direction * drift.dot(approach_direction);
+		local_land_point -= cross_drift;
+	}
+
 	// calculate the altitude setpoint based on the landing glide slope
 	const float along_track_dist_to_touchdown = -landing_approach_vector.unit_or_zero().dot(
 				local_position - local_land_point);
@@ -1511,6 +1525,42 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 	} else {
 		// continue horizontally
 		altitude_setpoint = _current_altitude;
+	}
+
+	if (_param_fw_lnd_para_en.get() && !_parachute_release_commanded) {
+		// follow the normal landing approach down to the release altitude, then continue level
+		// towards the landing point until the release condition below is met
+		altitude_setpoint = math::max(altitude_setpoint, terrain_alt + parachute_release_alt);
+	}
+
+
+	// parachute landing: release once the predicted touchdown point under canopy reaches the landing
+	// point. the vehicle is carried forward by its ground speed while the parachute deploys, and
+	// drifts with the wind while descending under canopy.
+	if (_param_fw_lnd_para_en.get() && !_parachute_release_commanded && !_flare_states.flaring
+	    && _landing_abort_status == position_controller_landing_status_s::NOT_ABORTED) {
+
+		const float altitude_above_ground = math::max(_current_altitude - terrain_alt, 0.f);
+
+		// only release in the altitude band around the level-off: this makes the release
+		// altitude deterministic, and leaves the canopy room to open when arriving below
+		const bool at_release_altitude = altitude_above_ground < parachute_release_alt + kParachuteReleaseAltitudeMargin
+						 && altitude_above_ground > _param_fw_lnd_para_sink.get() * _param_fw_lnd_para_time.get();
+
+		if (at_release_altitude) {
+			const Vector2f approach_direction = landing_approach_vector.unit_or_zero();
+			const float ground_speed_along_track = math::max(ground_speed.dot(approach_direction), 0.f);
+			const float wind_along_track = _wind_valid ? _wind_vel.dot(approach_direction) : 0.f;
+			const float descent_time = altitude_above_ground / math::max(_param_fw_lnd_para_sink.get(), 0.5f);
+
+			const float release_distance = ground_speed_along_track * _param_fw_lnd_para_time.get()
+						       + wind_along_track * descent_time;
+
+			if (along_track_dist_to_touchdown <= release_distance) {
+				releaseParachute(now);
+				_parachute_release_commanded = true;
+			}
+		}
 	}
 
 	// flare at the maximum of the altitude determined by the time before touchdown and a minimum flare altitude
@@ -1837,6 +1887,20 @@ FixedWingModeManager::control_auto_landing_circular(const hrt_abstime &now, cons
 
 	landing_status_publish();
 	publishOrbitStatus(pos_sp_curr);
+}
+
+void
+FixedWingModeManager::releaseParachute(const hrt_abstime &now)
+{
+	vehicle_command_s vehicle_command{};
+	vehicle_command.timestamp = now;
+	vehicle_command.command = vehicle_command_s::VEHICLE_CMD_DO_PARACHUTE;
+	vehicle_command.param1 = vehicle_command_s::PARACHUTE_ACTION_RELEASE;
+	vehicle_command.target_system = _vehicle_status.system_id;
+	vehicle_command.target_component = 161; // MAV_COMP_ID_PARACHUTE, forwarded to external parachute systems
+	vehicle_command.source_system = _vehicle_status.system_id;
+	vehicle_command.source_component = _vehicle_status.component_id;
+	_vehicle_command_pub.publish(vehicle_command);
 }
 
 void
@@ -2443,6 +2507,8 @@ FixedWingModeManager::reset_landing_state()
 
 	_local_landing_orbit_center.setNaN();
 	_lateral_touchdown_position_offset = 0.0f;
+
+	_parachute_release_commanded = false;
 
 	_last_time_terrain_alt_was_valid = 0;
 

--- a/src/modules/fw_mode_manager/FixedWingModeManager.hpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.hpp
@@ -280,6 +280,9 @@ private:
 	// [.] true once this module has commanded the parachute release during a parachute landing
 	bool _parachute_release_commanded{false};
 
+	// [.] true once the vehicle has been inside the parachute release altitude band during the current landing
+	bool _parachute_release_band_entered{false};
+
 	// MANUAL MODES
 
 	// indicates whether we have completed a manual takeoff in a position control mode

--- a/src/modules/fw_mode_manager/FixedWingModeManager.hpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.hpp
@@ -72,6 +72,7 @@
 #include <uORB/topics/fixed_wing_longitudinal_setpoint.h>
 #include <uORB/topics/fixed_wing_runway_control.h>
 #include <uORB/topics/landing_gear.h>
+#include <uORB/topics/parachute.h>
 #include <uORB/topics/launch_detection_status.h>
 #include <uORB/topics/normalized_unsigned_setpoint.h>
 #include <uORB/topics/parameter_update.h>
@@ -179,6 +180,7 @@ private:
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	uORB::Subscription _airspeed_validated_sub{ORB_ID(airspeed_validated)};
+	uORB::Subscription _parachute_sub{ORB_ID(parachute)};
 	uORB::Subscription _wind_sub{ORB_ID(wind)};
 	uORB::Subscription _control_mode_sub{ORB_ID(vehicle_control_mode)};
 	uORB::Subscription _global_pos_sub{ORB_ID(vehicle_global_position)};
@@ -231,6 +233,7 @@ private:
 		FW_POSCTRL_MODE_AUTO_TAKEOFF_NO_NAV,
 		FW_POSCTRL_MODE_AUTO_LANDING_STRAIGHT,
 		FW_POSCTRL_MODE_AUTO_LANDING_CIRCULAR,
+		FW_POSCTRL_MODE_AUTO_LANDING_PARACHUTE,
 		FW_POSCTRL_MODE_AUTO_PATH,
 		FW_POSCTRL_MODE_MANUAL_POSITION,
 		FW_POSCTRL_MODE_MANUAL_ALTITUDE,
@@ -266,6 +269,9 @@ private:
 	float _reference_altitude{NAN}; // [m AMSL] altitude of the local projection reference point
 
 	bool _landed{true};
+
+	// [.] true if a parachute release was detected while in air. Never reset in flight.
+	bool _parachute_released{false};
 
 	// MANUAL MODES
 
@@ -432,6 +438,8 @@ private:
 	void manual_control_setpoint_poll();
 	void vehicle_attitude_poll();
 	void vehicle_attitude_setpoint_poll();
+	void parachute_poll();
+
 	void vehicle_command_poll();
 	void vehicle_control_mode_poll();
 
@@ -623,6 +631,16 @@ private:
 	 */
 	void control_auto_landing_circular(const hrt_abstime &now, const float control_interval, const Vector2f &ground_speed,
 					   const position_setpoint_s &pos_sp_curr);
+
+	/**
+	 * @brief Controls the descent under a deployed parachute.
+	 *
+	 * Keeps the throttle at zero (motor off) and holds a level attitude open-loop. Entered
+	 * once a parachute release is detected in air, and never left until landed and disarmed.
+	 *
+	 * @param now Current system time [us]
+	 */
+	void control_auto_landing_parachute(const hrt_abstime &now);
 
 	/* manual control methods */
 

--- a/src/modules/fw_mode_manager/FixedWingModeManager.hpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.hpp
@@ -152,6 +152,9 @@ static constexpr float POST_TOUCHDOWN_CLAMP_TIME = 0.5f;
 // [] Stick deadzon
 static constexpr float kStickDeadBand = 0.06f;
 
+// [m] altitude margin above the parachute release altitude within which the release is allowed
+static constexpr float kParachuteReleaseAltitudeMargin = 5.0f;
+
 class FixedWingModeManager final : public ModuleBase, public ModuleParams,
 	public px4::WorkItem
 {
@@ -200,6 +203,7 @@ private:
 	uORB::Publication<landing_gear_s> _landing_gear_pub {ORB_ID(landing_gear)};
 	uORB::Publication<normalized_unsigned_setpoint_s> _flaps_setpoint_pub{ORB_ID(flaps_setpoint)};
 	uORB::Publication<normalized_unsigned_setpoint_s> _spoilers_setpoint_pub{ORB_ID(spoilers_setpoint)};
+	uORB::Publication<vehicle_command_s> _vehicle_command_pub{ORB_ID(vehicle_command)};
 	uORB::PublicationData<fixed_wing_lateral_setpoint_s> _lateral_ctrl_sp_pub{ORB_ID(fixed_wing_lateral_setpoint)};
 	uORB::PublicationData<fixed_wing_longitudinal_setpoint_s> _longitudinal_ctrl_sp_pub{ORB_ID(fixed_wing_longitudinal_setpoint)};
 	uORB::Publication<fixed_wing_lateral_guidance_status_s> _fixed_wing_lateral_guidance_status_pub{ORB_ID(fixed_wing_lateral_guidance_status)};
@@ -272,6 +276,9 @@ private:
 
 	// [.] true if a parachute release was detected while in air. Never reset in flight.
 	bool _parachute_released{false};
+
+	// [.] true once this module has commanded the parachute release during a parachute landing
+	bool _parachute_release_commanded{false};
 
 	// MANUAL MODES
 
@@ -642,6 +649,14 @@ private:
 	 */
 	void control_auto_landing_parachute(const hrt_abstime &now);
 
+	/**
+	 * @brief Commands the parachute release via DO_PARACHUTE, triggering both the parachute
+	 * output function and any external parachute system.
+	 *
+	 * @param now Current system time [us]
+	 */
+	void releaseParachute(const hrt_abstime &now);
+
 	/* manual control methods */
 
 	/**
@@ -877,6 +892,10 @@ private:
 		(ParamFloat<px4::params::FW_LND_FLALT>) _param_fw_lnd_flalt,
 		(ParamBool<px4::params::FW_LND_EARLYCFG>) _param_fw_lnd_earlycfg,
 		(ParamInt<px4::params::FW_LND_USETER>) _param_fw_lnd_useter,
+		(ParamBool<px4::params::FW_LND_PARA_EN>) _param_fw_lnd_para_en,
+		(ParamFloat<px4::params::FW_LND_PARA_ALT>) _param_fw_lnd_para_alt,
+		(ParamFloat<px4::params::FW_LND_PARA_TIME>) _param_fw_lnd_para_time,
+		(ParamFloat<px4::params::FW_LND_PARA_SINK>) _param_fw_lnd_para_sink,
 
 		(ParamFloat<px4::params::FW_P_LIM_MAX>) _param_fw_p_lim_max,
 		(ParamFloat<px4::params::FW_P_LIM_MIN>) _param_fw_p_lim_min,

--- a/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
+++ b/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
@@ -26,6 +26,69 @@ parameters:
       min: 0.0
       decimal: 1
       increment: 0.5
+    FW_LND_PARA_EN:
+      description:
+        short: Enable parachute landing on mission landing approach
+        long: |-
+          If enabled, the vehicle follows the normal landing approach down to the parachute
+          release altitude (FW_LND_PARA_ALT), then continues level towards the landing point and
+          releases the parachute once the predicted touchdown point under canopy reaches the
+          landing point. The prediction is based on ground speed, the release lead time
+          (FW_LND_PARA_TIME), the wind estimate and the expected sink rate under canopy
+          (FW_LND_PARA_SINK).
+
+          Under canopy the vehicle drifts with the wind: expect the horizontal touchdown speed
+          to match the wind speed, and reduced accuracy as the wind approaches the landing
+          airspeed (COM_WIND_MAX can enforce a wind limit).
+
+          Requires a parachute output (or external parachute system) that is released by the
+          DO_PARACHUTE command.
+      type: boolean
+      default: 0
+    FW_LND_PARA_ALT:
+      description:
+        short: Parachute landing release altitude above ground
+        long: |-
+          Altitude above the landing point at which the parachute is released. Lower reduces the
+          wind drift of the touchdown point, but must leave enough altitude for the parachute to
+          fully open and stabilize the descent.
+
+          NOTE: max(FW_LND_PARA_ALT, FW_LND_PARA_TIME * FW_LND_PARA_SINK) is taken as the release
+          altitude.
+      type: float
+      default: 20.0
+      unit: m
+      min: 5.0
+      max: 200.0
+      decimal: 1
+      increment: 0.5
+    FW_LND_PARA_SINK:
+      description:
+        short: Sink rate under the deployed parachute
+        long: |-
+          Expected steady-state sink rate under canopy. Used to predict the descent duration and
+          therewith the wind drift of the touchdown point.
+      type: float
+      default: 5.0
+      unit: m/s
+      min: 0.5
+      max: 20.0
+      decimal: 1
+      increment: 0.1
+    FW_LND_PARA_TIME:
+      description:
+        short: Parachute landing release lead time
+        long: |-
+          Time between commanding the release and the parachute being fully deployed. The vehicle
+          keeps moving at ground speed during this time, which shifts the predicted touchdown
+          point forward accordingly.
+      type: float
+      default: 1.0
+      unit: s
+      min: 0.0
+      max: 10.0
+      decimal: 1
+      increment: 0.1
     FW_LND_USETER:
       description:
         short: Use terrain estimation during landing

--- a/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
+++ b/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
@@ -42,7 +42,7 @@ parameters:
           airspeed (COM_WIND_MAX can enforce a wind limit).
 
           Requires a parachute output (or external parachute system) that is released by the
-          DO_PARACHUTE command.
+          DO_PARACHUTE command. Not supported on VTOL.
       type: boolean
       default: 0
     FW_LND_PARA_ALT:

--- a/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
+++ b/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
@@ -30,19 +30,13 @@ parameters:
       description:
         short: Enable parachute landing on mission landing approach
         long: |-
-          If enabled, the vehicle follows the normal landing approach down to the parachute
-          release altitude (FW_LND_PARA_ALT), then continues level towards the landing point and
-          releases the parachute once the predicted touchdown point under canopy reaches the
-          landing point. The prediction is based on ground speed, the release lead time
-          (FW_LND_PARA_TIME), the wind estimate and the expected sink rate under canopy
-          (FW_LND_PARA_SINK).
+          If enabled, the vehicle follows the mission landing approach down to the release
+          altitude (FW_LND_PARA_ALT) and releases the parachute such that the
+          predicted touchdown point under canopy lies on the landing point, accounting for
+          ground speed, wind drift and the release lead time (FW_LND_PARA_TIME,
+          FW_LND_PARA_SINK).
 
-          Under canopy the vehicle drifts with the wind: expect the horizontal touchdown speed
-          to match the wind speed, and reduced accuracy as the wind approaches the landing
-          airspeed (COM_WIND_MAX can enforce a wind limit).
-
-          Requires a parachute output (or external parachute system) that is released by the
-          DO_PARACHUTE command. Not supported on VTOL.
+          Requires a parachute system released by DO_PARACHUTE. Not supported on VTOL.
       type: boolean
       default: 0
     FW_LND_PARA_ALT:


### PR DESCRIPTION
### Solved Problem
Fixed-wing vehicles with a parachute can currently only use it through flight termination. That makes it unusable as a planned landing method: termination locks the system, kills all outputs and gives up control of where the vehicle comes down. There is no way to plan a mission that ends in a parachute descent onto the landing point, for example for recovery in a small field.

### Solution

With `FW_LND_PARA_EN` set, the vehicle flies the normal mission landing approach down to the release altitude, levels off towards the landing point, and releases the parachute (DO_PARACHUTE) when the predicted touchdown point under canopy reaches the landing point.

The prediction is simple: 
- The vehicle is carried forward by its ground speed while the parachute deploys (`FW_LND_PARA_TIME`), then drifts with the wind while it sinks (`FW_LND_PARA_SINK`). 
- Crosswind is handled by shifting the aim point upwind, using the same lateral offset mechanism as `FW_LND_NUDGE.` 
- The release altitude is `max(FW_LND_PARA_ALT, FW_LND_PARA_TIME * FW_LND_PARA_SINK)` (similar to flare altitude).

Other considerations that were addressed: 
- The vehicle stays armed and in control during the descent. 
- The failure detector suppresses its attitude triggers (hanging under the canopy exceeds them on purpose) and the failsafe state machine ignores the failsafes that would only command a mode change: RC loss, GCS loss, wind and flight time limits, low position accuracy. 
- Termination and geofence stay active. 

Not supported: orbit-to-altitude landings (only the straight mission landing approach) and VTOL (an MC failsafe such as the quadchute during the descent would spool up the hover motors into the parachute lines).

Stacked on #[27943](https://github.com/PX4/PX4-Autopilot/pull/27943) (parachute command) and #[28044](https://github.com/PX4/PX4-Autopilot/pull/28044) (gz parachute plugin). 

### Changelog Entry
For release notes:
```
Feature: fixed-wing parachute landing on the mission landing approach
New parameter: FW_LND_PARA_EN
New parameter: FW_LND_PARA_ALT
New parameter: FW_LND_PARA_SINK
New parameter: FW_LND_PARA_TIME
Documentation: needs a section on the fixed-wing landing page (docs.px4.io/main/en/flight_modes_fw/mission.html)

```
### Test coverage

SITL-tested with cross and head-wind (see screen-recording) with:
`HEADLESS=1 PX4_GZ_WORLD=windy make px4_sitl gz_advanced_plane`. 

[Screencast from 07-21-2026 05:26:29 PM.webm](https://github.com/user-attachments/assets/62637549-d9d2-47bd-bba5-fa0f04c457e1)

Also SITL tested with gliding flight with cross and head wind. 

- Still need to test all the failsafes. 