### PR TITLE
chore(docs): bump vp-dynamic-nav to preserve page on version switch

### DIFF
--- a/docs/.vitepress/navbar.json
+++ b/docs/.vitepress/navbar.json
@@ -14,6 +14,7 @@
     { "text": "Support", "link": "https://docs.px4.io/main/en/contribute/support.html" },
     {
       "text": "Version",
+      "preservePath": true,
       "items": [
         { "text": "main", "link": "https://docs.px4.io/main/en/" },
         { "text": "v1.17 (stable)", "link": "https://docs.px4.io/v1.17/en/" },

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
     "medium-zoom": "^1.1.0",
     "open-editor": "^5.0.0",
     "vitepress": "^1.6.3",
-    "vp-dynamic-nav": "0.0.3",
+    "vp-dynamic-nav": "0.1.0",
     "vue3-tabs-component": "^1.3.7"
   },
   "devDependencies": {

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1785,10 +1785,10 @@ vitepress@^1.6.3:
     vite "^5.4.14"
     vue "^3.5.13"
 
-vp-dynamic-nav@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/vp-dynamic-nav/-/vp-dynamic-nav-0.0.3.tgz"
-  integrity sha512-qkDeki7TA21bhA12uiR0kEWZHVqeFusza3/XsGjD75Ht6qUoDOS/+YrCPyw9+6Zm+5/BvzK7j0jpDXPwW20m3g==
+vp-dynamic-nav@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/vp-dynamic-nav/-/vp-dynamic-nav-0.1.0.tgz#7f0136edfe2c7d2eaa0e8a75b99d8dd5b409e7c5"
+  integrity sha512-AXGT1uYpjngEqtRSVWsJu/8O08uxqyYb84glF31w3ozTlp1TiBWVLELCPKIhj0ukX/x6J7lfaQNDS2R/8DNO9Q==
 
 vue3-tabs-component@^1.3.7:
   version "1.3.7"


### PR DESCRIPTION
## Summary
Bumps `vp-dynamic-nav` to 0.1.0 and opts the "Version" navbar group into its new `preservePath` behavior, so switching doc versions keeps the reader on the equivalent page instead of dropping them on that version's front page.

This is an alternative to #28130

## Problem

The Version entries in `docs/.vitepress/navbar.json` are static links to each version's root (e.g. `https://docs.px4.io/v1.16/en/`). A reader deep in some page who switches version lands on the front page and has to navigate back. `vp-dynamic-nav` (the plugin that renders this navbar dynamically from this same JSON file, so older deployed doc versions pick up the current nav without a rebuild) had no way to express "keep the reader on this page" — that's only knowable in the browser.

## Solution
`vp-dynamic-nav` 0.1.0 adds an opt-in `preservePath` flag: nav items/groups that set it get their `link` rewritten at render time to the equivalent page on the target root, computed from the reader's current path. Same-origin only; falls back to the plain link otherwise (dev server, preview deploys). Implementation: hamishwillee/vp-dynamic-nav, branch `pr_version_switcher`.

This PR just opts the Version group in via `navbar.json` and bumps the dependency.

**Blocked on**: the `pr_version_switcher` branch in `vp-dynamic-nav` being merged and published to npm as `0.1.0`. Marking this draft until then — `yarn.lock` still pins `0.0.3` (yarn can't resolve `0.1.0` yet), and needs `yarn install` rerun once it's published.

**Tested**: `vp-dynamic-nav`'s own playground build (`npm run test`) and a standalone check of the path-rewrite logic against the real `navbar.json` shape. Not yet tested as an integrated `docs/` build here, since that needs the published `0.1.0` package.