### PR TITLE
fix(drivers/invensense): leave FIFO_HIRES_EN off when publishing 16-bit

### DIFF
--- a/boards/nxp/mr-tropic/nuttx-config/scripts/itcm_functions_includes.ld
+++ b/boards/nxp/mr-tropic/nuttx-config/scripts/itcm_functions_includes.ld
@@ -65,7 +65,6 @@
 *(.text._ZN7Mavlink15get_free_tx_bufEv)
 *(.text.nx_poll)
 *(.text._ZN15MavlinkReceiver3runEv)
-*(.text._ZN9ICM42688P18ProcessTemperatureEPKN20InvenSense_ICM42688P4FIFO4DATAEh)
 *(.text._ZN15OutputPredictor19correctOutputStatesEyRKN6matrix10QuaternionIfEERKNS0_7Vector3IfEERK9LatLonAltS8_S8_)
 *(.text._ZN3Ekf12predictStateERKN9estimator9imuSampleE)
 *(.text._ZN3px46logger6Logger3runEv)

--- a/boards/nxp/tropic-community/nuttx-config/scripts/itcm_functions_includes.ld
+++ b/boards/nxp/tropic-community/nuttx-config/scripts/itcm_functions_includes.ld
@@ -65,7 +65,6 @@
 *(.text._ZN7Mavlink15get_free_tx_bufEv)
 *(.text.nx_poll)
 *(.text._ZN15MavlinkReceiver3runEv)
-*(.text._ZN9ICM42688P18ProcessTemperatureEPKN20InvenSense_ICM42688P4FIFO4DATAEh)
 *(.text._ZN15OutputPredictor19correctOutputStatesEyRKN6matrix10QuaternionIfEERKNS0_7Vector3IfEERK9LatLonAltS8_S8_)
 *(.text._ZN3Ekf12predictStateERKN9estimator9imuSampleE)
 *(.text._ZN3px46logger6Logger3runEv)

--- a/boards/px4/fmu-v6xrt/nuttx-config/scripts/itcm_functions_includes.ld
+++ b/boards/px4/fmu-v6xrt/nuttx-config/scripts/itcm_functions_includes.ld
@@ -65,7 +65,6 @@
 *(.text._ZN7Mavlink15get_free_tx_bufEv)
 *(.text.nx_poll)
 *(.text._ZN15MavlinkReceiver3runEv)
-*(.text._ZN9ICM42688P18ProcessTemperatureEPKN20InvenSense_ICM42688P4FIFO4DATAEh)
 *(.text._ZN15OutputPredictor19correctOutputStatesEyRKN6matrix10QuaternionIfEERKNS0_7Vector3IfEERK9LatLonAltS8_S8_)
 *(.text._ZN3Ekf12predictStateERKN9estimator9imuSampleE)
 *(.text._ZN3px46logger6Logger3runEv)

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
@@ -310,6 +310,10 @@ void ICM42688P::RunImpl()
 					perf_count(_bad_register_perf);
 					Reset();
 				}
+
+			} else if (hrt_elapsed_time(&_temperature_update_timestamp) >= 1_s) {
+				UpdateTemperature();
+				_temperature_update_timestamp = now;
 			}
 		}
 
@@ -413,11 +417,8 @@ bool ICM42688P::Configure()
 		}
 	}
 
-	// 20-bits data format used
-	//  For the 688 the only FSR settings that are operational are ±2000dps for gyroscope and ±16g for accelerometer
-	//  For the 686 the only FSR settings that are operational are ±4000dps for gyroscope and ±32g for accelerometer
-
-	// data is published from the 16 bit FIFO registers (data[19:4]), which always span the full range
+	// 16-bit FIFO (FIFO_HIRES_EN clear). Full-scale is ±2000 dps / ±16 g on the 688
+	// and ±4000 dps / ±32 g on the 686.
 	if (isICM686) {
 		_px4_accel.set_range(32.f * CONSTANTS_ONE_G);
 		_px4_gyro.set_range(math::radians(4000.f));
@@ -583,8 +584,8 @@ bool ICM42688P::FIFORead(const hrt_abstime &timestamp_sample, uint8_t samples)
 			// gyro bit not set
 			valid = false;
 
-		} else if (!(FIFO_HEADER & FIFO::FIFO_HEADER_BIT::HEADER_20)) {
-			// Packet does not contain a new and valid extended 20-bit data
+		} else if (FIFO_HEADER & FIFO::FIFO_HEADER_BIT::HEADER_20) {
+			// 20-bit extension is not enabled
 			valid = false;
 
 		} else if ((FIFO_HEADER & FIFO::FIFO_HEADER_BIT::HEADER_TIMESTAMP_FSYNC) != Bit3) {
@@ -610,11 +611,9 @@ bool ICM42688P::FIFORead(const hrt_abstime &timestamp_sample, uint8_t samples)
 	}
 
 	if (valid_samples > 0) {
-		if (ProcessTemperature(buffer.f, valid_samples)) {
-			ProcessGyro(timestamp_sample, buffer.f, valid_samples);
-			ProcessAccel(timestamp_sample, buffer.f, valid_samples);
-			return true;
-		}
+		ProcessGyro(timestamp_sample, buffer.f, valid_samples);
+		ProcessAccel(timestamp_sample, buffer.f, valid_samples);
+		return true;
 	}
 
 	return false;
