### PR TITLE
fix(nuttx/SerialImpl.cpp): Fix printf modifier for 64-bit targets

### DIFF
--- a/platforms/nuttx/src/px4/common/SerialImpl.cpp
+++ b/platforms/nuttx/src/px4/common/SerialImpl.cpp
@@ -129,11 +129,7 @@ bool SerialImpl::configure()
 
 	default:
 		speed = _baudrate;
-#ifdef CONFIG_ARCH_CHIP_ESP32
-		PX4_WARN("Using non-standard baudrate: %u", _baudrate);
-#else
-		PX4_WARN("Using non-standard baudrate: %lu", _baudrate);
-#endif
+		PX4_WARN("Using non-standard baudrate: %" PRIu32, _baudrate);
 		break;
 	}
 


### PR DESCRIPTION
### Solved Problem

SerialImpl.cpp has a wrong printf modifier for uint32_t 64-bit targets.

### Solution

This has been previously fixed separately for ESP32. Instead, use PRIu32 for uint32_t to support compilation for all NuttX targets.
