### PR TITLE
docs(ros2): add instruction for configuring firmware depending on chosen middleware

### DIFF
--- a/docs/en/middleware/uxrce_dds.md
+++ b/docs/en/middleware/uxrce_dds.md
@@ -338,7 +338,7 @@ If `CONFIG_MODULES_UXRCE_DDS_CLIENT=y` is not preset you can add this key to you
 Note that due to flash constraints you may need to remove other components in order to include the module.
 
 ::: tip
-You can check if uXRCE-DDS is present at runtime by using QGroundControl to [find the parameter](../advanced_config/parameters.md#UXRCE_DDS_CFG) [ZENOH_ENABLE](../advanced_config/parameter_reference.md#UXRCE_DDS_CFG).
+You can check if uXRCE-DDS is present at runtime by using QGroundControl to [find the parameter](../advanced_config/parameters.md#finding-a-parameter) [UXRCE_DDS_CFG](../advanced_config/parameter_reference.md#UXRCE_DDS_CFG).
 If present, the module is installed.
 :::
 

--- a/docs/en/middleware/uxrce_dds.md
+++ b/docs/en/middleware/uxrce_dds.md
@@ -327,13 +327,27 @@ sudo MicroXRCEAgent serial --dev /dev/AMA0 -b 921600
 For more information about setting up communications channels see [Pixhawk + Companion Setup > Serial Port setup](../companion_computer/pixhawk_companion.md#serial-port-setup), and sub-documents.
 :::
 
+### PX4 Firmware
+
+The uXRCE-DDS client module [uxrce_dds_client](../modules/modules_system.md#uxrce-dds-client) is included by default in most firmware and simulator targets.
+
+You can check if the module is present on your board by searching for the key `CONFIG_MODULES_UXRCE_DDS_CLIENT=y` in your board's `default.px4board` [KConfig file](../hardware/porting_guide_config.md).
+For example, you can see that the module is present in `px4_fmu-v6x` build targets from [/boards/px4/fmu-v6x/default.px4board](https://github.com/PX4/PX4-Autopilot/blob/main/boards/px4/fmu-v6x/default.px4board#L81).
+
+If `CONFIG_MODULES_UXRCE_DDS_CLIENT=y` is not preset you can add this key to your board configuration and rebuild.
+Note that due to flash constraints you may need to remove other components in order to include the module.
+
+::: tip
+You can check if uXRCE-DDS is present at runtime by using QGroundControl to [find the parameter](../advanced_config/parameters.md#UXRCE_DDS_CFG) [ZENOH_ENABLE](../advanced_config/parameter_reference.md#UXRCE_DDS_CFG).
+If present, the module is installed.
+:::
+
 ### Starting the Client
 
-The uXRCE-DDS client module ([uxrce_dds_client](../modules/modules_system.md#uxrce-dds-client)) is included by default in all firmware and the simulator.
-This must be started with appropriate settings for the communication channel that you wish to use to communicate with the agent.
+`uxrce_dds_client` must be started with appropriate settings for the communication channel that you wish to use to communicate with the agent.
 
 ::: info
-The simulator automatically starts the client on localhost UDP port `8888` using the default uxrce-dds namespace.
+The simulator automatically starts the client on localhost UDP port `8888` using the default uxrce-dds namespace unless the `zenoh` target (`px4_sitl_zenoh`) is used.
 :::
 
 The configuration can be done using the [UXRCE-DDS parameters](../advanced_config/parameter_reference.md#uxrce-dds-client):

--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -758,7 +758,7 @@ int main(int argc, char *argv[])
 ## Using Flight Controller Hardware
 
 ROS 2 with PX4 running on a flight controller is almost the same as working with PX4 on the simulator.
-The only differences are:
+The differences are:
 
 - You need to ensure your PX4 firmware contains the client module.
 - You need to start both the agent _and the client_, with settings appropriate for the communication channel.

--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -177,6 +177,7 @@ DDS is recommended for most users, as it is more established and has been more t
 :::
 
 Make sure that your firmware has the corresponding module enabled: the [uxrce_dds_client](../modules/modules_system.md#uxrce-dds-client) module is included by default in most builds, while the [zenoh](../middleware/zenoh.md#px4-firmware) module must be explicitly enabled.
+Please refer to the [using flight controller hardware](#using-flight-controller-hardware) setup section for more information about including the modules in you PX4 target.
 
 #### DDS {#dds_setup}
 
@@ -757,9 +758,32 @@ int main(int argc, char *argv[])
 ## Using Flight Controller Hardware
 
 ROS 2 with PX4 running on a flight controller is almost the same as working with PX4 on the simulator.
-The only difference is that you need to start both the agent _and the client_, with settings appropriate for the communication channel.
+The only differences are:
 
-For more information see [Starting uXRCE-DDS](../middleware/uxrce_dds.md#starting-agent-and-client).
+- You need to ensure your PX4 firmware contains the client module.
+- You need to start both the agent _and the client_, with settings appropriate for the communication channel.
+
+:::: tabs
+
+::: tab uXRCE-DDS Client
+The key `CONFIG_MODULES_UXRCE_DDS_CLIENT=y` must be in your board's `default.px4board` [KConfig file](../hardware/porting_guide_config.md).
+
+See uXRCE-DDS client [firmware setup](../middleware/uxrce_dds.md#px4-firmware) for complete information.
+
+Client configuration is instead handled through PX4 parameters, see [Starting uXRCE-DDS](../middleware/uxrce_dds.md#starting-agent-and-client).
+:::
+
+::: tab Zenoh Client
+The key `CONFIG_MODULES_ZENOH=y` must be in your board's `default.px4board` [KConfig file](../hardware/porting_guide_config.md).
+
+After that it can be enabled on PX4 startup by setting the [ZENOH_ENABLE](../advanced_config/parameter_reference.md#ZENOH_ENABLE) parameter to `1`.
+
+Node configuration (network, pubishers options, topic mapping) is instead handled by configuration files (`zenoh/net.txt`, `zenoh/pub.csv`, `zenoh/sub.csv`) stored in the flight controller SD card and it can be modified at runtime using the `zenoh config` CLI tool.
+
+See Zenoh client [node setup](../middleware/zenoh.md#px4-zenoh-pico-node-setup) for complete information.
+:::
+
+::::
 
 ## Custom uORB Topics
 


### PR DESCRIPTION
This PR addresses the comments left in https://github.com/PX4/PX4-Autopilot/pull/28251:

- The instruction to add the `zenoh` module to the PX4 targets available in https://docs.px4.io/main/en/middleware/zenoh#px4-firmware are now mirrored in https://docs.px4.io/main/en/middleware/uxrce_dds
- The ROS 2 user guide page now points to the specific firmware configuration docs for Zenoh and uXRCE-DDS.