### PR TITLE
fix(SerialImpl): set necessary serial flag on posix/linux platform

### DIFF
--- a/platforms/posix/src/px4/common/SerialImpl.cpp
+++ b/platforms/posix/src/px4/common/SerialImpl.cpp
@@ -170,7 +170,7 @@ bool SerialImpl::configure()
 	uart_config.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
 
 	// Control modes
-	uart_config.c_cflag = 0;
+	uart_config.c_cflag = CREAD | CLOCAL;
 
 	switch (_bytesize) {
 	case ByteSize::FiveBits:  uart_config.c_cflag |= CS5; break;


### PR DESCRIPTION

### Solved Problem

On POSIX/Linux, the common `SerialImpl::configure()` implementation clears the termios `c_cflag` while rebuilding the serial configuration, but does not restore `CREAD` or `CLOCAL`:

```cpp
uart_config.c_cflag = 0;
```

introduced by commit: 17f3db9231

As a result, drivers using the common `device::Serial` implementation can successfully open the port, configure its baud rate, and transmit data, but cannot read received serial data.

### Problem Behavior

An u-blox GPS was started on a Linux target with:

```sh
gps start -d /dev/ttyS1 -b 115200 -p ubx
```

The GPS driver started but never completed receiver configuration:

```text
protocol: UBX
status: NOT OK, port: /dev/ttyS1, baudrate: 115200
rate reading: 0 B/s
sensor_gps: never published
```

At the same time, the Linux serial driver RX counter continued to increase:

```text
1: uart:16550A mmio:0xFF0B0000 irq:46 tx:8692 rx:154634
```

After stopping the PX4 GPS driver and reading `/dev/ttyS1` directly, valid u-blox `UBX-NAV-PVT` frames were received at 115200 baud:

```text
b5 62 01 07 5c 00 ...
```

The effective termios state while the GPS driver was running was:

```text
speed 115200 baud
-parenb -parodd cs8 -cstopb -cread -clocal -crtscts
```

The critical flag is:

```text
-cread
```

`CREAD` enables the serial receiver. The Linux UART driver may still account for received characters at the hardware/kernel level, but without `CREAD` those characters are not delivered to userspace reads.

### Solution
Initialize the rebuilt `c_cflag` with receiver and local-port operation enabled:

```cpp
uart_config.c_cflag = CREAD | CLOCAL;
```

After the fix, the effective termios state became:

```text
speed 115200 baud
-parenb -parodd cs8 -cstopb cread clocal -crtscts
```

Using the same GPS module and wiring, the PX4 GPS driver successfully configured the u-blox receiver and continuously received data:

```text
protocol: UBX
status: OK, port: /dev/ttyS1, baudrate: 115200
rate reading:      1259 B/s
rate position:     7.99 Hz
rate velocity:     7.99 Hz
rate publication:  7.09 Hz
```

The `sensor_gps` topic was then published continuously. During the indoor test, `fix_type=0` and `satellites_used=0` only indicated that no satellite fix was available; this was unrelated to serial communication.




