### PR TITLE
fix(uavcan): report generic ESC failure when no recognized vendor status

### DIFF
--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -242,7 +242,11 @@ uint32_t UavcanEscController::get_failures(uint8_t esc_index, uint8_t node_id)
 			}
 		}
 
-		return failures;
+		if (failures != 0) {
+			return failures;
+		}
+
+		// vendor reported ERROR/CRITICAL but set no recognized status bits, fall through to generic failure below
 	}
 
 	// Generic parsing

--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -202,53 +202,46 @@ uint32_t UavcanEscController::get_failures(uint8_t esc_index, uint8_t node_id)
 		}
 	}
 
-	const bool failure = (node_health == dronecan_node_status_s::HEALTH_ERROR)
-			     || (node_health == dronecan_node_status_s::HEALTH_CRITICAL);
+	uint32_t failures = 0;
 
-	if (!failure) {
-		return 0;
-	}
+	if ((node_health == dronecan_node_status_s::HEALTH_ERROR)
+	    || (node_health == dronecan_node_status_s::HEALTH_CRITICAL)) {
+		// Parse VertiQ = iq_motion ESC error flags
+		device_information_s device_information{};
 
-	// Parse VertiQ = iq_motion ESC error flags
-	device_information_s device_information{};
+		if (_device_information_sub.copy(&device_information)
+		    && device_information.device_type == device_information_s::DEVICE_TYPE_ESC
+		    && device_information.device_id == esc_index
+		    && strstr(device_information.name, "iq_motion") != nullptr) {
+			static const struct {
+				uint8_t bit;
+				uint8_t failure_type;
+			} bit_to_failure_map[] = {
+				{0,  esc_report_s::FAILURE_OVER_VOLTAGE},
+				{1,  esc_report_s::FAILURE_OVER_VOLTAGE},
+				{2,  esc_report_s::FAILURE_OVER_VOLTAGE},
+				{3,  esc_report_s::FAILURE_OVER_CURRENT},
+				{4,  esc_report_s::FAILURE_OVER_CURRENT},
+				{5,  esc_report_s::FAILURE_OVER_ESC_TEMPERATURE},
+				{6,  esc_report_s::FAILURE_MOTOR_OVER_TEMPERATURE},
+				{7,  esc_report_s::FAILURE_GENERIC},
+				{8,  esc_report_s::FAILURE_OVER_RPM},
+				{9,  esc_report_s::FAILURE_WARN_ESC_TEMPERATURE},
+				{10, esc_report_s::FAILURE_MOTOR_WARN_TEMPERATURE},
+				{11, esc_report_s::FAILURE_OVER_VOLTAGE},
+			};
 
-	if (_device_information_sub.copy(&device_information)
-	    && device_information.device_type == device_information_s::DEVICE_TYPE_ESC
-	    && device_information.device_id == esc_index
-	    && strstr(device_information.name, "iq_motion") != nullptr) {
-		static const struct {
-			uint8_t bit;
-			uint8_t failure_type;
-		} bit_to_failure_map[] = {
-			{0,  esc_report_s::FAILURE_OVER_VOLTAGE},
-			{1,  esc_report_s::FAILURE_OVER_VOLTAGE},
-			{2,  esc_report_s::FAILURE_OVER_VOLTAGE},
-			{3,  esc_report_s::FAILURE_OVER_CURRENT},
-			{4,  esc_report_s::FAILURE_OVER_CURRENT},
-			{5,  esc_report_s::FAILURE_OVER_ESC_TEMPERATURE},
-			{6,  esc_report_s::FAILURE_MOTOR_OVER_TEMPERATURE},
-			{7,  esc_report_s::FAILURE_GENERIC},
-			{8,  esc_report_s::FAILURE_OVER_RPM},
-			{9,  esc_report_s::FAILURE_WARN_ESC_TEMPERATURE},
-			{10, esc_report_s::FAILURE_MOTOR_WARN_TEMPERATURE},
-			{11, esc_report_s::FAILURE_OVER_VOLTAGE},
-		};
-
-		uint32_t failures = 0;
-
-		for (const auto &mapping : bit_to_failure_map) {
-			if (vendor_specific_status_code & (1 << mapping.bit)) {
-				failures |= (1 << mapping.failure_type);
+			for (const auto &mapping : bit_to_failure_map) {
+				if (vendor_specific_status_code & (1 << mapping.bit)) {
+					failures |= (1 << mapping.failure_type);
+				}
 			}
 		}
 
-		if (failures != 0) {
-			return failures;
+		if (failures == 0) { // no specific error parsed
+			failures = (1 << esc_report_s::FAILURE_GENERIC);
 		}
-
-		// vendor reported ERROR/CRITICAL but set no recognized status bits, fall through to generic failure below
 	}
 
-	// Generic parsing
-	return (1 << esc_report_s::FAILURE_GENERIC);
+	return failures;
 }


### PR DESCRIPTION
### Solved Problem
`UavcanEscController::get_failures()` returns `0` (healthy) when a vertiq ESC reports `HEALTH_ERROR` or `HEALTH_CRITICAL` but sets no recognized `vendor_specific_status_code` bits.

The generic fallback `return (1 << FAILURE_GENERIC)` at the end of the function is unreachable for vertiq path because the vendor branch returns unconditionally.

Since `esc_report.failures == 0` causes `EscChecks::checkEscStatus()` to `continue`, the critical health is fully invisible.

### Solution
Return the parsed bits only when non-zero. If not, fall through to the existing generic failure. Also covers unmapped bits, not just an all-zero status code.

#### Note: Latching the failure handling in allocator
`esc_report.failures` feeds `EscChecks::checkEscStatus()` -> `motor_failure_mask` -> `ControlAllocator::check_for_motor_failures()`, which shuts off the failing motor and its geometric opposite according to `CA_FAILURE_MODE`. Nothing in that chain latches. `get_failures()` returns to 0 as soon as node health returns to OK, `fd_motor` de-asserts, and the allocator restores the motors via ramp-in. A fault that oscillates therefore produces repeated isolate/restore cycles in flight. This is an allocator problem.

### Changelog Entry
For release notes:
```
Bugfix: DroneCAN ESCs reporting an error/critical node health with an unrecognized vendor status code are now reported as a generic ESC failure instead of being treated as healthy
```

### Alternatives

### Test coverage
- Observed a Vertiq ESC report node health `ERROR` for several cycles with no vendor status bits set in flight and `esc_status.esc[i].failures` stayed `0` throughout
- Built for `px4_fmu-v6x_default`; format checks pass.

### Context
Vertiq status code layout:
https://iqmotion.readthedocs.io/en/latest/communication_protocols/dronecan_protocol.html#vertiq-s-vendor-specific-nodestatus-code-breakdown