### PR TITLE
feat(hagl): enforce max height above ground in takeoff and VTOL transition

### DIFF
--- a/msg/NavigatorStatus.msg
+++ b/msg/NavigatorStatus.msg
@@ -3,7 +3,7 @@
 uint64 timestamp  # time since system start (microseconds)
 
 uint8 nav_state   # Source mode (values in VehicleStatus)
-uint8 failure     # Navigator failure enum
+uint8 failure     # Navigator failure enum, refers to the mode in nav_state
 
 uint8 FAILURE_NONE = 0
 uint8 FAILURE_HAGL = 1 # Target altitude exceeds maximum height above ground

--- a/msg/versioned/VehicleLocalPosition.msg
+++ b/msg/versioned/VehicleLocalPosition.msg
@@ -81,6 +81,7 @@ bool dead_reckoning                     # True if this position is estimated thr
 float32 vxy_max				# maximum horizontal speed (meters/sec)
 float32 vz_max				# maximum vertical speed (meters/sec)
 float32 hagl_min			# minimum height above ground level (meters)
+# the hagl_max limits are hard limits, consumers are expected to apply their own margin to them
 float32 hagl_max_z			# maximum height above ground level for z-control (meters)
 float32 hagl_max_xy			# maximum height above ground level for xy-control (meters)
 

--- a/msg/versioned/VehicleLocalPosition.msg
+++ b/msg/versioned/VehicleLocalPosition.msg
@@ -81,8 +81,10 @@ bool dead_reckoning                     # True if this position is estimated thr
 float32 vxy_max				# maximum horizontal speed (meters/sec)
 float32 vz_max				# maximum vertical speed (meters/sec)
 float32 hagl_min			# minimum height above ground level (meters)
-float32 hagl_max_z			# maximum height above ground level for z-control (meters)
-float32 hagl_max_xy			# maximum height above ground level for xy-control (meters)
+float32 hagl_max_z			# maximum height above ground level for z-control (meters), hard limit, controllers should
+                            # apply margins accordingly
+float32 hagl_max_xy			# maximum height above ground level for xy-control (meters), hard limit, controllers should
+                            # apply margins accordingly
 
 # TOPICS vehicle_local_position vehicle_local_position_groundtruth external_ins_local_position
 # TOPICS estimator_local_position

