### PR TITLE
fix(drivers/imu): clip FIFO samples against the declared range, not the int16 rail

### DIFF
--- a/msg/SensorAccelFifo.msg
+++ b/msg/SensorAccelFifo.msg
@@ -4,10 +4,10 @@ uint64 timestamp_sample
 uint32 device_id          # unique device ID for the sensor that does not change between power cycles
 
 float32 dt                # delta time between samples (microseconds)
-float32 scale
+float32 scale             # m/s^2 per count
 
 uint8 samples             # number of valid samples
 
-int16[32] x               # acceleration in the FRD board frame X-axis in m/s^2
-int16[32] y               # acceleration in the FRD board frame Y-axis in m/s^2
-int16[32] z               # acceleration in the FRD board frame Z-axis in m/s^2
+int16[32] x               # FRD board frame X-axis raw counts (m/s^2 = x * scale)
+int16[32] y               # FRD board frame Y-axis raw counts (m/s^2 = y * scale)
+int16[32] z               # FRD board frame Z-axis raw counts (m/s^2 = z * scale)

--- a/msg/SensorGyroFifo.msg
+++ b/msg/SensorGyroFifo.msg
@@ -4,12 +4,12 @@ uint64 timestamp_sample
 uint32 device_id          # unique device ID for the sensor that does not change between power cycles
 
 float32 dt                # delta time between samples (microseconds)
-float32 scale
+float32 scale             # rad/s per count
 
 uint8 samples             # number of valid samples
 
-int16[32] x               # angular velocity in the FRD board frame X-axis in rad/s
-int16[32] y               # angular velocity in the FRD board frame Y-axis in rad/s
-int16[32] z               # angular velocity in the FRD board frame Z-axis in rad/s
+int16[32] x               # FRD board frame X-axis raw counts (rad/s = x * scale)
+int16[32] y               # FRD board frame Y-axis raw counts (rad/s = y * scale)
+int16[32] z               # FRD board frame Z-axis raw counts (rad/s = z * scale)
 
 uint8 ORB_QUEUE_LENGTH = 4

--- a/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
@@ -50,15 +50,13 @@ static constexpr int32_t sum(const int16_t samples[], uint8_t len)
 	return sum;
 }
 
