### PR TITLE
fix(boards/ark/pi6x): drop bl_update from the encrypted_logs target

### DIFF
--- a/boards/ark/pi6x/encrypted_logs.px4board
+++ b/boards/ark/pi6x/encrypted_logs.px4board
@@ -4,3 +4,4 @@ CONFIG_DRIVERS_SW_CRYPTO=y
 # CONFIG_EKF2_AUX_GLOBAL_POSITION is not set
 CONFIG_PUBLIC_KEY0="../../../Tools/test_keys/key0.pub"
 CONFIG_PUBLIC_KEY1="../../../Tools/test_keys/rsa2048.pub"
+# CONFIG_SYSTEMCMDS_BL_UPDATE is not set


### PR DESCRIPTION
## Summary
Reclaims 45576 bytes of flash on `ark_pi6x_encrypted_logs`, which had 884 bytes left.

## Problem
The target links at 99.95% (1834124 of 1835008 bytes), so any growth in the crypto or logging paths breaks the build. Most of that space is not code — the ROMFS image is 144624 bytes, and `SYSTEMCMDS_BL_UPDATE` makes it carry a full copy of the board bootloader plus `rc.board_bootloader_upgrade`. That is 43914 bytes with nothing to do with encrypted logging.

## Solution
Disable `SYSTEMCMDS_BL_UPDATE` on this label only. A clean build lands at 1788548 bytes (97.47%).

The `default` label keeps `bl_update`, so the bootloader stays updatable — flash `default` once, then `encrypted_logs`. `rcS` guards the upgrade script with a `-f` test, so its absence is a no-op at boot.