### PR TITLE
fix(perf): run perf_iterate_all callbacks without the list mutex

### DIFF
--- a/src/lib/perf/CMakeLists.txt
+++ b/src/lib/perf/CMakeLists.txt
@@ -34,3 +34,5 @@
 add_library(perf perf_counter.cpp)
 add_dependencies(perf prebuild_targets)
 target_compile_options(perf PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
+
+px4_add_functional_gtest(SRC PerfCounterTest.cpp LINKLIBS perf)

--- a/src/lib/perf/PerfCounterTest.cpp
+++ b/src/lib/perf/PerfCounterTest.cpp
@@ -1,0 +1,317 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+
+#include "perf_counter.h"
+
+namespace
+{
+
+bool wait_until(const std::atomic<bool> &condition)
+{
+	const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+
+	while (!condition.load() && std::chrono::steady_clock::now() < deadline) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+	}
+
+	return condition.load();
+}
+
+} // namespace
+
+TEST(PerfCounter, IterateLineContent)
+{
+	perf_counter_t counter = perf_alloc(PC_COUNT, "test_perf_line_content");
+	ASSERT_NE(counter, nullptr);
+
+	perf_count(counter);
+	perf_count(counter);
+	perf_count(counter);
+
+	struct Context {
+		std::string line;
+	} context;
+
+	perf_iterate_all([](const char *counter_line, void *user) {
+		if (strstr(counter_line, "test_perf_line_content") != nullptr) {
+			static_cast<Context *>(user)->line = counter_line;
+		}
+	}, &context);
+
+	EXPECT_EQ(context.line, "test_perf_line_content: 3 events");
+
+	perf_free(counter);
+}
+
+TEST(PerfCounter, ConcurrentAllocDoesNotBlockOnSlowCallback)
+{
+	perf_counter_t counter = perf_alloc(PC_COUNT, "test_perf_slow_callback");
+	ASSERT_NE(counter, nullptr);
+
+	// while the first callback is running, another thread must be able to
+	// allocate and free a counter without waiting for the iteration to finish
+	struct Context {
+		std::atomic<bool> first{true};
+		std::atomic<bool> alloc_done{false};
+		std::atomic<bool> alloc_succeeded{false};
+		std::thread alloc_thread;
+	} context;
+
+	perf_iterate_all([](const char *, void *user) {
+		Context *ctx = static_cast<Context *>(user);
+
+		if (ctx->first.exchange(false)) {
+			ctx->alloc_thread = std::thread([ctx]() {
+				perf_counter_t other = perf_alloc(PC_COUNT, "test_perf_concurrent_alloc");
+				ctx->alloc_succeeded.store(other != nullptr);
+				perf_free(other);
+				ctx->alloc_done.store(true);
+			});
+
+			EXPECT_TRUE(wait_until(ctx->alloc_done));
+		}
+	}, &context);
+
+	if (context.alloc_thread.joinable()) {
+		context.alloc_thread.join();
+	}
+
+	EXPECT_TRUE(context.alloc_done.load());
+	EXPECT_TRUE(context.alloc_succeeded.load());
+
+	perf_free(counter);
+}
+
+TEST(PerfCounter, AllocFromCallbackDoesNotDeadlock)
+{
+	perf_counter_t counter = perf_alloc(PC_COUNT, "test_perf_callback_alloc");
+	ASSERT_NE(counter, nullptr);
+
+	// calling perf_alloc() from inside the callback self-deadlocked when the
+	// iteration held the mutex; run the iteration on its own thread so a
+	// regression fails the test instead of hanging it
+	struct Context {
+		std::atomic<bool> first{true};
+		std::atomic<bool> done{false};
+		perf_counter_t allocated{nullptr};
+	} context;
+
+	std::thread iterate_thread([&]() {
+		perf_iterate_all([](const char *, void *user) {
+			Context *ctx = static_cast<Context *>(user);
+
+			if (ctx->first.exchange(false)) {
+				ctx->allocated = perf_alloc(PC_COUNT, "test_perf_callback_alloc_inner");
+			}
+		}, &context);
+
+		context.done.store(true);
+	});
+
+	if (!wait_until(context.done)) {
+		iterate_thread.detach();
+		FAIL() << "perf_alloc() from the callback deadlocked";
+	}
+
+	iterate_thread.join();
+	EXPECT_NE(context.allocated, nullptr);
+
+	perf_free(context.allocated);
+	perf_free(counter);
+}
+
+TEST(PerfCounter, FreeDuringIterationIsDeferred)
+{
+	// allocation order puts counter_b at the list head, so it is visited first
+	perf_counter_t counter_a = perf_alloc(PC_COUNT, "test_perf_free_defer_a");
+	perf_counter_t counter_b = perf_alloc(PC_COUNT, "test_perf_free_defer_b");
+	ASSERT_NE(counter_a, nullptr);
+	ASSERT_NE(counter_b, nullptr);
+
+	struct Context {
+		perf_counter_t counter_a;
+		std::atomic<bool> free_done{false};
+		std::thread free_thread;
+		int lines_a{0};
+	} context{counter_a};
+
+	perf_iterate_all([](const char *counter_line, void *user) {
+		Context *ctx = static_cast<Context *>(user);
+
+		if (!ctx->free_thread.joinable() && strstr(counter_line, "test_perf_free_defer_b") != nullptr) {
+			// free a not-yet-visited counter while the iteration is running
+			ctx->free_thread = std::thread([ctx]() {
+				perf_free(ctx->counter_a);
+				ctx->free_done.store(true);
+			});
+
+			EXPECT_TRUE(wait_until(ctx->free_done));
+		}
+
+		if (strstr(counter_line, "test_perf_free_defer_a") != nullptr) {
+			ctx->lines_a++;
+		}
+	}, &context);
+
+	if (context.free_thread.joinable()) {
+		context.free_thread.join();
+	}
+
+	EXPECT_TRUE(context.free_done.load());
+	EXPECT_EQ(context.lines_a, 0);
+
+	// the freed entry must not reappear after deferred cleanup
+	struct CountContext {
+		int lines_a{0};
+	} count_context;
+
+	perf_iterate_all([](const char *counter_line, void *user) {
+		if (strstr(counter_line, "test_perf_free_defer_a") != nullptr) {
+			static_cast<CountContext *>(user)->lines_a++;
+		}
+	}, &count_context);
+
+	EXPECT_EQ(count_context.lines_a, 0);
+
+	perf_free(counter_b);
+}
+
+TEST(PerfCounter, FreeIsDeferredUntilLastOverlappingIterationEnds)
+{
+	// Both iterators stop on counter_b with counter_a cached as their next entry.
+	perf_counter_t counter_a = perf_alloc(PC_COUNT, "test_perf_overlap_a");
+	perf_counter_t counter_b = perf_alloc(PC_COUNT, "test_perf_overlap_b");
+	ASSERT_NE(counter_a, nullptr);
+	ASSERT_NE(counter_b, nullptr);
+
+	struct IterateContext {
+		std::atomic<bool> entered{false};
+		std::atomic<bool> release{false};
+		std::atomic<bool> timed_out{false};
+		int lines_a{0};
+		int replacement_lines{0};
+	} first_context, second_context;
+
+	perf_callback callback = [](const char *counter_line, void *user) {
+		IterateContext *ctx = static_cast<IterateContext *>(user);
+
+		if (strstr(counter_line, "test_perf_overlap_b") != nullptr) {
+			ctx->entered.store(true);
+
+			if (!wait_until(ctx->release)) {
+				ctx->timed_out.store(true);
+			}
+		}
+
+		if (strstr(counter_line, "test_perf_overlap_a") != nullptr) {
+			ctx->lines_a++;
+		}
+
+		if (strstr(counter_line, "test_perf_overlap_replacement") != nullptr) {
+			ctx->replacement_lines++;
+		}
+	};
+
+	std::thread first_thread([&]() { perf_iterate_all(callback, &first_context); });
+
+	if (!wait_until(first_context.entered)) {
+		first_context.release.store(true);
+		first_thread.join();
+		perf_free(counter_a);
+		perf_free(counter_b);
+		FAIL() << "first iterator did not reach the blocking callback";
+	}
+
+	std::thread second_thread([&]() { perf_iterate_all(callback, &second_context); });
+
+	if (!wait_until(second_context.entered)) {
+		first_context.release.store(true);
+		second_context.release.store(true);
+		first_thread.join();
+		second_thread.join();
+		perf_free(counter_a);
+		perf_free(counter_b);
+		FAIL() << "second iterator did not reach the blocking callback";
+	}
+
+	std::atomic<bool> free_done{false};
+	std::thread free_thread([&]() {
+		perf_free(counter_a);
+		free_done.store(true);
+	});
+
+	if (!wait_until(free_done)) {
+		first_context.release.store(true);
+		second_context.release.store(true);
+		first_thread.join();
+		second_thread.join();
+		free_thread.join();
+		perf_free(counter_b);
+		FAIL() << "perf_free() blocked on active callbacks";
+	}
+
+	free_thread.join();
+	first_context.release.store(true);
+	first_thread.join();
+
+	// If the first iterator incorrectly reclaimed counter_a, a same-sized
+	// allocation is likely to reuse the entry cached by the second iterator.
+	perf_counter_t replacement = perf_alloc(PC_COUNT, "test_perf_overlap_replacement");
+
+	if (replacement == nullptr) {
+		second_context.release.store(true);
+		second_thread.join();
+		perf_free(counter_b);
+		FAIL() << "replacement counter allocation failed";
+	}
+
+	second_context.release.store(true);
+	second_thread.join();
+
+	EXPECT_FALSE(first_context.timed_out.load());
+	EXPECT_FALSE(second_context.timed_out.load());
+	EXPECT_EQ(first_context.lines_a, 0);
+	EXPECT_EQ(second_context.lines_a, 0);
+	EXPECT_EQ(second_context.replacement_lines, 0);
+
+	perf_free(replacement);
+	perf_free(counter_b);
+}

