### PR TITLE
fix(mavlink): accept INT32_MIN as "param not used" in mission item validation

### DIFF
--- a/src/modules/mavlink/mavlink_command_params.hpp
+++ b/src/modules/mavlink/mavlink_command_params.hpp
@@ -43,7 +43,8 @@
  *   bits 4–6: params 5–7  (bit 4 = param5, bit 5 = param6, bit 6 = param7)
  *
  * For global-frame MISSION_ITEM_INT, check_params_int_for_vehicle() is used so
- * that p5/p6 are validated as int32 (INT32_MAX = unset) and p7 as float.
+ * that p5/p6 are validated as int32 (INT32_MAX or INT32_MIN = not used) and p7
+ * as float.
  *
  * A secondary VehicleParamOverrides table holds per-airframe additions (e.g.
  * NAV_TAKEOFF pitch angle on FW); use check_params_for_vehicle() for callers
@@ -157,10 +158,14 @@ static inline bool param_is_zero(float v)
 	return !std::isnan(v) && (bits & 0x7FFFFFFFu) == 0u;
 }
 
-// INT32_MAX is the MAVLink sentinel for "int32 param not provided".
+// INT32_MAX is the value the MAVLink spec defines to mean "this int32 param is
+// not used". Ground stations also convert unused NaN float params straight into
+// the int32 x/y fields of MISSION_ITEM_INT (QGC does this for camera items in
+// MAV_FRAME_MISSION), and converting NaN to int32 gives INT32_MIN on most
+// hardware — so treat that as "not used" too.
 static inline bool int_param_is_unset(int32_t v)
 {
-	return v == INT32_MAX;
+	return v == INT32_MAX || v == INT32_MIN;
 }
 
 // Vehicle type bitmask for per-vehicle parameter support.

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1664,8 +1664,9 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 				const mavlink_mission_item_int_t *item_int =
 					reinterpret_cast<const mavlink_mission_item_int_t *>(mavlink_mission_item);
 				// x/y are p5/p6 generic params (not lat/lon) for non-position frames.
-				// Normalize INT32_MAX (MISSION_ITEM_INT "unused" sentinel) to NaN so
-				// both the int sentinel and the NaN are treated as unset.
+				// Turn both int values that mean "param not used" (INT32_MAX per the
+				// spec, INT32_MIN from ground stations converting NaN to int32) into
+				// NaN so the validation treats them as not used.
 				const float p5 = mavlink_cmd_params::int_param_is_unset(item_int->x) ? NAN : (float)item_int->x;
 				const float p6 = mavlink_cmd_params::int_param_is_unset(item_int->y) ? NAN : (float)item_int->y;
 				bad = mavlink_cmd_params::check_params_for_vehicle(mavlink_mission_item->command, true, _vehicle_type_bitmask,

--- a/test/test_mavlink_param_validation.py
+++ b/test/test_mavlink_param_validation.py
@@ -51,9 +51,11 @@ CMD_NAV_VTOL_TAKEOFF = 84
 CMD_NAV_VTOL_LAND = 85
 CMD_NAV_DELAY = 93
 CMD_COMPONENT_ARM_DISARM = 400
+CMD_IMAGE_STOP_CAPTURE = 2001
 
 NAN = float("nan")
 INT32_MAX = 2_147_483_647
+INT32_MIN = -2_147_483_648
 
 # Helpers
 
@@ -314,6 +316,21 @@ def run_mission_tests(mav: Any, timeout: float) -> None:
     ], timeout)
     _check(
         "NAV_VTOL_TAKEOFF mission valid (p4=yaw only) -> ACCEPTED",
+        result, MAV_MISSION_ACCEPTED,
+    )
+
+    # 17. IMAGE_STOP_CAPTURE with x/y = INT32_MIN (mask 0x01: only p1).
+    # QGC camera-section items carry NaN in the unused float params and
+    # convert them into the int32 x/y fields of MISSION_ITEM_INT, which
+    # becomes INT32_MIN on x86. PX4 must treat both INT32_MAX and INT32_MIN
+    # as "param not used" and accept the item.
+    result = _upload_mission(mav, [
+        _item(0, CMD_IMAGE_STOP_CAPTURE, MAV_FRAME_MISSION,
+              p1=0.0, p2=NAN, p3=NAN, p4=NAN,
+              x=INT32_MIN, y=INT32_MIN, z=NAN),
+    ], timeout)
+    _check(
+        "IMAGE_STOP_CAPTURE NaN-cast x/y (INT32_MIN) -> ACCEPTED",
         result, MAV_MISSION_ACCEPTED,
     )
 


### PR DESCRIPTION
QGC leaves unused float params as NaN and converts them into the int32 x/y fields of MISSION_ITEM_INT, which comes out as INT32_MIN. This made PX4 reject any mission with camera items (set mode, take photo/video, stop photo/video) with INVALID_PARAM5. Treat INT32_MIN as "param not used", the same as INT32_MAX.

### Solved Problem

Since #27541, PX4 rejects mission items that carry a value in a param slot it does not use. GCS's may leave unused float params as NaN and converts them into the int32 x/y fields of MISSION_ITEM_INT, which comes out as INT32_MIN. PX4 only recognizes INT32_MAX as "param not used", so any mission containing a camera item (set camera mode, take photo, take video, stop photo/video) is rejected with MAV_MISSION_INVALID_PARAM5. This includes the fixed wing and VTOL landing patterns when "stop taking photos/video" is ticked.

### Solution

Treat INT32_MIN as "param not used", the same as INT32_MAX.

### Changelog Entry
For release notes:
```
Feature/Bugfix Fix missions with camera items getting rejected since the mission item param validation was introduced
```


### Test coverage

- Added a case to `test/test_mavlink_param_validation.py`
- Verified working in SITL by adding a landing item n a mission (was previously failing) 

