### PR TITLE
fix(mavlink): NACK MAV_CMD_DO_MOUNT_CONTROL_QUAT

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1680,7 +1680,6 @@ Commander::handle_command(const vehicle_command_s &cmd)
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_2:
 	case vehicle_command_s::VEHICLE_CMD_DO_MOUNT_CONTROL:
 	case vehicle_command_s::VEHICLE_CMD_DO_MOUNT_CONFIGURE:
-	case vehicle_command_s::VEHICLE_CMD_DO_MOUNT_CONTROL_QUAT:
 	case vehicle_command_s::VEHICLE_CMD_PREFLIGHT_SET_SENSOR_OFFSETS:
 	case vehicle_command_s::VEHICLE_CMD_PREFLIGHT_UAVCAN:
 	case vehicle_command_s::VEHICLE_CMD_PAYLOAD_PREPARE_DEPLOY:


### PR DESCRIPTION
## Summary

`MAV_CMD_DO_MOUNT_CONTROL_QUAT` was never ACKed or NACKed by PX4 — a GCS sending it just gets silence.

## Problem

Commander lists `VEHICLE_CMD_DO_MOUNT_CONTROL_QUAT` among commands "handled by other parts of the system," so it deliberately sends no ACK for it. But nothing else handles it either — the gimbal module never implemented this command (it was superseded by `MAV_CMD_DO_MOUNT_CONTROL` and the gimbal manager protocol). The command is simply dropped with no response.

## Solution

Remove it from Commander's ignore list so it falls through to the default case, which NACKs unknown/unhandled commands as `UNSUPPORTED`. Verified against SITL (`sihsim_quadx`) with a MAVLink command survey: the command now returns `UNSUPPORTED` instead of timing out, with no change to any other command's behavior. 

Same fix as #28236. Thanks Claude.