### PR TITLE
fix(uavcan): name the DroneCAN node after the board

### DIFF
--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -46,6 +46,7 @@
 #include <px4_platform_common/tasks.h>
 
 #include <inttypes.h>
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
@@ -496,7 +497,24 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 {
 	bus_events.registerSignalCallback(UavcanNode::busevent_signal_trampoline);
 
-	_node.setName("org.pixhawk.pixhawk");
+	// NodeInfo.name is reverse-domain, lowercase, 80 characters max; px4_board_name() is
+	// <VENDOR>_<MODEL> in upper snake case.
+	char node_name[81] {};
+	const char *board = px4_board_name();
+	const char *model = strchr(board, '_');
+
+	if (model != nullptr) {
+		snprintf(node_name, sizeof(node_name), "org.%.*s.%s", static_cast<int>(model - board), board, model + 1);
+
+	} else {
+		snprintf(node_name, sizeof(node_name), "org.%s", board);
+	}
+
+	for (char *c = node_name; *c != '\0'; c++) {
+		*c = (*c == '_') ? '-' : static_cast<char>(tolower(static_cast<unsigned char>(*c)));
+	}
+
+	_node.setName(node_name);
 
 	_node.setNodeID(node_id);
 


### PR DESCRIPTION
## Summary

DroneCAN `NodeInfo.name` now comes from `px4_board_name()`: `ARK_FMU_V6XRT` becomes `org.ark.fmu-v6xrt`, `PX4_FMU_V6X` becomes `org.px4.fmu-v6x`.

## Problem

Every FMU has advertised the hardcoded `org.pixhawk.pixhawk` since 2014, and `hwver.major`/`minor` are 0 on everything but FMUv2, so two autopilots on one bus are separable only by unique id. The cannodes already name themselves per board through `board_get_uavcan_hw_name()`.

## Solution

Split the vendor off `px4_board_name()` at the first underscore, lowercase, `_` to `-`. No new per-board files. Hardware version untouched — it wants a real per-board major/minor.

Anything matching on `org.pixhawk.pixhawk` stops matching; nothing in-tree does.

<img width="635" height="147" alt="image" src="https://github.com/user-attachments/assets/162394e9-2bba-49c3-98df-95b5f959936b" />