@@ -648,14 +647,11 @@ void ICM42688P::ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DA
 			accel.dt = (float)timestamp_fifo * FIFO_TIMESTAMP_SCALING;
 		}
 
-		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
-		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
-		// published scale stays constant instead of toggling with batch content.
 		const int16_t accel_x = combine(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0);
 		const int16_t accel_y = combine(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0);
 		const int16_t accel_z = combine(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0);
 
-		// sample invalid if -32768 (16 bit truncation of the hires invalid marker -524288)
+		// sample invalid if -32768 (FIFO_HOLD_LAST_DATA_EN is clear)
 		if (accel_x != INT16_MIN && accel_y != INT16_MIN && accel_z != INT16_MIN) {
 			accel.x[accel.samples] = accel_x;
 			accel.y[accel.samples] = accel_y;
@@ -698,14 +694,11 @@ void ICM42688P::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DAT
 			gyro.dt = (float)timestamp_fifo * FIFO_TIMESTAMP_SCALING;
 		}
 
-		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
-		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
-		// published scale stays constant instead of toggling with batch content.
 		const int16_t gyro_x = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
 		const int16_t gyro_y = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
 		const int16_t gyro_z = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
 
-		// sample invalid if -32768 (16 bit truncation of the hires invalid marker -524288)
+		// sample invalid if -32768 (FIFO_HOLD_LAST_DATA_EN is clear)
 		if (gyro_x != INT16_MIN && gyro_y != INT16_MIN && gyro_z != INT16_MIN) {
 			gyro.x[gyro.samples] = gyro_x;
 			gyro.y[gyro.samples] = gyro_y;
@@ -731,47 +724,22 @@ void ICM42688P::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DAT
 	}
 }
 
-bool ICM42688P::ProcessTemperature(const FIFO::DATA fifo[], const uint8_t samples)
+void ICM42688P::UpdateTemperature()
 {
-	int16_t temperature[FIFO_MAX_SAMPLES];
-	float temperature_sum{0};
+	uint8_t temperature_buf[3] {};
+	temperature_buf[0] = static_cast<uint8_t>(Register::BANK_0::TEMP_DATA1) | DIR_READ;
+	SelectRegisterBank(REG_BANK_SEL_BIT::BANK_SEL_0);
 
-	int valid_samples = 0;
-
-	for (int i = 0; i < samples; i++) {
-		const int16_t t = combine(fifo[i].TEMP_DATA1, fifo[i].TEMP_DATA0);
-
-		// sample invalid if -32768
-		if (t != -32768) {
-			temperature_sum += t;
-			temperature[valid_samples] = t;
-			valid_samples++;
-		}
+	if (transfer(temperature_buf, temperature_buf, sizeof(temperature_buf)) != PX4_OK) {
+		perf_count(_bad_transfer_perf);
+		return;
 	}
 
-	if (valid_samples > 0) {
-		const float temperature_avg = temperature_sum / valid_samples;
+	const int16_t TEMP_DATA = combine(temperature_buf[1], temperature_buf[2]);
+	const float TEMP_degC = (TEMP_DATA / TEMPERATURE_SENSITIVITY) + TEMPERATURE_OFFSET;
 
-		for (int i = 0; i < valid_samples; i++) {
-			// temperature changing wildly is an indication of a transfer error
-			if (fabsf(temperature[i] - temperature_avg) > 1000) {
-				perf_count(_bad_transfer_perf);
-				return false;
-			}
-		}
-
-		// use average temperature reading
-		const float TEMP_degC = (temperature_avg / TEMPERATURE_SENSITIVITY) + TEMPERATURE_OFFSET;
-
-		if (PX4_ISFINITE(TEMP_degC)) {
-			_px4_accel.set_temperature(TEMP_degC);
-			_px4_gyro.set_temperature(TEMP_degC);
-			return true;
-
-		} else {
-			perf_count(_bad_transfer_perf);
-		}
+	if (PX4_ISFINITE(TEMP_degC)) {
+		_px4_accel.set_temperature(TEMP_degC);
+		_px4_gyro.set_temperature(TEMP_degC);
 	}
-
-	return false;
 }

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
@@ -140,7 +140,7 @@ private:
 
 	void ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DATA fifo[], const uint8_t samples);
 	void ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA fifo[], const uint8_t samples);
-	bool ProcessTemperature(const FIFO::DATA fifo[], const uint8_t samples);
+	void UpdateTemperature();
 
 	const spi_drdy_gpio_t _drdy_gpio;
 
@@ -193,7 +193,7 @@ private:
 		{ Register::BANK_0::GYRO_ACCEL_CONFIG0,   0, GYRO_ACCEL_CONFIG0_BIT::ACCEL_UI_FILT_BW | GYRO_ACCEL_CONFIG0_BIT::GYRO_UI_FILT_BW },
 		{ Register::BANK_0::ACCEL_CONFIG1,        0, ACCEL_CONFIG1_BIT::ACCEL_UI_FILT_ORD },
 		{ Register::BANK_0::TMST_CONFIG,          TMST_CONFIG_BIT::TMST_EN | TMST_CONFIG_BIT::TMST_DELTA_EN | TMST_CONFIG_BIT::TMST_TO_REGS_EN | TMST_CONFIG_BIT::TMST_RES, TMST_CONFIG_BIT::TMST_FSYNC_EN },
