### PR TITLE
fix(mavlink): NACK Camera/Gimbal commands if module not present or disabled

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -822,6 +822,8 @@ Commander::Commander() :
 	param_t param_mav_sys_id = param_find("MAV_SYS_ID");
 	_param_mav_type = param_find("MAV_TYPE");
 	_param_rc_map_fltmode = param_find("RC_MAP_FLTMODE");
+	_param_trig_mode = param_find("TRIG_MODE");
+	_param_mnt_mode_in = param_find("MNT_MODE_IN");
 
 	int32_t value_int32 = 0;
 
@@ -1674,23 +1676,31 @@ Commander::handle_command(const vehicle_command_s &cmd)
 		}
 		break;
 
+	case vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL:
+	case vehicle_command_s::VEHICLE_CMD_DO_TRIGGER_CONTROL:
+	case vehicle_command_s::VEHICLE_CMD_DO_SET_CAM_TRIGG_DIST:
+	case vehicle_command_s::VEHICLE_CMD_DO_SET_CAM_TRIGG_INTERVAL:
+	case vehicle_command_s::VEHICLE_CMD_OBLIQUE_SURVEY:
+		nackIfModuleDisabled(cmd, _param_trig_mode, 0);
+		break;
+
+	case vehicle_command_s::VEHICLE_CMD_DO_MOUNT_CONTROL:
+	case vehicle_command_s::VEHICLE_CMD_DO_MOUNT_CONFIGURE:
+	case vehicle_command_s::VEHICLE_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
+	case vehicle_command_s::VEHICLE_CMD_DO_GIMBAL_MANAGER_CONFIGURE:
+		nackIfModuleDisabled(cmd, _param_mnt_mode_in, -1);
+		break;
+
 	case vehicle_command_s::VEHICLE_CMD_START_RX_PAIR:
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_0:
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_1:
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_2:
-	case vehicle_command_s::VEHICLE_CMD_DO_MOUNT_CONTROL:
-	case vehicle_command_s::VEHICLE_CMD_DO_MOUNT_CONFIGURE:
 	case vehicle_command_s::VEHICLE_CMD_DO_MOUNT_CONTROL_QUAT:
 	case vehicle_command_s::VEHICLE_CMD_PREFLIGHT_SET_SENSOR_OFFSETS:
 	case vehicle_command_s::VEHICLE_CMD_PREFLIGHT_UAVCAN:
 	case vehicle_command_s::VEHICLE_CMD_PAYLOAD_PREPARE_DEPLOY:
 	case vehicle_command_s::VEHICLE_CMD_PAYLOAD_CONTROL_DEPLOY:
 	case vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION:
-	case vehicle_command_s::VEHICLE_CMD_DO_TRIGGER_CONTROL:
-	case vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL:
-	case vehicle_command_s::VEHICLE_CMD_DO_SET_CAM_TRIGG_DIST:
-	case vehicle_command_s::VEHICLE_CMD_OBLIQUE_SURVEY:
-	case vehicle_command_s::VEHICLE_CMD_DO_SET_CAM_TRIGG_INTERVAL:
 	case vehicle_command_s::VEHICLE_CMD_SET_CAMERA_MODE:
 	case vehicle_command_s::VEHICLE_CMD_SET_CAMERA_ZOOM:
 	case vehicle_command_s::VEHICLE_CMD_SET_CAMERA_FOCUS:
@@ -1709,8 +1719,6 @@ Commander::handle_command(const vehicle_command_s &cmd)
 	case vehicle_command_s::VEHICLE_CMD_INJECT_FAILURE:
 	case vehicle_command_s::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN:
 	case vehicle_command_s::VEHICLE_CMD_DO_SET_GLOBAL_ORIGIN:
-	case vehicle_command_s::VEHICLE_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
-	case vehicle_command_s::VEHICLE_CMD_DO_GIMBAL_MANAGER_CONFIGURE:
 	case vehicle_command_s::VEHICLE_CMD_CONFIGURE_ACTUATOR:
 	case vehicle_command_s::VEHICLE_CMD_ESC_REQUEST_EEPROM:
 	case vehicle_command_s::VEHICLE_CMD_REQUEST_MESSAGE:
