### PR TITLE
feat(gps): Galileo HAS mode, correction protocol reporting, GPSDrivers bump

### DIFF
--- a/msg/SensorGps.msg
+++ b/msg/SensorGps.msg
@@ -80,12 +80,20 @@ float32 heading_accuracy	# heading accuracy (rad, [0, 2PI])
 float32 rtcm_injection_rate	# RTCM message injection rate Hz
 uint8 selected_rtcm_instance	# uorb instance that is being used for RTCM corrections
 
-bool rtcm_crc_failed		# RTCM message CRC failure detected
+uint8 CORRECTIONS_PROTOCOL_UNKNOWN = 0
+uint8 CORRECTIONS_PROTOCOL_RTCM3 = 1
+uint8 CORRECTIONS_PROTOCOL_SPARTN = 2
+uint8 CORRECTIONS_PROTOCOL_HAS = 3	# Galileo High Accuracy Service, received on E6
+uint8 CORRECTIONS_PROTOCOL_PMP = 4	# SPARTN over L-band (u-blox NEO-D9S)
+uint8 CORRECTIONS_PROTOCOL_QZSS_L6 = 5	# QZSS CLAS
+uint8 corrections_protocol	# Protocol of the last correction message the receiver parsed
 
-uint8 RTCM_MSG_USED_UNKNOWN = 0
-uint8 RTCM_MSG_USED_NOT_USED = 1
-uint8 RTCM_MSG_USED_USED = 2
-uint8 rtcm_msg_used		# Indicates if the RTCM message was used successfully by the receiver
+bool corrections_crc_failed	# Last correction message failed its CRC or content check
+
+uint8 CORRECTIONS_MSG_USED_UNKNOWN = 0
+uint8 CORRECTIONS_MSG_USED_NOT_USED = 1
+uint8 CORRECTIONS_MSG_USED_USED = 2
+uint8 corrections_msg_used	# Whether the receiver used the last correction message
 
 float32 antenna_offset_x	# [m] [@frame body frame FRD] X Position of GNSS antenna
 float32 antenna_offset_y	# [m] [@frame body frame FRD] Y Position of GNSS antenna

--- a/src/drivers/gnss/septentrio/septentrio.cpp
+++ b/src/drivers/gnss/septentrio/septentrio.cpp
@@ -1207,7 +1207,7 @@ int SeptentrioDriver::process_message()
 			ReceiverStatus receiver_status;
 
 			if (_sbf_decoder.parse(&receiver_status) == PX4_OK) {
-				_sensor_gps.rtcm_msg_used = receiver_status.rx_state_diff_corr_in ? sensor_gps_s::RTCM_MSG_USED_USED : sensor_gps_s::RTCM_MSG_USED_NOT_USED;
+				_sensor_gps.corrections_msg_used = receiver_status.rx_state_diff_corr_in ? sensor_gps_s::CORRECTIONS_MSG_USED_USED : sensor_gps_s::CORRECTIONS_MSG_USED_NOT_USED;
 				_time_synced = receiver_status.rx_state_wn_set && receiver_status.rx_state_tow_set;
 
 				_sensor_gps.system_error = sensor_gps_s::SYSTEM_ERROR_OK;

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -1016,6 +1016,10 @@ GPS::run()
 			ubx_mode = GPSDriverUBX::UBXMode::UCenterUART2;
 			break;
 
+		case 8:
+			ubx_mode = GPSDriverUBX::UBXMode::GalileoHAS;
+			break;
+
 		default:
 			break;
 

--- a/src/drivers/gps/params.yaml
+++ b/src/drivers/gps/params.yaml
@@ -116,6 +116,10 @@ parameters:
           while UART2 outputs UBX at GPS_UBX_BAUD2 for u-center. Keep GPS_UBX_BAUD2 at 115200 or above,
           the diagnostic message set saturates a slower link. UBX input is left enabled on UART2, so
           anything attached there can also reconfigure the receiver.
+          Mode 8 uses the free Galileo HAS corrections broadcast on E6 (ZED-X20P with HPG 2.10 or
+          later) for a PPP solution of roughly 20 cm after a few minutes of convergence. The
+          receiver only processes HAS while host corrections are off, so RTCM and SPARTN from the
+          autopilot are ignored in this mode; use mode 0 whenever a correction link is available.
       type: enum
       values:
         0: Default
@@ -128,9 +132,10 @@ parameters:
           UART2)
         6: Ground Control Station (UART2 outputs NMEA)
         7: u-center on UART2 (UART2 outputs UBX diagnostics)
+        8: Galileo HAS (X20P, PPP from E6, RTCM/SPARTN input disabled)
       default: 0
       min: 0
-      max: 7
+      max: 8
       reboot_required: true
     GPS_UBX_BAUD1:
       description:

--- a/src/drivers/ins/microstrain/MicroStrain.cpp
+++ b/src/drivers/ins/microstrain/MicroStrain.cpp
@@ -1728,9 +1728,9 @@ void MicroStrain::gnssCallback(void *user, const mip_packet *packet, mip::Timest
 
 		gps.rtcm_injection_rate = 0;
 		gps.selected_rtcm_instance = 0;
-		gps.rtcm_crc_failed = 0;
+		gps.corrections_crc_failed = 0;
 
-		gps.rtcm_msg_used = 0;
+		gps.corrections_msg_used = 0;
 
 		gps.timestamp = hrt_absolute_time();
 


### PR DESCRIPTION
## Summary

Adds `GPS_UBX_MODE = 8` (Galileo HAS), renames the `sensor_gps` RTCM status fields to `corrections_*` with a new `corrections_protocol`, and bumps GPSDrivers to the head of PX4/PX4-GPSDrivers#231, which also brings UBX-SEC-SIG jamming state for F9 HPG 1.51 / X20, UBX-RXM-COR correction status, and the CFG-ITFM gating. #231 is merged; the pointer is at its squash on PX4-GPSDrivers `main` (`1b27986`).

## Problem

HPG 2.10 on the ZED-X20P can compute an RTK-float class solution (roughly 20 cm after a few minutes of convergence) from the free Galileo HAS corrections on E6, with no correction link at all. The receiver only processes HAS while `CFG-NAVCOR-ENABLE_HOST` is off, which makes RTCM and SPARTN from the autopilot dead input, so it cannot be on by default and the user has to opt in knowingly.

`rtcm_msg_used` / `rtcm_crc_failed` were fed only by UBX-RXM-RTCM, which the X20 does not have and which ignores SPARTN and HAS, so nothing in the log said whether a correction stream was actually being used.

## Solution

Mode 8 maps to the new `UBXMode::GalileoHAS`; the parameter description states what it gives up. `corrections_msg_used`, `corrections_crc_failed` and `corrections_protocol` (RTCM3 / SPARTN / HAS / PMP / QZSS L6) are fed by UBX-RXM-COR on u-blox; the Septentrio and MicroStrain writers are updated for the rename. Only builds (`px4_fmu-v6x`, `px4_sitl`) have been run; HAS and RXM-COR have not been tested on hardware yet.
