### PR TITLE
[BACKPORT 1.18] fix(drivers/invensense): correct 20-bit gyro scales and IIM-42653 range

### DIFF
--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
@@ -801,13 +801,13 @@ void ICM42688P::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DAT
 	}
 
 	if (!scale_20bit) {
-		// On the 686, if highres enabled gyro data is always 65.5 LSB/dps
-		// On the 688, if highres enabled gyro data is always 131 LSB/dps
+		// published data is the 20 bit value shifted right by 1, so it spans the full range in
+		// 2^18 counts: 65.536 LSB/dps on the 686, 131.072 LSB/dps on the 688
 		if (isICM686) {
-			_px4_gyro.set_scale(math::radians(1.f / 65.5f));
+			_px4_gyro.set_scale(math::radians(4000.f / 262144.f));
 
 		} else {
-			_px4_gyro.set_scale(math::radians(1.f / 131.f));
+			_px4_gyro.set_scale(math::radians(2000.f / 262144.f));
 		}
 
 	} else {
@@ -819,7 +819,7 @@ void ICM42688P::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DAT
 		}
 
 		if (isICM686) {
-			_px4_gyro.set_scale(math::radians(2000.f / 16384.f));
+			_px4_gyro.set_scale(math::radians(4000.f / 32768.f));
 
 		} else {
 			_px4_gyro.set_scale(math::radians(2000.f / 32768.f));

--- a/src/drivers/imu/invensense/iim42652/IIM42652.cpp
+++ b/src/drivers/imu/invensense/iim42652/IIM42652.cpp
@@ -777,8 +777,9 @@ void IIM42652::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 	}
 
 	if (!scale_20bit) {
-		// if highres enabled gyro data is always 131 LSB/dps
-		_px4_gyro.set_scale(math::radians(1.f / 131.f));
+		// published data is the 20 bit value shifted right by 1, so it spans the full range in
+		// 2^18 counts: 131.072 LSB/dps
+		_px4_gyro.set_scale(math::radians(2000.f / 262144.f));
 
 	} else {
 		// 20 bit data scaled to 16 bit (2^4)

--- a/src/drivers/imu/invensense/iim42653/IIM42653.cpp
+++ b/src/drivers/imu/invensense/iim42653/IIM42653.cpp
@@ -778,8 +778,9 @@ void IIM42653::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 	}
 
 	if (!scale_20bit) {
-		// if highres enabled gyro data is always 65.5 LSB/dps
-		_px4_gyro.set_scale(math::radians(1.f / 65.5f));
+		// published data is the 20 bit value shifted right by 1, so it spans the full range in
+		// 2^18 counts: 65.536 LSB/dps
+		_px4_gyro.set_scale(math::radians(4000.f / 262144.f));
 
 	} else {
 		// 20 bit data scaled to 16 bit (2^4)

--- a/src/drivers/imu/invensense/iim42653/IIM42653.cpp
+++ b/src/drivers/imu/invensense/iim42653/IIM42653.cpp
@@ -411,9 +411,9 @@ bool IIM42653::Configure()
 	}
 
 	// 20-bits data format used
-	//  the only FSR settings that are operational are ±2000dps for gyroscope and ±16g for accelerometer
-	_px4_accel.set_range(16.f * CONSTANTS_ONE_G);
-	_px4_gyro.set_range(math::radians(2000.f));
+	//  IIM-42653 FSR: ±4000 dps gyroscope and ±32 g accelerometer (default full-scale)
+	_px4_accel.set_range(32.f * CONSTANTS_ONE_G);
+	_px4_gyro.set_range(math::radians(4000.f));
 
 	return success;
 }


### PR DESCRIPTION
## Summary

Backport of #28133 and #28177 to `release/1.18`. Both are clean cherry-picks; the three touched driver files are now byte-identical to `main`.

## Problem

Two independent gyro/accel scaling defects in the Invensense 20-bit drivers ship in 1.18:

- IIM-42653 programs `ACCEL_FS_SEL` ±32 g and `GYRO_FS_SEL` ±4000 dps and uses FIFO scale factors that match, but `Configure()` reported ±16 g / ±2000 dps from `set_range` — leftover IIM-42652 / ICM-42688 values. Range metadata and clip thresholds were wrong, so PX4 flagged clipping above ~16 g on hardware that is fine to 32 g. There is no parameter to work around it.
- The 20-bit high-resolution gyro scales used the datasheet's rounded 131 / 65.5 LSB/dps instead of the exact FSR/2^18 the hardware produces (131.072 / 65.536), so the published rate is 0.055% low, and the high-resolution and fallback branches disagree by that factor — the reported rate steps every time a batch crosses the threshold between them.

## Solution

#28133 uses exact `FSR/262144` scales in ICM42688P, IIM42652 and IIM42653, so both decode branches agree, and spells the 686 fallback as `4000/32768` to match its ±4000 dps range. #28177 reports 32 g / 4000 dps from IIM-42653 `set_range`.

Built `px4_fmu-v6x` and `px4_sitl`. No hardware verification of clipping flags above 16 g on this branch.