-		{ Register::BANK_0::FIFO_CONFIG1,         FIFO_CONFIG1_BIT::FIFO_WM_GT_TH | FIFO_CONFIG1_BIT::FIFO_HIRES_EN | FIFO_CONFIG1_BIT::FIFO_TEMP_EN | FIFO_CONFIG1_BIT::FIFO_GYRO_EN | FIFO_CONFIG1_BIT::FIFO_ACCEL_EN, FIFO_CONFIG1_BIT::FIFO_TMST_FSYNC_EN },
+		{ Register::BANK_0::FIFO_CONFIG1,         FIFO_CONFIG1_BIT::FIFO_WM_GT_TH | FIFO_CONFIG1_BIT::FIFO_TEMP_EN | FIFO_CONFIG1_BIT::FIFO_GYRO_EN | FIFO_CONFIG1_BIT::FIFO_ACCEL_EN, FIFO_CONFIG1_BIT::FIFO_HIRES_EN | FIFO_CONFIG1_BIT::FIFO_TMST_FSYNC_EN },
 		{ Register::BANK_0::FIFO_CONFIG2,         0, 0 }, // FIFO_WM[7:0] set at runtime
 		{ Register::BANK_0::FIFO_CONFIG3,         0, 0 }, // FIFO_WM[11:8] set at runtime
 		{ Register::BANK_0::INT_CONFIG0,          INT_CONFIG0_BIT::CLEAR_ON_FIFO_READ, 0 },

--- a/src/drivers/imu/invensense/icm42688p/InvenSense_ICM42688P_registers.hpp
+++ b/src/drivers/imu/invensense/icm42688p/InvenSense_ICM42688P_registers.hpp
@@ -390,30 +390,26 @@ namespace FIFO
 static constexpr size_t SIZE = 2048;
 
 // FIFO_DATA layout when FIFO_CONFIG1 has FIFO_GYRO_EN and FIFO_ACCEL_EN set
-
-// Packet 4
+// Packet 3 (16-bit, no FIFO_HIRES_EN)
 struct DATA {
 	uint8_t FIFO_Header;
-	uint8_t ACCEL_DATA_X1; // Accel X [19:12]
-	uint8_t ACCEL_DATA_X0; // Accel X [11:4]
-	uint8_t ACCEL_DATA_Y1; // Accel Y [19:12]
-	uint8_t ACCEL_DATA_Y0; // Accel Y [11:4]
-	uint8_t ACCEL_DATA_Z1; // Accel Z [19:12]
-	uint8_t ACCEL_DATA_Z0; // Accel Z [11:4]
-	uint8_t GYRO_DATA_X1;  // Gyro X [19:12]
-	uint8_t GYRO_DATA_X0;  // Gyro X [11:4]
-	uint8_t GYRO_DATA_Y1;  // Gyro Y [19:12]
-	uint8_t GYRO_DATA_Y0;  // Gyro Y [11:4]
-	uint8_t GYRO_DATA_Z1;  // Gyro Z [19:12]
-	uint8_t GYRO_DATA_Z0;  // Gyro Z [11:4]
-	uint8_t TEMP_DATA1;    // Temperature[15:8]
-	uint8_t TEMP_DATA0;    // Temperature[7:0]
+	uint8_t ACCEL_DATA_X1; // Accel X [15:8]
+	uint8_t ACCEL_DATA_X0; // Accel X [7:0]
+	uint8_t ACCEL_DATA_Y1; // Accel Y [15:8]
+	uint8_t ACCEL_DATA_Y0; // Accel Y [7:0]
+	uint8_t ACCEL_DATA_Z1; // Accel Z [15:8]
+	uint8_t ACCEL_DATA_Z0; // Accel Z [7:0]
+	uint8_t GYRO_DATA_X1;  // Gyro X [15:8]
+	uint8_t GYRO_DATA_X0;  // Gyro X [7:0]
+	uint8_t GYRO_DATA_Y1;  // Gyro Y [15:8]
+	uint8_t GYRO_DATA_Y0;  // Gyro Y [7:0]
+	uint8_t GYRO_DATA_Z1;  // Gyro Z [15:8]
+	uint8_t GYRO_DATA_Z0;  // Gyro Z [7:0]
+	uint8_t temperature;   // Temperature[7:0]
 	uint8_t TimeStamp_h;   // TimeStamp[15:8]
 	uint8_t TimeStamp_l;   // TimeStamp[7:0]
-	uint8_t Ext_Accel_X_Gyro_X; // Accel X [3:0] Gyro X [3:0]
-	uint8_t Ext_Accel_Y_Gyro_Y; // Accel Y [3:0] Gyro Y [3:0]
-	uint8_t Ext_Accel_Z_Gyro_Z; // Accel Z [3:0] Gyro Z [3:0]
 };
+static_assert(sizeof(DATA) == 16, "FIFO packet 3 is 16 bytes");
 
 // With FIFO_ACCEL_EN and FIFO_GYRO_EN header should be 8’b_0110_10xx
 enum FIFO_HEADER_BIT : uint8_t {

--- a/src/drivers/imu/invensense/iim42652/IIM42652.cpp
+++ b/src/drivers/imu/invensense/iim42652/IIM42652.cpp
@@ -306,6 +306,10 @@ void IIM42652::RunImpl()
 					perf_count(_bad_register_perf);
 					Reset();
 				}
+
+			} else if (hrt_elapsed_time(&_temperature_update_timestamp) >= 1_s) {
+				UpdateTemperature();
+				_temperature_update_timestamp = now;
 			}
 		}
 
@@ -409,9 +413,7 @@ bool IIM42652::Configure()
 		}
 	}
 
