### PR TITLE
fix(fw_latlon_control): prevent NaN eas2tas from zero-airspeed division

### DIFF
--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -638,7 +638,12 @@ void FwLateralLongitudinalControl::updateAirspeed() {
 
 			_time_airspeed_last_valid = airspeed_validated.timestamp;
 			_long_control_state.airspeed_eas = airspeed_validated.calibrated_airspeed_m_s;
-			_long_control_state.eas2tas = constrain(airspeed_validated.true_airspeed_m_s / airspeed_validated.calibrated_airspeed_m_s, 0.9f, 2.0f);
+
+			// before takeoff the ratio can be 0/0 = NaN, which constrain() passes through; keep the previous value then
+			if (fabsf(airspeed_validated.calibrated_airspeed_m_s) > FLT_EPSILON) {
+				_long_control_state.eas2tas = constrain(airspeed_validated.true_airspeed_m_s /
+									airspeed_validated.calibrated_airspeed_m_s, 0.9f, 2.0f);
+			}
 		}
 	}
 


### PR DESCRIPTION
### Solved Problem

Before takeoff, if TAS = CAS = 0, the `eas2tas` conversion computed in the FwLateralLongitudinalControl module becomes NaN. This then results in a NAN TAS, the TECS STE filter doesn't recover from that, and the throttle goes to zero. 

<img width="473" height="336" alt="image" src="https://github.com/user-attachments/assets/0b10f19c-bc3c-4222-8a15-3fe52fb3c903" />

Part of the TECS nan propogation issue (the pitch part) was fixed [here](https://github.com/PX4/PX4-Autopilot/pull/27749), but wasn't flown in the above case. Throttle part not addressed yet. 

### Solution

If `CAS < FLT_EPSILON`, keep the previous `eas2tas`. 


### Changelog Entry
For release notes:
```
Feature/Bugfix  prevent NaN eas2tas from zero-airspeed division in fixedwing controller
```

### Alternatives

The real solution for all of these cases would be to not allow a NaN measurement into the filter and/or reset it if it does enter. While I do that though, this fixes the immediate issue and I would like to get this in. 

