### PR TITLE
fix(mc_pos_control): reject non-positive automatic vertical speed limits

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -259,26 +259,36 @@ void MulticopterPositionControl::parameters_update(bool force)
 					    "Manual sideways speed has been constrained by forward speed", _param_mpc_vel_manual.get());
 		}
 
-		if (_param_mpc_z_v_auto_up.get() > _param_mpc_z_vel_max_up.get()) {
-			_param_mpc_z_v_auto_up.set(_param_mpc_z_vel_max_up.get());
+		if (_param_mpc_z_v_auto_up.get() > _param_mpc_z_vel_max_up.get() ||
+		    _param_mpc_z_v_auto_up.get() <= 0.f) {
+			const bool keep_previous = (_param_mpc_z_v_auto_up.get() <= 0.f) && (_z_v_auto_up_last_valid > 0.f);
+			_param_mpc_z_v_auto_up.set(keep_previous ? _z_v_auto_up_last_valid : _param_mpc_z_vel_max_up.get());
 			_param_mpc_z_v_auto_up.commit();
-			mavlink_log_critical(&_mavlink_log_pub, "Ascent speed has been constrained by max speed\t");
+			mavlink_log_critical(&_mavlink_log_pub, "Ascent speed limit invalid\t");
 			/* EVENT
 			 * @description <param>MPC_Z_V_AUTO_UP</param> is set to {1:.0}.
 			 */
 			events::send<float>(events::ID("mc_pos_ctrl_up_vel_set"), events::Log::Warning,
-					    "Ascent speed has been constrained by max speed", _param_mpc_z_vel_max_up.get());
+					    "Ascent speed limit invalid", _param_mpc_z_v_auto_up.get());
+
+		} else {
+			_z_v_auto_up_last_valid = _param_mpc_z_v_auto_up.get();
 		}
 
-		if (_param_mpc_z_v_auto_dn.get() > _param_mpc_z_vel_max_dn.get()) {
-			_param_mpc_z_v_auto_dn.set(_param_mpc_z_vel_max_dn.get());
+		if (_param_mpc_z_v_auto_dn.get() > _param_mpc_z_vel_max_dn.get() ||
+		    _param_mpc_z_v_auto_dn.get() <= 0.f) {
+			const bool keep_previous = (_param_mpc_z_v_auto_dn.get() <= 0.f) && (_z_v_auto_dn_last_valid > 0.f);
+			_param_mpc_z_v_auto_dn.set(keep_previous ? _z_v_auto_dn_last_valid : _param_mpc_z_vel_max_dn.get());
 			_param_mpc_z_v_auto_dn.commit();
-			mavlink_log_critical(&_mavlink_log_pub, "Descent speed has been constrained by max speed\t");
+			mavlink_log_critical(&_mavlink_log_pub, "Descent speed limit invalid\t");
 			/* EVENT
 			 * @description <param>MPC_Z_V_AUTO_DN</param> is set to {1:.0}.
 			 */
 			events::send<float>(events::ID("mc_pos_ctrl_down_vel_set"), events::Log::Warning,
-					    "Descent speed has been constrained by max speed", _param_mpc_z_vel_max_dn.get());
+					    "Descent speed limit invalid", _param_mpc_z_v_auto_dn.get());
+
+		} else {
+			_z_v_auto_dn_last_valid = _param_mpc_z_v_auto_dn.get();
 		}
 
 		if (_param_mpc_thr_hover.get() > _param_mpc_thr_max.get() ||

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -211,6 +211,9 @@ private:
 
 	bool _hover_thrust_initialized{false};
 
+	float _z_v_auto_up_last_valid{0.f};
+	float _z_v_auto_dn_last_valid{0.f};
+
 	/** Timeout in us for trajectory data to get considered invalid */
 	static constexpr uint64_t TRAJECTORY_STREAM_TIMEOUT_US = 500_ms;
 


### PR DESCRIPTION
## Summary

fixes #27890, fixes #27909

A negative `MPC_Z_V_AUTO_UP` or `MPC_Z_V_AUTO_DN` inverts the bounds of the clamp
in the trajectory generator and turns an automatic climb into a full rate
descent. `mc_pos_control` now rejects non-positive values.

## Problem

Parameter metadata ranges are advisory and are not enforced on a runtime write,
so a negative speed reaches the trajectory generator. The parameter is not the
value being limited, it is the limit itself: it becomes
`VelocitySmoothing::_max_vel` by way of `GotoControl` and `PositionSmoothing`,
and supplies both bounds of

https://github.com/PX4/PX4-Autopilot/blob/5356d24e5fa5027f62c0514c94a7eb113ef50966/src/lib/motion_planning/VelocitySmoothing.cpp#L165

`math::constrain()` does not assert `min <= max`:

https://github.com/PX4/PX4-Autopilot/blob/5356d24e5fa5027f62c0514c94a7eb113ef50966/src/lib/mathlib/math/Limits.hpp#L122

With `_max_vel = -3` the bounds are `(3, -3)`, the last branch is unreachable and
the function can only return a bound. In NED an ascent request of -2 m/s comes
back as +3 m/s. The clamp stops limiting the setpoint and starts replacing it.

The check that already guards these two parameters tested only `> max`, so a
negative value passed it untouched.

## Solution

The non-positive case folds into those existing out of range blocks and reuses
their message, event and commit, so it adds no new string, event or metadata
entry. The module keeps the last value that passed the check: a non-positive
write is warned about and otherwise ignored, and the vehicle keeps the limit it
already had. Too large values still clamp to `MPC_Z_VEL_MAX_UP` /
`MPC_Z_VEL_MAX_DN`, and so does a non-positive value on boot, when nothing valid
has been cached yet. The message becomes `Ascent speed limit invalid`, since the
block now takes two different actions.

Restoring the metadata default through `param_get_default_value()` was the first
attempt. It costs +336 byte and overflowed `auterion_fmu-v6s_default` by 132
byte; that board has roughly 200 byte of headroom on `main`. This version costs
+72 byte.

@MaEtUgR — is validating parameters one at a time worth that FLASH, with #27889,
#27978 and #28094 open in the same shape? `fabsf()` in
`VelocitySmoothing::setMaxVel()` would cover all six callers and close the hole
this leaves, since the fallback `MPC_Z_VEL_MAX_UP` / `MPC_Z_VEL_MAX_DN` is not
itself validated. An assert in `math::constrain()` under `#ifndef NDEBUG` would
catch the whole class in SITL and unit tests for no FLASH, but it compiles out of
flight builds, so something still has to stay in the image at runtime. Happy to
move the guard or widen it.