-	// 20-bits data format used
-	//  the only FSR settings that are operational are ±2000dps for gyroscope and ±16g for accelerometer
-	// data is published from the 16 bit FIFO registers (data[19:4]), which always span the full range
+	// 16-bit FIFO (FIFO_HIRES_EN clear). Full-scale is ±2000 dps / ±16 g.
 	_px4_accel.set_range(16.f * CONSTANTS_ONE_G);
 	_px4_gyro.set_range(math::radians(2000.f));
 	_px4_accel.set_scale(16.f * CONSTANTS_ONE_G / 32768.f);
@@ -569,8 +571,8 @@ bool IIM42652::FIFORead(const hrt_abstime &timestamp_sample, uint8_t samples)
 			// gyro bit not set
 			valid = false;
 
-		} else if (!(FIFO_HEADER & FIFO::FIFO_HEADER_BIT::HEADER_20)) {
-			// Packet does not contain a new and valid extended 20-bit data
+		} else if (FIFO_HEADER & FIFO::FIFO_HEADER_BIT::HEADER_20) {
+			// 20-bit extension is not enabled
 			valid = false;
 
 		} else if ((FIFO_HEADER & FIFO::FIFO_HEADER_BIT::HEADER_TIMESTAMP_FSYNC) != Bit3) {
@@ -596,11 +598,9 @@ bool IIM42652::FIFORead(const hrt_abstime &timestamp_sample, uint8_t samples)
 	}
 
 	if (valid_samples > 0) {
-		if (ProcessTemperature(buffer.f, valid_samples)) {
-			ProcessGyro(timestamp_sample, buffer.f, valid_samples);
-			ProcessAccel(timestamp_sample, buffer.f, valid_samples);
-			return true;
-		}
+		ProcessGyro(timestamp_sample, buffer.f, valid_samples);
+		ProcessAccel(timestamp_sample, buffer.f, valid_samples);
+		return true;
 	}
 
 	return false;
@@ -634,14 +634,11 @@ void IIM42652::ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DAT
 			accel.dt = (float)timestamp_fifo * FIFO_TIMESTAMP_SCALING;
 		}
 
-		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
-		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
-		// published scale stays constant instead of toggling with batch content.
 		const int16_t accel_x = combine(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0);
 		const int16_t accel_y = combine(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0);
 		const int16_t accel_z = combine(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0);
 
-		// sample invalid if -32768 (16 bit truncation of the hires invalid marker -524288)
+		// sample invalid if -32768 (FIFO_HOLD_LAST_DATA_EN is clear)
 		if (accel_x != INT16_MIN && accel_y != INT16_MIN && accel_z != INT16_MIN) {
 			accel.x[accel.samples] = accel_x;
 			accel.y[accel.samples] = accel_y;
@@ -684,14 +681,11 @@ void IIM42652::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 			gyro.dt = (float)timestamp_fifo * FIFO_TIMESTAMP_SCALING;
 		}
 
-		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
-		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
-		// published scale stays constant instead of toggling with batch content.
 		const int16_t gyro_x = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
 		const int16_t gyro_y = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
 		const int16_t gyro_z = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
 
-		// sample invalid if -32768 (16 bit truncation of the hires invalid marker -524288)
+		// sample invalid if -32768 (FIFO_HOLD_LAST_DATA_EN is clear)
 		if (gyro_x != INT16_MIN && gyro_y != INT16_MIN && gyro_z != INT16_MIN) {
 			gyro.x[gyro.samples] = gyro_x;
 			gyro.y[gyro.samples] = gyro_y;
@@ -717,47 +711,22 @@ void IIM42652::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 	}
 }
 
-bool IIM42652::ProcessTemperature(const FIFO::DATA fifo[], const uint8_t samples)
+void IIM42652::UpdateTemperature()
 {
-	int16_t temperature[FIFO_MAX_SAMPLES];
-	float temperature_sum{0};
+	uint8_t temperature_buf[3] {};
+	temperature_buf[0] = static_cast<uint8_t>(Register::BANK_0::TEMP_DATA1) | DIR_READ;
+	SelectRegisterBank(REG_BANK_SEL_BIT::BANK_SEL_0);
 
-	int valid_samples = 0;
-
-	for (int i = 0; i < samples; i++) {
-		const int16_t t = combine(fifo[i].TEMP_DATA1, fifo[i].TEMP_DATA0);
-
-		// sample invalid if -32768
-		if (t != -32768) {
-			temperature_sum += t;
-			temperature[valid_samples] = t;
-			valid_samples++;
-		}
+	if (transfer(temperature_buf, temperature_buf, sizeof(temperature_buf)) != PX4_OK) {
+		perf_count(_bad_transfer_perf);
+		return;
 	}
 
-	if (valid_samples > 0) {
-		const float temperature_avg = temperature_sum / valid_samples;
+	const int16_t TEMP_DATA = combine(temperature_buf[1], temperature_buf[2]);
+	const float TEMP_degC = (TEMP_DATA / TEMPERATURE_SENSITIVITY) + TEMPERATURE_OFFSET;
 
-		for (int i = 0; i < valid_samples; i++) {
-			// temperature changing wildly is an indication of a transfer error
-			if (fabsf(temperature[i] - temperature_avg) > 1000) {
-				perf_count(_bad_transfer_perf);
-				return false;
-			}
-		}
-
-		// use average temperature reading
-		const float TEMP_degC = (temperature_avg / TEMPERATURE_SENSITIVITY) + TEMPERATURE_OFFSET;
-
-		if (PX4_ISFINITE(TEMP_degC)) {
-			_px4_accel.set_temperature(TEMP_degC);
-			_px4_gyro.set_temperature(TEMP_degC);
-			return true;
-
-		} else {
-			perf_count(_bad_transfer_perf);
-		}
+	if (PX4_ISFINITE(TEMP_degC)) {
+		_px4_accel.set_temperature(TEMP_degC);
+		_px4_gyro.set_temperature(TEMP_degC);
 	}
-
-	return false;
 }

--- a/src/drivers/imu/invensense/iim42652/IIM42652.hpp
+++ b/src/drivers/imu/invensense/iim42652/IIM42652.hpp
@@ -140,7 +140,7 @@ private:
 
 	void ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DATA fifo[], const uint8_t samples);
 	void ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA fifo[], const uint8_t samples);
