### PR TITLE
fix(sensors): fix initializer-count mismatch in advertised [ ] array

### DIFF
--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -117,7 +117,7 @@ private:
 		int32_t priority_configured[MAX_SENSOR_COUNT] {};
 		uint8_t last_best_vote{0}; /**< index of the latest best vote */
 		uint8_t subscription_count{0};
-		bool advertised[MAX_SENSOR_COUNT] {false, false, false};
+		bool advertised[MAX_SENSOR_COUNT] {false, false, false, false};
 	};
 
 	void initSensorClass(SensorData &sensor_data, uint8_t sensor_count_max);

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -117,7 +117,7 @@ private:
 		int32_t priority_configured[MAX_SENSOR_COUNT] {};
 		uint8_t last_best_vote{0}; /**< index of the latest best vote */
 		uint8_t subscription_count{0};
-		bool advertised[MAX_SENSOR_COUNT] {false, false, false, false};
+		bool advertised[MAX_SENSOR_COUNT] {};
 	};
 
 	void initSensorClass(SensorData &sensor_data, uint8_t sensor_count_max);


### PR DESCRIPTION
`advertised[MAX_SENSOR_COUNT]` (size 4) was only initialized with 3 explicit values, inconsistent with MAX_SENSOR_COUNT and with the two array members right above it (priority, priority_configured) which are fully zero-initialized.
C++ still zero-inits the missing element so there's no functional bug, just a readability/consistency nit. Added the 4th value to match the array size.
cc @dakejahl following up on our Discord discussion, opening this as a small follow-up. Happy to adjust if you'd rather fold it into something else. Thanks for the review