### PR TITLE
fix(navigator): keep a VTOL in multicopter mode through mission RTL

### DIFF
--- a/src/modules/navigator/rtl_direct_mission_land.cpp
+++ b/src/modules/navigator/rtl_direct_mission_land.cpp
@@ -193,18 +193,6 @@ void RtlDirectMissionLand::setActiveMissionItems()
 
 		new_work_item_type = WorkItemType::WORK_ITEM_TYPE_CLIMB;
 
-	} else if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
-		   _vehicle_status_sub.get().is_vtol &&
-		   !_land_detected_sub.get().landed && _work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) {
-		// Transition to fixed wing if necessary.
-		set_vtol_transition_item(&_mission_item, vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW);
-		_mission_item.yaw = _navigator->get_local_position()->heading;
-
-		// keep current setpoints (FW position controller generates wp to track during transition)
-		pos_sp_triplet->current.type = position_setpoint_s::SETPOINT_TYPE_POSITION;
-
-		new_work_item_type = WorkItemType::WORK_ITEM_TYPE_TRANSITION_AFTER_TAKEOFF;
-
 #if CONFIG_NAVIGATOR_GEOFENCE_AVOIDANCE
 
 	} else if (_navigator->get_geofence_avoidance_planner().hasMore()) {

--- a/src/modules/navigator/rtl_mission_fast.cpp
+++ b/src/modules/navigator/rtl_mission_fast.cpp
@@ -128,19 +128,7 @@ void RtlMissionFast::setActiveMissionItems()
 		}
 	}
 