-	bool ProcessTemperature(const FIFO::DATA fifo[], const uint8_t samples);
+	void UpdateTemperature();
 
 	const spi_drdy_gpio_t _drdy_gpio;
 
@@ -192,7 +192,7 @@ private:
 		{ Register::BANK_0::GYRO_ACCEL_CONFIG0,   0, GYRO_ACCEL_CONFIG0_BIT::ACCEL_UI_FILT_BW | GYRO_ACCEL_CONFIG0_BIT::GYRO_UI_FILT_BW },
 		{ Register::BANK_0::ACCEL_CONFIG1,        0, ACCEL_CONFIG1_BIT::ACCEL_UI_FILT_ORD },
 		{ Register::BANK_0::TMST_CONFIG,          TMST_CONFIG_BIT::TMST_EN | TMST_CONFIG_BIT::TMST_DELTA_EN | TMST_CONFIG_BIT::TMST_TO_REGS_EN | TMST_CONFIG_BIT::TMST_RES, TMST_CONFIG_BIT::TMST_FSYNC_EN },
-		{ Register::BANK_0::FIFO_CONFIG1,         FIFO_CONFIG1_BIT::FIFO_WM_GT_TH | FIFO_CONFIG1_BIT::FIFO_HIRES_EN | FIFO_CONFIG1_BIT::FIFO_TEMP_EN | FIFO_CONFIG1_BIT::FIFO_GYRO_EN | FIFO_CONFIG1_BIT::FIFO_ACCEL_EN, FIFO_CONFIG1_BIT::FIFO_TMST_FSYNC_EN },
+		{ Register::BANK_0::FIFO_CONFIG1,         FIFO_CONFIG1_BIT::FIFO_WM_GT_TH | FIFO_CONFIG1_BIT::FIFO_TEMP_EN | FIFO_CONFIG1_BIT::FIFO_GYRO_EN | FIFO_CONFIG1_BIT::FIFO_ACCEL_EN, FIFO_CONFIG1_BIT::FIFO_HIRES_EN | FIFO_CONFIG1_BIT::FIFO_TMST_FSYNC_EN },
 		{ Register::BANK_0::FIFO_CONFIG2,         0, 0 }, // FIFO_WM[7:0] set at runtime
 		{ Register::BANK_0::FIFO_CONFIG3,         0, 0 }, // FIFO_WM[11:8] set at runtime
 		{ Register::BANK_0::INT_CONFIG0,          INT_CONFIG0_BIT::CLEAR_ON_FIFO_READ, 0 },

--- a/src/drivers/imu/invensense/iim42652/InvenSense_IIM42652_registers.hpp
+++ b/src/drivers/imu/invensense/iim42652/InvenSense_IIM42652_registers.hpp
@@ -379,30 +379,26 @@ namespace FIFO
 static constexpr size_t SIZE = 2048;
 
 // FIFO_DATA layout when FIFO_CONFIG1 has FIFO_GYRO_EN and FIFO_ACCEL_EN set
-
-// Packet 4
+// Packet 3 (16-bit, no FIFO_HIRES_EN)
 struct DATA {
 	uint8_t FIFO_Header;
-	uint8_t ACCEL_DATA_X1; // Accel X [19:12]
-	uint8_t ACCEL_DATA_X0; // Accel X [11:4]
-	uint8_t ACCEL_DATA_Y1; // Accel Y [19:12]
-	uint8_t ACCEL_DATA_Y0; // Accel Y [11:4]
-	uint8_t ACCEL_DATA_Z1; // Accel Z [19:12]
-	uint8_t ACCEL_DATA_Z0; // Accel Z [11:4]
-	uint8_t GYRO_DATA_X1;  // Gyro X [19:12]
-	uint8_t GYRO_DATA_X0;  // Gyro X [11:4]
-	uint8_t GYRO_DATA_Y1;  // Gyro Y [19:12]
-	uint8_t GYRO_DATA_Y0;  // Gyro Y [11:4]
-	uint8_t GYRO_DATA_Z1;  // Gyro Z [19:12]
-	uint8_t GYRO_DATA_Z0;  // Gyro Z [11:4]
-	uint8_t TEMP_DATA1;    // Temperature[15:8]
-	uint8_t TEMP_DATA0;    // Temperature[7:0]
+	uint8_t ACCEL_DATA_X1; // Accel X [15:8]
+	uint8_t ACCEL_DATA_X0; // Accel X [7:0]
+	uint8_t ACCEL_DATA_Y1; // Accel Y [15:8]
+	uint8_t ACCEL_DATA_Y0; // Accel Y [7:0]
+	uint8_t ACCEL_DATA_Z1; // Accel Z [15:8]
+	uint8_t ACCEL_DATA_Z0; // Accel Z [7:0]
+	uint8_t GYRO_DATA_X1;  // Gyro X [15:8]
+	uint8_t GYRO_DATA_X0;  // Gyro X [7:0]
+	uint8_t GYRO_DATA_Y1;  // Gyro Y [15:8]
+	uint8_t GYRO_DATA_Y0;  // Gyro Y [7:0]
+	uint8_t GYRO_DATA_Z1;  // Gyro Z [15:8]
+	uint8_t GYRO_DATA_Z0;  // Gyro Z [7:0]
+	uint8_t temperature;   // Temperature[7:0]
 	uint8_t TimeStamp_h;   // TimeStamp[15:8]
 	uint8_t TimeStamp_l;   // TimeStamp[7:0]
-	uint8_t Ext_Accel_X_Gyro_X; // Accel X [3:0] Gyro X [3:0]
-	uint8_t Ext_Accel_Y_Gyro_Y; // Accel Y [3:0] Gyro Y [3:0]
-	uint8_t Ext_Accel_Z_Gyro_Z; // Accel Z [3:0] Gyro Z [3:0]
 };
