### PR TITLE
fix(ekf2): prevent mag resets after manual heading

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
@@ -176,6 +176,8 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 			_control_status.flags.mag_fault = false;
 		}
 
+		const bool no_ne_aiding_or_not_moving = !isNorthEastAidingActive() || _control_status.flags.vehicle_at_rest;
+
 		{
 
 			const bool mag_consistent_or_no_ne_aiding = _control_status.flags.mag_heading_consistent || !isNorthEastAidingActive();
@@ -196,6 +198,10 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 			_control_status.flags.mag_hdg = common_conditions_passing
 							&& ((_params.ekf2_mag_type == static_cast<int32_t>(MagFuseType::HEADING))
 							    || (_params.ekf2_mag_type == static_cast<int32_t>(MagFuseType::AUTO) && !_control_status.flags.mag_3D));
+
+			// if we are using 3-axis magnetometer fusion, but without external NE aiding,
+			// then the declination must be fused as an observation to prevent long term heading drift
+			_control_status.flags.mag_dec = _control_status.flags.mag && no_ne_aiding_or_not_moving;
 		}
 
 		if (_control_status.flags.mag_3D && !_control_status_prev.flags.mag_3D) {
@@ -204,11 +210,6 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 		} else if (!_control_status.flags.mag_3D && _control_status_prev.flags.mag_3D) {
 			ECL_INFO("stopping mag 3D fusion");
 		}
