### PR TITLE
fix(commander): gate in-air home altitude correction on GNSS-hgt-ref

### DIFF
--- a/src/modules/commander/HomePosition.cpp
+++ b/src/modules/commander/HomePosition.cpp
@@ -42,7 +42,16 @@
 HomePosition::HomePosition(const failsafe_flags_s &failsafe_flags): ModuleParams(nullptr),
 	_failsafe_flags(failsafe_flags),
 	_param_ekf2_gps_ctrl_handle(param_find("EKF2_GPS_CTRL"))
-{}
+{
+	int32_t ekf2_hgt_ref = kHeightReferenceGnss;
+	const param_t param_ekf2_hgt_ref_handle = param_find("EKF2_HGT_REF");
+
+	if (param_ekf2_hgt_ref_handle != PARAM_INVALID) {
+		param_get(param_ekf2_hgt_ref_handle, &ekf2_hgt_ref);
+	}
+
+	_gnss_height_reference = (ekf2_hgt_ref == kHeightReferenceGnss);
+}
 
 bool HomePosition::hasMovedFromCurrentHomeLocation()
 {
@@ -386,7 +395,8 @@ void HomePosition::update(bool set_automatically, bool check_if_changed)
 					       && isGpsPositionFusionEnabled();
 
 		if (_param_com_home_en.get() && _gps_position_for_home_valid && _last_gps_timestamp != 0 && _last_baro_timestamp != 0
-		    && _takeoff_time != 0 && now < _takeoff_time + kHomePositionCorrectionTimeWindow) {
+		    && _takeoff_time != 0 && now < _takeoff_time + kHomePositionCorrectionTimeWindow
+		    && _gnss_height_reference) {
 
 			const float gps_alt = static_cast<float>(_gps_alt);
 

--- a/src/modules/commander/HomePosition.hpp
+++ b/src/modules/commander/HomePosition.hpp
@@ -53,6 +53,7 @@ static constexpr float kHomePositionGPSRequiredEPH = 5.f;
 static constexpr float kHomePositionGPSRequiredEPV = 10.f;
 static constexpr float kHomePositionGPSRequiredEVH = 1.f;
 static constexpr int32_t kGpsCtrlHorizontalAndAltitude = (1 << 0) | (1 << 1);
+static constexpr int32_t kHeightReferenceGnss = 1;
 static constexpr float kMinHomePositionChangeEPH = 1.f;
 static constexpr float kMinHomePositionChangeEPV = 1.5f;
 static constexpr float kLpfBaroTimeConst = 5.f;
@@ -118,4 +119,5 @@ private:
 		(ParamBool<px4::params::COM_HOME_EN>) _param_com_home_en
 	)
 	param_t _param_ekf2_gps_ctrl_handle{PARAM_INVALID};
+	bool _gnss_height_reference{true};
 };


### PR DESCRIPTION
### Solved Problem
The in-air home altitude correction (#25003) assumes the estimated altitude follows raw GNSS altitude. When GNSS is not the EKF height reference (e.g. `EKF2_HGT_REF = 0`, baro), the EKF absorbs GNSS altitude drift in its GNSS height bias estimator and the estimate stays put, so the correction moves home by the full drift and corrupts altitude-above-home.

### Solution
Only apply the correction when GNSS is the EKF height reference. `EKF2_HGT_REF` is reboot-required, so it is read once at construction; if the parameter does not exist (builds without EKF2) the correction stays enabled as before.

### Changelog Entry

For release notes:
```
Bugfix: in-air home position altitude correction is now only applied when GNSS is the EKF height reference (EKF2_HGT_REF = GPS)
```