@@ -1826,6 +1834,23 @@ unsigned Commander::handleCommandActuatorTest(const vehicle_command_s &cmd)
 
 	_actuator_test_pub.publish(actuator_test);
 	return vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED;
+}
+
+void Commander::nackIfModuleDisabled(const vehicle_command_s &cmd, param_t enabled_param, int32_t disabled_value)
+{
+	int32_t value = disabled_value;
+
+	if (enabled_param != PARAM_INVALID) {
+		param_get(enabled_param, &value);
+	}
+
+	if (value == disabled_value) {
+		// Not compiled in (param never registered, value stays at disabled_value) or
+		// explicitly disabled at boot -- nothing else will answer this command.
+		answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED);
+	}
+
+	// Otherwise stay silent -- the owning module is expected to ack this itself.
 }
 
 void Commander::executeActionRequest(const action_request_s &action_request)

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -167,6 +167,8 @@ private:
 
 	unsigned handleCommandActuatorTest(const vehicle_command_s &cmd);
 
+	void nackIfModuleDisabled(const vehicle_command_s &cmd, param_t enabled_param, int32_t disabled_value);
+
 	void executeActionRequest(const action_request_s &action_request);
 
 	void printRejectMode(uint8_t nav_state);
@@ -335,6 +337,8 @@ private:
 	// optional parameters
 	param_t _param_mav_type{PARAM_INVALID};
 	param_t _param_rc_map_fltmode{PARAM_INVALID};
+	param_t _param_trig_mode{PARAM_INVALID};    // camera_trigger module (may not be compiled in)
+	param_t _param_mnt_mode_in{PARAM_INVALID};  // gimbal module (may not be compiled in)
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::COM_DISARM_LAND>)  _param_com_disarm_land,


### PR DESCRIPTION
MAVLink commands are always supposed to either ACK or NACK with a reason. A number of gimbal and camera commands were doing neither in SITL:

- DO_DIGICAM_CONTROL, DO_MOUNT_CONFIGURE, DO_MOUNT_CONTROL, 
- DO_SET_CAM_TRIGG_DIST, DO_GIMBAL_MANAGER_PITCHYAW, DO_GIMBAL_MANAGER_CONFIGURE
  DO_SET_CAM_TRIGG_INTERVAL, OBLIQUE_SURVEY, DO_TRIGGER_CONTROL

The reason in this particular case was that handling of those commands was deferred to the module, and the module wasn't installed. Following a similar pattern to other cases, this PR checks if the enabling parameter is present (indicating the module is in firmware), and if it is, that it is not the "feature disabled" value. IN this case the module should be handling the command, and otherwise we NACK it.

This has been tested on SITL and now we get an unsupported NACK by default for the messages.

> [!NOTE]
> This doesn't fully fix all cases: if the module chooses not to handle a command when it is enabled, this code won't deal with that.
> Gimbal has this problem in some modes. That's a separate problem that needs to be looked at in the Gimbal, if we so wish.

| `MNT_MODE_IN` | Input class instantiated | What happens post-fix |
  |---|---|---|
  | `-1` (disabled) | none | Commander NACKs — fixed by this change. |
  | `0` (AUTO) / `4` (MAVLINK_V2) | `InputMavlinkGimbalV2` | All 4 commands get real acks. Fully fixed. |
  | `3` (MAVLINK_DO_MOUNT, legacy) | `InputMavlinkCmdMount` | `DO_MOUNT_CONTROL`/`DO_MOUNT_CONFIGURE` get real acks. `DO_GIMBAL_MANAGER_PITCHYAW`/`CONFIGURE` still get no ack at all — that class never handles them. |
  | `1` (RC) | none that touch `vehicle_command` | All 4 commands still get no ack — RC input mode never  subscribes to MAVLink commands at all. |
  | `2` (MAVLINK_ROI, legacy) | `InputMavlinkROI` | All 4 commands still get no ack — this class only consumes   `position_setpoint_triplet`, never subscribes to `vehicle_command`. |
  | `5` (Fixed) | none that touch `vehicle_command` | Same as RC — no ack for any of the 4. |