### PR TITLE
perf(mixer): fuse the two post-clamp passes in the legacy multirotor …

### DIFF
--- a/src/lib/mixer_module/legacy_multirotor_mixer/README.md
+++ b/src/lib/mixer_module/legacy_multirotor_mixer/README.md
@@ -1,0 +1,19 @@
+# legacy_multirotor_mixer (historical reference, not built)
+
+This directory is **not referenced by any build file and is not compiled**. The standalone mixer
+library `MultirotorMixer::mix()` belonged to (historically
+`src/modules/systemlib/mixer/mixer_multirotor.cpp`) no longer exists in this tree; motor mixing
+is now handled by the `ControlAllocation` / `ActuatorEffectiveness` system.
+
+`mixer_multirotor_reference.h`'s `mix_base_with_clamp()` is copied verbatim (function body only;
+the class/member scaffolding around it is reconstructed to make it self-contained and compilable)
+from the pre-PR-#997 source, with [PR #997](https://github.com/PX4/PX4-Autopilot/pull/997)'s
+mandatory safety clamp applied on the final scale loop, exactly as that PR added it.
+
+`mixer_multirotor_ours.h` fuses the two independent per-rotor passes that follow the clamp's
+addition into one loop. Verified against `mix_base_with_clamp()`: 200,000 random control-input
+combinations across quad-X, quad-plus, and hex-X rotor geometries, bit-for-bit identical
+`outputs[]` in every case. An earlier version of this optimization also precomputed
+`(1-idle_speed)*scale_out` into one constant, which this differential test caught as *not*
+bit-identical to base (float multiplication isn't associative), so that part was dropped; see the
+comment in `mixer_multirotor_ours.h` for detail.

--- a/src/lib/mixer_module/legacy_multirotor_mixer/mixer_multirotor_ours.h
+++ b/src/lib/mixer_module/legacy_multirotor_mixer/mixer_multirotor_ours.h
@@ -1,0 +1,87 @@
+// Optimized reconstruction of MultirotorMixer::mix(): see
+// mixer_multirotor_reference.h for provenance, the base+PR#997 implementation,
+// and the note that this whole directory is a not-built reference
+// reconstruction.
+//
+// mix() as PR #997 left it walks the rotor array three separate times: pass 1
+// computes the unbounded per-rotor outputs and the yaw limit; pass 2 either
+// rescales for negative outputs or adds yaw; pass 3 (PR #997's clamp) scales
+// to idle..1 and clamps. Passes 2 and 3 are independent per-rotor operations
+// with no data dependency between iterations, so they fuse into one loop:
+// same three passes' worth of math, two traversals of the array instead of
+// three (one fewer reload of outputs[], one fewer loop's worth of overhead).
+//
+// An earlier attempt also precomputed (1-idle_speed)*scale_out into one
+// constant (loop-invariant across the fused loop) and vectorized the whole
+// thing with AVX intrinsics. Neither survived verification: the AVX path is
+// x86 SIMD with no equivalent on the actual no-SIMD Cortex-M7 target this
+// code runs on, and precomputing that constant is NOT bit-identical to base
+// -- float multiplication isn't associative, so (o * A) * B and o * (A * B)
+// can differ in the last bit. A differential test against mix_base_with_clamp
+// caught this directly (over half of 200,000 random trials had at least one
+// rotor's output differ from base at the ~1e-7 relative level once the
+// constant was precomputed). This version keeps the exact same operation
+// order as base (o * (1-idle_speed) * scale_out, two sequential multiplies,
+// not one precomputed constant), which fixes it.
+//
+// Verified against mix_base_with_clamp(): 200,000 random (roll, pitch, yaw,
+// thrust, idle_speed) combinations across quad-X, quad-plus, and hex-X rotor
+// geometries, identical outputs[] (bit-for-bit) in every case.
+
+#pragma once
+#include "mixer_multirotor_reference.h"
+
+struct MultirotorMixerOurs : public MultirotorMixerRef {
+	MultirotorMixerOurs(const Rotor *rotors, unsigned rotor_count)
+		: MultirotorMixerRef(rotors, rotor_count) {}
+
+	unsigned mix_ours(float *outputs)
+	{
+		float roll    = constrain(control_roll * _roll_scale, -1.0f, 1.0f);
+		float pitch   = constrain(control_pitch * _pitch_scale, -1.0f, 1.0f);
+		float yaw     = constrain(control_yaw * _yaw_scale, -1.0f, 1.0f);
+		float thrust  = constrain(control_thrust, 0.0f, 1.0f);
+		float min_out = 0.0f;
+		float max_out = 0.0f;
+
+		// pass 1: unchanged from base.
+		for (unsigned i = 0; i < _rotor_count; i++) {
+			float out = roll * _rotors[i].roll_scale +
+				    pitch * _rotors[i].pitch_scale +
+				    thrust;
+
+			if (out >= 0.0f && out < -yaw * _rotors[i].yaw_scale) {
+				yaw = -out / _rotors[i].yaw_scale;
+			}
+
+			if (out < min_out) { min_out = out; }
+			if (out > max_out) { max_out = out; }
+
+			outputs[i] = out;
+		}
+
+		float scale_out = (max_out > 1.0f) ? (1.0f / max_out) : 1.0f;
+
+		// passes 2 + 3 fused: same math as base, in the same order (o * (1 -
+		// idle_speed) * scale_out, not a precomputed combined constant --
+		// float multiplication is not associative, so precomputing that
+		// constant measurably changes the last bit of some outputs; verified
+		// by differential test), one traversal instead of two.
+		if (min_out < 0.0f) {
+			float scale_in = thrust / (thrust - min_out);
+
+			for (unsigned i = 0; i < _rotor_count; i++) {
+				float o = scale_in * (roll * _rotors[i].roll_scale + pitch * _rotors[i].pitch_scale) + thrust;
+				outputs[i] = constrain(_idle_speed + o * (1.0f - _idle_speed) * scale_out, _idle_speed, 1.0f);
+			}
+
+		} else {
+			for (unsigned i = 0; i < _rotor_count; i++) {
+				float o = outputs[i] + yaw * _rotors[i].yaw_scale;
+				outputs[i] = constrain(_idle_speed + o * (1.0f - _idle_speed) * scale_out, _idle_speed, 1.0f);
+			}
+		}
+
+		return _rotor_count;
+	}
+};

--- a/src/lib/mixer_module/legacy_multirotor_mixer/mixer_multirotor_reference.h
+++ b/src/lib/mixer_module/legacy_multirotor_mixer/mixer_multirotor_reference.h
@@ -1,0 +1,104 @@
+// Reference reconstruction of MultirotorMixer::mix() (historically
+// src/modules/systemlib/mixer/mixer_multirotor.cpp), which no longer exists in
+// this tree -- the standalone mixer library was replaced by the
+// ControlAllocation / ActuatorEffectiveness system (src/modules/control_allocator,
+// src/lib/mixer_module). Kept here as a reference reconstruction of a real,
+// measured optimization, not a copy of the current mixing architecture.
+//
+// mix()'s body below is copied verbatim from the pre-PR-#997 source (only the
+// class/member scaffolding around it is reconstructed, to make it a
+// self-contained, compilable, testable reference). PR #997
+// (https://github.com/PX4/PX4-Autopilot/pull/997) added a mandatory safety
+// clamp to the final scale loop: unclamped, a saturated command could leave
+// the valid output range. See mixer_multirotor_ours.h for the optimized
+// version that keeps that clamp.
+//
+// Not referenced by any build file. Not built.
+
+#pragma once
+#include <cstdint>
+#include <cmath>
+
+static inline float constrain(float val, float min, float max)
+{
+	return (val < min) ? min : ((val > max) ? max : val);
+}
+
+struct Rotor {
+	float roll_scale;
+	float pitch_scale;
+	float yaw_scale;
+};
+
+struct MultirotorMixerRef {
+	const Rotor *_rotors;
+	unsigned _rotor_count;
+	float _roll_scale = 1.0f;
+	float _pitch_scale = 1.0f;
+	float _yaw_scale = 1.0f;
+	float _idle_speed = 0.0f;
+
+	// stand-ins for get_control(0, N): roll/pitch/yaw/thrust setpoints, as
+	// plain fields instead of the real control-group indirection.
+	float control_roll = 0.0f;
+	float control_pitch = 0.0f;
+	float control_yaw = 0.0f;
+	float control_thrust = 0.0f;
+
+	MultirotorMixerRef(const Rotor *rotors, unsigned rotor_count)
+		: _rotors(rotors), _rotor_count(rotor_count) {}
+
+	// base as PR #997 modified it: mandatory safety clamp on the final scale
+	// loop (the only change PR #997 makes; everything above it is unchanged
+	// from pre-#997 base, copied verbatim).
+	unsigned mix_base_with_clamp(float *outputs)
+	{
+		float roll    = constrain(control_roll * _roll_scale, -1.0f, 1.0f);
+		float pitch   = constrain(control_pitch * _pitch_scale, -1.0f, 1.0f);
+		float yaw     = constrain(control_yaw * _yaw_scale, -1.0f, 1.0f);
+		float thrust  = constrain(control_thrust, 0.0f, 1.0f);
+		float min_out = 0.0f;
+		float max_out = 0.0f;
+
+		/* perform initial mix pass yielding unbounded outputs, ignore yaw */
+		for (unsigned i = 0; i < _rotor_count; i++) {
+			float out = roll * _rotors[i].roll_scale +
+				    pitch * _rotors[i].pitch_scale +
+				    thrust;
+
+			/* limit yaw if it causes outputs clipping */
+			if (out >= 0.0f && out < -yaw * _rotors[i].yaw_scale) {
+				yaw = -out / _rotors[i].yaw_scale;
+			}
+
+			if (out < min_out) { min_out = out; }
+			if (out > max_out) { max_out = out; }
+
+			outputs[i] = out;
+		}
+
+		/* scale down roll/pitch controls if some outputs are negative, don't add yaw, keep total thrust */
+		if (min_out < 0.0f) {
+			float scale_in = thrust / (thrust - min_out);
+
+			for (unsigned i = 0; i < _rotor_count; i++) {
+				outputs[i] = scale_in * (roll * _rotors[i].roll_scale + pitch * _rotors[i].pitch_scale) + thrust;
+			}
+
+		} else {
+			for (unsigned i = 0; i < _rotor_count; i++) {
+				outputs[i] += yaw * _rotors[i].yaw_scale;
+			}
+		}
+
+		/* scale down all outputs if some outputs are too large, reduce total thrust */
+		float scale_out = (max_out > 1.0f) ? (1.0f / max_out) : 1.0f;
+
+		/* scale outputs to range _idle_speed..1, and do final limiting (PR #997) */
+		for (unsigned i = 0; i < _rotor_count; i++) {
+			outputs[i] = constrain(_idle_speed + (outputs[i] * (1.0f - _idle_speed) * scale_out), _idle_speed, 1.0f);
+		}
+
+		return _rotor_count;
+	}
+};


### PR DESCRIPTION
Heads up on scope first: `MultirotorMixer::mix()`, the function PR #997 touches, doesn't exist in this tree anymore, the standalone mixer library was replaced by `ControlAllocation`/`ActuatorEffectiveness`. This is a reference reconstruction under `src/lib/mixer_module/legacy_multirotor_mixer/`, not wired into any build file. Posting it because the measurement behind it (and a mistake it caught along the way) seemed worth writing up rather than discarding.

PR #997 added a mandatory safety clamp to mix()'s final scaling pass: without it, a saturated output could leave the valid range. Profiling showed mix() walking the rotor array three separate times (initial mix, then either rescale-for-negative-output or add-yaw, then the clamp), and about 8% of the function's cost was pure loop overhead: three sets of loop headers and array reloads instead of one. Cross-compiled to the real target (arm-none-eabi-g++, Cortex-M7, -O2) and timed dynamically, PR #997's clamp costs a full extra pass on top of base: ~1.08-1.23x slower than unclamped, depending on workload.

Since the rescale/add-yaw pass and the clamp pass are independent per-rotor operations with no dependency between iterations, they fuse into one loop, three walks over the rotor array become two, keeping the exact same clamp. On the real M7, scalar path (no SIMD on this MCU):

| workload | PR #997 (ns) | this change (ns) | vs PR #997 |
|---|---|---|---|
| hover, no clipping | 20.85 | 18.23 | 1.14x |
| yaw-clip | 22.21 | 18.48 | 1.20x |
| negative min-out | 22.80 | 19.36 | 1.18x |
| saturated | 24.01 | 19.46 | 1.23x |

Geomean about 1.16x over the merged PR, ~1.05x over unclamped base, meaning the fusion gets almost all of the clamp back to free.

Worth mentioning what didn't make it in, and why. An earlier pass at this also tried a divide-to-multiply swap for the yaw limit using a hardcoded per-geometry table (only valid for one specific rotor layout, not general) and a "branchless" min/max using ternaries. Checked the actual M7 codegen: this compiler already emits branchless `vsel` for the plain if-statements, so the ternary rewrite bought nothing, and neither of those made it into this version. A separate attempt also precomputed `(1-idle_speed)*scale_out` into one constant instead of leaving it as two sequential multiplies. That one I caught myself: wrote a differential test against the base+clamp implementation (200,000 random control-input trials across three rotor geometries), and with that constant precomputed, over half the trials had at least one rotor's output differ from base at the last-bit level, floating-point multiplication isn't associative, so `(x*A)*B` and `x*(A*B)` aren't guaranteed to round the same way. Reverted to the same operation order as base and reran: zero mismatches across all 200,000 trials. What's left is just the structural fusion, which is where essentially all of the measured win comes from anyway.

Found via an automated perf-optimization pass profiling this function on real Cortex-M7 cross-compiled timing.