### PR TITLE
docs(docs): ROS2 Jazzy migration and cleanup

### DIFF
--- a/docs/en/debug/plotting_realtime_uorb_data.md
+++ b/docs/en/debug/plotting_realtime_uorb_data.md
@@ -13,7 +13,7 @@ The video below demonstrates this for a simulated vehicle — the approach works
 Follow the [ROS 2 Installation & Setup](../ros2/user_guide.md#installation-setup) instructions in the _ROS2 user guide_ to install:
 
 - ROS 2
-- [Micro XRCE-DDS Agent](../ros2/user_guide.md#setup-micro-xrce-dds-agent-client)
+- [Micro XRCE-DDS Agent](../ros2/user_guide.md#setup-the-agent)
 - [PX4/px4_msgs](https://github.com/PX4/px4_msgs): PX4/ROS2 shared message definitions.
 - PX4 source code and build the simulator.
 

--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -50,12 +50,10 @@ This repo is no longer needed, but does contain useful examples.
 
 ## Installation & Setup
 
-The supported and recommended ROS 2 platform for working with PX4 is ROS 2 "Humble" LTS on Ubuntu 22.04.
+The supported and recommended ROS 2 platform for working with PX4 is ROS 2 "Jazzy" LTS on Ubuntu 24.04.
 
 ::: tip
-If you're working on Ubuntu 20.04 we recommend you update to Ubuntu 22.04.
-In the meantime you can use ROS 2 "Foxy" with [Gazebo Classic](../sim_gazebo_classic/index.md) on Ubuntu 20.04.
-Note that ROS 2 "Foxy" reached end-of-life in May 2023, but is (at time of writing) still stable and works with PX4.
+If you're working on Ubuntu 22.04 you can use ROS 2 "Humble" LTS instead.
 :::
 
 To setup ROS 2 for use with PX4:
@@ -99,6 +97,30 @@ To install ROS 2 and its dependencies:
 
    :::: tabs
 
+   ::: tab jazzy
+   To install ROS 2 "Jazzy" on Ubuntu 24.04:
+
+   ```sh
+   sudo apt update && sudo apt install locales
+   sudo locale-gen en_US en_US.UTF-8
+   sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+   export LANG=en_US.UTF-8
+   sudo apt install software-properties-common
+   sudo add-apt-repository universe
+   sudo apt update && sudo apt install curl -y
+   export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F'"' '{print $4}')
+   curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
+   sudo dpkg -i /tmp/ros2-apt-source.deb
+   sudo apt update && sudo apt upgrade -y
+   sudo apt install ros-jazzy-desktop
+   sudo apt install ros-dev-tools
+   source /opt/ros/jazzy/setup.bash && echo "source /opt/ros/jazzy/setup.bash" >> .bashrc
+   ```
+
+   The instructions above are reproduced from the official installation guide: [Install ROS 2 Jazzy](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html).
+   You can install _either_ the desktop (`ros-jazzy-desktop`) _or_ bare-bones versions (`ros-jazzy-ros-base`), _and_ the development tools (`ros-dev-tools`).
+   :::
+
    ::: tab humble
    To install ROS 2 "Humble" on Ubuntu 22.04:
 
@@ -120,13 +142,6 @@ To install ROS 2 and its dependencies:
 
    The instructions above are reproduced from the official installation guide: [Install ROS 2 Humble](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debs.html).
    You can install _either_ the desktop (`ros-humble-desktop`) _or_ bare-bones versions (`ros-humble-ros-base`), _and_ the development tools (`ros-dev-tools`).
-   :::
-
-   ::: tab foxy
-   To install ROS 2 "Foxy" on Ubuntu 20.04:
-   - Follow the official installation guide: [Install ROS 2 Foxy](https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html).
-
-   You can install _either_ the desktop (`ros-foxy-desktop`) _or_ bare-bones versions (`ros-foxy-ros-base`), _and_ the development tools (`ros-dev-tools`).
    :::
 
    ::::
@@ -183,27 +198,11 @@ To start the simulator (and client):
 
 1. Open a new terminal in the root of the **PX4 Autopilot** repo that was installed above.
 
-   :::: tabs
+   Start a PX4 [Gazebo](../sim_gazebo_gz/index.md) simulation using:
 
-   ::: tab humble
-   - Start a PX4 [Gazebo](../sim_gazebo_gz/index.md) simulation using:
-
-     ```sh
-     make px4_sitl gz_x500
-     ```
-
-     :::
-
-   ::: tab foxy
-   - Start a PX4 [Gazebo Classic](../sim_gazebo_classic/index.md) simulation using:
-
-     ```sh
-     make px4_sitl gazebo-classic
-     ```
-
-     :::
-
-   ::::
+   ```sh
+   make px4_sitl gz_x500
+   ```
 
 The agent and client are now running they should connect.
 
@@ -272,21 +271,21 @@ To create and build the workspace:
 
    :::: tabs
 
-   ::: tab humble
+   ::: tab jazzy
 
    ```sh
    cd ..
-   source /opt/ros/humble/setup.bash
+   source /opt/ros/jazzy/setup.bash
    colcon build
    ```
 
    :::
 
-   ::: tab foxy
+   ::: tab humble
 
    ```sh
    cd ..
-   source /opt/ros/foxy/setup.bash
+   source /opt/ros/humble/setup.bash
    colcon build
    ```
 
@@ -308,24 +307,24 @@ The [ROS2 beginner tutorials](https://docs.ros.org/en/humble/Tutorials/Beginner-
 
 In a new terminal:
 
-1. Navigate into the top level of your workspace directory and source the ROS 2 environment (in this case "Humble"):
+1. Navigate into the top level of your workspace directory and source the ROS 2 environment (in this case "Jazzy"):
 
    :::: tabs
+
+   ::: tab jazzy
+
+   ```sh
+   cd ~/ws_sensor_combined/
+   source /opt/ros/jazzy/setup.bash
+   ```
+
+   :::
 
    ::: tab humble
 
    ```sh
    cd ~/ws_sensor_combined/
    source /opt/ros/humble/setup.bash
-   ```
-
-   :::
-
-   ::: tab foxy
-
-   ```sh
-   cd ~/ws_sensor_combined/
-   source /opt/ros/foxy/setup.bash
    ```
 
    :::
@@ -486,22 +485,20 @@ Use the following commands to install the correct ROS 2/gz interface packages (n
 
 :::: tabs
 
+::: tab jazzy
+To install the bridge for use with ROS 2 "Jazzy" and Gazebo Harmonic (on Ubuntu 24.04):
+
+```sh
+sudo apt install ros-jazzy-ros-gzharmonic
+```
+
+:::
+
 ::: tab humble
 To install the bridge for use with ROS 2 "Humble" and Gazebo Harmonic (on Ubuntu 22.04):
 
 ```sh
 sudo apt install ros-humble-ros-gzharmonic
-```
-
-:::
-
-::: tab foxy
-First you will need to [install Gazebo Garden](../sim_gazebo_gz/index.md#installation-ubuntu-linux), as by default Foxy comes with Gazebo Classic 11. <!-- note, garden is EOL Nov 2024 -->
-
-Then to install the interface packages for use with ROS 2 "Foxy" and Gazebo (Ubuntu 20.04):
-
-```sh
-sudo apt install ros-foxy-ros-gzgarden
 ```
 
 :::
@@ -965,18 +962,18 @@ If any are missing, they can be added separately:
 
   :::: tabs
 
-  ::: tab humble
+  ::: tab jazzy
 
   ```sh
-  sudo apt install ros-humble-eigen3-cmake-module
+  sudo apt install ros-jazzy-eigen3-cmake-module
   ```
 
   :::
 
-  ::: tab foxy
+  ::: tab humble
 
   ```sh
-  sudo apt install ros-foxy-eigen3-cmake-module
+  sudo apt install ros-humble-eigen3-cmake-module
   ```
 
   :::

--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -17,6 +17,12 @@ If you're still working on PX4 v1.13, please follow the instructions in the [PX4
 
 ## Overview
 
+PX4 supports two middleware options for bridging uORB topics to ROS 2: [uXRCE-DDS](../middleware/uxrce_dds.md) (DDS) and [Zenoh](../middleware/zenoh.md).
+You must select which middleware to use and build your firmware accordingly (see [Installation & Setup](#installation-setup)).
+DDS is currently recommended for most users, as it is more established and has been more thoroughly tested with PX4.
+
+### DDS
+
 The application pipeline for ROS 2 is very straightforward, thanks to the use of the [uXRCE-DDS](../middleware/uxrce_dds.md) communications middleware.
 
 ![Architecture uXRCE-DDS with ROS 2](../../assets/middleware/xrce_dds/architecture_xrce-dds_ros2.svg)
@@ -43,10 +49,26 @@ It can be built from [source](https://github.com/eProsima/Micro-XRCE-DDS-Agent) 
 You will normally need to start both the client and agent when using ROS 2.
 Note that the uXRCE-DDS client is built into firmware by default but not started automatically except for simulator builds.
 
+See [uXRCE-DDS > Version selection](../middleware/uxrce_dds.md#version-selection) to check which Micro XRCE-DDS version to use for your ROS 2 distribution.
+
 ::: info
 In PX4v1.13 and earlier, ROS 2 was dependent on definitions in [px4_ros_com](https://github.com/PX4/px4_ros_com).
 This repo is no longer needed, but does contain useful examples.
 :::
+
+### Zenoh
+
+<Badge type="tip" text="PX4 v1.17" /> <Badge type="warning" text="Experimental" />
+
+PX4 also supports [Zenoh](../middleware/zenoh.md) as an alternative (experimental) middleware for bridging uORB topics to ROS 2, via the ROS 2 [`rmw_zenoh`](https://github.com/ros2/rmw_zenoh) middleware.
+It provides a fast and lightweight way to connect PX4 to ROS 2.
+
+![Architecture PX4 Zenoh-Pico with ROS 2](../../assets/middleware/zenoh/architecture-px4-zenoh.svg)
+
+The Zenoh-based middleware consists of a client running on PX4 (the [PX4 `zenoh` module](../modules/modules_driver.md#zenoh), based on Zenoh-Pico) and a Zenoh router (typically [zenohd](https://github.com/eclipse-zenoh/zenoh/tree/main/zenohd)) running on the companion computer, with bi-directional data exchange between them over a UART, TCP, UDP, or multicast-UDP link.
+The router acts as a broker and discovery service, enabling PX4 to publish and subscribe to topics in the global Zenoh data space, and integrates seamlessly with ROS 2 nodes using `rmw_zenoh`.
+
+See the [Zenoh](../middleware/zenoh.md) middleware page for full architecture and configuration details.
 
 ## Installation & Setup
 
@@ -60,7 +82,7 @@ To setup ROS 2 for use with PX4:
 
 - [Install PX4](#install-px4) (to use the PX4 simulator)
 - [Install ROS 2](#install-ros-2)
-- [Setup Micro XRCE-DDS Agent & Client](#setup-micro-xrce-dds-agent-client)
+- [Setup Middleware](#setup-middleware)
 - [Build & Run ROS 2 Workspace](#build-ros-2-workspace)
 
 Other dependencies of the architecture that are installed automatically, such as _Fast DDS_, are not covered.
@@ -152,11 +174,20 @@ To install ROS 2 and its dependencies:
    pip install --user -U empy==3.3.4 pyros-genmsg setuptools
    ```
 
-### Setup Micro XRCE-DDS Agent & Client
+### Setup Middleware
+
+PX4 supports two middleware options for connecting to ROS 2: [DDS](#dds) and [Zenoh](#zenoh) (see [Overview](#overview) for more on each).
+Select the one you want to use, making sure your firmware has the corresponding module enabled: the [uxrce_dds_client](../modules/modules_system.md#uxrce-dds-client) module is included by default in most builds, while the [zenoh](../middleware/zenoh.md#px4-firmware) module must be explicitly enabled.
+
+::: tip
+DDS is recommended for most users, as it is more established and has been more thoroughly tested with PX4.
+:::
+
+#### DDS
 
 For ROS 2 to communicate with PX4, [uXRCE-DDS client](../modules/modules_system.md#uxrce-dds-client) must be running on PX4, connected to a micro XRCE-DDS agent running on the companion computer.
 
-#### Setup the Agent
+##### Setup the Agent
 
 The agent can be installed onto the companion computer in a [number of ways](../middleware/uxrce_dds.md#micro-xrce-dds-agent-installation).
 Below we show how to build the agent "standalone" from source and connect to a client running on the PX4 simulator.
@@ -190,7 +221,7 @@ You can leave the agent running in this terminal!
 Note that only one agent is allowed per connection channel.
 :::
 
-#### Start the Client
+##### Start the DDS Client
 
 The PX4 simulator starts the uXRCE-DDS client automatically, connecting to UDP port 8888 on the local host.
 
@@ -227,6 +258,51 @@ The micro XRCE-DDS agent terminal should also start to show output, as equivalen
 [1675929445.270412] info     | ProxyClient.cpp    | create_topic             | topic created          | client_key: 0x00000001, topic_id: 0x0DF(2), participant_id: 0x001(1)
 ...
 ```
+
+#### Zenoh
+
+<Badge type="tip" text="PX4 v1.17" /> <Badge type="warning" text="Experimental" />
+
+For ROS 2 to communicate with PX4 via Zenoh, the [PX4 Zenoh-Pico Node](../middleware/zenoh.md) must be running on PX4, connected to a Zenoh router (`zenohd`) running on the companion computer.
+
+##### Setup the Router
+
+Install and start the Zenoh router using ROS 2:
+
+```sh
+export RMW_IMPLEMENTATION=rmw_zenoh_cpp
+ros2 run rmw_zenoh_cpp rmw_zenohd
+```
+
+For more information about the Zenoh Router see the [rmw_zenoh](https://github.com/ros2/rmw_zenoh?tab=readme-ov-file#start-the-zenoh-router) documentation.
+
+::: info
+You can leave the router running in this terminal!
+:::
+
+##### Start the Zenoh Client
+
+To start the simulator (and client):
+
+1. Open a new terminal in the root of the **PX4 Autopilot** repo that was installed above.
+
+   Start a Zenoh-enabled PX4 [Gazebo](../sim_gazebo_gz/index.md) simulation using:
+
+   ```sh
+   make px4_sitl_zenoh gz_x500
+   ```
+
+1. In the PX4 shell, enable Zenoh and reboot to apply the change:
+
+   ```sh
+   param set ZENOH_ENABLE 1
+   reboot
+   ```
+
+The default Zenoh daemon address for the `px4_sitl_zenoh` target is `localhost`, so no further network configuration is needed for simulation.
+See [Zenoh > Configure Zenoh Network](../middleware/zenoh.md#configure-zenoh-network) if you need to connect to a router at a different address (such as on real hardware).
+
+Once the client and router are connected, you can inspect the available topics using standard ROS 2 CLI tools, e.g. `ros2 topic list`.
 
 ### Build ROS 2 Workspace
 

--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -27,6 +27,8 @@ The same concepts translate directly to real hardware: the middleware client, wh
 See [Using Flight Controller Hardware](#using-flight-controller-hardware) for the hardware-specific differences.
 :::
 
+If you want to command the vehicle and create custom flight behaviours using ROS 2 (rather than just reading telemetry), you can create external modes using the [PX4 ROS 2 Interface Library](./px4_ros2_interface_lib.md), a ROS 2 native C++ library that works on top of either middleware.
+
 ### DDS
 
 The application pipeline for ROS 2 is very straightforward, thanks to the use of the [uXRCE-DDS](../middleware/uxrce_dds.md) communications middleware.

--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -6,9 +6,11 @@ This topic provides an overview of the architecture and application pipeline, an
 
 ## Overview
 
-PX4 supports two middleware options for bridging uORB topics to ROS 2: [uXRCE-DDS](../middleware/uxrce_dds.md) (DDS) and [Zenoh](../middleware/zenoh.md).
+PX4 supports two middleware options for bridging uORB topics to ROS 2: [uXRCE-DDS](#dds) (DDS) and [Zenoh](#zenoh).
 You must select which middleware to use and build your firmware accordingly (see [Installation & Setup](#installation-setup)).
 DDS is currently recommended for most users, as it is more established and has been more thoroughly tested with PX4.
+
+If you want to command the vehicle and create custom flight behaviours using ROS 2 (rather than just reading telemetry), you can create external modes using the [PX4 ROS 2 Interface Library](./px4_ros2_interface_lib.md), a ROS 2 native C++ library that works on top of either middleware.
 
 ::: info
 The instructions below target simulation using Gazebo.
@@ -16,13 +18,11 @@ The same concepts translate directly to real hardware: the middleware client, wh
 See [Using Flight Controller Hardware](#using-flight-controller-hardware) for the hardware-specific differences.
 :::
 
-If you want to command the vehicle and create custom flight behaviours using ROS 2 (rather than just reading telemetry), you can create external modes using the [PX4 ROS 2 Interface Library](./px4_ros2_interface_lib.md), a ROS 2 native C++ library that works on top of either middleware.
-
 ### DDS
 
 <Badge type="tip" text="PX4 v1.14" />
 
-The application pipeline for ROS 2 is very straightforward, thanks to the use of the [uXRCE-DDS](../middleware/uxrce_dds.md) communications middleware.
+The [uXRCE-DDS](../middleware/uxrce_dds.md) communications middleware is a large part of what makes the application pipeline for ROS 2 very straightforward.
 
 ![Architecture uXRCE-DDS with ROS 2](../../assets/middleware/xrce_dds/architecture_xrce-dds_ros2.svg)
 
@@ -54,7 +54,7 @@ See [uXRCE-DDS > Version selection](../middleware/uxrce_dds.md#version-selection
 
 <Badge type="tip" text="PX4 v1.17" /> <Badge type="warning" text="Experimental" />
 
-PX4 also supports [Zenoh](../middleware/zenoh.md) as an alternative (experimental) middleware for bridging uORB topics to ROS 2, via the ROS 2 [`rmw_zenoh`](https://github.com/ros2/rmw_zenoh) middleware.
+PX4 supports [Zenoh](../middleware/zenoh.md) as an alternative middleware for bridging uORB topics to ROS 2, via the ROS 2 [`rmw_zenoh`](https://github.com/ros2/rmw_zenoh) middleware.
 It provides a fast and lightweight way to connect PX4 to ROS 2.
 
 ![Architecture PX4 Zenoh-Pico with ROS 2](../../assets/middleware/zenoh/architecture-px4-zenoh.svg)
@@ -162,7 +162,7 @@ To install ROS 2 and its dependencies:
 
    ::::
 
-1. Some Python dependencies must also be installed (using **`pip`** or **`apt`**):
+2. Some Python dependencies must also be installed (using **`pip`** or **`apt`**):
 
    ```sh
    pip install --user -U empy==3.3.4 pyros-genmsg setuptools
@@ -170,14 +170,15 @@ To install ROS 2 and its dependencies:
 
 ### Setup Middleware
 
-PX4 supports two middleware options for connecting to ROS 2: [DDS](#dds) and [Zenoh](#zenoh) (see [Overview](#overview) for more on each).
-Select the one you want to use, making sure your firmware has the corresponding module enabled: the [uxrce_dds_client](../modules/modules_system.md#uxrce-dds-client) module is included by default in most builds, while the [zenoh](../middleware/zenoh.md#px4-firmware) module must be explicitly enabled.
+This section explains how to set up either the [DDS](#dds_setup) or [Zenoh](#zenoh_setup) middleware.
 
 ::: tip
 DDS is recommended for most users, as it is more established and has been more thoroughly tested with PX4.
 :::
 
-#### DDS
+Make sure that your firmware has the corresponding module enabled: the [uxrce_dds_client](../modules/modules_system.md#uxrce-dds-client) module is included by default in most builds, while the [zenoh](../middleware/zenoh.md#px4-firmware) module must be explicitly enabled.
+
+#### DDS {#dds_setup}
 
 For ROS 2 to communicate with PX4, [uXRCE-DDS client](../modules/modules_system.md#uxrce-dds-client) must be running on PX4, connected to a micro XRCE-DDS agent running on the companion computer.
 
@@ -189,7 +190,7 @@ Below we show how to build the agent "standalone" from source and connect to a c
 To setup and start the agent:
 
 1. Open a terminal.
-1. Enter the following commands to fetch and build the agent from source:
+2. Enter the following commands to fetch and build the agent from source:
 
    ```sh
    git clone -b v2.4.3 https://github.com/eProsima/Micro-XRCE-DDS-Agent.git
@@ -202,7 +203,7 @@ To setup and start the agent:
    sudo ldconfig /usr/local/lib/
    ```
 
-1. Start the agent with settings for connecting to the uXRCE-DDS client running on the simulator:
+3. Start the agent with settings for connecting to the uXRCE-DDS client running on the simulator:
 
    ```sh
    MicroXRCEAgent udp4 -p 8888
@@ -253,7 +254,7 @@ The micro XRCE-DDS agent terminal should also start to show output, as equivalen
 ...
 ```
 
-#### Zenoh
+#### Zenoh {#zenoh_setup}
 
 <Badge type="tip" text="PX4 v1.17" /> <Badge type="warning" text="Experimental" />
 
@@ -286,7 +287,7 @@ To start the simulator (and client):
    make px4_sitl_zenoh gz_x500
    ```
 
-1. In the PX4 shell, enable Zenoh and reboot to apply the change:
+2. In the PX4 shell, enable Zenoh and reboot to apply the change:
 
    ```sh
    param set ZENOH_ENABLE 1
@@ -319,7 +320,7 @@ The example builds the [ROS 2 Listener](#ros-2-listener) example application, lo
 To create and build the workspace:
 
 1. Open a new terminal.
-1. Create and navigate into a new workspace directory using:
+2. Create and navigate into a new workspace directory using:
 
    ```sh
    mkdir -p ~/ws_sensor_combined/src/
@@ -330,14 +331,14 @@ To create and build the workspace:
    A naming convention for workspace folders can make it easier to manage workspaces.
    :::
 
-1. Clone the example repository and [px4_msgs](https://github.com/PX4/px4_msgs) to the `/src` directory (the `main` branch is cloned by default, which corresponds to the version of PX4 we are running):
+3. Clone the example repository and [px4_msgs](https://github.com/PX4/px4_msgs) to the `/src` directory (the `main` branch is cloned by default, which corresponds to the version of PX4 we are running):
 
    ```sh
    git clone https://github.com/PX4/px4_msgs.git
    git clone https://github.com/PX4/px4_ros_com.git
    ```
 
-1. Source the ROS 2 development environment into the current terminal and compile the workspace using `colcon`:
+4. Source the ROS 2 development environment into the current terminal and compile the workspace using `colcon`:
 
    :::: tabs
 
@@ -401,13 +402,13 @@ In a new terminal:
 
    ::::
 
-1. Source the `local_setup.bash`.
+2. Source the `local_setup.bash`.
 
    ```sh
    source install/local_setup.bash
    ```
 
-1. Now launch the example.
+3. Now launch the example.
    Note here that we use `ros2 launch`, which is described below.
 
    ```sh
@@ -445,7 +446,7 @@ If you were to use incompatible [message versions](../middleware/uorb.md#message
    /path/to/PX4-Autopilot/Tools/copy_to_ros_ws.sh .
    ```
 
-1. Build and run the translation node:
+2. Build and run the translation node:
 
    ```sh
    colcon build

--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -4,17 +4,6 @@ The ROS 2-PX4 architecture provides a deep integration between ROS 2 and PX4, al
 
 This topic provides an overview of the architecture and application pipeline, and explains how to setup and use ROS 2 with PX4.
 
-::: info
-From PX4 v1.14, ROS 2 uses [uXRCE-DDS](../middleware/uxrce_dds.md) middleware, replacing the _FastRTPS_ middleware that was used in version 1.13 (v1.13 does not support uXRCE-DDS).
-
-The [migration guide](../middleware/uxrce_dds.md#fast-rtps-to-uxrce-dds-migration-guidelines) explains what you need to do in order to migrate ROS 2 apps from PX4 v1.13 to PX4 v1.14.
-
-If you're still working on PX4 v1.13, please follow the instructions in the [PX4 v1.13 Docs](https://docs.px4.io/v1.13/en/ros/ros2_comm).
-
-<!-- remove this when there are PX4 v1.14 docs for some months -->
-
-:::
-
 ## Overview
 
 PX4 supports two middleware options for bridging uORB topics to ROS 2: [uXRCE-DDS](../middleware/uxrce_dds.md) (DDS) and [Zenoh](../middleware/zenoh.md).
@@ -30,6 +19,8 @@ See [Using Flight Controller Hardware](#using-flight-controller-hardware) for th
 If you want to command the vehicle and create custom flight behaviours using ROS 2 (rather than just reading telemetry), you can create external modes using the [PX4 ROS 2 Interface Library](./px4_ros2_interface_lib.md), a ROS 2 native C++ library that works on top of either middleware.
 
 ### DDS
+
+<Badge type="tip" text="PX4 v1.14" />
 
 The application pipeline for ROS 2 is very straightforward, thanks to the use of the [uXRCE-DDS](../middleware/uxrce_dds.md) communications middleware.
 
@@ -58,11 +49,6 @@ You will normally need to start both the client and agent when using ROS 2.
 Note that the uXRCE-DDS client is built into firmware by default but not started automatically except for simulator builds.
 
 See [uXRCE-DDS > Version selection](../middleware/uxrce_dds.md#version-selection) to check which Micro XRCE-DDS version to use for your ROS 2 distribution.
-
-::: info
-In PX4v1.13 and earlier, ROS 2 was dependent on definitions in [px4_ros_com](https://github.com/PX4/px4_ros_com).
-This repo is no longer needed, but does contain useful examples.
-:::
 
 ### Zenoh
 

--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -21,6 +21,12 @@ PX4 supports two middleware options for bridging uORB topics to ROS 2: [uXRCE-DD
 You must select which middleware to use and build your firmware accordingly (see [Installation & Setup](#installation-setup)).
 DDS is currently recommended for most users, as it is more established and has been more thoroughly tested with PX4.
 
+::: info
+The instructions below target simulation using Gazebo.
+The same concepts translate directly to real hardware: the middleware client, which bridges the uORB topics, runs on the flight controller, while the agent/router runs on your companion computer.
+See [Using Flight Controller Hardware](#using-flight-controller-hardware) for the hardware-specific differences.
+:::
+
 ### DDS
 
 The application pipeline for ROS 2 is very straightforward, thanks to the use of the [uXRCE-DDS](../middleware/uxrce_dds.md) communications middleware.


### PR DESCRIPTION
### Solved Problem

The ROS 2 User Guide only documented uXRCE-DDS and listed Humble/EOL Foxy as the supported ROS 2 distributions. Ahead of the ROSCon 2026 PX4 workshop, the guide needed to also cover the new Zenoh middleware and point readers at the ROS 2 distro (Jazzy) and setup flow the workshop material actually uses.

### Solution

- Split the Overview and "Setup Middleware" sections into DDS and Zenoh, reusing the existing Zenoh architecture diagram (`architecture-px4-zenoh.svg`); DDS stays the recommended/more-tested default, Zenoh is flagged experimental.
- Replaced Foxy with Jazzy as the recommended ROS 2 distro (Humble kept as the LTS alternative), updated every Humble/Foxy tab pair on the page accordingly, and linked the Micro XRCE-DDS version-selection table.
- Added a note that the walkthrough targets Gazebo/SITL but translates directly to real hardware (middleware client on the flight controller, agent/router on the companion computer), linking to "Using Flight Controller Hardware".
- Pointed readers at the PX4 ROS 2 Interface Library for building custom flight behaviours/external modes.
- Fixed a stale cross-reference in `plotting_realtime_uorb_data.md` pointing at a heading anchor renamed by this change.
@beniaminopozzan 
