### PR TITLE
refactor(drv_hrt): out-line hrt_elapsed_time to save flash

### DIFF
--- a/platforms/common/CMakeLists.txt
+++ b/platforms/common/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(px4_platform STATIC
 	board_common.c
 	board_identity.c
 	external_reset_lockout.cpp
+	hrt.cpp
 	i2c.cpp
 	i2c_spi_buses.cpp
 	module.cpp

--- a/platforms/common/hrt.cpp
+++ b/platforms/common/hrt.cpp
@@ -1,0 +1,48 @@
+/****************************************************************************
+ *
+ * Copyright (C) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <drivers/drv_hrt.h>
+
+hrt_abstime hrt_elapsed_time(const hrt_abstime *then)
+{
+	hrt_abstime now = hrt_absolute_time();
+
+	// Cannot allow a negative elapsed time as this would appear
+	// to be a huge positive elapsed time when represented as an
+	// unsigned value!
+	if (*then > now) {
+		return 0;
+	}
+
+	return now - *then;
+}

--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -160,19 +160,7 @@ static inline void abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
  *
  * This function is not interrupt save.
  */
-static inline hrt_abstime hrt_elapsed_time(const hrt_abstime *then)
-{
-	hrt_abstime now = hrt_absolute_time();
-
-	// Cannot allow a negative elapsed time as this would appear
-	// to be a huge positive elapsed time when represented as an
-	// unsigned value!
-	if (*then > now) {
-		return 0;
-	}
-
-	return now - *then;
-}
+__EXPORT extern hrt_abstime hrt_elapsed_time(const hrt_abstime *then);
 
 /**
  * Store the absolute time in an interrupt-safe fashion.

--- a/src/modules/px4iofirmware/CMakeLists.txt
+++ b/src/modules/px4iofirmware/CMakeLists.txt
@@ -34,6 +34,7 @@
 option(PX4IO_PERF "Enable px4io perf counters" OFF)
 
 add_library(px4iofirmware
+	${PX4_SOURCE_DIR}/platforms/common/hrt.cpp
 	adc.cpp
 	controls.cpp
 	mixer.cpp


### PR DESCRIPTION
## Summary
Extracted from @mbjd's https://github.com/PX4/PX4-Autopilot/pull/27816. Author: Balduin <balduin@auterion.com>.

Out-line `hrt_elapsed_time` so each of ~450 call sites is a single call.

## Problem
The static inline expanded to ~15 bytes everywhere (`hrt_absolute_time` plus a 64-bit compare and subtract).

## Solution
Move the definition into `px4_platform`. px4iofirmware does not link that library, so it compiles the new source directly. Saves 3592 B flash on `px4_fmu-v6x_default`.