### PR TITLE
fix(logging_system): Delete the optional attribute for the telemetry_status

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -175,7 +175,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic_multi("sensor_temp", 100, 4);
 	add_optional_topic_multi("rpm", 200);
 	add_topic_multi("timesync_status", 1000, 3);
-	add_optional_topic_multi("telemetry_status", 1000, 4);
+	add_topic_multi("telemetry_status", 1000, 4);
 
 	// EKF multi topics
 	{


### PR DESCRIPTION
### Solved Problem
The `telemetry_status` topic was logged as an "optional" topic, which means the logger only subscribes to a given instance if it is already being published at the moment the logger starts. Telemetry links that come up after the logger has started are never logged for the rest of the session, even after they start publishing.

### Solution
Log `telemetry_status` as a regular multi-topic, so all instances are subscribed unconditionally and get logged as soon as they start publishing, regardless of when the link comes up relative to logger startup.

### Test coverage
Tested on bench, `telemetry_status` logged with multi-topic.