+static_assert(sizeof(DATA) == 16, "FIFO packet 3 is 16 bytes");
 
 // With FIFO_ACCEL_EN and FIFO_GYRO_EN header should be 8’b_0110_10xx
 enum FIFO_HEADER_BIT : uint8_t {

--- a/src/drivers/imu/invensense/iim42653/IIM42653.cpp
+++ b/src/drivers/imu/invensense/iim42653/IIM42653.cpp
@@ -306,6 +306,10 @@ void IIM42653::RunImpl()
 					perf_count(_bad_register_perf);
 					Reset();
 				}
+
+			} else if (hrt_elapsed_time(&_temperature_update_timestamp) >= 1_s) {
+				UpdateTemperature();
+				_temperature_update_timestamp = now;
 			}
 		}
 
@@ -410,9 +414,7 @@ bool IIM42653::Configure()
 		}
 	}
 
-	// 20-bits data format used
-	//  the only FSR settings that are operational are ±4000dps for gyroscope and ±32g for accelerometer
-	// data is published from the 16 bit FIFO registers (data[19:4]), which always span the full range
+	// 16-bit FIFO (FIFO_HIRES_EN clear). Full-scale is ±4000 dps / ±32 g.
 	_px4_accel.set_range(32.f * CONSTANTS_ONE_G);
 	_px4_gyro.set_range(math::radians(4000.f));
 	_px4_accel.set_scale(32.f * CONSTANTS_ONE_G / 32768.f);
@@ -570,8 +572,8 @@ bool IIM42653::FIFORead(const hrt_abstime &timestamp_sample, uint8_t samples)
 			// gyro bit not set
 			valid = false;
 
-		} else if (!(FIFO_HEADER & FIFO::FIFO_HEADER_BIT::HEADER_20)) {
-			// Packet does not contain a new and valid extended 20-bit data
+		} else if (FIFO_HEADER & FIFO::FIFO_HEADER_BIT::HEADER_20) {
+			// 20-bit extension is not enabled
 			valid = false;
 
 		} else if ((FIFO_HEADER & FIFO::FIFO_HEADER_BIT::HEADER_TIMESTAMP_FSYNC) != Bit3) {
@@ -597,11 +599,9 @@ bool IIM42653::FIFORead(const hrt_abstime &timestamp_sample, uint8_t samples)
 	}
 
 	if (valid_samples > 0) {
-		if (ProcessTemperature(buffer.f, valid_samples)) {
-			ProcessGyro(timestamp_sample, buffer.f, valid_samples);
-			ProcessAccel(timestamp_sample, buffer.f, valid_samples);
-			return true;
-		}
+		ProcessGyro(timestamp_sample, buffer.f, valid_samples);
+		ProcessAccel(timestamp_sample, buffer.f, valid_samples);
+		return true;
 	}
 
 	return false;
@@ -635,14 +635,11 @@ void IIM42653::ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DAT
 			accel.dt = (float)timestamp_fifo * FIFO_TIMESTAMP_SCALING;
 		}
 
-		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
-		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
-		// published scale stays constant instead of toggling with batch content.
 		const int16_t accel_x = combine(fifo[i].ACCEL_DATA_X1, fifo[i].ACCEL_DATA_X0);
 		const int16_t accel_y = combine(fifo[i].ACCEL_DATA_Y1, fifo[i].ACCEL_DATA_Y0);
 		const int16_t accel_z = combine(fifo[i].ACCEL_DATA_Z1, fifo[i].ACCEL_DATA_Z0);
 
-		// sample invalid if -32768 (16 bit truncation of the hires invalid marker -524288)
+		// sample invalid if -32768 (FIFO_HOLD_LAST_DATA_EN is clear)
 		if (accel_x != INT16_MIN && accel_y != INT16_MIN && accel_z != INT16_MIN) {
 			accel.x[accel.samples] = accel_x;
 			accel.y[accel.samples] = accel_y;
@@ -685,14 +682,11 @@ void IIM42653::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 			gyro.dt = (float)timestamp_fifo * FIFO_TIMESTAMP_SCALING;
 		}
 
