### PR TITLE
fix(land_detector): gravity-compensate FW horizontal acceleration check

### DIFF
--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -41,6 +41,8 @@
 
 #include "FixedwingLandDetector.h"
 
+#include <lib/geo/geo.h>
+
 namespace land_detector
 {
 
@@ -121,10 +123,19 @@ bool FixedwingLandDetector::_get_landed_state()
 			_airspeed_filtered = 0.95f * _airspeed_filtered + 0.05f * airspeed_validated.true_airspeed_m_s;
 		}
 
-		// A leaking lowpass prevents biases from building up, but
-		// gives a mostly correct response for short impulses.
-		const float acc_hor = matrix::Vector2f(_acceleration).norm();
-		_xy_accel_filtered = _xy_accel_filtered * 0.8f + acc_hor * 0.18f;
+		// rotate the body-frame specific force to the earth frame and add gravity back,
+		// such that a stationary vehicle measures ~0 at any attitude.
+		vehicle_attitude_s vehicle_attitude;
+
+		if (_vehicle_attitude_sub.copy(&vehicle_attitude)) {
+			const matrix::Vector3f accel_earth = matrix::Quatf(vehicle_attitude.q).rotateVector(_acceleration)
+							     + matrix::Vector3f(0.f, 0.f, CONSTANTS_ONE_G);
+			const float acc_hor = matrix::Vector2f(accel_earth.xy()).norm();
+
+			// A leaking lowpass prevents biases from building up, but
+			// gives a mostly correct response for short impulses.
+			_xy_accel_filtered = _xy_accel_filtered * 0.8f + acc_hor * 0.18f;
+		}
 
 		// Check for angular velocity
 		const float rot_vel_hor = _angular_velocity.norm();

--- a/src/modules/land_detector/FixedwingLandDetector.h
+++ b/src/modules/land_detector/FixedwingLandDetector.h
@@ -46,6 +46,7 @@
 #include <uORB/topics/airspeed_validated.h>
 #include <uORB/topics/fixed_wing_runway_control.h>
 #include <uORB/topics/launch_detection_status.h>
+#include <uORB/topics/vehicle_attitude.h>
 
 #include "LandDetector.h"
 
@@ -68,6 +69,7 @@ private:
 	uORB::Subscription _airspeed_validated_sub{ORB_ID(airspeed_validated)};
 	uORB::Subscription _launch_detection_status_sub{ORB_ID(launch_detection_status)};
 	uORB::Subscription _fixed_wing_runway_control_sub{ORB_ID(fixed_wing_runway_control)};
+	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 
 	float _airspeed_filtered{0.0f};
 	float _velocity_xy_filtered{0.0f};

--- a/src/modules/land_detector/land_detector_params_fw.yaml
+++ b/src/modules/land_detector/land_detector_params_fw.yaml
@@ -28,8 +28,8 @@ parameters:
     LNDFW_XYACC_MAX:
       description:
         short: 'Fixed-wing land detector: Max horizontal acceleration'
-        long: Maximum horizontal (x,y body axes) acceleration allowed in the landed
-          state
+        long: Maximum gravity-compensated horizontal (earth frame) acceleration allowed
+          in the landed state.
       type: float
       default: 8.0
       unit: m/s^2


### PR DESCRIPTION
### Solved Problem
The fixed-wing land detector's horizontal acceleration check (`LNDFW_XYACC_MAX`) uses the norm of the body-frame XY specific force. At non-level attitudes gravity leaks into the body XY axes, so takeoff can be detected (`=!_landed`) even when completely stationary.  

### Solution
Rotate the measured specific force into the earth frame using the attitude estimate and add gravity back, so a stationary vehicle measures ~0 horizontal acceleration at any attitude. 

### Changelog Entry
For release notes:
```
Feature/Bugfix fixed-wing land detector acceleration check is now gravity-compensated (earth-frame), removing attitude-dependent bias
```

### Test coverage

