### PR TITLE
feat(mavlink): serve and accept packed parameters as @PARAM/param.pck

### DIFF
--- a/Tools/mavftp_param.py
+++ b/Tools/mavftp_param.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+############################################################################
+#
+#   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+"""Download @PARAM/param.pck over MAVLink FTP and optionally check it against PARAM_VALUE.
+
+Requires pymavlink. Firmware without the virtual file NAKs File Not Found.
+
+Examples:
+    Tools/mavftp_param.py /dev/ttyACM0
+    Tools/mavftp_param.py /dev/ttyUSB0 -b 57600 --save param.pck
+    Tools/mavftp_param.py udp:127.0.0.1:14550 --ftp-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import struct
+import sys
+import time
+
+try:
+    from pymavlink import mavftp, mavutil
+except ImportError as e:
+    print("Failed to import pymavlink: " + str(e))
+    print("")
+    print("You may need to install it with:")
+    print("    pip3 install --user pymavlink")
+    print("")
+    sys.exit(2)
+
+# pymavlink: add_message() can TypeError on FILE_TRANSFER_PROTOCOL sharing a
+# link with instanced telemetry (BATTERY_STATUS, ...). Wrap it.
+_orig_add_message = mavutil.add_message
+
+
+def _safe_add_message(messages, mtype, msg):
+    try:
+        _orig_add_message(messages, mtype, msg)
+    except TypeError:
+        messages[mtype] = msg
+
+
+mavutil.add_message = _safe_add_message
+
+# packed type 3/4 vs MAV_PARAM_TYPE_INT32/REAL32
+_MAV_TO_PCK = {6: 3, 9: 4}
+
+
+def _param_name(msg) -> str:
+    raw = msg.param_id
+    if isinstance(raw, bytes):
+        return raw.split(b"\x00", 1)[0].decode("ascii", "replace")
+    return raw.split("\x00", 1)[0]
+
+
+def collect_param_value(m, timeout: float) -> dict[str, tuple[int, int]]:
+    """name -> (mav_type, uint32 bits). Skips _HASH_CHECK."""
+    t0 = time.time()
+    while time.time() - t0 < 0.3:
+        m.recv_match(type="PARAM_VALUE", blocking=True, timeout=0.05)
+
+    m.mav.param_request_list_send(m.target_system, m.target_component)
+    got: dict[str, tuple[int, int]] = {}
+    expected = None
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        msg = m.recv_match(type="PARAM_VALUE", blocking=True, timeout=0.5)
+        if msg is None:
+            if expected is not None and len(got) >= expected:
+                break
+            continue
+        name = _param_name(msg)
+        expected = int(msg.param_count)
+        if name == "_HASH_CHECK":
+            continue
+        bits = struct.unpack("<I", struct.pack("<f", msg.param_value))[0]
+        got[name] = (int(msg.param_type), bits)
+        if expected and len(got) >= expected:
+            extra_end = time.time() + 0.4
+            while time.time() < extra_end:
+                msg = m.recv_match(type="PARAM_VALUE", blocking=True, timeout=0.1)
+                if msg is None:
+                    break
+                name = _param_name(msg)
+                if name == "_HASH_CHECK":
+                    continue
+                bits = struct.unpack("<I", struct.pack("<f", msg.param_value))[0]
+                got[name] = (int(msg.param_type), bits)
+            break
+
+    return got, expected
+
+
+def ftp_get(m, remote: str, timeout: float):
+    ftp = mavftp.MAVFTP(m, target_system=m.target_system, target_component=m.target_component)
+    ftp.ftp_settings.burst_read_size = 239
+    ftp.ftp_settings.idle_detection_time = 1.2
+    holder = {"data": None}
+
+    def cb(fh):
+        if fh is not None:
+            holder["data"] = fh.read()
+
+    ret = ftp.cmd_get([remote], callback=cb)
+    if ret.error_code != mavftp.FtpError.Success:
+        return None, ret
+    ret = ftp.process_ftp_reply("OpenFileRO", timeout=timeout)
+    return holder["data"], ret
+
+
+def decode_pck(data: bytes):
+    pdata = mavftp.MAVFTP.ftp_param_decode(data)
+    if pdata is None:
+        return None
+    values = {}
+    for name, value, ptype in pdata.params:
+        n = name.decode("utf-8") if isinstance(name, bytes) else name
+        if ptype == 3:
+            bits = struct.unpack("<I", struct.pack("<i", int(value)))[0]
+        else:
+            bits = struct.unpack("<I", struct.pack("<f", float(value)))[0]
+        values[n] = (ptype, bits)
+    return values
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("port", help="MAVLink connection (serial device, udp:HOST:PORT, tcp:HOST:PORT)")
+    p.add_argument("--baudrate", "-b", type=int, default=57600, help="serial baud rate (default: %(default)s)")
+    p.add_argument("--timeout", type=float, default=60, help="seconds for FTP and PARAM_VALUE (default: %(default)s)")
+    p.add_argument("--withdefaults", action="store_true", default=True,
+                   help="request ?withdefaults=1 (default)")
+    p.add_argument("--no-withdefaults", action="store_false", dest="withdefaults")
+    p.add_argument("--ftp-only", action="store_true", help="skip the PARAM_VALUE comparison")
+    p.add_argument("--save", metavar="FILE", help="write the packed file to FILE")
+    args = p.parse_args()
+
+    remote = "@PARAM/param.pck?withdefaults=1" if args.withdefaults else "@PARAM/param.pck"
+
+    m = mavutil.mavlink_connection(args.port, baud=args.baudrate, autoreconnect=True, source_system=250)
+    hb = m.wait_heartbeat(timeout=8)
+    if hb is None:
+        print(f"no heartbeat on {args.port}")
+        return 1
+    print(f"heartbeat sys={hb.get_srcSystem()} comp={hb.get_srcComponent()}")
+
+    stream = {}
+    expected = None
+    if not args.ftp_only:
+        t0 = time.time()
+        stream, expected = collect_param_value(m, args.timeout)
+        print(f"PARAM_VALUE: {len(stream)} params" +
+              (f" (of {expected})" if expected else "") +
+              f" in {time.time() - t0:.2f}s")
+
+    t0 = time.time()
+    data, ret = ftp_get(m, remote, args.timeout)
+    t_ftp = time.time() - t0
+    nbytes = 0 if data is None else len(data)
+    print(f"FTP {remote}: error={ret.error_code} errno={ret.system_error} {t_ftp:.2f}s bytes={nbytes}")
+    m.close()
+
+    if data is None or ret.error_code != mavftp.FtpError.Success:
+        return 1
+
+    if args.save:
+        with open(args.save, "wb") as f:
+            f.write(data)
+        print(f"wrote {args.save}")
+
+    packed = decode_pck(data)
+    if packed is None:
+        print("failed to decode packed file")
+        return 1
+
+    magic, num, total = struct.unpack("<HHH", data[:6])
+    print(f"packed magic=0x{magic:x} num={num} total={total} decoded={len(packed)}")
+
+    if args.ftp_only:
+        return 0 if len(packed) == num else 1
+
+    only_stream = sorted(set(stream) - set(packed))
+    only_packed = sorted(set(packed) - set(stream))
+    mismatches = []
+    compared = 0
+    for name, (mav_type, bits) in stream.items():
+        if name not in packed:
+            continue
+        ptype, pbits = packed[name]
+        if _MAV_TO_PCK.get(mav_type) != ptype or bits != pbits:
+            mismatches.append(name)
+        compared += 1
+
+    print(f"compared {compared}; only_stream={len(only_stream)} only_packed={len(only_packed)} mismatches={len(mismatches)}")
+    if only_stream[:8]:
+        print("  only_stream", only_stream[:8])
+    if only_packed[:8]:
+        print("  only_packed", only_packed[:8])
+    if mismatches[:8]:
+        print("  mismatches", mismatches[:8])
+
+    stream_complete = expected is not None and len(stream) >= expected
+    if mismatches or only_stream:
+        return 1
+    if stream_complete and only_packed:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tools/mavftp_param.py
+++ b/Tools/mavftp_param.py
@@ -45,8 +45,10 @@ Examples:
 from __future__ import annotations
 
 import argparse
+import os
 import struct
 import sys
+import tempfile
 import time
 
 try:
@@ -72,6 +74,19 @@ def _safe_add_message(messages, mtype, msg):
 
 
 mavutil.add_message = _safe_add_message
+
+# PX4 has one FTP session and always ACKs session 0. pymavlink increments the
+# session on an Open retry, then discards the ACK as the wrong session.
+_orig_ftp_send = mavftp.MAVFTP._MAVFTP__send
+
+
+def _ftp_send_session0(self, op):
+    self.session = 0
+    op.session = 0
+    return _orig_ftp_send(self, op)
+
+
+mavftp.MAVFTP._MAVFTP__send = _ftp_send_session0
 
 # packed type 3/4 vs MAV_PARAM_TYPE_INT32/REAL32
 _MAV_TO_PCK = {6: 3, 9: 4}
@@ -123,21 +138,100 @@ def collect_param_value(m, timeout: float) -> dict[str, tuple[int, int]]:
     return got, expected
 
 
-def ftp_get(m, remote: str, timeout: float):
-    ftp = mavftp.MAVFTP(m, target_system=m.target_system, target_component=m.target_component)
-    ftp.ftp_settings.burst_read_size = 239
-    ftp.ftp_settings.idle_detection_time = 1.2
+def _radio_link(port: str, baud: int) -> bool:
+    p = port.lower()
+    if p.startswith(("udp", "tcp", "udpin", "tcpin")):
+        return False
+    if "ttyacm" in p or "fmu" in p or "cdc" in p:
+        return False
+    return baud <= 115200
+
+
+def _ftp_settings(port: str, baud: int):
+    # MAVFTP.__init__ ResetSessions uses process_ftp_reply timeout=5, which asserts
+    # timeout > idle_detection_time. idle must also be > read_retry_time.
+    # On SiK, a 0.5s burst retry restarts the stream while radio frames are still
+    # in flight and blows a hole the gap-filler then has to walk.
+    radio = _radio_link(port, baud)
+    if radio:
+        idle, read_retry, retry = 2.5, 2.0, 2.0
+    else:
+        idle, read_retry, retry = 1.2, 1.0, 0.5
+    return mavftp.MAVFTPSettings([
+        ("debug", int, 0),
+        ("pkt_loss_tx", int, 0),
+        ("pkt_loss_rx", int, 0),
+        ("max_backlog", int, 5),
+        ("burst_read_size", int, 239),
+        ("write_size", int, 80),
+        ("write_qsize", int, 5),
+        ("idle_detection_time", float, idle),
+        ("read_retry_time", float, read_retry),
+        ("retry_time", float, retry),
+    ]), radio
+
+
+def _complete_pck(data) -> bool:
+    if not data or len(data) < 6:
+        return False
+    magic, num, _total = struct.unpack("<HHH", data[:6])
+    if magic not in (0x671B, 0x671C):
+        return False
+    packed = decode_pck(data)
+    return packed is not None and len(packed) == num
+
+
+def _drain_ftp(m, quiet: float, cap: float) -> int:
+    """Discard in-flight FILE_TRANSFER_PROTOCOL until the link is quiet."""
+    n = 0
+    deadline = time.time() + cap
+    quiet_since = time.time()
+    while time.time() < deadline:
+        msg = m.recv_match(type="FILE_TRANSFER_PROTOCOL", blocking=True,
+                           timeout=min(0.2, quiet))
+        if msg is None:
+            if time.time() - quiet_since >= quiet:
+                break
+            continue
+        n += 1
+        quiet_since = time.time()
+    return n
+
+
+def ftp_get(m, remote: str, timeout: float, settings, drain: bool):
+    ftp = mavftp.MAVFTP(m, target_system=m.target_system, target_component=m.target_component,
+                        settings=settings)
+    if drain:
+        _drain_ftp(m, quiet=0.4, cap=4.0)
     holder = {"data": None}
 
     def cb(fh):
         if fh is not None:
+            pos = fh.tell()
+            fh.seek(0)
             holder["data"] = fh.read()
+            fh.seek(pos)
 
-    ret = ftp.cmd_get([remote], callback=cb)
-    if ret.error_code != mavftp.FtpError.Success:
-        return None, ret
-    ret = ftp.process_ftp_reply("OpenFileRO", timeout=timeout)
-    return holder["data"], ret
+    # pymavlink writes self.filename after the callback even when using BytesIO
+    fd, local = tempfile.mkstemp(prefix="mavftp-param-", suffix=".pck")
+    os.close(fd)
+    try:
+        ret = ftp.cmd_get([remote, local], callback=cb)
+        if ret.error_code != mavftp.FtpError.Success:
+            return None, ret
+        ret = ftp.process_ftp_reply("OpenFileRO", timeout=timeout)
+        data = holder["data"]
+        if not _complete_pck(data) and os.path.isfile(local):
+            with open(local, "rb") as f:
+                on_disk = f.read()
+            if _complete_pck(on_disk):
+                data = on_disk
+        return data, ret
+    finally:
+        try:
+            os.unlink(local)
+        except OSError:
+            pass
 
 
 def decode_pck(data: bytes):
@@ -160,6 +254,7 @@ def main() -> int:
     p.add_argument("port", help="MAVLink connection (serial device, udp:HOST:PORT, tcp:HOST:PORT)")
     p.add_argument("--baudrate", "-b", type=int, default=57600, help="serial baud rate (default: %(default)s)")
     p.add_argument("--timeout", type=float, default=60, help="seconds for FTP and PARAM_VALUE (default: %(default)s)")
+    p.add_argument("--attempts", type=int, default=3, help="FTP Open/burst attempts (default: %(default)s)")
     p.add_argument("--withdefaults", action="store_true", default=True,
                    help="request ?withdefaults=1 (default)")
     p.add_argument("--no-withdefaults", action="store_false", dest="withdefaults")
@@ -185,14 +280,35 @@ def main() -> int:
               (f" (of {expected})" if expected else "") +
               f" in {time.time() - t0:.2f}s")
 
+    settings, radio = _ftp_settings(args.port, args.baudrate)
+    if radio:
+        print(f"radio timings (baud={args.baudrate}): idle={settings.idle_detection_time}s "
+              f"open-retry={settings.read_retry_time}s burst-retry={settings.retry_time}s")
+        n = _drain_ftp(m, quiet=0.4, cap=4.0)
+        if n:
+            print(f"drained {n} leftover FTP frames")
+
     t0 = time.time()
-    data, ret = ftp_get(m, remote, args.timeout)
+    data, ret = None, None
+    for attempt in range(1, max(1, args.attempts) + 1):
+        data, ret = ftp_get(m, remote, args.timeout, settings, drain=radio)
+        if _complete_pck(data):
+            break
+        nbytes = 0 if data is None else len(data)
+        err = "?" if ret is None else f"error={ret.error_code} errno={ret.system_error}"
+        print(f"FTP attempt {attempt}/{args.attempts} failed: {err} bytes={nbytes}")
+        if attempt < args.attempts:
+            if radio:
+                _drain_ftp(m, quiet=0.4, cap=4.0)
+            else:
+                time.sleep(0.5)
     t_ftp = time.time() - t0
     nbytes = 0 if data is None else len(data)
-    print(f"FTP {remote}: error={ret.error_code} errno={ret.system_error} {t_ftp:.2f}s bytes={nbytes}")
+    err = "?" if ret is None else f"error={ret.error_code} errno={ret.system_error}"
+    print(f"FTP {remote}: {err} {t_ftp:.2f}s bytes={nbytes}")
     m.close()
 
-    if data is None or ret.error_code != mavftp.FtpError.Success:
+    if not _complete_pck(data):
         return 1
 
     if args.save:

