### PR TITLE
fix(manifest): return the matching PAB manifest entry

### DIFF
--- a/platforms/common/pab_manifest.c
+++ b/platforms/common/pab_manifest.c
@@ -560,7 +560,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 	if (boards_manifest != px4_hw_mft_list_uninitialized)
 		for (unsigned int ndx = 0; ndx < boards_manifest->entries; ndx++) {
 			if (boards_manifest->mft[ndx].id == id) {
-				rv = &boards_manifest->mft[id];
+				rv = &boards_manifest->mft[ndx];
 				break;
 			}
 		}


### PR DESCRIPTION
## Summary
`board_query_manifest` returned `mft[id]` after finding `mft[ndx]`.

## Problem
PAB lists are not a dense enum array. Looking up `PX4_MFT_T100_ETH` (id 7) in a 7-entry list that skipped `T1_ETH` indexes one past the end. Any sparse list returns the wrong row.

## Solution
Return `&mft[ndx]`. Built `px4_fmu-v6x`. Not run on hardware.