### PR TITLE
fix(release): backport 10 bugfixes for v1.18

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -239,6 +239,7 @@ private:
 	perf_counter_t _rtcm_moving_baseline_injection_perf{perf_alloc(PC_COUNT, MODULE_NAME": rtcm moving baseline injected")};
 
 	static px4::atomic_bool _is_gps_main_advertised; ///< for the second gps we want to make sure that it gets instance 1
+	static px4::atomic_bool _is_sat_info_main_advertised; ///< for the second gps we want to make sure that it gets instance 1
 	/// and thus we wait until the first one publishes at least one message.
 
 	static px4::atomic<GPS *> _secondary_instance;
@@ -333,6 +334,7 @@ private:
 };
 
 px4::atomic_bool GPS::_is_gps_main_advertised{false};
+px4::atomic_bool GPS::_is_sat_info_main_advertised{false};
 px4::atomic<GPS *> GPS::_secondary_instance{nullptr};
 ModuleBase::Descriptor GPS::desc{task_spawn, custom_command, print_usage};
 
@@ -1433,15 +1435,12 @@ GPS::publish()
 void
 GPS::publishSatelliteInfo()
 {
-	if (_instance == Instance::Main || _is_gps_main_advertised.load()) {
+	if (_instance == Instance::Main || _is_sat_info_main_advertised.load()) {
 		if (_p_report_sat_info != nullptr) {
 			_report_sat_info_pub.publish(*_p_report_sat_info);
 		}
 
-		_is_gps_main_advertised.store(true);
-
-	} else {
-		//we don't publish satellite info for the secondary gps
+		_is_sat_info_main_advertised.store(true);
 	}
 }
 

--- a/src/drivers/uavcan/sensors/rangefinder.cpp
+++ b/src/drivers/uavcan/sensors/rangefinder.cpp
@@ -82,7 +82,9 @@ void UavcanRangefinderBridge::range_sub_cb(const
 		return;
 	}
 
-	if (!_inited) {
+	const int8_t channel_idx = get_channel_index_for_node(msg.getSrcNodeID().get());
+
+	if (channel_idx >= 0 && !_channel_initialized[channel_idx]) {
 
 		uint8_t rangefinder_type = 0;
 
@@ -107,7 +109,7 @@ void UavcanRangefinderBridge::range_sub_cb(const
 		rangefinder->set_min_distance(_range_min_m);
 		rangefinder->set_max_distance(_range_max_m);
 
-		_inited = true;
+		_channel_initialized[channel_idx] = true;
 	}
 
 	// TOO_CLOSE, TOO_FAR and UNDEFINED readings do not carry a usable range

--- a/src/drivers/uavcan/sensors/rangefinder.hpp
+++ b/src/drivers/uavcan/sensors/rangefinder.hpp
@@ -70,6 +70,6 @@ private:
 	float _range_min_m{0.0f};
 	float _range_max_m{0.0f};
 
-	bool _inited{false};
+	bool _channel_initialized[DEFAULT_MAX_CHANNELS] {};
 
 };

--- a/src/drivers/vtx/VTX.cpp
+++ b/src/drivers/vtx/VTX.cpp
@@ -437,7 +437,7 @@ int VTX::print_status()
 	PX4_INFO("  pit mode: %s", _pit_mode ? "on" : "off");
 
 	if (!(_comms_ok && _protocol && _protocol->print_settings())) {
-		PX4_ERR("%s device not found", _param_vtx_device.get() == 1 ? "Tramp" : "SmartAudio");
+		PX4_ERR("%s device not found", (_param_vtx_device.get() & 0xff) == vtx_s::PROTOCOL_TRAMP ? "Tramp" : "SmartAudio");
 	}
 
 	perf_print_counter(_perf_cycle);

--- a/src/drivers/vtx/tramp.cpp
+++ b/src/drivers/vtx/tramp.cpp
@@ -50,7 +50,9 @@ int Tramp::get_settings()
 	if (rv != 0) { return rv; }
 
 	px4_usleep(30_ms);
-	return get_temperature();
+	int temperature_data = get_temperature();
+	// ignore temperature data if not available
+	return temperature_data == -ETIMEDOUT ? 0 : temperature_data;
 }
 
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
@@ -314,8 +314,13 @@ void BatteryChecks::rtlEstimateCheck(const Context &context, Report &reporter, f
 			&& rtl_time_estimate.safe_time_estimate * hysteresis_factor >= worst_battery_time_s;
 
 
-	if (reporter.failsafeFlags().battery_low_remaining_time) {
+	// Only report if the failsafe action is enabled, otherwise the condition has no effect
+	if (reporter.failsafeFlags().battery_low_remaining_time && _param_com_fltt_low_act.get() > 0) {
 		/* EVENT
+		 * @description
+		 * <profile name="dev">
+		 * This check can be configured via <param>COM_FLTT_LOW_ACT</param> parameter.
+		 * </profile>
 		 */
 		reporter.armingCheckFailure(NavModes::All, health_component_t::battery, events::ID("check_battery_rem_flight_time_low"),
 					    events::Log::Error, "Remaining flight time low");

--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.hpp
@@ -58,6 +58,7 @@ private:
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
 					(ParamFloat<px4::params::COM_ARM_BAT_MIN>) _param_com_arm_bat_min,
-					(ParamInt<px4::params::CBRK_SUPPLY_CHK>) _param_cbrk_supply_chk
+					(ParamInt<px4::params::CBRK_SUPPLY_CHK>) _param_cbrk_supply_chk,
+					(ParamInt<px4::params::COM_FLTT_LOW_ACT>) _param_com_fltt_low_act
 				       )
 };

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -203,12 +203,14 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 	}
 
 
-	if ((_param_com_arm_mag_str.get() >= 1)
+	if (_param_com_arm_mag_str.get()
 	    && (!context.isArmed() && estimator_status.pre_flt_fail_mag_field_disturbed)) {
+
+		const MagArmingCheck mag_arming_check = static_cast<MagArmingCheck>(_param_com_arm_mag_str.get());
 
 		NavModes required_groups_mag = required_groups;
 
-		if (_param_com_arm_mag_str.get() != 1) {
+		if (mag_arming_check != MagArmingCheck::DenyArming) {
 			required_groups_mag = NavModes::None; // optional
 		}
 
@@ -228,7 +230,14 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 				estimator_status.mag_inclination_deg, estimator_status.mag_inclination_ref_deg);
 
 		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Strong magnetic interference");
+			const char *message = "Preflight%s: Strong magnetic interference";
+
+			if (mag_arming_check == MagArmingCheck::DenyArming) {
+				mavlink_log_critical(reporter.mavlink_log_pub(), message, " Fail");
+
+			} else {
+				mavlink_log_warning(reporter.mavlink_log_pub(), message, "");
+			}
 		}
 	}
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
@@ -65,6 +65,12 @@ private:
 		Disabled = 2
 	};
 
