### PR TITLE
fix(drivers/bmp388): wait for cmd_rdy before soft reset

### DIFF
--- a/src/drivers/barometer/bmp388/bmp388.cpp
+++ b/src/drivers/barometer/bmp388/bmp388.cpp
@@ -209,33 +209,35 @@ BMP388::collect()
 bool
 BMP388::soft_reset()
 {
-	uint8_t status;
-	int ret = _interface->get_reg(BMP3_SENS_STATUS_REG_ADDR, &status);
+	uint8_t status = 0;
 
-	if (ret != OK) {
+	/* STATUS resets to 0, so cmd_rdy is 0 until the decoder is ready. */
+	const hrt_abstime start = hrt_absolute_time();
+
+	while (true) {
+		if ((_interface->get_reg(BMP3_SENS_STATUS_REG_ADDR, &status) == OK) &&
+		    (status & BMP3_CMD_RDY)) {
+			break;
+		}
+
+		if (hrt_elapsed_time(&start) > BMP3_CMD_RDY_WAIT_TIME) {
+			return false;
+		}
+
+		px4_usleep(500);
+	}
+
+	if (_interface->set_reg(BPM3_CMD_SOFT_RESET, BMP3_CMD_ADDR) != OK) {
 		return false;
 	}
 
-	bool result = false;
+	px4_usleep(BMP3_POST_RESET_WAIT_TIME);
 
-	if (status & BMP3_CMD_RDY) {
-		ret = _interface->set_reg(BPM3_CMD_SOFT_RESET, BMP3_CMD_ADDR);
-
-		if (ret == OK) {
-			usleep(BMP3_POST_RESET_WAIT_TIME);
-			ret = _interface->get_reg(BMP3_ERR_REG_ADDR, &status);
-
-			if (ret != OK) {
-				return false;
-			}
-
-			if ((status & BMP3_CMD_ERR) == 0) {
-				result = true;
-			}
-		}
+	if (_interface->get_reg(BMP3_ERR_REG_ADDR, &status) != OK) {
+		return false;
 	}
 
-	return result;
+	return (status & BMP3_CMD_ERR) == 0;
 }
 
 /*

--- a/src/drivers/barometer/bmp388/bmp388.h
+++ b/src/drivers/barometer/bmp388/bmp388.h
@@ -163,6 +163,7 @@
 // From https://github.com/BoschSensortec/BMP3-Sensor-API/blob/master/self-test/bmp3_selftest.c
 #define BMP3_POST_SLEEP_WAIT_TIME         5000
 #define BMP3_POST_RESET_WAIT_TIME         2000
+#define BMP3_CMD_RDY_WAIT_TIME            10000 /* STATUS.cmd_rdy after POR; tstartup is 2 ms */
 #define BMP3_POST_INIT_WAIT_TIME          40000
 #define BMP3_TRIM_CRC_DATA_ADDR           0x30
 #define BPM3_CMD_SOFT_RESET               0xB6


### PR DESCRIPTION
## Summary
BMP388/BMP390 init now waits for `STATUS.cmd_rdy` before issuing the soft-reset command.

## Problem
`STATUS` resets to 0, so `cmd_rdy` is 0 until the command decoder is ready (`tstartup` is 2 ms after both VDD and VDDIO are up). A single STATUS read can miss that and fail init with no retry.

## Solution
Poll `cmd_rdy` for up to 10 ms, then send `0xB6` and wait the existing 2 ms post-reset.

Built `px4_fmu-v6x` and `px4_sitl`. Not run on hardware.