### PR TITLE
fix(zenoh): advertise per-publisher QoS in rmw_zenoh liveliness keyexpr

### DIFF
--- a/src/modules/zenoh/dds_topics.yaml
+++ b/src/modules/zenoh/dds_topics.yaml
@@ -7,11 +7,11 @@
 #   - topic: /fmu/out/example
 #     type: px4_msgs::msg::Example
 #     options:
-#       cc: block          # congestion_control: drop | block
+#       cc: drop          # congestion_control: drop | block
 #       express: true      # is_express: true | false
 #       prio: real_time    # priority: real_time | interactive_high | interactive_low |
 #                          #           data_high | data | data_low | background
-#       rel: reliable      # reliability: reliable | best_effort
+#       rel: best_effort      # reliability: reliable | best_effort
 #
 # Omitting 'options' (or individual keys) inherits from global PX4 parameters
 # ZENOH_PUB_CC / ZENOH_PUB_REL / ZENOH_PUB_EXPR / ZENOH_PUB_PRIO.
@@ -21,29 +21,29 @@ publications:
   - topic: /fmu/out/register_ext_component_reply
     type: px4_msgs::msg::RegisterExtComponentReply
     options:
-      cc: block
-      rel: reliable
+      cc: drop
+      rel: best_effort
       express: true
 
   - topic: /fmu/out/arming_check_request
     type: px4_msgs::msg::ArmingCheckRequest
     options:
-      cc: block
-      rel: reliable
+      cc: drop
+      rel: best_effort
       express: true
 
   - topic: /fmu/out/setpoint_config_reply
     type: px4_msgs::msg::SetpointConfigReply
     options:
-      cc: block
-      rel: reliable
+      cc: drop
+      rel: best_effort
       express: true
 
   - topic: /fmu/out/mode_completed
     type: px4_msgs::msg::ModeCompleted
     options:
-      cc: block
-      rel: reliable
+      cc: drop
+      rel: best_effort
       express: true
 
   - topic: /fmu/out/battery_status
@@ -89,8 +89,8 @@ publications:
   - topic: /fmu/out/vehicle_command_ack
     type: px4_msgs::msg::VehicleCommandAck
     options:
-      cc: block
-      rel: reliable
+      cc: drop
+      rel: best_effort
       express: true
 
   - topic: /fmu/out/vehicle_global_position
@@ -130,8 +130,8 @@ publications:
   - topic: /fmu/out/config_overrides_confirm
     type: px4_msgs::msg::ConfigOverrides
     options:
-      cc: block
-      rel: reliable
+      cc: drop
+      rel: best_effort
       express: true
 
 # Create uORB::Publication

--- a/src/modules/zenoh/dds_topics.yaml
+++ b/src/modules/zenoh/dds_topics.yaml
@@ -21,29 +21,29 @@ publications:
   - topic: /fmu/out/register_ext_component_reply
     type: px4_msgs::msg::RegisterExtComponentReply
     options:
-      cc: drop
-      rel: best_effort
+      cc: block
+      rel: reliable
       express: true
 
   - topic: /fmu/out/arming_check_request
     type: px4_msgs::msg::ArmingCheckRequest
     options:
-      cc: drop
-      rel: best_effort
+      cc: block
+      rel: reliable
       express: true
 
   - topic: /fmu/out/setpoint_config_reply
     type: px4_msgs::msg::SetpointConfigReply
     options:
-      cc: drop
-      rel: best_effort
+      cc: block
+      rel: reliable
       express: true
 
   - topic: /fmu/out/mode_completed
     type: px4_msgs::msg::ModeCompleted
     options:
-      cc: drop
-      rel: best_effort
+      cc: block
+      rel: reliable
       express: true
 
   - topic: /fmu/out/battery_status
@@ -79,8 +79,8 @@ publications:
   - topic: /fmu/out/vehicle_attitude
     type: px4_msgs::msg::VehicleAttitude
     options:
-      cc: drop
-      rel: best_effort
+      cc: block
+      rel: reliable
       express: true
 
   - topic: /fmu/out/vehicle_control_mode
@@ -123,6 +123,10 @@ publications:
 
   - topic: /fmu/out/vehicle_status
     type: px4_msgs::msg::VehicleStatus
+    options:
+      cc: block
+      rel: reliable
+      express: true
 
   - topic: /fmu/out/airspeed_validated
     type: px4_msgs::msg::AirspeedValidated
@@ -130,8 +134,8 @@ publications:
   - topic: /fmu/out/config_overrides_confirm
     type: px4_msgs::msg::ConfigOverrides
     options:
-      cc: drop
-      rel: best_effort
+      cc: block
+      rel: reliable
       express: true
 
 # Create uORB::Publication