--- a/src/lib/hagl_limits/hagl_limits.hpp
+++ b/src/lib/hagl_limits/hagl_limits.hpp
@@ -1,0 +1,141 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file hagl_limits.hpp
+ *
+ * The estimator publishes the maximum height above the ground it can support with the currently available
+ * aiding sources as a hard limit in vehicle_local_position. Consumers keep a margin to that limit so that
+ * normal tracking errors do not push the vehicle past the point where the aiding source drops out.
+ *
+ * These helpers exist so that all consumers use the same margin: the commander checks commanded takeoff
+ * altitudes, the navigator limits altitude setpoints and the flight tasks limit their own setpoints. If those
+ * disagreed, an altitude accepted by one would immediately be limited by the other.
+ */
+
+#pragma once
+
+#include <mathlib/mathlib.h>
+#include <px4_platform_common/defines.h>
+
+namespace hagl_limits
+{
+
+static constexpr float kMarginFraction = 0.1f; ///< fraction of the reported maximum height above ground kept as margin
+static constexpr float kMarginMaxXY = 1.f; ///< upper bound of the margin applied for xy-control [m]
+
+/**
+ * Apply the margin to the maximum height above the ground for z-control reported by the estimator.
+ *
+ * @param hagl_max maximum height above the ground for z-control reported by the estimator [m]
+ * @return height above the ground to limit to [m]
+ */
+static inline float withMarginZ(const float hagl_max)
+{
+	return (1.f - kMarginFraction) * hagl_max;
+}
+
+/**
+ * Apply the margin to the maximum height above the ground for xy-control reported by the estimator.
+ *
+ * @param hagl_max_xy maximum height above the ground for xy-control reported by the estimator [m]
+ * @return height above the ground to limit to [m]
+ */
+static inline float withMarginXY(const float hagl_max_xy)
+{
+	return hagl_max_xy - math::min(kMarginFraction * hagl_max_xy, kMarginMaxXY);
+}
+
+/**
+ * Combine the maximum height above the ground reported for z- and xy-control into a single limit.
+ *
+ * An axis that is not limited is reported as INFINITY in vehicle_local_position, but as NAN by
+ * Ekf::get_ekf_ctrl_limits() before EKF2 converts it. Neither must mask a finite limit on the other axis, and
+ * math::min() cannot be used directly for the NAN case: it returns its second argument whenever either one is
+ * NAN, so a limit would be dropped depending on the argument order.
+ *
+ * @param hagl_max_z maximum height above the ground for z-control reported by the estimator [m]
+ * @param hagl_max_xy maximum height above the ground for xy-control reported by the estimator [m]
+ * @return the tighter of the two limits [m], NAN if neither axis is limited
+ */
+static inline float combineMax(const float hagl_max_z, const float hagl_max_xy)
+{
+	if (!PX4_ISFINITE(hagl_max_z)) {
+		return hagl_max_xy;
+	}
+
+	if (!PX4_ISFINITE(hagl_max_xy)) {
+		return hagl_max_z;
+	}
+
+	return math::min(hagl_max_z, hagl_max_xy);
+}
+
+/**
+ * Lowest height above the ground the vehicle has to stay below to keep all aiding sources.
+ *
+ * Each axis keeps its own margin before the two are combined, so that the tighter limit is the one that
+ * applies and neither axis is limited by the other's margin.
+ *
+ * @param hagl_max_z maximum height above the ground for z-control reported by the estimator [m]
+ * @param hagl_max_xy maximum height above the ground for xy-control reported by the estimator [m]
+ * @return height above the ground to limit to [m], NAN if neither axis is limited
+ */
+static inline float getLowestLimit(const float hagl_max_z, const float hagl_max_xy)
+{
+	return combineMax(withMarginZ(hagl_max_z), withMarginXY(hagl_max_xy));
+}
+
+/**
+ * Highest altitude a takeoff can be commanded to without exceeding the maximum height above the ground the
+ * estimator can support with the currently available aiding sources.
+ *
+ * Only meaningful while the vehicle is on the ground, where the terrain altitude is the altitude the vehicle
+ * will climb away from.
+ *
+ * @param hagl_max_z maximum height above the ground for z-control reported by the estimator [m]
+ * @param hagl_max_xy maximum height above the ground for xy-control reported by the estimator [m]
+ * @param terrain_alt terrain altitude below the vehicle [m AMSL]
+ * @return maximum takeoff altitude [m AMSL], NAN if there is no limit
+ */
+static inline float maxTakeoffAltitudeAmsl(const float hagl_max_z, const float hagl_max_xy, const float terrain_alt)
+{
+	const float hagl_max = getLowestLimit(hagl_max_z, hagl_max_xy);
+
+	if (!PX4_ISFINITE(hagl_max) || !PX4_ISFINITE(terrain_alt)) {
+		return NAN;
+	}
+
+	return terrain_alt + hagl_max;
+}
+
+} // namespace hagl_limits

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -55,6 +55,7 @@
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_tone_alarm.h>
 #include <lib/geo/geo.h>
+#include <lib/hagl_limits/hagl_limits.hpp>
 #include <mathlib/mathlib.h>
 #include <px4_platform_common/events.h>
 #include <px4_platform_common/px4_config.h>
