### PR TITLE
docs(docs): Display version when first load docs

### DIFF
--- a/docs/.vitepress/theme/components/VersionToast.vue
+++ b/docs/.vitepress/theme/components/VersionToast.vue
@@ -1,0 +1,87 @@
+<script setup>
+import { onMounted, ref } from "vue";
+import { useData, inBrowser } from "vitepress";
+
+const DISPLAY_MS = 2000;
+
+const { site } = useData();
+const visible = ref(false);
+const message = ref("");
+
+// Layout mounts once per real page load and persists across in-session SPA
+// navigation, so this fires once per hard load/refresh, never per page view.
+onMounted(() => {
+  if (!inBrowser) return;
+
+  message.value = `Now viewing ${site.value.title}`;
+  visible.value = true;
+  setTimeout(() => {
+    visible.value = false;
+  }, DISPLAY_MS);
+});
+</script>
+
+<template>
+  <Transition name="version-toast-fade">
+    <div v-if="visible" class="version-toast vp-doc" role="status">
+      <h1>{{ message }}</h1>
+      <button
+        class="version-toast-close"
+        aria-label="Dismiss"
+        @click="visible = false"
+      >
+        &times;
+      </button>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.version-toast {
+  position: fixed;
+  top: 33vh;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 90;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  width: 90vw;
+  max-width: 688px; /* matches VitePress's default doc content column width */
+  padding: 24px 32px;
+  /* Opaque page-surface base with the theme's translucent tip tint layered
+     on top, so the tint stays theme-adaptive without looking washed out. */
+  background-color: var(--vp-c-bg);
+  background-image: linear-gradient(var(--vp-c-tip-soft), var(--vp-c-tip-soft));
+  color: var(--vp-c-tip-1);
+  border-radius: 8px;
+  box-shadow: var(--vp-shadow-3);
+  text-align: center;
+}
+
+/* The "vp-doc" class on .version-toast makes this pick up VitePress's own
+   .vp-doc h1 font-size/line-height rule (including its responsive
+   breakpoint) instead of duplicating those numbers here. h1 margin is
+   already reset to 0 by VitePress's base.css. */
+
+.version-toast-close {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  cursor: pointer;
+  font-size: 32px;
+  line-height: 1;
+}
+
+.version-toast-fade-enter-active,
+.version-toast-fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.version-toast-fade-enter-from,
+.version-toast-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -20,7 +20,10 @@ if (inBrowser) {
 // Support redirect plugin
 import Redirect from "./components/Redirect.vue";
 
-import { createDynamicNav } from "vp-dynamic-nav";
+// Toast shown once per page load, announcing the current docs version
+import VersionToast from "./components/VersionToast.vue";
+
+import { createDynamicNav, DynamicNav } from "vp-dynamic-nav";
 
 // Tabs: https://github.com/Red-Asuka/vitepress-plugin-tabs
 import { Tab, Tabs } from "vue3-tabs-component";
@@ -28,7 +31,17 @@ import "@red-asuka/vitepress-plugin-tabs/dist/style.css";
 
 /** @type {import('vitepress').Theme} */
 export default {
+  // createDynamicNav(DefaultTheme).Layout is a parameterless function that
+  // doesn't forward slots passed to it, so its nav-bar slots are reproduced
+  // here directly against DefaultTheme.Layout instead of nesting through it
+  // (nesting silently drops any slot we'd add, e.g. layout-top for the toast).
   extends: createDynamicNav(DefaultTheme),
+  Layout: () =>
+    h(DefaultTheme.Layout, null, {
+      "nav-bar-content-before": () => h(DynamicNav),
+      "nav-screen-content-after": () => h(DynamicNav, { screen: true }),
+      "layout-top": () => h(VersionToast),
+    }),
   enhanceApp({ app, router, siteData }) {
     app.component("Redirect", Redirect); //Redirect plugin
     //Tabs: https://github.com/Red-Asuka/vitepress-plugin-tabs


### PR DESCRIPTION
### Solved Problem

Users don't always know what version they are on, in particularly coming from a search. We also auto-switch to main when you look at release notes etc, and this switch might not be obvious.

### Solution

This adds a 2 second toast that appears when the library is first loaded (or reloaded) that displays the site title - which includes the version.

So you won't get it if you navigate within a library, but if you open a new version or reload the page then you will. 

It uses Vitepress styles, and works OK in light and dark mode.

### Changelog Entry

For release notes:
```
Documentation: Display version in toast when open new docs version
```