-		// The 16 bit FIFO registers hold data[19:4] of the 20 bit hires sample, which always spans
-		// the full range (scale set in Configure()). The 20 bit extension nibble is unused so the
-		// published scale stays constant instead of toggling with batch content.
 		const int16_t gyro_x = combine(fifo[i].GYRO_DATA_X1, fifo[i].GYRO_DATA_X0);
 		const int16_t gyro_y = combine(fifo[i].GYRO_DATA_Y1, fifo[i].GYRO_DATA_Y0);
 		const int16_t gyro_z = combine(fifo[i].GYRO_DATA_Z1, fifo[i].GYRO_DATA_Z0);
 
-		// sample invalid if -32768 (16 bit truncation of the hires invalid marker -524288)
+		// sample invalid if -32768 (FIFO_HOLD_LAST_DATA_EN is clear)
 		if (gyro_x != INT16_MIN && gyro_y != INT16_MIN && gyro_z != INT16_MIN) {
 			gyro.x[gyro.samples] = gyro_x;
 			gyro.y[gyro.samples] = gyro_y;
@@ -718,47 +712,22 @@ void IIM42653::ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA
 	}
 }
 
-bool IIM42653::ProcessTemperature(const FIFO::DATA fifo[], const uint8_t samples)
+void IIM42653::UpdateTemperature()
 {
-	int16_t temperature[FIFO_MAX_SAMPLES];
-	float temperature_sum{0};
+	uint8_t temperature_buf[3] {};
+	temperature_buf[0] = static_cast<uint8_t>(Register::BANK_0::TEMP_DATA1) | DIR_READ;
+	SelectRegisterBank(REG_BANK_SEL_BIT::BANK_SEL_0);
 
-	int valid_samples = 0;
-
-	for (int i = 0; i < samples; i++) {
-		const int16_t t = combine(fifo[i].TEMP_DATA1, fifo[i].TEMP_DATA0);
-
-		// sample invalid if -32768
-		if (t != -32768) {
-			temperature_sum += t;
-			temperature[valid_samples] = t;
-			valid_samples++;
-		}
+	if (transfer(temperature_buf, temperature_buf, sizeof(temperature_buf)) != PX4_OK) {
+		perf_count(_bad_transfer_perf);
+		return;
 	}
 
-	if (valid_samples > 0) {
-		const float temperature_avg = temperature_sum / valid_samples;
+	const int16_t TEMP_DATA = combine(temperature_buf[1], temperature_buf[2]);
+	const float TEMP_degC = (TEMP_DATA / TEMPERATURE_SENSITIVITY) + TEMPERATURE_OFFSET;
 
-		for (int i = 0; i < valid_samples; i++) {
-			// temperature changing wildly is an indication of a transfer error
-			if (fabsf(temperature[i] - temperature_avg) > 1000) {
-				perf_count(_bad_transfer_perf);
-				return false;
-			}
-		}
-
-		// use average temperature reading
-		const float TEMP_degC = (temperature_avg / TEMPERATURE_SENSITIVITY) + TEMPERATURE_OFFSET;
-
-		if (PX4_ISFINITE(TEMP_degC)) {
-			_px4_accel.set_temperature(TEMP_degC);
-			_px4_gyro.set_temperature(TEMP_degC);
-			return true;
-
-		} else {
-			perf_count(_bad_transfer_perf);
-		}
+	if (PX4_ISFINITE(TEMP_degC)) {
+		_px4_accel.set_temperature(TEMP_degC);
+		_px4_gyro.set_temperature(TEMP_degC);
 	}
-
-	return false;
 }

--- a/src/drivers/imu/invensense/iim42653/IIM42653.hpp
+++ b/src/drivers/imu/invensense/iim42653/IIM42653.hpp
@@ -140,7 +140,7 @@ private:
 
 	void ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DATA fifo[], const uint8_t samples);
 	void ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA fifo[], const uint8_t samples);
-	bool ProcessTemperature(const FIFO::DATA fifo[], const uint8_t samples);
+	void UpdateTemperature();
 
 	const spi_drdy_gpio_t _drdy_gpio;
 
@@ -192,7 +192,7 @@ private:
 		{ Register::BANK_0::GYRO_ACCEL_CONFIG0,   0, GYRO_ACCEL_CONFIG0_BIT::ACCEL_UI_FILT_BW | GYRO_ACCEL_CONFIG0_BIT::GYRO_UI_FILT_BW },
 		{ Register::BANK_0::ACCEL_CONFIG1,        0, ACCEL_CONFIG1_BIT::ACCEL_UI_FILT_ORD },
 		{ Register::BANK_0::TMST_CONFIG,          TMST_CONFIG_BIT::TMST_EN | TMST_CONFIG_BIT::TMST_DELTA_EN | TMST_CONFIG_BIT::TMST_TO_REGS_EN | TMST_CONFIG_BIT::TMST_RES, TMST_CONFIG_BIT::TMST_FSYNC_EN },
