### PR TITLE
fix(mc_hover_estimator): prevent 0% hover thrust estimate

### DIFF
--- a/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.cpp
+++ b/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.cpp
@@ -39,8 +39,6 @@
 
 #include "MulticopterHoverThrustEstimator.hpp"
 
-#include <mathlib/mathlib.h>
-
 using namespace time_literals;
 
 ModuleBase::Descriptor MulticopterHoverThrustEstimator::desc{task_spawn, custom_command, print_usage};
@@ -89,10 +87,8 @@ void MulticopterHoverThrustEstimator::updateParams()
 
 	_hover_thrust_ekf.setAccelInnovGate(_param_hte_acc_gate.get());
 
-	_hover_thrust_ekf.setMinHoverThrust(math::constrain(_param_mpc_thr_hover.get() - _param_hte_thr_range.get(), 0.f,
-					    0.8f));
-	_hover_thrust_ekf.setMaxHoverThrust(math::constrain(_param_mpc_thr_hover.get() + _param_hte_thr_range.get(), 0.2f,
-					    0.9f));
+	_hover_thrust_ekf.setMinHoverThrust(_param_mpc_thr_hover.get() - _param_hte_thr_range.get());
+	_hover_thrust_ekf.setMaxHoverThrust(_param_mpc_thr_hover.get() + _param_hte_thr_range.get());
 }
 
 void MulticopterHoverThrustEstimator::Run()

--- a/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf.hpp
+++ b/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf.hpp
@@ -78,13 +78,13 @@ public:
 	void predict(float _dt);
 	void fuseAccZ(float acc_z, float thrust);
 
-	void setHoverThrust(float hover_thrust) { _hover_thr = math::constrain(hover_thrust, 0.1f, 0.9f); }
+	void setHoverThrust(float hover_thrust) { _hover_thr = math::constrain(hover_thrust, _hover_thr_min, _hover_thr_max); }
 	void setProcessNoiseStdDev(float process_noise) { _process_var = process_noise * process_noise; }
 	void setMeasurementNoiseScale(float scale) { _acc_var_scale = scale * scale; }
 	void setHoverThrustStdDev(float hover_thrust_noise) { _state_var = hover_thrust_noise * hover_thrust_noise; }
 	void setAccelInnovGate(float gate_size) { _gate_size = gate_size; }
-	void setMinHoverThrust(float hover_thrust_min) { _hover_thr_min = hover_thrust_min; }
-	void setMaxHoverThrust(float hover_thrust_max) { _hover_thr_max = hover_thrust_max; }
+	void setMinHoverThrust(float hover_thrust_min) { _hover_thr_min = math::constrain(hover_thrust_min, 0.1f, 0.8f); }
+	void setMaxHoverThrust(float hover_thrust_max) { _hover_thr_max = math::constrain(hover_thrust_max, 0.2f, 0.9f); }
 
 	float getHoverThrustEstimate() const { return _hover_thr; }
 	float getHoverThrustEstimateVar() const { return _state_var; }

--- a/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf_test.cpp
+++ b/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf_test.cpp
@@ -65,13 +65,13 @@ public:
 		      float thr_noise = 0.f);
 
 private:
-	ZeroOrderHoverThrustEkf _ekf{};
 	static constexpr float _dt = 0.02f;
 
 	std::normal_distribution<float> _standard_normal_distribution;
 	std::default_random_engine _random_generator; // Pseudo-random generator with constant seed
 
 protected:
+	ZeroOrderHoverThrustEkf _ekf{};
 	static constexpr float _accel_noise_var_min = 1.f; // Constrained in the implementation
 };
 
@@ -220,4 +220,39 @@ TEST_F(ZeroOrderHoverThrustEkfTest, testHoverThrustJump)
 	EXPECT_NEAR(status.hover_thrust_var, 0.f, 1e-3f);
 	// After a recovery, the noise variance estimate takes more time to converge back to the true value
 	EXPECT_NEAR(status.accel_noise_var, accel_var, 2.f * accel_var);
