### PR TITLE
feat(fw_mode_manager): parachute landing via flight termination

### DIFF
--- a/docs/en/flight_modes_fw/mission.md
+++ b/docs/en/flight_modes_fw/mission.md
@@ -336,6 +336,44 @@ The parameters that affect flaring are listed below.
 | <a id="RWTO_PSP"></a>[RWTO_PSP](../advanced_config/parameter_reference.md#RWTO_PSP)                   | Pitch setpoint while on the runway. For tricycle gear, typically near zero. For tail draggers, positive.                                                            |
 | <a id="FW_THR_IDLE"></a>[FW_THR_IDLE](../advanced_config/parameter_reference.md#FW_THR_IDLE)          | Idle throttle setting. The vehicle will retain this setting throughout the flare and roll out.                                                                      |
 
+### Parachute Landing
+
+A mission landing can end in a parachute descent, releasing the parachute such that the vehicle touches down on the land waypoint ([MAV_CMD_NAV_LAND](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LAND)).
+This allows recovery in areas where a rollout or belly landing is not possible.
+
+The feature is enabled with [FW_LND_PARA_EN](#FW_LND_PARA_EN) and requires a [parachute](../peripherals/parachute.md), either on a flight controller output (_Parachute_ output function) or as an external MAVLink parachute system ([COM_PARACHUTE](../advanced_config/parameter_reference.md#COM_PARACHUTE)).
+
+The vehicle follows the normal landing approach down to the release altitude ([FW_LND_PARA_ALT](#FW_LND_PARA_ALT)), then continues level towards the land waypoint.
+The parachute is released by triggering [flight termination](../advanced_config/flight_termination.md) once the predicted touchdown point under canopy lies on the land waypoint.
+The prediction accounts for the forward carry while the parachute deploys, and the drift with the estimated wind while the vehicle sinks at [FW_LND_PARA_SINK](#FW_LND_PARA_SINK).
+Crosswind is compensated by aiming upwind of the land waypoint.
+
+:::warning
+The release triggers flight termination: the landing cannot be aborted after the release, and the vehicle must be rebooted before the next flight.
+[Operator abort](#operator-abort) works normally at any time before the release.
+:::
+
+Notes:
+
+- The touchdown point drifts with the wind, and the horizontal touchdown speed matches the wind speed.
+  Accuracy and touchdown quality degrade as the wind approaches the landing airspeed ([COM_WIND_MAX](../advanced_config/parameter_reference.md#COM_WIND_MAX) can enforce a wind limit).
+- Lowering the release altitude reduces the wind drift.
+  For safety reasons, the release altitude is clamped to a minimum of 3 seconds of descent at [FW_LND_PARA_SINK](#FW_LND_PARA_SINK), so that the canopy has room to open before touchdown.
+- [FW_LND_PARA_ALT](#FW_LND_PARA_ALT) is the altitude the vehicle holds while waiting for the release point.
+  The release prediction always uses the actual altitude:
+  - A vehicle that holds the altitude releases at the configured altitude, or above it if the release point is reached while still on the approach slope.
+  - A vehicle that cannot hold the altitude (for example a motor-less glider) keeps sinking while the prediction adapts, and still releases such that it touches down on the land waypoint.
+    Only if it sinks to the minimum release altitude before reaching the release point does it release there, and touch down short of the waypoint.
+- Not supported on VTOL.
+
+#### Parachute Landing Parameters
+
+| Parameter                                                                                                   | Description                                                                             |
+| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| <a id="FW_LND_PARA_EN"></a>[FW_LND_PARA_EN](../advanced_config/parameter_reference.md#FW_LND_PARA_EN)       | Enable parachute landing on the mission landing approach.                               |
+| <a id="FW_LND_PARA_ALT"></a>[FW_LND_PARA_ALT](../advanced_config/parameter_reference.md#FW_LND_PARA_ALT)    | Release altitude above the land waypoint.                                               |
+| <a id="FW_LND_PARA_SINK"></a>[FW_LND_PARA_SINK](../advanced_config/parameter_reference.md#FW_LND_PARA_SINK) | Expected sink rate under canopy, used to predict the wind drift of the touchdown point. |
+
 ### Abort
 
 #### Operator Abort

--- a/src/modules/fw_mode_manager/CMakeLists.txt
+++ b/src/modules/fw_mode_manager/CMakeLists.txt
@@ -65,6 +65,8 @@ px4_add_module(
 		FirstOrderHoldAltitude.hpp
 		ControllerConfigurationHandler.cpp
 		ControllerConfigurationHandler.hpp
+		ParachuteRelease.cpp
+		ParachuteRelease.hpp
 	MODULE_CONFIG
 		fw_mode_manager_params.yaml
 	DEPENDS
@@ -72,3 +74,4 @@ px4_add_module(
 	)
 
 px4_add_unit_gtest(SRC FirstOrderHoldAltitudeTest.cpp EXTRA_SRCS FirstOrderHoldAltitude.cpp LINKLIBS geo mathlib)
+px4_add_unit_gtest(SRC ParachuteReleaseTest.cpp EXTRA_SRCS ParachuteRelease.cpp LINKLIBS mathlib)

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -1459,6 +1459,14 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 	local_land_point = calculateTouchdownPosition(control_interval, local_land_point);
 	const Vector2f landing_approach_vector = calculateLandingApproachVector();
 
+	const bool parachute_landing_active = _param_fw_lnd_para_en.get() && !_parachute_release_commanded
+					      && !_vehicle_status.is_vtol;
+
+	const float parachute_release_floor = parachuteReleaseFloor(_param_fw_lnd_para_sink.get());
+
+	const float parachute_release_alt = parachuteReleaseAltitude(_param_fw_lnd_para_alt.get(),
+					    _param_fw_lnd_para_sink.get());
+
 	// calculate the altitude setpoint based on the landing glide slope
 	const float along_track_dist_to_touchdown = -landing_approach_vector.unit_or_zero().dot(
 				local_position - local_land_point);
@@ -1481,6 +1489,13 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 	const float glide_slope_reference_alt = (_param_fw_lnd_useter.get() ==
 						TerrainEstimateUseOnLanding::kFollowTerrainRelativeLandingGlideSlope) ? terrain_alt : pos_sp_curr.alt;
 
+	if (parachute_landing_active && _wind_valid) {
+		// compensate the crosswind drift under canopy by aiming upwind of the landing point
+		local_land_point -= parachuteCrosswindAimShift(_wind_vel, landing_approach_vector.unit_or_zero(),
+				    _current_altitude - terrain_alt, parachute_release_alt, parachute_release_floor,
+				    _param_fw_lnd_para_sink.get());
+	}
+
 	float altitude_setpoint;
 
 	if (_current_altitude > glide_slope_reference_alt + glide_slope_rel_alt) {
@@ -1490,6 +1505,40 @@ FixedWingModeManager::control_auto_landing_straight(const hrt_abstime &now, cons
 	} else {
 		// continue horizontally
 		altitude_setpoint = _current_altitude;
+	}
+
+	if (parachute_landing_active) {
+		// follow the normal landing approach down to the release altitude, then continue level
+		// towards the landing point until the release condition below is met
+		altitude_setpoint = math::max(altitude_setpoint, terrain_alt + parachute_release_alt);
+	}
+
+	// parachute landing: release once the predicted touchdown point under canopy reaches the landing
+	// point, by triggering flight termination. the vehicle is carried forward by its ground speed
+	// while the parachute deploys, and drifts with the wind while descending under canopy.
+	if (parachute_landing_active && !_flare_states.flaring
+	    && _landing_abort_status == position_controller_landing_status_s::NOT_ABORTED) {
+
+		const float altitude_above_ground = math::max(_current_altitude - terrain_alt, 0.f);
+
+		const float release_distance = parachuteReleaseDistance(ground_speed, _wind_vel, _wind_valid,
+					       landing_approach_vector.unit_or_zero(), altitude_above_ground,
+					       _param_fw_lnd_para_sink.get());
+
+		if (along_track_dist_to_touchdown <= release_distance) {
+			terminateForParachuteLanding(now);
+			_parachute_release_commanded = true;
+
+		} else if (altitude_above_ground <= parachute_release_floor) {
+			// too low to wait for the release point: the canopy needs room to open. Release now,
+			// short of the landing point (e.g. a motor-less glider that cannot hold the release
+			// altitude, or an approach arriving below the minimum release altitude)
+			terminateForParachuteLanding(now);
+			_parachute_release_commanded = true;
+
+			events::send(events::ID("fw_mode_manager_parachute_release_floor"), events::Log::Warning,
+				     "Releasing parachute at minimum altitude");
+		}
 	}
 
 	// flare at the maximum of the altitude determined by the time before touchdown and a minimum flare altitude
@@ -2389,6 +2438,23 @@ FixedWingModeManager::reset_takeoff_state()
 }
 
 void
+FixedWingModeManager::terminateForParachuteLanding(const hrt_abstime &now)
+{
+	events::send(events::ID("fw_mode_manager_parachute_landing_release"), events::Log::Info,
+		     "Releasing parachute, terminating flight");
+
+	vehicle_command_s vehicle_command{};
+	vehicle_command.timestamp = now;
+	vehicle_command.command = vehicle_command_s::VEHICLE_CMD_DO_FLIGHTTERMINATION;
+	vehicle_command.param1 = 1.f;
+	vehicle_command.target_system = _vehicle_status.system_id;
+	vehicle_command.target_component = _vehicle_status.component_id;
+	vehicle_command.source_system = _vehicle_status.system_id;
+	vehicle_command.source_component = _vehicle_status.component_id;
+	_vehicle_command_pub.publish(vehicle_command);
+}
+
+void
 FixedWingModeManager::reset_landing_state()
 {
 	_time_started_landing = 0;
@@ -2397,6 +2463,8 @@ FixedWingModeManager::reset_landing_state()
 
 	_local_landing_orbit_center.setNaN();
 	_lateral_touchdown_position_offset = 0.0f;
+
+	_parachute_release_commanded = false;
 
 	_last_time_terrain_alt_was_valid = 0;
 

--- a/src/modules/fw_mode_manager/FixedWingModeManager.hpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.hpp
@@ -44,6 +44,7 @@
 #include "runway_takeoff/RunwayTakeoff.h"
 #include "ControllerConfigurationHandler.hpp"
 #include "FirstOrderHoldAltitude.hpp"
+#include "ParachuteRelease.hpp"
 
 #include <float.h>
 #include <drivers/drv_hrt.h>
@@ -198,6 +199,7 @@ private:
 	uORB::Publication<landing_gear_s> _landing_gear_pub {ORB_ID(landing_gear)};
 	uORB::Publication<normalized_unsigned_setpoint_s> _flaps_setpoint_pub{ORB_ID(flaps_setpoint)};
 	uORB::Publication<normalized_unsigned_setpoint_s> _spoilers_setpoint_pub{ORB_ID(spoilers_setpoint)};
+	uORB::Publication<vehicle_command_s> _vehicle_command_pub{ORB_ID(vehicle_command)};
 	uORB::PublicationData<fixed_wing_lateral_setpoint_s> _lateral_ctrl_sp_pub{ORB_ID(fixed_wing_lateral_setpoint)};
 	uORB::PublicationData<fixed_wing_longitudinal_setpoint_s> _longitudinal_ctrl_sp_pub{ORB_ID(fixed_wing_longitudinal_setpoint)};
 	uORB::Publication<fixed_wing_lateral_guidance_status_s> _fixed_wing_lateral_guidance_status_pub{ORB_ID(fixed_wing_lateral_guidance_status)};
@@ -266,6 +268,9 @@ private:
 	float _reference_altitude{NAN}; // [m AMSL] altitude of the local projection reference point
 
 	bool _landed{true};
+
+	// [.] true once this module has commanded the parachute release during a parachute landing
+	bool _parachute_release_commanded{false};
 
 	// MANUAL MODES
 
@@ -667,6 +672,13 @@ private:
 	void reset_landing_state();
 
 	/**
+	 * @brief Releases the parachute by triggering flight termination.
+	 *
+	 * @param now Current system time [us]
+	 */
+	void terminateForParachuteLanding(const hrt_abstime &now);
+
+	/**
 	 * @brief Decides which control mode to execute.
 	 *
 	 * May also change the position setpoint type depending on the desired behavior.
@@ -859,6 +871,9 @@ private:
 		(ParamFloat<px4::params::FW_LND_FLALT>) _param_fw_lnd_flalt,
 		(ParamBool<px4::params::FW_LND_EARLYCFG>) _param_fw_lnd_earlycfg,
 		(ParamInt<px4::params::FW_LND_USETER>) _param_fw_lnd_useter,
+		(ParamBool<px4::params::FW_LND_PARA_EN>) _param_fw_lnd_para_en,
+		(ParamFloat<px4::params::FW_LND_PARA_ALT>) _param_fw_lnd_para_alt,
+		(ParamFloat<px4::params::FW_LND_PARA_SINK>) _param_fw_lnd_para_sink,
 
 		(ParamFloat<px4::params::FW_P_LIM_MAX>) _param_fw_p_lim_max,
 		(ParamFloat<px4::params::FW_P_LIM_MIN>) _param_fw_p_lim_min,

--- a/src/modules/fw_mode_manager/ParachuteRelease.cpp
+++ b/src/modules/fw_mode_manager/ParachuteRelease.cpp
@@ -1,0 +1,67 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "ParachuteRelease.hpp"
+
+#include <mathlib/mathlib.h>
+
+float parachuteReleaseFloor(const float sink_rate)
+{
+	return math::max(sink_rate, kParachuteMinSinkRate) * kParachuteCanopyOpenTime;
+}
+
+float parachuteReleaseAltitude(const float release_alt_param, const float sink_rate)
+{
+	return math::max(release_alt_param, parachuteReleaseFloor(sink_rate));
+}
+
+matrix::Vector2f parachuteCrosswindAimShift(const matrix::Vector2f &wind_vel,
+		const matrix::Vector2f &approach_direction, const float altitude_above_ground, const float release_alt,
+		const float release_floor, const float sink_rate)
+{
+	const float release_alt_expected = math::constrain(altitude_above_ground, release_floor, release_alt);
+	const matrix::Vector2f drift = wind_vel * release_alt_expected / math::max(sink_rate, kParachuteMinSinkRate);
+
+	return drift - approach_direction * drift.dot(approach_direction);
+}
+
+float parachuteReleaseDistance(const matrix::Vector2f &ground_speed, const matrix::Vector2f &wind_vel,
+			       const bool wind_valid, const matrix::Vector2f &approach_direction, const float altitude_above_ground,
+			       const float sink_rate)
+{
+	const float ground_speed_along_track = math::max(ground_speed.dot(approach_direction), 0.f);
+	const float wind_along_track = wind_valid ? wind_vel.dot(approach_direction) : 0.f;
+	const float descent_time = altitude_above_ground / math::max(sink_rate, kParachuteMinSinkRate);
+
+	return ground_speed_along_track * kParachuteDeploymentTime + wind_along_track * descent_time;
+}

--- a/src/modules/fw_mode_manager/ParachuteRelease.hpp
+++ b/src/modules/fw_mode_manager/ParachuteRelease.hpp
@@ -1,0 +1,107 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file ParachuteRelease.hpp
+ * Release point prediction for the fixed-wing parachute landing.
+ */
+
+#pragma once
+
+#include <matrix/matrix/math.hpp>
+
+// [s] nominal time from the release command until the canopy decelerates the vehicle, used to
+// predict the forward carry of the touchdown point
+static constexpr float kParachuteDeploymentTime = 1.0f;
+
+// [s] conservative time for the canopy to fully open: the release is never triggered below
+// FW_LND_PARA_SINK times this, so that the canopy has room to open before touchdown
+static constexpr float kParachuteCanopyOpenTime = 3.0f;
+
+// [m/s] guard against division by a zero or negative sink rate
+static constexpr float kParachuteMinSinkRate = 0.1f;
+
+/**
+ * @brief Minimum release altitude, below which the canopy cannot fully open before touchdown.
+ *
+ * @param sink_rate Expected sink rate under canopy [m/s]
+ * @return Release floor above ground [m]
+ */
+float parachuteReleaseFloor(float sink_rate);
+
+/**
+ * @brief Release altitude: the configured altitude, floored for the canopy opening.
+ *
+ * @param release_alt_param Configured release altitude above ground (FW_LND_PARA_ALT) [m]
+ * @param sink_rate Expected sink rate under canopy [m/s]
+ * @return Release altitude above ground [m]
+ */
+float parachuteReleaseAltitude(float release_alt_param, float sink_rate);
+
+/**
+ * @brief Aim point shift compensating the crosswind drift under canopy.
+ *
+ * The release timing can only correct the drift along the approach; the crosswind component is
+ * corrected by aiming upwind of the landing point (subtract the returned shift from it). The
+ * drift is predicted from the altitude the release is expected to happen at: the release
+ * altitude, or lower if the vehicle cannot hold it (e.g. a motor-less glider).
+ *
+ * @param wind_vel Wind velocity estimate, NE [m/s]
+ * @param approach_direction Unit vector along the landing approach, NE
+ * @param altitude_above_ground Current altitude above the landing point [m]
+ * @param release_alt Release altitude above ground [m]
+ * @param release_floor Minimum release altitude above ground [m]
+ * @param sink_rate Expected sink rate under canopy [m/s]
+ * @return Crosswind drift during the descent, NE [m]
+ */
+matrix::Vector2f parachuteCrosswindAimShift(const matrix::Vector2f &wind_vel,
+		const matrix::Vector2f &approach_direction, float altitude_above_ground, float release_alt,
+		float release_floor, float sink_rate);
+
+/**
+ * @brief Along-track distance to the touchdown point at which to release the parachute.
+ *
+ * Signed: negative in a headwind stronger than the deployment carry, placing the release past
+ * the landing point so that the canopy drifts back onto it.
+ *
+ * @param ground_speed Ground velocity, NE [m/s]
+ * @param wind_vel Wind velocity estimate, NE [m/s]
+ * @param wind_valid Whether the wind estimate is valid (drift term is zero otherwise)
+ * @param approach_direction Unit vector along the landing approach, NE
+ * @param altitude_above_ground Current altitude above the landing point [m]
+ * @param sink_rate Expected sink rate under canopy [m/s]
+ * @return Release distance before the landing point [m]
+ */
+float parachuteReleaseDistance(const matrix::Vector2f &ground_speed, const matrix::Vector2f &wind_vel,
+			       bool wind_valid, const matrix::Vector2f &approach_direction, float altitude_above_ground,
+			       float sink_rate);

--- a/src/modules/fw_mode_manager/ParachuteReleaseTest.cpp
+++ b/src/modules/fw_mode_manager/ParachuteReleaseTest.cpp
@@ -1,0 +1,188 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "ParachuteRelease.hpp"
+
+using matrix::Vector2f;
+
+// approach flying due north, landing point ahead
+static const Vector2f kApproachDirection(1.f, 0.f);
+
+// defaults used throughout: 20 m release altitude, 5 m/s sink -> 15 m floor, 4 s descent from 20 m
+static constexpr float kSink = 5.f;
+static constexpr float kReleaseAlt = 20.f;
+
+TEST(ParachuteRelease, releaseAltitudeIsFlooredForCanopyOpening)
+{
+	const float floor = parachuteReleaseFloor(kSink);
+	EXPECT_FLOAT_EQ(floor, kSink * kParachuteCanopyOpenTime);
+
+	// configured altitude above the floor is used as is
+	EXPECT_FLOAT_EQ(parachuteReleaseAltitude(20.f, kSink), 20.f);
+
+	// configured altitude below the floor is raised to it
+	EXPECT_FLOAT_EQ(parachuteReleaseAltitude(5.f, kSink), floor);
+}
+
+TEST(ParachuteRelease, noWindReleaseDistanceIsDeploymentCarry)
+{
+	const Vector2f ground_speed(20.f, 0.f);
+
+	const float dist = parachuteReleaseDistance(ground_speed, Vector2f(0.f, 0.f), true, kApproachDirection,
+			   kReleaseAlt, kSink);
+
+	EXPECT_FLOAT_EQ(dist, 20.f * kParachuteDeploymentTime);
+}
+
+TEST(ParachuteRelease, invalidWindIsIgnored)
+{
+	const Vector2f ground_speed(20.f, 0.f);
+	const Vector2f wind(-15.f, 10.f);
+
+	const float dist = parachuteReleaseDistance(ground_speed, wind, false, kApproachDirection, kReleaseAlt, kSink);
+
+	EXPECT_FLOAT_EQ(dist, 20.f * kParachuteDeploymentTime);
+}
+
+TEST(ParachuteRelease, headwindMovesReleasePastLandingPoint)
+{
+	// strong headwind: barely progressing at 5 m/s ground speed
+	const Vector2f ground_speed(5.f, 0.f);
+	const Vector2f wind(-15.f, 0.f);
+
+	const float dist = parachuteReleaseDistance(ground_speed, wind, true, kApproachDirection, kReleaseAlt, kSink);
+
+	// 5 m carry, 60 m drift back during the 4 s descent: release 55 m past the point
+	EXPECT_FLOAT_EQ(dist, 5.f - 60.f);
+}
+
+TEST(ParachuteRelease, windAboveGroundSpeedStaysFinite)
+{
+	// wind pushes the vehicle backwards: the carry is clamped to zero, no release before the point
+	const Vector2f ground_speed(-2.f, 0.f);
+	const Vector2f wind(-25.f, 0.f);
+
+	const float dist = parachuteReleaseDistance(ground_speed, wind, true, kApproachDirection, kReleaseAlt, kSink);
+
+	EXPECT_TRUE(std::isfinite(dist));
+	EXPECT_FLOAT_EQ(dist, -25.f * 4.f);
+}
+
+TEST(ParachuteRelease, tailwindReleasesEarlier)
+{
+	const Vector2f ground_speed(25.f, 0.f);
+	const Vector2f wind(5.f, 0.f);
+
+	const float dist = parachuteReleaseDistance(ground_speed, wind, true, kApproachDirection, kReleaseAlt, kSink);
+
+	EXPECT_FLOAT_EQ(dist, 25.f + 20.f);
+}
+
+TEST(ParachuteRelease, pureCrosswindDoesNotChangeReleaseDistance)
+{
+	const Vector2f ground_speed(20.f, 0.f);
+	const Vector2f wind(0.f, 8.f);
+
+	const float dist = parachuteReleaseDistance(ground_speed, wind, true, kApproachDirection, kReleaseAlt, kSink);
+
+	EXPECT_FLOAT_EQ(dist, 20.f * kParachuteDeploymentTime);
+}
+
+TEST(ParachuteRelease, crosswindAimShiftIsPerpendicularAndDownwind)
+{
+	const float floor = parachuteReleaseFloor(kSink);
+	const Vector2f wind(0.f, 5.f); // pure crosswind from the west, drifting the vehicle east
+
+	// holding the release altitude
+	const float altitude_above_ground = kReleaseAlt;
+	const Vector2f shift = parachuteCrosswindAimShift(wind, kApproachDirection, altitude_above_ground, kReleaseAlt,
+			       floor, kSink);
+
+	// no along-track component: that part is handled by the release timing
+	EXPECT_FLOAT_EQ(shift.dot(kApproachDirection), 0.f);
+
+	// 4 s descent at 5 m/s crosswind: 20 m drift east; subtracting the shift aims 20 m upwind (west)
+	EXPECT_FLOAT_EQ(shift(1), 20.f);
+}
+
+TEST(ParachuteRelease, diagonalWindSplitsIntoTimingAndAimShift)
+{
+	const float floor = parachuteReleaseFloor(kSink);
+	const Vector2f ground_speed(20.f, 0.f);
+	const Vector2f wind(-3.f, 4.f);
+
+	// the along-track component only affects the release distance
+	const float dist = parachuteReleaseDistance(ground_speed, wind, true, kApproachDirection, kReleaseAlt, kSink);
+	EXPECT_FLOAT_EQ(dist, 20.f - 3.f * 4.f);
+
+	// the cross component only affects the aim shift, holding the release altitude
+	const float altitude_above_ground = kReleaseAlt;
+	const Vector2f shift = parachuteCrosswindAimShift(wind, kApproachDirection, altitude_above_ground, kReleaseAlt,
+			       floor, kSink);
+	EXPECT_FLOAT_EQ(shift(0), 0.f);
+	EXPECT_FLOAT_EQ(shift(1), 4.f * 4.f);
+}
+
+TEST(ParachuteRelease, aimShiftUsesExpectedReleaseAltitude)
+{
+	const float floor = parachuteReleaseFloor(kSink);
+	const Vector2f wind(0.f, 5.f);
+
+	// above the release altitude: the release will happen at the release altitude
+	const Vector2f shift_above = parachuteCrosswindAimShift(wind, kApproachDirection, 60.f, kReleaseAlt, floor, kSink);
+	EXPECT_FLOAT_EQ(shift_above(1), 5.f * kReleaseAlt / kSink);
+
+	// inside the band (e.g. a glider sinking through): the release happens at the current altitude
+	const Vector2f shift_inside = parachuteCrosswindAimShift(wind, kApproachDirection, 17.f, kReleaseAlt, floor, kSink);
+	EXPECT_FLOAT_EQ(shift_inside(1), 5.f * 17.f / kSink);
+
+	// below the floor: the release cannot happen lower than the floor
+	const Vector2f shift_below = parachuteCrosswindAimShift(wind, kApproachDirection, 5.f, kReleaseAlt, floor, kSink);
+	EXPECT_FLOAT_EQ(shift_below(1), 5.f * floor / kSink);
+}
+
+TEST(ParachuteRelease, zeroSinkRateIsGuarded)
+{
+	const Vector2f ground_speed(20.f, 0.f);
+	const Vector2f wind(-5.f, 5.f);
+
+	const float dist = parachuteReleaseDistance(ground_speed, wind, true, kApproachDirection, kReleaseAlt, 0.f);
+	EXPECT_TRUE(std::isfinite(dist));
+
+	const Vector2f shift = parachuteCrosswindAimShift(wind, kApproachDirection, kReleaseAlt, kReleaseAlt,
+			       parachuteReleaseFloor(0.f), 0.f);
+	EXPECT_TRUE(std::isfinite(shift(0)));
+	EXPECT_TRUE(std::isfinite(shift(1)));
+}

--- a/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
+++ b/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
@@ -26,6 +26,49 @@ parameters:
       min: 0.0
       decimal: 1
       increment: 0.5
+    FW_LND_PARA_EN:
+      description:
+        short: Enable parachute landing on mission landing approach
+        long: |-
+          If enabled, the vehicle follows the mission landing approach down to the release
+          altitude (FW_LND_PARA_ALT) and releases the parachute by triggering flight
+          termination, such that the predicted touchdown point under canopy lies on the
+          landing point, accounting for ground speed, estimated wind drift during the descent
+          (FW_LND_PARA_SINK) and the forward carry while the parachute deploys.
+
+          The parachute is released through the flight termination failsafe outputs, or an
+          external parachute system (COM_PARACHUTE). Not supported on VTOL.
+      type: boolean
+      default: 0
+    FW_LND_PARA_ALT:
+      description:
+        short: Parachute landing release altitude above ground
+        long: |-
+          Altitude the vehicle descends to and holds for the release. The release happens
+          higher if the predicted touchdown point reaches the landing point while still on
+          the approach slope, or lower for a vehicle that cannot hold the altitude, but
+          never below 3 seconds of descent at FW_LND_PARA_SINK, so that the canopy has
+          room to open.
+
+          Lower values reduce the wind drift of the touchdown point.
+      type: float
+      default: 20.0
+      unit: m
+      min: 1.0
+      decimal: 1
+      increment: 0.5
+    FW_LND_PARA_SINK:
+      description:
+        short: Sink rate under the deployed parachute
+        long: |-
+          Expected steady-state sink rate under canopy. Used to predict the descent duration and
+          therewith the wind drift of the touchdown point.
+      type: float
+      default: 5.0
+      unit: m/s
+      min: 0.1
+      decimal: 1
+      increment: 0.1
     FW_LND_USETER:
       description:
         short: Use terrain estimation during landing


### PR DESCRIPTION
Replaces: https://github.com/PX4/PX4-Autopilot/pull/28052


### Solved Problem
Fixed-wing vehicles with a parachute can currently only deploy it as an unplanned emergency reaction, with no control over where the vehicle comes down. There is no way to plan a mission that ends in a parachute descent onto the landing point, for example for recovery in a small field.

### Solution

With `FW_LND_PARA_EN` set, the vehicle flies the normal mission landing approach down to the release altitude, levels off towards the landing point, and triggers flight termination when the predicted touchdown point under canopy reaches the landing point. The parachute is released through the existing termination path: the failsafe values for a parachute output function, and the `DO_PARACHUTE` command for external parachute systems (`COM_PARACHUTE`).

The prediction is simple:

- The vehicle is carried forward by its ground speed while the parachute deploys, then drifts with the wind while it sinks (`FW_LND_PARA_SINK`). 
- Crosswind is handled by shifting the aim point upwind, using the same lateral offset mechanism as `FW_LND_NUDGE`.
The release altitude is `FW_LND_PARA_ALT`. 

### Changelog Entry
For release notes:
```
Feature: fixed-wing parachute landing on the mission landing approach
New parameter: FW_LND_PARA_EN
New parameter: FW_LND_PARA_ALT
New parameter: FW_LND_PARA_SINK
Documentation: needs a section on the fixed-wing landing page (docs.px4.io/main/en/flight_modes_fw/mission.html)
```


