### PR TITLE
fix(drivers/iis2mdc): read the temperature registers in their own transfer

### DIFF
--- a/src/drivers/magnetometer/st/iis2mdc/iis2mdc.cpp
+++ b/src/drivers/magnetometer/st/iis2mdc/iis2mdc.cpp
@@ -84,9 +84,16 @@ void IIS2MDC::RunImpl()
 			int16_t x = int16_t((data.xout1 << 8) | data.xout0);
 			int16_t y = int16_t((data.yout1 << 8) | data.yout0);
 			int16_t z = -int16_t((data.zout1 << 8) | data.zout0);
-			int16_t t = int16_t((data.tout1 << 8) | data.tout0);
-			// 16 bits twos complement with a sensitivity of 8 LSB/°C. Typically, the output zero level corresponds to 25 °C.
-			_px4_mag.set_temperature(float(t) / 8.f + 25.f);
+			uint8_t temp[2] {};
+
+			// A burst read wraps around inside OUTX..OUTZ, so a read that runs on into
+			// TEMP_OUT_L/H returns OUTX again; the temperature needs its own transfer.
+			if (_interface->read(IIS2MDC_ADDR_TEMP_OUT_L_REG, temp, sizeof(temp)) == PX4_OK) {
+				int16_t t = int16_t((temp[1] << 8) | temp[0]);
+				// 8 LSB/°C, zero level at 25 °C
+				_px4_mag.set_temperature(float(t) / 8.f + 25.f);
+			}
+
 			_px4_mag.update(hrt_absolute_time(), x, y, z);
 			_px4_mag.set_error_count(perf_event_count(_comms_errors));
 			perf_count(_sample_count);

--- a/src/drivers/magnetometer/st/iis2mdc/iis2mdc.h
+++ b/src/drivers/magnetometer/st/iis2mdc/iis2mdc.h
@@ -42,6 +42,7 @@
 #define IIS2MDC_ADDR_CFG_REG_C  0x62
 #define IIS2MDC_ADDR_STATUS_REG 0x67
 #define IIS2MDC_ADDR_OUTX_L_REG 0x68
+#define IIS2MDC_ADDR_TEMP_OUT_L_REG 0x6E
 #define IIS2MDC_ADDR_WHO_AM_I   0x4F
 
 // IIS2MDC Definitions
@@ -71,8 +72,6 @@ public:
 		uint8_t yout1;
 		uint8_t zout0;
 		uint8_t zout1;
-		uint8_t tout0;
-		uint8_t tout1;
 	};
 
 	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);


### PR DESCRIPTION
## Summary
`sensor_mag.temperature` from the IIS2MDC was the X field in disguise. Read `TEMP_OUT_L/H` in a separate transfer.

## Problem
The sample path burst-reads 8 bytes from `OUTX_L` and takes the last two as `TEMP_OUT`. On this part a multi-byte read wraps around inside `OUTX..OUTZ` rather than continuing into the temperature registers, with or without the sub-address auto-increment bit — a 10-byte read from `0x68` returns `8E FF B7 FE 03 FF 8E FF B7 FE`. So the published temperature was `x / 8 + 25`: ~25 °C on a calibrated mag and flat while the board warmed from 40 to 55 °C.

## Solution
Drop the temperature bytes from the burst and read `TEMP_OUT_L/H` on their own, as ST's reference driver does. Verified on an ARK FMU v6X-RT: the mag now reports 49.6–51.0 °C against 51–54 °C from the neighbouring IMUs and baro, tracking through warm-up, with no comms errors.