### PR TITLE
fix(mavftp): initialize burst_complete to false

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -1079,6 +1079,7 @@ void MavlinkFTP::send()
 		payload->opcode = kRspAck;
 		payload->req_opcode = kCmdBurstReadFile;
 		payload->offset = _session_info.stream_offset;
+		payload->burst_complete = false;
 		_session_info.stream_seq_number++;
 
 		PX4_DEBUG("stream send: offset %" PRIu32, _session_info.stream_offset);
@@ -1137,7 +1138,6 @@ void MavlinkFTP::send()
 
 			} else {
 				more_data = true;
-				payload->burst_complete = false;
 				max_bytes_to_send -= get_size();
 			}
 		}


### PR DESCRIPTION
### Solved Problem

`payload->burst_complete` was only explicitly set to `false` inside the `more_data = true` branch of `MavlinkFTP::send()`. In the error path and in the bandwidth-limited-but-not-chunk-complete path, the field was left uninitialized (stack garbage), so a burst packet could spuriously signal `burst_complete = 1` to the GCS.

### Solution

Move `payload->burst_complete = false` to the top-level payload initialization block alongside the other header fields (`opcode`, `req_opcode`, `offset`, etc.), so it is unconditionally set to `false` for every outgoing burst packet. The only place it is set to `true` remains the intentional 35 K chunk-boundary path.

### Changelog Entry
For release notes:
Bugfix: MAVLink FTP burst download: fix uninitialized burst_complete field causing spurious transfer interruptions


### Alternatives

Zero-initializing the entire `mavlink_file_transfer_protocol_t ftp_msg` struct at declaration (`ftp_msg{}`) would also fix this, but has a measurable performance cost in the hot send path and was rejected.

### Test coverage

Covered by the existing MAVLink FTP unit tests. 

### Context

The bug could cause a GCS to stop a burst transfer early (treating a non-final packet as the last in a burst) when the `burst_complete` byte happened to be non-zero on the stack.