### PR TITLE
fix(gps): Ensure correct instance when publishing satellite info

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -284,6 +284,7 @@ private:
 	perf_counter_t _rtcm_moving_baseline_injection_perf{perf_alloc(PC_COUNT, MODULE_NAME": rtcm moving baseline injected")};
 
 	static px4::atomic_bool _is_gps_main_advertised; ///< for the second gps we want to make sure that it gets instance 1
+	static px4::atomic_bool _is_sat_info_main_advertised; ///< for the second gps we want to make sure that it gets instance 1
 	/// and thus we wait until the first one publishes at least one message.
 
 	static px4::atomic<GPS *> _secondary_instance;
@@ -380,6 +381,7 @@ private:
 };
 
 px4::atomic_bool GPS::_is_gps_main_advertised{false};
+px4::atomic_bool GPS::_is_sat_info_main_advertised{false};
 px4::atomic<GPS *> GPS::_secondary_instance{nullptr};
 ModuleBase::Descriptor GPS::desc{task_spawn, custom_command, print_usage};
 
@@ -1574,12 +1576,12 @@ GPS::publish()
 void
 GPS::publishSatelliteInfo()
 {
-	if (_instance == Instance::Main || _is_gps_main_advertised.load()) {
+	if (_instance == Instance::Main || _is_sat_info_main_advertised.load()) {
 		if (_p_report_sat_info != nullptr) {
 			_report_sat_info_pub.publish(*_p_report_sat_info);
 		}
 
-		_is_gps_main_advertised.store(true);
+		_is_sat_info_main_advertised.store(true);
 
 	} else {
 		//we don't publish satellite info for the secondary gps

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -1582,9 +1582,6 @@ GPS::publishSatelliteInfo()
 		}
 
 		_is_sat_info_main_advertised.store(true);
-
-	} else {
-		//we don't publish satellite info for the secondary gps
 	}
 }
 


### PR DESCRIPTION
### Solved Problem
Fixes an edge case introduced with  [PR 23567}](https://github.com/PX4/PX4-Autopilot/pull/23567): Prior to this fix, it's possible to have the following sequence : 
1. `publishSatelliteInfo()` triggers first on the Main GNSS and sets `_is_gps_main_advertised` to true
2. `publish()` then triggers on the Secondary GNSS and publishes into the instance 0 -> issue.

### Solution
Dedicated atomic bool to ensure the correct instance when publishing satellite_info on main and secondary instances.

### Test coverage
Log where both instances are logged : https://logs.px4.io/plot_app?log=b688edf5-25d8-4a11-b1f9-d703473592c6
<img width="268" height="223" alt="image" src="https://github.com/user-attachments/assets/7e0e0639-099d-4ccc-983f-406e4e81c836" />