### PR TITLE
fix(uxrce_dds): align SITL namespace prefix

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -301,8 +301,8 @@ navigator start
 uxrce_dds_ns=""
 if [ "$px4_instance" -ne "0" ]
 then
-	# for multi intances setup, add namespace prefix
-	uxrce_dds_ns="-n px4_$px4_instance"
+	# for multi instances setup, add namespace prefix
+	uxrce_dds_ns="-n uav_$px4_instance"
 fi
 if [ "${PX4_UXRCE_DDS_NS+x}" ]; then
 	# Override, as variable is set (empty or not)


### PR DESCRIPTION
### Solved Problem

Fixes #28092

SITL multi-instance startup generated `px4_<instance>` namespaces, while hardware configurations using `UXRCE_DDS_NS_IDX` generated `uav_<index>`. This required different ROS 2 namespace assumptions between simulation and hardware.

### Solution

Use the existing `uav_` namespace prefix for non-zero SITL instances as well. The explicit `PX4_UXRCE_DDS_NS` override remains unchanged, including support for clearing the namespace with an empty value.

This preserves the existing hardware-side convention while making SITL and hardware multi-vehicle topic names consistent.

### Changelog Entry

```
Bugfix: Align default UXRCE-DDS namespaces between SITL multi-instance and UXRCE_DDS_NS_IDX configurations.
```

### Alternatives

Changing the `UXRCE_DDS_NS_IDX` fallback prefix from `uav_` to `px4_` would also make both paths consistent, but would change the existing hardware-side namespace convention.

### Test coverage

- Verified the startup script now generates `uav_<instance>` for non-zero SITL instances.
- Verified the `PX4_UXRCE_DDS_NS` override logic is unchanged.
- Ran `git diff --check`.
- A full PX4 build was not run because the current Windows environment does not have the PX4 build toolchain installed.

Assisted-by: OpenAI Codex: GPT-5