--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -108,6 +108,7 @@ px4_add_module(
 		mavlink_command_sender.cpp
 		mavlink_events.cpp
 		mavlink_ftp.cpp
+		mavlink_ftp_param.cpp
 		mavlink_log_handler.cpp
 		mavlink_main.cpp
 		mavlink_messages.cpp
@@ -163,6 +164,8 @@ px4_add_unit_gtest(SRC MavlinkStatustextHandlerTest.cpp
 	LINKLIBS
 		modules__mavlink
 	)
+
+px4_add_unit_gtest(SRC MavlinkFtpParamTest.cpp EXTRA_SRCS mavlink_ftp_param.cpp)
 
 if(CONFIG_NET AND "${PX4_PLATFORM}" MATCHES "nuttx")
 	target_link_libraries(modules__mavlink PRIVATE nuttx_apps) # netlib_get_ipv4netmask

--- a/src/modules/mavlink/MavlinkFtpParamTest.cpp
+++ b/src/modules/mavlink/MavlinkFtpParamTest.cpp
@@ -1,0 +1,390 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "mavlink_ftp_param.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+struct FakeParam {
+	std::string name;
+	param_type_t type;
+	bool used;
+	uint32_t value;
+	uint32_t default_value;
+};
+
+std::vector<FakeParam> g_params;
+
+uint32_t bits(float f)
+{
+	uint32_t u;
+	memcpy(&u, &f, sizeof(u));
+	return u;
+}
+
+FakeParam f32(const char *name, bool used, float value, float default_value)
+{
+	return {name, PARAM_TYPE_FLOAT, used, bits(value), bits(default_value)};
+}
+
+FakeParam i32(const char *name, bool used, int32_t value, int32_t default_value)
+{
+	return {name, PARAM_TYPE_INT32, used, static_cast<uint32_t>(value), static_cast<uint32_t>(default_value)};
+}
+
+std::vector<FakeParam> used_params()
+{
+	std::vector<FakeParam> out;
+
+	for (const auto &p : g_params) {
+		if (p.used) {
+			out.push_back(p);
+		}
+	}
+
+	return out;
+}
+
+struct Entry {
+	std::string name;
+	uint8_t type;
+	uint8_t common_len;
+	uint32_t value;
+	bool has_default;
+	uint32_t default_value;
+	size_t value_ofs;
+};
+
+struct Decoded {
+	uint16_t magic;
+	uint16_t num;
+	uint16_t total;
+	std::vector<Entry> entries;
+};
+
+bool decode(const std::vector<uint8_t> &f, Decoded &d)
+{
+	if (f.size() < ParamPckFile::kHeaderLen) {
+		return false;
+	}
+
+	memcpy(&d.magic, f.data(), 2);
+	memcpy(&d.num, f.data() + 2, 2);
+	memcpy(&d.total, f.data() + 4, 2);
+	d.entries.clear();
+
+	std::string prev;
+	size_t i = ParamPckFile::kHeaderLen;
+
+	while (i < f.size()) {
+		if (f[i] == 0) {
+			i++;
+			continue;
+		}
+
+		if ((i + 2) > f.size()) {
+			return false;
+		}
+
+		Entry e{};
+		e.type = f[i] & 0x0F;
+		e.has_default = (f[i] >> 4) & 0x01;
+		e.common_len = f[i + 1] & 0x0F;
+		const uint8_t name_len = (f[i + 1] >> 4) + 1;
+		i += 2;
+
+		if ((e.common_len > prev.size()) || ((e.common_len + name_len) > 16) || ((i + name_len) > f.size())) {
+			return false;
+		}
+
+		e.name = prev.substr(0, e.common_len) + std::string(reinterpret_cast<const char *>(f.data() + i), name_len);
+		i += name_len;
+		e.value_ofs = i;
+
+		if ((i + 4) > f.size()) {
+			return false;
+		}
+
+		memcpy(&e.value, f.data() + i, 4);
+		i += 4;
+
+		if (e.has_default) {
+			if ((i + 4) > f.size()) {
+				return false;
+			}
+
+			memcpy(&e.default_value, f.data() + i, 4);
+			i += 4;
+		}
+
+		d.entries.push_back(e);
+		prev = e.name;
+	}
+
+	return d.entries.size() == d.num;
+}
+
+/// Sequential reads of block bytes, the way a burst download proceeds
+std::vector<uint8_t> download(ParamPckFile &file, uint16_t block)
+{
+	std::vector<uint8_t> out;
+	uint8_t buf[512];
+
+	for (uint32_t ofs = 0;;) {
+		const int n = file.read(ofs, buf, block);
+		EXPECT_GE(n, 0);
+
+		if (n <= 0) {
+			break;
+		}
+
+		out.insert(out.end(), buf, buf + n);
+		ofs += n;
+	}
+
+	return out;
+}
+
+class MavlinkFtpParam : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+		g_params = {
+			f32("MPC_XY_P", true, 0.95f, 0.95f),
+			f32("MPC_XY_VEL_P_ACC", true, 1.8f, 1.8f),
+			f32("MPC_XY_VEL_I_ACC", false, 0.4f, 0.4f),
+			f32("MPC_Z_P", true, 1.2f, 1.0f),
+			i32("SYS_AUTOSTART", true, 4001, 0),
+			i32("SYS_AUTOCONFIG", false, 0, 0),
+			i32("SYS_HITL", true, 0, 0),
+			i32("A", true, -1, -1),
+			f32("ABCDEFGHIJKLMNOP", true, 2.f, 2.f),
+			f32("ABCDEFGHIJKLMNOQ", true, 3.f, 2.f),
+			i32("B", true, 7, 7),
+		};
+
+		for (int i = 0; i < 300; i++) {
+			char name[17];
+			snprintf(name, sizeof(name), "GEN_%03d_X", i);
+			g_params.push_back(i32(name, (i % 5) != 0, i, (i % 3 == 0) ? 0 : i));
+		}
+	}
+};
+
+} // namespace
+
+// parameter API backed by g_params; only the accessors ParamPckFile uses, plus the
+// logger behind param.h's SITL type check
+void px4_log_modulename(int, const char *, const char *, ...) {}
+#undef param_get
+unsigned param_count() { return g_params.size(); }
+unsigned param_count_used() { return used_params().size(); }
+param_t param_for_index(unsigned index) { return (index < g_params.size()) ? index : PARAM_INVALID; }
+bool param_used(param_t param) { return (param < g_params.size()) && g_params[param].used; }
+const char *param_name(param_t param) { return g_params[param].name.c_str(); }
+param_type_t param_type(param_t param) { return g_params[param].type; }
+int param_get(param_t param, void *val) { memcpy(val, &g_params[param].value, 4); return 0; }
+int param_get_default_value(param_t param, void *val) { memcpy(val, &g_params[param].default_value, 4); return 0; }
+
+TEST_F(MavlinkFtpParam, Path)
+{
+	EXPECT_TRUE(ParamPckFile::is_param_path("@PARAM/param.pck"));
+	EXPECT_TRUE(ParamPckFile::is_param_path("@PARAM/param.pck?withdefaults=1"));
+	EXPECT_FALSE(ParamPckFile::is_param_path("@PARAM/param.pckx"));
+	EXPECT_FALSE(ParamPckFile::is_param_path("@PARAM/other"));
+	EXPECT_FALSE(ParamPckFile::is_param_path("/fs/microsd/param.pck"));
+
+	ParamPckFile file;
+	EXPECT_TRUE(file.open("@PARAM/param.pck", 239));
+	EXPECT_TRUE(file.open("@PARAM/param.pck?start=1&count=2&withdefaults=1", 239));
+	EXPECT_TRUE(file.open("@PARAM/param.pck?unknown=1", 239));
+	EXPECT_FALSE(file.open("@PARAM/param.pck?withdefaults=2", 239));
+	EXPECT_FALSE(file.open("@PARAM/param.pck?count=65535", 239));
+	EXPECT_FALSE(file.open("@PARAM/param.pck?start=100000", 239));
+	EXPECT_FALSE(file.open("@PARAM/param.pck", 0));
+
+	const std::string past_end = "@PARAM/param.pck?start=" + std::to_string(used_params().size());
+	EXPECT_FALSE(file.open(past_end.c_str(), 239));
+}
+
+TEST_F(MavlinkFtpParam, Roundtrip)
+{
+	ParamPckFile file;
+	ASSERT_TRUE(file.open("@PARAM/param.pck", 239));
+
+	const std::vector<uint8_t> f = download(file, 239);
+	EXPECT_EQ(f.size(), file.size());
+
+	Decoded d;
+	ASSERT_TRUE(decode(f, d));
+	EXPECT_EQ(d.magic, 0x671B);
+
+	const std::vector<FakeParam> used = used_params();
+	EXPECT_EQ(d.num, used.size());
+	EXPECT_EQ(d.total, used.size());
+	ASSERT_EQ(d.entries.size(), used.size());
+
+	for (size_t i = 0; i < used.size(); i++) {
+		EXPECT_EQ(d.entries[i].name, used[i].name);
+		EXPECT_EQ(d.entries[i].type, (used[i].type == PARAM_TYPE_INT32) ? 3 : 4);
+		EXPECT_EQ(d.entries[i].value, used[i].value);
+		EXPECT_FALSE(d.entries[i].has_default);
+	}
+
+	// "MPC_XY_VEL_P_ACC" after "MPC_XY_P", "ABCDEFGHIJKLMNOQ" after "ABCDEFGHIJKLMNOP"
+	EXPECT_EQ(d.entries[0].common_len, 0);
+	EXPECT_EQ(d.entries[1].common_len, 7);
+	EXPECT_EQ(d.entries[7].common_len, 15);
+
+	uint8_t buf[8];
+	EXPECT_EQ(file.read(f.size(), buf, sizeof(buf)), 0);
+	EXPECT_EQ(file.read(f.size() + 1000, buf, sizeof(buf)), 0);
+
+	file.close();
+	EXPECT_FALSE(file.is_open());
+	EXPECT_EQ(file.read(0, buf, sizeof(buf)), 0);
+}
+
+TEST_F(MavlinkFtpParam, WithDefaults)
+{
+	ParamPckFile file;
+	ASSERT_TRUE(file.open("@PARAM/param.pck?withdefaults=1", 239));
+
+	const std::vector<uint8_t> f = download(file, 239);
+	EXPECT_EQ(f.size(), file.size());
+
+	Decoded d;
+	ASSERT_TRUE(decode(f, d));
+	EXPECT_EQ(d.magic, 0x671C);
+
+	const std::vector<FakeParam> used = used_params();
+	ASSERT_EQ(d.entries.size(), used.size());
+
+	for (size_t i = 0; i < used.size(); i++) {
+		EXPECT_EQ(d.entries[i].value, used[i].value);
+		EXPECT_EQ(d.entries[i].has_default, used[i].value != used[i].default_value) << used[i].name;
+
+		if (d.entries[i].has_default) {
+			EXPECT_EQ(d.entries[i].default_value, used[i].default_value);
+		}
+	}
+}
+
+TEST_F(MavlinkFtpParam, StartCount)
+{
+	ParamPckFile file;
+	ASSERT_TRUE(file.open("@PARAM/param.pck?start=2&count=3", 239));
+
+	Decoded d;
+	ASSERT_TRUE(decode(download(file, 239), d));
+
+	const std::vector<FakeParam> used = used_params();
+	EXPECT_EQ(d.num, 3);
+	EXPECT_EQ(d.total, used.size());
+	ASSERT_EQ(d.entries.size(), 3u);
+
+	for (size_t i = 0; i < 3; i++) {
+		EXPECT_EQ(d.entries[i].name, used[2 + i].name);
+		EXPECT_EQ(d.entries[i].value, used[2 + i].value);
+	}
+
+	EXPECT_EQ(d.entries[0].common_len, 0);
+
+	const std::string last = "@PARAM/param.pck?start=" + std::to_string(used.size() - 1);
+	ASSERT_TRUE(file.open(last.c_str(), 239));
+	ASSERT_TRUE(decode(download(file, 239), d));
+	EXPECT_EQ(d.num, 1);
+	ASSERT_EQ(d.entries.size(), 1u);
+	EXPECT_EQ(d.entries[0].name, used.back().name);
+}
+
+TEST_F(MavlinkFtpParam, RandomAccessMatchesSequential)
+{
+	const uint16_t block = 32;
+	ParamPckFile file;
+	ASSERT_TRUE(file.open("@PARAM/param.pck?withdefaults=1", block));
+
+	const std::vector<uint8_t> f = download(file, block);
+	EXPECT_EQ(f.size(), file.size());
+	ASSERT_GT(f.size(), 20u * block);
+
+	std::vector<uint32_t> offsets;
+
+	for (uint32_t ofs = 0; ofs < f.size(); ofs += block) {
+		offsets.push_back(ofs);
+	}
+
+	// hole fill: same block size, arbitrary order
+	std::reverse(offsets.begin(), offsets.end());
+	std::swap(offsets[3], offsets[offsets.size() / 2]);
+
+	for (const uint32_t ofs : offsets) {
+		uint8_t buf[block];
+		const int n = file.read(ofs, buf, block);
+		ASSERT_GT(n, 0);
+		ASSERT_EQ(static_cast<size_t>(n), std::min<size_t>(block, f.size() - ofs));
+		EXPECT_EQ(memcmp(buf, f.data() + ofs, n), 0) << "offset " << ofs;
+	}
+
+	// reads smaller than the block size return the same bytes
+	for (uint32_t ofs = 1; ofs < f.size(); ofs += 7) {
+		uint8_t buf[5];
+		const int n = file.read(ofs, buf, sizeof(buf));
+		ASSERT_GT(n, 0);
+		EXPECT_EQ(memcmp(buf, f.data() + ofs, n), 0) << "offset " << ofs;
+	}
+}
+
+TEST_F(MavlinkFtpParam, ValueNeverStraddlesBlock)
+{
+	for (const uint16_t block : {16, 239}) {
+		ParamPckFile file;
+		ASSERT_TRUE(file.open("@PARAM/param.pck", block));
+
+		Decoded d;
+		ASSERT_TRUE(decode(download(file, block), d));
+
+		for (const Entry &e : d.entries) {
+			EXPECT_EQ(e.value_ofs / block, (e.value_ofs + 3) / block) << e.name << " block " << block;
+		}
+	}
+}

--- a/src/modules/mavlink/MavlinkFtpParamTest.cpp
+++ b/src/modules/mavlink/MavlinkFtpParamTest.cpp
@@ -36,6 +36,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -49,6 +50,7 @@ struct FakeParam {
 	bool used;
 	uint32_t value;
 	uint32_t default_value;
+	bool readonly{false};
 };
 
 std::vector<FakeParam> g_params;
@@ -65,9 +67,9 @@ FakeParam f32(const char *name, bool used, float value, float default_value)
 	return {name, PARAM_TYPE_FLOAT, used, bits(value), bits(default_value)};
 }
 
-FakeParam i32(const char *name, bool used, int32_t value, int32_t default_value)
+FakeParam i32(const char *name, bool used, int32_t value, int32_t default_value, bool readonly = false)
 {
-	return {name, PARAM_TYPE_INT32, used, static_cast<uint32_t>(value), static_cast<uint32_t>(default_value)};
+	return {name, PARAM_TYPE_INT32, used, static_cast<uint32_t>(value), static_cast<uint32_t>(default_value), readonly};
 }
 
 std::vector<FakeParam> used_params()
@@ -200,6 +202,7 @@ protected:
 			f32("ABCDEFGHIJKLMNOP", true, 2.f, 2.f),
 			f32("ABCDEFGHIJKLMNOQ", true, 3.f, 2.f),
 			i32("B", true, 7, 7),
+			i32("CAL_GYRO0_ID", true, 99, 0, true),
 		};
 
 		for (int i = 0; i < 300; i++) {
@@ -224,6 +227,27 @@ const char *param_name(param_t param) { return g_params[param].name.c_str(); }
 param_type_t param_type(param_t param) { return g_params[param].type; }
 int param_get(param_t param, void *val) { memcpy(val, &g_params[param].value, 4); return 0; }
 int param_get_default_value(param_t param, void *val) { memcpy(val, &g_params[param].default_value, 4); return 0; }
+param_t param_find_no_notification(const char *name)
+{
+	for (size_t i = 0; i < g_params.size(); i++) {
+		if (g_params[i].name == name) {
+			return static_cast<param_t>(i);
+		}
+	}
+
+	return PARAM_INVALID;
+}
+bool param_is_readonly(param_t param) { return (param < g_params.size()) && g_params[param].readonly; }
+int param_set_no_notification(param_t param, const void *val)
+{
+	if ((param >= g_params.size()) || g_params[param].readonly) {
+		return -1;
+	}
+
+	memcpy(&g_params[param].value, val, 4);
+	return 0;
+}
+void param_notify_changes() {}
 
 TEST_F(MavlinkFtpParam, Path)
 {
@@ -440,4 +464,177 @@ TEST_F(MavlinkFtpParam, ValueNeverStraddlesBlock)
 			}
 		}
 	}
