### PR TITLE
fix(ekf2): refresh height fusion timeout on range height fusion

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/range_finder/range_height_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/range_finder/range_height_fusion.cpp
@@ -62,6 +62,10 @@ bool Ekf::fuseHaglRng(estimator_aid_source1d_s &aid_src, bool update_height, boo
 	aid_src.time_last_fuse = _time_delayed_us;
 	aid_src.fused = true;
 
+	if (update_height) {
+		_time_last_hgt_fuse = _time_delayed_us;
+	}
+
 	if (update_terrain) {
 		_time_last_terrain_fuse = _time_delayed_us;
 	}

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -77,6 +77,12 @@ void EkfWrapper::enableRangeHeightFusion()
 	_fc->rng.enabled = true;
 }
 
+void EkfWrapper::enableConditionalRangeHeightFusion()
+{
+	_ekf_params->ekf2_rng_ctrl = static_cast<int32_t>(RngCtrl::CONDITIONAL);
+	_fc->rng.enabled = true;
+}
+
 void EkfWrapper::disableRangeHeightFusion()
 {
 	_ekf_params->ekf2_rng_ctrl = static_cast<int32_t>(RngCtrl::DISABLED);

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
@@ -61,6 +61,7 @@ public:
 
 	void setRangeHeightRef();
 	void enableRangeHeightFusion();
+	void enableConditionalRangeHeightFusion();
 	void disableRangeHeightFusion();
 	bool isIntendingRangeHeightFusion() const;
 

--- a/src/modules/ekf2/test/test_EKF_height_fusion.cpp
+++ b/src/modules/ekf2/test/test_EKF_height_fusion.cpp
@@ -486,6 +486,137 @@ TEST_F(EkfHeightFusionTest, baroRefAllHgtFailReset)
 	EXPECT_TRUE(reset_logging_checker.isVerticalVelocityResetCounterIncreasedBy(0));
 }
 
