### PR TITLE
fix(external-modes): instantiate params at init

### DIFF
--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -82,6 +82,16 @@ void ModeExecutors::printStatus(int executor_in_charge) const
 	}
 }
 
+Modes::Modes()
+{
+	char hash_param_name[17];
+
+	for (int i = 0; i < MAX_NUM; i++) {
+		snprintf(hash_param_name, sizeof(hash_param_name), "COM_MODE%d_HASH", i);
+		_mode_hash_handles[i] = param_find(hash_param_name);
+	}
+}
+
 bool Modes::hasFreeExternalModes() const
 {
 	for (int i = 0; i < MAX_NUM; ++i) {
@@ -108,9 +118,7 @@ uint8_t Modes::addExternalMode(const Modes::Mode &mode)
 	int matching_idx = -1;
 
 	for (int i = 0; i < MAX_NUM; ++i) {
-		char hash_param_name[17];
-		snprintf(hash_param_name, sizeof(hash_param_name), "COM_MODE%d_HASH", i);
-		const param_t handle = param_find(hash_param_name);
+		const param_t handle = _mode_hash_handles[i];
 		int32_t current_hash{};
 
 		if (handle != PARAM_INVALID && param_get(handle, &current_hash) == 0) {
@@ -165,9 +173,7 @@ uint8_t Modes::addExternalMode(const Modes::Mode &mode)
 
 	if (new_mode_idx != -1 && !_modes[new_mode_idx].valid) {
 		if (need_to_update_param) {
-			char hash_param_name[17];
-			snprintf(hash_param_name, sizeof(hash_param_name), "COM_MODE%d_HASH", new_mode_idx);
-			const param_t handle = param_find(hash_param_name);
+			const param_t handle = _mode_hash_handles[new_mode_idx];
 
 			if (handle != PARAM_INVALID) {
 				param_set_no_notification(handle, &mode_name_hash);

--- a/src/modules/commander/ModeManagement.hpp
+++ b/src/modules/commander/ModeManagement.hpp
@@ -102,6 +102,8 @@ public:
 		mode_util::SetpointType current_setpoint_type{kDefaultSetpointType};
 	};
 
+	Modes();
+
 	void printStatus() const;
 
 	bool valid(uint8_t nav_state) const { return nav_state >= FIRST_EXTERNAL_NAV_STATE && nav_state <= LAST_EXTERNAL_NAV_STATE && _modes[nav_state - FIRST_EXTERNAL_NAV_STATE].valid; }
@@ -114,6 +116,7 @@ public:
 
 private:
 	Mode _modes[MAX_NUM] {};
+	param_t _mode_hash_handles[MAX_NUM];
 };
 
 


### PR DESCRIPTION
### Solved Problem

- External modes get registered at runtime, so the used param count may dynamically change after PX4 already booted
- This can mess up QGC (other ground stations), when the param count changes while they are trying to download parameters, because the change in param count shifts used param indices, causing param downloads to fail 

### Solution

- In general we should avoid that the amount of **used** parameters changes after QGC is already connected as this can lead to unexpected behavior
- In this case it was the external modes that may be get used while they were not used when QGC connected. This is fixed by always having them marked as used in the constructor. This costs us minimal param storage (8 params) and solves param downloading issues

### Test coverage

Tested on the bench with a v6s