### PR TITLE
docs(docs): Update v1.16 version switcher plugin to use path redirect

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,7 @@
     "medium-zoom": "^1.1.0",
     "open-editor": "^5.0.0",
     "vitepress": "^1.6.3",
-    "vp-dynamic-nav": "0.0.3",
+    "vp-dynamic-nav": "0.1.0",
     "vue3-tabs-component": "^1.3.7"
   }
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1671,10 +1671,10 @@ vitepress@^1.6.3:
     vite "^5.4.14"
     vue "^3.5.13"
 
-vp-dynamic-nav@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/vp-dynamic-nav/-/vp-dynamic-nav-0.0.3.tgz#2b796d1be069c502fc2e4b42fd4c1437c66b80b0"
-  integrity sha512-qkDeki7TA21bhA12uiR0kEWZHVqeFusza3/XsGjD75Ht6qUoDOS/+YrCPyw9+6Zm+5/BvzK7j0jpDXPwW20m3g==
+vp-dynamic-nav@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/vp-dynamic-nav/-/vp-dynamic-nav-0.1.0.tgz#7f0136edfe2c7d2eaa0e8a75b99d8dd5b409e7c5"
+  integrity sha512-AXGT1uYpjngEqtRSVWsJu/8O08uxqyYb84glF31w3ozTlp1TiBWVLELCPKIhj0ukX/x6J7lfaQNDS2R/8DNO9Q==
 
 vue3-tabs-component@^1.3.7:
   version "1.3.7"


### PR DESCRIPTION
Backport #28136 to v1.16. This allows a version switcher to navigate to same page on selected version, provided it exists.