### PR TITLE
fix(pr-nuttx12-12): mavlink_shell no echo of cmd; nshterm out of stack

### DIFF
--- a/src/modules/mavlink/mavlink_shell.cpp
+++ b/src/modules/mavlink/mavlink_shell.cpp
@@ -70,6 +70,10 @@ MavlinkShell::~MavlinkShell()
 	if (_from_shell_fd >= 0) {
 		close(_from_shell_fd);
 	}
+
+	if (_shell_fds[1] >= 0) {
+		close(_shell_fds[1]);
+	}
 }
 
 int MavlinkShell::start()
@@ -170,9 +174,8 @@ int MavlinkShell::start()
 
 #endif
 
-	//close unused pipe fd's
+	//close unused pipe fd's; _shell_fds[1] is kept open, write() reuses it to echo input
 	close(_shell_fds[0]);
-	close(_shell_fds[1]);
 
 #ifdef __PX4_NUTTX
 	sched_unlock();
@@ -214,6 +217,10 @@ int MavlinkShell::shell_start_thread(int argc, char *argv[])
 
 size_t MavlinkShell::write(uint8_t *buffer, size_t len)
 {
+	if (::write(_shell_fds[1], buffer, len) < 0) {
+		PX4_WARN("echo failed");
+	}
+
 	return ::write(_to_shell_fd, buffer, len);
 }
 

--- a/src/systemcmds/nshterm/CMakeLists.txt
+++ b/src/systemcmds/nshterm/CMakeLists.txt
@@ -34,6 +34,7 @@ px4_add_module(
 	MODULE systemcmds__nshterm
 	MAIN nshterm
 	PRIORITY "SCHED_PRIORITY_DEFAULT-30"
+	STACK_MAIN 4096
 	COMPILE_FLAGS
 	SRCS
 		nshterm.cpp


### PR DESCRIPTION
pr https://github.com/PX4/PX4-Autopilot/pull/26215 will introduce Nuttx12-12,
minor issues still persist:

# Solved Problem
1. nhsterm does run out of stack
`nsh> rm WARN  [load_mon] nshterm low on stack! (8 bytes left)`

3. mavlink_shell does not echo commands anymore
(Upstream-NuttX-Apps-Commit 8160dd0d5 (PR apache/nuttx-apps#1608, März 2023) did remove readline's eigenes own echo-char.)
``` shell
# eg1:
nsh> nsh: lll: command not found
nsh> /:
-------
# eg 2:
nsh> nsh> nsh> nsh> 
```

# Solution
1. increase nshterm stack-size
2. mavlink_shell does now echo commands-passed
``` shell
# eg1:
nsh> lll
nsh: lll: command not found
-------
# eg 2:
nsh> 
nsh> 
nsh> 
nsh> 
```

# Test
did test for
v6x, v5x and v6s
