### PR TITLE
fix(gps): limit GPS_UBX_DYNMODEL to models u-blox defines

### DIFF
--- a/src/drivers/gps/params.yaml
+++ b/src/drivers/gps/params.yaml
@@ -27,14 +27,17 @@ parameters:
           the expected application environment.
       type: enum
       values:
+        0: portable
         2: stationary
+        3: pedestrian
         4: automotive
+        5: sea
         6: airborne with <1g acceleration
         7: airborne with <2g acceleration
         8: airborne with <4g acceleration
       default: 7
       min: 0
-      max: 9
+      max: 8
       reboot_required: true
     GPS_UBX_DGNSS_TO:
       description:


### PR DESCRIPTION
## Summary

Caps `GPS_UBX_DYNMODEL` at the dynamic models u-blox defines. The driver half of the same failure (PX4/PX4-GPSDrivers#225) is already on main, so this is the parameter-side remainder — the submodule bump this PR used to carry is gone.

## Problem
The range allowed 1, which is reserved on every u-blox generation, and 9 (wrist-worn watch), which is not available on all products. Either one is rejected by the receiver, and the dynamic model rides in a `UBX-CFG-VALSET` whose NAK aborts the whole configuration, so a parameter change alone was enough to leave the vehicle with no GPS at all.

## Solution
Cap the range at the airborne models. The portable, pedestrian and sea models were already inside the old range but undocumented, so they are listed rather than dropped.
