### PR TITLE
docs(ros2): clarify VehicleCommand routing

### DIFF
--- a/docs/en/ros2/multi_vehicle.md
+++ b/docs/en/ros2/multi_vehicle.md
@@ -53,8 +53,9 @@ Therefore, when ROS 2 nodes want to send `VehicleCommand` to PX4, they must ensu
 
 For example, if you want to send a command to your third vehicle, which has `px4_instance=2`, you need to set `target_system=3` in all your `VehicleCommand` messages.
 
-PX4 applies the same filtering to `target_component`: a command is handled when the value is `0` (broadcast) or matches the receiving component ID.
-A non-zero value for another component is ignored. For a normal PX4 flight controller, `target_component=1` addresses the autopilot component.
+PX4 applies the same filtering to `target_component`: a command is handled when the value is `0` (broadcast) or matches the component ID of the autopilot (as set with [MAV_COMP_ID](../advanced_config/parameter_reference.md#MAV_COMP_ID)).
+For a normal PX4 flight controller, `target_component=1` addresses the autopilot component.
+Any other non-zero value is ignored, as it is intended for another component 
 
 Commands published by ROS 2 or another process outside PX4 should set `from_external=true`, as shown in the ROS 2 examples.
 This prevents the MAVLink module from forwarding the command as if it originated inside PX4.

--- a/docs/en/ros2/multi_vehicle.md
+++ b/docs/en/ros2/multi_vehicle.md
@@ -55,7 +55,7 @@ For example, if you want to send a command to your third vehicle, which has `px4
 
 PX4 applies the same filtering to `target_component`: a command is handled when the value is `0` (broadcast) or matches the component ID of the autopilot (as set with [MAV_COMP_ID](../advanced_config/parameter_reference.md#MAV_COMP_ID)).
 For a normal PX4 flight controller, `target_component=1` addresses the autopilot component.
-Any other non-zero value is ignored, as it is intended for another component
+Any other non-zero value is ignored, as it is intended for another component.
 
 Commands published by ROS 2 or another process outside PX4 must set `target_system`, `target_component`, `source_system`, and `source_component` appropriately for routing and acknowledgements.
 The `from_external` flag is not required for routing; it affects how PX4 handles commands originating outside the autopilot, including forced arm commands.

--- a/docs/en/ros2/multi_vehicle.md
+++ b/docs/en/ros2/multi_vehicle.md
@@ -53,13 +53,9 @@ Therefore, when ROS 2 nodes want to send `VehicleCommand` to PX4, they must ensu
 
 For example, if you want to send a command to your third vehicle, which has `px4_instance=2`, you need to set `target_system=3` in all your `VehicleCommand` messages.
 
-PX4 applies the same filtering to `target_component`: a command is handled when
-the value is `0` (broadcast) or matches the receiving component ID. A non-zero
-value for another component is ignored. For a normal PX4 flight controller,
-`target_component=1` addresses the autopilot component.
+PX4 applies the same filtering to `target_component`: a command is handled when the value is `0` (broadcast) or matches the receiving component ID.
+A non-zero value for another component is ignored. For a normal PX4 flight controller, `target_component=1` addresses the autopilot component.
 
-Commands published by ROS 2 or another process outside PX4 should set
-`from_external=true`, as shown in the ROS 2 examples. This prevents the MAVLink
-module from forwarding the command as if it originated inside PX4. Set
-`source_system` and `source_component` to identify the sender; command
-acknowledgements use those values as their target IDs.
+Commands published by ROS 2 or another process outside PX4 should set `from_external=true`, as shown in the ROS 2 examples.
+This prevents the MAVLink module from forwarding the command as if it originated inside PX4.
+Set `source_system` and `source_component` to identify the sender; command acknowledgements use those values as their target IDs.

--- a/docs/en/ros2/multi_vehicle.md
+++ b/docs/en/ros2/multi_vehicle.md
@@ -55,8 +55,7 @@ For example, if you want to send a command to your third vehicle, which has `px4
 
 PX4 applies the same filtering to `target_component`: a command is handled when the value is `0` (broadcast) or matches the component ID of the autopilot (as set with [MAV_COMP_ID](../advanced_config/parameter_reference.md#MAV_COMP_ID)).
 For a normal PX4 flight controller, `target_component=1` addresses the autopilot component.
-Any other non-zero value is ignored, as it is intended for another component 
+Any other non-zero value is ignored, as it is intended for another component
 
-Commands published by ROS 2 or another process outside PX4 should set `from_external=true`, as shown in the ROS 2 examples.
-This prevents the MAVLink module from forwarding the command as if it originated inside PX4.
-Set `source_system` and `source_component` to identify the sender; command acknowledgements use those values as their target IDs.
+Commands published by ROS 2 or another process outside PX4 must set `target_system`, `target_component`, `source_system`, and `source_component` appropriately for routing and acknowledgements.
+The `from_external` flag is not required for routing; it affects how PX4 handles commands originating outside the autopilot, including forced arm commands.

--- a/docs/en/ros2/multi_vehicle.md
+++ b/docs/en/ros2/multi_vehicle.md
@@ -45,10 +45,21 @@ The default client configuration in simulation is summarized as follows:
 | not provided       | >0             | `px4_instance+1` | `px4_${px4_instance}` |
 | provided           | >0             | `px4_instance+1` | `PX4_UXRCE_DDS_NS`    |
 
-## Adjusting the `target_system` value
+## Adjusting `VehicleCommand` routing fields
 
 PX4 accepts [VehicleCommand](../msg_docs/VehicleCommand.md) messages only if their `target_system` field is zero (broadcast communication) or coincides with `MAV_SYS_ID`.
 In all other situations, the messages are ignored.
 Therefore, when ROS 2 nodes want to send `VehicleCommand` to PX4, they must ensure that the messages are filled with the appropriate `target_system` value.
 
 For example, if you want to send a command to your third vehicle, which has `px4_instance=2`, you need to set `target_system=3` in all your `VehicleCommand` messages.
+
+PX4 applies the same filtering to `target_component`: a command is handled when
+the value is `0` (broadcast) or matches the receiving component ID. A non-zero
+value for another component is ignored. For a normal PX4 flight controller,
+`target_component=1` addresses the autopilot component.
+
+Commands published by ROS 2 or another process outside PX4 should set
+`from_external=true`, as shown in the ROS 2 examples. This prevents the MAVLink
+module from forwarding the command as if it originated inside PX4. Set
+`source_system` and `source_component` to identify the sender; command
+acknowledgements use those values as their target IDs.


### PR DESCRIPTION
### Solved Problem

The ROS 2 multi-vehicle guide only explains `target_system`, leaving the related component, origin, and acknowledgement routing fields unclear.

Related to #22671.

### Solution

Document how PX4 filters `target_component`, which routing fields external ROS 2 publishers must populate, and how `from_external` affects command handling rather than routing.

### Changelog Entry

```
Documentation: Clarify VehicleCommand routing fields for ROS 2 multi-vehicle setups.
```

### Alternatives

The generated uORB message reference lists these fields, but does not explain how they interact when ROS 2 nodes address multiple PX4 instances.

### Test coverage

- `git diff --check`
- `pnpm dlx prettier@3.8.3 --check docs/en/ros2/multi_vehicle.md`

### Context

The documented behavior was verified against Commander command filtering, MAVLink command forwarding, the `VehicleCommand` message definition, and command acknowledgement construction.