### PR TITLE
fix(dshot): decode EDT current as 1A steps

### DIFF
--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -673,7 +673,7 @@ bool DShot::process_bdshot_telemetry()
 				}
 
 				if (up_bdshot_get_extended_telemetry(output_channel, DSHOT_EDT_CURRENT, &value) == PX4_OK) {
-					esc.current = static_cast<float>(value) / 2.f; // BDShot current is in 0.5A
+					esc.current = static_cast<float>(value); // EDT current is in 1A steps
 
 				} else {
 					esc.current = _esc_status.esc[motor_index].esc_current; // use previous


### PR DESCRIPTION
## Summary

Align bidirectional DShot EDT current decoding with the EDT specification and the AM32 fix in https://github.com/am32-firmware/AM32/pull/403.

## Problem

PX4 divided EDT current by 2 (0.5A steps). That matched a long-standing AM32 encoding bug (`centiamps / 50`) but not the [EDT spec](https://github.com/bird-sanctuary/extended-dshot-telemetry) (1A steps). ArduPilot and Betaflight already used 1A, so they reported double current from AM32 ESCs.

## Solution

Decode the current frame as amps with no scaling, matching the spec and post-fix AM32 firmware. Pre-fix AM32 builds will read 2× high until upgraded.