### PR TITLE
fix(ekf2): repair the ULog to replay csv converter

### DIFF
--- a/src/modules/ekf2/test/sensor_simulator/convertULogToSensorData.py
+++ b/src/modules/ekf2/test/sensor_simulator/convertULogToSensorData.py
@@ -6,16 +6,16 @@ def getVioData(ulog: ULog) -> pd.DataFrame:
 	vehicle_visual_odometry = ulog.get_dataset("vehicle_visual_odometry").data
 	vio = pd.DataFrame({'timestamp': vehicle_visual_odometry['timestamp'],
 		'sensor' : 'vio',
-		'x': vehicle_visual_odometry["x"],
-		'y': vehicle_visual_odometry["y"],
-		'z': vehicle_visual_odometry["z"],
+		'x': vehicle_visual_odometry["position[0]"],
+		'y': vehicle_visual_odometry["position[1]"],
+		'z': vehicle_visual_odometry["position[2]"],
 		'qw': vehicle_visual_odometry["q[0]"],
 		'qx': vehicle_visual_odometry["q[1]"],
 		'qy': vehicle_visual_odometry["q[2]"],
 		'qz': vehicle_visual_odometry["q[3]"],
-		'vx': vehicle_visual_odometry["vx"],
-		'vy': vehicle_visual_odometry["vy"],
-		'vz': vehicle_visual_odometry["vz"]
+		'vx': vehicle_visual_odometry["velocity[0]"],
+		'vy': vehicle_visual_odometry["velocity[1]"],
+		'vz': vehicle_visual_odometry["velocity[2]"]
 		})
 	return vio
 
@@ -48,51 +48,42 @@ def getAirspeedData(ulog: ULog) -> pd.DataFrame:
 
 def getRangeFinderData(ulog: ULog) -> pd.DataFrame:
 
-	range = pd.DataFrame()
-	try:
-		range_0 = ulog.get_dataset("distance_sensor", 0).data
-		rng_0 = pd.DataFrame({'timestamp': range_0['timestamp'],
-			'sensor' : 'range',
-			'data': range_0["current_distance"],
-			'quality': range_0["signal_quality"]
-			})
-		range = pd.concat([range, rng_0], ignore_index=True, sort=False)
-	except:
-		pass
+	# The column names have to be unique across all sensors: the tables are merged by
+	# column name and the resulting column order defines the order of the values in the
+	# csv. 'quality' is already used by the optical flow, reusing it here would append
+	# the distance behind the quality and swap the two arguments of
+	# _rng.setData(distance, quality) in SensorSimulator::setSingleReplaySample().
+	rng = pd.DataFrame()
 
-	try:
-		range_1 = ulog.get_dataset("distance_sensor", 1).data
-		rng_1 = pd.DataFrame({'timestamp': range_1['timestamp'],
-			'sensor' : 'range',
-			'data': range_1["current_distance"],
-			'quality': range_1["signal_quality"]
-			})
-		range = pd.concat([range, rng_1], ignore_index=True, sort=False)
-	except:
-		pass
+	for instance in range(3):
+		try:
+			distance_sensor = ulog.get_dataset("distance_sensor", instance).data
+		except (KeyError, IndexError, ValueError):
+			# instance not logged
+			continue
 
