### PR TITLE
refactor(drivers/uavcan): de-templatize GenericSubscriber transfer forwarder

### DIFF
--- a/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/node/generic_subscriber.hpp
+++ b/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/node/generic_subscriber.hpp
@@ -103,11 +103,21 @@ protected:
         , failure_count_(0)
     { }
 
-    ~GenericSubscriberBase() { }
+    virtual ~GenericSubscriberBase() { }
 
     int genericStart(TransferListener* listener, bool (Dispatcher::*registration_method)(TransferListener*));
 
     void stop(TransferListener* listener);
+
+    /**
+     * Type-specific handler for a fully received transfer (message decoding followed by dispatch
+     * to the user callback). It is implemented by the templated GenericSubscriber and invoked
+     * through TransferForwarder, which keeps this (relatively large) logic the only per-data-type
+     * code that has to be generated.
+     */
+    virtual void handleIncomingTransfer(IncomingTransfer& transfer) = 0;
+
+    template <typename TransferListenerType> friend class TransferForwarder;
 
 public:
     /**
@@ -121,44 +131,110 @@ public:
 };
 
 /**
+ * Data-type-agnostic transfer forwarder. It only depends on the transfer listener type
+ * (TransferListener or TransferListenerWithFilter), so at most two instantiations are generated
+ * regardless of how many data types are subscribed to. The received transfer is dispatched to the
+ * owning subscriber through a virtual call, which keeps all per-data-type code inside
+ * GenericSubscriber::handleIncomingTransfer().
+ */
+template <typename TransferListenerType>
+class UAVCAN_EXPORT TransferForwarder : public TransferListenerType
+{
+    GenericSubscriberBase& obj_;
+
+    void handleIncomingTransfer(IncomingTransfer& transfer) override
+    {
+        obj_.handleIncomingTransfer(transfer);
+    }
+
+public:
+    TransferForwarder(GenericSubscriberBase& obj,
+                      const DataTypeDescriptor& data_type,
+                      uint16_t max_buffer_size,
+                      IPoolAllocator& allocator) :
+        TransferListenerType(obj.getNode().getDispatcher().getTransferPerfCounter(),
+                             data_type,
+                             max_buffer_size,
+                             allocator),
+        obj_(obj)
+    { }
+};
+
+/**
+ * Intermediate base that owns the lazily-constructed transfer forwarder and implements the
+ * subscription setup. It is parametrized only by the transfer listener type, so this
+ * (relatively large) setup/forwarder machinery is instantiated at most twice instead of once
+ * per subscribed data type.
+ */
+template <typename TransferListenerType>
+class UAVCAN_EXPORT GenericSubscriberOnListener : public GenericSubscriberBase
+{
+    LazyConstructor<TransferForwarder<TransferListenerType> > forwarder_;
+
+protected:
+    explicit GenericSubscriberOnListener(INode& node) : GenericSubscriberBase(node)
+    { }
+
+    int checkInitAndStart(DataTypeKind data_type_kind, const char* data_type_full_name, uint16_t max_buffer_size,
+                          bool (Dispatcher::*registration_method)(TransferListener*))
+    {
+        if (!forwarder_)
+        {
+            GlobalDataTypeRegistry::instance().freeze();
+            const DataTypeDescriptor* const descr =
+                GlobalDataTypeRegistry::instance().find(data_type_kind, data_type_full_name);
+            if (descr == UAVCAN_NULLPTR)
+            {
+                UAVCAN_TRACE("GenericSubscriber", "Type [%s] is not registered", data_type_full_name);
+                return -ErrUnknownDataType;
+            }
+
+            forwarder_.template construct<GenericSubscriberBase&, const DataTypeDescriptor&, uint16_t, IPoolAllocator&>
+                (*this, *descr, max_buffer_size, node_.getAllocator());
+        }
+
+        return GenericSubscriberBase::genericStart(forwarder_, registration_method);
+    }
+
+    /**
+     * By default, anonymous transfers will be ignored.
+     * This option allows to enable reception of anonymous transfers.
+     */
+    void allowAnonymousTransfers()
+    {
+        forwarder_->allowAnonymousTransfers();
+    }
+
+    /**
+     * Terminate the subscription.
+     * Dispatcher core will remove this instance from the subscribers list.
+     */
+    void stop()
+    {
+        GenericSubscriberBase::stop(forwarder_);
+    }
+
+    TransferListenerType* getTransferListener() { return forwarder_; }
+};
+
+/**
  * Please note that the reference passed to the RX callback points to a stack-allocated object, which means
  * that it gets invalidated shortly after the callback returns.
  */
 template <typename DataSpec, typename DataStruct, typename TransferListenerType>
