### PR TITLE
fix(logging/fuelt_tank_status): log all instances of fuel_tank_status

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -76,7 +76,6 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("follow_target_status", 400);
 	add_optional_topic("flaps_setpoint", 1000);
 	add_optional_topic("flight_phase_estimation", 1000);
-	add_topic("fuel_tank_status", 10);
 	add_optional_topic("gain_compression", 100);
 	add_topic("gimbal_manager_set_attitude", 500);
 	add_optional_topic("generator_status");
@@ -170,6 +169,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic_multi("actuator_outputs", 100, 3);
 	add_optional_topic_multi("airspeed_wind", 1000, 4);
 	add_optional_topic_multi("control_allocator_status", 200, 2);
+	add_topic_multi("fuel_tank_status", 200, 3);
 	add_optional_topic_multi("rate_ctrl_status", 200, 2);
 	add_optional_topic_multi("sensor_hygrometer", 500, 4);
 	add_optional_topic_multi("sensor_temp", 100, 4);


### PR DESCRIPTION
### Solved Problem
Currently only one instance of fuel_tank_status is actually logged
Also logging with 10ms

### Solution
change `add_topic` to `add_topic_multi` with 3 instances
change to logging-freq to 200

### Test
Tested with 2 simulated fueltanks
<img width="1302" height="150" alt="image" src="https://github.com/user-attachments/assets/3cd5315b-6920-45f8-9c10-8662e4f091cc" />
