### PR TITLE
fix(uavcan): classify TX frames dropped while peeking the queue

### DIFF
--- a/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/transport/can_io.hpp
+++ b/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/transport/can_io.hpp
@@ -117,6 +117,8 @@ public:
     /// The 'or equal' condition is necessary to avoid frame reordering.
     bool topPriorityHigherOrEqual(const CanFrame& rhs_frame) const;
 
+    /// Total. Every drop is also counted in exactly one of the two below, so a total that exceeds
+    /// their sum means a drop path was added without classifying it.
     uint32_t getRejectedFrameCount() const { return rejected_frames_cnt_; }
 
     /// Frames dropped because their transmit deadline had already passed. Not a memory shortage.

--- a/src/drivers/uavcan/libdronecan/libuavcan/src/transport/uc_can_io.cpp
+++ b/src/drivers/uavcan/libdronecan/libuavcan/src/transport/uc_can_io.cpp
@@ -207,7 +207,7 @@ CanTxQueue::Entry* CanTxQueue::peek()
         {
             UAVCAN_TRACE("CanTxQueue", "Peek: Expired %s", p->toString().c_str());
             Entry* const next = p->getNextListNode();
-            registerRejectedFrame();
+            registerExpiredFrame();
             remove(p);
             p = next;
         }


### PR DESCRIPTION
## Summary

Follow-up to #28395. One of the four TX drop paths was left unclassified, so the per-cause split it added under-reports.

## Problem

`CanTxQueue::peek()` discards entries whose transmit deadline has passed before returning the head of the queue, counting them with a bare `registerRejectedFrame()`. #28395 split the reject count into "expired" and "no memory" across the three paths in `push()` and missed this fourth one, so those frames land in the total and in neither bucket:

```
	TX rejected:   64 frames (0 expired, 0 no memory)
```

That reads as "nothing worth caring about" when 64 frames belonging to in-flight multi-frame transfers had just been discarded. Serving a DroneCAN node firmware update hits this path on every interface — measured 61-78 frames per update on an FMU-v6XRT, none of them visible in the split.

## Solution

Count them as expired, which is what they are.

The total stays a separate counter rather than becoming the sum of the two buckets. A total exceeding the buckets is what makes an unclassified path visible at all, and is how this one was found; deriving it would have hidden the bug rather than exposed it.