### PR TITLE
fix(mavlink): MAV_CMD_NAV_DELAY should not be handled as a command

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1700,7 +1700,6 @@ Commander::handle_command(const vehicle_command_s &cmd)
 	case vehicle_command_s::VEHICLE_CMD_DO_SET_MISSION_CURRENT:
 	case vehicle_command_s::VEHICLE_CMD_LOGGING_START:
 	case vehicle_command_s::VEHICLE_CMD_LOGGING_STOP:
-	case vehicle_command_s::VEHICLE_CMD_NAV_DELAY:
 	case vehicle_command_s::VEHICLE_CMD_DO_SET_ROI:
 	case vehicle_command_s::VEHICLE_CMD_NAV_ROI:
 	case vehicle_command_s::VEHICLE_CMD_DO_SET_ROI_LOCATION:


### PR DESCRIPTION
This fixes the `MAV_CMD_NAV_DELAY` not providing a NACK or ACK. This was happening because it was in the list of commands handled elsewhere, but it isn't handled anywhere, Worse, it can't be handled as a command - it makes no sense in this context as it is intended to delay a step in a mission.

The fix is simply to remove it from the list of commands so that it falls to the default handler.

Tested, and it now returns unsupported. Claude also deems this good, and as having no side effects.