### PR TITLE
fix(drivers/invensense): always publish full-scale FIFO data

### DIFF
--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
@@ -417,13 +417,18 @@ bool ICM42688P::Configure()
 	//  For the 688 the only FSR settings that are operational are ±2000dps for gyroscope and ±16g for accelerometer
 	//  For the 686 the only FSR settings that are operational are ±4000dps for gyroscope and ±32g for accelerometer
 
+	// data is published from the 16 bit FIFO registers (data[19:4]), which always span the full range
 	if (isICM686) {
 		_px4_accel.set_range(32.f * CONSTANTS_ONE_G);
 		_px4_gyro.set_range(math::radians(4000.f));
+		_px4_accel.set_scale(32.f * CONSTANTS_ONE_G / 32768.f);
+		_px4_gyro.set_scale(math::radians(4000.f / 32768.f));
 
 	} else {
 		_px4_accel.set_range(16.f * CONSTANTS_ONE_G);
 		_px4_gyro.set_range(math::radians(2000.f));
+		_px4_accel.set_scale(16.f * CONSTANTS_ONE_G / 32768.f);
+		_px4_gyro.set_scale(math::radians(2000.f / 32768.f));
 	}
 
 	return success;
@@ -626,33 +631,12 @@ void ICM42688P::FIFOReset()
 	_drdy_timestamp_sample.store(0);
 }
 
