### PR TITLE
fix(TECS): Make underspeed detection depend on minimum and stall airspeed

### DIFF
--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -52,6 +52,20 @@ using math::min;
 
 static inline constexpr bool TIMESTAMP_VALID(float dt) { return (PX4_ISFINITE(dt) && dt > FLT_EPSILON);}
 
+// Where underspeed mitigation is fully ramped in, as a fraction of the way from the stall airspeed to the
+// minimum airspeed demand. 0 puts full mitigation at the stall airspeed, 1 puts it at the minimum airspeed
+// demand. Sitting in between means mitigation is saturated with stall margin still in hand, while the ramp
+// still spans enough of the margin not to act as a step.
+static constexpr float kUnderspeedFullMitigationFraction{0.5f};
+// Smallest airspeed interval the ramp is spread over [m/s]. Only relevant for an airframe configured with
+// (almost) no stall margin at all, where it keeps the ramp a steep ramp just below the minimum airspeed demand
+// instead of a discontinuity exactly at it.
+static constexpr float kUnderspeedRampWidthMin{0.1f};
+// Expected (safe) airspeed tracking error, as a fraction of the trim airspeed. Gives a second, stall airspeed
+// independent place to put full mitigation, so that a stall airspeed left far too low cannot stretch the ramp and
+// delay mitigation indefinitely.
+static constexpr float kUnderspeedTasErrorFraction{0.15f};
+
 void TECSAirspeedFilter::initialize(const float equivalent_airspeed, const float equivalent_airspeed_trim,
 				    const bool airspeed_sensor_available)
 {
@@ -363,17 +377,27 @@ void TECSControl::_detectUnderspeed(const Input &input, const Param &param, cons
 		return;
 	}
 
-	// this is the expected (something like standard) deviation from the airspeed setpoint that we allow the airspeed
-	// to vary in before ramping in underspeed mitigation
-	const float tas_error_bound = param.tas_error_percentage * param.equivalent_airspeed_trim;
+	// Underspeed mitigation is ramped in across the stall margin the operator configured: it is inactive at and
+	// above the minimum airspeed demand, and fully ramped in part of the way down to the stall airspeed. Both
+	// bounds are true airspeeds carrying the same load factor and flap compensation as the airspeed demand, so the
+	// ramp tracks the actual stall speed of the wing rather than a fixed fraction of the trim airspeed.
+	// The stall airspeed is capped at the minimum airspeed demand so that a misconfigured airframe (stall airspeed
+	// at or above the minimum airspeed) cannot place the ramp above the airspeed being flown.
+	const float tas_stall = math::min(param.tas_stall, param.tas_min);
+	const float tas_starting_to_underspeed = param.tas_min;
 
-	// this is the soft boundary where underspeed mitigation is ramped in
-	// NOTE: it's currently the same as the error bound, but separated here to indicate these values do not in general
-	// need to be the same
-	const float tas_underspeed_soft_bound = param.tas_error_percentage * param.equivalent_airspeed_trim;
+	// Part of the way down the configured stall margin.
+	const float tas_fully_undersped_stall = tas_stall + kUnderspeedFullMitigationFraction *
+						(param.tas_min - tas_stall);
 
-	const float tas_fully_undersped = math::max(param.tas_min - tas_error_bound - tas_underspeed_soft_bound, 0.0f);
-	const float tas_starting_to_underspeed = math::max(param.tas_min - tas_error_bound, tas_fully_undersped);
+	// One expected airspeed tracking error below the minimum airspeed demand. This does not depend on the stall
+	// airspeed, so it still ramps mitigation in soon enough if that parameter was never configured.
+	const float tas_fully_undersped_error = param.tas_min - kUnderspeedTasErrorFraction * param.tas_trim;
+
+	// Whichever of the two saturates earlier wins, so either the stall airspeed or the tracking error catches an
+	// underspeed condition. The ramp must still not collapse onto the minimum airspeed demand itself.
+	const float tas_fully_undersped = math::max(math::min(math::max(tas_fully_undersped_stall,
+					  tas_fully_undersped_error), param.tas_min - kUnderspeedRampWidthMin), 0.0f);
 
 	_ratio_undersped = 1.0f - math::constrain((input.tas - tas_fully_undersped) /
 			   math::max(tas_starting_to_underspeed - tas_fully_undersped, FLT_EPSILON), 0.0f, 1.0f);
@@ -674,7 +698,9 @@ void TECS::initControlParams(float target_climbrate, float target_sinkrate, floa
 	_reference_param.target_climbrate = target_climbrate;
 	_reference_param.target_sinkrate = target_sinkrate;
 	// Control
+	_control_param.tas_trim = eas_to_tas * _control_param.equivalent_airspeed_trim;
 	_control_param.tas_min = eas_to_tas * _equivalent_airspeed_min;
+	_control_param.tas_stall = eas_to_tas * _equivalent_airspeed_stall;
 	_control_param.tas_max = eas_to_tas * _equivalent_airspeed_max;
 	_control_param.pitch_max = pitch_limit_max;
 	_control_param.pitch_min = pitch_limit_min;

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -223,7 +223,9 @@ public:
 		float max_climb_rate;			///< Climb rate produced by max allowed throttle [m/s].
 		float vert_accel_limit;			///< Magnitude of the maximum vertical acceleration allowed [m/s²].
 		float equivalent_airspeed_trim;		///< Equivalent cruise airspeed for airspeed less mode [m/s].
+		float tas_trim;				///< True airspeed corresponding to the trim airspeed [m/s].
 		float tas_min;				///< True airspeed demand lower limit [m/s].
+		float tas_stall;			///< True airspeed at which the wing stalls [m/s].
 		float tas_max;				///< True airspeed demand upper limit [m/s].
 		float pitch_max;			///< Maximum pitch angle above trim allowed in [rad].
 		float pitch_min;			///< Minimal pitch angle below trim allowed in [rad].
@@ -236,8 +238,6 @@ public:
 		float altitude_setpoint_gain_ff;	///< Gain from altitude demand derivative to demanded climb rate.
 
 		// Airspeed control param
-		/// [0,1] percentage of true airspeed trim corresponding to expected (safe) true airspeed tracking errors
-		float tas_error_percentage;
 		float airspeed_error_gain;				///< Airspeed error inverse time constant [1/s].
 
 		// Energy control param
@@ -637,6 +637,7 @@ public:
 
 	void set_equivalent_airspeed_min(float airspeed) { _equivalent_airspeed_min = airspeed; }
 	void set_equivalent_airspeed_max(float airspeed) { _equivalent_airspeed_max = airspeed; }
+	void set_equivalent_airspeed_stall(float airspeed) { _equivalent_airspeed_stall = airspeed; }
 	void set_equivalent_airspeed_trim(float airspeed) { _control_param.equivalent_airspeed_trim = airspeed; _airspeed_filter_param.equivalent_airspeed_trim = airspeed; }
 
 	void set_pitch_damping(float damping) { _control_param.pitch_damping_gain = damping; }
@@ -718,6 +719,7 @@ private:
 
 	float _equivalent_airspeed_min{10.0f};				///< equivalent airspeed demand lower limit (m/sec)
 	float _equivalent_airspeed_max{20.0f};				///< equivalent airspeed demand upper limit (m/sec)
+	float _equivalent_airspeed_stall{7.0f};				///< equivalent airspeed at which the wing stalls (m/sec)
 	float _fast_descend_alt_err{-1.f};	 				///< Altitude difference between current altitude to altitude setpoint needed to descend with higher airspeed [m].
 	float _fast_descend{0.f};					///< Value for fast descend in [0,1]. continuous value used to flatten the high speed value out when close to target altitude.
 	hrt_abstime _enabled_fast_descend_timestamp{0U};		///< timestamp at activation of fast descend mode
@@ -749,7 +751,9 @@ private:
 		.max_climb_rate = 5.0f,
 		.vert_accel_limit = 0.0f,
 		.equivalent_airspeed_trim = 15.0f,
+		.tas_trim = 15.0f,
 		.tas_min = 10.0f,
+		.tas_stall = 7.0f,
 		.tas_max = 20.0f,
 		.pitch_max = 0.5f,
 		.pitch_min = -0.5f,
@@ -758,7 +762,6 @@ private:
 		.throttle_min = 0.1f,
 		.altitude_error_gain = 0.2f,
 		.altitude_setpoint_gain_ff = 0.0f,
-		.tas_error_percentage = 0.15f,
 		.airspeed_error_gain = 0.1f,
 		.ste_rate_time_const = 0.1f,
 		.seb_rate_ff = 1.0f,

--- a/src/lib/tecs/TECSTest.cpp
+++ b/src/lib/tecs/TECSTest.cpp
@@ -50,7 +50,9 @@ TECSControl::Param makeParam()
 	param.max_climb_rate = 5.f;
 	param.vert_accel_limit = 10.f;
 	param.equivalent_airspeed_trim = 15.f;
+	param.tas_trim = 15.f;
 	param.tas_min = 10.f;
+	param.tas_stall = 7.f;
 	param.tas_max = 30.f;
 	param.pitch_max = radians(15.f);
 	param.pitch_min = radians(-15.f);
@@ -59,7 +61,6 @@ TECSControl::Param makeParam()
 	param.throttle_min = 0.f;
 	param.altitude_error_gain = 0.2f;
 	param.altitude_setpoint_gain_ff = 0.f;
-	param.tas_error_percentage = 0.15f;
 	param.airspeed_error_gain = 0.1f;
 	param.ste_rate_time_const = 0.1f;
 	param.seb_rate_ff = 1.f;
@@ -203,4 +204,146 @@ TEST(TECSControlTest, PitchIntegratorSurvivesSustainedNonFiniteInput)
 		EXPECT_TRUE(PX4_ISFINITE(control.getDebugOutput().pitch_integrator));
 		EXPECT_TRUE(PX4_ISFINITE(control.getPitchSetpoint()));
 	}
+}
+
+namespace
+{
+
+// Run one update at the given true airspeed and report the resulting underspeed ratio.
+float underspeedRatioAt(float tas, TECSControl::Param param, const TECSControl::Flag &flag = makeFlag())
+{
+	TECSControl control;
+	TECSControl::Input input = makeInput();
+	input.tas = tas;
+
+	control.initialize(makeSetpoint(), input, param, flag);
+	control.update(0.02f, makeSetpoint(), input, param, flag);
+
+	return control.getRatioUndersped();
+}
+
+} // namespace
+
+// Underspeed mitigation is referenced to the stall airspeed, not to a percentage of the trim airspeed: it stays
+// inactive at and above the minimum airspeed demand and saturates part way down the stall margin, so it is fully
+// ramped in with stall margin still in hand.
+TEST(TECSControlTest, UnderspeedRatioIsReferencedToStallAirspeed)
+{
+	TECSControl::Param param = makeParam(); // tas_min = 10, tas_stall = 7
+	// Full mitigation half way from the stall airspeed to the minimum airspeed demand.
+	const float tas_fully_undersped = 0.5f * (param.tas_stall + param.tas_min); // 8.5
+
+	// At and above the minimum airspeed demand there is no mitigation.
+	EXPECT_FLOAT_EQ(underspeedRatioAt(param.tas_min + 5.f, param), 0.f);
+	EXPECT_FLOAT_EQ(underspeedRatioAt(param.tas_min, param), 0.f);
+
+	// Saturated with stall margin still in hand, and stays saturated below that.
+	EXPECT_FLOAT_EQ(underspeedRatioAt(tas_fully_undersped, param), 1.f);
+	EXPECT_FLOAT_EQ(underspeedRatioAt(param.tas_stall, param), 1.f);
+	EXPECT_FLOAT_EQ(underspeedRatioAt(0.f, param), 1.f);
+
+	// Linear in between.
+	const float midpoint = 0.5f * (param.tas_min + tas_fully_undersped);
+	EXPECT_NEAR(underspeedRatioAt(midpoint, param), 0.5f, 1e-4f);
+}
+
+// The ramp bounds follow the minimum airspeed demand, which the caller compensates for load factor and flap
+// setting. A higher demand (e.g. in a bank) must move the onset up with it.
+TEST(TECSControlTest, UnderspeedRatioFollowsMinimumAirspeedDemand)
+{
+	TECSControl::Param param = makeParam();
+
+	TECSControl::Param banked = param;
+	banked.tas_min *= 1.2f; // load factor compensated minimum airspeed demand
+	banked.tas_stall *= 1.2f;
+
+	EXPECT_FLOAT_EQ(underspeedRatioAt(param.tas_min, param), 0.f);
+	EXPECT_GT(underspeedRatioAt(param.tas_min, banked), 0.f);
+	EXPECT_FLOAT_EQ(underspeedRatioAt(banked.tas_min, banked), 0.f);
+}
+
+// The ramp spans a fixed fraction of the configured stall margin, so a tighter margin gives a correspondingly
+// narrower ramp. What must hold regardless of the margin is that there is no mitigation at the minimum airspeed
+// demand: mitigation ramping in during normal cruise would latch throttle at maximum.
+TEST(TECSControlTest, UnderspeedRatioScalesWithStallMargin)
+{
+	TECSControl::Param tight = makeParam();
+	tight.tas_min = 10.f;
+	tight.tas_stall = 9.f; // 1 m/s of stall margin -> full mitigation at 9.5
+
+	EXPECT_FLOAT_EQ(underspeedRatioAt(tight.tas_min, tight), 0.f);
+	EXPECT_FLOAT_EQ(underspeedRatioAt(9.5f, tight), 1.f);
+	EXPECT_NEAR(underspeedRatioAt(9.75f, tight), 0.5f, 1e-3f);
+
+	// The wide margin of the nominal parameter set puts the same half-way point much further down.
+	const TECSControl::Param wide = makeParam(); // tas_min = 10, tas_stall = 7
+	EXPECT_LT(underspeedRatioAt(9.5f, wide), underspeedRatioAt(9.5f, tight));
+}
+
+// A stall airspeed left far too low (e.g. never configured while the minimum airspeed demand was raised) must not
+// be able to delay mitigation. The airspeed tracking error term does not depend on the stall airspeed, so it takes
+// over and saturates mitigation one tracking error below the minimum airspeed demand.
+TEST(TECSControlTest, UnderspeedRatioFallsBackToTrackingErrorForTooLowStallAirspeed)
+{
+	TECSControl::Param param = makeParam();
+	param.tas_min = 20.f;
+	param.tas_stall = 7.f;  // left at the default while the minimum airspeed demand was raised
+	param.tas_trim = 15.f;
+
+	// The stall term alone would only saturate at 13.5 m/s. The tracking error term saturates at
+	// 20 - 0.15 * 15 = 17.75 m/s, and being the higher of the two it wins.
+	EXPECT_FLOAT_EQ(underspeedRatioAt(param.tas_min, param), 0.f);
+	EXPECT_NEAR(underspeedRatioAt(18.875f, param), 0.5f, 1e-4f);
+	EXPECT_FLOAT_EQ(underspeedRatioAt(17.75f, param), 1.f);
+	EXPECT_FLOAT_EQ(underspeedRatioAt(13.5f, param), 1.f);
+}
+
+// Conversely, on an airframe with a properly configured stall airspeed the stall term is the higher of the two and
+// governs, so a large trim airspeed cannot pull the saturation point down.
+TEST(TECSControlTest, UnderspeedRatioUsesStallTermWhenItSaturatesEarlier)
+{
+	TECSControl::Param param = makeParam();
+	param.tas_min = 20.f;
+	param.tas_stall = 16.f; // 25% stall margin -> stall term saturates at 18 m/s
+	param.tas_trim = 30.f;  // tracking error term would only saturate at 20 - 4.5 = 15.5 m/s
+
+	EXPECT_FLOAT_EQ(underspeedRatioAt(param.tas_min, param), 0.f);
+	EXPECT_NEAR(underspeedRatioAt(19.f, param), 0.5f, 1e-4f);
+	EXPECT_FLOAT_EQ(underspeedRatioAt(18.f, param), 1.f);
+}
+
+// A degenerate configuration (no stall margin, or a stall airspeed above the minimum airspeed demand, which the
+// performance model sanity checks reject but TECS must still survive) collapses the ramp to a step at the minimum
+// airspeed demand. It must never place the ramp above the airspeed being flown, which would pin the ratio to 1.
+TEST(TECSControlTest, UnderspeedRatioHandlesDegenerateStallMargin)
+{
+	TECSControl::Param zero_margin = makeParam();
+	zero_margin.tas_min = 10.f;
+	zero_margin.tas_stall = 10.f;
+
+	EXPECT_FLOAT_EQ(underspeedRatioAt(zero_margin.tas_min + 1.f, zero_margin), 0.f);
+	EXPECT_FLOAT_EQ(underspeedRatioAt(zero_margin.tas_min, zero_margin), 0.f);
+	EXPECT_FLOAT_EQ(underspeedRatioAt(9.9f, zero_margin), 1.f); // ramp width floor is 0.1 m/s
+
+	TECSControl::Param inverted = makeParam();
+	inverted.tas_min = 10.f;
+	inverted.tas_stall = 12.f; // stall airspeed above the minimum airspeed demand
+
+	EXPECT_FLOAT_EQ(underspeedRatioAt(inverted.tas_min + 1.f, inverted), 0.f);
+	EXPECT_FLOAT_EQ(underspeedRatioAt(inverted.tas_min, inverted), 0.f);
+	EXPECT_FLOAT_EQ(underspeedRatioAt(9.9f, inverted), 1.f);
+}
+
+// Detection must be inert whenever it is disabled or no airspeed is available.
+TEST(TECSControlTest, UnderspeedRatioIsZeroWhenDisabled)
+{
+	const TECSControl::Param param = makeParam();
+
+	TECSControl::Flag disabled = makeFlag();
+	disabled.detect_underspeed_enabled = false;
+	EXPECT_FLOAT_EQ(underspeedRatioAt(0.f, param, disabled), 0.f);
+
+	TECSControl::Flag no_airspeed = makeFlag();
+	no_airspeed.airspeed_enabled = false;
+	EXPECT_FLOAT_EQ(underspeedRatioAt(0.f, param, no_airspeed), 0.f);
 }

