### PR TITLE
chore: dedupe equal_value_threshold default

### DIFF
--- a/src/modules/sensors/data_validator/DataValidator.hpp
+++ b/src/modules/sensors/data_validator/DataValidator.hpp
@@ -170,6 +170,9 @@ public:
 	static constexpr uint32_t ERROR_FLAG_HIGH_ERRCOUNT = (0x00000001U << 3);
 	static constexpr uint32_t ERROR_FLAG_HIGH_ERRDENSITY = (0x00000001U << 4);
 
+	static const constexpr unsigned VALUE_EQUAL_COUNT_DEFAULT =
+		100; /**< if the sensor value is the same (accumulated also between axes) this many times, flag it */
+
 private:
 	uint32_t _error_mask{ERROR_FLAG_NO_ERROR}; /**< sensor error state */
 
@@ -198,8 +201,6 @@ private:
 	static const constexpr unsigned NORETURN_ERRCOUNT =
 		10000; /**< if the error count reaches this value, return sensor as invalid */
 	static const constexpr float ERROR_DENSITY_WINDOW = 100.0f; /**< window in measurement counts for errors */
-	static const constexpr unsigned VALUE_EQUAL_COUNT_DEFAULT =
-		100; /**< if the sensor value is the same (accumulated also between axes) this many times, flag it */
 
 	/* we don't want this class to be copied */
 	DataValidator(const DataValidator &) = delete;

--- a/src/modules/sensors/data_validator/DataValidatorGroup.hpp
+++ b/src/modules/sensors/data_validator/DataValidatorGroup.hpp
@@ -136,7 +136,7 @@ private:
 	DataValidator *_last{nullptr};  /**< last node in the group */
 
 	uint32_t _timeout_interval_us{0}; /**< currently set timeout */
-	uint32_t _equal_value_threshold{100}; /**< currently set equal value threshold */
+	uint32_t _equal_value_threshold{DataValidator::VALUE_EQUAL_COUNT_DEFAULT}; /**< currently set equal value threshold */
 
 	int _curr_best{-1}; /**< currently best index */
 	int _prev_best{-1}; /**< the previous best index */


### PR DESCRIPTION
﻿Small follow-up to #27822. DataValidatorGroup was initializing `_equal_value_threshold` with a hardcoded 100, which just so happened to match `DataValidator::VALUE_EQUAL_COUNT_DEFAULT`. Moved that constant to public in DataValidator.hpp and referenced it directly instead, so the two values can't quietly drift apart if the default ever changes.
Thanks to @dakejahl for flagging this during review on the last PR!
