### PR TITLE
fix(ekf2): prevent recurring range height resets

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/range_finder/range_height_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/range_finder/range_height_fusion.cpp
@@ -62,6 +62,10 @@ bool Ekf::fuseHaglRng(estimator_aid_source1d_s &aid_src, bool update_height, boo
 	aid_src.time_last_fuse = _time_delayed_us;
 	aid_src.fused = true;
 
+	if (update_height) {
+		_time_last_hgt_fuse = _time_delayed_us;
+	}
+
 	if (update_terrain) {
 		_time_last_terrain_fuse = _time_delayed_us;
 	}

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -71,6 +71,12 @@ void EkfWrapper::setRangeHeightRef()
 	_ekf_params->ekf2_hgt_ref = static_cast<int32_t>(HeightSensor::RANGE);
 }
 
+void EkfWrapper::enableConditionalRangeHeightFusion()
+{
+	_ekf_params->ekf2_rng_ctrl = static_cast<int32_t>(RngCtrl::CONDITIONAL);
+	_fc->rng.enabled = true;
+}
+
 void EkfWrapper::enableRangeHeightFusion()
 {
 	_ekf_params->ekf2_rng_ctrl = static_cast<int32_t>(RngCtrl::ENABLED);

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
@@ -60,6 +60,7 @@ public:
 	bool isIntendingGpsHeightFusion() const;
 
 	void setRangeHeightRef();
+	void enableConditionalRangeHeightFusion();
 	void enableRangeHeightFusion();
 	void disableRangeHeightFusion();
 	bool isIntendingRangeHeightFusion() const;

--- a/src/modules/ekf2/test/test_EKF_height_fusion.cpp
+++ b/src/modules/ekf2/test/test_EKF_height_fusion.cpp
@@ -93,6 +93,30 @@ TEST_F(EkfHeightFusionTest, noAiding)
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionHeightFusion());
 }
 
+TEST_F(EkfHeightFusionTest, rangeRefNoRecurringHeightReset)
+{
+	// GIVEN: range finder is the only height source
+	_ekf_wrapper.setRangeHeightRef();
+	_ekf_wrapper.enableConditionalRangeHeightFusion();
+	_sensor_simulator.runSeconds(1);
+
+	ASSERT_TRUE(_ekf_wrapper.isIntendingRangeHeightFusion());
+	ASSERT_FALSE(_ekf_wrapper.isIntendingBaroHeightFusion());
+	ASSERT_FALSE(_ekf_wrapper.isIntendingGpsHeightFusion());
+	ASSERT_FALSE(_ekf_wrapper.isIntendingExternalVisionHeightFusion());
+	ASSERT_EQ(_ekf->getHeightSensorRef(), HeightSensor::RANGE);
+	ASSERT_TRUE(_ekf->aid_src_rng_hgt().fused);
+
+	const uint8_t height_reset_count = _ekf->get_posD_reset_count();
+
+	// WHEN: healthy range height fusion continues beyond the height fusion timeout
+	_sensor_simulator.runSeconds(6);
+
+	// THEN: the height estimate is not reset again
+	EXPECT_TRUE(_ekf_wrapper.isIntendingRangeHeightFusion());
+	EXPECT_EQ(_ekf->get_posD_reset_count(), height_reset_count);
+}
+
 TEST_F(EkfHeightFusionTest, baroRef)
 {
 	// GIVEN: baro reference with GPS and range height fusion

--- a/src/modules/ekf2/test/test_EKF_terrain.cpp
+++ b/src/modules/ekf2/test/test_EKF_terrain.cpp
@@ -188,9 +188,9 @@ TEST_F(EkfTerrainTest, testRngForTerrainFusion)
 	EXPECT_NEAR(estimated_distance_to_ground, rng_height, 0.01f);
 }
 
-TEST_F(EkfTerrainTest, testHeightReset)
+TEST_F(EkfTerrainTest, testRangeHeightFusionPreventsReset)
 {
-	// GIVEN: rng for terrain but not flow
+	// GIVEN: range height fusion is active as a secondary height source
 	_ekf_wrapper.disableFlowFusion();
 	_ekf_wrapper.enableRangeHeightFusion();
 
@@ -203,15 +203,15 @@ TEST_F(EkfTerrainTest, testHeightReset)
 	ResetLoggingChecker reset_logging_checker(_ekf);
 	reset_logging_checker.capturePreResetState();
 
-	// WHEN: the baro height is suddenly changed to trigger a height reset
+	// WHEN: the baro height is suddenly changed and GNSS height aiding is stopped
 	const float new_baro_height = _sensor_simulator._baro.getData() + 50.f;
 	_sensor_simulator._baro.setData(new_baro_height);
 	_sensor_simulator.stopGps(); // prevent from switching to GNSS height
 	_sensor_simulator.runSeconds(10);
 
-	// THEN: a height reset occurred and the estimated distance to the ground remains constant
+	// THEN: the healthy range height fusion prevents a height reset
 	reset_logging_checker.capturePostResetState();
-	EXPECT_TRUE(reset_logging_checker.isVerticalPositionResetCounterIncreasedBy(1));
+	EXPECT_TRUE(reset_logging_checker.isVerticalPositionResetCounterIncreasedBy(0));
 	EXPECT_NEAR(estimated_distance_to_ground, _ekf->getHagl(), 1e-3f);
 }
 


### PR DESCRIPTION
### Solved Problem

Fixes #28263.

When range finder data is the only active height source, successful range height fusion did not refresh the EKF's global height-fusion timestamp. The estimator therefore treated all height sources as timed out and reset altitude repeatedly after the five-second fusion timeout.

### Solution

Refresh `_time_last_hgt_fuse` whenever `fuseHaglRng()` successfully updates height.

Add regression coverage for conditional range fusion with range configured as the sole height reference. Update the existing terrain test to verify that healthy secondary range height fusion prevents a reset when the barometer becomes inconsistent.

### Changelog Entry

Bugfix EKF2: Prevent recurring altitude resets when range finder data is the only height source.

### Test coverage

- `make tests TESTFILTER=EKF_height_fusion`
- `make tests TESTFILTER=EKF_terrain`
- `make tests` — 187/187 tests passed
- `make format_changed`
- `make check_format`
- `git diff --check`

The new regression test failed before the production change because the vertical-position reset counter increased again after the timeout. It passes with this fix.
