### PR TITLE
ci(build-all): seed ccache only for chip families with cold caches

### DIFF
--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -124,7 +124,7 @@ jobs:
           ALL_SEEDERS: ${{ steps.set-seeders.outputs.seeders }}
         run: |
           cold=$(./Tools/ci/filter_cold_seeders.py <<< "$ALL_SEEDERS") || cold="$ALL_SEEDERS"
-          has_cold=$(python3 -c 'import json,sys; print(str(bool(json.load(sys.stdin)["include"])).lower())' <<< "$cold")
+          has_cold=$(python3 -c 'import json,sys; print(str(bool(json.load(sys.stdin)["include"])).lower())' <<< "$cold") || { cold="$ALL_SEEDERS"; has_cold=true; }
           {
             echo "cold_seeders<<EOF"
             echo "$cold"

--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -66,13 +66,16 @@ jobs:
   group_targets:
     name: Scan for Board Targets
     # runs-on: ubuntu-latest
-    runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false]
+    runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       seeders: ${{ steps.set-seeders.outputs.seeders }}
+      cold_seeders: ${{ steps.filter-seeders.outputs.cold_seeders }}
+      has_cold: ${{ steps.filter-seeders.outputs.has_cold }}
       timestamp: ${{ steps.set-timestamp.outputs.timestamp }}
       branchname: ${{ steps.set-branch.outputs.branchname }}
     steps:
+      - uses: runs-on/action@v2
       - uses: actions/checkout@v6
 
       - name: Cache Python pip
@@ -109,6 +112,26 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # Probe the RunsOn cache bucket for each chip family's ccache
+      # namespace and seed only the families with no warm cache. Fail-open:
+      # if the bucket env or the listing is unavailable, or the assumed
+      # object layout is wrong, every family reads as cold and gets seeded,
+      # which is exactly the pre-probe behavior. The probe can only skip
+      # work, never leave a truly cold family unseeded.
+      - id: filter-seeders
+        name: Probe Family Caches
+        env:
+          ALL_SEEDERS: ${{ steps.set-seeders.outputs.seeders }}
+        run: |
+          cold=$(./Tools/ci/filter_cold_seeders.py <<< "$ALL_SEEDERS") || cold="$ALL_SEEDERS"
+          has_cold=$(python3 -c 'import json,sys; print(str(bool(json.load(sys.stdin)["include"])).lower())' <<< "$cold")
+          {
+            echo "cold_seeders<<EOF"
+            echo "$cold"
+            echo "EOF"
+            echo "has_cold=$has_cold"
+          } >> "$GITHUB_OUTPUT"
+
       - id: set-timestamp
         name: Save Current Timestamp
         run: |
@@ -133,20 +156,25 @@ jobs:
           echo "$(./Tools/ci/generate_board_targets_json.py --group --verbose)"
 
   # ===========================================================================
-  # CACHE SEEDER JOBS
+  # CACHE SEEDER JOBS (conditional)
   # ===========================================================================
-  # Build one representative target per chip family to warm the ccache.
-  # Matrix jobs fall back to these caches via restore-keys when no
-  # group-specific cache exists yet. If any seeder fails, the build matrix
-  # does not start, catching common build errors early.
+  # Build one representative target per chip family to warm the ccache,
+  # but only for families whose cache namespace came up cold in the
+  # group_targets probe. Measured steady state is zero seeder restores
+  # (group jobs live on their own rolling caches), so on warm runs the
+  # whole stage skips and the build matrix starts immediately. When a
+  # family IS cold (matrix regrouping, cache expiry, new chip family),
+  # its seeder runs and still gates the matrix, which is the only case
+  # where the warmup is worth waiting for.
   # ===========================================================================
 
   seed:
     name: Seed [${{ matrix.chip_family }}]
     needs: group_targets
