### PR TITLE
docs(update): Logger max file size from 2 to 4 GB

### DIFF
--- a/docs/en/dev_log/logging.md
+++ b/docs/en/dev_log/logging.md
@@ -118,7 +118,7 @@ This ensures that stale logs from a different time mode are cleaned up before cu
 ## File size limitations
 
 The maximum file size depends on the file system and OS.
-The size limit on NuttX is currently around 2GB.
+The size limit on NuttX is currently around 4GB.
 
 ## Dropouts
 


### PR DESCRIPTION
@dakejahl Isn't this what follows from (files from 2 to 4 GB, but for PX4 that is likely only to affect big logs).

- #28043