-class UAVCAN_EXPORT GenericSubscriber : public GenericSubscriberBase
+class UAVCAN_EXPORT GenericSubscriber : public GenericSubscriberOnListener<TransferListenerType>
 {
-    typedef GenericSubscriber<DataSpec, DataStruct, TransferListenerType> SelfType;
+    typedef GenericSubscriberOnListener<TransferListenerType> BaseType;
 
-    // We need to break the inheritance chain here to implement lazy initialization
-    class TransferForwarder : public TransferListenerType
+    void handleIncomingTransfer(IncomingTransfer& transfer) override;
+
+    int genericStart(bool (Dispatcher::*registration_method)(TransferListener*))
     {
-        SelfType& obj_;
-
-        void handleIncomingTransfer(IncomingTransfer& transfer) override
-        {
-            obj_.handleIncomingTransfer(transfer);
-        }
-
-    public:
-        TransferForwarder(SelfType& obj,
-                          const DataTypeDescriptor& data_type,
-                          uint16_t max_buffer_size,
-                          IPoolAllocator& allocator) :
-            TransferListenerType(obj.node_.getDispatcher().getTransferPerfCounter(),
-                                 data_type,
-                                 max_buffer_size,
-                                 allocator),
-            obj_(obj)
-        { }
-    };
-
-    LazyConstructor<TransferForwarder> forwarder_;
-
-    int checkInit();
-
-    void handleIncomingTransfer(IncomingTransfer& transfer);
-
-    int genericStart(bool (Dispatcher::*registration_method)(TransferListener*));
+        return BaseType::checkInitAndStart(DataTypeKind(DataSpec::DataTypeKind),
+                                           DataSpec::getDataTypeFullName(),
+                                           uint16_t(BitLenToByteLen<DataStruct::MaxBitLen>::Result),
+                                           registration_method);
+    }
 
 protected:
     struct ReceivedDataStructureSpec : public ReceivedDataStructure<DataStruct>
@@ -170,10 +246,10 @@ protected:
         { }
     };
 
-    explicit GenericSubscriber(INode& node) : GenericSubscriberBase(node)
+    explicit GenericSubscriber(INode& node) : BaseType(node)
     { }
 
-    virtual ~GenericSubscriber() { stop(); }
+    virtual ~GenericSubscriber() { this->stop(); }
 
     virtual void handleReceivedDataStruct(ReceivedDataStructure<DataStruct>&) = 0;
 
@@ -196,27 +272,6 @@ protected:
                      DataSpec::getDataTypeFullName());
         return genericStart(&Dispatcher::registerServiceResponseListener);
     }
-
-    /**
-     * By default, anonymous transfers will be ignored.
-     * This option allows to enable reception of anonymous transfers.
-     */
-    void allowAnonymousTransfers()
-    {
-        forwarder_->allowAnonymousTransfers();
-    }
-
-    /**
-     * Terminate the subscription.
-     * Dispatcher core will remove this instance from the subscribers list.
-     */
-    void stop()
-    {
-        UAVCAN_TRACE("GenericSubscriber", "Stop; dtname=%s", DataSpec::getDataTypeFullName());
-        GenericSubscriberBase::stop(forwarder_);
-    }
-
-    TransferListenerType* getTransferListener() { return forwarder_; }
 };
 
 // ----------------------------------------------------------------------------
