### PR TITLE
feat(failure_injection): add ESC failure unit (off/wrong) with correct MAVLink semantics

### DIFF
--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -129,7 +129,11 @@ void UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<
 		_esc_status.esc_online_flags = check_escs_status();
 		_esc_status.esc_armed_flags = (1 << _rotor_count) - 1;
 		_esc_status.timestamp = esc_report.timestamp;
-		_esc_status_pub.publish(_esc_status);
+
+		_failure_config.update();
+		esc_status_s esc_status = _esc_status;   // copy so Wrong doesn't compound on the persistent status
+		failure_injection::process_esc(_failure_config, esc_status);
+		_esc_status_pub.publish(esc_status);
 	}
 
 	// Register device capability for each ESC channel

--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -131,9 +131,7 @@ void UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<
 		_esc_status.timestamp = esc_report.timestamp;
 
 		_failure_config.update();
-		esc_status_s esc_status = _esc_status;   // copy so Wrong doesn't compound on the persistent status
-		failure_injection::process_esc(_failure_config, esc_status);
-		_esc_status_pub.publish(esc_status);
+		_esc_status_pub.publish(failure_injection::process_esc(_failure_config, _esc_status));
 	}
 
 	// Register device capability for each ESC channel

--- a/src/drivers/uavcan/actuators/esc.hpp
+++ b/src/drivers/uavcan/actuators/esc.hpp
@@ -55,6 +55,7 @@
 #include <uORB/topics/esc_status.h>
 #include <uORB/topics/esc_report.h>
 #include <uORB/topics/dronecan_node_status.h>
+#include <lib/failure_injection/FailureInjection.hpp>
 #include "../node_info.hpp"
 
 class UavcanEscController
@@ -124,6 +125,8 @@ private:
 	uORB::Subscription _device_information_sub{ORB_ID(device_information)};
 
 	uint8_t		_rotor_count{0};
