### PR TITLE
fix(commander): only report flight time low if ACT is at Warn or higher

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
@@ -314,8 +314,13 @@ void BatteryChecks::rtlEstimateCheck(const Context &context, Report &reporter, f
 			&& rtl_time_estimate.safe_time_estimate * hysteresis_factor >= worst_battery_time_s;
 
 
-	if (reporter.failsafeFlags().battery_low_remaining_time) {
+	// Only report if the failsafe action is enabled, otherwise the condition has no effect
+	if (reporter.failsafeFlags().battery_low_remaining_time && _param_com_fltt_low_act.get() > 0) {
 		/* EVENT
+		 * @description
+		 * <profile name="dev">
+		 * This check can be configured via <param>COM_FLTT_LOW_ACT</param> parameter.
+		 * </profile>
 		 */
 		reporter.armingCheckFailure(NavModes::All, health_component_t::battery, events::ID("check_battery_rem_flight_time_low"),
 					    events::Log::Error, "Remaining flight time low");

--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.hpp
@@ -58,6 +58,7 @@ private:
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
 					(ParamFloat<px4::params::COM_ARM_BAT_MIN>) _param_com_arm_bat_min,
-					(ParamInt<px4::params::CBRK_SUPPLY_CHK>) _param_cbrk_supply_chk
+					(ParamInt<px4::params::CBRK_SUPPLY_CHK>) _param_cbrk_supply_chk,
+					(ParamInt<px4::params::COM_FLTT_LOW_ACT>) _param_com_fltt_low_act
 				       )
 };


### PR DESCRIPTION

### Solved Problem
PX4 reports "flight time low" even if `COM_FLTT_LOW_ACT` is to o (Disabled)
<img width="679" height="200" alt="image" src="https://github.com/user-attachments/assets/1e42308f-66ff-439b-b81a-46b0e3098a2b" />


### Solution
Check `COM_FLTT_LOW_ACT` before raising the warning. 