+	enum class MagArmingCheck : uint8_t {
+		Disabled = 0,
+		DenyArming = 1,
+		WarningOnly = 2
+	};
+
 	void checkEstimatorStatus(const Context &context, Report &reporter, const estimator_status_s &estimator_status,
 				  NavModes required_groups);
 	void checkSensorBias(const Context &context, Report &reporter, NavModes required_groups);

--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -82,6 +82,16 @@ void ModeExecutors::printStatus(int executor_in_charge) const
 	}
 }
 
+Modes::Modes()
+{
+	char hash_param_name[17];
+
+	for (int i = 0; i < MAX_NUM; i++) {
+		snprintf(hash_param_name, sizeof(hash_param_name), "COM_MODE%d_HASH", i);
+		_mode_hash_handles[i] = param_find(hash_param_name);
+	}
+}
+
 bool Modes::hasFreeExternalModes() const
 {
 	for (int i = 0; i < MAX_NUM; ++i) {
@@ -108,9 +118,7 @@ uint8_t Modes::addExternalMode(const Modes::Mode &mode)
 	int matching_idx = -1;
 
 	for (int i = 0; i < MAX_NUM; ++i) {
-		char hash_param_name[17];
-		snprintf(hash_param_name, sizeof(hash_param_name), "COM_MODE%d_HASH", i);
-		const param_t handle = param_find(hash_param_name);
+		const param_t handle = _mode_hash_handles[i];
 		int32_t current_hash{};
 
 		if (handle != PARAM_INVALID && param_get(handle, &current_hash) == 0) {
@@ -165,9 +173,7 @@ uint8_t Modes::addExternalMode(const Modes::Mode &mode)
 
 	if (new_mode_idx != -1 && !_modes[new_mode_idx].valid) {
 		if (need_to_update_param) {
-			char hash_param_name[17];
-			snprintf(hash_param_name, sizeof(hash_param_name), "COM_MODE%d_HASH", new_mode_idx);
-			const param_t handle = param_find(hash_param_name);
+			const param_t handle = _mode_hash_handles[new_mode_idx];
 
 			if (handle != PARAM_INVALID) {
 				param_set_no_notification(handle, &mode_name_hash);

--- a/src/modules/commander/ModeManagement.hpp
+++ b/src/modules/commander/ModeManagement.hpp
@@ -102,6 +102,8 @@ public:
 		mode_util::SetpointType current_setpoint_type{kDefaultSetpointType};
 	};
 
+	Modes();
+
 	void printStatus() const;
 
 	bool valid(uint8_t nav_state) const { return nav_state >= FIRST_EXTERNAL_NAV_STATE && nav_state <= LAST_EXTERNAL_NAV_STATE && _modes[nav_state - FIRST_EXTERNAL_NAV_STATE].valid; }
@@ -114,6 +116,7 @@ public:
 
 private:
 	Mode _modes[MAX_NUM] {};
+	param_t _mode_hash_handles[MAX_NUM];
 };
 
 

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -678,6 +678,10 @@ bool FlightTaskAuto::_compute_heading_from_2D_vector(float &heading, Vector2f v)
 void FlightTaskAuto::_ekfResetHandlerPositionXY(const matrix::Vector2f &delta_xy)
 {
 	_position_smoothing.forceSetPosition({_position(0), _position(1), NAN});
+
+	if (_takeoff_locked_xy.isAllFinite()) {
+		_takeoff_locked_xy += delta_xy;
+	}
 }
 
 void FlightTaskAuto::_ekfResetHandlerVelocityXY(const matrix::Vector2f &delta_vxy)
@@ -688,6 +692,10 @@ void FlightTaskAuto::_ekfResetHandlerVelocityXY(const matrix::Vector2f &delta_vx
 void FlightTaskAuto::_ekfResetHandlerPositionZ(const float delta_z)
 {
 	_position_smoothing.forceSetPosition({NAN, NAN, _position(2)});
+
+	if (PX4_ISFINITE(_takeoff_liftoff_z)) {
+		_takeoff_liftoff_z += delta_z;
+	}
 }
 
 void FlightTaskAuto::_ekfResetHandlerVelocityZ(const float delta_vz)

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -574,8 +574,7 @@ FixedWingModeManager::control_auto(const float control_interval, const Vector2d 
 	move_position_setpoint_for_vtol_transition(current_sp);
 
 	// Course setpoints are handled directly to avoid entering hold mode
-	if (PX4_ISFINITE(current_sp.course)
-	    && _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_GUIDED_COURSE) {
+	if (PX4_ISFINITE(current_sp.course)) {
 		control_auto_position(control_interval, curr_pos, ground_speed, pos_sp_prev, current_sp);
 		return;
 	}
@@ -779,8 +778,7 @@ FixedWingModeManager::control_auto_position(const float control_interval, const 
 		const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr)
 {
 	// Course Hold: if a course is explicitly set, navigate along that bearing (ground track)
-	if (PX4_ISFINITE(pos_sp_curr.course)
-	    && _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_GUIDED_COURSE) {
+	if (PX4_ISFINITE(pos_sp_curr.course)) {
 		const float target_airspeed = pos_sp_curr.cruising_speed > FLT_EPSILON ? pos_sp_curr.cruising_speed : NAN;
 
 		const Vector2f curr_pos_local{_local_pos.x, _local_pos.y};

--- a/src/modules/mavlink/streams/GPS_RAW_INT.hpp
+++ b/src/modules/mavlink/streams/GPS_RAW_INT.hpp
@@ -59,6 +59,7 @@ private:
 
 	uORB::Subscription _sensor_gps_sub{ORB_ID(sensor_gps), 0};
 	hrt_abstime _last_send_ts {};
+	bool _yaw_capable{false}; ///< a heading has been reported at least once
 	static constexpr hrt_abstime kNoGpsSendInterval {1_s};
 
 	bool send() override
@@ -97,6 +98,8 @@ private:
 			msg.vel_acc = gps.s_variance_m_s * 1e3f; // speed uncertainty in mm
 
 			if (PX4_ISFINITE(gps.heading)) {
+				_yaw_capable = true;
+
 				if (fabsf(gps.heading) < FLT_EPSILON) {
 					msg.yaw = 36000; // Use 36000 for north.
 
@@ -107,6 +110,11 @@ private:
 				if (PX4_ISFINITE(gps.heading_accuracy)) {
 					msg.hdg_acc = math::degrees(gps.heading_accuracy) * 1e5f; // Heading / track uncertainty in degE5
 				}
+
+			} else if (_yaw_capable) {
+				// 0 means the receiver never provides yaw, so a receiver that does has to
+				// report the samples it has no heading for as invalid instead
+				msg.yaw = UINT16_MAX;
 			}
 
 			mavlink_msg_gps_raw_int_send_struct(_mavlink->get_channel(), &msg);
@@ -121,6 +129,11 @@ private:
 			msg.vel = UINT16_MAX;
 			msg.cog = UINT16_MAX;
 			msg.satellites_visible = UINT8_MAX;
+
+			if (_yaw_capable) {
+				msg.yaw = UINT16_MAX;
+			}
+
 			mavlink_msg_gps_raw_int_send_struct(_mavlink->get_channel(), &msg);
 			_last_send_ts = now;
 

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -164,12 +164,14 @@ Loiter::reposition()
 		pos_sp_triplet->previous.lon = _navigator->get_global_position()->lon;
 		pos_sp_triplet->previous.alt = _navigator->get_global_position()->alt;
 		memcpy(&pos_sp_triplet->current, &rep->current, sizeof(rep->current));
-		pos_sp_triplet->current.course = NAN;
 		pos_sp_triplet->next.valid = false;
 
 		_navigator->set_position_setpoint_triplet_updated();
 
-		// mark this as done
-		memset(rep, 0, sizeof(*rep));
+		// mark this as done: reset instead of zeroing so unset fields (yaw, course)
+		// stay NaN when the triplet is repopulated by a partial reposition command
+		_navigator->reset_position_setpoint(rep->previous);
+		_navigator->reset_position_setpoint(rep->current);
+		_navigator->reset_position_setpoint(rep->next);
 	}
 }

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -620,6 +620,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 	sp->lon = item.lon;
 	sp->alt = get_absolute_altitude_for_item(item);
 	sp->yaw = item.yaw;
+	sp->course = NAN; // mission items never command a course, only Course mode sets it
 	sp->loiter_radius = (fabsf(item.loiter_radius) > FLT_EPSILON) ? fabsf(item.loiter_radius) :
 			    _navigator->get_default_loiter_rad();
 	sp->loiter_direction_counter_clockwise = item.loiter_radius < 0;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -163,6 +163,12 @@ void Navigator::run()
 
 	params_update();
 
+	// the reposition triplet is only partially populated by reposition commands,
+	// reset it so unset fields (yaw, course) are NaN instead of zero
+	reset_position_setpoint(_reposition_triplet.previous);
+	reset_position_setpoint(_reposition_triplet.current);
+	reset_position_setpoint(_reposition_triplet.next);
+
 	/* wakeup source(s) */
 	px4_pollfd_struct_t fds[3] {};
 

--- a/src/modules/sensors/data_validator/DataValidator.hpp
+++ b/src/modules/sensors/data_validator/DataValidator.hpp
@@ -154,6 +154,13 @@ public:
 	uint32_t get_timeout() const { return _timeout_interval; }
 
 	/**
+	 * Get the equal count threshold
+	 *
+	 * @return The number of equal values before considering the sensor stale
+	 */
+	uint32_t get_equal_value_threshold() const { return _value_equal_count_threshold; }
+
+	/**
 	 * Data validator error states
 	 */
 	static constexpr uint32_t ERROR_FLAG_NO_ERROR = (0x00000000U);

--- a/src/modules/sensors/data_validator/DataValidatorGroup.cpp
+++ b/src/modules/sensors/data_validator/DataValidatorGroup.cpp
@@ -103,6 +103,7 @@ DataValidator *DataValidatorGroup::add_new_validator()
 	}
 
 	_last->set_timeout(_timeout_interval_us);
+	_last->set_equal_value_threshold(_equal_value_threshold);
 	return _last;
 }
 
@@ -128,6 +129,8 @@ void DataValidatorGroup::set_equal_value_threshold(uint32_t threshold)
 		next->set_equal_value_threshold(threshold);
 		next = next->sibling();
 	}
+
+	_equal_value_threshold = threshold;
 }
 
 void DataValidatorGroup::put(unsigned index, uint64_t timestamp, const float val[3], uint32_t error_count,

--- a/src/modules/sensors/data_validator/DataValidatorGroup.hpp
+++ b/src/modules/sensors/data_validator/DataValidatorGroup.hpp
@@ -136,6 +136,7 @@ private:
 	DataValidator *_last{nullptr};  /**< last node in the group */
 
 	uint32_t _timeout_interval_us{0}; /**< currently set timeout */
+	uint32_t _equal_value_threshold{100}; /**< currently set equal value threshold */
 
 	int _curr_best{-1}; /**< currently best index */
 	int _prev_best{-1}; /**< the previous best index */

--- a/src/modules/sensors/data_validator/tests/test_data_validator_group.cpp
+++ b/src/modules/sensors/data_validator/tests/test_data_validator_group.cpp
@@ -48,7 +48,7 @@
 
 
 const uint32_t base_timeout_usec = 2000;//from original private value
-const int equal_value_count = 100; //default is private VALUE_EQUAL_COUNT_DEFAULT
+const int equal_value_count = 1000; //default is private VALUE_EQUAL_COUNT_DEFAULT
 const uint64_t base_timestamp = 666;
 const unsigned base_num_siblings = 4;
 
@@ -74,8 +74,7 @@ DataValidatorGroup  *setup_base_group(unsigned *sibling_count)
 
 	//this sets the timeout on all current members of the group, as well as members added later
 	group->set_timeout(base_timeout_usec);
-	//the following sets the threshold on all CURRENT members of the group, but not any added later
-	//TODO This is likely a bug in DataValidatorGroup
+	//this sets the equal value threshold on all current members and members added later
 	group->set_equal_value_threshold(equal_value_count);
 
 	//return values
@@ -154,9 +153,8 @@ DataValidator *add_validator_to_group(DataValidatorGroup *group)
 	DataValidator *validator = group->add_new_validator();
 	//verify the previously set timeout applies to the new group member
 	assert(validator->get_timeout() == base_timeout_usec);
-	//for testing purposes, ensure this newly added member is consistent with the rest of the group
-	//TODO this is likely a bug in DataValidatorGroup
-	validator->set_equal_value_threshold(equal_value_count);
+	//verify the previously set equal value threshold applies to the new group member
+	assert(validator->get_equal_value_threshold() == equal_value_count);
 
 	return validator;
 }


### PR DESCRIPTION
## Summary
fixes #28207

Bundles the ten merged PRs carrying `status:needs-backport` that were missing from `release/1.18`, as requested in https://github.com/PX4/PX4-Autopilot/issues/28207#issuecomment-5247793825, so they go through CI in a single pass instead of as one-offs.

Backported PRs: #27942, #27807, #28047, #27998, #28099, #27822, #28095, #28115, #28096, #28178.

## Problem
Each of these fixes a defect present in `release/1.18`. The most consequential: external mode registration changes the *used* param count at runtime, shifting param indices mid-download and breaking QGC param sync (#28115); with multiple DroneCAN rangefinders only instance 0 receives its type, FOV and min/max distance, so the remaining instances feed wrong limits into EKF and collision prevention (#28047); magnetometer validators added after construction silently keep the default equal-value threshold instead of the configured one, causing premature stale-sensor detection and spurious failover (#27822); a stale or zero-initialised course leaks into published position setpoints outside Course mode (#27807); and an EKF position reset during auto takeoff leaves the takeoff lock at pre-reset coordinates (#27998).

The remainder are lower-severity but self-contained: a dual-antenna receiver reporting itself as not yaw-capable on any heading dropout (#28095), secondary GPS satellite info gated on the wrong advertise flag (#28096), a tramp VTX without temperature support failing `get_settings()` outright (#28178), a spurious arming-check failure when the flight-time-low action is disabled (#28099), and a "Preflight Fail" message shown when the mag strength check is configured as warning-only (#27942).

## Solution
Cherry-picked with `-x` in dependency order; every commit applied without conflict, so each is unmodified from `main`. #27807 carries both its fix and the companion revert that drops the now-redundant `GUIDED_COURSE` guard. From #27998 only the fix commit is taken — its sibling is a pure refactor that conflicts and is not needed for the fix.

No message definitions, submodules or board configs are touched, so there is no uORB ABI change on the release branch.

`px4_fmu-v6x_default` builds clean and `make check_format` passes. Flash goes *down* by 104 bytes against the branch point (1940480 → 1940376), with `.bss` and `.data` unchanged — worth noting given v6x sits at 98.7% flash, so this wave costs no headroom.
