### PR TITLE
fix(simulation): model reverse thrust for reversible motors  for hex

### DIFF
--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -466,7 +466,7 @@ void Sih::generate_force_and_torques(const float dt)
 		float u_sq[6];
 
 		for (int i = 0; i < 6; ++i) {
-			u_sq[i] = _u[i] * _u[i]; // quadratic thrust model, keep _u[i] intact for the filter
+			u_sq[i] = _u[i] * fabsf(_u[i]);
 		}
 
 		_T_B = Vector3f(0.0f, 0.0f, -_T_MAX * (+u_sq[0] + u_sq[1] + u_sq[2] + u_sq[3] + u_sq[4] + u_sq[5]));


### PR DESCRIPTION

### Solved Problem
The SIH hexacopter dynamics square the motor command (`u_sq = u * u`), which
discards its sign, so a reversed (negative) command produces forward thrust
instead of reverse.

### Solution
Use a signed square (`u * |u|`) so a reversed command yields reverse thrust and
the correspondingly flipped roll/pitch/yaw torque. Hexacopter only

### Test coverage
Behaviour-neutral for `u >= 0` (the only regime the plain square could represent).
Enables SITL validation of reversible-motor failure recovery (#28078).