### PR TITLE
fix(sagetech_mxs): prevent buffer overflow when decoding flight ID an…

### DIFF
--- a/src/drivers/transponder/sagetech_mxs/sg_sdk/sgDecodeFlightId.c
+++ b/src/drivers/transponder/sagetech_mxs/sg_sdk/sgDecodeFlightId.c
@@ -34,8 +34,8 @@ bool sgDecodeFlightId(uint8_t *buffer, sg_flightid_t *id)
 	flightid_t sgId;
 	memcpy(&sgId, buffer, sizeof(flightid_t));
 
-	strcpy(id->flightId, sgId.flightId);
-	memset(&id->flightId[SG_ID_LEN], '\0', 1); // Ensure flight id is null-terminated
+	memcpy(id->flightId, sgId.flightId, SG_ID_LEN);
+	id->flightId[SG_ID_LEN] = '\0'; // Ensure flight id is null-terminated
 
 	return true;
 }

--- a/src/drivers/transponder/sagetech_mxs/sg_sdk/sgDecodeInstall.c
+++ b/src/drivers/transponder/sagetech_mxs/sg_sdk/sgDecodeInstall.c
@@ -60,8 +60,8 @@ bool sgDecodeInstall(uint8_t *buffer, sg_install_t *stl)
 	memcpy(&sgStl, buffer, sizeof(stl_t));
 
 	stl->icao           = toIcao(sgStl.icao);
-	strcpy(stl->reg,      sgStl.registration);
-	memset(&stl->reg[SG_REG_LEN], 0, 1);  // Ensure registration is null-terminated
+	memcpy(stl->reg, sgStl.registration, SG_REG_LEN);
+	stl->reg[SG_REG_LEN] = '\0'; // Ensure registration is null-terminated
 	stl->com0           = (sg_baud_t)(sgStl.com0);
 	stl->com1           = (sg_baud_t)(sgStl.com1);
 	stl->eth.ipAddress  = toUint32(sgStl.ipAddress);


### PR DESCRIPTION
### Solved Problem
Fixes #28428

The on-wire `flightId` (8 bytes) and `registration` (7 bytes) fields in the Sagetech protocol response structures are fixed-width character arrays without guaranteed null-termination. 

Using `strcpy()` on these non-null-terminated fields leads to out-of-bounds reads from the input packet buffer and out-of-bounds writes (stack buffer overflow) to the destination struct whenever the subsequent protocol bytes are non-zero. Writing a NUL byte with `memset()` afterwards does not prevent the corruption because the memory overwrite occurs during `strcpy()`.

### Solution
- Replaced unsafe `strcpy()` with explicit, bounded `memcpy()` in both `sgDecodeFlightId.c` and `sgDecodeInstall.c`.
- Explicitly appended the null-terminator byte (`\0`) at index `8` (for Flight ID) and index `7` (for Registration) in destination buffers (`sg_flightid_t` and `sg_install_t`).

### Changelog Entry
For release notes:
- **Bugfix**: Prevent stack buffer overflow in Sagetech MXS transponder Flight ID and Registration decoders.

### Alternatives
None. Using `memcpy()` with explicit length and dedicated null-termination is the standard and safest design pattern for fixed-width binary protocol decoding.

### Test Coverage
- Verified buffer boundary bounds against non-null-terminated 8-byte Flight ID and 7-byte Registration payload fields.
- Confirmed destination strings are safely null-terminated without heap or stack corruption.

### Context
- Fixes issue: https://github.com/PX4/PX4-Autopilot/issues/28428
