### PR TITLE
fix(mc_pos_control): handle rejected velocity filter cutoffs

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -95,24 +95,18 @@ void MulticopterPositionControl::parameters_update(bool force)
 			_vel_z_notch_filter.disable();
 		}
 
-		// velocity xy/z low pass filter
-		if (_param_mpc_vel_lp.get() > 0.f) {
-			_vel_xy_lp_filter.setCutoffFreq(sample_freq_hz, _param_mpc_vel_lp.get());
-			_vel_z_lp_filter.setCutoffFreq(sample_freq_hz, _param_mpc_vel_lp.get());
-
-		} else {
-			// disable filtering
+		// velocity xy/z low pass filter, unfiltered when the cutoff is not achievable
+		if (!((_param_mpc_vel_lp.get() > 0.f)
+		      && _vel_xy_lp_filter.setCutoffFreq(sample_freq_hz, _param_mpc_vel_lp.get())
+		      && _vel_z_lp_filter.setCutoffFreq(sample_freq_hz, _param_mpc_vel_lp.get()))) {
 			_vel_xy_lp_filter.setAlpha(1.f);
 			_vel_z_lp_filter.setAlpha(1.f);
 		}
 
-		// velocity derivative xy/z low pass filter
-		if (_param_mpc_veld_lp.get() > 0.f) {
-			_vel_deriv_xy_lp_filter.setCutoffFreq(sample_freq_hz, _param_mpc_veld_lp.get());
-			_vel_deriv_z_lp_filter.setCutoffFreq(sample_freq_hz, _param_mpc_veld_lp.get());
-
-		} else {
-			// disable filtering
+		// velocity derivative xy/z low pass filter, unfiltered when the cutoff is not achievable
+		if (!((_param_mpc_veld_lp.get() > 0.f)
+		      && _vel_deriv_xy_lp_filter.setCutoffFreq(sample_freq_hz, _param_mpc_veld_lp.get())
+		      && _vel_deriv_z_lp_filter.setCutoffFreq(sample_freq_hz, _param_mpc_veld_lp.get()))) {
 			_vel_deriv_xy_lp_filter.setAlpha(1.f);
 			_vel_deriv_z_lp_filter.setAlpha(1.f);
 		}


### PR DESCRIPTION
## Summary

Follow-up from the #28415 review sweep. The velocity low pass configuration in the position controller now checks whether the filter accepted the requested cutoff.

## Problem

All four setCutoffFreq calls ignored the return value, and the call is a silent no-op when the cutoff is at or above half the sample rate. The filters start at an alpha of zero, so a rejected configuration freezes the velocity feedback at zero. MPC_VEL_LP permits up to 50 Hz while the position loop runs at 100 Hz or less, so the maximum permitted value triggers this. In SIH a hover with MPC_VEL_LP=50 oscillates half a metre in altitude with vertical speed peaks near 1 m/s.

## Solution

Check the return and bypass the low pass stage when the cutoff is not achievable, the pattern VehicleAngularVelocity already uses. The same hover then holds 2.5 m within a centimetre, and the default and valid cutoff configurations behave as before. One deliberate behaviour change, a runtime switch from a valid to an unachievable cutoff now bypasses the stage instead of keeping the stale configuration. The notch filter call at the same site also ignores its return but disables itself internally on invalid input, and a warning on rejection could be added here if wanted.

![hover A/B](https://raw.githubusercontent.com/Saibernard/PX4-Autopilot/nn-evidence-final/.github/vel_lp_ab.png)
