### PR TITLE
fix(i2c_launcher): default battery index from the -t argument

### DIFF
--- a/src/systemcmds/i2c_launcher/i2c_launcher.cpp
+++ b/src/systemcmds/i2c_launcher/i2c_launcher.cpp
@@ -43,14 +43,9 @@ constexpr I2CLauncher::I2CDevice I2CLauncher::_devices[];
 I2CLauncher::I2CLauncher(int bus, int batt_index) :
 	ModuleParams(nullptr),
 	ScheduledWorkItem(MODULE_NAME, px4::device_bus_to_wq(bus)),
-	_bus(bus)
+	_bus(bus),
+	_batt_index(batt_index == -1 ? bus : batt_index)
 {
-	if (_batt_index == -1) {
-		_batt_index = bus;
-
-	}  else {
-		_batt_index = batt_index;
-	}
 }
 
 I2CLauncher::~I2CLauncher()
@@ -214,8 +209,8 @@ Daemon that starts drivers based on found I2C devices.
 
 	PRINT_MODULE_USAGE_NAME("i2c_launcher", "system");
 	PRINT_MODULE_USAGE_COMMAND("start");
-	PRINT_MODULE_USAGE_PARAM_INT('b', 0, 1, 4, "Bus number", false);
-	PRINT_MODULE_USAGE_PARAM_INT('t', 1, 1, 3, "battery index for calibration values (1 or 3)", false);
+	PRINT_MODULE_USAGE_PARAM_INT('b', 1, 1, I2C_BUS_MAX_BUS_ITEMS, "Bus number", false);
+	PRINT_MODULE_USAGE_PARAM_INT('t', 1, 1, 3, "battery index for calibration values (1-3)", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 
 	return 0;
@@ -227,7 +222,7 @@ extern "C" __EXPORT int i2c_launcher_main(int argc, char *argv[])
 {
 	using ThisDriver = I2CLauncher;
 
-	static I2CLauncher* instances[I2C_BUS_MAX_BUS_ITEMS];
+	static I2CLauncher *instances[I2C_BUS_MAX_BUS_ITEMS + 1] {};
 	int bus = -1;
 	int batt_index = -1;
 	int myoptind = 1;
@@ -256,7 +251,7 @@ extern "C" __EXPORT int i2c_launcher_main(int argc, char *argv[])
 		return PX4_ERROR;
 	}
 
-	if (bus > I2C_BUS_MAX_BUS_ITEMS) {
+	if (bus < 1 || bus > I2C_BUS_MAX_BUS_ITEMS) {
 		PX4_ERR("bus out of bound");
 		return PX4_ERROR;
 	}

--- a/src/systemcmds/i2c_launcher/i2c_launcher.hpp
+++ b/src/systemcmds/i2c_launcher/i2c_launcher.hpp
@@ -85,7 +85,7 @@ private:
 	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};          // regular subscription for additional data
 
-	int _bus;
-	int _batt_index;
+	int _bus {-1};
+	int _batt_index {-1};
 	bool _armed {false};
 };


### PR DESCRIPTION
## Summary

Fixes https://github.com/PX4/PX4-Autopilot/issues/28359

`i2c_launcher start -b N` with no `-t` now defaults the INA battery index to the bus number, and the instance table is large enough for 1-based bus `N`.

## Problem
[#24865](https://github.com/PX4/PX4-Autopilot/pull/24865) added `-t` but the ctor tested uninitialized `_batt_index` instead of the parameter. Typical `start -b 1` therefore stored `-1`, and after [#28316](https://github.com/PX4/PX4-Autopilot/pull/28316) INA226 rejects that. `instances[]` is indexed by physical bus number but was sized as the bus count, so `bus == I2C_BUS_MAX_BUS_ITEMS` (I2C6 on RT117x, I2C4 on v6x) wrote one past the end.

## Solution
Initialize `_batt_index` from the parameter (default to bus when `-t` is omitted). Size `instances` as `N+1` and reject bus `< 1` or `> N`.