### PR TITLE
fix(uavcan): warn while the dynamic node ID allocation table is full

### DIFF
--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -759,6 +759,10 @@ UavcanNode::Run()
 		_servers->setArmed(actuator_armed.armed || actuator_armed.prearmed);
 	}
 
+	if (_servers != nullptr) {
+		_servers->warn_if_node_id_allocation_table_full();
+	}
+
 #ifdef CONFIG_MODULES_NFS_MOUNT
 
 	if (_servers != nullptr) {

--- a/src/drivers/uavcan/uavcan_servers.cpp
+++ b/src/drivers/uavcan/uavcan_servers.cpp
@@ -154,6 +154,30 @@ int UavcanServers::init()
 	return 0;
 }
 
+void UavcanServers::warn_if_node_id_allocation_table_full()
+{
+	/*
+	The table never evicts an entry, so a node ID spent on a board that is no longer present stays spent. Once
+	all of them are, every board the table has not seen before is refused a node ID, and the refusal is silent
+	on the bus and here - the node just never appears, which reads as a dead node rather than a full table.
+	Keep saying so: the table does not empty itself, so this is a fault someone has to clear.
+	*/
+	if (_server_instance.getNumAllocations() < uavcan::NodeID::MaxRecommendedForRegularNodes) {
+		return;
+	}
+
+	const hrt_abstime now = hrt_absolute_time();
+
+	if (_node_id_table_full_warned != 0 && now - _node_id_table_full_warned < NODE_ID_TABLE_FULL_WARN_INTERVAL) {
+		return;
+	}
+
+	_node_id_table_full_warned = now;
+	PX4_ERR("dynamic node ID table is full (%u/%u): no new node can join, delete %s and reboot",
+		static_cast<unsigned>(_server_instance.getNumAllocations()),
+		static_cast<unsigned>(uavcan::NodeID::MaxRecommendedForRegularNodes), UAVCAN_NODE_DB_PATH);
+}
+
 #ifdef CONFIG_MODULES_NFS_MOUNT
 void UavcanServers::check_nfs()
 {

--- a/src/drivers/uavcan/uavcan_servers.hpp
+++ b/src/drivers/uavcan/uavcan_servers.hpp
@@ -71,6 +71,8 @@ public:
 
 	int init();
 
+	void warn_if_node_id_allocation_table_full();
+
 #ifdef CONFIG_MODULES_NFS_MOUNT
 	void check_nfs();
 #endif
@@ -86,6 +88,8 @@ public:
 
 private:
 
+	static constexpr hrt_abstime NODE_ID_TABLE_FULL_WARN_INTERVAL{5_s};
+
 	void unpackFwFromROMFS(const char *sd_path, const char *romfs_path);
 	void migrateFWFromRoot(const char *sd_path, const char *sd_root_path);
 	int copyFw(const char *dst, const char *src);
@@ -99,6 +103,8 @@ private:
 	uavcan::BasicFileServer _fw_server;
 
 	uavcan::NodeInfoRetriever &_node_info_retriever;
+
+	hrt_abstime _node_id_table_full_warned{0};
 
 	uORB::Subscription _nfs_up_sub{ORB_ID(nfs_up)};
 };


### PR DESCRIPTION
## Summary

Log an error while the DroneCAN dynamic node ID allocation table is full, instead of silently refusing every node that isn't already in it.

## Problem

`centralized::Storage` never evicts, so a node ID spent on a board that is gone stays spent. Once all of 1..`MaxRecommendedForRegularNodes` are taken, `handleAllocationRequest` drops the request via a `UAVCAN_TRACE` that compiles to nothing here — nothing on the bus, nothing on the console, the node just never appears.

Boards already in the table still get their cached ID and join fine, so the bus looks healthy and the fault reads as a dead node. A manufacturing test station that cycles boards through one flight controller was found at 125/125; identifying it took a teardown of the fixture's SD card.

## Solution

Check `getNumAllocations()` in the `Run()` loop and `PX4_ERR` every 5 s while the table is full, naming the count and the path to delete. It repeats because the table doesn't empty itself — a node that can't join is a fault someone has to clear, not a one-time notice.

Not logged at the point of refusal: that lives in libdronecan, which has no PX4 headers, and the in-library route (`registerInternalFailure`) would publish a `LogMessage` per retry onto the bus.
