### PR TITLE
fix(boards): v6x start correct second baro

### DIFF
--- a/boards/auterion/fmu-v6x/init/rc.board_sensors
+++ b/boards/auterion/fmu-v6x/init/rc.board_sensors
@@ -81,6 +81,9 @@ then
 	then
 		bmp388 -I -a 0x77 start
 	fi
+
+	# External baro
+	bmp388 -X start
 else
 	# Internal SPI bus ICM45686
 	icm45686 -R 0 -s start
@@ -93,13 +96,13 @@ else
 	then
 		bmp581 -I -a 0x47 start
 	fi
+
+	# External baro
+	bmp581 -X start
 fi
 
 # External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
 ist8310 -X -b 1 -R 10 start
-
-#external baro
-bmp388 -X start
 
 unset INA_CONFIGURED
 unset HAVE_PM2


### PR DESCRIPTION
### Solved Problem

- On the new FMU HW for v6x/v6n the second baro was not correctly started (it is also a bmp581 instead of a bmp388)

### Solution

- Start the second bmp581 on the new FMU HW

### Test coverage

- Tested on the bench with the new FMU HW