--- a/src/lib/perf/perf_counter.cpp
+++ b/src/lib/perf/perf_counter.cpp
@@ -86,6 +86,7 @@ private:
 struct perf_ctr_header {
 	sq_entry_t		link;	/**< list linkage */
 	enum perf_counter_type	type;	/**< counter type */
+	bool			pending_free;	/**< freed during iteration, deleted after the last iteration ends */
 	const char		*name;	/**< counter name */
 };
 
@@ -135,6 +136,54 @@ pthread_mutex_t perf_counters_mutex = PTHREAD_MUTEX_INITIALIZER;
 // Note: the mutex only protects the linked list, not individual counter data.
 // Counter fields go through PerfVar (atomic on POSIX/TSan, plain on embedded).
 
+/**
+ * Number of perf_iterate_all() calls currently in progress (guarded by perf_counters_mutex).
+ * While non-zero, perf_free() only marks entries as pending_free; the last
+ * iteration to finish deletes them.
+ */
+static int perf_iterate_active = 0;
+
+static void
+perf_delete(perf_counter_t handle)
+{
+	switch (handle->type) {
+	case PC_COUNT:
+		delete (struct perf_ctr_count *)handle;
+		break;
+
+	case PC_ELAPSED:
+		delete (struct perf_ctr_elapsed *)handle;
+		break;
+
+	case PC_INTERVAL:
+		delete (struct perf_ctr_interval *)handle;
+		break;
+
+	default:
+		break;
+	}
+}
+
+/**
+ * Delete all entries marked pending_free. Call with perf_counters_mutex held
+ * and no iteration active.
+ */
+static void
+perf_free_pending_locked()
+{
+	perf_counter_t handle = (perf_counter_t)sq_peek(&perf_counters);
+
+	while (handle != nullptr) {
+		perf_counter_t next = (perf_counter_t)sq_next(&handle->link);
+
+		if (handle->pending_free) {
+			sq_rem(&handle->link, &perf_counters);
+			perf_delete(handle);
+		}
+
+		handle = next;
+	}
+}
 
 perf_counter_t
 perf_alloc(enum perf_counter_type type, const char *name)
