### PR TITLE
fix(land_detector): latch diagnostic flags between publications

### DIFF
--- a/msg/versioned/VehicleLandDetected.msg
+++ b/msg/versioned/VehicleLandDetected.msg
@@ -8,14 +8,13 @@ bool maybe_landed # true if the vehicle might have landed (2. stage)
 bool landed # true if vehicle is currently landed on the ground (3. stage)
 
 bool in_ground_effect # indicates if from the perspective of the landing detector the vehicle might be in ground effect (baro). This flag will become true if the vehicle is not moving horizontally and is descending (crude assumption that user is landing).
-bool in_descend
 
-bool has_low_throttle
-
-bool vertical_movement
-bool horizontal_movement
-bool rotational_movement # true if roll/pitch rate exceeds LNDMC_ROT_MAX at any land detector update since the previous publication (peak-held, not instantaneous)
-
-bool close_to_ground_or_skipped_check
+# Flags in this paragraph are for diagnostic logging only
+bool in_descend # true only if commanded to descend faster than 1.1 * LNDMC_Z_VEL_MAX for every update since the previous publication
+bool has_low_throttle # true only if throttle was at or below the low-throttle threshold for every update since the previous publication
+bool vertical_movement # false only if vertical velocity stayed below LNDMC_Z_VEL_MAX for every update since the previous publication
+bool horizontal_movement # false only if horizontal velocity stayed below LNDMC_XY_VEL_MAX for every update since the previous publication
+bool rotational_movement # false only if roll/pitch rate stayed below LNDMC_ROT_MAX for every update since the previous publication
+bool close_to_ground_or_skipped_check # true only if close to the ground, or the check was skipped (no distance sensor), for every update since the previous publication
 
 bool at_rest

--- a/msg/versioned/VehicleLandDetected.msg
+++ b/msg/versioned/VehicleLandDetected.msg
@@ -1,11 +1,11 @@
 uint32 MESSAGE_VERSION = 0
 
-uint64 timestamp	# time since system start (microseconds)
+uint64 timestamp # time since system start (microseconds)
 
-bool freefall		# true if vehicle is currently in free-fall
-bool ground_contact	# true if vehicle has ground contact but is not landed (1. stage)
-bool maybe_landed	# true if the vehicle might have landed (2. stage)
-bool landed		# true if vehicle is currently landed on the ground (3. stage)
+bool freefall # true if vehicle is currently in free-fall
+bool ground_contact # true if vehicle has ground contact but is not landed (1. stage)
+bool maybe_landed # true if the vehicle might have landed (2. stage)
+bool landed # true if vehicle is currently landed on the ground (3. stage)
 
 bool in_ground_effect # indicates if from the perspective of the landing detector the vehicle might be in ground effect (baro). This flag will become true if the vehicle is not moving horizontally and is descending (crude assumption that user is landing).
 bool in_descend
@@ -14,7 +14,7 @@ bool has_low_throttle
 
 bool vertical_movement
 bool horizontal_movement
-bool rotational_movement
+bool rotational_movement # true if roll/pitch rate exceeds LNDMC_ROT_MAX at any land detector update since the previous publication (peak-held, not instantaneous)
 
 bool close_to_ground_or_skipped_check
 

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -55,8 +55,8 @@ LandDetector::LandDetector() :
 	_land_detected.maybe_landed = true;
 	_land_detected.landed = true;
 	_land_detected.in_ground_effect = true;
-	_land_detected.in_descend = false;
-	_land_detected.has_low_throttle = false;
+	_land_detected.in_descend = true;
+	_land_detected.has_low_throttle = true;
 	_land_detected.vertical_movement = false;
 	_land_detected.horizontal_movement = false;
 	_land_detected.rotational_movement = false;
@@ -130,49 +130,46 @@ void LandDetector::Run()
 	_landed_hysteresis.set_state_and_update(_get_landed_state(), now_us);
 	_ground_effect_hysteresis.set_state_and_update(_get_ground_effect_state(), now_us);
 
-	const bool freefallDetected = _freefall_hysteresis.get_state();
-	const bool ground_contactDetected = _ground_contact_hysteresis.get_state();
-	const bool maybe_landedDetected = _maybe_landed_hysteresis.get_state();
-	const bool landDetected = _landed_hysteresis.get_state();
+	const bool freefall = _freefall_hysteresis.get_state();
+	const bool ground_contact = _ground_contact_hysteresis.get_state();
+	const bool maybe_landed = _maybe_landed_hysteresis.get_state();
+	const bool landed = _landed_hysteresis.get_state();
 	const bool in_ground_effect = _ground_effect_hysteresis.get_state();
 
 	UpdateVehicleAtRest();
 