@@ -1203,8 +1204,13 @@ Commander::handle_command(const vehicle_command_s &cmd)
 		break;
 
 	case vehicle_command_s::VEHICLE_CMD_NAV_TAKEOFF: {
-			/* ok, home set, use it to take off */
-			if (_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, getSourceFromCommand(cmd))) {
+			// param7: takeoff altitude [m AMSL], not necessarily set
+			if (isTakeoffAltitudeAboveLimit(getTakeoffAltitudeAmsl(cmd.param7))) {
+				printRejectTakeoffAltitude();
+				cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_DENIED;
+
+			} else if (_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF,
+							       getSourceFromCommand(cmd))) {
 				cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED;
 
 			} else {
@@ -1217,8 +1223,13 @@ Commander::handle_command(const vehicle_command_s &cmd)
 	case vehicle_command_s::VEHICLE_CMD_NAV_VTOL_TAKEOFF:
 #if CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
 
-		/* ok, home set, use it to take off */
-		if (_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, getSourceFromCommand(cmd))) {
+		// param7: altitude [m AMSL] at which the vehicle transitions to forward flight
+		if (isTakeoffAltitudeAboveLimit(cmd.param7)) {
+			printRejectTakeoffAltitude();
+			cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_DENIED;
+
+		} else if (_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF,
+						       getSourceFromCommand(cmd))) {
 			cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED;
 
 		} else {
@@ -2776,6 +2787,75 @@ void Commander::updateControlMode()
 		    || _vehicle_control_mode.flag_control_velocity_enabled);
 	_vehicle_control_mode.timestamp = hrt_absolute_time();
 	_vehicle_control_mode_pub.publish(_vehicle_control_mode);
+}
+
+float Commander::getTakeoffAltitudeAmsl(const float commanded_altitude_amsl)
+{
+	if (PX4_ISFINITE(commanded_altitude_amsl)) {
+		return commanded_altitude_amsl;
+	}
+
+	// A takeoff command does not have to carry an altitude. The navigator then takes off to MIS_TAKEOFF_ALT
+	// above the altitude the vehicle is at when the mode is activated, see Takeoff::set_takeoff_position().
+	float mis_takeoff_alt{NAN};
+
+	if (param_get(_param_mis_takeoff_alt_handle, &mis_takeoff_alt) != PX4_OK) {
+		return NAN;
+	}
+
+	_global_position_sub.update();
+
+	if (!_global_position_sub.get().alt_valid) {
+		return NAN;
+	}
+
+	return _global_position_sub.get().alt + mis_takeoff_alt;
+}
+
+float Commander::getMaxTakeoffAltitudeAmsl()
+{
+	// The limit is derived from the terrain altitude, which is the altitude the vehicle climbs away from, so it
+	// only applies to a takeoff from the ground. There is nothing to reject once the vehicle is in air, the
+	// navigator limits the altitude setpoint during the climb instead.
+	if (!_vehicle_land_detected.landed) {
+		return NAN;
+	}
+
+	_local_position_sub.update();
+	_global_position_sub.update();
+
+	if (!_global_position_sub.get().terrain_alt_valid) {
+		return NAN;
+	}
+
+	return hagl_limits::maxTakeoffAltitudeAmsl(_local_position_sub.get().hagl_max_z,
+			_local_position_sub.get().hagl_max_xy,
+			_global_position_sub.get().terrain_alt);
+}
+
+bool Commander::isTakeoffAltitudeAboveLimit(const float altitude_amsl)
+{
+	// Either side is NAN when it is unknown or unlimited, in which case the comparison is false and the takeoff
+	// is not rejected.
+	return altitude_amsl > getMaxTakeoffAltitudeAmsl();
+}
+
+void Commander::printRejectTakeoffAltitude()
+{
+	// Report the limit as the height the vehicle may still climb rather than as an absolute altitude, which is
+	// what the operator has to act on. The limit only exists while landed, so the difference to the current
+	// altitude is the height above the ground the takeoff can reach.
+	const float max_height_above_ground = getMaxTakeoffAltitudeAmsl() - _global_position_sub.get().alt;
+
+	mavlink_log_critical(&_mavlink_log_pub, "Takeoff denied: altitude above navigation limit of %.1f m above ground\t",
+			     (double)max_height_above_ground);
+	/* EVENT
+	 * @description
+	 * The commanded takeoff altitude is above the maximum height above the ground the estimator can
+	 * support with the currently available aiding sources.
+	 */
+	events::send<float>(events::ID("commander_takeoff_denied_max_hagl"), {events::Log::Critical, events::LogInternal::Info},
+			    "Takeoff denied: altitude above navigation limit of {1:.1m} above ground", max_height_above_ground);
 }
 
 void Commander::printRejectMode(uint8_t nav_state)

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -80,6 +80,7 @@
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_land_detected.h>
+#include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vtol_vehicle_status.h>
 
 using math::constrain;