+}
+
+namespace
+{
+
+struct UploadEntry {
+	std::string name;
+	uint8_t ptype;
+	std::vector<uint8_t> value;
+};
+
+UploadEntry up_i8(const char *name, int8_t v)
+{
+	return {name, 1, {static_cast<uint8_t>(v)}};
+}
+
+UploadEntry up_i32(const char *name, int32_t v)
+{
+	uint8_t b[4];
+	memcpy(b, &v, 4);
+	return {name, 3, {b, b + 4}};
+}
+
+UploadEntry up_f32(const char *name, float v)
+{
+	uint8_t b[4];
+	memcpy(b, &v, 4);
+	return {name, 4, {b, b + 4}};
+}
+
+std::vector<uint8_t> encode_upload(const std::vector<UploadEntry> &entries, uint16_t magic = 0x671B)
+{
+	std::vector<uint8_t> body;
+	std::string prev;
+
+	for (const auto &e : entries) {
+		size_t common = 0;
+
+		while ((common < e.name.size()) && (common < prev.size()) && (e.name[common] == prev[common])) {
+			common++;
+		}
+
+		size_t name_len = e.name.size() - common;
+
+		if (name_len == 0) {
+			name_len = 1;
+			common--;
+		}
+
+		body.push_back(e.ptype);
+		body.push_back(static_cast<uint8_t>(common | ((name_len - 1) << 4)));
+		body.insert(body.end(), e.name.begin() + common, e.name.end());
+		body.insert(body.end(), e.value.begin(), e.value.end());
+		prev = e.name;
+	}
+
+	std::vector<uint8_t> out(ParamPckFile::kHeaderLen + body.size());
+	const uint16_t num = static_cast<uint16_t>(entries.size());
+	const uint16_t flen = static_cast<uint16_t>(out.size());
+	memcpy(out.data(), &magic, 2);
+	memcpy(out.data() + 2, &num, 2);
+	memcpy(out.data() + 4, &flen, 2);
+	memcpy(out.data() + ParamPckFile::kHeaderLen, body.data(), body.size());
+	return out;
+}
+
+bool upload_bytes(ParamPckFile &file, const std::vector<uint8_t> &f, uint16_t chunk)
+{
+	if (!file.open_write()) {
+		return false;
+	}
+
+	for (size_t ofs = 0; ofs < f.size();) {
+		const uint16_t n = static_cast<uint16_t>(std::min<size_t>(chunk, f.size() - ofs));
+
+		if (file.write(static_cast<uint32_t>(ofs), f.data() + ofs, n) != n) {
+			return false;
+		}
+
+		ofs += n;
+	}
+
+	return file.finish_write();
+}
+
+uint32_t param_bits(const char *name)
+{
+	const param_t p = param_find_no_notification(name);
+	return g_params[p].value;
+}
+
+} // namespace
+
+TEST_F(MavlinkFtpParam, UploadAppliesAndSkips)
+{
+	const std::vector<uint8_t> f = encode_upload({
+		up_f32("MPC_XY_P", 1.5f),
+		up_i8("SYS_HITL", 1),
+		up_i32("SYS_AUTOSTART", 4002),
+		up_i32("CAL_GYRO0_ID", 1234),
+		up_f32("NO_SUCH_PARAM", 9.f),
+	});
+
+	ParamPckFile file;
+	ASSERT_TRUE(upload_bytes(file, f, 8));
+	file.close();
+
+	EXPECT_EQ(param_bits("MPC_XY_P"), bits(1.5f));
+	EXPECT_EQ(param_bits("SYS_HITL"), static_cast<uint32_t>(1));
+	EXPECT_EQ(param_bits("SYS_AUTOSTART"), static_cast<uint32_t>(4002));
+	EXPECT_EQ(param_bits("CAL_GYRO0_ID"), static_cast<uint32_t>(99));
+}
+
+TEST_F(MavlinkFtpParam, UploadPrefixAndRetry)
+{
+	const std::vector<uint8_t> f = encode_upload({
+		up_f32("ABCDEFGHIJKLMNOP", 8.f),
+		up_f32("ABCDEFGHIJKLMNOQ", 9.f),
+	});
+
+	ParamPckFile file;
+	ASSERT_TRUE(file.open_write());
+	ASSERT_EQ(file.write(0, f.data(), 6), 6);
+	ASSERT_EQ(file.write(0, f.data(), 6), 6); // retry of the header
+	ASSERT_EQ(file.write(6, f.data() + 6, static_cast<uint16_t>(f.size() - 6)),
+		  static_cast<int>(f.size() - 6));
+	ASSERT_TRUE(file.finish_write());
+	file.close();
+
+	EXPECT_EQ(param_bits("ABCDEFGHIJKLMNOP"), bits(8.f));
+	EXPECT_EQ(param_bits("ABCDEFGHIJKLMNOQ"), bits(9.f));
+}
+
+TEST_F(MavlinkFtpParam, UploadRejectsDefaultsMagicAndHoles)
+{
+	ParamPckFile file;
+	const std::vector<uint8_t> with_defaults = encode_upload({up_f32("MPC_XY_P", 1.f)}, 0x671C);
+	EXPECT_FALSE(upload_bytes(file, with_defaults, 80));
+	file.close();
+	EXPECT_EQ(param_bits("MPC_XY_P"), bits(0.95f));
+
+	const std::vector<uint8_t> ok = encode_upload({up_f32("MPC_Z_P", 4.f)});
+	ASSERT_TRUE(file.open_write());
+	EXPECT_EQ(file.write(3, ok.data(), static_cast<uint16_t>(ok.size())), -1);
+	EXPECT_FALSE(file.finish_write());
+	file.close();
+
+	std::vector<uint8_t> truncated = encode_upload({up_i32("SYS_HITL", 2), up_i32("SYS_AUTOSTART", 1)});
+	truncated.resize(truncated.size() - 3);
+	EXPECT_FALSE(upload_bytes(file, truncated, 80));
+}
+
+TEST_F(MavlinkFtpParam, UploadRoundtripDownload)
+{
+	ParamPckFile src;
+	ASSERT_TRUE(src.open("@PARAM/param.pck", 239));
+	const std::vector<uint8_t> downloaded = download(src, 239);
+	src.close();
+
+	// download header total_params is the used count; rewrite as file length
+	std::vector<uint8_t> f = downloaded;
+	const uint16_t flen = static_cast<uint16_t>(f.size());
+	memcpy(f.data() + 4, &flen, 2);
+
+	g_params[0].value = bits(0.1f);
+	g_params[4].value = 0;
+
+	ParamPckFile dst;
+	ASSERT_TRUE(upload_bytes(dst, f, 80));
+	dst.close();
+
+	EXPECT_EQ(param_bits("MPC_XY_P"), bits(0.95f));
+	EXPECT_EQ(param_bits("SYS_AUTOSTART"), static_cast<uint32_t>(4001));
 }

