### PR TITLE
Fix SIH position jumping in 0.7 m steps on real flight controllers

### DIFF
--- a/src/lib/lat_lon_alt/lat_lon_alt.cpp
+++ b/src/lib/lat_lon_alt/lat_lon_alt.cpp
@@ -41,7 +41,7 @@ LatLonAlt LatLonAlt::fromEcef(const Vector3d &p_ecef)
 {
 	// Convert position using Borkowski closed-form exact solution
 	// P. D. Groves, "Principles of GNSS, inertial, and multisensor integrated navigation systems, 2nd edition (appendix C)
-	const double k1 = sqrt(1 - Wgs84::eccentricity2) * std::abs(p_ecef(2));
+	const double k1 = sqrt(1 - Wgs84::eccentricity2) * fabs(p_ecef(2));
 	const double k2 = Wgs84::eccentricity2 * Wgs84::equatorial_radius;
 	const double beta = sqrt(p_ecef(0) * p_ecef(0) + p_ecef(1) * p_ecef(1));
 	const double E = (k1 - k2) / beta;


### PR DESCRIPTION
### Solved Problem

I was testing an SIH feature on a Pixhawk 6C (`px4_fmu-v6c_default`) when I noticed jagged groundtruth in the logs while reviewing them in Hawkeye. The sawtooth was most visible on diagonal legs, where the north component stepped while east ran smooth. It was present only in north, it was triggered by distance travelled rather than time, and it never appeared in SITL on the same commit, which ruled out timing, dropped samples and the estimator.

<img width="1469" height="920" alt="Screenshot 2026-08-21 at 3 57 59 PM" src="https://github.com/user-attachments/assets/c60a6541-b621-4857-8fa0-57c4531aa077" />


On the board, SIH groundtruth and the simulated GPS step north by about 0.68 m every 1.48 m of travel at the default `SIH_LOC_LAT0`. East and altitude are clean.

This is very likely the same defect as #26734. That PR showed ~0.6 m steps in both groundtruth topics at the default SIH latitude with longitude and east untouched, and it was closed without a root cause.

### Solution

The cause is one line in `LatLonAlt::fromEcef()`.

```cpp
const double k1 = sqrt(1 - Wgs84::eccentricity2) * std::abs(p_ecef(2));
```

When running on the FMU, a float gets unnecessarily converted to an int and back again. `p_ecef(2)` is a `double`. PX4's NuttX builds compile with `-nostdinc++` and NuttX's own C++ headers in `platforms/nuttx/NuttX/nuttx/include/cxx/`. That `<cstdlib>` provides only the C `int abs(int)` through `using ::abs;`, and that `<cmath>` has no floating `std::abs` overloads. Overload resolution binds `std::abs(double)` to `int abs(int)`, and the ECEF Z coordinate is truncated to whole meters every physics step. libstdc++ on POSIX has `std::abs(double)`, so SITL is unaffected. The build has `-Werror` but not `-Wfloat-conversion`, so the implicit conversion is silent.

`fabs()` has only a floating signature, so the same source compiles correctly on every target.

```diff
-    const double k1 = sqrt(1 - Wgs84::eccentricity2) * std::abs(p_ecef(2));
+    const double k1 = sqrt(1 - Wgs84::eccentricity2) * fabs(p_ecef(2));
```

This is the fmu-v6c disassembly of `LatLonAlt::fromEcef` before and after the change.

```
8143006: vldr         d8, [r1, #16]     ; load p_ecef(2) as double
8143012: vcvt.s32.f64 s14, d8           ; double -> int32, fraction discarded
8143026: neglt        r3, r3            ; integer abs()
8143030: vcvt.f64.s32 d7, s14           ; int32 -> double, now whole meters
```
```
8143006: vldr         d8, [r1, #16]
8143032: vabs.f64     d3, d8            ; fabs(), stays double
```

### Changelog Entry

```
Bugfix: SIH groundtruth and simulated GPS latitude stepped by cos(lat) m on NuttX targets (std::abs resolved to int abs in LatLonAlt::fromEcef)
```

### Alternatives
- #26734 bypassed `fromEcef()` for the local position only. That hides the steps in `vehicle_local_position_groundtruth.x`, but `_lla`, the global groundtruth and the simulated GPS keep stepping.

### Test coverage

- Built `px4_fmu-v6c_default`, which came out 16 B smaller, flashed a Pixhawk 6C, and flew the same SIH route as an old-firmware reference run with the same parameters. The old firmware showed 245 north steps with a residual std of 0.149 m. This fix showed 0 steps with a residual std of 0.0001 m, matching SITL sample for sample.
- Bare SIH on the old firmware was flown at 47.398° and 60.000°. Crawl ratios were 0.5418 and 0.7475 against a predicted sin² of 0.5418 and 0.7500. Step spacings were 1.480 m and 1.976 m against a predicted 1/cos of 1.477 m and 2.000 m.
- To reproduce, run SIH on any NuttX board, arm in Position mode, fly forward for 20 m or more, and plot `vehicle_local_position_groundtruth.x`. Without this change the steps are visible by eye, as in the #26734 screenshot. With it the trace is smooth.
- SITL is unaffected.

### Context

**Why it makes that shape.** Latitude from ECEF is, to first order, atan(Z / p). For a northward step *ds*, cos²(lat)·*ds* of the change comes from Z and sin²(lat)·*ds* from *p*. With Z frozen at whole meters only the sin² share remains. When Z crosses the next meter, latitude jumps cos(lat) m. East changes X and Y only. Altitude uses the raw Z and is first-order insensitive to latitude.

VIDEO
[![Sawtooth in the Hawkeye replay](https://img.youtube.com/vi/PfHlH0oRGsU/maxresdefault.jpg)](https://youtu.be/PfHlH0oRGsU)

The first chart shows reported north minus integrated north velocity on the same route and the same board, with the old firmware above and this fix below.

<img width="1104" height="404" alt="north_residual_before_after" src="https://github.com/user-attachments/assets/7a6cf629-535b-4a5b-bacf-c65433700e15" />

The second chart is the same test on all three axes with the old firmware, and only north saws. The slow east slope is the local projection's spherical radius against the ellipsoid's east radius at this latitude. It is identical in SITL and unrelated to this change.

<img width="1104" height="354" alt="ned_residual_old_firmware" src="https://github.com/user-attachments/assets/bbbe4b59-d068-41c2-9726-fcf6922fa455" />

The logs also show which axis was truncated. Convert the reported lat/lon/alt back to ECEF and look at the fractional meter of each coordinate. A clean coordinate is spread evenly across the meter. A Z held at whole meters regains only sin²(lat) of its fraction through the altitude term, so it stays below 0.542. On the old firmware Z never crossed that line in 911 samples. X and Y were spread evenly. On the fixed firmware Z is spread evenly too.

<img width="1104" height="274" alt="ecef_fraction_histograms" src="https://github.com/user-attachments/assets/0ad5a525-4d2e-4d86-bf03-5e1af1d83eac" />

**Impact.** Every groundtruth sample from SIH on NuttX carried a 0 to cos(lat) m sawtooth toward the equator. Totals and route completion were unaffected. Instantaneous position was off by up to 0.68 m at mid latitudes, and EKF2 was fed the same sawtooth through the simulated GPS.

You can see here the truncation in action when comparing two flights in Ghost Mode in Hawkeye. It's noticeable in a top down view with the correlation curtain is engaged you can see the jagged edges clearly. It would not be noticeable in a purely north or south driven flight.

<img width="1470" height="951" alt="Screenshot 2026-08-21 at 11 11 00 AM" src="https://github.com/user-attachments/assets/e2ae4635-0509-4a12-b813-1c35dfebd453" />
<img width="1470" height="956" alt="Screenshot 2026-08-21 at 11 11 15 AM" src="https://github.com/user-attachments/assets/f3bf3c2f-1783-4ffa-b423-bf359b985852" />
<img width="1470" height="956" alt="Screenshot 2026-08-21 at 11 11 21 AM" src="https://github.com/user-attachments/assets/05aedd30-46c4-483c-81fb-43735c4404ed" />

Under the same exact controls the divergence was substantial in a 2 minute flight, at points climbing to 40m+ distance

VIDEO
[![Old firmware against this fix, ghost mode](https://img.youtube.com/vi/nuvIWCpofyg/maxresdefault.jpg)](https://youtu.be/nuvIWCpofyg)