### PR TITLE
fix(mavlink): safely expand cached FTP replies

### DIFF
--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -152,6 +152,18 @@ endif()
 
 target_link_libraries(modules__mavlink PRIVATE failure_injection)
 
+px4_add_unit_gtest(SRC MavlinkFTPTest.cpp
+	INCLUDES
+		${MAVLINK_LIBRARY_DIR}
+		${MAVLINK_LIBRARY_DIR}/${CONFIG_MAVLINK_DIALECT}
+		${MAVLINK_LIBRARY_DIR}/${MAVLINK_DIALECT_UAVIONIX}
+	COMPILE_FLAGS
+		-Wno-address-of-packed-member # TODO: fix in c_library_v2
+		-Wno-cast-align # TODO: fix
+	LINKLIBS
+		modules__mavlink
+	)
+
 px4_add_unit_gtest(SRC MavlinkStatustextHandlerTest.cpp
 	INCLUDES
 		${MAVLINK_LIBRARY_DIR}

--- a/src/modules/mavlink/MavlinkFTPTest.cpp
+++ b/src/modules/mavlink/MavlinkFTPTest.cpp
@@ -1,0 +1,53 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "mavlink_ftp_reply_cache.h"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+TEST(MavlinkFTP, ExpandReplyCacheZeroFillsUncachedPayload)
+{
+	uint8_t compact_reply[19] {};
+	memset(compact_reply, 0xa5, sizeof(compact_reply));
+
+	const mavlink_file_transfer_protocol_t reply = mavlink_ftp::expand_reply_cache(compact_reply);
+	const auto *reply_bytes = reinterpret_cast<const uint8_t *>(&reply);
+
+	EXPECT_EQ(memcmp(reply_bytes, compact_reply, sizeof(compact_reply)), 0);
+
+	for (size_t i = sizeof(compact_reply); i < sizeof(reply); ++i) {
+		EXPECT_EQ(reply_bytes[i], 0) << "non-zero byte at offset " << i;
+	}
+}

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -43,6 +43,7 @@
 #include <cstring>
 
 #include "mavlink_ftp.h"
+#include "mavlink_ftp_reply_cache.h"
 #include "mavlink_main.h"
 
 using namespace time_literals;
@@ -140,16 +141,16 @@ MavlinkFTP::_process_request(
 
 	// check the sequence number: if this is a resent request, resend the last response
 	if (_last_reply_valid) {
-		mavlink_file_transfer_protocol_t *last_reply = reinterpret_cast<mavlink_file_transfer_protocol_t *>(_last_reply);
-		PayloadHeader *last_payload = reinterpret_cast<PayloadHeader *>(&last_reply->payload[0]);
+		const mavlink_file_transfer_protocol_t last_reply = mavlink_ftp::expand_reply_cache(_last_reply);
+		const PayloadHeader *last_payload = reinterpret_cast<const PayloadHeader *>(&last_reply.payload[0]);
 
 		if (payload->seq_number + 1 == last_payload->seq_number
-		    && last_reply->target_system == target_system_id
-		    && last_reply->target_component == target_comp_id) {
+		    && last_reply.target_system == target_system_id
+		    && last_reply.target_component == target_comp_id) {
 			// this is the same request as the one we replied to last. It means the (n)ack got lost, and the GCS
 			// resent the request
 			_mavlink.lock_send();
-			mavlink_msg_file_transfer_protocol_send_struct(_mavlink.get_channel(), last_reply);
+			mavlink_msg_file_transfer_protocol_send_struct(_mavlink.get_channel(), &last_reply);
 			_mavlink.unlock_send();
 			return;
 		}
@@ -295,6 +296,9 @@ MavlinkFTP::_reply(mavlink_file_transfer_protocol_t *ftp_req)
 {
 	PayloadHeader *payload = reinterpret_cast<PayloadHeader *>(&ftp_req->payload[0]);
 
+	// clear any not used payload data to correctly trim mavlink ftp message reply
+	memset(&payload->data[payload->size], 0, kMaxDataLength - payload->size);
+
 	// keep a copy of the last sent response ((n)ack), so that if it gets lost and the GCS resends the request,
 	// we can simply resend the response.
 	// we only keep small responses to reduce RAM usage and avoid large memcpy's. The larger responses are all data
@@ -303,9 +307,6 @@ MavlinkFTP::_reply(mavlink_file_transfer_protocol_t *ftp_req)
 		_last_reply_valid = true;
 		memcpy(_last_reply, ftp_req, sizeof(_last_reply));
 	}
-
-	// clear any not used payload data to correctly trim mavlink ftp message reply
-	memset(&payload->data[payload->size], 0, kMaxDataLength - payload->size);
 
 	PX4_DEBUG("FTP: %s seq_number: %" PRIu16, payload->opcode == kRspAck ? "Ack" : "Nak", payload->seq_number);
 

--- a/src/modules/mavlink/mavlink_ftp_reply_cache.h
+++ b/src/modules/mavlink/mavlink_ftp_reply_cache.h
@@ -1,0 +1,55 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "mavlink_bridge_header.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace mavlink_ftp
+{
+
+template<size_t N>
+mavlink_file_transfer_protocol_t expand_reply_cache(const uint8_t (&compact_reply)[N])
+{
+	static_assert(N <= sizeof(mavlink_file_transfer_protocol_t), "FTP reply cache exceeds the MAVLink message");
+
+	mavlink_file_transfer_protocol_t reply{};
+	memcpy(&reply, compact_reply, N);
+	return reply;
+}
+
+} // namespace mavlink_ftp


### PR DESCRIPTION
### Solved Problem

Fixes #28347.

The MAVLink FTP resend path retains a compact 19-byte cache for small replies, but previously reinterpreted that cache as a full `mavlink_file_transfer_protocol_t` before serialization. The serializer can therefore read beyond the cached object.

### Solution

Expand the compact cache into a zero-initialized full MAVLink FTP message before checking or resending it. Unused payload bytes are cleared before the compact response is cached, preserving deterministic duplicate replies without increasing the persistent cache size.

### Changelog Entry

Bugfix MAVLink FTP duplicate-reply serialization.

### Alternatives

Storing the full MAVLink structure would avoid the expansion step but would increase persistent per-instance RAM usage. This change retains the existing compact-cache design.

### Test coverage

* `make tests TESTFILTER=MavlinkFTP -j4` — PASS
* `unit-MavlinkFTP --gtest_filter=MavlinkFTP.*` — PASS
* `make px4_sitl_default -j4` — PASS
* Exact serialization probe under AddressSanitizer: baseline reports an out-of-bounds read; fixed path completes without a sanitizer finding.

Scope boundary: an end-to-end live SITL transport probe was not claimed because the managed test environment blocked PX4’s internal Unix-socket creation.
