### PR TITLE
fix(flight_mode_manager): return to a waypoint that was not reached

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -768,8 +768,8 @@ bool FlightTaskAuto::isTargetModified() const
 
 bool FlightTaskAuto::_hasPassedCurrentWaypoint() const
 {
-	const Vector2f u_previous_to_current = Vector2f(_triplet_current - _triplet_previous).unit_or_zero();
-	return u_previous_to_current * Vector2f(_triplet_current - _position) < 0.f;
+	const Vector3f u_previous_to_current = (_triplet_current - _triplet_previous).unit_or_zero();
+	return u_previous_to_current * (_triplet_current - _position) < 0.f;
 }
 
 void FlightTaskAuto::_updateTrajConstraints()

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -182,6 +182,11 @@ bool FlightTaskAuto::update()
 	_checkEmergencyBraking();
 	Vector3f waypoints[] = {_triplet_previous, _position_setpoint, _triplet_next};
 
+	if (_type == WaypointType::position && _hasPassedCurrentWaypoint()) {
+		// Anchor the leg at the current position to not extrapolate past an unreached waypoint
+		waypoints[0] = _position;
+	}
+
 	if (isTargetModified()) {
 		// In case the target has been modified, we take this as the next waypoints
 		waypoints[2] = _position_setpoint;
@@ -759,6 +764,12 @@ bool FlightTaskAuto::isTargetModified() const
 	const bool z_modified =  z_valid && std::fabs((_triplet_current - _position_setpoint)(2)) > FLT_EPSILON;
 
 	return xy_modified || z_modified;
+}
+
+bool FlightTaskAuto::_hasPassedCurrentWaypoint() const
+{
+	const Vector2f u_previous_to_current = Vector2f(_triplet_current - _triplet_previous).unit_or_zero();
+	return u_previous_to_current * Vector2f(_triplet_current - _position) < 0.f;
 }
 
 void FlightTaskAuto::_updateTrajConstraints()

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -195,6 +195,6 @@ private:
 	bool _evaluatePositionSetpointTriplet();
 	bool _isFinite(const position_setpoint_s &sp); /**< Checks if all waypoint triplets are finite. */
 	bool _evaluateGlobalReference(); /**< Check is global reference is available. */
-	bool _hasPassedCurrentWaypoint() const; /**< True if the vehicle is horizontally past the current waypoint */
+	bool _hasPassedCurrentWaypoint() const; /**< True if the vehicle is past the current waypoint */
 	void _set_heading_from_mode(); /**< @see  MPC_YAW_MODE */
 };

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -195,5 +195,6 @@ private:
 	bool _evaluatePositionSetpointTriplet();
 	bool _isFinite(const position_setpoint_s &sp); /**< Checks if all waypoint triplets are finite. */
 	bool _evaluateGlobalReference(); /**< Check is global reference is available. */
+	bool _hasPassedCurrentWaypoint() const; /**< True if the vehicle is horizontally past the current waypoint */
 	void _set_heading_from_mode(); /**< @see  MPC_YAW_MODE */
 };


### PR DESCRIPTION


### Solved Problem
When a multicopter flies past a mission waypoint that has not been marked as reached, it can diverge from the mission

### Solution

When the vehicle is horizontally past the current waypoint, anchor the segment at the current position rather than the previous waypoint. This flips u_prev_to_target to point from the vehicle toward the missed waypoint. 

### Test coverage

Tested in simulation 

fly away behaviour :
<img width="2229" height="1561" alt="flyaway" src="https://github.com/user-attachments/assets/63d56494-6c2c-459d-8b0d-ba98115bc687" />
The fix, which stop the vehicle and make it come back to the missed waypoint
<img width="2229" height="1561" alt="fix" src="https://github.com/user-attachments/assets/22984142-b4d4-4aa5-8754-6729d3f815af" />
