### PR TITLE
fix(boards/micoair): drive PWM output pins low on reset

### DIFF
--- a/boards/micoair/h743-aio/src/init.c
+++ b/boards/micoair/h743-aio/src/init.c
@@ -95,7 +95,7 @@ __EXPORT void board_peripheral_reset(int ms)
 __EXPORT void board_on_reset(int status)
 {
 	for (int i = 0; i < DIRECT_PWM_OUTPUT_CHANNELS; ++i) {
-		px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
+		px4_arch_configgpio(io_timer_channel_get_gpio_output(i));
 	}
 
 	/*

--- a/boards/micoair/h743-lite/src/init.c
+++ b/boards/micoair/h743-lite/src/init.c
@@ -95,7 +95,7 @@ __EXPORT void board_peripheral_reset(int ms)
 __EXPORT void board_on_reset(int status)
 {
 	for (int i = 0; i < DIRECT_PWM_OUTPUT_CHANNELS; ++i) {
-		px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
+		px4_arch_configgpio(io_timer_channel_get_gpio_output(i));
 	}
 
 	/*

--- a/boards/micoair/h743-v2/src/init.c
+++ b/boards/micoair/h743-v2/src/init.c
@@ -95,7 +95,7 @@ __EXPORT void board_peripheral_reset(int ms)
 __EXPORT void board_on_reset(int status)
 {
 	for (int i = 0; i < DIRECT_PWM_OUTPUT_CHANNELS; ++i) {
-		px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
+		px4_arch_configgpio(io_timer_channel_get_gpio_output(i));
 	}
 
 	/*

--- a/boards/micoair/h743/src/init.c
+++ b/boards/micoair/h743/src/init.c
@@ -95,7 +95,7 @@ __EXPORT void board_peripheral_reset(int ms)
 __EXPORT void board_on_reset(int status)
 {
 	for (int i = 0; i < DIRECT_PWM_OUTPUT_CHANNELS; ++i) {
-		px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
+		px4_arch_configgpio(io_timer_channel_get_gpio_output(i));
 	}
 
 	/*


### PR DESCRIPTION
### Solved Problem
Fixes #26748

On MicoAir boards (H743, H743-AIO, H743-Lite, H743-V2), configuring PWM channels as input during board reset prevents bidirectional DShot from properly initializing or communicating with ESCs.

### Solution
- Updated `board_on_reset()` for all MicoAir variants (`h743`, `h743-aio`, `h743-lite`, `h743-v2`) to configure PWM output pins as GPIO output low (`io_timer_channel_get_gpio_output(i)`) instead of input.
- Aligned MicoAir reset logic with bidirectional DShot pin requirements.

### Changelog Entry
For release notes:

Bugfix: Drive PWM output pins low on reset for MicoAir boards to fix bidirectional DShot

### Alternatives
None.

### Test coverage
- Verified PWM pins are properly set to low on reset.
- Tested on MicoAir board hardware with bidirectional DShot enabled.

### Context
- Related issue: #26748
- Reference PR: #27876