### PR TITLE
fix(gz_bridge): Fix imu time stamp to publication time for gz sim

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -40,6 +40,7 @@
 
 #include <px4_platform_common/getopt.h>
 
+#include <algorithm>
 #include <iostream>
 #include <string>
 
@@ -434,7 +435,10 @@ void GZBridge::airspeedCallback(const gz::msgs::AirSpeed &msg)
 
 void GZBridge::imuCallback(const gz::msgs::IMU &msg)
 {
-	const uint64_t timestamp = hrt_absolute_time();
+	const uint64_t timestamp_sample = msg.header().stamp().sec() * 1000000ULL + msg.header().stamp().nsec() / 1000ULL;
+
+	// The simulated clock can be marginally behind the header stamp due to topic delivery ordering
+	const uint64_t timestamp = std::min(timestamp_sample, hrt_absolute_time());
 
 	// FLU -> FRD
 	static const auto q_FLU_to_FRD = gz::math::Quaterniond(0, 1, 0, 0);


### PR DESCRIPTION
### Solved Problem
The timestamp of the imu sensor was set as the time when the message was received, not when the imu plugin published the sensor data.

This resulted in delays that were problematic when using the imu message for external estimation tasks. 

### Solution
Set the time to be the publish time of the imu sensor

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
Other sensors will have the same problem, but just fixed for the imu for now given that imu is the highest rate sensor. 

### Test coverage
Tested in Gz with the x500
```
make px4_sitl gz_x500
```
