### PR TITLE
build(container): bake optional requirements into px4-dev image

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/dev_container.yml'
       - 'Tools/setup/ubuntu.sh'
       - 'Tools/setup/requirements.txt'
+      - 'Tools/setup/optional-requirements.txt'
       - 'Tools/setup/Dockerfile'
       - 'Tools/setup/docker-entrypoint.sh'
   workflow_dispatch:

--- a/Tools/setup/Dockerfile
+++ b/Tools/setup/Dockerfile
@@ -23,6 +23,12 @@ COPY ubuntu.sh /tmp/ubuntu.sh
 
 RUN bash /tmp/ubuntu.sh --no-sim-tools
 
+# Install the optional tooling requirements as well, so CI jobs that need them
+# (itcm_check) don't have to reach out to PyPI on every run.
+COPY optional-requirements.txt /tmp/optional-requirements.txt
+
+RUN python3 -m pip install --break-system-packages -r /tmp/optional-requirements.txt
+
 # Make sure git is ok with your local copy
 RUN git config --global --add safe.directory '*'
 

--- a/Tools/setup/optional-requirements.txt
+++ b/Tools/setup/optional-requirements.txt
@@ -1,2 +1,4 @@
 pyelftools>=0.32,<1
-symforce>=0.9.0
+# symforce publishes no Linux aarch64 wheel and no sdist, so it cannot be
+# installed there. Skip it on that platform instead of failing the install.
+symforce>=0.9.0; sys_platform != "linux" or platform_machine != "aarch64"


### PR DESCRIPTION
## Summary

Installs `Tools/setup/optional-requirements.txt` into the `px4-dev` container image so CI jobs stop fetching those packages from PyPI on every run.

## Problem

`Tools/setup/Dockerfile` copies `requirements.txt` and runs `ubuntu.sh`, which installs only that file. `optional-requirements.txt` sits in the same directory and is inside the build context, but was never copied or installed, so nothing in the image provides `pyelftools`.

That left `itcm_check.yml` running `pip3 install -r Tools/setup/optional-requirements.txt` on every job, reaching out to PyPI each time. Over the last 30 days, PyPI 502s from `files.pythonhosted.org` killed 29 CI runs across 5 workflows, 6 of them in the ITCM check. On Aug 15 and Aug 18 that was roughly 60% of all CI failures for the day. None of it was covered by a declared incident on status.python.org, so there was no upstream signal to wait on.

Baking it in also drops `symforce` from the ITCM job, which never needed it. `Tools/itcm_check.py` imports only `elftools`; `symforce` is used exclusively by the derivation scripts under `src/lib/wind_estimator/`, `src/modules/vision_target_estimator/`, and `src/modules/fw_att_control/`, none of which run in CI.

## Solution

Copy `optional-requirements.txt` into the image and pip install it after `ubuntu.sh`.

`symforce` publishes no Linux aarch64 wheel and no sdist, in any version ever released, so installing the file unguarded fails hard on the `linux/arm64` leg of the container matrix. It is gated behind a PEP 508 environment marker so aarch64 installs `pyelftools` only, while x86_64 and macOS keep the current behaviour.

`optional-requirements.txt` is now a container build input, so it is added to the `pull_request` paths filter in `dev_container.yml`.

Draft because it can't do anything on its own. It needs a new `px4-dev` tag cut, then a follow-up bumping the pins (currently `v1.17.0-rc2` across eight workflow files, with `sitl_tests.yml` and `fuzzing.yml` still on older `px4io/px4-dev` v1.16 tags) and deleting `itcm_check.yml:69`. If that step survives the bump, pip still reaches PyPI for the `symforce` line every run.

Verified the dependency resolution on both target architectures in clean `python:3.12-slim` containers: `linux/amd64` resolves `pyelftools` plus `symforce` and its 14 transitive deps; `linux/arm64` resolves `pyelftools` alone and exits 0, where the unmarked requirement fails with `No matching distribution found for symforce>=0.9.0`. The container workflow on this PR then built both arches green.

Two things worth a reviewer's eye.

Image growth, measured against `v1.17.0-rc2` rather than estimated. amd64 goes from 6.12GB to 6.37GB on disk (+253MB, +4.1%) and the registry pull goes from 2.01GB to roughly 2.13GB (+120MB compressed, ~+6%), across 4524 added files: `scipy`, `ruff`, `skymarshal`, `symforce-sym`, `sympy`, and a pip-installed `clang-format`. Every px4-dev-based job pays that pull. arm64 is unaffected beyond `pyelftools` itself, since the marker skips symforce there, so its 1.72GB pull is essentially unchanged.

The pip `clang-format` (21.1.2) may shadow the apt one from `ubuntu.sh:139`. `check_format` uses astyle so it should be inert, but it is a new binary on PATH.
