### PR TITLE
fix(logger): correct mission log lifecycle for SDLOG_MODE 2 and 4

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1141,13 +1141,34 @@ bool Logger::start_stop_logging()
 			updated = true;
 		}
 
-	} else if (_log_mode != LogMode::boot_until_shutdown) {
+	} else {
 		// arming-based logging
 		vehicle_status_s vehicle_status;
 
 		if (_vehicle_status_sub.update(&vehicle_status)) {
+			const bool armed = vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED;
+			const bool full_log_continues =
+				_log_mode == LogMode::boot_until_shutdown ||
+				(_log_mode == LogMode::arm_until_shutdown && _prev_file_log_start_state);
 
-			desired_state = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) ||
+			if (full_log_continues) {
+				if ((MissionLogType)_param_sdlog_mission.get() != MissionLogType::Disabled) {
+					if (armed || _manually_logging_override.load()) {
+						if (_writer.is_started(LogType::Full, LogWriter::BackendFile)) {
+							start_log_file(LogType::Mission);
+						}
+
+					} else {
+						stop_log_file(LogType::Mission);
+					}
+				}
+
+				if (_log_mode == LogMode::boot_until_shutdown) {
+					return false;
+				}
+			}
+
+			desired_state = armed ||
 					(_prev_file_log_start_state && _log_mode == LogMode::arm_until_shutdown);
 			updated = true;
 		}


### PR DESCRIPTION
  ### Solved Problem

  The mission log lifecycle was not handled correctly when the full log continued across arming-state changes:

  - With SDLOG_MODE=2, the mission log did not start when the vehicle was armed.
  - With SDLOG_MODE=4, the mission log started on the first arm but did not stop on disarm or start a new mission log on subsequent arming.

  ### Solution

  Process vehicle arming-state updates when the full log is configured to continue running.

  When the full log continues:

  - Start the mission log when armed.
  - Stop the mission log when disarmed.
  - Start a new mission log when the vehicle is rearmed.
  - Start the mission log only if the full file backend is active.

  The existing full-log lifecycle and transition logic remain unchanged.

  ### Changelog Entry

  Bugfix logger: Correct mission log lifecycle for SDLOG_MODE 2 and 4
  New parameter: None
  Documentation: No documentation changes required

  ### Alternatives

  A larger refactor separating the full-log and mission-log state machines was considered. It was not used because the issue can be addressed within the existing transition logic with a smaller scope and lower regression risk.

  ### Test coverage

  - git diff --check
  - Tools/astyle/check_code_style.sh src/modules/logger/logger.cpp
  - make px4_sitl_default -j4
  - Validated on a Pixhawk 6X:
      - SDLOG_MODE=0: full and mission logs start on arm and stop on disarm.
      - SDLOG_MODE=1: the full log starts at boot; the mission log starts on arm and stops on disarm.
      - SDLOG_MODE=2: the full log remains active from boot; the mission log starts on arm, stops on disarm, and a new mission log is created after rearming.
      - SDLOG_MODE=4: the full log starts on the first arm and remains active; the mission log stops on disarm, and a new mission log is created after rearming.

  ### Context

  The mission log is a subset of the full log. The change therefore verifies that the full file backend is active before starting the mission log.

  The existing behavior of the full log, SDLOG_BOOT_BAT, AUX-controlled logging, MAVLink logging, and delayed full-log stopping is preserved.
