### PR TITLE
fix(uavcan): reply to file services on the request interface

### DIFF
--- a/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/node/generic_publisher.hpp
+++ b/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/node/generic_publisher.hpp
@@ -73,6 +73,8 @@ public:
     TransferPriority getPriority() const { return sender_.getPriority(); }
     void setPriority(const TransferPriority prio) { sender_.setPriority(prio); }
 
+    void setIfaceMask(uint8_t iface_mask) { sender_.setIfaceMask(iface_mask); }
+
     INode& getNode() const { return node_; }
 };
 

--- a/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/node/service_server.hpp
+++ b/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/node/service_server.hpp
@@ -103,6 +103,7 @@ private:
     PublisherType publisher_;
     Callback callback_;
     uint32_t response_failure_count_;
+    bool respond_on_request_iface_;
 
     virtual void handleReceivedDataStruct(ReceivedDataStructure<RequestType>& request) override
     {
@@ -123,6 +124,10 @@ private:
         if (response.isResponseEnabled())
         {
             publisher_.setPriority(request.getPriority());      // Responding at the same priority.
+
+            publisher_.setIfaceMask(respond_on_request_iface_ ?
+                                    uint8_t(1U << request.getIfaceIndex()) :
+                                    uint8_t(TransferSender::AllIfacesMask));
 
             const int res = publisher_.publish(response, TransferTypeServiceResponse, request.getSrcNodeID(),
                                                request.getTransferID());
@@ -145,6 +150,7 @@ public:
         , publisher_(node, getDefaultTxTimeout())
         , callback_()
         , response_failure_count_(0)
+        , respond_on_request_iface_(false)
     {
         UAVCAN_ASSERT(getTxTimeout() == getDefaultTxTimeout());  // Making sure it is valid
 
@@ -186,6 +192,12 @@ public:
 
     MonotonicDuration getTxTimeout() const { return publisher_.getTxTimeout(); }
     void setTxTimeout(MonotonicDuration tx_timeout) { publisher_.setTxTimeout(tx_timeout); }
+
+    /**
+     * Default false: responses go out on every CAN interface (UAVCAN v0 redundant-bus).
+     * Set true to reply only on the interface that carried the request.
+     */
+    void setRespondOnRequestIface(bool enable) { respond_on_request_iface_ = enable; }
 
     /**
      * Returns the number of failed attempts to decode data structs. Generally, a failed attempt means either:

--- a/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/node/service_server.hpp
+++ b/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/node/service_server.hpp
@@ -125,9 +125,10 @@ private:
         {
             publisher_.setPriority(request.getPriority());      // Responding at the same priority.
 
-            publisher_.setIfaceMask(respond_on_request_iface_ ?
-                                    uint8_t(1U << request.getIfaceIndex()) :
-                                    uint8_t(TransferSender::AllIfacesMask));
+            if (respond_on_request_iface_)
+            {
+                publisher_.setIfaceMask(uint8_t(1U << request.getIfaceIndex()));
+            }
 
             const int res = publisher_.publish(response, TransferTypeServiceResponse, request.getSrcNodeID(),
                                                request.getTransferID());

--- a/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/node/service_server.hpp
+++ b/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/node/service_server.hpp
@@ -125,10 +125,9 @@ private:
         {
             publisher_.setPriority(request.getPriority());      // Responding at the same priority.
 
-            if (respond_on_request_iface_)
-            {
-                publisher_.setIfaceMask(uint8_t(1U << request.getIfaceIndex()));
-            }
+            publisher_.setIfaceMask(respond_on_request_iface_ ?
+                                    uint8_t(1U << request.getIfaceIndex()) :
+                                    uint8_t(TransferSender::AllIfacesMask));
 
             const int res = publisher_.publish(response, TransferTypeServiceResponse, request.getSrcNodeID(),
                                                request.getTransferID());

--- a/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/protocol/file_server.hpp
+++ b/src/drivers/uavcan/libdronecan/libuavcan/include/uavcan/protocol/file_server.hpp
@@ -227,7 +227,13 @@ public:
         : get_info_srv_(node)
         , read_srv_(node)
         , backend_(backend)
-    { }
+    {
+        // Dual-CAN boards are usually independent buses, not redundant copies of one.
+        // File.Read is the firmware-update payload; echoing it onto the other iface
+        // fills that iface's TX queue with traffic nobody asked for.
+        get_info_srv_.setRespondOnRequestIface(true);
+        read_srv_.setRespondOnRequestIface(true);
+    }
 
     int start(const char* server_root = UAVCAN_NULLPTR, const char* server_alt_root = UAVCAN_NULLPTR)
     {
@@ -302,7 +308,11 @@ public:
         , write_srv_(node)
         , delete_srv_(node)
         , get_directory_entry_info_srv_(node)
-    { }
+    {
+        write_srv_.setRespondOnRequestIface(true);
+        delete_srv_.setRespondOnRequestIface(true);
+        get_directory_entry_info_srv_.setRespondOnRequestIface(true);
+    }
 
     int start()
     {

--- a/src/drivers/uavcan/libdronecan/libuavcan/test/node/service_server.cpp
+++ b/src/drivers/uavcan/libdronecan/libuavcan/test/node/service_server.cpp
@@ -133,6 +133,71 @@ TEST(ServiceServer, Basic)
 }
 
 
+static void pushStringServiceRequest(CanDriverMock& can_driver, SystemClockDriver& clock_driver,
+                                     uint8_t iface_index, uint8_t src_node_id, uint8_t transfer_id)
+{
+    uavcan::Frame frame(root_ns_a::StringService::DefaultDataTypeID, uavcan::TransferTypeServiceRequest,
+                        uavcan::NodeID(src_node_id), 1, transfer_id);
+
+    const uint8_t req[] = {'r', 'e', 'q', '0'};
+    frame.setPayload(req, sizeof(req));
+    frame.setStartOfTransfer(true);
+    frame.setEndOfTransfer(true);
+    frame.setPriority(0);
+
+    uavcan::RxFrame rx_frame(frame, clock_driver.getMonotonic(), clock_driver.getUtc(), iface_index);
+    can_driver.ifaces.at(iface_index).pushRx(rx_frame);
+}
+
+TEST(ServiceServer, ResponseIfaceFromRequest)
+{
+    uavcan::GlobalDataTypeRegistry::instance().reset();
+    uavcan::DefaultDataTypeRegistrator<root_ns_a::StringService> _registrator;
+
+    SystemClockDriver clock_driver;
+    CanDriverMock can_driver(2, clock_driver);
+    TestNode node(can_driver, clock_driver, 1);
+
+    StringServerImpl impl("456");
+    uavcan::ServiceServer<root_ns_a::StringService, StringServerImpl::Binder> server(node);
+    ASSERT_EQ(0, server.start(impl.bind()));
+
+    // Default: request on iface 1 is answered on both ifaces.
+    pushStringServiceRequest(can_driver, clock_driver, 1, 0x10, 0);
+    node.spin(clock_driver.getMonotonic() + uavcan::MonotonicDuration::fromUSec(10000));
+    ASSERT_EQ(2, can_driver.ifaces[0].tx.size());
+    ASSERT_EQ(2, can_driver.ifaces[1].tx.size());
+
+    while (!can_driver.ifaces[0].tx.empty())
+    {
+        (void)can_driver.ifaces[0].popTxFrame();
+    }
+    while (!can_driver.ifaces[1].tx.empty())
+    {
+        (void)can_driver.ifaces[1].popTxFrame();
+    }
+
+    server.setRespondOnRequestIface(true);
+
+    // Request on iface 1 stays on iface 1.
+    pushStringServiceRequest(can_driver, clock_driver, 1, 0x10, 1);
+    node.spin(clock_driver.getMonotonic() + uavcan::MonotonicDuration::fromUSec(10000));
+    ASSERT_EQ(0, can_driver.ifaces[0].tx.size());
+    ASSERT_EQ(2, can_driver.ifaces[1].tx.size());
+
+    while (!can_driver.ifaces[1].tx.empty())
+    {
+        (void)can_driver.ifaces[1].popTxFrame();
+    }
+
+    // Next request on iface 0 must not stick to the previous mask.
+    pushStringServiceRequest(can_driver, clock_driver, 0, 0x11, 2);
+    node.spin(clock_driver.getMonotonic() + uavcan::MonotonicDuration::fromUSec(10000));
+    ASSERT_EQ(2, can_driver.ifaces[0].tx.size());
+    ASSERT_EQ(0, can_driver.ifaces[1].tx.size());
+}
+
+
 TEST(ServiceServer, Empty)
 {
     // Manual type registration - we can't rely on the GDTR state

--- a/src/drivers/uavcan/libdronecan/libuavcan/test/node/service_server.cpp
+++ b/src/drivers/uavcan/libdronecan/libuavcan/test/node/service_server.cpp
@@ -195,6 +195,19 @@ TEST(ServiceServer, ResponseIfaceFromRequest)
     node.spin(clock_driver.getMonotonic() + uavcan::MonotonicDuration::fromUSec(10000));
     ASSERT_EQ(2, can_driver.ifaces[0].tx.size());
     ASSERT_EQ(0, can_driver.ifaces[1].tx.size());
+
+    while (!can_driver.ifaces[0].tx.empty())
+    {
+        (void)can_driver.ifaces[0].popTxFrame();
+    }
+
+    server.setRespondOnRequestIface(false);
+
+    // Disabling must restore the all-interface mask, not keep the last request iface.
+    pushStringServiceRequest(can_driver, clock_driver, 1, 0x10, 3);
+    node.spin(clock_driver.getMonotonic() + uavcan::MonotonicDuration::fromUSec(10000));
+    ASSERT_EQ(2, can_driver.ifaces[0].tx.size());
+    ASSERT_EQ(2, can_driver.ifaces[1].tx.size());
 }
 
 


### PR DESCRIPTION
## Summary
File.GetInfo and File.Read responses go out only on the CAN interface that carried the request.

Bench (ARK FMU-v6XRT, ARK GPS on CAN1, ARK X20 on CAN2, sniffer on CAN1, 2026-08-29): updating the CAN2 node put 88 650 File.Read replies on the idle CAN1 without this change and 0 with it; CAN1 transmitted 2 713 frames during the update instead of 90 922, its TX queue peaked at 8/84 blocks instead of 44/84 with no expiries, and the update completed in both runs.

## Problem
A node firmware update is a stream of File.Read replies. libdronecan queued every transfer on every interface, so an update on CAN1 also filled CAN2's TX queue with the image.

## Solution
The file server now sets the response iface mask from the request. Other services keep the all-interfaces default.