### PR TITLE
fix(drivers/iim42653): report 32 g / 4000 dps full-scale range

### DIFF
--- a/src/drivers/imu/invensense/iim42653/IIM42653.cpp
+++ b/src/drivers/imu/invensense/iim42653/IIM42653.cpp
@@ -411,9 +411,9 @@ bool IIM42653::Configure()
 	}
 
 	// 20-bits data format used
-	//  the only FSR settings that are operational are ±2000dps for gyroscope and ±16g for accelerometer
-	_px4_accel.set_range(16.f * CONSTANTS_ONE_G);
-	_px4_gyro.set_range(math::radians(2000.f));
+	//  IIM-42653 FSR: ±4000 dps gyroscope and ±32 g accelerometer (default full-scale)
+	_px4_accel.set_range(32.f * CONSTANTS_ONE_G);
+	_px4_gyro.set_range(math::radians(4000.f));
 
 	return success;
 }


### PR DESCRIPTION
## Summary

Align IIM-42653 software-reported accel/gyro ranges with the chip FSR already programmed in the driver registers.

## Problem

The driver writes `ACCEL_FS_SEL` ±32 g and `GYRO_FS_SEL` ±4000 dps (chip defaults) and uses matching FIFO scale factors, but `Configure()` still called `set_range(16 g)` / `set_range(2000 dps)` — a leftover from IIM-42652 / ICM-42688. PX4 clipping therefore flagged above ~16 g even though the sensor and scales support 32 g. There is no parameter to change this.

## Solution

Report 32 g and 4000 dps from `set_range` so range metadata and clip thresholds match the configured FSR. FIFO scales were already correct for 32 g / 4000 dps and are unchanged.

Built: `make px4_fmu-v6x`, `make px4_sitl`. No hardware flight/bench verification of clipping flags above 16 g in this change.