### PR TITLE
docs(sim_sih): fix Hexarotor SIH make target (sihsim_hexa -> sihsim_hex)

### DIFF
--- a/docs/en/sim_sih/index.md
+++ b/docs/en/sim_sih/index.md
@@ -33,7 +33,7 @@ The following vehicle types are supported:
 | Vehicle                                                         | Make Target                                | Status       |
 | --------------------------------------------------------------- | ------------------------------------------ | ------------ |
 | Quadrotor X <Badge type="tip" text="PX4 v1.9" />                | `make px4_sitl_sih sihsim_quadx`           | Stable       |
-| Hexarotor X <Badge type="tip" text="PX4 v1.16" />               | `make px4_sitl_sih sihsim_hexa`            | Experimental |
+| Hexarotor X <Badge type="tip" text="PX4 v1.16" />               | `make px4_sitl_sih sihsim_hex`             | Experimental |
 | Fixed-wing (airplane) <Badge type="tip" text="PX4 v1.13" />     | `make px4_sitl_sih sihsim_airplane`        | Experimental |
 | Tailsitter VTOL <Badge type="tip" text="PX4 v1.13" />           | `make px4_sitl_sih sihsim_xvert`           | Experimental |
 | Standard VTOL (QuadPlane) <Badge type="tip" text="PX4 v1.16" /> | `make px4_sitl_sih sihsim_standard_vtol`   | Experimental |


### PR DESCRIPTION
## Summary

fixes the documented SIH hexarotor make target, which currently fails.

## Problem

The [SIH supported-vehicle-types table](https://github.com/PX4/PX4-Autopilot/blob/main/docs/en/sim_sih/index.md) lists the hexarotor build as `make px4_sitl_sih sihsim_hexa`, but the airframe is registered as `sihsim_hex` (`ROMFS/px4fmu_common/init.d-posix/airframes/10044_sihsim_hex`, added in `init.d-posix/airframes/CMakeLists.txt:114`). Following the docs verbatim fails, because no `sihsim_hexa` model exists. The `px4_sitl_sih` config target and every other model name in the table are correct — only the hexarotor name had a trailing `a`.

## Solution

`sihsim_hexa` → `sihsim_hex` in `docs/en/sim_sih/index.md`. One-word fix, table alignment preserved.

Verified the target name against the airframe registry: models resolve by the `sihsim_<name>` → `*_sihsim_<name>` glob, so `sihsim_hex` matches `10044_sihsim_hex` while `sihsim_hexa` matches nothing (same pattern as the working `sihsim_quadx` entry above it). The `docs/zh`, `docs/uk`, and `docs/ko` copies carry the same typo but are Crowdin-managed, so only the English source is changed here.
