### PR TITLE
fix(commander): report the worst IMU in the consistency check

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/imuConsistencyCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/imuConsistencyCheck.cpp
@@ -43,64 +43,66 @@ void ImuConsistencyChecks::checkAndReport(const Context &context, Report &report
 
 	// Use the difference between IMU's to detect a bad calibration.
 	// If a single IMU is fitted, the value being checked will be zero so this check will always pass.
+	// Report argmax: a single bad IMU also pulls the healthy ones off the mean.
+	unsigned worst_accel_i = 0;
+	float worst_accel = 0.f;
+
 	for (unsigned i = 0; i < (sizeof(imu.accel_inconsistency_m_s_s) / sizeof(imu.accel_inconsistency_m_s_s[0])); i++) {
-		if (imu.accel_device_ids[i] != 0) {
-
-			const float accel_inconsistency_m_s_s = imu.accel_inconsistency_m_s_s[i];
-
-			if (accel_inconsistency_m_s_s > _param_com_arm_imu_acc.get()) {
-				/* EVENT
-				 * @description
-				 * Check the calibration.
-				 *
-				 * Inconsistency value: {2}.
-				 * Configured Threshold: {3}.
-				 *
-				 * <profile name="dev">
-				 * This check can be configured via <param>COM_ARM_IMU_ACC</param> parameter.
-				 * </profile>
-				 */
-				reporter.armingCheckFailure<uint8_t, float, float>(NavModes::All, health_component_t::accel,
-						events::ID("check_imu_accel_inconsistent"),
-						events::Log::Warning, "Accel {1} inconsistent", i, accel_inconsistency_m_s_s, _param_com_arm_imu_acc.get());
-
-				if (reporter.mavlink_log_pub()) {
-					mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Accel %u inconsistent - check cal", i);
-				}
-
-				break;
-			}
+		if ((imu.accel_device_ids[i] != 0) && (imu.accel_inconsistency_m_s_s[i] > worst_accel)) {
+			worst_accel = imu.accel_inconsistency_m_s_s[i];
+			worst_accel_i = i;
 		}
 	}
 
-	// Fail if gyro difference greater than 5 deg/sec and notify if greater than 2.5 deg/sec
+	if (worst_accel > _param_com_arm_imu_acc.get()) {
+		/* EVENT
+		 * @description
+		 * Check the calibration.
+		 *
+		 * Inconsistency value: {2}.
+		 * Configured Threshold: {3}.
+		 *
+		 * <profile name="dev">
+		 * This check can be configured via <param>COM_ARM_IMU_ACC</param> parameter.
+		 * </profile>
+		 */
+		reporter.armingCheckFailure<uint8_t, float, float>(NavModes::All, health_component_t::accel,
+				events::ID("check_imu_accel_inconsistent"),
+				events::Log::Warning, "Accel {1} inconsistent", worst_accel_i, worst_accel, _param_com_arm_imu_acc.get());
+
+		if (reporter.mavlink_log_pub()) {
+			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Accel %u inconsistent - check cal", worst_accel_i);
+		}
+	}
+
+	unsigned worst_gyro_i = 0;
+	float worst_gyro = 0.f;
+
 	for (unsigned i = 0; i < (sizeof(imu.gyro_inconsistency_rad_s) / sizeof(imu.gyro_inconsistency_rad_s[0])); i++) {
-		if (imu.gyro_device_ids[i] != 0) {
+		if ((imu.gyro_device_ids[i] != 0) && (imu.gyro_inconsistency_rad_s[i] > worst_gyro)) {
+			worst_gyro = imu.gyro_inconsistency_rad_s[i];
+			worst_gyro_i = i;
+		}
+	}
 
-			const float gyro_inconsistency_rad_s = imu.gyro_inconsistency_rad_s[i];
+	if (worst_gyro > _param_com_arm_imu_gyr.get()) {
+		/* EVENT
+		 * @description
+		 * Check the calibration.
+		 *
+		 * Inconsistency value: {2}.
+		 * Configured Threshold: {3}.
+		 *
+		 * <profile name="dev">
+		 * This check can be configured via <param>COM_ARM_IMU_GYR</param> parameter.
+		 * </profile>
+		 */
+		reporter.armingCheckFailure<uint8_t, float, float>(NavModes::All, health_component_t::gyro,
+				events::ID("check_imu_gyro_inconsistent"),
+				events::Log::Warning, "Gyro {1} inconsistent", worst_gyro_i, worst_gyro, _param_com_arm_imu_gyr.get());
 
-			if (gyro_inconsistency_rad_s > _param_com_arm_imu_gyr.get()) {
-				/* EVENT
-				 * @description
-				 * Check the calibration.
-				 *
-				 * Inconsistency value: {2}.
-				 * Configured Threshold: {3}.
-				 *
-				 * <profile name="dev">
-				 * This check can be configured via <param>COM_ARM_IMU_GYR</param> parameter.
-				 * </profile>
-				 */
-				reporter.armingCheckFailure<uint8_t, float, float>(NavModes::All, health_component_t::gyro,
-						events::ID("check_imu_gyro_inconsistent"),
-						events::Log::Warning, "Gyro {1} inconsistent", i, gyro_inconsistency_rad_s, _param_com_arm_imu_gyr.get());
-
-				if (reporter.mavlink_log_pub()) {
-					mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Gyro %u inconsistent - check cal", i);
-				}
-
-				break;
-			}
+		if (reporter.mavlink_log_pub()) {
+			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Gyro %u inconsistent - check cal", worst_gyro_i);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
The preflight IMU consistency check now names the sensor with the largest deviation from the mean, not the first one over the threshold.

## Problem
Inconsistency is each IMU's deviation from the mean of all of them. A single fault therefore also moves the healthy IMUs, so the first index over `COM_ARM_IMU_ACC`/`COM_ARM_IMU_GYR` can be a good sensor.

## Solution
Report argmax for accel and gyro.

Built `px4_fmu-v6x` and `px4_sitl`. Not flown.