+TEST_F(EkfHeightFusionTest, rngRefOnlyHeightSource)
+{
+	// GIVEN: the range finder is the one and only height source.
+	// Note: only RngCtrl::CONDITIONAL keeps the range finder as the height
+	// reference; with RngCtrl::ENABLED controlRangeHaglFusion() clears the
+	// reference back to UNKNOWN on every iteration.
+	_ekf_wrapper.setRangeHeightRef();
+	_ekf_wrapper.enableConditionalRangeHeightFusion();
+	_sensor_simulator.runSeconds(2);
+
+	ASSERT_TRUE(_ekf_wrapper.isIntendingRangeHeightFusion());
+	ASSERT_FALSE(_ekf_wrapper.isIntendingBaroHeightFusion());
+	ASSERT_FALSE(_ekf_wrapper.isIntendingGpsHeightFusion());
+	ASSERT_FALSE(_ekf_wrapper.isIntendingExternalVisionHeightFusion());
+	ASSERT_EQ(_ekf->getNumberOfActiveVerticalPositionAidingSources(), 1);
+	ASSERT_TRUE(_ekf->getHeightSensorRef() == HeightSensor::RANGE);
+
+	ResetLoggingChecker reset_logging_checker(_ekf);
+	reset_logging_checker.capturePreResetState();
+	_ekf->clear_information_events();
+
+	// WHEN: the range finder keeps delivering healthy data for much longer than
+	// the height fusion timeout (hgt_fusion_timeout_max is 5s)
+	_sensor_simulator.runSeconds(20);
+
+	// THEN: fusing the range finder keeps the height fusion timeout alive, so no
+	// height reset is requested and the estimate keeps running on the range finder
+	reset_logging_checker.capturePostResetState();
+	EXPECT_TRUE(_ekf->aid_src_rng_hgt().fused); // the range finder is really still fusing height
+	EXPECT_TRUE(reset_logging_checker.isVerticalPositionResetCounterIncreasedBy(0));
+	// forward guard: vertical velocity aiding is active, so this cannot trip in this fixture
+	EXPECT_TRUE(reset_logging_checker.isVerticalVelocityResetCounterIncreasedBy(0));
+	EXPECT_FALSE(_ekf->information_event_flags().reset_hgt_to_rng);
+	EXPECT_TRUE(_ekf_wrapper.isIntendingRangeHeightFusion());
+}
+
+TEST_F(EkfHeightFusionTest, rngRefWithBaroControl)
+{
+	// GIVEN: the same conditional range height setup as rngRefOnlyHeightSource
+	// but with the baro fusing height as well
+	_ekf_wrapper.setRangeHeightRef();
+	_ekf_wrapper.enableBaroHeightFusion();
+	_ekf_wrapper.enableConditionalRangeHeightFusion();
+	_sensor_simulator.runSeconds(2);
+
+	ASSERT_TRUE(_ekf_wrapper.isIntendingRangeHeightFusion());
+	ASSERT_TRUE(_ekf_wrapper.isIntendingBaroHeightFusion());
+	ASSERT_FALSE(_ekf_wrapper.isIntendingGpsHeightFusion());
+	ASSERT_FALSE(_ekf_wrapper.isIntendingExternalVisionHeightFusion());
+	ASSERT_EQ(_ekf->getNumberOfActiveVerticalPositionAidingSources(), 2);
+	ASSERT_TRUE(_ekf->getHeightSensorRef() == HeightSensor::RANGE);
+
+	ResetLoggingChecker reset_logging_checker(_ekf);
+	reset_logging_checker.capturePreResetState();
+	_ekf->clear_information_events();
+
+	// WHEN: both sensors keep delivering healthy data for much longer than the
+	// height fusion timeout
+	_sensor_simulator.runSeconds(20);
+
+	// THEN: no height reset is requested
+	reset_logging_checker.capturePostResetState();
+	EXPECT_TRUE(_ekf->aid_src_rng_hgt().fused); // the range finder is really still fusing height
+	EXPECT_TRUE(reset_logging_checker.isVerticalPositionResetCounterIncreasedBy(0));
+	// forward guard: vertical velocity aiding is active, so this cannot trip in this fixture
+	EXPECT_TRUE(reset_logging_checker.isVerticalVelocityResetCounterIncreasedBy(0));
+	EXPECT_FALSE(_ekf->information_event_flags().reset_hgt_to_rng);
+	EXPECT_TRUE(_ekf_wrapper.isIntendingRangeHeightFusion());
+}
+
+TEST_F(EkfHeightFusionTest, rngKeepsBaroFaultDetectionAlive)
+{
+	// GIVEN: baro as the configured height reference with the range finder also
+	// fusing height in conditional mode
+	_ekf_wrapper.setBaroHeightRef();
+	_ekf_wrapper.enableBaroHeightFusion();
+	_ekf_wrapper.enableConditionalRangeHeightFusion();
+	_sensor_simulator.runSeconds(5);
+
+	ASSERT_TRUE(_ekf_wrapper.isIntendingBaroHeightFusion());
+	ASSERT_TRUE(_ekf_wrapper.isIntendingRangeHeightFusion());
+	ASSERT_FALSE(_ekf_wrapper.isIntendingGpsHeightFusion());
+	ASSERT_FALSE(_ekf_wrapper.isIntendingExternalVisionHeightFusion());
+	ASSERT_FALSE(_ekf->control_status_flags().baro_fault);
+
+	const float altitude_before_fault = _ekf->getPosition()(2);
+
+	// WHEN: the baro steps by 50m while the range finder keeps reporting a
+	// constant and healthy distance to the ground
+	_sensor_simulator._baro.setData(_sensor_simulator._baro.getData() + 50.f);
+	_sensor_simulator.runSeconds(20);
+
+	// THEN: the range finder counts as "some other height source still working",
+	// so the baro is latched faulty instead of being restarted on the faulty
+	// measurement, and the altitude stays on the range finder
+	EXPECT_TRUE(_ekf->control_status_flags().baro_fault);
+	EXPECT_FALSE(_ekf_wrapper.isIntendingBaroHeightFusion());
+	EXPECT_TRUE(_ekf_wrapper.isIntendingRangeHeightFusion());
+	EXPECT_NEAR(_ekf->getPosition()(2), altitude_before_fault, 1.f);
+	EXPECT_NEAR(_ekf->getHagl(), 1.f, 0.1f);
+}
+
+TEST_F(EkfHeightFusionTest, rngTerrainOnlyIsNotAHeightSource)
+{
+	// GIVEN: baro as the height reference and the range finder in conditional mode, but
+	// flying above the maximum height for conditional range aid. The range finder then
+	// only updates the terrain state; all the other Kalman gains are zeroed, so it does
+	// not observe the height state at all.
+	_ekf_wrapper.setBaroHeightRef();
+	_ekf_wrapper.enableBaroHeightFusion();
+	_ekf->getParamHandle()->ekf2_rng_a_hmax = 0.1f;
+	_ekf_wrapper.enableConditionalRangeHeightFusion();
+	_sensor_simulator.runSeconds(5);
+
+	ASSERT_TRUE(_ekf_wrapper.isIntendingBaroHeightFusion());
+	ASSERT_TRUE(_ekf_wrapper.isIntendingTerrainRngFusion());
+	ASSERT_FALSE(_ekf_wrapper.isIntendingRangeHeightFusion());
+	ASSERT_TRUE(_ekf->aid_src_rng_hgt().fused); // the range finder is fusing, terrain only
+	ASSERT_FALSE(_ekf->control_status_flags().baro_fault);
+
+	// WHEN: the baro steps by 50m while the range finder keeps fusing terrain
+	_sensor_simulator._baro.setData(_sensor_simulator._baro.getData() + 50.f);
+	_sensor_simulator.runSeconds(20);
+
+	// THEN: terrain-only range fusion does not count as a height fusion, so the baro is
+	// the last remaining height source: it is reset to instead of being latched faulty
+	EXPECT_FALSE(_ekf->control_status_flags().baro_fault);
+	EXPECT_TRUE(_ekf_wrapper.isIntendingBaroHeightFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingRangeHeightFusion());
+}
+
 TEST_F(EkfHeightFusionTest, changeEkfOriginAlt)
 {
 	_sensor_simulator.startBaro();

--- a/src/modules/ekf2/test/test_EKF_terrain.cpp
+++ b/src/modules/ekf2/test/test_EKF_terrain.cpp
@@ -203,15 +203,17 @@ TEST_F(EkfTerrainTest, testHeightReset)
 	ResetLoggingChecker reset_logging_checker(_ekf);
 	reset_logging_checker.capturePreResetState();
 
-	// WHEN: the baro height is suddenly changed to trigger a height reset
+	// WHEN: the baro height is suddenly changed while the range finder keeps fusing height
 	const float new_baro_height = _sensor_simulator._baro.getData() + 50.f;
 	_sensor_simulator._baro.setData(new_baro_height);
 	_sensor_simulator.stopGps(); // prevent from switching to GNSS height
 	_sensor_simulator.runSeconds(10);
 
-	// THEN: a height reset occurred and the estimated distance to the ground remains constant
+	// THEN: the range finder still fuses height, so the height is not reset to the faulty baro.
+	// The baro is latched faulty instead and the estimated distance to the ground stays constant.
 	reset_logging_checker.capturePostResetState();
-	EXPECT_TRUE(reset_logging_checker.isVerticalPositionResetCounterIncreasedBy(1));
+	EXPECT_TRUE(reset_logging_checker.isVerticalPositionResetCounterIncreasedBy(0));
+	EXPECT_TRUE(_ekf->control_status_flags().baro_fault);
 	EXPECT_NEAR(estimated_distance_to_ground, _ekf->getHagl(), 1e-3f);
 }
 


