### PR TITLE
fix(mc_pos_control): stop the velocity limit cutting out the braking feedforward

### DIFF
--- a/msg/VehicleConstraints.msg
+++ b/msg/VehicleConstraints.msg
@@ -7,3 +7,5 @@ float32 speed_up # in meters/sec
 float32 speed_down # in meters/sec
 
 bool want_takeoff # tell the controller to initiate takeoff when idling (ignored during flight)
+
+bool emergency_braking # the flight task is braking from outside the normal velocity envelope

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -180,6 +180,7 @@ bool FlightTaskAuto::update()
 	}
 
 	_checkEmergencyBraking();
+	_constraints.emergency_braking = _is_emergency_braking_active;
 	Vector3f waypoints[] = {_triplet_previous, _position_setpoint, _triplet_next};
 
 	if (_type == WaypointType::position && _hasPassedCurrentWaypoint()) {
@@ -198,9 +199,8 @@ bool FlightTaskAuto::update()
 	_updateTrajConstraints();
 
 	if (_is_emergency_braking_active) {
-		// Re-seed the trajectory to the measured state every cycle so controller saturation doesn't
-		// cause a velocity error inversion during emergency braking.
-		_position_smoothing.forceSetVelocity(_velocity);
+		// Keep the trajectory position on the vehicle so the position error doesn't get corrected at
+		// the expense of the braking feedforward.
 		_position_smoothing.forceSetPosition(_position);
 	}
 
@@ -732,9 +732,9 @@ void FlightTaskAuto::_checkEmergencyBraking()
 
 	} else {
 		// Deactivate emergency braking once slow enough for ordinary guidance to finish the stop.
-		// Must clear velocity estimate noise, otherwise braking latches and guidance never resumes.
-		if (math::isInRange(_position_smoothing.getCurrentVelocityZ(), -1.f, 1.f)
-		    && !_position_smoothing.getCurrentVelocityXY().longerThan(1.f)) {
+		// Check the measured velocity since the trajectory reaches zero well before the vehicle does.
+		if (math::isInRange(_velocity(2), -1.f, 1.f)
+		    && !Vector2f(_velocity).longerThan(1.f)) {
 			_is_emergency_braking_active = false;
 		}
 	}

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -39,6 +39,7 @@
 #include <float.h>
 
 using namespace matrix;
+using namespace time_literals;
 
 bool FlightTaskAuto::activate(const trajectory_setpoint_s &last_setpoint)
 {
@@ -718,24 +719,54 @@ void FlightTaskAuto::_ekfResetHandlerHeading(const float delta_psi)
 void FlightTaskAuto::_checkEmergencyBraking()
 {
 	if (!_is_emergency_braking_active) {
-		// activate emergency braking if significantly outside of velocity bounds
+		// Activate emergency braking if either the vehicle or the trajectory is significantly outside of
+		// velocity bounds. activate() seeds the trajectory from the previous task's setpoint, which
+		// is not bounded by this task's limits.
 		const float factor = 1.3f;
-		const bool is_vertical_speed_exceeded = _position_smoothing.getCurrentVelocityZ() >
-							(factor * _param_mpc_z_vel_max_dn.get())
-							|| _position_smoothing.getCurrentVelocityZ() < -(factor * _param_mpc_z_vel_max_up.get());
-		const bool is_horizontal_speed_exceeded = _position_smoothing.getCurrentVelocityXY().longerThan(
-					factor * _param_mpc_xy_vel_max.get());
+		const float speed_down = math::max(_velocity(2), _position_smoothing.getCurrentVelocityZ());
+		const float speed_up = -math::min(_velocity(2), _position_smoothing.getCurrentVelocityZ());
+		const float speed_horizontal = math::max(Vector2f(_velocity).norm(),
+					       _position_smoothing.getCurrentVelocityXY().norm());
+		// _updateTrajConstraints() lets ordinary descents past MPC_Z_VEL_MAX_DN, so the margin has to be
+		// taken against what guidance can actually reach or a downdraft would trigger braking mid-mission.
+		const float max_speed_down = math::max(_param_mpc_z_vel_max_dn.get(), 1.2f * _param_mpc_z_v_auto_dn.get());
+		const bool is_vertical_speed_exceeded = (speed_down > factor * max_speed_down)
+							|| (speed_up > factor * _param_mpc_z_vel_max_up.get());
+		const bool is_horizontal_speed_exceeded = speed_horizontal > (factor * _param_mpc_xy_vel_max.get());
 
 		if (is_vertical_speed_exceeded || is_horizontal_speed_exceeded) {
 			_is_emergency_braking_active = true;
+			// Start the braking ramp from the vehicle not the reference.
+			_position_smoothing.forceSetVelocity(_velocity);
+
+			_emergency_braking_best_speed = math::max(fabsf(_velocity(2)), Vector2f(_velocity).norm());
+			_emergency_braking_progress_timestamp = _time_stamp_current;
 		}
 
 	} else {
 		// Deactivate emergency braking once slow enough for ordinary guidance to finish the stop.
 		// Check the measured velocity since the trajectory reaches zero well before the vehicle does.
-		if (math::isInRange(_velocity(2), -1.f, 1.f)
-		    && !Vector2f(_velocity).longerThan(1.f)) {
+		const bool is_slow_enough = math::isInRange(_velocity(2), -1.f, 1.f)
+					    && !Vector2f(_velocity).longerThan(1.f);
+
+		// Track the lowest speed reached and deactivate emergency braking if it stops improving.
+		// Avoids getting stuck in emergency braking.
+		const float speed = math::max(fabsf(_velocity(2)), Vector2f(_velocity).norm());
+
+		if (speed < _emergency_braking_best_speed - 0.5f) {
+			_emergency_braking_best_speed = speed;
+			_emergency_braking_progress_timestamp = _time_stamp_current;
+		}
+
+		const bool is_not_slowing_down = _time_stamp_current > _emergency_braking_progress_timestamp + 3_s;
+
+		if (is_slow_enough || is_not_slowing_down) {
 			_is_emergency_braking_active = false;
+
+			// Hand back a trajectory that ordinary guidance can take over. Emergency braking runs the smoother at
+			// 1g right up to the release, so its acceleration state is still around 9.8 m/s^2 while its
+			// velocity state is near zero.
+			_position_smoothing.forceSetAcceleration({0.f, 0.f, 0.f});
 		}
 	}
 }

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -142,6 +142,8 @@ protected:
 	matrix::Vector3f _land_position;
 	WaypointType _type_previous{WaypointType::idle}; /**< Previous type of current target triplet. */
 	bool _is_emergency_braking_active{false};
+	float _emergency_braking_best_speed{0.f}; /**< lowest speed reached since braking was activated */
+	hrt_abstime _emergency_braking_progress_timestamp{}; /**< last time the braking was still slowing down */
 	bool _want_takeoff{false};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,

--- a/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.cpp
+++ b/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.cpp
@@ -4,7 +4,7 @@
 
 constexpr uint64_t FlightTask::_timeout;
 const trajectory_setpoint_s FlightTask::empty_trajectory_setpoint = {0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN};
-const vehicle_constraints_s FlightTask::empty_constraints = {0, NAN, NAN, false, {}};
+const vehicle_constraints_s FlightTask::empty_constraints = {0, NAN, NAN, false, false, {}};
 const landing_gear_s FlightTask::empty_landing_gear_default_keep = {0, landing_gear_s::GEAR_KEEP, {}};
 
 bool FlightTask::activate(const trajectory_setpoint_s &last_setpoint)
@@ -223,6 +223,7 @@ void FlightTask::_setDefaultConstraints()
 	_constraints.speed_up = _param_mpc_z_vel_max_up.get();
 	_constraints.speed_down = _param_mpc_z_vel_max_dn.get();
 	_constraints.want_takeoff = false;
+	_constraints.emergency_braking = false;
 }
 
 bool FlightTask::_checkTakeoff()

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -536,10 +536,27 @@ void MulticopterPositionControl::Run()
 				max_speed_xy = math::min(max_speed_xy, vehicle_local_position.vxy_max);
 			}
 
-			_control.setVelocityLimits(
-				max_speed_xy,
-				math::min(speed_up, _param_mpc_z_vel_max_up.get()), // takeoff ramp starts with negative velocity limit
-				math::max(speed_down, 0.f));
+			float limit_speed_up = math::min(speed_up,
+							 _param_mpc_z_vel_max_up.get()); // takeoff ramp starts with negative velocity limit
+			float limit_speed_down = math::max(speed_down, 0.f);
+
+			if (_vehicle_constraints.emergency_braking) {
+				// Don't clamp the braking setpoint: the acceleration feedforward describes the unclamped
+				// ramp, so clamping the velocity inverts the error once the vehicle overtakes it.
+				// Only the direction of travel is raised.
+				const Vector2f velocity_setpoint_xy(_setpoint.velocity);
+
+				if (velocity_setpoint_xy.isAllFinite()) {
+					max_speed_xy = math::max(max_speed_xy, velocity_setpoint_xy.norm());
+				}
+
+				if (PX4_ISFINITE(_setpoint.velocity[2])) {
+					limit_speed_up = math::max(limit_speed_up, -_setpoint.velocity[2]);
+					limit_speed_down = math::max(limit_speed_down, _setpoint.velocity[2]);
+				}
+			}
+
+			_control.setVelocityLimits(max_speed_xy, limit_speed_up, limit_speed_down);
 
 			_control.setInputSetpoint(_setpoint);
 
@@ -585,7 +602,7 @@ void MulticopterPositionControl::Run()
 				// Still failing / not within timeout - Go to failsafe
 				if (!_control.update(dt)) {
 
-					_vehicle_constraints = {0, NAN, NAN, false, {}}; // reset constraints
+					_vehicle_constraints = {0, NAN, NAN, false, false, {}}; // reset constraints
 
 					_control.setInputSetpoint(generateFailsafeSetpoint(vehicle_local_position.timestamp_sample, states, true));
 					_control.setVelocityLimits(_param_mpc_xy_vel_max.get(), _param_mpc_z_vel_max_up.get(), _param_mpc_z_vel_max_dn.get());

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -458,6 +458,11 @@ void MulticopterPositionControl::Run()
 				_vehicle_constraints.speed_up = _param_mpc_z_vel_max_up.get();
 			}
 
+			// Never act on a braking flag left behind by a flight task that is no longer running.
+			if (_setpoint.timestamp > _vehicle_constraints.timestamp + 100_ms) {
+				_vehicle_constraints.emergency_braking = false;
+			}
+
 			if (_vehicle_control_mode.flag_control_offboard_enabled) {
 
 				const bool want_takeoff = _vehicle_control_mode.flag_armed
@@ -540,19 +545,24 @@ void MulticopterPositionControl::Run()
 							 _param_mpc_z_vel_max_up.get()); // takeoff ramp starts with negative velocity limit
 			float limit_speed_down = math::max(speed_down, 0.f);
 
-			if (_vehicle_constraints.emergency_braking) {
-				// Don't clamp the braking setpoint: the acceleration feedforward describes the unclamped
-				// ramp, so clamping the velocity inverts the error once the vehicle overtakes it.
-				// Only the direction of travel is raised.
-				const Vector2f velocity_setpoint_xy(_setpoint.velocity);
+			if (_vehicle_constraints.emergency_braking && flying) {
+				// Raise the limits to the speed the vehicle actually has, so the trajectory velocity
+				// reaches the velocity loop uncut.
+				// Clamping it leaves a large velocity error which the horizontal anti-windup back-calculates
+				// into an integrator opposing the brake.
+				const Vector2f velocity_xy(states.velocity);
 
-				if (velocity_setpoint_xy.isAllFinite()) {
-					max_speed_xy = math::max(max_speed_xy, velocity_setpoint_xy.norm());
+				if (velocity_xy.isAllFinite()) {
+					max_speed_xy = math::max(max_speed_xy, velocity_xy.norm());
 				}
 
-				if (PX4_ISFINITE(_setpoint.velocity[2])) {
-					limit_speed_up = math::max(limit_speed_up, -_setpoint.velocity[2]);
-					limit_speed_down = math::max(limit_speed_down, _setpoint.velocity[2]);
+				if (PX4_ISFINITE(states.velocity(2))) {
+					if (states.velocity(2) < 0.f) {
+						limit_speed_up = math::max(limit_speed_up, -states.velocity(2));
+
+					} else {
+						limit_speed_down = math::max(limit_speed_down, states.velocity(2));
+					}
 				}
 			}
 


### PR DESCRIPTION
### Solved Problem

Emergency braking is activated when entering an autonomous mode at `1.3x` the modes velocity limits. Its intention is to bring the vehicle to a full stop before continuing with the mission. It functions by setting a zero velocity target and raises the acceleration limit on all axes to 1 g.

- However `PositionControl::_positionControl()` clamped the velocity setpoint to the controller's limits while the trajectory published an acceleration feedforward for the unclamped ramp.
- Due to the different velocity profiles, the feedforward drove the vehicle through the clamped setpoint, the velocity error then changed sign, and the loop commanded re-acceleration until the setpoint caught up. 
- The consequence was increased time and distance required for the vehicle to come to a full stop during an emergency brake.

The original code raised `_constraints.speed_up/down` "to avoid cutting out the feedforward" but the raise was silently neglected upward by `math::min(speed_up, MPC_Z_VEL_MAX_UP)` (`speed_down` uses `math::max`) and there is no horizontal constraint field.

#28170 suppressed this by re-seeding the trajectory to the measured state every cycle. That removed the inversion but made the reference follow the plant, pinning the velocity error at one control step. Braking became pure feedforward, and tracking anti-windup then drove the velocity integrator up which in turn cancelled the feedforward resulting in a late release out of emergency braking.

### Solution

Don't let the velocity limit clamp the braking setpoint. 
 - While `vehicle_constraints.emergency_braking` is active, raise the velocity limits to the vehicle's measured velocity (recalculated each cycle, in the direction of travel).
 - Revert the the per-cycle velocity reseeding (`forceSetVelocity`) to restore genuine tracking error, while seeding the trajectory onto the vehicle once, at activation.
 - However, keep `forceSetPosition` since the clamp applies to the sum of the position term and the feedforward, and `constrainXY()` gives the  position term priority, so a position error would be corrected at the expense of the braking feedforward.
 - Release on the measured velocity since with the velocity re-seed gone the reference reaches zero before the vehicle does so releasing on the reference would hand back too early.
- Deactivate emergency braking once slow enough for ordinary guidance to finish the stop.

#### Updates
- The limit raise now reads the vehicle, not the setpoint.
    - The first version of this PR raised the controller's velocity limits to the magnitude of `_setpoint.velocity`. Flight testing showed that is unsafe whenever the trajectory is seeded ahead of the vehicle which happens on any mode change out of a task whose own velocity limit was binding at the controller.
- Incorporated a progress check to avoid getting stuck in emergency braking.
- Trajectory acceleration is set to 0 on deactivation. 
    - Braking runs the smoother at 1g right up to the release, so its acceleration state is still ~9.8 m/s^2 while its velocity state is near zero. Ordinary guidance only has `MPC_JERK_AUTO` to unwind that, so the velocity state kept building past `MPC_Z_V_AUTO_UP` before the acceleration reached zero.
- Trajectory is seeded onto the vehicle once on activation rather than every cycle to clear trajectory from previous task, while avoiding open loop braking. 
- Activation now triggers when the measured or trajectory are out of the mode limits. 
    - Just trajectory would not activate if measured is significantly above mode limits.
    - Just measured would not activate if a trajectory higher than the measured velocity is passed from a previous mode. 
- The descent threshold is taken against `max(MPC_Z_VEL_MAX_DN, 1.2 * MPC_Z_V_AUTO_DN)` rather than `MPC_Z_VEL_MAX_DN` alone. 
    - `_updateTrajConstraints()` deliberately lets ordinary auto descents exceed `MPC_Z_VEL_MAX_DN`, so raising `MPC_Z_V_AUTO_DN` on its own would otherwise put every normal descent above the trigger.
- The controller ignores a braking flag left behind by a flight task that has stopped publishing constraints (fixed-wing, external modes), and the limit raise is gated on `flying` so it cannot disturb the takeoff ramp, where `limit_speed_up` is legitimately negative.
- Added a progress check to mitigate the possibility of getting stuck in emergency braking if <1m/s velocity threshold cannot be reached e.g. due to estimator bias or integral windup.

#### Final proposed emergency braking state machine

##### While inactive

Evaluated every cycle in `_checkEmergencyBraking()`:

Take the larger of the measured and trajectory velocity per direction, and compare against `1.3 x` the relevant limit:

| axis | threshold |
|---|---|
| up | `1.3 * MPC_Z_VEL_MAX_UP` |
| down | `1.3 * max(MPC_Z_VEL_MAX_DN, 1.2 * MPC_Z_V_AUTO_DN)` |
| horizontal | `1.3 * MPC_XY_VEL_MAX` |

##### On activation

- Set `_is_emergency_braking_active`, published as `vehicle_constraints.emergency_braking`.
- `forceSetVelocity(_velocity)` once, on all three axes: the braking ramp starts from the vehicle, so the reference can never ask for more speed than the vehicle already has. 
- Initialise the progress watermark to the current speed.

##### While active

- `force_zero_velocity_setpoint` drives the smoother's target to zero on all axes; acceleration and jerk limits go to 1g.
- `forceSetPosition(_position)` every cycle keeps the position-P term near zero so `constrainXY()` cannot discard the feedforward in favour of position.
- The controller raises its velocity limits to `max(normal, |measured|)` in the direction of travel only, recomputed every cycle, gated on `flying`.
  
##### Deactivation

- Measured velocity under 1 m/s on both the vertical and horizontal axes.
- Or the progress watermark has not improved by 0.5 m/s in 3 s, so braking cannot latch on a biased velocity estimate or integral windup.
 
##### On deactivation

- `forceSetAcceleration({0, 0, 0})` so ordinary guidance takes over a trajectory at rest in acceleration rather than inheriting 1g.

### Changelog Entry
For release notes:
```
Bugfix: during emergency braking, the velocity setpoint is no longer clamped away from its acceleration
feedforward, which inverted the velocity error or delayed ebraking deactivation.
```

### Alternatives

 - Release at 1.0× the velocity limits and let ordinary guidance finish the stop. 
     - The idea with ebraking is that you would like to stop as fast as possible so performing a fast brake and then handing over at the limit to slow brake seems counter intuitive e.g. when entering hold from stabilised.

### Test coverage

Tested in SIH. Below shows the pre and post fix performance of emergency braking.

#### Initial behaviour
Velocity error inversion.
<img width="1802" height="1770" alt="image" src="https://github.com/user-attachments/assets/0c8f6207-3a39-499d-b501-f623a022989e" />

#### Proposed fix (`stab --> return`)
Increase controller velocity limits during emergency braking.
<img width="1802" height="1770" alt="image" src="https://github.com/user-attachments/assets/d713c920-602c-4569-aedc-433e1a418376" />
