### PR TITLE
fix(mavlink): declare INJECT_FAILURE param4 (instance bitmask) in command param validation

### DIFF
--- a/src/modules/mavlink/mavlink_command_params.hpp
+++ b/src/modules/mavlink/mavlink_command_params.hpp
@@ -108,7 +108,7 @@ static constexpr Entry SupportedCommandParams[] = {
 	{  214, 0x07, 0x07 }, // DO_SET_CAM_TRIGG_INTERVAL:  p1:cycle,p2:shutter,p3:camera_id
 	{  224, 0x00, 0x03 }, // DO_SET_MISSION_CURRENT:      cmd:p1:seq,p2:reset_jump_counters
 	{  400, 0x03, 0x03 }, // COMPONENT_ARM_DISARM:        p1:arm,p2:force
-	{  420, 0x07, 0x07 }, // INJECT_FAILURE:              p1:unit,p2:type,p3:instance
+	{  420, 0x0F, 0x0F }, // INJECT_FAILURE:              p1:unit,p2:type,p3:instance,p4:instance bitmask
 	{  530, 0x03, 0x03 }, // SET_CAMERA_MODE:             p1:camera_id,p2:mode
 	{  532, 0x07, 0x07 }, // SET_CAMERA_FOCUS:            p1:focus_type,p2:value,p3:camera_id
 	{  534, 0x07, 0x07 }, // SET_CAMERA_SOURCE:           p1:camera_id,p2:primary,p3:secondary


### PR DESCRIPTION
 ## Summary

  Declare param4 of `MAV_CMD_INJECT_FAILURE` in the command param validation table.

  ## Problem

  #27832 added an instance bitmask in param4, but the validation table (#27541) still only declares params 1–3. Undeclared params must arrive NaN/0.0, so multi-instance injections over MAVLink are DENIED at the receiver boundary — the `failure` console command (direct uORB) works, which hides the bug.

  ## Solution

  Extend the table entry for command 420 from `0x07` to `0x0F`.