-static constexpr int32_t reassemble_20bit(const uint32_t a, const uint32_t b, const uint32_t c)
-{
-	// 0xXXXAABBC
-	uint32_t high   = ((a << 12) & 0x000FF000);
-	uint32_t low    = ((b << 4)  & 0x00000FF0);
-	uint32_t lowest = (c         & 0x0000000F);
-
-	uint32_t x = high | low | lowest;
-
-	if (a & Bit7) {
-		// sign extend
-		x |= 0xFFF00000u;
-	}
-
-	return static_cast<int32_t>(x);
-}
-
 void ICM42688P::ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DATA fifo[], const uint8_t samples)
 {
 	sensor_accel_fifo_s accel{};
 	accel.timestamp_sample = timestamp_sample;
 	accel.samples = 0;
 
-	// 18-bits of accelerometer data, sent as 20-bits, 2 least significant bits always 0
-	bool scale_20bit = false;
-
-	// first pass
 	for (int i = 0; i < samples; i++) {
 
 		uint16_t timestamp_fifo = combine_uint(fifo[i].TimeStamp_h, fifo[i].TimeStamp_l);
@@ -664,72 +648,19 @@ void ICM42688P::ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DA
 			accel.dt = (float)timestamp_fifo * FIFO_TIMESTAMP_SCALING;
 		}
 
-		// 20 bit hires mode
-		// Sign extension + Accel [19:12] + Accel [11:4] + Accel [3:2] (20 bit extension byte)
-		// Accel data is 18 bit ()
-		int32_t accel_x = reassemble_20bit(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0,
-						   fifo[i].Ext_Accel_X_Gyro_X & 0xF0 >> 4);
-		int32_t accel_y = reassemble_20bit(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0,
-						   fifo[i].Ext_Accel_Y_Gyro_Y & 0xF0 >> 4);
-		int32_t accel_z = reassemble_20bit(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0,
-						   fifo[i].Ext_Accel_Z_Gyro_Z & 0xF0 >> 4);
+		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
+		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
+		// published scale stays constant instead of toggling with batch content.
+		const int16_t accel_x = combine(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0);
+		const int16_t accel_y = combine(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0);
+		const int16_t accel_z = combine(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0);
 
-		// sample invalid if -524288
-		if (accel_x != -524288 && accel_y != -524288 && accel_z != -524288) {
-			// check if any values are going to exceed int16 limits
-			static constexpr int16_t max_accel = INT16_MAX;
-			static constexpr int16_t min_accel = INT16_MIN;
-
-			if (accel_x >= max_accel || accel_x <= min_accel) {
-				scale_20bit = true;
-			}
-
-			if (accel_y >= max_accel || accel_y <= min_accel) {
-				scale_20bit = true;
-			}
-
-			if (accel_z >= max_accel || accel_z <= min_accel) {
-				scale_20bit = true;
-			}
-
-			// shift by 2 (2 least significant bits are always 0)
-			accel.x[accel.samples] = accel_x / 4;
-			accel.y[accel.samples] = accel_y / 4;
-			accel.z[accel.samples] = accel_z / 4;
+		// sample invalid if -32768 (16 bit truncation of the hires invalid marker -524288)
+		if (accel_x != INT16_MIN && accel_y != INT16_MIN && accel_z != INT16_MIN) {
+			accel.x[accel.samples] = accel_x;
+			accel.y[accel.samples] = accel_y;
+			accel.z[accel.samples] = accel_z;
 			accel.samples++;
-		}
-	}
-
-	if (!scale_20bit) {
-		// On the 686, if highres enabled accel data is always 4096 LSB/g
-		// On the 688, if highres enabled accel data is always 8192 LSB/g
-		if (isICM686) {
-			_px4_accel.set_scale(CONSTANTS_ONE_G / 4096.f);
-
-		} else {
-			_px4_accel.set_scale(CONSTANTS_ONE_G / 8192.f);
-		}
-
-	} else {
-		// 20 bit data scaled to 16 bit (2^4)
-		for (int i = 0; i < samples; i++) {
-			// 20 bit hires mode
-			// Sign extension + Accel [19:12] + Accel [11:4] + Accel [3:2] (20 bit extension byte)
-			// Accel data is 18 bit ()
-			int16_t accel_x = combine(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0);
-			int16_t accel_y = combine(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0);
-			int16_t accel_z = combine(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0);
-
-			accel.x[i] = accel_x;
-			accel.y[i] = accel_y;
-			accel.z[i] = accel_z;
-		}
-
-		if (isICM686) {
-			_px4_accel.set_scale(CONSTANTS_ONE_G / 1024.f);
-
-		} else {
-			_px4_accel.set_scale(CONSTANTS_ONE_G / 2048.f);
 		}
 	}
 
@@ -756,10 +687,6 @@ void ICM42688P::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DAT
 	gyro.timestamp_sample = timestamp_sample;
 	gyro.samples = 0;
 
-	// 19-bits of gyroscope data sent as 20-bits, LSB bit is 0
-	bool scale_20bit = false;
-
-	// first pass
 	for (int i = 0; i < samples; i++) {
 
 		uint16_t timestamp_fifo = combine_uint(fifo[i].TimeStamp_h, fifo[i].TimeStamp_l);
@@ -771,60 +698,13 @@ void ICM42688P::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DAT
 			gyro.dt = (float)timestamp_fifo * FIFO_TIMESTAMP_SCALING;
 		}
 
-		// 20 bit hires mode
-		// Gyro [19:12] + Gyro [11:4] + Gyro [3:0] (bottom 4 bits of 20 bit extension byte)
-		int32_t gyro_x = reassemble_20bit(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0, fifo[i].Ext_Accel_X_Gyro_X & 0x0F);
-		int32_t gyro_y = reassemble_20bit(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0, fifo[i].Ext_Accel_Y_Gyro_Y & 0x0F);
-		int32_t gyro_z = reassemble_20bit(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0, fifo[i].Ext_Accel_Z_Gyro_Z & 0x0F);
-
-		// check if any values are going to exceed int16 limits
-		static constexpr int16_t max_gyro = INT16_MAX;
-		static constexpr int16_t min_gyro = INT16_MIN;
-
-		if (gyro_x >= max_gyro || gyro_x <= min_gyro) {
-			scale_20bit = true;
-		}
-
-		if (gyro_y >= max_gyro || gyro_y <= min_gyro) {
-			scale_20bit = true;
-		}
-
-		if (gyro_z >= max_gyro || gyro_z <= min_gyro) {
-			scale_20bit = true;
-		}
-
-		// shift by 1 (least significant bit is always 0)
-		gyro.x[gyro.samples] = gyro_x / 2;
-		gyro.y[gyro.samples] = gyro_y / 2;
-		gyro.z[gyro.samples] = gyro_z / 2;
+		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
+		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
+		// published scale stays constant instead of toggling with batch content.
+		gyro.x[gyro.samples] = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
+		gyro.y[gyro.samples] = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
+		gyro.z[gyro.samples] = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
 		gyro.samples++;
-	}
-
-	if (!scale_20bit) {
-		// published data is the 20 bit value shifted right by 1, so it spans the full range in
-		// 2^18 counts: 65.536 LSB/dps on the 686, 131.072 LSB/dps on the 688
-		if (isICM686) {
-			_px4_gyro.set_scale(math::radians(4000.f / 262144.f));
-
-		} else {
-			_px4_gyro.set_scale(math::radians(2000.f / 262144.f));
-		}
-
-	} else {
-		// 20 bit data scaled to 16 bit (2^4)
-		for (int i = 0; i < samples; i++) {
-			gyro.x[i] = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
-			gyro.y[i] = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
-			gyro.z[i] = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
-		}
-
-		if (isICM686) {
-			_px4_gyro.set_scale(math::radians(4000.f / 32768.f));
-
-		} else {
-			_px4_gyro.set_scale(math::radians(2000.f / 32768.f));
-		}
-
 	}
 
 	// correct frame for publication

