### PR TITLE
fix(macos.sh): replace discoteq/discoteq/flock since there's homebrew/core/flock now

### DIFF
--- a/Tools/setup/macos.sh
+++ b/Tools/setup/macos.sh
@@ -49,16 +49,25 @@ then
 	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 fi
 
+# discoteq/discoteq used to be the only source of flock (required by the
+# NuttX apps archive step), but homebrew/core now carries the identical
+# formula (same upstream, same version). Drop the old tap so `flock`
+# resolves unambiguously from homebrew/core instead of erroring with
+# "installed from the discoteq/discoteq tap but you are trying to install
+# it from homebrew/core" on machines that still have it tapped.
+if brew tap | grep -q '^discoteq/discoteq$'; then
+	brew uninstall flock 2>/dev/null
+	brew untap discoteq/discoteq
+fi
+
 # Required taps. Homebrew 4.5+ no longer auto-resolves cross-tap
 # dependencies, so every tap that a package lives in must be added
 # explicitly here before `brew install`.
 #
 # - osx-cross/arm: arm-gcc-bin@13 (ARM cross-compiler)
 # - PX4/px4:       fastdds, genromfs, kconfig-frontends (PX4-specific)
-# - discoteq/discoteq: flock (required by NuttX apps archive step)
 brew tap osx-cross/arm
 brew tap PX4/px4
-brew tap discoteq/discoteq
 
 # Homebrew 6.0+ refuses to load formulae from third-party taps unless they
 # are explicitly trusted ("Refusing to load formula ... from untrusted tap").
@@ -69,7 +78,6 @@ brew tap discoteq/discoteq
 if brew trust --help &> /dev/null; then
 	brew trust osx-cross/arm
 	brew trust PX4/px4
-	brew trust discoteq/discoteq
 fi
 
 # Package list. This replaces the px4-dev meta-formula, which is kept


### PR DESCRIPTION
### Solved Problem
`Tools/setup/macos.sh` tapped `discoteq/discoteq` for `flock`, but `homebrew/core` now ships the identical formula. On a machine that already has the old tap (e.g. after `brew autoremove`), `brew install flock` errors with

> flock was installed from the discoteq/discoteq tap but you are trying to install it from homebrew/core

aborting the whole installation script.

### Solution
Drop the `discoteq/discoteq` tap/trust step. If it's still present, untap it and drop the old `flock` first, so `flock` resolves unambiguously from `homebrew/core`.

### Changelog Entry
```
fix(macos.sh): replace discoteq/discoteq/flock since there's homebrew/core/flock now
```

### Test coverage
Manually reproduced the failure on an up-to-date machine with the old `discoteq/discoteq` tap + `flock` installed, applied the fix, reran `Tools/setup/macos.sh`, and confirmed it untaps cleanly and installs everything including `flock` successfully.