### PR TITLE
refactor(platform): out-line BusCLIArguments constructor to save flash

### DIFF
--- a/platforms/common/i2c_spi_buses.cpp
+++ b/platforms/common/i2c_spi_buses.cpp
@@ -48,6 +48,21 @@
 static List<I2CSPIInstance *> i2c_spi_module_instances; ///< list of currently running instances
 static pthread_mutex_t i2c_spi_module_instances_mutex = PTHREAD_MUTEX_INITIALIZER;
 
+BusCLIArguments::BusCLIArguments(bool i2c_support, bool spi_support)
+#if defined(CONFIG_I2C) || defined(CONFIG_SPI)
+	:
+#endif // CONFIG_I2C || CONFIG_SPI
+#if defined(CONFIG_I2C)
+	_i2c_support(i2c_support)
+#endif // CONFIG_I2C
+#if defined(CONFIG_I2C) && defined(CONFIG_SPI)
+	,
+#endif // CONFIG_I2C && CONFIG_SPI
+#if defined(CONFIG_SPI)
+	_spi_support(spi_support)
+#endif // CONFIG_SPI
+{}
+
 
 I2CSPIDriverConfig::I2CSPIDriverConfig(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
 				       const px4::wq_config_t &wq_config_)

--- a/platforms/common/include/px4_platform_common/i2c_spi_buses.h
+++ b/platforms/common/include/px4_platform_common/i2c_spi_buses.h
@@ -140,20 +140,7 @@ private:
 class BusCLIArguments
 {
 public:
-	BusCLIArguments(bool i2c_support, bool spi_support)
-#if defined(CONFIG_I2C) || defined(CONFIG_SPI)
-		:
-#endif // CONFIG_I2C || CONFIG_SPI
-#if defined(CONFIG_I2C)
-		_i2c_support(i2c_support)
-#endif // CONFIG_I2C
-#if defined(CONFIG_I2C) && defined(CONFIG_SPI)
-		,
-#endif // CONFIG_I2C && CONFIG_SPI
-#if defined(CONFIG_SPI)
-		_spi_support(spi_support)
-#endif // CONFIG_SPI
-	{}
+	BusCLIArguments(bool i2c_support, bool spi_support);
 
 	/**
 	 * Parse CLI arguments (for drivers that don't need any custom arguments, otherwise getopt() should be used)


### PR DESCRIPTION
## Summary
Extracted from @mbjd's https://github.com/PX4/PX4-Autopilot/pull/27816. Author: Balduin <balduin@auterion.com>.

Out-line `BusCLIArguments`'s constructor so every I2C/SPI driver CLI entry point does not emit it.

## Problem
The header-inline constructor carries ~15 default member initializers and a 32-byte `_options` zero-fill, costing ~50–70 B per driver.

## Solution
Move the definition verbatim into `i2c_spi_buses.cpp`, which already owns the rest of CLI parsing. Cold path only (driver start). Saves 2456 B flash on `px4_fmu-v6x_default`.