### PR TITLE
fix(drivers/invensense): use exact 20-bit gyro scale factors

### DIFF
--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
@@ -801,13 +801,13 @@ void ICM42688P::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DAT
 	}
 
 	if (!scale_20bit) {
-		// On the 686, if highres enabled gyro data is always 65.5 LSB/dps
-		// On the 688, if highres enabled gyro data is always 131 LSB/dps
+		// published data is the 20 bit value shifted right by 1, so it spans the full range in
+		// 2^18 counts: 65.536 LSB/dps on the 686, 131.072 LSB/dps on the 688
 		if (isICM686) {
-			_px4_gyro.set_scale(math::radians(1.f / 65.5f));
+			_px4_gyro.set_scale(math::radians(4000.f / 262144.f));
 
 		} else {
-			_px4_gyro.set_scale(math::radians(1.f / 131.f));
+			_px4_gyro.set_scale(math::radians(2000.f / 262144.f));
 		}
 
 	} else {
@@ -819,7 +819,7 @@ void ICM42688P::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DAT
 		}
 
 		if (isICM686) {
-			_px4_gyro.set_scale(math::radians(2000.f / 16384.f));
+			_px4_gyro.set_scale(math::radians(4000.f / 32768.f));
 
 		} else {
 			_px4_gyro.set_scale(math::radians(2000.f / 32768.f));

--- a/src/drivers/imu/invensense/iim42652/IIM42652.cpp
+++ b/src/drivers/imu/invensense/iim42652/IIM42652.cpp
@@ -777,8 +777,9 @@ void IIM42652::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 	}
 
 	if (!scale_20bit) {
-		// if highres enabled gyro data is always 131 LSB/dps
-		_px4_gyro.set_scale(math::radians(1.f / 131.f));
+		// published data is the 20 bit value shifted right by 1, so it spans the full range in
+		// 2^18 counts: 131.072 LSB/dps
+		_px4_gyro.set_scale(math::radians(2000.f / 262144.f));
 
 	} else {
 		// 20 bit data scaled to 16 bit (2^4)

--- a/src/drivers/imu/invensense/iim42653/IIM42653.cpp
+++ b/src/drivers/imu/invensense/iim42653/IIM42653.cpp
@@ -778,8 +778,9 @@ void IIM42653::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 	}
 
 	if (!scale_20bit) {
-		// if highres enabled gyro data is always 65.5 LSB/dps
-		_px4_gyro.set_scale(math::radians(1.f / 65.5f));
+		// published data is the 20 bit value shifted right by 1, so it spans the full range in
+		// 2^18 counts: 65.536 LSB/dps
+		_px4_gyro.set_scale(math::radians(4000.f / 262144.f));
 
 	} else {
 		// 20 bit data scaled to 16 bit (2^4)


### PR DESCRIPTION
## Summary

The 20-bit high resolution gyro scales in the ICM42688P, IIM42652 and IIM42653 drivers are built from rounded datasheet sensitivity figures instead of the exact values the hardware produces, so the published rate is 0.055% low and steps whenever the driver switches between its two decode branches.

## Problem

In 20-bit FIFO mode these drivers decode each sample twice. The high resolution branch publishes the 20-bit word shifted right by 1 (the LSB is always zero) and scales it by the datasheet's `131 LSB/dps` on the ±2000 dps parts or `65.5 LSB/dps` on the ±4000 dps parts. The fallback branch publishes the raw 16-bit registers — the same word shifted right by 4 — and scales by the exact `FSR / 32768`.

Since both branches decode the same measurement and differ only by a shift of 3, their scales must differ by exactly 8. They differ by 7.996, because the true sensitivity is `FSR / 2^18`: 131.072 and 65.536 LSB/dps. The datasheet figures are those values rounded for presentation.

Two consequences: the high resolution branch reports 0.055% low, and the reported rate steps by that amount every time a batch crosses the threshold between branches. The step is amplitude-dependent, so it does not calibrate out.

## Solution

Express both high resolution scales as `FSR / 262144`, matching the shift-by-1 and the `set_range()` above it. The fallback branches are already exact and unchanged.

Also spell the ICM42686P fallback as `4000 / 32768` rather than the numerically identical `2000 / 16384`, which read as if that part were ±2000 dps.