### PR TITLE
fix(uavcan): make DroneCAN time sync work on SocketCAN

### DIFF
--- a/src/drivers/uavcan/uavcan_drivers/socketcan/driver/include/uavcan_nuttx/clock.hpp
+++ b/src/drivers/uavcan/uavcan_drivers/socketcan/driver/include/uavcan_nuttx/clock.hpp
@@ -34,13 +34,8 @@
 
 #pragma once
 
-#include <cassert>
-#include <time.h>
 #include <cstdint>
-
-#include <unistd.h>
-#include <sys/time.h>
-#include <sys/types.h>
+#include <time.h>
 
 #include <uavcan/driver/system_clock.hpp>
 
@@ -49,194 +44,75 @@ namespace uavcan_socketcan
 namespace clock
 {
 /**
- * Performs UTC phase and frequency adjustment.
- * The UTC time will be zero until first adjustment has been performed.
- * This function is thread safe.
+ * Performs UTC phase adjustment on the shared clock instance.
+ * The UTC time is zero until the first adjustment has been performed.
  */
 void adjustUtc(uavcan::UtcDuration adjustment);
-//FIXME
 }
-/**
- * Different adjustment modes can be used for time synchronization
- */
-enum class ClockAdjustmentMode {
-	SystemWide,      ///< Adjust the clock globally for the whole system; requires root privileges
-	PerDriverPrivate ///< Adjust the clock only for the current driver instance
-};
 
 /**
- * Linux system clock driver.
- * Requires librt.
+ * Monotonic time is CLOCK_MONOTONIC, the clock behind SO_TIMESTAMP on
+ * received frames. UTC is private to this driver: the first adjustment sets
+ * it (PX4 seeds it with hrt_absolute_time() so the bus time base is the FC's
+ * HRT), later ones move it by the given offset.
  */
 class SystemClock : public uavcan::ISystemClock
 {
-	uavcan::UtcDuration private_adj_;
-	uavcan::UtcDuration gradual_adj_limit_;
-	const ClockAdjustmentMode adj_mode_;
-	std::uint64_t step_adj_cnt_;
-	std::uint64_t gradual_adj_cnt_;
+	uavcan::UtcDuration utc_offset_;
+	bool utc_set_{false};
+	std::uint64_t adj_cnt_{0};
 
-	static constexpr std::int64_t Int1e6   = 1000000;
 	static constexpr std::uint64_t UInt1e6 = 1000000;
 
-	bool performStepAdjustment(const uavcan::UtcDuration adjustment)
-	{
-		step_adj_cnt_++;
-		const std::int64_t usec = adjustment.toUSec();
-		timeval tv;
-
-		if (gettimeofday(&tv, NULL) != 0) {
-			return false;
-		}
-
-		tv.tv_sec  += usec / Int1e6;
-		tv.tv_usec += usec % Int1e6;
-		return settimeofday(&tv, nullptr) == 0;
-	}
-
-#ifdef CONFIG_CLOCK_TIMEKEEPING
-	bool performGradualAdjustment(const uavcan::UtcDuration adjustment)
-	{
-		gradual_adj_cnt_++;
-		const std::int64_t usec = adjustment.toUSec();
-		timeval tv;
-		tv.tv_sec  = usec / Int1e6;
-		tv.tv_usec = usec % Int1e6;
-		return adjtime(&tv, nullptr) == 0;
-	}
-#endif
-
 public:
-	/**
-	 * By default, the clock adjustment mode will be selected automatically - global if root, private otherwise.
-	 */
-	explicit SystemClock(ClockAdjustmentMode adj_mode = detectPreferredClockAdjustmentMode())
-		: gradual_adj_limit_(uavcan::UtcDuration::fromMSec(4000))
-		, adj_mode_(adj_mode)
-		, step_adj_cnt_(0)
-		, gradual_adj_cnt_(0)
-	{ }
-
-	/**
-	 * Returns monotonic timestamp from librt.
-	 * @throws uavcan_nuttx::Exception.
-	 */
 	uavcan::MonotonicTime getMonotonic() const override
 	{
-		timespec ts;
-
-		if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
-			//throw Exception("Failed to get monotonic time");
-		}
-
+		timespec ts{};
+		(void)clock_gettime(CLOCK_MONOTONIC, &ts);
 		return uavcan::MonotonicTime::fromUSec(std::uint64_t(ts.tv_sec) * UInt1e6 + ts.tv_nsec / 1000);
 	}
 
