### PR TITLE
fix(dataman): increase task stack size

### DIFF
--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -68,7 +68,7 @@ __END_DECLS
 #ifdef CONFIG_FS_LITTLEFS
 static constexpr int TASK_STACK_SIZE = 2000;  /* littlefs needs more stack */
 #else
-static constexpr int TASK_STACK_SIZE = 1800;  /* 64-bit off_t (FS_LARGEFILE) widened the FAT/SD path */
+static constexpr int TASK_STACK_SIZE = 1800; 
 #endif
 
 #ifdef CONFIG_DATAMAN_PERSISTENT_STORAGE

--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -68,7 +68,7 @@ __END_DECLS
 #ifdef CONFIG_FS_LITTLEFS
 static constexpr int TASK_STACK_SIZE = 2000;  /* littlefs needs more stack */
 #else
-static constexpr int TASK_STACK_SIZE = 1420;
+static constexpr int TASK_STACK_SIZE = 1800;  /* 64-bit off_t (FS_LARGEFILE) widened the FAT/SD path */
 #endif
 
 #ifdef CONFIG_DATAMAN_PERSISTENT_STORAGE

--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -65,11 +65,7 @@ __BEGIN_DECLS
 __EXPORT int dataman_main(int argc, char *argv[]);
 __END_DECLS
 
-#ifdef CONFIG_FS_LITTLEFS
-static constexpr int TASK_STACK_SIZE = 2000;  /* littlefs needs more stack */
-#else
-static constexpr int TASK_STACK_SIZE = 1800; 
-#endif
+static constexpr int TASK_STACK_SIZE = 2000;
 
 #ifdef CONFIG_DATAMAN_PERSISTENT_STORAGE
 /* Private File based Operations */


### PR DESCRIPTION
## Summary

Raise the dataman task stack to 2000 bytes and drop the littlefs/non-littlefs split.

## Problem

```
WARN  [load_mon] dataman low on stack! (252 bytes left)
```

`CONFIG_FS_LARGEFILE` (#28043) widened `off_t` and `fsblkcnt_t` to 64-bit through the VFS, FAT and mmcsd layers that the dataman file backend calls into on every `lseek`/`read`/`write`. Dataman had no room to absorb it: `PX4_STACK_ADJUSTED` is a no-op on 32-bit NuttX, so the task got exactly 1420 bytes and was already sitting ~200 bytes above the 300 byte warning threshold. Seen on ARK FMU-v6X with the default file backend on FAT.

## Solution

1420 was not enough, and the littlefs case was only 200 bytes away, which is not worth a conditional. Use 2000 unconditionally, leaving ~830 bytes free at the observed peak and keeping littlefs targets where they were.