### PR TITLE
feat(failure_injection): add failure strings for unit and type names

### DIFF
--- a/src/modules/failure_injection_manager/CMakeLists.txt
+++ b/src/modules/failure_injection_manager/CMakeLists.txt
@@ -37,6 +37,7 @@ px4_add_module(
 	SRCS
 		FailureInjectionManager.cpp
 		FailureInjectionManager.hpp
+		FailureStrings.hpp
 		FailureTable.cpp
 		FailureTable.hpp
 	MODULE_CONFIG

--- a/src/modules/failure_injection_manager/FailureInjectionManager.cpp
+++ b/src/modules/failure_injection_manager/FailureInjectionManager.cpp
@@ -32,6 +32,7 @@
  ****************************************************************************/
 
 #include "FailureInjectionManager.hpp"
+#include "FailureStrings.hpp"
 
 #include <cmath>
 
@@ -131,10 +132,19 @@ void FailureInjectionManager::evaluateRcInjection()
 			_rc_active_instance = static_cast<uint8_t>(_param_sys_fail_rc_inst.get());
 			_rc_active = true;
 
-			_table.inject(_rc_active_unit, static_cast<uint8_t>(_param_sys_fail_rc_mode.get()), _rc_active_instance);
+			const uint8_t type = static_cast<uint8_t>(_param_sys_fail_rc_mode.get());
+
+			if (_table.inject(_rc_active_unit, type, _rc_active_instance) == failure_injection::FailureTable::AckResult::Accepted) {
+				announceFailure(_rc_active_unit, type, failure_injection::FailureTable::instanceToMask(_rc_active_instance));
+			}
 
 		} else if (!triggered && _rc_active) {
-			_table.inject(_rc_active_unit, failure_injection_s::FAILURE_TYPE_OK, _rc_active_instance);
+			if (_table.inject(_rc_active_unit, failure_injection_s::FAILURE_TYPE_OK,
+					  _rc_active_instance) == failure_injection::FailureTable::AckResult::Accepted) {
+				announceFailure(_rc_active_unit, failure_injection_s::FAILURE_TYPE_OK,
+						failure_injection::FailureTable::instanceToMask(_rc_active_instance));
+			}
+
 			_rc_active = false;
 		}
 	}
@@ -145,14 +155,19 @@ void FailureInjectionManager::handleCommand(const vehicle_command_s &cmd)
 	const uint8_t unit = static_cast<uint8_t>(lroundf(cmd.param1));
 	const uint8_t type = static_cast<uint8_t>(lroundf(cmd.param2));
 
-	failure_injection::FailureTable::AckResult ack;
+	uint16_t mask;
 
 	if (PX4_ISFINITE(cmd.param3)) {
-		ack = _table.inject(unit, type, static_cast<uint8_t>(lroundf(cmd.param3)));
+		mask = failure_injection::FailureTable::instanceToMask(static_cast<uint8_t>(lroundf(cmd.param3)));
 
 	} else {
-		const uint16_t mask = PX4_ISFINITE(cmd.param4) ? static_cast<uint16_t>(lroundf(cmd.param4)) : 0;
-		ack = _table.injectMask(unit, type, mask);
+		mask = PX4_ISFINITE(cmd.param4) ? static_cast<uint16_t>(lroundf(cmd.param4)) : 0;
+	}
+
+	const failure_injection::FailureTable::AckResult ack = _table.injectMask(unit, type, mask);
+
+	if (ack == failure_injection::FailureTable::AckResult::Accepted && mask != 0) {
+		announceFailure(unit, type, mask);
 	}
 
 	uint8_t result;
@@ -173,6 +188,21 @@ void FailureInjectionManager::handleCommand(const vehicle_command_s &cmd)
 	}
 
 	publishAck(cmd, result);
+}
+
+void FailureInjectionManager::announceFailure(uint8_t unit, uint8_t type, uint16_t mask)
+{
+	char phrase[64];
+	failure_injection::instancePhrase(mask, phrase, sizeof(phrase));
+
+	if (type == failure_injection_s::FAILURE_TYPE_OK) {
+		mavlink_log_warning(&_mavlink_log_pub, "Cleared: %s, %s",
+				    failure_injection::unitName(unit), phrase);
+
+	} else {
+		mavlink_log_warning(&_mavlink_log_pub, "Injected: %s %s, %s",
+				    failure_injection::unitName(unit), failure_injection::typeName(type), phrase);
+	}
 }
 
 void FailureInjectionManager::publishAck(const vehicle_command_s &cmd, uint8_t result)

--- a/src/modules/failure_injection_manager/FailureInjectionManager.hpp
+++ b/src/modules/failure_injection_manager/FailureInjectionManager.hpp
@@ -48,6 +48,7 @@
 #include <px4_platform_common/module.h>
 #include <px4_platform_common/module_params.h>
 #include <px4_platform_common/px4_work_queue/WorkItem.hpp>
