### PR TITLE
fix(battery_status): keep analog filter state across parameter updates

### DIFF
--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -157,10 +157,18 @@ AnalogBattery::updateParams()
 
 	if (_analog_params.v_filt > FLT_EPSILON) {
 		_voltage_filter = AlphaFilter<float>(static_cast<uint64_t>(_analog_params.v_filt * 1e6f));
+
+	} else {
+		// reseed from the next sample if the filter is enabled again
+		_voltage_filter_seeded = false;
 	}
 
 	if (_analog_params.i_filt > FLT_EPSILON) {
 		_current_filter = AlphaFilter<float>(static_cast<uint64_t>(_analog_params.i_filt * 1e6f));
+
+	} else {
+		// reseed from the next sample if the filter is enabled again
+		_current_filter_seeded = false;
 	}
 
 	Battery::updateParams();

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -91,10 +91,20 @@ AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, 
 		_last_timestamp = timestamp;
 
 		if (_analog_params.v_filt > FLT_EPSILON) {
+			if (!_voltage_filter_seeded) {
+				_voltage_filter.reset(fmaxf(voltage_v, 0.f));
+				_voltage_filter_seeded = true;
+			}
+
 			voltage_v = _voltage_filter.update(fmaxf(voltage_v, 0.f), dt_us);
 		}
 
 		if (_analog_params.i_filt > FLT_EPSILON) {
+			if (!_current_filter_seeded) {
+				_current_filter.reset(fmaxf(current_a, 0.f));
+				_current_filter_seeded = true;
+			}
+
 			current_a = _current_filter.update(fmaxf(current_a, 0.f), dt_us);
 		}
 	}

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -156,7 +156,12 @@ AnalogBattery::updateParams()
 	param_get(_analog_param_handles.i_filt, &_analog_params.i_filt);
 
 	if (_analog_params.v_filt > FLT_EPSILON) {
+		const float voltage_state = _voltage_filter.getState();
 		_voltage_filter = AlphaFilter<float>(static_cast<uint64_t>(_analog_params.v_filt * 1e6f));
+
+		if (_voltage_filter_seeded) {
+			_voltage_filter.reset(voltage_state);
+		}
 
 	} else {
 		// reseed from the next sample if the filter is enabled again
@@ -164,7 +169,12 @@ AnalogBattery::updateParams()
 	}
 
 	if (_analog_params.i_filt > FLT_EPSILON) {
+		const float current_state = _current_filter.getState();
 		_current_filter = AlphaFilter<float>(static_cast<uint64_t>(_analog_params.i_filt * 1e6f));
+
+		if (_current_filter_seeded) {
+			_current_filter.reset(current_state);
+		}
 
 	} else {
 		// reseed from the next sample if the filter is enabled again

--- a/src/modules/battery_status/analog_battery.h
+++ b/src/modules/battery_status/analog_battery.h
@@ -98,4 +98,6 @@ private:
 	hrt_abstime _last_timestamp{0};
 	AlphaFilter<float> _voltage_filter{};
 	AlphaFilter<float> _current_filter{};
+	bool _voltage_filter_seeded{false};
+	bool _current_filter_seeded{false};
 };


### PR DESCRIPTION
## Summary

Follow-up from the #28415 review sweep, the last of its findings. The analog battery filters now keep their state across parameter updates and start from the first sample instead of zero.

## Problem

updateParams replaced both filters with freshly constructed ones, and it runs on every parameter change anywhere in the system. With filtering enabled, any change therefore restarted the filtered voltage and current from zero. The next published voltage sits below the 2.1 V battery recognition threshold, which reports the battery as disconnected, and while armed the battery warning only escalates, so a single in flight param set could latch a critical battery failsafe and command RTL or land per COM_LOW_BAT_ACT. Nothing seeded the filters at boot either, so the first seconds of estimation always climbed from zero volts.

## Solution

Carry the previous state across the reconstruction, seed each filter with its first sample, and reseed when a filter is disabled and enabled again. The module only runs on hardware ADC paths, so this is verified by inspection and by fmu-v5x and SITL builds, the reset semantics are the documented AlphaFilter behaviour. An alternative would be a time constant setter on AlphaFilter itself, which would remove the reconstruction entirely, happy to do that instead if preferred.

Demonstration with the real filter, battery at 12.6 V and BAT_V_FILT at 2 s. Half a second after boot the unseeded filter reads 2.78 V. On a parameter change the old pattern goes from a steady 12.60 V to 0.00 V and is still at 7.95 V two seconds later. With this change it reads 12.60 V throughout.

```
== boot without seeding ==
  0.5 s after boot the filtered voltage reads 2.78 V
  4.0 s after boot the filtered voltage reads 10.89 V
== parameter change, old pattern ==
steady before the change 12.60 V
right after any parameter change 0.00 V
2 s later, still recovering 7.95 V
== parameter change, with this fix ==
steady before the change 12.60 V
right after the parameter change 12.60 V
```
