### PR TITLE
fix(FlightTaskManualAltitude): Always invalidate stored distance when exiting terrain hold

### DIFF
--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -64,6 +64,8 @@ bool FlightTaskManualAltitude::activate(const trajectory_setpoint_s &last_setpoi
 	_acceleration_setpoint = Vector3f(0.f, 0.f, NAN); // altitude is controlled from position/velocity
 	_position_setpoint(2) = _position(2);
 	_velocity_setpoint(2) = 0.f;
+	_terrain_hold = false;
+	_dist_to_ground_lock = NAN;
 	_stick_yaw.reset(_yaw, _unaided_yaw);
 	_setDefaultConstraints();
 

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -132,8 +132,9 @@ void FlightTaskManualAltitude::_updateAltitudeLock()
 
 				} else {
 					_position_setpoint(2) = _position(2);
-					_dist_to_ground_lock = NAN;
 				}
+
+				_dist_to_ground_lock = NAN;
 			}
 
 		} else {


### PR DESCRIPTION
### Problem

When terrain hold disengages due to horizontal stick input, `_dist_to_ground_lock` currently keeps its last value. If terrain hold then re-engages while the altitude sp is NaN (vertical velocity control) the vehicle flies back to the old height above ground.

### Solution

Always invalidate `_dist_to_ground_lock` when exiting terrain hold.

Related fix (claude found when reviewing the first): 10584a9fae968849ad454d14cb821fdba2091d5 - reset terrain hold state in `activate()` to avoid flying to completely stale altitudes after switching to external mode and back. Can put in separate PR if preferred. 

### Testing

Reproduce the failure / verify the fix:
 - `make px4_sitl gz_x500_lidar_down` with default params, particularly `MPC_ALT_MODE=2`
 - Take off in position mode, hover at low altitude to lock
 - Give horizontal stick input to disengage terrain hold
 - Give throttle up to ascend
 - Stop giving horizontal stick input
 - Release throttle at higher altitude

[Result before](https://review.px4.io/plot_app?log=3b09ed81-d0a2-4ad3-803c-895f458b0947): Vehicle descends down to initial altitude

<img width="1247" height="1136" alt="image" src="https://github.com/user-attachments/assets/3815fb5c-5754-4105-bd67-0d4cbd8b2b6d" />


[Result after](https://review.px4.io/plot_app?log=e1f274c5-327f-45e9-9af2-51a0c73e8d01): Vehicle stays at altitude where throttle was released + braking distance

<img width="1247" height="1136" alt="image" src="https://github.com/user-attachments/assets/355cf36f-8e1b-4a6b-9506-04910574cfc5" />



### Changelog Entry
For release notes:
```
Fix: Always invalidate stored distance when exiting terrain hold to avoid flying to stale altitude
```
