### PR TITLE
fix(dshot): resynchronise serial ESC telemetry to its request

### DIFF
--- a/src/drivers/dshot/DShotTelemetry.cpp
+++ b/src/drivers/dshot/DShotTelemetry.cpp
@@ -45,6 +45,11 @@ using namespace time_literals;
 
 #define DSHOT_TELEMETRY_UART_BAUDRATE 115200
 
+// How long an ESC gets to deliver its 10-byte response before we give up on it and poll the next motor.
+// Generous on purpose: an ESC busy commutating can be slow to answer, and abandoning a response that is
+// still on its way costs a full round-robin pass of telemetry rather than a single frame.
+static constexpr hrt_abstime TELEMETRY_RESPONSE_TIMEOUT = 30_ms;
+
 DShotTelemetry::~DShotTelemetry()
 {
 	_uart.close();
@@ -203,7 +208,7 @@ TelemetryStatus DShotTelemetry::parseTelemetryPacket(EscData *esc_data)
 	int bytes = _uart.read(buf, sizeof(buf));
 
 	if (bytes <= 0) {
-		if (elapsed > 5_ms) {
+		if (elapsed > TELEMETRY_RESPONSE_TIMEOUT) {
 			++_num_timeouts;
 
 			// Mark telemetry request as finished
@@ -291,6 +296,10 @@ bool DShotTelemetry::commandResponseStarted()
 
 void DShotTelemetry::startTelemetryRequest()
 {
+	// Discard whatever is still buffered before asking the next ESC. Responses are matched to a motor by
+	// which request was outstanding, not by anything in the frame, so a late response left in the RX FIFO
+	// would decode cleanly as the next motor's and offset every reading by one ESC from then on.
+	_uart.flush();
 	_frame_position = 0;
 	_telemetry_request_start = hrt_absolute_time();
 }


### PR DESCRIPTION
## Summary

Serial ESC telemetry can end up permanently attributed to the wrong motor. Flushing the RX buffer when a telemetry request is started fixes it; the response timeout goes back to the 30 ms it was before the driver rework, which is what stops the misattribution from being provoked in the first place.

## Problem

A serial telemetry response is matched to a motor by which request was outstanding when it was decoded, not by anything in the frame. `startTelemetryRequest()` reset only `_frame_position`, the driver-side byte counter — nothing discarded bytes already sitting in the UART. So a response that arrived after its own request had timed out stayed in the RX FIFO and was decoded as the *next* motor's response: an intact frame with a valid CRC, simply credited to the wrong ESC.

The offset is self-sustaining. From then on every request finds a complete frame already buffered, decodes it immediately, and therefore never times out again to fall back into step — every ESC reading stays shifted by one motor until something else resets the stream.

`parseTelemetryPacket()` gives an ESC 800 µs to 5 ms to answer. That is short enough that a busy ESC regularly misses it, which is what generates the late responses. Before the driver rework the timeout was 30 ms and this was correspondingly rare.

On a multirotor the symptom hides well: the motors report similar voltage, current and temperature, so a one-motor shift is close to invisible in those fields. RPM is the field that differs per motor, so it shows up on any setup that spins one motor at a time — that motor reads **0 rpm while its voltage and temperature look perfectly healthy**.

Measured on a 4-in-1 AM32 ESC production test fixture (four ESCs on one shared telemetry wire and one supply rail, motors spun one at a time), across 9,172 motor spins on five benches: spins reporting 0 rpm with valid voltage went from **1.9% on v1.17.0 to 14.1% on v1.18.0-beta1**. Within a run the failure is all-or-nothing — all four motors reporting zero occurs **270× more often than independent per-spin failure would produce**, which is the signature of a stream that is offset for the whole run rather than of intermittent dropouts. In those spins the ESC reported a normal 47.4 V and the vehicle's own shunt read a normal 5.5 A, so the motors were genuinely spinning.

## Solution

`_uart.flush()` in `startTelemetryRequest()`, so a response can only ever be attributed to the motor it was asked of. Nothing writes to this UART, so there is no pending TX to lose.

Restore the 30 ms response timeout, named rather than inline. Giving up early costs a whole round-robin pass rather than a single frame, and `_serial_telem_skip_mask` already bounds what a genuinely dead ESC costs.
