### PR TITLE
fix(VTX): ignore temperature data if not available for tramp protocol

### DIFF
--- a/src/drivers/vtx/VTX.cpp
+++ b/src/drivers/vtx/VTX.cpp
@@ -437,7 +437,7 @@ int VTX::print_status()
 	PX4_INFO("  pit mode: %s", _pit_mode ? "on" : "off");
 
 	if (!(_comms_ok && _protocol && _protocol->print_settings())) {
-		PX4_ERR("%s device not found", _param_vtx_device.get() == 1 ? "Tramp" : "SmartAudio");
+		PX4_ERR("%s device not found", (_param_vtx_device.get() & 0xff) == vtx_s::PROTOCOL_TRAMP ? "Tramp" : "SmartAudio");
 	}
 
 	perf_print_counter(_perf_cycle);

--- a/src/drivers/vtx/tramp.cpp
+++ b/src/drivers/vtx/tramp.cpp
@@ -50,7 +50,9 @@ int Tramp::get_settings()
 	if (rv != 0) { return rv; }
 
 	px4_usleep(30_ms);
-	return get_temperature();
+	int temperature_data = get_temperature();
+	// ignore temperature data if not available
+	return temperature_data == -ETIMEDOUT ? 0 : temperature_data;
 }
 
 


### PR DESCRIPTION
### Solved Problem

VTX transmitters using tramp protocol and w/o temperature sensors can not response with messages containing its temperature value. Temperature requests from controller side fails with timeout in this case. This behavior causes VTX transmitter status failing and therefore its absence in the system.

Also, corrected error message text on VTX transmitter absence during printing transmitter status

### Solution

Ignore temperature status if it marked as timed out.

### Changelog Entry
For release notes:
```
* Bugfix: VTX transmitters using tramp protocol w/o built-in temperature sensor is now correctly recognized
* Bugfix: corrected error message text on VTX transmitter absence during printing transmitter status
```