### PR TITLE
feat(fw): time based fixed-wing takeoff climbout

### DIFF
--- a/docs/en/flight_modes_fw/takeoff.md
+++ b/docs/en/flight_modes_fw/takeoff.md
@@ -41,6 +41,10 @@ Irrespective of the modality, a flight path (starting point and takeoff course) 
 By default, on takeoff the aircraft will follow the line defined by the starting point and course, climbing at the maximum climb rate ([FW_T_CLMB_MAX](../advanced_config/parameter_reference.md#FW_T_CLMB_MAX)) until reaching the clearance altitude.
 Reaching the clearance altitude causes the vehicle to enter [Hold mode](../flight_modes_fw/takeoff.md).
 
+[FW_TKO_CLMB_T](#FW_TKO_CLMB_T) ends the climbout after a fixed time instead.
+The vehicle holds at whatever altitude it has reached by then, or climbs to the clearance altitude if it is still below it.
+Use it where altitude is a poor measure of when the climbout is done, such as a rocket-assisted launch.
+
 If a valid waypoint target is set, using `MAV_CMD_NAV_TAKEOFF` or the [VehicleCommand](../msg_docs/VehicleCommand.md) uORB topic, the vehicle will instead track towards the waypoint, and enter [Hold mode](../flight_modes_fw/takeoff.md) after reaching the waypoint altitude (within the acceptance radius).
 
 ::: tip
@@ -77,6 +81,7 @@ Parameters that affect both catapult/hand-launch and runway takeoffs:
 | <a id="FW_TKO_AIRSPD"></a>[FW_TKO_AIRSPD][FW_TKO_AIRSPD]          | Takeoff airspeed (is set to [FW_AIRSPD_MIN][FW_AIRSPD_MIN] if not defined by operator)                                                                   |
 | <a id="FW_TKO_PITCH_MIN"></a>[FW_TKO_PITCH_MIN][FW_TKO_PITCH_MIN] | This is the minimum pitch angle setpoint during the climbout phase                                                                                       |
 | <a id="FW_T_CLMB_MAX"></a>[FW_T_CLMB_MAX][FW_T_CLMB_MAX]          | Climb rate setpoint during climbout to takeoff altitude.                                                                                                 |
+| <a id="FW_TKO_CLMB_T"></a>[FW_TKO_CLMB_T][FW_TKO_CLMB_T]          | Duration of the climbout. If > 0 the climbout ends after this time instead of at the takeoff altitude.                                                   |
 | <a id="FW_FLAPS_TO_SCL"></a>[FW_FLAPS_TO_SCL][FW_FLAPS_TO_SCL]    | Flaps setpoint during takeoff                                                                                                                            |
 | <a id="FW_AIRSPD_FLP_SC"></a>[FW_AIRSPD_FLP_SC][FW_AIRSPD_FLP_SC] | Factor applied to the minimum airspeed when flaps are fully deployed. Needed if [FW_TKO_AIRSPD](#FW_TKO_AIRSPD) is below [FW_AIRSPD_MIN][FW_AIRSPD_MIN]. |
 
@@ -87,6 +92,7 @@ Parameters that affect both catapult/hand-launch and runway takeoffs:
 [MIS_TAKEOFF_ALT]: ../advanced_config/parameter_reference.md#MIS_TAKEOFF_ALT
 [FW_TKO_PITCH_MIN]: ../advanced_config/parameter_reference.md#FW_TKO_PITCH_MIN
 [FW_T_CLMB_MAX]: ../advanced_config/parameter_reference.md#FW_T_CLMB_MAX
+[FW_TKO_CLMB_T]: ../advanced_config/parameter_reference.md#FW_TKO_CLMB_T
 
 ::: info
 The vehicle always respects normal FW max/min throttle settings during takeoff ([FW_THR_MIN](../advanced_config/parameter_reference.md#FW_THR_MIN), [FW_THR_MAX](../advanced_config/parameter_reference.md#FW_THR_MAX)).

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -100,6 +100,7 @@ set(msg_files
 	FixedWingLateralGuidanceStatus.msg
 	FixedWingLateralStatus.msg
 	FixedWingRunwayControl.msg
+	FixedWingTakeoffStatus.msg
 	GeneratorStatus.msg
 	GeofenceResult.msg
 	GeofenceStatus.msg

--- a/msg/FixedWingTakeoffStatus.msg
+++ b/msg/FixedWingTakeoffStatus.msg
@@ -1,0 +1,6 @@
+# Status of a fixed-wing takeoff
+# Passes information from the FixedWingModeManager to the Navigator.
+
+uint64 timestamp # [us] time since system start
+
+bool climbout_completed  # Whether the takeoff climbout is finished (altitude, or time if FW_TKO_CLMB_T is set)

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -1168,10 +1168,14 @@ FixedWingModeManager::control_auto_takeoff(const hrt_abstime &now, const float c
 		const float pitch_min = _runway_takeoff.getMinPitch(math::radians(_takeoff_pitch_min.get()),
 					math::radians(_param_fw_p_lim_min.get()));
 
+		// a time based climbout has to keep climbing for the whole window, so command the climb rate
+		// instead of capturing the clearance altitude
+		const bool time_based_climbout = _param_fw_tko_clmb_t.get() > FLT_EPSILON;
+
 		const fixed_wing_longitudinal_setpoint_s fw_longitudinal_control_sp = {
 			.timestamp = now,
-			.altitude = altitude_setpoint_amsl,
-			.height_rate = NAN,
+			.altitude = time_based_climbout ? NAN : altitude_setpoint_amsl,
+			.height_rate = time_based_climbout ? _param_fw_t_clmb_max.get() : NAN,
 			.equivalent_airspeed = takeoff_airspeed,
 			.pitch_direct = _runway_takeoff.getPitch(),
 			.throttle_direct = _runway_takeoff.getThrottle(_param_fw_thr_idle.get())
@@ -2460,15 +2464,35 @@ FixedWingModeManager::reset_takeoff_state()
 
 	_time_launch_detected = 0;
 
+	_time_climbout_started = 0;
+
 	_takeoff_ground_alt = _current_altitude;
 }
 
 void
 FixedWingModeManager::publishTakeoffStatus(const bool waiting_for_launch, const float clearance_altitude_amsl)
 {
+	const hrt_abstime now = hrt_absolute_time();
+
+	if (!waiting_for_launch && _time_climbout_started == 0) {
+		// the vehicle just started climbing, either off the launcher or off the runway
+		_time_climbout_started = now;
+	}
+
+	bool climbout_completed = false;
+
+	if (!waiting_for_launch) {
+		if (_param_fw_tko_clmb_t.get() > FLT_EPSILON) {
+			climbout_completed = hrt_elapsed_time(&_time_climbout_started) >= _param_fw_tko_clmb_t.get() * 1_s;
+
+		} else {
+			climbout_completed = _current_altitude >= clearance_altitude_amsl;
+		}
+	}
+
 	fixed_wing_takeoff_status_s fixed_wing_takeoff_status{};
-	fixed_wing_takeoff_status.timestamp = hrt_absolute_time();
-	fixed_wing_takeoff_status.climbout_completed = !waiting_for_launch && _current_altitude >= clearance_altitude_amsl;
+	fixed_wing_takeoff_status.timestamp = now;
+	fixed_wing_takeoff_status.climbout_completed = climbout_completed;
 
 	_fixed_wing_takeoff_status_pub.publish(fixed_wing_takeoff_status);
 }

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -1323,6 +1323,11 @@ FixedWingModeManager::control_auto_takeoff(const hrt_abstime &now, const float c
 
 	_flaps_setpoint = _param_fw_flaps_to_scl.get();
 
+	const bool waiting_for_launch = _runway_takeoff.runwayTakeoffEnabled()
+					? _runway_takeoff.getState() < RunwayTakeoffState::CLIMBOUT
+					: _launchDetector.getLaunchDetected() == launch_detection_status_s::STATE_WAITING_FOR_LAUNCH;
+	publishTakeoffStatus(waiting_for_launch, clearance_altitude_amsl);
+
 	if (!_vehicle_status.in_transition_to_fw) {
 		publishLocalPositionSetpoint(pos_sp_curr);
 	}
@@ -1454,6 +1459,11 @@ FixedWingModeManager::control_auto_takeoff_no_nav(const hrt_abstime &now, const 
 	}
 
 	_flaps_setpoint = _param_fw_flaps_to_scl.get();
+
+	const bool waiting_for_launch = _runway_takeoff.runwayTakeoffEnabled()
+					? _runway_takeoff.getState() < RunwayTakeoffState::CLIMBOUT
+					: _launchDetector.getLaunchDetected() == launch_detection_status_s::STATE_WAITING_FOR_LAUNCH;
+	publishTakeoffStatus(waiting_for_launch, current_setpoint_altitude_amsl);
 }
 
 void
@@ -2451,6 +2461,16 @@ FixedWingModeManager::reset_takeoff_state()
 	_time_launch_detected = 0;
 
 	_takeoff_ground_alt = _current_altitude;
+}
+
+void
+FixedWingModeManager::publishTakeoffStatus(const bool waiting_for_launch, const float clearance_altitude_amsl)
+{
+	fixed_wing_takeoff_status_s fixed_wing_takeoff_status{};
+	fixed_wing_takeoff_status.timestamp = hrt_absolute_time();
+	fixed_wing_takeoff_status.climbout_completed = !waiting_for_launch && _current_altitude >= clearance_altitude_amsl;
+
+	_fixed_wing_takeoff_status_pub.publish(fixed_wing_takeoff_status);
 }
 
 void

--- a/src/modules/fw_mode_manager/FixedWingModeManager.hpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.hpp
@@ -72,6 +72,7 @@
 #include <uORB/topics/fixed_wing_lateral_guidance_status.h>
 #include <uORB/topics/fixed_wing_longitudinal_setpoint.h>
 #include <uORB/topics/fixed_wing_runway_control.h>
+#include <uORB/topics/fixed_wing_takeoff_status.h>
 #include <uORB/topics/landing_gear.h>
 #include <uORB/topics/launch_detection_status.h>
 #include <uORB/topics/normalized_unsigned_setpoint.h>
@@ -204,6 +205,7 @@ private:
 	uORB::PublicationData<fixed_wing_longitudinal_setpoint_s> _longitudinal_ctrl_sp_pub{ORB_ID(fixed_wing_longitudinal_setpoint)};
 	uORB::Publication<fixed_wing_lateral_guidance_status_s> _fixed_wing_lateral_guidance_status_pub{ORB_ID(fixed_wing_lateral_guidance_status)};
 	uORB::Publication<fixed_wing_runway_control_s> _fixed_wing_runway_control_pub{ORB_ID(fixed_wing_runway_control)};
+	uORB::Publication<fixed_wing_takeoff_status_s> _fixed_wing_takeoff_status_pub{ORB_ID(fixed_wing_takeoff_status)};
 
 	position_setpoint_triplet_s _pos_sp_triplet{};
 	vehicle_control_mode_s _control_mode{};
@@ -670,6 +672,8 @@ private:
 
 	void reset_takeoff_state();
 	void reset_landing_state();
+
+	void publishTakeoffStatus(const bool waiting_for_launch, const float clearance_altitude_amsl);
 
 	/**
 	 * @brief Releases the parachute by triggering flight termination.

--- a/src/modules/fw_mode_manager/FixedWingModeManager.hpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.hpp
@@ -310,6 +310,9 @@ private:
 	// [us] time stamp of (runway/catapult) launch detection
 	hrt_abstime _time_launch_detected{0};
 
+	// [us] time stamp of the start of the climbout, 0 while the takeoff has not started climbing yet
+	hrt_abstime _time_climbout_started{0};
+
 	// [deg] global position of the vehicle at the time launch is detected (using launch detector) or takeoff is started (runway)
 	Vector2d _takeoff_init_position{0, 0};
 
@@ -914,6 +917,7 @@ private:
 		(ParamInt<px4::params::FW_LND_NUDGE>) _param_fw_lnd_nudge,
 		(ParamInt<px4::params::FW_LND_ABORT>) _param_fw_lnd_abort,
 		(ParamFloat<px4::params::FW_TKO_AIRSPD>) _param_fw_tko_airspd,
+		(ParamFloat<px4::params::FW_TKO_CLMB_T>) _param_fw_tko_clmb_t,
 		(ParamFloat<px4::params::RWTO_PSP>) _param_rwto_psp,
 		(ParamFloat<px4::params::FW_AIRSPD_MAX>) _param_fw_airspd_max,
 		(ParamFloat<px4::params::FW_AIRSPD_MIN>) _param_fw_airspd_min,

--- a/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
+++ b/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
@@ -295,7 +295,6 @@ parameters:
       default: 0.0
       unit: s
       min: 0.0
-      max: 60.0
       decimal: 1
       increment: 1.0
     FW_LAUN_DETCN_ON:

--- a/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
+++ b/src/modules/fw_mode_manager/fw_mode_manager_params.yaml
@@ -283,6 +283,21 @@ parameters:
       min: -1.0
       decimal: 1
       increment: 0.1
+    FW_TKO_CLMB_T:
+      description:
+        short: Takeoff climbout duration
+        long: |-
+          Ends the takeoff climbout this many seconds after the vehicle started climbing, instead of
+          when the takeoff altitude is reached.
+
+          If set to 0, the climbout ends at the takeoff altitude.
+      type: float
+      default: 0.0
+      unit: s
+      min: 0.0
+      max: 60.0
+      decimal: 1
+      increment: 1.0
     FW_LAUN_DETCN_ON:
       description:
         short: Fixed-wing launch detection

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -163,6 +163,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("fixed_wing_lateral_guidance_status", 100);
 	add_optional_topic("fixed_wing_lateral_status", 100);
 	add_optional_topic("fixed_wing_runway_control", 100);
+	add_optional_topic("fixed_wing_takeoff_status", 100);
 	add_optional_topic("ranging_beacon", 100);
 
 	// multi topics

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -212,8 +212,8 @@ MissionBlock::is_mission_item_reached_or_completed()
 
 		} else if (_mission_item.nav_cmd == NAV_CMD_TAKEOFF
 			   && _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
-			/* fixed-wing takeoff is reached once the vehicle has exceeded the takeoff altitude */
-			if (_navigator->get_global_position()->alt > mission_item_altitude_amsl) {
+			/* fixed-wing takeoff is reached once the mode manager has finished the climbout */
+			if (_navigator->fw_climbout_completed(mission_item_altitude_amsl)) {
 				_waypoint_position_reached = true;
 			}
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -76,6 +76,7 @@
 #include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/distance_sensor_mode_change_request.h>
 #include <uORB/topics/fixed_wing_lateral_guidance_status.h>
+#include <uORB/topics/fixed_wing_takeoff_status.h>
 #include <uORB/topics/geofence_result.h>
 #include <uORB/topics/gimbal_manager_set_attitude.h>
 #include <uORB/topics/home_position.h>
@@ -201,6 +202,12 @@ public:
 	bool home_alt_valid() { return (_home_pos.valid_alt); }
 
 	bool home_global_position_valid() { return (_home_pos.valid_alt && _home_pos.valid_hpos); }
+
+	/**
+	 * Whether the fixed-wing mode manager has finished the climbout of the current takeoff.
+	 * Falls back to the given altitude when no takeoff is being flown.
+	 */
+	bool fw_climbout_completed(float fallback_altitude_amsl);
 
 	Geofence &get_geofence() { return _geofence; }
 
@@ -368,6 +375,7 @@ private:
 	uORB::Subscription _home_pos_sub{ORB_ID(home_position)};		/**< home position subscription */
 	uORB::Subscription _land_detected_sub{ORB_ID(vehicle_land_detected)};	/**< vehicle land detected subscription */
 	uORB::Subscription _pos_ctrl_landing_status_sub{ORB_ID(position_controller_landing_status)};	/**< position controller landing status subscription */
+	uORB::Subscription _fw_takeoff_status_sub{ORB_ID(fixed_wing_takeoff_status)};	/**< fixed-wing takeoff status subscription */
 	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};	/**< vehicle commands (onboard and offboard) */
 
 	uORB::Publication<geofence_result_s>		_geofence_result_pub{ORB_ID(geofence_result)};

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1475,6 +1475,25 @@ void Navigator::check_traffic()
 }
 #endif // CONFIG_NAVIGATOR_ADSB
 
+bool Navigator::fw_climbout_completed(float fallback_altitude_amsl)
+{
+	if (_pos_sp_triplet.current.type != position_setpoint_s::SETPOINT_TYPE_TAKEOFF) {
+		// no takeoff is being flown, for example because the mode was entered while already in air,
+		// so the mode manager does not report anything and the altitude decides as it did before
+		return _global_pos.alt >= fallback_altitude_amsl;
+	}
+
+	fixed_wing_takeoff_status_s fixed_wing_takeoff_status;
+
+	if (_fw_takeoff_status_sub.copy(&fixed_wing_takeoff_status)) {
+		// the report has to be newer than the setpoint, as it could otherwise still refer to a previous takeoff
+		return fixed_wing_takeoff_status.climbout_completed
+		       && fixed_wing_takeoff_status.timestamp > _pos_sp_triplet.timestamp;
+	}
+
+	return false;
+}
+
 bool Navigator::abort_landing()
 {
 	// only abort if currently landing and position controller status updated

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -82,7 +82,10 @@ Takeoff::on_active()
 					_mission_item.time_inside = 1.f;
 					_mission_item.loiter_radius = _navigator->get_default_loiter_rad();
 					_mission_item.acceptance_radius  = _navigator->get_acceptance_radius();
-					_mission_item.altitude = _loiter_altitude_msl;
+
+					// the climbout does not necessarily end at the loiter altitude, and the vehicle should
+					// not descend back to it if it ended up higher
+					_mission_item.altitude = math::max(_loiter_altitude_msl, _navigator->get_global_position()->alt);
 
 					mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
 					const bool loiter_lat_valid = PX4_ISFINITE(_loiter_position_lat_lon(0))
@@ -126,7 +129,7 @@ Takeoff::on_active()
 					lateral_acceptance_reached = distance_to_loiter < _navigator->get_acceptance_radius() + mission_item_loiter_radius_abs;
 				}
 
-				const bool vertical_acceptance_reached = _navigator->get_global_position()->alt >= _loiter_altitude_msl -
+				const bool vertical_acceptance_reached = _navigator->get_global_position()->alt >= _mission_item.altitude -
 						_navigator->get_altitude_acceptance_radius();
 
 				if (lateral_acceptance_reached && vertical_acceptance_reached) {

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -68,7 +68,7 @@ Takeoff::on_active()
 
 		switch (_fw_takeoff_state) {
 		case fw_takeoff_state::CLIMBOUT: {
-				if (_navigator->get_global_position()->alt >= _loiter_altitude_msl) {
+				if (_navigator->fw_climbout_completed(_loiter_altitude_msl)) {
 
 					setLoiterItemCommonFields(&_mission_item);
 


### PR DESCRIPTION
### Solved Problem

The fixed-wing takeoff climbout always ends at the takeoff altitude. That assumes the altitude is a good measure of when the takeoff is "done", which it is not necessarily the best criteria. 

### Solution

Commit by commit:

1. The mode manager reports the end of the climbout on a new `fixed_wing_takeoff_status` topic, and the Navigator acts on it in both Takeoff mode and the mission takeoff item, instead of comparing the global altitude itself. 
2. `FW_TKO_CLMB_T` ends the climbout that many seconds after the vehicle started climbing, instead of at the takeoff altitude. 
4. After climbout, loiter at `max(current_alt, loiter_alt)`, to prevent diving down. 

Behaviour is unchanged with the default parameters.

### Changelog Entry

For release notes:

```
Feature: FW Takeoff: end the climbout after a fixed time with FW_TKO_CLMB_T
```

### Alternatives 

I introduced a new message here called `FixedWingTakeoffStatus`. Open to discussion about this but I would consider then adding a follow-up PR that unifies the runway and launch detection messaged into this one message. 

### Test coverage

SITL, SIH airplane (10041)

Runway takeoff:

| | main | this branch |
| --- | --- | --- |
| `FW_TKO_CLMB_T=0` (default) | transition to loiter 6 s @ 26 m | transition to loiter 6 s @ 26 m |
| `FW_TKO_CLMB_T=20` | n/a | transition to loiter 23 s @ 181 m holds there |

Launch/catapult path: 

| | main | this branch |
| --- | --- | --- |
| `FW_TKO_CLMB_T=0` (default) | transition to loiter 4 s @ 26.9 m | transition to loiter 4 s @ 27.0 m |
| `FW_TKO_CLMB_T=20` | n/a | transition to loiter 21 s @ 176 m, holds there |
| `FW_TKO_CLMB_T=20`, waiting for launch | n/a | no completion in 60 s, still on the ground |

Last row shows that the time does not start running while the vehicle is armed and waiting to be launched.
