### PR TITLE
fix(ekf2): advertise global position and odometry in single-EKF mode too

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -232,24 +232,22 @@ EKF2::~EKF2()
 
 void EKF2::AdvertiseTopics()
 {
-	// advertise expected minimal topic set immediately for logging
+	// Advertise up front: these are PublicationMulti, so whoever advertises first owns
+	// instance 0. In multi mode the handles point at estimator_* and ekf2_selector owns
+	// the vehicle_* topics, so this is a no-op there.
 	_attitude_pub.advertise();
 	_local_position_pub.advertise();
+	_global_position_pub.advertise();
+	_odometry_pub.advertise();
 	_estimator_event_flags_pub.advertise();
 	_estimator_sensor_bias_pub.advertise();
 	_estimator_status_pub.advertise();
 	_estimator_status_flags_pub.advertise();
 	_estimator_fc_pub.advertise();
 
-	if (_multi_mode) {
-		// only force advertise these in multi mode to ensure consistent uORB instance numbering
-		_global_position_pub.advertise();
-		_odometry_pub.advertise();
-
 #if defined(CONFIG_EKF2_WIND)
-		_wind_pub.advertise();
+	_wind_pub.advertise();
 #endif // CONFIG_EKF2_WIND
-	}
 
 #if defined(CONFIG_EKF2_GNSS)
 


### PR DESCRIPTION
### Solved Problem

In single-EKF mode `vehicle_global_position` can end up on uORB instance 1 if another module advertises it first. Everything reading the default instance — logger, commander, navigator — then sees an empty topic, and nothing reports it. On our vehicle the navigator built its AUTO.LAND setpoint from lat=0/lon=0 and it crashed.

### Solution

Advertise it (plus odometry and wind) unconditionally, as attitude and local position already are. Multi mode is unaffected: those handles point at `estimator_*` there and `ekf2_selector` advertises the `vehicle_*` topics in its constructor.

### Test coverage

Reproduced in SITL and on hardware. Flight logs available if useful.

Supersedes #28244 (same change, description rewritten).
