### PR TITLE
fix(drivers/bmp388): poll STATUS without consuming the data registers

### DIFF
--- a/src/drivers/barometer/bmp388/bmp388.cpp
+++ b/src/drivers/barometer/bmp388/bmp388.cpp
@@ -101,9 +101,12 @@ void BMP388::RunImpl()
 	switch (_state) {
 	case STATE::RESET:
 
-		// the command decoder is not ready until tstartup (2 ms) after POR
-		if (RegisterRead(Register::STATUS) & STATUS_BIT::CMD_RDY) {
+		// the command decoder is not ready until tstartup (2 ms) after POR. Give up on the
+		// gate after 10 ms so a wedged sensor falls into the 100 ms retry below instead of
+		// polling this bus at 500 Hz forever.
+		if ((RegisterRead(Register::STATUS) & STATUS_BIT::CMD_RDY) || (_cmd_rdy_polls++ >= 5)) {
 			RegisterWrite(Register::CMD, CMD_VALUE::SOFTRESET);
+			_cmd_rdy_polls = 0;
 			_failure_count = 0;
 			_state = STATE::WAIT_FOR_RESET;
 			perf_count(_reset_perf);
@@ -131,11 +134,17 @@ void BMP388::RunImpl()
 
 	case STATE::CONFIGURE:
 		if (Configure()) {
+			_configure_failures = 0;
 			_state = STATE::MEASURE;
 			ScheduleNow();
 
 		} else {
-			PX4_DEBUG("configure failed, resetting");
+			// init() returns before the first configure, so this is the only place a bad
+			// calibration CRC or a dead sensor can be reported
+			if (++_configure_failures == 10) {
+				PX4_ERR("configure failed, not publishing");
+			}
+
 			_state = STATE::RESET;
 			ScheduleDelayed(100_ms);
 		}
@@ -193,19 +202,27 @@ bool BMP388::Measure()
 
 int BMP388::Collect()
 {
-	status_data data{};
+	// poll STATUS on its own: DS table 29, drdy is cleared by reading a DATA register,
+	// so bundling the data into the poll would drop a conversion that lands mid-burst
+	uint8_t status = 0;
 
-	if (!RegisterRead(Register::STATUS, &data, sizeof(data))) {
+	if (!RegisterRead(Register::STATUS, &status, sizeof(status))) {
 		return -EIO;
 	}
 
-	if ((data.status & (STATUS_BIT::DRDY_PRESS | STATUS_BIT::DRDY_TEMP)) != (STATUS_BIT::DRDY_PRESS | STATUS_BIT::DRDY_TEMP)) {
+	if ((status & (STATUS_BIT::DRDY_PRESS | STATUS_BIT::DRDY_TEMP)) != (STATUS_BIT::DRDY_PRESS | STATUS_BIT::DRDY_TEMP)) {
 		if (hrt_elapsed_time(&_measure_timestamp) < _conversion_time_max_us) {
 			return -EAGAIN;
 		}
 
 		perf_count(_conversion_timeout_perf);
 		return -ETIMEDOUT;
+	}
+
+	sensor_data data{};
+
+	if (!RegisterRead(Register::DATA_0, &data, sizeof(data))) {
+		return -EIO;
 	}
 
 	const uint32_t uncomp_press = ((uint32_t)data.press_23_16 << 16) | ((uint32_t)data.press_15_8 << 8) | data.press_7_0;

--- a/src/drivers/barometer/bmp388/bmp388.h
+++ b/src/drivers/barometer/bmp388/bmp388.h
@@ -63,6 +63,7 @@ enum class Register : uint8_t {
 	REV_ID = 0x01,
 	ERR_REG = 0x02,
 	STATUS = 0x03,
+	DATA_0 = 0x04, // pressure 0x04..0x06, temperature 0x07..0x09
 	PWR_CTRL = 0x1B,
 	OSR = 0x1C,
 	TRIM_CRC = 0x30, // CRC-8 over NVM_PAR_T1..NVM_PAR_P11 (bmp3_selftest.c)
@@ -119,9 +120,8 @@ struct calib_data {
 	int8_t par_p11;
 };
 
-// STATUS followed by DATA_0..DATA_5 (0x03..0x09)
-struct status_data {
-	uint8_t status;
+// DATA_0..DATA_5 (0x04..0x09). DS 3.10 asks for one burst from press_xlsb to temp_msb.
+struct sensor_data {
 	uint8_t press_7_0;
 	uint8_t press_15_8;
 	uint8_t press_23_16;
@@ -132,7 +132,7 @@ struct status_data {
 #pragma pack(pop)
 
 static_assert(sizeof(calib_data) == 21);
-static_assert(sizeof(status_data) == 7);
+static_assert(sizeof(sensor_data) == 6);
 
 } // namespace Bosch_BMP388
 
@@ -184,6 +184,8 @@ private:
 
 	hrt_abstime _measure_timestamp{0};
 	int _failure_count{0};
+	int _configure_failures{0};
+	int _cmd_rdy_polls{0};
 
 	uint8_t _chip_id{0};
 	uint8_t _rev_id{0};


### PR DESCRIPTION
## Summary

Follow-up to #28331. The forced-mode DRDY retry path added there cannot work as written, because the poll itself destroys the flag it is waiting on. Untested on hardware so far — build-verified only (`px4_fmu-v6x`, `px4_sitl`). I have a BMP390 on the bench and can soak it, but no BMP388 part, which is the variant most exposed.

## Problem

`drdy_press` / `drdy_temp` are cleared when a DATA register is read out (BMP390 DS table 29, same wording in the BMP388 DS), unconditionally — it does not matter whether the read returned fresh data. `Collect()` polls with a single 0x03..0x09 burst, so the not-ready path has already consumed DATA_0..DATA_5. If the conversion finishes during that burst, the result lands in the shadow registers (DS 3.10.1), `drdy` asserts, and our own read immediately clears it. Every subsequent 2 ms poll then sees the flags clear, the sample dies at `_conversion_time_max_us`, and 11 of those in a row reset the chip.

The first poll is scheduled at the typical conversion time. For the BMP390 that is 37.14 ms, exactly what DS 3.9.2 computes for osr_p x16 / osr_t x2 (`234 + 392 + 16*2020 + 163 + 2*2020 = 37149 us`), and on the bench it consistently landed after DRDY. The BMP388's typical for the same OSR is 36.9 ms (DS001 table 21) — 249 us below that same formula — so it starts the burst closer to, or before, the real end of conversion, right inside the race. DS 3.10 also asks that forced-mode readout respect the *maximum* measurement time.

Two smaller regressions from the same rewrite: the `CMD_RDY` gate in `RESET` has no bound, so a sensor that never reports ready keeps the state machine hammering a shared I2C bus at 500 Hz forever; and since `init()` now returns before the first `Configure()`, a bad calibration CRC leaves the driver silently not publishing where it used to fail `bmp388 start`.

## Solution

Poll STATUS on its own — a 1 byte read does not touch the data registers, so DRDY survives — and burst DATA_0..DATA_5 only once both flags are set. This is what the Bosch BMP3 API and the Zephyr driver do, and it matches the DS 3.10 recommendation to burst from press_xlsb to temp_msb. Scheduling the first poll at the typical time is then safe, so the 26 Hz rate is unchanged.

Give up on the `CMD_RDY` gate after 10 ms and fall through to the existing 100 ms reset retry, and log once after ten consecutive `Configure()` failures.