### PR TITLE
build(uxrce_dds_client): fix Micro-XRCE-DDS client build with GCC 14

### DIFF
--- a/src/modules/uxrce_dds_client/CMakeLists.txt
+++ b/src/modules/uxrce_dds_client/CMakeLists.txt
@@ -61,6 +61,11 @@ else()
 		set(cxx_flags_with_includes "${cxx_flags_with_includes} -I${dir}")
 	endforeach()
 
+	# GCC 14 promotes implicit function declarations to hard errors; the
+	# client's POSIX UDP transport (compiled but never linked on NuttX)
+	# trips this via getaddrinfo/freeaddrinfo
+	set(c_flags_with_includes "${c_flags_with_includes} -Wno-error=implicit-function-declaration")
+
 	set(lib_dir ${CMAKE_INSTALL_LIBDIR})
 	if("${lib_dir}" STREQUAL "")
 		set(lib_dir "lib")


### PR DESCRIPTION
## Summary

The Micro-XRCE-DDS client no longer compiles for NuttX targets with GCC 14 (`arm-none-eabi-gcc 14.2.1`). This restores the pre-GCC-14 behaviour for the client's external-project build only.

## Problem

GCC 14 turned implicit function declarations into hard errors. The client is built with `UCLIENT_PROFILE_UDP=ON` on every board, so `udp_transport_posix.c` is compiled even where NuttX has no networking, and there `<netdb.h>` declares neither `getaddrinfo` nor `freeaddrinfo`:

```
udp_transport_posix.c:46:18: error: implicit declaration of function 'getaddrinfo' [-Wimplicit-function-declaration]
```

Every board with `CONFIG_MODULES_UXRCE_DDS_CLIENT=y` and no `CONFIG_LIBC_NETDB` is affected — Kakute H7, Matek H743, CORVON 743v2 and the like.

## Solution

Pass `-Wno-error=implicit-function-declaration` in the C flags handed to the client build on NuttX. The UDP transport object is never linked on those boards, so this is exactly as harmless as it was with GCC 13. Verified with GCC 14.2.1: `matek_h743-slim_default` fails on current `main` with the error above and builds with this change. Not tested with the older toolchain, where the flag is a no-op.
