### PR TITLE
fix(mavlinkftp): increase session timeout to 30s

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -1040,7 +1040,7 @@ void MavlinkFTP::send()
 
 	} else if (_session_info.fd != -1) {
 		// close session without activity
-		if (hrt_elapsed_time(&_last_work_buffer_access) > 10_s) {
+		if (hrt_elapsed_time(&_last_work_buffer_access) > 30_s) {
 			::close(_session_info.fd);
 			_session_info.fd = -1;
 			_session_info.stream_download = false;


### PR DESCRIPTION
### Solved Problem
There is a 10s inactivity timeout in mavftp: after 10s of no message received from the GCS, the session is considered stale and closed. During burst reads, if everything is going fine, the GCS is not supposed to emit any message. So on reliable, but slow links, a burst read of a big file (like parameters metadata) will often trigger the timeout causing the session to be killed even if the file transfer is healthy and in progress

### Solution
Increase session timeout to 30s. The session timeout is link dependent so finding the optimal value is hard.
