### PR TITLE
fix(external-modes): avoid creation of duplicated external modes

### DIFF
--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -103,7 +103,7 @@ bool Modes::hasFreeExternalModes() const
 	return false;
 }
 
-uint8_t Modes::addExternalMode(const Modes::Mode &mode)
+int Modes::addExternalMode(const Modes::Mode &mode)
 {
 	int32_t mode_name_hash = (int32_t)events::util::hash_32_fnv1a_const(mode.name);
 
@@ -140,21 +140,12 @@ uint8_t Modes::addExternalMode(const Modes::Mode &mode)
 	int new_mode_idx = -1;
 
 	if (matching_idx != -1) {
-		// If we found a match, try to use it but check for hash collisions or duplicate mode name
 		if (_modes[matching_idx].valid) {
-			// This can happen when restarting modes while armed
-			PX4_WARN("Mode '%s' already registered (as '%s')", mode.name, _modes[matching_idx].name);
-
-			if (first_unused_idx != -1) {
-				new_mode_idx = first_unused_idx;
-				// Do not update the hash
-
-			} else {
-				// Need to overwrite a hash. Reset it as we can't store duplicate hashes anyway
-				new_mode_idx = first_invalid_idx;
-				need_to_update_param = true;
-				mode_name_hash = 0;
-			}
+			// Hash collision with a currently registered mode, should not happen in practice
+			// with 32-bit FNV-1a over 8 names. Stale same-name registrations are evicted before
+			// this is called, so this branch is a logic error.
+			PX4_ERR("Mode '%s' already registered (hash collision or logic error)", mode.name);
+			return -1;
 
 		} else {
 			new_mode_idx = matching_idx;
@@ -222,7 +213,7 @@ ModeManagement::ModeManagement(ExternalChecks &external_checks)
 	_external_checks.setExternalNavStates(Modes::FIRST_EXTERNAL_NAV_STATE, Modes::LAST_EXTERNAL_NAV_STATE);
 }
 
-void ModeManagement::checkNewRegistrations(UpdateRequest &update_request)
+void ModeManagement::checkNewRegistrations(uint8_t user_intended_nav_state, UpdateRequest &update_request)
 {
 	register_ext_component_request_s request;
 	int max_updates = 5;
@@ -255,9 +246,33 @@ void ModeManagement::checkNewRegistrations(UpdateRequest &update_request)
 
 		reply.success = false;
 
+		bool restore_executor_in_charge = false;
+		bool evicted_active_mode = false;
+
 		if (request_valid) {
 			// check free space
 			reply.success = true;
+
+			if (request.register_mode) {
+				// Evict stale registration with the same name. Happens if the external app that drives the mode:
+				// - Restarted or crashed
+				// - Re-registers fast enough that its not yet flagged unresponsive
+				// - or is the current active mode and thus never gets removed automatically
+				// Must run before free-slot checks so freed slots count.
+				for (int i = Modes::FIRST_EXTERNAL_NAV_STATE; i <= Modes::LAST_EXTERNAL_NAV_STATE; ++i) {
+					if (_modes.valid(i) && strncmp(_modes.mode(i).name, request.name, sizeof(request.name)) == 0) {
+						PX4_WARN("Mode '%s' re-registered, evicting stale slot", request.name);
+						const Modes::Mode &stale_mode = _modes.mode(i);
+						restore_executor_in_charge = request.register_mode_executor && (_mode_executor_in_charge == stale_mode.mode_executor_registration_id);
+						evicted_active_mode = (i == user_intended_nav_state);
+
+						_external_checks.removeRegistration(stale_mode.arming_check_registration_id, i);
+						_modes.removeExternalMode(i, stale_mode.name);
+						removeModeExecutor(stale_mode.mode_executor_registration_id);
+						break;
+					}
+				}
+			}
 
 			if (request.register_arming_check && !_external_checks.hasFreeRegistrations()) {
 				PX4_WARN("No free slots for arming checks");
@@ -290,7 +305,7 @@ void ModeManagement::checkNewRegistrations(UpdateRequest &update_request)
 				reply.success = false;
 			}
 
-			// register component(s)
+			// try to register component(s)
 			if (reply.success) {
 				int nav_mode_id = -1;
 
@@ -306,36 +321,53 @@ void ModeManagement::checkNewRegistrations(UpdateRequest &update_request)
 
 					nav_mode_id = _modes.addExternalMode(mode);
 					reply.mode_id = nav_mode_id;
+
+					if (nav_mode_id == -1) {
+						reply.success = false;
+					}
 				}
 
-				if (request.register_mode_executor) {
-					ModeExecutors::ModeExecutor executor{};
-					executor.owned_nav_state = nav_mode_id;
-					int registration_id = _mode_executors.addExecutor(executor);
+				if (reply.success) {
+					if (request.register_mode_executor) {
+						ModeExecutors::ModeExecutor executor{};
+						executor.owned_nav_state = nav_mode_id;
+						int registration_id = _mode_executors.addExecutor(executor);
 
-					if (nav_mode_id != -1) {
-						_modes.mode(nav_mode_id).mode_executor_registration_id = registration_id;
+						if (nav_mode_id != -1) {
+							_modes.mode(nav_mode_id).mode_executor_registration_id = registration_id;
+						}
+
+						reply.mode_executor_id = registration_id;
+
+						if (restore_executor_in_charge) {
+							_mode_executor_in_charge = registration_id;
+						}
 					}
 
-					reply.mode_executor_id = registration_id;
-				}
+					if (request.register_arming_check) {
+						int8_t replace_nav_state = request.enable_replace_internal_mode ? request.replace_internal_mode : -1;
+						int registration_id = _external_checks.addRegistration(nav_mode_id, replace_nav_state);
 
-				if (request.register_arming_check) {
-					int8_t replace_nav_state = request.enable_replace_internal_mode ? request.replace_internal_mode : -1;
-					int registration_id = _external_checks.addRegistration(nav_mode_id, replace_nav_state);
+						if (nav_mode_id != -1) {
+							_modes.mode(nav_mode_id).arming_check_registration_id = registration_id;
+						}
 
-					if (nav_mode_id != -1) {
-						_modes.mode(nav_mode_id).arming_check_registration_id = registration_id;
+						reply.arming_check_id = registration_id;
 					}
 
-					reply.arming_check_id = registration_id;
+					// Activate the mode?
+					if (request.register_mode_executor && request.activate_mode_immediately && nav_mode_id != -1) {
+						update_request.change_user_intended_nav_state = true;
+						update_request.user_intended_nav_state = nav_mode_id;
+					}
 				}
+			}
 
-				// Activate the mode?
-				if (request.register_mode_executor && request.activate_mode_immediately && nav_mode_id != -1) {
-					update_request.change_user_intended_nav_state = true;
-					update_request.user_intended_nav_state = nav_mode_id;
-				}
+			if (evicted_active_mode && !reply.success) {
+				// New registration failed after evicting the active mode, fall back to AUTO_LOITER
+				// rather than leaving the vehicle in an unregistered nav_state.
+				update_request.change_user_intended_nav_state = true;
+				update_request.user_intended_nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER;
 			}
 		}
 
@@ -414,7 +446,7 @@ void ModeManagement::update(uint8_t vehicle_type, bool armed, uint8_t user_inten
 
 		// As we're disarmed we can use the user intended mode, as no failsafe will be active.
 		// Note that this might not be true if COM_MODE_ARM_CHK is set
-		checkNewRegistrations(update_request);
+		checkNewRegistrations(user_intended_nav_state, update_request);
 		checkUnregistrations(user_intended_nav_state, update_request);
 	}
 

--- a/src/modules/commander/ModeManagement.hpp
+++ b/src/modules/commander/ModeManagement.hpp
@@ -111,7 +111,7 @@ public:
 	const Mode &mode(uint8_t nav_state) const { return _modes[nav_state - FIRST_EXTERNAL_NAV_STATE]; }
 
 	bool hasFreeExternalModes() const;
-	uint8_t addExternalMode(const Mode &mode);
+	int addExternalMode(const Mode &mode);
 	bool removeExternalMode(uint8_t nav_state, const char *name);
 
 private:
@@ -171,7 +171,7 @@ public:
 
 private:
 	bool checkConfigControlSetpointUpdates(uint8_t vehicle_type);
-	void checkNewRegistrations(UpdateRequest &update_request);
+	void checkNewRegistrations(uint8_t user_intended_nav_state, UpdateRequest &update_request);
 	void checkUnregistrations(uint8_t user_intended_nav_state, UpdateRequest &update_request);
 	void checkConfigOverrides();
 

--- a/src/modules/commander/ModeManagementTest.cpp
+++ b/src/modules/commander/ModeManagementTest.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2023 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2026 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,13 @@
 
 #include <gtest/gtest.h>
 #include "ModeManagement.hpp"
+#include "HealthAndArmingChecks/checks/externalChecks.hpp"
+#include <uORB/uORBManager.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/register_ext_component_request.h>
+#include <uORB/topics/register_ext_component_reply.h>
+#include <uORB/topics/unregister_ext_component.h>
 
 static bool modeValid(uint8_t mode)
 {
@@ -84,12 +91,13 @@ TEST(ModeManagementTest, Hashes)
 	snprintf(mode.name, sizeof(mode.name), "mode %i", mode_to_add_idx);
 	EXPECT_EQ(modes.addExternalMode(mode), Modes::FIRST_EXTERNAL_NAV_STATE + mode_to_add_idx);
 
-	// Try to add another one with the same name: should succeed, with the hash of the added index reset
+	// Duplicate name registration must fail, stale entries are evicted in checkNewRegistrations()
+	// before addExternalMode() is called, so a valid slot with the same name is a logic error.
 	uint8_t added_mode_nav_state = modes.addExternalMode(mode);
-	EXPECT_EQ(readHash(added_mode_nav_state - Modes::FIRST_EXTERNAL_NAV_STATE), 0);
+	EXPECT_FALSE(modeValid(added_mode_nav_state));
 
-	// 3 Modes are used now. Add N-3 new ones which must overwrite previous hashes
-	for (int i = 0; i < Modes::MAX_NUM - 3; ++i) {
+	// 2 Modes are used now. Add N-2 new ones which must overwrite previous hashes
+	for (int i = 0; i < Modes::MAX_NUM - 2; ++i) {
 		snprintf(mode.name, sizeof(mode.name), "new mode %i", i);
 		added_mode_nav_state = modes.addExternalMode(mode);
 		EXPECT_TRUE(modeValid(added_mode_nav_state));
@@ -98,4 +106,230 @@ TEST(ModeManagementTest, Hashes)
 	}
 
 	EXPECT_FALSE(modes.hasFreeExternalModes());
+}
+
+// ---------------------------------------------------------------------------
+// Registration fixture, tests for ModeManagement::checkNewRegistrations()
+// ---------------------------------------------------------------------------
+
+static constexpr uint8_t kVehicleType = 0; // multirotor
+static constexpr uint8_t kLoiter = vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER;
+
+class ModeManagementRegistrationTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+		param_control_autosave(false);
+
+		for (int i = 0; i < Modes::MAX_NUM; ++i) {
+			char buf[20];
+			snprintf(buf, sizeof(buf), "COM_MODE%u_HASH", i);
+			param_reset(param_find(buf));
+		}
+
+		orb_advertise(ORB_ID(register_ext_component_request), nullptr);
+		orb_advertise(ORB_ID(unregister_ext_component), nullptr);
+		orb_advertise(ORB_ID(arming_check_reply), nullptr);
+
+		external_checks = new ExternalChecks();
+		mode_management = new ModeManagement(*external_checks);
+		request_pub = new uORB::Publication<register_ext_component_request_s>(ORB_ID(register_ext_component_request));
+		unreg_pub = new uORB::Publication<unregister_ext_component_s>(ORB_ID(unregister_ext_component));
+		reply_sub = new uORB::Subscription(ORB_ID(register_ext_component_reply));
+		drainStaleMessages();
+	}
+
+	// Flush stale request (from previous test) that the new ModeManagement subscription would
+	// otherwise re-process, and drain the resulting replies so every test starts clean.
+	void drainStaleMessages()
+	{
+		ModeManagement::UpdateRequest dummy{};
+		mode_management->update(kVehicleType, false, kLoiter, dummy);
+		register_ext_component_reply_s stale{};
+
+		while (reply_sub->update(&stale)) {}
+	}
+
+	void TearDown() override
+	{
+		delete reply_sub;
+		delete unreg_pub;
+		delete request_pub;
+		delete mode_management;
+		delete external_checks;
+	}
+
+	register_ext_component_reply_s doRegister(const char *name,
+			uint8_t nav_state = kLoiter,
+			bool with_executor = true)
+	{
+		register_ext_component_request_s req{};
+		strncpy(req.name, name, sizeof(req.name));
+		req.register_mode = true;
+		req.register_arming_check = true;
+		req.register_mode_executor = with_executor;
+		req.request_id = next_request_id++;
+		req.timestamp = hrt_absolute_time();
+		request_pub->publish(req);
+
+		last_update = {};
+		mode_management->update(kVehicleType, false, nav_state, last_update);
+
+		register_ext_component_reply_s reply{};
+		reply_sub->update(&reply);
+		return reply;
+	}
+
+	void doUnregister(const register_ext_component_reply_s &reply, const char *name, uint8_t nav_state)
+	{
+		unregister_ext_component_s req{};
+		strncpy(req.name, name, sizeof(req.name));
+		req.mode_id = reply.mode_id;
+		req.mode_executor_id = reply.mode_executor_id;
+		req.arming_check_id = reply.arming_check_id;
+		req.timestamp = hrt_absolute_time();
+		unreg_pub->publish(req);
+		last_update = {};
+		mode_management->update(kVehicleType, false, nav_state, last_update);
+	}
+
+	ExternalChecks *external_checks{};
+	ModeManagement *mode_management{};
+	uORB::Publication<register_ext_component_request_s> *request_pub{};
+	uORB::Publication<unregister_ext_component_s> *unreg_pub{};
+	uORB::Subscription *reply_sub{};
+
+	uint64_t next_request_id{1};
+	ModeManagement::UpdateRequest last_update{};
+};
+
+// T1: baseline, first registration gets deterministic slot 0
+TEST_F(ModeManagementRegistrationTest, FirstRegistration)
+{
+	auto reply = doRegister("mode A");
+	EXPECT_TRUE(reply.success);
+	EXPECT_EQ(reply.mode_id, Modes::FIRST_EXTERNAL_NAV_STATE);
+	EXPECT_EQ(reply.mode_executor_id, ModeExecutors::FIRST_EXECUTOR_ID);
+	EXPECT_EQ(reply.arming_check_id, 0);
+	EXPECT_FALSE(last_update.change_user_intended_nav_state);
+}
+
+// T2: two different names coexist, no eviction
+TEST_F(ModeManagementRegistrationTest, TwoDifferentModes)
+{
+	auto reply_A = doRegister("mode A");
+	auto reply_B = doRegister("mode B");
+	EXPECT_TRUE(reply_A.success);
+	EXPECT_TRUE(reply_B.success);
+	EXPECT_EQ(reply_A.mode_id, Modes::FIRST_EXTERNAL_NAV_STATE);
+	EXPECT_EQ(reply_B.mode_id, Modes::FIRST_EXTERNAL_NAV_STATE + 1);
+	EXPECT_NE(reply_A.mode_executor_id, reply_B.mode_executor_id);
+	EXPECT_NE(reply_A.arming_check_id, reply_B.arming_check_id);
+	EXPECT_FALSE(last_update.change_user_intended_nav_state);
+}
+
+// T3: fast restart, mode not active, same ids returned, executor in charge unchanged
+TEST_F(ModeManagementRegistrationTest, FastRestartModeNotActive)
+{
+	auto reply1 = doRegister("mode A", kLoiter);
+	auto reply2 = doRegister("mode A", kLoiter);
+
+	EXPECT_TRUE(reply2.success);
+	EXPECT_EQ(reply2.mode_id, reply1.mode_id);
+	EXPECT_EQ(reply2.mode_executor_id, reply1.mode_executor_id);
+	EXPECT_EQ(reply2.arming_check_id, reply1.arming_check_id);
+	EXPECT_FALSE(last_update.change_user_intended_nav_state);
+	EXPECT_EQ(mode_management->modeExecutorInCharge(), ModeExecutors::AUTOPILOT_EXECUTOR_ID);
+}
+
+// T4: fast restart while mode is active, executor handed over within the same update() call
+TEST_F(ModeManagementRegistrationTest, FastRestartModeActive)
+{
+	auto reply1 = doRegister("mode A", kLoiter);
+	mode_management->onUserIntendedNavStateChange(ModeChangeSource::User, reply1.mode_id);
+	EXPECT_EQ(mode_management->modeExecutorInCharge(), reply1.mode_executor_id);
+
+	auto reply2 = doRegister("mode A", reply1.mode_id);
+
+	EXPECT_TRUE(reply2.success);
+	EXPECT_EQ(reply2.mode_id, reply1.mode_id);
+	EXPECT_EQ(reply2.mode_executor_id, reply1.mode_executor_id);
+	EXPECT_EQ(reply2.arming_check_id, reply1.arming_check_id);
+	EXPECT_EQ(mode_management->modeExecutorInCharge(), reply2.mode_executor_id); // restored immediately
+	EXPECT_FALSE(last_update.change_user_intended_nav_state); // no spurious mode switch
+}
+
+// T5: eviction runs before free-slot checks, restart succeeds even when executor pool appears full
+TEST_F(ModeManagementRegistrationTest, EvictionBeforeFreeSlotCheck)
+{
+	auto reply_A = doRegister("mode A", kLoiter); // executor 1
+	doRegister("mode 1", kLoiter);                // executor 2
+	doRegister("mode 2", kLoiter);                // executor 3
+	doRegister("mode 3", kLoiter);                // executor 4
+	doRegister("mode 4", kLoiter);                // executor 5, pool full
+
+	auto reply_A2 = doRegister("mode A", kLoiter);
+
+	EXPECT_TRUE(reply_A2.success);
+	EXPECT_EQ(reply_A2.mode_id, reply_A.mode_id);
+	EXPECT_EQ(reply_A2.mode_executor_id, reply_A.mode_executor_id);
+	EXPECT_EQ(reply_A2.arming_check_id, reply_A.arming_check_id);
+}
+
+// T6: active mode evicted, restart escalates to executor with full pool, AUTO_LOITER fallback fires
+TEST_F(ModeManagementRegistrationTest, ActiveModeEvictedRestartFails)
+{
+	auto reply_A = doRegister("mode A", kLoiter, false);
+	doRegister("mode 1", kLoiter); // executor 1
+	doRegister("mode 2", kLoiter); // executor 2
+	doRegister("mode 3", kLoiter); // executor 3
+	doRegister("mode 4", kLoiter); // executor 4
+	doRegister("mode 5", kLoiter); // executor 5, pool full
+
+	mode_management->onUserIntendedNavStateChange(ModeChangeSource::User, reply_A.mode_id);
+
+	auto reply_A2 = doRegister("mode A", reply_A.mode_id, true);
+
+	EXPECT_FALSE(reply_A2.success);
+	EXPECT_TRUE(last_update.change_user_intended_nav_state);
+	EXPECT_EQ(last_update.user_intended_nav_state, (uint8_t)vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER);
+}
+
+// T7: clean unregister of active mode still triggers AUTO_LOITER fallback (regression)
+TEST_F(ModeManagementRegistrationTest, CleanUnregisterActiveModeTriggersLoiterFallback)
+{
+	auto reply = doRegister("mode A", kLoiter);
+	doUnregister(reply, "mode A", reply.mode_id);
+
+	EXPECT_TRUE(last_update.change_user_intended_nav_state);
+	EXPECT_EQ(last_update.user_intended_nav_state, (uint8_t)vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER);
+}
+
+// T8: arming-check-only request, eviction loop not entered, two registrations coexist
+TEST_F(ModeManagementRegistrationTest, ArmingCheckOnlyNoEviction)
+{
+	auto doArmingCheckRegister = [&]() -> register_ext_component_reply_s {
+		register_ext_component_request_s req{};
+		strncpy(req.name, "check A", sizeof(req.name));
+		req.register_arming_check = true;
+		req.register_mode = false;
+		req.register_mode_executor = false;
+		req.request_id = next_request_id++;
+		req.timestamp = hrt_absolute_time();
+		request_pub->publish(req);
+		last_update = {};
+		mode_management->update(kVehicleType, false, kLoiter, last_update);
+		register_ext_component_reply_s reply{};
+		reply_sub->update(&reply);
+		return reply;
+	};
+
+	auto reply1 = doArmingCheckRegister();
+	auto reply2 = doArmingCheckRegister();
+
+	EXPECT_TRUE(reply1.success);
+	EXPECT_TRUE(reply2.success);
+	EXPECT_EQ(reply1.arming_check_id, 0);
+	EXPECT_EQ(reply2.arming_check_id, 1); // separate slot, no eviction
 }


### PR DESCRIPTION
### Solved Problem

Sporadically we noticed that the same external mode got registered twice in different slots. This is especially problematic if this external mode is the one currently being flown, as:
- The user currently flys the stale state of that external mode and the logic does not de-register external modes that are currently flown even when they are unresponsive
- The actual data is now received on another external mode, requiring the user to manually switch to this mode (if the user even notices that it exists)

This state can be reached rather easily in the following case:
- The external mode is the one currently selected
- The app driving the external mode crashes and re-starts, thus requesting a new registration
- The timeout logic does detect that the previous instance is unresponsive, but it does not delete it as its the mode currently being flown
  - This logic also can't be changed because at this point in time we don't know if data may come back
  - But latest at the time of receiving a new registration for the same app its obvious that it crashed 

### Solution

- When receiving a registration request for an external mode that already exists, evict the existing registration and replace it by the incoming one. The argumentation for this is:
  - It does not make sense to have two separate external apps that have the same external mode name
  - Receiving another registration request for the same name indicates that the external app is not in the state we expect it to be. It indicates that the external app crashed or had a timeout and is now back. Thus the previous registration is not valid anymore
- As we evict the previous registration the new one can take over the same slot with the existing logic
- If for whatever reason the registration does not succeed after we evicted the previous instance and the mode is the one currently being flown a fallback to `HOLD` is done  

### Test coverage

- Tested with the updated test suite (see code changes)
- Tested on the bench by restarting an external app, timing it out
- Flight test pending