### PR TITLE
ci(macos): measure --sim-tools setup time with Gazebo bottles available

### DIFF
--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -18,7 +18,11 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-15]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: install Python 3.10
       uses: actions/setup-python@v6
@@ -45,7 +49,7 @@ jobs:
 
     - name: setup
       run: |
-        ./Tools/setup/macos.sh
+        ./Tools/setup/macos.sh --sim-tools
         echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
 
     - uses: ./.github/actions/setup-ccache


### PR DESCRIPTION
The one thing to consider, is that build times depend on the formula bottles actually being present, this is relevant because the build times can increase by up to ~15min in average, and this can be true in the period in between the OSRF is updating bottles which typically takes around 60min, if we ever hit that window CI times will blow up for a bit. We can think of a way to address that if it ever becomes an issue, for now I think its worth adding the gz tooling to CI on macOS so we don't run into inconsistencies with dependencies going forward.

| | Aug 11 (OSRF bottles pulled) | Aug 18 (OSRF bottles back) |
|---|---|---|
| macos-latest setup step | 23m25s | 8m33s (sim install 6m21s) |
| macos-latest job | 30m13s | 14m43s |
| macos-15 setup step | 18m23s | 7m20s (sim install 5m37s) |
| macos-15 job | 23m51s | 14m07s |
