### PR TITLE
ci(build-all): drop per-job pynacl install, bump container to v1.18.0-beta2

### DIFF
--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -218,14 +218,6 @@ jobs:
           ccache -s
           ccache -z
 
-      - name: Install pynacl for secure-boot signing
-        # TODO: drop once the build container ships with pynacl preinstalled
-        # (currently pinned to v1.17.0-rc2 in Tools/ci/build_all_config.yml).
-        # Modern containers enforce PEP 668 and need --break-system-packages;
-        # older ones (e.g. voxl2) ship a pip that doesn't know the flag and
-        # don't need it either, so fall back to plain pip install.
-        run: pip install pynacl --break-system-packages || pip install pynacl
-
       - name: Building Artifacts for [${{ matrix.targets }}]
         run: |
             ./Tools/ci/build_all_runner.sh ${{matrix.targets}} ${{matrix.arch}}

--- a/Tools/ci/build_all_config.yml
+++ b/Tools/ci/build_all_config.yml
@@ -7,7 +7,7 @@
 
 # Container images
 containers:
-  default: "ghcr.io/px4/px4-dev:v1.17.0-rc2"
+  default: "ghcr.io/px4/px4-dev:v1.18.0-beta2"
   voxl2: "ghcr.io/px4/px4-dev-voxl2:v1.7"
 
 # Runner specs


### PR DESCRIPTION
## Summary

Removes the per-job `pip install pynacl` step from the build-all workflow and bumps the default build container from `v1.17.0-rc2` to `v1.18.0-beta2`, which ships pynacl preinstalled.

## Problem

#27237 added a pynacl install step to every matrix job as a stopgap, with a TODO to drop it once the build container ships pynacl preinstalled.

## Solution

Bump the default container pin and delete the step. Verified locally by building `px4_fmu-v6x_secureboot` inside `px4io/px4-dev:v1.18.0-beta2`: the firmware signing step runs against the baked-in pynacl with no pip install anywhere in the build log. The voxl2 container keeps its own pin and needs no fallback, since only `CONFIG_BOARD_SECUREBOOT` targets (NuttX platform only, currently just the fmu-v6x secureboot variant) invoke the signing script. This PR's own CI run validates the new image across every build group.

One heads-up for after merge: the first run on the new container is a cold-cache run for all groups (`compiler_check = content` invalidates every ccache namespace when the compilers change), so expect one slow build-all pass.