-		{ Register::BANK_0::FIFO_CONFIG1,         FIFO_CONFIG1_BIT::FIFO_WM_GT_TH | FIFO_CONFIG1_BIT::FIFO_HIRES_EN | FIFO_CONFIG1_BIT::FIFO_TEMP_EN | FIFO_CONFIG1_BIT::FIFO_GYRO_EN | FIFO_CONFIG1_BIT::FIFO_ACCEL_EN, FIFO_CONFIG1_BIT::FIFO_TMST_FSYNC_EN },
+		{ Register::BANK_0::FIFO_CONFIG1,         FIFO_CONFIG1_BIT::FIFO_WM_GT_TH | FIFO_CONFIG1_BIT::FIFO_TEMP_EN | FIFO_CONFIG1_BIT::FIFO_GYRO_EN | FIFO_CONFIG1_BIT::FIFO_ACCEL_EN, FIFO_CONFIG1_BIT::FIFO_HIRES_EN | FIFO_CONFIG1_BIT::FIFO_TMST_FSYNC_EN },
 		{ Register::BANK_0::FIFO_CONFIG2,         0, 0 }, // FIFO_WM[7:0] set at runtime
 		{ Register::BANK_0::FIFO_CONFIG3,         0, 0 }, // FIFO_WM[11:8] set at runtime
 		{ Register::BANK_0::INT_CONFIG0,          INT_CONFIG0_BIT::CLEAR_ON_FIFO_READ, 0 },

--- a/src/drivers/imu/invensense/iim42653/InvenSense_IIM42653_registers.hpp
+++ b/src/drivers/imu/invensense/iim42653/InvenSense_IIM42653_registers.hpp
@@ -415,30 +415,26 @@ namespace FIFO
 static constexpr size_t SIZE = 2048;
 
 // FIFO_DATA layout when FIFO_CONFIG1 has FIFO_GYRO_EN and FIFO_ACCEL_EN set
-
-// Packet 4
+// Packet 3 (16-bit, no FIFO_HIRES_EN)
 struct DATA {
 	uint8_t FIFO_Header;
-	uint8_t ACCEL_DATA_X1; // Accel X [19:12]
-	uint8_t ACCEL_DATA_X0; // Accel X [11:4]
-	uint8_t ACCEL_DATA_Y1; // Accel Y [19:12]
-	uint8_t ACCEL_DATA_Y0; // Accel Y [11:4]
-	uint8_t ACCEL_DATA_Z1; // Accel Z [19:12]
-	uint8_t ACCEL_DATA_Z0; // Accel Z [11:4]
-	uint8_t GYRO_DATA_X1;  // Gyro X [19:12]
-	uint8_t GYRO_DATA_X0;  // Gyro X [11:4]
-	uint8_t GYRO_DATA_Y1;  // Gyro Y [19:12]
-	uint8_t GYRO_DATA_Y0;  // Gyro Y [11:4]
-	uint8_t GYRO_DATA_Z1;  // Gyro Z [19:12]
-	uint8_t GYRO_DATA_Z0;  // Gyro Z [11:4]
-	uint8_t TEMP_DATA1;    // Temperature[15:8]
-	uint8_t TEMP_DATA0;    // Temperature[7:0]
+	uint8_t ACCEL_DATA_X1; // Accel X [15:8]
+	uint8_t ACCEL_DATA_X0; // Accel X [7:0]
+	uint8_t ACCEL_DATA_Y1; // Accel Y [15:8]
+	uint8_t ACCEL_DATA_Y0; // Accel Y [7:0]
+	uint8_t ACCEL_DATA_Z1; // Accel Z [15:8]
+	uint8_t ACCEL_DATA_Z0; // Accel Z [7:0]
+	uint8_t GYRO_DATA_X1;  // Gyro X [15:8]
+	uint8_t GYRO_DATA_X0;  // Gyro X [7:0]
+	uint8_t GYRO_DATA_Y1;  // Gyro Y [15:8]
+	uint8_t GYRO_DATA_Y0;  // Gyro Y [7:0]
+	uint8_t GYRO_DATA_Z1;  // Gyro Z [15:8]
+	uint8_t GYRO_DATA_Z0;  // Gyro Z [7:0]
+	uint8_t temperature;   // Temperature[7:0]
 	uint8_t TimeStamp_h;   // TimeStamp[15:8]
 	uint8_t TimeStamp_l;   // TimeStamp[7:0]
-	uint8_t Ext_Accel_X_Gyro_X; // Accel X [3:0] Gyro X [3:0]
-	uint8_t Ext_Accel_Y_Gyro_Y; // Accel Y [3:0] Gyro Y [3:0]
-	uint8_t Ext_Accel_Z_Gyro_Z; // Accel Z [3:0] Gyro Z [3:0]
 };
+static_assert(sizeof(DATA) == 16, "FIFO packet 3 is 16 bytes");
 
 // With FIFO_ACCEL_EN and FIFO_GYRO_EN header should be 8’b_0110_10xx
 enum FIFO_HEADER_BIT : uint8_t {


### PR DESCRIPTION
## Summary
Stacked on #28308 (#28134).

ICM42688P, IIM42652 and IIM42653 no longer set `FIFO_HIRES_EN`. FIFO packets are 16-bit (packet 3); temperature comes from `TEMP_DATA`.

## Problem
#28134 stopped using the 20-bit nibble but left `FIFO_HIRES_EN` set, so the chip still emits 20-byte packets and the driver still requires `HEADER_20`. That is 4 extra bytes per sample on the SPI bus for data that is discarded.

## Solution
Clear `FIFO_HIRES_EN`, parse the 16-byte packet, reject `HEADER_20`, and read temperature from the 16-bit `TEMP_DATA` registers (~1 Hz) instead of the 8-bit FIFO temp field.

ICM45686 still enables HIRES on #27663.

`px4_fmu-v6x` and `px4_sitl` build. Not run on hardware.