### PR TITLE
feat(uavcan): parse STATUS_FLAG_CHARGING from BatteryInfo

### DIFF
--- a/msg/versioned/BatteryStatus.msg
+++ b/msg/versioned/BatteryStatus.msg
@@ -41,14 +41,14 @@ float32 max_cell_voltage_delta # [V] Max difference between individual cell volt
 bool is_powering_off # Power off event imminent indication, false if unknown
 bool is_required # Set if the battery is explicitly required before arming
 
-uint8 warning # [@enum WARNING STATE] Current battery warning
+uint8 warning # [@enum WARNING] Current battery warning
 uint8 WARNING_NONE = 0 # No battery low voltage warning active
 uint8 WARNING_LOW = 1 # Low voltage warning
 uint8 WARNING_CRITICAL = 2 # Critical voltage, return / abort immediately
 uint8 WARNING_EMERGENCY = 3 # Immediate landing required
 uint8 WARNING_FAILED = 4 # Battery has failed completely
-uint8 STATE_UNHEALTHY = 6 # Battery is diagnosed to be defective or an error occurred, usage is discouraged / prohibited. Possible causes (faults) are listed in faults field
-uint8 STATE_CHARGING = 7 # Battery is charging
+uint8 WARNING_UNHEALTHY = 6 # Battery is diagnosed to be defective or an error occurred, usage is discouraged / prohibited. Possible causes (faults) are listed in faults field
+uint8 WARNING_CHARGING = 7 # Battery is charging
 
 uint16 faults # [@enum FAULT] Smart battery supply status/fault flags (bitmask) for health indication
 uint8 FAULT_DEEP_DISCHARGE = 0 # Battery has deep discharged

--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -158,7 +158,12 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 		_battery_status[instance].cell_count = 1;
 	}
 
-	_battery_status[instance].warning = _battery[instance]->determineWarning(_battery_status[instance].remaining);
+	if (msg.status_flags & uavcan::equipment::power::BatteryInfo::STATUS_FLAG_CHARGING) {
+		_battery_status[instance].warning = battery_status_s::STATE_CHARGING;
+
+	} else {
+		_battery_status[instance].warning = _battery[instance]->determineWarning(_battery_status[instance].remaining);
+	}
 
 	if (_batt_update_mod[instance] == BatteryDataType::Raw) {
 		publishBattery(msg.getSrcNodeID().get(), instance);
@@ -327,6 +332,10 @@ UavcanBatteryBridge::filterData(const uavcan::ReceivedDataStructure<uavcan::equi
 	_battery_status[instance] = _battery[instance]->getBatteryStatus();
 	_battery_status[instance].temperature = msg.temperature + atmosphere::kAbsoluteNullCelsius; // Kelvin to Celsius
 	_battery_status[instance].id = msg.battery_id;
+
+	if (msg.status_flags & uavcan::equipment::power::BatteryInfo::STATUS_FLAG_CHARGING) {
+		_battery_status[instance].warning = battery_status_s::STATE_CHARGING;
+	}
 
 	publishBattery(msg.getSrcNodeID().get(), instance);
 

--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -159,7 +159,7 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 	}
 
 	if (msg.status_flags & uavcan::equipment::power::BatteryInfo::STATUS_FLAG_CHARGING) {
-		_battery_status[instance].warning = battery_status_s::STATE_CHARGING;
+		_battery_status[instance].warning = battery_status_s::WARNING_CHARGING;
 
 	} else {
 		_battery_status[instance].warning = _battery[instance]->determineWarning(_battery_status[instance].remaining);
@@ -334,7 +334,7 @@ UavcanBatteryBridge::filterData(const uavcan::ReceivedDataStructure<uavcan::equi
 	_battery_status[instance].id = msg.battery_id;
 
 	if (msg.status_flags & uavcan::equipment::power::BatteryInfo::STATUS_FLAG_CHARGING) {
-		_battery_status[instance].warning = battery_status_s::STATE_CHARGING;
+		_battery_status[instance].warning = battery_status_s::WARNING_CHARGING;
 	}
 
 	publishBattery(msg.getSrcNodeID().get(), instance);

--- a/src/drivers/uavcannode/Publishers/BatteryInfo.hpp
+++ b/src/drivers/uavcannode/Publishers/BatteryInfo.hpp
@@ -120,7 +120,7 @@ public:
 				status_flags |= uavcan::equipment::power::BatteryInfo::STATUS_FLAG_IN_USE;
 			}
 
-			if (battery.warning == battery_status_s::STATE_CHARGING) {
+			if (battery.warning == battery_status_s::WARNING_CHARGING) {
 				status_flags |= uavcan::equipment::power::BatteryInfo::STATUS_FLAG_CHARGING;
 			}
 

--- a/src/modules/mavlink/streams/BATTERY_STATUS.hpp
+++ b/src/modules/mavlink/streams/BATTERY_STATUS.hpp
@@ -104,11 +104,11 @@ private:
 					bat_msg.charge_state = MAV_BATTERY_CHARGE_STATE_FAILED;
 					break;
 
-				case (battery_status_s::STATE_UNHEALTHY):
+				case (battery_status_s::WARNING_UNHEALTHY):
 					bat_msg.charge_state = MAV_BATTERY_CHARGE_STATE_UNHEALTHY;
 					break;
 
-				case (battery_status_s::STATE_CHARGING):
+				case (battery_status_s::WARNING_CHARGING):
 					bat_msg.charge_state = MAV_BATTERY_CHARGE_STATE_CHARGING;
 					break;
 


### PR DESCRIPTION
- Map UAVCAN STATUS_FLAG_CHARGING to uORB STATE_CHARGING
- Cover both Raw and Filter data paths
- Enables MAVLink BATTERY_STATUS.charge_state to report CHARGING(7)