--- a/src/drivers/imu/invensense/iim42652/IIM42652.cpp
+++ b/src/drivers/imu/invensense/iim42652/IIM42652.cpp
@@ -411,8 +411,11 @@ bool IIM42652::Configure()
 
 	// 20-bits data format used
 	//  the only FSR settings that are operational are ±2000dps for gyroscope and ±16g for accelerometer
+	// data is published from the 16 bit FIFO registers (data[19:4]), which always span the full range
 	_px4_accel.set_range(16.f * CONSTANTS_ONE_G);
 	_px4_gyro.set_range(math::radians(2000.f));
+	_px4_accel.set_scale(16.f * CONSTANTS_ONE_G / 32768.f);
+	_px4_gyro.set_scale(math::radians(2000.f / 32768.f));
 
 	return success;
 }
@@ -614,33 +617,12 @@ void IIM42652::FIFOReset()
 	_drdy_timestamp_sample.store(0);
 }
 
-static constexpr int32_t reassemble_20bit(const uint32_t a, const uint32_t b, const uint32_t c)
-{
-	// 0xXXXAABBC
-	uint32_t high   = ((a << 12) & 0x000FF000);
-	uint32_t low    = ((b << 4)  & 0x00000FF0);
-	uint32_t lowest = (c         & 0x0000000F);
-
-	uint32_t x = high | low | lowest;
-
-	if (a & Bit7) {
-		// sign extend
-		x |= 0xFFF00000u;
-	}
-
-	return static_cast<int32_t>(x);
-}
-
 void IIM42652::ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DATA fifo[], const uint8_t samples)
 {
 	sensor_accel_fifo_s accel{};
 	accel.timestamp_sample = timestamp_sample;
 	accel.samples = 0;
 
-	// 18-bits of accelerometer data
-	bool scale_20bit = false;
-
-	// first pass
 	for (int i = 0; i < samples; i++) {
 
 		uint16_t timestamp_fifo = combine_uint(fifo[i].TimeStamp_h, fifo[i].TimeStamp_l);
@@ -652,62 +634,20 @@ void IIM42652::ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DAT
 			accel.dt = (float)timestamp_fifo * FIFO_TIMESTAMP_SCALING;
 		}
 
-		// 20 bit hires mode
-		// Sign extension + Accel [19:12] + Accel [11:4] + Accel [3:2] (20 bit extension byte)
-		// Accel data is 18 bit ()
-		int32_t accel_x = reassemble_20bit(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0,
-						   fifo[i].Ext_Accel_X_Gyro_X & 0xF0 >> 4);
-		int32_t accel_y = reassemble_20bit(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0,
-						   fifo[i].Ext_Accel_Y_Gyro_Y & 0xF0 >> 4);
-		int32_t accel_z = reassemble_20bit(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0,
-						   fifo[i].Ext_Accel_Z_Gyro_Z & 0xF0 >> 4);
+		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
+		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
+		// published scale stays constant instead of toggling with batch content.
+		const int16_t accel_x = combine(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0);
+		const int16_t accel_y = combine(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0);
+		const int16_t accel_z = combine(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0);
 
-		// sample invalid if -524288
-		if (accel_x != -524288 && accel_y != -524288 && accel_z != -524288) {
-			// check if any values are going to exceed int16 limits
-			static constexpr int16_t max_accel = INT16_MAX;
-			static constexpr int16_t min_accel = INT16_MIN;
-
-			if (accel_x >= max_accel || accel_x <= min_accel) {
-				scale_20bit = true;
-			}
-
-			if (accel_y >= max_accel || accel_y <= min_accel) {
-				scale_20bit = true;
-			}
-
-			if (accel_z >= max_accel || accel_z <= min_accel) {
-				scale_20bit = true;
-			}
-
-			// shift by 2 (2 least significant bits are always 0)
-			accel.x[accel.samples] = accel_x / 4;
-			accel.y[accel.samples] = accel_y / 4;
-			accel.z[accel.samples] = accel_z / 4;
+		// sample invalid if -32768 (16 bit truncation of the hires invalid marker -524288)
+		if (accel_x != INT16_MIN && accel_y != INT16_MIN && accel_z != INT16_MIN) {
+			accel.x[accel.samples] = accel_x;
+			accel.y[accel.samples] = accel_y;
+			accel.z[accel.samples] = accel_z;
 			accel.samples++;
 		}
-	}
-
-	if (!scale_20bit) {
-		// if highres enabled accel data is always 8192 LSB/g
-		_px4_accel.set_scale(CONSTANTS_ONE_G / 8192.f);
-
-	} else {
-		// 20 bit data scaled to 16 bit (2^4)
-		for (int i = 0; i < samples; i++) {
-			// 20 bit hires mode
-			// Sign extension + Accel [19:12] + Accel [11:4] + Accel [3:2] (20 bit extension byte)
-			// Accel data is 18 bit ()
-			int16_t accel_x = combine(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0);
-			int16_t accel_y = combine(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0);
-			int16_t accel_z = combine(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0);
-
-			accel.x[i] = accel_x;
-			accel.y[i] = accel_y;
-			accel.z[i] = accel_z;
-		}
-
-		_px4_accel.set_scale(CONSTANTS_ONE_G / 2048.f);
 	}
 
 	// correct frame for publication
@@ -733,10 +673,6 @@ void IIM42652::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 	gyro.timestamp_sample = timestamp_sample;
 	gyro.samples = 0;
 
-	// 20-bits of gyroscope data
-	bool scale_20bit = false;
-
-	// first pass
 	for (int i = 0; i < samples; i++) {
 
 		uint16_t timestamp_fifo = combine_uint(fifo[i].TimeStamp_h, fifo[i].TimeStamp_l);
@@ -748,48 +684,13 @@ void IIM42652::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 			gyro.dt = (float)timestamp_fifo * FIFO_TIMESTAMP_SCALING;
 		}
 
-		// 20 bit hires mode
-		// Gyro [19:12] + Gyro [11:4] + Gyro [3:0] (bottom 4 bits of 20 bit extension byte)
-		int32_t gyro_x = reassemble_20bit(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0, fifo[i].Ext_Accel_X_Gyro_X & 0x0F);
-		int32_t gyro_y = reassemble_20bit(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0, fifo[i].Ext_Accel_Y_Gyro_Y & 0x0F);
-		int32_t gyro_z = reassemble_20bit(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0, fifo[i].Ext_Accel_Z_Gyro_Z & 0x0F);
-
-		// check if any values are going to exceed int16 limits
-		static constexpr int16_t max_gyro = INT16_MAX;
-		static constexpr int16_t min_gyro = INT16_MIN;
-
-		if (gyro_x >= max_gyro || gyro_x <= min_gyro) {
-			scale_20bit = true;
-		}
-
-		if (gyro_y >= max_gyro || gyro_y <= min_gyro) {
-			scale_20bit = true;
-		}
-
-		if (gyro_z >= max_gyro || gyro_z <= min_gyro) {
-			scale_20bit = true;
-		}
-
-		gyro.x[gyro.samples] = gyro_x / 2;
-		gyro.y[gyro.samples] = gyro_y / 2;
-		gyro.z[gyro.samples] = gyro_z / 2;
+		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
+		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
+		// published scale stays constant instead of toggling with batch content.
+		gyro.x[gyro.samples] = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
+		gyro.y[gyro.samples] = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
+		gyro.z[gyro.samples] = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
 		gyro.samples++;
-	}
-
-	if (!scale_20bit) {
-		// published data is the 20 bit value shifted right by 1, so it spans the full range in
-		// 2^18 counts: 131.072 LSB/dps
-		_px4_gyro.set_scale(math::radians(2000.f / 262144.f));
-
-	} else {
-		// 20 bit data scaled to 16 bit (2^4)
-		for (int i = 0; i < samples; i++) {
-			gyro.x[i] = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
-			gyro.y[i] = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
-			gyro.z[i] = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
-		}
-
-		_px4_gyro.set_scale(math::radians(2000.f / 32768.f));
 	}
 
 	// correct frame for publication

