### PR TITLE
fix(uavcan): publish UNKNOWN node timestamps until time-synced and map them through the bus time base on the FC

### DIFF
--- a/src/drivers/uavcan/sensors/accel.cpp
+++ b/src/drivers/uavcan/sensors/accel.cpp
@@ -63,7 +63,7 @@ void UavcanAccelBridge::imu_sub_cb(const uavcan::ReceivedDataStructure<uavcan::e
 {
 	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getSrcNodeID().get(), msg.getIfaceIndex());
 
-	const hrt_abstime timestamp_sample = (msg.timestamp.usec > 0) ? msg.timestamp.usec : hrt_absolute_time();
+	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec, hrt_absolute_time());
 
 	if (channel == nullptr) {
 		// Something went wrong - no channel to publish on; return

--- a/src/drivers/uavcan/sensors/accel.cpp
+++ b/src/drivers/uavcan/sensors/accel.cpp
@@ -78,8 +78,10 @@ void UavcanAccelBridge::imu_sub_cb(const uavcan::ReceivedDataStructure<uavcan::e
 		return;
 	}
 
+	const uavcan_bridge::ImuRateSample sample = uavcan_bridge::imu_rate_sample(timestamp_sample,
+			msg.integration_interval, msg.accelerometer_latest, msg.accelerometer_integral);
 	accel->set_error_count(0);
-	accel->update(timestamp_sample, msg.accelerometer_latest[0], msg.accelerometer_latest[1], msg.accelerometer_latest[2]);
+	accel->update(sample.timestamp_sample, sample.x, sample.y, sample.z);
 
 	// Register device capability if not already done
 	if (_node_info_publisher != nullptr) {

--- a/src/drivers/uavcan/sensors/accel.cpp
+++ b/src/drivers/uavcan/sensors/accel.cpp
@@ -63,8 +63,8 @@ void UavcanAccelBridge::imu_sub_cb(const uavcan::ReceivedDataStructure<uavcan::e
 {
 	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getSrcNodeID().get(), msg.getIfaceIndex());
 
-	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec, msg.getUtcTimestamp().toUSec(),
-					     hrt_absolute_time());
+	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec,
+					     _sub_imu_data.getNode().getUtcTime().toUSec(), hrt_absolute_time());
 
 	if (channel == nullptr) {
 		// Something went wrong - no channel to publish on; return

--- a/src/drivers/uavcan/sensors/accel.cpp
+++ b/src/drivers/uavcan/sensors/accel.cpp
@@ -63,7 +63,8 @@ void UavcanAccelBridge::imu_sub_cb(const uavcan::ReceivedDataStructure<uavcan::e
 {
 	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getSrcNodeID().get(), msg.getIfaceIndex());
 
-	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec, hrt_absolute_time());
+	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec, msg.getUtcTimestamp().toUSec(),
+					     hrt_absolute_time());
 
 	if (channel == nullptr) {
 		// Something went wrong - no channel to publish on; return

--- a/src/drivers/uavcan/sensors/gnss_relative.cpp
+++ b/src/drivers/uavcan/sensors/gnss_relative.cpp
@@ -64,7 +64,7 @@ void UavcanGnssRelativeBridge::rel_pos_heading_sub_cb(const
 	sensor_gnss_relative_s sensor_gnss_relative{};
 
 	sensor_gnss_relative.timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec,
-						msg.getUtcTimestamp().toUSec(), hrt_absolute_time());
+						_sub_rel_pos_heading.getNode().getUtcTime().toUSec(), hrt_absolute_time());
 
 	sensor_gnss_relative.heading_valid = msg.reported_heading_acc_available;
 	sensor_gnss_relative.heading = math::radians(msg.reported_heading_deg);

--- a/src/drivers/uavcan/sensors/gnss_relative.cpp
+++ b/src/drivers/uavcan/sensors/gnss_relative.cpp
@@ -63,7 +63,8 @@ void UavcanGnssRelativeBridge::rel_pos_heading_sub_cb(const
 {
 	sensor_gnss_relative_s sensor_gnss_relative{};
 
-	sensor_gnss_relative.timestamp_sample = uavcan::UtcTime(msg.timestamp).toUSec();
+	sensor_gnss_relative.timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec,
+						msg.getUtcTimestamp().toUSec(), hrt_absolute_time());
 
 	sensor_gnss_relative.heading_valid = msg.reported_heading_acc_available;
 	sensor_gnss_relative.heading = math::radians(msg.reported_heading_deg);

--- a/src/drivers/uavcan/sensors/gyro.cpp
+++ b/src/drivers/uavcan/sensors/gyro.cpp
@@ -75,7 +75,7 @@ void UavcanGyroBridge::imu_sub_cb(const uavcan::ReceivedDataStructure<uavcan::eq
 		return;
 	}
 
-	const hrt_abstime timestamp_sample = (msg.timestamp.usec > 0) ? msg.timestamp.usec : hrt_absolute_time();
+	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec, hrt_absolute_time());
 	gyro->update(timestamp_sample,
 		     msg.rate_gyro_latest[0],
 		     msg.rate_gyro_latest[1],

--- a/src/drivers/uavcan/sensors/gyro.cpp
+++ b/src/drivers/uavcan/sensors/gyro.cpp
@@ -75,7 +75,8 @@ void UavcanGyroBridge::imu_sub_cb(const uavcan::ReceivedDataStructure<uavcan::eq
 		return;
 	}
 
-	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec, hrt_absolute_time());
+	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec, msg.getUtcTimestamp().toUSec(),
+					     hrt_absolute_time());
 	gyro->update(timestamp_sample,
 		     msg.rate_gyro_latest[0],
 		     msg.rate_gyro_latest[1],

--- a/src/drivers/uavcan/sensors/gyro.cpp
+++ b/src/drivers/uavcan/sensors/gyro.cpp
@@ -77,10 +77,9 @@ void UavcanGyroBridge::imu_sub_cb(const uavcan::ReceivedDataStructure<uavcan::eq
 
 	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec,
 					     _sub_imu_data.getNode().getUtcTime().toUSec(), hrt_absolute_time());
-	gyro->update(timestamp_sample,
-		     msg.rate_gyro_latest[0],
-		     msg.rate_gyro_latest[1],
-		     msg.rate_gyro_latest[2]);
+	const uavcan_bridge::ImuRateSample sample = uavcan_bridge::imu_rate_sample(timestamp_sample,
+			msg.integration_interval, msg.rate_gyro_latest, msg.rate_gyro_integral);
+	gyro->update(sample.timestamp_sample, sample.x, sample.y, sample.z);
 
 	// Register device capability if not already done
 	if (_node_info_publisher != nullptr) {

--- a/src/drivers/uavcan/sensors/gyro.cpp
+++ b/src/drivers/uavcan/sensors/gyro.cpp
@@ -75,8 +75,8 @@ void UavcanGyroBridge::imu_sub_cb(const uavcan::ReceivedDataStructure<uavcan::eq
 		return;
 	}
 
-	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec, msg.getUtcTimestamp().toUSec(),
-					     hrt_absolute_time());
+	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec,
+					     _sub_imu_data.getNode().getUtcTime().toUSec(), hrt_absolute_time());
 	gyro->update(timestamp_sample,
 		     msg.rate_gyro_latest[0],
 		     msg.rate_gyro_latest[1],

--- a/src/drivers/uavcan/sensors/rangefinder.cpp
+++ b/src/drivers/uavcan/sensors/rangefinder.cpp
@@ -176,7 +176,8 @@ void UavcanRangefinderBridge::range_sub_cb(const
 		quality = 100;
 	}
 
-	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec, hrt_absolute_time());
+	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec, msg.getUtcTimestamp().toUSec(),
+					     hrt_absolute_time());
 
 	if (orientation == distance_sensor_s::ROTATION_CUSTOM) {
 		const matrix::Quatf q_sensor{uavcan_orientation_to_euler(msg.beam_orientation_in_body_frame)};

--- a/src/drivers/uavcan/sensors/rangefinder.cpp
+++ b/src/drivers/uavcan/sensors/rangefinder.cpp
@@ -176,8 +176,8 @@ void UavcanRangefinderBridge::range_sub_cb(const
 		quality = 100;
 	}
 
-	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec, msg.getUtcTimestamp().toUSec(),
-					     hrt_absolute_time());
+	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec,
+					     _sub_range_data.getNode().getUtcTime().toUSec(), hrt_absolute_time());
 
 	if (orientation == distance_sensor_s::ROTATION_CUSTOM) {
 		const matrix::Quatf q_sensor{uavcan_orientation_to_euler(msg.beam_orientation_in_body_frame)};

--- a/src/drivers/uavcan/sensors/rangefinder.cpp
+++ b/src/drivers/uavcan/sensors/rangefinder.cpp
@@ -176,7 +176,7 @@ void UavcanRangefinderBridge::range_sub_cb(const
 		quality = 100;
 	}
 
-	const hrt_abstime timestamp_sample = (msg.timestamp.usec > 0) ? msg.timestamp.usec : hrt_absolute_time();
+	const hrt_abstime timestamp_sample = uavcan_bridge::sample_timestamp(msg.timestamp.usec, hrt_absolute_time());
 
 	if (orientation == distance_sensor_s::ROTATION_CUSTOM) {
 		const matrix::Quatf q_sensor{uavcan_orientation_to_euler(msg.beam_orientation_in_body_frame)};

--- a/src/drivers/uavcan/sensors/sensor_bridge.hpp
+++ b/src/drivers/uavcan/sensors/sensor_bridge.hpp
@@ -39,6 +39,7 @@
 
 #include <containers/List.hpp>
 #include <uavcan/uavcan.hpp>
+#include <drivers/drv_hrt.h>
 #include <drivers/drv_orb_dev.h>
 #include <lib/drivers/device/Device.hpp>
 #include <uORB/uORB.h>
@@ -94,6 +95,23 @@ struct Channel {
 	void *h_driver{nullptr};
 	uint8_t iface_index{0};
 };
+
+// Nodes stamp their acquisition time in the bus shared time base, which the FC
+// seeds with its own HRT and then disciplines as time-sync master, so a synced
+// stamp is directly usable. A node whose clock is not yet disciplined, or one
+// stamping a foreign epoch, lands outside any plausible transport window; use
+// the receive time there rather than feeding a bogus sample time downstream.
+inline hrt_abstime sample_timestamp(uint64_t node_timestamp_us, hrt_abstime rx_time)
+{
+	static constexpr hrt_abstime kMaxTransportDelay = 100_ms;
+
+	if (node_timestamp_us > 0 && node_timestamp_us <= rx_time
+	    && (rx_time - node_timestamp_us) < kMaxTransportDelay) {
+		return static_cast<hrt_abstime>(node_timestamp_us);
+	}
+
+	return rx_time;
+}
 } // namespace uavcan_bridge
 
 /**

--- a/src/drivers/uavcan/sensors/sensor_bridge.hpp
+++ b/src/drivers/uavcan/sensors/sensor_bridge.hpp
@@ -96,18 +96,20 @@ struct Channel {
 	uint8_t iface_index{0};
 };
 
-// Nodes stamp their acquisition time in the bus shared time base, which the FC
-// seeds with its own HRT and then disciplines as time-sync master, so a synced
-// stamp is directly usable. A node whose clock is not yet disciplined, or one
-// stamping a foreign epoch, lands outside any plausible transport window; use
-// the receive time there rather than feeding a bogus sample time downstream.
-inline hrt_abstime sample_timestamp(uint64_t node_timestamp_us, hrt_abstime rx_time)
+// Nodes stamp their acquisition time in the bus shared time base, and the CAN
+// ISR stamps each received transfer in that same base, so the sample age is the
+// difference between the two no matter how the bus base relates to HRT (the FC
+// seeds its bus clock from HRT only after its own init, and may be a slave to
+// another master). An undisciplined node stamps UNKNOWN, and a node stamping a
+// foreign epoch lands outside any plausible transport window; both get the
+// receive time.
+inline hrt_abstime sample_timestamp(uint64_t node_timestamp_us, uint64_t rx_bus_timestamp_us, hrt_abstime rx_time)
 {
-	static constexpr hrt_abstime kMaxTransportDelay = 100_ms;
+	static constexpr uint64_t kMaxTransportDelay = 100_ms;
 
-	if (node_timestamp_us > 0 && node_timestamp_us <= rx_time
-	    && (rx_time - node_timestamp_us) < kMaxTransportDelay) {
-		return static_cast<hrt_abstime>(node_timestamp_us);
+	if (node_timestamp_us > 0 && rx_bus_timestamp_us >= node_timestamp_us
+	    && (rx_bus_timestamp_us - node_timestamp_us) < kMaxTransportDelay) {
+		return rx_time - (rx_bus_timestamp_us - node_timestamp_us);
 	}
 
 	return rx_time;

--- a/src/drivers/uavcan/sensors/sensor_bridge.hpp
+++ b/src/drivers/uavcan/sensors/sensor_bridge.hpp
@@ -114,6 +114,38 @@ inline hrt_abstime sample_timestamp(uint64_t node_timestamp_us, uint64_t bus_now
 
 	return now;
 }
+
+/**
+ * Rate and sample time to publish from a RawIMU field pair.
+ *
+ * When an integral is present its mean over the interval is preferred over the
+ * point sample: it is float32 rather than float16, it is anti-aliased against the
+ * node's full-rate stream, and successive means spaced one interval apart
+ * integrate back to the node's exact deltas in VehicleIMU. A mean belongs at the
+ * centroid of its window, half an interval before the acquisition timestamp that
+ * closes it. Without an integral the point sample is used at the timestamp.
+ */
+static constexpr float kMaxImuIntegrationInterval = 0.1f;
+
+struct ImuRateSample {
+	hrt_abstime timestamp_sample;
+	float x;
+	float y;
+	float z;
+};
+
+template<typename LatestT, typename IntegralT>
+inline ImuRateSample imu_rate_sample(hrt_abstime timestamp_sample, float integration_interval,
+				     const LatestT &latest, const IntegralT &integral)
+{
+	if (integration_interval > 0.f && integration_interval < kMaxImuIntegrationInterval) {
+		const float inv_dt = 1.f / integration_interval;
+		const hrt_abstime half_interval = static_cast<hrt_abstime>(integration_interval * 0.5e6f);
+		return {timestamp_sample - half_interval, integral[0] *inv_dt, integral[1] *inv_dt, integral[2] *inv_dt};
+	}
+
+	return {timestamp_sample, latest[0], latest[1], latest[2]};
+}
 } // namespace uavcan_bridge
 
 /**

--- a/src/drivers/uavcan/sensors/sensor_bridge.hpp
+++ b/src/drivers/uavcan/sensors/sensor_bridge.hpp
@@ -96,23 +96,23 @@ struct Channel {
 	uint8_t iface_index{0};
 };
 
-// Nodes stamp their acquisition time in the bus shared time base, and the CAN
-// ISR stamps each received transfer in that same base, so the sample age is the
-// difference between the two no matter how the bus base relates to HRT (the FC
-// seeds its bus clock from HRT only after its own init, and may be a slave to
-// another master). An undisciplined node stamps UNKNOWN, and a node stamping a
-// foreign epoch lands outside any plausible transport window; both get the
-// receive time.
-inline hrt_abstime sample_timestamp(uint64_t node_timestamp_us, uint64_t rx_bus_timestamp_us, hrt_abstime rx_time)
+// Node timestamps are in the bus shared time base, whose offset from HRT is
+// arbitrary: the FC seeds its bus clock from HRT at whatever phase the driver's
+// free-running timer happens to be, and a lower node ID master can discipline
+// it. Subtracting the bus-time age from an HRT reading taken at the same
+// instant cancels the offset; the ISR receive stamp would leave the transfer
+// and scheduling latency in the result. UNKNOWN, unconverged and foreign-epoch
+// stamps fall back to the receive time.
+inline hrt_abstime sample_timestamp(uint64_t node_timestamp_us, uint64_t bus_now_us, hrt_abstime now)
 {
 	static constexpr uint64_t kMaxTransportDelay = 100_ms;
 
-	if (node_timestamp_us > 0 && rx_bus_timestamp_us >= node_timestamp_us
-	    && (rx_bus_timestamp_us - node_timestamp_us) < kMaxTransportDelay) {
-		return rx_time - (rx_bus_timestamp_us - node_timestamp_us);
+	if (node_timestamp_us > 0 && bus_now_us >= node_timestamp_us
+	    && (bus_now_us - node_timestamp_us) < kMaxTransportDelay) {
+		return now - (bus_now_us - node_timestamp_us);
 	}
 
-	return rx_time;
+	return now;
 }
 } // namespace uavcan_bridge
 

--- a/src/drivers/uavcannode/Publishers/BatteryInfo.hpp
+++ b/src/drivers/uavcannode/Publishers/BatteryInfo.hpp
@@ -84,7 +84,7 @@ public:
 		if (uORB::SubscriptionCallbackWorkItem::update(&battery)) {
 			ardupilot::equipment::power::BatteryInfoAux battery_info_aux{};
 
-			battery_info_aux.timestamp.usec = bus_timestamp_usec(getNode().getUtcTime().toUSec(), battery.timestamp);
+			battery_info_aux.timestamp.usec = bus_timestamp_usec(getNode(), battery.timestamp);
 
 			for (uint8_t i = 0; i < battery.cell_count && i < arraySize(battery_status_s::voltage_cell_v); i++) {
 				battery_info_aux.voltage_cell.push_back(battery.voltage_cell_v[i]);

--- a/src/drivers/uavcannode/Publishers/BatteryInfo.hpp
+++ b/src/drivers/uavcannode/Publishers/BatteryInfo.hpp
@@ -84,7 +84,7 @@ public:
 		if (uORB::SubscriptionCallbackWorkItem::update(&battery)) {
 			ardupilot::equipment::power::BatteryInfoAux battery_info_aux{};
 
-			battery_info_aux.timestamp.usec = battery.timestamp;
+			battery_info_aux.timestamp.usec = bus_timestamp_usec(getNode().getUtcTime().toUSec(), battery.timestamp);
 
 			for (uint8_t i = 0; i < battery.cell_count && i < arraySize(battery_status_s::voltage_cell_v); i++) {
 				battery_info_aux.voltage_cell.push_back(battery.voltage_cell_v[i]);

--- a/src/drivers/uavcannode/Publishers/RangeSensorMeasurement.hpp
+++ b/src/drivers/uavcannode/Publishers/RangeSensorMeasurement.hpp
@@ -75,7 +75,7 @@ public:
 		if (uORB::SubscriptionCallbackWorkItem::update(&dist)) {
 			uavcan::equipment::range_sensor::Measurement range_sensor{};
 
-			range_sensor.timestamp.usec = getNode().getUtcTime().toUSec() - (hrt_absolute_time() - dist.timestamp);
+			range_sensor.timestamp.usec = bus_timestamp_usec(getNode().getUtcTime().toUSec(), dist.timestamp);
 			range_sensor.sensor_id = get_instance();
 			range_sensor.range = dist.current_distance;
 			range_sensor.field_of_view = dist.h_fov;

--- a/src/drivers/uavcannode/Publishers/RangeSensorMeasurement.hpp
+++ b/src/drivers/uavcannode/Publishers/RangeSensorMeasurement.hpp
@@ -75,7 +75,7 @@ public:
 		if (uORB::SubscriptionCallbackWorkItem::update(&dist)) {
 			uavcan::equipment::range_sensor::Measurement range_sensor{};
 
-			range_sensor.timestamp.usec = bus_timestamp_usec(getNode().getUtcTime().toUSec(), dist.timestamp);
+			range_sensor.timestamp.usec = bus_timestamp_usec(getNode(), dist.timestamp);
 			range_sensor.sensor_id = get_instance();
 			range_sensor.range = dist.current_distance;
 			range_sensor.field_of_view = dist.h_fov;

--- a/src/drivers/uavcannode/Publishers/RawIMU.hpp
+++ b/src/drivers/uavcannode/Publishers/RawIMU.hpp
@@ -37,7 +37,10 @@
 
 #include <uavcan/equipment/ahrs/RawIMU.hpp>
 
+#include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_gyro.h>
 #include <uORB/topics/vehicle_imu.h>
 
 namespace uavcannode
@@ -76,22 +79,47 @@ public:
 
 			uavcan::equipment::ahrs::RawIMU raw_imu{};
 
+			// timestamp is the acquisition time of the latest sample, which is also the
+			// end of the integration window: VehicleIMU stamps vehicle_imu with the
+			// sensor sample that closed the window.
 			raw_imu.timestamp.usec = bus_timestamp_usec(getNode(), vehicle_imu.timestamp_sample);
 
 			// integration_interval is in seconds; delta_angle_dt is in microseconds
 			raw_imu.integration_interval = vehicle_imu.delta_angle_dt * 1e-6f;
 
-			raw_imu.rate_gyro_latest[0] = (vehicle_imu.delta_angle[0] / vehicle_imu.delta_angle_dt) * 1000000;
-			raw_imu.rate_gyro_latest[1] = (vehicle_imu.delta_angle[1] / vehicle_imu.delta_angle_dt) * 1000000;
-			raw_imu.rate_gyro_latest[2] = (vehicle_imu.delta_angle[2] / vehicle_imu.delta_angle_dt) * 1000000;
+			// *_latest is the latest point sample, not the window mean: the mean lags
+			// the timestamp by half the interval, and consumers that want the mean
+			// have the integral. The sensor topics are the driver's uncalibrated
+			// output, as a point sample from any other IMU driver would be.
+			sensor_gyro_s gyro;
+
+			if (latest_sample(_sensor_gyro_sub, vehicle_imu.gyro_device_id, gyro)) {
+				raw_imu.rate_gyro_latest[0] = gyro.x;
+				raw_imu.rate_gyro_latest[1] = gyro.y;
+				raw_imu.rate_gyro_latest[2] = gyro.z;
+
+			} else {
+				raw_imu.rate_gyro_latest[0] = (vehicle_imu.delta_angle[0] / vehicle_imu.delta_angle_dt) * 1000000;
+				raw_imu.rate_gyro_latest[1] = (vehicle_imu.delta_angle[1] / vehicle_imu.delta_angle_dt) * 1000000;
+				raw_imu.rate_gyro_latest[2] = (vehicle_imu.delta_angle[2] / vehicle_imu.delta_angle_dt) * 1000000;
+			}
 
 			raw_imu.rate_gyro_integral[0] = vehicle_imu.delta_angle[0];
 			raw_imu.rate_gyro_integral[1] = vehicle_imu.delta_angle[1];
 			raw_imu.rate_gyro_integral[2] = vehicle_imu.delta_angle[2];
 
-			raw_imu.accelerometer_latest[0] = (vehicle_imu.delta_velocity[0] / vehicle_imu.delta_velocity_dt) * 1000000;
-			raw_imu.accelerometer_latest[1] = (vehicle_imu.delta_velocity[1] / vehicle_imu.delta_velocity_dt) * 1000000;
-			raw_imu.accelerometer_latest[2] = (vehicle_imu.delta_velocity[2] / vehicle_imu.delta_velocity_dt) * 1000000;
+			sensor_accel_s accel;
+
+			if (latest_sample(_sensor_accel_sub, vehicle_imu.accel_device_id, accel)) {
+				raw_imu.accelerometer_latest[0] = accel.x;
+				raw_imu.accelerometer_latest[1] = accel.y;
+				raw_imu.accelerometer_latest[2] = accel.z;
+
+			} else {
+				raw_imu.accelerometer_latest[0] = (vehicle_imu.delta_velocity[0] / vehicle_imu.delta_velocity_dt) * 1000000;
+				raw_imu.accelerometer_latest[1] = (vehicle_imu.delta_velocity[1] / vehicle_imu.delta_velocity_dt) * 1000000;
+				raw_imu.accelerometer_latest[2] = (vehicle_imu.delta_velocity[2] / vehicle_imu.delta_velocity_dt) * 1000000;
+			}
 
 			raw_imu.accelerometer_integral[0] = vehicle_imu.delta_velocity[0];
 			raw_imu.accelerometer_integral[1] = vehicle_imu.delta_velocity[1];
@@ -103,5 +131,30 @@ public:
 			uORB::SubscriptionCallbackWorkItem::registerCallback();
 		}
 	}
+
+private:
+	// Copy the newest sample of the sensor instance feeding vehicle_imu, re-selecting
+	// the instance if the one subscribed does not carry the expected device id.
+	template<typename SampleT>
+	static bool latest_sample(uORB::Subscription &sub, uint32_t device_id, SampleT &sample)
+	{
+		if (sub.copy(&sample) && sample.device_id == device_id) {
+			return true;
+		}
+
+		for (uint8_t instance = 0; instance < ORB_MULTI_MAX_INSTANCES; instance++) {
+			uORB::Subscription candidate{sub.orb_id(), instance};
+
+			if (candidate.copy(&sample) && sample.device_id == device_id) {
+				sub.ChangeInstance(instance);
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	uORB::Subscription _sensor_gyro_sub{ORB_ID(sensor_gyro)};
+	uORB::Subscription _sensor_accel_sub{ORB_ID(sensor_accel)};
 };
 } // namespace uavcannode

--- a/src/drivers/uavcannode/Publishers/RawIMU.hpp
+++ b/src/drivers/uavcannode/Publishers/RawIMU.hpp
@@ -76,7 +76,7 @@ public:
 
 			uavcan::equipment::ahrs::RawIMU raw_imu{};
 
-			raw_imu.timestamp.usec = bus_timestamp_usec(getNode().getUtcTime().toUSec(), vehicle_imu.timestamp_sample);
+			raw_imu.timestamp.usec = bus_timestamp_usec(getNode(), vehicle_imu.timestamp_sample);
 
 			// integration_interval is in seconds; delta_angle_dt is in microseconds
 			raw_imu.integration_interval = vehicle_imu.delta_angle_dt * 1e-6f;

--- a/src/drivers/uavcannode/Publishers/RawIMU.hpp
+++ b/src/drivers/uavcannode/Publishers/RawIMU.hpp
@@ -76,11 +76,10 @@ public:
 
 			uavcan::equipment::ahrs::RawIMU raw_imu{};
 
-			raw_imu.timestamp.usec = getNode().getUtcTime().toUSec() - (hrt_absolute_time() -
-						 vehicle_imu.timestamp_sample);
+			raw_imu.timestamp.usec = bus_timestamp_usec(getNode().getUtcTime().toUSec(), vehicle_imu.timestamp_sample);
 
-			raw_imu.integration_interval = vehicle_imu.delta_angle_dt;
-			// raw_imu.integration_interval = vehicle_imu.delta_velocity_dt;
+			// integration_interval is in seconds; delta_angle_dt is in microseconds
+			raw_imu.integration_interval = vehicle_imu.delta_angle_dt * 1e-6f;
 
 			raw_imu.rate_gyro_latest[0] = (vehicle_imu.delta_angle[0] / vehicle_imu.delta_angle_dt) * 1000000;
 			raw_imu.rate_gyro_latest[1] = (vehicle_imu.delta_angle[1] / vehicle_imu.delta_angle_dt) * 1000000;

--- a/src/drivers/uavcannode/Publishers/RelPosHeading.hpp
+++ b/src/drivers/uavcannode/Publishers/RelPosHeading.hpp
@@ -78,8 +78,8 @@ public:
 		if (uORB::SubscriptionCallbackWorkItem::update(&sensor_gnss_relative)) {
 			ardupilot::gnss::RelPosHeading rel_pos_heading{};
 
-			// TODO: FIX (timestamp_sample and UAVCAN timestamp)
-			rel_pos_heading.timestamp = uavcan::UtcTime::fromUSec(getNode().getMonotonicTime().toUSec());
+			rel_pos_heading.timestamp.usec = bus_timestamp_usec(getNode().getUtcTime().toUSec(),
+							 sensor_gnss_relative.timestamp_sample);
 
 			rel_pos_heading.reported_heading_acc_available = sensor_gnss_relative.heading_valid; // bool
 			rel_pos_heading.reported_heading_deg = math::degrees(sensor_gnss_relative.heading); // float32

--- a/src/drivers/uavcannode/Publishers/RelPosHeading.hpp
+++ b/src/drivers/uavcannode/Publishers/RelPosHeading.hpp
@@ -78,8 +78,7 @@ public:
 		if (uORB::SubscriptionCallbackWorkItem::update(&sensor_gnss_relative)) {
 			ardupilot::gnss::RelPosHeading rel_pos_heading{};
 
-			rel_pos_heading.timestamp.usec = bus_timestamp_usec(getNode().getUtcTime().toUSec(),
-							 sensor_gnss_relative.timestamp_sample);
+			rel_pos_heading.timestamp.usec = bus_timestamp_usec(getNode(), sensor_gnss_relative.timestamp_sample);
 
 			rel_pos_heading.reported_heading_acc_available = sensor_gnss_relative.heading_valid; // bool
 			rel_pos_heading.reported_heading_deg = math::degrees(sensor_gnss_relative.heading); // float32

--- a/src/drivers/uavcannode/Publishers/UavcanPublisherBase.hpp
+++ b/src/drivers/uavcannode/Publishers/UavcanPublisherBase.hpp
@@ -42,16 +42,16 @@
 namespace uavcannode
 {
 
-// Acquisition time in the bus shared time base for a sample taken at sample_hrt.
-// The bus time is 0 until the time-sync master disciplines our clock, and the
-// subtraction is unsigned, so publish UNKNOWN rather than underflow the uint56
-// field.
-inline uint64_t bus_timestamp_usec(uint64_t bus_time_us, hrt_abstime sample_hrt)
+// Acquisition time of a sample taken at sample_hrt, in the bus shared time
+// base. The bus time is 0 until the time-sync slave disciplines the clock, and
+// the subtraction is unsigned, so publish UNKNOWN rather than underflow the
+// uint56 field.
+inline uint64_t bus_timestamp_usec(const uavcan::INode &node, hrt_abstime sample_hrt)
 {
+	const uint64_t bus_now_us = node.getUtcTime().toUSec();
 	const uint64_t sample_age_us = hrt_absolute_time() - sample_hrt;
-	return (bus_time_us > sample_age_us) ? (bus_time_us - sample_age_us) : 0;
+	return (bus_now_us > sample_age_us) ? (bus_now_us - sample_age_us) : 0;
 }
-
 
 class UavcanPublisherBase : public IntrusiveSortedListNode<UavcanPublisherBase *>
 {

--- a/src/drivers/uavcannode/Publishers/UavcanPublisherBase.hpp
+++ b/src/drivers/uavcannode/Publishers/UavcanPublisherBase.hpp
@@ -37,9 +37,21 @@
 #include <uavcan/uavcan.hpp>
 
 #include <uavcan/node/publisher.hpp>
+#include <drivers/drv_hrt.h>
 
 namespace uavcannode
 {
+
+// Acquisition time in the bus shared time base for a sample taken at sample_hrt.
+// The bus time is 0 until the time-sync master disciplines our clock, and the
+// subtraction is unsigned, so publish UNKNOWN rather than underflow the uint56
+// field.
+inline uint64_t bus_timestamp_usec(uint64_t bus_time_us, hrt_abstime sample_hrt)
+{
+	const uint64_t sample_age_us = hrt_absolute_time() - sample_hrt;
+	return (bus_time_us > sample_age_us) ? (bus_time_us - sample_age_us) : 0;
+}
+
 
 class UavcanPublisherBase : public IntrusiveSortedListNode<UavcanPublisherBase *>
 {


### PR DESCRIPTION
## Summary

Fix the cannode `RawIMU` and `RangeSensor` publishers underflowing their bus timestamp to ~2^56 before the node's clock is disciplined, fix `RawIMU.integration_interval` being published in microseconds instead of seconds, and make the FC-side accel, gyro, rangefinder and RelPosHeading bridges convert a node timestamp through the bus time base instead of assuming it is HRT. The `RelPosHeading` and `BatteryInfoAux` publishers stamped node-local time into the same bus-base field and take the same helper. The last commit also fixes what `RawIMU` carries: `*_latest` becomes a true point sample and the FC bridges consume the integral at its window centroid.

## Problem

`uavcan.Timestamp` fields are in the bus shared time base. The node computed them as `getUtcTime() - (hrt_now - sample_hrt)`. `getUtcTime()` returns 0 until the time-sync slave has disciplined the clock, so the unsigned subtraction underflows and the truncated `uint56` is transmitted as ~7.2e16 µs.

The FC bridges took any non-zero `msg.timestamp.usec` verbatim as `timestamp_sample`, which assumes the bus base is HRT. It is not: the FC seeds its bus clock with `adjustUtc(hrt_absolute_time())`, and the stm32/kinetis drivers add their free-running 16-bit timer count on top of the seed, so the bus base leads HRT by the timer phase at seeding (up to 65 ms). The FC may also be disciplined by a lower node ID master. An undisciplined or foreign-epoch node therefore pushed the sample time arbitrarily far from HRT, and even a correctly synced node stamped samples in the future, which `VehicleIMU` reports as `timestamp < timestamp_sample`.

Separately, `integration_interval` is specified in seconds but was assigned `vehicle_imu.delta_angle_dt`, which is in microseconds.

`RawIMU.rate_gyro_latest` / `accelerometer_latest` carried `delta / interval`, the window mean, under a field the DSDL defines as the latest point sample. The mean lags the message timestamp by half the interval (2.5 ms at `IMU_INTEG_RATE` 200), and the FC published it as an instantaneous rate at the window end while ignoring the float32 integral in favour of the float16 mean.

## Solution

Node: one shared helper publishes `UNKNOWN` while the clock is undisciplined and the bus-base acquisition time otherwise, used by `RawIMU`, `RangeSensorMeasurement`, `RelPosHeading` and `BatteryInfoAux`. Scale `delta_angle_dt` by `1e-6` so `integration_interval` is in seconds; the `rate_gyro_latest`/`accelerometer_latest` math relies on dt in microseconds and is unchanged.

FC: read the bus clock and HRT at the same instant in the callback. The sample age is `bus_now - msg.timestamp` and the sample time is `hrt_now - age`, whatever the offset between the bus base and HRT. Bound the age to a plausible transport window and fall back to the receive time otherwise, in one shared helper used by all four bridges. The ISR receive stamp is deliberately not used: it is taken at the first frame of the transfer, so pairing it with a later HRT read leaves the transfer and scheduling latency in `timestamp_sample` as jitter.

Node: fill `*_latest` from the `sensor_gyro` / `sensor_accel` instance behind `vehicle_imu`, the same batch-end sample every PX4 IMU driver produces, keeping the integrals and timestamp as they were.

FC: when an integral is present, publish `integral / interval` stamped at `timestamp - interval / 2`. Successive means one interval apart integrate back to the node's exact delta angle in `VehicleIMU`, the value is float32 and anti-aliased against the node's full-rate stream, and this is independent of which node firmware filled `*_latest`. The point sample is used only when the node reports no integral, as the DSDL specifies. Measured on ARK FMU-V6X with an ARK Flow MR (IIM-42653, 200 Hz `vehicle_imu`) on CAN2: node gyro `timestamp_sample` arrives 2.3 to 3.3 ms after acquisition through the bus mapping, and the remaining 2.5 ms group delay of the window mean is what the centroid stamp removes.
