### PR TITLE
docs(commander): document terminate options for critical battery and lost position failsafes

### DIFF
--- a/docs/en/config/safety.md
+++ b/docs/en/config/safety.md
@@ -83,12 +83,13 @@ You can configure both the levels and the failsafe actions at each level in QGro
 ![Safety - Battery (QGC)](../../assets/qgc/setup/safety/safety_battery.png)
 
 The most common configuration is to set the values and action as above (with `Warn > Failsafe > Emergency`), and to set the [Failsafe Action](#COM_LOW_BAT_ACT) to warn at "warn level", trigger Return mode at "Failsafe level", and land immediately at "Emergency level".
+Vehicles that carry a parachute can instead run [Flight termination](#act_term) at "Emergency level" (`COM_LOW_BAT_ACT = 4`), which may be preferable to landing wherever the vehicle happens to be. <Badge type="tip" text="PX4 v1.19" />
 
 The settings and underlying parameters are shown below.
 
 | Setting                                             | Parameter                                                                    | Description                                                                           |
 | --------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| <a id="COM_LOW_BAT_ACT"></a>Failsafe Action         | [COM_LOW_BAT_ACT](../advanced_config/parameter_reference.md#COM_LOW_BAT_ACT) | Warn, Return, or Land based when capacity drops below the trigger levels.             |
+| <a id="COM_LOW_BAT_ACT"></a>Failsafe Action         | [COM_LOW_BAT_ACT](../advanced_config/parameter_reference.md#COM_LOW_BAT_ACT) | Warn, Return, Land, or Terminate based when capacity drops below the trigger levels.  |
 | <a id="BAT_LOW_THR"></a>Battery Warn Level          | [BAT_LOW_THR](../advanced_config/parameter_reference.md#BAT_LOW_THR)         | Percentage capacity for warnings (or other actions).                                  |
 | <a id="BAT_CRIT_THR"></a>Battery Failsafe Level     | [BAT_CRIT_THR](../advanced_config/parameter_reference.md#BAT_CRIT_THR)       | Percentage capacity for Return action (or other actions if a single action selected). |
 | <a id="BAT_EMERGEN_THR"></a>Battery Emergency Level | [BAT_EMERGEN_THR](../advanced_config/parameter_reference.md#BAT_EMERGEN_THR) | Percentage capacity for triggering Land (immediately) action.                         |
@@ -227,13 +228,17 @@ Multicopters will switch to [Altitude mode](../flight_modes_mc/altitude.md) if a
 Fixed-wing planes, and VTOLs not configured to land in hover ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)), have a parameter ([FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT)) that defines how long they will loiter (circle with a constant roll angle ([FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)) at the current altitude) after losing position before attempting to land.
 If VTOLs have are configured to switch to hover for landing ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)) then they will first transition and then descend.
 
+The above applies while the pilot can still take over; in autonomous modes, or if manual control is lost as well, the failsafe escalates through Return and Land to [Descend mode (MC)](../flight_modes_mc/descend.md) or [Descend mode (FW)](../flight_modes_fw/descend.md), which drifts with the wind.
+Set [COM_POS_FS_ACT](#COM_POS_FS_ACT) to `Terminate` to run [Flight termination](#act_term) instead of descending, which is intended for unpiloted vehicles that carry a parachute. <Badge type="tip" text="PX4 v1.19" />
+
 The relevant parameters are:
 
-| Parameter                                                                                       | Description                                                                                                                                  |
-| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| <a id="FW_GPSF_LT"></a>[FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT)       | Fixed-wing only: Loiter time (waiting at current altitude for position estimation recovery before starting to descend). Set to 0 to disable. |
-| <a id="FW_GPSF_R"></a>[FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)          | Fixed roll/bank angle while circling.                                                                                                        |
-| <a id="NAV_FORCE_VT"></a>[NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT) | If true, force VTOL takeoff and landing, even in `Descend` failsafe.                                                                         |
+| Parameter                                                                                             | Description                                                                                                                                  |
+| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| <a id="COM_POS_FS_ACT"></a>[COM_POS_FS_ACT](../advanced_config/parameter_reference.md#COM_POS_FS_ACT) | Action when the failsafe would otherwise Descend. `0`: Descend if possible (default), `1`: Terminate. <Badge type="tip" text="PX4 v1.19" />  |
+| <a id="FW_GPSF_LT"></a>[FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT)             | Fixed-wing only: Loiter time (waiting at current altitude for position estimation recovery before starting to descend). Set to 0 to disable. |
+| <a id="FW_GPSF_R"></a>[FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)                | Fixed roll/bank angle while circling.                                                                                                        |
+| <a id="NAV_FORCE_VT"></a>[NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)       | If true, force VTOL takeoff and landing, even in `Descend` failsafe.                                                                         |
 
 ### Position Accuracy Low Failsafe
 

--- a/docs/en/config/safety.md
+++ b/docs/en/config/safety.md
@@ -82,17 +82,30 @@ You can configure both the levels and the failsafe actions at each level in QGro
 
 ![Safety - Battery (QGC)](../../assets/qgc/setup/safety/safety_battery.png)
 
-The most common configuration is to set the values and action as above (with `Warn > Failsafe > Emergency`), and to set the [Failsafe Action](#COM_LOW_BAT_ACT) to warn at "warn level", trigger Return mode at "Failsafe level", and land immediately at "Emergency level".
-Vehicles that carry a parachute can instead run [Flight termination](#act_term) at "Emergency level" (`COM_LOW_BAT_ACT = 4`), which may be preferable to landing wherever the vehicle happens to be. <Badge type="tip" text="PX4 v1.19" />
+You should set the failsafe levels with `Warn > Failsafe > Emergency` as shown above.
+Note that PX4 will warn if the battery drops to the "Warn level" for any of action settings.
+
+The failsafe actions can then be set to one of:
+
+- `0: Warning` — Warn only.
+- `2: Land mode` — Land at the "Failsafe level".
+- `3: Return at critical level, land at emergency level`: (recommended) — Return mode at "Failsafe" level, Land at "Emergency level".
+- `4: Return at critical level, terminate at emergency level`<Badge type="tip" text="main (PX4 v2.0)" /> — Return mode at "Failsafe" level, [Flight termination](#act_term) at "Emergency level".
+
+  ::: tip
+  This option may be preferred for vehicles that have a [parachute](../peripherals/parachute.md), as it enables controlled landing when there is no power at all.
+
+  If it is not available in the setup screen, [set the parameter](../advanced_config/parameters.md) directly to [COM_LOW_BAT_ACT = 4](../advanced_config/parameter_reference.md#COM_LOW_BAT_ACT).
+  :::
 
 The settings and underlying parameters are shown below.
 
-| Setting                                             | Parameter                                                                    | Description                                                                           |
-| --------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| <a id="COM_LOW_BAT_ACT"></a>Failsafe Action         | [COM_LOW_BAT_ACT](../advanced_config/parameter_reference.md#COM_LOW_BAT_ACT) | Warn, Return, Land, or Terminate based when capacity drops below the trigger levels.  |
-| <a id="BAT_LOW_THR"></a>Battery Warn Level          | [BAT_LOW_THR](../advanced_config/parameter_reference.md#BAT_LOW_THR)         | Percentage capacity for warnings (or other actions).                                  |
-| <a id="BAT_CRIT_THR"></a>Battery Failsafe Level     | [BAT_CRIT_THR](../advanced_config/parameter_reference.md#BAT_CRIT_THR)       | Percentage capacity for Return action (or other actions if a single action selected). |
-| <a id="BAT_EMERGEN_THR"></a>Battery Emergency Level | [BAT_EMERGEN_THR](../advanced_config/parameter_reference.md#BAT_EMERGEN_THR) | Percentage capacity for triggering Land (immediately) action.                         |
+| Setting                                             | Parameter                                                                    | Description                                                                                    |
+| --------------------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| <a id="COM_LOW_BAT_ACT"></a>Failsafe Action         | [COM_LOW_BAT_ACT](../advanced_config/parameter_reference.md#COM_LOW_BAT_ACT) | Warn, Land, or Return and then Land or Terminate when capacity drops below the trigger levels. |
+| <a id="BAT_LOW_THR"></a>Battery Warn Level          | [BAT_LOW_THR](../advanced_config/parameter_reference.md#BAT_LOW_THR)         | Percentage capacity for warnings (or other actions).                                           |
+| <a id="BAT_CRIT_THR"></a>Battery Failsafe Level     | [BAT_CRIT_THR](../advanced_config/parameter_reference.md#BAT_CRIT_THR)       | Percentage capacity for Return action (or other actions if a single action selected).          |
+| <a id="BAT_EMERGEN_THR"></a>Battery Emergency Level | [BAT_EMERGEN_THR](../advanced_config/parameter_reference.md#BAT_EMERGEN_THR) | Percentage capacity for triggering Land (immediately) action.                                  |
 
 ### Flight Time Failsafes
 
@@ -223,22 +236,27 @@ The relevant parameters shown below.
 
 ### Position Loss Failsafe Action
 
-Multicopters will switch to [Altitude mode](../flight_modes_mc/altitude.md) if a height estimate is available, otherwise [Stabilized mode](../flight_modes_mc/manual_stabilized.md).
+Multicopters flying in a position-dependent manual mode, such as [Position mode](../flight_modes_mc/position.md), will switch to [Altitude mode](../flight_modes_mc/altitude.md) if a height estimate is available, and otherwise [Stabilized mode](../flight_modes_mc/manual_stabilized.md).
 
-Fixed-wing planes, and VTOLs not configured to land in hover ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)), have a parameter ([FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT)) that defines how long they will loiter (circle with a constant roll angle ([FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)) at the current altitude) after losing position before attempting to land.
-If VTOLs have are configured to switch to hover for landing ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)) then they will first transition and then descend.
+If manual control is lost as well, or in autonomous modes, PX4 instead attempts _Return mode_ (needs a valid global position and home position), falling back to _Land mode_ (needs a local position estimate), and finally to [Descend mode (MC)](../flight_modes_mc/descend.md) if no position estimate is available at all.
 
-The above applies while the pilot can still take over; in autonomous modes, or if manual control is lost as well, the failsafe escalates through Return and Land to [Descend mode (MC)](../flight_modes_mc/descend.md) or [Descend mode (FW)](../flight_modes_fw/descend.md), which drifts with the wind.
-Set [COM_POS_FS_ACT](#COM_POS_FS_ACT) to `Terminate` to run [Flight termination](#act_term) instead of descending, which is intended for unpiloted vehicles that carry a parachute. <Badge type="tip" text="PX4 v1.19" />
+Fixed-wing planes flying in a position-dependent manual mode, such as [Cruise mode](../flight_modes_fw/cruise.md), will similarly switch to [Altitude mode](../flight_modes_fw/altitude.md) if a height estimate is available, and otherwise [Stabilized mode](../flight_modes_fw/stabilized.md).
+If manual control is lost as well, or in autonomous modes, PX4 again attempts _Return mode_, falling back to _Land mode_, and finally to [Descend mode (FW)](../flight_modes_fw/descend.md).
+In [Descend mode (FW)](../flight_modes_fw/descend.md), the vehicle first loiters — circling with a constant roll angle ([FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)) at the current altitude — for [FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT) seconds, before descending.
+
+VTOLs follow the fixed-wing behaviour above, unless configured to land in hover ([NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)), in which case they instead first transition to hover and then follow the multicopter behaviour.
+
+<Badge type="tip" text="main (PX4 v2.0)" />You can set [COM_POS_FS_ACT](#COM_POS_FS_ACT) to `Terminate` to engage [Flight termination](#act_term) instead of Descend mode.
+This is is intended for unpiloted vehicles that carry a parachute.
 
 The relevant parameters are:
 
-| Parameter                                                                                             | Description                                                                                                                                  |
-| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| <a id="COM_POS_FS_ACT"></a>[COM_POS_FS_ACT](../advanced_config/parameter_reference.md#COM_POS_FS_ACT) | Action when the failsafe would otherwise Descend. `0`: Descend if possible (default), `1`: Terminate. <Badge type="tip" text="PX4 v1.19" />  |
-| <a id="FW_GPSF_LT"></a>[FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT)             | Fixed-wing only: Loiter time (waiting at current altitude for position estimation recovery before starting to descend). Set to 0 to disable. |
-| <a id="FW_GPSF_R"></a>[FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)                | Fixed roll/bank angle while circling.                                                                                                        |
-| <a id="NAV_FORCE_VT"></a>[NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)       | If true, force VTOL takeoff and landing, even in `Descend` failsafe.                                                                         |
+| Parameter                                                                                             | Description                                                                                                                                       |
+| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <a id="COM_POS_FS_ACT"></a>[COM_POS_FS_ACT](../advanced_config/parameter_reference.md#COM_POS_FS_ACT) | <Badge type="tip" text="main (PX4 v2.0)" /> Action when the failsafe would otherwise Descend. `0`: Descend if possible (default), `1`: Terminate. |
+| <a id="FW_GPSF_LT"></a>[FW_GPSF_LT](../advanced_config/parameter_reference.md#FW_GPSF_LT)             | Fixed-wing only: Loiter time (waiting at current altitude for position estimation recovery before starting to descend). Set to 0 to disable.      |
+| <a id="FW_GPSF_R"></a>[FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)                | Fixed roll/bank angle while circling.                                                                                                             |
+| <a id="NAV_FORCE_VT"></a>[NAV_FORCE_VT](../advanced_config/parameter_reference.md#NAV_FORCE_VT)       | If true, force VTOL takeoff and landing, even in `Descend` failsafe.                                                                              |
 
 ### Position Accuracy Low Failsafe
 

--- a/docs/en/flight_modes_fw/descend.md
+++ b/docs/en/flight_modes_fw/descend.md
@@ -16,7 +16,7 @@ It is the last resort used when the vehicle must come down but has no valid posi
 
 ## When It Occurs
 
-Descend is the bottom of the failsafe chain (`Hold → Return → Land → Descend`).
+Descend is the bottom of the failsafe chain (`Hold → Return → Land → Descend`), unless [COM_POS_FS_ACT](../advanced_config/parameter_reference.md#COM_POS_FS_ACT) is set to `Terminate`, which replaces it with [Flight termination](../advanced_config/flight_termination.md). <Badge type="tip" text="PX4 v1.19" />
 PX4 falls through to it whenever a failsafe needs to bring the vehicle down or hold position but the position estimate is missing, so none of the higher options can run. For example:
 
 - Losing the position estimate while landing, e.g. GNSS and airspeed sensors fail during [Land](../flight_modes_fw/land.md): the vehicle keeps descending, but now open-loop as _Descend_.

--- a/docs/en/flight_modes_fw/descend.md
+++ b/docs/en/flight_modes_fw/descend.md
@@ -1,7 +1,7 @@
 # Descend Mode (Fixed-Wing)
 
-_Descend_ is a [failsafe](../config/safety.md) fallback mode.
-It is activated automatically by PX4 and cannot be selected by the pilot. It only appears as a status label.
+_Descend_ is a [failsafe](../config/safety.md) fallback mode that is activated automatically by PX4.
+The mode is published when active but cannot be selected by the pilot.
 
 The vehicle descends open-loop: it circles at a fixed bank angle ([FW_GPSF_R](../advanced_config/parameter_reference.md#FW_GPSF_R)) and descends at a fixed 0.5 m/s, but does not control its ground position, so the circle drifts with the wind.
 It is the last resort used when the vehicle must come down but has no valid position estimate for a controlled descent.
@@ -16,8 +16,18 @@ It is the last resort used when the vehicle must come down but has no valid posi
 
 ## When It Occurs
 
-Descend is the bottom of the failsafe chain (`Hold → Return → Land → Descend`), unless [COM_POS_FS_ACT](../advanced_config/parameter_reference.md#COM_POS_FS_ACT) is set to `Terminate`, which replaces it with [Flight termination](../advanced_config/flight_termination.md). <Badge type="tip" text="PX4 v1.19" />
-PX4 falls through to it whenever a failsafe needs to bring the vehicle down or hold position but the position estimate is missing, so none of the higher options can run. For example:
+Descend mode is at the bottom of the failsafe chain (along with [Flight termination](../advanced_config/flight_termination.md)):
+
+```text
+Hold → Return → Land → ( Descend | Terminate )
+```
+
+::: tip
+[COM_POS_FS_ACT](../advanced_config/parameter_reference.md#COM_POS_FS_ACT) <Badge type="tip" text="main (PX4 v2.0)" /> selects whether `Descend` or `Terminate` is used as the failsafe.
+:::
+
+PX4 falls through to Descend mode whenever a failsafe needs to bring the vehicle down or hold position but the position estimate is missing, so none of the higher options can run.
+For example:
 
 - Losing the position estimate while landing, e.g. GNSS and airspeed sensors fail during [Land](../flight_modes_fw/land.md): the vehicle keeps descending, but now open-loop as _Descend_.
 - Losing the position estimate in [Hold](../flight_modes_fw/hold.md), [Mission](../flight_modes_fw/mission.md) or [Return](../flight_modes_fw/return.md): with no position to hold, fly to, or return with, the failsafe escalates down to _Descend_.
@@ -25,10 +35,10 @@ PX4 falls through to it whenever a failsafe needs to bring the vehicle down or h
 
 ## Exiting Descend
 
-Descend ends when either:
+Descend ends when either the:
 
-- the failsafe condition is resolved (e.g. the position estimate recovers), and the vehicle returns to its previous mode; or
-- the pilot takes over by switching to a manual mode ([Cruise](../flight_modes_fw/cruise.md), [Altitude](../flight_modes_fw/altitude.md) or [Stabilized](../flight_modes_fw/stabilized.md)).
+- failsafe condition is resolved (e.g. the position estimate recovers), and the vehicle returns to its previous mode; or
+- pilot takes over by switching to a manual mode ([Cruise](../flight_modes_fw/cruise.md), [Altitude](../flight_modes_fw/altitude.md) or [Stabilized](../flight_modes_fw/stabilized.md)).
 
 ## See Also
 

--- a/docs/en/flight_modes_mc/descend.md
+++ b/docs/en/flight_modes_mc/descend.md
@@ -16,7 +16,7 @@ It is the last resort used when the vehicle must come down but has no valid posi
 
 ## When It Occurs
 
-Descend is the bottom of the failsafe chain (`Hold → Return → Land → Descend`).
+Descend is the bottom of the failsafe chain (`Hold → Return → Land → Descend`), unless [COM_POS_FS_ACT](../advanced_config/parameter_reference.md#COM_POS_FS_ACT) is set to `Terminate`, which replaces it with [Flight termination](../advanced_config/flight_termination.md). <Badge type="tip" text="PX4 v1.19" />
 PX4 falls through to it whenever a failsafe needs to bring the vehicle down or hold position but the position estimate is missing, so none of the higher options can run. For example:
 
 - Losing the position estimate while landing, e.g. GNSS fails during [Land](../flight_modes_mc/land.md): the vehicle keeps descending, but now open-loop as _Descend_.

--- a/docs/en/flight_modes_mc/descend.md
+++ b/docs/en/flight_modes_mc/descend.md
@@ -1,7 +1,7 @@
 # Descend Mode (Multicopter)
 
-_Descend_ is a [failsafe](../config/safety.md) fallback mode.
-It is activated automatically by PX4 and cannot be selected by the pilot. It only appears as a status label.
+_Descend_ is a [failsafe](../config/safety.md) fallback mode that is activated automatically by PX4.
+The mode is published when active but cannot be selected by the pilot.
 
 The vehicle descends open-loop: it keeps its attitude and reduces altitude, but does not control its horizontal position, so it drifts with the wind.
 It is the last resort used when the vehicle must come down but has no valid position estimate for a controlled descent.
@@ -16,8 +16,18 @@ It is the last resort used when the vehicle must come down but has no valid posi
 
 ## When It Occurs
 
-Descend is the bottom of the failsafe chain (`Hold → Return → Land → Descend`), unless [COM_POS_FS_ACT](../advanced_config/parameter_reference.md#COM_POS_FS_ACT) is set to `Terminate`, which replaces it with [Flight termination](../advanced_config/flight_termination.md). <Badge type="tip" text="PX4 v1.19" />
-PX4 falls through to it whenever a failsafe needs to bring the vehicle down or hold position but the position estimate is missing, so none of the higher options can run. For example:
+Descend mode is at the bottom of the failsafe chain (along with [Flight termination](../advanced_config/flight_termination.md)):
+
+```text
+Hold → Return → Land → ( Descend | Terminate )
+```
+
+::: tip
+[COM_POS_FS_ACT](../advanced_config/parameter_reference.md#COM_POS_FS_ACT) <Badge type="tip" text="main (PX4 v2.0)" /> selects whether `Descend` or `Terminate` is used as the failsafe.
+:::
+
+PX4 falls through to Descend mode whenever a failsafe needs to bring the vehicle down or hold position but the position estimate is missing, so none of the higher options can run.
+For example:
 
 - Losing the position estimate while landing, e.g. GNSS fails during [Land](../flight_modes_mc/land.md): the vehicle keeps descending, but now open-loop as _Descend_.
 - Losing the position estimate in [Hold](../flight_modes_mc/hold.md), [Mission](../flight_modes_mc/mission.md) or [Return](../flight_modes_mc/return.md): with no position to hold, fly to, or return with, the failsafe escalates down to _Descend_.
@@ -25,10 +35,11 @@ PX4 falls through to it whenever a failsafe needs to bring the vehicle down or h
 
 ## Exiting Descend
 
-Descend ends when either:
+Descend ends when either the:
 
-- the failsafe condition is resolved (e.g. the position estimate recovers), and the vehicle returns to its previous mode; or
-- the pilot takes over by switching to a manual mode ([Position](../flight_modes_mc/position.md), [Altitude](../flight_modes_mc/altitude.md) or [Stabilized](../flight_modes_mc/manual_stabilized.md)). On a multicopter, moving the sticks does this [by default](../flight_modes_mc/land.md#MAN_OVERRIDE_SPD).
+- failsafe condition is resolved (e.g. the position estimate recovers), and the vehicle returns to its previous mode; or
+- pilot takes over by switching to a manual mode ([Position](../flight_modes_mc/position.md), [Altitude](../flight_modes_mc/altitude.md) or [Stabilized](../flight_modes_mc/manual_stabilized.md)).
+  On a multicopter, moving the sticks does this [by default](../flight_modes_mc/land.md#MAN_OVERRIDE_SPD).
 
 ## See Also
 

--- a/docs/en/releases/main.md
+++ b/docs/en/releases/main.md
@@ -51,7 +51,8 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 ### Safety
 
 - [Geofence Aware Return mode](../flight_modes/return.md#geofence_awareness). ([PX4-Autopilot#27145: feat(navigator): Geofence Aware RTL](https://github.com/PX4/PX4-Autopilot/pull/27145), [PX4-Autopilot#28001: docs(navigator): [geofence] added some more warnings about limitations](https://github.com/PX4/PX4-Autopilot/pull/28001)).
-- Flight termination can now be used instead of a blind descent, for unpiloted vehicles that carry a parachute: see [Battery level failsafe](../config/safety.md#battery-level-failsafe) ([COM_LOW_BAT_ACT](../advanced_config/parameter_reference.md#COM_LOW_BAT_ACT)) and [Position Loss Failsafe Action](../config/safety.md#position-loss-failsafe-action) (new [COM_POS_FS_ACT](../advanced_config/parameter_reference.md#COM_POS_FS_ACT)). ([PX4-Autopilot#28064: feat(commander): add terminate options for critical battery and lost position failsafes](https://github.com/PX4/PX4-Autopilot/pull/28064)).
+- [Flight termination](../advanced_config/flight_termination.md) can now be used instead of a Descent mode as a fallback failsafe mode, allowing safer landing for unpiloted vehicles that carry a parachute.
+  See [Battery level failsafe](../config/safety.md#battery-level-failsafe) ([COM_LOW_BAT_ACT](../advanced_config/parameter_reference.md#COM_LOW_BAT_ACT)) and [Position Loss Failsafe Action](../config/safety.md#position-loss-failsafe-action) (new [COM_POS_FS_ACT](../advanced_config/parameter_reference.md#COM_POS_FS_ACT)). ([PX4-Autopilot#28064: feat(commander): add terminate options for critical battery and lost position failsafes](https://github.com/PX4/PX4-Autopilot/pull/28064)).
 
 ### Estimation
 

--- a/docs/en/releases/main.md
+++ b/docs/en/releases/main.md
@@ -51,6 +51,7 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 ### Safety
 
 - [Geofence Aware Return mode](../flight_modes/return.md#geofence_awareness). ([PX4-Autopilot#27145: feat(navigator): Geofence Aware RTL](https://github.com/PX4/PX4-Autopilot/pull/27145), [PX4-Autopilot#28001: docs(navigator): [geofence] added some more warnings about limitations](https://github.com/PX4/PX4-Autopilot/pull/28001)).
+- Flight termination can now be used instead of a blind descent, for unpiloted vehicles that carry a parachute: see [Battery level failsafe](../config/safety.md#battery-level-failsafe) ([COM_LOW_BAT_ACT](../advanced_config/parameter_reference.md#COM_LOW_BAT_ACT)) and [Position Loss Failsafe Action](../config/safety.md#position-loss-failsafe-action) (new [COM_POS_FS_ACT](../advanced_config/parameter_reference.md#COM_POS_FS_ACT)). ([PX4-Autopilot#28064: feat(commander): add terminate options for critical battery and lost position failsafes](https://github.com/PX4/PX4-Autopilot/pull/28064)).
 
 ### Estimation
 

--- a/src/modules/commander/commander_params.yaml
+++ b/src/modules/commander/commander_params.yaml
@@ -373,7 +373,7 @@ parameters:
       description:
         short: Loss of position failsafe action
         long: |-
-          Final fallback failsafe action for loss of horizontal position:
+          Final fallback failsafe action for loss of horizontal position in autonomous modes:
           - Descend (potential for horizontal drift on landing)
           - Flight termination (allows parachute landing)
       type: enum

--- a/src/modules/commander/commander_params.yaml
+++ b/src/modules/commander/commander_params.yaml
@@ -371,17 +371,14 @@ parameters:
       decimal: 1
     COM_POS_FS_ACT:
       description:
-        short: Loss of position autonomous failsafe action
+        short: Loss of position failsafe action
         long: |-
-          If no autonomous horizontal navigation is possible anymore should the vehicle attempt to
-          descend blindly and land or terminate which can be preferable if there's a parachute and no pilot.
-
-          Action to take when autonomous horizontal navigation is lost:
-          - "Descend if possible" blind with potential drift and uncontrolled landing (risk of hitting obstacles)
-          - "Terminate" can be preferred for unpiloted use with emergency parachute
+          Final fallback failsafe action for loss of horizontal position:
+          - Descend (potential for horizontal drift on landing)
+          - Flight termination (allows parachute landing)
       type: enum
       values:
-        0: Descend if possible
+        0: Descend mode
         1: Terminate
       default: 0
     COM_VEL_FS_EVH:


### PR DESCRIPTION
### Solved Problem

#28064 added flight termination as a failsafe action for critical battery and loss of position, but the Safety configuration docs still described only the land/descend behaviour, so neither new option was discoverable.

Documentation follow-up requested in review on #28064 by @hamishwillee.

### Solution

- **[Battery level failsafe](https://docs.px4.io/main/en/config/safety#battery-level-failsafe)** — note that a vehicle carrying a parachute can run flight termination at "Emergency level" (`COM_LOW_BAT_ACT = 4`), and extend the `COM_LOW_BAT_ACT` row to include Terminate.
- **[Position Loss Failsafe Action](https://docs.px4.io/main/en/config/safety#position-loss-failsafe-action)** — document the new `COM_POS_FS_ACT`. This section previously described only the case where the pilot can still take over (fallback to Altitude/Stabilized), so it now also covers the escalation to Descend that applies in autonomous modes, or when manual control is lost as well.
- **Descend mode (MC and FW)** — both pages stated that Descend is unconditionally the bottom of the failsafe chain (`Hold → Return → Land → Descend`). `COM_POS_FS_ACT = 1` makes that untrue, so that sentence is amended on each page.
- **Release notes** — one entry under `### Safety` in `releases/main.md`.

### Changelog Entry

```
Documentation: flight termination can now be selected instead of a blind descent, for unpiloted vehicles carrying a parachute: docs.px4.io/main/en/config/safety#battery-level-failsafe and docs.px4.io/main/en/config/safety#position-loss-failsafe-action
```

### Test coverage

Docs-only change; no flight testing applicable. The underlying behaviour was tested in #28064 (SIH: position loss and battery drain scenarios, confirming termination at the emergency threshold).

### Context

- Code PR: #28064 (merged 2026-07-28 as `8ffe6e5`)
- Parameters: `COM_LOW_BAT_ACT`, `COM_POS_FS_ACT`
- Pages touched: `config/safety.md`, `flight_modes_mc/descend.md`, `flight_modes_fw/descend.md`, `releases/main.md`