### PR TITLE
fix(nxp_mr-tropic): invalid DShot timing configuration

### DIFF
--- a/boards/nxp/mr-tropic/src/init.c
+++ b/boards/nxp/mr-tropic/src/init.c
@@ -298,7 +298,7 @@ void imxrt_flexio_clocking(void)
 
 	/* Set PLL3 PFD2 to 480 * 18 / CONFIG_PLL3_PFD2_FRAC */
 
-	reg |= ((uint32_t)(CONFIG_PLL3_PFD2_FRAC) << CCM_ANALOG_PFD_480_PFD3_FRAC_SHIFT);
+	reg |= ((uint32_t)(CONFIG_PLL3_PFD2_FRAC) << CCM_ANALOG_PFD_480_PFD2_FRAC_SHIFT);
 
 	putreg32(reg, IMXRT_CCM_ANALOG_PFD_480);
 


### PR DESCRIPTION


### Solved Problem
Fixes #28258

On the NXP Tropic (i.MX RT1064), DShot600 produces ~1.86 µs bit periods instead of the required 1.67 µs. ESCs receive a non-standard ~DShot533 signal and fail to detect.


### Solution

Fixed the DShot timing configuration for NXP-VMU-TROPIC:
- Corrected the PLL3 PFD2 configuration used during FlexIO initialization.
  - An incorrect bit shift caused invalid timing parameters to be programmed, producing invalid DShot bit periods.


### Changelog Entry
For release notes:
```
Bugfix: Invalid DShot timing configuration on nxp_mr-tropic causing ESCs to not detect the commands
```

### Test coverage

DShot600 frame after the fix:
<img width="962" height="245" alt="image" src="https://github.com/user-attachments/assets/37d63f06-0dfb-4451-a48e-8e72dfb73ee0" />


Full analysis (PWM 50/100/200/400 Hz, DShot150/300/600):
[dshot_bug_data.pdf](https://github.com/user-attachments/files/31417292/dshot_bug_data.pdf)

> **Note:** The pdf analysis was performed on a test commit prior to the final upstream commit, so the git hash differs from this PR.


### Context

Related documentation: i.MX RT1064 Processor Reference Manual, page 1148

