### PR TITLE
fix(tools): exclude docs from newline checks again

### DIFF
--- a/Tools/astyle/check_newlines.sh
+++ b/Tools/astyle/check_newlines.sh
@@ -3,14 +3,14 @@
 return_value=0
 
 # Check if there are files checked in that don't end in a newline (POSIX requirement)
-git grep --cached -Il '' -- ':!docs/public/' ':!docs/ko/' ':!docs/uk/' ':!docs/zh/' | xargs -L1 bash -c 'if test "$(tail -c 1 "$0")"; then echo "No new line at end of $0"; exit 1; fi'
+git grep --cached -Il '' -- ':!docs/*' | xargs -L1 bash -c 'if test "$(tail -c 1 "$0")"; then echo "No new line at end of $0"; exit 1; fi'
 
 if [ $? -ne 0 ]; then
 	return_value=1
 fi
 
 # Check if there are files checked in that have duplicate newlines at the end (fail trailing whitespace checks)
-git grep --cached -Il '' -- ':!docs/public/' ':!docs/ko/' ':!docs/uk/' ':!docs/zh/' | xargs -L1 bash -c 'if tail -c 2 "$0" | ( read x && read y && [ x"$x" = x ] && [ x"$y" = x ]); then echo "Multiple newlines at the end of $0"; exit 1; fi'
+git grep --cached -Il '' -- ':!docs/*' | xargs -L1 bash -c 'if tail -c 2 "$0" | ( read x && read y && [ x"$x" = x ] && [ x"$y" = x ]); then echo "Multiple newlines at the end of $0"; exit 1; fi'
 
 if [ $? -ne 0 ]; then
 	return_value=1


### PR DESCRIPTION
## Summary

Restores the `docs/` exclusion in `check_newlines.sh`, which has been failing on main and on every PR opened since 2026-08-20.

## Problem

```
Checking for missing or duplicate newlines at the end of files
No new line at end of docs/_link_checker_sc/ignore_errors.json
make: *** [Makefile:444: check_newlines] Error 1
```

`8ed15e6b19c` ("docs(docs): Fix broken external links", #28300) dropped the trailing newline from that file. It is not a PR-specific failure: main is red, so every branch cut from it fails the same way.

The exclusion that would have covered this already existed and was narrowed:

- `a88679a26f5` set it to `':!docs/*'`
- `2bc04f91f8d` narrowed it to `':!docs/public/' ':!docs/ko/' ':!docs/uk/' ':!docs/zh/'` after fixing the offenders present at the time, leaving the rest of `docs/` in scope

That scope cannot hold, because `checks.yml:7-13` carries `paths-ignore: 'docs/**'` on both `push` and `pull_request`. The check inspects files whose changes can never trigger it. A docs-only PR can break it with no signal, and the failure surfaces on whoever opens the next unrelated PR. That is precisely the sequence here: #28300 touched only `docs/`, Checks never ran, main went red.

This is the second time, not the first. Over the last 30 days `check_newlines` failed 28 times, and 17 of those come from this same blind spot in two separate incidents:

- **2026-08-06**, 9 failures: `Multiple newlines at the end of docs/scripts/get_mode_requirements/get_mode_requirements.py`, from #26084, also docs-only, also skipped by `paths-ignore`. Hand-fixed 5.5 hours later by `3228b45ceb6` "fix(docs): remove trailing newlines", which cleared the symptom and left the mechanism in place.
- **2026-08-20**, 8 failures: this one.

The other 11 failures are the check working correctly on non-docs contributor code, so nothing here argues for weakening it.

## Solution

Restore `':!docs/*'`, so the files the check inspects are the files whose changes can run it. The diff returns the script to the exact blob from `a88679a26f5`.

Fixing the JSON file instead would clear today's red without addressing the gap, and the next docs-only PR would do it again.

Verified against unmodified main content, with `ignore_errors.json` still missing its newline: `check_newlines` exits 0.

Applying the script's rules to every text file on main also confirms the exclusion is sufficient by itself: exactly one violation exists in the tree, the JSON file above, and there are none outside `docs/`. (Checked on main only, not the release branches.)

## Follow-ups, not in this PR

`checks.yml:29` sets `fail-fast: true`, so this one byte does not merely fail `check_newlines`, it cancels its siblings: `Gate Checks [shellcheck_all]` was cancelled outright rather than reporting. Losing unrelated gate results to an unrelated failure is worth changing on its own.

And whether `docs/` should be linted for this at all is a real question, since after this PR nothing polices it. 71 of the last 234 commits on main were docs-only, so roughly 30% of merges bypass this gate entirely. If you want actual coverage, the fix is dropping `paths-ignore` in `checks.yml` rather than widening the script, and it is cheaper than it looks: the gate matrix runs about 2 to 3 minutes per job, and `main` has no required status checks, so adding jobs to docs PRs would not block merges.
