### PR TITLE
fix(vtol): check tailsitter fixed-wing position control

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/vtolCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/vtolCheck.cpp
@@ -37,6 +37,28 @@ using namespace time_literals;
 
 void VtolChecks::checkAndReport(const Context &context, Report &reporter)
 {
+#if !defined(CONFIG_MODULES_FW_MODE_MANAGER) || !defined(CONFIG_MODULES_FW_LATERAL_LONGITUDINAL_CONTROL)
+
+	if (context.status().is_vtol_tailsitter) {
+		/* EVENT
+		 * @description
+		 * The firmware does not include the fixed-wing position control modules required by tailsitter airframes.
+		 * Enable CONFIG_MODULES_FW_MODE_MANAGER and CONFIG_MODULES_FW_LATERAL_LONGITUDINAL_CONTROL
+		 * in the board configuration, then reinstall the firmware.
+		 */
+		reporter.armingCheckFailure(NavModes::All, health_component_t::system,
+					    events::ID("check_vtol_tailsitter_fw_pos_control_missing"),
+					    events::Log::Error,
+					    "Tailsitter requires fixed-wing position control");
+
+		if (reporter.mavlink_log_pub()) {
+			mavlink_log_critical(reporter.mavlink_log_pub(),
+					     "Preflight Fail: Tailsitter requires fixed-wing position control");
+		}
+	}
+
+#endif
+
 	vtol_vehicle_status_s vtol_vehicle_status;
 
 	if (_vtol_vehicle_status_sub.copy(&vtol_vehicle_status)) {


### PR DESCRIPTION
## Description

This PR adds a preflight arming check for tailsitter VTOL airframes to ensure that the fixed-wing position control modules are included in the firmware.

A tailsitter firmware built without either of the following modules can currently boot and arm without reporting that the fixed-wing position control chain is unavailable:

- `CONFIG_MODULES_FW_MODE_MANAGER`
- `CONFIG_MODULES_FW_LATERAL_LONGITUDINAL_CONTROL`

The VTOL startup script attempts to start these modules, but it does not ensure that they were compiled into the firmware. Since the startup scripts continue after a command failure, a missing module does not prevent the rest of the boot sequence or arming.

## Motivation

This issue was discovered following a tailsitter flight incident.

Before the flight, I performed ground tests in Manual and Stabilized modes and verified that the control surfaces responded correctly. These tests exercised the fixed-wing attitude and rate controllers, so the actuator outputs appeared normal.

However, the firmware had accidentally been built without the fixed-wing position control modules, and Position mode was not tested before flight.

During the flight, I selected Position mode and commanded a transition to fixed-wing flight. The transition completed, but the fixed-wing position control chain was unavailable. The expected fixed-wing actuator outputs were not generated after the transition, resulting in a loss of control.

This configuration error is difficult to detect through Manual or Stabilized ground tests because the fixed-wing attitude and rate controllers can still produce valid control-surface outputs.

## Incident Evidence

For privacy reasons, the complete flight log is not provided.

The screenshot below contains only the relevant actuator-output plot from the affected part of the flight. It shows that the expected fixed-wing actuator outputs were absent.

<img width="1896" height="1042" alt="bokeh_plot" src="https://github.com/user-attachments/assets/809dedde-4c19-4d2c-8419-d8f34630e220" />


## Changes

The VTOL health and arming checks now verify the firmware configuration when the selected airframe is identified as a tailsitter.

If either required fixed-wing position control module is missing, arming is denied for all flight modes and the following error is reported:

```text
Preflight Fail: Tailsitter requires fixed-wing position control
```

The check is limited to tailsitter airframes. Other VTOL and custom firmware configurations are not forced to include the internal fixed-wing position controller.

## Safety Impact

A tailsitter can appear functional during ground tests in Manual or Stabilized mode even when its fixed-wing position control modules are missing. The fixed-wing attitude and rate controllers may still generate valid control-surface responses, hiding the incomplete firmware configuration.

The failure may only become apparent when a position-controlled mode is used. If the vehicle transitions to fixed-wing flight in Position, Mission, Loiter, or RTL mode without the required position control chain, the expected fixed-wing actuator outputs may not be generated.

Preventing arming makes this configuration error visible before flight instead of allowing it to remain hidden until the first position-controlled transition.

## Implementation

The check combines:

- Compile-time detection of whether `CONFIG_MODULES_FW_MODE_MANAGER` is enabled.
- Compile-time detection of whether `CONFIG_MODULES_FW_LATERAL_LONGITUDINAL_CONTROL` is enabled.
- Runtime airframe detection using `vehicle_status.is_vtol_tailsitter`.

If the selected airframe is a tailsitter and either module is missing, `VtolChecks::checkAndReport()` reports an arming failure for all navigation modes.

This is intentionally implemented as an arming check rather than a Kconfig dependency because the airframe is selected at runtime, while firmware modules are selected at build time.

It also avoids forcing other VTOL or custom firmware configurations to include an internal fixed-wing position controller when they intentionally use manual or external control.