### PR TITLE
feat(uavcan): configureable max rates for ESC/Servo output

### DIFF
--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -80,6 +80,12 @@ int UavcanEscController::init()
 		_uavcan_pub_raw_cmd.getTransferSender().setIfaceMask(iface_mask);
 	}
 
+	int32_t rate_max{400};
+
+	if (param_get(param_find("UAVCAN_ESC_RTMAX"), &rate_max) == OK) {
+		_max_rate_hz = (unsigned)rate_max;
+	}
+
 	_initialized = true;
 
 	return res;
@@ -90,7 +96,7 @@ void UavcanEscController::update_outputs(float outputs[MAX_ACTUATORS], uint8_t o
 	// TODO: configurable rate limit
 	const auto timestamp = _node.getMonotonicTime();
 
-	if ((timestamp - _prev_cmd_pub).toUSec() < (1000000 / MAX_RATE_HZ)) {
+	if ((timestamp - _prev_cmd_pub).toUSec() < (1000000 / _max_rate_hz)) {
 		return;
 	}
 

--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -93,7 +93,6 @@ int UavcanEscController::init()
 
 void UavcanEscController::update_outputs(float outputs[MAX_ACTUATORS], uint8_t output_array_size)
 {
-	// TODO: configurable rate limit
 	const auto timestamp = _node.getMonotonicTime();
 
 	if ((timestamp - _prev_cmd_pub).toUSec() < (1000000 / _max_rate_hz)) {

--- a/src/drivers/uavcan/actuators/esc.hpp
+++ b/src/drivers/uavcan/actuators/esc.hpp
@@ -62,7 +62,6 @@ class UavcanEscController
 {
 public:
 	static constexpr int MAX_ACTUATORS = esc_status_s::CONNECTED_ESC_MAX;
-	static constexpr unsigned MAX_RATE_HZ = 400;
 
 	static_assert(uavcan::equipment::esc::RawCommand::FieldTypes::cmd::MaxSize >= MAX_ACTUATORS, "Too many actuators");
 
@@ -84,6 +83,8 @@ public:
 	void set_node_info_publisher(NodeInfoPublisher *publisher) { _node_info_publisher = publisher; }
 
 	static int max_output_value() { return uavcan::equipment::esc::RawCommand::FieldTypes::cmd::RawValueType::max(); }
+
+	unsigned max_rate_hz() const { return _max_rate_hz; }
 
 	esc_status_s &esc_status() { return _esc_status; }
 
@@ -117,6 +118,8 @@ private:
 		void (UavcanEscController::*)(const uavcan::TimerEvent &)> TimerCbBinder;
 
 	bool _initialized = false;
+
+	unsigned _max_rate_hz{400};
 
 	esc_status_s	_esc_status{};
 

--- a/src/drivers/uavcan/actuators/servo.cpp
+++ b/src/drivers/uavcan/actuators/servo.cpp
@@ -34,25 +34,28 @@
 #include "servo.hpp"
 #include <systemlib/err.h>
 #include <drivers/drv_hrt.h>
-#include <parameters/param.h>
 
 using namespace time_literals;
 
 UavcanServoController::UavcanServoController(uavcan::INode &node) :
+	ModuleParams(nullptr),
 	_node(node),
 	_uavcan_pub_array_cmd(node)
 {
 	_uavcan_pub_array_cmd.setPriority(UAVCAN_COMMAND_TRANSFER_PRIORITY);
-
-	int32_t rate_max{50};
-
-	if (param_get(param_find("UAVCAN_SV_RTMAX"), &rate_max) == OK) {
-		_max_rate_hz = (unsigned)rate_max;
-	}
+	_max_rate_hz = (unsigned)_param_sv_rtmax.get();
 }
 
 void UavcanServoController::update_outputs(float outputs[MAX_ACTUATORS], unsigned num_outputs)
 {
+	const auto timestamp = _node.getMonotonicTime();
+
+	if ((timestamp - _prev_cmd_pub).toUSec() < (1000000 / _max_rate_hz)) {
+		return;
+	}
+
+	_prev_cmd_pub = timestamp;
+
 	uavcan::equipment::actuator::ArrayCommand msg;
 
 	for (unsigned i = 0; i < num_outputs; ++i) {

--- a/src/drivers/uavcan/actuators/servo.cpp
+++ b/src/drivers/uavcan/actuators/servo.cpp
@@ -34,6 +34,7 @@
 #include "servo.hpp"
 #include <systemlib/err.h>
 #include <drivers/drv_hrt.h>
+#include <parameters/param.h>
 
 using namespace time_literals;
 
@@ -42,6 +43,12 @@ UavcanServoController::UavcanServoController(uavcan::INode &node) :
 	_uavcan_pub_array_cmd(node)
 {
 	_uavcan_pub_array_cmd.setPriority(UAVCAN_COMMAND_TRANSFER_PRIORITY);
+
+	int32_t rate_max{50};
+
+	if (param_get(param_find("UAVCAN_SV_RTMAX"), &rate_max) == OK) {
+		_max_rate_hz = (unsigned)rate_max;
+	}
 }
 
 void UavcanServoController::update_outputs(float outputs[MAX_ACTUATORS], unsigned num_outputs)

--- a/src/drivers/uavcan/actuators/servo.hpp
+++ b/src/drivers/uavcan/actuators/servo.hpp
@@ -46,7 +46,6 @@ class UavcanServoController
 {
 public:
 	static constexpr int MAX_ACTUATORS = 15;
-	static constexpr unsigned MAX_RATE_HZ = 50;
 	static constexpr unsigned UAVCAN_COMMAND_TRANSFER_PRIORITY = 6;	///< 0..31, inclusive, 0 - highest, 31 - lowest
 
 	UavcanServoController(uavcan::INode &node);
@@ -54,7 +53,11 @@ public:
 
 	void update_outputs(float outputs[MAX_ACTUATORS], unsigned num_outputs);
 
+	unsigned max_rate_hz() const { return _max_rate_hz; }
+
 private:
+	unsigned _max_rate_hz{50};
+
 	uavcan::INode								&_node;
 	uavcan::Publisher<uavcan::equipment::actuator::ArrayCommand> _uavcan_pub_array_cmd;
 };

--- a/src/drivers/uavcan/actuators/servo.hpp
+++ b/src/drivers/uavcan/actuators/servo.hpp
@@ -41,8 +41,9 @@
 #include <uORB/topics/actuator_outputs.h>
 #include <drivers/drv_hrt.h>
 #include <lib/mixer_module/mixer_module.hpp>
+#include <px4_platform_common/module_params.h>
 
-class UavcanServoController
+class UavcanServoController : public ModuleParams
 {
 public:
 	static constexpr int MAX_ACTUATORS = 15;
@@ -58,6 +59,11 @@ public:
 private:
 	unsigned _max_rate_hz{50};
 
-	uavcan::INode								&_node;
-	uavcan::Publisher<uavcan::equipment::actuator::ArrayCommand> _uavcan_pub_array_cmd;
+	uavcan::MonotonicTime						_prev_cmd_pub;
+	uavcan::INode							&_node;
+	uavcan::Publisher<uavcan::equipment::actuator::ArrayCommand>	_uavcan_pub_array_cmd;
+
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::UAVCAN_SV_RTMAX>) _param_sv_rtmax
+	)
 };

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -28,6 +28,15 @@ parameters:
       min: 1
       max: 255
       reboot_required: true
+    UAVCAN_ESC_RTMAX:
+      description:
+        short: Maximum UAVCAN ESC output rate
+      type: int32
+      default: 400
+      min: 1
+      max: 1000
+      unit: Hz
+      reboot_required: true
     UAVCAN_LGT_NUM:
       description:
         short: Number of UAVCAN lights to configure
@@ -73,6 +82,15 @@ parameters:
         5: Status/Red
         6: Status/Green
         7: Status/Off
+    UAVCAN_SV_RTMAX:
+      description:
+        short: Maximum UAVCAN servo output rate
+      type: int32
+      default: 50
+      min: 1
+      max: 400
+      unit: Hz
+      reboot_required: true
 actuator_output:
   show_subgroups_if: 'UAVCAN_ENABLE>=3'
   config_parameters:

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -121,8 +121,7 @@ UavcanNode::UavcanNode(uavcan::ICanDriver &can_driver, uavcan::ISystemClock &sys
 	}
 
 #if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
-	_mixing_interface_esc.mixingOutput().setMaxTopicUpdateRate(1000000 / UavcanEscController::MAX_RATE_HZ);
-	_mixing_interface_servo.mixingOutput().setMaxTopicUpdateRate(1000000 / UavcanServoController::MAX_RATE_HZ);
+	_mixing_interface_servo.mixingOutput().setMaxTopicUpdateRate(1000000 / _servo_controller.max_rate_hz());
 #endif
 }
 
@@ -541,6 +540,8 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 		if (ret < 0) {
 			return ret;
 		}
+
+		_mixing_interface_esc.mixingOutput().setMaxTopicUpdateRate(1000000 / _esc_controller.max_rate_hz());
 	}
 
 #endif


### PR DESCRIPTION
### Solved Problem

- The ESC / Servo UAVCAN output has a fixed maximum rate of 400 / 50 Hz which is not configureable
- In some settings it is desired to reach for example ESC output to remove strain from the CAN bus

### Solution

- Add params to set the maximum update frequency

### Test coverage

- Tested on the bench with the dronecan_gui_tool to measure if the params successfully restrict the update rate