+
+	failure_injection::Config _failure_config;
 
 	/*
 	 * libuavcan related things

--- a/src/lib/failure_injection/FailureInjection.cpp
+++ b/src/lib/failure_injection/FailureInjection.cpp
@@ -91,6 +91,34 @@ void process_battery(const Config &config, uint8_t instance, battery_status_s &b
 	battery_status.warning = battery_status_s::WARNING_EMERGENCY;
 }
 
+void process_esc(const Config &config, esc_status_s &status)
+{
+	for (int i = 0; i < status.esc_count && i < esc_status_s::CONNECTED_ESC_MAX; i++) {
+		const uint8_t function = status.esc[i].actuator_function;
+
+		if (function < esc_report_s::ACTUATOR_FUNCTION_MOTOR1 || function > esc_report_s::ACTUATOR_FUNCTION_MOTOR_MAX) {
+			continue; // not a motor output
+		}
+
+		const uint8_t instance = function - esc_report_s::ACTUATOR_FUNCTION_MOTOR1 + 1; // 1-based ESC instance
+
+		switch (config.mode(failure_injection_s::FAILURE_UNIT_SYSTEM_ESC, instance)) {
+		case Mode::Off:
+			status.esc_online_flags &= ~(1u << i);
+			break;
+
+		case Mode::Wrong:
+			status.esc[i].esc_voltage *= 0.1f;
+			status.esc[i].esc_current *= 0.1f;
+			status.esc[i].esc_rpm *= 10;
+			break;
+
+		default:
+			break;
+		}
+	}
+}
+
 } // namespace failure_injection
 
 #endif // CONFIG_MODULES_FAILURE_INJECTION_MANAGER

--- a/src/lib/failure_injection/FailureInjection.cpp
+++ b/src/lib/failure_injection/FailureInjection.cpp
@@ -107,6 +107,9 @@ esc_status_s process_esc(const Config &config, const esc_status_s &status)
 		switch (config.mode(failure_injection_s::FAILURE_UNIT_SYSTEM_ESC, instance)) {
 		case Mode::Off:
 			result.esc_online_flags &= ~(1u << i);
+			result.esc_armed_flags &= ~(1u << i);
+			result.esc[i] = esc_report_s{};
+			result.esc[i].actuator_function = function;
 			break;
 
 		case Mode::Wrong:

--- a/src/lib/failure_injection/FailureInjection.cpp
+++ b/src/lib/failure_injection/FailureInjection.cpp
@@ -91,10 +91,12 @@ void process_battery(const Config &config, uint8_t instance, battery_status_s &b
 	battery_status.warning = battery_status_s::WARNING_EMERGENCY;
 }
 
-void process_esc(const Config &config, esc_status_s &status)
+esc_status_s process_esc(const Config &config, const esc_status_s &status)
 {
-	for (int i = 0; i < status.esc_count && i < esc_status_s::CONNECTED_ESC_MAX; i++) {
-		const uint8_t function = status.esc[i].actuator_function;
+	esc_status_s result = status;
+
+	for (int i = 0; i < result.esc_count && i < esc_status_s::CONNECTED_ESC_MAX; i++) {
+		const uint8_t function = result.esc[i].actuator_function;
 
 		if (function < esc_report_s::ACTUATOR_FUNCTION_MOTOR1 || function > esc_report_s::ACTUATOR_FUNCTION_MOTOR_MAX) {
 			continue; // not a motor output
@@ -104,19 +106,21 @@ void process_esc(const Config &config, esc_status_s &status)
 
 		switch (config.mode(failure_injection_s::FAILURE_UNIT_SYSTEM_ESC, instance)) {
 		case Mode::Off:
-			status.esc_online_flags &= ~(1u << i);
+			result.esc_online_flags &= ~(1u << i);
 			break;
 
 		case Mode::Wrong:
-			status.esc[i].esc_voltage *= 0.1f;
-			status.esc[i].esc_current *= 0.1f;
-			status.esc[i].esc_rpm *= 10;
+			result.esc[i].esc_voltage *= 0.1f;
+			result.esc[i].esc_current *= 0.1f;
+			result.esc[i].esc_rpm *= 10;
 			break;
 
 		default:
 			break;
 		}
 	}
+
+	return result;
 }
 
 } // namespace failure_injection

--- a/src/lib/failure_injection/FailureInjection.hpp
+++ b/src/lib/failure_injection/FailureInjection.hpp
@@ -49,6 +49,7 @@
 #include <cstdint>
 
 #include <uORB/Subscription.hpp>
+#include <uORB/topics/esc_status.h>
 #include <uORB/topics/failure_injection.h>
 
 struct battery_status_s;
@@ -195,6 +196,13 @@ inline bool process(const Config &config, uint8_t unit, uint8_t uorb_instance)
  */
 void process_battery(const Config &config, uint8_t instance, battery_status_s &battery_status);
 
+/**
+ * ESC counterpart to process(): apply the active FAILURE_UNIT_SYSTEM_ESC failures to an esc_status
+ * (matched per ESC by actuator_function). Off reports the ESC offline; Wrong keeps it online but reports
+ * consistently wrong values. Call after Config::update().
+ */
+void process_esc(const Config &config, esc_status_s &status);
+
 #else // !CONFIG_MODULES_FAILURE_INJECTION_MANAGER
 
 class Config
@@ -221,6 +229,8 @@ inline bool process(Mode) { return true; }
 inline bool process(const Config &, uint8_t, uint8_t) { return true; }
 
 inline void process_battery(const Config &, uint8_t, battery_status_s &) {}
+
+inline void process_esc(const Config &, esc_status_s &) {}
 
 #endif // CONFIG_MODULES_FAILURE_INJECTION_MANAGER
 

--- a/src/lib/failure_injection/FailureInjection.hpp
+++ b/src/lib/failure_injection/FailureInjection.hpp
@@ -197,11 +197,13 @@ inline bool process(const Config &config, uint8_t unit, uint8_t uorb_instance)
 void process_battery(const Config &config, uint8_t instance, battery_status_s &battery_status);
 
 /**
- * ESC counterpart to process(): apply the active FAILURE_UNIT_SYSTEM_ESC failures to an esc_status
- * (matched per ESC by actuator_function). Off reports the ESC offline; Wrong keeps it online but reports
- * consistently wrong values. Call after Config::update().
+ * ESC counterpart to process(): apply the active FAILURE_UNIT_SYSTEM_ESC failures to a copy of
+ * status (matched per ESC by actuator_function). Off reports the ESC offline; Wrong keeps it online
+ * but reports consistently wrong values. Takes status by const reference and returns the mutated
+ * copy so callers can't accidentally apply it in place to a persistent status, which would compound
+ * Wrong across calls. Call after Config::update().
  */
