### PR TITLE
fix(rtl): handle RTL_TPYE 6 with multiple batteries

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -82,7 +82,6 @@ void RTL::on_inactive()
 	_mission_sub.update();
 	_home_pos_sub.update();
 	_wind_sub.update();
-	_battery_status_sub.update();
 
 	parameters_update();
 
@@ -141,7 +140,6 @@ void RTL::on_activation()
 	_mission_sub.update();
 	_home_pos_sub.update();
 	_wind_sub.update();
-	_battery_status_sub.update();
 	setRtlTypeAndDestination();
 
 	switch (_rtl_type) {
@@ -298,16 +296,33 @@ void RTL::setRtlTypeAndDestination()
 		_rtl_direct.setRtlPosition(destination, landing_loiter);
 
 		const rtl_time_estimate_s time_to_home = _rtl_direct.calc_rtl_time_estimate();
-		const float battery_remaining_s = _battery_status_sub.get().time_remaining_s;
+
+		// Take the worst (smallest) remaining time across all connected batteries, matching the
+		// battery_low_remaining_time failsafe check in BatteryChecks::rtlEstimateCheck()
+		float worst_battery_time_s{NAN};
+
+		for (auto &battery_sub : _battery_status_subs) {
+			battery_status_s battery;
+
+			if (!battery_sub.copy(&battery)) {
+				continue;
+			}
+
+			if (battery.connected
+			    && PX4_ISFINITE(battery.time_remaining_s)
+			    && (!PX4_ISFINITE(worst_battery_time_s) || (battery.time_remaining_s < worst_battery_time_s))) {
+				worst_battery_time_s = battery.time_remaining_s;
+			}
+		}
 
 		const bool home_within_reach = time_to_home.valid
-					       && PX4_ISFINITE(battery_remaining_s)
-					       && (time_to_home.safe_time_estimate < battery_remaining_s);
+					       && PX4_ISFINITE(worst_battery_time_s)
+					       && (time_to_home.safe_time_estimate < worst_battery_time_s);
 
 		if (!home_within_reach) {
 			// If battery data is valid, home is out of range: pick the closest rally point unconditionally
 			// If battery data is unavailable (NaN), we cannot assess reachability: pick the closest home or rally point
-			const float min_dist = PX4_ISFINITE(battery_remaining_s)
+			const float min_dist = PX4_ISFINITE(worst_battery_time_s)
 					       ? FLT_MAX
 					       : get_distance_to_next_waypoint(_global_pos_sub.get().lat,
 							       _global_pos_sub.get().lon,

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -54,12 +54,13 @@
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
+#include <uORB/SubscriptionMultiArray.hpp>
+#include <uORB/topics/battery_status.h>
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/mission.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/rtl_status.h>
 #include <uORB/topics/rtl_time_estimate.h>
-#include <uORB/topics/battery_status.h>
 
 class Navigator;
 class MissionRouteCache;
@@ -205,7 +206,7 @@ private:
 	uORB::SubscriptionData<mission_s> _mission_sub{ORB_ID(mission)};
 	uORB::SubscriptionData<home_position_s> _home_pos_sub{ORB_ID(home_position)};
 	uORB::SubscriptionData<wind_s>		_wind_sub{ORB_ID(wind)};
-	uORB::SubscriptionData<battery_status_s> _battery_status_sub{ORB_ID(battery_status)};
+	uORB::SubscriptionMultiArray<battery_status_s, battery_status_s::MAX_INSTANCES> _battery_status_subs{ORB_ID::battery_status};
 
 	uORB::Publication<rtl_time_estimate_s> _rtl_time_estimate_pub{ORB_ID(rtl_time_estimate)};
 	uORB::Publication<rtl_status_s> _rtl_status_pub{ORB_ID(rtl_status)};


### PR DESCRIPTION
### Solved Problem
https://github.com/PX4/PX4-Autopilot/pull/26968 was merged before I reviewed which should be blamed on ym slow response :see_no_evil: 
I still had a look and figured if there are multiple batteries (which I think @anilkir use case has) then it always takes the remaining time reported by the first one. This might work ok in most cases where the batteries deplete at roughly the same rate but it's technically not correct and could lead to inconsistent cases.

### Solution
Do it like in commander where the remaining flight time based failsafe is triggered and subscribe to all battery instances taking the worst reported time here:
https://github.com/PX4/PX4-Autopilot/blob/cda3c3603f0b0c52e878ed1852c1a80131bddf01/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp#L180-L184
It will pick up only connected and valid battery reports but condider the worst reported time.

This should of course be done once centrally in a fuel monitor such that modules and user get an abstracted remaining "fuel" and remaning operation time but that's for the next iteration. (JFYI @alexcekay)

### Changelog Entry
```
fix(rtl): handle RTL_TPYE 6 with multiple batteries
```

### Test coverage
I've not retested this. Could you double-check @anilkir ? :innocent: 
