### PR TITLE
docs: fix typo incomming -> incoming

### DIFF
--- a/docs/en/msg_docs/SensorUwb.md
+++ b/docs/en/msg_docs/SensorUwb.md
@@ -21,10 +21,10 @@ UWB distance contains the distance information measured by an ultra-wideband pos
 | <a id="fld_status"></a>status                                 | `uint16`  |              |            | status feedback #                                           |
 | <a id="fld_nlos"></a>nlos                                     | `uint8`   |              |            | None line of site condition y/n                             |
 | <a id="fld_distance"></a>distance                             | `float32` |              |            | distance in m to the UWB receiver                           |
-| <a id="fld_aoa_azimuth_dev"></a>aoa_azimuth_dev               | `float32` |              |            | Angle of arrival of first incomming RX msg                  |
-| <a id="fld_aoa_elevation_dev"></a>aoa_elevation_dev           | `float32` |              |            | Angle of arrival of first incomming RX msg                  |
-| <a id="fld_aoa_azimuth_resp"></a>aoa_azimuth_resp             | `float32` |              |            | Angle of arrival of first incomming RX msg at the responder |
-| <a id="fld_aoa_elevation_resp"></a>aoa_elevation_resp         | `float32` |              |            | Angle of arrival of first incomming RX msg at the responder |
+| <a id="fld_aoa_azimuth_dev"></a>aoa_azimuth_dev               | `float32` |              |            | Angle of arrival of first incoming RX msg                  |
+| <a id="fld_aoa_elevation_dev"></a>aoa_elevation_dev           | `float32` |              |            | Angle of arrival of first incoming RX msg                  |
+| <a id="fld_aoa_azimuth_resp"></a>aoa_azimuth_resp             | `float32` |              |            | Angle of arrival of first incoming RX msg at the responder |
+| <a id="fld_aoa_elevation_resp"></a>aoa_elevation_resp         | `float32` |              |            | Angle of arrival of first incoming RX msg at the responder |
 | <a id="fld_aoa_azimuth_fom"></a>aoa_azimuth_fom               | `uint8`   |              |            | AOA Azimuth FOM                                             |
 | <a id="fld_aoa_elevation_fom"></a>aoa_elevation_fom           | `uint8`   |              |            | AOA Elevation FOM                                           |
 | <a id="fld_aoa_dest_azimuth_fom"></a>aoa_dest_azimuth_fom     | `uint8`   |              |            | AOA Azimuth FOM                                             |
@@ -58,10 +58,10 @@ float32 distance		# distance in m to the UWB receiver
 
 
 #Angle of arrival, Angle in Degree -60..+60; FOV in both axis is 120 degrees
-float32 aoa_azimuth_dev	# Angle of arrival of first incomming RX msg
-float32 aoa_elevation_dev	# Angle of arrival of first incomming RX msg
-float32 aoa_azimuth_resp	# Angle of arrival of first incomming RX msg at the responder
-float32 aoa_elevation_resp	# Angle of arrival of first incomming RX msg at the responder
+float32 aoa_azimuth_dev	# Angle of arrival of first incoming RX msg
+float32 aoa_elevation_dev	# Angle of arrival of first incoming RX msg
+float32 aoa_azimuth_resp	# Angle of arrival of first incoming RX msg at the responder
+float32 aoa_elevation_resp	# Angle of arrival of first incoming RX msg at the responder
 
 # Figure of merit for the angle measurements
 uint8 aoa_azimuth_fom		# AOA Azimuth FOM


### PR DESCRIPTION
Corrects the misspelling `incomming` -> `incoming` in `docs/en/msg_docs/SensorUwb.md`.

Documentation only, no behaviour change.