### PR TITLE
fix(ark): pin the primary IMU on fmu-v6x and pi6x

### DIFF
--- a/boards/ark/fmu-v6x/init/rc.board_defaults
+++ b/boards/ark/fmu-v6x/init/rc.board_defaults
@@ -26,11 +26,24 @@ param set-default UAVCAN_ESC_IFACE 2
 
 if ver hwtypecmp ARKV6X000
 then
+	# IIM-42652 on SPI1 is the primary IMU: seed its calibration slot with a
+	# higher voter priority so selection is deterministic rather than a boot
+	# race between the three equal-priority IMUs, falling back to the others
+	# only if it degrades. The heater regulates on it too.
+	param set-default CAL_ACC0_ID 2818058
+	param set-default CAL_GYRO0_ID 2818058
+	param set-default CAL_ACC0_PRIO 100
+	param set-default CAL_GYRO0_PRIO 100
 	param set-default HEATER1_SENS_ID 2818058
 fi
 
 if ver hwtypecmp ARKV6X001
 then
+	# IIM-42653 on SPI1 is the primary IMU (see ARKV6X000 above).
+	param set-default CAL_ACC0_ID 3014666
+	param set-default CAL_GYRO0_ID 3014666
+	param set-default CAL_ACC0_PRIO 100
+	param set-default CAL_GYRO0_PRIO 100
 	param set-default HEATER1_SENS_ID 3014666
 fi
 

--- a/boards/ark/pi6x/init/rc.board_defaults
+++ b/boards/ark/pi6x/init/rc.board_defaults
@@ -30,7 +30,14 @@ param set-default UAVCAN_ESC_IFACE 1
 
 if ver hwtypecmp ARKPI6X000
 then
-	# TODO: Add the correct sensor ID
+	# ICM-42688-P on SPI1 is the primary IMU: seed its calibration slot with a
+	# higher voter priority so selection is deterministic rather than a boot
+	# race between the two equal-priority IMUs, falling back to the SPI2
+	# ICM-42688-P only if it degrades. The heater regulates on it too.
+	param set-default CAL_ACC0_ID 2490378
+	param set-default CAL_GYRO0_ID 2490378
+	param set-default CAL_ACC0_PRIO 100
+	param set-default CAL_GYRO0_PRIO 100
 	param set-default HEATER1_SENS_ID 2490378
 fi
 


### PR DESCRIPTION
## Summary
Pin the intended primary IMU on the ARK FMU-v6X and Pi6X so the sensor voter selects it deterministically instead of by a boot race.

## Problem
Both boards run multiple IMUs at equal voter priority (`SENS_IMU_MODE 1`, all `CAL_*_PRIO` 50). `DataValidatorGroup::get_best` makes the first IMU to reach valid confidence the primary and, at equal priority, never displaces it — so which IMU ends up primary is a non-deterministic boot-order race. On the closely-related FMU-v6XRT this was observed on a test flight to land the primary on a non-default IMU.

## Solution
Seed the intended primary's calibration slot (`CAL_ACC0_ID`/`CAL_GYRO0_ID`) and give it a higher priority (`CAL_ACC0_PRIO`/`CAL_GYRO0_PRIO` 100) in `rc.board_defaults`, inside the existing per-hwtype blocks:

- **fmu-v6x**: IIM-42652 (ARKV6X000) / IIM-42653 (ARKV6X001), the SPI1 IMU the heater already regulates on.
- **pi6x**: the SPI1 ICM-42688-P; this also replaces the placeholder `# TODO: Add the correct sensor ID` on `HEATER1_SENS_ID` — that id is the running SPI1 device.

The voter matches the running device_id to that slot and reads the higher priority, so the primary is deterministic; it still fails over to the other IMU(s) if the primary degrades below the confidence threshold.

Note: `param set-default` is shadowed by a stored calibration value, so this takes effect on a board flashed with this firmware and calibrated afterwards; an already-calibrated board keeps its stored `CAL_*_PRIO` until the params are reset. The companion FMU-v6XRT board carries the same change.