-	// Transition to fixed wing if necessary.
-	if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
-	    _vehicle_status_sub.get().is_vtol &&
-	    !_land_detected_sub.get().landed && _work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) {
-		set_vtol_transition_item(&_mission_item, vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW);
-		_mission_item.yaw = _navigator->get_local_position()->heading;
-
-		// keep current setpoints (FW position controller generates wp to track during transition)
-		pos_sp_triplet->current.type = position_setpoint_s::SETPOINT_TYPE_POSITION;
-
-		new_work_item_type = WorkItemType::WORK_ITEM_TYPE_TRANSITION_AFTER_TAKEOFF;
-
-	} else if (mission_item_contains_position(_mission_item)) {
+	if (mission_item_contains_position(_mission_item)) {
 
 		static constexpr size_t max_num_next_items{1u};
 		int32_t next_mission_items_index[max_num_next_items];

--- a/src/modules/navigator/rtl_mission_fast_reverse.cpp
+++ b/src/modules/navigator/rtl_mission_fast_reverse.cpp
@@ -116,19 +116,7 @@ void RtlMissionFastReverse::setActiveMissionItems()
 	WorkItemType new_work_item_type{WorkItemType::WORK_ITEM_TYPE_DEFAULT};
 	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-	// Transition to fixed wing if necessary.
-	if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
-	    _vehicle_status_sub.get().is_vtol &&
-	    !_land_detected_sub.get().landed && _work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) {
-		set_vtol_transition_item(&_mission_item, vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW);
-		_mission_item.yaw = _navigator->get_local_position()->heading;
-
-		// keep current setpoints (FW position controller generates wp to track during transition)
-		pos_sp_triplet->current.type = position_setpoint_s::SETPOINT_TYPE_POSITION;
-
-		new_work_item_type = WorkItemType::WORK_ITEM_TYPE_TRANSITION_AFTER_TAKEOFF;
-
-	} else if (mission_item_contains_position(_mission_item)) {
+	if (mission_item_contains_position(_mission_item)) {
 		int32_t next_mission_item_index;
 		size_t num_found_items = 0;
 		getPreviousPositionItems(_mission.current_seq, &next_mission_item_index, num_found_items, 1u);

--- a/src/modules/navigator/test/test_RTL.cpp
+++ b/src/modules/navigator/test/test_RTL.cpp
@@ -51,6 +51,8 @@
 #include <uORB/topics/mission.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/home_position.h>
+#include <uORB/topics/vehicle_global_position.h>
+#include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/wind.h>
 
 #include "navigator.h"
@@ -59,6 +61,7 @@
 #include "mission_route_types.h"
 #include "support/mission_route_cache_test_peer.h"
 #include "support/mission_route_test_helpers.h"
+#include "support/vector_mission_item_store.h"
 
 namespace
 {
@@ -211,6 +214,29 @@ public:
 		RtlDirectMissionLand(navigator, mission) {}
 
 	const mission_s &mission() const { return _mission; }
+
+	void loadTestMission(const std::vector<mission_item_s> &items)
+	{
+		_mission_store.setItems(items);
+		_mission.count = static_cast<int32_t>(_mission_store.itemCount());
+	}
+
+	void activateForTest()
+	{
+		_vehicle_status_sub.update();
+		on_activation();
+	}
+
+	uint16_t activeNavCommand() const { return _mission_item.nav_cmd; }
+
+protected:
+	bool loadMissionItemFromCache(int32_t index, mission_item_s &mission_item) override
+	{
+		return _mission_store.loadItem(index, mission_item);
+	}
+
+private:
+	navigator_test::VectorMissionItemStore _mission_store{};
 };
 
 class RTLTest : public NavigatorDatamanTestBase
@@ -259,6 +285,16 @@ protected:
 		if (_mission_pub != nullptr) {
 			orb_unadvertise(_mission_pub);
 			_mission_pub = nullptr;
+		}
+
+		if (_global_position_pub != nullptr) {
+			orb_unadvertise(_global_position_pub);
+			_global_position_pub = nullptr;
+		}
+
+		if (_land_detected_pub != nullptr) {
+			orb_unadvertise(_land_detected_pub);
+			_land_detected_pub = nullptr;
 		}
 
 		param_control_autosave(true);
@@ -335,6 +371,36 @@ protected:
 		}
 	}
 
+	void publishGlobalPosition(double lat, double lon, float altitude)
+	{
+		vehicle_global_position_s global_position{};
+		global_position.timestamp = hrt_absolute_time();
+		global_position.lat = lat;
+		global_position.lon = lon;
+		global_position.alt = altitude;
+
+		if (_global_position_pub == nullptr) {
+			_global_position_pub = orb_advertise(ORB_ID(vehicle_global_position), &global_position);
+
+		} else {
+			orb_publish(ORB_ID(vehicle_global_position), _global_position_pub, &global_position);
+		}
+	}
+
+	void publishLandDetected(bool landed)
+	{
+		vehicle_land_detected_s land_detected{};
+		land_detected.timestamp = hrt_absolute_time();
+		land_detected.landed = landed;
+
+		if (_land_detected_pub == nullptr) {
+			_land_detected_pub = orb_advertise(ORB_ID(vehicle_land_detected), &land_detected);
+
+		} else {
+			orb_publish(ORB_ID(vehicle_land_detected), _land_detected_pub, &land_detected);
+		}
+	}
+
 	void publishWind(float windspeed_north, float windspeed_east)
 	{
 		wind_s wind{};
@@ -363,6 +429,8 @@ protected:
 	orb_advert_t _vehicle_status_pub{nullptr};
 	orb_advert_t _wind_pub{nullptr};
 	orb_advert_t _mission_pub{nullptr};
+	orb_advert_t _global_position_pub{nullptr};
+	orb_advert_t _land_detected_pub{nullptr};
 	DatamanClient _dataman_client{};
 	uint32_t _safe_points_id{0};
 	uint32_t _safe_points_opaque_id{0};
@@ -410,6 +478,39 @@ TEST_F(RTLTest, DirectMissionLandStartsWithCurrentMission)
 	EXPECT_EQ(direct_mission_land.mission().land_start_index, mission.land_start_index);
 	EXPECT_EQ(direct_mission_land.mission().land_index, mission.land_index);
 	EXPECT_EQ(direct_mission_land.mission().mission_dataman_id, mission.mission_dataman_id);
+}
+
+TEST_F(RTLTest, DirectMissionLandKeepsVtolInMulticopterMode)
+{
+	mission_s mission{};
+	mission.timestamp = hrt_absolute_time();
+	mission.current_seq = 0;
+	mission.land_start_index = 0;
+	mission.land_index = 2;
+	mission.mission_dataman_id = DM_KEY_WAYPOINTS_OFFBOARD_1;
+
+	mission_item_s land_start{};
+	land_start.nav_cmd = NAV_CMD_DO_LAND_START;
+	land_start.autocontinue = true;
+
+	mission_item_s approach = makeLandApproachItem(kBaseLat, kBaseLon, kAlt, kApproachRadius);
+	approach.autocontinue = true;
+
+	mission_item_s land = makeSafePointItem(kBaseLat, kBaseLon, kAlt, NAV_FRAME_GLOBAL, NAV_CMD_VTOL_LAND);
+	land.autocontinue = true;
+
+	publishVehicleStatus(true, vehicle_status_s::VEHICLE_TYPE_ROTARY_WING);
+	publishGlobalPosition(kBaseLat, kBaseLon, kAlt);
+	publishLandDetected(false);
+	_navigator.get_mission_result()->valid = true;
+
+	RtlDirectMissionLandTestPeer direct_mission_land{&_navigator, mission};
+	direct_mission_land.loadTestMission({land_start, approach, land});
+	direct_mission_land.setRtlAlt(kAlt);
+
+	direct_mission_land.activateForTest();
+
+	EXPECT_EQ(direct_mission_land.activeNavCommand(), NAV_CMD_DO_LAND_START);
 }
 
 // WHY: No land point means no usable approach bearing.

--- a/src/modules/navigator/test/test_RTL.cpp
+++ b/src/modules/navigator/test/test_RTL.cpp
@@ -58,6 +58,8 @@
 #include "navigator.h"
 #include "rtl.h"
 #include "rtl_direct_mission_land.h"
+#include "rtl_mission_fast.h"
+#include "rtl_mission_fast_reverse.h"
 #include "mission_route_types.h"
 #include "support/mission_route_cache_test_peer.h"
 #include "support/mission_route_test_helpers.h"
@@ -207,27 +209,28 @@ public:
 	}
 };
 