-	const bool at_rest = landDetected && _at_rest;
+	const bool at_rest = landed && _at_rest;
 
-	// report the peak rotational movement since last publication
-	_rotational_movement_since_publish |= _get_rotational_movement();
-
-	// publish at 1 Hz, very first time, when the result has changed, or when rotation was first detected
+	// publish at 1 Hz, very first time, or when the core land detection state (not diagnostic flags) changed
 	if ((hrt_elapsed_time(&_land_detected.timestamp) >= 1_s) ||
-	    (_land_detected.landed != landDetected) ||
-	    (_land_detected.freefall != freefallDetected) ||
-	    (_land_detected.maybe_landed != maybe_landedDetected) ||
-	    (_land_detected.ground_contact != ground_contactDetected) ||
+	    (_land_detected.freefall != freefall) ||
+	    (_land_detected.ground_contact != ground_contact) ||
+	    (_land_detected.maybe_landed != maybe_landed) ||
+	    (_land_detected.landed != landed) ||
 	    (_land_detected.in_ground_effect != in_ground_effect) ||
-	    (_land_detected.at_rest != at_rest) ||
-	    (_rotational_movement_since_publish && !_land_detected.rotational_movement)) {
+	    (_land_detected.at_rest != at_rest)) {
 
-		if (!landDetected && _land_detected.landed && _takeoff_time == 0) { /* only set take off time once, until disarming */
+		if (!landed && _land_detected.landed && _takeoff_time == 0) { /* only set take off time once, until disarming */
 			// We did take off
 			_takeoff_time = now_us;
 		}
 
-		_land_detected.landed = landDetected;
-		_land_detected.freefall = freefallDetected;
-		_land_detected.maybe_landed = maybe_landedDetected;
-		_land_detected.ground_contact = ground_contactDetected;
+		_land_detected.freefall = freefall;
+		_land_detected.ground_contact = ground_contact;
+		_land_detected.maybe_landed = maybe_landed;
+		_land_detected.landed = landed;
 		_land_detected.in_ground_effect = in_ground_effect;
-		_land_detected.in_descend = _get_in_descend();
-		_land_detected.has_low_throttle = _get_has_low_throttle();
-		_land_detected.horizontal_movement = _get_horizontal_movement();
-		_land_detected.vertical_movement = _get_vertical_movement();
-		_land_detected.rotational_movement = _rotational_movement_since_publish;
-		_rotational_movement_since_publish = false;
-		_land_detected.close_to_ground_or_skipped_check = _get_close_to_ground_or_skipped_check();
 		_land_detected.at_rest = at_rest;
 		_land_detected.timestamp = hrt_absolute_time();
 		_vehicle_land_detected_pub.publish(_land_detected);
+
+		// reset diagnostic flags for latching logic
+		_land_detected.vertical_movement = false;
+		_land_detected.horizontal_movement = false;
+		_land_detected.rotational_movement = false;
+		_land_detected.in_descend = true;
+		_land_detected.has_low_throttle = true;
+		_land_detected.close_to_ground_or_skipped_check = true;
 	}
 
 	// set the flight time when disarming (not necessarily when landed, because all param changes should

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -140,14 +140,18 @@ void LandDetector::Run()
 
 	const bool at_rest = landDetected && _at_rest;
 
-	// publish at 1 Hz, very first time, or when the result has changed
+	// report the peak rotational movement since last publication
+	_rotational_movement_since_publish |= _get_rotational_movement();
+
+	// publish at 1 Hz, very first time, when the result has changed, or when rotation was first detected
 	if ((hrt_elapsed_time(&_land_detected.timestamp) >= 1_s) ||
 	    (_land_detected.landed != landDetected) ||
 	    (_land_detected.freefall != freefallDetected) ||
 	    (_land_detected.maybe_landed != maybe_landedDetected) ||
 	    (_land_detected.ground_contact != ground_contactDetected) ||
 	    (_land_detected.in_ground_effect != in_ground_effect) ||
-	    (_land_detected.at_rest != at_rest)) {
+	    (_land_detected.at_rest != at_rest) ||
+	    (_rotational_movement_since_publish && !_land_detected.rotational_movement)) {
 
 		if (!landDetected && _land_detected.landed && _takeoff_time == 0) { /* only set take off time once, until disarming */
 			// We did take off
@@ -163,7 +167,8 @@ void LandDetector::Run()
 		_land_detected.has_low_throttle = _get_has_low_throttle();
 		_land_detected.horizontal_movement = _get_horizontal_movement();
 		_land_detected.vertical_movement = _get_vertical_movement();
-		_land_detected.rotational_movement = _get_rotational_movement();
+		_land_detected.rotational_movement = _rotational_movement_since_publish;
+		_rotational_movement_since_publish = false;
 		_land_detected.close_to_ground_or_skipped_check = _get_close_to_ground_or_skipped_check();
 		_land_detected.at_rest = at_rest;
 		_land_detected.timestamp = hrt_absolute_time();

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -136,13 +136,6 @@ protected:
 	 */
 	virtual bool _get_ground_effect_state() { return false; }
 
-	virtual bool _get_in_descend() { return false; }
-	virtual bool _get_has_low_throttle() { return false; }
-	virtual bool _get_horizontal_movement() { return false; }
-	virtual bool _get_vertical_movement() { return false; }
-	virtual bool _get_rotational_movement() { return false; }
-	virtual bool _get_close_to_ground_or_skipped_check() {  return false; }
-
 	systemlib::Hysteresis _freefall_hysteresis{false};
 	systemlib::Hysteresis _landed_hysteresis{true};
 	systemlib::Hysteresis _maybe_landed_hysteresis{true};
@@ -158,13 +151,13 @@ protected:
 	bool _armed{false};
 	bool _previous_armed_state{false};	///< stores the previous actuator_armed.armed state
 
+	vehicle_land_detected_s _land_detected{};
+
 private:
 	void Run() override;
 
 	void UpdateVehicleAtRest();
 
-	vehicle_land_detected_s _land_detected{};
-	bool _rotational_movement_since_publish{false};	///< latched: rotation above threshold seen at any update since the last publication
 	hrt_abstime _takeoff_time{0};
 	hrt_abstime _total_flight_time{0};	///< total vehicle flight time in microseconds
 

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -164,6 +164,7 @@ private:
 	void UpdateVehicleAtRest();
 
 	vehicle_land_detected_s _land_detected{};
+	bool _rotational_movement_since_publish{false};	///< latched: rotation above threshold seen at any update since the last publication
 	hrt_abstime _takeoff_time{0};
 	hrt_abstime _total_flight_time{0};	///< total vehicle flight time in microseconds
 

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -167,6 +167,8 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 
 	const bool lpos_available = ((time_now_us - _vehicle_local_position.timestamp) < 1_s);
 
+	bool vertical_movement;
+
 	if (lpos_available) {
 		// Check if we are moving vertically.
 		// Use wider threshold if currently in "maybe landed" state, as estimation for
@@ -180,20 +182,21 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 		}
 
 		if (_vehicle_local_position.v_z_valid && (fabsf(_vehicle_local_position.vz) < vertical_velocity_threshold)) {
-			_vertical_movement = false;
+			vertical_movement = false;
 
 		} else if (_vehicle_local_position.z_valid && (fabsf(_vehicle_local_position.z_deriv) < vertical_velocity_threshold)) {
 			// The Z derivative is often less accurate than VZ but is less affected by biased velocity measurements.
-			_vertical_movement = false;
+			vertical_movement = false;
 
 		} else {
-			_vertical_movement = true;
+			vertical_movement = true;
 		}
 
 	} else {
-		_vertical_movement = true;
+		vertical_movement = true;
 	}
 
+	_land_detected.vertical_movement |= vertical_movement;
 
 	// Check if we are moving horizontally.
 	if (lpos_available && _vehicle_local_position.v_xy_valid) {
@@ -203,6 +206,8 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 	} else {
 		_horizontal_movement = false; // not known
 	}
+
+	_land_detected.horizontal_movement |= _horizontal_movement;
 
 	if (lpos_available && _vehicle_local_position.dist_bottom_valid && _param_lndmc_alt_gnd_effect.get() > 0) {
 		_below_gnd_effect_hgt = _vehicle_local_position.dist_bottom < _param_lndmc_alt_gnd_effect.get();
@@ -229,8 +234,9 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 	// so stale data would cause false landed-state detection. This intentionally disables
 	// thrust-based landing detection for that mode — the companion should handle its own
 	// landing logic.
-	_has_low_throttle = _vehicle_thrust_setpoint_valid && (_vehicle_thrust_setpoint_throttle <= sys_low_throttle);
-	bool ground_contact = _has_low_throttle;
+	const bool has_low_throttle = _vehicle_thrust_setpoint_valid && (_vehicle_thrust_setpoint_throttle <= sys_low_throttle);
+	_land_detected.has_low_throttle &= has_low_throttle;
+	bool ground_contact = has_low_throttle;
 
 	// if we have a valid velocity setpoint and the vehicle is demanded to go down but no vertical movement present,
 	// we then can assume that the vehicle hit ground
@@ -252,16 +258,19 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 		_in_descend = false;
 	}
 
+	_land_detected.in_descend &= _in_descend;
+
 	// if there is no distance to ground estimate available then don't enforce using it.
 	// if a distance to the ground estimate is generally available (_dist_bottom_is_observable=true), then
 	// we already increased the hysteresis for the land detection states in order to reduce the chance of false positives.
 	const bool skip_close_to_ground_check = !_dist_bottom_is_observable || !_vehicle_local_position.dist_bottom_valid;
-	_close_to_ground_or_skipped_check = _is_close_to_ground() || skip_close_to_ground_check;
+	const bool close_to_ground_or_skipped_check = _is_close_to_ground() || skip_close_to_ground_check;
+	_land_detected.close_to_ground_or_skipped_check &= close_to_ground_or_skipped_check;
 
 	// TODO: we need an accelerometer based check for vertical movement for flying without GPS
 	return !_armed ||
-	       (_close_to_ground_or_skipped_check && ground_contact
-		&& !_horizontal_movement && !_vertical_movement);
+	       (close_to_ground_or_skipped_check && ground_contact
+		&& !_horizontal_movement && !vertical_movement);
 }
 
 bool MulticopterLandDetector::_get_maybe_landed_state()
@@ -294,7 +303,8 @@ bool MulticopterLandDetector::_get_maybe_landed_state()
 		max_rotation_threshold *= 2.5f;
 	}
 
