### PR TITLE
fix(msp_osd): fix OSD_SYMBOLS parameter bitmask behavior and missing elements

### DIFF
--- a/docs/en/peripherals/osd.md
+++ b/docs/en/peripherals/osd.md
@@ -27,10 +27,11 @@ PX4 currently sends a subset of MSP messages.
 Reliably-working display items include:
 
 - Craft name and flight mode / arming state
-- Battery voltage, current draw, mAh consumed, average cell voltage
+- Average cell voltage, current draw, mAh consumed
 - GPS latitude, longitude, satellite count, ground speed
-- Home distance and direction
+- Home distance
 - Altitude (from GNSS / baro)
+- Roll / pitch angle
 - RSSI
 - Crosshairs toggle
 
@@ -63,7 +64,8 @@ Then rebuild and flash.
 3. Reboot.
 4. Tune the display via the [`OSD_*` parameters](../advanced_config/parameter_reference.md#osd):
    - [`OSD_SYMBOLS`](../advanced_config/parameter_reference.md#OSD_SYMBOLS) — bitmask selecting which items appear.
-   - [`OSD_CH_HEIGHT`](../advanced_config/parameter_reference.md#OSD_CH_HEIGHT) — vertical position of the crosshairs.
+   - [`OSD_CH_POS_VER`](../advanced_config/parameter_reference.md#OSD_CH_POS_VER) — vertical position of the crosshairs.
+   - [`OSD_CH_POS_HOR`](../advanced_config/parameter_reference.md#OSD_CH_POS_HOR) — horizontal position of the crosshairs.
    - [`OSD_LOG_LEVEL`](../advanced_config/parameter_reference.md#OSD_LOG_LEVEL) — minimum severity for on-screen warnings.
    - [`OSD_SCROLL_RATE`](../advanced_config/parameter_reference.md#OSD_SCROLL_RATE) / [`OSD_DWELL_TIME`](../advanced_config/parameter_reference.md#OSD_DWELL_TIME) — scrolling of long messages.
    - [`OSD_RC_STICK`](../advanced_config/parameter_reference.md#OSD_RC_STICK) — forward RC sticks to the VTX when disarmed, so you can navigate the VTX menu.

--- a/src/drivers/osd/msp_osd/module.yaml
+++ b/src/drivers/osd/msp_osd/module.yaml
@@ -30,7 +30,7 @@ parameters:
                 10: MAH_DRAWN
                 11: RSSI_VALUE
                 12: ALTITUDE
-                13: NUMERICAL_VARIO
+                13: (unused) NUMERICAL_VARIO
                 # the following are reserved but not currently functional
                 14: (unused) FLYMODE
                 15: (unused) ESC_TMP

--- a/src/drivers/osd/msp_osd/module.yaml
+++ b/src/drivers/osd/msp_osd/module.yaml
@@ -34,8 +34,8 @@ parameters:
                 # the following are reserved but not currently functional
                 14: (unused) FLYMODE
                 15: (unused) ESC_TMP
-                16: (unused) PITCH_ANGLE
-                17: (unused) ROLL_ANGLE
+                16: PITCH_ANGLE
+                17: ROLL_ANGLE
                 18: CROSSHAIRS
                 19: AVG_CELL_VOLTAGE
                 20: (unused) HORIZON_SIDEBARS

--- a/src/drivers/osd/msp_osd/module.yaml
+++ b/src/drivers/osd/msp_osd/module.yaml
@@ -24,8 +24,8 @@ parameters:
                 4: GPS_SATS
                 5: GPS_SPEED
                 6: HOME_DIST
-                7: HOME_DIR
-                8: MAIN_BATT_VOLTAGE
+                7: (unused) HOME_DIR
+                8: (unused) MAIN_BATT_VOLTAGE
                 9: CURRENT_DRAW
                 10: MAH_DRAWN
                 11: RSSI_VALUE
@@ -39,7 +39,7 @@ parameters:
                 18: CROSSHAIRS
                 19: AVG_CELL_VOLTAGE
                 20: (unused) HORIZON_SIDEBARS
-                21: POWER
+                21: (unused) POWER
             default: 16383
 
         # OSD Crosshairs Vertical Position

--- a/src/drivers/osd/msp_osd/module.yaml
+++ b/src/drivers/osd/msp_osd/module.yaml
@@ -43,13 +43,26 @@ parameters:
             default: 16383
 
         # OSD Crosshairs Vertical Position
-        OSD_CH_HEIGHT:
+        OSD_CH_POS_VER:
             description:
-                short: OSD Crosshairs Height
+                short: OSD Crosshairs Vertical Position
                 long: |
                   Controls the vertical position of the crosshair display.
                   Resolution is limited by OSD to 15 discrete values. Negative
                   values will display the crosshairs below the horizon
+            type: int32
+            default: 0
+            min: -8
+            max: 8
+
+        # OSD Crosshairs Horizontal Position
+        OSD_CH_POS_HOR:
+            description:
+                short: OSD Crosshairs Horizontal Position
+                long: |
+                  Controls the horizontal position of the crosshair display.
+                  Resolution is limited by OSD to 15 discrete values. Negative
+                  values will display the crosshairs left of the center of the screen
             type: int32
             default: 0
             min: -8

--- a/src/drivers/osd/msp_osd/msp_defines.h
+++ b/src/drivers/osd/msp_osd/msp_defines.h
@@ -876,12 +876,30 @@ struct msp_battery_state_t {
 } __attribute__((packed));
 
 struct msp_rendor_battery_state_t {
-	uint8_t subCommand; // 0x03 write string. fixed
+	uint8_t subCommand = 0x03; // 0x03 write string. fixed
 	uint8_t screenYPosition;
 	uint8_t screenXPosition;
-	uint8_t iconAttrs;
+	uint8_t iconAttrs = 0x00;
 	uint8_t iconIndex;
 	char str[5];
+} __attribute__((packed));
+
+struct msp_rendor_current_draw_t {
+	uint8_t subCommand = 0x03; // 0x03 write string. fixed
+	uint8_t screenYPosition;
+	uint8_t screenXPosition;
+	uint8_t iconAttrs = 0x00;
+	uint8_t iconIndex = 0x9A;
+	char str[7]; // 100.00
+} __attribute__((packed));
+
+struct msp_rendor_mah_drawn_t {
+	uint8_t subCommand = 0x03; // 0x03 write string. fixed
+	uint8_t screenYPosition;
+	uint8_t screenXPosition;
+	uint8_t iconAttrs = 0x00;
+	uint8_t iconIndex = 0x07;
+	char str[8]; // 10000.0
 } __attribute__((packed));
 
 struct msp_rendor_crosshairs_t {

--- a/src/drivers/osd/msp_osd/msp_defines.h
+++ b/src/drivers/osd/msp_osd/msp_defines.h
@@ -884,6 +884,16 @@ struct msp_rendor_battery_state_t {
 	char str[5];
 } __attribute__((packed));
 
+struct msp_rendor_crosshairs_t {
+	uint8_t subCommand = 0x03; // 0x03 write string. fixed
+	uint8_t screenYPosition;
+	uint8_t screenXPosition;
+	uint8_t iconAttrs = 0x00;
+	uint8_t iconIndex = 0x72; //SYM_AH_CENTER_LINE
+	uint8_t iconIndex2 = 0x73; //SYM_AH_CENTER
+	uint8_t iconIndex3 = 0x74; //SYM_AH_CENTER_LINE_RIGHT
+} __attribute__((packed));
+
 // MSP_STATUS reply customized for BF/DJI
 struct msp_status_BF_t {
 	uint16_t task_delta_time;

--- a/src/drivers/osd/msp_osd/msp_defines.h
+++ b/src/drivers/osd/msp_osd/msp_defines.h
@@ -469,6 +469,15 @@ struct msp_rendor_satellites_used_t {
 	char str[3]; // 99
 } __attribute__((packed));
 
+struct msp_rendor_gps_speed_t {
+	uint8_t subCommand = 0x03; // 0x03 subcommand write string. fixed
+	uint8_t screenYPosition;
+	uint8_t screenXPosition;
+	uint8_t iconAttrs = 0x00;
+	uint8_t iconIndex = 0x9F; //mps icon
+
+	char str[7]; // 115.25
+} __attribute__((packed));
 
 // MSP_COMP_GPS reply
 struct msp_comp_gps_t {

--- a/src/drivers/osd/msp_osd/msp_osd.cpp
+++ b/src/drivers/osd/msp_osd/msp_osd.cpp
@@ -400,6 +400,11 @@ void MspOsd::Run()
 			const auto msg = msp_osd::construct_rendor_GPS_NUM(vehicle_gps_position);
 			this->Send(MSP_CMD_DISPLAYPORT, &msg, sizeof(msp_rendor_satellites_used_t));
 		}
+
+		if (enabled(SymbolIndex::GPS_SPEED)) {
+			const auto msg = msp_osd::construct_rendor_GPS_SPEED(vehicle_gps_position);
+			this->Send(MSP_CMD_DISPLAYPORT, &msg, sizeof(msp_rendor_gps_speed_t));
+		}
 	}
 
 	// MSP_COMP_GPS
@@ -412,7 +417,6 @@ void MspOsd::Run()
 
 		if (enabled(SymbolIndex::HOME_DIST)) {
 			const auto msg =  msp_osd::construct_rendor_distanceToHome(home_position, vehicle_global_position);
-
 			this->Send(MSP_CMD_DISPLAYPORT, &msg, sizeof(msp_rendor_distanceToHome_t));
 		}
 	}

--- a/src/drivers/osd/msp_osd/msp_osd.cpp
+++ b/src/drivers/osd/msp_osd/msp_osd.cpp
@@ -365,9 +365,20 @@ void MspOsd::Run()
 		const auto msg_original = msp_osd::construct_BATTERY_STATE(battery_status);
 		this->Send(MSP_BATTERY_STATE, &msg_original);
 
-		const auto msg = msp_osd::construct_rendor_BATTERY_STATE(battery_status);
-		this->Send(MSP_CMD_DISPLAYPORT, &msg, sizeof(msp_rendor_battery_state_t));
+		if (enabled(SymbolIndex::AVG_CELL_VOLTAGE)) {
+			const auto msg = msp_osd::construct_rendor_BATTERY_STATE(battery_status);
+			this->Send(MSP_CMD_DISPLAYPORT, &msg, sizeof(msp_rendor_battery_state_t));
+		}
 
+		if (enabled(SymbolIndex::CURRENT_DRAW)) {
+			const auto msg = msp_osd::construct_rendor_CURRENT_DRAW(battery_status);
+			this->Send(MSP_CMD_DISPLAYPORT, &msg, sizeof(msp_rendor_current_draw_t));
+		}
+
+		if (enabled(SymbolIndex::MAH_DRAWN)) {
+			const auto msg = msp_osd::construct_rendor_MAH_DRAWN(battery_status);
+			this->Send(MSP_CMD_DISPLAYPORT, &msg, sizeof(msp_rendor_mah_drawn_t));
+		}
 	}
 
 	// MSP_RAW_GPS

--- a/src/drivers/osd/msp_osd/msp_osd.cpp
+++ b/src/drivers/osd/msp_osd/msp_osd.cpp
@@ -412,12 +412,16 @@ void MspOsd::Run()
 		_vehicle_attitude_sub.copy(&vehicle_attitude);
 
 		{
-			const auto msg = msp_osd::construct_rendor_PITCH(vehicle_attitude);
-			this->Send(MSP_CMD_DISPLAYPORT, &msg, sizeof(msp_rendor_pitch_t));
+			if (enabled(SymbolIndex::PITCH_ANGLE)) {
+				const auto msg = msp_osd::construct_rendor_PITCH(vehicle_attitude);
+				this->Send(MSP_CMD_DISPLAYPORT, &msg, sizeof(msp_rendor_pitch_t));
+			}
 		}
 		{
-			const auto msg = msp_osd::construct_rendor_ROLL(vehicle_attitude);
-			this->Send(MSP_CMD_DISPLAYPORT, &msg, sizeof(msp_rendor_roll_t));
+			if (enabled(SymbolIndex::ROLL_ANGLE)) {
+				const auto msg = msp_osd::construct_rendor_ROLL(vehicle_attitude);
+				this->Send(MSP_CMD_DISPLAYPORT, &msg, sizeof(msp_rendor_roll_t));
+			}
 		}
 	}
 

--- a/src/drivers/osd/msp_osd/msp_osd.cpp
+++ b/src/drivers/osd/msp_osd/msp_osd.cpp
@@ -193,7 +193,7 @@ void MspOsd::SendConfig()
 	msp_osd_config.osd_crosshairs_pos = LOCATION_HIDDEN;
 
 	if (enabled(SymbolIndex::CROSSHAIRS)) {
-		msp_osd_config.osd_crosshairs_pos = osd_crosshairs_pos - 32 * _param_osd_ch_height.get();
+		msp_osd_config.osd_crosshairs_pos = osd_crosshairs_pos - 32 * _param_osd_ch_pos_ver.get();
 	}
 
 	// possibly available, but not currently used
@@ -469,6 +469,15 @@ void MspOsd::Run()
 
 		const auto msg = msp_osd::construct_MSP_STATUS(vehicle_status);
 		this->Send(MSP_STATUS, &msg, sizeof(msp_status_t));
+	}
+
+	// MSP_CROSSHAIRS
+	{
+		if (enabled(SymbolIndex::CROSSHAIRS)) {
+			const auto msg = msp_osd::construct_rendor_CROSSHAIRS(_param_osd_ch_pos_ver.get(), _param_osd_ch_pos_hor.get());
+
+			this->Send(MSP_CMD_DISPLAYPORT, &msg, sizeof(msp_rendor_crosshairs_t));
+		}
 	}
 
 	subcmd = MSP_DP_DRAW_SCREEN;

--- a/src/drivers/osd/msp_osd/msp_osd.hpp
+++ b/src/drivers/osd/msp_osd/msp_osd.hpp
@@ -173,7 +173,8 @@ private:
 	// parameters
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::OSD_SYMBOLS>) _param_osd_symbols,
-		(ParamInt<px4::params::OSD_CH_HEIGHT>) _param_osd_ch_height,
+		(ParamInt<px4::params::OSD_CH_POS_VER>) _param_osd_ch_pos_ver,
+		(ParamInt<px4::params::OSD_CH_POS_HOR>) _param_osd_ch_pos_hor,
 		(ParamInt<px4::params::OSD_SCROLL_RATE>) _param_osd_scroll_rate,
 		(ParamInt<px4::params::OSD_DWELL_TIME>) _param_osd_dwell_time,
 		(ParamInt<px4::params::OSD_LOG_LEVEL>) _param_osd_log_level,

--- a/src/drivers/osd/msp_osd/uorb_to_msp.cpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.cpp
@@ -587,6 +587,17 @@ msp_status_t construct_MSP_STATUS(const vehicle_status_s &vehicle_status)
 	return status;
 }
 
+msp_rendor_crosshairs_t construct_rendor_CROSSHAIRS(const int pos_vertical_offset, const int pos_horizontal_offset)
+{
+	// initialize result
+	msp_rendor_crosshairs_t crosshairs;
+
+	crosshairs.screenYPosition = 0x0A - pos_vertical_offset;
+	crosshairs.screenXPosition = 0x1A + pos_horizontal_offset;
+
+	return crosshairs;
+}
+
 
 
 } // namespace msp_osd

--- a/src/drivers/osd/msp_osd/uorb_to_msp.cpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.cpp
@@ -210,7 +210,7 @@ msp_analog_t construct_ANALOG(const battery_status_s &battery_status, const inpu
 
 msp_rendor_rssi_t construct_rendor_RSSI(const input_rc_s &input_rc)
 {
-	msp_rendor_rssi_t rssi;
+	msp_rendor_rssi_t rssi {};
 	rssi.screenYPosition = 0x02;
 	rssi.screenXPosition = 0x02;
 
@@ -248,12 +248,10 @@ msp_battery_state_t construct_BATTERY_STATE(const battery_status_s &battery_stat
 msp_rendor_battery_state_t construct_rendor_BATTERY_STATE(const battery_status_s &battery_status)
 {
 	// initialize result
-	msp_rendor_battery_state_t battery_state;
+	msp_rendor_battery_state_t battery_state {};
 
-	battery_state.subCommand = MSP_DP_WRITE_STRING; // 3 write string. fixed
 	battery_state.screenYPosition = 0x04;
 	battery_state.screenXPosition = 0x02;
-	battery_state.iconAttrs = 0x00;
 
 	float sigle_cell_v = battery_status.voltage_v / battery_status.cell_count;
 
@@ -278,7 +276,7 @@ msp_rendor_battery_state_t construct_rendor_BATTERY_STATE(const battery_status_s
 msp_rendor_current_draw_t construct_rendor_CURRENT_DRAW(const battery_status_s &battery_status)
 {
 	// initialize result
-	msp_rendor_current_draw_t current_draw;
+	msp_rendor_current_draw_t current_draw {};
 
 	current_draw.screenYPosition = 0x05;
 	current_draw.screenXPosition = 0x02;
@@ -291,7 +289,7 @@ msp_rendor_current_draw_t construct_rendor_CURRENT_DRAW(const battery_status_s &
 msp_rendor_mah_drawn_t construct_rendor_MAH_DRAWN(const battery_status_s &battery_status)
 {
 	// initialize result
-	msp_rendor_mah_drawn_t mah_drawn;
+	msp_rendor_mah_drawn_t mah_drawn {};
 
 	mah_drawn.screenYPosition = 0x06;
 	mah_drawn.screenXPosition = 0x02;
@@ -361,7 +359,7 @@ msp_raw_gps_t construct_RAW_GPS(const sensor_gps_s &vehicle_gps_position,
 
 msp_rendor_latitude_t construct_rendor_GPS_LAT(const sensor_gps_s &vehicle_gps_position)
 {
-	msp_rendor_latitude_t lat;
+	msp_rendor_latitude_t lat {};
 
 	lat.screenYPosition = 0x0A;
 	lat.screenXPosition = 0x29;
@@ -378,7 +376,7 @@ msp_rendor_latitude_t construct_rendor_GPS_LAT(const sensor_gps_s &vehicle_gps_p
 
 msp_rendor_longitude_t construct_rendor_GPS_LON(const sensor_gps_s &vehicle_gps_position)
 {
-	msp_rendor_longitude_t lon;
+	msp_rendor_longitude_t lon {};
 
 	lon.screenYPosition = 0x09;
 	lon.screenXPosition = 0x29;
@@ -395,7 +393,7 @@ msp_rendor_longitude_t construct_rendor_GPS_LON(const sensor_gps_s &vehicle_gps_
 
 msp_rendor_satellites_used_t construct_rendor_GPS_NUM(const sensor_gps_s &vehicle_gps_position)
 {
-	msp_rendor_satellites_used_t num;
+	msp_rendor_satellites_used_t num {};
 
 	num.screenYPosition = 0x08;
 	num.screenXPosition = 0x29;
@@ -408,7 +406,7 @@ msp_rendor_satellites_used_t construct_rendor_GPS_NUM(const sensor_gps_s &vehicl
 
 msp_rendor_gps_speed_t construct_rendor_GPS_SPEED(const sensor_gps_s &vehicle_gps_position)
 {
-	msp_rendor_gps_speed_t speed;
+	msp_rendor_gps_speed_t speed {};
 
 	speed.screenYPosition = 0x08;
 	speed.screenXPosition = 0x02;
@@ -458,7 +456,7 @@ msp_comp_gps_t construct_COMP_GPS(const home_position_s &home_position,
 msp_rendor_distanceToHome_t construct_rendor_distanceToHome(const home_position_s &home_position,
 		const vehicle_global_position_s &vehicle_global_position)
 {
-	msp_rendor_distanceToHome_t distance;
+	msp_rendor_distanceToHome_t distance {};
 
 	distance.screenYPosition = 0x0A;
 	distance.screenXPosition = 0x02;
@@ -510,7 +508,7 @@ msp_attitude_t construct_ATTITUDE(const vehicle_attitude_s &vehicle_attitude)
 msp_rendor_pitch_t  construct_rendor_PITCH(const vehicle_attitude_s &vehicle_attitude)
 {
 	// initialize results
-	msp_rendor_pitch_t pit;
+	msp_rendor_pitch_t pit {};
 
 	pit.screenYPosition = 0x0D;
 	pit.screenXPosition = 0x29;
@@ -529,7 +527,7 @@ msp_rendor_pitch_t  construct_rendor_PITCH(const vehicle_attitude_s &vehicle_att
 msp_rendor_roll_t  construct_rendor_ROLL(const vehicle_attitude_s &vehicle_attitude)
 {
 	// initialize results
-	msp_rendor_roll_t roll;
+	msp_rendor_roll_t roll {};
 
 	roll.screenYPosition = 0x0E;
 	roll.screenXPosition = 0x29;
@@ -572,7 +570,7 @@ msp_altitude_t construct_ALTITUDE(const sensor_gps_s &vehicle_gps_position,
 msp_rendor_altitude_t construct_Rendor_ALTITUDE(const sensor_gps_s &vehicle_gps_position,
 		const vehicle_local_position_s &vehicle_local_position)
 {
-	msp_rendor_altitude_t altitude;
+	msp_rendor_altitude_t altitude {};
 
 	altitude.screenYPosition = 0x09;
 	altitude.screenXPosition = 0x02;
@@ -630,7 +628,7 @@ msp_status_t construct_MSP_STATUS(const vehicle_status_s &vehicle_status)
 msp_rendor_crosshairs_t construct_rendor_CROSSHAIRS(const int pos_vertical_offset, const int pos_horizontal_offset)
 {
 	// initialize result
-	msp_rendor_crosshairs_t crosshairs;
+	msp_rendor_crosshairs_t crosshairs {};
 
 	crosshairs.screenYPosition = 0x0A - pos_vertical_offset;
 	crosshairs.screenXPosition = 0x1A + pos_horizontal_offset;

--- a/src/drivers/osd/msp_osd/uorb_to_msp.cpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.cpp
@@ -247,7 +247,7 @@ msp_battery_state_t construct_BATTERY_STATE(const battery_status_s &battery_stat
 msp_rendor_battery_state_t construct_rendor_BATTERY_STATE(const battery_status_s &battery_status)
 {
 	// initialize result
-	msp_rendor_battery_state_t battery_state = {0};
+	msp_rendor_battery_state_t battery_state;
 
 	battery_state.subCommand = MSP_DP_WRITE_STRING; // 3 write string. fixed
 	battery_state.screenYPosition = 0x04;
@@ -269,8 +269,35 @@ msp_rendor_battery_state_t construct_rendor_BATTERY_STATE(const battery_status_s
 		battery_state.iconIndex = 0x96; // Dead battery Icon
 	}
 
+	memset(&battery_state.str[0], 0, sizeof(battery_state.str));
 	snprintf(&battery_state.str[0], sizeof(battery_state.str), "%.1fV", (double)sigle_cell_v);
 	return battery_state;
+}
+
+msp_rendor_current_draw_t construct_rendor_CURRENT_DRAW(const battery_status_s &battery_status)
+{
+	// initialize result
+	msp_rendor_current_draw_t current_draw;
+
+	current_draw.screenYPosition = 0x05;
+	current_draw.screenXPosition = 0x02;
+
+	memset(&current_draw.str[0], 0, sizeof(current_draw.str));
+	snprintf(&current_draw.str[0], sizeof(current_draw.str), "%.2f", (double)battery_status.current_a);
+	return current_draw;
+}
+
+msp_rendor_mah_drawn_t construct_rendor_MAH_DRAWN(const battery_status_s &battery_status)
+{
+	// initialize result
+	msp_rendor_mah_drawn_t mah_drawn;
+
+	mah_drawn.screenYPosition = 0x06;
+	mah_drawn.screenXPosition = 0x02;
+
+	memset(&mah_drawn.str[0], 0, sizeof(mah_drawn.str));
+	snprintf(&mah_drawn.str[0], sizeof(mah_drawn.str), "%.0f", (double)battery_status.discharged_mah);
+	return mah_drawn;
 }
 
 
@@ -420,7 +447,7 @@ msp_rendor_distanceToHome_t construct_rendor_distanceToHome(const home_position_
 {
 	msp_rendor_distanceToHome_t distance;
 
-	distance.screenYPosition = 0x08;
+	distance.screenYPosition = 0x0A;
 	distance.screenXPosition = 0x02;
 
 	int16_t dist_i = 0;
@@ -534,7 +561,7 @@ msp_rendor_altitude_t construct_Rendor_ALTITUDE(const sensor_gps_s &vehicle_gps_
 {
 	msp_rendor_altitude_t altitude;
 
-	altitude.screenYPosition = 0x06;
+	altitude.screenYPosition = 0x09;
 	altitude.screenXPosition = 0x02;
 
 	double alt;

--- a/src/drivers/osd/msp_osd/uorb_to_msp.cpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.cpp
@@ -214,6 +214,7 @@ msp_rendor_rssi_t construct_rendor_RSSI(const input_rc_s &input_rc)
 	rssi.screenYPosition = 0x02;
 	rssi.screenXPosition = 0x02;
 
+	memset(&rssi.str[0], 0, sizeof(rssi.str));
 	snprintf(&rssi.str[0], sizeof(rssi.str), "%3d", input_rc.link_quality);
 	rssi.str[3] = '%';
 
@@ -405,6 +406,18 @@ msp_rendor_satellites_used_t construct_rendor_GPS_NUM(const sensor_gps_s &vehicl
 	return num;
 }
 
+msp_rendor_gps_speed_t construct_rendor_GPS_SPEED(const sensor_gps_s &vehicle_gps_position)
+{
+	msp_rendor_gps_speed_t speed;
+
+	speed.screenYPosition = 0x08;
+	speed.screenXPosition = 0x02;
+
+	memset(&speed.str[0], 0, sizeof(speed.str));
+	snprintf(&speed.str[0], sizeof(speed.str), "%.2f", (double)(vehicle_gps_position.vel_m_s));
+
+	return speed;
+}
 
 msp_comp_gps_t construct_COMP_GPS(const home_position_s &home_position,
 				  const vehicle_global_position_s &vehicle_global_position,

--- a/src/drivers/osd/msp_osd/uorb_to_msp.hpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.hpp
@@ -110,6 +110,8 @@ msp_rendor_longitude_t construct_rendor_GPS_LON(const sensor_gps_s &vehicle_gps_
 
 msp_rendor_satellites_used_t construct_rendor_GPS_NUM(const sensor_gps_s &vehicle_gps_position);
 
+msp_rendor_gps_speed_t construct_rendor_GPS_SPEED(const sensor_gps_s &vehicle_gps_position);
+
 // construct an MSP_ATTITUDE struct
 msp_attitude_t construct_ATTITUDE(const vehicle_attitude_s &vehicle_attitude);
 

--- a/src/drivers/osd/msp_osd/uorb_to_msp.hpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.hpp
@@ -91,6 +91,10 @@ msp_battery_state_t construct_BATTERY_STATE(const battery_status_s &battery_stat
 
 msp_rendor_battery_state_t construct_rendor_BATTERY_STATE(const battery_status_s &battery_status);
 
+msp_rendor_current_draw_t construct_rendor_CURRENT_DRAW(const battery_status_s &battery_status);
+
+msp_rendor_mah_drawn_t construct_rendor_MAH_DRAWN(const battery_status_s &battery_status);
+
 // construct an MSP_RAW_GPS struct
 msp_raw_gps_t construct_RAW_GPS(const sensor_gps_s &vehicle_gps_position,
 				const airspeed_validated_s &airspeed_validated);

--- a/src/drivers/osd/msp_osd/uorb_to_msp.hpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.hpp
@@ -132,4 +132,7 @@ msp_rc_t construct_MSP_RC(const input_rc_s &input_rc);
 // construct an MSP_STATUS struct
 msp_status_t construct_MSP_STATUS(const vehicle_status_s &vehicle_status);
 
+// construct an MSP_CROSSHAIRS struct
+msp_rendor_crosshairs_t construct_rendor_CROSSHAIRS(const int pos_vertical_offset, const int pos_horizontal_offset);
+
 } // namespace msp_osd


### PR DESCRIPTION
## Summary
Fixes inconsistencies in the `msp_osd` module where parameter toggles in `OSD_SYMBOLS` did not match actual telemetry transmission behavior.

## Problem
* **Always-on Telemetry:** `AVG Cell Voltage`, `Roll Angle`, and `Pitch Angle` were being continuously transmitted to OSD/goggles even when unchecked/disabled in `OSD_SYMBOLS`.
* **Missing Telemetry:** `Crosshairs`, `Current Draw`, `mAh Drawn`, and `GPS Speed` were not marked as `unused` in parameter definitions, but failed to transmit data when enabled.
* **Misleading Parameters:** `Home Dir`, `Main Bat Voltage`, and `Power` were non-functional but not marked as `unused`, leading to confusion during configuration.

## Solution
* Made `AVG Cell Voltage`, `Roll Angle`, and `Pitch Angle` properly configurable and responsive to the `OSD_SYMBOLS` bitmask.
* Implemented transmission logic for `Crosshairs`, `Current Draw`, `mAh Drawn`, and `GPS Speed`.
* Marked `Home Dir`, `Main Bat Voltage`, and `Power` as `unused` in the parameter metadata to accurately reflect current support status.

## Test Coverage
- [x] Tested on real hardware / SITL
- [x] Verified individual bitmask toggles in `OSD_SYMBOLS` correctly enable/disable corresponding elements on OSD display.

> **Note for reviewers:** Tested with Walksnail Avatar GT