### PR TITLE
fix(ci): align voxl2 group chip family with its seeder cache key

### DIFF
--- a/Tools/ci/build_all_config.yml
+++ b/Tools/ci/build_all_config.yml
@@ -24,6 +24,8 @@ cache:
     stm32f4: "800M"
     stm32f7: "800M"
     imxrt: "800M"
+    # voxl2 cache holds objects for two toolchains (aarch64-gnu + hexagon-clang)
+    voxl2: "800M"
 
 # Board grouping limits
 grouping:

--- a/Tools/ci/generate_board_targets_json.py
+++ b/Tools/ci/generate_board_targets_json.py
@@ -463,7 +463,7 @@ if (args.group):
                     "container": grouped_targets[arch]['container'],
                     "targets": comma_targets(all_targets),
                     "arch": arch,
-                    "chip_family": "native",
+                    "chip_family": "voxl2",
                     "runner": runner,
                     "group": "voxl2-0",
                     "len": len(all_targets),
@@ -519,11 +519,7 @@ if (args.group):
         # Determine which chip families actually have groups
         active_families = set()
         for g in final_groups:
-            cf = g['chip_family']
-            active_families.add(cf)
-            # voxl2 gets its own seeder with a different container
-            if g['group'].startswith('voxl2'):
-                active_families.add('voxl2')
+            active_families.add(g['chip_family'])
 
         seeders = []
         for cf in sorted(active_families):
@@ -537,11 +533,10 @@ if (args.group):
                     'runner': 'x64',
                 })
             elif cf == 'native':
-                # One seeder per runner arch that has native groups (exclude voxl2
-                # which has its own seeder with a different container)
+                # One seeder per runner arch that has native groups
                 native_runners = set()
                 for g in final_groups:
-                    if g['chip_family'] == 'native' and not g['group'].startswith('voxl2'):
+                    if g['chip_family'] == 'native':
                         native_runners.add(g['runner'])
                 for r in sorted(native_runners):
                     seeders.append({


### PR DESCRIPTION
## Summary

Fix a ccache key namespace mismatch in `build_all_targets` that has been silently discarding the voxl2 seeder cache on every run.

## Problem

`Tools/ci/generate_board_targets_json.py` assigns the voxl2 build group `chip_family: native` while the voxl2 seeder gets `chip_family: voxl2`, and the workflow derives ccache keys from `chip_family`. In the logs of the last 10 successful runs (and live on `release/1.18`), `Seed [voxl2]` saves under

```
ccache-voxl2-x64-seeder-<ref>-<sha>
```

while `Build [x64][voxl2-0]` restores/saves under

```
ccache-native-x64-voxl2-0-<ref>-<sha>
```

The build job's restore-keys chain bottoms out at `ccache-native-x64-` and can never reach the seeder namespace, so the seeder's `modalai_voxl2_default` build on an 8-cpu runner is thrown away every run. On a cold cache the build instead falls back to the SITL seeder cache, which holds host gcc objects with zero possible hits against `aarch64-linux-gnu-gcc` or hexagon-clang (ccache runs with `compiler_check=content`), wasting the group's 400M budget. The inconsistency dates to #27050.

## Solution

Give the voxl2 group `chip_family: voxl2` so group and seeder share one key namespace. That makes the seeder-generation special case for voxl2 groups redundant (the family now lands in `active_families` naturally) and kills the dead `not g['group'].startswith('voxl2')` clause in the native-seeder runner loop, so both are removed; the voxl2 seeder branch itself stays since it needs a different container. The voxl2 cache is also sized at 800M like the other overrides, since it holds objects for two toolchains (aarch64-gnu + hexagon-clang) and already sits at ~357 MB of the 400M limit.

Verified by diffing the generator output before/after: the only changes are the voxl2-0 group's `chip_family` (`native` -> `voxl2`) and `cache_size` (`400M` -> `800M`); the `--seeders` output is byte-identical. No firmware code is touched, so no firmware builds were run.
