### PR TITLE
docs(ros2): reorder setup step to have standalone px4_msgs ROS 2 workspace first

### DIFF
--- a/docs/en/advanced_config/ethernet_setup.md
+++ b/docs/en/advanced_config/ethernet_setup.md
@@ -241,7 +241,7 @@ To set up ROS 2:
    MicroXRCEAgent udp4 -p 8888
    ```
 
-4. Run a [listener node](../ros2/user_guide.md#running-the-example) in a new terminal to confirm the connection is established:
+4. Run a [listener node](../ros2/user_guide.md#running-an-example-optional) in a new terminal to confirm the connection is established:
 
    ```sh
    source ~/ws_sensor_combined/install/setup.bash

--- a/docs/en/companion_computer/holybro_pixhawk_jetson_baseboard.md
+++ b/docs/en/companion_computer/holybro_pixhawk_jetson_baseboard.md
@@ -1297,7 +1297,7 @@ You can now start your ROS2 nodes and continue the development.
 
 ### ROS 2 Sensor Combined Tests
 
-You can test the Client and agent by using the `sensor_combined` example in [Build ROS 2 Workspace](../ros2/user_guide.md#build-ros-2-workspace) (ROS2 User Guide).
+You can test the Client and agent by using the `sensor_combined` example in [Running an example (optional)](../ros2/user_guide.md#running-an-example-optional) (ROS2 User Guide).
 
 ::: tip
 [VSCode over SSH](https://code.visualstudio.com/docs/remote/ssh) enables faster development and application of changes to your ROS 2 code!

--- a/docs/en/debug/plotting_realtime_uorb_data.md
+++ b/docs/en/debug/plotting_realtime_uorb_data.md
@@ -36,7 +36,7 @@ This allows ROS 2 and PlotJuggler to interpret the messages.
 If you're using unmodified PX4, the definitions from [PX4/px4_msgs](https://github.com/PX4/px4_msgs) can be used.
 
 ::: info
-This is the same process as covered in [Build ROS 2 Workspace](../ros2/user_guide.md#build-ros-2-workspace) in _ROS 2 Installation & Setup_.
+This is the same process as covered in [Running an example (optional)](../ros2/user_guide.md#running-an-example-optional) in _ROS 2 Installation & Setup_.
 :::
 
 Assuming your ROS 2 workspace is named `~/ros2_ws/`, fetch and build the `px4_msgs` package in a terminal as shown:

--- a/docs/en/ros2/offboard_control.md
+++ b/docs/en/ros2/offboard_control.md
@@ -24,7 +24,7 @@ To subscribe to data coming from nodes that publish in a different frame (for ex
 
 Follow the instructions in [ROS 2 User Guide](../ros2/user_guide.md) to install PX and run the multicopter simulator, install ROS 2, and start the XRCE-DDS Agent.
 
-After that we can follow a similar set of steps to those in [ROS 2 User Guide > Build ROS 2 Workspace](../ros2/user_guide.md#build-ros-2-workspace) to run the example.
+After that we can follow a similar set of steps to those in [ROS 2 User Guide > Running an example (optional)](../ros2/user_guide.md#running-an-example-optional) to run the example.
 
 ::: tip
 Make sure that QGC is connected to PX4 before running the ROS 2 node.

--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -174,8 +174,8 @@ A minimal ROS 2 workspace containing the [px4_msgs](https://github.com/PX4/px4_m
 
 This section shows how to create a ROS 2 workspace hosted in your home directory (modify the commands as needed to put the source code elsewhere).
 
-You should use a version of the px4_msgs package with the _same_ message definitions as the PX4 firmware you have installed in the step above.
-Tags and branches in the px4_msgs repo are named to correspond to the message definitions for different PX4 releases and release branches.
+You should use a version of the `px4_msgs` package with the _same_ message definitions as the PX4 firmware you have installed in the step above.
+Tags and branches in the `px4_msgs` repo are named to correspond to the message definitions for different PX4 releases and release branches.
 If for any reason you cannot ensure the same message definitions between your PX4 firmware and ROS 2 px4_msgs package, you will additionally need to [start the message translation node](#optional-starting-the-translation-node) as part of your setup process.
 
 To create and build the workspace:
@@ -196,6 +196,7 @@ To create and build the workspace:
 
    ```sh
    git clone https://github.com/PX4/px4_msgs.git
+   
 
 4. Source the ROS 2 development environment into the current terminal and compile the workspace using `colcon`:
 

--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -76,8 +76,9 @@ To setup ROS 2 for use with PX4:
 
 - [Install PX4](#install-px4) (to use the PX4 simulator)
 - [Install ROS 2](#install-ros-2)
+- [Setup ROS 2 Workspace](#setup-ros-2-workspace)
 - [Setup Middleware](#setup-middleware)
-- [Build & Run ROS 2 Workspace](#build-ros-2-workspace)
+- [Running an example (optional)](#running-an-example-optional)
 
 Other dependencies of the architecture that are installed automatically, such as _Fast DDS_, are not covered.
 
@@ -622,7 +623,7 @@ The ROS 2 [listener examples](https://github.com/PX4/px4_ros_com/tree/main/src/e
 Here we consider the [sensor_combined_listener.cpp](https://github.com/PX4/px4_ros_com/blob/main/src/examples/listeners/sensor_combined_listener.cpp) node under `px4_ros_com/src/examples/listeners`, which subscribes to the [SensorCombined](../msg_docs/SensorCombined.md) message.
 
 ::: info
-[Build ROS 2 Workspace](#build-ros-2-workspace) shows how to build and run this example.
+[Running an example (optional)](#running-an-example-optional) shows how to build and run this example.
 :::
 
 The code first imports the C++ libraries needed to interface with the ROS 2 middleware and the header file for the `SensorCombined` message to which the node subscribes:

--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -176,7 +176,7 @@ This section shows how to create a ROS 2 workspace hosted in your home directory
 
 You should use a version of the `px4_msgs` package with the _same_ message definitions as the PX4 firmware you have installed in the step above.
 Tags and branches in the `px4_msgs` repo are named to correspond to the message definitions for different PX4 releases and release branches.
-If for any reason you cannot ensure the same message definitions between your PX4 firmware and ROS 2 px4_msgs package, you will additionally need to [start the message translation node](#optional-starting-the-translation-node) as part of your setup process.
+If for any reason you cannot ensure the same message definitions between your PX4 firmware and ROS 2 `px4_msgs` package, you will additionally need to [start the message translation node](#optional-starting-the-translation-node) as part of your setup process.
 
 To create and build the workspace:
 

--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -168,6 +168,65 @@ To install ROS 2 and its dependencies:
    pip install --user -U empy==3.3.4 pyros-genmsg setuptools
    ```
 
+### Setup ROS 2 workspace
+
+A minimal ROS 2 workspace containing the [px4_msgs](https://github.com/PX4/px4_msgs) package is required to interpret the PX4 messages coming from the autopilot.
+
+This section shows how to create a ROS 2 workspace hosted in your home directory (modify the commands as needed to put the source code elsewhere).
+
+You should use a version of the px4_msgs package with the _same_ message definitions as the PX4 firmware you have installed in the step above.
+Tags and branches in the px4_msgs repo are named to correspond to the message definitions for different PX4 releases and release branches.
+If for any reason you cannot ensure the same message definitions between your PX4 firmware and ROS 2 px4_msgs package, you will additionally need to [start the message translation node](#optional-starting-the-translation-node) as part of your setup process.
+
+To create and build the workspace:
+
+1. Open a new terminal.
+2. Create and navigate into a new workspace directory using:
+
+   ```sh
+   mkdir -p ~/ros2_px4_ws/src/
+   cd ~/ros2_px4_ws/src/
+   ```
+
+   ::: info
+   A naming convention for workspace folders can make it easier to manage workspaces.
+   :::
+
+3. Clone [px4_msgs](https://github.com/PX4/px4_msgs) to the `/src` directory (the `main` branch is cloned by default, which corresponds to the version of PX4 we are running):
+
+   ```sh
+   git clone https://github.com/PX4/px4_msgs.git
+
+4. Source the ROS 2 development environment into the current terminal and compile the workspace using `colcon`:
+
+   :::: tabs
+
+   ::: tab jazzy
+
+   ```sh
+   cd ~/ros2_px4_ws
+   source /opt/ros/jazzy/setup.bash
+   colcon build
+   ```
+
+   :::
+
+   ::: tab humble
+
+   ```sh
+   cd ~/ros2_px4_ws
+   source /opt/ros/humble/setup.bash
+   colcon build
+   ```
+
+   :::
+
+   ::::
+
+   This builds all the folders under `/src` using the sourced toolchain.
+   You can now source the workspace with `source ~/ros2_px4_ws/install/setup.bash` to access the PX4 message definitions.
+   For example, try `ros2 interface show px4_msgs/msg/SensorCombined`.
+
 ### Setup Middleware
 
 This section explains how to set up either the [DDS](#dds_setup) or [Zenoh](#zenoh_setup) middleware.
@@ -186,27 +245,47 @@ For ROS 2 to communicate with PX4, [uXRCE-DDS client](../modules/modules_system.
 ##### Setup the Agent
 
 The agent can be installed onto the companion computer in a [number of ways](../middleware/uxrce_dds.md#micro-xrce-dds-agent-installation).
-Below we show how to build the agent "standalone" from source and connect to a client running on the PX4 simulator.
+Below we show how to build the agent inside the ROS 2 workspace `~/ros2_px4_ws` created above and connect to a client running on the PX4 simulator.
 
 To setup and start the agent:
 
 1. Open a terminal.
-2. Enter the following commands to fetch and build the agent from source:
+2. Enter the following commands to fetch the agent:
+
+   :::: tabs
+
+   ::: tab jazzy
 
    ```sh
+   cd ~/ros2_px4_ws/src/
    git clone -b v2.4.3 https://github.com/eProsima/Micro-XRCE-DDS-Agent.git
-   cd Micro-XRCE-DDS-Agent
-   mkdir build
-   cd build
-   cmake ..
-   make
-   sudo make install
-   sudo ldconfig /usr/local/lib/
    ```
 
-3. Start the agent with settings for connecting to the uXRCE-DDS client running on the simulator:
+   :::
+
+   ::: tab humble
 
    ```sh
+   cd ~/ros2_px4_ws/src/
+   git clone -b v2.4.2 https://github.com/eProsima/Micro-XRCE-DDS-Agent.git
+   ```
+
+   :::
+
+   ::::
+
+3. Now re-build the ROS 2 workspace
+
+   ```sh
+   cd ~/ros2_px4_ws
+   source install/setup.bash
+   colcon build
+   ```
+
+4. Start the agent with settings for connecting to the uXRCE-DDS client running on the simulator:
+
+   ```sh
+   source ~/ros2_px4_ws/install/setup.bash
    MicroXRCEAgent udp4 -p 8888
    ```
 
@@ -298,27 +377,17 @@ To start the simulator (and client):
 The default Zenoh daemon address for the `px4_sitl_zenoh` target is `localhost`, so no further network configuration is needed for simulation.
 See [Zenoh > Configure Zenoh Network](../middleware/zenoh.md#configure-zenoh-network) if you need to connect to a router at a different address (such as on real hardware).
 
-Once the client and router are connected, you can inspect the available topics using standard ROS 2 CLI tools, e.g. `ros2 topic list`.
+Once the client and router are connected, you can inspect the available topics using standard ROS 2 CLI tools, e.g. `ros2 topic list`, just make sure you ran `export RMW_IMPLEMENTATION=rmw_zenoh_cpp` in your terminal.
 
-### Build ROS 2 Workspace
+### Running an example (optional)
 
-This section shows how to create a ROS 2 workspace hosted in your home directory (modify the commands as needed to put the source code elsewhere).
+This optional section shows how to create a new ROS 2 workspace that:
 
-The [px4_ros_com](https://github.com/PX4/px4_ros_com) and [px4_msgs](https://github.com/PX4/px4_msgs) packages are cloned to a workspace folder, and then the `colcon` tool is used to build the workspace.
-The example is run using `ros2 launch`.
+- extends the one made in [Setup ROS 2 workspace](#setup-ros-2-workspace),
+- clones the [px4_ros_com](https://github.com/PX4/px4_ros_com) package into it and
+- launch the `sensor_combined_listener.launch.py` roslaunch file.
 
-You should use a version of the px4*msgs package with the \_same* message definitions as the PX4 firmware you have installed in the step above.
-Branches in the px4_msgs repo are named to correspond to the message definitions for different PX4 releases.
-If for any reason you cannot ensure the same message definitions between your PX4 firmware and ROS 2 px4_msgs package, you will additionally need to [start the message translation node](#optional-starting-the-translation-node) as part of your setup process.
-
-::: info
-The example builds the [ROS 2 Listener](#ros-2-listener) example application, located in [px4_ros_com](https://github.com/PX4/px4_ros_com).
-[px4_msgs](https://github.com/PX4/px4_msgs) is needed too so that the example can interpret PX4 ROS 2 topics.
-:::
-
-#### Building the Workspace
-
-To create and build the workspace:
+To create and build the new workspace:
 
 1. Open a new terminal.
 2. Create and navigate into a new workspace directory using:
@@ -326,52 +395,20 @@ To create and build the workspace:
    ```sh
    mkdir -p ~/ws_sensor_combined/src/
    cd ~/ws_sensor_combined/src/
-   ```
 
-   ::: info
-   A naming convention for workspace folders can make it easier to manage workspaces.
-   :::
-
-3. Clone the example repository and [px4_msgs](https://github.com/PX4/px4_msgs) to the `/src` directory (the `main` branch is cloned by default, which corresponds to the version of PX4 we are running):
+3. Clone the example repository to the `src` directory:
 
    ```sh
-   git clone https://github.com/PX4/px4_msgs.git
    git clone https://github.com/PX4/px4_ros_com.git
    ```
 
-4. Source the ROS 2 development environment into the current terminal and compile the workspace using `colcon`:
-
-   :::: tabs
-
-   ::: tab jazzy
+4. Source the previously built ROS 2 PX4 development environment into the current terminal and compile the workspace using `colcon`:
 
    ```sh
    cd ..
-   source /opt/ros/jazzy/setup.bash
+   source ~/ros2_px4_ws/install/setup.bash
    colcon build
    ```
-
-   :::
-
-   ::: tab humble
-
-   ```sh
-   cd ..
-   source /opt/ros/humble/setup.bash
-   colcon build
-   ```
-
-   :::
-
-   ::::
-
-   This builds all the folders under `/src` using the sourced toolchain.
-
-#### Running the Example
-
-To run the executables that you just built, you need to source `local_setup.bash`.
-This provides access to the "environment hooks" for the current workspace.
-In other words, it makes the executables that were just built available in the current terminal.
 
 ::: info
 The [ROS2 beginner tutorials](https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html#source-the-overlay) recommend that you _open a new terminal_ for running your executables.
@@ -379,34 +416,17 @@ The [ROS2 beginner tutorials](https://docs.ros.org/en/humble/Tutorials/Beginner-
 
 In a new terminal:
 
-1. Navigate into the top level of your workspace directory and source the ROS 2 environment (in this case "Jazzy"):
-
-   :::: tabs
-
-   ::: tab jazzy
+1. Navigate into the top level of your workspace directory and source the ROS 2 environment:
 
    ```sh
    cd ~/ws_sensor_combined/
-   source /opt/ros/jazzy/setup.bash
+   source ~/ws_sensor_combined/install/setup.bash
    ```
 
-   :::
-
-   ::: tab humble
+2. If using `zenoh` change the ROS 2 middleware to zenoh:
 
    ```sh
-   cd ~/ws_sensor_combined/
-   source /opt/ros/humble/setup.bash
-   ```
-
-   :::
-
-   ::::
-
-2. Source the `local_setup.bash`.
-
-   ```sh
-   source install/local_setup.bash
+   export RMW_IMPLEMENTATION=rmw_zenoh_cpp
    ```
 
 3. Now launch the example.


### PR DESCRIPTION
This PR reorders the Installation and Setup section of the ROS 2 user guide page, the new order has:

1. PX4 SILT setup (unchanged)
2. ROS 2 base setup (unchanged)
3. **ROS 2 workspace setup**: this has been moved up and now it only consists in creating a new ROS 2 workspace, cloning PX4 msgs into it and building the workspace. The idea is to have a minimal ROS 2 + PX4 dependencies workspace that is build just once and that the user can use as a base layer for ther ROS 2 application worspaces.
4. Setup middleware.
   - In setup middleware the uXRCE-DDS Agent is now build inside the ROS 2 workspace created above instead of being built standalone. This reduces build time
   - For zenoh middleware, more notes about needing to use `export RMW_IMPLEMENTATION=rmw_zenoh_cpp` are added.
5. **Running an example (optional)**: This replaces the old _Build ROS 2 Workspace_. The new workpace extends the one created in step 2.