+}
+
+TEST_F(ZeroOrderHoverThrustEkfTest, testMinMaxHoverThrustClamping)
+{
+	// GIVEN: a min/max band requested outside the class's own absolute safe range
+	_ekf.setMinHoverThrust(-1.f);
+	_ekf.setMaxHoverThrust(2.f);
+
+	// WHEN: the hover thrust is (re-)initialized at either edge of [0, 1]
+	_ekf.setHoverThrust(0.f);
+
+	// THEN: the state is clamped to the absolute lower bound, never 0
+	EXPECT_GE(_ekf.getHoverThrustEstimate(), 0.1f);
+
+	_ekf.setHoverThrust(1.f);
+
+	// THEN: the state is clamped to the absolute upper bound
+	EXPECT_LE(_ekf.getHoverThrustEstimate(), 0.9f);
+}
+
+TEST_F(ZeroOrderHoverThrustEkfTest, testHoverThrustNeverReachesZero)
+{
+	// GIVEN: a low MPC_THR_HOVER with the default HTE_THR_RANGE, which used to collapse
+	// the estimator's minimum bound to 0 (division by hover thrust would then produce NaN/inf)
+	const float mpc_thr_hover = 0.1f;
+	const float hte_thr_range = 0.2f;
+	_ekf.setMinHoverThrust(mpc_thr_hover - hte_thr_range);
+	_ekf.setMaxHoverThrust(mpc_thr_hover + hte_thr_range);
+	_ekf.setHoverThrust(mpc_thr_hover);
+
+	// WHEN: the true hover thrust is below the achievable band, driving the estimate towards its floor
+	ZeroOrderHoverThrustEkfTest::Status status = runEkf(0.05f, 0.02f, 5.f);
+
+	// THEN: the estimate is pinned at the absolute floor instead of collapsing to (or past) 0
+	EXPECT_NEAR(status.hover_thrust, 0.1f, 1e-2f);
 }

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -192,7 +192,7 @@ public:
 
 private:
 	// The range limits of the hover thrust configuration/estimate
-	static constexpr float HOVER_THRUST_MIN = 0.05f;
+	static constexpr float HOVER_THRUST_MIN = 0.1f;
 	static constexpr float HOVER_THRUST_MAX = 0.9f;
 
 	bool _inputValid();

--- a/src/modules/mc_pos_control/multicopter_position_control_params.yaml
+++ b/src/modules/mc_pos_control/multicopter_position_control_params.yaml
@@ -14,7 +14,7 @@ parameters:
       default: 0.5
       unit: norm
       min: 0.1
-      max: 0.8
+      max: 0.9
       decimal: 2
       increment: 0.01
     MPC_THR_XY_MARG:

--- a/src/modules/mc_pos_control/multicopter_stabilized_mode_params.yaml
+++ b/src/modules/mc_pos_control/multicopter_stabilized_mode_params.yaml
@@ -34,7 +34,7 @@ parameters:
       default: 0.08
       unit: norm
       min: 0
-      max: 1
+      max: 0.5
       decimal: 2
       increment: 0.01
     MPC_THR_CURVE:


### PR DESCRIPTION
### Solved Problem
Hover thrust config `MPC_THR_HOVER` is at 20% (5:1 thrust to weight ratio) and limits are hence 20±20% which allows 0-40%.
This especially when land detection is not immediate leads to the hover thrust estimate decreasing further and further making land detection impossible at some point (related https://github.com/PX4/PX4-Autopilot/pull/28158).

### Solution
Disallow 0% for numerical reasons and disallow This leads to all kinds of issues 0% to numerical, close to 0 to logic e.g. land detection. This needs better dynamic limiting but a hard limit between 10 and 90% for the hover thrust make sense since >10:1 thust to weight ratio was not seen yet and we can adjust if someone has this use case.

### Changelog Entry
```
fix(mc_hover_estimator): prevent 0% hover thrust estimate
```

### Test coverage
**EDIT:** Added unit tests.