-	_rotational_movement = _angular_velocity.xy().norm() > max_rotation_threshold;
+	const bool rotational_movement = _angular_velocity.xy().norm() > max_rotation_threshold;
+	_land_detected.rotational_movement |= rotational_movement;
 
 	// If vertical velocity is available: ground contact, no thrust, no movement -> landed
 	const bool local_position_updated = (now - _vehicle_local_position.timestamp) < 1_s;
@@ -302,7 +312,7 @@ bool MulticopterLandDetector::_get_maybe_landed_state()
 	const bool vertical_estimate = local_position_updated && vertical_velocity_valid;
 
 	return !_armed ||
-	       (minimum_thrust_now && !_freefall_hysteresis.get_state() && !_rotational_movement
+	       (minimum_thrust_now && !_freefall_hysteresis.get_state() && !rotational_movement
 		&& ((vertical_estimate && _ground_contact_hysteresis.get_state())
 		    || (!vertical_estimate && _minimum_thrust_8s_hysteresis.get_state())));
 }

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -70,12 +70,6 @@ protected:
 	bool _get_maybe_landed_state() override;
 	bool _get_freefall_state() override;
 	bool _get_ground_effect_state() override;
-	bool _get_in_descend() override { return _in_descend; }
-	bool _get_has_low_throttle() override { return _has_low_throttle; }
-	bool _get_horizontal_movement() override { return _horizontal_movement; }
-	bool _get_vertical_movement() override { return _vertical_movement; }
-	bool _get_rotational_movement() override { return _rotational_movement; }
-	bool _get_close_to_ground_or_skipped_check() override { return _close_to_ground_or_skipped_check; }
 
 private:
 	bool _is_close_to_ground();