--- a/src/drivers/imu/invensense/iim42653/IIM42653.cpp
+++ b/src/drivers/imu/invensense/iim42653/IIM42653.cpp
@@ -411,9 +411,12 @@ bool IIM42653::Configure()
 	}
 
 	// 20-bits data format used
-	//  IIM-42653 FSR: ±4000 dps gyroscope and ±32 g accelerometer (default full-scale)
+	//  the only FSR settings that are operational are ±4000dps for gyroscope and ±32g for accelerometer
+	// data is published from the 16 bit FIFO registers (data[19:4]), which always span the full range
 	_px4_accel.set_range(32.f * CONSTANTS_ONE_G);
 	_px4_gyro.set_range(math::radians(4000.f));
+	_px4_accel.set_scale(32.f * CONSTANTS_ONE_G / 32768.f);
+	_px4_gyro.set_scale(math::radians(4000.f / 32768.f));
 
 	return success;
 }
@@ -615,33 +618,12 @@ void IIM42653::FIFOReset()
 	_drdy_timestamp_sample.store(0);
 }
 
-static constexpr int32_t reassemble_20bit(const uint32_t a, const uint32_t b, const uint32_t c)
-{
-	// 0xXXXAABBC
-	uint32_t high   = ((a << 12) & 0x000FF000);
-	uint32_t low    = ((b << 4)  & 0x00000FF0);
-	uint32_t lowest = (c         & 0x0000000F);
-
-	uint32_t x = high | low | lowest;
-
-	if (a & Bit7) {
-		// sign extend
-		x |= 0xFFF00000u;
-	}
-
-	return static_cast<int32_t>(x);
-}
-
 void IIM42653::ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DATA fifo[], const uint8_t samples)
 {
 	sensor_accel_fifo_s accel{};
 	accel.timestamp_sample = timestamp_sample;
 	accel.samples = 0;
 
-	// 18-bits of accelerometer data
-	bool scale_20bit = false;
-
-	// first pass
 	for (int i = 0; i < samples; i++) {
 
 		uint16_t timestamp_fifo = combine_uint(fifo[i].TimeStamp_h, fifo[i].TimeStamp_l);
@@ -653,62 +635,20 @@ void IIM42653::ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DAT
 			accel.dt = (float)timestamp_fifo * FIFO_TIMESTAMP_SCALING;
 		}
 
-		// 20 bit hires mode
-		// Sign extension + Accel [19:12] + Accel [11:4] + Accel [3:2] (20 bit extension byte)
-		// Accel data is 18 bit ()
-		int32_t accel_x = reassemble_20bit(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0,
-						   fifo[i].Ext_Accel_X_Gyro_X & 0xF0 >> 4);
-		int32_t accel_y = reassemble_20bit(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0,
-						   fifo[i].Ext_Accel_Y_Gyro_Y & 0xF0 >> 4);
-		int32_t accel_z = reassemble_20bit(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0,
-						   fifo[i].Ext_Accel_Z_Gyro_Z & 0xF0 >> 4);
+		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
+		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
+		// published scale stays constant instead of toggling with batch content.
+		const int16_t accel_x = combine(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0);
+		const int16_t accel_y = combine(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0);
+		const int16_t accel_z = combine(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0);
 
-		// sample invalid if -524288
-		if (accel_x != -524288 && accel_y != -524288 && accel_z != -524288) {
-			// check if any values are going to exceed int16 limits
-			static constexpr int16_t max_accel = INT16_MAX;
-			static constexpr int16_t min_accel = INT16_MIN;
-
-			if (accel_x >= max_accel || accel_x <= min_accel) {
-				scale_20bit = true;
-			}
-
-			if (accel_y >= max_accel || accel_y <= min_accel) {
-				scale_20bit = true;
-			}
-
-			if (accel_z >= max_accel || accel_z <= min_accel) {
-				scale_20bit = true;
-			}
-
-			// shift by 2 (2 least significant bits are always 0)
-			accel.x[accel.samples] = accel_x / 4;
-			accel.y[accel.samples] = accel_y / 4;
-			accel.z[accel.samples] = accel_z / 4;
+		// sample invalid if -32768 (16 bit truncation of the hires invalid marker -524288)
+		if (accel_x != INT16_MIN && accel_y != INT16_MIN && accel_z != INT16_MIN) {
+			accel.x[accel.samples] = accel_x;
+			accel.y[accel.samples] = accel_y;
+			accel.z[accel.samples] = accel_z;
 			accel.samples++;
 		}
-	}
-
-	if (!scale_20bit) {
-		// if highres enabled accel data is always 4096 LSB/g
-		_px4_accel.set_scale(CONSTANTS_ONE_G / 4096.f);
-
-	} else {
-		// 20 bit data scaled to 16 bit (2^4)
-		for (int i = 0; i < samples; i++) {
-			// 20 bit hires mode
-			// Sign extension + Accel [19:12] + Accel [11:4] + Accel [3:2] (20 bit extension byte)
-			// Accel data is 18 bit ()
-			int16_t accel_x = combine(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0);
-			int16_t accel_y = combine(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0);
-			int16_t accel_z = combine(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0);
-
-			accel.x[i] = accel_x;
-			accel.y[i] = accel_y;
-			accel.z[i] = accel_z;
-		}
-
-		_px4_accel.set_scale(CONSTANTS_ONE_G / 1024.f);
 	}
 
 	// correct frame for publication
@@ -734,10 +674,6 @@ void IIM42653::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 	gyro.timestamp_sample = timestamp_sample;
 	gyro.samples = 0;
 
-	// 20-bits of gyroscope data
-	bool scale_20bit = false;
-
-	// first pass
 	for (int i = 0; i < samples; i++) {
 
 		uint16_t timestamp_fifo = combine_uint(fifo[i].TimeStamp_h, fifo[i].TimeStamp_l);
@@ -749,48 +685,13 @@ void IIM42653::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 			gyro.dt = (float)timestamp_fifo * FIFO_TIMESTAMP_SCALING;
 		}
 
-		// 20 bit hires mode
-		// Gyro [19:12] + Gyro [11:4] + Gyro [3:0] (bottom 4 bits of 20 bit extension byte)
-		int32_t gyro_x = reassemble_20bit(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0, fifo[i].Ext_Accel_X_Gyro_X & 0x0F);
-		int32_t gyro_y = reassemble_20bit(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0, fifo[i].Ext_Accel_Y_Gyro_Y & 0x0F);
-		int32_t gyro_z = reassemble_20bit(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0, fifo[i].Ext_Accel_Z_Gyro_Z & 0x0F);
-
-		// check if any values are going to exceed int16 limits
-		static constexpr int16_t max_gyro = INT16_MAX;
-		static constexpr int16_t min_gyro = INT16_MIN;
-
-		if (gyro_x >= max_gyro || gyro_x <= min_gyro) {
-			scale_20bit = true;
-		}
-
-		if (gyro_y >= max_gyro || gyro_y <= min_gyro) {
-			scale_20bit = true;
-		}
-
-		if (gyro_z >= max_gyro || gyro_z <= min_gyro) {
-			scale_20bit = true;
-		}
-
-		gyro.x[gyro.samples] = gyro_x / 2;
-		gyro.y[gyro.samples] = gyro_y / 2;
-		gyro.z[gyro.samples] = gyro_z / 2;
+		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
+		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
+		// published scale stays constant instead of toggling with batch content.
+		gyro.x[gyro.samples] = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
+		gyro.y[gyro.samples] = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
+		gyro.z[gyro.samples] = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
 		gyro.samples++;
-	}
-
-	if (!scale_20bit) {
-		// published data is the 20 bit value shifted right by 1, so it spans the full range in
-		// 2^18 counts: 65.536 LSB/dps
-		_px4_gyro.set_scale(math::radians(4000.f / 262144.f));
-
-	} else {
-		// 20 bit data scaled to 16 bit (2^4)
-		for (int i = 0; i < samples; i++) {
-			gyro.x[i] = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
-			gyro.y[i] = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
-			gyro.z[i] = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
-		}
-
-		_px4_gyro.set_scale(math::radians(4000.f / 32768.f));
 	}
 
 	// correct frame for publication

