### PR TITLE
fix(flashparams): compact the param sector at boot instead of at the disarm-edge save

### DIFF
--- a/src/lib/parameters/flashparams/flashfs.h
+++ b/src/lib/parameters/flashparams/flashfs.h
@@ -212,6 +212,23 @@ __EXPORT int parameter_flashfs_write(flash_file_token_t ft, uint8_t *buffer, siz
 __EXPORT int parameter_flashfs_erase(void);
 
 /****************************************************************************
+ * Name: parameter_flashfs_compact_if_full
+ *
+ * Description:
+ *   If the sector lacks room for another entry the size of the stored one,
+ *   rewrite it through the normal wrap path now (sector erase + rewrite).
+ *   Called at boot so the erase, which stalls every read of its flash bank
+ *   while it runs, cannot land on a save made once the vehicle is armed.
+ *
+ * Returned value:
+ *   1 if a compaction was performed, 0 if there was enough space or nothing
+ *   is stored, or a negative errno.
+ *
+ ****************************************************************************/
+
+__EXPORT int parameter_flashfs_compact_if_full(void);
+
+/****************************************************************************
  * Name: parameter_flashfs_alloc
  *
  * Description:

--- a/src/lib/parameters/flashparams/flashfs32.c
+++ b/src/lib/parameters/flashparams/flashfs32.c
@@ -1108,6 +1108,83 @@ int parameter_flashfs_erase(void)
 
 
 /****************************************************************************
+ * Name: parameter_flashfs_compact_if_full
+ *
+ * Description:
+ *   If the sector cannot take another entry the size of the one it holds
+ *   (plus a growth margin), rewrite that entry now through the normal write
+ *   path, which wraps and erases the sector.
+ *
+ *   An erase stalls every read of the bank the sector lives in until it
+ *   completes, which for a 128 KB sector on STM32H7 is on the order of a
+ *   second. Where the firmware image shares that bank, execution halts for
+ *   the duration. A save can be triggered at any time - including the
+ *   autosave released on disarm - so paying the wrap here bounds that halt
+ *   to a point where the vehicle is not yet armed and nothing is being
+ *   controlled. In-service saves then stay append-only (a few 32-byte row
+ *   programs). If the stored data outgrows the margin between boots, the
+ *   save-time wrap still covers it.
+ *
+ *   Cost: a boot that compacts takes one erase longer to reach the rest of
+ *   board init. Every other boot pays only the free-space check below.
+ *
+ * Returned value:
+ *   1 if a compaction (sector erase + rewrite) was performed, 0 if there
+ *   was enough space or nothing is stored, or a negative errno.
+ *
+ ****************************************************************************/
+
+int parameter_flashfs_compact_if_full(void)
+{
+	if (sector_map == NULL) {
+		return -ENXIO;
+	}
+
+	flash_entry_header_t *pf = find_entry(parameters_token);
+
+	if (pf == NULL) {
+		return 0;
+	}
+
+	/* Headroom kept beyond one more copy of the current entry. Each save
+	 * stores the same parameter set give or take a few values, so a couple
+	 * of KB covers normal growth over a run of saves; data that outgrows it
+	 * takes the save-time wrap once, as before.
+	 */
+
+	const size_t growth_margin = 2048;
+
+	size_t data_length = entry_data_length(pf);
+	size_t entry_total = sizeof(flash_entry_header_t) + data_length + SizeMask;
+	size_t reserve = entry_total + growth_margin;
+
+	if (check_free_space_in_sector(pf, reserve) == NULL) {
+		return 0;
+	}
+
+	/* The entry data lives in the flash about to be erased: copy it out first. */
+
+	uint8_t *buffer;
+	size_t buffer_size = data_length;
+	int rv = parameter_flashfs_alloc(parameters_token, &buffer, &buffer_size);
+
+	if (rv != 0) {
+		return rv;
+	}
+
+	if (buffer_size < data_length) {
+		parameter_flashfs_free();
+		return -ENOMEM;
+	}
+
+	memcpy(buffer, entry_data(pf), data_length);
+	rv = parameter_flashfs_write(parameters_token, buffer, data_length);
+	parameter_flashfs_free();
+
+	return rv >= 0 ? 1 : rv;
+}
+
+/****************************************************************************
  * Name: parameter_flashfs_init
  *
  * Description:
@@ -1161,6 +1238,14 @@ int parameter_flashfs_init(sector_descriptor_t *fconfig, uint8_t *buffer, uint16
 		// A positive return value means flash space has been erased successfully.
 		if (rv > 0) {
 			rv = 0;
+		}
+
+	} else {
+		// Pay the sector-wrap erase here at boot, not on a save at the disarm edge.
+		int compacted = parameter_flashfs_compact_if_full();
+
+		if (compacted < 0) {
+			rv = compacted;
 		}
 	}
 


### PR DESCRIPTION
## Summary
Move the param sector's wrap erase from the save that follows disarm to boot.

## Problem
In the field this shows up as occasional ESC reboots on disarm.

Params append into a single 128 KB sector; when an append wraps, flashfs erases the sector inline. The erase stalls every read of that flash bank until it completes (~1 s for 128 KB on STM32H7), and where the firmware image shares the bank, execution halts for the duration. Armed-time param writes are deferred to the disarm edge by autosave, and disarm always dirties `COM_FLIGHT_UUID`, so the wrap lands on a save ~300 ms after disarm. An explicit `param save` while armed skips the deferral entirely and can stall in flight.

Measured on an ARK FPV (STM32H743, ~780 KB of .text in the param bank) with a logic analyzer on the motor outputs: a wrap erase during the post-disarm save left the DShot line with no frames for 768.6 ms. That is past the 0.5 s armed signal-loss timeout in AM32 (`faults.c`), at which the ESC resets itself - so the stall is long enough to account for the reboots. The datasheet erase time for a 128 KB sector runs to 2.2 s, so other parts can stall longer than this one did.

## Solution
`parameter_flashfs_compact_if_full()`, called from `parameter_flashfs_init()`: if the sector cannot take another entry of the stored size plus a 2 KB growth margin, rewrite the entry through the existing wrap path at boot, before anything is armed. In-service saves stay appends (measured 0.3-72 ms). Data that outgrows the margin between boots still takes the save-time wrap, as before.

Same forced-save workload on the fixed build (110 saves across sessions with reboots): no save-time erases, the wrap ran during a reboot instead.