### PR TITLE
fix(nuttx): provide floating and wide abs() overloads on NuttX targets

### DIFF
--- a/platforms/nuttx/NuttX/include/cxx/abs_overloads.hpp
+++ b/platforms/nuttx/NuttX/include/cxx/abs_overloads.hpp
@@ -1,0 +1,54 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+// Force-included into every C++ translation unit built with -nostdinc++.
+//
+// NuttX's <cstdlib> only re-exports the C int abs(int) into std, and its <cmath>
+// adds no abs overloads, so abs(double) silently truncates through int on every
+// NuttX target while the same source is correct under libstdc++. These are the
+// overloads libstdc++ provides. The using-declaration is repeated here because
+// <cstdlib>'s own `using ::abs;` may already have run (visibility.h is
+// force-included first) and only carries the overloads visible at that point.
+
+constexpr float abs(float x) { return __builtin_fabsf(x); }
+constexpr double abs(double x) { return __builtin_fabs(x); }
+constexpr long double abs(long double x) { return __builtin_fabsl(x); }
+constexpr long abs(long x) { return __builtin_labs(x); }
+constexpr long long abs(long long x) { return __builtin_llabs(x); }
+
+namespace std
+{
+using ::abs;
+}

--- a/platforms/nuttx/cmake/px4_impl_os.cmake
+++ b/platforms/nuttx/cmake/px4_impl_os.cmake
@@ -91,6 +91,7 @@ function(px4_os_add_flags)
 
 	if(NOT CONFIG_LIB_TFLM)
 		list(APPEND cxx_flags -nostdinc++) # prevent using the toolchain's std c++ library if building for anything else than TFLM
+		list(APPEND cxx_flags -include${PX4_SOURCE_DIR}/platforms/nuttx/NuttX/include/cxx/abs_overloads.hpp)
 	endif()
 
 	foreach(flag ${cxx_flags})


### PR DESCRIPTION
## Summary
Adds the `abs(float/double/long double/long/long long)` overloads libstdc++ provides, force-included into every `-nostdinc++` C++ TU, so `abs()` and `std::abs()` on non-int arguments stop truncating through `int abs(int)` on NuttX. Generalises #28333 to every site at once and prevents the class from recurring.

## Problem
NuttX's `<cstdlib>` only re-exports the C `int abs(int)` into `std` and its `<cmath>` adds no `abs` overloads, so under `-nostdinc++` any `abs(double)` binds to `int abs(int)` and truncates, while the same source is correct on SITL. `-Werror` never sees it. A build-time trap (deleted float/double/long/long long `abs` declarations force-included into v5, v6x, v6xrt and v6x_uuv builds) found these truncating sites:

| Site | Arg | Effect |
|---|---|---|
| `lat_lon_alt.cpp:44` | double | #28333 |
| `drivers/ins/ilabs/ILabs.cpp:323` | double | `trunc(\|lat\|) > 1e-7` is false within 1° of the equator or prime meridian, INS position rejected |
| `local_position_estimator/BlockLocalPositionEstimator.cpp:962` | float | `BIAS_MAX = 0.1`; saturation only engages at \|b\| ≥ 1, and then `0.1·b/trunc(\|b\|)` is not a clamp |
| `uuv_pos_control.cpp:346,352,361` | float | thresholds become `\|x\| < ceil(limit)` |
| `drivers/telemetry/hott/messages.cpp:275` | double | western longitudes truncated to whole degrees |
| `uxrce_dds_client.cpp:603` | int64 | µs delta reduced to its low 32 bits before the 5 s check |
| `ekf2/EKF/ekf_helper.cpp:76` | double | accepts \|lat\| < 91, \|lon\| < 181 |
| `uavcan_drivers/{stm32,stm32h7,kinetis}/.../uc_*_clock.cpp:296` | float | UTC lock thresholds rounded up |

`int32_t`/`long` sites (geofence_utils, VehicleAngularVelocity, gps, septentrio) are the same width on 32-bit targets and were unaffected.

## Solution
`platforms/nuttx/NuttX/include/cxx/abs_overloads.hpp` declares the five overloads in the global namespace and re-issues `using ::abs;` in `std` (the force-included `visibility.h` already pulled `<cstdlib>` in, and that first using-declaration only carries the overloads visible at that point). It is passed with `-include` next to `-nostdinc++`, so TFLM builds using libstdc++ are untouched. No call sites change; unqualified and `std::` calls both resolve to the correct width.

Verified `px4_fmu-v5_default`, `v6x_default`, `v6xrt_default`, `v6x_uuv` and `v6c_neural` build; `fromEcef`, `BlockLocalPositionEstimator` and `ILabs` now emit `vabs.f64`/`vabs.f32` with no `vcvt.s32`. v6x `.text` is 264 B smaller.