### PR TITLE
fix(uavcan): publish esc_status once per ESC status round

### DIFF
--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -108,9 +108,7 @@ void UavcanEscController::update_outputs(float outputs[MAX_ACTUATORS], uint8_t o
 void UavcanEscController::set_rotor_count(uint8_t count)
 {
 	_rotor_count = count;
-
-	// the set of reporting ESC indices may change with the mixer configuration
-	_seen_status_mask = 0;
+	_seen_status_mask = 0; // the set of reporting ESC indices may change with the mixer configuration
 }
 
 void UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::esc::Status> &msg)
@@ -126,12 +124,11 @@ void UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<
 		esc_report.esc_errorcount = msg.error_count;
 		esc_report.failures = get_failures(msg.esc_index, msg.getSrcNodeID().get());
 
-		// Each ESC broadcasts its own Status on an independent timer, so arrival order
-		// is not sorted by index. A repeated index marks the start of a new round.
-		// Publish once per round so the topic rate matches the per-ESC status rate.
+		// A repeated ESC index marks the start of a new round; publish once per round.
 		const uint16_t index_bit = 1u << msg.esc_index;
 
 		if (_seen_status_mask & index_bit) {
+			_seen_status_mask = 0;
 			_esc_status.esc_count = _rotor_count;
 			_esc_status.counter += 1;
 			_esc_status.esc_connectiontype = esc_status_s::ESC_CONNECTION_TYPE_CAN;
@@ -141,7 +138,6 @@ void UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<
 
 			_failure_config.update();
 			_esc_status_pub.publish(failure_injection::process_esc(_failure_config, _esc_status));
-			_seen_status_mask = 0;
 		}
 
 		_seen_status_mask |= index_bit;

--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -108,6 +108,9 @@ void UavcanEscController::update_outputs(float outputs[MAX_ACTUATORS], uint8_t o
 void UavcanEscController::set_rotor_count(uint8_t count)
 {
 	_rotor_count = count;
+
+	// the set of reporting ESC indices may change with the mixer configuration
+	_seen_status_mask = 0;
 }
 
 void UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::esc::Status> &msg)
@@ -123,15 +126,25 @@ void UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<
 		esc_report.esc_errorcount = msg.error_count;
 		esc_report.failures = get_failures(msg.esc_index, msg.getSrcNodeID().get());
 
-		_esc_status.esc_count = _rotor_count;
-		_esc_status.counter += 1;
-		_esc_status.esc_connectiontype = esc_status_s::ESC_CONNECTION_TYPE_CAN;
-		_esc_status.esc_online_flags = check_escs_status();
-		_esc_status.esc_armed_flags = (1 << _rotor_count) - 1;
-		_esc_status.timestamp = esc_report.timestamp;
+		// Each ESC broadcasts its own Status on an independent timer, so arrival order
+		// is not sorted by index. A repeated index marks the start of a new round.
+		// Publish once per round so the topic rate matches the per-ESC status rate.
+		const uint16_t index_bit = 1u << msg.esc_index;
 
-		_failure_config.update();
-		_esc_status_pub.publish(failure_injection::process_esc(_failure_config, _esc_status));
+		if (_seen_status_mask & index_bit) {
+			_esc_status.esc_count = _rotor_count;
+			_esc_status.counter += 1;
+			_esc_status.esc_connectiontype = esc_status_s::ESC_CONNECTION_TYPE_CAN;
+			_esc_status.esc_online_flags = check_escs_status();
+			_esc_status.esc_armed_flags = (1 << _rotor_count) - 1;
+			_esc_status.timestamp = esc_report.timestamp;
+
+			_failure_config.update();
+			_esc_status_pub.publish(failure_injection::process_esc(_failure_config, _esc_status));
+			_seen_status_mask = 0;
+		}
+
+		_seen_status_mask |= index_bit;
 	}
 
 	// Register device capability for each ESC channel

--- a/src/drivers/uavcan/actuators/esc.hpp
+++ b/src/drivers/uavcan/actuators/esc.hpp
@@ -126,6 +126,11 @@ private:
 
 	uint8_t		_rotor_count{0};
 
+	// bitmask of ESC indices seen since the last publish; a repeat marks a new round
+	uint16_t	_seen_status_mask{0};
+	static_assert(esc_status_s::CONNECTED_ESC_MAX <= 8 * sizeof(_seen_status_mask),
+		      "_seen_status_mask cannot hold CONNECTED_ESC_MAX bits");
+
 	failure_injection::Config _failure_config;
 
 	/*


### PR DESCRIPTION
### Solved Problem
Each DroneCAN ESC broadcasts `esc.Status` on its own timer, and the uavcan driver published the full `esc_status` topic on every incoming message. The topic rate was therefore `esc_count` * the per-ESC status rate, flooding logs with per-motor duplicate data points.

### Solution
Publish `esc_status` once per telemetry round instead of once per message. A round is detected with a seen-index bitmask: when an ESC index that already reported since the last publish arrives again, a full round has elapsed — publish the accumulated array and restart the mask.

- Index ordering is deliberately not used: CAN arrival order is arbitrary, not sorted by index
- Robust to ESC dropout: any surviving index repeating still closes the round
- The mask is `uint16_t` with a `static_assert` against `CONNECTED_ESC_MAX` and is reset in `set_rotor_count()` since the reporting index set can change with the mixer configuration

**Known trade-offs**: with heterogeneous per-ESC status rates the topic follows the fastest ESC. A final partial round is not flushed if the status stream stops, `StatusExtended`-fed fields reach uORB up to one round later.

### Changelog Entry
For release notes:
```
Bugfix: uavcan: publish esc_status once per ESC status round instead of per message
Documentation: none required
```

### Test coverage
- Flight-tested on a vehicle with 6 Vertiq DroneCAN ESCs: `esc_status` drops from ~280 Hz published / ~175 Hz logged to one publish per round at the per-ESC rate, every sample carrying all motors' latest reports. Verified in ULog.
- Built `px4_fmu-v6x_default` cleanly.

### Context
Related links, screenshot before/after, video
