### PR TITLE
fix(mag_cal): make rotation auto-detection robust to invalid mag fits

### DIFF
--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -862,7 +862,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 
 
 						// Check that the average error across all samples (relative to internal mag) is less than the minimum earth field (~0.25 Gauss)
-						const float mag_error_gs = sqrt(min_mse / last_sample_index);
+						const float mag_error_gs = sqrtf(min_mse);
 						bool total_error_check_passed = (mag_error_gs < 0.25f);
 
 #if defined(DEBUG_BUILD)

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -742,12 +742,16 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 
 			// find first internal mag with a valid fit to use as reference
 			int internal_index = -1;
+			bool has_internal = false;
 
 			for (unsigned cur_mag = 0; cur_mag < MAX_MAGS; cur_mag++) {
-				if (!worker_data.calibration[cur_mag].external() && (worker_data.calibration[cur_mag].device_id() != 0)
-				    && fit_valid[cur_mag]) {
-					internal_index = cur_mag;
-					break;
+				if (!worker_data.calibration[cur_mag].external() && (worker_data.calibration[cur_mag].device_id() != 0)) {
+					has_internal = true;
+
+					if (fit_valid[cur_mag]) {
+						internal_index = cur_mag;
+						break;
+					}
 				}
 			}
 
@@ -920,6 +924,20 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 									cur_mag, worker_data.calibration[cur_mag].device_id(), r, (double)MSE[r]);
 							}
 						}
+					}
+				}
+
+			} else if (has_internal) {
+				// reference fit failed; stay silent when no internal mag exists as rotations are then configured manually
+				for (unsigned cur_mag = 0; cur_mag < MAX_MAGS; cur_mag++) {
+					const calibration::Magnetometer &cal = worker_data.calibration[cur_mag];
+
+					// skip disabled mags and mags with manually configured rotations
+					if (cal.external() && (cal.device_id() != 0) && cal.enabled()
+					    && (cal.rotation_enum() != ROTATION_CUSTOM)
+					    && (cal.rotation_enum() != ROTATION_ROLL_90_PITCH_68_YAW_293)) {
+						calibration_log_critical(mavlink_log_pub, "Compass %u rotation unverified, check CAL_MAG%u_ROT",
+									 cur_mag, cur_mag);
 					}
 				}
 			}

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -571,6 +571,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 	Vector3f diag[MAX_MAGS];
 	Vector3f offdiag[MAX_MAGS];
 	float sphere_radius[MAX_MAGS];
+	bool fit_valid[MAX_MAGS] {};
 
 	const float mag_sphere_radius = get_sphere_radius();
 
@@ -681,6 +682,9 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 						offdiag[cur_mag].zero();
 						result = calibrate_return_ok;
 					}
+
+				} else {
+					fit_valid[cur_mag] = true;
 				}
 			}
 		}
@@ -736,11 +740,12 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 
 		if ((worker_data.calibration_sides >= 3) && (param_sens_mag_autorot == 1)) {
 
-			// find first internal mag to use as reference
+			// find first internal mag with a valid fit to use as reference
 			int internal_index = -1;
 
 			for (unsigned cur_mag = 0; cur_mag < MAX_MAGS; cur_mag++) {
-				if (!worker_data.calibration[cur_mag].external() && (worker_data.calibration[cur_mag].device_id() != 0)) {
+				if (!worker_data.calibration[cur_mag].external() && (worker_data.calibration[cur_mag].device_id() != 0)
+				    && fit_valid[cur_mag]) {
 					internal_index = cur_mag;
 					break;
 				}
@@ -786,7 +791,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 
 				// external mags try all rotations and compute mean square error (MSE) compared with first internal mag
 				for (int cur_mag = 0; cur_mag < MAX_MAGS; cur_mag++) {
-					if ((worker_data.calibration[cur_mag].device_id() != 0) && (cur_mag != internal_index)) {
+					if ((worker_data.calibration[cur_mag].device_id() != 0) && fit_valid[cur_mag] && (cur_mag != internal_index)) {
 
 						const int last_sample_index = math::min(worker_data.calibration_counter_total[internal_index],
 											worker_data.calibration_counter_total[cur_mag]);

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -897,8 +897,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 								}
 
 							} else {
-								PX4_ERR("External Mag: %d (%" PRIu32 ")), determining rotation failed", cur_mag,
-									worker_data.calibration[cur_mag].device_id());
+								calibration_log_critical(mavlink_log_pub, "Compass %d rotation unverified, check CAL_MAG%d_ROT", cur_mag, cur_mag);
 								print_all_mse = true;
 							}
 


### PR DESCRIPTION
### Solved Problem
A disabled mag whose sphere fit fails (e.g. large offsets) is reset to raw values, but it is still used as the reference for external mag rotation auto-detection. 

The MSE comparison then runs against uncalibrated data and always fails its sanity checks, so the rotation is never determined. The failure is only a console PX4_ERR while the calibration reports success, leaving the vehicle with an unverified external mag rotation - and potentially a large heading error.

### Solution

Three commits: 

1. Only use mags with a valid fit in rotation detection: a mag whose fit failed (and whose calibration values were reset) can not serve as a reference. 
2. Report rotation detection failure to GCS.
3. When detection is skipped because no valid reference exists, tell the user which CAL_MAGx_ROT to set manually (skipping mags with manually configured/custom rotations, matching the detection loop's own skip list). No warning when there is no internal mag. 

No behavior change for vehicles with a healthy internal mag, or with SENS_MAG_AUTOROT=0.

### Changelog Entry
For release notes:
```
Feature/Bugfix make rotation auto-detection robust to invalid mag fits
```

### Alternatives 

I am still unsure on how this should be effectively communicated to the user, and whether the message I suggested is clear enough. 

### Test coverage

Needs to be tested on a vehicle. 

