### PR TITLE
fix(mavlink): NACK MAV_CMD DO_FIGURE_EIGHT and NAV_VTOL_TAKEOFF

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -919,12 +919,6 @@ Commander::handle_command(const vehicle_command_s &cmd)
 		}
 		break;
 
-	case vehicle_command_s::VEHICLE_CMD_GUIDED_CHANGE_HEADING: {
-			// Navigator handles this command: it acks ACCEPTED when
-			// the vehicle is in course mode with a valid position, DENIED otherwise.
-		}
-		break;
-
 	case vehicle_command_s::VEHICLE_CMD_DO_SET_MODE: {
 			uint8_t base_mode = (uint8_t)cmd.param1;
 			uint8_t custom_main_mode = (uint8_t)cmd.param2;
@@ -1679,6 +1673,9 @@ Commander::handle_command(const vehicle_command_s &cmd)
 
 		return true;
 
+	// VEHICLE_CMD_GUIDED_CHANGE_HEADING is handled by navigator: it acks ACCEPTED when
+	// the vehicle is in course mode with a valid position, DENIED otherwise.
+	case vehicle_command_s::VEHICLE_CMD_GUIDED_CHANGE_HEADING:
 	case vehicle_command_s::VEHICLE_CMD_START_RX_PAIR:
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_0:
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_1:

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1673,9 +1673,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 
 		return true;
 
-	// VEHICLE_CMD_GUIDED_CHANGE_HEADING is handled by navigator: it acks ACCEPTED when
-	// the vehicle is in course mode with a valid position, DENIED otherwise.
-	case vehicle_command_s::VEHICLE_CMD_GUIDED_CHANGE_HEADING:
+	case vehicle_command_s::VEHICLE_CMD_GUIDED_CHANGE_HEADING: // Handled by navigator
 	case vehicle_command_s::VEHICLE_CMD_START_RX_PAIR:
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_0:
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_1:

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -859,7 +859,10 @@ Commander::handle_command(const vehicle_command_s &cmd)
 		return false;
 	}
 
-	/* result of the command */
+	/* result of the command, sent via answer_command() once after the switch below.
+	 * Cases that answer_command() themselves (e.g. because they must reply before an
+	 * irreversible action, or because another module owns the reply) must `return true;`
+	 * instead of `break;`, so they are not answered a second time here. */
 	unsigned cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;
 
 	/* request to set different system mode */
@@ -1425,7 +1428,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 			}
 		}
 
-		break;
+		return true;
 
 	case vehicle_command_s::VEHICLE_CMD_PREFLIGHT_CALIBRATION: {
 
@@ -1453,7 +1456,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 					   (int)(cmd.param5) == vehicle_command_s::PREFLIGHT_CALIBRATION_TEMPERATURE_CALIBRATION ||
 					   (int)(cmd.param7) == vehicle_command_s::PREFLIGHT_CALIBRATION_TEMPERATURE_CALIBRATION) {
 					/* temperature calibration: handled in events module */
-					break;
+					return true;
 
 				} else if ((int)(cmd.param2) == 1) {
 					/* magnetometer calibration */
@@ -1544,7 +1547,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 				}
 			}
 
-			break;
+			return true;
 		}
 
 	case vehicle_command_s::VEHICLE_CMD_FIXED_MAG_CAL_YAW: {
@@ -1586,7 +1589,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 				_worker_thread.startTask(WorkerThread::Request::MagCalibrationQuick);
 			}
 
-			break;
+			return true;
 		}
 
 	case vehicle_command_s::VEHICLE_CMD_PREFLIGHT_STORAGE: {
@@ -1620,7 +1623,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 				}
 			}
 
-			break;
+			return true;
 		}
 
 	case vehicle_command_s::VEHICLE_CMD_DO_SET_STANDARD_MODE: {
@@ -1640,16 +1643,17 @@ Commander::handle_command(const vehicle_command_s &cmd)
 				}
 			}
 		}
-		break;
+
+		return true;
 
 	case vehicle_command_s::VEHICLE_CMD_RUN_PREARM_CHECKS:
 		_health_and_arming_checks.update(true);
 		answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED);
-		break;
+		return true;
 
 	case vehicle_command_s::VEHICLE_CMD_DO_SET_ACTUATOR:
 		answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED);
-		break;
+		return true;
 
 	case vehicle_command_s::VEHICLE_CMD_DO_SET_SAFETY_SWITCH_STATE: {
 			// reject if armed, only allow pre or post flight for safety
@@ -1672,7 +1676,8 @@ Commander::handle_command(const vehicle_command_s &cmd)
 				}
 			}
 		}
-		break;
+
+		return true;
 
 	case vehicle_command_s::VEHICLE_CMD_START_RX_PAIR:
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_0:
@@ -1722,21 +1727,17 @@ Commander::handle_command(const vehicle_command_s &cmd)
 	case vehicle_command_s::VEHICLE_CMD_DO_AUTOTUNE_ENABLE:
 	case vehicle_command_s::VEHICLE_CMD_ESTIMATOR_SENSOR_ENABLE:
 	case vehicle_command_s::VEHICLE_CMD_ACTUATOR_GROUP_TEST:
