### PR TITLE
fix(ekf2): fix sequential position fusion of the external position reset

### DIFF
--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -363,30 +363,51 @@ bool Ekf::resetGlobalPosToExternalObservation(const double latitude, const doubl
 			// inhibiting the update.
 			_control_status.flags.heading_observable = true;
 
+			const LatLonAlt gpos_before_fusion = _gpos;
+
+			// Artificially setting the observation variance to a small value to
+			// increase the Kalman gain to basically 1 to force a reset of the position
+			// through fusion. This also enforces a strong correction of the correlated states
+			// (e.g.: velocity, heading, wind)
+			const float R_small = 0.1f;
+
+			const VectorState P_north = P.row(State::pos.idx);
+			VectorState P_east = P.row(State::pos.idx + 1);
+
+			{
+				const float innov_var_north = P_north(State::pos.idx) + R_small;
+				VectorState K = P_north / innov_var_north;
+				clearInhibitedStateKalmanGains(K);
+				fuse(K, innov(0));
+
+				P_east -= P_north * (P_north(State::pos.idx + 1) / innov_var_north);
+			}
+
+			// The 2nd axis needs to be fused using the state covariance that would have been
+			// obtained with this artificially low observation variance
+			{
+				// recalculate the innovation using the state updated by the North fusion
+				const float innovation = (_gpos - gpos_corrected)(1);
+				const float innov_var_east = P_east(State::pos.idx + 1) + R_small;
+				VectorState K = P_east / innov_var_east;
+				clearInhibitedStateKalmanGains(K);
+				fuse(K, innovation);
+			}
+
+			// The update of the covariance matrix is performed with the correct observation variance
+			// to not artificially reduce the state uncertainty and cross-correlations.
 			VectorState H;
-			VectorState K;
-			Vector2f innov_var_temp = Vector2f(getStateVariance<State::pos>()) + 0.1f;
 
 			for (unsigned index = 0; index < 2; index++) {
-				// Artificially setting the observation variance to a small value to
-				// increase the Kalman gain to basically 1 to force a reset of the position
-				// through fusion. This also enforces a strong correction of the correlated states
-				// (e.g.: velocity, heading, wind)
-				// The update of the covariance matrix is still performed with the correct observation variance
-				// to not artificially reduce the state uncertainty and cross-correlations.
-				K = VectorState(P.row(State::pos.idx + index)) / innov_var_temp(index);
 				H(State::pos.idx + index) = 1.f;
-
-				clearInhibitedStateKalmanGains(K);
-				fuse(K, innov(index));
-
-				K = VectorState(P.row(State::pos.idx + index)) / innov_var(index);
+				const float state_var = P(State::pos.idx + index, State::pos.idx + index);
+				VectorState K = VectorState(P.row(State::pos.idx + index)) / (state_var + obs_var);
 				measurementUpdate(K, H, obs_var, 0.f);
 				H(State::pos.idx + index) = 0.f; // Reset the whole vector to 0
 			}
 
 			// Use the reset counters to inform the controllers about a position jump
-			updateHorizontalPositionResetStatus(-innov);
+			updateHorizontalPositionResetStatus((_gpos - gpos_before_fusion).xy());
 
 			// Reset the positon of the output predictor to avoid a transient that would disturb the
 			// position controller

--- a/src/modules/ekf2/test/test_EKF_airspeed.cpp
+++ b/src/modules/ekf2/test/test_EKF_airspeed.cpp
@@ -346,3 +346,52 @@ TEST_F(EkfAirspeedTest, testExternalWindResetOnGround)
 	EXPECT_TRUE(_ekf_wrapper.isIntendingBetaFusion());
 	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
 }
+
+TEST_F(EkfAirspeedTest, testExternalPosResetWithCorrelatedPosUncertainty)
+{
+	// GIVEN: a fixed-wing dead-reckoning on airspeed and sideslip without magnetometer.
+	// The heading uncertainty makes the velocity error perpendicular to the velocity vector,
+	// which correlates the North and East velocity errors when flying diagonally. Integrating
+	// that over time correlates the horizontal position errors.
+	_ekf_wrapper.setMagFuseTypeNone();
+
+	_ekf->set_in_air_status(true);
+	_ekf->set_vehicle_at_rest(false);
+	_ekf->set_is_fixed_wing(true);
+
+	const float eph = 50.f;
+	const float epv = 1.f;
+
+	// the first call only initialises the origin
+	_ekf->resetGlobalPosToExternalObservation(-15.0000005, -115.0000005, 1500.f, eph, epv, 0);
+
+	_ekf_wrapper.enableBetaFusion();
+	_sensor_simulator.startAirspeedSensor();
+	_sensor_simulator._airspeed.setData(15.f, 15.f);
+	_sensor_simulator.runSeconds(300);
+
+	const float pos_var_n = _ekf->stateCovariance(State::pos.idx, State::pos.idx);
+	const float pos_var_e = _ekf->stateCovariance(State::pos.idx + 1, State::pos.idx + 1);
+	const float pos_corr_ne = _ekf->stateCovariance(State::pos.idx, State::pos.idx + 1)
+				  / sqrtf(pos_var_n * pos_var_e);
+	ASSERT_LT(pos_corr_ne, -0.5f);
+
+	// WHEN: an external position observation close enough to the estimate to be fused
+	// instead of hard reset is sent
+	const LatLonAlt gpos_before_reset = _ekf->getLatLonAlt();
+	const LatLonAlt gpos_obs = gpos_before_reset + Vector3f(110.f, 110.f, 0.f);
+
+	_ekf->resetGlobalPosToExternalObservation(gpos_obs.latitude_deg(), gpos_obs.longitude_deg(), 1500.f, eph, epv,
+			_sensor_simulator.getTime());
+
+	const LatLonAlt gpos_est = _ekf->getLatLonAlt();
+	const Vector2f pos_err = (gpos_est - gpos_obs).xy();
+
+	EXPECT_LT(pos_err.norm(), 1.f);
+
+	// AND: the position jump reported to the controllers matches the jump that was applied
+	const Vector2f actual_jump = (gpos_est - gpos_before_reset).xy();
+	const Vector2f reported_jump = _ekf->state_reset_status().posNE_change;
+	EXPECT_NEAR(reported_jump(0), actual_jump(0), 1.f);
+	EXPECT_NEAR(reported_jump(1), actual_jump(1), 1.f);
+}


### PR DESCRIPTION
Follows https://github.com/PX4/PX4-Autopilot/pull/28273

### Solved Problem
External position reset (fusion path) was forgotten in my [previous PR](https://github.com/PX4/PX4-Autopilot/pull/28273). After fixing the innovation/innov_var re-computation after the first axis fusion I found that the error after the fusion was larger than expected.

The problem was caused by the fact that we're using a different observation noise for the state and covariance updates.

### Solution
1. recompute innovation and innovation variance after 1st axis fusion
2. use theoretical state covariance that would have been obtained if the artificially small observation variance was used for the covariance update

Additionally, we now report the actual state jump to the controller instead of the innovation (since the actual innovation is never completely applied).

### Test coverage
Added unit test
Also tested in SIH (plane), no GNSS