-	/**
-	 * Returns wall time from gettimeofday().
-	 */
 	uavcan::UtcTime getUtc() const override
 	{
-		timeval tv;
-
-		if (gettimeofday(&tv, NULL) != 0) {
-			//throw Exception("Failed to get UTC time");
-		}
-
-		uavcan::UtcTime utc = uavcan::UtcTime::fromUSec(std::uint64_t(tv.tv_sec) * UInt1e6 + tv.tv_usec);
-
-		if (adj_mode_ == ClockAdjustmentMode::PerDriverPrivate) {
-			utc += private_adj_;
-		}
-
-		return utc;
+		return utcFromMonotonic(getMonotonic());
 	}
 
 	/**
-	 * Adjusts the wall clock.
-	 * Behavior depends on the selected clock adjustment mode - @ref ClockAdjustmentMode.
-	 * Clock adjustment mode can be set only once via constructor.
-	 *
-	 * If the system wide adjustment mode is selected, two ways for performing adjustment exist:
-	 *  - Gradual adjustment using adjtime(), if the phase error is less than gradual adjustment limit.
-	 *  - Step adjustment using settimeofday(), if the phase error is above gradual adjustment limit.
-	 * The gradual adjustment limit can be configured at any time via the setter method.
-	 *
+	 * UTC corresponding to a monotonic timestamp, e.g. a frame's SO_TIMESTAMP.
+	 * Zero while UTC is unset.
 	 */
+	uavcan::UtcTime utcFromMonotonic(uavcan::MonotonicTime mono) const
+	{
+		if (!utc_set_) {
+			return uavcan::UtcTime();
+		}
+
+		return uavcan::UtcTime::fromUSec(mono.toUSec()) + utc_offset_;
+	}
+
 	void adjustUtc(const uavcan::UtcDuration adjustment) override
 	{
-		if (adj_mode_ == ClockAdjustmentMode::PerDriverPrivate) {
-			private_adj_ += adjustment;
+		if (!utc_set_) {
+			// First adjustment is absolute: UTC now equals the adjustment
+			utc_offset_ = adjustment - uavcan::UtcDuration::fromUSec(getMonotonic().toUSec());
+			utc_set_ = true;
 
 		} else {
-			assert(private_adj_.isZero());
-			assert(!gradual_adj_limit_.isNegative());
-
-#ifdef CONFIG_CLOCK_TIMEKEEPING
-
-			if (adjustment.getAbs() < gradual_adj_limit_) {
-				performGradualAdjustment(adjustment);
-
-			} else
-#endif
-			{
-				performStepAdjustment(adjustment);
-			}
-		}
-	}
-
-	/**
-	 * Sets the maximum phase error to use adjtime().
-	 * If the phase error exceeds this value, settimeofday() will be used instead.
-	 */
-	void setGradualAdjustmentLimit(uavcan::UtcDuration limit)
-	{
-		if (limit.isNegative()) {
-			limit = uavcan::UtcDuration();
+			utc_offset_ += adjustment;
 		}
 
-		gradual_adj_limit_ = limit;
+		adj_cnt_++;
 	}
 
-	uavcan::UtcDuration getGradualAdjustmentLimit() const { return gradual_adj_limit_; }
+	bool isUtcSet() const { return utc_set_; }
 
-	ClockAdjustmentMode getAdjustmentMode() const { return adj_mode_; }
-
-	/**
-	 * This is only applicable if the selected clock adjustment mode is private.
-	 * In system wide mode this method will always return zero duration.
-	 */
-	uavcan::UtcDuration getPrivateAdjustment() const { return private_adj_; }
-
-	/**
-	 * Statistics that allows to evaluate clock sync preformance.
-	 */
-	std::uint64_t getStepAdjustmentCount() const { return step_adj_cnt_; }
-	std::uint64_t getGradualAdjustmentCount() const { return gradual_adj_cnt_; }
-	std::uint64_t getAdjustmentCount() const
-	{
-		return getStepAdjustmentCount() + getGradualAdjustmentCount();
-	}
-
-	/**
-	 * This static method decides what is the optimal clock sync adjustment mode for the current configuration.
-	 * It selects system wide mode if the application is running as root; otherwise it prefers
-	 * the private adjustment mode because the system wide mode requires root privileges.
-	 */
-	static ClockAdjustmentMode detectPreferredClockAdjustmentMode()
-	{
-		const bool godmode = 0; // geteuid() == 0;
-		return godmode ? ClockAdjustmentMode::SystemWide : ClockAdjustmentMode::PerDriverPrivate;
-	}
+	std::uint64_t getAdjustmentCount() const { return adj_cnt_; }
 
 	static SystemClock &instance()
 	{
 		static SystemClock self;
 		return self;
 	}
-
-
 };
