### PR TITLE
fix(drivers/invensense): drop invalid gyro FIFO samples

### DIFF
--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
@@ -701,10 +701,17 @@ void ICM42688P::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DAT
 		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
 		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
 		// published scale stays constant instead of toggling with batch content.
-		gyro.x[gyro.samples] = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
-		gyro.y[gyro.samples] = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
-		gyro.z[gyro.samples] = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
-		gyro.samples++;
+		const int16_t gyro_x = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
+		const int16_t gyro_y = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
+		const int16_t gyro_z = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
+
+		// sample invalid if -32768 (16 bit truncation of the hires invalid marker -524288)
+		if (gyro_x != INT16_MIN && gyro_y != INT16_MIN && gyro_z != INT16_MIN) {
+			gyro.x[gyro.samples] = gyro_x;
+			gyro.y[gyro.samples] = gyro_y;
+			gyro.z[gyro.samples] = gyro_z;
+			gyro.samples++;
+		}
 	}
 
 	// correct frame for publication

--- a/src/drivers/imu/invensense/iim42652/IIM42652.cpp
+++ b/src/drivers/imu/invensense/iim42652/IIM42652.cpp
@@ -687,10 +687,17 @@ void IIM42652::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
 		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
 		// published scale stays constant instead of toggling with batch content.
-		gyro.x[gyro.samples] = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
-		gyro.y[gyro.samples] = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
-		gyro.z[gyro.samples] = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
-		gyro.samples++;
+		const int16_t gyro_x = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
+		const int16_t gyro_y = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
+		const int16_t gyro_z = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
+
+		// sample invalid if -32768 (16 bit truncation of the hires invalid marker -524288)
+		if (gyro_x != INT16_MIN && gyro_y != INT16_MIN && gyro_z != INT16_MIN) {
+			gyro.x[gyro.samples] = gyro_x;
+			gyro.y[gyro.samples] = gyro_y;
+			gyro.z[gyro.samples] = gyro_z;
+			gyro.samples++;
+		}
 	}
 
 	// correct frame for publication

--- a/src/drivers/imu/invensense/iim42653/IIM42653.cpp
+++ b/src/drivers/imu/invensense/iim42653/IIM42653.cpp
@@ -688,10 +688,17 @@ void IIM42653::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
 		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
 		// published scale stays constant instead of toggling with batch content.
-		gyro.x[gyro.samples] = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
-		gyro.y[gyro.samples] = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
-		gyro.z[gyro.samples] = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
-		gyro.samples++;
+		const int16_t gyro_x = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
+		const int16_t gyro_y = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
+		const int16_t gyro_z = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
+
+		// sample invalid if -32768 (16 bit truncation of the hires invalid marker -524288)
+		if (gyro_x != INT16_MIN && gyro_y != INT16_MIN && gyro_z != INT16_MIN) {
+			gyro.x[gyro.samples] = gyro_x;
+			gyro.y[gyro.samples] = gyro_y;
+			gyro.z[gyro.samples] = gyro_z;
+			gyro.samples++;
+		}
 	}
 
 	// correct frame for publication


### PR DESCRIPTION
## Summary
Stacked on #28134.

Apply the accel path's invalid-sample check to the gyro path in the ICM42688P, IIM42652 and IIM42653 drivers.

## Problem
With `FIFO_HOLD_LAST_DATA_EN` clear (the reset value, which all three drivers keep) the sensor inserts `-32768` for any accel or gyro sample that carries no data: from power-on until the first ODR sample, while a sensor is disabled, or when accel and gyro run at different ODRs. To make the marker unambiguous it also limits valid samples to `-32766..+32767`, so `INT16_MIN` can never be a real reading (IIM-42653 DS-000529 p.63, INTF_CONFIG0 bit 7; ICM-42688-P DS-000347 has the same table).

The accel path drops these. The gyro path publishes them, so the samples between enable and first output integrate as -2000 dps (-4000 dps on the IIM42653) on every axis.

## Solution
Decode into locals and skip the sample when any axis reads `INT16_MIN`, matching the accel path.

Build-checked on `px4_fmu-v6x`; not yet run on hardware.
