### PR TITLE
fix(rc): reject invalid ST24 packet lengths

### DIFF
--- a/src/lib/rc/rc_tests/RCTest.cpp
+++ b/src/lib/rc/rc_tests/RCTest.cpp
@@ -38,6 +38,7 @@ private:
 	bool dsmTest22msDSMX16Ch();
 	bool dsmTestOrangeDsmx();
 	bool sbus2Test();
+	bool st24MalformedLengthTest();
 	bool st24Test();
 	bool sumdTest();
 };
@@ -51,6 +52,7 @@ bool RCTest::run_tests()
 	ut_run_test(dsmTest22msDSMX16Ch);
 	ut_run_test(dsmTestOrangeDsmx);
 	ut_run_test(sbus2Test);
+	ut_run_test(st24MalformedLengthTest);
 	ut_run_test(st24Test);
 	ut_run_test(sumdTest);
 
@@ -393,6 +395,38 @@ bool RCTest::sbus2Test()
 
 	ut_test(ret == EOF);
 
+	return true;
+}
+
+bool RCTest::st24MalformedLengthTest()
+{
+	uint8_t rssi{};
+	uint8_t lost_count{};
+	uint16_t channel_count{};
+	uint16_t channels[24] {};
+	const uint8_t invalid_lengths[] {0, 1};
+
+	for (const uint8_t invalid_length : invalid_lengths) {
+		const uint8_t prefix[] {ST24_STX1, ST24_STX2, invalid_length, 0};
+
+		for (const uint8_t byte : prefix) {
+			(void)st24_decode(byte, &rssi, &lost_count, &channel_count, channels, 24);
+		}
+
+		for (unsigned i = 0; i <= ST24_DATA_LEN_MAX; ++i) {
+			(void)st24_decode(0xaa, &rssi, &lost_count, &channel_count, channels, 24);
+		}
+	}
+
+	uint8_t minimal_packet[] {ST24_STX1, ST24_STX2, 2, 0xff, 0};
+	minimal_packet[4] = st24_common_crc8(&minimal_packet[2], 2);
+	int result = 1;
+
+	for (const uint8_t byte : minimal_packet) {
+		result = st24_decode(byte, &rssi, &lost_count, &channel_count, channels, 24);
+	}
+
+	ut_test(result == 2);
 	return true;
 }
 

--- a/src/lib/rc/st24.cpp
+++ b/src/lib/rc/st24.cpp
@@ -125,7 +125,8 @@ int st24_decode(uint8_t byte, uint8_t *rssi, uint8_t *lost_count, uint16_t *chan
 	case ST24_DECODE_STATE_GOT_STX2:
 
 		/* ensure no data overflow failure or hack is possible */
-		if ((unsigned)byte <= sizeof(_rxpacket.length) + sizeof(_rxpacket.type) + sizeof(_rxpacket.st24_data)) {
+		if ((unsigned)byte >= sizeof(_rxpacket.type) + sizeof(_rxpacket.crc8)
+		    && (unsigned)byte <= sizeof(_rxpacket.type) + sizeof(_rxpacket.st24_data) + sizeof(_rxpacket.crc8)) {
 			_rxpacket.length = byte;
 			_rxlen = 0;
 			_decode_state = ST24_DECODE_STATE_GOT_LEN;
@@ -139,7 +140,7 @@ int st24_decode(uint8_t byte, uint8_t *rssi, uint8_t *lost_count, uint16_t *chan
 	case ST24_DECODE_STATE_GOT_LEN:
 		_rxpacket.type = byte;
 		_rxlen++;
-		_decode_state = ST24_DECODE_STATE_GOT_TYPE;
+		_decode_state = (_rxlen == (_rxpacket.length - 1)) ? ST24_DECODE_STATE_GOT_DATA : ST24_DECODE_STATE_GOT_TYPE;
 		break;
 
 	case ST24_DECODE_STATE_GOT_TYPE:


### PR DESCRIPTION
### Solved Problem

Fixes #28425

The ST24 decoder accepted packet lengths of 0 and 1 even though the length field must contain at least the packet type and CRC. These malformed lengths could leave the parser writing beyond `st24_data[64]`.

### Solution

* Reject lengths smaller than the type-plus-CRC minimum.
* Preserve the existing 64-byte payload maximum.
* Handle the valid minimum length of 2 by transitioning directly from the type byte to CRC processing.
* Add a regression test covering malformed lengths, overflow-driving input, parser recovery, and a valid zero-payload frame.

### Alternatives

Rejecting all lengths below 3 would avoid the additional state transition, but would also reject structurally valid zero-payload frames.

### Test coverage

* `make px4_sitl_default` — passed; the complete SITL binary linked successfully.
* `ninja -C build/px4_sitl_default lib__rc__rc_tests` — passed; the updated parser and regression test compiled successfully.
* Exact-source ASan/UBSan reproducer:

  * Before the fix: reproduced a global-buffer-overflow in `src/lib/rc/st24.cpp`.
  * After the fix: completed without sanitizer diagnostics.
* The linked `rc_tests` module could not be launched in this workspace because its runtime prohibits the Unix-domain socket required by PX4’s module launcher.
