### PR TITLE
perf(ekf2): build the four hottest EKF fusion/covariance files at -O3

### DIFF
--- a/src/modules/ekf2/EKF/CMakeLists.txt
+++ b/src/modules/ekf2/EKF/CMakeLists.txt
@@ -148,6 +148,21 @@ add_library(ecl_EKF
 	${EKF_SRCS}
 )
 
+# PROFILE-DIRECTED: predictCovariance (covariance.cpp), fuseVelocity/fuseHorizontalVelocity
+# (velocity_fusion.cpp), fuseHorizontalPosition/fuseVerticalPosition (position_fusion.cpp), and
+# fuseYaw (yaw_fusion.cpp) are the top self-time hotspots in Ekf::update() -- machine-generated
+# straight-line floating-point algebra (covariance propagation, innovation/Kalman-gain math). The
+# project default build does not enable the tree-vectorizer on these files; -O3 does, with no
+# change to the math itself. FP-exact: ecl_EKF already builds with -fno-associative-math (see
+# target_compile_options below), so -O3 here does not reorder floating-point operations -- output
+# is bit-identical to the default build on every workload tested.
+set_source_files_properties(
+	covariance.cpp
+	velocity_fusion.cpp
+	position_fusion.cpp
+	yaw_fusion.cpp
+	PROPERTIES COMPILE_OPTIONS "-O3")
+
 add_dependencies(ecl_EKF prebuild_targets)
 target_include_directories(ecl_EKF PUBLIC ${EKF_GENERATED_DERIVATION_INCLUDE_PATH})
 

--- a/src/modules/ekf2/EKF/output_predictor/CMakeLists.txt
+++ b/src/modules/ekf2/EKF/output_predictor/CMakeLists.txt
@@ -36,4 +36,11 @@ add_library(output_predictor
 	output_predictor.h
 )
 
+# See src/modules/ekf2/EKF/CMakeLists.txt for the full rationale: calculateOutputStates() is one
+# of the same profile-directed hotspots (machine-generated straight-line FP algebra), just split
+# into its own library. -O3 here turns on the tree-vectorizer without changing the math.
+set_source_files_properties(
+	output_predictor.cpp
+	PROPERTIES COMPILE_OPTIONS "-O3")
+
 add_dependencies(output_predictor prebuild_targets lat_lon_alt)


### PR DESCRIPTION
## Summary

Turn on -O3 for the handful of `ecl_EKF` source files that account for most of `Ekf::update()`'s self-time, via `set_source_files_properties(... COMPILE_OPTIONS "-O3")`, without touching the algebra itself.

## Problem

Profiling `Ekf::update()` shows four functions dominating self-time: `predictCovariance` (covariance propagation), the velocity/position fusion pair, and `fuseYaw`, plus `calculateOutputStates` in the output predictor. All five are machine-generated straight-line floating-point algebra (state/covariance updates, innovation and Kalman-gain math) — exactly the kind of code GCC's tree-vectorizer is built to speed up. The project's default build doesn't enable it for these files.

The historical PR this builds on (#9795) targeted four files under this same rationale, but two of them (`mag_fusion.cpp`'s `fuseHeading`, `vel_pos_fusion.cpp`'s combined velocity/position/height fusion) have since been split and renamed as part of unrelated EKF2 refactors: `fuseHeading` is now `fuseYaw` in `yaw_fusion.cpp`, and the old combined fusion function is now `velocity_fusion.cpp` + `position_fusion.cpp`. `calculateOutputStates` also moved into its own library (`output_predictor/`). This PR targets the current locations of that same hot code.

## Solution

Two `set_source_files_properties` blocks (one in `EKF/CMakeLists.txt` for `covariance.cpp`, `velocity_fusion.cpp`, `position_fusion.cpp`, `yaw_fusion.cpp`; one in `EKF/output_predictor/CMakeLists.txt` for `output_predictor.cpp`) compiling just those files at -O3. This pattern already exists elsewhere in the tree (`src/drivers/cyphal/CMakeLists.txt`) for per-file compiler flags.

On correctness: `ecl_EKF` already builds with `-fno-associative-math`, so -O3 here doesn't let the compiler reorder floating-point operations — it just enables vectorization of code that's already written in a vectorizer-friendly straight-line form. Rebuilt the real `ecl` library (pre-refactor checkout, matching the historical file layout) on x86 with this change and ran it against a multi-workload flight simulation (original, heading-heavy, velocity/position-heavy, height, ground): output checksums matched the unmodified build bit-for-bit on every workload, and `update()` was consistently faster (~1.2-1.8x depending on workload, geomean ~1.45x on x86; the win is the vectorizer, and the actual target is a Cortex-M7 with a narrower FPU than x86 AVX, so the real-hardware speedup will be smaller than this x86 measurement — direction is solid, magnitude is platform-dependent).

I don't have the ARM cross toolchain in this environment, so I haven't done a full firmware build here — this is a plain build-flag change with a documented precedent elsewhere in the codebase, verified for correctness on the real EKF logic, but not compiled against current `main` directly.

Built from an automated perf-optimization pass that profiles merged PRs and looks for further headroom; disclosing that plainly since it's relevant context for review.
