### PR TITLE
fix(crsf_rc): avoid out-of-range packet type enum conversion

### DIFF
--- a/src/drivers/rc/crsf_rc/CMakeLists.txt
+++ b/src/drivers/rc/crsf_rc/CMakeLists.txt
@@ -55,3 +55,11 @@ px4_add_unit_gtest(
 		QueueBuffer.cpp
 		Crc8.cpp
 	)
+
+px4_add_unit_gtest(
+	SRC CrsfParserTest.cpp
+	EXTRA_SRCS
+		CrsfParser.cpp
+		QueueBuffer.cpp
+		Crc8.cpp
+	)

--- a/src/drivers/rc/crsf_rc/CrsfParser.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfParser.cpp
@@ -167,7 +167,7 @@ static uint8_t temp_queue_buffer[RX_QUEUE_BUFFER_SIZE];
 static uint8_t process_buffer[CRSF_MAX_PACKET_LEN];
 static CrsfPacketDescriptor_t *working_descriptor = NULL;
 
-static CrsfPacketDescriptor_t *FindCrsfDescriptor(const enum CRSF_PACKET_TYPE packet_type);
+static CrsfPacketDescriptor_t *FindCrsfDescriptor(const uint8_t packet_type);
 
 void CrsfParser_Init(void)
 {
@@ -334,7 +334,7 @@ static bool ProcessMspWrite(const uint8_t *data, const uint32_t size, CrsfPacket
 }
 #endif
 
-static CrsfPacketDescriptor_t *FindCrsfDescriptor(const enum CRSF_PACKET_TYPE packet_type)
+static CrsfPacketDescriptor_t *FindCrsfDescriptor(const uint8_t packet_type)
 {
 	uint32_t i;
 
@@ -414,7 +414,7 @@ bool CrsfParser_TryParseCrsfPacket(CrsfPacket_t *const new_packet, CrsfParserSta
 				continue;
 			}
 
-			working_descriptor = FindCrsfDescriptor((enum CRSF_PACKET_TYPE)packet_type);
+			working_descriptor = FindCrsfDescriptor(packet_type);
 
 			// If we know what this packet is...
 			if (working_descriptor != NULL) {

--- a/src/drivers/rc/crsf_rc/CrsfParserTest.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfParserTest.cpp
@@ -1,0 +1,87 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "Crc8.hpp"
+#include "CrsfParser.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace
+{
+
+constexpr uint8_t CRSF_HEADER_VALUE = 0xC8;
+constexpr uint8_t CRSF_CHANNEL_TYPE = 0x16;
+constexpr uint8_t CRSF_UNSUPPORTED_TYPE = 0xA8;
+constexpr size_t CRSF_CHANNEL_PAYLOAD_SIZE = 22;
+
+std::vector<uint8_t> makeFrame(uint8_t type, const std::vector<uint8_t> &payload)
+{
+	const uint8_t length = static_cast<uint8_t>(payload.size() + 2);
+	std::vector<uint8_t> frame{CRSF_HEADER_VALUE, length, type};
+	frame.insert(frame.end(), payload.begin(), payload.end());
+	frame.push_back(Crc8Calc(frame.data() + 2, length - 1));
+	return frame;
+}
+
+class CrsfParserTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+		Crc8Init(0xD5);
+		CrsfParser_Init();
+	}
+};
+
+TEST_F(CrsfParserTest, UnsupportedTypeIsIgnoredAndParserRecovers)
+{
+	const uint32_t empty_queue_size = CrsfParser_FreeQueueSize();
+	const std::vector<uint8_t> unsupported_frame = makeFrame(CRSF_UNSUPPORTED_TYPE, {});
+	ASSERT_TRUE(CrsfParser_LoadBuffer(unsupported_frame.data(), unsupported_frame.size()));
+
+	CrsfPacket_t packet{};
+	CrsfParserStatistics_t statistics{};
+	EXPECT_FALSE(CrsfParser_TryParseCrsfPacket(&packet, &statistics));
+	EXPECT_EQ(statistics.crcs_valid_unknown_packets, 1u);
+	EXPECT_EQ(CrsfParser_FreeQueueSize(), empty_queue_size);
+
+	const std::vector<uint8_t> channel_frame = makeFrame(CRSF_CHANNEL_TYPE,
+			std::vector<uint8_t>(CRSF_CHANNEL_PAYLOAD_SIZE));
+	ASSERT_TRUE(CrsfParser_LoadBuffer(channel_frame.data(), channel_frame.size()));
+	ASSERT_TRUE(CrsfParser_TryParseCrsfPacket(&packet, &statistics));
+	EXPECT_EQ(packet.message_type, CRSF_MESSAGE_TYPE_RC_CHANNELS);
+	EXPECT_EQ(CrsfParser_FreeQueueSize(), empty_queue_size);
+}
+
+} // namespace


### PR DESCRIPTION
### Problem

The CRSF packet type is an untrusted byte read from the serial frame. The
parser currently converts every value to `CRSF_PACKET_TYPE` before looking it
up in the descriptor table. Values that are not represented by an enumerator,
such as a valid unsupported packet type, trigger an invalid-enum undefined
behavior report under PX4's `UndefinedBehaviorSanitizer` profile.

PX4 applies this sanitizer profile to explicitly selected POSIX builds, such
as native tests and SITL. Standard deployed NuttX flight-controller firmware
is not instrumented with `-fsanitize=enum`, so it will not produce this runtime
diagnostic. No crash or operational failure in deployed firmware has been
demonstrated. The change removes the underlying C++ undefined behavior at the
serial-input boundary.

### Change

- Keep the wire packet type as `uint8_t` during descriptor lookup.
- Add a focused parser regression test that feeds a CRC-valid unsupported type,
  checks that it is ignored and counted, and verifies that a subsequent valid
  channel frame is still parsed.
- Enable the CRSF driver in the SITL test board so the native test is included.

### Testing

- `unit-CrsfParser`: passed, 1/1.
- `unit-CrsfParser` with `UndefinedBehaviorSanitizer` and
  `UBSAN_OPTIONS=halt_on_error=1`: passed, 1/1.
- UBSan-instrumented `drivers__rc__crsf_rc` SITL target: compiled and linked.
- PX4 AStyle 3.1 checks: passed for both edited C++ files.
