### PR TITLE
fix(simulation): fixed test filter for loiter tests

### DIFF
--- a/test/mavsdk_tests/autopilot_tester_loiter.cpp
+++ b/test/mavsdk_tests/autopilot_tester_loiter.cpp
@@ -329,3 +329,10 @@ float AutopilotTesterLoiter::default_loiter_radius()
 	CHECK(result.first == Param::Result::Success);
 	return result.second;
 }
+
+float AutopilotTesterLoiter::fw_altitude_acceptance_radius()
+{
+	const auto result = getParams()->get_param_float("NAV_FW_ALT_RAD");
+	CHECK(result.first == Param::Result::Success);
+	return result.second;
+}

--- a/test/mavsdk_tests/autopilot_tester_loiter.h
+++ b/test/mavsdk_tests/autopilot_tester_loiter.h
@@ -112,6 +112,9 @@ public:
 	// NAV_LOITER_RAD default loiter radius in meters.
 	float default_loiter_radius();
 
+	// NAV_FW_ALT_RAD fixed-wing altitude acceptance radius in meters.
+	float fw_altitude_acceptance_radius();
+
 private:
 	// Horizontal distance in meters between a NED sample and a local coordinate.
 	static double horizontal_distance(const mavsdk::Telemetry::PositionVelocityNed &sample, const LocalCoordinate &c);

--- a/test/mavsdk_tests/test_vtol_loiter_reposition.cpp
+++ b/test/mavsdk_tests/test_vtol_loiter_reposition.cpp
@@ -88,7 +88,7 @@ void establish_work_orbit(AutopilotTesterLoiter &tester)
 
 } // namespace
 
-TEST_CASE("Loiter: RTL climbs on an established non-default-radius loiter", "[loiter]")
+TEST_CASE("Loiter: RTL climbs on an established non-default-radius loiter", "[vtol]")
 {
 	AutopilotTesterLoiter tester;
 	arm_takeoff_transition_hold(tester);
@@ -105,7 +105,7 @@ TEST_CASE("Loiter: RTL climbs on an established non-default-radius loiter", "[lo
 				      kAltitudeTolerance, 180s);
 }
 
-TEST_CASE("Loiter: Hold during an altitude change keeps the loiter and locks the current altitude", "[loiter]")
+TEST_CASE("Loiter: Hold during an altitude change keeps the loiter and locks the current altitude", "[vtol]")
 {
 	AutopilotTesterLoiter tester;
 	arm_takeoff_transition_hold(tester);
@@ -132,7 +132,7 @@ TEST_CASE("Loiter: Hold during an altitude change keeps the loiter and locks the
 	tester.check_stays_on_loiter(kWorkCenter, kNonDefaultRadius, kRadiusTolerance, 40s);
 }
 
-TEST_CASE("Loiter: Hold while transiting creates a new loiter at the current position", "[loiter]")
+TEST_CASE("Loiter: Hold while transiting creates a new loiter at the current position", "[vtol]")
 {
 	AutopilotTesterLoiter tester;
 	arm_takeoff_transition_hold(tester);
@@ -155,7 +155,7 @@ TEST_CASE("Loiter: Hold while transiting creates a new loiter at the current pos
 	tester.check_never_reaches(far_center, 150.f, 40s);
 }
 
-TEST_CASE("Loiter: Hold on a figure-eight reverts to a plain circular loiter", "[loiter]")
+TEST_CASE("Loiter: Hold on a figure-eight reverts to a plain circular loiter", "[vtol]")
 {
 	AutopilotTesterLoiter tester;
 	arm_takeoff_transition_hold(tester);
@@ -176,7 +176,7 @@ TEST_CASE("Loiter: Hold on a figure-eight reverts to a plain circular loiter", "
 	tester.check_stays_within(hold_position, default_radius + 70.f, 40s);
 }
 
-TEST_CASE("Loiter: altitude-only reposition keeps the loiter and only changes altitude", "[loiter]")
+TEST_CASE("Loiter: altitude-only reposition keeps the loiter and only changes altitude", "[vtol]")
 {
 	AutopilotTesterLoiter tester;
 	arm_takeoff_transition_hold(tester);

--- a/test/mavsdk_tests/test_vtol_loiter_reposition.cpp
+++ b/test/mavsdk_tests/test_vtol_loiter_reposition.cpp
@@ -99,10 +99,13 @@ TEST_CASE("Loiter: RTL climbs on an established non-default-radius loiter", "[vt
 	tester.set_rtl_altitude(rtl_altitude);
 	tester.execute_rtl();
 
+	// Accept the altitude the controller itself considers "reached", with 20% margin on top.
+	const float altitude_tolerance = 1.2f * tester.fw_altitude_acceptance_radius();
+
 	// RTL must climb to the return altitude while continuing to circle the very same loiter
 	// (same center and non-default radius), not re-center a new circle.
 	tester.check_climbs_on_loiter(kWorkCenter, kNonDefaultRadius, kRadiusTolerance, rtl_altitude,
-				      kAltitudeTolerance, 180s);
+				      altitude_tolerance, 180s);
 }
 
 TEST_CASE("Loiter: Hold during an altitude change keeps the loiter and locks the current altitude", "[vtol]")


### PR DESCRIPTION
The fixed wing loiter tests were not running because the test filter did not match.

Also the test was failing because the altitude threshold when to stop checking the "established on loiter" criteria was lower than the fixed wing altitude acceptance radius ans so the tests was always failing.