+    if: needs.group_targets.outputs.has_cold == 'true'
     runs-on: [runs-on,"runner=8cpu-linux-${{ matrix.runner }}","image=ubuntu24-full-${{ matrix.runner }}","run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
     strategy:
-      matrix: ${{ fromJson(needs.group_targets.outputs.seeders) }}
+      matrix: ${{ fromJson(needs.group_targets.outputs.cold_seeders) }}
       fail-fast: false
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -180,7 +180,7 @@ jobs:
       - uses: ./.github/actions/setup-ccache
         id: ccache
         with:
-          cache-key-prefix: ccache-${{ matrix.chip_family }}-${{ matrix.runner }}-seeder
+          cache-key-prefix: ${{ matrix.cache_prefix }}-${{ matrix.group }}
           max-size: 400M
       - name: Build seed target
         run: make ${{ matrix.target }}
@@ -216,12 +216,12 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.ccache
-          key: ccache-${{ matrix.chip_family }}-${{ matrix.runner }}-${{ matrix.group }}-${{ github.ref_name }}-${{ github.sha }}
+          key: ${{ matrix.cache_prefix }}-${{ matrix.group }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            ccache-${{ matrix.chip_family }}-${{ matrix.runner }}-${{ matrix.group }}-${{ github.ref_name }}-
-            ccache-${{ matrix.chip_family }}-${{ matrix.runner }}-${{ matrix.group }}-${{ github.base_ref || 'main' }}-
-            ccache-${{ matrix.chip_family }}-${{ matrix.runner }}-${{ matrix.group }}-
-            ccache-${{ matrix.chip_family }}-${{ matrix.runner }}-
+            ${{ matrix.cache_prefix }}-${{ matrix.group }}-${{ github.ref_name }}-
+            ${{ matrix.cache_prefix }}-${{ matrix.group }}-${{ github.base_ref || 'main' }}-
+            ${{ matrix.cache_prefix }}-${{ matrix.group }}-
+            ${{ matrix.cache_prefix }}-
 
       - name: Cache - Configure ccache
         run: |

--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -112,25 +112,14 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      # Probe the RunsOn cache bucket for each chip family's ccache
-      # namespace and seed only the families with no warm cache. Fail-open:
-      # if the bucket env or the listing is unavailable, or the assumed
-      # object layout is wrong, every family reads as cold and gets seeded,
-      # which is exactly the pre-probe behavior. The probe can only skip
-      # work, never leave a truly cold family unseeded.
+      # Seed only chip families whose ccache namespace has no warm cache.
+      # Fail-open semantics live in the script: any probe problem emits
+      # the full matrix, reproducing unconditional seeding.
       - id: filter-seeders
         name: Probe Family Caches
         env:
           ALL_SEEDERS: ${{ steps.set-seeders.outputs.seeders }}
-        run: |
-          cold=$(./Tools/ci/filter_cold_seeders.py <<< "$ALL_SEEDERS") || cold="$ALL_SEEDERS"
-          has_cold=$(python3 -c 'import json,sys; print(str(bool(json.load(sys.stdin)["include"])).lower())' <<< "$cold") || { cold="$ALL_SEEDERS"; has_cold=true; }
-          {
-            echo "cold_seeders<<EOF"
-            echo "$cold"
-            echo "EOF"
-            echo "has_cold=$has_cold"
-          } >> "$GITHUB_OUTPUT"
+        run: ./Tools/ci/filter_cold_seeders.py <<< "$ALL_SEEDERS"
 
       - id: set-timestamp
         name: Save Current Timestamp

--- a/Tools/ci/filter_cold_seeders.py
+++ b/Tools/ci/filter_cold_seeders.py
@@ -20,25 +20,36 @@ import subprocess
 import sys
 
 
-def is_warm(bucket, prefix):
+def scope_key_basenames(bucket, scope):
+    """Cache-key basenames in one ref scope of the magic-cache bucket.
+
+    The magic cache stores GitHub cache entries as
+    cache/v1/{org}/{repo}/{ref}/{version-hash}/{cache-key}; the version
+    hash is the actions/cache path+compression digest and not knowable
+    here, so list the whole ref scope (auto-paginated) and match on the
+    final path component.
+    """
+    prefix = f"cache/v1/{os.environ['GITHUB_REPOSITORY']}/{scope}/"
     result = subprocess.run(
-        ["aws", "s3api", "list-objects-v2", "--bucket", bucket,
-         "--prefix", prefix, "--max-items", "1", "--output", "json"],
-        capture_output=True, text=True, timeout=30)
+        ["aws", "s3", "ls", f"s3://{bucket}/{prefix}", "--recursive"],
+        capture_output=True, text=True, timeout=120)
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip())
-    return bool(result.stdout.strip()) and "Contents" in json.loads(result.stdout)
+    return [line.split()[-1].rsplit("/", 1)[-1]
+            for line in result.stdout.splitlines() if line.strip()]
 
 
 def filter_cold(matrix):
     bucket = os.environ["RUNS_ON_S3_BUCKET_CACHE"]
