### PR TITLE
docs(docs): fix typo in QGroundControl

### DIFF
--- a/docs/en/assembly/quick_start_cube.md
+++ b/docs/en/assembly/quick_start_cube.md
@@ -193,7 +193,7 @@ If connecting peripherals to the port labeled `GPS2`, assign the PX4 [serial por
 
 ## Configuration
 
-Configuration is performed using [QGroundContro](https://qgroundcontrol.com/).
+Configuration is performed using [QGroundControl](https://qgroundcontrol.com/).
 
 After downloading, installing and running _QGroundControl_, connect the board to your computer as shown.
 


### PR DESCRIPTION
This is a very minor change which fixes a typo I noticed while browsing the docs, where QGroundControl is missing the "L" at the end.
