### PR TITLE
fix(release): backport 7 bugfixes for v1.18.0-beta2

### DIFF
--- a/boards/cuav/x25-mega/init/rc.board_defaults
+++ b/boards/cuav/x25-mega/init/rc.board_defaults
@@ -22,12 +22,12 @@ param set-default UAVCAN_SUB_GPS 1
 param set-default UAVCAN_SUB_BAT 1
 
 # IMU thermal control (multi-instance heater)
-# HEATER1_IMU_ID: 6029322(ADIS16607 SPI1)
-# HEATER2_IMU_ID: 3014698(IIM42653 SPI5)
+# HEATER1_SENS_ID: 6029322(ADIS16607 SPI1)
+# HEATER2_SENS_ID: 3014698(IIM42653 SPI5)
 param set-default SENS_EN_THERMAL 1
-param set-default HEATER1_IMU_ID 6029322
+param set-default HEATER1_SENS_ID 6029322
 param set-default HEATER1_TEMP 45
-param set-default HEATER2_IMU_ID 3014698
+param set-default HEATER2_SENS_ID 3014698
 param set-default HEATER2_TEMP 45
 
 # CUAV pwm voltage 3.3V/5V switch

--- a/boards/px4/fmu-v6xrt/src/imxrt_flexspi_fram.c
+++ b/boards/px4/fmu-v6xrt/src/imxrt_flexspi_fram.c
@@ -26,9 +26,11 @@
 
 #include <stdbool.h>
 #include <errno.h>
+#include <string.h>
 #include <debug.h>
 
 #include <nuttx/kmalloc.h>
+#include <nuttx/mutex.h>
 #include <nuttx/signal.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/mtd/mtd.h>
@@ -111,6 +113,12 @@ struct imxrt_flexspi_fram_dev_s {
 	uint8_t *ahb_base;
 	enum flexspi_port_e port;
 	struct flexspi_device_config_s *config;
+	mutex_t lock;                    /* Serializes access to page_buffer */
+	/* Bounce buffer for callers that pass a non word-aligned buffer. Kept
+	 * here rather than on the stack so that write() on this device does not
+	 * add a page worth of stack usage to every caller.
+	 */
+	uint32_t page_buffer[FRAM_PAGE_SIZE / sizeof(uint32_t)];
 };
 
 /****************************************************************************
@@ -178,7 +186,8 @@ static struct imxrt_flexspi_fram_dev_s g_flexspi_nor = {
 	.flexspi = (void *)0,
 	.ahb_base = (uint8_t *) IMXRT_FLEXSPI2_CIPHER_BASE,
 	.port = FLEXSPI_PORT_A1,
-	.config = &g_flexspi_device_config
+	.config = &g_flexspi_device_config,
+	.lock = NXMUTEX_INITIALIZER
 };
 
 /****************************************************************************
@@ -488,23 +497,50 @@ static ssize_t imxrt_flexspi_fram_bwrite(struct mtd_dev_s *dev,
 		(struct imxrt_flexspi_fram_dev_s *)dev;
 	size_t len = nblocks * FRAM_PAGE_SIZE;
 	off_t offset = startblock * FRAM_PAGE_SIZE;
-	uint8_t *src = (uint8_t *) buffer;
+	const uint8_t *src = (const uint8_t *) buffer;
 #ifdef CONFIG_ARMV7M_DCACHE
 	uint8_t *dst = priv->ahb_base + startblock * FRAM_PAGE_SIZE;
 #endif
 	int i;
+	int ret;
 
 	finfo("startblock: %08lx nblocks: %d\n", (long)startblock, (int)nblocks);
 
+	/* priv->page_buffer is shared, and the partitions layered on this device
+	 * do not serialize their callers.
+	 */
+
+	ret = nxmutex_lock(&priv->lock);
+
+	if (ret < 0) {
+		return ret;
+	}
+
 	while (len) {
+		const uint8_t *page_src = src;
 		i = MIN(FRAM_PAGE_SIZE, len);
+
+		/* imxrt_flexspi_fram_page_program() casts this buffer to uint32_t *
+		 * and imxrt_flexspi_write_blocking() reads through it one word at a
+		 * time, but the MTD interface makes no alignment guarantee and the
+		 * block layer above does pass byte-aligned buffers. Copy the page to
+		 * a word-aligned buffer when needed.
+		 */
+		if (((uintptr_t)src & 3u) != 0u) {
+			memcpy(priv->page_buffer, src, i);
+			page_src = (const uint8_t *)priv->page_buffer;
+		}
+
 		imxrt_flexspi_fram_write_enable(priv);
-		imxrt_flexspi_fram_page_program(priv, offset, src, i);
+		imxrt_flexspi_fram_page_program(priv, offset, page_src, i);
 		imxrt_flexspi_fram_wait_bus_busy(priv);
 		FLEXSPI_SOFTWARE_RESET(priv->flexspi);
 		offset += i;
+		src += i;
 		len -= i;
 	}
