### PR TITLE
docs(voxl2): fix spelling typo initalize -> initialize in README

### DIFF
--- a/boards/modalai/voxl2/README.md
+++ b/boards/modalai/voxl2/README.md
@@ -83,7 +83,7 @@ ______  __   __    ___
 px4 starting.
 
 INFO  [px4] Calling startup script: /bin/sh /etc/modalai/voxl-px4.config 0
-INFO  [muorb] muorb protobuf initalize method succeeded
+INFO  [muorb] muorb protobuf initialize method succeeded
 INFO  [px4] Startup script returned successfully
 pxh>
 ```


### PR DESCRIPTION
Fixes a minor spelling typo in `boards/modalai/voxl2/README.md`, correcting `initalize` to `initialize` in the sample startup log output. Closes #28215.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._