### PR TITLE
fix(sihsim): restore and tune the airplane forward thruster of sihsim_airplane

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
@@ -16,13 +16,22 @@ param set-default SENS_EN_BAROSIM 1
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 1
 
-param set-default SIH_T_MAX 6
 param set-default SIH_MASS 0.3
 param set-default SIH_IXX 0.00402
 param set-default SIH_IYY 0.0144
 param set-default SIH_IZZ 0.0177
 param set-default SIH_IXZ 0.00046
 param set-default SIH_KDV 0.2
+
+# pusher propeller model with advance ratio, model from UIUC APC 8x6"
+param set-default SIH_F_CT0 0.131
+param set-default SIH_F_CT1 0.004
+param set-default SIH_F_CT2 -0.146
+param set-default SIH_F_CP0 0.0777
+param set-default SIH_F_CP1 0.0498
+param set-default SIH_F_CP2 -0.11
+param set-default SIH_F_DIA_INCH 8
+param set-default SIH_F_RPM_MAX 9000
 
 param set-default SIH_VEHICLE_TYPE 1 # sih as fixed wing
 param set-default RWTO_TKOFF 1 # enable takeoff from runway (as opposed to launched)

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
@@ -31,10 +31,15 @@ param set-default SIH_F_CP0 0.0777
 param set-default SIH_F_CP1 0.0498
 param set-default SIH_F_CP2 -0.11
 param set-default SIH_F_DIA_INCH 8
-param set-default SIH_F_RPM_MAX 9000
+param set-default SIH_F_RPM_MAX 13000
 
 param set-default SIH_VEHICLE_TYPE 1 # sih as fixed wing
 param set-default RWTO_TKOFF 1 # enable takeoff from runway (as opposed to launched)
+
+# 13000 RPM gives ~11 N of thrust at trim airspeed, which is a 30 deg climb at
+# trim and 20 m/s in level flight. Raise the climb rate so TECS
+# can command that climb (15 m/s * sin(30 deg) = 7.5 m/s)
+param set-default FW_T_CLMB_MAX 8
 
 param set-default CA_ROTOR_COUNT 1
 param set-default CA_ROTOR0_PX 0.3


### PR DESCRIPTION
## Summary

The SIH airplane could not take off: full throttle produced less than 6 m/s.
Adopt the advance-ratio propeller model for the forward thruster and give it
enough power to climb steeply and cruise at 20 m/s.

## Problem

`feat(sih): add propeller model with advance ratio` (3c5574c051) moved the
fixed-wing thrust onto the forward thruster model, which reads `SIH_F_*`
instead of `SIH_T_MAX`. `10043_sihsim_standard_vtol` was updated with the new
parameters, `10041_sihsim_airplane` was not: it kept setting the now unused
`SIH_T_MAX 6` and silently ran on the 2 N `SIH_F_T_MAX` default.

Restoring the original 6 N is not enough either. The model needs about 5.3 N
to hold trim airspeed level, so the old 9000 RPM propeller (4.6 N at trim)
could not sustain 15 m/s in the first place.

## Solution

Use the UIUC APC 8x6" propeller model, as `10043_sihsim_standard_vtol`
already does, at 13000 RPM for 11.3 N at trim airspeed. The step from the
nominal 9000 RPM is large because the thrust is fed to the tailplane and fin
as prop wash, so roughly three quarters of any added thrust returns as drag.

`FW_T_CLMB_MAX` goes to 8 m/s, since a 30 deg climb at trim airspeed needs
15 m/s * sin(30 deg) = 7.5 m/s.

Verified in SITL (`make px4_sitl`, `sihsim_airplane`): 19.7 m/s at full
throttle in near level flight, and a climb of over 30 deg when the pitch
limits are opened up. Unrelated and still open: once the takeoff completes
the vehicle descends in `AUTO_LOITER` despite a valid altitude setpoint.
