### PR TITLE
  fix(docs): keep current page when switching version

### DIFF
--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -38,6 +38,27 @@ export default {
     app.config.globalProperties.$buildTime = JSON.stringify(
       new Date().toISOString()
     );
+    // Switching version in the navbar keeps the current page. The "Version"
+    // links in navbar.json point at each version's root (e.g.
+    // https://docs.px4.io/v1.16/en/), so swap the path of the current page in.
+    // Pages that do not exist in the target version 404.
+    if (inBrowser) {
+      addEventListener(
+        "click",
+        (e) => {
+          if (e.defaultPrevented || e.button || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return;
+          const link = e.target.closest?.(".VPNav a[href]");
+          // Only bare version roots, i.e. the version switcher entries: the site
+          // logo is root-relative and "Support" has a deeper path.
+          const version = link?.getAttribute("href").match(/^(https?:\/\/[^/]+\/(?:main|v\d+\.\d+)\/)(?:[a-z]{2}\/)?$/);
+          if (!version || new URL(link.href).origin !== location.origin) return;
+          if (!/^\/(?:main|v\d+\.\d+)\//.test(location.pathname)) return;
+          e.preventDefault();
+          location.href = version[1] + location.pathname.split("/").slice(2).join("/") + location.hash;
+        },
+        true
+      );
+    }
   },
 
   // to support medium zoom: https://github.com/vuejs/vitepress/issues/854


### PR DESCRIPTION
## Summary
  Switching version in the navbar keeps you on the page you were reading instead of dropping you on that version's front page.

  ## Problem
  The `Version` entries in `docs/.vitepress/navbar.json` are static links to each version's root (`https://docs.px4.io/v1.16/en/`), so a reader on, say, the parameter reference who switches version lands on the front page and has to navigate back. The right destination depends on which page is being viewed, which is only known in the browser, so no static link can express it.

  ## Solution
  A capture-phase click listener in the theme: for navbar links whose href is a bare version root, swap in the path of the current page plus its anchor, and navigate in the same tab.

  Scoped to `.VPNav` and anchored to the version-root shape, so the site logo, `Support`, the language switcher, and `docs.px4.io` links in page content are left alone. Inert when the nav links are cross-origin, i.e. on the dev server and under the `/px4_user_guide/` base.

  Pages that do not exist in the target version 404. Handling that in the client would mean probing each candidate before navigating; the cheaper fix is a per-prefix CloudFront error document, which lives outside this repo.

## Notes
once this PR is in, i will back port it to all older releases, because this will currently o so this alone covers `main` → any version. and also back port it to versions which had the docs in the separate repo


https://github.com/user-attachments/assets/7481ed8b-888e-49c5-9689-7a401e437162

