### PR TITLE
feat(vtx): Separate device and protocol parameters for vtx driver

### DIFF
--- a/docs/en/vtx/index.md
+++ b/docs/en/vtx/index.md
@@ -19,7 +19,8 @@ Connect the SmartAudio or Tramp pin of the VTX to the TX pin of a free serial po
 Then set the following parameters:
 
 - `VTX_SER_CFG`: Select the serial port used for VTX communication.
-- `VTX_DEVICE`: Selects the VTX device (generic SmartAudio/Tramp or a specific device).
+- `VTX_PROTOCOL`: Selects the wire protocol (SmartAudio or Tramp).
+- `VTX_DEVICE`: Selects the specific VTX model.
 
 Note that since the VTX communication is half-duplex, you can, for example, use the single-pin Radio Controller port for the VTX and use a full duplex TELEM port for CRSF communication.
 
@@ -264,25 +265,32 @@ Key configuration options:
     - `2`: MSP controls frequency, AUX controls power
     - `3`: MSP controls power, AUX controls band/channel
     - `4`: Not used with MSP support
+- `VTX_PROTOCOL`: Wire protocol used to talk to the VTX (see below)
 - `VTX_DEVICE`: Device-specific configuration (see below)
 
-## Device-Specific Configuration
+## Protocol and Device Configuration
 
-The `VTX_DEVICE` parameter allows device-specific workarounds.
-It encodes both the protocol type and device variant:
+The wire protocol and the device model are configured independently.
 
-- Low byte (bits 0-7): Protocol selection
-  - `0`: SmartAudio (default)
-  - `1`: Tramp
-- High byte (bits 8-15): Device-specific variant
-  - `0`: Generic device
-  - `20`: Peak THOR T67
-  - `40`: Rush Max Solo
+`VTX_PROTOCOL` selects the wire protocol. Set it to the protocol listed in the manual of your VTX:
+
+| Value | Protocol                |
+| ----- | ----------------------- |
+| `0`   | SmartAudio v1, v2, v2.1 |
+| `100` | Tramp                   |
+
+`VTX_DEVICE` selects the specific VTX model and only enables device-specific workarounds. Leave at Generic unless your VTX is listed
+
+| Value   | Device        |
+| ------- | ------------- |
+| `0`     | Generic       |
+| `5120`  | Peak THOR T67 |
+| `10240` | Rush MAX SOLO |
+
+Peak THOR devices speak SmartAudio and the Rush MAX SOLO speaks Tramp, so set `VTX_PROTOCOL` to match the model you select.
 
 ### Known Device Workarounds
 
 **Peak THOR T67** (`VTX_DEVICE` = 5120):
 This device incorrectly reports pit mode status but otherwise functions normally.
 The driver applies a workaround to override the reported status with the actual configured state.
-
-For generic devices, use `VTX_DEVICE` = 0 (SmartAudio) or `VTX_DEVICE` = 1 (Tramp).

