### PR TITLE
fix(logger): Fix log_writer_file compilation on some platforms

### DIFF
--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -243,7 +243,7 @@ bool LogWriterFile::start_log(LogType type, const char *filename)
 
 int LogWriterFile::hardfault_store_filename(const char *log_file)
 {
-#if defined(__PX4_NUTTX) && defined(px4_savepanic)
+#if defined(__PX4_NUTTX) && defined(px4_savepanic) && defined(HARDFAULT_ULOG_PATH)
 	int fd = open(HARDFAULT_ULOG_PATH, O_TRUNC | O_WRONLY | O_CREAT);
 
 	if (fd < 0) {
@@ -662,7 +662,7 @@ bool LogWriterFile::LogFileBuffer::start_log(const char *filename)
 						    (ssize_t)_buffer_size_min);
 
 		if ((reduced_buffer_size > 0) && ((ssize_t)_buffer_size > reduced_buffer_size)) {
-			PX4_WARN("requested buffer size %dB limited to available %dB (available plus 1 kB margin)",
+			PX4_WARN("requested buffer size %zuB limited to available %zdB (available plus 1 kB margin)",
 				 _buffer_size, reduced_buffer_size);
 
 			_buffer_size = reduced_buffer_size;


### PR DESCRIPTION
### Solved Problem
log_writer_file doesn't compile for 64-bit targets.

### Solution
Fix the two issues:
- HARDFAULT_ULOG_PATH is not necessarily defined for all the targets which have px4_savepanic defined. Check it.
- %d formatter only works for size_t for 32-bit targets. Use %zu instead, which should work for all.