-static constexpr uint8_t clipping(const int16_t samples[], uint8_t len)
+static constexpr uint8_t clipping(const int16_t samples[], uint8_t len, int16_t clip_limit)
 {
 	unsigned clip_count = 0;
 
 	for (int n = 0; n < len; n++) {
-		// - consider data clipped/saturated if it's INT16_MIN/INT16_MAX or within 1
-		// - this accommodates rotated data (|INT16_MIN| = INT16_MAX + 1)
-		//   and sensors that may re-use the lowest bit for other purposes (sync indicator, etc)
-		if ((samples[n] <= INT16_MIN + 1) || (samples[n] >= INT16_MAX - 1)) {
+		// symmetric about zero: rotation negates samples and |INT16_MIN| = INT16_MAX + 1
+		if ((samples[n] <= -clip_limit) || (samples[n] >= clip_limit)) {
 			clip_count++;
 		}
 	}
@@ -181,9 +179,13 @@ void PX4Accelerometer::updateFIFO(sensor_accel_fifo_s &sample)
 	_last_sample[1] = sample.y[N - 1];
 	_last_sample[2] = sample.z[N - 1];
 
-	report.clip_counter[0] = clipping(sample.x, N);
-	report.clip_counter[1] = clipping(sample.y, N);
-	report.clip_counter[2] = clipping(sample.z, N);
+	// The declared range is not the int16 rail on every part (ST high-g and dps scales leave
+	// headroom in the word), so clip against range/scale like update() does. The 0.999 margin
+	// in _clip_limit also covers sensors that reuse the lowest bit for a sync flag.
+	const int16_t clip_limit = static_cast<int16_t>(math::min(_clip_limit, (float)(INT16_MAX - 1)));
+	report.clip_counter[0] = clipping(sample.x, N, clip_limit);
+	report.clip_counter[1] = clipping(sample.y, N, clip_limit);
+	report.clip_counter[2] = clipping(sample.z, N, clip_limit);
 	report.samples = N;
 	report.timestamp = hrt_absolute_time();
 

--- a/src/lib/drivers/gyroscope/PX4Gyroscope.cpp
+++ b/src/lib/drivers/gyroscope/PX4Gyroscope.cpp
@@ -50,15 +50,13 @@ static constexpr int32_t sum(const int16_t samples[], uint8_t len)
 	return sum;
 }
 
-static constexpr uint8_t clipping(const int16_t samples[], uint8_t len)
+static constexpr uint8_t clipping(const int16_t samples[], uint8_t len, int16_t clip_limit)
 {
 	unsigned clip_count = 0;
 
 	for (int n = 0; n < len; n++) {
-		// - consider data clipped/saturated if it's INT16_MIN/INT16_MAX or within 1
-		// - this accommodates rotated data (|INT16_MIN| = INT16_MAX + 1)
-		//   and sensors that may re-use the lowest bit for other purposes (sync indicator, etc)
-		if ((samples[n] <= INT16_MIN + 1) || (samples[n] >= INT16_MAX - 1)) {
+		// symmetric about zero: rotation negates samples and |INT16_MIN| = INT16_MAX + 1
+		if ((samples[n] <= -clip_limit) || (samples[n] >= clip_limit)) {
 			clip_count++;
 		}
 	}
@@ -180,9 +178,13 @@ void PX4Gyroscope::updateFIFO(sensor_gyro_fifo_s &sample)
 	_last_sample[1] = sample.y[N - 1];
 	_last_sample[2] = sample.z[N - 1];
 
-	report.clip_counter[0] = clipping(sample.x, N);
-	report.clip_counter[1] = clipping(sample.y, N);
-	report.clip_counter[2] = clipping(sample.z, N);
+	// The declared range is not the int16 rail on every part (ST high-g and dps scales leave
+	// headroom in the word), so clip against range/scale like update() does. The 0.999 margin
+	// in _clip_limit also covers sensors that reuse the lowest bit for a sync flag.
+	const int16_t clip_limit = static_cast<int16_t>(math::min(_clip_limit, (float)(INT16_MAX - 1)));
+	report.clip_counter[0] = clipping(sample.x, N, clip_limit);
+	report.clip_counter[1] = clipping(sample.y, N, clip_limit);
+	report.clip_counter[2] = clipping(sample.z, N, clip_limit);
 	report.samples = N;
 	report.timestamp = hrt_absolute_time();
 


### PR DESCRIPTION
## Summary
`PX4Accelerometer::updateFIFO()` and `PX4Gyroscope::updateFIFO()` now detect clipping against `_clip_limit` (range/scale), the same threshold the non-FIFO `update()` path already uses, instead of the int16 rail. `SensorGyroFifo`/`SensorAccelFifo` comments now match that: `x/y/z` are raw counts, SI is `count * scale`.

## Problem
The FIFO path counted a sample as clipped only within 1 LSB of `INT16_MIN`/`INT16_MAX`. That equals the declared range only when sensitivity is exactly range/32768, which holds for Invensense and 16-bit Bosch parts but not for others: the LSM6DSV80X high-g channel (±80 g at 3.904 mg/LSB) saturates at 20492 counts, ST gyros at ±4000/±2000 dps (140/70 mdps/LSB) at 28571, the LSM9DS1 and ADIS16607 leave similar headroom, and the BMI055's 12-bit accel word never reaches the rail. On all of these no clip was ever reported from the FIFO path, so `vehicle_imu_status` clipping and the EKF's delta-velocity clipping handling never engaged.

The FIFO message comments also called those int16 arrays rad/s and m/s². They are counts; `sensor_gyro`/`sensor_accel` are the converted topics.

## Solution
Pass the range-derived limit (capped at `INT16_MAX - 1`) into the per-sample check in both FIFO publishers. Rail-scaled sensors move from 32766 to 32735 counts, the existing 0.999 margin of `_clip_limit`.

Verified on an ARK FMU-v6XRT (ICM-45686, IIM-20670, LSM6DSV80X): accumulated `accel_clipping`/`gyro_clipping` stay zero at rest on all three; `px4_fmu-v6x` and `px4_sitl` build. Not exercised at actual saturation.