### PR TITLE
fix(boards/px4_fmu-v6xrt): correct FRAM bwrite loop and alignment

### DIFF
--- a/boards/px4/fmu-v6xrt/src/imxrt_flexspi_fram.c
+++ b/boards/px4/fmu-v6xrt/src/imxrt_flexspi_fram.c
@@ -30,6 +30,7 @@
 #include <debug.h>
 
 #include <nuttx/kmalloc.h>
+#include <nuttx/mutex.h>
 #include <nuttx/signal.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/mtd/mtd.h>
@@ -112,6 +113,12 @@ struct imxrt_flexspi_fram_dev_s {
 	uint8_t *ahb_base;
 	enum flexspi_port_e port;
 	struct flexspi_device_config_s *config;
+	mutex_t lock;                    /* Serializes access to page_buffer */
+	/* Bounce buffer for callers that pass a non word-aligned buffer. Kept
+	 * here rather than on the stack so that write() on this device does not
+	 * add a page worth of stack usage to every caller.
+	 */
+	uint32_t page_buffer[FRAM_PAGE_SIZE / sizeof(uint32_t)];
 };
 
 /****************************************************************************
@@ -179,7 +186,8 @@ static struct imxrt_flexspi_fram_dev_s g_flexspi_nor = {
 	.flexspi = (void *)0,
 	.ahb_base = (uint8_t *) IMXRT_FLEXSPI2_CIPHER_BASE,
 	.port = FLEXSPI_PORT_A1,
-	.config = &g_flexspi_device_config
+	.config = &g_flexspi_device_config,
+	.lock = NXMUTEX_INITIALIZER
 };
 
 /****************************************************************************
@@ -493,11 +501,20 @@ static ssize_t imxrt_flexspi_fram_bwrite(struct mtd_dev_s *dev,
 #ifdef CONFIG_ARMV7M_DCACHE
 	uint8_t *dst = priv->ahb_base + startblock * FRAM_PAGE_SIZE;
 #endif
-	/* Bounce buffer for callers that pass a non word-aligned buffer. */
-	uint32_t aligned_page[FRAM_PAGE_SIZE / sizeof(uint32_t)];
 	int i;
+	int ret;
 
 	finfo("startblock: %08lx nblocks: %d\n", (long)startblock, (int)nblocks);
+
+	/* priv->page_buffer is shared, and the partitions layered on this device
+	 * do not serialize their callers.
+	 */
+
+	ret = nxmutex_lock(&priv->lock);
+
+	if (ret < 0) {
+		return ret;
+	}
 
 	while (len) {
 		const uint8_t *page_src = src;
@@ -510,8 +527,8 @@ static ssize_t imxrt_flexspi_fram_bwrite(struct mtd_dev_s *dev,
 		 * a word-aligned buffer when needed.
 		 */
 		if (((uintptr_t)src & 3u) != 0u) {
-			memcpy(aligned_page, src, i);
-			page_src = (const uint8_t *)aligned_page;
+			memcpy(priv->page_buffer, src, i);
+			page_src = (const uint8_t *)priv->page_buffer;
 		}
 
 		imxrt_flexspi_fram_write_enable(priv);
@@ -522,6 +539,8 @@ static ssize_t imxrt_flexspi_fram_bwrite(struct mtd_dev_s *dev,
 		src += i;
 		len -= i;
 	}
+
+	nxmutex_unlock(&priv->lock);
 
 #ifdef CONFIG_ARMV7M_DCACHE
 	up_invalidate_dcache((uintptr_t)dst,

--- a/boards/px4/fmu-v6xrt/src/imxrt_flexspi_fram.c
+++ b/boards/px4/fmu-v6xrt/src/imxrt_flexspi_fram.c
@@ -26,6 +26,7 @@
 
 #include <stdbool.h>
 #include <errno.h>
+#include <string.h>
 #include <debug.h>
 
 #include <nuttx/kmalloc.h>
@@ -488,21 +489,37 @@ static ssize_t imxrt_flexspi_fram_bwrite(struct mtd_dev_s *dev,
 		(struct imxrt_flexspi_fram_dev_s *)dev;
 	size_t len = nblocks * FRAM_PAGE_SIZE;
 	off_t offset = startblock * FRAM_PAGE_SIZE;
-	uint8_t *src = (uint8_t *) buffer;
+	const uint8_t *src = (const uint8_t *) buffer;
 #ifdef CONFIG_ARMV7M_DCACHE
 	uint8_t *dst = priv->ahb_base + startblock * FRAM_PAGE_SIZE;
 #endif
+	/* Bounce buffer for callers that pass a non word-aligned buffer. */
+	uint32_t aligned_page[FRAM_PAGE_SIZE / sizeof(uint32_t)];
 	int i;
 
 	finfo("startblock: %08lx nblocks: %d\n", (long)startblock, (int)nblocks);
 
 	while (len) {
+		const uint8_t *page_src = src;
 		i = MIN(FRAM_PAGE_SIZE, len);
+
+		/* imxrt_flexspi_fram_page_program() casts this buffer to uint32_t *
+		 * and imxrt_flexspi_write_blocking() reads through it one word at a
+		 * time, but the MTD interface makes no alignment guarantee and the
+		 * block layer above does pass byte-aligned buffers. Copy the page to
+		 * a word-aligned buffer when needed.
+		 */
+		if (((uintptr_t)src & 3u) != 0u) {
+			memcpy(aligned_page, src, i);
+			page_src = (const uint8_t *)aligned_page;
+		}
+
 		imxrt_flexspi_fram_write_enable(priv);
-		imxrt_flexspi_fram_page_program(priv, offset, src, i);
+		imxrt_flexspi_fram_page_program(priv, offset, page_src, i);
 		imxrt_flexspi_fram_wait_bus_busy(priv);
 		FLEXSPI_SOFTWARE_RESET(priv->flexspi);
 		offset += i;
+		src += i;
 		len -= i;
 	}
 


### PR DESCRIPTION
On FMU V6XRT, saving parameters using "param save" on Mavlink shell led to save to fail and fmu to reboot. This can be reproduced using Mavlink shell with a large set of custom parameters. Without this fix, almost each save led to a fmu reboot. No reboot observed after.

The root cause, explanation and correction have been done using AI (Claude Opus 5)

Technical explanation

imxrt_flexspi_fram_bwrite() advances offset and len for each page but never advances src, so a write of more than one block programs the data of the first page into every following page.

imxrt_flexspi_fram_page_program() also casts the caller's buffer to uint32_t * and imxrt_flexspi_write_blocking() reads it one word at a time, while the MTD interface makes no alignment guarantee and the block layer above does pass byte-aligned buffers. Copy the page into a word-aligned buffer when the source is not aligned.

On the default configuration the alignment issue is latent, because unaligned loads from normal memory are permitted. With D-cache disabled the MPU marks RAM as strongly-ordered, where any unaligned access faults, and every param save hard-faulted the board.

Bench tested on a Pixhawk 6X-RT: 10 consecutive param save with no reboot, plus a set/save/reboot round-trip confirming persistence. Before the fix the same test hard-faulted on the first save.

Assisted-by: Claude:claude-opus-5

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