@@ -121,10 +115,6 @@ private:
 
 	bool _in_descend{false};		///< vehicle is commanded to desend
 	bool _horizontal_movement{false};	///< vehicle is moving horizontally
-	bool _vertical_movement{false};
-	bool _rotational_movement{false};
-	bool _has_low_throttle{false};
-	bool _close_to_ground_or_skipped_check{false};
 	bool _below_gnd_effect_hgt{false};	///< vehicle height above ground is below height where ground effect occurs
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(


### PR DESCRIPTION
### Solved Problem
`vehicle_land_detected` publishes at 1 Hz unless one of the latched state flags changes, but `rotational_movement` was sampled instantaneously at publication time. When a rotation spike starts and decays between two publications or at the publication time, the instantaneous reading happens to be at not the peak (and below `LNDMC_ROT_MAX`), the flag logs `false` even though the detector sees rotation above `LNDMC_ROT_MAX` and uses it to suppress the landed state. That leads to logs being misleading when diagnosing why a landing was rejected.

Landing/disarm behavior unchanged, just reporting.

### Solution
Latch the flag across publications rather than sampling it instantaneously and publish on the rising edge. `rotational_movement` now means "it exceeded the threshold since the last message".

### Changelog Entry
For release notes:
```
Bugfix: land_detector: vehicle_land_detected.rotational_movement is now peak-held between publications instead of instantaneously sampled, so short rotation spikes are no longer missed in logs.
```

### Alternatives

### Test coverage
- `make px4_sitl_default` builds clean
- `Tools/astyle/check_code_style.sh` passes on both C++ files
- `.msg` file: Added a comment and fixed whitespace formatting of existing comments

### Context
Related links, screenshot before/after, video