### PR TITLE
fix(macos): install opencv@4 and hint its prefix

### DIFF
--- a/Tools/setup/macos.sh
+++ b/Tools/setup/macos.sh
@@ -129,12 +129,14 @@ if [[ $INSTALL_SIM == "--sim-tools" ]]; then
 		brew trust osrf/simulation
 	fi
 
+	# opencv@4: the unversioned formula is OpenCV 5, which PX4-OpticalFlow
+	# does not build against.
 	PX4_SIM_BREW_PACKAGES=(
 		exiftool
 		glog
 		graphviz
 		gstreamer
-		opencv
+		opencv@4
 		osrf/simulation/gz-harmonic
 		protobuf
 	)

--- a/platforms/posix/cmake/px4_impl_os.cmake
+++ b/platforms/posix/cmake/px4_impl_os.cmake
@@ -49,6 +49,23 @@ if(APPLE AND NOT DEFINED Qt5_DIR)
 	endif()
 endif()
 
+# Homebrew's opencv formula is now OpenCV 5, which PX4-OpticalFlow does not
+# build against: OpenCV 5 removed <opencv2/core/types_c.h> and moved
+# cv::undistortPoints when calib3d was split. The compatible opencv@4 is
+# keg-only, so without a prefix hint find_package resolves to 5.x instead.
+# Only runs when the user has not already set OpenCV_DIR.
+if(APPLE AND NOT DEFINED OpenCV_DIR)
+	execute_process(
+		COMMAND brew --prefix opencv@4
+		OUTPUT_VARIABLE _brew_opencv4_prefix
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+		ERROR_QUIET
+	)
+	if(_brew_opencv4_prefix AND EXISTS "${_brew_opencv4_prefix}/lib/cmake/opencv4")
+		list(APPEND CMAKE_PREFIX_PATH "${_brew_opencv4_prefix}")
+	endif()
+endif()
+
 #=============================================================================
 #
 #	Defined functions in this file


### PR DESCRIPTION
## Problem

`Tools/setup/macos.sh --sim-tools` installs the unversioned Homebrew `opencv`
formula, which is now 5.0.0. `PX4-OpticalFlow` does not build against it, so a
fresh macOS setup fails partway through `make px4_sitl`:

```
trackFeatures.cpp:43:10: fatal error: 'opencv2/core/types_c.h' file not found
flow_opencv.cpp:110:7:  fatal error: no member named 'undistortPoints' in namespace 'cv'
```

`types_c.h` was removed in OpenCV 5, and `undistortPoints` moved when `calib3d`
was split into `3d`/`calib`.

## Solution

* `macos.sh`: install `opencv@4`.
* `px4_impl_os.cmake`: add a prefix hint for it, next to the existing `qt@5`
  hint. `opencv@4` is keg-only, so `find_package` still resolves to 5.0.0
  without one — installing it alone does not fix the build.

## Test Coverage

- [x] macOS 15.6 arm64, Gazebo Harmonic 8.14.0, with OpenCV 5.0.0 still
      installed and linked so the hint has to win against it
- [x] Fresh configure resolves `opencv@4/4.14.0`; `make px4_sitl` completes
      clean; `gz_x500` arms and takes off
