### PR TITLE
feat(uavcan_esc): add DroneCAN device quirks bitmask parameter for non-compliant ESCs

### DIFF
--- a/docs/en/dronecan/escs.md
+++ b/docs/en/dronecan/escs.md
@@ -41,6 +41,15 @@ In addition to the general setup:
 - Select the specific CAN interface(s) used for ESC data output using the [UAVCAN_ESC_IFACE](../advanced_config/parameter_reference.md#UAVCAN_ESC_IFACE) parameter (all interfaces are selected by default).
 - Configure the [motor order and servo outputs](../config/actuators.md).
 
+## Known Quirks {#known-quirks}
+
+Sadly some DroneCAN devices deviate from the DSDL specification in ways that require a workaround on the PX4 side.
+These workarounds are disabled by default and can be enabled with the [UAVCAN_QUIRKS](../advanced_config/parameter_reference.md#UAVCAN_QUIRKS) bitmask parameter.
+
+- **Hobbywing ESCs:** some Hobbywing DroneCAN ESCs report `uavcan.equipment.esc.Status.esc_index` starting at 1 for the first ESC instead of 0 as required by the specification, while still expecting `RawCommand.cmd[0]` to command the first ESC.
+  This causes ESC status feedback (e.g. RPM, voltage, current) to be matched to the wrong motor.
+  Set bit 0 of `UAVCAN_QUIRKS` to correct for this off-by-one indexing.
+
 ## Reversible Motors {#reversible-motors}
 
 <Badge type="tip" text="main (PX4 v2.0)" />

--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -86,6 +86,8 @@ int UavcanEscController::init()
 		_max_rate_hz = (unsigned)rate_max;
 	}
 
+	param_get(param_find("UAVCAN_QUIRKS"), &_param_uavcan_quirks);
+
 	_initialized = true;
 
 	return res;
@@ -118,8 +120,19 @@ void UavcanEscController::set_rotor_count(uint8_t count)
 
 void UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::esc::Status> &msg)
 {
-	if (msg.esc_index < esc_status_s::CONNECTED_ESC_MAX) {
-		esc_report_s &esc_report = _esc_status.esc[msg.esc_index];
+	uint8_t esc_index = msg.esc_index;
+
+	if (_param_uavcan_quirks & static_cast<int32_t>(Quirk::HobbywingEscIdx1)) {
+		if (msg.esc_index == 0) {
+			// non-compliant ESC firmware: esc_index 0 is not expected, ignore
+			return;
+		}
+
+		esc_index -= 1;
+	}
+
+	if (esc_index < esc_status_s::CONNECTED_ESC_MAX) {
+		esc_report_s &esc_report = _esc_status.esc[esc_index];
 		esc_report.timestamp = hrt_absolute_time();
 		esc_report.esc_voltage = msg.voltage;
 		esc_report.esc_current = msg.current;
@@ -127,7 +140,7 @@ void UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<
 		// esc_report.motor_temperature is filled in the extended status callback
 		esc_report.esc_rpm = msg.rpm;
 		esc_report.esc_errorcount = msg.error_count;
-		esc_report.failures = get_failures(msg.esc_index, msg.getSrcNodeID().get());
+		esc_report.failures = get_failures(esc_index, msg.getSrcNodeID().get());
 
 		// A repeated ESC index marks the start of a new round; publish once per round.
 		const uint16_t index_bit = 1u << msg.esc_index;
@@ -151,7 +164,7 @@ void UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<
 	// Register device capability for each ESC channel
 	if (_node_info_publisher != nullptr) {
 		uint8_t node_id = msg.getSrcNodeID().get();
-		uint32_t device_id = msg.esc_index;
+		uint32_t device_id = esc_index;
 		_node_info_publisher->registerDeviceCapability(node_id, device_id, NodeInfoPublisher::DeviceCapability::ESC);
 	}
 }
@@ -159,6 +172,15 @@ void UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<
 void UavcanEscController::esc_status_extended_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::esc::StatusExtended> &msg)
 {
 	uint8_t index = msg.esc_index;
+
+	if (_param_uavcan_quirks & static_cast<int32_t>(Quirk::HobbywingEscIdx1)) {
+		if (msg.esc_index == 0) {
+			// non-compliant ESC firmware: esc_index 0 is not expected, ignore
+			return;
+		}
+
+		index -= 1;
+	}
 
 	if (index < esc_status_s::CONNECTED_ESC_MAX) {
 		esc_report_s &esc_report = _esc_status.esc[index];

--- a/src/drivers/uavcan/actuators/esc.hpp
+++ b/src/drivers/uavcan/actuators/esc.hpp
@@ -136,6 +136,11 @@ private:
 
 	failure_injection::Config _failure_config;
 
+	int32_t _param_uavcan_quirks{0};
+	enum class Quirk : int32_t {
+		HobbywingEscIdx1 = (1 << 0), ///< ESCs reporting a 1-based esc_index instead of 0-based
+	};
+
 	/*
 	 * libuavcan related things
 	 */

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -37,6 +37,16 @@ parameters:
       max: 1000
       unit: Hz
       reboot_required: true
+    UAVCAN_QUIRKS:
+      description:
+        short: DroneCAN device quirks bitmask
+        long: |
+          Enables workarounds for non-compliant DroneCAN devices. See PX4 docs for details.
+      type: bitmask
+      bit:
+        0: Hobbywing 1-based esc_index
+      default: 0
+      reboot_required: true
     UAVCAN_LGT_NUM:
       description:
         short: Number of UAVCAN lights to configure


### PR DESCRIPTION
### Solved Problem
@Th3o5 and @ischollETH realized when using Hobbywing ESCs over DroneCAN they report telemetry indexed by 1 instead of the clear message definition by 0:

https://github.com/dronecan/DSDL/blob/b4653c7abc3c47cb31b16efa24ea755232774756/uavcan/equipment/esc/1034.Status.uavcan#L19

I had to realize they are not the only ones but it [seems to be a systematic issue with Hobbywing DroneCAN compliance](https://discuss.px4.io/t/hobbywing-uavcan-dronecan-esc-x6plus-h6m-x9/38940/7). They should get compliant with the standard but I still had to do this change locally to get the telemetry usable at all.

### Solution
Introduces a general UAVCAN_QUIRKS bitmask so workarounds for other non-compliant DroneCAN devices can be added as new bits without introducing a new parameter each time. Bit 0 covers the Hobbywing ESC esc_index off-by-one quirk.

### Changelog Entry
```
Add UAVCAN quirks parameter to reindex Hobbywing ESC telemetry
```

### Test coverage
The reindexing without the parameter is successfully used on an 8 motor Hobbywing ESC powered multirotor with DroneCAN as interface.