### PR TITLE
ci(itcm): bump px4-dev container and drop pip install

### DIFF
--- a/.github/workflows/itcm_check.yml
+++ b/.github/workflows/itcm_check.yml
@@ -24,7 +24,7 @@ jobs:
     name: Checking ${{ matrix.target }}
     runs-on: [runs-on,runner=4cpu-linux-x64,image=ubuntu24-full-x64,"run-id=${{ github.run_id }}",spot=false,extras=s3-cache]
     container:
-      image: ghcr.io/px4/px4-dev:v1.17.0-rc2
+      image: ghcr.io/px4/px4-dev:v1.18.0-beta1-327-ga7aecfb9fb1
     strategy:
       fail-fast: false
       matrix:
@@ -64,9 +64,6 @@ jobs:
 
       - name: Copy built ELF
         run: cp ./build/**/*.elf ./built.elf
-
-      - name: Install itcm-check dependencies
-        run: pip3 install -r Tools/setup/optional-requirements.txt --break-system-packages
 
       - name: Execute the itcm-check
         run: python3 Tools/itcm_check.py --elf-file built.elf --script-files ${{ matrix.scripts }}


### PR DESCRIPTION
## Summary

Points the ITCM check at the newly published `px4-dev` image and removes its `pip3 install` step, so the job stops depending on PyPI at run time.

## Problem

`px4-dev:v1.17.0-rc2` was built 2026-03-13 and ships neither `pyelftools` nor `pynacl`, so the ITCM job installed `optional-requirements.txt` from PyPI on every run. That install is a recurring failure: 502s from `files.pythonhosted.org` killed 6 ITCM jobs in the last 30 days, part of 29 CI runs lost to the same cause across five workflows. None of it was covered by a declared incident on status.python.org, so there was no upstream signal to wait on.

## Solution

`v1.18.0-beta1-327-ga7aecfb9fb1` (built from `a7aecfb`) ships `pyelftools`, so the install step goes away entirely.

Removing the step matters as much as the bump. Left in place it would still reach PyPI for the `symforce` line, which this check has never needed. `Tools/itcm_check.py` imports only `elftools`; `symforce` is used exclusively by derivation scripts that regenerate checked-in headers by hand and never run in CI.

Verified by running `Tools/itcm_check.py` inside the published image with no pip step, on `linux/amd64`: it imports and runs clean. The image itself was verified to carry `pyelftools` and `pynacl` on both `amd64` and `arm64`.

Beyond that, untested locally. `make px4_fmu-v6x` and `make px4_sitl` cannot exercise a workflow file, so the ITCM run on this PR is the real check.

One thing for a reviewer to watch rather than assume: this moves ITCM's toolchain forward roughly three months, from a March image to an August one. The check compares built ELF symbols against checked-in linker scripts, so a different compiler could legitimately shift what lands in ITCM. If the check reports a diff, that is a real finding to look at, not flakiness.

Draft until that CI run is read.
