### PR TITLE
[BACKPORT 1.18] fix(simulation): use automatic NVENC encoder selection for GStreamer

### DIFF
--- a/src/modules/simulation/gz_plugins/gstreamer/GstCameraSystem.cpp
+++ b/src/modules/simulation/gz_plugins/gstreamer/GstCameraSystem.cpp
@@ -352,7 +352,7 @@ void CameraStream::gstThreadFunc()
 	GstElement *encoder;
 
 	if (_useCuda) {
-		encoder = gst_element_factory_make("nvh264enc", nullptr);
+		encoder = gst_element_factory_make("nvautogpuh264enc", nullptr);
 
 		if (encoder) {
 			// Higher quality NVIDIA encoder settings


### PR DESCRIPTION
## Summary

Backport of #27944 to `release-1.18`. 

Fixes #27296 for the upcoming `1.18` release.
