### PR TITLE
feat(commander): add terminate options for critical battery and lost position failsafes

### DIFF
--- a/src/modules/commander/commander_params.yaml
+++ b/src/modules/commander/commander_params.yaml
@@ -164,6 +164,7 @@ parameters:
         0: Warning
         2: Land mode
         3: Return at critical level, land at emergency level
+        4: Return at critical level, terminate at emergency level
       default: 0
     COM_FAIL_ACT_T:
       description:
@@ -368,6 +369,21 @@ parameters:
       min: -1
       max: 400
       decimal: 1
+    COM_POS_FS_ACT:
+      description:
+        short: Loss of position autonomous failsafe action
+        long: |-
+          If no autonomous horizontal navigation is possible anymore should the vehicle attempt to
+          descend blindly and land or terminate which can be preferable if there's a parachute and no pilot.
+
+          Action to take when autonomous horizontal navigation is lost:
+          - "Descend if possible" blind with potential drift and uncontrolled landing (risk of hitting obstacles)
+          - "Terminate" can be preferred for unpiloted use with emergency parachute
+      type: enum
+      values:
+        0: Descend if possible
+        1: Terminate
+      default: 0
     COM_VEL_FS_EVH:
       description:
         short: Horizontal velocity error threshold

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -188,6 +188,7 @@ FailsafeBase::ActionOptions Failsafe::fromBatteryWarningActParam(int param_value
 		switch ((LowBatteryAction)param_value) {
 		case LowBatteryAction::Return:
 		case LowBatteryAction::ReturnOrLand:
+		case LowBatteryAction::ReturnOrTerminate:
 			options.action = Action::RTL;
 			break;
 
@@ -218,6 +219,10 @@ FailsafeBase::ActionOptions Failsafe::fromBatteryWarningActParam(int param_value
 
 		case LowBatteryAction::Warning:
 			options.action = Action::Warn;
+			break;
+
+		case LowBatteryAction::ReturnOrTerminate:
+			options.action = Action::Terminate;
 			break;
 		}
 

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -63,12 +63,12 @@ private:
 
 	// COM_LOW_BAT_ACT parameter values
 	enum class LowBatteryAction : int32_t {
-		Warning = 0,        	// Warning
-		Return = 1,         	// Return mode (deprecated)
-		Land = 2,           	// Land mode
-		ReturnOrLand = 3,	// Return mode at critically low level, Land mode at current position if reaching dangerously low levels
-		ReturnOrTerminate = 4	// Return mode at critically low level, Terminate if reaching dangerously low levels
-	};
+		Warning = 0, // Warning
+		Return = 1, // Return mode (deprecated)
+		Land = 2, // Land mode
+		ReturnOrLand = 3, // Return mode at critically low level, Land mode at current position if reaching dangerously low levels
+		ReturnOrTerminate = 4 // Return mode at critically low level, Terminate if reaching dangerously low levels
+};
 
 	enum class offboard_loss_failsafe_mode : int32_t {
 		Position_mode = 0,

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -63,10 +63,11 @@ private:
 
 	// COM_LOW_BAT_ACT parameter values
 	enum class LowBatteryAction : int32_t {
-		Warning = 0,        // Warning
-		Return = 1,         // Return mode (deprecated)
-		Land = 2,           // Land mode
-		ReturnOrLand = 3    // Return mode at critically low level, Land mode at current position if reaching dangerously low levels
+		Warning = 0,        	// Warning
+		Return = 1,         	// Return mode (deprecated)
+		Land = 2,           	// Land mode
+		ReturnOrLand = 3,	// Return mode at critically low level, Land mode at current position if reaching dangerously low levels
+		ReturnOrTerminate = 4	// Return mode at critically low level, Terminate if reaching dangerously low levels
 	};
 
 	enum class offboard_loss_failsafe_mode : int32_t {

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -68,7 +68,7 @@ private:
 		Land = 2, // Land mode
 		ReturnOrLand = 3, // Return mode at critically low level, Land mode at current position if reaching dangerously low levels
 		ReturnOrTerminate = 4 // Return mode at critically low level, Terminate if reaching dangerously low levels
-};
+	};
 
 	enum class offboard_loss_failsafe_mode : int32_t {
 		Position_mode = 0,

--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -600,7 +600,8 @@ void FailsafeBase::getSelectedAction(const State &state, const failsafe_flags_s 
 
 	// fallthrough
 	case Action::Descend:
-		if (modeCanRun(status_flags, vehicle_status_s::NAVIGATION_STATE_DESCEND)) {
+		if (modeCanRun(status_flags, vehicle_status_s::NAVIGATION_STATE_DESCEND)
+		    && _param_com_pos_fs_act.get() != (int32_t)PositionFailsafeAction::Terminate) {
 			selected_action = Action::Descend;
 			break;
 		}

--- a/src/modules/commander/failsafe/framework.h
+++ b/src/modules/commander/failsafe/framework.h
@@ -240,6 +240,12 @@ protected:
 	void updateParams() override;
 
 private:
+	// COM_POS_FS_ACT parameter values
+	enum class PositionFailsafeAction : int32_t {
+		Descend = 0,
+		Terminate = 1
+	};
+
 	/**
 	 * Remove actions matching a condition
 	 */
@@ -288,7 +294,8 @@ private:
 	void *_on_notify_user_arg{nullptr};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(ModuleParams,
-					(ParamFloat<px4::params::COM_FAIL_ACT_T>) 	_param_com_fail_act_t
+					(ParamFloat<px4::params::COM_FAIL_ACT_T>) _param_com_fail_act_t,
+					(ParamInt<px4::params::COM_POS_FS_ACT>) _param_com_pos_fs_act
 				       );
 
 };


### PR DESCRIPTION
### Solved Problem

- No option to terminate (which deploys parachute) instead of a blind descent when critical failsafes trigger.
    - Specifically for battery reaching emergency level or losing autonomous horizontal navigation.

### Solution

- Added new value: `COM_LOW_BAT_ACT 4`: "Return at critical level, terminate at emergency level".
- Added new paramater: `COM_POS_FS_ACT` with `0`: "Descend if possible" (default) and `1`: "Terminate".
- Note: `COM_POS_FS_ACT` only takes effect when there's no pilot able to take manual control by either
  flying a fully autonomous mode (Hold/Loiter, Mission, RTL) or flying manually with manual control also
  lost (e.g. RC disconnected). If a pilot can still take over manually, losing position instead falls back
  to Altitude mode (existing behavior, unchanged).

### Changelog Entry

- New value `COM_LOW_BAT_ACT 4`: "Return at critical level, terminate at emergency level".
- New param `COM_POS_FS_ACT 0`: "Descend if possible" (default) and `COM_POS_FS_ACT 1`: "Terminate".

### Test coverage

#### `COM_POS_FS_ACT`

Tested in SIH:
- Flying in Position mode with manual control disconnected (RC lost) and GPS lost: 
    - RTL and Land fail without position, so the fallback cascades down to Descend/Terminate.
        - With `COM_POS_FS_ACT 0` it descends like usual.
        - With `COM_POS_FS_ACT 1` it terminates directly.
- Same result flying a fully autonomous mode (Hold/Loiter) with position lost.
- In Position mode with a pilot still connected, losing GPS falls back to Altitude mode (as before) rather than Descend/Terminate.

#### `COM_LOW_BAT_ACT 4`

Tested in SIH with 
- `battery_simulator`
- `SIM_BAT_MIN_PCT 0`
- `SIM_BAT_DRAIN 20`

Goes to RTL at critical battery level, then successfully terminates at emergency level:

<img width="544" height="594" alt="image" src="https://github.com/user-attachments/assets/0ade05ce-5d6f-44c8-930c-f623be82a64d" />