### PR TITLE
fix(commander): fix gnss redudancy checks

### DIFF
--- a/docs/en/advanced_config/parameter_reference.md
+++ b/docs/en/advanced_config/parameter_reference.md
@@ -44790,9 +44790,9 @@ Control if and how many GNSS receivers are required.
 0: No minimum receiver count required. Position divergence between two receivers
 and loss of a GNSS receiver still produce a warning but never trigger the
 COM_GNSSLOSS_ACT failsafe action.
-1-N: Require the presence of N GNSS receivers for arming and during flight.
+1-N: Require the presence of N GNSS receivers for arming.
 If the active count drops below this value in flight, COM_GNSSLOSS_ACT is triggered.
-When set to 2, position divergence between the two receivers also triggers COM_GNSSLOSS_ACT.
+When set to 2, position divergence between the two receivers also blocks arming when not armed and triggers COM_GNSSLOSS_ACT in flight.
 
 | Reboot | minValue | maxValue | increment | default | unit | Read-Only |
 | ------ | -------- | -------- | --------- | ------- | ---- | --------- |

--- a/docs/en/config/safety.md
+++ b/docs/en/config/safety.md
@@ -283,8 +283,8 @@ Loss of a single GPS when none are required is handled by other GPS health check
 
 | Parameter                                                                                                   | Description                                                                                                               |
 | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| <a id="SYS_HAS_NUM_GNSS"></a>[SYS_HAS_NUM_GNSS](../advanced_config/parameter_reference.md#SYS_HAS_NUM_GNSS) | Number of usable GNSS receivers required for arming and flight. If two are required then they also need to be consistent. |
-| <a id="COM_GNSSLOSS_ACT"></a>[COM_GNSSLOSS_ACT](../advanced_config/parameter_reference.md#COM_GNSSLOSS_ACT) | Failsafe action when a GNSS failure is detected. Actions other than a warning also lead to arming being blocked.          |
+| <a id="SYS_HAS_NUM_GNSS"></a>[SYS_HAS_NUM_GNSS](../advanced_config/parameter_reference.md#SYS_HAS_NUM_GNSS) | Number of usable GNSS receivers required for arming. If two are required then they also need to be consistent.|
+| <a id="COM_GNSSLOSS_ACT"></a>[COM_GNSSLOSS_ACT](../advanced_config/parameter_reference.md#COM_GNSSLOSS_ACT) | Failsafe action when a GNSS failure is detected in flight.           |
 
 ## Offboard Loss Failsafe
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/gnssRedundancyCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/gnssRedundancyCheck.cpp
@@ -105,7 +105,7 @@ void GnssRedundancyChecks::checkAndReport(const Context &context, Report &report
 	reporter.failsafeFlags().gnss_lost = below_required || divergence_triggers_failsafe;
 
 	if (below_required || dropped_below_peak) {
-		const bool block_arming = below_required && act_configured;
+		const bool block_arming = below_required  && (act_configured || !context.isArmed());
 		const NavModes nav_modes = block_arming ? NavModes::All : NavModes::None;
 		const events::Log log_level = block_arming ? events::Log::Error : events::Log::Warning;
 		const int expected = below_required ? _param_sys_has_num_gnss.get() : _peak_fixed_count;
@@ -139,7 +139,7 @@ void GnssRedundancyChecks::checkAndReport(const Context &context, Report &report
 	}
 
 	if (_divergence_hysteresis.get_state()) {
-		const bool block_arming = divergence_triggers_failsafe && act_configured;
+		const bool block_arming = divergence_triggers_failsafe && (act_configured || !context.isArmed());
 		const NavModes nav_modes = block_arming ? NavModes::All : NavModes::None;
 		const events::Log log_level = block_arming ? events::Log::Error : events::Log::Warning;
 


### PR DESCRIPTION
## Background
PX4 has many failsafe modes, the two of interest for this issue are the GNSS loss and position loss failsafe.

- GNSS loss is triggered when gnss count drops below `SYS_HAS_NUM_GNSS` and the action taken depends on `COM_GNSSLOSS_ACT` 
- position loss failsafe is triggered when ["the quality of the PX4 position estimate falls below acceptable levels (this might be caused by GPS loss)](https://docs.px4.io/v1.18/en/config/safety#position-estimation-failsafes)".

PX4 also performs many preflight checks to prevent arming in case of a problem. The one that interests us here is the gnss preflight check.
- GNSS preflight check verifies that there are no less than `SYS_HAS_NUM_GNSS` GNSS connected to the board. If it does not and `COM_GNSSLOSS_ACT` is > "warn", then prevent arming.
 
## Issue
The main issue is that the GNSS loss failsafe and the preflight gnss checks are coupled, whereas they should probably not be. If you want to say you have 2 GNSS to prevent arming without one of them, you have to also force the drone to either "Return", "Land", or "Terminate", when one of the GNSS is lost in flight.

## Proposed Solution
Prevent arming if the system has less than `SYS_HAS_NUM_GNSS` connected, regardless of `COM_GNSSLOSS_ACT` 
In flight, if the system has less than `SYS_HAS_NUM_GNSS`  connected, react according to `COM_GNSSLOSS_ACT` 

The proposed solution is aimed at solving the bug with the minimal amount of code change. In this case it would just be the following change : 
In the file gnssRedundancyCheck: 

```
-  const bool block_arming = below_required && act_configured;
+  const bool block_arming = below_required  && (act_configured || !context.isArmed());

-  const bool block_arming = divergence_triggers_failsafe && act_configured;
+  const bool block_arming = divergence_triggers_failsafe && (act_configured || !context.isArmed());
```

### PS : this is my first PR, feedback is deeply appreciated :) 

(Moved this issue from the wrongly used Mavlink repo)