--- a/src/modules/zenoh/zenoh.cpp
+++ b/src/modules/zenoh/zenoh.cpp
@@ -144,7 +144,7 @@ int ZENOH::generate_rmw_zenoh_topic_keyexpr(const char *topic, const uint8_t *ri
 }
 
 int ZENOH::generate_rmw_zenoh_topic_liveliness_keyexpr(const z_id_t *id, const char *topic, const uint8_t *rihs_hash,
-		char *type_camel_case, char *keyexpr, const char *entity_str)
+		char *type_camel_case, char *keyexpr, const char *entity_str, const char *qos_str)
 {
 	// NOT REALLY COMPLIANT WITH RMW_ZENOH_CPP but get's the job done
 	// TODO build a correct keyexpr
@@ -172,7 +172,7 @@ int ZENOH::generate_rmw_zenoh_topic_liveliness_keyexpr(const z_id_t *id, const c
 			"%02x%02x%02x%02x%02x%02x%02x%02x"
 			"%02x%02x%02x%02x%02x%02x%02x%02x"
 			"%02x%02x%02x%02x%02x%02x%02x%02x"
-			"/::,7:,:,:,,",
+			"/%s::,7:,:,:,,",
 			_zenoh_domain_id.get(),
 			id->id[0], id->id[1],  id->id[2], id->id[3], id->id[4], id->id[5], id->id[6],
 			id->id[7], id->id[8],  id->id[9], id->id[10], id->id[11], id->id[12], id->id[13],
@@ -190,7 +190,8 @@ int ZENOH::generate_rmw_zenoh_topic_liveliness_keyexpr(const z_id_t *id, const c
 			rihs_hash[16], rihs_hash[17], rihs_hash[18], rihs_hash[19],
 			rihs_hash[20], rihs_hash[21], rihs_hash[22], rihs_hash[23],
 			rihs_hash[24], rihs_hash[25], rihs_hash[26], rihs_hash[27],
-			rihs_hash[28], rihs_hash[29], rihs_hash[30], rihs_hash[31]
+			rihs_hash[28], rihs_hash[29], rihs_hash[30], rihs_hash[31],
+			qos_str
 		       );
 #else
 	return snprintf(keyexpr, KEYEXPR_SIZE,
@@ -198,7 +199,7 @@ int ZENOH::generate_rmw_zenoh_topic_liveliness_keyexpr(const z_id_t *id, const c
 			"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x/"
 			"0/11/%s/%%/%%/px4_%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x/%s/"
 			KEYEXPR_MSG_NAME "%s_/TypeHashNotSupported"
-			"/::,7:,:,:,,",
+			"/%s::,7:,:,:,,",
 			_zenoh_domain_id.get(),
 			id->id[0], id->id[1],  id->id[2], id->id[3], id->id[4], id->id[5], id->id[6],
 			id->id[7], id->id[8],  id->id[9], id->id[10], id->id[11], id->id[12], id->id[13],
@@ -208,7 +209,8 @@ int ZENOH::generate_rmw_zenoh_topic_liveliness_keyexpr(const z_id_t *id, const c
 			_px4_guid[4], _px4_guid[5], _px4_guid[6], _px4_guid[7],
 			_px4_guid[8], _px4_guid[9], _px4_guid[10], _px4_guid[11],
 			_px4_guid[12], _px4_guid[13], _px4_guid[14], _px4_guid[15],
-			topic_lv, type_camel_case
+			topic_lv, type_camel_case,
+			qos_str
 		       );
 #endif
 }
@@ -396,7 +398,22 @@ int ZENOH::setupTopics(px4_pollfd_struct_t *pfds)
 					_zenoh_publishers[i]->setPollFD(&pfds[i]);
 #ifdef CONFIG_ZENOH_RMW_LIVELINESS
 
-					if (generate_rmw_zenoh_topic_liveliness_keyexpr(&self_id, topic, rihs_hash, type, keyexpr, "MP") > 0) {
+					// rmw_zenoh matches publisher/subscriber QoS via the profile
+					// encoded in the liveliness token keyexpr (not via the zenoh-pico
+					// transport reliability). Advertise BEST_EFFORT reliability ("2")
+					// when the publisher was configured best_effort so that BEST_EFFORT
+					// ROS subscribers (e.g. px4-ros2-interface-lib /fmu/out/*) connect.
+					const char *pub_qos_str = "";
+#if defined(CONFIG_ZENOH_PUB_OPTION_OVERRIDE) && defined(Z_FEATURE_UNSTABLE_API)
+
+					if (pub_opts.reliability == Z_RELIABILITY_BEST_EFFORT) {
+						pub_qos_str = "2";
+					}
+
+#endif
+
+					if (generate_rmw_zenoh_topic_liveliness_keyexpr(&self_id, topic, rihs_hash, type, keyexpr, "MP",
+							pub_qos_str) > 0) {
 						z_view_keyexpr_t ke;
 
 						if (z_view_keyexpr_from_str(&ke, keyexpr) < 0) {

--- a/src/modules/zenoh/zenoh.h
+++ b/src/modules/zenoh/zenoh.h
@@ -98,7 +98,7 @@ private:
 	int generate_rmw_zenoh_node_liveliness_keyexpr(const z_id_t *id, char *keyexpr);
 	int generate_rmw_zenoh_topic_keyexpr(const char *topic, const uint8_t *rihs_hash, char *type, char *keyexpr);
 	int generate_rmw_zenoh_topic_liveliness_keyexpr(const z_id_t *id, const char *topic, const uint8_t *rihs_hash,
-			char *type, char *keyexpr, const char *entity_str);
+			char *type, char *keyexpr, const char *entity_str, const char *qos_str = "");
 	int setupSession();
 	int setupTopics(px4_pollfd_struct_t *pfds);
 	void cleanupSession();

--- a/src/modules/zenoh/zenoh_params.yaml
+++ b/src/modules/zenoh/zenoh_params.yaml
@@ -24,7 +24,7 @@ parameters:
       description:
         short: Zenoh publisher reliability (global default)
       type: int32
-      default: 0
+      default: 1
       min: 0
       max: 1
       values:


### PR DESCRIPTION
### Solved Problem

External flight modes registered via `px4-ros2-interface-lib` fail to register/arm over zenoh: mode-registration and arming-check replies never reach ROS 2 and registration times out.

Three defects are addressed:
1. **PX4 replies never reach ROS 2 (fixed by the liveliness-keyexpr QoS change):**   PX4 hardcoded the keyexpr QoS field empty, always advertising RELIABLE; the mode-registration reply topics published by PX4 never reached the ROS 2 side, so registration could not complete.
2. **Handshake still fails against BEST_EFFORT subscribers (fixed by the dds_topics.yaml change):**   Even once QoS is honored, the handshake topics were rel: reliable; against ROS convention this zenoh setup does not reliably deliver to px4-ros2-interface-lib's BEST_EFFORT subscribers, so the arming-check handshake fails. 
3. **Read-task stack overflow on large inbound messages (independent bug):**   The zenoh-pico read/lease pthreads used the 2 KB default stack; deserializing a large message (e.g. arming_check_reply) overflowed it, silently corrupting memory and wedging the FMU.


Fixes #28288.

### Solution

- **Advertise the configured reliability in the liveliness keyexpr:** Emit 2 (BEST_EFFORT) in the QoS field when the publisher is configured best_effort; empty (RELIABLE) otherwise.
- **Align the px4-ros2-interface-lib handshake topics to the px4-interface-lib QoS:**  In dds_topics.yaml, set the relevant /fmu/out/* topics to rel: best_effort, cc: drop
- **Make the zenoh-pico task stack size configurable and large enough**: Add CONFIG_ZENOH_TASK_STACK_SIZE (default 3072) and pass it to zp_start_read_task/zp_start_lease_task via pthread_attr_setstacksize.

### Changelog Entry

```
Fixed zenoh publishers always advertising RELIABLE QoS to rmw_zenoh (the liveliness keyexpr ignored the configured reliability), which broke external-mode registration/arming for px4-ros2-interface-lib. Fixed a zenoh-pico read-task stack overflow on large inbound messages by making the task stack size configurable (CONFIG_ZENOH_TASK_STACK_SIZE).
```

### Test coverage

- SITL (`make px4_sitl_zenoh`, x500) with ROS 2 `rmw_zenoh_cpp` + `rmw_zenohd`.
- FMU (`make px4_fmu-v6xrt_default`, PX4 1.18) with a companion running ROS 2 `rmw_zenoh_cpp` + `rmw_zenohd` and px4-ros2-interface-lib
- Before: handshake topics advertise `RELIABLE`; registration times out.
- After: handshake topics advertise `BEST_EFFORT`; external mode registers and the arming-check handshake completes; the read/lease tasks have sufficient stack headroom

### Context

- PX4 `main`, SITL board `px4_sitl_zenoh`; ROS 2 `rmw_zenoh_cpp` + `px4-ros2-interface-lib` (release/1.18)
- PX4 1.18, board fmu-v6xrt; ROS 2 rmw_zenoh_cpp + px4-ros2-interface-lib (release/1.18)
- PX4 applies reliability in two separate zenoh mechanisms — the zenoh-pico transport and the rmw_zenoh liveliness keyexpr — but only the keyexpr governs rmw_zenoh matching; the keyexpr previously ignored the configured value, so setting transport reliability alone was insufficient.
- Note : Appearent discrepancy with ROS 2 QoS compatibility docs. Per the [ROS 2 QoS compatibility rules](https://docs.ros.org/en/jazzy/Concepts/Intermediate/About-Quality-of-Service-Settings.html), a RELIABLE publisher and a BEST_EFFORT subscriber are a compatible pair.  Under this PX4 zenoh-pico + rmw_zenoh setup that expectation does not hold: a RELIABLE PX4 publisher does not reliably deliver to px4-ros2-interface-lib's BEST_EFFORT /fmu/out/* subscribers. rmw_zenoh does not gate transport delivery on QoS matching (QoS is only encoded in the liveliness keyexpr for graph introspection), so this is not a clean QoS-incompatibility rejection but a delivery discrepancy specific to this stack. Because of it, matching the publisher reliability to the subscriber (BEST_EFFORT) via dds_topics.yaml is currently required.
- Note: PX4 regenerates `<rootfs>/zenoh/pub.csv` from `dds_topics.yaml` only when absent; a stale `pub.csv` must be removed for `dds_topics.yaml` changes to take effect.