### PR DESCRIPTION
## Summary

fixes #28263

With the range finder as the only active height source, EKF2 hard-resets the altitude estimate every 5 s for the whole flight, even though range height fusion is running and healthy the entire time.

## Problem

`_time_last_hgt_fuse` is written in exactly three places: zero-initialised in `Ekf::reset()`, refreshed by `fuseVerticalPosition()`, and refreshed by `resetAltitudeTo()`. Baro, GNSS altitude and vision height all fuse through `fuseVerticalPosition()`, so they keep it fresh. Since the terrain state moved into the main filter in 68980b59e26, range height is fused through `fuseHaglRng()` instead, which updates `aid_src.time_last_fuse` and `_time_last_terrain_fuse` but never `_time_last_hgt_fuse`.

So with range alone the timeout is never refreshed by fusion. `isHeightResetRequired()` reports `hgt_fusion_timeout`, `controlRangeHaglFusion()` takes the "all height sources failing" branch and calls `resetAltitudeTo()`, that refreshes the timeout, and the cycle repeats indefinitely. `getNumberOfActiveVerticalPositionAidingSources()` already counts `rng_hgt`, so the filter simultaneously reported that vertical position aiding was active and that no vertical position had been fused in 5 s.

The reset itself is a gauge shift along the unobservable altitude/terrain direction: `resetAltitudeTo()` adds the same delta to the terrain state, so HAGL is preserved exactly and only the altitude datum walks, by one innovation per cycle. That is why the symptom is a `z_reset_counter` increment every 5 s rather than an obviously broken height estimate.

The same stale timeout also disables the `baro_fault` latch in `controlBaroHeightFusion()`, which is guarded on `isRecent(_time_last_hgt_fuse, ...)`. With a range finder as the only other height source that guard never passes, so a baro that steps far enough to fail its own gate is stopped but not latched faulty, and restarts onto the faulty measurement on the next cycle.

Reproducing it needs `EKF2_RNG_CTRL=1`. In `RngCtrl::ENABLED` the height reference is released before the reset branch tests it, so that branch is unreachable and the loop does not occur.

## Solution

Stamp `_time_last_hgt_fuse` in `fuseHaglRng()` when the height state is updated, mirroring `fuseVerticalPosition()` and the terrain timeout stamped three lines below. Terrain-only range fusion zeroes every Kalman gain except terrain, so the stamp is gated on `update_height` and terrain-only fusion still does not count as a height fusion.

`EkfTerrainTest.testHeightReset` asserted a vertical position reset onto a baro that had just jumped 50 m while a healthy range finder was fusing height. That reset only occurred because the timeout was stale; the baro is now latched faulty and the altitude stays on the range finder, so the expectation is updated.

Built `px4_fmu-v6x`; the EKF unit test suite passes. Not yet flown on hardware, and the flight logs in the issue predate the fix.

Left for follow-ups: `baro_fault` has no in-flight de-latch, unlike `gnss_hgt_fault`, which is pre-existing and reachable today without a range finder under the default `EKF2_HGT_REF=GNSS`; and in `RngCtrl::ENABLED` the height reference is released and immediately restored by `checkHeightSensorRefFallback()` on every iteration.