--- a/src/drivers/vtx/VTX.cpp
+++ b/src/drivers/vtx/VTX.cpp
@@ -72,8 +72,9 @@ VTX::~VTX()
 int VTX::init()
 {
 	_param_vtx_device.update();
+	_param_vtx_protocol.update();
 	_device = (_param_vtx_device.get() >> 8);
-	const uint8_t protocol = (_param_vtx_device.get() & 0xff);
+	const uint8_t protocol = _param_vtx_protocol.get();
 
 	if (_protocol == nullptr) {
 		if (protocol == vtx_s::PROTOCOL_TRAMP) {
@@ -437,7 +438,8 @@ int VTX::print_status()
 	PX4_INFO("  pit mode: %s", _pit_mode ? "on" : "off");
 
 	if (!(_comms_ok && _protocol && _protocol->print_settings())) {
-		PX4_ERR("%s device not found", (_param_vtx_device.get() & 0xff) == vtx_s::PROTOCOL_TRAMP ? "Tramp" : "SmartAudio");
+		PX4_ERR("%s device not found",
+			_param_vtx_protocol.get() == vtx_s::PROTOCOL_TRAMP ? "Tramp" : "SmartAudio");
 	}
 
 	perf_print_counter(_perf_cycle);

--- a/src/drivers/vtx/VTX.hpp
+++ b/src/drivers/vtx/VTX.hpp
@@ -95,7 +95,8 @@ private:
 		(ParamInt<px4::params::VTX_POWER>) _param_vtx_power,
 		(ParamBool<px4::params::VTX_PIT_MODE>) _param_vtx_pit_mode,
 		(ParamInt<px4::params::VTX_MAP_CONFIG>) _param_vtx_map_config,
-		(ParamInt<px4::params::VTX_DEVICE>) _param_vtx_device
+		(ParamInt<px4::params::VTX_DEVICE>) _param_vtx_device,
+		(ParamInt<px4::params::VTX_PROTOCOL>) _param_vtx_protocol
 	);
 
 	perf_counter_t _perf_cycle;

--- a/src/drivers/vtx/module.yaml
+++ b/src/drivers/vtx/module.yaml
@@ -118,15 +118,29 @@ parameters:
           3: MSP for Power, AUX for Band and Channel
           4: AUX for Power, Band and Channel
         default: 0
+      VTX_PROTOCOL:
+        description:
+          short: VTX protocol
+          long: |
+            Wire protocol used to communicate with the VTX. Select the protocol
+            listed in the manual of your VTX.
+        type: enum
+        # Note: keep values in sync with the PROTOCOL_* constants in msg/Vtx.msg
+        values:
+          0: SmartAudio v1, v2, v2.1
+          100: Tramp
+        default: 0
+        reboot_required: true
       VTX_DEVICE:
         description:
           short: VTX device
-          long: Specific VTX device useful for workarounds and optimizations
+          long: |
+            Specific VTX model, only used to enable device-specific workarounds.
+            Leave at Generic unless your VTX is listed.
         type: enum
-        # Note: keep values in sync with msg/Vtx.msg: lower 8-bit is protocol, next 8-bit is device
+        # Note: values are due to legacy compatibility; keep in sync with msg/Vtx.msg
         values:
-          0: SmartAudio v1, v2, v2.1 Protocol
-          100: Tramp Protocol
+          0: Generic
           5120: Peak THOR T67
           10240: Rush MAX SOLO
         default: 0

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -40,6 +40,7 @@
 #include <drivers/drv_sensor.h>
 #include <lib/parameters/param.h>
 #include <lib/mathlib/mathlib.h>
+#include <uORB/topics/vtx.h>
 
 param_modify_on_import_ret param_modify_on_import(bson_node_t node)
 {
@@ -305,6 +306,45 @@ param_modify_on_import_ret param_modify_on_import(bson_node_t node)
 			strcpy(node->name, "COM_TRAFF_AVOID");
 			PX4_INFO("migrating %s -> %s", "COM_ARM_TRAFF", "COM_TRAFF_AVOID");
 			return param_modify_on_import_ret::PARAM_MODIFIED;
+		}
+	}
+
+	// 2026-08-05: the protocol selection moved out of VTX_DEVICE into VTX_PROTOCOL. VTX_DEVICE keeps
+	// the old layout that holds the device in its high byte, so only the protocol has to be derived:
+	// the Peak THOR T67 speaks SmartAudio, the Rush MAX SOLO speaks Tramp. A value that is not listed
+	// stays untouched and acts as a generic device on SmartAudio, which is what both parameters
+	// default to, so the old value 0 needs nothing.
+	{
+		static constexpr int32_t PROTOCOL_SMART_AUDIO = 0; // VTX_PROTOCOL value, not in msg/Vtx.msg
+
+		if ((node->type == bson_type_t::BSON_INT32) && (strcmp("VTX_DEVICE", node->name) == 0)) {
+			int32_t device = -1;
+			int32_t protocol = PROTOCOL_SMART_AUDIO;
+
+			switch (node->i32) {
+			case 100: // generic device, Tramp
+				device = vtx_s::DEVICE_UNKNOWN << 8;
+				protocol = vtx_s::PROTOCOL_TRAMP;
+				break;
+
+			case 5120: // Peak THOR T67, SmartAudio only
+				device = vtx_s::DEVICE_PEAK_THOR_T67 << 8;
+				protocol = PROTOCOL_SMART_AUDIO;
+				break;
+
+			case 10240: // Rush MAX SOLO, Tramp only
+				device = vtx_s::DEVICE_RUSH_MAX_SOLO << 8;
+				protocol = vtx_s::PROTOCOL_TRAMP;
+				break;
+			}
+
+			if (device >= 0) {
+				node->i32 = device;
+				param_set(param_find("VTX_PROTOCOL"), &protocol);
+				PX4_INFO("migrating VTX_DEVICE -> VTX_DEVICE %" PRId32 " + VTX_PROTOCOL %" PRId32,
+					 device, protocol);
+				return param_modify_on_import_ret::PARAM_MODIFIED;
+			}
 		}
 	}
 


### PR DESCRIPTION
### Solved Problem
Before the **VTX_DEVICE** parameter contains both actual vtx device and the protocol to be used. Because both were in one enum, the user had to choose between naming the protocol or naming the device.

### Solution
The protocol moves into its own parameter and **VTX_DEVICE** keeps only the device model. 

**VTX_PROTOCOL** selects the wire protocol.
0: SmartAudio
100: Tramp

VTX_DEVICE now contains:
0: Generic
5120: Peak THOR T67
10240: Rush MAX SOLO

### Test coverage
I tested that the new parameters are set correctly based on the old parameter values: 
VTX_DEVICE = 5120 keeps its value and sets VTX_PROTOCOL to SmartAudio 
VTX_DEVICE = 10240 keeps its value and sets VTX_PROTOCOL to Tramp. 