--- a/src/drivers/imu/invensense/iim42653/IIM42653.cpp
+++ b/src/drivers/imu/invensense/iim42653/IIM42653.cpp
@@ -411,9 +411,12 @@ bool IIM42653::Configure()
 	}
 
 	// 20-bits data format used
-	//  the only FSR settings that are operational are ±2000dps for gyroscope and ±16g for accelerometer
-	_px4_accel.set_range(16.f * CONSTANTS_ONE_G);
-	_px4_gyro.set_range(math::radians(2000.f));
+	//  the only FSR settings that are operational are ±4000dps for gyroscope and ±32g for accelerometer
+	// data is published from the 16 bit FIFO registers (data[19:4]), which always span the full range
+	_px4_accel.set_range(32.f * CONSTANTS_ONE_G);
+	_px4_gyro.set_range(math::radians(4000.f));
+	_px4_accel.set_scale(32.f * CONSTANTS_ONE_G / 32768.f);
+	_px4_gyro.set_scale(math::radians(4000.f / 32768.f));
 
 	return success;
 }
@@ -615,33 +618,12 @@ void IIM42653::FIFOReset()
 	_drdy_timestamp_sample.store(0);
 }
 
-static constexpr int32_t reassemble_20bit(const uint32_t a, const uint32_t b, const uint32_t c)
-{
-	// 0xXXXAABBC
-	uint32_t high   = ((a << 12) & 0x000FF000);
-	uint32_t low    = ((b << 4)  & 0x00000FF0);
-	uint32_t lowest = (c         & 0x0000000F);
-
-	uint32_t x = high | low | lowest;
-
-	if (a & Bit7) {
-		// sign extend
-		x |= 0xFFF00000u;
-	}
-
-	return static_cast<int32_t>(x);
-}
-
 void IIM42653::ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DATA fifo[], const uint8_t samples)
 {
 	sensor_accel_fifo_s accel{};
 	accel.timestamp_sample = timestamp_sample;
 	accel.samples = 0;
 
-	// 18-bits of accelerometer data
-	bool scale_20bit = false;
-
-	// first pass
 	for (int i = 0; i < samples; i++) {
 
 		uint16_t timestamp_fifo = combine_uint(fifo[i].TimeStamp_h, fifo[i].TimeStamp_l);
@@ -653,62 +635,20 @@ void IIM42653::ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DAT
 			accel.dt = (float)timestamp_fifo * FIFO_TIMESTAMP_SCALING;
 		}
 
-		// 20 bit hires mode
-		// Sign extension + Accel [19:12] + Accel [11:4] + Accel [3:2] (20 bit extension byte)
-		// Accel data is 18 bit ()
-		int32_t accel_x = reassemble_20bit(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0,
-						   fifo[i].Ext_Accel_X_Gyro_X & 0xF0 >> 4);
-		int32_t accel_y = reassemble_20bit(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0,
-						   fifo[i].Ext_Accel_Y_Gyro_Y & 0xF0 >> 4);
-		int32_t accel_z = reassemble_20bit(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0,
-						   fifo[i].Ext_Accel_Z_Gyro_Z & 0xF0 >> 4);
+		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
+		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
+		// published scale stays constant instead of toggling with batch content.
+		const int16_t accel_x = combine(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0);
+		const int16_t accel_y = combine(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0);
+		const int16_t accel_z = combine(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0);
 
-		// sample invalid if -524288
-		if (accel_x != -524288 && accel_y != -524288 && accel_z != -524288) {
-			// check if any values are going to exceed int16 limits
-			static constexpr int16_t max_accel = INT16_MAX;
-			static constexpr int16_t min_accel = INT16_MIN;
-
-			if (accel_x >= max_accel || accel_x <= min_accel) {
-				scale_20bit = true;
-			}
-
-			if (accel_y >= max_accel || accel_y <= min_accel) {
-				scale_20bit = true;
-			}
-
-			if (accel_z >= max_accel || accel_z <= min_accel) {
-				scale_20bit = true;
-			}
-
-			// shift by 2 (2 least significant bits are always 0)
-			accel.x[accel.samples] = accel_x / 4;
-			accel.y[accel.samples] = accel_y / 4;
-			accel.z[accel.samples] = accel_z / 4;
+		// sample invalid if -32768 (16 bit truncation of the hires invalid marker -524288)
+		if (accel_x != INT16_MIN && accel_y != INT16_MIN && accel_z != INT16_MIN) {
+			accel.x[accel.samples] = accel_x;
+			accel.y[accel.samples] = accel_y;
+			accel.z[accel.samples] = accel_z;
 			accel.samples++;
 		}
-	}
-
-	if (!scale_20bit) {
-		// if highres enabled accel data is always 4096 LSB/g
-		_px4_accel.set_scale(CONSTANTS_ONE_G / 4096.f);
-
-	} else {
-		// 20 bit data scaled to 16 bit (2^4)
-		for (int i = 0; i < samples; i++) {
-			// 20 bit hires mode
-			// Sign extension + Accel [19:12] + Accel [11:4] + Accel [3:2] (20 bit extension byte)
-			// Accel data is 18 bit ()
-			int16_t accel_x = combine(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0);
-			int16_t accel_y = combine(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0);
-			int16_t accel_z = combine(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0);
-
-			accel.x[i] = accel_x;
-			accel.y[i] = accel_y;
-			accel.z[i] = accel_z;
-		}
-
-		_px4_accel.set_scale(CONSTANTS_ONE_G / 1024.f);
 	}
 
 	// correct frame for publication
@@ -734,10 +674,6 @@ void IIM42653::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 	gyro.timestamp_sample = timestamp_sample;
 	gyro.samples = 0;
 
-	// 20-bits of gyroscope data
-	bool scale_20bit = false;
-
-	// first pass
 	for (int i = 0; i < samples; i++) {
 
 		uint16_t timestamp_fifo = combine_uint(fifo[i].TimeStamp_h, fifo[i].TimeStamp_l);
@@ -749,48 +685,13 @@ void IIM42653::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 			gyro.dt = (float)timestamp_fifo * FIFO_TIMESTAMP_SCALING;
 		}
 
-		// 20 bit hires mode
-		// Gyro [19:12] + Gyro [11:4] + Gyro [3:0] (bottom 4 bits of 20 bit extension byte)
-		int32_t gyro_x = reassemble_20bit(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0, fifo[i].Ext_Accel_X_Gyro_X & 0x0F);
-		int32_t gyro_y = reassemble_20bit(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0, fifo[i].Ext_Accel_Y_Gyro_Y & 0x0F);
-		int32_t gyro_z = reassemble_20bit(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0, fifo[i].Ext_Accel_Z_Gyro_Z & 0x0F);
-
-		// check if any values are going to exceed int16 limits
-		static constexpr int16_t max_gyro = INT16_MAX;
-		static constexpr int16_t min_gyro = INT16_MIN;
-
-		if (gyro_x >= max_gyro || gyro_x <= min_gyro) {
-			scale_20bit = true;
-		}
-
-		if (gyro_y >= max_gyro || gyro_y <= min_gyro) {
-			scale_20bit = true;
-		}
-
-		if (gyro_z >= max_gyro || gyro_z <= min_gyro) {
-			scale_20bit = true;
-		}
-
-		gyro.x[gyro.samples] = gyro_x / 2;
-		gyro.y[gyro.samples] = gyro_y / 2;
-		gyro.z[gyro.samples] = gyro_z / 2;
+		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
+		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
+		// published scale stays constant instead of toggling with batch content.
+		gyro.x[gyro.samples] = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
+		gyro.y[gyro.samples] = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
+		gyro.z[gyro.samples] = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
 		gyro.samples++;
-	}
-
-	if (!scale_20bit) {
-		// published data is the 20 bit value shifted right by 1, so it spans the full range in
-		// 2^18 counts: 65.536 LSB/dps
-		_px4_gyro.set_scale(math::radians(4000.f / 262144.f));
-
-	} else {
-		// 20 bit data scaled to 16 bit (2^4)
-		for (int i = 0; i < samples; i++) {
-			gyro.x[i] = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
-			gyro.y[i] = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
-			gyro.z[i] = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
-		}
-
-		_px4_gyro.set_scale(math::radians(4000.f / 32768.f));
 	}
 
 	// correct frame for publication


