### PR TITLE
feat(ver): add command to compare population option

### DIFF
--- a/platforms/common/include/px4_platform_common/board_common.h
+++ b/platforms/common/include/px4_platform_common/board_common.h
@@ -301,6 +301,18 @@ typedef uint16_t hw_base_id_t;
 #  define GET_HW_BASE_ID()      (HW_BASE_ID(board_get_hw_version()))
 #endif
 
+/* Boards can define HW_INFO_POP_MASK to mark a sub-field of a numeric HW info
+ * value as a population option (eg. which of several sensor variants is
+ * populated).
+ * HW_INFO_POP_SOURCE selects which value that sub-field is taken
+ * from (for example board_get_hw_revision or board_get_hw_version). */
+#if defined(HW_INFO_POP_MASK)
+#  ifndef HW_INFO_POP_SOURCE
+#    define HW_INFO_POP_SOURCE board_get_hw_revision
+#  endif
+#  define GET_HW_POP_ID()      (((unsigned)HW_INFO_POP_SOURCE() & HW_INFO_POP_MASK) >> __builtin_ctz(HW_INFO_POP_MASK))
+#endif
+
 #define HW_INFO_REV_DIGITS    3
 #define HW_INFO_VER_DIGITS    3
 

--- a/src/systemcmds/ver/ver.cpp
+++ b/src/systemcmds/ver/ver.cpp
@@ -44,6 +44,7 @@
 #include <px4_platform_common/module.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include <version/version.h>
 
@@ -53,6 +54,9 @@ static const char sz_ver_hwcmp_str[]    = "hwcmp";
 static const char sz_ver_hwtypecmp_str[]    = "hwtypecmp";
 #if defined(BOARD_HAS_HW_SPLIT_VERSIONING)
 static const char sz_ver_hwbasecmp_str[]    = "hwbasecmp";
+#endif
+#if defined(HW_INFO_POP_MASK)
+static const char sz_ver_hwpopcmp_str[]    = "hwpopcmp";
 #endif
 static const char sz_ver_git_str[] 	= "git";
 static const char sz_ver_bdate_str[]    = "bdate";
@@ -91,6 +95,12 @@ static void usage(const char *reason)
 	PRINT_MODULE_USAGE_COMMAND_DESCR("hwbasecmp", "Compare hardware base (returns 0 on match)");
 	PRINT_MODULE_USAGE_ARG("<hwbase> [<hwbase2>]",
 			       "Hardware type to compare against (eg. V2). An OR comparison is used if multiple are specified", false);
+#endif
+#if defined(HW_INFO_POP_MASK)
+	PRINT_MODULE_USAGE_COMMAND_DESCR("hwpopcmp", "Compare HW population option (returns 0 on match)");
+	PRINT_MODULE_USAGE_ARG("<value> [<value2>]",
+			       "Hex population option value(s) to compare against (eg. 06, cafe, ffff). An OR comparison is used if multiple are specified",
+			       false);
 #endif
 }
 
@@ -151,6 +161,27 @@ extern "C" __EXPORT int ver_main(int argc, char *argv[])
 
 				} else {
 					PX4_ERR("Not enough arguments, try 'ver hwbasecmp {000...999}[1:*]'");
+				}
+
+				return 1;
+			}
+
+#endif
+
+#if defined(HW_INFO_POP_MASK)
+
+			if (!strncmp(argv[1], sz_ver_hwpopcmp_str, sizeof(sz_ver_hwpopcmp_str))) {
+				if (argc >= 3 && argv[2] != nullptr) {
+					uint32_t population = GET_HW_POP_ID();
+
+					for (int i = 2; i < argc; ++i) {
+						if (population == (uint32_t)strtol(argv[i], nullptr, 16)) {
+							return 0; // if one of the arguments match, return success
+						}
+					}
+
+				} else {
+					PX4_ERR("Not enough arguments, try 'ver hwpopcmp {0..ffff}[1:*]");
 				}
 
 				return 1;


### PR DESCRIPTION
### Solved Problem

- In PX4 one can describe (with HW VER splitting) which version the FMU and base board has
- This is already great for supporting multiple revision of the PCB
- What we currently face is that it is hard to describe population options
  - You can have the same PCB revision but with a different BOM, for example pin-compatible sensors
  - Sometimes the solution is to just start all possible sensors but this is not always the case

### Solution

- Adds a configureable "Population option" that can be queried in code and NSH scripts
- This works by configuring the source in `HW_INFO_POP_SOURCE`
  - For example (and by default): `board_get_hw_revision`
- In addition a mask can be given using `HW_INFO_POP_MASK`
  - For example in one of our products: `HW_INFO_POP_MASK 0xff00`
- This way one can for example encode 255 possible PCB revisions and use the population option to:
  - Encode a bit mask to specify which sensors are placed
  - Or just a plain number that is used to identify what is populated     

### Test coverage

- We use this internally for a number of non released products (will upstream as soon as possible). Tested it with those products
- Usage examples:
```
# Set param based on population option
param set-default SAMPLE_PARAM 1

if ver hwpopcmp 2
then
	param set-default SAMPLE_PARAM 2
fi

if ver hwpopcmp 3
then
	param set-default SAMPLE_PARAM 3
fi
```