+
+	nxmutex_unlock(&priv->lock);
 
 #ifdef CONFIG_ARMV7M_DCACHE
 	up_invalidate_dcache((uintptr_t)dst,

--- a/src/modules/mavlink/mavlink_command_params.hpp
+++ b/src/modules/mavlink/mavlink_command_params.hpp
@@ -197,8 +197,9 @@ struct VehicleOverride {
 
 // When adding vehicle-specific param differences, add entries here.
 static constexpr VehicleOverride VehicleParamOverrides[] = {
-	// NAV_TAKEOFF: p1 (minimum pitch angle) is used by FW and VTOL-FW; not applicable to MC.
-	{ 22, VEHICLE_FW | VEHICLE_VTOL, 0x01, 0x01 },
+	// NAV_TAKEOFF: p1 (minimum pitch angle) is used by FW and VTOL-FW; MC ignores it, but
+	// GCS (e.g. QGC) send p1=-1 on MC takeoff, so accept p1 for MC too instead of denying.
+	{ 22, VEHICLE_FW | VEHICLE_VTOL | VEHICLE_MC, 0x01, 0x01 },
 };
 
 // Binary search + vehicle override lookup. Returns the adjusted mask, or -1 if cmd not in table.

--- a/src/modules/mavlink/mavlink_command_params.hpp
+++ b/src/modules/mavlink/mavlink_command_params.hpp
@@ -88,7 +88,7 @@ static constexpr Entry SupportedCommandParams[] = {
 	{   31, 0x7B, 0x7B }, // NAV_LOITER_TO_ALT:           p1:hdg,p2:radius,p4:xtrack; p5-7:lat/lon/alt
 	{   80, 0x77, 0x77 }, // NAV_ROI:                     p1:mode,p2:wp_idx,p3:roi_idx; p5-7:lat/lon/alt
 	{   84, 0x78, 0x7C }, // NAV_VTOL_TAKEOFF:            mission:p4:yaw only (p3 unused by mission_block); cmd:p3:approach_hdg,p4:yaw; p5-7:lat/lon/alt
-	{   85, 0x78, 0x7F }, // NAV_VTOL_LAND:               mission:p4:yaw only (p1-3 unused by mission_block); cmd:p1:options,p2:approach_hdg,p3:loiter_r,p4:yaw; p5-7:lat/lon/alt
+	{   85, 0x7C, 0x7F }, // NAV_VTOL_LAND:               mission:p3:approach_alt (QGC sets it; unused by mission_block),p4:yaw; cmd:p1:options,p2:approach_hdg,p3:loiter_r,p4:yaw; p5-7:lat/lon/alt
 	{   93, 0x0F, 0x0F }, // NAV_DELAY:                   p1:delay,p2:hour,p3:min,p4:sec
 	{  112, 0x01, 0x01 }, // CONDITION_DELAY:             p1:seconds
 	{  114, 0x01, 0x01 }, // CONDITION_DISTANCE:          p1:distance
@@ -96,7 +96,7 @@ static constexpr Entry SupportedCommandParams[] = {
 	{  177, 0x03, 0x03 }, // DO_JUMP:                     p1:index,p2:count
 	{  178, 0x07, 0x07 }, // DO_CHANGE_SPEED:             p1:type,p2:speed,p3:throttle
 	{  179, 0x7F, 0x7F }, // DO_SET_HOME:                 p1:use_current,p2:roll,p3:pitch,p4:yaw; p5-7:lat/lon/alt
-	{  189, 0x00, 0x00 }, // DO_LAND_START:               no params
+	{  189, 0x70, 0x70 }, // DO_LAND_START:               p5-7:lat/lon/alt (optional marker position per spec; QGC sets it)
 	{  195, 0x70, 0x71 }, // DO_SET_ROI_LOCATION:         mission:p5-7:lat/lon/alt; cmd:p1:gimbal,p5-7:lat/lon/alt
 	{  196, 0x01, 0x01 }, // DO_SET_ROI_WPNEXT_OFFSET:   p1:gimbal_id
 	{  197, 0x01, 0x01 }, // DO_SET_ROI_NONE:             p1:gimbal_id

--- a/src/modules/mavlink/mavlink_command_params.hpp
+++ b/src/modules/mavlink/mavlink_command_params.hpp
@@ -43,7 +43,8 @@
  *   bits 4–6: params 5–7  (bit 4 = param5, bit 5 = param6, bit 6 = param7)
  *
  * For global-frame MISSION_ITEM_INT, check_params_int_for_vehicle() is used so
- * that p5/p6 are validated as int32 (INT32_MAX = unset) and p7 as float.
+ * that p5/p6 are validated as int32 (INT32_MAX or INT32_MIN = not used) and p7
+ * as float.
  *
  * A secondary VehicleParamOverrides table holds per-airframe additions (e.g.
  * NAV_TAKEOFF pitch angle on FW); use check_params_for_vehicle() for callers
@@ -157,10 +158,14 @@ static inline bool param_is_zero(float v)
 	return !std::isnan(v) && (bits & 0x7FFFFFFFu) == 0u;
 }
 
-// INT32_MAX is the MAVLink sentinel for "int32 param not provided".
+// INT32_MAX is the value the MAVLink spec defines to mean "this int32 param is
+// not used". Ground stations also convert unused NaN float params straight into
+// the int32 x/y fields of MISSION_ITEM_INT (QGC does this for camera items in
+// MAV_FRAME_MISSION), and converting NaN to int32 gives INT32_MIN on most
+// hardware — so treat that as "not used" too.
 static inline bool int_param_is_unset(int32_t v)
 {
-	return v == INT32_MAX;
+	return v == INT32_MAX || v == INT32_MIN;
 }
 
 // Vehicle type bitmask for per-vehicle parameter support.

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1664,8 +1664,9 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 				const mavlink_mission_item_int_t *item_int =
 					reinterpret_cast<const mavlink_mission_item_int_t *>(mavlink_mission_item);
 				// x/y are p5/p6 generic params (not lat/lon) for non-position frames.
-				// Normalize INT32_MAX (MISSION_ITEM_INT "unused" sentinel) to NaN so
-				// both the int sentinel and the NaN are treated as unset.
+				// Turn both int values that mean "param not used" (INT32_MAX per the
+				// spec, INT32_MIN from ground stations converting NaN to int32) into
+				// NaN so the validation treats them as not used.
 				const float p5 = mavlink_cmd_params::int_param_is_unset(item_int->x) ? NAN : (float)item_int->x;
 				const float p6 = mavlink_cmd_params::int_param_is_unset(item_int->y) ? NAN : (float)item_int->y;
 				bad = mavlink_cmd_params::check_params_for_vehicle(mavlink_mission_item->command, true, _vehicle_type_bitmask,

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
@@ -598,7 +598,6 @@ void McAutotuneAttitudeControl::saveGainsToParams()
 void McAutotuneAttitudeControl::stopAutotune()
 {
 	_vehicle_cmd_start_autotune = false;
-	_vehicle_torque_setpoint_sub.unregisterCallback();
 }
 
 const Vector3f McAutotuneAttitudeControl::getIdentificationSignal()

--- a/test/test_mavlink_param_validation.py
+++ b/test/test_mavlink_param_validation.py
@@ -51,9 +51,11 @@ CMD_NAV_VTOL_TAKEOFF = 84
 CMD_NAV_VTOL_LAND = 85
 CMD_NAV_DELAY = 93
 CMD_COMPONENT_ARM_DISARM = 400
+CMD_IMAGE_STOP_CAPTURE = 2001
 
 NAN = float("nan")
 INT32_MAX = 2_147_483_647
+INT32_MIN = -2_147_483_648
 
 # Helpers
 
@@ -314,6 +316,21 @@ def run_mission_tests(mav: Any, timeout: float) -> None:
     ], timeout)
     _check(
         "NAV_VTOL_TAKEOFF mission valid (p4=yaw only) -> ACCEPTED",
+        result, MAV_MISSION_ACCEPTED,
+    )
+
+    # 17. IMAGE_STOP_CAPTURE with x/y = INT32_MIN (mask 0x01: only p1).
+    # QGC camera-section items carry NaN in the unused float params and
+    # convert them into the int32 x/y fields of MISSION_ITEM_INT, which
+    # becomes INT32_MIN on x86. PX4 must treat both INT32_MAX and INT32_MIN
+    # as "param not used" and accept the item.
+    result = _upload_mission(mav, [
+        _item(0, CMD_IMAGE_STOP_CAPTURE, MAV_FRAME_MISSION,
+              p1=0.0, p2=NAN, p3=NAN, p4=NAN,
+              x=INT32_MIN, y=INT32_MIN, z=NAN),
+    ], timeout)
+    _check(
+        "IMAGE_STOP_CAPTURE NaN-cast x/y (INT32_MIN) -> ACCEPTED",
         result, MAV_MISSION_ACCEPTED,
     )
 


### PR DESCRIPTION
Backports seven bugfixes from main to release/1.18 for v1.18.0-beta2. All commits are cherry-picked as they landed on main with `-x` provenance; every patch is byte-identical to its original except the NuttX submodule bump, which starts from the release pin instead of main's but lands on the same commit.

In pick order:

- #27851: mc_autotune kept its WorkItem unscheduled after a completed run, so autotune could only run once per boot. The original commit title says "unregister" but the change registers the callback on stop; kept verbatim as it landed on main.
- #27846: cuav x25-mega still referenced the pre-#27716 heater param name, leaving the IMU heater unconfigured on beta1.
- #27853: QGC multicopter guided takeoff (NAV_TAKEOFF with param1 set) was silently DENIED, a 1.18 regression from #27541.
- fb4e62fd92b (from #26032, picked by SHA since that PR was rebase-merged): NAV_VTOL_LAND param3 and DO_LAND_START param5-7 are spec-defined and written by QGC, but validation rejected them, so QGC VTOL landing plans failed to upload.
- #28071: NuttX submodule bump for the STM32H7 SDMMC RX DMA cache coherency fix; without it SD reads (ULog download, FAT metadata) can silently corrupt on H7 boards. The pin moves from c32297427a66 to 60da95f41f42, a fast-forward on px4_firmware_nuttx-10.3.0+ that converges with main's pin; the two ancestor commits it pulls in (NuttX #386 IGMP fix and the #388 FS_LARGEFILE compiler guard) are inert for these targets.
- #28079: mission item validation only accepted INT32_MAX as "param not used", so QGC missions containing camera items were rejected, also a regression from #27541.
- #28127: the fmu-v6xrt FRAM bwrite loop never advanced its source pointer, corrupting multi-page parameter writes.

Built locally on this branch: px4_fmu-v6x (with the new NuttX pin checked out), px4_fmu-v6xrt, cuav_x25-mega_default, and px4_sitl_sih. A hardware smoke test of SD logging plus MAVLink ULog download on a v6c or v6x before tagging beta2 would be a good double-check of the SDMMC fix.