@@ -161,6 +210,7 @@ perf_alloc(enum perf_counter_type type, const char *name)
 	if (ctr != nullptr) {
 		ctr->type = type;
 		ctr->name = name;
+		ctr->pending_free = false;
 		pthread_mutex_lock(&perf_counters_mutex);
 		sq_addfirst(&ctr->link, &perf_counters);
 		pthread_mutex_unlock(&perf_counters_mutex);
@@ -176,7 +226,7 @@ perf_alloc_once(enum perf_counter_type type, const char *name)
 	perf_counter_t handle = (perf_counter_t)sq_peek(&perf_counters);
 
 	while (handle != nullptr) {
-		if (!strcmp(handle->name, name)) {
+		if (!handle->pending_free && !strcmp(handle->name, name)) {
 			if (type == handle->type) {
 				/* they are the same counter */
 				pthread_mutex_unlock(&perf_counters_mutex);
@@ -206,25 +256,19 @@ perf_free(perf_counter_t handle)
 	}
 
 	pthread_mutex_lock(&perf_counters_mutex);
+
+	if (perf_iterate_active > 0) {
+		// an iteration may be positioned on this entry: keep it linked
+		// and let the last active iteration delete it
+		handle->pending_free = true;
+		pthread_mutex_unlock(&perf_counters_mutex);
+		return;
+	}
+
 	sq_rem(&handle->link, &perf_counters);
 	pthread_mutex_unlock(&perf_counters_mutex);
 
-	switch (handle->type) {
-	case PC_COUNT:
-		delete (struct perf_ctr_count *)handle;
-		break;
-
-	case PC_ELAPSED:
-		delete (struct perf_ctr_elapsed *)handle;
-		break;
-
-	case PC_INTERVAL:
-		delete (struct perf_ctr_interval *)handle;
-		break;
-
-	default:
-		break;
-	}
+	perf_delete(handle);
 }
 
 void
@@ -653,12 +697,35 @@ perf_mean(perf_counter_t handle)
 void
 perf_iterate_all(perf_callback cb, void *user)
 {
+	static constexpr size_t PERF_COUNTER_LINE_BUFFER_SIZE = 220;
+	char buffer[PERF_COUNTER_LINE_BUFFER_SIZE];
+
 	pthread_mutex_lock(&perf_counters_mutex);
+	++perf_iterate_active;
+
 	perf_counter_t handle = (perf_counter_t)sq_peek(&perf_counters);
 
 	while (handle != nullptr) {
-		cb(handle, user);
-		handle = (perf_counter_t)sq_next(&handle->link);
+		// advance while locked; entries stay linked until all active iterations end
+		perf_counter_t next = (perf_counter_t)sq_next(&handle->link);
+
+		if (!handle->pending_free) {
+			perf_print_counter_buffer(buffer, sizeof(buffer), handle);
+
+			// the callback may block (the logger waits for MAVLink acks here), so run
+			// it without the global mutex: perf_alloc()/perf_free() on other threads
+			// keep working, and 'next' stays valid because perf_free() defers deletion
+			// while perf_iterate_active > 0
+			pthread_mutex_unlock(&perf_counters_mutex);
+			cb(buffer, user);
+			pthread_mutex_lock(&perf_counters_mutex);
+		}
+
+		handle = next;
+	}
+
+	if (--perf_iterate_active == 0) {
+		perf_free_pending_locked();
 	}
 
 	pthread_mutex_unlock(&perf_counters_mutex);
@@ -671,7 +738,10 @@ perf_print_all(void)
 	perf_counter_t handle = (perf_counter_t)sq_peek(&perf_counters);
 
 	while (handle != nullptr) {
-		perf_print_counter(handle);
+		if (!handle->pending_free) {
+			perf_print_counter(handle);
+		}
+
 		handle = (perf_counter_t)sq_next(&handle->link);
 	}
 
@@ -701,7 +771,10 @@ perf_reset_all(void)
 	perf_counter_t handle = (perf_counter_t)sq_peek(&perf_counters);
 
 	while (handle != nullptr) {
-		perf_reset(handle);
+		if (!handle->pending_free) {
+			perf_reset(handle);
+		}
+
 		handle = (perf_counter_t)sq_next(&handle->link);
 	}
 

--- a/src/lib/perf/perf_counter.h
+++ b/src/lib/perf/perf_counter.h
@@ -81,6 +81,10 @@ __EXPORT extern perf_counter_t	perf_alloc_once(enum perf_counter_type type, cons
 /**
  * Free a counter.
  *
+ * If one or more perf_iterate_all() calls are in progress, the counter is
+ * hidden from subsequent callbacks immediately and deleted after the last
+ * iteration ends.
+ *
  * @param handle		The performance counter's handle.
  */
 __EXPORT extern void		perf_free(perf_counter_t handle);
@@ -190,14 +194,15 @@ __EXPORT extern int		perf_print_counter_buffer(char *buffer, int length, perf_co
 __EXPORT extern void		perf_print_all(void);
 
 
-typedef void (*perf_callback)(perf_counter_t handle, void *user);
+typedef void (*perf_callback)(const char *counter_line, void *user);
 
 /**
  * Iterate over all performance counters using a callback.
  *
- * Caution: This will aquire the mutex, so do not call any other perf_* method
- * that aquire the mutex as well from the callback (If this is needed, configure
- * the mutex to be reentrant).
+ * The callback gets each counter formatted as with perf_print_counter_buffer();
+ * the string is only valid during the call. The internal mutex is released
+ * while the callback runs, therefore blocking inside the callback (e.g. on I/O)
+ * does not stall other perf callers, and the callback may itself call perf methods.
  *
  * @param cb callback method
  * @param user custom argument for the callback

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1602,14 +1602,10 @@ void Logger::handle_file_write_error()
 	}
 }
 
-void Logger::perf_iterate_callback(perf_counter_t handle, void *user)
+void Logger::perf_iterate_callback(const char *counter_line, void *user)
 {
 	perf_callback_data_t *callback_data = (perf_callback_data_t *)user;
-	const int buffer_length = 220;
-	char buffer[buffer_length];
 	const char *perf_name;
-
-	perf_print_counter_buffer(buffer, buffer_length, handle);
 
 	switch (callback_data->reason) {
 	case PrintLoadReason::Preflight:
@@ -1626,7 +1622,7 @@ void Logger::perf_iterate_callback(perf_counter_t handle, void *user)
 		break;
 	}
 
-	callback_data->logger->write_info_multiple(LogType::Full, perf_name, buffer, callback_data->counter != 0);
+	callback_data->logger->write_info_multiple(LogType::Full, perf_name, counter_line, callback_data->counter != 0);
 	++callback_data->counter;
 }
 

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -256,7 +256,7 @@ private:
 	/**
 	 * callback to write the performance counters
 	 */
-	static void perf_iterate_callback(perf_counter_t handle, void *user);
+	static void perf_iterate_callback(const char *counter_line, void *user);
 
 	/**
 	 * callback for print_load_buffer() to print the process load


### PR DESCRIPTION
### Context
`perf_iterate_all()` held the global perf counter list mutex across each callback. At mavlink log start and stop, `Logger` enables reliable transfer while writing performance counters. Every full `ulog_stream` packet can therefore wait for a `LOGGING_ACK` up to 2.5 s per packet (`ACK_TIMEOUT * ACK_MAX_TRIES = 50 ms * 50`). During those waits any concurrent `perf_alloc()`, `perf_alloc_once()` or `perf_free()` blocked on the list mutex.

The most likely trigger was removed in https://github.com/PX4/PX4-Autopilot/pull/22626 (EKF2 no longer allocates counters on first sensor samples), but other rare paths remain, e.g. `VehicleAngularVelocity` on `wq:rate_ctrl` allocates its dynamic notch counters on the first parameter update after enabling `IMU_GYRO_DNF_EN`.

### Solution
`perf_iterate_all()` now formats each counter under the list lock and invokes the callback after unlocking. Frees requested while any iterator is active are marked pending and reclaimed after the last iterator finishes, keeping cached list nodes valid. Pending counters are omitted from the following callbacks. The callback receives the formatted line instead of the handle. Logger is the only production caller. Existing counter line formatting is unchanged.

Tested with unit tests.
