### PR TITLE
fix(fixed_wing): Keep the drone level during takeoff

### DIFF
--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -1248,19 +1248,35 @@ FixedWingModeManager::control_auto_takeoff(const hrt_abstime &now, const float c
 		if (_launchDetector.getLaunchDetected() > launch_detection_status_s::STATE_WAITING_FOR_LAUNCH) {
 			/* Launch has been detected, hence we have to control the plane. */
 
-			const DirectionalGuidanceOutput sp = navigateLine(launch_local_position, takeoff_bearing, local_2D_position,
-							     ground_speed,
-							     _wind_vel);
-
 			fixed_wing_lateral_setpoint_s fw_lateral_ctrl_sp{empty_lateral_control_setpoint};
 			fw_lateral_ctrl_sp.timestamp = now;
-			fw_lateral_ctrl_sp.course = sp.course_setpoint;
-			fw_lateral_ctrl_sp.lateral_acceleration = sp.lateral_acceleration_feedforward;
+
+			const bool in_launch_climbout = (_current_altitude - _takeoff_ground_alt) < _param_fw_laun_clr_alt.get();
+
+			if (in_launch_climbout) {
+				// hold the launch bearing (course, wind-compensated) during the initial climbout, without the extra
+				// line-following feedforward, until we're above FW_LAUN_CLR_ALT
+				fw_lateral_ctrl_sp.course = takeoff_bearing;
+				fw_lateral_ctrl_sp.lateral_acceleration = 0.f;
+
+			} else {
+				const DirectionalGuidanceOutput sp = navigateLine(launch_local_position, takeoff_bearing, local_2D_position,
+								     ground_speed,
+								     _wind_vel);
+				fw_lateral_ctrl_sp.course = sp.course_setpoint;
+				fw_lateral_ctrl_sp.lateral_acceleration = sp.lateral_acceleration_feedforward;
+			}
 
 			_lateral_ctrl_sp_pub.publish(fw_lateral_ctrl_sp);
 
-			const float roll_wingtip_strike = getMaxRollAngleNearGround(_current_altitude, _takeoff_ground_alt);
-			_ctrl_configuration_handler.setLateralAccelMax(rollAngleToLateralAccel(roll_wingtip_strike));
+			float roll_limit = getMaxRollAngleNearGround(_current_altitude, _takeoff_ground_alt);
+
+			const float launch_clr_alt = math::max(_param_fw_laun_clr_alt.get(), FLT_EPSILON);
+			const float launch_climbout_ratio = math::constrain((_current_altitude - _takeoff_ground_alt) / launch_clr_alt,
+							    0.f, 1.f);
+			roll_limit = math::min(roll_limit, launch_climbout_ratio * math::radians(_param_fw_r_lim.get()));
+
+			_ctrl_configuration_handler.setLateralAccelMax(rollAngleToLateralAccel(roll_limit));
 
 			const float max_takeoff_throttle = (_launchDetector.getLaunchDetected() < launch_detection_status_s::STATE_FLYING) ?
 							   _param_fw_thr_idle.get() : NAN;

--- a/src/modules/fw_mode_manager/FixedWingModeManager.hpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.hpp
@@ -878,6 +878,7 @@ private:
 		// Launch detection parameters
 		(ParamBool<px4::params::FW_LAUN_DETCN_ON>) _param_fw_laun_detcn_on,
 		(ParamFloat<px4::params::FW_LAUN_CS_LK_DY>) _param_fw_laun_cs_lk_dy,
+		(ParamFloat<px4::params::FW_LAUN_CLR_ALT>) _param_fw_laun_clr_alt,
 
 		// external parameters
 		(ParamBool<px4::params::FW_USE_AIRSPD>) _param_fw_use_airspd,

--- a/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
+++ b/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
@@ -261,6 +261,21 @@ parameters:
       min: 0.0
       decimal: 1
       increment: 0.1
+    FW_LAUN_CLR_ALT:
+      description:
+        short: Launch climbout clearance altitude
+        long: |-
+          Height above the launch point below which the vehicle holds the wind-compensated launch bearing
+          instead of the normal line-following guidance, and the roll limit is ramped linearly from 0 at
+          the launch point up to FW_R_LIM at this altitude, so that a poor heading estimate or a bad launch
+          cannot induce a large bank close to the ground. Only relevant for hand- or catapult-launched
+          vehicles (FW_LAUN_DETCN_ON).
+      type: float
+      default: 5.0
+      unit: m
+      min: 0.0
+      decimal: 1
+      increment: 1.0
     FW_FLAPS_TO_SCL:
       description:
         short: Flaps setting during take-off


### PR DESCRIPTION


### Solved Problem

During takeoff of a fixed wing, if the heading estimate is wrong the plane will immediately roll to correct onto the commanded course/bearing, leading to undesirable behaviour (an aggressive, unwarranted bank shortly after a hand- or catapult-launch).

### Solution

Add new parameter:
- FW_LAUN_CLR_ALT(Launch climbout clearance altitude): height above the launch point below which the roll used for course tracking is limited.

Below FW_LAUN_CLR_ALT, the aircraft still holds the wind-compensated launch bearing (so it doesn't drift downwind), but the roll command is ramped up linearly with altitude— so a poor heading estimate can only produce a gentle correction, not a hard bank close to the ground. Only applies to the hand-/catapult-launch path (FW_LAUN_DETCN_ON); runway takeoff.

### Changelog Entry

### Test coverage
The code was flight-tested in these situations and worked well:

1. Nominal conditions with GPS and takeoff waypoint straight ahead
2. GPS with takeoff waypoint immediately right of the takeoff point

