### PR TITLE
fix(platforms): correct sRGB DMA channel 1 setup

### DIFF
--- a/platforms/nuttx/src/px4/stm/stm32_common/srgbled_dma/srgbled_dma.cpp
+++ b/platforms/nuttx/src/px4/stm/stm32_common/srgbled_dma/srgbled_dma.cpp
@@ -239,7 +239,7 @@
 #endif
 
 #if S_RGB_LED_CHANNEL == 1
-# define SLED_CCER      (CCER_CCnxE << 0) |
+# define SLED_CCER      (CCER_CCnxE << 0)
 # define SLED_CCMR1     GTIM_CCMR1_OC1PE | (GTIM_CCMR_MODE_PWM1 << GTIM_CCMR1_OC1M_SHIFT)
 # define SLED_CCMR2     0
 # define SLED_rCCR      rCCR1


### PR DESCRIPTION
### Solved Problem

  The sRGB LED DMA driver fails to compile when `S_RGB_LED_CHANNEL` is set to channel 1.

  This issue was discovered while testing the NewBeeDrone Hummingbird FC305 H7 board support, which uses PE5/TIM15_CH1 for its DMA-driven RGB LED.

  The `SLED_CCER` macro for channel 1 contains a trailing `|`, which expands into an invalid expression when used by `neopixel_init()`.

  ### Solution

  Remove the trailing `|` from the channel 1 `SLED_CCER` definition.

  This only corrects the channel 1 expression. The channel 2, channel 3, channel 4, and complementary-output paths are unchanged.

  ### Changelog Entry

  For release notes:


  Bugfix: Fix sRGB LED DMA compilation when using timer channel 1.


  ### Alternatives

  A board-specific workaround would require selecting an incorrect timer channel or changing the hardware pin mapping. Fixing the malformed common-driver macro
  is the minimal and correct solution.

  ### Test coverage

  Successfully built:

  - `make 3dr_ctrl-n1_default`
    - STM32H7
    - sRGB DMA on TIM3 channel 4
  - `make cuav_can-gps-v1_default`
    - STM32F4
    - sRGB DMA on TIM1 complementary channel 2
  - `make newbeedrone_hummingbird_fc305_h7_default`
    - STM32H7
    - sRGB DMA on TIM15 channel 1
    - Tested using the NewBeeDrone Hummingbird FC305 H7 board-support branch

  The Hummingbird build successfully includes `neopixel_main`, `neopixel_init`, and `neopixel_write`.

  Existing PX4 main boards using channel 2N and channel 4 continue to build successfully.

  ### Context

  This problem was found during the bring-up and hardware testing of the NewBeeDrone Hummingbird FC305 H7 flight controller.

  The board connects its RGB LED to PE5 using TIM15_CH1 and DMA1. Enabling the PX4 NeoPixel DMA driver exposed the malformed channel 1 macro in the common STM32
  sRGB LED DMA implementation.

  No board currently enabling the DMA NeoPixel driver on PX4 main uses channel 1, which is why this compile error was not previously exercised by existing board
  builds.