### PR TITLE
ci(docs): trigger docs deploy on .vitepress/package changes

### DIFF
--- a/.github/workflows/docs_deploy_aws.yml
+++ b/.github/workflows/docs_deploy_aws.yml
@@ -10,12 +10,18 @@ on:
       - "docs/zh/**"
       - "docs/uk/**"
       - "docs/ko/**"
+      - "docs/.vitepress/**"
+      - "docs/package.json"
+      - "docs/yarn.lock"
   pull_request:
     paths:
       - "docs/en/**"
       - "docs/zh/**"
       - "docs/uk/**"
       - "docs/ko/**"
+      - "docs/.vitepress/**"
+      - "docs/package.json"
+      - "docs/yarn.lock"
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- The `Docs - Deploy PX4 User Guide to AWS` workflow only triggers on changes under `docs/en/**`, `docs/zh/**`, `docs/uk/**`, `docs/ko/**`.
- Changes confined to `docs/.vitepress/**` (theme/config, e.g. the recent version-toast feature) or `docs/package.json`/`docs/yarn.lock` never matched the path filter, so pushes touching only those paths silently skipped the deploy job — the live site kept serving a stale build with no error or indication anything was wrong.
- This is why https://docs.px4.io/v1.17/en/ did not show the new "you're on an old version" toast even though it merged and works locally/on `main` (on `main` it was masked by an unrelated follow-up commit that happened to touch `docs/en/**` and dragged the change along).
- Adds `docs/.vitepress/**`, `docs/package.json`, and `docs/yarn.lock` to both the `push` and `pull_request` path filters.

## Test plan
- [x] Manually re-triggered `workflow_dispatch` on `release/1.17` to catch the site up immediately (independent of this fix).
- [ ] Confirm a future PR touching only `docs/.vitepress/**` triggers the deploy workflow.