### PR TITLE
fix(commander): convert the baro timestamp delta to seconds for the home altitude filter

### DIFF
--- a/src/modules/commander/HomePosition.cpp
+++ b/src/modules/commander/HomePosition.cpp
@@ -364,7 +364,7 @@ void HomePosition::update(bool set_automatically, bool check_if_changed)
 		const float baro_alt = baro_data.baro_alt_meter;
 
 		if (_last_baro_timestamp != 0) {
-			const float dt = baro_data.timestamp - _last_baro_timestamp;
+			const float dt = 1e-6f * (baro_data.timestamp - _last_baro_timestamp);
 			_lpf_baro.update(baro_alt, dt);
 
 		} else {


### PR DESCRIPTION
## Summary

The low pass filter that smooths barometric altitude for the in-air home position correction is fed the raw uORB timestamp difference, which is in microseconds, while `AlphaFilter::setParameters()` documents both of its arguments as seconds and the filter is constructed with a 5 second time constant.

`src/modules/commander/HomePosition.cpp`:

```c
const float dt = baro_data.timestamp - _last_baro_timestamp;   // microseconds
_lpf_baro.update(baro_alt, dt);
```

## Effect

Since `alpha = dt / (tau + dt)`:

| baro rate | dt | alpha (before) | alpha (intended) |
|---|---|---|---|
| 50 Hz | 0.0200 s | 0.999750 | 0.003984 |
| 100 Hz | 0.0100 s | 0.999500 | 0.001996 |
| 200 Hz | 0.0050 s | 0.999001 | 0.000999 |

At an alpha of 0.9997 the filter passes essentially every raw sample through. The effective time constant is 5 us instead of 5 s, so `_lpf_baro.getState()` has been effectively unfiltered barometric altitude.

That state feeds the in-air home altitude correction: it is offset by `_baro_gps_static_offset` and compared against GNSS altitude, and `home.alt` is shifted when the two differ by more than `kAltitudeDifferenceThreshold`. A GNSS velocity integral gates that comparison for consistency.

## Why this looks like an oversight

The same conversion is already done correctly a few lines below in this file for the GNSS velocity integral:

```c
_gps_vel_integral += 1e-6f * (vehicle_gps_position.timestamp - _last_gps_timestamp) * (-vehicle_gps_position.vel_d_m_s);
```

and in EKF2 for the geoid height filter, which uses the identical `setParameters(dt, tau)` call.

## Note on behaviour change

This does change behaviour: the filter now actually applies its 5 second time constant, so `_lpf_baro.getState()` lags during a climb by roughly the time constant times the climb rate. `_baro_gps_static_offset` is captured once when the correction window opens, so that lag does not cancel and it biases `baro_alt_corrected` while climbing.

I would appreciate a look from whoever knows this feature: the 5 second constant and the 1 m threshold were both tuned while the filter was effectively a pass-through, so it is worth confirming they are still the values you want now that it filters.

## Testing

`make px4_sitl` builds and `make check_format` passes. The unit analysis above is the substantive evidence and can be checked against the `AlphaFilter` docstring without running anything. I do not have flight logs for this; happy to add SITL traces if that would help the review.
