### PR TITLE
fix(ekf2): advertise global position and odometry in single-EKF mode too

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -232,24 +232,25 @@ EKF2::~EKF2()
 
 void EKF2::AdvertiseTopics()
 {
-	// advertise expected minimal topic set immediately for logging
+	// Advertise the expected minimal topic set immediately. These are uORB::PublicationMulti,
+	// so the instance is decided by whoever advertises first: if another module gets there
+	// before us it takes instance 0, and subscribers reading the default instance see an empty
+	// topic while the estimate goes to instance 1. Advertising up front keeps the assignment
+	// deterministic instead of a boot race. In multi mode these handles point at estimator_*
+	// and ekf2_selector owns (and already unconditionally advertises) the vehicle_* topics.
 	_attitude_pub.advertise();
 	_local_position_pub.advertise();
+	_global_position_pub.advertise();
+	_odometry_pub.advertise();
 	_estimator_event_flags_pub.advertise();
 	_estimator_sensor_bias_pub.advertise();
 	_estimator_status_pub.advertise();
 	_estimator_status_flags_pub.advertise();
 	_estimator_fc_pub.advertise();
 
-	if (_multi_mode) {
-		// only force advertise these in multi mode to ensure consistent uORB instance numbering
-		_global_position_pub.advertise();
-		_odometry_pub.advertise();
-
 #if defined(CONFIG_EKF2_WIND)
-		_wind_pub.advertise();
+	_wind_pub.advertise();
 #endif // CONFIG_EKF2_WIND
-	}
 
 #if defined(CONFIG_EKF2_GNSS)
 


### PR DESCRIPTION
### Solved Problem

In single-EKF mode `vehicle_global_position` and `vehicle_odometry` can end up on uORB
instance 1 instead of instance 0. Nothing reports an error: EKF2 keeps estimating and
publishing normally, but every subscriber that reads the default instance — logger,
commander, navigator — sees a topic that is never written.

`EKF2::AdvertiseTopics()` force-advertises the minimal topic set at startup, but
`_global_position_pub` / `_odometry_pub` / `_wind_pub` are inside `if (_multi_mode)`
(EKF2.cpp:244-252). In single mode they are therefore advertised lazily, on their first
`publish()`. For global position that first publish is gated on

```cpp
if (_ekf.global_origin_valid() && _ekf.control_status().flags.yaw_align) {   // EKF2.cpp:1330
```

so it happens tens of seconds into the boot, once GNSS has converged.

These handles are `uORB::PublicationMulti` (EKF2.hpp:476-479), and `advertise()` therefore
calls `orb_advertise_multi(get_topic(), nullptr, &instance)` (`Publication.cpp:76-84`; the
same file's `PublicationMultiBase::publish()` is what advertises lazily on first use).
`uORBDeviceMaster::advertise()` only lets a caller claim an already-advertised node when it is
a *single*-instance advertiser:

```cpp
const bool is_single_instance_advertiser = is_advertiser && !instance;      // uORBDeviceMaster.cpp:128
if (existing_node != nullptr
    && (!existing_node->is_advertised() || is_single_instance_advertiser || !is_advertiser)) {
```

With `instance != nullptr` that is false, so a `PublicationMulti` cannot reclaim instance 0
— it is pushed to the next free instance and `publish()` silently writes there.

The result is that instance assignment for these three topics is a boot race, and EKF2
enters it late by design.

`_attitude_pub` and `_local_position_pub` sit a few lines earlier in the same function
(`EKF2.cpp:236-237`), are advertised unconditionally, and are therefore immune to exactly the
same hazard. That asymmetry is what this PR removes.

#### Why it matters downstream

`Navigator` subscribes to the default instance (`navigator.h:366`) and keeps its
zero-initialised `vehicle_global_position _global_pos{}` (`navigator.h:388`).
`MissionBlock`/`Land` guard on `get_local_position()->xy_global` and then read
`get_global_position()->lat/lon` (`mission_block.cpp:822-824`, `land.cpp:64-66`) —
`xy_global` is true (the origin *is* valid), so the guard passes and the landing item is
built from `lat = 0, lon = 0`.

#### Observed on a real vehicle

Three flights of a single-EKF multicopter (fmu-v6xrt, GNSS RTK fix, 28–32 sats):

| | value |
|---|---|
| `vehicle_global_position` (instance 0) | **0 samples** — subscribed by the logger, no `REMOVE`, no dropouts |
| `vehicle_local_position` (instance 0) | 3431 samples, normal |
| `estimator_status_flags.cs_yaw_align` | true, 360/360 samples, 0 transitions |
| `vehicle_local_position.xy_global` | true, 3431/3431 |
| `estimator_gps_status.checks_passed` | 686/686 |
| `failsafe_flags.global_position_invalid` | **1, 625/625 samples** |
| `position_setpoint_triplet` on AUTO.TAKEOFF | `lat = 0.0, lon = 0.0` |
| `position_setpoint_triplet` on AUTO.LAND | `lat = -2.646e-6, lon = -1.96e-7` (= (0,0) + stop-point projection) |

On AUTO.LAND the vehicle accelerated toward that waypoint — about 12,081 km away in the
local projection — ramping the velocity setpoint to −3.72 m/s while descending, deviating
8.08 m from the commanded point and hitting the ground inverted (roll max +85.3°).

The estimator was healthy the whole time. Only the delivery path was broken.

In that build the module that won the race was the Zenoh bridge: its default inbound config
mapped `/fmu/in/aux_global_position` onto the uORB topic `vehicle_global_position` at
instance 0, and its subscriber constructor calls `orb_advertise()` at startup
(`src/modules/zenoh/subscribers/uorb_subscriber.hpp:53-64`). That particular mapping was
fixed by #26564 / #27598, but the hazard is not specific to it — **any** module that
advertises one of these topics before the estimator's first publish produces the same
outcome, and there is no diagnostic when it happens.

---

### Solution

Advertise `_global_position_pub`, `_odometry_pub` and `_wind_pub` unconditionally, next to
`_attitude_pub` and `_local_position_pub`, and drop the now-empty `if (_multi_mode)` block.

```diff
-	// advertise expected minimal topic set immediately for logging
+	// Advertise the expected minimal topic set immediately. These are uORB::PublicationMulti,
+	// so the instance is decided by whoever advertises first: if another module gets there
+	// before us it takes instance 0, and subscribers reading the default instance see an empty
+	// topic while the estimate goes to instance 1. Advertising up front keeps the assignment
+	// deterministic instead of a boot race. In multi mode these handles point at estimator_*
+	// and ekf2_selector owns (and already unconditionally advertises) the vehicle_* topics.
 	_attitude_pub.advertise();
 	_local_position_pub.advertise();
+	_global_position_pub.advertise();
+	_odometry_pub.advertise();
 	_estimator_event_flags_pub.advertise();
 	_estimator_sensor_bias_pub.advertise();
 	_estimator_status_pub.advertise();
 	_estimator_status_flags_pub.advertise();
 	_estimator_fc_pub.advertise();

-	if (_multi_mode) {
-		// only force advertise these in multi mode to ensure consistent uORB instance numbering
-		_global_position_pub.advertise();
-		_odometry_pub.advertise();
-
 #if defined(CONFIG_EKF2_WIND)
-		_wind_pub.advertise();
+	_wind_pub.advertise();
 #endif // CONFIG_EKF2_WIND
-	}
```

`ekf2` is started at `ROMFS/px4fmu_common/init.d/rcS:448`, well before `zenoh start` at
`rcS:607`, so advertising here wins the race deterministically rather than by luck.

#### Multi mode is unchanged

The existing comment — *"only force advertise these in multi mode to ensure consistent uORB
instance numbering"* — is about numbering the `estimator_*` instances across several EKF2
instances. In single mode there is one EKF2 and `_instance` is fixed at 0, so there is no
numbering to keep consistent.

Removing the condition cannot affect multi mode, because in multi mode these handles are not
bound to the `vehicle_*` topics at all:

```cpp
// EKF2.cpp:57-62
_attitude_pub       (multi_mode ? ORB_ID(estimator_attitude)        : ORB_ID(vehicle_attitude)),
_local_position_pub (multi_mode ? ORB_ID(estimator_local_position)  : ORB_ID(vehicle_local_position)),
_global_position_pub(multi_mode ? ORB_ID(estimator_global_position) : ORB_ID(vehicle_global_position)),
_odometry_pub       (multi_mode ? ORB_ID(estimator_odometry)        : ORB_ID(vehicle_odometry)),
_wind_pub           (multi_mode ? ORB_ID(estimator_wind)            : ORB_ID(wind)),
```

and the `vehicle_*` topics are owned by `ekf2_selector`, which already advertises all of them
unconditionally in its constructor, as single-instance `uORB::Publication`:

```cpp
// EKF2Selector.cpp:46-52
_vehicle_global_position_pub.advertise();
_vehicle_local_position_pub.advertise();
_vehicle_odometry_pub.advertise();
_wind_pub.advertise();
```

So in multi mode the change advertises the same `estimator_*` topics it already advertised;
behaviour is identical. Only single mode gains the early `vehicle_*` advertisement.

#### Cost

Advertising allocates the uORB node (and its queue) at startup rather than on first publish.
On a vehicle that never produces a global position — no GNSS and no other global aiding — the
`vehicle_global_position` node is now allocated and stays empty. `advertise()` publishes no
data, so no consumer sees a spurious zero sample; the cost is RAM only, on the order of a few
hundred bytes for the three topics.

For context: `if (_multi_mode)` was introduced in #16099 to save 944 B on fmu-v4, which is no
longer a supported board. If that trade-off is still unwanted on the smallest targets, an
alternative is below.

---

### Changelog Entry

```
Bugfix: ekf2 now advertises vehicle_global_position, vehicle_odometry and wind at startup in
single-EKF mode, so they are always on uORB instance 0. Previously another module advertising
one of these topics first could push the estimator to instance 1, leaving navigator, commander
and the logger reading an empty topic with no error reported.
```

---

### Alternatives

1. **Advertise only `_global_position_pub` and `_odometry_pub`, leave `_wind_pub` inside the
   conditional.** Rejected: with `CONFIG_EKF2_WIND` disabled that leaves an empty
   `if (_multi_mode) {}` block, and `wind` has exactly the same defect — the asymmetry would
   just move.
2. **Fix each module that advertises these topics (e.g. route bridge inbound topics to a
   spare instance).** Necessary hygiene, but it does not generalise: it has to be repeated for
   every current and future advertiser, and nothing detects a regression. The estimator
   claiming its own topic is the invariant that actually holds.
3. **Validate on the consumer side instead** — have navigator check
   `vehicle_global_position.lat_lon_valid` rather than proxying through
   `vehicle_local_position.xy_global`. That is a real and complementary gap (see #28070) but it
   is a different fix in a different module; it turns a fly-away into a refusal to land, which
   is better but still a failure.
4. **Keep the lazy advertise and make `PublicationMulti` able to reclaim instance 0.** Changes
   uORB semantics globally; far riskier than this.

---

### Test coverage

**SITL reproduction on unmodified `main`.** The failure needs another advertiser to get there
first, and — with the Zenoh bridge — the bridge only creates its subscribers *after* its
session opens: `ZENOH::run()` calls `setupSession()` at `zenoh.cpp:484` and only reaches
`setupTopics()` at `:495` once that returns, while `setupSession()` spins on
`do { ... } while ((ret = z_open(&_s, z_move(config), NULL)) < 0);` (`zenoh.cpp:252`).
**The router must therefore be running before PX4**, otherwise no inbound subscriber is ever
constructed and the bug does not appear. This is why the same symptom has previously been
reported as non-reproducible.

```
1. make px4_sitl_zenoh gz_x500          # single EKF2 (EKF2_MULTI_IMU disabled)
2. echo '/fmu/in/anything;vehicle_global_position;0' \
     >> build/px4_sitl_zenoh/rootfs/fs/microsd/zenoh/sub.csv
   # or: zenoh config add subscriber /fmu/in/anything vehicle_global_position
3. ros2 run rmw_zenoh_cpp rmw_zenohd    # router FIRST
4. start PX4, confirm `zenoh status` is connected before the estimator sets its origin
5. publish nothing on /fmu/in/anything
```

- Before: `listener vehicle_global_position` reports **2 instances**; instance 0 is empty and
  the estimate is on instance 1. `listener failsafe_flags` shows
  `global_position_invalid: True`. `commander mode auto:land` builds its landing item from
  lat=0/lon=0.
- After: **1 instance**, populated as soon as the origin is set;
  `global_position_invalid: False`; the landing item carries the real coordinates.

Reversing the start order (PX4 first) yields `1 instance` on both builds — the estimator wins
that race — which is the expected non-failing case, not a refutation.

**Flight-log evidence** from the three-flight sequence summarised above (ULogs available on
request).

**Regression risk**: multi mode is byte-identical (argument above); `make check_format`
(astyle 3.1) reports no changes; `_multi_mode` is still referenced at two other call sites in
the same file, so removing this one does not leave it unused.

---

### Context

- #26183 — same mechanism observed in SITL. The maintainer comment there describes it exactly:
  the bridge advertises `vehicle_global_position` instance 0 before EKF2, so EKF2's
  `PublicationMulti` lands on instance 1. Closed by fixing the bridge's default topic mapping
  (#26564 / #27598); the estimator-side race was not addressed.
- #22266, #26305 — the same class of hazard on the uXRCE-DDS side, fixed there by routing
  inbound topics to multi instances. `src/modules/zenoh` was not covered by either.
- #28070 — similar symptom, ruled out as this bug (multi-EKF). That vehicle runs
  `EKF2_MULTI_IMU = 3`, where `ekf2_selector` advertises `vehicle_global_position`
  unconditionally in its constructor (`EKF2Selector.cpp:46-52`), so the instance race
  described here cannot occur. Thanks to @JBotwina for checking.
- #16099, #16522, #19357 — history of the `if (_multi_mode)` condition and the
  "consistent uORB instance numbering" comment.
