### PR TITLE
docs(ros2): global rename of "ROS2" into "ROS 2"

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -936,7 +936,7 @@
     - [Continuous Integration](test_and_ci/continous_integration.md)
     - [Integration Testing](test_and_ci/integration_testing.md)
       - [MAVSDK Integration Testing](test_and_ci/integration_testing_mavsdk.md)
-      - [PX4 ROS2 Interface Library Integration Testing](test_and_ci/integration_testing_px4_ros2_interface.md)
+      - [PX4 ROS 2 Interface Library Integration Testing](test_and_ci/integration_testing_px4_ros2_interface.md)
     - [Docker Containers](test_and_ci/docker.md)
     - [Maintenance](test_and_ci/maintenance.md)
 - [Drone Apps & APIs](robotics/index.md)

--- a/docs/en/_sidebar.md
+++ b/docs/en/_sidebar.md
@@ -938,7 +938,7 @@
     - [Continuous Integration](/test_and_ci/continous_integration.md)
     - [Integration Testing](/test_and_ci/integration_testing.md)
       - [MAVSDK Integration Testing](/test_and_ci/integration_testing_mavsdk.md)
-      - [PX4 ROS2 Interface Library Integration Testing](/test_and_ci/integration_testing_px4_ros2_interface.md)
+      - [PX4 ROS 2 Interface Library Integration Testing](/test_and_ci/integration_testing_px4_ros2_interface.md)
     - [Docker Containers](/test_and_ci/docker.md)
     - [Maintenance](/test_and_ci/maintenance.md)
 - [Drone Apps & APIs](/robotics/index.md)

--- a/docs/en/companion_computer/holybro_pixhawk_jetson_baseboard.md
+++ b/docs/en/companion_computer/holybro_pixhawk_jetson_baseboard.md
@@ -1172,7 +1172,7 @@ INFO  [uxrce_dds_client] init serial /dev/ttyS4 @ 921600 baud
 
 ### XRCE-DDS Agent & ROS 2 Setup
 