-class RtlDirectMissionLandTestPeer : public RtlDirectMissionLand
+template <typename RtlMissionType>
+class RtlMissionTestPeer : public RtlMissionType
 {
 public:
-	RtlDirectMissionLandTestPeer(Navigator *navigator, const mission_s &mission) :
-		RtlDirectMissionLand(navigator, mission) {}
+	RtlMissionTestPeer(Navigator *navigator, const mission_s &mission) :
+		RtlMissionType(navigator, mission) {}
 
-	const mission_s &mission() const { return _mission; }
+	const mission_s &mission() const { return this->_mission; }
 
 	void loadTestMission(const std::vector<mission_item_s> &items)
 	{
 		_mission_store.setItems(items);
-		_mission.count = static_cast<int32_t>(_mission_store.itemCount());
+		this->_mission.count = static_cast<int32_t>(_mission_store.itemCount());
 	}
 
 	void activateForTest()
 	{
-		_vehicle_status_sub.update();
-		on_activation();
+		this->_vehicle_status_sub.update();
+		this->on_activation();
 	}
 
-	uint16_t activeNavCommand() const { return _mission_item.nav_cmd; }
+	uint16_t activeNavCommand() const { return this->_mission_item.nav_cmd; }
 
 protected:
 	bool loadMissionItemFromCache(int32_t index, mission_item_s &mission_item) override
@@ -238,6 +241,10 @@ protected:
 private:
 	navigator_test::VectorMissionItemStore _mission_store{};
 };
