### PR TITLE
fix(nxp/adc): initialise each ADC once, not once globally

### DIFF
--- a/platforms/nuttx/src/px4/nxp/imxrt/adc/adc.cpp
+++ b/platforms/nuttx/src/px4/nxp/imxrt/adc/adc.cpp
@@ -85,74 +85,90 @@ typedef uint32_t 	adc_chan_t;
 
 int px4_arch_adc_init(uint32_t base_address)
 {
-	static bool once = false;
+	/* Perform ADC init once per ADC */
 
-	if (!once) {
+	static uint32_t once[SYSTEM_ADC_COUNT] {};
 
-		once = true;
+	uint32_t *free = nullptr;
 
-		/* Input is Buss Clock 144 Mhz We will use /4 for 36 Mhz */
-
-		irqstate_t flags = px4_enter_critical_section();
-
-		imxrt_clockall_adc1();
-
-		rCFG(base_address) = ADC_CFG_ADICLK_IPG | ADC_CFG_MODE_12BIT | \
-				     ADC_CFG_ADIV_DIV4 | ADC_CFG_ADLSMP | ADC_CFG_ADSTS_7_21 | \
-				     ADC_CFG_AVGS_4SMPL | ADC_CFG_OVWREN;
-		px4_leave_critical_section(flags);
-
-		/* Clear the CALF and begin the calibration */
-
-		rGS(base_address) = ADC_GS_CALF;
-		rGC(base_address) = ADC_GC_CAL;
-		uint32_t guard = 100;
-
-		while (guard != 0 && (rGS(base_address) & ADC_GC_CAL) == 0) {
-			guard--;
-			usleep(1);
+	for (uint32_t i = 0; i < SYSTEM_ADC_COUNT; i++) {
+		if (once[i] == base_address) {
+			return OK;
 		}
 
-		while ((rGS(base_address) & ADC_GC_CAL) == ADC_GC_CAL) {
-
-			usleep(100);
-
-			if (rGS(base_address) & ADC_GS_CALF) {
-				return -1;
-			}
+		if (free == nullptr && once[i] == 0) {
+			free = &once[i];
 		}
+	}
 
-		if ((rHS(base_address) & ADC_HS_COCO0) == 0) {
-			return -2;
-		}
+	if (free == nullptr) {
+		/* ADC misconfigured SYSTEM_ADC_COUNT too small */;
+		PANIC();
+	}
+
+	*free = base_address;
+
+	/* Input is Buss Clock 144 Mhz We will use /4 for 36 Mhz */
+
+	irqstate_t flags = px4_enter_critical_section();
+
+	imxrt_clockall_adc1();
+
+	rCFG(base_address) = ADC_CFG_ADICLK_IPG | ADC_CFG_MODE_12BIT | \
+			     ADC_CFG_ADIV_DIV4 | ADC_CFG_ADLSMP | ADC_CFG_ADSTS_7_21 | \
+			     ADC_CFG_AVGS_4SMPL | ADC_CFG_OVWREN;
+	px4_leave_critical_section(flags);
+
+	/* Clear the CALF and begin the calibration */
+
+	rGS(base_address) = ADC_GS_CALF;
+	rGC(base_address) = ADC_GC_CAL;
+	uint32_t guard = 100;
+
+	while (guard != 0 && (rGS(base_address) & ADC_GC_CAL) == 0) {
+		guard--;
+		usleep(1);
+	}
+
+	while ((rGS(base_address) & ADC_GC_CAL) == ADC_GC_CAL) {
+
+		usleep(100);
 
 		if (rGS(base_address) & ADC_GS_CALF) {
-			return -3;
+			return -1;
 		}
+	}
 
-		/* dummy read to clear COCO of calibration */
+	if ((rHS(base_address) & ADC_HS_COCO0) == 0) {
+		return -2;
+	}
 
-		int32_t r = rR0(base_address);
-		UNUSED(r);
+	if (rGS(base_address) & ADC_GS_CALF) {
+		return -3;
+	}
 
-		/* kick off a sample and wait for it to complete */
-		hrt_abstime now = hrt_absolute_time();
-		rGC(base_address) = ADC_GC_AVGE;
-		rHC0(base_address) =  0xd; // VREFSH = internal channel, for ADC self-test, hard connected to VRH internally
+	/* dummy read to clear COCO of calibration */
 
-		while (!(rHS(base_address) & ADC_HS_COCO0)) {
+	int32_t r = rR0(base_address);
+	UNUSED(r);
 
-			/* don't wait for more than 500us, since that means something broke -
-			 * should reset here if we see this
-			 */
+	/* kick off a sample and wait for it to complete */
+	hrt_abstime now = hrt_absolute_time();
+	rGC(base_address) = ADC_GC_AVGE;
+	rHC0(base_address) =  0xd; // VREFSH = internal channel, for ADC self-test, hard connected to VRH internally
 
-			if ((hrt_absolute_time() - now) > 500) {
-				return -4;
-			}
+	while (!(rHS(base_address) & ADC_HS_COCO0)) {
+
+		/* don't wait for more than 500us, since that means something broke -
+		 * should reset here if we see this
+		 */
+
+		if ((hrt_absolute_time() - now) > 500) {
+			return -4;
 		}
+	}
 
-		r = rR0(base_address);
-	} // once
+	r = rR0(base_address);
 
 	return 0;
 }

--- a/platforms/nuttx/src/px4/nxp/rt117x/adc/adc.cpp
+++ b/platforms/nuttx/src/px4/nxp/rt117x/adc/adc.cpp
@@ -114,64 +114,80 @@ typedef uint32_t 	adc_chan_t;
 
 int px4_arch_adc_init(uint32_t base_address)
 {
-	static bool once = false;
+	/* Perform ADC init once per ADC */
 
-	if (!once) {
+	static uint32_t once[SYSTEM_ADC_COUNT] {};
 
-		once = true;
+	uint32_t *free = nullptr;
 
-		/* Input is ADCx_CLK_ROOT_SYS_PLL2_CLK with devide by 6.
-		 *  528 Mhz / 6 = 88 Mhz.
+	for (uint32_t i = 0; i < SYSTEM_ADC_COUNT; i++) {
+		if (once[i] == base_address) {
+			return OK;
+		}
+
+		if (free == nullptr && once[i] == 0) {
+			free = &once[i];
+		}
+	}
+
+	if (free == nullptr) {
+		/* ADC misconfigured SYSTEM_ADC_COUNT too small */;
+		PANIC();
+	}
+
+	*free = base_address;
+
+	/* Input is ADCx_CLK_ROOT_SYS_PLL2_CLK with devide by 6.
+	 *  528 Mhz / 6 = 88 Mhz.
+	 */
+
+
+	if (base_address == IMXRT_LPADC1_BASE) {
+		imxrt_clockall_adc1();
+
+	} else if (base_address == IMXRT_LPADC2_BASE) {
+		imxrt_clockall_adc2();
+	}
+
+
+	irqstate_t flags = px4_enter_critical_section();
+	rCTRL(base_address) |= IMXRT_LPADC_CTRL_RST;
+	rCTRL(base_address) &= ~IMXRT_LPADC_CTRL_RST;
+	rCTRL(base_address) |= IMXRT_LPADC_CTRL_RSTFIFO;
+	rCFG(base_address) =  IMXRT_LPADC_CFG_REFSEL_REFSEL_0 | IMXRT_LPADC_CFG_PWREN | IMXRT_LPADC_CFG_PWRSEL_PWRSEL_3 |
+			      IMXRT_LPADC_CFG_PUDLY(128);
+	rCTRL(base_address) = IMXRT_LPADC_CTRL_ADCEN;
+
+	px4_leave_critical_section(flags);
+
+	/* Read ADC1 vtemp_sensor_plus */
+
+	rCMDL1(base_address) = IMXRT_LPADC_CMDL1_ADCH_ADCH_7;
+
+	rCMDH1(base_address) = IMXRT_LPADC_CMDH1_STS_STS_7 | IMXRT_LPADC_CMDH1_AVGS_AVGS_0;
+	rTCTRL0(base_address) = IMXRT_LPADC_TCTRL0_TCMD_TCMD_1;
+	rSTAT(base_address) = IMXRT_LPADC_STAT_FOF;
+
+	/* kick off a sample and wait for it to complete */
+	hrt_abstime now = hrt_absolute_time();
+
+	rSWTRIG(base_address) = IMXRT_LPADC_SWTRIG_SWT0;
+
+	while (!(rSTAT(base_address) & IMXRT_LPADC_STAT_RDY)) {
+
+		/* don't wait for more than 100us, since that means something broke -
+		 * should reset here if we see this
 		 */
 
-
-		if (base_address == IMXRT_LPADC1_BASE) {
-			imxrt_clockall_adc1();
-
-		} else if (base_address == IMXRT_LPADC2_BASE) {
-			imxrt_clockall_adc2();
+		if ((hrt_absolute_time() - now) > 100) {
+			rCTRL(base_address) &= ~IMXRT_LPADC_CTRL_ADCEN;
+			return -4;
 		}
+	}
 
-
-		irqstate_t flags = px4_enter_critical_section();
-		rCTRL(base_address) |= IMXRT_LPADC_CTRL_RST;
-		rCTRL(base_address) &= ~IMXRT_LPADC_CTRL_RST;
-		rCTRL(base_address) |= IMXRT_LPADC_CTRL_RSTFIFO;
-		rCFG(base_address) =  IMXRT_LPADC_CFG_REFSEL_REFSEL_0 | IMXRT_LPADC_CFG_PWREN | IMXRT_LPADC_CFG_PWRSEL_PWRSEL_3 |
-				      IMXRT_LPADC_CFG_PUDLY(128);
-		rCTRL(base_address) = IMXRT_LPADC_CTRL_ADCEN;
-
-		px4_leave_critical_section(flags);
-
-		/* Read ADC1 vtemp_sensor_plus */
-
-		rCMDL1(base_address) = IMXRT_LPADC_CMDL1_ADCH_ADCH_7;
-
-		rCMDH1(base_address) = IMXRT_LPADC_CMDH1_STS_STS_7 | IMXRT_LPADC_CMDH1_AVGS_AVGS_0;
-		rTCTRL0(base_address) = IMXRT_LPADC_TCTRL0_TCMD_TCMD_1;
-		rSTAT(base_address) = IMXRT_LPADC_STAT_FOF;
-
-		/* kick off a sample and wait for it to complete */
-		hrt_abstime now = hrt_absolute_time();
-
-		rSWTRIG(base_address) = IMXRT_LPADC_SWTRIG_SWT0;
-
-		while (!(rSTAT(base_address) & IMXRT_LPADC_STAT_RDY)) {
-
-			/* don't wait for more than 100us, since that means something broke -
-			 * should reset here if we see this
-			 */
-
-			if ((hrt_absolute_time() - now) > 100) {
-				rCTRL(base_address) &= ~IMXRT_LPADC_CTRL_ADCEN;
-				return -4;
-			}
-		}
-
-		int32_t r = (rRESFIFO(base_address) & IMXRT_LPADC_RESFIFO_D_MASK) >> 3;
-		UNUSED(r);
-		rCTRL(base_address) &= ~IMXRT_LPADC_CTRL_ADCEN;
-	} // once
+	int32_t r = (rRESFIFO(base_address) & IMXRT_LPADC_RESFIFO_D_MASK) >> 3;
+	UNUSED(r);
+	rCTRL(base_address) &= ~IMXRT_LPADC_CTRL_ADCEN;
 
 	return 0;
 }


### PR DESCRIPTION
## Summary
LPADC1 on i.MX RT117x never received its CFG write because a single `once` flag was shared with LPADC2.

## Problem
`board_determine_hw_info()` calls `px4_arch_adc_init(LPADC2)` first. The function-static `once` is then true, so `board_adc`'s later `px4_arch_adc_init(LPADC1)` returns without clocking, resetting, or writing CFG. Conversions still trigger via ADCEN per sample, but PWREN/PWRSEL/PUDLY stay at reset: rail and brick ADC readings are low/noisy while `ver all` (ADC2) looks healthy. Same pattern in the RT106x driver.

## Solution
Track init per ADC base, matching STM32. Built `px4_fmu-v6xrt`. Not run on hardware.