### PR TITLE
ci(macos): key ccache per matrix OS

### DIFF
--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -55,7 +55,11 @@ jobs:
     - uses: ./.github/actions/setup-ccache
       id: ccache
       with:
-        cache-key-prefix: ccache-macos
+        # Keyed per OS: the two legs run different Apple clang builds, and
+        # ccache's compiler_check=content means objects cached by one are
+        # never reusable by the other. Sharing one key also made the legs
+        # race to save it, so one lost its cache every run.
+        cache-key-prefix: ccache-macos-${{ matrix.os }}
         max-size: 200M
 
     - name: Build px4_sitl


### PR DESCRIPTION
## Summary

Gives each leg of the macOS matrix its own ccache key.

## Problem

`setup-ccache` builds the key as `<prefix>-<ref_name>-<sha>`, and the prefix carried no OS component, so `macos-15` and `macos-latest` computed an identical key. Reproducible on every run I checked:

One leg always loses its save: `Failed to save: Unable to reserve cache with key ccache-macos-<ref>-<sha>, another job may be creating this cache`.

The survivor then poisons the other. `compiler_check = content` means ccache hashes the compiler binary, and `macos-latest` now resolves to macOS 26 while `macos-15` is macOS 15, so neither can reuse the other's objects. Measured on run 32291495373, same commit, after `ccache -z`:

| leg | px4_sitl hit rate | full run |
|---|---|---|
| macos-latest (macOS 26) | 860/944 (91.10%) | 2814/3004 (93.68%) |
| macos-15 | 332/944 (35.17%) | 2234/3004 (74.37%) |

Whichever leg wrote the cache last gets a warm one; the other recompiles roughly two thirds of what it should have had. The 200M budget is shared between both toolchains too, and reports full, so they also evict each other.

## Solution

Key the prefix on `${{ matrix.os }}`. Each OS gets its own entry, which removes the save race, removes the cross-toolchain misses, and gives each leg the full 200M rather than half of a contested one.

The losing leg should land near the ~91% its sibling already gets. Worth watching the first run after merge, since both keys start cold and populate from the `restore-keys` fallback.
