### PR TITLE
feat(mavlink): AVAILABLE_MODES.seq added

### DIFF
--- a/src/modules/mavlink/streams/AVAILABLE_MODES.hpp
+++ b/src/modules/mavlink/streams/AVAILABLE_MODES.hpp
@@ -93,6 +93,7 @@ private:
 		mavlink_available_modes_t available_modes{};
 		available_modes.mode_index = mode_index;
 		available_modes.number_modes = total_num_modes;
+		available_modes.seq = _dynamic_update_seq;
 		px4_custom_mode custom_mode{get_px4_custom_mode(nav_state)};
 		available_modes.custom_mode = custom_mode.data;
 		const bool cannot_be_selected = (vehicle_status.can_set_nav_states_mask & (1u << nav_state)) == 0;


### PR DESCRIPTION
`AVAILABLE_MODES.seq` was added in https://github.com/mavlink/mavlink/pull/2557 , allowing a GCS to always know what set of modes it has. This fixes and edge case where a GCS has to download modes twice because it doesn't know what the sequence number is first time that it downloads them.

The code change is trivial - both mode messages are sent from the same method, so we have access to this counter and just use it to set the seq.

When this goes in, 
- update the MAVLink docs, https://github.com/mavlink/mavlink-devguide/pull/739
- add issue for QGC to have option to use it. https://github.com/mavlink/qgroundcontrol/issues/14856