### PR TITLE
ci(macos): enable --sim-tools in macOS build workflow

### DIFF
--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: setup
       run: |
-        ./Tools/setup/macos.sh
+        ./Tools/setup/macos.sh --sim-tools
         echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
 
     - uses: ./.github/actions/setup-ccache

--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
     - name: install Python 3.10
       uses: actions/setup-python@v6


### PR DESCRIPTION
Adds ```--sim-tools``` to macOS CI . 

@mrpollo FYI! 

<!--

### Solved Problem


### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
