### PR TITLE
refactor(px4_work_queue): out-line ScheduledWorkItem ctor and ScheduleNow

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp
@@ -77,7 +77,7 @@ public:
 
 protected:
 
-	ScheduledWorkItem(const char *name, const wq_config_t &config) : WorkItem(name, config) {}
+	ScheduledWorkItem(const char *name, const wq_config_t &config);
 
 	virtual void print_run_status() override;
 

--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkItem.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkItem.hpp
@@ -64,12 +64,7 @@ public:
 	// WorkItems sorted by name
 	bool operator<=(const WorkItem &rhs) const { return (strcmp(ItemName(), rhs.ItemName()) <= 0); }
 
-	inline void ScheduleNow()
-	{
-		if (_wq != nullptr) {
-			_wq->Add(this);
-		}
-	}
+	void ScheduleNow();
 
 	virtual void print_run_status();
 

--- a/platforms/common/px4_work_queue/ScheduledWorkItem.cpp
+++ b/platforms/common/px4_work_queue/ScheduledWorkItem.cpp
@@ -37,6 +37,8 @@
 namespace px4
 {
 
+ScheduledWorkItem::ScheduledWorkItem(const char *name, const wq_config_t &config) : WorkItem(name, config) {}
+
 ScheduledWorkItem::~ScheduledWorkItem()
 {
 	if (_call.arg != nullptr) {

--- a/platforms/common/px4_work_queue/WorkItem.cpp
+++ b/platforms/common/px4_work_queue/WorkItem.cpp
@@ -116,6 +116,13 @@ void WorkItem::Deinit()
 	}
 }
 
+void WorkItem::ScheduleNow()
+{
+	if (_wq != nullptr) {
+		_wq->Add(this);
+	}
+}
+
 void WorkItem::ScheduleClear()
 {
 	if (_wq != nullptr) {


### PR DESCRIPTION
## Summary
Extracted from @mbjd's https://github.com/PX4/PX4-Autopilot/pull/27816. Author: Balduin <balduin@auterion.com>.

Two commits, intended for rebase-merge: out-line the `ScheduledWorkItem` constructor and `WorkItem::ScheduleNow`.

## Problem
The empty `ScheduledWorkItem` constructor was inlined into ~150 derived classes (zero-filling `hrt_call` each time), and `ScheduleNow` was inlined at ~240 call sites.

## Solution
Move both definitions into the existing work-queue `.cpp` files. Saves 1376 B + 672 B flash on `px4_fmu-v6x_default`.