### PR TITLE
fix(commander): Updating Commander to check Remote ID Arm Status and Increase Remote ID MAX_RATE_HZ

### DIFF
--- a/src/drivers/uavcan/remoteid.hpp
+++ b/src/drivers/uavcan/remoteid.hpp
@@ -69,7 +69,7 @@ private:
 	typedef uavcan::MethodBinder<UavcanRemoteIDController *, void (UavcanRemoteIDController::*)(const uavcan::TimerEvent &)>
 	TimerCbBinder;
 
-	static constexpr unsigned MAX_RATE_HZ = 1;
+	static constexpr unsigned MAX_RATE_HZ = 2;
 	uavcan::TimerEventForwarder<TimerCbBinder> _timer;
 
 	void periodic_update(const uavcan::TimerEvent &);

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3023,6 +3023,23 @@ void Commander::dataLinkCheck()
 		}
 	}
 
+	open_drone_id_arm_status_s open_drone_id_arm_status;
+
+	if (_open_drone_id_arm_status_sub.update(&open_drone_id_arm_status)) {
+		if (_open_drone_id_system_lost) {
+			_open_drone_id_system_lost = false;
+
+			if (_datalink_last_heartbeat_open_drone_id_system != 0) {
+				mavlink_log_info(&_mavlink_log_pub, "Remote ID system regained\t");
+			}
+		}
+
+		bool healthy = open_drone_id_arm_status.status == 0;
+
+		_datalink_last_heartbeat_open_drone_id_system = open_drone_id_arm_status.timestamp;
+		_vehicle_status.open_drone_id_system_present = true;
+		_vehicle_status.open_drone_id_system_healthy = healthy;
+	}
 
 	// GCS data link loss failsafe
 	if (!_vehicle_status.gcs_connection_lost) {

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -71,6 +71,7 @@
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/mission_result.h>
 #include <uORB/topics/offboard_control_mode.h>
+#include <uORB/topics/open_drone_id_arm_status.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/power_button_state.h>
 #include <uORB/topics/rtl_time_estimate.h>
@@ -302,6 +303,7 @@ private:
 	uORB::Subscription					_cpuload_sub{ORB_ID(cpuload)};
 	uORB::Subscription					_iridiumsbd_status_sub{ORB_ID(iridiumsbd_status)};
 	uORB::Subscription					_manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
+	uORB::Subscription					_open_drone_id_arm_status_sub{ORB_ID(open_drone_id_arm_status)};
 	uORB::Subscription					_system_power_sub{ORB_ID(system_power)};
 	uORB::Subscription					_vehicle_command_sub{ORB_ID(vehicle_command)};
 	uORB::Subscription					_vehicle_command_mode_executor_sub{ORB_ID(vehicle_command_mode_executor)};


### PR DESCRIPTION
## Solved Problem

The Remote ID module's `OPEN_DRONE_ID_ARM_STATUS` message is received and published
to uORB, but its content is never evaluated. `open_drone_id_system_healthy` is only
derived from the heartbeat, so a Remote ID module actively reporting
`PRE_ARM_FAIL_GENERIC` (e.g. missing operator ID, no GNSS lock on the beacon) does
not block arming, even with `COM_ARM_ODID` set. The vehicle can arm and take off
while broadcasting a non-compliant Remote ID.

Separately, the UAVCAN Remote ID controller runs its periodic update at
`MAX_RATE_HZ = 1`. The dynamic Remote ID messages (location, system) must be
broadcast at a minimum of 1 Hz, so any scheduling jitter that drops the effective
rate below 1 Hz (e.g. 0.9 Hz) causes the Remote ID module to flag a failure.
There is no rate margin.

## Solution

- `Commander::dataLinkCheck()` now subscribes to `open_drone_id_arm_status` and
  updates `open_drone_id_system_present` / `open_drone_id_system_healthy` from the
  reported status (`healthy` only when status is `MAV_ODID_ARM_STATUS_GOOD_TO_ARM`).
  The existing `openDroneIDCheck` health and arming check then blocks arming via
  `COM_ARM_ODID`, and reports recovery when the system regains.
- Increased `MAX_RATE_HZ` in the UAVCAN Remote ID controller from 1 to 2 so the
  dynamic messages are sent with margin above the 1 Hz minimum required by the
  Remote ID specification.