@@ -167,9 +168,42 @@ private:
 
 	unsigned handleCommandActuatorTest(const vehicle_command_s &cmd);
 
+	/**
+	 * @brief Resolve the altitude a takeoff command will climb to
+	 *
+	 * A takeoff command does not have to carry an altitude. In that case the navigator takes off to
+	 * MIS_TAKEOFF_ALT above the current altitude, so the altitude the command results in has to be resolved
+	 * here to be able to check it. Does not apply to a VTOL takeoff, which has no such default.
+	 *
+	 * @param commanded_altitude_amsl altitude of the takeoff command, NAN if not set [m AMSL]
+	 * @return altitude the vehicle will climb to, NAN if it cannot be determined [m AMSL]
+	 */
+	float getTakeoffAltitudeAmsl(float commanded_altitude_amsl);
+
+	/**
+	 * @brief Highest altitude a takeoff can be commanded to
+	 *
+	 * Derived from the maximum height above the ground the estimator can support with the currently available
+	 * aiding sources, so that a takeoff is rejected before the vehicle leaves the ground instead of running
+	 * into the limit during the climb.
+	 *
+	 * @return maximum takeoff altitude [m AMSL], NAN if there is no limit
+	 */
+	float getMaxTakeoffAltitudeAmsl();
+
+	/**
+	 * @brief Check a commanded takeoff altitude against the limit
+	 *
+	 * @param altitude_amsl commanded takeoff altitude [m AMSL]
+	 * @return true if the commanded altitude exceeds the limit
+	 */
+	bool isTakeoffAltitudeAboveLimit(float altitude_amsl);
+
 	void executeActionRequest(const action_request_s &action_request);
 
 	void printRejectMode(uint8_t nav_state);
+
+	void printRejectTakeoffAltitude();
 
 	void updateControlMode();
 
@@ -317,6 +351,8 @@ private:
 #endif // BOARD_HAS_POWER_CONTROL
 
 	uORB::SubscriptionData<mission_result_s>		_mission_result_sub{ORB_ID(mission_result)};
+	uORB::SubscriptionData<vehicle_global_position_s>	_global_position_sub{ORB_ID(vehicle_global_position)};
+	uORB::SubscriptionData<vehicle_local_position_s>		_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::SubscriptionData<offboard_control_mode_s>		_offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
 
 	// Publications
@@ -352,4 +388,8 @@ private:
 		(ParamInt<px4::params::COM_FLTMODE_BOOT>)   _param_com_fltmode_boot,
 		(ParamInt<px4::params::NAV_RCL_ACT>)        _param_nav_rcl_act
 	)
