### PR TITLE
fix(simulation): align gz_x500 rotor geometry with model

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500
@@ -16,20 +16,20 @@ param set-default SIM_GZ_EN 1
 param set-default CA_AIRFRAME 0
 param set-default CA_ROTOR_COUNT 4
 
-param set-default CA_ROTOR0_PX 0.13
-param set-default CA_ROTOR0_PY 0.22
+param set-default CA_ROTOR0_PX 0.174
+param set-default CA_ROTOR0_PY 0.174
 param set-default CA_ROTOR0_KM 0.05
 
-param set-default CA_ROTOR1_PX -0.13
-param set-default CA_ROTOR1_PY -0.2
+param set-default CA_ROTOR1_PX -0.174
+param set-default CA_ROTOR1_PY -0.174
 param set-default CA_ROTOR1_KM 0.05
 
-param set-default CA_ROTOR2_PX 0.13
-param set-default CA_ROTOR2_PY -0.22
+param set-default CA_ROTOR2_PX 0.174
+param set-default CA_ROTOR2_PY -0.174
 param set-default CA_ROTOR2_KM -0.05
 
-param set-default CA_ROTOR3_PX -0.13
-param set-default CA_ROTOR3_PY 0.2
+param set-default CA_ROTOR3_PX -0.174
+param set-default CA_ROTOR3_PY 0.174
 param set-default CA_ROTOR3_KM -0.05
 
 param set-default SIM_GZ_EC_FUNC1 101


### PR DESCRIPTION
### Solved Problem

The `gz_x500` SITL airframe configures asymmetric `CA_ROTOR` positions
(`|PX| = 0.13 m`, `|PY| = 0.20–0.22 m`), while the current Gazebo
`x500_base` model places all four rotors symmetrically at
`|x| = |y| = 0.174 m`.

Because PX4 builds the ControlAllocator effectiveness matrix from these
`CA_ROTOR` positions, the mismatch introduces a fixed roll/pitch
control-effectiveness asymmetry into an otherwise symmetric simulated vehicle.

The configured geometry ratio is approximately `1.615`, while the Gazebo
model geometry ratio is `1.0`.

Git history shows that these values originated in the older Ignition X3
airframe and were retained when x500 replaced X3.

### Solution

Align `CA_ROTOR0-3_PX/PY` in `4001_gz_x500` with the current Gazebo x500
geometry (`±0.174 m`).

This PR changes only the rotor positions. It does not change:

- ControlAllocator logic
- rotor ordering or spin direction
- `CT`
- `KM`
- `THR_MDL_FAC`
- ESC scaling
- Gazebo motor dynamics
- controller gains

The separate isotropic motor/thrust-model nonlinearity is intentionally out of
scope.

### Changelog Entry

Bugfix: align gz_x500 ControlAllocator rotor geometry with the Gazebo x500 model.

### Test coverage

Validated in stock `gz_x500` SITL using PX4's position controller with identical
takeoff, hover, horizontal step, and landing profiles.

Four flights completed without PX4 errors or failsafes.

Measured roll/pitch control effectiveness:

| | Before | After |
|---|---:|---:|
| OLS `K_pitch / K_roll` | 1.3804 ± 0.0114 | 1.0015 ± 0.0002 |
| TLS `K_pitch / K_roll` | 1.8156 ± 0.0017 | 1.0001 ± 0.0007 |
| Successful flights | 2/2 | 2/2 |

The allocator geometry predicts an asymmetry of `1.615` before the patch and
`1.0` after it. Before the patch, independent OLS and TLS identification bracket
that predicted asymmetry; after the patch, both converge to approximately unity.

No automated ROMFS/SDF consistency test is included because the current unit-test
infrastructure does not load both the airframe shell configuration and the
Gazebo model.

### Context

The mismatch is simulation-specific. The `4001_gz_x500` values were inherited
from the older Ignition X3 configuration and do not match the geometry of the
current x500 Gazebo model.