### PR TITLE
refactor(platform): constant-initialise static descriptor tables to save flash

### DIFF
--- a/platforms/common/include/px4_platform_common/atomic.h
+++ b/platforms/common/include/px4_platform_common/atomic.h
@@ -100,7 +100,7 @@ public:
 #endif // __PX4_POSIX
 
 	atomic() = default;
-	explicit atomic(T value) : _value(value) {}
+	explicit constexpr atomic(T value) : _value(value) {}
 
 	/**
 	 * Atomically read the current value

--- a/platforms/common/include/px4_platform_common/module.h
+++ b/platforms/common/include/px4_platform_common/module.h
@@ -81,7 +81,8 @@ public:
 	 * and storage (object pointer, task ID).
 	 */
 	struct Descriptor {
-		Descriptor(int (*ts)(int, char **), int (*cc)(int, char **), int (*pu)(const char *))
+		// constexpr so the per-module static desc is constant-initialised instead of by static-init code
+		constexpr Descriptor(int (*ts)(int, char **), int (*cc)(int, char **), int (*pu)(const char *))
 			: task_spawn(ts), custom_command(cc), print_usage(pu) {}
 
 		int (*task_spawn)(int argc, char *argv[]);

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -41,9 +41,9 @@ using namespace time_literals;
 
 struct FunctionProvider {
 	using Constructor = FunctionProviderBase * (*)(const FunctionProviderBase::Context &context);
-	FunctionProvider(OutputFunction min_func_, OutputFunction max_func_, Constructor constructor_)
+	constexpr FunctionProvider(OutputFunction min_func_, OutputFunction max_func_, Constructor constructor_)
 		: min_func(min_func_), max_func(max_func_), constructor(constructor_) {}
-	FunctionProvider(OutputFunction func, Constructor constructor_)
+	constexpr FunctionProvider(OutputFunction func, Constructor constructor_)
 		: min_func(func), max_func(func), constructor(constructor_) {}
 
 	OutputFunction min_func;
@@ -51,7 +51,7 @@ struct FunctionProvider {
 	Constructor constructor;
 };
 
-static const FunctionProvider all_function_providers[] = {
+static constexpr FunctionProvider all_function_providers[] = {
 	// Providers higher up take precedence for subscription callback in case there are multiple
 	{OutputFunction::Constant_Min, &FunctionConstantMin::allocate},
 	{OutputFunction::Constant_Max, &FunctionConstantMax::allocate},


### PR DESCRIPTION
### Problem

Flash overflow by a couple 100B:
 - PR https://github.com/PX4/PX4-Autopilot/pull/27999
 - Build https://github.com/PX4/PX4-Autopilot/actions/runs/30897251365/job/91954015677?pr=27999

### Solution

Make `px4::atomic`'s value constructor and `ModuleBase::Descriptor` constexpr so the ~40 per-module 'desc' statics are constant-initialised instead of each emitting static-init code, and apply the same to the `mixer_module` `FunctionProvider` table.

Picked from #27816. 