### PR TITLE
feat(reboot): new param to reset also CAL_* params with reboot 

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -253,10 +253,12 @@ else
 	fi
 
 	# To trigger a parameter reset during boot SYS_AUTOCONFIG was set to 1 before
+	set PARAM_RESET_DONE no
 	if param greater SYS_AUTOCONFIG 0
 	then
 		# Reset parameters except airframe, parameter version, sensor calibration, total flight time, flight UUID
-		param reset_all SYS_AUTOSTART SYS_PARAM_VER CAL_* LND_FLIGHT* TC_* COM_FLIGHT*
+		param reset_all SYS_AUTOSTART SYS_PARAM_VER SYS_AUTOCFG_CAL CAL_* LND_FLIGHT* TC_* COM_FLIGHT*
+		set PARAM_RESET_DONE yes
 	fi
 
 	#
@@ -312,6 +314,15 @@ else
 		echo "ERROR [init] No airframe file found for SYS_AUTOSTART value"
 		param set SYS_AUTOSTART 0
 		tune_control play error
+	fi
+
+	# Calibration defaults
+	if [ ${PARAM_RESET_DONE} = yes ]
+	then
+		if param greater SYS_AUTOCFG_CAL 0
+		then
+			param reset CAL_*
+		fi
 	fi
 
 	# Check parameter version and reset upon airframe configuration version mismatch.
@@ -765,6 +776,7 @@ unset LOGGER_BUF
 unset PARAM_FILE
 unset PARAM_BACKUP_FILE
 unset PARAM_DEFAULTS_VER
+unset PARAM_RESET_DONE
 unset RC_INPUT_ARGS
 unset STORAGE_AVAILABLE
 unset STORAGE_CHECK

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -317,9 +317,9 @@ else
 	fi
 
 	# Calibration defaults
-	if [ ${PARAM_RESET_DONE} = yes ]
+	if param greater SYS_AUTOCFG_CAL 0
 	then
-		if param greater SYS_AUTOCFG_CAL 0
+		if [ ${PARAM_RESET_DONE} = yes ]
 		then
 			param reset CAL_* SYS_AUTOCFG_CAL
 		fi

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -321,7 +321,7 @@ else
 	then
 		if param greater SYS_AUTOCFG_CAL 0
 		then
-			param reset CAL_*
+			param reset CAL_* SYS_AUTOCFG_CAL
 		fi
 	fi
 

--- a/src/lib/systemlib/system_params.yaml
+++ b/src/lib/systemlib/system_params.yaml
@@ -26,14 +26,10 @@ parameters:
       default: 0
     SYS_AUTOCFG_CAL:
       description:
-        short: Include sensor calibration in the SYS_AUTOCONFIG reset
+        short: Sensor calibration in SYS_AUTOCONFIG reset
         long: |-
-          Sensor calibration is preserved when a parameter reset is triggered via
-          SYS_AUTOCONFIG. Enable this on airframes that ship their own calibration
-          defaults, so those defaults are re-applied by the reset instead of being
-          shadowed by the stored calibration.
-
-          Has no effect unless SYS_AUTOCONFIG triggers a reset.
+          If enabled, a SYS_AUTOCONFIG reset overwrites stored sensor calibration with the airframe's built-in defaults.
+          Enable when the airframe ships its own calibration.
       type: boolean
       default: 0
     SYS_HITL:

--- a/src/lib/systemlib/system_params.yaml
+++ b/src/lib/systemlib/system_params.yaml
@@ -24,6 +24,18 @@ parameters:
         0: Keep parameters
         1: Reset parameters to airframe defaults
       default: 0
+    SYS_AUTOCFG_CAL:
+      description:
+        short: Include sensor calibration in the SYS_AUTOCONFIG reset
+        long: |-
+          Sensor calibration is preserved when a parameter reset is triggered via
+          SYS_AUTOCONFIG. Enable this on airframes that ship their own calibration
+          defaults, so those defaults are re-applied by the reset instead of being
+          shadowed by the stored calibration.
+
+          Has no effect unless SYS_AUTOCONFIG triggers a reset.
+      type: boolean
+      default: 0
     SYS_HITL:
       description:
         short: Enable HITL/SIH mode on next boot


### PR DESCRIPTION
### Solved Problem
A reboot with SYS_AUTOCONFIG = 1 does not reset those CAL_* values to the airframe default as CAL_* values are excluded from this process together with:
SYS_AUTOSTART, SYS_PARAM_VER, CAL_* , LND_FLIGHT*, TC_* ,  COM_FLIGHT* .

This behaviour is in general wanted but for those airframe that have calibration parameters (CAL_*) in the airframe file, this is a limitation as CAL_ values of the airframe are never applied

### Solution
New parameter SYS_AUTOCFG_CAL default set to 0 that if enabled when also SYS_AUTOCONFIG is enabled, allows setting resetting the CAL_* parameters after a reboot.

Details:
- SYS_AUTOCFG_CAL **can be written in an airframe** file and will apply on the first flash because of the following:
The SYS_AUTOCONFIG block at [rcS:265] before rc.autostart at [rcS:299], so the airframe's param set-default SYS_AUTOCFG_CAL 1 hasn't executed yet and a nested if would read the firmware default of 0 and never fire. PARAM_RESET_DONE carries the fact that a reset happened forward to after the airframe has run, where the flag is finally readable.

- the SYS_AUTOCONFIG block happens before the airframe is actually loaded [rcS:299, . ${R}etc/init.d/rc.autostart] while the one dictated by SYS_AUTOCFG_CAL happens after it so that it can work also with default airframe values. Putting it before would allow running CAL_* values calibration by hand but not using a airframe param default

### Changelog Entry
For release notes:
```
New parameter: SYS_AUTOCFG_CAL
```

### Test coverage

https://github.com/user-attachments/assets/c3faaa49-dea7-408b-aa43-158efd267e97


### Important Note
With this modification if we reset SYS_AUTOCONFIG with SYS_AUTOCFG_CAL enebled we will also see for a couple of seconds after reboot an error due to Gyro not calibrated if gyro calibration values are not stored in the airframe (as in the case of the video below). However since SENS_IMU_AUTOCAL is default 1 after just a couple of seconds it recalibrates automatically.


https://github.com/user-attachments/assets/8a0df657-71ea-4f7c-b1b2-b6f208379304


