### PR TITLE
fix(dshot): resynchronise serial ESC telemetry to its request

### DIFF
--- a/src/drivers/dshot/DShotTelemetry.cpp
+++ b/src/drivers/dshot/DShotTelemetry.cpp
@@ -45,6 +45,11 @@ using namespace time_literals;
 
 #define DSHOT_TELEMETRY_UART_BAUDRATE 115200
 
+// How long an ESC gets to deliver its 10-byte response before we give up on it and poll the next motor.
+// Generous on purpose: an ESC busy commutating can be slow to answer, and abandoning a response that is
+// still on its way costs a full round-robin pass of telemetry rather than a single frame.
+static constexpr hrt_abstime TELEMETRY_RESPONSE_TIMEOUT = 30_ms;
+
 DShotTelemetry::~DShotTelemetry()
 {
 	_uart.close();
@@ -203,7 +208,7 @@ TelemetryStatus DShotTelemetry::parseTelemetryPacket(EscData *esc_data)
 	int bytes = _uart.read(buf, sizeof(buf));
 
 	if (bytes <= 0) {
-		if (elapsed > 5_ms) {
+		if (elapsed > TELEMETRY_RESPONSE_TIMEOUT) {
 			++_num_timeouts;
 
 			// Mark telemetry request as finished
@@ -291,6 +296,10 @@ bool DShotTelemetry::commandResponseStarted()
 
 void DShotTelemetry::startTelemetryRequest()
 {
+	// Discard whatever is still buffered before asking the next ESC. Responses are matched to a motor by
+	// which request was outstanding, not by anything in the frame, so a late response left in the RX FIFO
+	// would decode cleanly as the next motor's and offset every reading by one ESC from then on.
+	_uart.flush();
 	_frame_position = 0;
 	_telemetry_request_start = hrt_absolute_time();
 }


### PR DESCRIPTION
## Summary

Backport of #28222 to `release/1.18`. Cherry-pick, no conflicts and no changes from the original.

## Problem

Serial ESC telemetry can end up permanently attributed to the wrong motor: a response arriving after its request timed out stays in the RX FIFO and is decoded as the next motor's, and the resulting one-ESC offset is self-sustaining. See #28222 for the full account.

This first shipped in 1.18 (the driver rework in f00e46f618 replaced the 30 ms response timeout and the pre-read `bytesAvailable()` check with an 800 µs–5 ms window), so 1.18 is the release that needs it. Measured on a 4-in-1 AM32 production fixture: spins reporting 0 rpm with valid voltage went from 1.9% on v1.17.0 to 14.1% on v1.18.0-beta1.

## Solution

`_uart.flush()` when a telemetry request is started, so a response can only be attributed to the motor it was asked of, and the response timeout restored to 30 ms.