-
-		// if we are using 3-axis magnetometer fusion, but without external NE aiding,
-		// then the declination must be fused as an observation to prevent long term heading drift
-		const bool no_ne_aiding_or_not_moving = !isNorthEastAidingActive() || _control_status.flags.vehicle_at_rest;
-		_control_status.flags.mag_dec = _control_status.flags.mag && no_ne_aiding_or_not_moving;
 
 		if (_control_status.flags.mag) {
 

--- a/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
@@ -77,7 +77,7 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 			_mag_lpf.reset(mag_sample.mag);
 			_mag_counter = 1;
 
-			if (!_control_status.flags.in_air) {
+			if (!_control_status.flags.in_air && !_control_status.flags.yaw_manual) {
 				// Assume that a reset on the ground is caused by a change in mag calibration
 				// Clear alignment to force a clean reset
 				_control_status.flags.yaw_align = false;
@@ -139,8 +139,7 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 		Vector3f mag_innov;
 		Vector3f innov_var;
 
-		// Observation jacobian and Kalman gain vectors
-		VectorState H;
+		VectorState H; // Observation jacobian
 		sym::ComputeMagInnovInnovVarAndHx(_state.vector(), P, mag_sample.mag, R_MAG, FLT_EPSILON, &mag_innov, &innov_var, &H);
 
 		updateAidSourceStatus(aid_src,
@@ -218,7 +217,9 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 				if (checkHaglYawResetReq() && (_control_status.flags.mag_hdg || _control_status.flags.mag_3D
 							       || _control_status.flags.yaw_manual)) {
 					ECL_INFO("reset to %s", AID_SRC_NAME);
-					const bool reset_heading = ((_control_status.flags.mag_hdg || _control_status.flags.mag_3D) && !isNorthEastAidingActive());
+					const bool reset_heading = isHeadingResetToMagAllowed()
+								   && !isNorthEastAidingActive(); // NE aiding makes heading observable
+
 					resetMagStates(_mag_lpf.getState(), reset_heading);
 
 					// record the start time for the magnetic field alignment
@@ -227,7 +228,7 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 					aid_src.time_last_fuse = imu_sample.time_us;
 
 				} else if (wmm_updated && no_ne_aiding_or_not_moving) {
-					const bool reset_heading = _control_status.flags.mag_hdg || _control_status.flags.mag_3D;
+					const bool reset_heading = isHeadingResetToMagAllowed();
 					resetMagStates(_mag_lpf.getState(), reset_heading);
 					aid_src.time_last_fuse = imu_sample.time_us;
 
@@ -277,7 +278,8 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 				if (is_fusion_failing) {
 					if (no_ne_aiding_or_not_moving) {
 						ECL_WARN("%s fusion failing, resetting", AID_SRC_NAME);
-						resetMagStates(_mag_lpf.getState(), _control_status.flags.mag_hdg || _control_status.flags.mag_3D);
+						const bool reset_heading = isHeadingResetToMagAllowed();
+						resetMagStates(_mag_lpf.getState(), reset_heading);
 						aid_src.time_last_fuse = imu_sample.time_us;
 
 					} else {
@@ -388,6 +390,12 @@ bool Ekf::checkHaglYawResetReq() const
 #endif // CONFIG_EKF2_TERRAIN
 
 	return false;
+}
+
+bool Ekf::isHeadingResetToMagAllowed() const
+{
+	return (_control_status.flags.mag_hdg || _control_status.flags.mag_3D)
+	       && !_control_status.flags.yaw_manual; // do not override manual reset
 }
 
 void Ekf::resetMagStates(const Vector3f &mag, bool reset_heading)

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -174,4 +174,31 @@ void Ekf::controlFusionModes(const imuSample &imu_delayed)
 	const bool yaw_aiding = _control_status.flags.mag_hdg || _control_status.flags.mag_3D
 				|| _control_status.flags.ev_yaw || _control_status.flags.gnss_yaw;
 	_control_status.flags.heading_observable = isNorthEastAidingActive() || yaw_aiding;
+
+	updateYawManualValidity();
+}
+
+void Ekf::updateYawManualValidity()
+{
+	const bool heading_observation_fusing = !isTimedOut(_time_last_heading_fuse, _params.no_aid_timeout_max);
+
+	if (!_control_status.flags.yaw_manual || !heading_observation_fusing) {
+		_time_heading_fusion_start = 0;
+		return;
+	}
+
+	if (_time_heading_fusion_start == 0) {
+		_time_heading_fusion_start = _time_delayed_us;
+		return;
+	}
+
+	// A manually set heading is protected from automatic heading resets, but only until the
+	// heading aiding sources have had the opportunity to drive the heading themselves. After
+	// that the estimate is aiding derived and the manual value is stale, so keeping the
+	// protection would only block recovery resets.
+	static constexpr uint64_t kHeadingFusionTimeToClearYawManual = 30'000'000;
+
+	if ((_time_delayed_us - _time_heading_fusion_start) > kHeadingFusionTimeToClearYawManual) {
+		_control_status.flags.yaw_manual = false;
+	}
 }

--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -110,6 +110,7 @@ void Ekf::reset()
 	_time_last_ver_vel_fuse = 0;
 	_time_last_heading_fuse = 0;
 	_time_last_terrain_fuse = 0;
+	_time_heading_fusion_start = 0;
 
 	_last_known_gpos.setZero();
 

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -537,6 +537,7 @@ private:
 	uint64_t _time_last_hor_vel_fuse{0};	///< time the last fusion of horizontal velocity measurements was performed (uSec)
 	uint64_t _time_last_ver_vel_fuse{0};	///< time the last fusion of verticalvelocity measurements was performed (uSec)
 	uint64_t _time_last_heading_fuse{0};
+	uint64_t _time_heading_fusion_start{0};	///< start of the current uninterrupted period of heading observation fusion, while yaw was set manually (uSec)
 	uint64_t _time_last_terrain_fuse{0};
 
 	LatLonAlt _last_known_gpos{};
@@ -880,6 +881,8 @@ private:
 	// Control the filter fusion modes
 	void controlFusionModes(const imuSample &imu_delayed);
 
+	void updateYawManualValidity();
+
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
 	// control fusion of external vision observations
 	void controlExternalVisionFusion(const imuSample &imu_sample);
@@ -976,6 +979,7 @@ private:
 	void controlMagFusion(const imuSample &imu_sample);
 
 	bool checkHaglYawResetReq() const;
+	bool isHeadingResetToMagAllowed() const;
 
 	void resetMagHeading(const Vector3f &mag);
 	void resetMagStates(const Vector3f &mag, bool reset_heading = true);

--- a/src/modules/ekf2/test/test_EKF_mag.cpp
+++ b/src/modules/ekf2/test/test_EKF_mag.cpp
@@ -272,6 +272,148 @@ TEST_F(EkfMagTest, velocityRotationOnYawReset)
 	EXPECT_GT(yaw_change, 0.3f) << "Yaw change: " << degrees(yaw_change) << " deg";
 }
 
+TEST_F(EkfMagTest, manualYawExpiresWhenHeadingIsFused)
+{
+	// GIVEN: mag fusion is aligned in flight, so the mag remains the heading source
+	// even after a manual heading reset
+	const float mag_heading = M_PI_F / 4.f;
+	_sensor_simulator._mag.setData(Vector3f(0.2f * cosf(mag_heading), -0.2f * sinf(mag_heading), 0.4f));
+	_sensor_simulator.runSeconds(_init_duration_s);
+
+	_ekf->set_in_air_status(true);
+	_ekf->set_vehicle_at_rest(false);
+	_sensor_simulator._rng.setData(5.f, 100);
+	_sensor_simulator.startRangeFinder();
+	_sensor_simulator.runSeconds(5.f);
+
+	ASSERT_TRUE(_ekf_wrapper.isIntendingMagHeadingFusion() || _ekf_wrapper.isIntendingMag3DFusion());
+	ASSERT_FALSE(_ekf->control_status_flags().yaw_manual);
+
+	// WHEN: the heading is set manually
+	_ekf->resetHeadingToExternalObservation(mag_heading + radians(30.f), radians(2.f));
+	_sensor_simulator.runSeconds(1.f);
+
+	// THEN: the manual heading is protected from being overridden by the mag
+	EXPECT_TRUE(_ekf->control_status_flags().yaw_manual);
+
+	// AND WHEN: the mag keeps being fused as heading source for a long time
+	_sensor_simulator.runSeconds(20.f);
+	EXPECT_TRUE(_ekf->control_status_flags().yaw_manual);
+
+	_sensor_simulator.runSeconds(15.f);
+
+	// THEN: the heading is mag derived again and the manual reset no longer protected
+	EXPECT_FALSE(_ekf->control_status_flags().yaw_manual);
+}
+
+TEST_F(EkfMagTest, manualYawSurvivesWithGnssAidingOnly)
+{
+	// GIVEN: the vehicle sits on the ground with GNSS velocity and position fused
+	const float mag_heading = M_PI_F / 4.f;
+	_sensor_simulator._mag.setData(Vector3f(0.2f * cosf(mag_heading), -0.2f * sinf(mag_heading), 0.4f));
+	_sensor_simulator.runSeconds(_init_duration_s);
+
+	_ekf->set_min_required_gps_health_time(1e6);
+	_ekf_wrapper.enableGpsFusion();
+	_sensor_simulator.startGps();
+	_sensor_simulator.runSeconds(10.f);
+
+	ASSERT_TRUE(_ekf->control_status_flags().gnss_vel);
+	ASSERT_TRUE(_ekf->control_status_flags().gnss_pos);
+
+	// WHEN: the heading is set manually, which stops the mag from being used as heading source
+	_ekf->resetHeadingToExternalObservation(mag_heading + radians(30.f), radians(2.f));
+	_sensor_simulator.runSeconds(2.f);
+
+	ASSERT_FALSE(_ekf_wrapper.isIntendingMagHeadingFusion());
+	ASSERT_FALSE(_ekf_wrapper.isIntendingMag3DFusion());
+
+	// THEN: GNSS aiding alone does not observe the heading of a vehicle that is not
+	// accelerating laterally, so the manual heading is kept indefinitely
+	_sensor_simulator.runSeconds(60.f);
+	EXPECT_TRUE(_ekf->control_status_flags().yaw_manual);
+	EXPECT_NEAR(_ekf_wrapper.getYawAngle(), mag_heading + radians(30.f), radians(2.f));
+}
+
+TEST_F(EkfMagTest, manualYawOnGroundBlocksMagHeadingFusionIndefinitely)
+{
+	// GIVEN: the mag is the heading source of a vehicle that has not taken off yet
+	const float mag_heading = M_PI_F / 4.f;
+	_sensor_simulator._mag.setData(Vector3f(0.2f * cosf(mag_heading), -0.2f * sinf(mag_heading), 0.4f));
+	_sensor_simulator.runSeconds(_init_duration_s);
+
+	ASSERT_TRUE(_ekf_wrapper.isIntendingMagHeadingFusion());
+
+	// WHEN: the heading is set manually while still on the ground
+	const float manual_heading = mag_heading + radians(30.f);
+	_ekf->resetHeadingToExternalObservation(manual_heading, radians(2.f));
+	_sensor_simulator.runSeconds(2.f);
+
+	// THEN: the mag is no longer used as heading source, because in-flight mag alignment is the
+	// only condition that lets mag heading fusion resume after a manual heading reset
+	EXPECT_TRUE(_ekf->control_status_flags().yaw_manual);
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMagHeadingFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMag3DFusion());
+
+	// AND: this does not resolve itself while the vehicle stays on the ground. No heading
+	// observation is fused, so the manual heading never expires, which in turn keeps mag
+	// heading fusion disabled.
+	_sensor_simulator.runSeconds(120.f);
+
+	EXPECT_TRUE(_ekf->control_status_flags().yaw_manual);
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMagHeadingFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMag3DFusion());
+
+	// AND: the manual heading is never overridden by the mag
+	EXPECT_NEAR(_ekf_wrapper.getYawAngle(), manual_heading, radians(3.f));
+	// AND: the missing in-flight alignment is the only thing holding heading fusion off; the mag
+	// itself is still healthy and being fused into the field states
+	EXPECT_FALSE(_ekf->control_status_flags().mag_aligned_in_flight);
+	EXPECT_TRUE(_ekf->control_status_flags().mag);
+	EXPECT_TRUE(_ekf->control_status_flags().yaw_align);
+	EXPECT_FALSE(_ekf->control_status_flags().mag_fault);
+	EXPECT_FALSE(_ekf->control_status_flags().mag_field_disturbed);
+}
+
+TEST_F(EkfMagTest, manualYawSurvivesTakeoffUntilHeadingFused)
+{
+	// GIVEN: the heading was set manually on the ground, before any in-flight mag alignment
+	const float mag_heading = M_PI_F / 4.f;
+	_sensor_simulator._mag.setData(Vector3f(0.2f * cosf(mag_heading), -0.2f * sinf(mag_heading), 0.4f));
+	_sensor_simulator.runSeconds(_init_duration_s);
+
+	const float manual_heading = mag_heading + radians(30.f);
+	_ekf->resetHeadingToExternalObservation(manual_heading, radians(2.f));
+	_sensor_simulator.runSeconds(2.f);
+
+	ASSERT_TRUE(_ekf->control_status_flags().yaw_manual);
+	ASSERT_FALSE(_ekf->control_status_flags().mag_aligned_in_flight);
+
+	// WHEN: the vehicle takes off and climbs above the height of the ground mag anomalies,
+	// which triggers the in-flight mag alignment
+	_ekf->set_in_air_status(true);
+	_ekf->set_vehicle_at_rest(false);
+	_sensor_simulator._rng.setData(5.f, 100);
+	_sensor_simulator.startRangeFinder();
+	_sensor_simulator.runSeconds(5.f);
+
+	// THEN: the mag becomes the heading source again, but the manual heading is neither
+	// overridden by the alignment nor immediately declared stale by it
+	EXPECT_TRUE(_ekf->control_status_flags().mag_aligned_in_flight);
+	EXPECT_TRUE(_ekf_wrapper.isIntendingMag3DFusion());
+	EXPECT_TRUE(_ekf->control_status_flags().yaw_manual);
+	EXPECT_NEAR(_ekf_wrapper.getYawAngle(), manual_heading, radians(1.f));
+
+	// AND WHEN: the mag has been driving the heading for long enough
+	_sensor_simulator.runSeconds(20.f);
+	EXPECT_TRUE(_ekf->control_status_flags().yaw_manual);
+
+	_sensor_simulator.runSeconds(15.f);
+
+	// THEN: the manual heading expires
+	EXPECT_FALSE(_ekf->control_status_flags().yaw_manual);
+}
+
 TEST_F(EkfMagTest, magHeadingChangeRateLimited)
 {
 	// GIVEN: EKF just had its initial yaw alignment from mag, setting heading variance to


### PR DESCRIPTION
### Solved Problem
Heading can be set manually by the operator before takeoff or during flight if the current heading seems wrong. This is often used when the mag cannot provide an accurate heading before takeoff.
The problem is that the mag was still allowed to perform a heading reset after takeoff or when the fusion times-out.

### Solution
When a manual heading reset was performed recently, the mag can only reset its own states (not the heading). The manual heading flag now has a validity period: it expires if a yaw aiding source is being constantly fused for at least 30 seconds. The "manual heading" value that was fused in the EKF is anyway long gone if another sensor is being fused.

### Test coverage
A couple of unit tests were added to cover some of the relevant cases:
- _manualYawExpiresWhenHeadingIsFused_: with mag 3D aligned in flight, yaw_manual clears after ~30 s of continuous heading fusion.
- _manualYawSurvivesWithGnssAidingOnly_: parked with GNSS vel+pos fused, yaw_manual and the commanded heading survive 60 s, since GNSS aiding alone does not observe heading without acceleration (this could change in the future with a better observability check)
- _manualYawOnGroundBlocksMagHeadingFusionIndefinitely_: on the ground a manual reset keeps mag heading fusion off for 122 s (even with good mag data)
- _manualYawSurvivesTakeoffUntilHeadingFused_: across the HAGL climb-out alignment (1.5m reset) the heading is neither reset to mag nor declared stale immediately; yaw_manual survives takeoff and expires only after 30 s of mag fusion.


SITL test showing the `manual_heading` flag being reset after 30s of active `mag_3d` fusion
<img width="938" height="389" alt="image" src="https://github.com/user-attachments/assets/e1e670fd-a2d2-44a0-be4f-e9d01032d409" />
