### PR TITLE
ci(build-all): install only what the matrix generator needs

### DIFF
--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -78,16 +78,13 @@ jobs:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v6
 
-      - name: Cache Python pip
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**./Tools/setup/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
+      # This job runs outside the build container, so it installs its own
+      # dependencies. It needs what the matrix generator actually reaches:
+      # yaml, kconfiglib via Tools/kconfig/loadconfig.py, and empy plus
+      # pyros-genmsg for the zenoh generator that loadconfig shells out to
+      # in ensure_env(). Everything else it runs is stdlib.
       - name: Install Python Dependencies
-        run: pip3 install -U packaging -r ./Tools/setup/requirements.txt
+        run: pip3 install pyyaml kconfiglib 'empy>=3.3,<4' pyros-genmsg
 
       # The generator runs as a standalone assignment so a non-zero exit
       # fails the step; embedded in `echo "x=$(...)"` it would be masked

--- a/Tools/kconfig/loadconfig.py
+++ b/Tools/kconfig/loadconfig.py
@@ -46,10 +46,18 @@ def ensure_env():
     atexit.register(shutil.rmtree, out_dir, ignore_errors=True)
     msg_files = sorted(glob.glob(os.path.join(PX4_ROOT, 'msg', '*.msg')) +
                        glob.glob(os.path.join(PX4_ROOT, 'msg', 'versioned', '*.msg')))
-    # stdout must stay clean: several callers print machine-parsed output
-    subprocess.run([sys.executable, _ZENOH_GENERATOR, '--zenoh-config',
-                    '-f'] + msg_files + ['-o', out_dir, '-e', _ZENOH_TEMPLATES],
-                   check=True, stdout=subprocess.DEVNULL)
+    # stdout must stay clean: several callers print machine-parsed output.
+    # Capture rather than discard it, because the generator reports missing
+    # imports on stdout; discarding left a CalledProcessError whose argv dump
+    # (every .msg path, ~9kB on one line) buried the actual cause.
+    result = subprocess.run([sys.executable, _ZENOH_GENERATOR, '--zenoh-config',
+                             '-f'] + msg_files + ['-o', out_dir, '-e', _ZENOH_TEMPLATES],
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if result.returncode != 0:
+        detail = ((result.stdout or '') + (result.stderr or '')).strip()
+        sys.exit('loadconfig: {} failed (exit {})\n{}'.format(
+            os.path.basename(_ZENOH_GENERATOR), result.returncode,
+            detail or '(no output)'))
     os.environ['ZENOH_KCONFIG_TOPICS'] = os.path.join(out_dir, 'Kconfig.topics')
 
 


### PR DESCRIPTION
## Summary

Narrows the scan job's Python install from all 31 entries of `requirements.txt` to the four packages it actually reaches, and drops the pip cache step with it.

## Problem

`group_targets` is the one job in this workflow with no `container:`, so it installs its own Python dependencies on a bare runner. It was installing the whole of `requirements.txt` to run `generate_board_targets_json.py`, and each of the other 27 packages was a chance to fail on a job that gates the entire build matrix. It has died on `packaging` and on `lxml`, neither of which it imports.

The pip cache step next to it was not helping either. Its key was `hashFiles('**./Tools/setup/requirements.txt')`, and `**.` matches nothing, so the hash came back empty and the key collapsed to `Linux-pip-`, identical to its own restore-key. That means it hit exactly every time and never saved again after the first write, so the live entry has been frozen since 2026-04-09 and cannot reflect changes to `requirements.txt`.

## Solution

Install `pyyaml`, `kconfiglib`, `empy` and `pyros-genmsg`.

`pyyaml` and `kconfiglib` alone are not enough, which is worth flagging because it is not visible from the imports: `loadconfig.ensure_env()` shells out to `Tools/zenoh/px_generate_zenoh_topic_files.py`, which needs `em` and `genmsg.template_tools`. Everything else the job runs, including `filter_cold_seeders.py`, is stdlib.

The cache step goes away rather than getting its glob repaired. Restoring it took about as long as fetching four small wheels, so at this size it was a net loss, and removing it frees a 76MB entry from a repo cache budget currently sitting at its 10GB limit.

Second commit makes that class of mistake legible. `ensure_env()` sent the child's stdout to `DEVNULL` to keep this process's stdout parseable, but the generator reports missing imports with `print()`, so the useful output was exactly what got discarded. What surfaced instead was a `CalledProcessError` whose message repeats the argv, and the argv carries every `.msg` path: 9901 bytes on a single line, naming neither cause nor remedy. It now captures both streams and exits with the child's own output, 167 bytes for the same failure:

```
loadconfig: px_generate_zenoh_topic_files.py failed (exit 1)
Failed to import em: No module named 'em'

You may need to install it using:
    pip3 install --user empy
```

The message names the command and its exit code rather than asserting what kind of failure occurred, so it stays accurate regardless of why the child failed. stdout stays clean on success, so callers that parse it are unaffected.

## Result in CI

Measured on this branch against the newest `main` run of the same job:

| | whole job | Install Python Dependencies | Cache Python pip |
|---|---|---|---|
| main | 48s | 26s | 2s |
| this PR | **22s** | **3s** | removed |

The job gates the whole build matrix, so that 26s comes off the critical path of every `Build all targets` run.

## Verification

Tested on an Ubuntu 24.04 container, matching the job's `image=ubuntu24-full-x64` runner base, against this tree. Both invocations the job actually makes succeed:

```
generate_board_targets_json.py --group            -> rc=0, 33 entries
generate_board_targets_json.py --group --seeders  -> rc=0, 10 entries
```

Each package was then dropped individually to confirm none is redundant:

| variant | result | failure |
|---|---|---|
| all four | rc=0 | |
| drop `pyyaml` | rc=1 | `No module named 'yaml'` |
| drop `kconfiglib` | rc=1 | `No module named 'kconfiglib'` |
| drop `empy` | rc=1 | `CalledProcessError` (zenoh generator) |
| drop `pyros-genmsg` | rc=1 | `CalledProcessError` (zenoh generator) |
| none installed | rc=1 | control |

So the set is both sufficient and minimal.

The error-surfacing change was smoke tested on the same image:

| case | result |
|---|---|
| happy path, `--group` and `--group --seeders` | rc=0, parseable JSON on stdout |
| missing `empy` | names cause and remedy, 167 bytes |
| missing `pyros-genmsg` | names cause and remedy, 183 bytes |
| generator file renamed away | `renamed_away.py failed (exit 2)` plus the interpreter's own "can't open file" |
| child exits 3 with no output | `silent.py failed (exit 3)` / `(no output)` |
| `ZENOH_KCONFIG_TOPICS` already set | generator skipped entirely, unchanged |