--- a/src/modules/mavlink/MavlinkFtpParamTest.cpp
+++ b/src/modules/mavlink/MavlinkFtpParamTest.cpp
@@ -376,15 +376,19 @@ TEST_F(MavlinkFtpParam, RandomAccessMatchesSequential)
 
 TEST_F(MavlinkFtpParam, ValueNeverStraddlesBlock)
 {
-	for (const uint16_t block : {16, 239}) {
-		ParamPckFile file;
-		ASSERT_TRUE(file.open("@PARAM/param.pck", block));
+	for (const char *path : {"@PARAM/param.pck", "@PARAM/param.pck?withdefaults=1"}) {
+		for (const uint16_t block : {16, 239}) {
+			ParamPckFile file;
+			ASSERT_TRUE(file.open(path, block));
 
-		Decoded d;
-		ASSERT_TRUE(decode(download(file, block), d));
+			Decoded d;
+			ASSERT_TRUE(decode(download(file, block), d));
 
-		for (const Entry &e : d.entries) {
-			EXPECT_EQ(e.value_ofs / block, (e.value_ofs + 3) / block) << e.name << " block " << block;
+			for (const Entry &e : d.entries) {
+				const size_t data_len = 4 + (e.has_default ? 4 : 0);
+				EXPECT_EQ(e.value_ofs / block, (e.value_ofs + data_len - 1) / block)
+						<< e.name << " block " << block << " " << path;
+			}
 		}
 	}
 }

--- a/src/modules/mavlink/MavlinkFtpParamTest.cpp
+++ b/src/modules/mavlink/MavlinkFtpParamTest.cpp
@@ -384,8 +384,9 @@ TEST_F(MavlinkFtpParam, FrozenMembershipLiveValues)
 	ASSERT_FALSE(d0.entries.empty());
 	const uint32_t size0 = file.size();
 
-	const auto find = [](const Decoded &d, const char *name) -> const Entry * {
-		for (const Entry &e : d.entries) {
+	const auto find = [](const Decoded & d, const char *name) -> const Entry * {
+		for (const Entry &e : d.entries)
+		{
 			if (e.name == name) {
 				return &e;
 			}

--- a/src/modules/mavlink/MavlinkFtpParamTest.cpp
+++ b/src/modules/mavlink/MavlinkFtpParamTest.cpp
@@ -374,30 +374,52 @@ TEST_F(MavlinkFtpParam, RandomAccessMatchesSequential)
 	}
 }
 
-TEST_F(MavlinkFtpParam, SnapshotIgnoresLaterChanges)
+TEST_F(MavlinkFtpParam, FrozenMembershipLiveValues)
 {
 	ParamPckFile file;
 	ASSERT_TRUE(file.open("@PARAM/param.pck?withdefaults=1", 239));
 
-	const std::vector<uint8_t> before = download(file, 239);
 	Decoded d0;
-	ASSERT_TRUE(decode(before, d0));
+	ASSERT_TRUE(decode(download(file, 239), d0));
 	ASSERT_FALSE(d0.entries.empty());
+	const uint32_t size0 = file.size();
 
-	// boot-style churn: value crosses default, a used param drops, a new one appears
-	g_params[0].value = bits(42.f);
-	g_params[4].value = g_params[4].default_value;
-	g_params[3].used = false;
+	const auto find = [](const Decoded &d, const char *name) -> const Entry * {
+		for (const Entry &e : d.entries) {
+			if (e.name == name) {
+				return &e;
+			}
+		}
+
+		return nullptr;
+	};
+
+	ASSERT_NE(find(d0, "MPC_XY_P"), nullptr);
+	ASSERT_NE(find(d0, "MPC_Z_P"), nullptr);
+	ASSERT_TRUE(find(d0, "SYS_AUTOSTART")->has_default);
+
+	// value crosses default, a used param drops, a new one appears
+	g_params[0].value = bits(42.f);                 // MPC_XY_P, was at default
+	g_params[4].value = g_params[4].default_value;  // SYS_AUTOSTART, had a default field
+	g_params[3].used = false;                       // MPC_Z_P
 	g_params.push_back(i32("NEW_PARAM", true, 1, 0));
 
-	const std::vector<uint8_t> after = download(file, 239);
-	EXPECT_EQ(after, before);
-	EXPECT_EQ(after.size(), file.size());
-
 	Decoded d1;
-	ASSERT_TRUE(decode(after, d1));
-	EXPECT_EQ(d1.entries.size(), d0.entries.size());
-	EXPECT_EQ(d1.entries[0].value, d0.entries[0].value);
+	ASSERT_TRUE(decode(download(file, 239), d1));
+	EXPECT_EQ(file.size(), size0);
+	ASSERT_EQ(d1.entries.size(), d0.entries.size());
+
+	for (size_t i = 0; i < d0.entries.size(); i++) {
+		EXPECT_EQ(d1.entries[i].name, d0.entries[i].name);
+		EXPECT_EQ(d1.entries[i].has_default, d0.entries[i].has_default);
+	}
+
+	EXPECT_EQ(find(d1, "MPC_XY_P")->value, bits(42.f));
+	EXPECT_FALSE(find(d1, "MPC_XY_P")->has_default);
+	EXPECT_EQ(find(d1, "SYS_AUTOSTART")->value, g_params[4].default_value);
+	EXPECT_TRUE(find(d1, "SYS_AUTOSTART")->has_default);
+	EXPECT_NE(find(d1, "MPC_Z_P"), nullptr);
+	EXPECT_EQ(find(d1, "NEW_PARAM"), nullptr);
 }
 
 TEST_F(MavlinkFtpParam, ValueNeverStraddlesBlock)

--- a/src/modules/mavlink/MavlinkFtpParamTest.cpp
+++ b/src/modules/mavlink/MavlinkFtpParamTest.cpp
@@ -374,6 +374,32 @@ TEST_F(MavlinkFtpParam, RandomAccessMatchesSequential)
 	}
 }
 
+TEST_F(MavlinkFtpParam, SnapshotIgnoresLaterChanges)
+{
+	ParamPckFile file;
+	ASSERT_TRUE(file.open("@PARAM/param.pck?withdefaults=1", 239));
+
+	const std::vector<uint8_t> before = download(file, 239);
+	Decoded d0;
+	ASSERT_TRUE(decode(before, d0));
+	ASSERT_FALSE(d0.entries.empty());
+
+	// boot-style churn: value crosses default, a used param drops, a new one appears
+	g_params[0].value = bits(42.f);
+	g_params[4].value = g_params[4].default_value;
+	g_params[3].used = false;
+	g_params.push_back(i32("NEW_PARAM", true, 1, 0));
+
+	const std::vector<uint8_t> after = download(file, 239);
+	EXPECT_EQ(after, before);
+	EXPECT_EQ(after.size(), file.size());
+
+	Decoded d1;
+	ASSERT_TRUE(decode(after, d1));
+	EXPECT_EQ(d1.entries.size(), d0.entries.size());
+	EXPECT_EQ(d1.entries[0].value, d0.entries[0].value);
+}
+
 TEST_F(MavlinkFtpParam, ValueNeverStraddlesBlock)
 {
 	for (const char *path : {"@PARAM/param.pck", "@PARAM/param.pck?withdefaults=1"}) {

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -196,16 +196,20 @@ MavlinkFTP::_process_request(
 
 	// check the sequence number: if this is a resent request, resend the last response
 	if (_last_reply_valid) {
-		mavlink_file_transfer_protocol_t *last_reply = reinterpret_cast<mavlink_file_transfer_protocol_t *>(_last_reply);
-		PayloadHeader *last_payload = reinterpret_cast<PayloadHeader *>(&last_reply->payload[0]);
+		const mavlink_file_transfer_protocol_t *last_reply = reinterpret_cast<const mavlink_file_transfer_protocol_t *>
+				(_last_reply);
+		const PayloadHeader *last_payload = reinterpret_cast<const PayloadHeader *>(&last_reply->payload[0]);
 
 		if (payload->seq_number + 1 == last_payload->seq_number
 		    && last_reply->target_system == target_system_id
 		    && last_reply->target_component == target_comp_id) {
 			// this is the same request as the one we replied to last. It means the (n)ack got lost, and the GCS
-			// resent the request
+			// resent the request. The request buffer is no longer needed, so expand the compact cache into it;
+			// the serializer reads the whole message.
+			memset(ftp_req, 0, sizeof(*ftp_req));
+			memcpy(ftp_req, _last_reply, sizeof(_last_reply));
 			_mavlink.lock_send();
-			mavlink_msg_file_transfer_protocol_send_struct(_mavlink.get_channel(), last_reply);
+			mavlink_msg_file_transfer_protocol_send_struct(_mavlink.get_channel(), ftp_req);
 			_mavlink.unlock_send();
 			return;
 		}
@@ -351,6 +355,9 @@ MavlinkFTP::_reply(mavlink_file_transfer_protocol_t *ftp_req)
 {
 	PayloadHeader *payload = reinterpret_cast<PayloadHeader *>(&ftp_req->payload[0]);
 
+	// clear any not used payload data to correctly trim mavlink ftp message reply
+	memset(&payload->data[payload->size], 0, kMaxDataLength - payload->size);
+
 	// keep a copy of the last sent response ((n)ack), so that if it gets lost and the GCS resends the request,
 	// we can simply resend the response.
 	// we only keep small responses to reduce RAM usage and avoid large memcpy's. The larger responses are all data
@@ -359,9 +366,6 @@ MavlinkFTP::_reply(mavlink_file_transfer_protocol_t *ftp_req)
 		_last_reply_valid = true;
 		memcpy(_last_reply, ftp_req, sizeof(_last_reply));
 	}
-
-	// clear any not used payload data to correctly trim mavlink ftp message reply
-	memset(&payload->data[payload->size], 0, kMaxDataLength - payload->size);
 
 	PX4_DEBUG("FTP: %s seq_number: %" PRIu16, payload->opcode == kRspAck ? "Ack" : "Nak", payload->seq_number);
 

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -361,8 +361,10 @@ MavlinkFTP::_reply(mavlink_file_transfer_protocol_t *ftp_req)
 	// keep a copy of the last sent response ((n)ack), so that if it gets lost and the GCS resends the request,
 	// we can simply resend the response.
 	// we only keep small responses to reduce RAM usage and avoid large memcpy's. The larger responses are all data
-	// retrievals without side-effects, meaning it's ok to reexecute them if a response gets lost
-	if (payload->size <= sizeof(uint32_t) && payload->data[0] != kErrNoSessionsAvailable) {
+	// retrievals without side-effects, meaning it's ok to reexecute them if a response gets lost.
+	// Skip only a no-sessions NAK so a retry can Open again. data[0] on an Open ACK is the file-size LSB, not an error code.
+	if (payload->size <= sizeof(uint32_t)
+	    && !(payload->opcode == kRspNak && payload->data[0] == kErrNoSessionsAvailable)) {
 		_last_reply_valid = true;
 		memcpy(_last_reply, ftp_req, sizeof(_last_reply));
 	}

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -64,8 +64,60 @@ MavlinkFTP::MavlinkFTP(Mavlink &mavlink) :
 
 MavlinkFTP::~MavlinkFTP()
 {
+	_close_session();
 	delete[] _work_buffer1;
 	delete[] _work_buffer2;
+}
+
+bool
+MavlinkFTP::_session_open() const
+{
+	return (_session_info.fd >= 0) || _session_info.param.is_open();
+}
+
+void
+MavlinkFTP::_close_session()
+{
+	if (_session_info.fd >= 0) {
+		::close(_session_info.fd);
+	}
+
+	_session_info.fd = -1;
+	_session_info.param.close();
+	_session_info.stream_download = false;
+	_session_info.file_size = 0;
+}
+
+int
+MavlinkFTP::_read_session(uint32_t offset, uint8_t *buf, uint16_t count)
+{
+	if (_session_info.param.is_open()) {
+		const int bytes_read = _session_info.param.read(offset, buf, count);
+
+		if (bytes_read < 0) {
+			_our_errno = EIO;
+		}
+
+		return bytes_read;
+	}
+
+	// lseek allows seeking past EOF, so test it ourselves
+	if (offset >= _session_info.file_size) {
+		return 0;
+	}
+
+	if (lseek(_session_info.fd, offset, SEEK_SET) < 0) {
+		_our_errno = errno;
+		return -1;
+	}
+
+	const int bytes_read = ::read(_session_info.fd, buf, count);
+
+	if (bytes_read < 0) {
+		_our_errno = errno;
+	}
+
+	return bytes_read;
 }
 
 unsigned
@@ -510,62 +562,72 @@ MavlinkFTP::_workList(PayloadHeader *payload, bool include_time)
 MavlinkFTP::ErrorCode
 MavlinkFTP::_workOpen(PayloadHeader *payload, int oflag)
 {
-	if (_session_info.fd >= 0) {
+	if (_session_open()) {
 		PX4_ERR("FTP: Open failed - out of sessions");
 		return kErrNoSessionsAvailable;
 	}
 
-	_constructPath(_work_buffer1, _work_buffer1_len, _data_as_cstring(payload));
+	const char *path = _data_as_cstring(payload);
+	const bool for_write = (oflag & O_ACCMODE) != O_RDONLY;
+	uint32_t file_size = 0;
 
-	if (!_validatePath(_work_buffer1)) {
-		return kErrFailFileProtected;
-	}
+	if (ParamPckFile::is_param_path(path)) {
+		if (for_write) {
+			return kErrFailFileProtected;
+		}
 
-	// CreateFile and OpenFileWO create or truncate the file as part of the open, so the
-	// effect lands before any write arrives and has to be authorized here.
-	if ((oflag & (O_WRONLY | O_RDWR | O_CREAT | O_TRUNC)) != 0
-	    && !_validatePathIsWritable(_work_buffer1)) {
-		return kErrFailFileProtected;
-	}
+		if (!_session_info.param.open(path, kMaxDataLength)) {
+			_our_errno = EINVAL;
+			return kErrFailErrno;
+		}
 
-	PX4_DEBUG("FTP: open '%s'", _work_buffer1);
+		file_size = _session_info.param.size();
 
-	uint32_t fileSize = 0;
-	struct stat st;
+	} else {
+		_constructPath(_work_buffer1, _work_buffer1_len, path);
 
-	PX4_DEBUG("stat: %s", _work_buffer1);
+		if (!_validatePath(_work_buffer1)) {
+			return kErrFailFileProtected;
+		}
 
-	if (stat(_work_buffer1, &st) != 0) {
-		// fail only if requested open for read
-		if (oflag & O_RDONLY) {
+		// CreateFile and OpenFileWO create or truncate the file as part of the open, so the
+		// effect lands before any write arrives and has to be authorized here.
+		if ((oflag & (O_WRONLY | O_RDWR | O_CREAT | O_TRUNC)) != 0
+		    && !_validatePathIsWritable(_work_buffer1)) {
+			return kErrFailFileProtected;
+		}
+
+		PX4_DEBUG("FTP: open '%s'", _work_buffer1);
+
+		struct stat st;
+
+		if (stat(_work_buffer1, &st) == 0) {
+			file_size = st.st_size;
+
+		} else if (!for_write) {
 			_our_errno = errno;
 			PX4_ERR("stat failed read: %s", strerror(_our_errno));
 			return kErrFailErrno;
-
-		} else {
-			st.st_size = 0;
 		}
+
+		// Set mode to 666 incase oflag has O_CREAT
+		int fd = ::open(_work_buffer1, oflag, PX4_O_MODE_666);
+
+		if (fd < 0) {
+			_our_errno = errno;
+			PX4_ERR("open failed: %s", strerror(_our_errno));
+			return kErrFailErrno;
+		}
+
+		_session_info.fd = fd;
 	}
 
-	fileSize = st.st_size;
-
-	PX4_DEBUG("open: %s", _work_buffer1);
-	// Set mode to 666 incase oflag has O_CREAT
-	int fd = ::open(_work_buffer1, oflag, PX4_O_MODE_666);
-
-	if (fd < 0) {
-		_our_errno = errno;
-		PX4_ERR("open failed: %s", strerror(_our_errno));
-		return kErrFailErrno;
-	}
-
-	_session_info.fd = fd;
-	_session_info.file_size = fileSize;
+	_session_info.file_size = file_size;
 	_session_info.stream_download = false;
 
 	payload->session = 0;
 	payload->size = sizeof(uint32_t);
-	std::memcpy(payload->data, &fileSize, payload->size);
+	std::memcpy(payload->data, &file_size, payload->size);
 
 	return kErrNone;
 }
@@ -574,33 +636,22 @@ MavlinkFTP::_workOpen(PayloadHeader *payload, int oflag)
 MavlinkFTP::ErrorCode
 MavlinkFTP::_workRead(PayloadHeader *payload)
 {
-	if (payload->session != 0 || _session_info.fd < 0) {
+	if ((payload->session != 0) || !_session_open()) {
 		return kErrInvalidSession;
 	}
 
-	PX4_DEBUG("FTP: read offset:%ld" PRIu32, payload->offset);
+	PX4_DEBUG("FTP: read offset:%" PRIu32, payload->offset);
 
-	// We have to test seek past EOF ourselves, lseek will allow seek past EOF
-	if (payload->offset >= _session_info.file_size) {
-		PX4_WARN("request past EOF");
-		return kErrEOF;
-	}
-
-	PX4_DEBUG("lseek with offset: %ld", payload->offset);
-
-	if (lseek(_session_info.fd, payload->offset, SEEK_SET) < 0) {
-		_our_errno = errno;
-		PX4_ERR("seek fail: %s", strerror(_our_errno));
-		return kErrFailErrno;
-	}
-
-	int bytes_read = ::read(_session_info.fd, &payload->data[0], payload->size);
+	const int bytes_read = _read_session(payload->offset, payload->data, payload->size);
 
 	if (bytes_read < 0) {
-		// Negative return indicates error other than eof
-		_our_errno = errno;
-		PX4_ERR("read fail %d, %s", bytes_read, strerror(_our_errno));
+		PX4_ERR("read fail: %s", strerror(_our_errno));
 		return kErrFailErrno;
+	}
+
+	if (bytes_read == 0) {
+		PX4_WARN("request past EOF");
+		return kErrEOF;
 	}
 
 	payload->size = bytes_read;
@@ -612,7 +663,7 @@ MavlinkFTP::_workRead(PayloadHeader *payload)
 MavlinkFTP::ErrorCode
 MavlinkFTP::_workBurst(PayloadHeader *payload, uint8_t target_system_id, uint8_t target_component_id)
 {
-	if (payload->session != 0 || _session_info.fd < 0) {
+	if ((payload->session != 0) || !_session_open()) {
 		PX4_DEBUG("_workBurst: no session or no fd");
 		return kErrInvalidSession;
 	}
@@ -633,9 +684,13 @@ MavlinkFTP::_workBurst(PayloadHeader *payload, uint8_t target_system_id, uint8_t
 MavlinkFTP::ErrorCode
 MavlinkFTP::_workWrite(PayloadHeader *payload)
 {
-	if (payload->session != 0 || _session_info.fd < 0) {
+	if ((payload->session != 0) || !_session_open()) {
 		PX4_DEBUG("_workWrite: no session or no fd");
 		return kErrInvalidSession;
+	}
+
+	if (_session_info.param.is_open()) {
+		return kErrFailFileProtected;
 	}
 
 	// The path is authorized in _workOpen(), which is where the descriptor this writes to
@@ -643,8 +698,8 @@ MavlinkFTP::_workWrite(PayloadHeader *payload)
 	// intervening request overwrites, rather than the path behind _session_info.fd.
 
 	if (lseek(_session_info.fd, payload->offset, SEEK_SET) < 0) {
-		// Unable to see to the specified location
-		PX4_ERR("seek fail");
+		_our_errno = errno;
+		PX4_ERR("seek fail: %s", strerror(_our_errno));
 		return kErrFailErrno;
 	}
 
@@ -808,14 +863,12 @@ MavlinkFTP::_workTruncateFile(PayloadHeader *payload)
 MavlinkFTP::ErrorCode
 MavlinkFTP::_workTerminate(PayloadHeader *payload)
 {
-	if (payload->session != 0 || _session_info.fd < 0) {
+	if ((payload->session != 0) || !_session_open()) {
 		return kErrInvalidSession;
 	}
 
 	PX4_DEBUG("work terminate: close");
-	::close(_session_info.fd);
-	_session_info.fd = -1;
-	_session_info.stream_download = false;
+	_close_session();
 
 	payload->size = 0;
 
@@ -827,12 +880,7 @@ MavlinkFTP::ErrorCode
 MavlinkFTP::_workReset(PayloadHeader *payload)
 {
 	PX4_DEBUG("work reset: close");
-
-	if (_session_info.fd != -1) {
-		::close(_session_info.fd);
-		_session_info.fd = -1;
-		_session_info.stream_download = false;
-	}
+	_close_session();
 
 	payload->size = 0;
 
@@ -1049,12 +1097,10 @@ void MavlinkFTP::send()
 			}
 		}
 
-	} else if (_session_info.fd != -1) {
+	} else if (_session_open()) {
 		// close session without activity
 		if (hrt_elapsed_time(&_last_work_buffer_access) > 30_s) {
-			::close(_session_info.fd);
-			_session_info.fd = -1;
-			_session_info.stream_download = false;
+			_close_session();
 			_last_reply_valid = false;
 			PX4_WARN("Session was closed without activity");
 		}
@@ -1095,32 +1141,20 @@ void MavlinkFTP::send()
 
 		PX4_DEBUG("stream send: offset %" PRIu32, _session_info.stream_offset);
 
-		// We have to test seek past EOF ourselves, lseek will allow seek past EOF
-		if (_session_info.stream_offset >= _session_info.file_size) {
+		const int bytes_read = _read_session(payload->offset, &payload->data[0], kMaxDataLength);
+
+		if (bytes_read < 0) {
+			error_code = kErrFailErrno;
+			PX4_WARN("stream download: read fail: %s", strerror(_our_errno));
+
+		} else if (bytes_read == 0) {
 			error_code = kErrEOF;
 			PX4_DEBUG("stream download: sending Nak EOF");
-		}
 
-		if (error_code == kErrNone) {
-			if (lseek(_session_info.fd, payload->offset, SEEK_SET) < 0) {
-				error_code = kErrFailErrno;
-				PX4_WARN("stream download: seek fail");
-			}
-		}
-
-		if (error_code == kErrNone) {
-			int bytes_read = ::read(_session_info.fd, &payload->data[0], kMaxDataLength);
-
-			if (bytes_read < 0) {
-				// Negative return indicates error other than eof
-				error_code = kErrFailErrno;
-				PX4_WARN("stream download: read fail");
-
-			} else {
-				payload->size = bytes_read;
-				_session_info.stream_offset += bytes_read;
-				_session_info.stream_chunk_transmitted += bytes_read;
-			}
+		} else {
+			payload->size = bytes_read;
+			_session_info.stream_offset += bytes_read;
+			_session_info.stream_chunk_transmitted += bytes_read;
 		}
 
 		if (error_code != kErrNone) {

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -564,15 +564,18 @@ MavlinkFTP::_workOpen(PayloadHeader *payload, int oflag)
 
 	if (ParamPckFile::is_param_path(path)) {
 		if (for_write) {
-			return kErrFailFileProtected;
-		}
+			if (!_session_info.param.open_write()) {
+				_our_errno = EINVAL;
+				return kErrFailErrno;
+			}
 
-		if (!_session_info.param.open(path, kMaxDataLength)) {
+		} else if (!_session_info.param.open(path, kMaxDataLength)) {
 			_our_errno = EINVAL;
 			return kErrFailErrno;
-		}
 
-		file_size = _session_info.param.size();
+		} else {
+			file_size = _session_info.param.size();
+		}
 
 	} else {
 		_constructPath(_work_buffer1, _work_buffer1_len, path);
@@ -681,7 +684,20 @@ MavlinkFTP::_workWrite(PayloadHeader *payload)
 	}
 
 	if (_session_info.param.is_open()) {
-		return kErrFailFileProtected;
+		if (!_session_info.param.is_writing()) {
+			return kErrFailFileProtected;
+		}
+
+		const int bytes_written = _session_info.param.write(payload->offset, payload->data, payload->size);
+
+		if (bytes_written < 0) {
+			_our_errno = EINVAL;
+			return kErrFailErrno;
+		}
+
+		payload->size = sizeof(uint32_t);
+		std::memcpy(payload->data, &bytes_written, payload->size);
+		return kErrNone;
 	}
 
 	// The path is authorized in _workOpen(), which is where the descriptor this writes to
@@ -859,7 +875,14 @@ MavlinkFTP::_workTerminate(PayloadHeader *payload)
 	}
 
 	PX4_DEBUG("work terminate: close");
+
+	const bool write_ok = !_session_info.param.is_writing() || _session_info.param.finish_write();
 	_close_session();
+
+	if (!write_ok) {
+		_our_errno = EINVAL;
+		return kErrFailErrno;
+	}
 
 	payload->size = 0;
 

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -65,8 +65,6 @@ MavlinkFTP::MavlinkFTP(Mavlink &mavlink) :
 MavlinkFTP::~MavlinkFTP()
 {
 	_close_session();
-	delete[] _work_buffer1;
-	delete[] _work_buffer2;
 }
 
 bool
@@ -86,6 +84,7 @@ MavlinkFTP::_close_session()
 	_session_info.param.close();
 	_session_info.stream_download = false;
 	_session_info.file_size = 0;
+	_last_reply_valid = false;
 }
 
 int
@@ -180,12 +179,7 @@ MavlinkFTP::_process_request(
 
 	ErrorCode errorCode = kErrNone;
 
-	if (!_ensure_buffers_exist()) {
-		PX4_ERR("Failed to allocate buffers");
-		errorCode = kErrFailErrno;
-		_our_errno = ENOMEM;
-		goto out;
-	}
+	_ensure_buffers_exist();
 
 	// basic sanity checks; must validate length before use
 	if (payload->size > kMaxDataLength) {
@@ -334,19 +328,9 @@ out:
 	}
 }
 
-bool MavlinkFTP::_ensure_buffers_exist()
+void MavlinkFTP::_ensure_buffers_exist()
 {
 	_last_work_buffer_access = hrt_absolute_time();
-
-	if (!_work_buffer1) {
-		_work_buffer1 = new char[_work_buffer1_len];
-	}
-
-	if (!_work_buffer2) {
-		_work_buffer2 = new char[_work_buffer2_len];
-	}
-
-	return _work_buffer1 && _work_buffer2;
 }
 
 /// @brief Sends the specified FTP response message out through mavlink
@@ -569,8 +553,9 @@ MavlinkFTP::ErrorCode
 MavlinkFTP::_workOpen(PayloadHeader *payload, int oflag)
 {
 	if (_session_open()) {
-		PX4_ERR("FTP: Open failed - out of sessions");
-		return kErrNoSessionsAvailable;
+		// One session. A lost Terminate on a slow link otherwise NAKs every retry
+		// until the 30 s idle close.
+		_close_session();
 	}
 
 	const char *path = _data_as_cstring(payload);
@@ -1088,28 +1073,9 @@ MavlinkFTP::_copy_file(const char *src_path, const char *dst_path, size_t length
 
 void MavlinkFTP::send()
 {
-
-	if (_work_buffer1 || _work_buffer2) {
-		// free the work buffers if they are not used for a while
-		if (hrt_elapsed_time(&_last_work_buffer_access) > 2_s) {
-			if (_work_buffer1) {
-				delete[] _work_buffer1;
-				_work_buffer1 = nullptr;
-			}
-
-			if (_work_buffer2) {
-				delete[] _work_buffer2;
-				_work_buffer2 = nullptr;
-			}
-		}
-
-	} else if (_session_open()) {
-		// close session without activity
-		if (hrt_elapsed_time(&_last_work_buffer_access) > 30_s) {
-			_close_session();
-			_last_reply_valid = false;
-			PX4_WARN("Session was closed without activity");
-		}
+	if (_session_open() && (hrt_elapsed_time(&_last_work_buffer_access) > 30_s)) {
+		_close_session();
+		PX4_WARN("Session was closed without activity");
 	}
 
 	// Anything to stream?

--- a/src/modules/mavlink/mavlink_ftp.h
+++ b/src/modules/mavlink/mavlink_ftp.h
@@ -159,11 +159,8 @@ private:
 	bool _validatePath(const char *path);
 	bool _validatePathIsWritable(const char *path);
 
-	/**
-	 * make sure that the working buffers _work_buffer* are allocated
-	 * @return true if buffers exist, false if allocation failed
-	 */
-	bool _ensure_buffers_exist();
+	/// Stamp last request time; drives the 30 s idle session close.
+	void _ensure_buffers_exist();
 
 	static const char	kDirentFile = 'F';	///< Identifies File returned from List command
 	static const char	kDirentDir = 'D';	///< Identifies Directory returned from List command
@@ -191,12 +188,11 @@ private:
 	MavlinkFTP(const MavlinkFTP &);
 	MavlinkFTP operator=(const MavlinkFTP &);
 
-	/* work buffers: they're allocated as soon as we get the first request (lazy, since FTP is rarely used) */
-	char *_work_buffer1{nullptr};
 	static constexpr int _work_buffer1_len = kMaxDataLength;
-	char *_work_buffer2{nullptr};
 	static constexpr int _work_buffer2_len = 256;
-	hrt_abstime _last_work_buffer_access{0}; ///< timestamp when the buffers were last accessed
+	char _work_buffer1[_work_buffer1_len];
+	char _work_buffer2[_work_buffer2_len];
+	hrt_abstime _last_work_buffer_access{0};
 
 	// prepend a root directory to each file/dir access to avoid enumerating the full FS tree (e.g. on Linux).
 	// Path traversal via ".." is rejected by _validatePath().

--- a/src/modules/mavlink/mavlink_ftp.h
+++ b/src/modules/mavlink/mavlink_ftp.h
@@ -44,6 +44,7 @@
 #include <drivers/drv_hrt.h>
 
 #include "mavlink_bridge_header.h"
+#include "mavlink_ftp_param.h"
 
 class Mavlink;
 
@@ -144,6 +145,12 @@ private:
 	uint8_t _getServerComponentId(void);
 	uint8_t _getServerChannel(void);
 
+	bool _session_open() const;
+	void _close_session();
+
+	/// Read from the open session. Returns bytes read, 0 at EOF, -1 on error with _our_errno set.
+	int _read_session(uint32_t offset, uint8_t *buf, uint16_t count);
+
 	/**
 	 * Construct local path by appending `path` to `_root_dir` and storing the result in `dst`.
 	 */
@@ -174,6 +181,7 @@ private:
 		uint8_t		stream_target_system_id;
 		uint8_t         stream_target_component_id;
 		unsigned	stream_chunk_transmitted;
+		ParamPckFile	param;			///< virtual parameter file, open instead of fd
 	};
 	struct SessionInfo _session_info {};	///< Session info, fd=-1 for no active session
 

--- a/src/modules/mavlink/mavlink_ftp_param.cpp
+++ b/src/modules/mavlink/mavlink_ftp_param.cpp
@@ -44,6 +44,37 @@ bool ParamPckFile::is_param_path(const char *path)
 	return (strncmp(path, kPath, kPathLen) == 0) && ((path[kPathLen] == '\0') || (path[kPathLen] == '?'));
 }
 
+bool ParamPckFile::bit(const uint8_t *bits, param_t param) const
+{
+	return (param < kMaxParams) && ((bits[param / 8] & (1u << (param % 8))) != 0);
+}
+
+void ParamPckFile::set_bit(uint8_t *bits, param_t param)
+{
+	bits[param / 8] |= (uint8_t)(1u << (param % 8));
+}
+
+bool ParamPckFile::default_differs(param_t param) const
+{
+	union {
+		int32_t i;
+		float f;
+		uint8_t b[4];
+	} value, def {};
+
+	const bool is_int32 = (param_type(param) == PARAM_TYPE_INT32);
+
+	if ((is_int32 ? param_get(param, &value.i) : param_get(param, &value.f)) != 0) {
+		return false;
+	}
+
+	if (param_get_default_value(param, def.b) != 0) {
+		return false;
+	}
+
+	return memcmp(value.b, def.b, sizeof(value.b)) != 0;
+}
+
 bool ParamPckFile::open(const char *path, uint16_t block_size)
 {
 	close();
@@ -67,12 +98,13 @@ bool ParamPckFile::open(const char *path, uint16_t block_size)
 	}
 
 	const unsigned long used = param_count_used();
+	const unsigned nparams = param_count();
 
-	if ((start >= used) || (count >= UINT16_MAX) || (with_defaults > 1) || (block_size == 0)) {
+	if ((start >= used) || (count >= UINT16_MAX) || (with_defaults > 1) || (block_size == 0)
+	    || (nparams > kMaxParams)) {
 		return false;
 	}
 
-	_start = start;
 	_total = used;
 	_num = used - start;
 
@@ -83,107 +115,75 @@ bool ParamPckFile::open(const char *path, uint16_t block_size)
 	_with_defaults = (with_defaults == 1);
 	_block_size = block_size;
 
-	// one pass: pack into a heap snapshot so a param_set during the download cannot
-	// change later entry lengths or splice a retried block with a new value
-	if (!grow(kHeaderLen + (uint32_t)_num * 16)) {
-		close();
-		return false;
+	const uint16_t end_used = start + _num;
+	uint16_t used_i = 0;
+
+	for (unsigned i = 0; i < nparams; i++) {
+		const param_t param = param_for_index(i);
+
+		if (!param_used(param)) {
+			continue;
+		}
+
+		if ((used_i >= start) && (used_i < end_used)) {
+			set_bit(_included, param);
+
+			if (_with_defaults && default_differs(param)) {
+				set_bit(_has_default, param);
+			}
+		}
+
+		used_i++;
 	}
 
 	rewind();
-	write_header();
-
 	param_t param;
 	uint8_t entry[kMaxEntryLen];
 
 	while (next_param(param)) {
 		const size_t len = pack(entry, param, _cursor_ofs);
 
-		if ((len == 0) || !grow(_cursor_ofs + len)) {
+		if (len == 0) {
 			close();
 			return false;
 		}
 
-		memcpy(_data + _cursor_ofs, entry, len);
 		advance(param, _cursor_ofs + len);
 	}
 
 	_size = _cursor_ofs;
+	rewind();
 	_open = true;
 	return true;
 }
 
 void ParamPckFile::close()
 {
-	delete[] _data;
-	_data = nullptr;
-	_cap = 0;
+	memset(_included, 0, sizeof(_included));
+	memset(_has_default, 0, sizeof(_has_default));
 	_size = 0;
 	_open = false;
-}
-
-bool ParamPckFile::grow(uint32_t cap)
-{
-	if (cap <= _cap) {
-		return true;
-	}
-
-	uint32_t ncap = (_cap > 0) ? _cap : 256;
-
-	while (ncap < cap) {
-		ncap *= 2;
-	}
-
-	uint8_t *data = new uint8_t[ncap];
-
-	if (data == nullptr) {
-		return false;
-	}
-
-	if ((_data != nullptr) && (_cursor_ofs > 0)) {
-		memcpy(data, _data, _cursor_ofs);
-	}
-
-	delete[] _data;
-	_data = data;
-	_cap = ncap;
-	return true;
-}
-
-void ParamPckFile::write_header()
-{
-	const uint16_t magic = _with_defaults ? kMagicWithDefaults : kMagic;
-	memcpy(&_data[0], &magic, sizeof(magic));
-	memcpy(&_data[2], &_num, sizeof(_num));
-	memcpy(&_data[4], &_total, sizeof(_total));
 }
 
 void ParamPckFile::rewind()
 {
 	_cursor_ofs = kHeaderLen;
 	_cursor_index = 0;
-	_cursor_used = 0;
 	memset(_prev_name, 0, sizeof(_prev_name));
 }
 
 bool ParamPckFile::next_param(param_t &param)
 {
 	const unsigned count = param_count();
-	const uint16_t end_used = _start + _num;
 
-	while ((_cursor_index < count) && (_cursor_used < end_used)) {
+	while (_cursor_index < count) {
 		param = param_for_index(_cursor_index);
 
-		if (!param_used(param)) {
-			_cursor_index++;
-
-		} else if (_cursor_used < _start) {
-			_cursor_index++;
-			_cursor_used++;
-
-		} else {
+		if (bit(_included, param)) {
 			return true;
 		}
+
+		_cursor_index++;
 	}
 
 	return false;
@@ -195,7 +195,6 @@ void ParamPckFile::advance(param_t param, uint32_t ofs)
 	_prev_name[sizeof(_prev_name) - 1] = '\0';
 	_cursor_ofs = ofs;
 	_cursor_index++;
-	_cursor_used++;
 }
 
 size_t ParamPckFile::pack(uint8_t *buf, param_t param, uint32_t ofs) const
@@ -235,15 +234,16 @@ size_t ParamPckFile::pack(uint8_t *buf, param_t param, uint32_t ofs) const
 		float f;
 		uint8_t b[4];
 	} value;
-	uint8_t default_value[4];
-	bool add_default = false;
+	uint8_t default_value[4] {};
 
 	if ((is_int32 ? param_get(param, &value.i) : param_get(param, &value.f)) != 0) {
 		return 0;
 	}
 
-	if (_with_defaults && (param_get_default_value(param, default_value) == 0)) {
-		add_default = (memcmp(value.b, default_value, sizeof(value.b)) != 0);
+	const bool add_default = bit(_has_default, param);
+
+	if (add_default && (param_get_default_value(param, default_value) != 0)) {
+		memset(default_value, 0, sizeof(default_value));
 	}
 
 	const uint8_t type = is_int32 ? kTypeInt32 : kTypeFloat;
@@ -278,11 +278,60 @@ size_t ParamPckFile::pack(uint8_t *buf, param_t param, uint32_t ofs) const
 
 int ParamPckFile::read(uint32_t offset, uint8_t *buf, uint16_t count)
 {
-	if (!_open || (_data == nullptr) || (count == 0) || (offset >= _size)) {
+	if (!_open || (count == 0) || (offset >= _size)) {
 		return 0;
 	}
 
-	const uint32_t n = ((uint32_t)count < (_size - offset)) ? count : (_size - offset);
-	memcpy(buf, _data + offset, n);
-	return n;
+	if (offset + count > _size) {
+		count = _size - offset;
+	}
+
+	uint16_t copied = 0;
+
+	if (offset < kHeaderLen) {
+		const uint16_t magic = _with_defaults ? kMagicWithDefaults : kMagic;
+		uint8_t hdr[kHeaderLen];
+		memcpy(&hdr[0], &magic, sizeof(magic));
+		memcpy(&hdr[2], &_num, sizeof(_num));
+		memcpy(&hdr[4], &_total, sizeof(_total));
+
+		const size_t n = ((kHeaderLen - offset) < count) ? (kHeaderLen - offset) : count;
+		memcpy(buf, &hdr[offset], n);
+		copied = n;
+		offset += n;
+	}
+
+	if (offset < _cursor_ofs) {
+		rewind();
+	}
+
+	param_t param;
+	uint8_t entry[kMaxEntryLen];
+
+	while ((copied < count) && next_param(param)) {
+		const size_t len = pack(entry, param, _cursor_ofs);
+
+		if (len == 0) {
+			return -1;
+		}
+
+		const uint32_t entry_end = _cursor_ofs + len;
+
+		if (offset < entry_end) {
+			const size_t skip = offset - _cursor_ofs;
+			const size_t avail = len - skip;
+			const size_t n = (avail < static_cast<size_t>(count - copied)) ? avail : (count - copied);
+			memcpy(buf + copied, entry + skip, n);
+			copied += n;
+			offset += n;
+		}
+
+		if (offset < entry_end) {
+			break;
+		}
+
+		advance(param, entry_end);
+	}
+
+	return copied;
 }

--- a/src/modules/mavlink/mavlink_ftp_param.cpp
+++ b/src/modules/mavlink/mavlink_ftp_param.cpp
@@ -157,12 +157,43 @@ bool ParamPckFile::open(const char *path, uint16_t block_size)
 	return true;
 }
 
+bool ParamPckFile::open_write()
+{
+	close();
+	_write = true;
+	_write_failed = false;
+	_header_done = false;
+	_write_num = 0;
+	_write_file_len = 0;
+	_write_seen = 0;
+	_applied = 0;
+	_write_ofs = 0;
+	_pending_len = 0;
+	memset(_pending, 0, sizeof(_pending));
+	memset(_prev_name, 0, sizeof(_prev_name));
+	_open = true;
+	return true;
+}
+
 void ParamPckFile::close()
 {
+	if (_write && (_applied > 0)) {
+		param_notify_changes();
+	}
+
 	memset(_included, 0, sizeof(_included));
 	memset(_has_default, 0, sizeof(_has_default));
 	_size = 0;
 	_open = false;
+	_write = false;
+	_write_failed = false;
+	_header_done = false;
+	_write_num = 0;
+	_write_file_len = 0;
+	_write_seen = 0;
+	_applied = 0;
+	_write_ofs = 0;
+	_pending_len = 0;
 }
 
 void ParamPckFile::rewind()
@@ -278,8 +309,8 @@ size_t ParamPckFile::pack(uint8_t *buf, param_t param, uint32_t ofs) const
 
 int ParamPckFile::read(uint32_t offset, uint8_t *buf, uint16_t count)
 {
-	if (!_open || (count == 0) || (offset >= _size)) {
-		return 0;
+	if (!_open || _write || (count == 0) || (offset >= _size)) {
+		return _write ? -1 : 0;
 	}
 
 	if (offset + count > _size) {
@@ -334,4 +365,242 @@ int ParamPckFile::read(uint32_t offset, uint8_t *buf, uint16_t count)
 	}
 
 	return copied;
+}
+
+uint8_t ParamPckFile::packed_value_len(uint8_t ptype)
+{
+	switch (ptype) {
+	case kTypeInt8:
+		return 1;
+
+	case kTypeInt16:
+		return 2;
+
+	case kTypeInt32:
+	case kTypeFloat:
+		return 4;
+
+	default:
+		return 0;
+	}
+}
+
+bool ParamPckFile::apply_entry(const char *name, uint8_t ptype, const uint8_t *raw)
+{
+	const param_t param = param_find_no_notification(name);
+
+	if ((param == PARAM_INVALID) || param_is_readonly(param)) {
+		return true;
+	}
+
+	const param_type_t dest = param_type(param);
+	union {
+		int32_t i;
+		float f;
+		uint8_t b[4];
+	} value {};
+
+	int32_t as_int = 0;
+	float as_float = 0.f;
+
+	switch (ptype) {
+	case kTypeInt8:
+		as_int = static_cast<int8_t>(raw[0]);
+		as_float = static_cast<float>(as_int);
+		break;
+
+	case kTypeInt16: {
+			int16_t v;
+			memcpy(&v, raw, sizeof(v));
+			as_int = v;
+			as_float = static_cast<float>(v);
+			break;
+		}
+
+	case kTypeInt32:
+		memcpy(&as_int, raw, sizeof(as_int));
+		as_float = static_cast<float>(as_int);
+		break;
+
+	case kTypeFloat:
+		memcpy(&as_float, raw, sizeof(as_float));
+		as_int = static_cast<int32_t>(as_float);
+		break;
+
+	default:
+		return false;
+	}
+
+	if (dest == PARAM_TYPE_INT32) {
+		value.i = as_int;
+
+	} else if (dest == PARAM_TYPE_FLOAT) {
+		value.f = as_float;
+
+	} else {
+		return true;
+	}
+
+	if (param_set_no_notification(param, value.b) == 0) {
+		_applied++;
+	}
+
+	return true;
+}
+
+bool ParamPckFile::parse_pending()
+{
+	if (!_header_done) {
+		if (_pending_len < kHeaderLen) {
+			return true;
+		}
+
+		uint16_t magic;
+		memcpy(&magic, _pending, sizeof(magic));
+		memcpy(&_write_num, _pending + 2, sizeof(_write_num));
+		memcpy(&_write_file_len, _pending + 4, sizeof(_write_file_len));
+
+		if ((magic != kMagic) || (_write_file_len < kHeaderLen)) {
+			return false;
+		}
+
+		memmove(_pending, _pending + kHeaderLen, _pending_len - kHeaderLen);
+		_pending_len -= kHeaderLen;
+		_header_done = true;
+	}
+
+	while (_pending_len > 0) {
+		if (_pending[0] == 0) {
+			memmove(_pending, _pending + 1, _pending_len - 1);
+			_pending_len--;
+			continue;
+		}
+
+		if (_pending_len < 2) {
+			return true;
+		}
+
+		const uint8_t ptype = _pending[0] & 0x0F;
+		const uint8_t flags = _pending[0] >> 4;
+		const uint8_t common_len = _pending[1] & 0x0F;
+		const uint8_t name_len = (_pending[1] >> 4) + 1;
+		const uint8_t vlen = packed_value_len(ptype);
+		const size_t prev_len = strlen(_prev_name);
+
+		if ((flags != 0) || (vlen == 0) || ((common_len + name_len) > 16) || (common_len > prev_len)) {
+			return false;
+		}
+
+		const size_t need = 2 + name_len + vlen;
+
+		if (need > sizeof(_pending)) {
+			return false;
+		}
+
+		if (_pending_len < need) {
+			return true;
+		}
+
+		char name[17];
+		memcpy(name, _prev_name, common_len);
+		memcpy(name + common_len, _pending + 2, name_len);
+		name[common_len + name_len] = '\0';
+
+		if (!apply_entry(name, ptype, _pending + 2 + name_len)) {
+			return false;
+		}
+
+		strncpy(_prev_name, name, sizeof(_prev_name) - 1);
+		_prev_name[sizeof(_prev_name) - 1] = '\0';
+		memmove(_pending, _pending + need, _pending_len - need);
+		_pending_len -= need;
+		_write_seen++;
+	}
+
+	return true;
+}
+
+bool ParamPckFile::ingest(const uint8_t *data, uint16_t count)
+{
+	while (count > 0) {
+		if (_pending_len == sizeof(_pending)) {
+			if (!parse_pending() || (_pending_len == sizeof(_pending))) {
+				return false;
+			}
+		}
+
+		const uint16_t room = static_cast<uint16_t>(sizeof(_pending) - _pending_len);
+		const uint16_t n = (count < room) ? count : room;
+		memcpy(_pending + _pending_len, data, n);
+		_pending_len += n;
+		data += n;
+		count -= n;
+		_write_ofs += n;
+
+		if (!parse_pending()) {
+			return false;
+		}
+
+		if (_header_done && (_write_ofs > _write_file_len)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+int ParamPckFile::write(uint32_t offset, const uint8_t *buf, uint16_t count)
+{
+	if (!_open || !_write || _write_failed) {
+		return -1;
+	}
+
+	if (count == 0) {
+		return 0;
+	}
+
+	const uint32_t end = offset + count;
+
+	if (end <= _write_ofs) {
+		return count;
+	}
+
+	if (offset > _write_ofs) {
+		_write_failed = true;
+		return -1;
+	}
+
+	const uint16_t skip = static_cast<uint16_t>(_write_ofs - offset);
+
+	if (!ingest(buf + skip, count - skip)) {
+		_write_failed = true;
+		return -1;
+	}
+
+	return count;
+}
+
+bool ParamPckFile::finish_write()
+{
+	if (!_open || !_write || _write_failed) {
+		return false;
+	}
+
+	if (!parse_pending()) {
+		_write_failed = true;
+		return false;
+	}
+
+	while ((_pending_len > 0) && (_pending[0] == 0)) {
+		memmove(_pending, _pending + 1, _pending_len - 1);
+		_pending_len--;
+	}
+
+	if (!_header_done || (_pending_len != 0) || (_write_ofs != _write_file_len)
+	    || (_write_seen != _write_num)) {
+		_write_failed = true;
+		return false;
+	}
+
+	return true;
 }

--- a/src/modules/mavlink/mavlink_ftp_param.cpp
+++ b/src/modules/mavlink/mavlink_ftp_param.cpp
@@ -46,6 +46,8 @@ bool ParamPckFile::is_param_path(const char *path)
 
 bool ParamPckFile::open(const char *path, uint16_t block_size)
 {
+	close();
+
 	unsigned long start = 0;
 	unsigned long count = 0;
 	unsigned long with_defaults = 0;
@@ -80,28 +82,80 @@ bool ParamPckFile::open(const char *path, uint16_t block_size)
 
 	_with_defaults = (with_defaults == 1);
 	_block_size = block_size;
-	_open = true;
 
-	// measure: walk the entries once without copying
+	// one pass: pack into a heap snapshot so a param_set during the download cannot
+	// change later entry lengths or splice a retried block with a new value
+	if (!grow(kHeaderLen + (uint32_t)_num * 16)) {
+		close();
+		return false;
+	}
+
 	rewind();
+	write_header();
+
 	param_t param;
 	uint8_t entry[kMaxEntryLen];
 
 	while (next_param(param)) {
 		const size_t len = pack(entry, param, _cursor_ofs);
 
-		if (len == 0) {
-			_open = false;
+		if ((len == 0) || !grow(_cursor_ofs + len)) {
+			close();
 			return false;
 		}
 
+		memcpy(_data + _cursor_ofs, entry, len);
 		advance(param, _cursor_ofs + len);
 	}
 
 	_size = _cursor_ofs;
-	rewind();
-
+	_open = true;
 	return true;
+}
+
+void ParamPckFile::close()
+{
+	delete[] _data;
+	_data = nullptr;
+	_cap = 0;
+	_size = 0;
+	_open = false;
+}
+
+bool ParamPckFile::grow(uint32_t cap)
+{
+	if (cap <= _cap) {
+		return true;
+	}
+
+	uint32_t ncap = (_cap > 0) ? _cap : 256;
+
+	while (ncap < cap) {
+		ncap *= 2;
+	}
+
+	uint8_t *data = new uint8_t[ncap];
+
+	if (data == nullptr) {
+		return false;
+	}
+
+	if ((_data != nullptr) && (_cursor_ofs > 0)) {
+		memcpy(data, _data, _cursor_ofs);
+	}
+
+	delete[] _data;
+	_data = data;
+	_cap = ncap;
+	return true;
+}
+
+void ParamPckFile::write_header()
+{
+	const uint16_t magic = _with_defaults ? kMagicWithDefaults : kMagic;
+	memcpy(&_data[0], &magic, sizeof(magic));
+	memcpy(&_data[2], &_num, sizeof(_num));
+	memcpy(&_data[4], &_total, sizeof(_total));
 }
 
 void ParamPckFile::rewind()
@@ -109,7 +163,7 @@ void ParamPckFile::rewind()
 	_cursor_ofs = kHeaderLen;
 	_cursor_index = 0;
 	_cursor_used = 0;
-	_prev_name[0] = '\0';
+	memset(_prev_name, 0, sizeof(_prev_name));
 }
 
 bool ParamPckFile::next_param(param_t &param)
@@ -138,6 +192,7 @@ bool ParamPckFile::next_param(param_t &param)
 void ParamPckFile::advance(param_t param, uint32_t ofs)
 {
 	strncpy(_prev_name, param_name(param), sizeof(_prev_name) - 1);
+	_prev_name[sizeof(_prev_name) - 1] = '\0';
 	_cursor_ofs = ofs;
 	_cursor_index++;
 	_cursor_used++;
@@ -168,7 +223,13 @@ size_t ParamPckFile::pack(uint8_t *buf, param_t param, uint32_t ofs) const
 		return 0;
 	}
 
-	const bool is_int32 = (param_type(param) == PARAM_TYPE_INT32);
+	const param_type_t ptype = param_type(param);
+
+	if ((ptype != PARAM_TYPE_INT32) && (ptype != PARAM_TYPE_FLOAT)) {
+		return 0;
+	}
+
+	const bool is_int32 = (ptype == PARAM_TYPE_INT32);
 	union {
 		int32_t i;
 		float f;
@@ -217,57 +278,11 @@ size_t ParamPckFile::pack(uint8_t *buf, param_t param, uint32_t ofs) const
 
 int ParamPckFile::read(uint32_t offset, uint8_t *buf, uint16_t count)
 {
-	if (!_open || (count == 0) || (offset >= _size)) {
+	if (!_open || (_data == nullptr) || (count == 0) || (offset >= _size)) {
 		return 0;
 	}
 
-	uint16_t copied = 0;
-
-	if (offset < kHeaderLen) {
-		const uint16_t magic = _with_defaults ? kMagicWithDefaults : kMagic;
-		uint8_t hdr[kHeaderLen];
-		memcpy(&hdr[0], &magic, sizeof(magic));
-		memcpy(&hdr[2], &_num, sizeof(_num));
-		memcpy(&hdr[4], &_total, sizeof(_total));
-
-		const size_t n = ((kHeaderLen - offset) < count) ? (kHeaderLen - offset) : count;
-		memcpy(buf, &hdr[offset], n);
-		copied = n;
-		offset += n;
-	}
-
-	if (offset < _cursor_ofs) {
-		rewind();
-	}
-
-	param_t param;
-	uint8_t entry[kMaxEntryLen];
-
-	while ((copied < count) && next_param(param)) {
-		const size_t len = pack(entry, param, _cursor_ofs);
-
-		if (len == 0) {
-			return -1;
-		}
-
-		const uint32_t entry_end = _cursor_ofs + len;
-
-		if (offset < entry_end) {
-			const size_t skip = offset - _cursor_ofs;
-			const size_t avail = len - skip;
-			const size_t n = (avail < static_cast<size_t>(count - copied)) ? avail : (count - copied);
-			memcpy(buf + copied, entry + skip, n);
-			copied += n;
-			offset += n;
-		}
-
-		if (offset < entry_end) {
-			// the block ends inside this entry; the next read regenerates it
-			break;
-		}
-
-		advance(param, entry_end);
-	}
-
-	return copied;
+	const uint32_t n = ((uint32_t)count < (_size - offset)) ? count : (_size - offset);
+	memcpy(buf, _data + offset, n);
+	return n;
 }

--- a/src/modules/mavlink/mavlink_ftp_param.cpp
+++ b/src/modules/mavlink/mavlink_ftp_param.cpp
@@ -1,0 +1,272 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "mavlink_ftp_param.h"
+
+#include <cstdlib>
+#include <cstring>
+
+static constexpr char kPath[] = "@PARAM/param.pck";
+static constexpr size_t kPathLen = sizeof(kPath) - 1;
+
+bool ParamPckFile::is_param_path(const char *path)
+{
+	return (strncmp(path, kPath, kPathLen) == 0) && ((path[kPathLen] == '\0') || (path[kPathLen] == '?'));
+}
+
+bool ParamPckFile::open(const char *path, uint16_t block_size)
+{
+	unsigned long start = 0;
+	unsigned long count = 0;
+	unsigned long with_defaults = 0;
+
+	for (const char *c = strchr(path, '?'); c && *c; c = strchr(c, '&')) {
+		c++;
+
+		if (strncmp(c, "start=", 6) == 0) {
+			start = strtoul(c + 6, nullptr, 10);
+
+		} else if (strncmp(c, "count=", 6) == 0) {
+			count = strtoul(c + 6, nullptr, 10);
+
+		} else if (strncmp(c, "withdefaults=", 13) == 0) {
+			with_defaults = strtoul(c + 13, nullptr, 10);
+		}
+	}
+
+	const unsigned long used = param_count_used();
+
+	if ((start >= used) || (count >= UINT16_MAX) || (with_defaults > 1) || (block_size == 0)) {
+		return false;
+	}
+
+	_start = start;
+	_total = used;
+	_num = used - start;
+
+	if ((count > 0) && (count < _num)) {
+		_num = count;
+	}
+
+	_with_defaults = (with_defaults == 1);
+	_block_size = block_size;
+	_open = true;
+
+	// measure: walk the entries once without copying
+	rewind();
+	param_t param;
+	uint8_t entry[kMaxEntryLen];
+
+	while (next_param(param)) {
+		const size_t len = pack(entry, param, _cursor_ofs);
+
+		if (len == 0) {
+			_open = false;
+			return false;
+		}
+
+		advance(param, _cursor_ofs + len);
+	}
+
+	_size = _cursor_ofs;
+	rewind();
+
+	return true;
+}
+
+void ParamPckFile::rewind()
+{
+	_cursor_ofs = kHeaderLen;
+	_cursor_index = 0;
+	_cursor_used = 0;
+	_prev_name[0] = '\0';
+}
+
+bool ParamPckFile::next_param(param_t &param)
+{
+	const unsigned count = param_count();
+	const uint16_t end_used = _start + _num;
+
+	while ((_cursor_index < count) && (_cursor_used < end_used)) {
+		param = param_for_index(_cursor_index);
+
+		if (!param_used(param)) {
+			_cursor_index++;
+
+		} else if (_cursor_used < _start) {
+			_cursor_index++;
+			_cursor_used++;
+
+		} else {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void ParamPckFile::advance(param_t param, uint32_t ofs)
+{
+	strncpy(_prev_name, param_name(param), sizeof(_prev_name) - 1);
+	_cursor_ofs = ofs;
+	_cursor_index++;
+	_cursor_used++;
+}
+
+size_t ParamPckFile::pack(uint8_t *buf, param_t param, uint32_t ofs) const
+{
+	const char *name = param_name(param);
+	size_t common_len = 0;
+
+	while ((name[common_len] != '\0') && (name[common_len] == _prev_name[common_len])) {
+		common_len++;
+	}
+
+	size_t name_len = strlen(name + common_len);
+
+	if (name_len == 0) {
+		if (common_len == 0) {
+			return 0;
+		}
+
+		// the encoding cannot express an empty suffix
+		name_len = 1;
+		common_len--;
+	}
+
+	if ((common_len + name_len) > 16) {
+		return 0;
+	}
+
+	const bool is_int32 = (param_type(param) == PARAM_TYPE_INT32);
+	union {
+		int32_t i;
+		float f;
+		uint8_t b[4];
+	} value;
+	uint8_t default_value[4];
+	bool add_default = false;
+
+	if ((is_int32 ? param_get(param, &value.i) : param_get(param, &value.f)) != 0) {
+		return 0;
+	}
+
+	if (_with_defaults && (param_get_default_value(param, default_value) == 0)) {
+		add_default = (memcmp(value.b, default_value, sizeof(value.b)) != 0);
+	}
+
+	const uint8_t type = is_int32 ? kTypeInt32 : kTypeFloat;
+	const size_t packed_len = 2 + name_len + sizeof(value.b) + (add_default ? sizeof(default_value) : 0);
+
+	// pad so the trailing value does not straddle a block
+	size_t pad = 0;
+	const uint32_t end_mod = (ofs + packed_len) % _block_size;
+
+	if ((end_mod > 0) && (end_mod < sizeof(value.b))) {
+		pad = sizeof(value.b) - end_mod;
+	}
+
+	memset(buf, 0, pad);
+	uint8_t *p = buf + pad;
+	p[0] = type | (add_default ? 0x10 : 0x00);
+	p[1] = common_len | ((name_len - 1) << 4);
+
+	for (size_t i = 0; i < name_len; i++) {
+		p[2 + i] = name[common_len + i];
+	}
+
+	memcpy(&p[2 + name_len], value.b, sizeof(value.b));
+
+	if (add_default) {
+		memcpy(&p[2 + name_len + sizeof(value.b)], default_value, sizeof(default_value));
+	}
+
+	return pad + packed_len;
+}
+
+int ParamPckFile::read(uint32_t offset, uint8_t *buf, uint16_t count)
+{
+	if (!_open || (count == 0) || (offset >= _size)) {
+		return 0;
+	}
+
+	uint16_t copied = 0;
+
+	if (offset < kHeaderLen) {
+		const uint16_t magic = _with_defaults ? kMagicWithDefaults : kMagic;
+		uint8_t hdr[kHeaderLen];
+		memcpy(&hdr[0], &magic, sizeof(magic));
+		memcpy(&hdr[2], &_num, sizeof(_num));
+		memcpy(&hdr[4], &_total, sizeof(_total));
+
+		const size_t n = ((kHeaderLen - offset) < count) ? (kHeaderLen - offset) : count;
+		memcpy(buf, &hdr[offset], n);
+		copied = n;
+		offset += n;
+	}
+
+	if (offset < _cursor_ofs) {
+		rewind();
+	}
+
+	param_t param;
+	uint8_t entry[kMaxEntryLen];
+
+	while ((copied < count) && next_param(param)) {
+		const size_t len = pack(entry, param, _cursor_ofs);
+
+		if (len == 0) {
+			return -1;
+		}
+
+		const uint32_t entry_end = _cursor_ofs + len;
+
+		if (offset < entry_end) {
+			const size_t skip = offset - _cursor_ofs;
+			const size_t avail = len - skip;
+			const size_t n = (avail < static_cast<size_t>(count - copied)) ? avail : (count - copied);
+			memcpy(buf + copied, entry + skip, n);
+			copied += n;
+			offset += n;
+		}
+
+		if (offset < entry_end) {
+			// the block ends inside this entry; the next read regenerates it
+			break;
+		}
+
+		advance(param, entry_end);
+	}
+
+	return copied;
+}

--- a/src/modules/mavlink/mavlink_ftp_param.cpp
+++ b/src/modules/mavlink/mavlink_ftp_param.cpp
@@ -188,12 +188,13 @@ size_t ParamPckFile::pack(uint8_t *buf, param_t param, uint32_t ofs) const
 	const uint8_t type = is_int32 ? kTypeInt32 : kTypeFloat;
 	const size_t packed_len = 2 + name_len + sizeof(value.b) + (add_default ? sizeof(default_value) : 0);
 
-	// pad so the trailing value does not straddle a block
+	// pad so the trailing value, and default when present, do not straddle a block
 	size_t pad = 0;
+	const size_t data_len = sizeof(value.b) + (add_default ? sizeof(default_value) : 0);
 	const uint32_t end_mod = (ofs + packed_len) % _block_size;
 
-	if ((end_mod > 0) && (end_mod < sizeof(value.b))) {
-		pad = sizeof(value.b) - end_mod;
+	if ((end_mod > 0) && (end_mod < data_len)) {
+		pad = data_len - end_mod;
 	}
 
 	memset(buf, 0, pad);

--- a/src/modules/mavlink/mavlink_ftp_param.h
+++ b/src/modules/mavlink/mavlink_ftp_param.h
@@ -51,9 +51,9 @@
  *           value[4]
  *           default[4]                  only when flag bit 0 is set, i.e. value != default
  *
- * Zero bytes before an entry are padding so a value never straddles a read block of
- * block_size bytes. The path accepts a query `?start=N&count=N&withdefaults=0|1`;
- * count 0 means all parameters from start.
+ * Zero bytes before an entry are padding so the trailing value (and default, when
+ * present) never straddles a read block of block_size bytes. The path accepts a
+ * query `?start=N&count=N&withdefaults=0|1`; count 0 means all parameters from start.
  *
  * Entries are generated on demand from a cursor that follows sequential reads, so a
  * burst download costs one pass over the parameter table; open() makes one more pass
@@ -63,7 +63,7 @@ class ParamPckFile
 {
 public:
 	static constexpr size_t kHeaderLen = 6;
-	static constexpr size_t kMaxEntryLen = 3 + 2 + 16 + 4 + 4; ///< pad + header + name + value + default
+	static constexpr size_t kMaxEntryLen = 7 + 2 + 16 + 4 + 4; ///< pad + header + name + value + default
 
 	/// True if path names the packed parameter file, with or without a query
 	static bool is_param_path(const char *path);

--- a/src/modules/mavlink/mavlink_ftp_param.h
+++ b/src/modules/mavlink/mavlink_ftp_param.h
@@ -55,9 +55,10 @@
  * present) never straddles a read block of block_size bytes. The path accepts a
  * query `?start=N&count=N&withdefaults=0|1`; count 0 means all parameters from start.
  *
- * Entries are generated on demand from a cursor that follows sequential reads, so a
- * burst download costs one pass over the parameter table; open() makes one more pass
- * to report the exact length.
+ * open() walks the used set once and keeps the packed bytes. Reads are memcpy of that
+ * snapshot, so a param_set during the download cannot shift later entries or splice
+ * two generations of a value across a retried block. Typical size is ~20 KB, held
+ * until the FTP session closes.
  */
 class ParamPckFile
 {
@@ -65,19 +66,24 @@ public:
 	static constexpr size_t kHeaderLen = 6;
 	static constexpr size_t kMaxEntryLen = 7 + 2 + 16 + 4 + 4; ///< pad + header + name + value + default
 
+	ParamPckFile() = default;
+	~ParamPckFile() { close(); }
+	ParamPckFile(const ParamPckFile &) = delete;
+	ParamPckFile &operator=(const ParamPckFile &) = delete;
+
 	/// True if path names the packed parameter file, with or without a query
 	static bool is_param_path(const char *path);
 
-	/// Parse the query and measure the file. False on an invalid query or empty range.
+	/// Parse the query and build the snapshot. False on an invalid query, empty range, or OOM.
 	bool open(const char *path, uint16_t block_size);
-	void close() { _open = false; }
+	void close();
 	bool is_open() const { return _open; }
 
 	uint32_t size() const { return _size; }
 
 	/**
 	 * Copy up to count bytes starting at offset.
-	 * @return bytes copied, 0 at EOF, -1 on a parameter that cannot be packed
+	 * @return bytes copied, 0 at EOF
 	 */
 	int read(uint32_t offset, uint8_t *buf, uint16_t count);
 
@@ -97,6 +103,8 @@ private:
 	void advance(param_t param, uint32_t ofs);
 
 	void rewind();
+	bool grow(uint32_t cap);
+	void write_header();
 
 	bool _open{false};
 	bool _with_defaults{false};
@@ -105,8 +113,10 @@ private:
 	uint16_t _num{0};
 	uint16_t _total{0};
 	uint32_t _size{0};
+	uint32_t _cap{0};
+	uint8_t *_data{nullptr};
 
-	// cursor at the start of the next entry to generate
+	// cursor used only while building the snapshot
 	uint32_t _cursor_ofs{kHeaderLen};
 	unsigned _cursor_index{0};    ///< param_for_index() index
 	uint16_t _cursor_used{0};     ///< used-parameter index of _cursor_index

--- a/src/modules/mavlink/mavlink_ftp_param.h
+++ b/src/modules/mavlink/mavlink_ftp_param.h
@@ -55,16 +55,17 @@
  * present) never straddles a read block of block_size bytes. The path accepts a
  * query `?start=N&count=N&withdefaults=0|1`; count 0 means all parameters from start.
  *
- * open() walks the used set once and keeps the packed bytes. Reads are memcpy of that
- * snapshot, so a param_set during the download cannot shift later entries or splice
- * two generations of a value across a retried block. Typical size is ~20 KB, held
- * until the FTP session closes.
+ * open() freezes which used parameters appear and whether each includes a default
+ * (~1 KB of bitsets). Values are read live. Padding keeps each value/default inside
+ * one FTP block, so a param_set during the download cannot shift later entries or
+ * splice two generations of a number across a retried block.
  */
 class ParamPckFile
 {
 public:
 	static constexpr size_t kHeaderLen = 6;
 	static constexpr size_t kMaxEntryLen = 7 + 2 + 16 + 4 + 4; ///< pad + header + name + value + default
+	static constexpr unsigned kMaxParams = 4096;
 
 	ParamPckFile() = default;
 	~ParamPckFile() { close(); }
@@ -74,7 +75,7 @@ public:
 	/// True if path names the packed parameter file, with or without a query
 	static bool is_param_path(const char *path);
 
-	/// Parse the query and build the snapshot. False on an invalid query, empty range, or OOM.
+	/// Parse the query and freeze membership. False on an invalid query or empty range.
 	bool open(const char *path, uint16_t block_size);
 	void close();
 	bool is_open() const { return _open; }
@@ -83,7 +84,7 @@ public:
 
 	/**
 	 * Copy up to count bytes starting at offset.
-	 * @return bytes copied, 0 at EOF
+	 * @return bytes copied, 0 at EOF, -1 on a parameter that cannot be packed
 	 */
 	int read(uint32_t offset, uint8_t *buf, uint16_t count);
 
@@ -92,33 +93,32 @@ private:
 	static constexpr uint16_t kMagicWithDefaults = 0x671C;
 	static constexpr uint8_t kTypeInt32 = 3;
 	static constexpr uint8_t kTypeFloat = 4;
+	static constexpr unsigned kBitBytes = kMaxParams / 8;
 
 	/// Pack one entry starting at file offset ofs. Returns its length including padding, 0 on error.
 	size_t pack(uint8_t *buf, param_t param, uint32_t ofs) const;
 
-	/// Move the cursor to the next parameter in range without consuming it. False at the end.
+	/// Move the cursor to the next frozen parameter without consuming it. False at the end.
 	bool next_param(param_t &param);
 
 	/// Consume the parameter at the cursor, whose entry ends at ofs
 	void advance(param_t param, uint32_t ofs);
 
 	void rewind();
-	bool grow(uint32_t cap);
-	void write_header();
+	bool bit(const uint8_t *bits, param_t param) const;
+	void set_bit(uint8_t *bits, param_t param);
+	bool default_differs(param_t param) const;
 
 	bool _open{false};
 	bool _with_defaults{false};
 	uint16_t _block_size{0};
-	uint16_t _start{0};
 	uint16_t _num{0};
 	uint16_t _total{0};
 	uint32_t _size{0};
-	uint32_t _cap{0};
-	uint8_t *_data{nullptr};
+	uint8_t _included[kBitBytes] {};
+	uint8_t _has_default[kBitBytes] {};
 
-	// cursor used only while building the snapshot
 	uint32_t _cursor_ofs{kHeaderLen};
 	unsigned _cursor_index{0};    ///< param_for_index() index
-	uint16_t _cursor_used{0};     ///< used-parameter index of _cursor_index
 	char _prev_name[17] {};
 };

--- a/src/modules/mavlink/mavlink_ftp_param.h
+++ b/src/modules/mavlink/mavlink_ftp_param.h
@@ -1,0 +1,114 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <parameters/param.h>
+
+/**
+ * The used parameter set as a virtual MAVLink FTP file, `@PARAM/param.pck`,
+ * in ArduPilot's AP_Filesystem_Param wire format:
+ *
+ *   header: uint16 magic (0x671B, or 0x671C when defaults are included)
+ *           uint16 num_params  (entries in this file)
+ *           uint16 total_params
+ *   entry:  uint8  type:4 flags:4       type 3 = int32, 4 = float; flag bit 0 = default follows the value
+ *           uint8  common_len:4 name_len-1:4   name bytes shared with the previous entry, remaining name length
+ *           name[name_len]
+ *           value[4]
+ *           default[4]                  only when flag bit 0 is set, i.e. value != default
+ *
+ * Zero bytes before an entry are padding so a value never straddles a read block of
+ * block_size bytes. The path accepts a query `?start=N&count=N&withdefaults=0|1`;
+ * count 0 means all parameters from start.
+ *
+ * Entries are generated on demand from a cursor that follows sequential reads, so a
+ * burst download costs one pass over the parameter table; open() makes one more pass
+ * to report the exact length.
+ */
+class ParamPckFile
+{
+public:
+	static constexpr size_t kHeaderLen = 6;
+	static constexpr size_t kMaxEntryLen = 3 + 2 + 16 + 4 + 4; ///< pad + header + name + value + default
+
+	/// True if path names the packed parameter file, with or without a query
+	static bool is_param_path(const char *path);
+
+	/// Parse the query and measure the file. False on an invalid query or empty range.
+	bool open(const char *path, uint16_t block_size);
+	void close() { _open = false; }
+	bool is_open() const { return _open; }
+
+	uint32_t size() const { return _size; }
+
+	/**
+	 * Copy up to count bytes starting at offset.
+	 * @return bytes copied, 0 at EOF, -1 on a parameter that cannot be packed
+	 */
+	int read(uint32_t offset, uint8_t *buf, uint16_t count);
+
+private:
+	static constexpr uint16_t kMagic = 0x671B;
+	static constexpr uint16_t kMagicWithDefaults = 0x671C;
+	static constexpr uint8_t kTypeInt32 = 3;
+	static constexpr uint8_t kTypeFloat = 4;
+
+	/// Pack one entry starting at file offset ofs. Returns its length including padding, 0 on error.
+	size_t pack(uint8_t *buf, param_t param, uint32_t ofs) const;
+
+	/// Move the cursor to the next parameter in range without consuming it. False at the end.
+	bool next_param(param_t &param);
+
+	/// Consume the parameter at the cursor, whose entry ends at ofs
+	void advance(param_t param, uint32_t ofs);
+
+	void rewind();
+
+	bool _open{false};
+	bool _with_defaults{false};
+	uint16_t _block_size{0};
+	uint16_t _start{0};
+	uint16_t _num{0};
+	uint16_t _total{0};
+	uint32_t _size{0};
+
+	// cursor at the start of the next entry to generate
+	uint32_t _cursor_ofs{kHeaderLen};
+	unsigned _cursor_index{0};    ///< param_for_index() index
+	uint16_t _cursor_used{0};     ///< used-parameter index of _cursor_index
+	char _prev_name[17] {};
+};

--- a/src/modules/mavlink/mavlink_ftp_param.h
+++ b/src/modules/mavlink/mavlink_ftp_param.h
@@ -44,12 +44,12 @@
  *
  *   header: uint16 magic (0x671B, or 0x671C when defaults are included)
  *           uint16 num_params  (entries in this file)
- *           uint16 total_params
- *   entry:  uint8  type:4 flags:4       type 3 = int32, 4 = float; flag bit 0 = default follows the value
+ *           uint16 total_params  (download: used count; upload: byte length of the file)
+ *   entry:  uint8  type:4 flags:4       1 int8, 2 int16, 3 int32, 4 float; flag bit 0 = default follows
  *           uint8  common_len:4 name_len-1:4   name bytes shared with the previous entry, remaining name length
  *           name[name_len]
- *           value[4]
- *           default[4]                  only when flag bit 0 is set, i.e. value != default
+ *           value[type size]
+ *           default[type size]          only when flag bit 0 is set, i.e. value != default
  *
  * Zero bytes before an entry are padding so the trailing value (and default, when
  * present) never straddles a read block of block_size bytes. The path accepts a
@@ -59,6 +59,11 @@
  * (~1 KB of bitsets). Values are read live. Padding keeps each value/default inside
  * one FTP block, so a param_set during the download cannot shift later entries or
  * splice two generations of a number across a retried block.
+ *
+ * Upload (CreateFile/WriteFile/Terminate) accepts magic 0x671B only, no defaults,
+ * and treats total_params as the file length. Entries are applied as they complete;
+ * unknown and read-only names are skipped. Packed int8/int16 values are widened to
+ * the PX4 INT32/FLOAT type. Terminate ACKs only when the file is well-formed.
  */
 class ParamPckFile
 {
@@ -77,8 +82,13 @@ public:
 
 	/// Parse the query and freeze membership. False on an invalid query or empty range.
 	bool open(const char *path, uint16_t block_size);
+
+	/// Open for sequential WriteFile of a packed upload.
+	bool open_write();
+
 	void close();
 	bool is_open() const { return _open; }
+	bool is_writing() const { return _open && _write; }
 
 	uint32_t size() const { return _size; }
 
@@ -88,9 +98,20 @@ public:
 	 */
 	int read(uint32_t offset, uint8_t *buf, uint16_t count);
 
+	/**
+	 * Accept a WriteFile chunk. Sequential from 0, or a retry of already-consumed bytes.
+	 * @return count on success, -1 on a hole or a malformed stream
+	 */
+	int write(uint32_t offset, const uint8_t *buf, uint16_t count);
+
+	/// True when the uploaded file is complete and well-formed. Call before close() on Terminate.
+	bool finish_write();
+
 private:
 	static constexpr uint16_t kMagic = 0x671B;
 	static constexpr uint16_t kMagicWithDefaults = 0x671C;
+	static constexpr uint8_t kTypeInt8 = 1;
+	static constexpr uint8_t kTypeInt16 = 2;
 	static constexpr uint8_t kTypeInt32 = 3;
 	static constexpr uint8_t kTypeFloat = 4;
 	static constexpr unsigned kBitBytes = kMaxParams / 8;
@@ -109,7 +130,13 @@ private:
 	void set_bit(uint8_t *bits, param_t param);
 	bool default_differs(param_t param) const;
 
+	bool ingest(const uint8_t *data, uint16_t count);
+	bool parse_pending();
+	bool apply_entry(const char *name, uint8_t ptype, const uint8_t *raw);
+	static uint8_t packed_value_len(uint8_t ptype);
+
 	bool _open{false};
+	bool _write{false};
 	bool _with_defaults{false};
 	uint16_t _block_size{0};
 	uint16_t _num{0};
@@ -121,4 +148,14 @@ private:
 	uint32_t _cursor_ofs{kHeaderLen};
 	unsigned _cursor_index{0};    ///< param_for_index() index
 	char _prev_name[17] {};
+
+	bool _write_failed{false};
+	bool _header_done{false};
+	uint16_t _write_num{0};
+	uint16_t _write_file_len{0};
+	uint16_t _write_seen{0};
+	uint16_t _applied{0};
+	uint32_t _write_ofs{0};
+	uint8_t _pending_len{0};
+	uint8_t _pending[kMaxEntryLen] {};
 };

--- a/test/mavsdk_tests/CMakeLists.txt
+++ b/test/mavsdk_tests/CMakeLists.txt
@@ -41,6 +41,7 @@ if(MAVSDK_FOUND)
         test_vtol_mission_wind.cpp
         test_vtol_loiter_airspeed_failure_blockage.cpp
         test_multicopter_home.cpp
+        test_param_ftp.cpp
         # test_multicopter_follow_me.cpp
     )
 

--- a/test/mavsdk_tests/test_param_ftp.cpp
+++ b/test/mavsdk_tests/test_param_ftp.cpp
@@ -1,0 +1,201 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <mavsdk/plugins/ftp/ftp.h>
+#include <mavsdk/plugins/param/param.h>
+
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "autopilot_tester.h"
+
+namespace
+{
+
+// ArduPilot packed parameter format, as served by PX4 at @PARAM/param.pck
+struct PackedParam {
+	uint8_t type; // 3 = int32, 4 = float
+	uint32_t value_bits;
+	bool has_default;
+};
+
+bool decode_param_pck(const std::vector<uint8_t> &f, uint16_t &num, uint16_t &total,
+		      std::map<std::string, PackedParam> &out)
+{
+	if (f.size() < 6) {
+		return false;
+	}
+
+	uint16_t magic;
+	memcpy(&magic, f.data(), 2);
+	memcpy(&num, f.data() + 2, 2);
+	memcpy(&total, f.data() + 4, 2);
+
+	if ((magic != 0x671B) && (magic != 0x671C)) {
+		return false;
+	}
+
+	std::string prev;
+	size_t i = 6;
+
+	while (i < f.size()) {
+		if (f[i] == 0) {
+			i++; // pad
+			continue;
+		}
+
+		if ((i + 2) > f.size()) {
+			return false;
+		}
+
+		PackedParam p{};
+		p.type = f[i] & 0x0F;
+		p.has_default = (f[i] >> 4) & 0x01;
+		const uint8_t common_len = f[i + 1] & 0x0F;
+		const uint8_t name_len = (f[i + 1] >> 4) + 1;
+		i += 2;
+
+		if ((common_len > prev.size()) || ((common_len + name_len) > 16) || ((i + name_len + 4) > f.size())) {
+			return false;
+		}
+
+		const std::string name = prev.substr(0, common_len) + std::string(reinterpret_cast<const char *>(f.data() + i),
+					 name_len);
+		i += name_len;
+		memcpy(&p.value_bits, f.data() + i, 4);
+		i += 4;
+
+		if (p.has_default) {
+			if ((i + 4) > f.size()) {
+				return false;
+			}
+
+			i += 4;
+		}
+
+		out[name] = p;
+		prev = name;
+	}
+
+	return out.size() == num;
+}
+
+template<typename T>
+uint32_t bits_of(T v)
+{
+	uint32_t u;
+	memcpy(&u, &v, sizeof(u));
+	return u;
+}
+
+class AutopilotTesterParamFtp : public AutopilotTester
+{
+public:
+	mavsdk::Param::AllParams all_params() { return getParams()->get_all_params(); }
+	std::shared_ptr<mavsdk::System> system() { return get_system(); }
+};
+
+} // namespace
+
+TEST_CASE("Parameters download via MAVLink FTP", "[multicopter]")
+{
+	using namespace std::chrono_literals;
+
+	AutopilotTesterParamFtp tester;
+	tester.connect(connection_url);
+
+	// the reference: the conventional PARAM_VALUE stream
+	const mavsdk::Param::AllParams all = tester.all_params();
+	REQUIRE(all.int_params.size() + all.float_params.size() > 100);
+
+	const std::filesystem::path local_dir = std::filesystem::temp_directory_path() / "px4_mavsdk_tests_param_ftp";
+	std::filesystem::remove_all(local_dir);
+	std::filesystem::create_directories(local_dir);
+
+	mavsdk::Ftp ftp(tester.system());
+	std::promise<mavsdk::Ftp::Result> done;
+	auto result = done.get_future();
+	bool finished = false;
+
+	ftp.download_async("@PARAM/param.pck?withdefaults=1", local_dir.string(), true,
+	[&](mavsdk::Ftp::Result r, mavsdk::Ftp::ProgressData) {
+		if ((r != mavsdk::Ftp::Result::Next) && !finished) {
+			finished = true;
+			done.set_value(r);
+		}
+	});
+
+	REQUIRE(result.wait_for(60s) == std::future_status::ready);
+	REQUIRE(result.get() == mavsdk::Ftp::Result::Success);
+
+	std::ifstream file(local_dir / "param.pck?withdefaults=1", std::ios::binary);
+	REQUIRE(file.good());
+	const std::vector<uint8_t> data((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+
+	uint16_t num = 0;
+	uint16_t total = 0;
+	std::map<std::string, PackedParam> packed;
+	REQUIRE(decode_param_pck(data, num, total, packed));
+	CHECK(num == total);
+
+	size_t compared = 0;
+
+	for (const auto &p : all.int_params) {
+		if (p.name == "_HASH_CHECK") {
+			continue;
+		}
+
+		CAPTURE(p.name);
+		REQUIRE(packed.count(p.name) == 1);
+		CHECK(packed[p.name].type == 3);
+		CHECK(packed[p.name].value_bits == bits_of(p.value));
+		compared++;
+	}
+
+	for (const auto &p : all.float_params) {
+		CAPTURE(p.name);
+		REQUIRE(packed.count(p.name) == 1);
+		CHECK(packed[p.name].type == 4);
+		CHECK(packed[p.name].value_bits == bits_of(p.value));
+		compared++;
+	}
+
+	CHECK(compared == packed.size());
+	std::cout << "Compared " << compared << " parameters, " << data.size() << " bytes packed" << std::endl;
+}

--- a/test/mavsdk_tests/test_param_ftp.cpp
+++ b/test/mavsdk_tests/test_param_ftp.cpp
@@ -229,13 +229,13 @@ TEST_CASE("Parameters upload via MAVLink FTP", "[multicopter]")
 	tester.connect(connection_url);
 
 	mavsdk::Param param(tester.system());
-	const mavsdk::Param::AllParams all = param.get_all_params();
-	REQUIRE_FALSE(all.float_params.empty());
-
-	const std::string name = all.float_params.front().name;
-	const float original = all.float_params.front().value;
+	const std::string name = "MPC_XY_P";
+	const auto before = param.get_param_float(name);
+	REQUIRE(before.first == mavsdk::Param::Result::Success);
+	const float original = before.second;
 	const float updated = original + 1.f;
 	CAPTURE(name);
+	CAPTURE(original);
 
 	const std::filesystem::path local_dir = std::filesystem::temp_directory_path() / "px4_mavsdk_tests_param_ftp_up";
 	std::filesystem::remove_all(local_dir);

--- a/test/mavsdk_tests/test_param_ftp.cpp
+++ b/test/mavsdk_tests/test_param_ftp.cpp
@@ -199,3 +199,75 @@ TEST_CASE("Parameters download via MAVLink FTP", "[multicopter]")
 	CHECK(compared == packed.size());
 	std::cout << "Compared " << compared << " parameters, " << data.size() << " bytes packed" << std::endl;
 }
+
+std::vector<uint8_t> encode_one_float(const std::string &name, float value)
+{
+	std::vector<uint8_t> body;
+	body.push_back(4);
+	body.push_back(static_cast<uint8_t>((name.size() - 1) << 4));
+	body.insert(body.end(), name.begin(), name.end());
+	uint8_t bits[4];
+	memcpy(bits, &value, 4);
+	body.insert(body.end(), bits, bits + 4);
+
+	std::vector<uint8_t> out(6 + body.size());
+	const uint16_t magic = 0x671B;
+	const uint16_t num = 1;
+	const uint16_t flen = static_cast<uint16_t>(out.size());
+	memcpy(out.data(), &magic, 2);
+	memcpy(out.data() + 2, &num, 2);
+	memcpy(out.data() + 4, &flen, 2);
+	memcpy(out.data() + 6, body.data(), body.size());
+	return out;
+}
+
+TEST_CASE("Parameters upload via MAVLink FTP", "[multicopter]")
+{
+	using namespace std::chrono_literals;
+
+	AutopilotTesterParamFtp tester;
+	tester.connect(connection_url);
+
+	mavsdk::Param param(tester.system());
+	const mavsdk::Param::AllParams all = param.get_all_params();
+	REQUIRE_FALSE(all.float_params.empty());
+
+	const std::string name = all.float_params.front().name;
+	const float original = all.float_params.front().value;
+	const float updated = original + 1.f;
+	CAPTURE(name);
+
+	const std::filesystem::path local_dir = std::filesystem::temp_directory_path() / "px4_mavsdk_tests_param_ftp_up";
+	std::filesystem::remove_all(local_dir);
+	std::filesystem::create_directories(local_dir);
+	const std::filesystem::path local_file = local_dir / "param.pck";
+
+	{
+		const std::vector<uint8_t> packed = encode_one_float(name, updated);
+		std::ofstream out(local_file, std::ios::binary);
+		REQUIRE(out.good());
+		out.write(reinterpret_cast<const char *>(packed.data()), static_cast<std::streamsize>(packed.size()));
+	}
+
+	mavsdk::Ftp ftp(tester.system());
+	std::promise<mavsdk::Ftp::Result> done;
+	auto result = done.get_future();
+	bool finished = false;
+
+	ftp.upload_async(local_file.string(), "@PARAM",
+	[&](mavsdk::Ftp::Result r, mavsdk::Ftp::ProgressData) {
+		if ((r != mavsdk::Ftp::Result::Next) && !finished) {
+			finished = true;
+			done.set_value(r);
+		}
+	});
+
+	REQUIRE(result.wait_for(60s) == std::future_status::ready);
+	REQUIRE(result.get() == mavsdk::Ftp::Result::Success);
+
+	const auto got = param.get_param_float(name);
+	REQUIRE(got.first == mavsdk::Param::Result::Success);
+	CHECK(got.second == Approx(updated));
+
+	REQUIRE(param.set_param_float(name, original) == mavsdk::Param::Result::Success);
+}


### PR DESCRIPTION
## Summary
fixes #28349
fixes #28347

Serve the used parameter set as `@PARAM/param.pck` over MAVLink FTP in ArduPilot's packed format, and apply the same file on CreateFile/Write/Terminate, so QGroundControl's existing parser and burst download work on PX4 and a GCS can bulk-load without a PARAM_SET round trip. Companion download: https://github.com/mavlink/qgroundcontrol/pull/14983

## Problem
A `_HASH_CHECK` miss streams every used parameter as unacked `PARAM_VALUE`; on SiK that saturates the radio, QGC's retries land in the congestion, and Vehicle Setup stays locked. Two pre-existing FTP server bugs sit in the same code: `_workWrite` checked the write whitelist against a scratch buffer that any later path command overwrites (#28349), and the resend path serialized the 19-byte reply cache as a full 254-byte message, transmitting whatever followed it in memory (#28347). Upload was rejected, so the ArduPilot packed file could not be used to write parameters.

## Solution
`ParamPckFile` generates the packed stream on demand behind Open/Read/Burst: a cursor follows sequential reads so a download is one pass over the parameter table, `open()` reports the exact length (MAVSDK's client ends a burst on it), and values are padded so they never straddle a 239-byte block. `withdefaults`, `start` and `count` match ArduPilot. Writes accept magic `0x671B` only (`total_params` is the file length); complete entries are applied as they arrive, unknown and read-only names are skipped, and Terminate NAKs a truncated or defaulted file. Write sessions are validated at open, and a resent reply is expanded into the dead request buffer before serializing. A SIH test downloads the file through MAVSDK's burst path and checks every entry against the `PARAM_VALUE` stream; unit tests cover upload apply, skip, retry, and reject paths.