### PR TITLE
fix(drivers/icm45686): retry WHO_AM_I on probe

### DIFF
--- a/src/drivers/imu/invensense/icm45686/ICM45686.cpp
+++ b/src/drivers/imu/invensense/icm45686/ICM45686.cpp
@@ -135,13 +135,14 @@ int ICM45686::probe()
 	for (int i = 0; i < 3; i++) {
 		const uint8_t whoami = RegisterRead(Register::BANK_0::WHO_AM_I);
 
-		if (whoami != WHOAMI) {
-			DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
-			return PX4_ERROR;
+		if (whoami == WHOAMI) {
+			return PX4_OK;
 		}
+
+		DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
 	}
 
-	return PX4_OK;
+	return PX4_ERROR;
 }
 
 void ICM45686::RunImpl()


### PR DESCRIPTION
## Summary
`probe()` now retries WHO_AM_I on mismatch instead of failing the first bad read.

## Problem
The three-iteration loop returned on the first mismatch, so a single garbage SPI read after power-up failed the probe. The extra iterations only ran on the success path, which already had the right ID.

## Solution
Succeed on the first matching WHO_AM_I, fail after three attempts. Same form as ICM42688P.

Built `px4_fmu-v6x` and `px4_sitl`. Not run on hardware.