### PR TITLE
docs(docs): renaming Genius-tools into PID-Wise

### DIFF
--- a/docs/en/config_mc/index.md
+++ b/docs/en/config_mc/index.md
@@ -134,7 +134,7 @@ Tuning is the final step, carried out only after most other setup and configurat
 - [MC Setpoint Tuning (Trajectory Generator)](../config_mc/mc_trajectory_tuning.md)
   - [MC Jerk-limited Type Trajectory](../config_mc/mc_jerk_limited_type_trajectory.md)
 - [Multicopter Racer Setup](../config_mc/racer_setup.md)
-- [Genius Tools](https://www.altitude-rd.com/genius-tools) — a commercial web app for interactive multicopter tuning from a flight log.
+- [PID-Wise](https://www.altitude-rd.com/pid-wise) — a commercial web app for interactive multicopter tuning from a flight log.
   Bugs and questions should be addressed to the maintainer: [Altitude R&D](https://www.altitude-rd.com/home) (not the PX4 forums).
 
 ![Genius Tools](../../assets/config/mc/genius_tools.webp)


### PR DESCRIPTION
Replaced 'Genius Tools' link with 'PID-Wise' for multicopter tuning.

The name Genius-Tools was already a registered trademark, so we are rebranding.

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
