### PR TITLE
fix(land_detector): improve low throttle detection logic

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -229,7 +229,8 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 	// so stale data would cause false landed-state detection. This intentionally disables
 	// thrust-based landing detection for that mode — the companion should handle its own
 	// landing logic.
-	_has_low_throttle = _vehicle_thrust_setpoint_valid && (_vehicle_thrust_setpoint_throttle <= sys_low_throttle);
+	_has_low_throttle = _vehicle_thrust_setpoint_valid
+			    && (_vehicle_thrust_setpoint_throttle <= math::max(sys_low_throttle, _params.minManThrottle));
 	bool ground_contact = _has_low_throttle;
 
 	// if we have a valid velocity setpoint and the vehicle is demanded to go down but no vertical movement present,


### PR DESCRIPTION
## Summary

  Clamp the ground-contact low-throttle threshold to at least `MPC_MANTHR_MIN`, so landing detection cannot become unreachable in manual-thrust modes when the hover thrust estimate collapses. Verified against a real flight log where a vehicle got permanently stuck ARMED on the ground in Stabilized because of this.

  ## Problem

  `_get_ground_contact_state()` computes `sys_low_throttle = MPC_THR_MIN + (hover_thrust - MPC_THR_MIN) * pct`, using the hover thrust estimate when available. In Stabilized/Acro the thrust setpoint is floored at `MPC_MANTHR_MIN` and can never read below it, but the threshold formula doesn't know about that floor.

  The hover thrust estimator keeps fusing while the vehicle sits on the ground (`_in_air` latches at `dist_bottom > 1 m` and only clears on `landed`), so it converges down toward the applied thrust — the `MPC_MANTHR_MIN` floor itself. Once the estimate falls below `MPC_THR_MIN + (MPC_MANTHR_MIN - MPC_THR_MIN) / pct`, the threshold drops below what the setpoint can physically reach and `_has_low_throttle` can never
  trigger again. Since `ground_contact`, `maybe_landed`, `landed` and auto-disarm are all chained on it, the vehicle is stuck armed with no auto-disarm — a self-sustaining loop, because not-landed is also what keeps the throttle floor applied and the estimator fusing.

  Not triggerable with default parameters (`MPC_THR_MIN` 0.12, `MPC_THR_HOVER` 0.5, `HTE_THR_RANGE` 0.2 keeps the threshold ≥ 0.17), but it goes live on efficient airframes tuned with a low hover thrust and lowered `MPC_THR_MIN`, where `MPC_THR_HOVER - HTE_THR_RANGE` lets the estimate collapse toward or below the manual floor. 

  ## Solution

  Floor the threshold at `MPC_MANTHR_MIN`: `_vehicle_thrust_setpoint_throttle <= math::max(sys_low_throttle, _params.minManThrottle)`. The setpoint floor can then never exceed the threshold, regardless of what the hover thrust estimate does, in both the estimate-valid (0.6) and estimate-stale (0.3) branches.

  No behavior change with default parameters: the clamp only engages when the unclamped threshold falls below `MPC_MANTHR_MIN`, which requires the hover thrust estimate to already be far below any real hover value. Climb-rate-controlled modes are additionally unaffected in practice since `ground_contact` still requires `_in_descend` there.