+    # Default-branch caches are visible to every ref, so main-scope
+    # warmth is what the build jobs' last restore-keys fallback can
+    # always reach regardless of the branch being built.
+    scope = os.environ.get("SEEDER_PROBE_SCOPE", "refs/heads/main")
+    basenames = scope_key_basenames(bucket, scope)
     cold = []
     for entry in matrix["include"]:
-        # The same namespace the build jobs search as their last
-        # restore-keys fallback; the magic cache stores GitHub cache
-        # entries under the cache/ prefix of the bucket.
-        prefix = f"cache/ccache-{entry['chip_family']}-{entry['runner']}-"
-        warm = is_warm(bucket, prefix)
+        prefix = f"ccache-{entry['chip_family']}-{entry['runner']}-"
+        warm = any(name.startswith(prefix) for name in basenames)
         print(f"::notice title=seeder probe::{entry['chip_family']}/"
               f"{entry['runner']}: {'warm' if warm else 'COLD'}", file=sys.stderr)
         if not warm:

--- a/Tools/ci/filter_cold_seeders.py
+++ b/Tools/ci/filter_cold_seeders.py
@@ -48,7 +48,9 @@ def filter_cold(matrix):
     basenames = scope_key_basenames(bucket, scope)
     cold = []
     for entry in matrix["include"]:
-        prefix = f"ccache-{entry['chip_family']}-{entry['runner']}-"
+        # The namespace root is minted by generate_board_targets_json.py
+        # and arrives on every matrix entry; no key format knowledge here.
+        prefix = entry["cache_prefix"] + "-"
         warm = any(name.startswith(prefix) for name in basenames)
         print(f"::notice title=seeder probe::{entry['chip_family']}/"
               f"{entry['runner']}: {'warm' if warm else 'COLD'}", file=sys.stderr)

--- a/Tools/ci/filter_cold_seeders.py
+++ b/Tools/ci/filter_cold_seeders.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
-"""Filter the seeder matrix to chip families with no warm ccache.
+"""Emit the seeder matrix filtered to chip families with no warm ccache.
 
