### PR TITLE
refactor(platform): out-line ModuleParams setParent and destructor to save flash

### DIFF
--- a/boards/nxp/mr-tropic/nuttx-config/scripts/itcm_functions_includes.ld
+++ b/boards/nxp/mr-tropic/nuttx-config/scripts/itcm_functions_includes.ld
@@ -625,7 +625,6 @@
 *(.text._ZN36do_not_explicitly_use_this_namespace5ParamIfLN3px46paramsE919EEC1Ev) /* itcm-check-ignore */
 *(.text._ZN22MavlinkStreamHeartbeat8get_sizeEv)
 *(.text._ZN6matrix6MatrixIfLj3ELj1EEdVEf)
-*(.text._ZN17FlightTaskDescendC1Ev)
 *(.text._ZN26MavlinkStreamCameraTrigger8get_sizeEv)
 *(.text.iob_navail)
 *(.text._ZN12FailsafeBase25removeNonActivatedActionsEv)

--- a/boards/nxp/tropic-community/nuttx-config/scripts/itcm_functions_includes.ld
+++ b/boards/nxp/tropic-community/nuttx-config/scripts/itcm_functions_includes.ld
@@ -625,7 +625,6 @@
 *(.text._ZN36do_not_explicitly_use_this_namespace5ParamIfLN3px46paramsE919EEC1Ev) /* itcm-check-ignore */
 *(.text._ZN22MavlinkStreamHeartbeat8get_sizeEv)
 *(.text._ZN6matrix6MatrixIfLj3ELj1EEdVEf)
-*(.text._ZN17FlightTaskDescendC1Ev)
 *(.text._ZN26MavlinkStreamCameraTrigger8get_sizeEv)
 *(.text.iob_navail)
 *(.text._ZN12FailsafeBase25removeNonActivatedActionsEv)

--- a/boards/px4/fmu-v6xrt/nuttx-config/scripts/itcm_functions_includes.ld
+++ b/boards/px4/fmu-v6xrt/nuttx-config/scripts/itcm_functions_includes.ld
@@ -639,7 +639,6 @@
 *(.text._ZN36do_not_explicitly_use_this_namespace5ParamIfLN3px46paramsE919EEC1Ev) /* itcm-check-ignore */
 *(.text._ZN22MavlinkStreamHeartbeat8get_sizeEv)
 *(.text._ZN6matrix6MatrixIfLj3ELj1EEdVEf)
-*(.text._ZN17FlightTaskDescendC1Ev)
 *(.text._ZN26MavlinkStreamCameraTrigger8get_sizeEv)
 *(.text.iob_navail)
 *(.text._ZN12FailsafeBase25removeNonActivatedActionsEv)

--- a/platforms/common/CMakeLists.txt
+++ b/platforms/common/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(px4_platform STATIC
 	i2c.cpp
 	i2c_spi_buses.cpp
 	module.cpp
+	module_params.cpp
 	px4_getopt.c
 	px4_cli.cpp
 	shutdown.cpp

--- a/platforms/common/module_params.cpp
+++ b/platforms/common/module_params.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,62 +31,18 @@
  *
  ****************************************************************************/
 
-/**
- * @file module_params.h
- *
- * @class ModuleParams is a C++ base class for modules/classes using configuration parameters.
- */
+#include <px4_platform_common/module_params.h>
 
-#pragma once
-
-#include <containers/List.hpp>
-
-#include "param.h"
-
-class ModuleParams : public ListNode<ModuleParams *>
+void ModuleParams::setParent(ModuleParams *parent)
 {
-public:
-
-	ModuleParams(ModuleParams *parent)
-	{
-		setParent(parent);
+	if (parent) {
+		parent->_children.add(this);
 	}
 
-	/**
-	 * @brief Sets the parent module. This is typically not required,
-	 *         only in cases where the parent cannot be set via constructor.
-	 */
-	void setParent(ModuleParams *parent);
+	_parent = parent;
+}
 
-	virtual ~ModuleParams();
-
-	// Disallow copy construction and move assignment.
-	ModuleParams(const ModuleParams &) = delete;
-	ModuleParams &operator=(const ModuleParams &) = delete;
-	ModuleParams(ModuleParams &&) = delete;
-	ModuleParams &operator=(ModuleParams &&) = delete;
-
-protected:
-	/**
-	 * @brief Call this method whenever the module gets a parameter change notification.
-	 *        It will automatically call updateParams() for all children, which then call updateParamsImpl().
-	 */
-	virtual void updateParams()
-	{
-		for (const auto &child : _children) {
-			child->updateParams();
-		}
-
-		updateParamsImpl();
-	}
-
-	/**
-	 * @brief The implementation for this is generated with the macro DEFINE_PARAMETERS()
-	 */
-	virtual void updateParamsImpl() {}
-
-private:
-	/** @list _children The module parameter list of inheriting classes. */
-	List<ModuleParams *> _children;
-	ModuleParams *_parent{nullptr};
-};
+ModuleParams::~ModuleParams()
+{
+	if (_parent) { _parent->_children.remove(this); }
+}

--- a/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
+++ b/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
@@ -83,7 +83,7 @@ px4_add_library(health_and_arming_checks ${health_and_arming_checks_srcs})
 
 set_property(GLOBAL APPEND PROPERTY PX4_MODULE_CONFIG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/esc_check_params.yaml)
 add_dependencies(health_and_arming_checks mode_util)
-target_link_libraries(health_and_arming_checks PRIVATE geo hysteresis)
+target_link_libraries(health_and_arming_checks PRIVATE geo hysteresis px4_platform)
 
 px4_add_functional_gtest(SRC HealthAndArmingChecksTest.cpp
 	LINKLIBS health_and_arming_checks mode_util

--- a/src/modules/commander/failsafe/CMakeLists.txt
+++ b/src/modules/commander/failsafe/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(failsafe_test EXCLUDE_FROM_ALL
 	emscripten.cpp
 	failsafe.cpp
 	framework.cpp
+	${PX4_SOURCE_DIR}/platforms/common/module_params.cpp
 	)
 set_property(TARGET failsafe_test PROPERTY UNITY_BUILD ON) # avoids some method calls to e.g. param_name or param_type
 set_property(TARGET failsafe_test PROPERTY LINK_DEPENDS ${html_output_file})


### PR DESCRIPTION
## Summary
Split out from #27816 (@mbjd's work). Move `ModuleParams::setParent()` and `~ModuleParams()` out of the header. Saves 3968 B of `.text` on `px4_fmu-v6x_default`.

## Problem
Both were defined inline, so the `List` add/remove bodies were duplicated into the constructor and destructor of every one of the 150+ `ModuleParams`-derived classes. Construction and destruction are cold paths.

## Solution
Define them in a new `platforms/common/module_params.cpp`. Two consumers reach `ModuleParams` without `px4_platform` on the link line and now need the definitions explicitly: `health_and_arming_checks` (the `functional-ModeManagement` test only pulls it in transitively through `modules__commander`, after `px4_platform`) and the `failsafe_web` emscripten build, which compiles `module_params.cpp` directly. All other 159 test targets already link correctly.

The smaller constructors let GCC fully inline the defaulted `FlightTaskDescend()` on the ITCM boards (v6xrt, tropic), so its entry is dropped from those linker scripts per the ITCM check.

Built `px4_fmu-v6x_default`, `px4_fmu-v6xrt_default` (ITCM check passes), `px4_sitl`, `failsafe_web`; `make tests` passes.
