### PR TITLE
fix(commander): require rate and attitude to switch to Manual mode on MC

### DIFF
--- a/src/modules/commander/ModeUtil/control_mode.cpp
+++ b/src/modules/commander/ModeUtil/control_mode.cpp
@@ -38,11 +38,6 @@
 namespace mode_util
 {
 
-static bool stabilization_required(uint8_t vehicle_type)
-{
-	return vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING;
-}
-
 void getVehicleControlMode(uint8_t nav_state, uint8_t vehicle_type,
 			   const offboard_control_mode_s &offboard_control_mode,
 			   vehicle_control_mode_s &vehicle_control_mode, SetpointType external_mode_setpoint_type)
@@ -52,7 +47,7 @@ void getVehicleControlMode(uint8_t nav_state, uint8_t vehicle_type,
 	case vehicle_status_s::NAVIGATION_STATE_MANUAL:
 		vehicle_control_mode.flag_control_manual_enabled = true;
 
-		if (stabilization_required(vehicle_type)) {
+		if (stabilizationRequired(vehicle_type)) {
 			getControlMode(SetpointType::Attitude, vehicle_control_mode);
 
 		} else {

--- a/src/modules/commander/ModeUtil/control_mode.hpp
+++ b/src/modules/commander/ModeUtil/control_mode.hpp
@@ -35,12 +35,23 @@
 
 #include <uORB/topics/offboard_control_mode.h>
 #include <uORB/topics/vehicle_control_mode.h>
+#include <uORB/topics/vehicle_status.h>
 
 #include <stdint.h>
 #include "setpoint_types.hpp"
 
 namespace mode_util
 {
+
+/**
+ * Whether Manual mode is attitude-stabilized for a given vehicle type (as opposed to a direct
+ * passthrough to thrust and torque). If true, Manual is equivalent to Stabilized.
+ * @param vehicle_type one of vehicle_status_s::VEHICLE_TYPE_*
+ */
+static inline bool stabilizationRequired(uint8_t vehicle_type)
+{
+	return vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING;
+}
 
 void getVehicleControlMode(uint8_t nav_state, uint8_t vehicle_type,
 			   const offboard_control_mode_s &offboard_control_mode,

--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -32,6 +32,7 @@
  ****************************************************************************/
 
 #include "mode_requirements.hpp"
+#include "control_mode.hpp"
 #include <uORB/topics/vehicle_status.h>
 
 namespace mode_util
@@ -62,6 +63,12 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 
 	// NAVIGATION_STATE_MANUAL
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_MANUAL, flags.mode_req_manual_control);
+
+	if (stabilizationRequired(vehicle_type)) {
+		// Manual is attitude-stabilized, i.e. equivalent to Stabilized
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_MANUAL, flags.mode_req_angular_velocity);
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_MANUAL, flags.mode_req_attitude);
+	}
 
 	// NAVIGATION_STATE_ALTCTL
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_ALTCTL, flags.mode_req_angular_velocity);


### PR DESCRIPTION
### Solved Problem

On multicopters, Manual and Stabilized are the same mode: `getVehicleControlMode()`
maps `NAVIGATION_STATE_MANUAL` to `SetpointType::Attitude` for rotary wing, identical
to `NAVIGATION_STATE_STAB`. Only on fixed wing and rovers is Manual a direct
thrust-and-torque passthrough.

The mode requirements did not reflect this. `NAVIGATION_STATE_MANUAL` declared only
`mode_req_manual_control` for every vehicle type, while `NAVIGATION_STATE_STAB`
declared angular velocity + attitude + manual control. So on a multicopter, Manual
under-declared what the attitude controller actually needs, which affects:

- `modeCheck.cpp`: with `attitude_invalid` / `angular_velocity_invalid`, Manual was
  neither cleared from can-run nor reported as an arming failure, so it stayed
  armable and selectable even though nothing can close the attitude loop.
- `FailsafeBase::modeAvailable()`: Manual stayed available with an invalid attitude
  estimate.
- `estimatorCheck.cpp`: EKF pre-flight innovation failures are reported against the
  `mode_req_attitude` group, which excluded Manual on multicopters.

### Solution

Declare angular velocity and attitude requirements for Manual when the vehicle type
needs stabilization, so Manual and Stabilized have identical requirements on
multicopters and Manual stays a passthrough mode on fixed wing and rovers.

The `vehicle_type == VEHICLE_TYPE_ROTARY_WING` check was moved from a static helper
in `control_mode.cpp` into a shared `stabilizationRequired()` in `control_mode.hpp`,
used by both `getVehicleControlMode()` and `getModeRequirements()`. This is what
allowed the two to drift apart in the first place — they now derive the condition
from one place.

VTOL needs no special handling: `vehicle_type` is dynamic and `getModeRequirements()`
is re-run every check cycle from `Report::prepare()`, so requirements follow the
transition like the existing FW/MC branches in that file.

### Changelog Entry

For release notes:

Bugfix: Manual mode on multicopters now correctly requires a valid attitude and
angular velocity estimate, matching Stabilized mode. Previously it could be armed
and selected without them.

### Alternatives
Remove the "manual" mode completely for any hovering vehicle. The naming is bad and the duplication with Stabilized causes confusion.

### Test coverage

- `make format` / `make check_format` pass
- SITL builds clean
- No behaviour change for fixed wing, VTOL in FW mode, or rovers