### PR TITLE
refactor(mavlink): make streams_list constexpr to save flash and RAM

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -256,7 +256,8 @@ static_assert(41 == ROTATION_MAX, "Keep MAV_SENSOR_ROTATION and PX4 Rotation in 
 static_assert(MAV_SENSOR_ROTATION_CUSTOM == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_CUSTOM), "Custom Rotation");
 
 
-static const StreamListItem streams_list[] = {
+// constexpr so the table is emitted into .rodata instead of being built at runtime by static-init code
+static constexpr StreamListItem streams_list[] = {
 #if defined(HEARTBEAT_HPP)
 	create_stream_list_item<MavlinkStreamHeartbeat>(),
 #endif // HEARTBEAT_HPP

--- a/src/modules/mavlink/mavlink_messages.h
+++ b/src/modules/mavlink/mavlink_messages.h
@@ -54,7 +54,7 @@ public:
 	const char *name;
 	uint16_t id;
 
-	StreamListItem(MavlinkStream * (*inst)(Mavlink *mavlink), const char *_name, uint16_t _id) :
+	constexpr StreamListItem(MavlinkStream * (*inst)(Mavlink *mavlink), const char *_name, uint16_t _id) :
 		new_instance(inst),
 		name(_name),
 		id(_id) {}
@@ -64,7 +64,7 @@ public:
 };
 
 template <class T>
-static StreamListItem create_stream_list_item()
+static constexpr StreamListItem create_stream_list_item()
 {
 	return StreamListItem(&T::new_instance, T::get_name_static(), T::get_id_static());
 }


### PR DESCRIPTION
## Summary
Extracted from @mbjd's https://github.com/PX4/PX4-Autopilot/pull/27816. Author: Balduin <balduin@auterion.com>.

Put the MAVLink stream table in `.rodata` instead of building it into `.bss` at boot.

## Problem
`StreamListItem` was not constexpr, so the ~100-entry `streams_list` was constructed by static-init code (~2.3 KB) into `.bss`.

## Solution
Make the constructor and `create_stream_list_item()` constexpr so the table is a constant. Saves 1272 B flash and 1088 B RAM on `px4_fmu-v6x_default`.