### PR TITLE
fix(uavcan): decrease DefaultRequestInterval to 250ms

### DIFF
--- a/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/protocol/firmware_update_trigger.hpp
+++ b/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/protocol/firmware_update_trigger.hpp
@@ -142,7 +142,7 @@ class FirmwareUpdateTrigger : public INodeInfoListener,
 
     typedef IFirmwareVersionChecker::FirmwareFilePath FirmwareFilePath;
 
-    enum { DefaultRequestIntervalMs = 1000 };   ///< Shall not be less than default service response timeout.
+    enum { DefaultRequestIntervalMs = 250 };
 
     struct NextNodeIDSearchPredicate : ::uavcan::Noncopyable
     {


### PR DESCRIPTION
### Solved Problem

Firmware update fails when more than ~3 CAN nodes are updated simultaneously. Nodes enter the bootloader correctly but time out and jump back to the application before the server reaches them with a `BeginFirmwareUpdate` request. This behavior continues in a loop indefinitely.

### Solution

Reduce `DefaultRequestIntervalMs` in `FirmwareUpdateTrigger` from 1000 ms to 250 ms.

**Firmware update sequence:**
1. The server detects a node running outdated firmware via `GetNodeInfo` and adds it to a pending-update list.
2. `FirmwareUpdateTrigger` sends `BeginFirmwareUpdate` to the node. The application reboots into the bootloader.
3. The bootloader responds to `GetNodeInfo` and starts `OPT_TBOOT_MS` -> a one-shot timeout after which it boots back into the application if no `BeginFirmwareUpdate` has arrived. It is set to 3000 ms.
4. `FirmwareUpdateTrigger` fires on a periodic timer and sends `BeginFirmwareUpdate` to one pending node per tick (round-robin), skipping nodes whose previous call is still in-flight.
5. On receiving `BeginFirmwareUpdate` the bootloader begins transferring firmware blocks via `uavcan.protocol.file.Read`.

With a 1000 ms interval and N nodes pending, the server reaches node N in step 4 only after N × 1000 ms — already past `tboot` for N > 3. In practice other delays (bus load, `GetNodeInfo` retrieval) reduce the safe limit further.

At 250 ms the server reaches 10 nodes in 2500 ms, leaving 500 ms margin against `tboot`. The original comment *"Shall not be less than default service response timeout"* (1000 ms) is incorrect: when the interval is shorter than the 1000 ms `BeginFirmwareUpdate` call timeout, `pickNextNodeID()` skips any node that still has a call in-flight, so no duplicate requests are sent. At most one `BeginFirmwareUpdate` per node is ever in-flight.

### Changelog Entry

```
Bugfix: CAN node firmware update fails for fleets larger than ~3 nodes
```

### Alternatives

Increasing `OPT_TBOOT_MS` in the bootloader (e.g. to 30 000 ms) also fixes the symptom, but requires reflashing all bootloaders and causes every node to spend 30 sec. in the bootloader on each power cycle.

Sending `BeginFirmwareUpdate` to multiple (or all) pending nodes per tick instead of one would also work, but causes N concurrent `file.Read` streams on the CAN bus, multiplying bus load proportionally.

### Test coverage

Root cause confirmed on hardware: a `uavcan.protocol.debug.LogMessage` was added to the bootloader just before the `tboot`-expiry jump, making the timeout visible on the CAN bus. Fix verified by code inspection of the `FirmwareUpdateTrigger` call-in-flight guard (`hasPendingCallToServer()`).

### Context

- `src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/protocol/firmware_update_trigger.hpp` — server-side trigger (this change)
- Bootloader timeout: `boards/auterion/canio/src/boot_config.h` (`OPT_TBOOT_MS`)