### PR TITLE
feat(clock_source): Add system clock source parameter for main clock selection

### DIFF
--- a/src/drivers/gnss/septentrio/septentrio.cpp
+++ b/src/drivers/gnss/septentrio/septentrio.cpp
@@ -56,6 +56,7 @@
 #include <px4_platform_common/log.h>
 #include <px4_platform_common/time.h>
 #include <lib/systemlib/mavlink_log.h>
+#include <lib/systemlib/system_time_source.h>
 #include <uORB/topics/rtcm_data.h>
 #include <uORB/topics/sensor_gps.h>
 
@@ -1893,7 +1894,10 @@ bool SeptentrioDriver::clock_needs_update(timespec real_time)
 
 void SeptentrioDriver::set_clock(timespec rtc_gps_time)
 {
-	if (clock_needs_update(rtc_gps_time)) {
+	int32_t sys_time_src = 0;
+	get_parameter("SYS_TIME_SRC", &sys_time_src);
+
+	if (clock_needs_update(rtc_gps_time) && (sys_time_src & SYS_TIME_SRC_GPS)) {
 		px4_clock_settime(CLOCK_REALTIME, &rtc_gps_time);
 	}
 }

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -71,6 +71,7 @@
 
 #include <lib/failure_injection/FailureInjection.hpp>
 #include <lib/gnss/correction_framer.h>
+#include <systemlib/system_time_source.h>
 
 #include "devices/src/gps_helper.h"
 
@@ -569,7 +570,10 @@ int GPS::callback(GPSCallbackType type, void *data1, int data2, void *user)
 		timespec rtc_gps_time = *(timespec *)data1;
 		int drift_time = abs(static_cast<long>(rtc_system_time.tv_sec - rtc_gps_time.tv_sec));
 
-		if (drift_time >= SET_CLOCK_DRIFT_TIME_S) {
+		int32_t sys_time_src = 0;
+		param_get(param_find("SYS_TIME_SRC"), &sys_time_src);
+
+		if (drift_time >= SET_CLOCK_DRIFT_TIME_S && (sys_time_src & SYS_TIME_SRC_GPS)) {
 			// as of 2021 setting the time on Nuttx temporarily pauses interrupts
 			// so only set the time if it is very wrong.
 			// TODO: clock slewing of the RTC for small time differences

--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -45,6 +45,7 @@
 
 #include <drivers/drv_hrt.h>
 #include <systemlib/err.h>
+#include <systemlib/system_time_source.h>
 #include <mathlib/mathlib.h>
 #include <matrix/math.hpp>
 #include <lib/parameters/param.h>
@@ -560,15 +561,20 @@ void UavcanGnssBridge::process_fixx(const uavcan::ReceivedDataStructure<FixType>
 
 	// If we haven't already done so, set the system clock using GPS data
 	if (sensor_gps.time_utc_usec != 0 && (fix_type >= sensor_gps_s::FIX_TYPE_2D) && !_system_clock_set) {
-		timespec ts{};
+		int32_t sys_time_src = 0;
+		param_get(param_find("SYS_TIME_SRC"), &sys_time_src);
 
-		// get the whole microseconds
-		ts.tv_sec = sensor_gps.time_utc_usec / 1000000ULL;
+		if (sys_time_src & SYS_TIME_SRC_GPS) {
+			timespec ts{};
 
-		// get the remainder microseconds and convert to nanoseconds
-		ts.tv_nsec = (sensor_gps.time_utc_usec % 1000000ULL) * 1000;
+			// get the whole microseconds
+			ts.tv_sec = sensor_gps.time_utc_usec / 1000000ULL;
 
-		px4_clock_settime(CLOCK_REALTIME, &ts);
+			// get the remainder microseconds and convert to nanoseconds
+			ts.tv_nsec = (sensor_gps.time_utc_usec % 1000000ULL) * 1000;
+
+			px4_clock_settime(CLOCK_REALTIME, &ts);
+		}
 
 		_system_clock_set = true;
 	}

--- a/src/lib/systemlib/CMakeLists.txt
+++ b/src/lib/systemlib/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SRCS
 	mavlink_log.cpp
 	mavlink_log.h
 	px4_macros.h
+	system_time_source.h
 )
 
 if(${PX4_PLATFORM} STREQUAL "nuttx")

--- a/src/lib/systemlib/system_params.yaml
+++ b/src/lib/systemlib/system_params.yaml
@@ -241,3 +241,18 @@ parameters:
       type: boolean
       default: 0
       reboot_required: true
+    SYS_TIME_SRC:
+      description:
+        short: Select the source of the system time.
+        long: |-
+          This parameter selects the source allowed to set the system time.
+          The default value enables all sources.
+      type: bitmask
+      bit:
+        0: GPS time
+        1: MAVLink time
+        2: Software RTC time
+        3: DDS time
+        4: Input simulation time
+      default: 31
+      reboot_required: true

--- a/src/lib/systemlib/system_time_source.h
+++ b/src/lib/systemlib/system_time_source.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2024 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,48 +31,19 @@
  *
  ****************************************************************************/
 
+/**
+ * @file system_time_source.h
+ * Bit values for the SYS_TIME_SRC bitmask parameter.
+ */
+
 #pragma once
 
-#include <px4_platform_common/module.h>
-#include <px4_platform_common/module_params.h>
-#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
-#include <px4_platform_common/time.h>
-#include <systemlib/system_time_source.h>
+#include <cstdint>
 
-static constexpr const auto TIME_FILE_PATH = PX4_STORAGEDIR "/time_save.bin";
-
-using namespace time_literals;
-
-class TimePersistor : public ModuleBase, public ModuleParams, public px4::ScheduledWorkItem
-{
-public:
-	TimePersistor();
-	~TimePersistor() override;
-
-	static Descriptor desc;
-
-	/** @see ModuleBase */
-	static int task_spawn(int argc, char *argv[]);
-
-	/** @see ModuleBase */
-	static int custom_command(int argc, char *argv[]);
-
-	/** @see ModuleBase */
-	static int print_usage(const char *reason = nullptr);
-
-	/** @see ModuleBase::run() */
-	void Run() override;
-
-	void start();
-
-private:
-	int init();
-	int read_time(time_t *time);
-	int write_time(const time_t time);
-
-	FILE *_file = 0;
-
-	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::SYS_TIME_SRC>) _param_sys_time_src
-	)
+enum SystemTimeSource : int32_t {
+	SYS_TIME_SRC_GPS       = 1 << 0,
+	SYS_TIME_SRC_MAVLINK   = 1 << 1,
+	SYS_TIME_SRC_SOFT_RTC  = 1 << 2,
+	SYS_TIME_SRC_DDS       = 1 << 3,
+	SYS_TIME_SRC_SIMULATOR = 1 << 4,
 };

--- a/src/modules/mavlink/mavlink_timesync.cpp
+++ b/src/modules/mavlink/mavlink_timesync.cpp
@@ -43,6 +43,9 @@
 
 #include <stdlib.h>
 
+#include <lib/parameters/param.h>
+#include <systemlib/system_time_source.h>
+
 MavlinkTimesync::MavlinkTimesync(Mavlink &mavlink) :
 	_mavlink(mavlink)
 {
@@ -94,7 +97,10 @@ MavlinkTimesync::handle_message(const mavlink_message_t *msg)
 			time_t remote_time = time.time_unix_usec / 1000000;
 			bool update = (remote_time > PX4_EPOCH_SECS) && (remote_time > local_time + seconds_behind);
 
-			if (update) {
+			int32_t sys_time_src = 0;
+			param_get(param_find("SYS_TIME_SRC"), &sys_time_src);
+
+			if (update && (sys_time_src & SYS_TIME_SRC_MAVLINK)) {
 				PX4_INFO("Setting system clock from SYSTEM_TIME sent by %d/%d", msg->sysid, msg->compid);
 				tv.tv_sec = time.time_unix_usec / 1000000ULL;
 				tv.tv_nsec = (time.time_unix_usec % 1000000ULL) * 1000ULL;

--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -347,7 +347,10 @@ void GZBridge::clockCallback(const gz::msgs::Clock &msg)
 
 	if (!_realtime_clock_set) {
 		// Set initial real time clock at startup
-		px4_clock_settime(CLOCK_REALTIME, &ts);
+		if (_param_sys_time_src.get() & SYS_TIME_SRC_SIMULATOR) {
+			px4_clock_settime(CLOCK_REALTIME, &ts);
+		}
+
 		_realtime_clock_set = true;
 
 	} else {

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -51,6 +51,7 @@
 #include <lib/drivers/rangefinder/PX4Rangefinder.hpp>
 #include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <lib/geo/geo.h>
+#include <systemlib/system_time_source.h>
 
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/Subscription.hpp>
@@ -206,6 +207,7 @@ private:
 		(ParamInt<px4::params::SIM_GZ_EN_ODOM>) _sim_gz_en_odom,
 		(ParamInt<px4::params::SIM_GZ_EN_GPS>) _sim_gz_en_gps,
 		(ParamInt<px4::params::SIM_GZ_EN_IMU>) _sim_gz_en_imu,
-		(ParamInt<px4::params::SIM_GZ_EN_MAG>) _sim_gz_en_mag
+		(ParamInt<px4::params::SIM_GZ_EN_MAG>) _sim_gz_en_mag,
+		(ParamInt<px4::params::SYS_TIME_SRC>) _param_sys_time_src
 	)
 };

--- a/src/modules/time_persistor/TimePersistor.cpp
+++ b/src/modules/time_persistor/TimePersistor.cpp
@@ -142,7 +142,7 @@ int TimePersistor::init()
 
 	time_t t;
 
-	if (read_time(&t) == PX4_OK) {
+	if (read_time(&t) == PX4_OK && (_param_sys_time_src.get() & SYS_TIME_SRC_SOFT_RTC)) {
 		struct timespec ts;
 		ts.tv_sec = t;
 		ts.tv_nsec = 0;

--- a/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
+++ b/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
@@ -609,6 +609,10 @@ void UxrceddsClient::syncSystemClock(uxrSession *session)
 		return;
 	}
 
+	if (!(_param_sys_time_src.get() & SYS_TIME_SRC_DDS)) {
+		return;
+	}
+
 	ts.tv_sec = agent_utc / 1_s;
 	ts.tv_nsec = (agent_utc % 1_s) * 1000;
 

--- a/src/modules/uxrce_dds_client/uxrce_dds_client.h
+++ b/src/modules/uxrce_dds_client/uxrce_dds_client.h
@@ -45,6 +45,7 @@
 #include <lib/timesync/Timesync.hpp>
 
 #include <lib/perf/perf_counter.h>
+#include <systemlib/system_time_source.h>
 
 #if defined(CONFIG_NET) || defined(__PX4_POSIX)
 # define UXRCE_DDS_CLIENT_UDP 1
@@ -216,6 +217,7 @@ private:
 		(ParamInt<px4::params::UXRCE_DDS_SYNCT>) _param_uxrce_dds_synct,
 		(ParamInt<px4::params::UXRCE_DDS_TX_TO>) _param_uxrce_dds_tx_to,
 		(ParamInt<px4::params::UXRCE_DDS_RX_TO>) _param_uxrce_dds_rx_to,
-		(ParamInt<px4::params::UXRCE_DDS_FLCTRL>) _param_uxrce_dds_flctrl
+		(ParamInt<px4::params::UXRCE_DDS_FLCTRL>) _param_uxrce_dds_flctrl,
+		(ParamInt<px4::params::SYS_TIME_SRC>) _param_sys_time_src
 	)
 };


### PR DESCRIPTION
### Solved Problem
Since multiple subsystem can set the clock, it is good to have a way to control which subsystem can set the current clock time.

### Solution
The parameter **SYS_TIME_SRC** for that. It is a bitmask parameter, the definition can be found in: _src/lib/systemlib/system_params.yaml_. The default value is 31 so all clock source are enabled. Other values are the following:
bit 0: GPS time
bit 1: MAVLing time
bit 2: RTC time
bit 3: DDS time
bit 4: If also simulated time are accepted as input

### Test coverage
Tested on the bench with a septentrio gps connected with the antenna working. 
**Scenario 1**: All sources are accepted (value 31) using system_time set command a dummy time was set and based on the GPS the correct time was restored automatically.
**Scenario 2**: All sources are disabled (value 0)  using system_time set command a dummy time was set but since the clock cannot be set based on GPS the dummy time set before persist.
**Scenario 3**: Only GPS source is enabled (value 1) using system_time set command a dummy time was set and based on the GPS the correct time was restored automatically.
