### PR TITLE
[BACKPORT v1.18] docs(docs): Update v1.18 doc version title

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -9,7 +9,7 @@ import tabsPlugin from "@red-asuka/vitepress-plugin-tabs";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  title: "PX4 Guide (main)",
+  title: "PX4 Guide (v1.18)",
   description: "PX4 User and Developer Guide",
   base: process.env.BRANCH_NAME
     ? "/" + process.env.BRANCH_NAME + "/"


### PR DESCRIPTION
This fixes up the title of the versioned guide to v1.18 (previously "main")