+
+	// Owned by the navigator, which is not part of every build that includes the commander, hence the handle
+	// instead of a typed parameter.
+	const param_t _param_mis_takeoff_alt_handle{param_find("MIS_TAKEOFF_ALT")};
 };

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -349,8 +349,7 @@ void Ekf::get_ekf_ctrl_limits(float *vxy_max, float *vz_max, float *hagl_min, fl
 	// Calculate range finder limits
 	const float rangefinder_hagl_min = _range_sensor.getValidMinVal();
 
-	// Allow use of 90% of rangefinder maximum range to allow for angular motion
-	const float rangefinder_hagl_max = 0.9f * _range_sensor.getValidMaxVal();
+	const float rangefinder_hagl_max = _range_sensor.getValidMaxVal();
 
 	// TODO : calculate visual odometry limits
 	const bool relying_on_rangefinder = isOnlyActiveSourceOfVerticalPositionAiding(_control_status.flags.rng_hgt);
@@ -381,7 +380,6 @@ void Ekf::get_ekf_ctrl_limits(float *vxy_max, float *vz_max, float *hagl_min, fl
 
 		// Allow ground relative velocity to use 50% of available flow sensor range to allow for angular motion
 		float flow_vxy_max = 0.5f * _flow_max_rate * flow_constrained_height;
-		flow_hagl_max = math::max(flow_hagl_max * 0.9f, flow_hagl_max - 1.0f);
 
 		*vxy_max = flow_vxy_max;
 		*hagl_min = flow_hagl_min;

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -349,8 +349,7 @@ void Ekf::get_ekf_ctrl_limits(float *vxy_max, float *vz_max, float *hagl_min, fl
 	// Calculate range finder limits
 	const float rangefinder_hagl_min = _range_sensor.getValidMinVal();
 
-	// Allow use of 90% of rangefinder maximum range to allow for angular motion
-	const float rangefinder_hagl_max = 0.9f * _range_sensor.getValidMaxVal();
+	const float rangefinder_hagl_max = _range_sensor.getValidMaxVal();
 
 	// TODO : calculate visual odometry limits
 	const bool relying_on_rangefinder = isOnlyActiveSourceOfVerticalPositionAiding(_control_status.flags.rng_hgt);

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -381,7 +381,6 @@ void Ekf::get_ekf_ctrl_limits(float *vxy_max, float *vz_max, float *hagl_min, fl
 
 		// Allow ground relative velocity to use 50% of available flow sensor range to allow for angular motion
 		float flow_vxy_max = 0.5f * _flow_max_rate * flow_constrained_height;
-		flow_hagl_max = math::max(flow_hagl_max * 0.9f, flow_hagl_max - 1.0f);
 
 		*vxy_max = flow_vxy_max;
 		*hagl_min = flow_hagl_min;

--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
@@ -37,6 +37,8 @@
 
 #include "FlightTaskManualAcceleration.hpp"
 
+#include <lib/hagl_limits/hagl_limits.hpp>
+
 using namespace matrix;
 
 bool FlightTaskManualAcceleration::activate(const trajectory_setpoint_s &last_setpoint)
@@ -65,13 +67,16 @@ bool FlightTaskManualAcceleration::activate(const trajectory_setpoint_s &last_se
 bool FlightTaskManualAcceleration::update()
 {
 	const vehicle_local_position_s vehicle_local_pos = _sub_vehicle_local_position.get();
-	setMaxDistanceToGround(vehicle_local_pos.hagl_max_xy);
+	// Both axes have to be respected: this task overwrites the constraint FlightTaskManualAltitude derives
+	// from the z-limit, so taking only the xy-limit here would drop the z-limit entirely.
+	const float max_hagl = hagl_limits::getLowestLimit(vehicle_local_pos.hagl_max_z, vehicle_local_pos.hagl_max_xy);
+	setMaxDistanceToGround(max_hagl);
 	bool ret = FlightTaskManualAltitudeSmoothVel::update();
 
 	float max_hagl_ratio = 0.0f;
 
-	if (PX4_ISFINITE(vehicle_local_pos.hagl_max_xy) && vehicle_local_pos.hagl_max_xy > FLT_EPSILON) {
-		max_hagl_ratio = (vehicle_local_pos.dist_bottom) / vehicle_local_pos.hagl_max_xy;
+	if (PX4_ISFINITE(max_hagl) && max_hagl > FLT_EPSILON) {
+		max_hagl_ratio = (vehicle_local_pos.dist_bottom) / max_hagl;
 	}
 
 	// limit horizontal velocity near max hagl to decrease chance of larger gound distance jumps

--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
@@ -65,13 +65,14 @@ bool FlightTaskManualAcceleration::activate(const trajectory_setpoint_s &last_se
 bool FlightTaskManualAcceleration::update()
 {
 	const vehicle_local_position_s vehicle_local_pos = _sub_vehicle_local_position.get();
-	setMaxDistanceToGround(vehicle_local_pos.hagl_max_xy);
+	const float max_hagl = _haglMaxXYWithMargin(vehicle_local_pos.hagl_max_xy);
+	setMaxDistanceToGround(max_hagl);
 	bool ret = FlightTaskManualAltitudeSmoothVel::update();
 
 	float max_hagl_ratio = 0.0f;
 
-	if (PX4_ISFINITE(vehicle_local_pos.hagl_max_xy) && vehicle_local_pos.hagl_max_xy > FLT_EPSILON) {
-		max_hagl_ratio = (vehicle_local_pos.dist_bottom) / vehicle_local_pos.hagl_max_xy;
+	if (PX4_ISFINITE(max_hagl) && max_hagl > FLT_EPSILON) {
+		max_hagl_ratio = (vehicle_local_pos.dist_bottom) / max_hagl;
 	}
 
 	// limit horizontal velocity near max hagl to decrease chance of larger gound distance jumps

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -37,6 +37,7 @@
 
 #include "FlightTaskManualAltitude.hpp"
 #include <float.h>
+#include <lib/hagl_limits/hagl_limits.hpp>
 #include <mathlib/mathlib.h>
 #include <geo/geo.h>
 
@@ -82,7 +83,7 @@ void FlightTaskManualAltitude::_updateConstraintsFromEstimator()
 	}
 
 	if (!PX4_ISFINITE(_max_distance_to_ground) && PX4_ISFINITE(_sub_vehicle_local_position.get().hagl_max_z)) {
-		_max_distance_to_ground = _sub_vehicle_local_position.get().hagl_max_z;
+		_max_distance_to_ground = hagl_limits::withMarginZ(_sub_vehicle_local_position.get().hagl_max_z);
 	}
 }
 

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -82,7 +82,7 @@ void FlightTaskManualAltitude::_updateConstraintsFromEstimator()
 	}
 
 	if (!PX4_ISFINITE(_max_distance_to_ground) && PX4_ISFINITE(_sub_vehicle_local_position.get().hagl_max_z)) {
-		_max_distance_to_ground = _sub_vehicle_local_position.get().hagl_max_z;
+		_max_distance_to_ground = _haglMaxZWithMargin(_sub_vehicle_local_position.get().hagl_max_z);
 	}
 }
 

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -41,6 +41,7 @@
 
 #include <lib/stick_yaw/StickYaw.hpp>
 #include <lib/sticks/Sticks.hpp>
+#include <mathlib/mathlib.h>
 #include "FlightTask.hpp"
 #include "StickTiltXY.hpp"
 #include <uORB/Subscription.hpp>
@@ -65,6 +66,29 @@ protected:
 	virtual void _scaleSticks(); /**< scales sticks to velocity in z */
 	bool _checkTakeoff() override;
 	void _updateConstraintsFromEstimator();
+
+	static constexpr float kHaglMaxMarginFraction = 0.1f; /**< fraction of the reported maximum height above ground kept as margin */
+
+	/**
+	 * Apply a margin to the maximum height above ground for z-control reported by the estimator.
+	 * @param hagl_max_z maximum height above ground for z-control reported by the estimator [m]
+	 * @return height above ground the controller limits itself to [m]
+	 */
+	static float _haglMaxZWithMargin(const float hagl_max_z)
+	{
+		return (1.f - kHaglMaxMarginFraction) * hagl_max_z;
+	}
+
+	/**
+	 * Apply margin to the maximum height above ground reported by the estimator for xy-control.
+	 * @param hagl_max_xy maximum height above ground for xy-control reported by the estimator [m]
+	 * @return height above ground the controller limits itself to [m]
+	 */
+	static float _haglMaxXYWithMargin(const float hagl_max_xy)
+	{
+		static constexpr float margin_max = 1.f; // upper bound of the margin [m]
+		return hagl_max_xy - math::min(kHaglMaxMarginFraction * hagl_max_xy, margin_max);
+	}
 
 	/**
 	 *  Check and sets for position lock.

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -48,6 +48,7 @@
 #include <float.h>
 
 #include <lib/geo/geo.h>
+#include <lib/hagl_limits/hagl_limits.hpp>
 #include <systemlib/mavlink_log.h>
 #include <mathlib/mathlib.h>
 #include <uORB/uORB.h>
@@ -1050,10 +1051,8 @@ void MissionBlock::updateFailsafeChecks()
 
 void MissionBlock::updateMaxHaglFailsafe()
 {
-	const float target_alt = _navigator->get_position_setpoint_triplet()->current.alt;
-	const float max_alt = math::min(_navigator->get_local_position()->hagl_max_z, _navigator->get_local_position()->hagl_max_xy);
-	const float terrain_alt = _navigator->get_global_position()->terrain_alt;
-	const bool terrain_alt_valid = _navigator->get_global_position()->terrain_alt_valid;
+	const vehicle_local_position_s *local_pos = _navigator->get_local_position();
+	const float max_hagl = hagl_limits::getLowestLimit(local_pos->hagl_max_z, local_pos->hagl_max_xy);
 
 	// If the HAGL failsafe is declared during front transition, we enter a
 	// FW hold at the current low altitude while not having finished the
@@ -1062,7 +1061,15 @@ void MissionBlock::updateMaxHaglFailsafe()
 	// failsafe here.
 	const bool in_transition_to_fw = _navigator->get_vstatus()->in_transition_to_fw;
 
-	if (!in_transition_to_fw && terrain_alt_valid && (target_alt - terrain_alt) > max_alt) {
+	if (in_transition_to_fw || !PX4_ISFINITE(max_hagl)) {
+		return;
+	}
+
+	const float target_alt = _navigator->get_position_setpoint_triplet()->current.alt;
+	const float terrain_alt = _navigator->get_global_position()->terrain_alt;
+	const bool terrain_alt_valid = _navigator->get_global_position()->terrain_alt_valid;
+
+	if (terrain_alt_valid && (target_alt - terrain_alt) > max_hagl) {
 		// Handle case where the altitude setpoint is above the maximum HAGL (height above ground level)
 		mavlink_log_info(_navigator->get_mavlink_log_pub(), "Target altitude higher than max HAGL\t");
 		events::send(events::ID("navigator_fail_max_hagl"), events::Log::Error, "Target altitude higher than max HAGL");

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -227,5 +227,9 @@ protected:
 	float _command_timeout{0.f}; ///< Time in seconds any item_has_timeout() command should be waited for before continuing the mission
 
 private:
+	/**
+	 * Trigger the HAGL failsafe if the altitude setpoint is above the maximum height above the ground
+	 * reported by the estimator.
+	 */
 	void updateMaxHaglFailsafe();
 };


### PR DESCRIPTION
## Short Summary
- New shared helper lib src/lib/hagl_limits/hagl_limits.hpp replacing hardcoded margin values.
- EKF2 now publishes raw HAGL limits; margins are applied by consumers (flight tasks) instead.
- Commander rejects takeoff commands whose altitude exceeds the limit.

## Problem Solved

When commanding a VTOL Takeoff or a normal Takeoff (multicopter or fixed wing) and there is a
maximum height above ground limitation published by the estimator (the range finder is the only
source of vertical aiding, or optical flow the only source of horizontal aiding), then the system
should deny the takeoff if the final takeoff altitude is above that limit.

Prior to this change, the system would accept the takeoff, but as soon as the mode is running,
navigator would realize the issue with altitude exceeding the limits and would declare a fail-safe.
The result is that the vehicle actually arms and begins the takeoff before it enters the failsafe
mode, which is not a nice user experience.

Finally, the estimator applied its own margin to the limits before publishing them — 10% of the
range finder range, and the larger of 10% and 1 m for optical flow. 

## Solution

1. At the time when we receive the VTOL Takeoff or Takeoff command, we check the desired msl
   altitude and reject the command if it's above the limit. When the command carries no altitude,
   the `MIS_TAKEOFF_ALT` default is resolved first, so the check sees the altitude the vehicle would
   actually climb to. The rejection reports the limit as a height above the ground rather than an
   absolute altitude, which is what an operator can act on.


2. The estimator publishes the raw sensor limits and every consumer applies the same margin from the
   new `src/lib/hagl_limits`: the manual flight tasks, the navigator's setpoint limiting and the
   commander's takeoff check.

This gates the takeoff commands only. A mission whose takeoff item is above the limit is still
accepted and armed and a waypoint above the limit later (including the takeoff) in the mission still triggers the HAGL failsafe.

## Open issue
For a takeoff or a vtol takeoff as part of a mission, there is currently no check which would prevent the mission from starting when the relative takeoff altitude is above the navigation limits. I felt like it would increase the scope of this PR too much if that was also addressed in here.