+#include <systemlib/mavlink_log.h>
 #include <uORB/Publication.hpp>
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/failure_injection.h>
@@ -79,6 +80,7 @@ private:
 
 	void handleCommand(const vehicle_command_s &cmd);
 	void publishAck(const vehicle_command_s &cmd, uint8_t result);
+	void announceFailure(uint8_t unit, uint8_t type, uint16_t mask);
 
 	void evaluateRcInjection();
 
@@ -89,6 +91,8 @@ private:
 	uORB::Publication<vehicle_command_ack_s> _command_ack_pub{ORB_ID(vehicle_command_ack)};
 
 	failure_injection::FailureTable _table;
+
+	orb_advert_t _mavlink_log_pub{nullptr};
 
 	bool    _rc_active{false};
 	uint8_t _rc_active_unit{0};

--- a/src/modules/failure_injection_manager/FailureInjectionManagerTest.cpp
+++ b/src/modules/failure_injection_manager/FailureInjectionManagerTest.cpp
@@ -34,6 +34,9 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
+
+#include "FailureStrings.hpp"
 #include "FailureTable.hpp"
 
 using namespace failure_injection;
@@ -234,4 +237,55 @@ TEST(FailureTable, InjectMaskUnsupportedIsRejected)
 	FailureTable table;
 	EXPECT_EQ(table.injectMask(GYRO, WRONG, 0x1), AckResult::Unsupported);
 	EXPECT_EQ(table.count(), 0);
+}
+
+TEST(FailureStrings, UnitAndTypeNames)
+{
+	EXPECT_STREQ(unitName(GYRO), "gyro");
+	EXPECT_STREQ(unitName(MOTOR), "motor");
+	EXPECT_STREQ(unitName(ESC), "esc");
+	EXPECT_STREQ(unitName(42), "unknown");
+
+	EXPECT_STREQ(typeName(OK), "ok");
+	EXPECT_STREQ(typeName(OFF), "off");
+	EXPECT_STREQ(typeName(STUCK), "stuck");
+	EXPECT_STREQ(typeName(0xFF), "unknown");
+}
+
+TEST(FailureStrings, InstancePhraseSingleInstance)
+{
+	char buf[64];
+	instancePhrase(0x0004, buf, sizeof(buf));
+	EXPECT_STREQ(buf, "instances 3");
+
+	instancePhrase(0x8000, buf, sizeof(buf));
+	EXPECT_STREQ(buf, "instances 16");
+}
+
+TEST(FailureStrings, InstancePhraseListsMultipleInstances)
+{
+	char buf[64];
+	instancePhrase(0x000B, buf, sizeof(buf)); // bits 0, 1, 3 -> instances 1, 2, 4
+	EXPECT_STREQ(buf, "instances 1,2,4");
+
+	instancePhrase(0x0003, buf, sizeof(buf));
+	EXPECT_STREQ(buf, "instances 1,2");
+}
+
+TEST(FailureStrings, InstancePhraseSpecialMasks)
+{
+	char buf[64];
+	instancePhrase(0xFFFF, buf, sizeof(buf));
+	EXPECT_STREQ(buf, "all instances");
+
+	instancePhrase(0, buf, sizeof(buf));
+	EXPECT_STREQ(buf, "no instances");
+}
+
+TEST(FailureStrings, InstancePhraseTruncatesSafely)
+{
+	char buf[8];
+	instancePhrase(0x7FFF, buf, sizeof(buf)); // needs far more than 8 bytes
+	EXPECT_EQ(buf[sizeof(buf) - 1], '\0');
+	EXPECT_LT(strlen(buf), sizeof(buf));
 }