-
 
 }

--- a/src/drivers/uavcan/uavcan_drivers/socketcan/driver/include/uavcan_nuttx/socketcan.hpp
+++ b/src/drivers/uavcan/uavcan_drivers/socketcan/driver/include/uavcan_nuttx/socketcan.hpp
@@ -93,7 +93,23 @@ private:
 	struct cmsghdr     *_recv_cmsg {};
 	uint8_t            _recv_control[sizeof(struct cmsghdr) + sizeof(struct timeval)] {};
 
-	SystemClock clock;
+	/* Frames sent with CanIOFlagLoopback are handed back from receive() with
+	 * the time they entered a hardware mailbox. NuttX has no TX echo, so this
+	 * stands in for the true transmission timestamp; the bias is the
+	 * mailbox wait, bounded by one frame time when the frame wins arbitration.
+	 */
+	struct LoopbackItem {
+		uavcan::CanFrame      frame;
+		uavcan::MonotonicTime ts_mono;
+		uavcan::UtcTime       ts_utc;
+	};
+
+	static constexpr unsigned LoopbackDepth = 4;
+	LoopbackItem _loopback[LoopbackDepth];
+	unsigned     _loopback_head{0};
+	unsigned     _loopback_count{0};
+
+	void pushLoopback(const uavcan::CanFrame &frame);
 
 public:
 	uavcan::uint32_t socketInit(uint32_t index);
@@ -115,6 +131,8 @@ public:
 	uavcan::uint16_t getNumFilters() const override;
 
 	int getFD();
+
+	bool hasLoopbackPending() const { return _loopback_count > 0; }
 
 
 	/**
@@ -155,7 +173,6 @@ class CanDriver
 {
 	BusEvent update_event_;
 	CanIface if_[UAVCAN_SOCKETCAN_NUM_IFACES];
-	SystemClock clock;
 	struct pollfd pfds[UAVCAN_SOCKETCAN_NUM_IFACES];
 
 public:

--- a/src/drivers/uavcan/uavcan_drivers/socketcan/driver/src/clock.cpp
+++ b/src/drivers/uavcan/uavcan_drivers/socketcan/driver/src/clock.cpp
@@ -41,15 +41,9 @@ namespace uavcan_socketcan
 {
 namespace clock
 {
-/**
- * Performs UTC phase and frequency adjustment.
- * The UTC time will be zero until first adjustment has been performed.
- * This function is thread safe.
- */
 void adjustUtc(uavcan::UtcDuration adjustment)
 {
-	//printf("Adjust UTC\n");
-	//clock::adjustUtc(adjustment);
+	SystemClock::instance().adjustUtc(adjustment);
 }
 
 }

