### PR TITLE
fix(mavlink): sync ranging beacon timestamp to local clock domain

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2740,7 +2740,7 @@ MavlinkReceiver::handle_message_ranging_beacon(mavlink_message_t *msg)
 
 	ranging_beacon_s ranging_beacon{};
 	ranging_beacon.timestamp = hrt_absolute_time();
-	ranging_beacon.timestamp_sample = beacon_pos.time_usec;
+	ranging_beacon.timestamp_sample = _mavlink_timesync.sync_stamp(beacon_pos.time_usec);
 	ranging_beacon.beacon_id = beacon_pos.beacon_id;
 	ranging_beacon.range = (beacon_pos.range != UINT32_MAX) ? static_cast<float>(beacon_pos.range) * 1e-3f : NAN;
 	ranging_beacon.lat = static_cast<double>(beacon_pos.lat) * 1e-7;


### PR DESCRIPTION
## Summary

Fix ranging beacon sample timestamps not being converted to the local clock domain before EKF2 fusion.

## Problem

`MavlinkReceiver::handle_message_ranging_beacon` copied `RANGING_BEACON.time_usec` straight into `timestamp_sample`, unlike every other external-aiding handler in the file (mocap, vision odometry, landing_target_pose, gps_input target), which all convert via `_mavlink_timesync.sync_stamp()`. Per the MAVLink spec this field is in the sender's clock domain (Unix epoch or sender boot time), while EKF2's ranging beacon ring buffer and `controlRangingBeaconFusion()` compare it directly against `imu_delayed.time_us`, which is in the local `hrt_absolute_time()` domain. Left unsynced, this mismatch starves or corrupts beacon fusion depending on which clock domain is larger.

## Solution

Convert the timestamp with `_mavlink_timesync.sync_stamp(beacon_pos.time_usec)` before publishing, matching the pattern used by every other external-aiding MAVLink handler.