-	try:
-		range_2 = ulog.get_dataset("distance_sensor", 2).data
-		rng_2 = pd.DataFrame({'timestamp': range_2['timestamp'],
+		rng_instance = pd.DataFrame({'timestamp': distance_sensor['timestamp'],
 			'sensor' : 'range',
-			'data': range_2["current_distance"],
-			'quality': range_2["signal_quality"]
+			'range_distance': distance_sensor["current_distance"],
+			'range_quality': distance_sensor["signal_quality"]
 			})
-		range = pd.concat([range, rng_2], ignore_index=True, sort=False)
-	except:
-		pass
+		rng = pd.concat([rng, rng_instance], ignore_index=True, sort=False)
 
-	return range
+	return rng
 
 
 def getGpsData(ulog: ULog) -> pd.DataFrame:
 
 	vehicle_gps_position = ulog.get_dataset("vehicle_gps_position").data
+	# The column order has to match SensorSimulator::setSingleReplaySample(), which reads
+	# altitude, latitude, longitude. The loader also rescales the latitude and the
+	# longitude by 1e-7 because they used to be logged as scaled integers, so the degrees
+	# have to be scaled up by 1e7 here.
 	gps = pd.DataFrame({'timestamp': vehicle_gps_position['timestamp'],
 		'sensor' : 'gps',
-		'alt': vehicle_gps_position["alt"],
-		'lon': vehicle_gps_position["lon"],
-		'lat': vehicle_gps_position["lat"],
+		'alt': vehicle_gps_position["altitude_msl_m"],
+		'lat': vehicle_gps_position["latitude_deg"] * 1e7,
+		'lon': vehicle_gps_position["longitude_deg"] * 1e7,
 		'vel_N': vehicle_gps_position["vel_n_m_s"],
 		'vel_E': vehicle_gps_position["vel_e_m_s"],
 		'vel_D': vehicle_gps_position["vel_d_m_s"],

--- a/src/modules/ekf2/test/sensor_simulator/createSensorDataFile.py
+++ b/src/modules/ekf2/test/sensor_simulator/createSensorDataFile.py
@@ -4,9 +4,6 @@ import pandas as pd
 import csv
 import convertULogToSensorData as util
 
-path = "/home/kamil/Documents/QGroundControl/Logs/iris_vision.ulg"
-output_path = "/home/kamil/Documents/QGroundControl/Logs/sensor_data_iris_vision.csv"
-
 
 def get_arguments():
 	"""
@@ -31,72 +28,75 @@ def main() -> None:
 
 	try:
 		ulog = ULog(args.input_file)
-	except:
-		print("Could not find ulog file")
+	except Exception as e:
+		print("Could not read ulog file: {}: {}".format(type(e).__name__, e))
 		exit(-1)
 
 	try:
 		imu = util.getImuData(ulog)
 		print("IMU data detected")
 		table = pd.concat([table, imu], ignore_index=True, sort=False)
-	except:
-		print("IMU data not detected")
+	except Exception as e:
+		print("IMU data not detected: {}: {}".format(type(e).__name__, e))
 
 	try:
 		mag = util.getMagnetometerData(ulog)
 		print("Mag data detected")
 		table = pd.concat([table, mag], ignore_index=True, sort=False)
-	except:
-		print("Mag data not detected")
+	except Exception as e:
+		print("Mag data not detected: {}: {}".format(type(e).__name__, e))
 
 	try:
 		baro = util.getBarometerData(ulog)
 		print("Baro data detected")
 		table = pd.concat([table, baro], ignore_index=True, sort=False)
-	except:
-		print("Baro data not detected")
+	except Exception as e:
+		print("Baro data not detected: {}: {}".format(type(e).__name__, e))
 
 	try:
 		gps = util.getGpsData(ulog)
 		print("GPS data detected")
 		table = pd.concat([table, gps], ignore_index=True, sort=False)
-	except:
-		print("GPS data not detected")
+	except Exception as e:
+		print("GPS data not detected: {}: {}".format(type(e).__name__, e))
 
 	try:
 		airspeed = util.getAirspeedData(ulog)
 		print("Airspeed data detected")
 		table = pd.concat([table, airspeed], ignore_index=True, sort=False)
-	except:
-		print("Airspeed data not detected")
+	except Exception as e:
+		print("Airspeed data not detected: {}: {}".format(type(e).__name__, e))
 
+	# The optical flow has to be added before the range finder: the column order of the
+	# merged table defines the order of the values in the csv, which the C++ loader reads
+	# positionally.
 	try:
 		flow = util.getOpticalFlowData(ulog)
 		print("Flow data detected")
 		table = pd.concat([table, flow], ignore_index=True, sort=False)
-	except:
-		print("Flow data not detected")
+	except Exception as e:
+		print("Flow data not detected: {}: {}".format(type(e).__name__, e))
 
 	try:
 		range = util.getRangeFinderData(ulog)
 		print("Range data detected")
 		table = pd.concat([table, range], ignore_index=True, sort=False)
-	except:
-		print("Range data not detected")
+	except Exception as e:
+		print("Range data not detected: {}: {}".format(type(e).__name__, e))
 
 	try:
 		vio = util.getVioData(ulog)
 		print("VIO data detected")
 		table = pd.concat([table, vio], ignore_index=True, sort=False)
-	except:
-		print("VIO data not detected")
+	except Exception as e:
+		print("VIO data not detected: {}: {}".format(type(e).__name__, e))
 
 	try:
 		land = util.getVehicleLandingStatus(ulog)
 		print("Landing data detected")
 		table = pd.concat([table, land], ignore_index=True, sort=False)
-	except:
-		print("Landing data not detected")
+	except Exception as e:
+		print("Landing data not detected: {}: {}".format(type(e).__name__, e))
 
 	table = table.sort_values('timestamp', axis=0, ascending=True)
 	table['timestamp'] = table['timestamp'] - table['timestamp'].iloc[0]
@@ -116,8 +116,8 @@ def main() -> None:
 		with open(args.output_file, "w") as out_file:
 			csv_writer = csv.writer(out_file)
 			csv_writer.writerows(result)
-	except:
-		print("Could not write to specified output file")
+	except Exception as e:
+		print("Could not write to specified output file: {}: {}".format(type(e).__name__, e))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The scripts that generate the EKF2 replay CSVs had rotted: the rangefinder columns collided with the optical flow `quality` column so distance and quality came out swapped whenever a log had both sensors, and the GPS extractor still read the long-gone `alt`/`lon`/`lat` fields, which the bare `except` clauses turned into a silent "GPS data not detected". This gives the rangefinder its own column names, reads `altitude_msl_m`/`latitude_deg`/`longitude_deg` in the altitude/latitude/longitude order the C++ loader expects (scaled by 1e7 to cancel the loader's legacy 1e-7 rescale), fixes `getVioData` to use `position[]`/`velocity[]`, and makes the driver print the actual exception instead of swallowing it. Verified against a v1.18 log with DroneCAN flow + rangefinder + GPS; no C++ and no checked-in CSVs were touched.

Separately, and not fixed here: the committed `src/modules/ekf2/test/replay_data/*.csv` already have latitude and longitude transposed (column 1 decodes to 8.54, column 2 to 47.39, i.e. Zurich with the two swapped) and the altitude column is in millimetres, so the replay tests currently run the EKF at the wrong coordinates and altitude, which affects mag declination and earth rotation rate. Regenerating them churns the `change_indication` goldens, so that belongs in its own PR.
