### PR TITLE
ci(docs): trigger docs deploy on .vitepress/package changes

### DIFF
--- a/.github/workflows/docs_deploy_aws.yml
+++ b/.github/workflows/docs_deploy_aws.yml
@@ -10,12 +10,20 @@ on:
       - "docs/zh/**"
       - "docs/uk/**"
       - "docs/ko/**"
+      - "docs/.vitepress/**"
+      - "docs/package.json"
+      - "docs/yarn.lock"
   pull_request:
     paths:
       - "docs/en/**"
       - "docs/zh/**"
       - "docs/uk/**"
       - "docs/ko/**"
+      - "docs/.vitepress/**"
+      - "docs/package.json"
+      - "docs/yarn.lock"
+
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- The `Docs - Deploy PX4 User Guide to AWS` workflow only triggers on changes under `docs/en/**`, `docs/zh/**`, `docs/uk/**`, `docs/ko/**`.
- Changes confined to `docs/.vitepress/**` (theme/config) or `docs/package.json`/`docs/yarn.lock` never matched the path filter, so pushes touching only those paths silently skipped the deploy job — the live site kept serving a stale build with no error or indication anything was wrong.
- On `release/1.16` this means the most recent version-switcher fix (#28149, touching only `docs/package.json`/`docs/yarn.lock`) never deployed.
- Adds `docs/.vitepress/**`, `docs/package.json`, and `docs/yarn.lock` to both the `push` and `pull_request` path filters.
- Also adds `workflow_dispatch`, which `release/1.16` was missing — without it there was no way to manually re-trigger a deploy after a miss like this, unlike `main`/`release/1.17`.

Companion fix for `release/1.17`: #28160

## Test plan
- [ ] Confirm a future PR touching only `docs/.vitepress/**` triggers the deploy workflow.
- [ ] Confirm `workflow_dispatch` can be used to manually trigger a deploy on this branch.