### PR TITLE
fix(tools): handle DEL as backspace in mavlink shell

### DIFF
--- a/Tools/mavlink_shell.py
+++ b/Tools/mavlink_shell.py
@@ -191,11 +191,10 @@ def main():
                         cur_history_index = len(command_history)
                     mav_serialport.write(cur_line+'\n')
                     cur_line = ''
-                elif ord(ch) == 8: # backspace
+                elif ord(ch) == 8 or ord(ch) == 127: # backspace (BS or DEL)
                     if len(cur_line) > 0:
                         erase_last_n_chars(1)
                         cur_line = cur_line[:-1]
-                        sys.stdout.write(ch)
                 elif ord(ch) == 27:
                     ch = ubuf_stdin.read(1).decode('utf8') # skip one
                     ch = ubuf_stdin.read(1).decode('utf8')


### PR DESCRIPTION
Terminal emulators send DEL (0x7f) for the Backspace key, but only BS (0x08) was handled, so the keypress fell through to the catch-all branch and got appended to the line buffer instead of erasing. This made the shell effectively append-only.

Also drop the stray echo of the backspace character: erase_last_n_chars() already emits ESC[1D + ESC[K and leaves the cursor in the right column, so writing 0x08 on top of it moved the cursor one column too far left and the next keystroke overwrote the preceding character.

Assisted-by: Claude:claude-opus-5