### PR TITLE
fix(boards/modalai/voxl2): Add directory for keepalive failure file

### DIFF
--- a/boards/modalai/voxl2/debian/postinst
+++ b/boards/modalai/voxl2/debian/postinst
@@ -11,7 +11,10 @@ if [ -f /usr/bin/px4-alias.sh ]; then
     done
 fi
 
-# Detect platform and generate DSP test signature if needed
+# Detect the platform for platform-specific SLPI setup
+PLATFORM=$(/usr/bin/voxl-platform 2>/dev/null || true)
+
+# Generate DSP test signature if needed
 if ! /bin/ls /usr/lib/rfsa/adsp/testsig-*.so &> /dev/null; then
     echo "[INFO] Generating DSP test signature..."
     if [ -f /share/modalai/qcs6490-slpi-test-sig/generate-test-sig.sh ]; then
@@ -26,7 +29,14 @@ fi
 # Create required data directories
 mkdir -p /data/px4/param
 mkdir -p /data/px4/etc/extras
+mkdir -p /data/px4/slpi
 chown -R root:root /data/px4
+
+if [ "$PLATFORM" = "M0197" ]; then
+    chown fastrpc:fastrpc /data/px4/slpi
+else
+    chown system:system /data/px4/slpi
+fi
 
 # Reload systemd if available
 if command -v systemctl > /dev/null 2>&1; then


### PR DESCRIPTION
### Solved Problem

The VOXL2 Debian post-install script did not create `/data/px4/slpi`. PX4 uses this directory for the SLPI keepalive failure file, and it requires platform-specific ownership.

### Solution

  Update the VOXL2 post-install script to:

  - Detect the platform using `voxl-platform`.
  - Create `/data/px4/slpi`.
  - Assign `fastrpc:fastrpc` ownership on M0197.
  - Assign `system:system` ownership on other supported VOXL2 platforms.

### Context

PX4 writes the SLPI keepalive failure marker to:

  `/data/px4/slpi/keepalive_fail`

