### PR TITLE
refactor(parameters): merge Param<> constructor calls to save flash

### DIFF
--- a/boards/nxp/mr-tropic/nuttx-config/scripts/itcm_functions_includes.ld
+++ b/boards/nxp/mr-tropic/nuttx-config/scripts/itcm_functions_includes.ld
@@ -625,7 +625,6 @@
 *(.text._ZN36do_not_explicitly_use_this_namespace5ParamIfLN3px46paramsE919EEC1Ev) /* itcm-check-ignore */
 *(.text._ZN22MavlinkStreamHeartbeat8get_sizeEv)
 *(.text._ZN6matrix6MatrixIfLj3ELj1EEdVEf)
-*(.text._ZN17FlightTaskDescendC1Ev)
 *(.text._ZN26MavlinkStreamCameraTrigger8get_sizeEv)
 *(.text.iob_navail)
 *(.text._ZN12FailsafeBase25removeNonActivatedActionsEv)

--- a/boards/nxp/tropic-community/nuttx-config/scripts/itcm_functions_includes.ld
+++ b/boards/nxp/tropic-community/nuttx-config/scripts/itcm_functions_includes.ld
@@ -625,7 +625,6 @@
 *(.text._ZN36do_not_explicitly_use_this_namespace5ParamIfLN3px46paramsE919EEC1Ev) /* itcm-check-ignore */
 *(.text._ZN22MavlinkStreamHeartbeat8get_sizeEv)
 *(.text._ZN6matrix6MatrixIfLj3ELj1EEdVEf)
-*(.text._ZN17FlightTaskDescendC1Ev)
 *(.text._ZN26MavlinkStreamCameraTrigger8get_sizeEv)
 *(.text.iob_navail)
 *(.text._ZN12FailsafeBase25removeNonActivatedActionsEv)

--- a/boards/px4/fmu-v6xrt/nuttx-config/scripts/itcm_functions_includes.ld
+++ b/boards/px4/fmu-v6xrt/nuttx-config/scripts/itcm_functions_includes.ld
@@ -639,7 +639,6 @@
 *(.text._ZN36do_not_explicitly_use_this_namespace5ParamIfLN3px46paramsE919EEC1Ev) /* itcm-check-ignore */
 *(.text._ZN22MavlinkStreamHeartbeat8get_sizeEv)
 *(.text._ZN6matrix6MatrixIfLj3ELj1EEdVEf)
-*(.text._ZN17FlightTaskDescendC1Ev)
 *(.text._ZN26MavlinkStreamCameraTrigger8get_sizeEv)
 *(.text.iob_navail)
 *(.text._ZN12FailsafeBase25removeNonActivatedActionsEv)

--- a/platforms/common/include/px4_platform_common/param.h
+++ b/platforms/common/include/px4_platform_common/param.h
@@ -118,8 +118,7 @@ public:
 
 	Param()
 	{
-		param_set_used(handle());
-		update();
+		param_get_mark_used(handle(), &_val);
 	}
 
 	float get() const { return _val; }
@@ -170,8 +169,7 @@ public:
 	Param(float &external_val)
 		: _val(external_val)
 	{
-		param_set_used(handle());
-		update();
+		param_get_mark_used(handle(), &_val);
 	}
 
 	float get() const { return _val; }
@@ -220,8 +218,7 @@ public:
 
 	Param()
 	{
-		param_set_used(handle());
-		update();
+		param_get_mark_used(handle(), &_val);
 	}
 
 	int32_t get() const { return _val; }
@@ -272,8 +269,7 @@ public:
 	Param(int32_t &external_val)
 		: _val(external_val)
 	{
-		param_set_used(handle());
-		update();
+		param_get_mark_used(handle(), &_val);
 	}
 
 	int32_t get() const { return _val; }
@@ -322,8 +318,11 @@ public:
 
 	Param()
 	{
-		param_set_used(handle());
-		update();
+		int32_t value_int;
+
+		if (param_get_mark_used(handle(), &value_int) == 0) {
+			_val = value_int != 0;
+		}
 	}
 
 	bool get() const { return _val; }

--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -232,6 +232,18 @@ __EXPORT size_t		param_size(param_t param);
 __EXPORT int		param_get(param_t param, void *val);
 
 /**
+ * Mark a parameter as used and copy its value.
+ *
+ * Combines param_set_used() and param_get() into a single out-of-line call,
+ * saving flash at the many Param<> constructor call sites.
+ *
+ * @param param		A handle returned by param_find or passed by param_foreach.
+ * @param val		Where to return the value, assumed to point to suitable storage for the parameter type.
+ * @return		Zero if the parameter's value could be returned, nonzero otherwise.
+ */
+__EXPORT int		param_get_mark_used(param_t param, void *val);
+
+/**
  * Copy the (airframe-specific) default value of a parameter.
  *
  * @param param		A handle returned by param_find or passed by param_foreach.

--- a/src/lib/parameters/parameters_common.cpp
+++ b/src/lib/parameters/parameters_common.cpp
@@ -157,3 +157,10 @@ param_get_system_default_value(param_t param, void *default_val)
 
 	return ret;
 }
+
+int
+param_get_mark_used(param_t param, void *val)
+{
+	param_set_used(param);
+	return param_get(param, val);
+}

--- a/src/modules/commander/failsafe/emscripten.cpp
+++ b/src/modules/commander/failsafe/emscripten.cpp
@@ -102,6 +102,12 @@ void param_set_used(param_t param)
 	used_params[param] = p;
 }
 
+int param_get_mark_used(param_t param, void *val)
+{
+	param_set_used(param);
+	return param_get(param, val);
+}
+
 std::vector<std::string> get_used_params()
 {
 	std::vector<std::string> ret;


### PR DESCRIPTION
## Summary
Split out from #27816 (@mbjd's work). Fold the two calls in every `Param<>` constructor into one out-of-line `param_get_mark_used()`. Saves 7232 B of `.text` on `px4_fmu-v6x_default`.

## Problem
Each `Param<>` constructor inlines `param_set_used(handle())` followed by `param_get(handle(), &_val)`, materialising the handle constant and a call twice at each of the ~2000 instantiation sites.

## Solution
Add `param_get_mark_used()` to `parameters_common.cpp` (so both the flat and protected user-side builds get it) and call it once from each constructor. Behaviour is unchanged; the `bool` specialisation keeps its int32 → bool conversion.

Two knock-on fixes: the `failsafe_web` emscripten build stubs the param API itself and gets a matching stub; the smaller constructors let GCC fully inline the defaulted `FlightTaskDescend()` on the ITCM boards (v6xrt, tropic), so its entry is dropped from those linker scripts per the ITCM check.

Built `px4_fmu-v6x_default`, `px4_fmu-v6xrt_default` (ITCM check passes), `px4_fmu-v5_protected`, `px4_sitl`, `failsafe_web`; `make tests` passes.