@@ -224,31 +279,6 @@ protected:
 /*
  * GenericSubscriber
  */
-template <typename DataSpec, typename DataStruct, typename TransferListenerType>
-int GenericSubscriber<DataSpec, DataStruct, TransferListenerType>::checkInit()
-{
-    if (forwarder_)
-    {
-        return 0;
-    }
-
-    GlobalDataTypeRegistry::instance().freeze();
-    const DataTypeDescriptor* const descr =
-        GlobalDataTypeRegistry::instance().find(DataTypeKind(DataSpec::DataTypeKind), DataSpec::getDataTypeFullName());
-    if (descr == UAVCAN_NULLPTR)
-    {
-        UAVCAN_TRACE("GenericSubscriber", "Type [%s] is not registered", DataSpec::getDataTypeFullName());
-        return -ErrUnknownDataType;
-    }
-
-    static const uint16_t MaxBufferSize = BitLenToByteLen<DataStruct::MaxBitLen>::Result;
-
-    forwarder_.template construct<SelfType&, const DataTypeDescriptor&, uint16_t, IPoolAllocator&>
-        (*this, *descr, MaxBufferSize, node_.getAllocator());
-
-    return 0;
-}
-
 template <typename DataSpec, typename DataStruct, typename TransferListenerType>
 void GenericSubscriber<DataSpec, DataStruct, TransferListenerType>::handleIncomingTransfer(IncomingTransfer& transfer)
 {
@@ -269,28 +299,15 @@ void GenericSubscriber<DataSpec, DataStruct, TransferListenerType>::handleIncomi
     {
         UAVCAN_TRACE("GenericSubscriber", "Unable to decode the message [%i] [%s]",
                      decode_res, DataSpec::getDataTypeFullName());
-        failure_count_++;
-        node_.getDispatcher().getTransferPerfCounter().addError();
+        this->failure_count_++;
+        this->node_.getDispatcher().getTransferPerfCounter().addError();
         return;
     }
 
     /*
      * Invoking the callback
      */
-    handleReceivedDataStruct(rx_struct);
-}
-
-template <typename DataSpec, typename DataStruct, typename TransferListenerType>
-int GenericSubscriber<DataSpec, DataStruct, TransferListenerType>::
-genericStart(bool (Dispatcher::*registration_method)(TransferListener*))
-{
-    const int res = checkInit();
-    if (res < 0)
-    {
-        UAVCAN_TRACE("GenericSubscriber", "Initialization failure [%s]", DataSpec::getDataTypeFullName());
-        return res;
-    }
-    return GenericSubscriberBase::genericStart(forwarder_, registration_method);
+    this->handleReceivedDataStruct(rx_struct);
 }
 
 


### PR DESCRIPTION
### Solved Problem
UAVCAN flash savings

### Solution

Inspired by #26476, to find some flash savings.

GenericSubscriber was one big template based on the data type. Because of that, its setup code, the TransferForwarder, and the transfer listener code were built again for every data type, so the same code was copied many times.

Move the parts that don't depend on the data type out of the template so they are shared by all data types:

- TransferForwarder now only depends on the listener type (TransferListener / TransferListenerWithFilter), so there are at most two copies. It hands a received transfer to its subscriber through a virtual call (small runtime cost).
- A new base class GenericSubscriberOnListener holds the forwarder and the setup code, also only depending on the listener type.
- GenericSubscriber keeps only the code that really is per data type: decoding the transfer and passing the fixed values.


### Test coverage
- UAVCAN gtest test suite passes.
- Holybro M8N DroneCAN GNSS
```
INFO  [uavcan] advertising node_id 125 on index 0
INFO  [uavcan:125:] GPS 1: u-blox saving config
```