-Follow the instruction in the ROS2 User guide to [Install ROS 2](../ros2/user_guide.md#install-ros-2) on the Jetson.
+Follow the instruction in the ROS 2 User guide to [Install ROS 2](../ros2/user_guide.md#install-ros-2) on the Jetson.
 You don't have to install PX4 on the Jetson because we're not using the simulator, but you may wish to install the full desktop so you can use additional ROS 2 packages for further development:
 
 ```sh
@@ -1293,11 +1293,11 @@ Jul 30 01:37:52 ubuntu MicroXRCEAgent[1616]: [1722317872.098168] info    | Proxy
 Jul 30 01:37:52 ubuntu MicroXRCEAgent[1616]: [1722317872.098486] info    | ProxyClient.cpp   | create_datawriter       | datawriter created   | client_key: 0x00000001, datawriter_id: 0x10A(5), publisher_id: 0x10A(3)
 ```
 
-You can now start your ROS2 nodes and continue the development.
+You can now start your ROS 2 nodes and continue the development.
 
 ### ROS 2 Sensor Combined Tests
 
-You can test the Client and agent by using the `sensor_combined` example in [Running an example (optional)](../ros2/user_guide.md#running-an-example-optional) (ROS2 User Guide).
+You can test the Client and agent by using the `sensor_combined` example in [Running an example (optional)](../ros2/user_guide.md#running-an-example-optional) (ROS 2 User Guide).
 
 ::: tip
 [VSCode over SSH](https://code.visualstudio.com/docs/remote/ssh) enables faster development and application of changes to your ROS 2 code!

--- a/docs/en/companion_computer/pixhawk_rpi.md
+++ b/docs/en/companion_computer/pixhawk_rpi.md
@@ -235,7 +235,7 @@ MAVProxy on RPi should now connect to the Pixhawk, via RX/TX pins.
 You should be able to see this in the RPi terminal.
 
 We have now verified that our connection is wired up properly.
-In the next section we'll set up the both Pixhawk and RPi to use uXRCE-DDS and ROS2 instead of MAVLink.
+In the next section we'll set up the both Pixhawk and RPi to use uXRCE-DDS and ROS 2 instead of MAVLink.
 
 ## ROS 2 and uXRCE-DDS
 
@@ -260,7 +260,7 @@ The configuration steps are:
    ```
 
    [MAV_1_CONFIG=0](../advanced_config/parameter_reference.md#MAV_1_CONFIG) and [UXRCE_DDS_CFG=102](../advanced_config/parameter_reference.md#UXRCE_DDS_CFG) disable MAVLink on TELEM2 and enable the uXRCE-DDS client on TELEM2, respectively.
-   The `SER_TEL2_BAUD` rate sets the comms link data rate.  
+   The `SER_TEL2_BAUD` rate sets the comms link data rate.
    You could similarly configure a connection to `TELEM1` using either `MAV_1_CONFIG` or `MAV_0_CONFIG`.
 
    ::: info

--- a/docs/en/computer_vision/collision_prevention.md
+++ b/docs/en/computer_vision/collision_prevention.md
@@ -321,7 +321,7 @@ the quaternion `q` is only used if the `orientation` is set to `ROTATION_CUSTOM`
 
 #### Companion Computers
 
-Companion computers update the `obstacle_distance` topic using ROS2 or the [OBSTACLE_DISTANCE](https://mavlink.io/en/messages/common.html#OBSTACLE_DISTANCE) MAVLink message.
+Companion computers update the `obstacle_distance` topic using ROS 2 or the [OBSTACLE_DISTANCE](https://mavlink.io/en/messages/common.html#OBSTACLE_DISTANCE) MAVLink message.
 
 <!-- to edit the image, open it in inkscape -->
 <!-- Code to generate the scalefactor plot

--- a/docs/en/concept/flight_modes.md
+++ b/docs/en/concept/flight_modes.md
@@ -4,7 +4,7 @@ Modes ("flight modes", "drive modes", and so on) are special operational states 
 They are loosely grouped into _manual_, _assisted_ and _auto_ modes, based on the level/type of control provided by the autopilot.
 The pilot transitions between flight modes using switches on the remote control or with a ground control station.
 
-Modes can be implemented as [PX4 internal modes](#px4-internal-modes) running on the flight controller, or as [PX4 external (ROS2) modes](#px4-external-modes) running on a companion computer.
+Modes can be implemented as [PX4 internal modes](#px4-internal-modes) running on the flight controller, or as [PX4 external (ROS 2) modes](#px4-external-modes) running on a companion computer.
 From the perspective of a ground station (MAVLink), the origin of a mode is indistinguishable.
 
 This topic links to documentation for the supported modes, compares PX4 internal and external modes, provides implementation hints, and provides links to how PX4 modes can be used with MAVLink.
@@ -108,7 +108,7 @@ The requirements for all modes are set in `getModeRequirements()` in [src/module
 When adding a new mode you will need to add appropriate requirements in that method.
 
 ::: tip
-Readers may note that this image is from [PX4 ROS2 Control Interface > Failsafes and mode requirements](../ros2/px4_ros2_control_interface.md#failsafes-and-mode-requirements).
+Readers may note that this image is from [PX4 ROS 2 Control Interface > Failsafes and mode requirements](../ros2/px4_ros2_control_interface.md#failsafes-and-mode-requirements).
 The requirements and concepts are the same (though defined in different places).
 The main difference is that ROS 2 modes _infer_ the correct requirements to use, while modes in PX4 source code must explicitly specify them.
 :::

--- a/docs/en/debug/plotting_realtime_uorb_data.md
+++ b/docs/en/debug/plotting_realtime_uorb_data.md
@@ -2,7 +2,7 @@
 
 This topic shows how you can graph the "live" values of [uORB topics](../msg_docs/index.md) (in real time) using [PlotJuggler](../log/flight_log_analysis.md#plotjuggler) and the _uXRCE-DDS Agent_.
 
-This technique uses PX4 [uXRCE-DDS](../middleware/uxrce_dds.md) middleware to export uORB topics as ROS2 topics, which can then be read and plotted by PlotJuggler as they change (PlotJuggler cannot directly read uORB topics, but the values of the corresponding ROS 2 topics are the same).
+This technique uses PX4 [uXRCE-DDS](../middleware/uxrce_dds.md) middleware to export uORB topics as ROS 2 topics, which can then be read and plotted by PlotJuggler as they change (PlotJuggler cannot directly read uORB topics, but the values of the corresponding ROS 2 topics are the same).
 
 The video below demonstrates this for a simulated vehicle — the approach works equally well on real hardware.
 
@@ -14,7 +14,7 @@ Follow the [ROS 2 Installation & Setup](../ros2/user_guide.md#installation-setup
 
 - ROS 2
 - [Micro XRCE-DDS Agent](../ros2/user_guide.md#setup-the-agent)
-- [PX4/px4_msgs](https://github.com/PX4/px4_msgs): PX4/ROS2 shared message definitions.
+- [PX4/px4_msgs](https://github.com/PX4/px4_msgs): PX4/ROS 2 shared message definitions.
 - PX4 source code and build the simulator.
 
   ::: tip
@@ -23,7 +23,7 @@ Follow the [ROS 2 Installation & Setup](../ros2/user_guide.md#installation-setup
 
 You will also need to install:
 
-- [PlotJuggler for ROS2](https://github.com/PlotJuggler/PlotJuggler)
+- [PlotJuggler for ROS 2](https://github.com/PlotJuggler/PlotJuggler)
 
   ::: tip
   Use the Debian packages (the snap files are not supported).
@@ -106,11 +106,11 @@ If working with real hardware you will need to build and [install](../config/fir
 
 ### Modified Messages
 
-If you have modified any uORB messages you must update the ROS2 messages used by PlotJuggler.
+If you have modified any uORB messages you must update the ROS 2 messages used by PlotJuggler.
 
 You will need to rebuild PX4 with your new messages, and replace the `px4_msgs` (from the repository) in your workspace with the new ones.
 
-Assuming that you have already built PX4 in the directory `~/PX4-Autopilot/`, and that `~/ros2_ws` is your ROS2 workspace, enter the following commands to copy the messages across and rebuild your workspace:
+Assuming that you have already built PX4 in the directory `~/PX4-Autopilot/`, and that `~/ros2_ws` is your ROS 2 workspace, enter the following commands to copy the messages across and rebuild your workspace:
 
 ```sh
 rm -f ~/ros2_ws/src/px4_msgs/msg/*.msg

--- a/docs/en/middleware/zenoh.md
+++ b/docs/en/middleware/zenoh.md
@@ -134,8 +134,8 @@ The PX4 Zenoh-pico node stores its configuration on the **SD card** under the `z
 This folder contains three key files:
 
 - **`net.txt`** – Defines the **Zenoh network configuration**.
-- **`pub.csv`** – Maps **uORB topics to ROS2 topics** (used for publishing).
-- **`sub.csv`** – Maps **ROS2 topics to uORB topics** (used for subscribing).
+- **`pub.csv`** – Maps **uORB topics to ROS 2 topics** (used for publishing).
+- **`sub.csv`** – Maps **ROS 2 topics to uORB topics** (used for subscribing).
 
 #### Publisher Options
 
@@ -154,7 +154,7 @@ Individual publisher options can be overridden through the mapping configuration
 
 ### 4. Modifying Topic Mappings
 
-Zenoh topic mappings define how data flows between PX4's internal uORB topics and external ROS2 topics via Zenoh.
+Zenoh topic mappings define how data flows between PX4's internal uORB topics and external ROS 2 topics via Zenoh.
 These mappings are stored in `pub.csv` and `sub.csv` on the SD card, and can be modified at runtime using the `zenoh config` CLI tool.
 
 :::warning

--- a/docs/en/releases/1.15.md
+++ b/docs/en/releases/1.15.md
@@ -159,7 +159,7 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 - **[[uXRCE-DDS](../middleware/uxrce_dds.md)]** [DDS Topics YAML](../middleware/uxrce_dds.md#dds-topics-yaml) now allows the use of `subscription_multi` to specify that indicated ROS 2 topics are sent to a separate uORB topic instance reserved for ROS 2 ([PX4-Autopilot#22266](https://github.com/PX4/PX4-Autopilot/pull/22266))
   - This allows PX4 to differentiate between updates from ROS and those from PX4 uORB publishers
-  - With this change ROS2 users can now decide if the messages that they are sending to PX4 will overlap with the existing uORB ones or be kept in separate instances.
+  - With this change ROS 2 users can now decide if the messages that they are sending to PX4 will overlap with the existing uORB ones or be kept in separate instances.
 - Move VOXL from microdds client to UXRCE-DDS client ([PX4-Autopilot#22997](https://github.com/PX4/PX4-Autopilot/pull/22997))
 - Add parameter to disable time synchronization between Agent and Client ([PX4-Autopilot#21757](https://github.com/PX4/PX4-Autopilot/pull/21757))
   - **[New Parameter]** `UXRCE_DDS_SYNCT`

--- a/docs/en/releases/1.16.md
+++ b/docs/en/releases/1.16.md
@@ -136,7 +136,7 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
   - [Faster than Real-time Simulation](../simulation/index.md#simulation_speed) ([PX4-Autopilot#24421](https://github.com/PX4/PX4-Autopilot/pull/24421), [PX4-Autopilot#23783](https://github.com/PX4/PX4-Autopilot/pull/23783))
   - [PX4-Autopilot#24471](https://github.com/PX4/PX4-Autopilot/pull/24471): Gazebo: Moving platform
 
-### uXRCE-DDS / ROS2
+### uXRCE-DDS / ROS 2
 
 - [PX4-Autopilot#24113](https://github.com/PX4/PX4-Autopilot/pull/24113): <Badge type="warning" text="Experimental"/> [ROS 2 Message Translation Node](../ros2/px4_ros2_msg_translation_node.md) to translate PX4 messages from one definition version to another dynamically
 - <Badge type="warning" text="Experimental"/>[PX4 ROS 2 Interface Library](../ros2/px4_ros2_control_interface.md) support for [ROS-based waypoint missions](../ros2/px4_ros2_waypoint_missions.md).

--- a/docs/en/releases/main.md
+++ b/docs/en/releases/main.md
@@ -84,7 +84,7 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 - TBD
 
-### uXRCE-DDS / Zenoh / ROS2
+### uXRCE-DDS / Zenoh / ROS 2
 
 - TBD
 

--- a/docs/en/ros2/index.md
+++ b/docs/en/ros2/index.md
@@ -40,7 +40,7 @@ The main topics in this section are:
 - [ROS 2 Offboard Control Example](../ros2/offboard_control.md): A C++ tutorial examples showing how to do position control in [offboard mode](../flight_modes/offboard.md) from a ROS 2 node.
 - [ROS 2 Multi Vehicle Simulation](../ros2/multi_vehicle.md): Instructions for connecting to multiple PX4 simulations via single ROS 2 agent.
 - [PX4 ROS 2 Interface Library](../ros2/px4_ros2_interface_lib.md): A C++ library that simplifies interacting with PX4 from ROS 2.
-  Can be used to create and register flight modes written using ROS2 and send position estimates from ROS2 applications such as a VIO system.
+  Can be used to create and register flight modes written using ROS 2 and send position estimates from ROS 2 applications such as a VIO system.
 - [ROS 2 Message Translation Node](../ros2/px4_ros2_msg_translation_node.md): A ROS 2 message translation node that enables communication between PX4 and ROS 2 applications that were compiled with different sets of messages versions.
 
 ## Further Information

--- a/docs/en/ros2/offboard_control.md
+++ b/docs/en/ros2/offboard_control.md
@@ -216,4 +216,4 @@ The param and command fields map to [MAVLink commands](https://mavlink.io/en/mes
 
 ## See Also
 
-- [Python ROS2 offboard examples with PX4](https://github.com/Jaeyoung-Lim/px4-offboard) (Jaeyoung-Lim/px4-offboard).
+- [Python ROS 2 offboard examples with PX4](https://github.com/Jaeyoung-Lim/px4-offboard) (Jaeyoung-Lim/px4-offboard).

--- a/docs/en/ros2/px4_ros2_control_interface.md
+++ b/docs/en/ros2/px4_ros2_control_interface.md
@@ -17,7 +17,7 @@ The [PX4 ROS 2 Interface Library](../ros2/px4_ros2_interface_lib.md) is a C++ li
 
 Developers use the library to create and dynamically register modes written using ROS 2.
 These modes are dynamically registered with PX4, and appear to be part of PX4 to a ground station or other external system.
-They can even replace the default modes in PX4 with enhanced ROS 2 versions, falling back to the original version if the ROS2 mode fails.
+They can even replace the default modes in PX4 with enhanced ROS 2 versions, falling back to the original version if the ROS 2 mode fails.
 
 The library also provides classes for sending different types of setpoints, ranging from high-level navigation tasks all the way down to direct actuator controls.
 These classes abstract the internal setpoints used by PX4, and that can therefore be used to provide a consistent ROS 2 interface for future PX4 and ROS releases.
@@ -35,7 +35,7 @@ You are welcome to add and contribute missing classes.
 
 This diagram provides a conceptual overview of how the control interface modes and mode executors interact with PX4.
 
-![ROS2 modes overview diagram](../../assets/middleware/ros2/px4_ros2_interface_lib/ros2_modes_overview.svg)
+![ROS 2 modes overview diagram](../../assets/middleware/ros2/px4_ros2_interface_lib/ros2_modes_overview.svg)
 
 <!-- Source: https://docs.google.com/drawings/d/1WByCfgcytnaow7r41VhYJL8OGrw1RjFO51GoPMQBCNA/edit -->
 

--- a/docs/en/ros2/px4_ros2_interface_lib.md
+++ b/docs/en/ros2/px4_ros2_interface_lib.md
@@ -53,4 +53,4 @@ To get started using the library within an existing ROS 2 workspace:
 When opening a pull request to PX4, CI runs the library integration tests.
 These test that mode registration, failsafes, and mode replacement, work as expected.
 
-For more information see [PX4 ROS2 Interface Library Integration Testing](../test_and_ci/integration_testing_px4_ros2_interface.md).
+For more information see [PX4 ROS 2 Interface Library Integration Testing](../test_and_ci/integration_testing_px4_ros2_interface.md).

--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -39,7 +39,7 @@ The generator uses the uORB message definitions in the source tree: [PX4-Autopil
 ROS 2 applications need to be built in a workspace that has the _same_ message definitions that were used to create the uXRCE-DDS client module in the PX4 Firmware.
 You can include these by cloning the interface package [PX4/px4_msgs](https://github.com/PX4/px4_msgs) into your ROS 2 workspace (branches in the repo correspond to the messages for different PX4 releases).
 
-Starting from PX4 v1.16, in which [message versioning](../middleware/uorb.md#message-versioning) was introduced, ROS2 applications may use a different version of message definitions than those used to build PX4.
+Starting from PX4 v1.16, in which [message versioning](../middleware/uorb.md#message-versioning) was introduced, ROS 2 applications may use a different version of message definitions than those used to build PX4.
 This requires the [ROS 2 Message Translation Node](../ros2/px4_ros2_msg_translation_node.md) to be running to ensure that messages can be converted and exchanged correctly.
 
 Note that the micro XRCE-DDS _agent_ itself has no dependency on client-side code.
@@ -413,7 +413,7 @@ To create and build the new workspace:
    ```
 
 ::: info
-The [ROS2 beginner tutorials](https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html#source-the-overlay) recommend that you _open a new terminal_ for running your executables.
+The [ROS 2 beginner tutorials](https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html#source-the-overlay) recommend that you _open a new terminal_ for running your executables.
 :::
 
 In a new terminal:
@@ -459,7 +459,7 @@ accelerometer_integral_dt: 4739
 
 <Badge type="tip" text="PX4 v1.16" /> <Badge type="warning" text="Experimental" />
 
-This example is built with PX4 and ROS2 versions that use the same message definitions.
+This example is built with PX4 and ROS 2 versions that use the same message definitions.
 If you were to use incompatible [message versions](../middleware/uorb.md#message-versioning) you would need to install and run the [Message Translation Node](./px4_ros2_msg_translation_node.md) as well, before running the example:
 
 1. Include the [Message Translation Node](../ros2/px4_ros2_msg_translation_node.md) into the example workspace or a separate workspace by running the following script:
@@ -560,22 +560,22 @@ When the uXRCE-DDS client runs on a flight controller and the agent runs on a co
 For Gazebo simulations the GZBridge sets the PX4 time on every sim step (see [Change simulation speed](../sim_gazebo_gz/index.md#change-simulation-speed)).
 Note that this is different from the [simulation lockstep](../sim_gazebo_classic/index.md#lockstep) procedure adopted with Gazebo Classic.
 
-ROS2 users have then two possibilities regarding the [time source](https://design.ros2.org/articles/clock_and_time.html) of their nodes.
+ROS 2 users have then two possibilities regarding the [time source](https://design.ros2.org/articles/clock_and_time.html) of their nodes.
 
-#### ROS2 nodes use the OS clock as time source
+#### ROS 2 nodes use the OS clock as time source
 
-This scenario, which is the one considered in this page and in the [offboard_control](./offboard_control.md) guide, is also the standard behaviour of the ROS2 nodes.
+This scenario, which is the one considered in this page and in the [offboard_control](./offboard_control.md) guide, is also the standard behaviour of the ROS 2 nodes.
 The OS clock acts as time source and therefore it can be used only when the simulation real time factor is very close to one.
-The time synchronizer of the uXRCE-DDS client then bridges the OS clock on the ROS2 side with the Gazebo clock on the PX4 side.
+The time synchronizer of the uXRCE-DDS client then bridges the OS clock on the ROS 2 side with the Gazebo clock on the PX4 side.
 No further action is required by the user.
 
-#### ROS2 nodes use the Gazebo clock as time source
+#### ROS 2 nodes use the Gazebo clock as time source
 
-In this scenario, ROS2 also uses the Gazebo `/clock` topic as time source.
-This approach makes sense if the Gazebo simulation is running with real time factor different from one, or if ROS2 needs to directly interact with Gazebo.
-On the ROS2 side, direct interaction with Gazebo is achieved by the [ros_gz_bridge](https://github.com/gazebosim/ros_gz) package of the [ros_gz](https://github.com/gazebosim/ros_gz) repository.
+In this scenario, ROS 2 also uses the Gazebo `/clock` topic as time source.
+This approach makes sense if the Gazebo simulation is running with real time factor different from one, or if ROS 2 needs to directly interact with Gazebo.
+On the ROS 2 side, direct interaction with Gazebo is achieved by the [ros_gz_bridge](https://github.com/gazebosim/ros_gz) package of the [ros_gz](https://github.com/gazebosim/ros_gz) repository.
 
-Use the following commands to install the correct ROS 2/gz interface packages (not just the bridge) for the ROS2 and Gazebo version(s) supported by PX4.
+Use the following commands to install the correct ROS 2/gz interface packages (not just the bridge) for the ROS 2 and Gazebo version(s) supported by PX4.
 
 :::: tabs
 
@@ -600,7 +600,7 @@ sudo apt install ros-humble-ros-gzharmonic
 ::::
 
 ::: info
-The [repo](https://github.com/gazebosim/ros_gz#readme) and [package](https://github.com/gazebosim/ros_gz/tree/ros2/ros_gz_bridge#readme) READMEs show the package versions that need to be installed depending on your ROS2 and Gazebo versions.
+The [repo](https://github.com/gazebosim/ros_gz#readme) and [package](https://github.com/gazebosim/ros_gz/tree/ros2/ros_gz_bridge#readme) READMEs show the package versions that need to be installed depending on your ROS 2 and Gazebo versions.
 :::
 
 Once the packages are installed and sourced, the node `parameter_bridge` provides the bridging capabilities and can be used to create an unidirectional `/clock` bridge:
@@ -609,10 +609,10 @@ Once the packages are installed and sourced, the node `parameter_bridge` provide
 ros2 run ros_gz_bridge parameter_bridge /clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock
 ```
 
-At this point, every ROS2 node must be instructed to use the newly bridged `/clock` topic as time source instead of the OS one, this is done by setting the parameter `use_sim_time` (of _each_ node) to `true` (see [ROS clock and Time design](https://design.ros2.org/articles/clock_and_time.html)).
+At this point, every ROS 2 node must be instructed to use the newly bridged `/clock` topic as time source instead of the OS one, this is done by setting the parameter `use_sim_time` (of _each_ node) to `true` (see [ROS clock and Time design](https://design.ros2.org/articles/clock_and_time.html)).
 
-This concludes the modifications required on the ROS2 side. On the PX4 side, you are only required to stop the uXRCE-DDS time synchronization, setting the parameter [UXRCE_DDS_SYNCT](../advanced_config/parameter_reference.md#UXRCE_DDS_SYNCT) to `false`.
-By doing so, Gazebo will act as main and only time source for both ROS2 and PX4.
+This concludes the modifications required on the ROS 2 side. On the PX4 side, you are only required to stop the uXRCE-DDS time synchronization, setting the parameter [UXRCE_DDS_SYNCT](../advanced_config/parameter_reference.md#UXRCE_DDS_SYNCT) to `false`.
+By doing so, Gazebo will act as main and only time source for both ROS 2 and PX4.
 
 ## ROS 2 Example Applications
 
@@ -770,9 +770,9 @@ int main(int argc, char *argv[])
 
 ### Offboard Control
 
-[ROS 2 Offboard control example](../ros2/offboard_control.md) provides a complete C++ reference example of how to use [offboard control](../flight_modes/offboard.md) of PX4 with ROS2.
+[ROS 2 Offboard control example](../ros2/offboard_control.md) provides a complete C++ reference example of how to use [offboard control](../flight_modes/offboard.md) of PX4 with ROS 2.
 
-[Python ROS2 offboard examples with PX4](https://github.com/Jaeyoung-Lim/px4-offboard) (Jaeyoung-Lim/px4-offboard) provides a similar example for Python, and includes the scripts:
+[Python ROS 2 offboard examples with PX4](https://github.com/Jaeyoung-Lim/px4-offboard) (Jaeyoung-Lim/px4-offboard) provides a similar example for Python, and includes the scripts:
 
 - `offboard_control.py`: Example of offboard position control using position setpoints
 - `visualizer.py`: Used for visualizing vehicle states in Rviz
@@ -902,7 +902,7 @@ A complete _offboard control_ example using the VehicleCommand service is provid
 
 The example closely follows the _offboard control_ example described in [ROS 2 Offboard Control Example](../ros2/offboard_control.md) but uses the `VehicleCommand` service to request mode changes, vehicle arming and vehicle disarming.
 
-First the ROS 2 application declares a service client of type `px4_msgs::srv::VehicleCommand` using `rclcpp::Client()` as shown (this is the same approach used for all ROS2 service clients):
+First the ROS 2 application declares a service client of type `px4_msgs::srv::VehicleCommand` using `rclcpp::Client()` as shown (this is the same approach used for all ROS 2 service clients):
 
 ```cpp
 rclcpp::Client<px4_msgs::srv::VehicleCommand>::SharedPtr vehicle_command_client_;
@@ -1099,10 +1099,10 @@ If any are missing, they can be added separately:
 
 ### ros_gz_bridge not publishing on the \clock topic
 
-If your [ROS2 nodes use the Gazebo clock as time source](../ros2/user_guide.md#ros2-nodes-use-the-gazebo-clock-as-time-source) but the `ros_gz_bridge` node doesn't publish anything on the `/clock` topic, you may have the wrong version installed.
+If your [ROS 2 nodes use the Gazebo clock as time source](../ros2/user_guide.md#ros2-nodes-use-the-gazebo-clock-as-time-source) but the `ros_gz_bridge` node doesn't publish anything on the `/clock` topic, you may have the wrong version installed.
 This might happen if you install ROS 2 Humble with the default "Ignition Fortress" packages, rather than using those for PX4, which uses "Gazebo Harmonic".
 
-The following commands uninstall the default Ignition Fortress topics and install the correct bridge and other interface topics for **Gazebo Harmonic** with ROS2 **Humble**:
+The following commands uninstall the default Ignition Fortress topics and install the correct bridge and other interface topics for **Gazebo Harmonic** with ROS 2 **Humble**:
 
 ```bash
 # Remove the wrong version (for Ignition Fortress)

--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -197,7 +197,7 @@ To create and build the workspace:
 
    ```sh
    git clone https://github.com/PX4/px4_msgs.git
-   
+
 
 4. Source the ROS 2 development environment into the current terminal and compile the workspace using `colcon`:
 
@@ -1099,7 +1099,7 @@ If any are missing, they can be added separately:
 
 ### ros_gz_bridge not publishing on the \clock topic
 
-If your [ROS 2 nodes use the Gazebo clock as time source](../ros2/user_guide.md#ros2-nodes-use-the-gazebo-clock-as-time-source) but the `ros_gz_bridge` node doesn't publish anything on the `/clock` topic, you may have the wrong version installed.
+If your [ROS 2 nodes use the Gazebo clock as time source](../ros2/user_guide.md#ros-2-nodes-use-the-gazebo-clock-as-time-source) but the `ros_gz_bridge` node doesn't publish anything on the `/clock` topic, you may have the wrong version installed.
 This might happen if you install ROS 2 Humble with the default "Ignition Fortress" packages, rather than using those for PX4, which uses "Gazebo Harmonic".
 
 The following commands uninstall the default Ignition Fortress topics and install the correct bridge and other interface topics for **Gazebo Harmonic** with ROS 2 **Humble**:

--- a/docs/en/test_and_ci/index.md
+++ b/docs/en/test_and_ci/index.md
@@ -12,6 +12,6 @@ Test topics include:
 - [Continuous Integration (CI)](../test_and_ci/continous_integration.md)
 - [Integration Testing](../test_and_ci/integration_testing.md)
   - [MAVSDK Integration Testing](../test_and_ci/integration_testing_mavsdk.md)
-  - [PX4 ROS2 Interface Library Integration Testing](../test_and_ci/integration_testing_px4_ros2_interface.md)
+  - [PX4 ROS 2 Interface Library Integration Testing](../test_and_ci/integration_testing_px4_ros2_interface.md)
 - [Docker](../test_and_ci/docker.md)
 - [Maintenance](../test_and_ci/maintenance.md)

--- a/docs/en/test_and_ci/integration_testing.md
+++ b/docs/en/test_and_ci/integration_testing.md
@@ -6,4 +6,4 @@ The tests are run in [Continuous Integration (CI)](../test_and_ci/continous_inte
 
 - [MAVSDK Integration Testing](../test_and_ci/integration_testing_mavsdk.md) - MAVSDK-based test framework for PX4.
   _This is the recommended framework for writing new Integration tests_
-- [PX4 ROS2 Interface Library Integration Testing](../test_and_ci/integration_testing_px4_ros2_interface.md) - Integration Tests for the [PX4 ROS 2 Interface Library](../ros2/px4_ros2_interface_lib.md).
+- [PX4 ROS 2 Interface Library Integration Testing](../test_and_ci/integration_testing_px4_ros2_interface.md) - Integration Tests for the [PX4 ROS 2 Interface Library](../ros2/px4_ros2_interface_lib.md).


### PR DESCRIPTION
This PR replaces all occurrences in the docs of "ROS2" into "ROS 2" to comply with the official ROS 2 naming convention (https://www.ros.org/imgs/ROSBrandGuide.pdf, https://robotics.stackexchange.com/a/102502)