### PR TITLE
fix(mavlink): honor COMMAND_INT frame for altitude on global-frame commands

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -594,13 +594,13 @@ MavlinkReceiver::command_has_location(uint16_t command)
 }
 
 bool
-MavlinkReceiver::command_int_requires_global_frame(uint16_t command)
+MavlinkReceiver::command_int_requires_global_frame(const mavlink_command_int_t &cmd)
 {
 	// Commands whose consumers read param5/param6 as global lat/lon (deg) and param7 as altitude AMSL.
 	// Not the same set as command_has_location(): e.g. NAV_LAND lands at the current position,
-	// DO_SET_HOME with use_current=true must work before home exists, NAV_ROI/DO_SET_ROI have
-	// mode-dependent param7, and DO_SET_GLOBAL_ORIGIN defines the reference other frames need.
-	switch (command) {
+	// NAV_ROI/DO_SET_ROI have mode-dependent param7, and DO_SET_GLOBAL_ORIGIN defines the reference
+	// other frames need.
+	switch (cmd.command) {
 	case MAV_CMD_NAV_TAKEOFF:
 	case MAV_CMD_NAV_VTOL_TAKEOFF:
 	case MAV_CMD_DO_REPOSITION:
@@ -608,6 +608,12 @@ MavlinkReceiver::command_int_requires_global_frame(uint16_t command)
 	case MAV_CMD_DO_FIGURE_EIGHT:
 	case MAV_CMD_DO_SET_ROI_LOCATION:
 		return true;
+
+	case MAV_CMD_DO_SET_HOME:
+		// With use_current (param1) the location is ignored and the command must work before a
+		// home exists. With an explicit location the commander reads param5/6/7 as lat/lon/AMSL
+		// like the commands above. Same test of param1 as the commander's.
+		return !(cmd.param1 > 0.5f);
 
 	default:
 		return false;
@@ -675,7 +681,7 @@ MavlinkReceiver::handle_message_command_int(mavlink_message_t *msg)
 	vcmd.confirmation = false;
 	vcmd.from_external = true;
 
-	if (command_int_requires_global_frame(cmd_mavlink.command)) {
+	if (command_int_requires_global_frame(cmd_mavlink)) {
 		switch (cmd_mavlink.frame) {
 		case MAV_FRAME_GLOBAL:
 		case MAV_FRAME_GLOBAL_INT:
@@ -684,6 +690,9 @@ MavlinkReceiver::handle_message_command_int(mavlink_message_t *msg)
 
 		case MAV_FRAME_GLOBAL_RELATIVE_ALT:
 		case MAV_FRAME_GLOBAL_RELATIVE_ALT_INT:
+
+			// A NaN z means no altitude was given. The consumers keep their current altitude
+			// for NaN (reposition, orbit), so it is passed through untouched rather than converted.
 			if (PX4_ISFINITE(cmd_mavlink.z)) {
 				home_position_s home_position{};
 				_home_position_sub.copy(&home_position);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -593,6 +593,27 @@ MavlinkReceiver::command_has_location(uint16_t command)
 	}
 }
 
+bool
+MavlinkReceiver::command_int_requires_global_frame(uint16_t command)
+{
+	// Commands whose consumers read param5/param6 as global lat/lon (deg) and param7 as altitude AMSL.
+	// Not the same set as command_has_location(): e.g. NAV_LAND lands at the current position,
+	// DO_SET_HOME with use_current=true must work before home exists, NAV_ROI/DO_SET_ROI have
+	// mode-dependent param7, and DO_SET_GLOBAL_ORIGIN defines the reference other frames need.
+	switch (command) {
+	case MAV_CMD_NAV_TAKEOFF:
+	case MAV_CMD_NAV_VTOL_TAKEOFF:
+	case MAV_CMD_DO_REPOSITION:
+	case MAV_CMD_DO_ORBIT:
+	case MAV_CMD_DO_FIGURE_EIGHT:
+	case MAV_CMD_DO_SET_ROI_LOCATION:
+		return true;
+
+	default:
+		return false;
+	}
+}
+
 void
 MavlinkReceiver::handle_message_command_int(mavlink_message_t *msg)
 {
@@ -653,6 +674,49 @@ MavlinkReceiver::handle_message_command_int(mavlink_message_t *msg)
 	vcmd.source_component = msg->compid;
 	vcmd.confirmation = false;
 	vcmd.from_external = true;
+
+	if (command_int_requires_global_frame(cmd_mavlink.command)) {
+		switch (cmd_mavlink.frame) {
+		case MAV_FRAME_GLOBAL:
+		case MAV_FRAME_GLOBAL_INT:
+			// z is already altitude AMSL
+			break;
+
+		case MAV_FRAME_GLOBAL_RELATIVE_ALT:
+		case MAV_FRAME_GLOBAL_RELATIVE_ALT_INT:
+			if (PX4_ISFINITE(cmd_mavlink.z)) {
+				home_position_s home_position{};
+				_home_position_sub.copy(&home_position);
+
+				if (home_position.valid_alt) {
+					vcmd.param7 = home_position.alt + cmd_mavlink.z;
+
+				} else {
+					// home altitude required to convert to AMSL
+					if (evaluate_target_ok(cmd_mavlink.command, cmd_mavlink.target_system, cmd_mavlink.target_component)) {
+						acknowledge(msg->sysid, msg->compid, cmd_mavlink.command,
+							    vehicle_command_ack_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED);
+					}
+
+					return;
+				}
+			}
+
+			break;
+
+		default:
+
+			// Terrain frames need the terrain altitude at the target location (see DO_REPOSITION
+			// terrain tracking work), and local/mission/unknown frames would be misread as
+			// lat/lon/AMSL by the consumers of these commands: reject instead.
+			if (evaluate_target_ok(cmd_mavlink.command, cmd_mavlink.target_system, cmd_mavlink.target_component)) {
+				acknowledge(msg->sysid, msg->compid, cmd_mavlink.command,
+					    vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED_MAV_FRAME);
+			}
+
+			return;
+		}
+	}
 
 	handle_message_command_both(msg, vcmd);
 }

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -191,6 +191,7 @@ private:
 	void handle_message_command_int(mavlink_message_t *msg);
 	void handle_message_command_long(mavlink_message_t *msg);
 	bool command_has_location(uint16_t command);
+	bool command_int_requires_global_frame(uint16_t command);
 	void handle_message_distance_sensor(mavlink_message_t *msg);
 	void handle_message_follow_target(mavlink_message_t *msg);
 	void handle_message_generator_status(mavlink_message_t *msg);

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -191,7 +191,7 @@ private:
 	void handle_message_command_int(mavlink_message_t *msg);
 	void handle_message_command_long(mavlink_message_t *msg);
 	bool command_has_location(uint16_t command);
-	bool command_int_requires_global_frame(uint16_t command);
+	bool command_int_requires_global_frame(const mavlink_command_int_t &cmd);
 	void handle_message_distance_sensor(mavlink_message_t *msg);
 	void handle_message_follow_target(mavlink_message_t *msg);
 	void handle_message_generator_status(mavlink_message_t *msg);

--- a/test/test_mavlink_param_validation.py
+++ b/test/test_mavlink_param_validation.py
@@ -58,6 +58,7 @@ CMD_NAV_VTOL_LAND = 85
 CMD_NAV_DELAY = 93
 CMD_COMPONENT_ARM_DISARM = 400
 CMD_DO_SET_ROI_LOCATION = 195
+CMD_DO_SET_HOME = 179
 CMD_DO_SET_ROI_NONE = 197
 CMD_IMAGE_STOP_CAPTURE = 2001
 
@@ -524,8 +525,104 @@ def run_command_int_frame_tests(mav: Any, timeout: float) -> None:
         result, MAV_RESULT_UNSUPPORTED_MAV_FRAME,
     )
 
+    # 26. NaN altitude under a relative frame means no altitude was given.
+    # The receiver passes it through untouched instead of converting it.
+    result = _send_command_int(
+        mav, CMD_DO_SET_ROI_LOCATION, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
+        timeout, x=LAT, y=LON, z=float("nan"),
+    )
+    _check(
+        "ROI_LOCATION GLOBAL_RELATIVE_ALT_INT NaN z -> ACCEPTED",
+        result, MAV_RESULT_ACCEPTED,
+    )
+
     # Clear the ROI again (best effort).
     _send_command(mav, CMD_DO_SET_ROI_NONE, timeout)
+
+
+def _wait_home(mav: Any, timeout: float = 60.0) -> Any:
+    """Wait for a HOME_POSITION message and return it, or None."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        msg = mav.recv_match(type="HOME_POSITION", blocking=True, timeout=5.0)
+        if msg:
+            return msg
+    return None
+
+
+def _wait_home_altitude_change(
+    mav: Any, previous_alt_m: float, timeout: float = 30.0,
+) -> Optional[float]:
+    """Wait until HOME_POSITION reports an altitude at least 1 m away from
+    previous_alt_m; return the new altitude AMSL [m], or None."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        msg = mav.recv_match(type="HOME_POSITION", blocking=True, timeout=5.0)
+        if msg:
+            alt = float(msg.altitude) / 1e3
+            if abs(alt - previous_alt_m) >= 1.0:
+                return alt
+    return None
+
+
+def run_do_set_home_frame_tests(mav: Any, timeout: float) -> None:
+    print("\n=== COMMAND_INT frame tests (DO_SET_HOME) ===")
+
+    home = _wait_home(mav)
+    if home is None:
+        _check("HOME_POSITION available", None, "message")
+        return
+
+    lat = int(home.latitude)
+    lon = int(home.longitude)
+    alt = float(home.altitude) / 1e3
+    print(f"  home before: lat {lat} lon {lon} alt {alt:.1f} m AMSL")
+
+    # 27. Explicit location under a relative frame: z is converted with the
+    # home altitude, so the new home ends up 50 m above the old one, not at
+    # 50 m AMSL.
+    result = _send_command_int(
+        mav, CMD_DO_SET_HOME, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT, timeout,
+        p1=0.0, x=lat, y=lon, z=50.0,
+    )
+    _check(
+        "DO_SET_HOME explicit GLOBAL_RELATIVE_ALT_INT -> ACCEPTED",
+        result, MAV_RESULT_ACCEPTED,
+    )
+    new_alt = _wait_home_altitude_change(mav, alt)
+    print(f"  home after:  alt {new_alt} m AMSL")
+    _check(
+        "DO_SET_HOME relative z=50 -> home altitude raised by 50 m",
+        None if new_alt is None else round(new_alt - alt), 50,
+    )
+
+    # 28. Explicit location under a local frame: x/y would be metres and z
+    # a local down coordinate, the commander would read them as lat/lon/AMSL.
+    result = _send_command_int(
+        mav, CMD_DO_SET_HOME, MAV_FRAME_LOCAL_NED, timeout,
+        p1=0.0, x=100_000, y=100_000, z=10.0,
+    )
+    _check(
+        "DO_SET_HOME explicit LOCAL_NED -> UNSUPPORTED_MAV_FRAME",
+        result, MAV_RESULT_UNSUPPORTED_MAV_FRAME,
+    )
+
+    # 29. use_current ignores the location, so the frame must not matter and
+    # the command has to keep working as before.
+    result = _send_command_int(
+        mav, CMD_DO_SET_HOME, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT, timeout,
+        p1=1.0, x=0, y=0, z=0.0,
+    )
+    _check(
+        "DO_SET_HOME use_current GLOBAL_RELATIVE_ALT_INT -> ACCEPTED",
+        result, MAV_RESULT_ACCEPTED,
+    )
+
+    # Put the original home back (best effort).
+    _send_command_int(
+        mav, CMD_DO_SET_HOME, MAV_FRAME_GLOBAL_INT, timeout,
+        p1=0.0, x=lat, y=lon, z=alt,
+    )
 
 
 # Entry point
@@ -551,6 +648,7 @@ def main() -> int:
     run_mission_tests(mav, args.timeout)
     run_command_tests(mav, args.timeout)
     run_command_int_frame_tests(mav, args.timeout)
+    run_do_set_home_frame_tests(mav, args.timeout)
 
     passed = sum(_results)
     total = len(_results)

--- a/test/test_mavlink_param_validation.py
+++ b/test/test_mavlink_param_validation.py
@@ -37,7 +37,13 @@ MAV_MISSION_INVALID_PARAM6 = 11
 MAV_MISSION_INVALID_PARAM7 = 12
 
 MAV_RESULT_ACCEPTED = 0
+MAV_RESULT_TEMPORARILY_REJECTED = 1
 MAV_RESULT_DENIED = 2
+MAV_RESULT_UNSUPPORTED_MAV_FRAME = 9
+
+MAV_FRAME_LOCAL_NED = 1
+MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6
+MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11
 
 MAV_FRAME_GLOBAL_INT = 5
 MAV_FRAME_GLOBAL_RELATIVE_ALT = 3
@@ -51,6 +57,8 @@ CMD_NAV_VTOL_TAKEOFF = 84
 CMD_NAV_VTOL_LAND = 85
 CMD_NAV_DELAY = 93
 CMD_COMPONENT_ARM_DISARM = 400
+CMD_DO_SET_ROI_LOCATION = 195
+CMD_DO_SET_ROI_NONE = 197
 CMD_IMAGE_STOP_CAPTURE = 2001
 
 NAN = float("nan")
@@ -181,6 +189,39 @@ def _send_command(
         )
         if msg and msg.command == cmd:
             return int(msg.result)
+    return None
+
+
+def _send_command_int(
+    mav: Any, cmd: int, frame: int, timeout: float,
+    p1: float = 0.0, p2: float = 0.0,
+    p3: float = 0.0, p4: float = 0.0,
+    x: int = 0, y: int = 0, z: float = 0.0,
+) -> Optional[int]:
+    """Send COMMAND_INT and return the MAV_RESULT from the ACK, or None."""
+    mav.mav.command_int_send(
+        mav.target_system, mav.target_component,
+        frame, cmd, 0, 0,
+        p1, p2, p3, p4,
+        x, y, z,
+    )
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        msg = mav.recv_match(
+            type="COMMAND_ACK", blocking=True, timeout=timeout,
+        )
+        if msg and msg.command == cmd:
+            return int(msg.result)
+    return None
+
+
+def _wait_home_position(mav: Any, timeout: float = 60.0) -> Optional[float]:
+    """Wait until PX4 reports a home position; return home altitude AMSL [m]."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        msg = mav.recv_match(type="HOME_POSITION", blocking=True, timeout=5.0)
+        if msg:
+            return float(msg.altitude) / 1e3
     return None
 
 
@@ -410,6 +451,83 @@ def run_command_tests(mav: Any, timeout: float) -> None:
     )
 
 
+def run_command_int_frame_tests(mav: Any, timeout: float) -> None:
+    print("\n=== COMMAND_INT frame tests (DO_SET_ROI_LOCATION) ===")
+
+    # Coordinates reused from the mission tests; ROI does not validate them.
+    LAT = 473_977_420  # 1e-7 deg
+    LON = 85_456_060   # 1e-7 deg
+
+    home_alt = _wait_home_position(mav)
+    print(f"  home altitude AMSL: {home_alt} m")
+
+    # 20. Global frame with absolute altitude: supported, z is AMSL.
+    result = _send_command_int(
+        mav, CMD_DO_SET_ROI_LOCATION, MAV_FRAME_GLOBAL_INT, timeout,
+        x=LAT, y=LON, z=500.0,
+    )
+    _check(
+        "ROI_LOCATION GLOBAL_INT -> ACCEPTED",
+        result, MAV_RESULT_ACCEPTED,
+    )
+
+    # 21. Relative altitude (INT variant): converted to AMSL at ingest
+    # once home is available.
+    result = _send_command_int(
+        mav, CMD_DO_SET_ROI_LOCATION, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
+        timeout, x=LAT, y=LON, z=50.0,
+    )
+    _check(
+        "ROI_LOCATION GLOBAL_RELATIVE_ALT_INT -> ACCEPTED",
+        result, MAV_RESULT_ACCEPTED,
+    )
+
+    # 22. Relative altitude (non-INT synonym).
+    result = _send_command_int(
+        mav, CMD_DO_SET_ROI_LOCATION, MAV_FRAME_GLOBAL_RELATIVE_ALT,
+        timeout, x=LAT, y=LON, z=50.0,
+    )
+    _check(
+        "ROI_LOCATION GLOBAL_RELATIVE_ALT -> ACCEPTED",
+        result, MAV_RESULT_ACCEPTED,
+    )
+
+    # 23. Local frame: x/y would be metres, not degrees; consumers read
+    # them as lat/lon and z as AMSL, so the frame must be rejected.
+    result = _send_command_int(
+        mav, CMD_DO_SET_ROI_LOCATION, MAV_FRAME_LOCAL_NED, timeout,
+        x=100_000, y=100_000, z=10.0,
+    )
+    _check(
+        "ROI_LOCATION LOCAL_NED -> UNSUPPORTED_MAV_FRAME",
+        result, MAV_RESULT_UNSUPPORTED_MAV_FRAME,
+    )
+
+    # 24. Mission frame is meaningless for a direct command.
+    result = _send_command_int(
+        mav, CMD_DO_SET_ROI_LOCATION, MAV_FRAME_MISSION, timeout,
+        x=LAT, y=LON, z=50.0,
+    )
+    _check(
+        "ROI_LOCATION MISSION -> UNSUPPORTED_MAV_FRAME",
+        result, MAV_RESULT_UNSUPPORTED_MAV_FRAME,
+    )
+
+    # 25. Terrain-relative altitude needs the terrain height at the target
+    # location, which the receiver cannot resolve: rejected for now.
+    result = _send_command_int(
+        mav, CMD_DO_SET_ROI_LOCATION, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT,
+        timeout, x=LAT, y=LON, z=50.0,
+    )
+    _check(
+        "ROI_LOCATION GLOBAL_TERRAIN_ALT_INT -> UNSUPPORTED_MAV_FRAME",
+        result, MAV_RESULT_UNSUPPORTED_MAV_FRAME,
+    )
+
+    # Clear the ROI again (best effort).
+    _send_command(mav, CMD_DO_SET_ROI_NONE, timeout)
+
+
 # Entry point
 
 
@@ -432,6 +550,7 @@ def main() -> int:
 
     run_mission_tests(mav, args.timeout)
     run_command_tests(mav, args.timeout)
+    run_command_int_frame_tests(mav, args.timeout)
 
     passed = sum(_results)
     total = len(_results)


### PR DESCRIPTION
## Summary

fixes #28257

COMMAND_INT's `frame` field is now honored for altitude on the commands whose consumers require a global frame. Relative altitude is converted to AMSL at ingest, and frames PX4 cannot honor are rejected with `MAV_RESULT_COMMAND_UNSUPPORTED_MAV_FRAME` instead of being silently accepted and misinterpreted.

## Problem

`handle_message_command_int()` used `frame` only to select x/y integer scaling, then discarded it: `z` was copied verbatim into `vehicle_command.param7`, which every consumer of the affected commands (navigator ROI/reposition, `FlightTaskOrbit`, takeoff) reads as altitude AMSL — `navigator_main.cpp` even documents "only supports MAV_FRAME_GLOBAL and MAV_FRAMEs with absolute altitude amsl" without receiver-side enforcement. A `DO_SET_ROI_LOCATION` sent in `MAV_FRAME_GLOBAL_RELATIVE_ALT` with z=50 was ACCEPTED and aimed at 50 m AMSL (~439 m underground at a 489 m AMSL home in SIH); local/mission/terrain frames were likewise accepted with their coordinates misread as lat/lon/AMSL.

## Solution

Add a command-specific frame policy in `handle_message_command_int()` for `NAV_TAKEOFF`, `NAV_VTOL_TAKEOFF`, `DO_REPOSITION`, `DO_ORBIT`, `DO_FIGURE_EIGHT`, `DO_SET_ROI_LOCATION`, and `DO_SET_HOME` with an explicit location (deliberately **not** `command_has_location()`: e.g. `NAV_LAND` lands at the current position, `DO_SET_HOME` with `use_current=true` ignores the location and must work before home exists, legacy ROI has mode-dependent `param7`):

- `GLOBAL(_INT)`: unchanged, z is already AMSL.
- `GLOBAL_RELATIVE_ALT(_INT)`: finite z is converted with `home.alt + z` (existing `_home_position_sub`, same pattern as `SET_POSITION_TARGET_GLOBAL_INT`); NaN passes through; no valid home altitude → `TEMPORARILY_REJECTED`.
- Terrain/local/mission/unknown frames → `COMMAND_UNSUPPORTED_MAV_FRAME` (result 9), emitted only after target evaluation so forwarded commands are not answered. Terrain frames need the terrain altitude at the *target* location, which is what #27280 adds for `DO_REPOSITION` — this PR is intended as complementary receiver-side enforcement and can be rebased onto that series if preferred.

Tested via a new `COMMAND_INT frame tests` section in `test/test_mavlink_param_validation.py` against SIH SITL (`make px4_sitl sihsim_quadx`): 31/31 pass with this change, including a `DO_SET_HOME` section that checks the home altitude moves by the relative amount; on unfixed firmware the three frame-rejection cases fail (ACCEPTED instead of result 9), and `listener vehicle_command` shows `param7: 50.0` before vs `param7: 539.4` (home 489.4 + 50) after for the relative-altitude case. Existing param-validation cases all still pass. Possible compatibility note for release notes: senders that pre-converted z to AMSL while labeling the frame relative (as a workaround) would now double-convert.

