### PR TITLE
[BACKPORT 1.18] fix(dshot): decode EDT current as 1A steps

### DIFF
--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -673,7 +673,7 @@ bool DShot::process_bdshot_telemetry()
 				}
 
 				if (up_bdshot_get_extended_telemetry(output_channel, DSHOT_EDT_CURRENT, &value) == PX4_OK) {
-					esc.current = static_cast<float>(value) / 2.f; // BDShot current is in 0.5A
+					esc.current = static_cast<float>(value); // EDT current is in 1A steps
 
 				} else {
 					esc.current = _esc_status.esc[motor_index].esc_current; // use previous


### PR DESCRIPTION
## Summary

Backport of #28143 to `release/1.18`. Clean cherry-pick; the file is now identical to `main`.

## Problem

PX4 divided bidirectional DShot EDT current by 2 (0.5 A steps). That matched a long-standing AM32 encoding bug (`centiamps / 50`) but not the [EDT spec](https://github.com/bird-sanctuary/extended-dshot-telemetry), which is 1 A steps. ArduPilot and Betaflight already used 1 A, so they reported double current from AM32 ESCs.

## Solution

Decode the current frame as amps with no scaling, matching the spec and post-fix AM32 firmware (am32-firmware/AM32#403).

Note for the release branch: this is a user-visible change to reported ESC current. Pre-fix AM32 builds will read 2x high until the ESC firmware is upgraded — the same trade-off accepted on `main`.
