### PR TITLE
fix(mavlink): report GPS_RAW_INT yaw as invalid instead of unavailable

### DIFF
--- a/src/modules/mavlink/streams/GPS_RAW_INT.hpp
+++ b/src/modules/mavlink/streams/GPS_RAW_INT.hpp
@@ -61,6 +61,7 @@ private:
 	uORB::Subscription _sensor_gps_sub{ORB_ID(sensor_gps), 0};
 	SensorGpsSelector _gps_selector{};
 	hrt_abstime _last_send_ts {};
+	bool _yaw_capable{false}; ///< a heading has been reported at least once
 	static constexpr hrt_abstime kNoGpsSendInterval {1_s};
 
 	bool send() override
@@ -106,6 +107,8 @@ private:
 			msg.vel_acc = gps.s_variance_m_s * 1e3f; // speed uncertainty in mm
 
 			if (PX4_ISFINITE(gps.heading)) {
+				_yaw_capable = true;
+
 				if (fabsf(gps.heading) < FLT_EPSILON) {
 					msg.yaw = 36000; // Use 36000 for north.
 
@@ -116,6 +119,11 @@ private:
 				if (PX4_ISFINITE(gps.heading_accuracy)) {
 					msg.hdg_acc = math::degrees(gps.heading_accuracy) * 1e5f; // Heading / track uncertainty in degE5
 				}
+
+			} else if (_yaw_capable) {
+				// 0 means the receiver never provides yaw, so a receiver that does has to
+				// report the samples it has no heading for as invalid instead
+				msg.yaw = UINT16_MAX;
 			}
 
 			mavlink_msg_gps_raw_int_send_struct(_mavlink->get_channel(), &msg);
@@ -130,6 +138,11 @@ private:
 			msg.vel = UINT16_MAX;
 			msg.cog = UINT16_MAX;
 			msg.satellites_visible = UINT8_MAX;
+
+			if (_yaw_capable) {
+				msg.yaw = UINT16_MAX;
+			}
+
 			mavlink_msg_gps_raw_int_send_struct(_mavlink->get_channel(), &msg);
 			_last_send_ts = now;
 


### PR DESCRIPTION
### Summary

`GPS_RAW_INT.yaw` distinguishes two cases ([`common.xml`](https://github.com/mavlink/mavlink/blob/de1e078a3a7c53c9262a95b7417959a0f8bf4150/message_definitions/v1.0/common.xml#L5644)):

> Use 0 if this GPS does not provide yaw. Use UINT16_MAX if this GPS is configured to provide yaw and is currently unable to provide it.

The stream left the field at 0 whenever `sensor_gps.heading` was `NAN`, so a dual-antenna receiver that momentarily loses its heading reports itself as *not yaw-capable* rather than *temporarily unable*. A GCS cannot tell "this GPS has no yaw" from "this GPS lost yaw for one sample".

Once a finite heading has been seen, send `UINT16_MAX` instead — both for a sample without heading and in the no-GPS message, which had the same defect.

Affects any dual-antenna setup (F9P moving base, ZED-X20D, UM982). Found while adding X20D support in PX4/PX4-GPSDrivers#216.

### Testing
Behaviour for receivers that never report heading is unchanged — `_yaw_capable` stays false and yaw stays 0.