### PR TITLE
fix(uavcan): publish ArmingStatus when ESC output is enabled

### DIFF
--- a/docs/en/dronecan/escs.md
+++ b/docs/en/dronecan/escs.md
@@ -32,6 +32,9 @@ In addition to the general setup, such as setting `UAVCAN_ENABLE` to `3`:
 - Select the specific CAN interface(s) used for ESC data output using the [UAVCAN_ESC_IFACE](../advanced_config/parameter_reference.md#UAVCAN_ESC_IFACE) parameter (all that all interfaces are selected by default).
 - Configure the [motor order and servo outputs](../config/actuators.md).
 
+When ESC output is enabled, PX4 publishes [ArmingStatus](https://dronecan.github.io/Specification/7._List_of_standard_data_types/#armingstatus) (`STATUS_FULLY_ARMED` while armed or during QGC actuator tests).
+ESCs that require that message (for example ARK32 with `REQUIRE_ARMING`) work for both flight and the Actuators page without setting [UAVCAN_PUB_ARM](../advanced_config/parameter_reference.md#UAVCAN_PUB_ARM).
+
 ## Reversible Motors {#reversible-motors}
 
 <Badge type="tip" text="main (PX4 v2.0)" />

--- a/docs/en/dronecan/escs.md
+++ b/docs/en/dronecan/escs.md
@@ -33,7 +33,7 @@ In addition to the general setup, such as setting `UAVCAN_ENABLE` to `3`:
 - Configure the [motor order and servo outputs](../config/actuators.md).
 
 When ESC output is enabled, PX4 publishes [ArmingStatus](https://dronecan.github.io/Specification/7._List_of_standard_data_types/#armingstatus) (`STATUS_FULLY_ARMED` while armed or during QGC actuator tests).
-ESCs that require that message (for example ARK32 with `REQUIRE_ARMING`) work for both flight and the Actuators page without setting [UAVCAN_PUB_ARM](../advanced_config/parameter_reference.md#UAVCAN_PUB_ARM).
+ESCs that require that message work for both flight and the Actuators page without setting [UAVCAN_PUB_ARM](../advanced_config/parameter_reference.md#UAVCAN_PUB_ARM).
 
 ## Reversible Motors {#reversible-motors}
 

--- a/docs/en/dronecan/index.md
+++ b/docs/en/dronecan/index.md
@@ -146,6 +146,7 @@ For example, [SENS_FLOW_MINHGT](../advanced_config/parameter_reference.md#SENS_F
 
 For example, to use a connected DroneCAN smart battery you would enable the [UAVCAN_SUB_BAT](../advanced_config/parameter_reference.md#UAVCAN_SUB_BAT) parameter, which would subscribe PX4 to receive [BatteryInfo](https://dronecan.github.io/Specification/7._List_of_standard_data_types/#batteryinfo) DroneCAN messages.
 If using a peripheral that needs to know if PX4 is armed, you would need to set the [UAVCAN_PUB_ARM](../advanced_config/parameter_reference.md#UAVCAN_PUB_ARM) parameter so that PX4 starts publishing [ArmingStatus](https://dronecan.github.io/Specification/7._List_of_standard_data_types/#armingstatus) messages.
+ArmingStatus is published automatically when [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE) is `3` (ESC output).
 
 The parameter names are prefixed with `UAVCAN_SUB_` and `UAVCAN_PUB_` to indicate whether they enable PX4 subscribing or publishing.
 The remainder of the name indicates the specific message/feature being set.
@@ -275,6 +276,7 @@ If the rangefinder is connected via DroneCAN (whether inbuilt or separate), you 
 PX4 DroneCAN parameters:
 
 - [UAVCAN_PUB_ARM](../advanced_config/parameter_reference.md#UAVCAN_PUB_ARM) ([Arming Status](https://dronecan.github.io/Specification/7._List_of_standard_data_types/#armingstatus)): Publish when using DroneCAN components that require the PX4 arming status as a precondition for use.
+  Not required for DroneCAN ESCs: ArmingStatus is published automatically when [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE) is `3`.
 
 #### Grippers
 

--- a/src/drivers/uavcan/arming_status.cpp
+++ b/src/drivers/uavcan/arming_status.cpp
@@ -63,18 +63,20 @@ void UavcanArmingStatus::periodic_update(const uavcan::TimerEvent &)
 {
 	actuator_armed_s actuator_armed;
 
-	if (_actuator_armed_sub.update(&actuator_armed)) {
-		uavcan::equipment::safety::ArmingStatus cmd;
-
-		bool lockdown_active = actuator_armed.lockdown || actuator_armed.termination || actuator_armed.kill;
-
-		if (!lockdown_active && (actuator_armed.armed || _is_actuator_test_running)) {
-			cmd.status = cmd.STATUS_FULLY_ARMED;
-
-		} else {
-			cmd.status = cmd.STATUS_DISARMED;
-		}
-
-		(void)_arming_status_pub.broadcast(cmd);
+	if (!_actuator_armed_sub.copy(&actuator_armed)) {
+		return;
 	}
+
+	uavcan::equipment::safety::ArmingStatus cmd;
+
+	const bool lockdown_active = actuator_armed.lockdown || actuator_armed.termination || actuator_armed.kill;
+
+	if (!lockdown_active && (actuator_armed.armed || _is_actuator_test_running)) {
+		cmd.status = cmd.STATUS_FULLY_ARMED;
+
+	} else {
+		cmd.status = cmd.STATUS_DISARMED;
+	}
+
+	(void)_arming_status_pub.broadcast(cmd);
 }

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -509,7 +509,7 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 	(void)param_get(param_find("UAVCAN_ENABLE"), &uavcan_enable);
 #endif
 
-	// Publish ArmingStatus when ESC output is enabled. Many DroneCAN ESCs (e.g. ARK32)
+	// Publish ArmingStatus when ESC output is enabled. Many DroneCAN ESCs
 	// ignore RawCommand unless they see STATUS_FULLY_ARMED, including during actuator tests.
 	// UAVCAN_PUB_ARM still enables it for sensor-only buses.
 #if defined(CONFIG_UAVCAN_ARMING_CONTROLLER)

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -504,12 +504,19 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 
 	int ret;
 
-	// UAVCAN_PUB_ARM
+#if defined(CONFIG_UAVCAN_ARMING_CONTROLLER) || defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
+	int32_t uavcan_enable = 0;
+	(void)param_get(param_find("UAVCAN_ENABLE"), &uavcan_enable);
+#endif
+
+	// Publish ArmingStatus when ESC output is enabled. Many DroneCAN ESCs (e.g. ARK32)
+	// ignore RawCommand unless they see STATUS_FULLY_ARMED, including during actuator tests.
+	// UAVCAN_PUB_ARM still enables it for sensor-only buses.
 #if defined(CONFIG_UAVCAN_ARMING_CONTROLLER)
 	int32_t uavcan_pub_arm = 0;
-	param_get(param_find("UAVCAN_PUB_ARM"), &uavcan_pub_arm);
+	(void)param_get(param_find("UAVCAN_PUB_ARM"), &uavcan_pub_arm);
 
-	if (uavcan_pub_arm == 1) {
+	if (uavcan_pub_arm == 1 || uavcan_enable > 2) {
 		ret = _arming_status_controller.init();
 
 		if (ret < 0) {
@@ -530,8 +537,6 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 
 	// Actuators
 #if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
-	int32_t uavcan_enable = -1;
-	(void)param_get(param_find("UAVCAN_ENABLE"), &uavcan_enable);
 
 	if (uavcan_enable > 2) {
 
@@ -1002,7 +1007,7 @@ UavcanNode::Run()
 		}
 	}
 
-#if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER)
+#if defined(CONFIG_UAVCAN_OUTPUTS_CONTROLLER) && defined(CONFIG_UAVCAN_ARMING_CONTROLLER)
 	_arming_status_controller.setActuatorTestRunning(_mixing_interface_esc.isActuatorTestRunning());
 #endif
 

--- a/src/drivers/uavcan/uavcan_params.yaml
+++ b/src/drivers/uavcan/uavcan_params.yaml
@@ -125,6 +125,13 @@ parameters:
         long: |-
           Enable UAVCAN Arming Status stream publication
           uavcan::equipment::safety::ArmingStatus
+
+          Published automatically when UAVCAN_ENABLE is 3 (ESC output),
+          so DroneCAN ESCs that require ArmingStatus work for flight and
+          QGC actuator tests without extra setup.
+
+          Enable this to also publish ArmingStatus when ESC output is not used
+          (sensor-only buses with peripherals that need arming state).
       type: boolean
       default: 0
       reboot_required: true

--- a/src/drivers/uavcan/uavcan_params.yaml
+++ b/src/drivers/uavcan/uavcan_params.yaml
@@ -125,13 +125,6 @@ parameters:
         long: |-
           Enable UAVCAN Arming Status stream publication
           uavcan::equipment::safety::ArmingStatus
-
-          Published automatically when UAVCAN_ENABLE is 3 (ESC output),
-          so DroneCAN ESCs that require ArmingStatus work for flight and
-          QGC actuator tests without extra setup.
-
-          Enable this to also publish ArmingStatus when ESC output is not used
-          (sensor-only buses with peripherals that need arming state).
       type: boolean
       default: 0
       reboot_required: true


### PR DESCRIPTION
## Summary

Publish DroneCAN `ArmingStatus` automatically when ESC output is enabled so QGC actuator tests work on ESCs that require it, without setting `UAVCAN_PUB_ARM`.

## Problem

ARK32 and similar DroneCAN ESCs ignore `RawCommand` unless they see `STATUS_FULLY_ARMED`. PX4 only published `ArmingStatus` when `UAVCAN_PUB_ARM` was set, so the Actuators page sliders did nothing out of the box.

## Solution

Start the ArmingStatus publisher whenever `UAVCAN_ENABLE` is 3. `UAVCAN_PUB_ARM` remains for sensor-only buses. Broadcast at the 10 Hz arming-status rate from the latest `actuator_armed` so an actuator test is reported as fully armed immediately.

`make px4_fmu-v6x` and `make px4_sitl` succeed. Hardware actuator testing on ARK32 was not run as part of opening this PR.