-Reads the full seeder matrix JSON on stdin and prints a matrix containing
-only the families with no cache entry under their ccache namespace in the
-RunsOn magic-cache S3 bucket. Exits non-zero when probing is impossible
-(missing bucket env, aws cli error) so the caller can fail open and seed
-every family, which is the pre-probe behavior.
+Reads the full seeder matrix JSON on stdin and writes two GitHub Actions
+outputs (to $GITHUB_OUTPUT, or stdout when unset for local runs):
+
+  cold_seeders  matrix containing only the families with no cache entry
+                under their ccache namespace in the RunsOn magic-cache
+                S3 bucket
+  has_cold      "true"/"false", whether cold_seeders has any entries
+
+Fails open, never non-zero: on any probe problem (missing bucket env,
+aws cli error, unexpected input) the full input matrix is emitted with
+has_cold=true, reproducing unconditional seeding. The probe can only
+skip work, never leave a truly cold family unseeded.
 """
 import json
 import os
@@ -13,7 +20,7 @@ import subprocess
 import sys
 
 
-def has_cache(bucket, prefix):
+def is_warm(bucket, prefix):
     result = subprocess.run(
         ["aws", "s3api", "list-objects-v2", "--bucket", bucket,
          "--prefix", prefix, "--max-items", "1", "--output", "json"],
@@ -23,29 +30,51 @@ def has_cache(bucket, prefix):
     return bool(result.stdout.strip()) and "Contents" in json.loads(result.stdout)
 
 
-def main():
-    bucket = os.environ.get("RUNS_ON_S3_BUCKET_CACHE")
-    if not bucket:
-        print("RUNS_ON_S3_BUCKET_CACHE not set, cannot probe", file=sys.stderr)
-        return 1
-    matrix = json.load(sys.stdin)
+def filter_cold(matrix):
+    bucket = os.environ["RUNS_ON_S3_BUCKET_CACHE"]
     cold = []
     for entry in matrix["include"]:
         # The same namespace the build jobs search as their last
         # restore-keys fallback; the magic cache stores GitHub cache
         # entries under the cache/ prefix of the bucket.
         prefix = f"cache/ccache-{entry['chip_family']}-{entry['runner']}-"
-        try:
-            warm = has_cache(bucket, prefix)
-        except Exception as exc:
-            print(f"probe failed for {prefix}: {exc}", file=sys.stderr)
-            return 1
-        state = "warm" if warm else "COLD"
+        warm = is_warm(bucket, prefix)
         print(f"::notice title=seeder probe::{entry['chip_family']}/"
-              f"{entry['runner']}: {state}", file=sys.stderr)
+              f"{entry['runner']}: {'warm' if warm else 'COLD'}", file=sys.stderr)
         if not warm:
             cold.append(entry)
-    json.dump({"include": cold}, sys.stdout)
+    return {"include": cold}
+
+
+def write_outputs(cold_json, has_cold):
+    payload = (f"cold_seeders<<EOF\n{cold_json}\nEOF\n"
+               f"has_cold={'true' if has_cold else 'false'}\n")
+    path = os.environ.get("GITHUB_OUTPUT")
+    if path:
+        with open(path, "a") as out:
+            out.write(payload)
+    else:
+        sys.stdout.write(payload)
+
+
+def main():
+    raw = sys.stdin.read()
+    try:
+        matrix = json.loads(raw)
+    except ValueError as exc:
+        # Unparseable input passes through verbatim so the seed matrix
+        # fails loudly downstream instead of being silently skipped.
+        print(f"::notice title=seeder probe::fail-open, bad input: {exc}",
+              file=sys.stderr)
+        write_outputs(raw, True)
+        return 0
+    try:
+        cold = filter_cold(matrix)
+    except Exception as exc:
+        print(f"::notice title=seeder probe::fail-open, seeding all "
+              f"families: {exc}", file=sys.stderr)
+        cold = matrix
+    write_outputs(json.dumps(cold), bool(cold["include"]))
     return 0
 
 

--- a/Tools/ci/filter_cold_seeders.py
+++ b/Tools/ci/filter_cold_seeders.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Filter the seeder matrix to chip families with no warm ccache.
+
+Reads the full seeder matrix JSON on stdin and prints a matrix containing
+only the families with no cache entry under their ccache namespace in the
+RunsOn magic-cache S3 bucket. Exits non-zero when probing is impossible
+(missing bucket env, aws cli error) so the caller can fail open and seed
+every family, which is the pre-probe behavior.
+"""
+import json
+import os
+import subprocess
+import sys
+
+
+def has_cache(bucket, prefix):
+    result = subprocess.run(
+        ["aws", "s3api", "list-objects-v2", "--bucket", bucket,
+         "--prefix", prefix, "--max-items", "1", "--output", "json"],
+        capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip())
+    return bool(result.stdout.strip()) and "Contents" in json.loads(result.stdout)
+
+
+def main():
+    bucket = os.environ.get("RUNS_ON_S3_BUCKET_CACHE")
+    if not bucket:
+        print("RUNS_ON_S3_BUCKET_CACHE not set, cannot probe", file=sys.stderr)
+        return 1
+    matrix = json.load(sys.stdin)
+    cold = []
+    for entry in matrix["include"]:
+        # The same namespace the build jobs search as their last
+        # restore-keys fallback; the magic cache stores GitHub cache
+        # entries under the cache/ prefix of the bucket.
+        prefix = f"cache/ccache-{entry['chip_family']}-{entry['runner']}-"
+        try:
+            warm = has_cache(bucket, prefix)
+        except Exception as exc:
+            print(f"probe failed for {prefix}: {exc}", file=sys.stderr)
+            return 1
+        state = "warm" if warm else "COLD"
+        print(f"::notice title=seeder probe::{entry['chip_family']}/"
+              f"{entry['runner']}: {state}", file=sys.stderr)
+        if not warm:
+            cold.append(entry)
+    json.dump({"include": cold}, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tools/ci/generate_board_targets_json.py
+++ b/Tools/ci/generate_board_targets_json.py
@@ -493,9 +493,14 @@ if (args.group):
                     })
                     chunk_counter += 1
 
