### PR TITLE
docs: fix manufacturer URL for Accton Godwit G-A1

### DIFF
--- a/docs/en/flight_controller/accton-godwit_ga1.md
+++ b/docs/en/flight_controller/accton-godwit_ga1.md
@@ -2,7 +2,7 @@
 
 ::: warning
 PX4 does not manufacture this (or any) autopilot.
-Contact the [manufacturer](https://cubepilot.org/#/home) for hardware support or compliance issues.
+Contact the [manufacturer](https://www.accton-iot.com/godwit/) for hardware support or compliance issues.
 :::
 
 The G-A1 is a state-of-the-art flight controller derived from the [Pixhawk Autopilot v6X Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-012%20Pixhawk%20Autopilot%20v6X%20Standard.pdf).

--- a/docs/ko/flight_controller/accton-godwit_ga1.md
+++ b/docs/ko/flight_controller/accton-godwit_ga1.md
@@ -2,7 +2,7 @@
 
 :::warning
 PX4 does not manufacture this (or any) autopilot.
-Contact the [manufacturer](https://cubepilot.org/#/home) for hardware support or compliance issues.
+Contact the [manufacturer](https://www.accton-iot.com/godwit/) for hardware support or compliance issues.
 :::
 
 The G-A1 is a state-of-the-art flight controller derived from the [Pixhawk Autopilot v6X Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-012%20Pixhawk%20Autopilot%20v6X%20Standard.pdf).

--- a/docs/uk/flight_controller/accton-godwit_ga1.md
+++ b/docs/uk/flight_controller/accton-godwit_ga1.md
@@ -2,7 +2,7 @@
 
 :::warning
 PX4 не розробляє цей (або будь-який інший) автопілот.
-Contact the [manufacturer](https://cubepilot.org/#/home) for hardware support or compliance issues.
+Contact the [manufacturer](https://www.accton-iot.com/godwit/) for hardware support or compliance issues.
 :::
 
 The G-A1 is a state-of-the-art flight controller derived from the [Pixhawk Autopilot v6X Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-012%20Pixhawk%20Autopilot%20v6X%20Standard.pdf).

--- a/docs/zh/flight_controller/accton-godwit_ga1.md
+++ b/docs/zh/flight_controller/accton-godwit_ga1.md
@@ -2,7 +2,7 @@
 
 :::warning
 PX4 does not manufacture this (or any) autopilot.
-Contact the [manufacturer](https://cubepilot.org/#/home) for hardware support or compliance issues.
+Contact the [manufacturer](https://www.accton-iot.com/godwit/) for hardware support or compliance issues.
 :::
 
 The G-A1 is a state-of-the-art flight controller derived from the [Pixhawk Autopilot v6X Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-012%20Pixhawk%20Autopilot%20v6X%20Standard.pdf).


### PR DESCRIPTION
### Solved Problem
The manufacturer URL for the Accton Godwit G-A1 pointed to "cubepilot" instead of the correct "accton-iot godwit" page

### Solution
Updated the manufacturer URL in the Godwit G-A1 documentation across the affected language versions.

### Test coverage
N/A — documentation-only change.