-void process_esc(const Config &config, esc_status_s &status);
+esc_status_s process_esc(const Config &config, const esc_status_s &status);
 
 #else // !CONFIG_MODULES_FAILURE_INJECTION_MANAGER
 
@@ -230,7 +232,7 @@ inline bool process(const Config &, uint8_t, uint8_t) { return true; }
 
 inline void process_battery(const Config &, uint8_t, battery_status_s &) {}
 
-inline void process_esc(const Config &, esc_status_s &) {}
+inline esc_status_s process_esc(const Config &, const esc_status_s &status) { return status; }
 
 #endif // CONFIG_MODULES_FAILURE_INJECTION_MANAGER
 

--- a/src/lib/failure_injection/FailureInjection.hpp
+++ b/src/lib/failure_injection/FailureInjection.hpp
@@ -198,10 +198,11 @@ void process_battery(const Config &config, uint8_t instance, battery_status_s &b
 
 /**
  * ESC counterpart to process(): apply the active FAILURE_UNIT_SYSTEM_ESC failures to a copy of
- * status (matched per ESC by actuator_function). Off reports the ESC offline; Wrong keeps it online
- * but reports consistently wrong values. Takes status by const reference and returns the mutated
- * copy so callers can't accidentally apply it in place to a persistent status, which would compound
- * Wrong across calls. Call after Config::update().
+ * status (matched per ESC by actuator_function). Off zeroes the ESC's telemetry (keeping only
+ * actuator_function) and reports it offline and unarmed; Wrong keeps it online but reports
+ * consistently wrong values. Takes status by const reference and returns the mutated copy so callers
+ * can't accidentally apply it in place to a persistent status, which would compound Wrong across
+ * calls. Call after Config::update().
  */
 esc_status_s process_esc(const Config &config, const esc_status_s &status);
 

--- a/src/modules/commander/failure_detector/FailureInjector.cpp
+++ b/src/modules/commander/failure_detector/FailureInjector.cpp
@@ -33,9 +33,6 @@
 
 #include "FailureInjector.hpp"
 
-#include <cstring>
-#include <uORB/topics/actuator_motors.h>
-
 void FailureInjector::update()
 {
 	if (_failure_config.update()) {
@@ -46,47 +43,10 @@ void FailureInjector::update()
 void FailureInjector::rebuildMasks()
 {
 	_motor_stop_mask = 0;
-	_esc_telemetry_blocked_mask = 0;
-	_esc_telemetry_wrong_mask = 0;
 
 	for (int i = 0; i < esc_status_s::CONNECTED_ESC_MAX; i++) {
-		switch (_failure_config.mode(failure_injection_s::FAILURE_UNIT_SYSTEM_MOTOR, i + 1)) {
-		case failure_injection::Mode::Off:
+		if (_failure_config.mode(failure_injection_s::FAILURE_UNIT_SYSTEM_MOTOR, i + 1) == failure_injection::Mode::Off) {
 			_motor_stop_mask |= 1u << i;
-			break;
-
-		case failure_injection::Mode::Stuck:
-			_esc_telemetry_blocked_mask |= 1u << i;
-			break;
-
-		case failure_injection::Mode::Wrong:
-			_esc_telemetry_wrong_mask |= 1u << i;
-			break;
-
-		default:
-			break;
-		}
-	}
-}
-
-void FailureInjector::manipulateEscStatus(esc_status_s &status)
-{
-	if (_esc_telemetry_blocked_mask != 0 || _esc_telemetry_wrong_mask != 0) {
-		for (int i = 0; i < status.esc_count; i++) {
-			const unsigned i_esc = status.esc[i].actuator_function - actuator_motors_s::ACTUATOR_FUNCTION_MOTOR1;
-
-			if (_esc_telemetry_blocked_mask & (1 << i_esc)) {
-				unsigned function = status.esc[i].actuator_function;
-				memset(&status.esc[i], 0, sizeof(status.esc[i]));
-				status.esc[i].actuator_function = function;
-				status.esc_online_flags &= ~(1 << i);
-
-			} else if (_esc_telemetry_wrong_mask & (1 << i_esc)) {
-				// Create wrong rerport for this motor by scaling key values up and down
-				status.esc[i].esc_voltage *= 0.1f;
-				status.esc[i].esc_current *= 0.1f;
-				status.esc[i].esc_rpm *= 10.0f;
-			}
 		}
 	}
 }

--- a/src/modules/commander/failure_detector/FailureInjector.hpp
+++ b/src/modules/commander/failure_detector/FailureInjector.hpp
@@ -44,7 +44,6 @@ public:
 
 	void update();
 
-	void manipulateEscStatus(esc_status_s &status);
 	uint32_t getMotorStopMask() { return _motor_stop_mask; }
 private:
 	// Rebuild the motor masks from the active failure_injection configuration.
@@ -53,6 +52,4 @@ private:
 	failure_injection::Config _failure_config;
 
 	uint32_t _motor_stop_mask{};
-	uint32_t _esc_telemetry_blocked_mask{};
-	uint32_t _esc_telemetry_wrong_mask{};
 };

--- a/src/modules/failure_injection_manager/FailureInjectionConfigTest.cpp
+++ b/src/modules/failure_injection_manager/FailureInjectionConfigTest.cpp
@@ -79,6 +79,7 @@ failure_injection_s make_config(uint8_t unit, uint16_t instance_mask, uint8_t fa
 constexpr uint8_t GYRO  = failure_injection_s::FAILURE_UNIT_SENSOR_GYRO;
 constexpr uint8_t GPS   = failure_injection_s::FAILURE_UNIT_SENSOR_GPS;
 constexpr uint8_t MOTOR = failure_injection_s::FAILURE_UNIT_SYSTEM_MOTOR;
+constexpr uint8_t ESC   = failure_injection_s::FAILURE_UNIT_SYSTEM_ESC;
 
 constexpr uint8_t OK    = failure_injection_s::FAILURE_TYPE_OK;
 constexpr uint8_t OFF   = failure_injection_s::FAILURE_TYPE_OFF;
@@ -266,4 +267,73 @@ TEST(FailureInjectionConfig, ProcessMessageLessSuppressesOnlyOff)
 	// Convenience overload maps the 0-based uORB instance to the 1-based failure instance.
 	EXPECT_FALSE(process(config, GYRO, 1));
 	EXPECT_TRUE(process(config, GYRO, 0));
+}
+
+// ===========================================================================
+// process_esc(): ESC Off / Wrong on the multi-instance esc_status
+// ===========================================================================
+
+namespace
+{
+
+esc_status_s make_esc_status(uint8_t num_motors)
+{
+	esc_status_s status{};
+	status.esc_count = num_motors;
+	status.esc_online_flags = (1u << num_motors) - 1; // all online
+
+	for (uint8_t i = 0; i < num_motors; i++) {
+		status.esc[i].actuator_function = esc_report_s::ACTUATOR_FUNCTION_MOTOR1 + i;
+		status.esc[i].timestamp = 1000;
+		status.esc[i].esc_voltage = 16.f;
+		status.esc[i].esc_current = 5.f;
+		status.esc[i].esc_rpm = 4000;
+	}
+
+	return status;
+}
+
+} // namespace
+
+TEST(FailureInjectionConfig, ProcessEscOffReportsOffline)
+{
+	Config config;
+	config.set(make_config(ESC, 0x1, OFF)); // ESC 1
+
+	esc_status_s status = make_esc_status(4);
+	process_esc(config, status);
+
+	EXPECT_EQ(status.esc_online_flags & 0x1u, 0u);   // motor 1 reported offline
+	EXPECT_EQ(status.esc_online_flags & 0xEu, 0xEu); // motors 2-4 untouched
+}
+
+TEST(FailureInjectionConfig, ProcessEscMapsByActuatorFunction)
+{
+	// Motor 3 sits on ESC slot 0; failing motor 3 must take slot 0 offline.
+	Config config;
+	config.set(make_config(ESC, 0x4, OFF)); // ESC 3 -> instance bit (3 - 1)
+
+	esc_status_s status{};
+	status.esc_count = 1;
+	status.esc_online_flags = 0x1;
+	status.esc[0].actuator_function = esc_report_s::ACTUATOR_FUNCTION_MOTOR1 + 2; // Motor 3
+
+	process_esc(config, status);
+
+	EXPECT_EQ(status.esc_online_flags & 0x1u, 0u);
+}
+
+TEST(FailureInjectionConfig, ProcessEscWrongScalesTelemetryButStaysOnline)
+{
+	Config config;
+	config.set(make_config(ESC, 0x1, WRONG)); // ESC 1
+
+	esc_status_s status = make_esc_status(4);
+	process_esc(config, status);
+
+	EXPECT_EQ(status.esc_online_flags & 0xFu, 0xFu);  // all still online
+	EXPECT_FLOAT_EQ(status.esc[0].esc_voltage, 1.6f); // 16 * 0.1
+	EXPECT_FLOAT_EQ(status.esc[0].esc_current, 0.5f); // 5 * 0.1
+	EXPECT_EQ(status.esc[0].esc_rpm, 40000);          // 4000 * 10
+	EXPECT_FLOAT_EQ(status.esc[1].esc_voltage, 16.f); // other ESCs untouched
 }

--- a/src/modules/failure_injection_manager/FailureInjectionConfigTest.cpp
+++ b/src/modules/failure_injection_manager/FailureInjectionConfigTest.cpp
@@ -301,7 +301,7 @@ TEST(FailureInjectionConfig, ProcessEscOffReportsOffline)
 	config.set(make_config(ESC, 0x1, OFF)); // ESC 1
 
 	esc_status_s status = make_esc_status(4);
-	process_esc(config, status);
+	status = process_esc(config, status);
 
 	EXPECT_EQ(status.esc_online_flags & 0x1u, 0u);   // motor 1 reported offline
 	EXPECT_EQ(status.esc_online_flags & 0xEu, 0xEu); // motors 2-4 untouched
@@ -318,7 +318,7 @@ TEST(FailureInjectionConfig, ProcessEscMapsByActuatorFunction)
 	status.esc_online_flags = 0x1;
 	status.esc[0].actuator_function = esc_report_s::ACTUATOR_FUNCTION_MOTOR1 + 2; // Motor 3
 
-	process_esc(config, status);
+	status = process_esc(config, status);
 
 	EXPECT_EQ(status.esc_online_flags & 0x1u, 0u);
 }
@@ -329,7 +329,7 @@ TEST(FailureInjectionConfig, ProcessEscWrongScalesTelemetryButStaysOnline)
 	config.set(make_config(ESC, 0x1, WRONG)); // ESC 1
 
 	esc_status_s status = make_esc_status(4);
-	process_esc(config, status);
+	status = process_esc(config, status);
 
 	EXPECT_EQ(status.esc_online_flags & 0xFu, 0xFu);  // all still online
 	EXPECT_FLOAT_EQ(status.esc[0].esc_voltage, 1.6f); // 16 * 0.1

--- a/src/modules/failure_injection_manager/FailureInjectionManagerTest.cpp
+++ b/src/modules/failure_injection_manager/FailureInjectionManagerTest.cpp
@@ -45,6 +45,7 @@ namespace
 constexpr uint8_t GYRO  = failure_injection_s::FAILURE_UNIT_SENSOR_GYRO;
 constexpr uint8_t GPS   = failure_injection_s::FAILURE_UNIT_SENSOR_GPS;
 constexpr uint8_t MOTOR = failure_injection_s::FAILURE_UNIT_SYSTEM_MOTOR;
+constexpr uint8_t ESC   = failure_injection_s::FAILURE_UNIT_SYSTEM_ESC;
 
 constexpr uint8_t OK      = failure_injection_s::FAILURE_TYPE_OK;
 constexpr uint8_t OFF     = failure_injection_s::FAILURE_TYPE_OFF;
@@ -60,7 +61,12 @@ TEST(FailureTable, SupportedCatalogueMatchesInventory)
 	EXPECT_TRUE(FailureTable::isSupported(GYRO, STUCK));
 	EXPECT_FALSE(FailureTable::isSupported(GYRO, WRONG));   // no gyro WRONG today
 	EXPECT_TRUE(FailureTable::isSupported(GPS, WRONG));
-	EXPECT_TRUE(FailureTable::isSupported(MOTOR, WRONG));
+	EXPECT_TRUE(FailureTable::isSupported(MOTOR, OFF));
+	EXPECT_FALSE(FailureTable::isSupported(MOTOR, STUCK)); // motor is off-only (actuation)
+	EXPECT_FALSE(FailureTable::isSupported(MOTOR, WRONG));
+	EXPECT_TRUE(FailureTable::isSupported(ESC, OFF));
+	EXPECT_TRUE(FailureTable::isSupported(ESC, WRONG));   // ESC: offline or wrong telemetry
+	EXPECT_FALSE(FailureTable::isSupported(ESC, STUCK));   // no frozen-telemetry (stuck) support
 	EXPECT_FALSE(FailureTable::isSupported(GYRO, GARBAGE)); // GARBAGE unimplemented
 	// Distance sensor (rangefinder) supports OFF/STUCK on hardware, but not WRONG.
 	EXPECT_TRUE(FailureTable::isSupported(failure_injection_s::FAILURE_UNIT_SENSOR_DISTANCE_SENSOR, OFF));

--- a/src/modules/failure_injection_manager/FailureTable.cpp
+++ b/src/modules/failure_injection_manager/FailureTable.cpp
@@ -54,7 +54,6 @@ bool FailureTable::isSupported(uint8_t unit, uint8_t type)
 
 	case failure_injection_s::FAILURE_UNIT_SENSOR_GPS:
 	case failure_injection_s::FAILURE_UNIT_SENSOR_AIRSPEED:
-	case failure_injection_s::FAILURE_UNIT_SYSTEM_MOTOR:
 		return type == failure_injection_s::FAILURE_TYPE_OK
 		       || type == failure_injection_s::FAILURE_TYPE_OFF
 		       || type == failure_injection_s::FAILURE_TYPE_STUCK
@@ -62,8 +61,14 @@ bool FailureTable::isSupported(uint8_t unit, uint8_t type)
 
 	case failure_injection_s::FAILURE_UNIT_SENSOR_VIO:
 	case failure_injection_s::FAILURE_UNIT_SYSTEM_BATTERY:
+	case failure_injection_s::FAILURE_UNIT_SYSTEM_MOTOR:
 		return type == failure_injection_s::FAILURE_TYPE_OK
 		       || type == failure_injection_s::FAILURE_TYPE_OFF;
+
+	case failure_injection_s::FAILURE_UNIT_SYSTEM_ESC:
+		return type == failure_injection_s::FAILURE_TYPE_OK
+		       || type == failure_injection_s::FAILURE_TYPE_OFF
+		       || type == failure_injection_s::FAILURE_TYPE_WRONG;
 
 	default:
 		return false;

--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -74,6 +74,7 @@ if (gz-transport_FOUND)
 			drivers_magnetometer
 			drivers_rangefinder
 			drivers_barometer
+			failure_injection
 			mixer_module
 			px4_work_queue
 			${GZ_TRANSPORT_TARGET}

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -132,7 +132,8 @@ void GZMixingInterfaceESC::motorSpeedCallback(const gz::msgs::Actuators &actuato
 
 	if (esc_status.esc_count > 0) {
 		esc_status.timestamp = hrt_absolute_time();
-		_esc_status_pub.publish(esc_status);
+		_failure_config.update();
+		_esc_status_pub.publish(failure_injection::process_esc(_failure_config, esc_status));
 	}
 
 	pthread_mutex_unlock(&_node_mutex);

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.hpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.hpp
@@ -33,6 +33,7 @@
 
 #pragma once
 
+#include <lib/failure_injection/FailureInjection.hpp>
 #include <lib/mixer_module/mixer_module.hpp>
 
 #include <gz/msgs.hh>
@@ -82,5 +83,6 @@ private:
 	gz::transport::Node::Publisher _actuators_pub;
 
 	uORB::Publication<esc_status_s> _esc_status_pub{ORB_ID(esc_status)};
+	failure_injection::Config _failure_config;
 
 };

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
@@ -169,7 +169,8 @@ void SimulatorMavlink::send_esc_telemetry(mavlink_hil_actuator_controls_t hil_ac
 	esc_status.esc_armed_flags = (1u << esc_status.esc_count) - 1;
 	esc_status.esc_online_flags = (1u << esc_status.esc_count) - 1;
 
-	_esc_status_pub.publish(esc_status);
+	// _failure_config refreshed in updateFailureConfig(), called each loop before send_controls()
+	_esc_status_pub.publish(failure_injection::process_esc(_failure_config, esc_status));
 }
 
 void SimulatorMavlink::send_controls()

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -437,7 +437,9 @@ void Sih::publish_esc_status()
 		_esc_status.esc_armed_flags = (1u << motor_idx) - 1;
 	}
 
-	_esc_status_pub.publish(_esc_status);
+	esc_status_s esc_status = _esc_status;   // config refreshed in updateFailureConfig()
+	failure_injection::process_esc(_failure_config, esc_status);
+	_esc_status_pub.publish(esc_status);
 }
 
 void Sih::generate_force_and_torques(const float dt)

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -437,9 +437,7 @@ void Sih::publish_esc_status()
 		_esc_status.esc_armed_flags = (1u << motor_idx) - 1;
 	}
 
