### PR TITLE
feat(mag): identify current compensation from a flight log

### DIFF
--- a/docs/en/advanced_config/compass_power_compensation.md
+++ b/docs/en/advanced_config/compass_power_compensation.md
@@ -2,24 +2,32 @@
 
 Compensate magnetometer readings for magnetic fields from motor current when the compass cannot be moved away from the wiring. Cables must be fixed in place; moving them invalidates the coefficients.
 
-## Data collection
+[CAL_MAG_COMP_TYP](../advanced_config/parameter_reference.md#CAL_MAG_COMP_TYP) is 1 for thrust, 2 or 3 for battery current instance 0 or 1.
+
+## Flight log
 
 1. [Compass calibration](../config/compass.md#compass-calibration).
 2. [CAL_MAG_COMP_TYP](../advanced_config/parameter_reference.md#CAL_MAG_COMP_TYP) = 0.
 3. Enable [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) bit 11 (High rate sensors).
-4. Fly a couple of minutes with throttle changes. A restrained throttle ramp with props on also works.
-
-## Identification
+4. Fly a couple of minutes with throttle changes.
 
 ```sh
-python src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation.py LOG.ulg
+python src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation_flight.py LOG.ulg
 ```
 
 Optional second argument: `current` (default if battery current is in the log) or `thrust`. `--instance N` selects the battery/thrust instance.
 
 The script prints `CAL_MAG_COMP_TYP` and `CAL_MAGx_{X,Y,Z}COMP`. It estimates a bulk delay from the field norm vs current, then fits per-axis coefficients after removing the Earth field using `vehicle_attitude`. Current compensation is preferred when battery current is logged.
 
-Set the printed parameters. [CAL_MAG_COMP_TYP](../advanced_config/parameter_reference.md#CAL_MAG_COMP_TYP) is 1 for thrust, 2 or 3 for battery current instance 0 or 1.
+## Restrained throttle ramp
+
+Vehicle secured, props on, [ACRO](../flight_modes_mc/acro.md), [CAL_MAG_COMP_TYP](../advanced_config/parameter_reference.md#CAL_MAG_COMP_TYP) = 0. Arm, raise throttle to maximum, lower to zero, disarm. [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) bit 6 (Sensor comparison) is enough.
+
+```sh
+python src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation.py LOG.ulg current --instance 0
+```
+
+`current` or `thrust`. This script fits each mag axis directly against the power signal; do not use it on a flight log.
 
 ## See Also
 

--- a/docs/en/advanced_config/compass_power_compensation.md
+++ b/docs/en/advanced_config/compass_power_compensation.md
@@ -1,73 +1,25 @@
 # Compass Power Compensation
 
-Compasses (magnetometers) should be mounted as far as possible from cables that carry large currents, as these induce magnetic fields that may corrupt the compass readings.
+Compensate magnetometer readings for magnetic fields from motor current when the compass cannot be moved away from the wiring. Cables must be fixed in place; moving them invalidates the coefficients.
 
-This topic explains how to compensate for the induced magnetic fields in the cases where moving the compass is not realistic.
+## Data collection
 
-:::tip
-Moving the compass away from power-carrying cables is the easiest and most effective way to fix this issue, because the strength of the magnetic fields decreases quadratically with the distance from the cable.
-:::
+1. [Compass calibration](../config/compass.md#compass-calibration).
+2. [CAL_MAG_COMP_TYP](../advanced_config/parameter_reference.md#CAL_MAG_COMP_TYP) = 0.
+3. Enable [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) bit 11 (High rate sensors).
+4. Fly a couple of minutes with throttle changes. A restrained throttle ramp with props on also works.
 
-::: info
-The process is demonstrated for a multicopter, but is equally valid for other vehicle types.
-:::
+## Identification
 
-## When is Power Compensation Applicable?
+```sh
+python src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation.py LOG.ulg
+```
 
-Performing this power compensation is advisable only if all the following statements are true:
+Optional second argument: `current` (default if battery current is in the log) or `thrust`. `--instance N` selects the battery/thrust instance.
 
-1. The compass cannot be moved away from the power-carrying cables.
-2. There is a strong correlation between the compass readings and the thrust setpoint, and/or the battery current.
+The script prints `CAL_MAG_COMP_TYP` and `CAL_MAGx_{X,Y,Z}COMP`. It estimates a bulk delay from the field norm vs current, then fits per-axis coefficients after removing the Earth field using `vehicle_attitude`. Current compensation is preferred when battery current is logged.
 
-   ![Corrupted mag](../../assets/advanced_config/corrupted_mag.png)
-
-3. The drone cables are all fixed in place/do not move (calculated compensation parameters will be invalid if the current-carrying cables can move).
-
-## How to Compensate the Compass
-
-1. Make sure your drone runs a Firmware version supporting power compensation (current master, or releases from v.1.11.0).
-2. Perform the [standard compass calibration](../config/compass.md#compass-calibration).
-3. Set the parameter [SDLOG_MODE](../advanced_config/parameter_reference.md#SDLOG_MODE) to 2 to enable logging of data from boot.
-4. Set the parameter [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) checkbox for _Sensor comparison_ (bit 6) to get more data points.
-5. Secure the drone so that it cannot move, and attach the propellers (so the motors can draw the same current as in flight).
-   This example secures the vehicle using straps.
-
-   ![strap](../../assets/advanced_config/strap.png)
-
-6. Power the vehicle and switch into [ACRO flight mode](../flight_modes_mc/acro.md) (using this mode ensures the vehicle won't attempt to compensate for movement resulting from the straps).
-   - Arm the vehicle and slowly raise the throttle to the maximum
-   - Slowly lower the throttle down to zero
-   - Disarm the vehicle
-
-   ::: info
-   Perform the test carefully and closely monitor the vibrations.
-   :::
-
-7. Retrieve the ulog and use the python script [mag_compensation.py](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation.py) to identify the compensation parameters.
-
-   ```sh
-   python mag_compensation.py ~/path/to/log/logfile.ulg <type> [--instance <number>]
-   ```
-
-   where:
-   - `<type>`: `current` or `thrust` (power signal used for compensation)
-   - `--instance <number>` (optional): The number is `0` (default) or `1`, the instance of the current or thrust signal to use.
-
-   ::: info
-   If your log does not contain battery current measurements, you will need to comment out the respective lines in the Python script, such that it does the calculation for thrust only.
-   :::
-
-8. The script will return the parameter identification for thrust as well as for current and print them to the console.
-   The figures that pop up from the script show the "goodness of fit" for each compass instance, and how the data would look if compensated with the suggested values.
-   If a current measurement is available, using the current-compensation usually yields the better results.
-   Here is an example of a log, where the current fit is good, but the thrust parameters are unusable as the relationship is not linear.
-
-   ![line fit](../../assets/advanced_config/line_fit.png)
-
-9. Once the parameters are identified, the power compensation must be enabled by setting [CAL_MAG_COMP_TYP](../advanced_config/parameter_reference.md#CAL_MAG_COMP_TYP) to 1 (when using thrust parameters) or 2 (when using current parameters).
-   Additionally, the compensation parameters for each axis of each compass must be set.
-
-   ![comp params](../../assets/advanced_config/comp_params.png)
+Set the printed parameters. [CAL_MAG_COMP_TYP](../advanced_config/parameter_reference.md#CAL_MAG_COMP_TYP) is 1 for thrust, 2 or 3 for battery current instance 0 or 1.
 
 ## See Also
 

--- a/docs/en/advanced_config/compass_power_compensation.md
+++ b/docs/en/advanced_config/compass_power_compensation.md
@@ -1,33 +1,91 @@
 # Compass Power Compensation
 
-Compensate magnetometer readings for magnetic fields from motor current when the compass cannot be moved away from the wiring. Cables must be fixed in place; moving them invalidates the coefficients.
+Compasses (magnetometers) should be mounted as far as possible from cables that carry large currents, as these induce magnetic fields that may corrupt the compass readings.
 
-[CAL_MAG_COMP_TYP](../advanced_config/parameter_reference.md#CAL_MAG_COMP_TYP) is 1 for thrust, 2 or 3 for battery current instance 0 or 1.
+This topic explains how to compensate for the induced magnetic fields in the cases where moving the compass is not realistic.
 
-## Flight log
+:::tip
+Moving the compass away from power-carrying cables is the easiest and most effective way to fix this issue, because the strength of the magnetic fields decreases quadratically with the distance from the cable.
+:::
 
-1. [Compass calibration](../config/compass.md#compass-calibration).
-2. [CAL_MAG_COMP_TYP](../advanced_config/parameter_reference.md#CAL_MAG_COMP_TYP) = 0.
-3. Enable [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) bit 11 (High rate sensors).
+::: info
+The process is demonstrated for a multicopter, but is equally valid for other vehicle types.
+:::
+
+## When is Power Compensation Applicable?
+
+Performing this power compensation is advisable only if all the following statements are true:
+
+1. The compass cannot be moved away from the power-carrying cables.
+2. There is a strong correlation between the compass readings and the thrust setpoint, and/or the battery current.
+
+   ![Corrupted mag](../../assets/advanced_config/corrupted_mag.png)
+
+3. The drone cables are all fixed in place/do not move (calculated compensation parameters will be invalid if the current-carrying cables can move).
+
+## How to Compensate the Compass
+
+1. Make sure your drone runs a Firmware version supporting power compensation (current master, or releases from v.1.11.0).
+2. Perform the [standard compass calibration](../config/compass.md#compass-calibration).
+3. Set the parameter [SDLOG_MODE](../advanced_config/parameter_reference.md#SDLOG_MODE) to 2 to enable logging of data from boot.
+4. Set the parameter [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) checkbox for _Sensor comparison_ (bit 6) to get more data points.
+5. Secure the drone so that it cannot move, and attach the propellers (so the motors can draw the same current as in flight).
+   This example secures the vehicle using straps.
+
+   ![strap](../../assets/advanced_config/strap.png)
+
+6. Power the vehicle and switch into [ACRO flight mode](../flight_modes_mc/acro.md) (using this mode ensures the vehicle won't attempt to compensate for movement resulting from the straps).
+   - Arm the vehicle and slowly raise the throttle to the maximum
+   - Slowly lower the throttle down to zero
+   - Disarm the vehicle
+
+   ::: info
+   Perform the test carefully and closely monitor the vibrations.
+   :::
+
+7. Retrieve the ulog and use the python script [mag_compensation.py](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation.py) to identify the compensation parameters.
+
+   ```sh
+   python mag_compensation.py ~/path/to/log/logfile.ulg <type> [--instance <number>]
+   ```
+
+   where:
+   - `<type>`: `current` or `thrust` (power signal used for compensation)
+   - `--instance <number>` (optional): The number is `0` (default) or `1`, the instance of the current or thrust signal to use.
+
+   ::: info
+   If your log does not contain battery current measurements, you will need to comment out the respective lines in the Python script, such that it does the calculation for thrust only.
+   :::
+
+8. The script will return the parameter identification for thrust as well as for current and print them to the console.
+   The figures that pop up from the script show the "goodness of fit" for each compass instance, and how the data would look if compensated with the suggested values.
+   If a current measurement is available, using the current-compensation usually yields the better results.
+   Here is an example of a log, where the current fit is good, but the thrust parameters are unusable as the relationship is not linear.
+
+   ![line fit](../../assets/advanced_config/line_fit.png)
+
+9. Once the parameters are identified, the power compensation must be enabled by setting [CAL_MAG_COMP_TYP](../advanced_config/parameter_reference.md#CAL_MAG_COMP_TYP) to 1 (when using thrust parameters) or 2 (when using current parameters).
+   Additionally, the compensation parameters for each axis of each compass must be set.
+
+   ![comp params](../../assets/advanced_config/comp_params.png)
+
+## From a Flight Log
+
+The restrained throttle ramp above is the original identification method. The same parameters can also be identified from a normal flight using [mag_compensation_flight.py](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation_flight.py).
+
+1. Perform the [standard compass calibration](../config/compass.md#compass-calibration).
+2. Set [CAL_MAG_COMP_TYP](../advanced_config/parameter_reference.md#CAL_MAG_COMP_TYP) to 0.
+3. Enable [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) bit 11 (_High rate sensors_) so magnetometer data is logged at a high enough rate to estimate delay.
 4. Fly a couple of minutes with throttle changes.
+5. Retrieve the ulog and run:
 
-```sh
-python src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation_flight.py LOG.ulg
-```
+   ```sh
+   python mag_compensation_flight.py ~/path/to/log/logfile.ulg
+   ```
 
-Optional second argument: `current` (default if battery current is in the log) or `thrust`. `--instance N` selects the battery/thrust instance.
+   Optional second argument: `current` (default if battery current is in the log) or `thrust`. `--instance <number>` selects the battery or thrust instance (`0` or `1`).
 
-The script prints `CAL_MAG_COMP_TYP` and `CAL_MAGx_{X,Y,Z}COMP`. It estimates a bulk delay from the field norm vs current, then fits per-axis coefficients after removing the Earth field using `vehicle_attitude`. Current compensation is preferred when battery current is logged.
-
-## Restrained throttle ramp
-
-Vehicle secured, props on, [ACRO](../flight_modes_mc/acro.md), [CAL_MAG_COMP_TYP](../advanced_config/parameter_reference.md#CAL_MAG_COMP_TYP) = 0. Arm, raise throttle to maximum, lower to zero, disarm. [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) bit 6 (Sensor comparison) is enough.
-
-```sh
-python src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation.py LOG.ulg current --instance 0
-```
-
-`current` or `thrust`. This script fits each mag axis directly against the power signal; do not use it on a flight log.
+The script estimates a bulk delay from the field norm versus current, then fits per-axis coefficients after removing the Earth field using `vehicle_attitude`. It prints `CAL_MAG_COMP_TYP` and `CAL_MAGx_{X,Y,Z}COMP`. Enable compensation with those values as in step 9 above. Do not use `mag_compensation.py` on a flight log; it fits each mag axis directly against the power signal and will absorb attitude motion into the coefficients.
 
 ## See Also
 

--- a/src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation.py
+++ b/src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation.py
@@ -1,272 +1,387 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 """
-File: mag_compensation.py
-Author: Tanja Baumann
-Email: tanja@auterion.com
-Github: https://github.com/baumanta
-Description:
-    Computes linear coefficients for mag compensation from thrust and current
+Identify mag current/throttle compensation from a ulog.
+
+Estimates a bulk delay dt from |m| vs the power signal, then fits
+    m(t) = R(t)^T B + b + k * power(t - dt)
+and prints CAL_MAG* parameters.
+
 Usage:
-    python mag_compensation.py /path/to/log/logfile.ulg current --instance 1
-
-Remark:
-    If your logfile does not contain some of the topics, e.g.battery_status/current_a
-    you will have to comment out the corresponding parts in the script
+    python mag_compensation.py LOG.ulg
+    python mag_compensation.py LOG.ulg current --instance 0
+    python mag_compensation.py LOG.ulg thrust
 """
 
-
-import matplotlib.pylab as plt
-from mpl_toolkits.mplot3d import Axes3D
-from pyulog import ULog
-from pyulog.px4 import PX4ULog
-from pylab import *
-import numpy as np
-import textwrap as tw
 import argparse
+import sys
 
-#arguments
-parser = argparse.ArgumentParser(description='Calculate compensation parameters from ulog')
+import numpy as np
+from pyulog import ULog
 
-parser.add_argument('logfile', type=str, nargs='?', default=[],
-                    help='full path to ulog file')
-parser.add_argument('type', type=str, nargs='?', choices=['current', 'thrust'], default=[],
-                    help='Power signal used for compensation, supported is "current" or "thrust".')
-parser.add_argument('--instance', type=int, nargs='?', default=0,
-                    help='instance of the current or thrust signal to use (0 or 1)')
+# PX4 rot_lookup (roll, pitch, yaw deg), index = Rotation enum. See rotation.h.
+_ROT_LOOKUP = (
+    (0, 0, 0), (0, 0, 45), (0, 0, 90), (0, 0, 135), (0, 0, 180), (0, 0, 225),
+    (0, 0, 270), (0, 0, 315), (180, 0, 0), (180, 0, 45), (180, 0, 90),
+    (180, 0, 135), (0, 180, 0), (180, 0, 225), (180, 0, 270), (180, 0, 315),
+    (90, 0, 0), (90, 0, 45), (90, 0, 90), (90, 0, 135), (270, 0, 0),
+    (270, 0, 45), (270, 0, 90), (270, 0, 135), (0, 90, 0), (0, 270, 0),
+    (0, 180, 90), (0, 180, 270), (90, 90, 0), (180, 90, 0), (270, 90, 0),
+    (90, 180, 0), (270, 180, 0), (90, 270, 0), (180, 270, 0), (270, 270, 0),
+    (90, 180, 90), (90, 0, 270), (90, 68, 293), (0, 315, 0), (90, 315, 0),
+)
 
-args = parser.parse_args()
-log_name = args.logfile
-comp_type = args.type
-comp_instance = args.instance
+ARMING_STATE_ARMED = 2
 
-#Load the log data (produced by pyulog)
-log = ULog(log_name)
-pxlog = PX4ULog(log)
 
-def get_data(topic_name, variable_name, index):
-   try:
-      dataset = log.get_dataset(topic_name, index)
-      return dataset.data[variable_name]
-   except:
-      return []
+def get_data(log, topic, field, instance=0):
+    try:
+        return log.get_dataset(topic, instance).data[field]
+    except Exception:
+        return np.array([])
 
-def ms2s_list(time_ms_list):
-    if len(time_ms_list) > 0:
-        return 1e-6 * time_ms_list
-    else:
-        return time_ms_list
 
-# Select msgs and copy into arrays
-armed = get_data('vehicle_status', 'arming_state', 0)
-t_armed =  ms2s_list(get_data('vehicle_status', 'timestamp', 0))
+def get_param(log, name, default=None):
+    if name in log.initial_parameters:
+        return log.initial_parameters[name]
+    return default
 
-if comp_type == "thrust":
-	power = get_data('vehicle_rates_setpoint', 'thrust_body[2]', comp_instance)
-	power_t = ms2s_list(get_data('vehicle_rates_setpoint', 'timestamp', comp_instance))
-	comp_type_param = 1
-	factor = 1
-	unit = "[G]"
-elif comp_type == "current":
-	power = get_data('battery_status', 'current_a', comp_instance)
-	power = np.true_divide(power, 1000) #kA
-	power_t = ms2s_list(get_data('battery_status', 'timestamp', comp_instance))
-	comp_type_param = 2 + comp_instance
-	factor = -1
-	unit = "[G/kA]"
-else:
-	print("unknown compensation type {}. Supported is either 'thrust' or 'current'.".format(comp_type))
-	sys.exit(1)
 
-if len(power) == 0:
-	print("could not retrieve power signal from log, zero data points")
-	sys.exit(1)
+def us_to_s(t):
+    return t * 1e-6 if len(t) else t
 
-mag0X_body = get_data('sensor_mag', 'x', 0)
-mag0Y_body = get_data('sensor_mag', 'y', 0)
-mag0Z_body = get_data('sensor_mag', 'z', 0)
-t_mag0 =  ms2s_list(get_data('sensor_mag', 'timestamp', 0))
-mag0_ID = get_data('sensor_mag', 'device_id', 0)
 
-mag1X_body = get_data('sensor_mag', 'x', 1)
-mag1Y_body = get_data('sensor_mag', 'y', 1)
-mag1Z_body = get_data('sensor_mag', 'z', 1)
-t_mag1 = ms2s_list(get_data('sensor_mag', 'timestamp', 1))
-mag1_ID = get_data('sensor_mag', 'device_id', 1)
+def topic_time(log, topic, instance=0):
+    ts = get_data(log, topic, 'timestamp_sample', instance)
+    t = get_data(log, topic, 'timestamp', instance)
+    if len(ts) == len(t) and np.any(ts):
+        return us_to_s(ts)
+    return us_to_s(t)
 
-mag2X_body = get_data('sensor_mag', 'x', 2)
-mag2Y_body = get_data('sensor_mag', 'y', 2)
-mag2Z_body = get_data('sensor_mag', 'z', 2)
-t_mag2 = ms2s_list(get_data('sensor_mag', 'timestamp', 2))
-mag2_ID = get_data('sensor_mag', 'device_id', 2)
 
-mag3X_body = get_data('sensor_mag', 'x', 3)
-mag3Y_body = get_data('sensor_mag', 'y', 3)
-mag3Z_body = get_data('sensor_mag', 'z', 3)
-t_mag3 = ms2s_list(get_data('sensor_mag', 'timestamp', 3))
-mag3_ID = get_data('sensor_mag', 'device_id', 3)
+def dcm_from_quat(q):
+    """v_ned = R v_body. q is (N, 4) Hamilton wxyz, matching matrix::Dcm(Quat)."""
+    a, b, c, d = q.T
+    ab, ac, ad = a * b, a * c, a * d
+    bb, bc, bd = b * b, b * c, b * d
+    cc, cd, dd = c * c, c * d, d * d
+    R = np.empty((q.shape[0], 3, 3))
+    R[:, 0, 0] = 1 - 2 * (cc + dd)
+    R[:, 0, 1] = 2 * (bc - ad)
+    R[:, 0, 2] = 2 * (ac + bd)
+    R[:, 1, 0] = 2 * (bc + ad)
+    R[:, 1, 1] = 1 - 2 * (bb + dd)
+    R[:, 1, 2] = 2 * (cd - ab)
+    R[:, 2, 0] = 2 * (bd - ac)
+    R[:, 2, 1] = 2 * (ab + cd)
+    R[:, 2, 2] = 1 - 2 * (bb + cc)
+    return R
 
-magX_body = []
-magY_body = []
-magZ_body = []
-mag_id = []
-t_mag = []
 
-if len(mag0X_body) > 0:
-    magX_body.append(mag0X_body)
-    magY_body.append(mag0Y_body)
-    magZ_body.append(mag0Z_body)
-    t_mag.append(t_mag0)
-    mag_id.append(mag0_ID[0])
+def dcm_from_euler_deg(roll, pitch, yaw):
+    """3-2-1 intrinsic, matching matrix::Dcm(Eulerf)."""
+    phi, theta, psi = np.deg2rad([roll, pitch, yaw])
+    cp, sp = np.cos(phi), np.sin(phi)
+    ct, st = np.cos(theta), np.sin(theta)
+    cs, ss = np.cos(psi), np.sin(psi)
+    return np.array([
+        [ct * cs, -cp * ss + sp * st * cs, sp * ss + cp * st * cs],
+        [ct * ss, cp * cs + sp * st * ss, -sp * cs + cp * st * ss],
+        [-st, sp * ct, cp * ct],
+    ])
 
-if len(mag1X_body) > 0:
-    magX_body.append(mag1X_body)
-    magY_body.append(mag1Y_body)
-    magZ_body.append(mag1Z_body)
-    t_mag.append(t_mag1)
-    mag_id.append(mag1_ID[0])
 
-if len(mag2X_body) > 0:
-    magX_body.append(mag2X_body)
-    magY_body.append(mag2Y_body)
-    magZ_body.append(mag2Z_body)
-    t_mag.append(t_mag2)
-    mag_id.append(mag2_ID[0])
+def dcm_from_rot_enum(rot):
+    if rot == 100:
+        raise ValueError('custom rotation needs euler angles')
+    if rot < 0 or rot >= len(_ROT_LOOKUP):
+        rot = 0
+    return dcm_from_euler_deg(*_ROT_LOOKUP[rot])
 
-if len(mag3X_body) > 0:
-    magX_body.append(mag3X_body)
-    magY_body.append(mag3Y_body)
-    magZ_body.append(mag3Z_body)
-    t_mag.append(t_mag3)
-    mag_id.append(mag3_ID[0])
 
-n_mag = len(magX_body)
+def sensor_to_body_dcm(log, cal_instance):
+    rot = int(get_param(log, f'CAL_MAG{cal_instance}_ROT', -1))
+    if rot < 0:
+        rot = int(get_param(log, 'SENS_BOARD_ROT', 0))
+    if rot == 100:
+        return dcm_from_euler_deg(
+            float(get_param(log, f'CAL_MAG{cal_instance}_ROLL', 0)),
+            float(get_param(log, f'CAL_MAG{cal_instance}_PITCH', 0)),
+            float(get_param(log, f'CAL_MAG{cal_instance}_YAW', 0)),
+        )
+    return dcm_from_rot_enum(rot)
 
-#log index does not necessarily match mag calibration instance number
-calibration_instance = []
-instance_found = False
-for idx in range(n_mag):
-    instance_found = False
+
+def unwrap_quats(q):
+    q = np.array(q, dtype=float, copy=True)
+    for i in range(1, len(q)):
+        if np.dot(q[i], q[i - 1]) < 0:
+            q[i] *= -1
+    return q
+
+
+def interp_quats(t_src, q_src, t_dst):
+    q_src = unwrap_quats(q_src)
+    q = np.column_stack([np.interp(t_dst, t_src, q_src[:, i]) for i in range(4)])
+    n = np.linalg.norm(q, axis=1, keepdims=True)
+    n = np.clip(n, 1e-12, None)
+    return q / n
+
+
+def armed_mask(log, t):
+    armed = get_data(log, 'vehicle_status', 'arming_state', 0)
+    t_armed = topic_time(log, 'vehicle_status', 0)
+    if len(armed) == 0:
+        return np.ones(len(t), dtype=bool)
+    # step-hold arming onto mag times
+    idx = np.searchsorted(t_armed, t, side='right') - 1
+    idx = np.clip(idx, 0, len(armed) - 1)
+    return armed[idx] == ARMING_STATE_ARMED
+
+
+def estimate_dt(t_mag, mag_norm, t_p, power, dt_max=0.08, dt_step=0.002):
+    """Lag that maximises |corr| of first-differences of |m| and power."""
+    dt_grid = np.arange(-dt_max, dt_max + dt_step * 0.5, dt_step)
+    mag_d = np.diff(mag_norm)
+    best_dt = 0.0
+    best_c = 0.0
+    corr = np.zeros_like(dt_grid)
+    if len(mag_d) < 20 or np.std(mag_d) < 1e-9:
+        return best_dt, best_c, dt_grid, corr
+    for i, dt in enumerate(dt_grid):
+        p = np.interp(t_mag - dt, t_p, power)
+        p_d = np.diff(p)
+        if np.std(p_d) < 1e-12:
+            continue
+        c = np.corrcoef(mag_d, p_d)[0, 1]
+        if not np.isfinite(c):
+            continue
+        corr[i] = c
+        if abs(c) > abs(best_c):
+            best_c = c
+            best_dt = dt
+    return best_dt, best_c, dt_grid, corr
+
+
+def fit_comp(mag, power, R_ns=None):
+    """
+    mag (N,3), power (N,).
+    If R_ns (N,3,3) maps sensor → NED, fit m = R^T B + b + k * power.
+    Else fit m = b + k * power.
+    Returns k, b, B (or None), r2 of the power term.
+    """
+    n = mag.shape[0]
+    if n < 10:
+        return np.zeros(3), np.zeros(3), None, 0.0
+
+    if R_ns is None:
+        A = np.column_stack([np.ones(n), power])
+        k = np.zeros(3)
+        b = np.zeros(3)
+        for i in range(3):
+            coef, *_ = np.linalg.lstsq(A, mag[:, i], rcond=None)
+            b[i], k[i] = coef
+        resid = mag - (b + np.outer(power, k))
+        demeaned = mag - mag.mean(axis=0)
+        r2 = 1.0 - np.sum(resid ** 2) / max(np.sum(demeaned ** 2), 1e-18)
+        return k, b, None, r2
+
+    y = mag.reshape(n * 3)
+    A = np.zeros((n * 3, 9))
+    Rt = np.transpose(R_ns, (0, 2, 1))
+    A[:, 0:3] = Rt.reshape(n * 3, 3)
+    A[:, 3:6] = np.tile(np.eye(3), (n, 1))
+    A[:, 6:9] = (power[:, None, None] * np.eye(3)[None, :, :]).reshape(n * 3, 3)
+    x, *_ = np.linalg.lstsq(A, y, rcond=None)
+    B, b, k = x[0:3], x[3:6], x[6:9]
+    earth_b = np.einsum('nji,j->ni', R_ns, B) + b
+    resid = mag - earth_b - np.outer(power, k)
+    ref = mag - earth_b
+    r2 = 1.0 - np.sum(resid ** 2) / max(np.sum(ref ** 2), 1e-18)
+    return k, b, B, r2
+
+
+def load_power(log, comp_type, instance):
+    if comp_type == 'current':
+        current = get_data(log, 'battery_status', 'current_a', instance)
+        t = topic_time(log, 'battery_status', instance)
+        if len(current) == 0:
+            return None, None, None, None
+        power = current / 1000.0  # kA, matches VehicleMagnetometer
+        return power, t, 2 + instance, '[G/kA]'
+
+    xyz = [get_data(log, 'vehicle_thrust_setpoint', f'xyz[{i}]', instance) for i in range(3)]
+    if all(len(a) for a in xyz):
+        power = np.linalg.norm(np.column_stack(xyz), axis=1)
+        t = topic_time(log, 'vehicle_thrust_setpoint', instance)
+        return power, t, 1, '[G]'
+
+    thrust_z = get_data(log, 'vehicle_rates_setpoint', 'thrust_body[2]', instance)
+    t = topic_time(log, 'vehicle_rates_setpoint', instance)
+    if len(thrust_z) == 0:
+        return None, None, None, None
+    power = np.abs(thrust_z)
+    return power, t, 1, '[G]'
+
+
+def load_mags(log):
+    mags = []
+    for inst in range(4):
+        x = get_data(log, 'sensor_mag', 'x', inst)
+        if len(x) == 0:
+            continue
+        mag = np.column_stack([
+            x,
+            get_data(log, 'sensor_mag', 'y', inst),
+            get_data(log, 'sensor_mag', 'z', inst),
+        ])
+        t = topic_time(log, 'sensor_mag', inst)
+        device_id = int(get_data(log, 'sensor_mag', 'device_id', inst)[0])
+        mags.append((inst, device_id, t, mag))
+    return mags
+
+
+def load_attitude(log):
+    t = topic_time(log, 'vehicle_attitude', 0)
+    q = [get_data(log, 'vehicle_attitude', f'q[{i}]', 0) for i in range(4)]
+    if len(t) == 0 or any(len(c) == 0 for c in q):
+        return None, None
+    return t, np.column_stack(q)
+
+
+def calibration_instance(log, device_id):
     for j in range(4):
-        if mag_id[idx] == log.initial_parameters["CAL_MAG{}_ID".format(j)]:
-                calibration_instance.append(j)
-                instance_found = True
-    if not instance_found:
-        print('Mag {} calibration instance not found, run compass calibration first.'.format(mag_id[idx]))
-
-#get first arming sequence from data
-start_time = 0
-stop_time = 0
-for i in range(len(armed)-1):
-    if armed[i] == 1 and armed[i+1] == 2:
-        start_time = t_armed[i+1]
-    if armed[i] == 2 and armed[i+1] == 1:
-        stop_time = t_armed[i+1]
-        break
-
-#cut unarmed sequences from mag data
-index_start = 0
-index_stop = 0
-
-for idx in range(n_mag):
-    for i in range(len(t_mag[idx])):
-        if t_mag[idx][i] > start_time:
-            index_start = i
-            break
-
-    for i in range(len(t_mag[idx])):
-        if t_mag[idx][i] > stop_time:
-            index_stop = i -1
-            break
-
-    t_mag[idx] = t_mag[idx][index_start:index_stop]
-    magX_body[idx] = magX_body[idx][index_start:index_stop]
-    magY_body[idx] = magY_body[idx][index_start:index_stop]
-    magZ_body[idx] = magZ_body[idx][index_start:index_stop]
+        if int(get_param(log, f'CAL_MAG{j}_ID', 0)) == device_id:
+            return j
+    return None
 
 
-#resample data
-power_resampled = []
+def main():
+    parser = argparse.ArgumentParser(description='Mag current/throttle compensation from a ulog')
+    parser.add_argument('logfile', help='path to .ulg')
+    parser.add_argument('type', nargs='?', choices=['current', 'thrust'],
+                        help='power signal; default is current if present, else thrust')
+    parser.add_argument('--instance', type=int, default=0, help='battery/thrust instance')
+    parser.add_argument('--no-plot', action='store_true')
+    args = parser.parse_args()
 
-for idx in range(n_mag):
-    power_resampled.append(interp(t_mag[idx], power_t, power))
+    log = ULog(args.logfile)
 
-#fit linear to get coefficients
-px = []
-py = []
-pz = []
+    comp_type = args.type
+    if comp_type is None:
+        if len(get_data(log, 'battery_status', 'current_a', args.instance)) > 0:
+            comp_type = 'current'
+        else:
+            comp_type = 'thrust'
 
-for idx in range(n_mag):
-    px_temp, res_x, _, _, _ = polyfit(power_resampled[idx], magX_body[idx], 1,full = True)
-    py_temp, res_y, _, _, _ = polyfit(power_resampled[idx], magY_body[idx], 1,full = True)
-    pz_temp, res_z, _, _, _ = polyfit(power_resampled[idx], magZ_body[idx], 1, full = True)
+    power, t_power, comp_type_param, unit = load_power(log, comp_type, args.instance)
+    if power is None:
+        print(f'no {comp_type} data in log', file=sys.stderr)
+        sys.exit(1)
 
-    px.append(px_temp)
-    py.append(py_temp)
-    pz.append(pz_temp)
+    mags = load_mags(log)
+    if not mags:
+        print('no sensor_mag data in log', file=sys.stderr)
+        sys.exit(1)
 
-#print to console
-for idx in range(n_mag):
-    print('Mag{} device ID {} (calibration instance {})'.format(idx, mag_id[idx], calibration_instance[idx]))
-print('\033[91m \n{}-based compensation: \033[0m'.format(comp_type))
-print('\nparam set CAL_MAG_COMP_TYP {}'.format(comp_type_param))
-for idx in range(n_mag):
-    print('\nparam set CAL_MAG{}_XCOMP {:.3f}'.format(calibration_instance[idx], factor * px[idx][0]))
-    print('param set CAL_MAG{}_YCOMP {:.3f}'.format(calibration_instance[idx], factor * py[idx][0]))
-    print('param set CAL_MAG{}_ZCOMP {:.3f}'.format(calibration_instance[idx], factor * pz[idx][0]))
+    t_att, q_att = load_attitude(log)
 
-#plot data
+    print(f'\n{comp_type}-based compensation ({args.logfile}), COMP units {unit}')
+    print(f'param set CAL_MAG_COMP_TYP {comp_type_param}')
 
-for idx in range(n_mag):
-    fig = plt.figure(num=None, figsize=(25, 14), dpi=80, facecolor='w', edgecolor='k')
-    fig.suptitle('Compensation Parameter Fit \n{} \nmag {} ID: {} (calibration instance {})'.format(log_name, idx, mag_id[idx], calibration_instance[idx]), fontsize=14, fontweight='bold')
+    if not args.no_plot:
+        import matplotlib.pyplot as plt
 
-    plt.subplot(1,3,1)
-    plt.plot(power_resampled[idx], magX_body[idx], 'yo', power_resampled[idx], px[idx][0]*power_resampled[idx]+px[idx][1], '--k')
-    plt.xlabel('current [kA]')
-    plt.ylabel('mag X [G]')
+    for log_inst, device_id, t_mag, mag in mags:
+        cal_inst = calibration_instance(log, device_id)
+        if cal_inst is None:
+            print(f'\nMag log instance {log_inst} device ID {device_id}: no CAL_MAGx_ID match, skip')
+            continue
 
-    plt.subplot(1,3,2)
-    plt.plot(power_resampled[idx], magY_body[idx], 'yo', power_resampled[idx], py[idx][0]*power_resampled[idx]+py[idx][1], '--k')
-    plt.xlabel('current [kA]')
-    plt.ylabel('mag Y [G]')
+        finite = np.isfinite(mag).all(axis=1)
+        mask = finite & armed_mask(log, t_mag)
+        if mask.sum() < 50:
+            mask = finite
+            print(f'\nCAL_MAG{cal_inst} (id {device_id}): no armed interval, using the whole log')
+        if mask.sum() < 50:
+            print(f'\nCAL_MAG{cal_inst} (id {device_id}): not enough samples, skip')
+            continue
 
-    plt.subplot(1,3,3)
-    plt.plot(power_resampled[idx], magZ_body[idx], 'yo', power_resampled[idx], pz[idx][0]*power_resampled[idx]+pz[idx][1], '--k')
-    plt.xlabel('current [kA]')
-    plt.ylabel('mag Z [G]')
+        t = t_mag[mask]
+        m = mag[mask]
+        dt_med = np.median(np.diff(t)) if len(t) > 1 else 1.0
+        rate = 1.0 / dt_med if dt_med > 0 else 0.0
 
-    # display results
-    plt.figtext(0.24, 0.03, 'CAL_MAG{}_XCOMP: {:.3f} {}'.format(calibration_instance[idx],factor * px[idx][0],unit), horizontalalignment='center', fontsize=12, multialignment='left', bbox=dict(boxstyle="round", facecolor='#D8D8D8', ec="0.5", pad=0.5, alpha=1), fontweight='bold')
-    plt.figtext(0.51, 0.03, 'CAL_MAG{}_YCOMP: {:.3f} {}'.format(calibration_instance[idx],factor * py[idx][0],unit), horizontalalignment='center', fontsize=12, multialignment='left', bbox=dict(boxstyle="round", facecolor='#D8D8D8', ec="0.5", pad=0.5, alpha=1), fontweight='bold')
-    plt.figtext(0.79, 0.03, 'CAL_MAG{}_ZCOMP: {:.3f} {}'.format(calibration_instance[idx],factor * pz[idx][0],unit), horizontalalignment='center', fontsize=12, multialignment='left', bbox=dict(boxstyle="round", facecolor='#D8D8D8', ec="0.5", pad=0.5, alpha=1), fontweight='bold')
+        dt, dt_corr, dt_grid, dt_corr_curve = estimate_dt(t, np.linalg.norm(m, axis=1), t_power, power)
+        p = np.interp(t - dt, t_power, power)
+
+        R_ns = None
+        used_attitude = False
+        if t_att is not None:
+            q = interp_quats(t_att, q_att, t)
+            R_nb = dcm_from_quat(q)
+            R_cal = sensor_to_body_dcm(log, cal_inst)
+            R_ns = R_nb @ R_cal
+            used_attitude = True
+
+        k, b, B, r2 = fit_comp(m, p, R_ns)
+        # runtime: data + power * COMP, so COMP cancels k in m = ... + k * power
+        comp = -k
+
+        print(f'\nCAL_MAG{cal_inst} device ID {device_id}')
+        print(f'  mag rate {rate:.1f} Hz, dt {dt * 1e3:.1f} ms (|m| vs {comp_type} diff corr {dt_corr:.2f})')
+        print(f'  power-term R^2 {r2:.2f}' + (' (Earth field removed via attitude)' if used_attitude else ' (no attitude, constant-offset fit)'))
+        if rate < 20:
+            print('  warning: mag < 20 Hz; enable SDLOG_PROFILE high-rate sensors (bit 11) for a usable dt')
+        if np.std(p) < (0.001 if comp_type == 'current' else 0.05):
+            print('  warning: little variation in the power signal')
+        if used_attitude and B is not None and np.linalg.norm(B) < 0.1:
+            print('  warning: fitted |B_earth| is low; check mag / attitude alignment')
+        if r2 < 0.15:
+            print('  warning: weak current/throttle correlation; compensation may not help')
+        print(f'param set CAL_MAG{cal_inst}_XCOMP {comp[0]:.3f}')
+        print(f'param set CAL_MAG{cal_inst}_YCOMP {comp[1]:.3f}')
+        print(f'param set CAL_MAG{cal_inst}_ZCOMP {comp[2]:.3f}')
+
+        if args.no_plot:
+            continue
+
+        earth_b = b if R_ns is None else np.einsum('nji,j->ni', R_ns, B) + b
+        m_corr = m - np.outer(p, k)
+
+        fig, axes = plt.subplots(1, 3, figsize=(14, 5))
+        fig.suptitle(f'CAL_MAG{cal_inst} id {device_id}  dt={dt * 1e3:.1f} ms  R²={r2:.2f}')
+        for i, name in enumerate('XYZ'):
+            axes[i].plot(p, m[:, i] - earth_b[:, i], '.', color='C0', alpha=0.4, label='residual')
+            xline = np.linspace(p.min(), p.max(), 50)
+            axes[i].plot(xline, k[i] * xline, 'k--', label='fit')
+            axes[i].set_xlabel('current [kA]' if comp_type == 'current' else 'thrust')
+            axes[i].set_ylabel(f'mag {name} minus Earth/offset [G]')
+            axes[i].legend()
+        plt.tight_layout()
+
+        fig2, axes2 = plt.subplots(4, 1, figsize=(14, 8), sharex=True)
+        fig2.suptitle(f'CAL_MAG{cal_inst} original vs compensated')
+        for i, name in enumerate('XYZ'):
+            axes2[i].plot(t, m[:, i], label='original')
+            axes2[i].plot(t, m_corr[:, i], label='compensated')
+            axes2[i].set_ylabel(f'mag {name} [G]')
+            axes2[i].legend(loc='upper right')
+        axes2[3].plot(t, p)
+        axes2[3].set_ylabel(comp_type)
+        axes2[3].set_xlabel('time [s]')
+        plt.tight_layout()
+
+        fig3, ax3 = plt.subplots(figsize=(8, 4))
+        ax3.plot(dt_grid * 1e3, dt_corr_curve)
+        ax3.axvline(dt * 1e3, color='k', linestyle='--')
+        ax3.set_xlabel('dt [ms] (positive = mag lags power)')
+        ax3.set_ylabel('corr(d|m|, d power)')
+        ax3.set_title(f'CAL_MAG{cal_inst} delay from field norm')
+        plt.tight_layout()
+
+    if not args.no_plot:
+        plt.show()
 
 
-#compensation comparison plots
-for idx in range(n_mag):
-    fig = plt.figure(num=None, figsize=(25, 14), dpi=80, facecolor='w', edgecolor='k')
-    fig.suptitle('Original Data vs. Compensation \n{}\nmag {} ID: {} (calibration instance {})'.format(log_name, idx, mag_id[idx], calibration_instance[idx]), fontsize=14, fontweight='bold')
-
-    plt.subplot(3,1,1)
-    original_x, = plt.plot(t_mag[idx], magX_body[idx], label='original')
-    power_x, = plt.plot(t_mag[idx],magX_body[idx] - px[idx][0] * power_resampled[idx], label='compensated')
-    plt.legend(handles=[original_x, power_x])
-    plt.xlabel('Time [s]')
-    plt.ylabel('Mag X corrected[G]')
-
-    plt.subplot(3,1,2)
-    original_y, = plt.plot(t_mag[idx], magY_body[idx], label='original')
-    power_y, = plt.plot(t_mag[idx],magY_body[idx] - py[idx][0] * power_resampled[idx], label='compensated')
-    plt.legend(handles=[original_y, power_y])
-    plt.xlabel('Time [s]')
-    plt.ylabel('Mag Y corrected[G]')
-
-    plt.subplot(3,1,3)
-    original_z, = plt.plot(t_mag[idx], magZ_body[idx], label='original')
-    power_z, = plt.plot(t_mag[idx],magZ_body[idx] - pz[idx][0] * power_resampled[idx], label='compensated')
-    plt.legend(handles=[original_z, power_z])
-    plt.xlabel('Time [s]')
-    plt.ylabel('Mag Z corrected[G]')
-
-plt.show()
+if __name__ == '__main__':
+    main()

--- a/src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation.py
+++ b/src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation.py
@@ -1,387 +1,272 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 """
-Identify mag current/throttle compensation from a ulog.
-
-Estimates a bulk delay dt from |m| vs the power signal, then fits
-    m(t) = R(t)^T B + b + k * power(t - dt)
-and prints CAL_MAG* parameters.
-
+File: mag_compensation.py
+Author: Tanja Baumann
+Email: tanja@auterion.com
+Github: https://github.com/baumanta
+Description:
+    Computes linear coefficients for mag compensation from thrust and current
 Usage:
-    python mag_compensation.py LOG.ulg
-    python mag_compensation.py LOG.ulg current --instance 0
-    python mag_compensation.py LOG.ulg thrust
+    python mag_compensation.py /path/to/log/logfile.ulg current --instance 1
+
+Remark:
+    If your logfile does not contain some of the topics, e.g.battery_status/current_a
+    you will have to comment out the corresponding parts in the script
 """
 
-import argparse
-import sys
 
-import numpy as np
+import matplotlib.pylab as plt
+from mpl_toolkits.mplot3d import Axes3D
 from pyulog import ULog
+from pyulog.px4 import PX4ULog
+from pylab import *
+import numpy as np
+import textwrap as tw
+import argparse
 
-# PX4 rot_lookup (roll, pitch, yaw deg), index = Rotation enum. See rotation.h.
-_ROT_LOOKUP = (
-    (0, 0, 0), (0, 0, 45), (0, 0, 90), (0, 0, 135), (0, 0, 180), (0, 0, 225),
-    (0, 0, 270), (0, 0, 315), (180, 0, 0), (180, 0, 45), (180, 0, 90),
-    (180, 0, 135), (0, 180, 0), (180, 0, 225), (180, 0, 270), (180, 0, 315),
-    (90, 0, 0), (90, 0, 45), (90, 0, 90), (90, 0, 135), (270, 0, 0),
-    (270, 0, 45), (270, 0, 90), (270, 0, 135), (0, 90, 0), (0, 270, 0),
-    (0, 180, 90), (0, 180, 270), (90, 90, 0), (180, 90, 0), (270, 90, 0),
-    (90, 180, 0), (270, 180, 0), (90, 270, 0), (180, 270, 0), (270, 270, 0),
-    (90, 180, 90), (90, 0, 270), (90, 68, 293), (0, 315, 0), (90, 315, 0),
-)
+#arguments
+parser = argparse.ArgumentParser(description='Calculate compensation parameters from ulog')
 
-ARMING_STATE_ARMED = 2
+parser.add_argument('logfile', type=str, nargs='?', default=[],
+                    help='full path to ulog file')
+parser.add_argument('type', type=str, nargs='?', choices=['current', 'thrust'], default=[],
+                    help='Power signal used for compensation, supported is "current" or "thrust".')
+parser.add_argument('--instance', type=int, nargs='?', default=0,
+                    help='instance of the current or thrust signal to use (0 or 1)')
 
+args = parser.parse_args()
+log_name = args.logfile
+comp_type = args.type
+comp_instance = args.instance
 
-def get_data(log, topic, field, instance=0):
-    try:
-        return log.get_dataset(topic, instance).data[field]
-    except Exception:
-        return np.array([])
+#Load the log data (produced by pyulog)
+log = ULog(log_name)
+pxlog = PX4ULog(log)
 
+def get_data(topic_name, variable_name, index):
+   try:
+      dataset = log.get_dataset(topic_name, index)
+      return dataset.data[variable_name]
+   except:
+      return []
 
-def get_param(log, name, default=None):
-    if name in log.initial_parameters:
-        return log.initial_parameters[name]
-    return default
+def ms2s_list(time_ms_list):
+    if len(time_ms_list) > 0:
+        return 1e-6 * time_ms_list
+    else:
+        return time_ms_list
 
+# Select msgs and copy into arrays
+armed = get_data('vehicle_status', 'arming_state', 0)
+t_armed =  ms2s_list(get_data('vehicle_status', 'timestamp', 0))
 
-def us_to_s(t):
-    return t * 1e-6 if len(t) else t
+if comp_type == "thrust":
+	power = get_data('vehicle_rates_setpoint', 'thrust_body[2]', comp_instance)
+	power_t = ms2s_list(get_data('vehicle_rates_setpoint', 'timestamp', comp_instance))
+	comp_type_param = 1
+	factor = 1
+	unit = "[G]"
+elif comp_type == "current":
+	power = get_data('battery_status', 'current_a', comp_instance)
+	power = np.true_divide(power, 1000) #kA
+	power_t = ms2s_list(get_data('battery_status', 'timestamp', comp_instance))
+	comp_type_param = 2 + comp_instance
+	factor = -1
+	unit = "[G/kA]"
+else:
+	print("unknown compensation type {}. Supported is either 'thrust' or 'current'.".format(comp_type))
+	sys.exit(1)
 
+if len(power) == 0:
+	print("could not retrieve power signal from log, zero data points")
+	sys.exit(1)
 
-def topic_time(log, topic, instance=0):
-    ts = get_data(log, topic, 'timestamp_sample', instance)
-    t = get_data(log, topic, 'timestamp', instance)
-    if len(ts) == len(t) and np.any(ts):
-        return us_to_s(ts)
-    return us_to_s(t)
+mag0X_body = get_data('sensor_mag', 'x', 0)
+mag0Y_body = get_data('sensor_mag', 'y', 0)
+mag0Z_body = get_data('sensor_mag', 'z', 0)
+t_mag0 =  ms2s_list(get_data('sensor_mag', 'timestamp', 0))
+mag0_ID = get_data('sensor_mag', 'device_id', 0)
 
+mag1X_body = get_data('sensor_mag', 'x', 1)
+mag1Y_body = get_data('sensor_mag', 'y', 1)
+mag1Z_body = get_data('sensor_mag', 'z', 1)
+t_mag1 = ms2s_list(get_data('sensor_mag', 'timestamp', 1))
+mag1_ID = get_data('sensor_mag', 'device_id', 1)
 
-def dcm_from_quat(q):
-    """v_ned = R v_body. q is (N, 4) Hamilton wxyz, matching matrix::Dcm(Quat)."""
-    a, b, c, d = q.T
-    ab, ac, ad = a * b, a * c, a * d
-    bb, bc, bd = b * b, b * c, b * d
-    cc, cd, dd = c * c, c * d, d * d
-    R = np.empty((q.shape[0], 3, 3))
-    R[:, 0, 0] = 1 - 2 * (cc + dd)
-    R[:, 0, 1] = 2 * (bc - ad)
-    R[:, 0, 2] = 2 * (ac + bd)
-    R[:, 1, 0] = 2 * (bc + ad)
-    R[:, 1, 1] = 1 - 2 * (bb + dd)
-    R[:, 1, 2] = 2 * (cd - ab)
-    R[:, 2, 0] = 2 * (bd - ac)
-    R[:, 2, 1] = 2 * (ab + cd)
-    R[:, 2, 2] = 1 - 2 * (bb + cc)
-    return R
+mag2X_body = get_data('sensor_mag', 'x', 2)
+mag2Y_body = get_data('sensor_mag', 'y', 2)
+mag2Z_body = get_data('sensor_mag', 'z', 2)
+t_mag2 = ms2s_list(get_data('sensor_mag', 'timestamp', 2))
+mag2_ID = get_data('sensor_mag', 'device_id', 2)
 
+mag3X_body = get_data('sensor_mag', 'x', 3)
+mag3Y_body = get_data('sensor_mag', 'y', 3)
+mag3Z_body = get_data('sensor_mag', 'z', 3)
+t_mag3 = ms2s_list(get_data('sensor_mag', 'timestamp', 3))
+mag3_ID = get_data('sensor_mag', 'device_id', 3)
 
-def dcm_from_euler_deg(roll, pitch, yaw):
-    """3-2-1 intrinsic, matching matrix::Dcm(Eulerf)."""
-    phi, theta, psi = np.deg2rad([roll, pitch, yaw])
-    cp, sp = np.cos(phi), np.sin(phi)
-    ct, st = np.cos(theta), np.sin(theta)
-    cs, ss = np.cos(psi), np.sin(psi)
-    return np.array([
-        [ct * cs, -cp * ss + sp * st * cs, sp * ss + cp * st * cs],
-        [ct * ss, cp * cs + sp * st * ss, -sp * cs + cp * st * ss],
-        [-st, sp * ct, cp * ct],
-    ])
+magX_body = []
+magY_body = []
+magZ_body = []
+mag_id = []
+t_mag = []
 
+if len(mag0X_body) > 0:
+    magX_body.append(mag0X_body)
+    magY_body.append(mag0Y_body)
+    magZ_body.append(mag0Z_body)
+    t_mag.append(t_mag0)
+    mag_id.append(mag0_ID[0])
 
-def dcm_from_rot_enum(rot):
-    if rot == 100:
-        raise ValueError('custom rotation needs euler angles')
-    if rot < 0 or rot >= len(_ROT_LOOKUP):
-        rot = 0
-    return dcm_from_euler_deg(*_ROT_LOOKUP[rot])
+if len(mag1X_body) > 0:
+    magX_body.append(mag1X_body)
+    magY_body.append(mag1Y_body)
+    magZ_body.append(mag1Z_body)
+    t_mag.append(t_mag1)
+    mag_id.append(mag1_ID[0])
 
+if len(mag2X_body) > 0:
+    magX_body.append(mag2X_body)
+    magY_body.append(mag2Y_body)
+    magZ_body.append(mag2Z_body)
+    t_mag.append(t_mag2)
+    mag_id.append(mag2_ID[0])
 
-def sensor_to_body_dcm(log, cal_instance):
-    rot = int(get_param(log, f'CAL_MAG{cal_instance}_ROT', -1))
-    if rot < 0:
-        rot = int(get_param(log, 'SENS_BOARD_ROT', 0))
-    if rot == 100:
-        return dcm_from_euler_deg(
-            float(get_param(log, f'CAL_MAG{cal_instance}_ROLL', 0)),
-            float(get_param(log, f'CAL_MAG{cal_instance}_PITCH', 0)),
-            float(get_param(log, f'CAL_MAG{cal_instance}_YAW', 0)),
-        )
-    return dcm_from_rot_enum(rot)
+if len(mag3X_body) > 0:
+    magX_body.append(mag3X_body)
+    magY_body.append(mag3Y_body)
+    magZ_body.append(mag3Z_body)
+    t_mag.append(t_mag3)
+    mag_id.append(mag3_ID[0])
 
+n_mag = len(magX_body)
 
-def unwrap_quats(q):
-    q = np.array(q, dtype=float, copy=True)
-    for i in range(1, len(q)):
-        if np.dot(q[i], q[i - 1]) < 0:
-            q[i] *= -1
-    return q
-
-
-def interp_quats(t_src, q_src, t_dst):
-    q_src = unwrap_quats(q_src)
-    q = np.column_stack([np.interp(t_dst, t_src, q_src[:, i]) for i in range(4)])
-    n = np.linalg.norm(q, axis=1, keepdims=True)
-    n = np.clip(n, 1e-12, None)
-    return q / n
-
-
-def armed_mask(log, t):
-    armed = get_data(log, 'vehicle_status', 'arming_state', 0)
-    t_armed = topic_time(log, 'vehicle_status', 0)
-    if len(armed) == 0:
-        return np.ones(len(t), dtype=bool)
-    # step-hold arming onto mag times
-    idx = np.searchsorted(t_armed, t, side='right') - 1
-    idx = np.clip(idx, 0, len(armed) - 1)
-    return armed[idx] == ARMING_STATE_ARMED
-
-
-def estimate_dt(t_mag, mag_norm, t_p, power, dt_max=0.08, dt_step=0.002):
-    """Lag that maximises |corr| of first-differences of |m| and power."""
-    dt_grid = np.arange(-dt_max, dt_max + dt_step * 0.5, dt_step)
-    mag_d = np.diff(mag_norm)
-    best_dt = 0.0
-    best_c = 0.0
-    corr = np.zeros_like(dt_grid)
-    if len(mag_d) < 20 or np.std(mag_d) < 1e-9:
-        return best_dt, best_c, dt_grid, corr
-    for i, dt in enumerate(dt_grid):
-        p = np.interp(t_mag - dt, t_p, power)
-        p_d = np.diff(p)
-        if np.std(p_d) < 1e-12:
-            continue
-        c = np.corrcoef(mag_d, p_d)[0, 1]
-        if not np.isfinite(c):
-            continue
-        corr[i] = c
-        if abs(c) > abs(best_c):
-            best_c = c
-            best_dt = dt
-    return best_dt, best_c, dt_grid, corr
-
-
-def fit_comp(mag, power, R_ns=None):
-    """
-    mag (N,3), power (N,).
-    If R_ns (N,3,3) maps sensor → NED, fit m = R^T B + b + k * power.
-    Else fit m = b + k * power.
-    Returns k, b, B (or None), r2 of the power term.
-    """
-    n = mag.shape[0]
-    if n < 10:
-        return np.zeros(3), np.zeros(3), None, 0.0
-
-    if R_ns is None:
-        A = np.column_stack([np.ones(n), power])
-        k = np.zeros(3)
-        b = np.zeros(3)
-        for i in range(3):
-            coef, *_ = np.linalg.lstsq(A, mag[:, i], rcond=None)
-            b[i], k[i] = coef
-        resid = mag - (b + np.outer(power, k))
-        demeaned = mag - mag.mean(axis=0)
-        r2 = 1.0 - np.sum(resid ** 2) / max(np.sum(demeaned ** 2), 1e-18)
-        return k, b, None, r2
-
-    y = mag.reshape(n * 3)
-    A = np.zeros((n * 3, 9))
-    Rt = np.transpose(R_ns, (0, 2, 1))
-    A[:, 0:3] = Rt.reshape(n * 3, 3)
-    A[:, 3:6] = np.tile(np.eye(3), (n, 1))
-    A[:, 6:9] = (power[:, None, None] * np.eye(3)[None, :, :]).reshape(n * 3, 3)
-    x, *_ = np.linalg.lstsq(A, y, rcond=None)
-    B, b, k = x[0:3], x[3:6], x[6:9]
-    earth_b = np.einsum('nji,j->ni', R_ns, B) + b
-    resid = mag - earth_b - np.outer(power, k)
-    ref = mag - earth_b
-    r2 = 1.0 - np.sum(resid ** 2) / max(np.sum(ref ** 2), 1e-18)
-    return k, b, B, r2
-
-
-def load_power(log, comp_type, instance):
-    if comp_type == 'current':
-        current = get_data(log, 'battery_status', 'current_a', instance)
-        t = topic_time(log, 'battery_status', instance)
-        if len(current) == 0:
-            return None, None, None, None
-        power = current / 1000.0  # kA, matches VehicleMagnetometer
-        return power, t, 2 + instance, '[G/kA]'
-
-    xyz = [get_data(log, 'vehicle_thrust_setpoint', f'xyz[{i}]', instance) for i in range(3)]
-    if all(len(a) for a in xyz):
-        power = np.linalg.norm(np.column_stack(xyz), axis=1)
-        t = topic_time(log, 'vehicle_thrust_setpoint', instance)
-        return power, t, 1, '[G]'
-
-    thrust_z = get_data(log, 'vehicle_rates_setpoint', 'thrust_body[2]', instance)
-    t = topic_time(log, 'vehicle_rates_setpoint', instance)
-    if len(thrust_z) == 0:
-        return None, None, None, None
-    power = np.abs(thrust_z)
-    return power, t, 1, '[G]'
-
-
-def load_mags(log):
-    mags = []
-    for inst in range(4):
-        x = get_data(log, 'sensor_mag', 'x', inst)
-        if len(x) == 0:
-            continue
-        mag = np.column_stack([
-            x,
-            get_data(log, 'sensor_mag', 'y', inst),
-            get_data(log, 'sensor_mag', 'z', inst),
-        ])
-        t = topic_time(log, 'sensor_mag', inst)
-        device_id = int(get_data(log, 'sensor_mag', 'device_id', inst)[0])
-        mags.append((inst, device_id, t, mag))
-    return mags
-
-
-def load_attitude(log):
-    t = topic_time(log, 'vehicle_attitude', 0)
-    q = [get_data(log, 'vehicle_attitude', f'q[{i}]', 0) for i in range(4)]
-    if len(t) == 0 or any(len(c) == 0 for c in q):
-        return None, None
-    return t, np.column_stack(q)
-
-
-def calibration_instance(log, device_id):
+#log index does not necessarily match mag calibration instance number
+calibration_instance = []
+instance_found = False
+for idx in range(n_mag):
+    instance_found = False
     for j in range(4):
-        if int(get_param(log, f'CAL_MAG{j}_ID', 0)) == device_id:
-            return j
-    return None
+        if mag_id[idx] == log.initial_parameters["CAL_MAG{}_ID".format(j)]:
+                calibration_instance.append(j)
+                instance_found = True
+    if not instance_found:
+        print('Mag {} calibration instance not found, run compass calibration first.'.format(mag_id[idx]))
+
+#get first arming sequence from data
+start_time = 0
+stop_time = 0
+for i in range(len(armed)-1):
+    if armed[i] == 1 and armed[i+1] == 2:
+        start_time = t_armed[i+1]
+    if armed[i] == 2 and armed[i+1] == 1:
+        stop_time = t_armed[i+1]
+        break
+
+#cut unarmed sequences from mag data
+index_start = 0
+index_stop = 0
+
+for idx in range(n_mag):
+    for i in range(len(t_mag[idx])):
+        if t_mag[idx][i] > start_time:
+            index_start = i
+            break
+
+    for i in range(len(t_mag[idx])):
+        if t_mag[idx][i] > stop_time:
+            index_stop = i -1
+            break
+
+    t_mag[idx] = t_mag[idx][index_start:index_stop]
+    magX_body[idx] = magX_body[idx][index_start:index_stop]
+    magY_body[idx] = magY_body[idx][index_start:index_stop]
+    magZ_body[idx] = magZ_body[idx][index_start:index_stop]
 
 
-def main():
-    parser = argparse.ArgumentParser(description='Mag current/throttle compensation from a ulog')
-    parser.add_argument('logfile', help='path to .ulg')
-    parser.add_argument('type', nargs='?', choices=['current', 'thrust'],
-                        help='power signal; default is current if present, else thrust')
-    parser.add_argument('--instance', type=int, default=0, help='battery/thrust instance')
-    parser.add_argument('--no-plot', action='store_true')
-    args = parser.parse_args()
+#resample data
+power_resampled = []
 
-    log = ULog(args.logfile)
+for idx in range(n_mag):
+    power_resampled.append(interp(t_mag[idx], power_t, power))
 
-    comp_type = args.type
-    if comp_type is None:
-        if len(get_data(log, 'battery_status', 'current_a', args.instance)) > 0:
-            comp_type = 'current'
-        else:
-            comp_type = 'thrust'
+#fit linear to get coefficients
+px = []
+py = []
+pz = []
 
-    power, t_power, comp_type_param, unit = load_power(log, comp_type, args.instance)
-    if power is None:
-        print(f'no {comp_type} data in log', file=sys.stderr)
-        sys.exit(1)
+for idx in range(n_mag):
+    px_temp, res_x, _, _, _ = polyfit(power_resampled[idx], magX_body[idx], 1,full = True)
+    py_temp, res_y, _, _, _ = polyfit(power_resampled[idx], magY_body[idx], 1,full = True)
+    pz_temp, res_z, _, _, _ = polyfit(power_resampled[idx], magZ_body[idx], 1, full = True)
 
-    mags = load_mags(log)
-    if not mags:
-        print('no sensor_mag data in log', file=sys.stderr)
-        sys.exit(1)
+    px.append(px_temp)
+    py.append(py_temp)
+    pz.append(pz_temp)
 
-    t_att, q_att = load_attitude(log)
+#print to console
+for idx in range(n_mag):
+    print('Mag{} device ID {} (calibration instance {})'.format(idx, mag_id[idx], calibration_instance[idx]))
+print('\033[91m \n{}-based compensation: \033[0m'.format(comp_type))
+print('\nparam set CAL_MAG_COMP_TYP {}'.format(comp_type_param))
+for idx in range(n_mag):
+    print('\nparam set CAL_MAG{}_XCOMP {:.3f}'.format(calibration_instance[idx], factor * px[idx][0]))
+    print('param set CAL_MAG{}_YCOMP {:.3f}'.format(calibration_instance[idx], factor * py[idx][0]))
+    print('param set CAL_MAG{}_ZCOMP {:.3f}'.format(calibration_instance[idx], factor * pz[idx][0]))
 
-    print(f'\n{comp_type}-based compensation ({args.logfile}), COMP units {unit}')
-    print(f'param set CAL_MAG_COMP_TYP {comp_type_param}')
+#plot data
 
-    if not args.no_plot:
-        import matplotlib.pyplot as plt
+for idx in range(n_mag):
+    fig = plt.figure(num=None, figsize=(25, 14), dpi=80, facecolor='w', edgecolor='k')
+    fig.suptitle('Compensation Parameter Fit \n{} \nmag {} ID: {} (calibration instance {})'.format(log_name, idx, mag_id[idx], calibration_instance[idx]), fontsize=14, fontweight='bold')
 
-    for log_inst, device_id, t_mag, mag in mags:
-        cal_inst = calibration_instance(log, device_id)
-        if cal_inst is None:
-            print(f'\nMag log instance {log_inst} device ID {device_id}: no CAL_MAGx_ID match, skip')
-            continue
+    plt.subplot(1,3,1)
+    plt.plot(power_resampled[idx], magX_body[idx], 'yo', power_resampled[idx], px[idx][0]*power_resampled[idx]+px[idx][1], '--k')
+    plt.xlabel('current [kA]')
+    plt.ylabel('mag X [G]')
 
-        finite = np.isfinite(mag).all(axis=1)
-        mask = finite & armed_mask(log, t_mag)
-        if mask.sum() < 50:
-            mask = finite
-            print(f'\nCAL_MAG{cal_inst} (id {device_id}): no armed interval, using the whole log')
-        if mask.sum() < 50:
-            print(f'\nCAL_MAG{cal_inst} (id {device_id}): not enough samples, skip')
-            continue
+    plt.subplot(1,3,2)
+    plt.plot(power_resampled[idx], magY_body[idx], 'yo', power_resampled[idx], py[idx][0]*power_resampled[idx]+py[idx][1], '--k')
+    plt.xlabel('current [kA]')
+    plt.ylabel('mag Y [G]')
 
-        t = t_mag[mask]
-        m = mag[mask]
-        dt_med = np.median(np.diff(t)) if len(t) > 1 else 1.0
-        rate = 1.0 / dt_med if dt_med > 0 else 0.0
+    plt.subplot(1,3,3)
+    plt.plot(power_resampled[idx], magZ_body[idx], 'yo', power_resampled[idx], pz[idx][0]*power_resampled[idx]+pz[idx][1], '--k')
+    plt.xlabel('current [kA]')
+    plt.ylabel('mag Z [G]')
 
-        dt, dt_corr, dt_grid, dt_corr_curve = estimate_dt(t, np.linalg.norm(m, axis=1), t_power, power)
-        p = np.interp(t - dt, t_power, power)
-
-        R_ns = None
-        used_attitude = False
-        if t_att is not None:
-            q = interp_quats(t_att, q_att, t)
-            R_nb = dcm_from_quat(q)
-            R_cal = sensor_to_body_dcm(log, cal_inst)
-            R_ns = R_nb @ R_cal
-            used_attitude = True
-
-        k, b, B, r2 = fit_comp(m, p, R_ns)
-        # runtime: data + power * COMP, so COMP cancels k in m = ... + k * power
-        comp = -k
-
-        print(f'\nCAL_MAG{cal_inst} device ID {device_id}')
-        print(f'  mag rate {rate:.1f} Hz, dt {dt * 1e3:.1f} ms (|m| vs {comp_type} diff corr {dt_corr:.2f})')
-        print(f'  power-term R^2 {r2:.2f}' + (' (Earth field removed via attitude)' if used_attitude else ' (no attitude, constant-offset fit)'))
-        if rate < 20:
-            print('  warning: mag < 20 Hz; enable SDLOG_PROFILE high-rate sensors (bit 11) for a usable dt')
-        if np.std(p) < (0.001 if comp_type == 'current' else 0.05):
-            print('  warning: little variation in the power signal')
-        if used_attitude and B is not None and np.linalg.norm(B) < 0.1:
-            print('  warning: fitted |B_earth| is low; check mag / attitude alignment')
-        if r2 < 0.15:
-            print('  warning: weak current/throttle correlation; compensation may not help')
-        print(f'param set CAL_MAG{cal_inst}_XCOMP {comp[0]:.3f}')
-        print(f'param set CAL_MAG{cal_inst}_YCOMP {comp[1]:.3f}')
-        print(f'param set CAL_MAG{cal_inst}_ZCOMP {comp[2]:.3f}')
-
-        if args.no_plot:
-            continue
-
-        earth_b = b if R_ns is None else np.einsum('nji,j->ni', R_ns, B) + b
-        m_corr = m - np.outer(p, k)
-
-        fig, axes = plt.subplots(1, 3, figsize=(14, 5))
-        fig.suptitle(f'CAL_MAG{cal_inst} id {device_id}  dt={dt * 1e3:.1f} ms  R²={r2:.2f}')
-        for i, name in enumerate('XYZ'):
-            axes[i].plot(p, m[:, i] - earth_b[:, i], '.', color='C0', alpha=0.4, label='residual')
-            xline = np.linspace(p.min(), p.max(), 50)
-            axes[i].plot(xline, k[i] * xline, 'k--', label='fit')
-            axes[i].set_xlabel('current [kA]' if comp_type == 'current' else 'thrust')
-            axes[i].set_ylabel(f'mag {name} minus Earth/offset [G]')
-            axes[i].legend()
-        plt.tight_layout()
-
-        fig2, axes2 = plt.subplots(4, 1, figsize=(14, 8), sharex=True)
-        fig2.suptitle(f'CAL_MAG{cal_inst} original vs compensated')
-        for i, name in enumerate('XYZ'):
-            axes2[i].plot(t, m[:, i], label='original')
-            axes2[i].plot(t, m_corr[:, i], label='compensated')
-            axes2[i].set_ylabel(f'mag {name} [G]')
-            axes2[i].legend(loc='upper right')
-        axes2[3].plot(t, p)
-        axes2[3].set_ylabel(comp_type)
-        axes2[3].set_xlabel('time [s]')
-        plt.tight_layout()
-
-        fig3, ax3 = plt.subplots(figsize=(8, 4))
-        ax3.plot(dt_grid * 1e3, dt_corr_curve)
-        ax3.axvline(dt * 1e3, color='k', linestyle='--')
-        ax3.set_xlabel('dt [ms] (positive = mag lags power)')
-        ax3.set_ylabel('corr(d|m|, d power)')
-        ax3.set_title(f'CAL_MAG{cal_inst} delay from field norm')
-        plt.tight_layout()
-
-    if not args.no_plot:
-        plt.show()
+    # display results
+    plt.figtext(0.24, 0.03, 'CAL_MAG{}_XCOMP: {:.3f} {}'.format(calibration_instance[idx],factor * px[idx][0],unit), horizontalalignment='center', fontsize=12, multialignment='left', bbox=dict(boxstyle="round", facecolor='#D8D8D8', ec="0.5", pad=0.5, alpha=1), fontweight='bold')
+    plt.figtext(0.51, 0.03, 'CAL_MAG{}_YCOMP: {:.3f} {}'.format(calibration_instance[idx],factor * py[idx][0],unit), horizontalalignment='center', fontsize=12, multialignment='left', bbox=dict(boxstyle="round", facecolor='#D8D8D8', ec="0.5", pad=0.5, alpha=1), fontweight='bold')
+    plt.figtext(0.79, 0.03, 'CAL_MAG{}_ZCOMP: {:.3f} {}'.format(calibration_instance[idx],factor * pz[idx][0],unit), horizontalalignment='center', fontsize=12, multialignment='left', bbox=dict(boxstyle="round", facecolor='#D8D8D8', ec="0.5", pad=0.5, alpha=1), fontweight='bold')
 
 
-if __name__ == '__main__':
-    main()
+#compensation comparison plots
+for idx in range(n_mag):
+    fig = plt.figure(num=None, figsize=(25, 14), dpi=80, facecolor='w', edgecolor='k')
+    fig.suptitle('Original Data vs. Compensation \n{}\nmag {} ID: {} (calibration instance {})'.format(log_name, idx, mag_id[idx], calibration_instance[idx]), fontsize=14, fontweight='bold')
+
+    plt.subplot(3,1,1)
+    original_x, = plt.plot(t_mag[idx], magX_body[idx], label='original')
+    power_x, = plt.plot(t_mag[idx],magX_body[idx] - px[idx][0] * power_resampled[idx], label='compensated')
+    plt.legend(handles=[original_x, power_x])
+    plt.xlabel('Time [s]')
+    plt.ylabel('Mag X corrected[G]')
+
+    plt.subplot(3,1,2)
+    original_y, = plt.plot(t_mag[idx], magY_body[idx], label='original')
+    power_y, = plt.plot(t_mag[idx],magY_body[idx] - py[idx][0] * power_resampled[idx], label='compensated')
+    plt.legend(handles=[original_y, power_y])
+    plt.xlabel('Time [s]')
+    plt.ylabel('Mag Y corrected[G]')
+
+    plt.subplot(3,1,3)
+    original_z, = plt.plot(t_mag[idx], magZ_body[idx], label='original')
+    power_z, = plt.plot(t_mag[idx],magZ_body[idx] - pz[idx][0] * power_resampled[idx], label='compensated')
+    plt.legend(handles=[original_z, power_z])
+    plt.xlabel('Time [s]')
+    plt.ylabel('Mag Z corrected[G]')
+
+plt.show()

--- a/src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation_flight.py
+++ b/src/modules/sensors/vehicle_magnetometer/mag_compensation/python/mag_compensation_flight.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""
+Identify mag current/throttle compensation from a ulog.
+
+Estimates a bulk delay dt from |m| vs the power signal, then fits
+    m(t) = R(t)^T B + b + k * power(t - dt)
+and prints CAL_MAG* parameters.
+
+Usage:
+    python mag_compensation_flight.py LOG.ulg
+    python mag_compensation_flight.py LOG.ulg current --instance 0
+    python mag_compensation_flight.py LOG.ulg thrust
+
+For a restrained throttle ramp without attitude motion, use mag_compensation.py.
+"""
+
+import argparse
+import sys
+
+import numpy as np
+from pyulog import ULog
+
+# PX4 rot_lookup (roll, pitch, yaw deg), index = Rotation enum. See rotation.h.
+_ROT_LOOKUP = (
+    (0, 0, 0), (0, 0, 45), (0, 0, 90), (0, 0, 135), (0, 0, 180), (0, 0, 225),
+    (0, 0, 270), (0, 0, 315), (180, 0, 0), (180, 0, 45), (180, 0, 90),
+    (180, 0, 135), (0, 180, 0), (180, 0, 225), (180, 0, 270), (180, 0, 315),
+    (90, 0, 0), (90, 0, 45), (90, 0, 90), (90, 0, 135), (270, 0, 0),
+    (270, 0, 45), (270, 0, 90), (270, 0, 135), (0, 90, 0), (0, 270, 0),
+    (0, 180, 90), (0, 180, 270), (90, 90, 0), (180, 90, 0), (270, 90, 0),
+    (90, 180, 0), (270, 180, 0), (90, 270, 0), (180, 270, 0), (270, 270, 0),
+    (90, 180, 90), (90, 0, 270), (90, 68, 293), (0, 315, 0), (90, 315, 0),
+)
+
+ARMING_STATE_ARMED = 2
+
+
+def get_data(log, topic, field, instance=0):
+    try:
+        return log.get_dataset(topic, instance).data[field]
+    except Exception:
+        return np.array([])
+
+
+def get_param(log, name, default=None):
+    if name in log.initial_parameters:
+        return log.initial_parameters[name]
+    return default
+
+
+def us_to_s(t):
+    return t * 1e-6 if len(t) else t
+
+
+def topic_time(log, topic, instance=0):
+    ts = get_data(log, topic, 'timestamp_sample', instance)
+    t = get_data(log, topic, 'timestamp', instance)
+    if len(ts) == len(t) and np.any(ts):
+        return us_to_s(ts)
+    return us_to_s(t)
+
+
+def dcm_from_quat(q):
+    """v_ned = R v_body. q is (N, 4) Hamilton wxyz, matching matrix::Dcm(Quat)."""
+    a, b, c, d = q.T
+    ab, ac, ad = a * b, a * c, a * d
+    bb, bc, bd = b * b, b * c, b * d
+    cc, cd, dd = c * c, c * d, d * d
+    R = np.empty((q.shape[0], 3, 3))
+    R[:, 0, 0] = 1 - 2 * (cc + dd)
+    R[:, 0, 1] = 2 * (bc - ad)
+    R[:, 0, 2] = 2 * (ac + bd)
+    R[:, 1, 0] = 2 * (bc + ad)
+    R[:, 1, 1] = 1 - 2 * (bb + dd)
+    R[:, 1, 2] = 2 * (cd - ab)
+    R[:, 2, 0] = 2 * (bd - ac)
+    R[:, 2, 1] = 2 * (ab + cd)
+    R[:, 2, 2] = 1 - 2 * (bb + cc)
+    return R
+
+
+def dcm_from_euler_deg(roll, pitch, yaw):
+    """3-2-1 intrinsic, matching matrix::Dcm(Eulerf)."""
+    phi, theta, psi = np.deg2rad([roll, pitch, yaw])
+    cp, sp = np.cos(phi), np.sin(phi)
+    ct, st = np.cos(theta), np.sin(theta)
+    cs, ss = np.cos(psi), np.sin(psi)
+    return np.array([
+        [ct * cs, -cp * ss + sp * st * cs, sp * ss + cp * st * cs],
+        [ct * ss, cp * cs + sp * st * ss, -sp * cs + cp * st * ss],
+        [-st, sp * ct, cp * ct],
+    ])
+
+
+def dcm_from_rot_enum(rot):
+    if rot == 100:
+        raise ValueError('custom rotation needs euler angles')
+    if rot < 0 or rot >= len(_ROT_LOOKUP):
+        rot = 0
+    return dcm_from_euler_deg(*_ROT_LOOKUP[rot])
+
+
+def sensor_to_body_dcm(log, cal_instance):
+    rot = int(get_param(log, f'CAL_MAG{cal_instance}_ROT', -1))
+    if rot < 0:
+        rot = int(get_param(log, 'SENS_BOARD_ROT', 0))
+    if rot == 100:
+        return dcm_from_euler_deg(
+            float(get_param(log, f'CAL_MAG{cal_instance}_ROLL', 0)),
+            float(get_param(log, f'CAL_MAG{cal_instance}_PITCH', 0)),
+            float(get_param(log, f'CAL_MAG{cal_instance}_YAW', 0)),
+        )
+    return dcm_from_rot_enum(rot)
+
+
+def unwrap_quats(q):
+    q = np.array(q, dtype=float, copy=True)
+    for i in range(1, len(q)):
+        if np.dot(q[i], q[i - 1]) < 0:
+            q[i] *= -1
+    return q
+
+
+def interp_quats(t_src, q_src, t_dst):
+    q_src = unwrap_quats(q_src)
+    q = np.column_stack([np.interp(t_dst, t_src, q_src[:, i]) for i in range(4)])
+    n = np.linalg.norm(q, axis=1, keepdims=True)
+    n = np.clip(n, 1e-12, None)
+    return q / n
+
+
+def armed_mask(log, t):
+    armed = get_data(log, 'vehicle_status', 'arming_state', 0)
+    t_armed = topic_time(log, 'vehicle_status', 0)
+    if len(armed) == 0:
+        return np.ones(len(t), dtype=bool)
+    # step-hold arming onto mag times
+    idx = np.searchsorted(t_armed, t, side='right') - 1
+    idx = np.clip(idx, 0, len(armed) - 1)
+    return armed[idx] == ARMING_STATE_ARMED
+
+
+def estimate_dt(t_mag, mag_norm, t_p, power, dt_max=0.08, dt_step=0.002):
+    """Lag that maximises |corr| of first-differences of |m| and power."""
+    dt_grid = np.arange(-dt_max, dt_max + dt_step * 0.5, dt_step)
+    mag_d = np.diff(mag_norm)
+    best_dt = 0.0
+    best_c = 0.0
+    corr = np.zeros_like(dt_grid)
+    if len(mag_d) < 20 or np.std(mag_d) < 1e-9:
+        return best_dt, best_c, dt_grid, corr
+    for i, dt in enumerate(dt_grid):
+        p = np.interp(t_mag - dt, t_p, power)
+        p_d = np.diff(p)
+        if np.std(p_d) < 1e-12:
+            continue
+        c = np.corrcoef(mag_d, p_d)[0, 1]
+        if not np.isfinite(c):
+            continue
+        corr[i] = c
+        if abs(c) > abs(best_c):
+            best_c = c
+            best_dt = dt
+    return best_dt, best_c, dt_grid, corr
+
+
+def fit_comp(mag, power, R_ns=None):
+    """
+    mag (N,3), power (N,).
+    If R_ns (N,3,3) maps sensor → NED, fit m = R^T B + b + k * power.
+    Else fit m = b + k * power.
+    Returns k, b, B (or None), r2 of the power term.
+    """
+    n = mag.shape[0]
+    if n < 10:
+        return np.zeros(3), np.zeros(3), None, 0.0
+
+    if R_ns is None:
+        A = np.column_stack([np.ones(n), power])
+        k = np.zeros(3)
+        b = np.zeros(3)
+        for i in range(3):
+            coef, *_ = np.linalg.lstsq(A, mag[:, i], rcond=None)
+            b[i], k[i] = coef
+        resid = mag - (b + np.outer(power, k))
+        demeaned = mag - mag.mean(axis=0)
+        r2 = 1.0 - np.sum(resid ** 2) / max(np.sum(demeaned ** 2), 1e-18)
+        return k, b, None, r2
+
+    y = mag.reshape(n * 3)
+    A = np.zeros((n * 3, 9))
+    Rt = np.transpose(R_ns, (0, 2, 1))
+    A[:, 0:3] = Rt.reshape(n * 3, 3)
+    A[:, 3:6] = np.tile(np.eye(3), (n, 1))
+    A[:, 6:9] = (power[:, None, None] * np.eye(3)[None, :, :]).reshape(n * 3, 3)
+    x, *_ = np.linalg.lstsq(A, y, rcond=None)
+    B, b, k = x[0:3], x[3:6], x[6:9]
+    earth_b = np.einsum('nji,j->ni', R_ns, B) + b
+    resid = mag - earth_b - np.outer(power, k)
+    ref = mag - earth_b
+    r2 = 1.0 - np.sum(resid ** 2) / max(np.sum(ref ** 2), 1e-18)
+    return k, b, B, r2
+
+
+def load_power(log, comp_type, instance):
+    if comp_type == 'current':
+        current = get_data(log, 'battery_status', 'current_a', instance)
+        t = topic_time(log, 'battery_status', instance)
+        if len(current) == 0:
+            return None, None, None, None
+        power = current / 1000.0  # kA, matches VehicleMagnetometer
+        return power, t, 2 + instance, '[G/kA]'
+
+    xyz = [get_data(log, 'vehicle_thrust_setpoint', f'xyz[{i}]', instance) for i in range(3)]
+    if all(len(a) for a in xyz):
+        power = np.linalg.norm(np.column_stack(xyz), axis=1)
+        t = topic_time(log, 'vehicle_thrust_setpoint', instance)
+        return power, t, 1, '[G]'
+
+    thrust_z = get_data(log, 'vehicle_rates_setpoint', 'thrust_body[2]', instance)
+    t = topic_time(log, 'vehicle_rates_setpoint', instance)
+    if len(thrust_z) == 0:
+        return None, None, None, None
+    power = np.abs(thrust_z)
+    return power, t, 1, '[G]'
+
+
+def load_mags(log):
+    mags = []
+    for inst in range(4):
+        x = get_data(log, 'sensor_mag', 'x', inst)
+        if len(x) == 0:
+            continue
+        mag = np.column_stack([
+            x,
+            get_data(log, 'sensor_mag', 'y', inst),
+            get_data(log, 'sensor_mag', 'z', inst),
+        ])
+        t = topic_time(log, 'sensor_mag', inst)
+        device_id = int(get_data(log, 'sensor_mag', 'device_id', inst)[0])
+        mags.append((inst, device_id, t, mag))
+    return mags
+
+
+def load_attitude(log):
+    t = topic_time(log, 'vehicle_attitude', 0)
+    q = [get_data(log, 'vehicle_attitude', f'q[{i}]', 0) for i in range(4)]
+    if len(t) == 0 or any(len(c) == 0 for c in q):
+        return None, None
+    return t, np.column_stack(q)
+
+
+def calibration_instance(log, device_id):
+    for j in range(4):
+        if int(get_param(log, f'CAL_MAG{j}_ID', 0)) == device_id:
+            return j
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Mag current/throttle compensation from a ulog')
+    parser.add_argument('logfile', help='path to .ulg')
+    parser.add_argument('type', nargs='?', choices=['current', 'thrust'],
+                        help='power signal; default is current if present, else thrust')
+    parser.add_argument('--instance', type=int, default=0, help='battery/thrust instance')
+    parser.add_argument('--no-plot', action='store_true')
+    args = parser.parse_args()
+
+    log = ULog(args.logfile)
+
+    comp_type = args.type
+    if comp_type is None:
+        if len(get_data(log, 'battery_status', 'current_a', args.instance)) > 0:
+            comp_type = 'current'
+        else:
+            comp_type = 'thrust'
+
+    power, t_power, comp_type_param, unit = load_power(log, comp_type, args.instance)
+    if power is None:
+        print(f'no {comp_type} data in log', file=sys.stderr)
+        sys.exit(1)
+
+    mags = load_mags(log)
+    if not mags:
+        print('no sensor_mag data in log', file=sys.stderr)
+        sys.exit(1)
+
+    t_att, q_att = load_attitude(log)
+
+    print(f'\n{comp_type}-based compensation ({args.logfile}), COMP units {unit}')
+    print(f'param set CAL_MAG_COMP_TYP {comp_type_param}')
+
+    if not args.no_plot:
+        import matplotlib.pyplot as plt
+
+    for log_inst, device_id, t_mag, mag in mags:
+        cal_inst = calibration_instance(log, device_id)
+        if cal_inst is None:
+            print(f'\nMag log instance {log_inst} device ID {device_id}: no CAL_MAGx_ID match, skip')
+            continue
+
+        finite = np.isfinite(mag).all(axis=1)
+        mask = finite & armed_mask(log, t_mag)
+        if mask.sum() < 50:
+            mask = finite
+            print(f'\nCAL_MAG{cal_inst} (id {device_id}): no armed interval, using the whole log')
+        if mask.sum() < 50:
+            print(f'\nCAL_MAG{cal_inst} (id {device_id}): not enough samples, skip')
+            continue
+
+        t = t_mag[mask]
+        m = mag[mask]
+        dt_med = np.median(np.diff(t)) if len(t) > 1 else 1.0
+        rate = 1.0 / dt_med if dt_med > 0 else 0.0
+
+        dt, dt_corr, dt_grid, dt_corr_curve = estimate_dt(t, np.linalg.norm(m, axis=1), t_power, power)
+        p = np.interp(t - dt, t_power, power)
+
+        R_ns = None
+        used_attitude = False
+        if t_att is not None:
+            q = interp_quats(t_att, q_att, t)
+            R_nb = dcm_from_quat(q)
+            R_cal = sensor_to_body_dcm(log, cal_inst)
+            R_ns = R_nb @ R_cal
+            used_attitude = True
+
+        k, b, B, r2 = fit_comp(m, p, R_ns)
+        # runtime: data + power * COMP, so COMP cancels k in m = ... + k * power
+        comp = -k
+
+        print(f'\nCAL_MAG{cal_inst} device ID {device_id}')
+        print(f'  mag rate {rate:.1f} Hz, dt {dt * 1e3:.1f} ms (|m| vs {comp_type} diff corr {dt_corr:.2f})')
+        print(f'  power-term R^2 {r2:.2f}' + (' (Earth field removed via attitude)' if used_attitude else ' (no attitude, constant-offset fit)'))
+        if rate < 20:
+            print('  warning: mag < 20 Hz; enable SDLOG_PROFILE high-rate sensors (bit 11) for a usable dt')
+        if np.std(p) < (0.001 if comp_type == 'current' else 0.05):
+            print('  warning: little variation in the power signal')
+        if used_attitude and B is not None and np.linalg.norm(B) < 0.1:
+            print('  warning: fitted |B_earth| is low; check mag / attitude alignment')
+        if r2 < 0.15:
+            print('  warning: weak current/throttle correlation; compensation may not help')
+        print(f'param set CAL_MAG{cal_inst}_XCOMP {comp[0]:.3f}')
+        print(f'param set CAL_MAG{cal_inst}_YCOMP {comp[1]:.3f}')
+        print(f'param set CAL_MAG{cal_inst}_ZCOMP {comp[2]:.3f}')
+
+        if args.no_plot:
+            continue
+
+        earth_b = b if R_ns is None else np.einsum('nji,j->ni', R_ns, B) + b
+        m_corr = m - np.outer(p, k)
+
+        fig, axes = plt.subplots(1, 3, figsize=(14, 5))
+        fig.suptitle(f'CAL_MAG{cal_inst} id {device_id}  dt={dt * 1e3:.1f} ms  R²={r2:.2f}')
+        for i, name in enumerate('XYZ'):
+            axes[i].plot(p, m[:, i] - earth_b[:, i], '.', color='C0', alpha=0.4, label='residual')
+            xline = np.linspace(p.min(), p.max(), 50)
+            axes[i].plot(xline, k[i] * xline, 'k--', label='fit')
+            axes[i].set_xlabel('current [kA]' if comp_type == 'current' else 'thrust')
+            axes[i].set_ylabel(f'mag {name} minus Earth/offset [G]')
+            axes[i].legend()
+        plt.tight_layout()
+
+        fig2, axes2 = plt.subplots(4, 1, figsize=(14, 8), sharex=True)
+        fig2.suptitle(f'CAL_MAG{cal_inst} original vs compensated')
+        for i, name in enumerate('XYZ'):
+            axes2[i].plot(t, m[:, i], label='original')
+            axes2[i].plot(t, m_corr[:, i], label='compensated')
+            axes2[i].set_ylabel(f'mag {name} [G]')
+            axes2[i].legend(loc='upper right')
+        axes2[3].plot(t, p)
+        axes2[3].set_ylabel(comp_type)
+        axes2[3].set_xlabel('time [s]')
+        plt.tight_layout()
+
+        fig3, ax3 = plt.subplots(figsize=(8, 4))
+        ax3.plot(dt_grid * 1e3, dt_corr_curve)
+        ax3.axvline(dt * 1e3, color='k', linestyle='--')
+        ax3.set_xlabel('dt [ms] (positive = mag lags power)')
+        ax3.set_ylabel('corr(d|m|, d power)')
+        ax3.set_title(f'CAL_MAG{cal_inst} delay from field norm')
+        plt.tight_layout()
+
+    if not args.no_plot:
+        plt.show()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
Fit mag current/throttle compensation from a normal flight log, without dropping the strapdown script.

## Problem
The identification script required a strapped ACRO throttle ramp. Almost no one does that, and a naive axis-vs-current fit on a flight log absorbs attitude into the coefficients.

## Solution
Add `mag_compensation_flight.py`: delay from the field norm vs current, then per-axis coefficients after removing Earth field with `vehicle_attitude`. Leave `mag_compensation.py` for a restrained ramp. Docs cover both.