### PR TITLE
feat(device_information): expand enum with aditional types

### DIFF
--- a/msg/DeviceInformation.msg
+++ b/msg/DeviceInformation.msg
@@ -13,7 +13,7 @@ uint8 DEVICE_TYPE_SERVO = 3                   # Servo
 uint8 DEVICE_TYPE_GPS = 4                     # GPS
 uint8 DEVICE_TYPE_MAGNETOMETER = 5            # Magnetometer
 uint8 DEVICE_TYPE_PARACHUTE = 6               # Parachute
-uint8 DEVICE_TYPE_RANGEFINDER = 7             # Rangefinder
+uint8 DEVICE_TYPE_RANGEFINDER = 7             # 1D Rangefinder
 uint8 DEVICE_TYPE_WINCH = 8                   # Winch
 uint8 DEVICE_TYPE_BAROMETER = 9               # Barometer
 uint8 DEVICE_TYPE_OPTICAL_FLOW = 10           # Optical flow
@@ -22,6 +22,11 @@ uint8 DEVICE_TYPE_GYROSCOPE = 12              # Gyroscope
 uint8 DEVICE_TYPE_DIFFERENTIAL_PRESSURE = 13  # Differential pressure
 uint8 DEVICE_TYPE_BATTERY = 14                # Battery
 uint8 DEVICE_TYPE_HYGROMETER = 15             # Hygrometer
+uint8 DEVICE_TYPE_TRAFFIC_AVOIDANCE = 16      # Traffic Avoidance system (ADSB)
+uint8 DEVICE_TYPE_COMPUTE = 17                # Compute boards
+uint8 DEVICE_TYPE_LIDAR = 18                  # 3D scanning / multi-beam Lidar
+uint8 DEVICE_TYPE_STEREO_CAMERA = 19          # stereo/depth camera
+
 
 char[80] name # Name of device e.g. DroneCAN node name
 


### PR DESCRIPTION
Adding additional types to the device_information enum. to also be able to support tracking of Traffic avoidance recieveers, 3D Lidars, compute boards, and stereo cameras