--- a/src/modules/failure_injection_manager/FailureStrings.hpp
+++ b/src/modules/failure_injection_manager/FailureStrings.hpp
@@ -1,0 +1,152 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file FailureStrings.hpp
+ *
+ * Human-readable names for the failure injection announcement: failure unit
+ * and type names (matching the keys of the `failure` console command) and the
+ * instance-mask-to-phrase formatter. Header-only and free of the uORB runtime
+ * so it can be unit tested alongside FailureTable.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+#include <uORB/topics/failure_injection.h>
+
+namespace failure_injection
+{
+
+/** Name of a failure_injection_s::FAILURE_UNIT_* value, "unknown" if unmapped. */
+inline const char *unitName(uint8_t unit)
+{
+	// Same names as the `failure` console command keys, so the announcement
+	// matches what the operator typed.
+	switch (unit) {
+	case failure_injection_s::FAILURE_UNIT_SENSOR_GYRO: return "gyro";
+
+	case failure_injection_s::FAILURE_UNIT_SENSOR_ACCEL: return "accel";
+
+	case failure_injection_s::FAILURE_UNIT_SENSOR_MAG: return "mag";
+
+	case failure_injection_s::FAILURE_UNIT_SENSOR_BARO: return "baro";
+
+	case failure_injection_s::FAILURE_UNIT_SENSOR_GPS: return "gps";
+
+	case failure_injection_s::FAILURE_UNIT_SENSOR_OPTICAL_FLOW: return "optical_flow";
+
+	case failure_injection_s::FAILURE_UNIT_SENSOR_VIO: return "vio";
+
+	case failure_injection_s::FAILURE_UNIT_SENSOR_DISTANCE_SENSOR: return "distance_sensor";
+
+	case failure_injection_s::FAILURE_UNIT_SENSOR_AIRSPEED: return "airspeed";
+
+	case failure_injection_s::FAILURE_UNIT_SYSTEM_BATTERY: return "battery";
+
+	case failure_injection_s::FAILURE_UNIT_SYSTEM_MOTOR: return "motor";
+
+	case failure_injection_s::FAILURE_UNIT_SYSTEM_SERVO: return "servo";
+
+	case failure_injection_s::FAILURE_UNIT_SYSTEM_AVOIDANCE: return "avoidance";
+
+	case failure_injection_s::FAILURE_UNIT_SYSTEM_RC_SIGNAL: return "rc_signal";
+
+	case failure_injection_s::FAILURE_UNIT_SYSTEM_MAVLINK_SIGNAL: return "mavlink_signal";
+
+	case failure_injection_s::FAILURE_UNIT_SYSTEM_ESC: return "esc";
+
+	default: return "unknown";
+	}
+}
+
+/** Name of a failure_injection_s::FAILURE_TYPE_* value, "unknown" if unmapped. */
+inline const char *typeName(uint8_t type)
+{
+	switch (type) {
+	case failure_injection_s::FAILURE_TYPE_OK: return "ok";
+
+	case failure_injection_s::FAILURE_TYPE_OFF: return "off";
+
+	case failure_injection_s::FAILURE_TYPE_STUCK: return "stuck";
+
+	case failure_injection_s::FAILURE_TYPE_GARBAGE: return "garbage";
+
+	case failure_injection_s::FAILURE_TYPE_WRONG: return "wrong";
+
+	case failure_injection_s::FAILURE_TYPE_SLOW: return "slow";
+
+	case failure_injection_s::FAILURE_TYPE_DELAYED: return "delayed";
+
+	case failure_injection_s::FAILURE_TYPE_INTERMITTENT: return "intermittent";
+
+	default: return "unknown";
+	}
+}
+
+/**
+ * Format an instance mask (bit i = instance i+1) as a phrase:
+ * 0xFFFF -> "all instances", any other mask -> "instances 1,2,4",
+ * 0 -> "no instances".
+ */
+inline void instancePhrase(uint16_t mask, char *buf, size_t len)
+{
+	if (buf == nullptr || len == 0) {
+		return;
+	}
+
+	if (mask == 0) {
+		snprintf(buf, len, "no instances");
+		return;
+	}
+
+	if (mask == 0xFFFF) {
+		snprintf(buf, len, "all instances");
+		return;
+	}
+
+	size_t offset = snprintf(buf, len, "instances ");
+	bool first = true;
+
+	for (int bit = 0; bit < 16 && offset < len; bit++) {
+		if (mask & (1u << bit)) {
+			offset += snprintf(buf + offset, len - offset, first ? "%d" : ",%d", bit + 1);
+			first = false;
+		}
+	}
+}
+
+} // namespace failure_injection

--- a/src/modules/failure_injection_manager/FailureTable.hpp
+++ b/src/modules/failure_injection_manager/FailureTable.hpp
@@ -97,14 +97,15 @@ public:
 	/** Capability catalogue: which (unit, type) combinations the system supports. */
 	static bool isSupported(uint8_t unit, uint8_t type);
 
+	/** Instance addressing to mask: 0 -> all (0xFFFF), 1..16 -> its bit, >16 -> 0. */
+	static uint16_t instanceToMask(uint8_t instance);
+
 private:
 	struct Entry {
 		uint8_t  unit;
 		uint16_t instance_mask;
 		uint8_t  type;
 	};
-
-	static uint16_t instanceToMask(uint8_t instance);
 	int findEntry(uint8_t unit, uint8_t type) const;
 	void clearInstances(uint8_t unit, uint16_t mask, uint8_t keep_type);
 	void compact();


### PR DESCRIPTION
 ## Summary
Announce every accepted failure injection with its unit, type, and affected instances, e.g. `Injected: motor off, instances 1,3` / `Cleared: motor, all  instances`.

  ## Problem
Failure injections apply silently. During failure testing the operator has no confirmation on the GCS of what was injected, on which instances, or whether  a clear went through — especially opaque for RC-switch triggered injections and instance bitmasks.

  ## Solution

  The failure injection manager emits a `mavlink_log_warning` statustext for each accepted injection and clear, from all trigger paths (MAVLink command, `failure` console command, RC switch). A new header-only `FailureStrings.hpp` provides the unit/type names (matching the `failure` console keys) and  renders the instance bitmask as a readable list (`instances 1,2,4`, `all instances`), covered by unit tests.