-		/* ignore commands that are handled by other parts of the system */
-		break;
+		/* ignore commands that are handled by other parts of the system: no reply from here */
+		return true;
 
 	default:
-		/* Warn about unsupported commands, this makes sense because only commands
+		/* Command not handled above: reply UNSUPPORTED. This makes sense because only commands
 		 * to this component ID (or all) are passed by mavlink. */
-		answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED);
+		cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;
 		break;
 	}
 
-	if (cmd_result != vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED) {
-		/* already warned about unsupported commands in "default" case */
-		answer_command(cmd, cmd_result);
-	}
-
+	answer_command(cmd, cmd_result);
 	return true;
 }
 


### PR DESCRIPTION
`MAV_CMD_DO_FIGURE_EIGHT` and `MAV_CMD_NAV_VTOL_TAKEOFF` were not providing a NACK in some cases.

Claude provides a good walkthrough below, but it comes down to the code assuming commands that are not supported have all fallen through to `default` which already NACKs. The handler only then NACKs commands that are supported.
This breaks if other code sets that the command is not supported (which it does in some cases where figure8 isn't supported, such as VTO.

The fix adds a boolean to decide whether a NACK has been sent already. Tested before and after.

<details>

The old logic (buggy)

```cpp
  unsigned cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;  // default
  switch (cmd.command) {
      ... // dozens of cases set cmd_result to ACCEPTED/DENIED/TEMPORARILY_REJECTED/FAILED/UNSUPPORTED
      default:
          answer_command(cmd, UNSUPPORTED);  // self-acks
          break;
  }
  if (cmd_result != UNSUPPORTED) {
      answer_command(cmd, cmd_result);       // fires for everything EXCEPT result==UNSUPPORTED
  }
```

  The post-switch line is trying to express "if this command wasn't handled by default:, send its ACK now." But
  it approximates that by checking cmd_result != UNSUPPORTED — it's using the value of the result as a proxy for
  whether default: ran. Those two things happen to coincide for default: (which always resolves to
  UNSUPPORTED), but nothing stops a different, specific case from also concluding UNSUPPORTED on its own merits.
  When that happens, the proxy lies: the guard assumes "oh, this must be the default: path, already acked" and
  silently drops it.

  Why DO_FIGURE_EIGHT and NAV_VTOL_TAKEOFF hit this

  Both cases had branches that legitimately conclude "not supported" for reasons specific to that command
  (module not compiled, or wrong vehicle type) — not because they fell into default:

```cpp
  case VEHICLE_CMD_DO_FIGUREEIGHT: {
  #ifdef CONFIG_FIGURE_OF_EIGHT
      if (!(fixed_wing || is_vtol)) {
          cmd_result = UNSUPPORTED;   // <- sets the value, but never calls answer_command()
          break;
      }
      ...
  #else
      cmd_result = UNSUPPORTED;       // <- same problem
  #endif
  }
  break;
```
  They set cmd_result = UNSUPPORTED and just break, trusting the post-switch line to send the ACK. But the
  post-switch line saw cmd_result == UNSUPPORTED and assumed "must be default:, skip it." No ACK ever went out —
  matching exactly what your survey caught (silent timeout, not a NACK).

  The fix

```cpp
  bool already_answered = false;
  switch (cmd.command) {
      ... // unrelated cases unchanged
      /* ignore-list */:
          already_answered = true;
          break;
      default:
          answer_command(cmd, UNSUPPORTED);
          already_answered = true;
          break;
  }
  if (!already_answered) {
      answer_command(cmd, cmd_result);
  }
```
  Now "was this already ACKed inside the switch" is tracked directly with its own boolean, set exactly at the
  two places that actually do that (self-ack in default:, or deliberate no-ack-from-Commander in the
  ignore-list). It's no longer inferred from the result value. So DO_FIGUREEIGHT's two "unsupported" branches
  now fall through to the post-switch call with already_answered == false, and they get ACKed with UNSUPPORTED
  correctly — that's the whole fix.

  Why DO_REPOSITION (and the ~30 other "normal" cases) are untouched

  Look at DO_REPOSITION (Commander.cpp:868-903): every branch sets cmd_result to ACCEPTED, TEMPORARILY_REJECTED,
  or DENIED — it never produces UNSUPPORTED. That's true of nearly every case in the switch outside the two bug
  sites and the ignore-list/default:.

  For those cases, walk both versions of the guard:

  - Old: cmd_result != UNSUPPORTED → true (since it's ACCEPTED/DENIED/etc.) → answer_command() fires.
  - New: already_answered was never set to true for this case (only the ignore-list and default: touch that
  flag) → !already_answered → true → answer_command() fires.

  Same outcome, same number of ACK calls, same result value, in both versions. The two guards are only
  observably different in the one situation the old one got wrong: a case that concludes UNSUPPORTED on its own.
  Everywhere else — including DO_REPOSITION — the new flag and the old value-based check agree, so behavior is
  bit-for-bit identical.

</details>
