### PR TITLE
fix(simulator_sih): restore xvert front transition

### DIFF
--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -34,6 +34,7 @@ jobs:
         config:
           - {model: "quadx",         latitude:  "59.617693", longitude: "-151.145316", altitude:  "48", build_type: "RelWithDebInfo" } # Alaska
           - {model: "standard_vtol", latitude:  "47.397742", longitude:    "8.545594", altitude: "488", build_type: "Coverage" } # Zurich
+          - {model: "xvert",         latitude:  "47.397742", longitude:    "8.545594", altitude: "488", build_type: "RelWithDebInfo" } # Zurich
     env:
       PX4_CMAKE_BUILD_TYPE: ${{ matrix.config.build_type }}
       PX4_SBOM_DISABLE: 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
@@ -20,6 +20,8 @@ param set-default SENS_EN_BAROSIM 1
 param set-default SENS_EN_MAGSIM 1
 
 param set-default VT_B_TRANS_DUR 5
+param set-default VT_ARSP_BLEND 6
+param set-default VT_ARSP_TRANS 7
 param set-default VT_ELEV_MC_LOCK 0
 param set-default VT_TYPE 0
 param set-default VT_FW_DIFTHR_EN 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
@@ -26,6 +26,7 @@ param set-default VT_ELEV_MC_LOCK 0
 param set-default VT_TYPE 0
 param set-default VT_FW_DIFTHR_EN 1
 param set-default VT_FW_DIFTHR_S_Y 0.3
+param set-default FW_ARSP_SCALE_EN 0
 param set-default MPC_MAN_Y_MAX 60
 param set-default MC_PITCH_P 5
 

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -766,9 +766,9 @@ void Sih::send_airspeed(const hrt_abstime &time_now_us)
 	airspeed_s airspeed{};
 	airspeed.timestamp_sample = time_now_us;
 
-	// pitot tube measures forward (body-x) airspeed
 	const Vector3f v_apparent_B = _q.rotateVectorInverse(_v_apparent_N);
-	airspeed.true_airspeed_m_s = fmaxf(0.1f, v_apparent_B(0) + generate_wgn() * 0.2f);
+	const float v_pitot = (_vehicle == VehicleType::TailsitterVTOL) ? -v_apparent_B(2) : v_apparent_B(0);
+	airspeed.true_airspeed_m_s = fmaxf(0.1f, v_pitot + generate_wgn() * 0.2f);
 	airspeed.indicated_airspeed_m_s = airspeed.true_airspeed_m_s * sqrtf(_wing_l.get_rho() / RHO);
 	airspeed.confidence = 0.7f;
 	airspeed.timestamp = hrt_absolute_time();

--- a/test/mavsdk_tests/CMakeLists.txt
+++ b/test/mavsdk_tests/CMakeLists.txt
@@ -31,6 +31,7 @@ if(MAVSDK_FOUND)
         test_multicopter_offboard.cpp
         test_multicopter_manual.cpp
         test_multicopter_rtl_with_geofence.cpp
+        test_sih_xvert_transition.cpp
         test_vtol_mission.cpp
         test_vtol_figure_eight.cpp
         test_vtol_loiter_reposition.cpp

--- a/test/mavsdk_tests/configs/sih-sitl.json
+++ b/test/mavsdk_tests/configs/sih-sitl.json
@@ -31,6 +31,11 @@
             "model": "standard_vtol",
             "test_filter": "[vtol]",
             "timeout_min": 10
+        },
+        {
+            "model": "xvert",
+            "test_filter": "[sih_xvert_transition]",
+            "timeout_min": 5
         }
     ]
 }

--- a/test/mavsdk_tests/test_sih_xvert_transition.cpp
+++ b/test/mavsdk_tests/test_sih_xvert_transition.cpp
@@ -1,0 +1,54 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "autopilot_tester.h"
+
+#include <chrono>
+
+TEST_CASE("SIH XVert completes front transition", "[sih_xvert_transition]")
+{
+	AutopilotTester tester;
+	tester.connect(connection_url);
+	tester.wait_until_ready();
+
+	const float takeoff_altitude = 30.f;
+	tester.set_takeoff_altitude(takeoff_altitude);
+	tester.arm();
+	tester.takeoff();
+	tester.wait_until_hovering();
+	tester.wait_until_altitude(takeoff_altitude, std::chrono::seconds(30));
+	tester.transition_to_fixedwing();
+	tester.wait_until_fixedwing(std::chrono::seconds(15));
+	tester.sleep_for(std::chrono::seconds(10));
+	tester.wait_until_fixedwing(std::chrono::seconds(1));
+}


### PR DESCRIPTION

Closes #27762

### Solution

This fixes the SIH xvert front transition, which previously failed because the simulated pitot measurement used the wrong body axis and did not report increasing forward airspeed.

1. Measure tailsitter airspeed along body `-Z`, its actual forward axis, instead of body `+X`. This allows the reported airspeed to increase as the xvert accelerates during transition.

2. Set `VT_ARSP_BLEND` to 6 m/s and `VT_ARSP_TRANS` to 7 m/s. These thresholds match the speeds the simulated xvert can reach within the transition window, allowing control blending to begin and the transition to complete.

3. Add an MAVSDK integration test that takes off, requests a front transition, verifies fixed-wing mode is reached within 15 seconds, and confirms it remains in fixed-wing mode. The xvert test is also added to the SIH CI matrix.

4. Set `FW_ARSP_SCALE_EN` to `0` for this airframe. Its elevons remain effective in hover because they are inside the propeller slipstream, so scaling their commands from the low measured freestream airspeed causes excessive pitch response.


Significantly less jitter when compared to [previous transitions](https://github.com/PX4/PX4-Autopilot/issues/27762#issuecomment-4970051370)

Solutions logs: https://review.px4.io/plot_app?log=e8860a2b-d61b-45a5-8500-b139829750cb


cc @dakejahl @sfuhrer