+
+using RtlDirectMissionLandTestPeer = RtlMissionTestPeer<RtlDirectMissionLand>;
+using RtlMissionFastTestPeer = RtlMissionTestPeer<RtlMissionFast>;
+using RtlMissionFastReverseTestPeer = RtlMissionTestPeer<RtlMissionFastReverse>;
 
 class RTLTest : public NavigatorDatamanTestBase
 {
@@ -515,6 +522,68 @@ TEST_F(RTLTest, DirectMissionLandKeepsVtolInMulticopterMode)
 
 // WHY: No land point means no usable approach bearing.
 // WHAT: The chooser should return an invalid loiter.
+TEST_F(RTLTest, MissionFastKeepsVtolInMulticopterMode)
+{
+	// A VTOL flying in multicopter mode continues the mission as a multicopter.
+	// The attitude controller refuses a transition to fixed wing during RTL, so
+	// asking for one here left the vehicle waiting on it forever.
+	mission_s mission{};
+	mission.timestamp = hrt_absolute_time();
+	mission.current_seq = 0;
+	mission.land_start_index = -1;
+	mission.land_index = -1;
+	mission.mission_dataman_id = DM_KEY_WAYPOINTS_OFFBOARD_1;
+
+	const PositionYawSetpoint second_position = makePositionYawSetpointFromOffset(kBaseLat, kBaseLon, 200.f, 0.f, kAlt);
+	mission_item_s first = makeSafePointItem(kBaseLat, kBaseLon, kAlt, NAV_FRAME_GLOBAL, NAV_CMD_WAYPOINT);
+	first.autocontinue = true;
+	mission_item_s second = makeSafePointItem(second_position.lat, second_position.lon, kAlt, NAV_FRAME_GLOBAL,
+				NAV_CMD_WAYPOINT);
+	second.autocontinue = true;
+
+	publishVehicleStatus(true, vehicle_status_s::VEHICLE_TYPE_ROTARY_WING);
+	publishGlobalPosition(kBaseLat, kBaseLon, kAlt);
+	publishLandDetected(false);
+	_navigator.get_mission_result()->valid = true;
+
+	RtlMissionFastTestPeer mission_fast{&_navigator, mission};
+	mission_fast.loadTestMission({first, second});
+
+	mission_fast.activateForTest();
+
+	EXPECT_EQ(mission_fast.activeNavCommand(), NAV_CMD_WAYPOINT);
+}
+
+TEST_F(RTLTest, MissionFastReverseKeepsVtolInMulticopterMode)
+{
+	mission_s mission{};
+	mission.timestamp = hrt_absolute_time();
+	mission.current_seq = 0;
+	mission.land_start_index = -1;
+	mission.land_index = -1;
+	mission.mission_dataman_id = DM_KEY_WAYPOINTS_OFFBOARD_1;
+
+	const PositionYawSetpoint second_position = makePositionYawSetpointFromOffset(kBaseLat, kBaseLon, 200.f, 0.f, kAlt);
+	mission_item_s first = makeSafePointItem(kBaseLat, kBaseLon, kAlt, NAV_FRAME_GLOBAL, NAV_CMD_WAYPOINT);
+	first.autocontinue = true;
+	mission_item_s second = makeSafePointItem(second_position.lat, second_position.lon, kAlt, NAV_FRAME_GLOBAL,
+				NAV_CMD_WAYPOINT);
+	second.autocontinue = true;
+
+	// At the second waypoint, so the reverse mission has a previous item to fly to
+	publishVehicleStatus(true, vehicle_status_s::VEHICLE_TYPE_ROTARY_WING);
+	publishGlobalPosition(second_position.lat, second_position.lon, kAlt);
+	publishLandDetected(false);
+	_navigator.get_mission_result()->valid = true;
+
+	RtlMissionFastReverseTestPeer mission_fast_reverse{&_navigator, mission};
+	mission_fast_reverse.loadTestMission({first, second});
+
+	mission_fast_reverse.activateForTest();
+
+	EXPECT_EQ(mission_fast_reverse.activeNavCommand(), NAV_CMD_WAYPOINT);
+}
+
 TEST_F(RTLTest, ChooseBestLandingApproachRequiresLandLocation)
 {
 	// GIVEN: A valid loiter and no land point.

--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -217,6 +217,12 @@ void AutopilotTester::transition_to_multicopter()
 	REQUIRE(result == Action::Result::Success);
 }
 
+void AutopilotTester::wait_until_multicopter(std::chrono::seconds timeout)
+{
+	REQUIRE(poll_condition_with_timeout(
+	[this]() { return _telemetry->vtol_state() == Telemetry::VtolState::Mc; }, timeout));
+}
+
 void AutopilotTester::wait_until_disarmed(std::chrono::seconds timeout_duration)
 {
 	REQUIRE(poll_condition_with_timeout(

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -117,6 +117,7 @@ public:
 	void land();
 	void transition_to_fixedwing();
 	void transition_to_multicopter();
+	void wait_until_multicopter(std::chrono::seconds timeout);
 	void wait_until_disarmed(std::chrono::seconds timeout_duration = std::chrono::seconds(60));
 	void wait_until_hovering(); // TODO: name suggests, that function waits for drone velocity to be zero and not just drone in the air
 	void wait_until_altitude(float rel_altitude_m, std::chrono::seconds timeout, float delta = 0.5f);

--- a/test/mavsdk_tests/autopilot_tester_rtl.cpp
+++ b/test/mavsdk_tests/autopilot_tester_rtl.cpp
@@ -172,6 +172,22 @@ void AutopilotTesterRtl::check_rally_point_within(float acceptance_radius_m)
 	CHECK(within_rally_point);
 }
 
+void AutopilotTesterRtl::wait_until_disarmed_while_in_multicopter_mode(std::chrono::seconds timeout)
+{
+	const uint64_t start_time_us = getTelemetry()->attitude_quaternion().timestamp_us;
+	const uint64_t timeout_us = std::chrono::duration_cast<std::chrono::microseconds>(timeout).count();
+	bool remained_in_multicopter_mode = true;
+
+	while (getTelemetry()->armed() && remained_in_multicopter_mode
+	       && getTelemetry()->attitude_quaternion().timestamp_us - start_time_us < timeout_us) {
+		remained_in_multicopter_mode &= getTelemetry()->vtol_state() == Telemetry::VtolState::Mc;
+		sleep_for(std::chrono::milliseconds(100));
+	}
+
+	REQUIRE(remained_in_multicopter_mode);
+	REQUIRE_FALSE(getTelemetry()->armed());
+}
+
 void AutopilotTesterRtl::load_qgc_mission_and_geofence_here(const std::string &plan_file)
 {
 	auto import_result = getMissionRaw()->import_qgroundcontrol_mission(plan_file);

--- a/test/mavsdk_tests/autopilot_tester_rtl.h
+++ b/test/mavsdk_tests/autopilot_tester_rtl.h
@@ -61,6 +61,7 @@ public:
 	void connect(const std::string uri);
 	void check_rally_point_within(float acceptance_radius_m);
 	void check_rtl_approaches(float acceptance_radius_m, std::chrono::seconds timeout);
+	void wait_until_disarmed_while_in_multicopter_mode(std::chrono::seconds timeout);
 	void upload_rally_points();
 
 	// Import a QGC .plan and upload both the mission and any geofence polygons/circles it

--- a/test/mavsdk_tests/test_vtol_rtl.cpp
+++ b/test/mavsdk_tests/test_vtol_rtl.cpp
@@ -111,6 +111,44 @@ TEST_CASE("RTL with Reverse Mission", "[vtol]")
 	tester.wait_until_disarmed(std::chrono::seconds(150));
 }
 
+TEST_CASE("RTL with Mission Landing preserves multicopter mode", "[vtol]")
+{
+	AutopilotTesterRtl tester;
+	tester.connect(connection_url);
+	tester.wait_until_ready();
+	tester.store_home();
+	tester.load_qgc_mission_raw_and_move_here("test/mavsdk_tests/vtol_mission.plan");
+	tester.set_rtl_type(2);
+	tester.arm();
+	// In fixed wing by then, half way round the mission
+	tester.start_mission_raw_and_wait_for_sequence(4);
+	tester.transition_to_multicopter();
+	tester.wait_until_multicopter(std::chrono::seconds(60));
+	tester.execute_rtl();
+	// The rest of the mission and its landing are flown as a multicopter
+	tester.wait_until_disarmed_while_in_multicopter_mode(std::chrono::seconds(300));
+	tester.check_mission_land_within(5.0f);
+}
+
+TEST_CASE("RTL with Reverse Mission preserves multicopter mode", "[vtol]")
+{
+	AutopilotTesterRtl tester;
+	tester.connect(connection_url);
+	tester.wait_until_ready();
+	tester.store_home();
+	tester.set_takeoff_land_requirements(0);
+	tester.load_qgc_mission_raw_and_move_here("test/mavsdk_tests/vtol_mission_without_landing.plan");
+	tester.set_rtl_type(2);
+	tester.arm();
+	tester.start_mission_raw_and_wait_for_sequence(4);
+	tester.transition_to_multicopter();
+	tester.wait_until_multicopter(std::chrono::seconds(60));
+	tester.execute_rtl();
+	// The mission is flown back in reverse as a multicopter down to the home position
+	tester.wait_until_disarmed_while_in_multicopter_mode(std::chrono::seconds(300));
+	tester.check_home_within(5.0f);
+}
+
 TEST_CASE("RTL direct home without approaches", "[vtol]")
 {
 	AutopilotTesterRtl tester;

--- a/test/mavsdk_tests/test_vtol_rtl.cpp
+++ b/test/mavsdk_tests/test_vtol_rtl.cpp
@@ -64,6 +64,24 @@ TEST_CASE("RTL direct Mission Land", "[vtol]")
 	tester.check_mission_land_within(5.0f);
 }
 
+TEST_CASE("RTL direct Mission Land preserves multicopter mode", "[vtol]")
+{
+	AutopilotTesterRtl tester;
+	tester.connect(connection_url);
+	tester.wait_until_ready();
+	tester.store_home();
+	tester.load_qgc_mission_raw_and_move_here("test/mavsdk_tests/vtol_mission_with_land_start.plan");
+	tester.set_rtl_type(1);
+	tester.arm();
+	// Start at DO_LAND_START.
+	tester.start_mission_raw_and_wait_for_sequence(6);
+	tester.transition_to_multicopter();
+	tester.wait_until_multicopter(std::chrono::seconds(60));
+	tester.execute_rtl();
+	tester.wait_until_disarmed_while_in_multicopter_mode(std::chrono::seconds(180));
+	tester.check_mission_land_within(5.0f);
+}
+
 TEST_CASE("RTL with Mission Landing", "[vtol]")
 {
 	AutopilotTesterRtl tester;


### PR DESCRIPTION
## Summary

An MC-mode VTOL can now enter its planned mission landing without an unnecessary forward transition. The same applies to the fast and the reverse mission RTL. A VTOL that enters RTL in multicopter mode flies it as a multicopter, the same as direct RTL.

## Problem

Direct mission-land RTL forced MC-mode VTOLs into fixed-wing mode at return altitude. The vehicle could remain armed instead of starting the landing sequence.

## Solution

Preserve the current VTOL mode and advance directly to `DO_LAND_START`. The fast and the reverse mission RTL carried the same transition request, which the VTOL attitude controller rejects during RTL, so it is removed there as well, with a unit test and a SITL flight for each mode. This addresses the forced-transition behavior in #27817 and #24323; the separate invalid-mission race in #27817 remains out of scope.