### PR DESCRIPTION
## Summary

The ICM42688P, IIM42652 and IIM42653 drivers switch scale per batch depending on signal amplitude. Publish the 16-bit FIFO registers with a fixed scale instead. The resolution given up is ~0.5% of the gyro's own noise; the switching costs a lot more than that.

## Problem

In 20-bit FIFO mode these drivers decode every sample twice. The first pass reassembles the 20-bit word; if any axis of any sample would overflow `int16`, the batch is decoded again as plain 16-bit registers and published at a 4x (accel) or 8x (gyro) coarser scale.

The threshold is compared against the 20-bit value using `INT16_MAX`, but the value stored is that shifted right by 2 (accel) or 1 (gyro). So the switch fires 4x/2x earlier than the `int16` array actually requires: on the ICM42688P and IIM42652 the accel demotes at **1.0 g** and the gyro at 125 dps. Body-z carries ~1 g in hover, so the fine branch is unreachable in flight and the vehicle sits on the boundary, flipping scale batch to batch on vibration alone.

That costs:

- **`GyroFFT` discards its window on every switch** (`GyroFFT.cpp:350`, `// force reset if scale has changed`). At 512 samples / 8 kHz the window needs 64 ms to fill, so the dynamic notch stops updating while maneuvering.
- **Invalid samples can be published.** The first pass writes `accel.x[accel.samples]` and skips invalid samples; the second pass writes `accel.x[i]` across all `samples`. When anything is invalid the published batch is misaligned and includes the invalid entries.
- **Clipping is never reported.** `clipping()` counts at `INT16_MAX`, which in the fine branch is 4 g — unreachable, because the driver bails out at 1 g first.
- A second full decode pass per batch at 8 kHz.

