### PR TITLE
feat(ROMFS): make MAV_SYS_ID persist SYS_AUTOCONFIG parameter resets

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -120,11 +120,13 @@ else
 fi
 
 # To trigger a parameter reset during boot SYS_AUTOCONFIG was set to 1 before
+set PARAM_RESET_DONE no
 if param greater SYS_AUTOCONFIG 0
 then
-	# Reset parameters except airframe, parameter version, sensor calibration, total flight time, flight UUID
-	param reset_all SYS_AUTOSTART SYS_PARAM_VER MAV_SYS_ID CAL_* LND_FLIGHT* TC_* COM_FLIGHT*
+	# Reset parameters except airframe, parameter version, sensor calibration, total flight time, flight UUID, MAVLink sys_id
+	param reset_all SYS_AUTOSTART SYS_PARAM_VER SYS_AUTOCFG_CAL CAL_* LND_FLIGHT* TC_* COM_FLIGHT* MAV_SYS_ID
 	set AUTOCNF yes
+	set PARAM_RESET_DONE yes
 fi
 
 # multi-instance setup
@@ -135,22 +137,25 @@ param set UXRCE_DDS_KEY $((px4_instance+1))
 if [ $AUTOCNF = yes ]
 then
 	param set SYS_AUTOSTART $SYS_AUTOSTART
-
-	param set CAL_ACC0_ID 1310988 # 1310988: DRV_IMU_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
-	param set CAL_GYRO0_ID 1310988 # 1310988: DRV_IMU_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
-	param set CAL_ACC1_ID 1310996 # 1310996: DRV_IMU_DEVTYPE_SIM, BUS: 2, ADDR: 1, TYPE: SIMULATION
-	param set CAL_GYRO1_ID 1310996 # 1310996: DRV_IMU_DEVTYPE_SIM, BUS: 2, ADDR: 1, TYPE: SIMULATION
-	param set CAL_ACC2_ID 1311004 # 1311004: DRV_IMU_DEVTYPE_SIM, BUS: 3, ADDR: 1, TYPE: SIMULATION
-	param set CAL_GYRO2_ID 1311004 # 1311004: DRV_IMU_DEVTYPE_SIM, BUS: 3, ADDR: 1, TYPE: SIMULATION
-
-	param set CAL_MAG0_ID 197388
-	param set CAL_MAG0_PRIO 50
-	param set CAL_MAG1_ID 197644
-	param set CAL_MAG1_PRIO 50
-
-	param set SENS_BOARD_X_OFF 0.000001
-	param set SENS_DPRES_OFF 0.001
 fi
+
+# Simulated sensor calibration, declared via SYS_AUTOCFG_CAL the same way a real airframe's built-in calibration would
+param set-default SYS_AUTOCFG_CAL 1
+
+param set-default CAL_ACC0_ID 1310988 # 1310988: DRV_IMU_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
+param set-default CAL_GYRO0_ID 1310988 # 1310988: DRV_IMU_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
+param set-default CAL_ACC1_ID 1310996 # 1310996: DRV_IMU_DEVTYPE_SIM, BUS: 2, ADDR: 1, TYPE: SIMULATION
+param set-default CAL_GYRO1_ID 1310996 # 1310996: DRV_IMU_DEVTYPE_SIM, BUS: 2, ADDR: 1, TYPE: SIMULATION
+param set-default CAL_ACC2_ID 1311004 # 1311004: DRV_IMU_DEVTYPE_SIM, BUS: 3, ADDR: 1, TYPE: SIMULATION
+param set-default CAL_GYRO2_ID 1311004 # 1311004: DRV_IMU_DEVTYPE_SIM, BUS: 3, ADDR: 1, TYPE: SIMULATION
+
+param set-default CAL_MAG0_ID 197388
+param set-default CAL_MAG0_PRIO 50
+param set-default CAL_MAG1_ID 197644
+param set-default CAL_MAG1_PRIO 50
+
+param set-default SENS_BOARD_X_OFF 0.000001
+param set-default SENS_DPRES_OFF 0.001
 
 param set-default BAT1_N_CELLS 4
 
@@ -229,6 +234,14 @@ elif [ ! -e "$autostart_file" ] && [ "$SYS_AUTOSTART" -ne "0" ]
 then
 	echo "Error: no autostart file found ($autostart_file)"
 	exit 1
+fi
+
+if param greater SYS_AUTOCFG_CAL 0
+then
+	if [ ${PARAM_RESET_DONE} = yes ]
+	then
+		param reset CAL_* SYS_AUTOCFG_CAL
+	fi
 fi
 
 # Allow overriding parameters via env variables: export PX4_PARAM_{name}={value}

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -123,7 +123,7 @@ fi
 if param greater SYS_AUTOCONFIG 0
 then
 	# Reset parameters except airframe, parameter version, sensor calibration, total flight time, flight UUID
-	param reset_all SYS_AUTOSTART SYS_PARAM_VER CAL_* LND_FLIGHT* TC_* COM_FLIGHT*
+	param reset_all SYS_AUTOSTART SYS_PARAM_VER MAV_SYS_ID CAL_* LND_FLIGHT* TC_* COM_FLIGHT*
 	set AUTOCNF yes
 fi
 

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -257,7 +257,7 @@ else
 	if param greater SYS_AUTOCONFIG 0
 	then
 		# Reset parameters except airframe, parameter version, sensor calibration, total flight time, flight UUID
-		param reset_all SYS_AUTOSTART SYS_PARAM_VER SYS_AUTOCFG_CAL CAL_* LND_FLIGHT* TC_* COM_FLIGHT*
+		param reset_all SYS_AUTOSTART SYS_PARAM_VER SYS_AUTOCFG_CAL MAV_SYS_ID CAL_* LND_FLIGHT* TC_* COM_FLIGHT*
 		set PARAM_RESET_DONE yes
 	fi
 

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -256,8 +256,8 @@ else
 	set PARAM_RESET_DONE no
 	if param greater SYS_AUTOCONFIG 0
 	then
-		# Reset parameters except airframe, parameter version, sensor calibration, total flight time, flight UUID
-		param reset_all SYS_AUTOSTART SYS_PARAM_VER SYS_AUTOCFG_CAL MAV_SYS_ID CAL_* LND_FLIGHT* TC_* COM_FLIGHT*
+		# Reset parameters except airframe, parameter version, sensor calibration, total flight time, flight UUID, MAVLink sys_id
+		param reset_all SYS_AUTOSTART SYS_PARAM_VER SYS_AUTOCFG_CAL CAL_* LND_FLIGHT* TC_* COM_FLIGHT* MAV_SYS_ID
 		set PARAM_RESET_DONE yes
 	fi
 


### PR DESCRIPTION
### Issue solved
Before, everytime we wanted to reset airframe default parameters we enebled SYS_AUTOCONFIG and reboot.
MAV_SYS_ID gets also reset to airframe default. However if we have multiple drones with different MAV_SYS_ID they would all reset to their airframe default which is probably the same. Therefore after the user needs to manually reset all of them to the correct one. Moreover, in case of a swarm, this mav_sys_id change also leaves a "ghost vehicle" on the GS with the old sys_id until next full power-cycle. See video in whihc default airframe mav_sys_id was 10:


https://github.com/user-attachments/assets/d1e744b2-e261-4e93-96a3-780f1c73a48b

### Solution
Exclude MAV_SYS_ID from reset when SYS_AUTOCONIFIG is on
The example below is of a drone that had default MAV_SYS_ID 1



https://github.com/user-attachments/assets/c686f9fa-0de3-4f4c-8c00-b1b28fa0cd3c