-	esc_status_s esc_status = _esc_status;   // config refreshed in updateFailureConfig()
-	failure_injection::process_esc(_failure_config, esc_status);
-	_esc_status_pub.publish(esc_status);
+	_esc_status_pub.publish(failure_injection::process_esc(_failure_config, _esc_status));
 }
 
 void Sih::generate_force_and_torques(const float dt)

--- a/src/systemcmds/failure/failure.cpp
+++ b/src/systemcmds/failure/failure.cpp
@@ -64,6 +64,7 @@ static constexpr FailureUnit failure_units[] = {
 	{ "airspeed", vehicle_command_s::FAILURE_UNIT_SENSOR_AIRSPEED},
 	{ "battery", vehicle_command_s::FAILURE_UNIT_SYSTEM_BATTERY},
 	{ "motor", vehicle_command_s::FAILURE_UNIT_SYSTEM_MOTOR},
+	{ "esc", vehicle_command_s::FAILURE_UNIT_SYSTEM_ESC},
 	{ "servo", vehicle_command_s::FAILURE_UNIT_SYSTEM_SERVO},
 	{ "avoidance", vehicle_command_s::FAILURE_UNIT_SYSTEM_AVOIDANCE},
 	{ "rc_signal", vehicle_command_s::FAILURE_UNIT_SYSTEM_RC_SIGNAL},


### PR DESCRIPTION
### Solved Problem
`failure motor stuck/wrong` was a no-op on main: `FailureInjector::manipulateEscStatus()`
has had no callers since the ESC checks moved into `escCheck`, so its telemetry masks were
dead. Those effects also sat on the **motor** unit (101) while manipulating ESC **telemetry**,
which contradicts MAVLink standard.

### Solution
- Add `failure_injection::process_esc()`, applied where `esc_status` is produced (UAVCAN ESC
  driver + SIH): **Off** reports the ESC offline; **Wrong** reports scaled telemetry while the
  ESC stays online. Applied to the outgoing copy so `Wrong` scales exactly once on drivers that
  accumulate telemetry per-ESC.
- Wire the ESC unit (106) end to end: `failure esc …` CLI key + `FailureTable` (ESC = OK/OFF/WRONG).
- Regroup **motor** (101) to OK/OFF only (actuation); its path is unchanged.
- Drop `FailureInjector`'s dead ESC-telemetry masks and `manipulateEscStatus()`.

To use on a flight board, enable `CONFIG_MODULES_FAILURE_INJECTION_MANAGER` and
`CONFIG_SYSTEMCMDS_FAILURE` in its `.px4board` (SITL already has both).

### Test coverage
- Unit + functional gtests
- SITL/SIH: `esc off` → offline, `esotor off` → stop mask.
- Hardware (DroneCAN hex): `esc off`rong` → steady ×10 rpm / ×0.1 current; `motor off` → stop mask.
