### PR TITLE
fix(commander): don't report pre-flight failures or sensor bias during calibration

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -527,6 +527,11 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 
 void EstimatorChecks::checkSensorBias(const Context &context, Report &reporter, NavModes required_groups)
 {
+	// Skip the check to avoid warnings during calibration
+	if (context.status().calibration_enabled) {
+		return;
+	}
+
 	// _estimator_sensor_bias_sub instance got changed above already
 	estimator_sensor_bias_s bias;
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -144,7 +144,10 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 				reporter.failsafeFlags().mode_req_local_position_relaxed |
 				(1u << vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF));
 
-	if (!context.isArmed() && estimator_status.pre_flt_fail_innov_heading) {
+	// Skip the checks to avoid warnings during calibration (they recover once the vehicle is still again)
+	const bool report_innovation_failures = !context.isArmed() && !context.status().calibration_enabled;
+
+	if (report_innovation_failures && estimator_status.pre_flt_fail_innov_heading) {
 		/* EVENT
 		 * @description
 		 * Recalibrate compass or perform manual heading reset.
@@ -157,7 +160,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: heading estimate invalid");
 		}
 
-	} else if (!context.isArmed() && estimator_status.pre_flt_fail_innov_vel_horiz) {
+	} else if (report_innovation_failures && estimator_status.pre_flt_fail_innov_vel_horiz) {
 		/* EVENT
 		 */
 		reporter.armingCheckFailure(required_groups, health_component_t::local_position_estimate,
@@ -168,7 +171,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: horizontal velocity unstable");
 		}
 
-	} else if (!context.isArmed() && estimator_status.pre_flt_fail_innov_vel_vert) {
+	} else if (report_innovation_failures && estimator_status.pre_flt_fail_innov_vel_vert) {
 		/* EVENT
 		 */
 		reporter.armingCheckFailure(required_groups, health_component_t::local_position_estimate,
@@ -179,7 +182,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: vertical velocity unstable");
 		}
 
-	} else if (!context.isArmed() && estimator_status.pre_flt_fail_innov_pos_horiz) {
+	} else if (report_innovation_failures && estimator_status.pre_flt_fail_innov_pos_horiz) {
 		/* EVENT
 		 */
 		reporter.armingCheckFailure(required_groups, health_component_t::local_position_estimate,
@@ -190,7 +193,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: horizontal position unstable");
 		}
 
-	} else if (!context.isArmed() && estimator_status.pre_flt_fail_innov_height) {
+	} else if (report_innovation_failures && estimator_status.pre_flt_fail_innov_height) {
 		/* EVENT
 		 */
 		reporter.armingCheckFailure(required_groups, health_component_t::local_position_estimate,


### PR DESCRIPTION
### Solved Problem

Accel and compass calibration require moving the vehicle through different orientations, which triggers estimator preflight
warnings ("High Accelerometer Bias", "Heading estimate invalid", ...) while the user is just following the calibration instructions. 

### Solution

Suppress them while a calibration is running. 
- skip the accel/gyro bias check entirely. EKF2 resets the learned biases once the new calibration is applied
- skip the reporting of the five innovation preflight failures

### Changelog Entry
For release notes:
```
Feature/Bugfix fixed "High Accelerometer Bias" and estimator instability warnings appearing while moving the vehicle during accelerometer and compass calibration.
```

### Alternatives

Second commit IMO is optional but doesn't hurt. I think first commit is required. 


