### PR TITLE
fix(gz_bridge): create the missing-Gazebo fallback targets again

### DIFF
--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -137,22 +137,27 @@ if (gz-transport_FOUND)
 	configure_file(gz_env.sh.in ${PX4_BINARY_DIR}/rootfs/gz_env.sh @ONLY)
 
 else()
-	# Create fallback targets that provide helpful error messages when Gazebo dependencies are missing
+	# Create fallback targets that provide helpful error messages when Gazebo dependencies are missing.
+	# The worlds submodule (Tools/simulation/gz) is only initialized in the branch above, so the
+	# worlds glob can be empty here; the default-world targets must not depend on it.
+	file(GLOB gz_worlds ${PX4_SOURCE_DIR}/Tools/simulation/gz/worlds/*.sdf)
+	file(GLOB gz_airframes ${PX4_SOURCE_DIR}/ROMFS/px4fmu_common/init.d-posix/airframes/*_gz_*)
+
 	foreach(gz_airframe IN LISTS gz_airframes)
 		set(model_name)
 		string(REGEX REPLACE ".*_gz_" "" model_name ${gz_airframe})
 
+		add_custom_target(gz_${model_name}
+			COMMAND ${CMAKE_COMMAND} -E echo "ERROR: Gazebo simulation dependencies not found!"
+			COMMAND ${CMAKE_COMMAND} -E echo "  - For installation instructions, see: https://gazebosim.org/docs/harmonic/install_ubuntu/"
+			COMMAND ${CMAKE_COMMAND} -E false
+			VERBATIM
+		)
+
 		foreach(world ${gz_worlds})
 			get_filename_component("world_name" ${world} NAME_WE)
 
-			if(world_name STREQUAL "default")
-				add_custom_target(gz_${model_name}
-					COMMAND ${CMAKE_COMMAND} -E echo "ERROR: Gazebo simulation dependencies not found!"
-					COMMAND ${CMAKE_COMMAND} -E echo "  - For installation instructions, see: https://gazebosim.org/docs/harmonic/install_ubuntu/"
-					COMMAND ${CMAKE_COMMAND} -E false
-					VERBATIM
-				)
-			else()
+			if(NOT world_name STREQUAL "default")
 				add_custom_target(gz_${model_name}_${world_name}
 					COMMAND ${CMAKE_COMMAND} -E echo "ERROR: Gazebo simulation dependencies not found!"
 					COMMAND ${CMAKE_COMMAND} -E echo "  - For installation instructions, see: https://gazebosim.org/docs/harmonic/install_ubuntu/"


### PR DESCRIPTION
## Summary

fixes #28298

Restores the helpful "Gazebo simulation dependencies not found" error when a `gz_*` simulation target is built on a machine without Gazebo installed.

## Problem

The fallback error targets added in ff7c636065 (#24661) are generated from the `gz_airframes`/`gz_worlds` lists, but 05c5293596 moved both `file(GLOB ...)` calls into the `gz-transport_FOUND` branch (the worlds glob must run after the `Tools/simulation/gz` submodule is initialized there). The `else()` branch now loops over empty lists and creates no targets, so `make px4_sitl gz_x500` dies with `ninja: error: unknown target 'gz_x500'` — exactly the unhelpful error the fallback was added to prevent.

Hoisting the globs back above the `if` would not fix it: without gz-transport the worlds submodule is never initialized, so `gz_worlds` stays empty and even the default-world targets would still not be created — and on a fresh clone with Gazebo installed the worlds glob would again run before the submodule exists.

## Solution

Glob the lists in the `else()` branch as well, and create the default-world `gz_<model>` targets from the airframes list alone so they never depend on the submodule. World-suffixed `gz_<model>_<world>` targets are still created when the worlds directory is populated. The `gz-transport_FOUND` branch is unchanged.

Verified on macOS (arm64) without Gazebo: `make px4_sitl gz_x500` previously ended in `ninja: error: unknown target 'gz_x500'`, and now prints the intended error message. `ninja -t targets` lists 25 `gz_<model>` fallback targets without the worlds submodule and 350 including world variants with it, matching the real branch's naming one-for-one. A full `make px4_sitl` build passes. Not tested with Gazebo installed (no local install); that code path is byte-identical, so CI covers it.