--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -682,6 +682,9 @@ void FwLateralLongitudinalControl::updateAttitude() {
 		_tecs.set_equivalent_airspeed_min(
 			_performance_model.getMinimumCalibratedAirspeed(_load_factor_from_bank_angle, _flaps_setpoint)
 		);
+		_tecs.set_equivalent_airspeed_stall(
+			_performance_model.getCalibratedStallAirspeed(_load_factor_from_bank_angle, _flaps_setpoint)
+		);
 	}
 }
 


### PR DESCRIPTION
### Solved Problem
Underspeed detection was working based on the value of the minimum airspeed and a fraction of the trim airspeed. However, on a setup where the stall speed and the minimum airspeed are very close, the underspeed protection did not kick in early enough before the vehicle was stalled. 

Example: Trim airspeed: 17m/s -> fraction = 0.15 * 17 = 2.55 m/s
Minimum airspeed TASmin = 15
Stall airspeed TASstall = 14

In this case underspeed protection would start at TASmin - fraction = 15 - 2.55 = 12.65 m/s, which is already far below the configured stall speed of 14 m/s.

### Solution
1. Start underspeed detection of the minimum airspeed -> Avoids additional logic of having to define a soft bound. The underspeed logic is already implemented with a weight that fades in and out the underspeed logic, so no additional margin should be needed -> Keep unless testing shows otherwhise.
2. Keep original hard boundary for full underspeed detection logic based on a 15% fraction of the trim airspeed. However, calculate another boundary based on the stall speed parameter (midpoint between stall and minimum airspeed defines the beginning of the hard boundary). For actual underspeed detection, use the maximum of both values.
This protects setups from under-speeding where the stall parameter has been set correctly but is very close to the minimum airspeed.
However, it still keeps parts of the old logic in place, which can guard against setups where the stall speed parameter is not set and too low.


### Changelog Entry
For release notes:
```
Improve underspeed detection: Take into account stall airspeed parameter.
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
