### PR TITLE
[BACKPORT] fix(nxp_mr-tropic): invalid DShot timing configuration

### DIFF
--- a/boards/nxp/mr-tropic/src/init.c
+++ b/boards/nxp/mr-tropic/src/init.c
@@ -298,7 +298,7 @@ void imxrt_flexio_clocking(void)
 
 	/* Set PLL3 PFD2 to 480 * 18 / CONFIG_PLL3_PFD2_FRAC */
 
-	reg |= ((uint32_t)(CONFIG_PLL3_PFD2_FRAC) << CCM_ANALOG_PFD_480_PFD3_FRAC_SHIFT);
+	reg |= ((uint32_t)(CONFIG_PLL3_PFD2_FRAC) << CCM_ANALOG_PFD_480_PFD2_FRAC_SHIFT);
 
 	putreg32(reg, IMXRT_CCM_ANALOG_PFD_480);
 


### PR DESCRIPTION
### Solved Problem

On the NXP Tropic (i.MX RT1064), DShot600 produces ~1.86 µs bit periods instead of the required 1.67 µs. ESCs receive a non-standard ~DShot533 signal and fail to detect.

### Solution

Fixed the DShot timing configuration for NXP-VMU-TROPIC:
- Corrected the PLL3 PFD2 configuration used during FlexIO initialization.
  - An incorrect bit shift caused invalid timing parameters to be programmed, producing invalid DShot bit periods.


### Test coverage

DShot600 frame after the fix:
<img width="1130" height="222" alt="image" src="https://github.com/user-attachments/assets/4222a3a2-ea08-438a-abb0-5afe8692e7c1" />

Setup:
<img width="407" height="273" alt="image" src="https://github.com/user-attachments/assets/76e79bf4-7580-4803-8543-3dea49c63bf1" />



### Changelog Entry
For release notes:
```
Bugfix: Invalid DShot timing configuration on nxp_mr-tropic causing ESCs to not detect the commands
```

### Context

this is a backport fix from main ( git hash adc5a53b88fa5adb8d271c051e2d49ac7631ade9 )