What the fine branch buys, calculated from datasheet figures for the ICM42688P as configured here (8 kHz ODR, UI filter at ODR/2, gyro noise density 2.8 mdps/√Hz): the coarse LSB is 61 mdps against 177 mdps of sensor noise, so quantization contributes ~1% of the noise power and total noise rises **0.5%** for gyro, 0.05% for accel. For it to add even 5% you would need a gyro quieter than 0.87 mdps/√Hz. This is arithmetic from the datasheet rather than a bench measurement, but the margin is wide enough that it does not hinge on the exact noise figure.

## Solution

Publish `data[19:4]` — the 16-bit registers — and set the scale once in `Configure()` next to the range. Delete the dual pass, the threshold and `reassemble_20bit`.

`INT16_MAX` now corresponds to the sensor's true full scale, so clipping is reported when the sensor actually saturates, and the scale field never changes.

## Alternatives

Keep the 20-bit data and widen the pipeline to floats, as ArduPilot does — `uint20_to_float()` sign-extends straight to `float` and applies one fixed scale, so they get full resolution and full range with no branch. That requires `sensor_accel_fifo`/`sensor_gyro_fifo` to carry `float` or `int32` instead of `int16[32]`, which doubles the topic memory and touches every FIFO IMU driver, the logger, `GyroFFT` and `VehicleAngularVelocity`. For an 0.5% resolution difference that is not worth it.

Worth noting ArduPilot ships `HAL_INS_HIGHRES_SAMPLE` **off by default** and leaves it to individual boards to opt in — and their implementation pays none of the costs above.

The narrower alternative is to keep the two branches and just fix the threshold to account for the shift (2.83 g / 177 dps allowing for `rotate_3i`). That preserves the resolution but keeps the scale switching, and therefore the `GyroFFT` resets, for a benefit that is well under the noise floor.

