### PR TITLE
[BACKPORT 1.18] fix(dataman): increase task stack size

### DIFF
--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -65,11 +65,7 @@ __BEGIN_DECLS
 __EXPORT int dataman_main(int argc, char *argv[]);
 __END_DECLS
 
-#ifdef CONFIG_FS_LITTLEFS
-static constexpr int TASK_STACK_SIZE = 2000;  /* littlefs needs more stack */
-#else
-static constexpr int TASK_STACK_SIZE = 1420;
-#endif
+static constexpr int TASK_STACK_SIZE = 2000;
 
 #ifdef CONFIG_DATAMAN_PERSISTENT_STORAGE
 /* Private File based Operations */


### PR DESCRIPTION
## Summary

Backport of #28202 to `release/1.18`. Clean cherry-pick; the file is now identical to `main`.

## Problem

The dataman task only ever had 1420 bytes of stack on non-littlefs targets, since `PX4_STACK_ADJUSTED` is a no-op on 32-bit NuttX. That left roughly 1168 bytes of peak usage against a 300 byte warning threshold, so it was already running close to the limit. Widening `off_t` and `fsblkcnt_t` to 64-bit through the VFS, FAT and mmcsd layers the dataman file backend calls into pushes it past the `load_mon` threshold:

```
WARN  [load_mon] dataman low on stack! (252 bytes left)
```

## Solution

Use a single 2000 byte task stack for all targets. The littlefs and non-littlefs sizes were within 200 bytes of each other, so the conditional bought nothing and no target loses headroom.