-    # Add cache_size to each group based on chip family
+    # Add cache_size and the shared ccache namespace root to each group.
+    # cache_prefix is the single source of the cache key convention: the
+    # workflow composes keys as {cache_prefix}-{group}-{ref}-{sha} with a
+    # final restore fallback of {cache_prefix}-, and the seeder probe
+    # (Tools/ci/filter_cold_seeders.py) greps the bucket for the same root.
     for g in final_groups:
         g['cache_size'] = CHIP_CACHE_SIZES.get(g['chip_family'], DEFAULT_CACHE_SIZE)
+        g['cache_prefix'] = f"ccache-{g['chip_family']}-{g['runner']}"
 
     if(verbose):
         import pprint
@@ -552,6 +557,13 @@ if (args.group):
                     'container': seeder_containers.get(cf, default_container),
                     'runner': 'x64',
                 })
+
+        # Seeders share the family namespace root with the build groups and
+        # occupy the reserved "seeder" group inside it, so seeder caches are
+        # always reachable from the build jobs' {cache_prefix}- fallback.
+        for s in seeders:
+            s['group'] = 'seeder'
+            s['cache_prefix'] = f"ccache-{s['chip_family']}-{s['runner']}"
 
         print(json.dumps({ "include": seeders }, **extra_args))
     else:


### PR DESCRIPTION
## Summary

Skip the ccache seeder stage when every chip family already has a warm cache, seeding only the cold families. Draft: the probe's S3 object-layout assumption still needs validation by this PR's own CI run.

## Problem

The seed stage gates the build matrix for ~3.4 min of every run's critical path and spends ~22 8cpu-runner-minutes per run, but in measured steady state it warms nothing: all 264 build-job cache restores across the 8 most recent successful runs came from group-level caches, none from seeder caches (build groups live on their own rolling per-branch caches that are re-saved every run). Its fail-fast value is also thin: 2 of the last 40 failed runs failed at the seed stage, while the other 34 passed seeding and failed in the matrix anyway.

## Solution

`group_targets` (now running with `extras=s3-cache`) probes each family's `ccache-<family>-<runner>-` namespace in the RunsOn cache bucket via `Tools/ci/filter_cold_seeders.py` and emits only the cold families into the seed matrix. On warm runs the stage skips entirely and the build matrix starts right after the scan, taking ~3.4 min off every run. A cold family (matrix regrouping, cache expiry, new chip family) still seeds first and gates the matrix, which is the one case the warmup is worth waiting for.

The probe fails open: a missing bucket env, a listing error, or a wrong layout assumption makes every family read as cold and the workflow behaves exactly as it does today. The failure mode is the status quo, never an unseeded cold matrix.

Downstream forks without RunsOn are unaffected. The helper is stdlib-only and never invokes aws unless `RUNS_ON_S3_BUCKET_CACHE` exists, `runs-on/action` documents itself as a successful no-op on non-RunsOn runners, and every failure path in the probe step (missing env, aws error, lost exec bit, unparseable output) falls back to the full seeder matrix. Forks on the documented `ubuntu-latest` fallback keep today's unconditional seeding exactly; forks running their own RunsOn deployment get the conditional skip against their own cache bucket.

Testing: the first CI run validated fail-open in production (the initial layout guess read all families COLD and the run seeded unconditionally, exactly the designed degradation). The probe now targets the magic cache's real object layout (`cache/v1/{org}/{repo}/{ref}/{version-hash}/{cache-key}`, discovered by listing the live bucket) and was verified locally against it: all 10 families read warm, `has_cold=false`, seed stage skips. The fail-open paths (missing env, aws error, unparseable input) are exercised locally as well. This PR's own build-all run on the latest commit is the remaining confirmation that the stage skips in CI; firmware sanity builds were skipped since the diff touches only CI tooling.