--- a/src/drivers/uavcan/uavcan_drivers/socketcan/driver/src/socketcan.cpp
+++ b/src/drivers/uavcan/uavcan_drivers/socketcan/driver/src/socketcan.cpp
@@ -200,6 +200,10 @@ uavcan::int16_t CanIface::send(const uavcan::CanFrame &frame, uavcan::MonotonicT
 	res = sendmsg(_fd, &_send_msg, MSG_DONTWAIT);
 
 	if (res > 0) {
+		if (flags & uavcan::CanIOFlagLoopback) {
+			pushLoopback(frame);
+		}
+
 		return 1;
 	}
 
@@ -217,9 +221,39 @@ uavcan::int16_t CanIface::send(const uavcan::CanFrame &frame, uavcan::MonotonicT
 	return -1;
 }
 
+void CanIface::pushLoopback(const uavcan::CanFrame &frame)
+{
+	const SystemClock &clock = SystemClock::instance();
+	LoopbackItem &item = _loopback[(_loopback_head + _loopback_count) % LoopbackDepth];
+	item.frame = frame;
+	item.ts_mono = clock.getMonotonic();
+	item.ts_utc = clock.utcFromMonotonic(item.ts_mono);
+
+	if (_loopback_count < LoopbackDepth) {
+		_loopback_count++;
+
+	} else {
+		// Ring full: the oldest echo is overwritten and lost
+		_loopback_head = (_loopback_head + 1) % LoopbackDepth;
+	}
+}
+
 uavcan::int16_t CanIface::receive(uavcan::CanFrame &out_frame, uavcan::MonotonicTime &out_ts_monotonic,
 				  uavcan::UtcTime &out_ts_utc, uavcan::CanIOFlags &out_flags)
 {
+	if (_loopback_count > 0) {
+		const LoopbackItem &item = _loopback[_loopback_head];
+		out_frame = item.frame;
+		out_ts_monotonic = item.ts_mono;
+		out_ts_utc = item.ts_utc;
+		out_flags = uavcan::CanIOFlagLoopback;
+		_loopback_head = (_loopback_head + 1) % LoopbackDepth;
+		_loopback_count--;
+		return 1;
+	}
+
+	out_flags = 0;
+
 	int32_t result = recvmsg(_fd, &_recv_msg, MSG_DONTWAIT);
 
 	if (result < 0) {
@@ -263,7 +297,12 @@ uavcan::int16_t CanIface::receive(uavcan::CanFrame &out_frame, uavcan::Monotonic
 	if (_recv_cmsg->cmsg_level == SOL_SOCKET && _recv_cmsg->cmsg_type == SO_TIMESTAMP) {
 		struct timeval *tv = (struct timeval *)CMSG_DATA(_recv_cmsg);
 		out_ts_monotonic = uavcan::MonotonicTime::fromUSec(tv->tv_sec * 1000000ULL + tv->tv_usec);
+
+	} else {
+		out_ts_monotonic = SystemClock::instance().getMonotonic();
 	}
+
+	out_ts_utc = SystemClock::instance().utcFromMonotonic(out_ts_monotonic);
 
 	return result;
 }
@@ -473,7 +512,7 @@ uavcan::int16_t CanDriver::select(uavcan::CanSelectMasks &inout_masks,
 				  const uavcan::CanFrame * (&)[uavcan::MaxCanIfaces],
 				  uavcan::MonotonicTime blocking_deadline)
 {
-	std::int64_t timeout_usec = (blocking_deadline - clock.getMonotonic()).toUSec();
+	std::int64_t timeout_usec = (blocking_deadline - SystemClock::instance().getMonotonic()).toUSec();
 
 	if (timeout_usec < 0) {
 		timeout_usec = 0;
@@ -481,6 +520,13 @@ uavcan::int16_t CanDriver::select(uavcan::CanSelectMasks &inout_masks,
 
 	inout_masks.read = 0;
 	inout_masks.write = 0;
+
+	for (int i = 0; i < UAVCAN_SOCKETCAN_NUM_IFACES; i++) {
+		if (if_[i].hasLoopbackPending()) {
+			inout_masks.read |= 1U << i;
+			timeout_usec = 0;
+		}
+	}
 
 	if (poll(pfds, UAVCAN_SOCKETCAN_NUM_IFACES, timeout_usec / 1000) > 0) {
 		for (int i = 0; i < UAVCAN_SOCKETCAN_NUM_IFACES; i++) {


### PR DESCRIPTION
## Summary
FC-mastered DroneCAN time sync produces usable `GlobalTimeSync` messages on the SocketCAN boards (i.MX RT, Kinetis, S32K), and received frames carry a UTC timestamp in the FC's HRT base.

Verified on an ARK FMU-v6XRT with a USB-CAN sniffer on CAN1: every `GlobalTimeSync` carries a non-zero `previous_transmission_timestamp_usec`, consecutive values 0.999–1.002 s apart, equal to FC uptime. On main the field is always 0.

## Problem
`GlobalTimeSyncMaster` needs the TX timestamp of its previous sync frame, delivered as a loopback receive. The SocketCAN platform never set `CanIOFlagLoopback` and NuttX has no TX echo, so `previous_transmission_timestamp_usec` was 0 in every broadcast, which tells slaves to ignore it. Two further gaps would each have kept it broken: `receive()` never wrote `out_ts_utc`, and `clock::adjustUtc()` was a stub, leaving `getUtc()` on `gettimeofday()` instead of the `hrt_absolute_time()` seed the sensor bridges assume.

## Solution
`send()` with `CanIOFlagLoopback` queues the frame in a small per-interface ring stamped at mailbox entry; `select()` reports the interface readable and `receive()` returns it with the flag before reading the socket. The bias against the true transmission time is the mailbox wait, at most one frame time when the sync frame wins arbitration. Received frames get `ts_utc` from `SO_TIMESTAMP` plus the private UTC offset. `SystemClock` is one shared instance; its first `adjustUtc()` is absolute, so the existing seed makes bus time equal HRT. A NuttX TX echo (`CAN_RAW_RECV_OWN_MSGS` + `MSG_CONFIRM`) would replace the ring without changing this interface.
