### PR TITLE
feat(simulation): revive dual-IMU SIH with per-instance fault injection

### DIFF
--- a/docs/en/sim_sih/index.md
+++ b/docs/en/sim_sih/index.md
@@ -165,6 +165,21 @@ PX4 SITL opens the following UDP ports (all instance-aware, offset by instance n
 
 QGC auto-connects on port **14550** by default. MAVSDK connects on **14540**. No manual port configuration needed for single-instance use.
 
+### Fault and Failure Testing {#fault-testing}
+
+SIH publishes one IMU by default.
+Set [SIH_IMU_COUNT](../advanced_config/parameter_reference.md#SIH_IMU_COUNT) to 2 together with [EKF2_MULTI_IMU](../advanced_config/parameter_reference.md#EKF2_MULTI_IMU) 2 and `SENS_IMU_MODE` 0 to get a second IMU with independent noise and one EKF instance per IMU, which activates the estimator instance selector.
+Leaving `SIH_IMU_COUNT` at 1 keeps the single IMU setup, so a simulation that does not need multi-EKF does not pay for a second estimator.
+
+Two complementary mechanisms inject sensor faults, and they target individual IMUs:
+
+- [Failure injection](../debug/failure_injection.md) stops a sensor completely.
+  For example `failure accel off -i 2` stops the accelerometer of the second IMU only.
+  Use it for hard faults such as a dead sensor.
+- [SIH_FAULT_IMU](../advanced_config/parameter_reference.md#SIH_FAULT_IMU) and [SIH_FAULT_VIBE](../advanced_config/parameter_reference.md#SIH_FAULT_VIBE) add Z axis vibration to one IMU, railed at the measurement range so the driver reports it as clipping.
+  Use them when the sensor has to keep publishing while the data it publishes goes bad, which is what degrades one EKF instance without silencing it.
+  A binary failure cannot produce this state.
+
 ### Multi-Vehicle Simulation
 
 SIH supports multi-vehicle simulation using PX4's instance system.

--- a/src/modules/mc_pos_control/CMakeLists.txt
+++ b/src/modules/mc_pos_control/CMakeLists.txt
@@ -61,3 +61,5 @@ px4_add_module(
 		geo
 		SlewRate
 	)
+
+px4_add_functional_gtest(SRC MulticopterPositionControlTest.cpp LINKLIBS modules__mc_pos_control)

--- a/src/modules/mc_pos_control/GotoControl/CMakeLists.txt
+++ b/src/modules/mc_pos_control/GotoControl/CMakeLists.txt
@@ -36,3 +36,8 @@ px4_add_library(GotoControl
 	GotoControl.hpp
 )
 target_include_directories(GotoControl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+# GotoControl holds a PositionSmoothing member, so it needs the library that defines it.
+# Without this the dependency is only satisfied by link order, which breaks any target that
+# pulls GotoControl in transitively.
+target_link_libraries(GotoControl PUBLIC motion_planning)

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -434,7 +434,7 @@ void MulticopterPositionControl::Run()
 
 		_trajectory_setpoint_sub.update(&_setpoint);
 
-		adjustSetpointForEKFResets(vehicle_local_position, _setpoint);
+		adjustSetpointForEKFResets(vehicle_local_position, _setpoint, _last_valid_setpoint);
 
 		if (_vehicle_control_mode.flag_multicopter_position_control_enabled) {
 			// set failsafe setpoint if there hasn't been a new
@@ -577,8 +577,8 @@ void MulticopterPositionControl::Run()
 
 				// Initial update failed - Try fallback if within timeout
 				if (now < _last_valid_setpoint.timestamp + 200_ms) {
-					// Use last valid setpoint
-					adjustSetpointForEKFResets(vehicle_local_position, _last_valid_setpoint);
+					// Use last valid setpoint. It was already moved into the current estimate
+					// frame above, at the same time as _setpoint.
 					_control.setInputSetpoint(_last_valid_setpoint);
 				}
 
@@ -682,31 +682,39 @@ trajectory_setpoint_s MulticopterPositionControl::generateFailsafeSetpoint(const
 }
 
 void MulticopterPositionControl::adjustSetpointForEKFResets(const vehicle_local_position_s &vehicle_local_position,
-		trajectory_setpoint_s &setpoint)
+		trajectory_setpoint_s &setpoint, trajectory_setpoint_s &fallback_setpoint)
 {
-	if ((setpoint.timestamp != 0) && (setpoint.timestamp < vehicle_local_position.timestamp)) {
-		if (vehicle_local_position.vxy_reset_counter != _vxy_reset_counter) {
-			setpoint.velocity[0] += vehicle_local_position.delta_vxy[0];
-			setpoint.velocity[1] += vehicle_local_position.delta_vxy[1];
-		}
+	auto apply_reset_deltas = [&](trajectory_setpoint_s & setpoint_to_adjust) {
+		if ((setpoint_to_adjust.timestamp != 0) && (setpoint_to_adjust.timestamp < vehicle_local_position.timestamp)) {
+			if (vehicle_local_position.vxy_reset_counter != _vxy_reset_counter) {
+				setpoint_to_adjust.velocity[0] += vehicle_local_position.delta_vxy[0];
+				setpoint_to_adjust.velocity[1] += vehicle_local_position.delta_vxy[1];
+			}
 
-		if (vehicle_local_position.vz_reset_counter != _vz_reset_counter) {
-			setpoint.velocity[2] += vehicle_local_position.delta_vz;
-		}
+			if (vehicle_local_position.vz_reset_counter != _vz_reset_counter) {
+				setpoint_to_adjust.velocity[2] += vehicle_local_position.delta_vz;
+			}
 
-		if (vehicle_local_position.xy_reset_counter != _xy_reset_counter) {
-			setpoint.position[0] += vehicle_local_position.delta_xy[0];
-			setpoint.position[1] += vehicle_local_position.delta_xy[1];
-		}
+			if (vehicle_local_position.xy_reset_counter != _xy_reset_counter) {
+				setpoint_to_adjust.position[0] += vehicle_local_position.delta_xy[0];
+				setpoint_to_adjust.position[1] += vehicle_local_position.delta_xy[1];
+			}
 
-		if (vehicle_local_position.z_reset_counter != _z_reset_counter) {
-			setpoint.position[2] += vehicle_local_position.delta_z;
-		}
+			if (vehicle_local_position.z_reset_counter != _z_reset_counter) {
+				setpoint_to_adjust.position[2] += vehicle_local_position.delta_z;
+			}
 
-		if (vehicle_local_position.heading_reset_counter != _heading_reset_counter) {
-			setpoint.yaw = wrap_pi(setpoint.yaw + vehicle_local_position.delta_heading);
+			if (vehicle_local_position.heading_reset_counter != _heading_reset_counter) {
+				setpoint_to_adjust.yaw = wrap_pi(setpoint_to_adjust.yaw + vehicle_local_position.delta_heading);
+			}
 		}
-	}
+	};
+
+	apply_reset_deltas(setpoint);
+
+	// The stored fallback has to move in the same cycle. The counters are latched below, so a
+	// later call would find nothing changed and would leave it in the pre reset frame.
+	apply_reset_deltas(fallback_setpoint);
 
 	if (vehicle_local_position.vxy_reset_counter != _vxy_reset_counter) {
 		_vel_xy_lp_filter.reset(_vel_xy_lp_filter.getState() + Vector2f(vehicle_local_position.delta_vxy));

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -91,6 +91,8 @@ public:
 	bool init();
 
 private:
+	friend class PositionControlTestPeer;
+
 	void Run() override;
 
 	TakeoffHandling _takeoff; /**< state machine and ramp to bring the vehicle off the ground without jumps */

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -91,7 +91,7 @@ public:
 	bool init();
 
 private:
-	friend class PositionControlTestPeer;
+	friend class MulticopterPositionControlTestPeer;
 
 	void Run() override;
 
@@ -255,7 +255,10 @@ private:
 	 *
 	 * @param[in] vehicle_local_position struct containing EKF reset deltas and counters
 	 * @param[out] setpoint trajectory setpoint struct to be adjusted
+	 * @param[out] fallback_setpoint the stored last valid setpoint, adjusted with the same
+	 *             deltas because it is applied later in the same cycle, after the counters
+	 *             below have been latched
 	 */
 	void adjustSetpointForEKFResets(const vehicle_local_position_s &vehicle_local_position,
-					trajectory_setpoint_s &setpoint);
+					trajectory_setpoint_s &setpoint, trajectory_setpoint_s &fallback_setpoint);
 };

--- a/src/modules/mc_pos_control/MulticopterPositionControlTest.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControlTest.cpp
@@ -1,0 +1,436 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file MulticopterPositionControlTest.cpp
+ *
+ * When the estimator selector hands over to another instance it publishes the
+ * shift it applied to the local position estimate. The setpoint has to move by
+ * the same amount, otherwise the controller reads the shift as tracking error
+ * and flies the vehicle to correct for something that never moved.
+ */
+
+#include <gtest/gtest.h>
+
+#include "MulticopterPositionControl.hpp"
+
+#include <hrt_work.h>
+#include <px4_platform_common/px4_work_queue/WorkQueueManager.hpp>
+#include <px4_platform_common/time.h>
+
+#include <memory>
+
+#include <matrix/math.hpp>
+
+using namespace time_literals;
+
+// PX4 destroys a work queue when its last WorkItem detaches, so one keeper item pins
+// the queue for the whole process. It has to go before the manager stops, otherwise it
+// outlives its queue holding a dangling pointer.
+class WorkQueueKeeper : public px4::ScheduledWorkItem
+{
+public:
+	WorkQueueKeeper() : ScheduledWorkItem("wq_keeper", px4::wq_configurations::nav_and_controllers) {}
+
+private:
+	void Run() override {}
+};
+
+static std::unique_ptr<WorkQueueKeeper> work_queue_keeper;
+
+class MulticopterPositionControlTestEnvironment : public ::testing::Environment
+{
+public:
+	void SetUp() override { setvbuf(stdout, nullptr, _IONBF, 0); }
+	void TearDown() override
+	{
+		work_queue_keeper.reset();
+		px4::WorkQueueManagerStop();
+	}
+};
+
+static const auto *global_env = ::testing::AddGlobalTestEnvironment(new MulticopterPositionControlTestEnvironment());
+
+class PositionControlTestPeer
+{
+public:
+	static void adjustSetpointForEKFResets(MulticopterPositionControl &controller,
+					       const vehicle_local_position_s &vehicle_local_position,
+					       trajectory_setpoint_s &setpoint)
+	{
+		controller.adjustSetpointForEKFResets(vehicle_local_position, setpoint);
+	}
+
+	static void setVelocityFilterState(MulticopterPositionControl &controller, const matrix::Vector2f &xy, float z)
+	{
+		controller._vel_xy_lp_filter.reset(xy);
+		controller._vel_z_lp_filter.reset(z);
+	}
+
+	static matrix::Vector2f velocityFilterStateXy(const MulticopterPositionControl &controller)
+	{
+		return controller._vel_xy_lp_filter.getState();
+	}
+
+	static float velocityFilterStateZ(const MulticopterPositionControl &controller)
+	{
+		return controller._vel_z_lp_filter.getState();
+	}
+};
+
+class MulticopterPositionControlTest : public ::testing::Test
+{
+public:
+	void SetUp() override
+	{
+		// the controller attaches to the work queue at construction
+		static bool wq_manager_started = false;
+
+		if (!wq_manager_started) {
+			hrt_work_queue_init();
+			ASSERT_EQ(px4::WorkQueueManagerStart(), 0);
+			wq_manager_started = true;
+		}
+
+		if (!work_queue_keeper) {
+			const hrt_abstime wait_start = hrt_absolute_time();
+
+			while (px4::WorkQueueFindOrCreate(px4::wq_configurations::nav_and_controllers) == nullptr) {
+				ASSERT_LT(hrt_elapsed_time(&wait_start), 5_s);
+				px4_usleep(10_ms);
+			}
+
+			work_queue_keeper = std::make_unique<WorkQueueKeeper>();
+		}
+
+		_controller = new MulticopterPositionControl();
+		ASSERT_NE(_controller, nullptr);
+	}
+
+	void TearDown() override
+	{
+		delete _controller;
+		_controller = nullptr;
+	}
+
+protected:
+	// A local position sample that is newer than the setpoint, which is what the
+	// adjustment requires before it will touch anything.
+	vehicle_local_position_s makeLocalPosition() const
+	{
+		vehicle_local_position_s local_position{};
+		local_position.timestamp = hrt_absolute_time();
+		return local_position;
+	}
+
+	trajectory_setpoint_s makeSetpoint() const
+	{
+		trajectory_setpoint_s setpoint{};
+		setpoint.timestamp = hrt_absolute_time() - 100_ms;
+		setpoint.position[0] = 10.f;
+		setpoint.position[1] = 20.f;
+		setpoint.position[2] = -30.f;
+		setpoint.velocity[0] = 1.f;
+		setpoint.velocity[1] = 2.f;
+		setpoint.velocity[2] = 3.f;
+		setpoint.yaw = 0.5f;
+		return setpoint;
+	}
+
+	MulticopterPositionControl *_controller{nullptr};
+};
+
+// WHY: with no reset the setpoint is the commanded one and must be passed through.
+TEST_F(MulticopterPositionControlTest, NoResetLeavesTheSetpointAlone)
+{
+	vehicle_local_position_s local_position = makeLocalPosition();
+	trajectory_setpoint_s setpoint = makeSetpoint();
+	const trajectory_setpoint_s original = setpoint;
+
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+
+	EXPECT_FLOAT_EQ(setpoint.position[0], original.position[0]);
+	EXPECT_FLOAT_EQ(setpoint.position[1], original.position[1]);
+	EXPECT_FLOAT_EQ(setpoint.position[2], original.position[2]);
+	EXPECT_FLOAT_EQ(setpoint.yaw, original.yaw);
+}
+
+// WHY: this is the selector handover case. The estimate moved by delta_z, so the
+// setpoint has to move with it or the controller sees a step in its own error.
+TEST_F(MulticopterPositionControlTest, VerticalResetShiftsTheSetpointByTheSameDelta)
+{
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.z_reset_counter = 1;
+	local_position.delta_z = -1.5f;
+
+	trajectory_setpoint_s setpoint = makeSetpoint();
+	const float expected = setpoint.position[2] + local_position.delta_z;
+
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+
+	EXPECT_FLOAT_EQ(setpoint.position[2], expected);
+	// only the axis that was reset moves
+	EXPECT_FLOAT_EQ(setpoint.position[0], 10.f);
+	EXPECT_FLOAT_EQ(setpoint.position[1], 20.f);
+}
+
+// WHY: a horizontal handover shifts north and east together.
+TEST_F(MulticopterPositionControlTest, HorizontalResetShiftsTheSetpointByTheSameDelta)
+{
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.xy_reset_counter = 1;
+	local_position.delta_xy[0] = 2.5f;
+	local_position.delta_xy[1] = -3.5f;
+
+	trajectory_setpoint_s setpoint = makeSetpoint();
+
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+
+	EXPECT_FLOAT_EQ(setpoint.position[0], 12.5f);
+	EXPECT_FLOAT_EQ(setpoint.position[1], 16.5f);
+	EXPECT_FLOAT_EQ(setpoint.position[2], -30.f);
+}
+
+// WHY: velocity setpoints ride through a velocity reset the same way.
+TEST_F(MulticopterPositionControlTest, VelocityResetShiftsTheVelocitySetpoint)
+{
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.vxy_reset_counter = 1;
+	local_position.delta_vxy[0] = 0.5f;
+	local_position.delta_vxy[1] = -0.25f;
+	local_position.vz_reset_counter = 1;
+	local_position.delta_vz = 0.75f;
+
+	trajectory_setpoint_s setpoint = makeSetpoint();
+
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+
+	EXPECT_FLOAT_EQ(setpoint.velocity[0], 1.5f);
+	EXPECT_FLOAT_EQ(setpoint.velocity[1], 1.75f);
+	EXPECT_FLOAT_EQ(setpoint.velocity[2], 3.75f);
+}
+
+// WHY: the counters are latched after the first pass, so a second pass on the same
+// sample must not apply the shift again. Applying it twice would walk the setpoint
+// away by one delta on every cycle for as long as the counter stayed put.
+TEST_F(MulticopterPositionControlTest, SameResetIsNotAppliedTwice)
+{
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.z_reset_counter = 1;
+	local_position.delta_z = -1.5f;
+
+	trajectory_setpoint_s setpoint = makeSetpoint();
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+	const float after_first = setpoint.position[2];
+
+	local_position.timestamp = hrt_absolute_time();
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+
+	EXPECT_FLOAT_EQ(setpoint.position[2], after_first);
+}
+
+// WHY: a setpoint that is newer than the estimate sample was produced after the
+// reset was already accounted for, so shifting it again would double count.
+TEST_F(MulticopterPositionControlTest, SetpointNewerThanTheEstimateIsNotShifted)
+{
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.z_reset_counter = 1;
+	local_position.delta_z = -1.5f;
+
+	trajectory_setpoint_s setpoint = makeSetpoint();
+	setpoint.timestamp = local_position.timestamp + 100_ms;
+
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+
+	EXPECT_FLOAT_EQ(setpoint.position[2], -30.f);
+}
+
+// WHY: an empty setpoint has nothing to shift, and the counters still have to be
+// latched so the next real setpoint is not shifted by a reset it never saw.
+TEST_F(MulticopterPositionControlTest, UnsetSetpointIsNotShiftedAndStillLatchesTheCounter)
+{
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.z_reset_counter = 1;
+	local_position.delta_z = -1.5f;
+
+	trajectory_setpoint_s empty{};
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, empty);
+	EXPECT_FLOAT_EQ(empty.position[2], 0.f);
+
+	trajectory_setpoint_s setpoint = makeSetpoint();
+	local_position.timestamp = hrt_absolute_time();
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+
+	EXPECT_FLOAT_EQ(setpoint.position[2], -30.f);
+}
+
+// WHY: a heading reset wraps, so the shifted yaw has to come back inside +-pi rather
+// than drifting outside it.
+TEST_F(MulticopterPositionControlTest, HeadingResetShiftsYawAndWraps)
+{
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.heading_reset_counter = 1;
+	local_position.delta_heading = 3.f;
+
+	trajectory_setpoint_s setpoint = makeSetpoint();
+	setpoint.yaw = 3.f;
+
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+
+	// 3 + 3 is outside +-pi, so it wraps to 6 - 2*pi rather than staying at 6.
+	// The expected value is written out so this does not just restate the production call.
+	EXPECT_NEAR(setpoint.yaw, -0.283185307f, 1e-6f);
+}
+
+// WHY: the guard is a strict less than, so a setpoint stamped at the same time as the
+// estimate sample is not older than it and must not be shifted.
+TEST_F(MulticopterPositionControlTest, SetpointStampedWithTheEstimateIsNotShifted)
+{
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.z_reset_counter = 1;
+	local_position.delta_z = -1.5f;
+
+	trajectory_setpoint_s setpoint = makeSetpoint();
+	setpoint.timestamp = local_position.timestamp;
+
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+
+	EXPECT_FLOAT_EQ(setpoint.position[2], -30.f);
+}
+
+// WHY: skipping the shift must still latch the counter, otherwise the next setpoint
+// would be shifted by a reset that happened before it existed.
+TEST_F(MulticopterPositionControlTest, SkippedShiftStillLatchesTheCounter)
+{
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.z_reset_counter = 1;
+	local_position.delta_z = -1.5f;
+
+	trajectory_setpoint_s newer = makeSetpoint();
+	newer.timestamp = local_position.timestamp + 100_ms;
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, newer);
+	EXPECT_FLOAT_EQ(newer.position[2], -30.f);
+
+	trajectory_setpoint_s older = makeSetpoint();
+	local_position.timestamp = hrt_absolute_time();
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, older);
+
+	EXPECT_FLOAT_EQ(older.position[2], -30.f);
+}
+
+// WHY: an instance handover moves every state at once, so all five counters can change
+// in a single sample. Each axis has to take its own delta and nothing may be double
+// counted across axes.
+TEST_F(MulticopterPositionControlTest, AllCountersChangingInOneSampleShiftEveryAxis)
+{
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.vxy_reset_counter = 1;
+	local_position.delta_vxy[0] = 0.25f;
+	local_position.delta_vxy[1] = -0.5f;
+	local_position.vz_reset_counter = 1;
+	local_position.delta_vz = 0.75f;
+	local_position.xy_reset_counter = 1;
+	local_position.delta_xy[0] = 2.5f;
+	local_position.delta_xy[1] = -3.5f;
+	local_position.z_reset_counter = 1;
+	local_position.delta_z = -1.5f;
+	local_position.heading_reset_counter = 1;
+	local_position.delta_heading = 0.25f;
+
+	trajectory_setpoint_s setpoint = makeSetpoint();
+
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+
+	EXPECT_FLOAT_EQ(setpoint.velocity[0], 1.25f);
+	EXPECT_FLOAT_EQ(setpoint.velocity[1], 1.5f);
+	EXPECT_FLOAT_EQ(setpoint.velocity[2], 3.75f);
+	EXPECT_FLOAT_EQ(setpoint.position[0], 12.5f);
+	EXPECT_FLOAT_EQ(setpoint.position[1], 16.5f);
+	EXPECT_FLOAT_EQ(setpoint.position[2], -31.5f);
+	EXPECT_FLOAT_EQ(setpoint.yaw, 0.75f);
+}
+
+// WHY: the controller filters the measured velocity. If the estimate steps and the filter
+// state stays behind, the filtered velocity carries a step the vehicle never flew, so the
+// filter has to be moved by the same delta as the state it tracks.
+TEST_F(MulticopterPositionControlTest, VelocityResetCarriesTheVelocityFilterState)
+{
+	PositionControlTestPeer::setVelocityFilterState(*_controller, matrix::Vector2f(4.f, -2.f), 1.f);
+
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.vxy_reset_counter = 1;
+	local_position.delta_vxy[0] = 0.5f;
+	local_position.delta_vxy[1] = -1.5f;
+	local_position.vz_reset_counter = 1;
+	local_position.delta_vz = 0.25f;
+
+	trajectory_setpoint_s setpoint = makeSetpoint();
+
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+
+	const matrix::Vector2f filter_xy = PositionControlTestPeer::velocityFilterStateXy(*_controller);
+	EXPECT_FLOAT_EQ(filter_xy(0), 4.5f);
+	EXPECT_FLOAT_EQ(filter_xy(1), -3.5f);
+	EXPECT_FLOAT_EQ(PositionControlTestPeer::velocityFilterStateZ(*_controller), 1.25f);
+}
+
+// WHY: the filter reset sits outside the timestamp guard on purpose. The guard is about
+// whether a setpoint predates the reset, which says nothing about the measured velocity,
+// so a setpoint newer than the estimate must still leave the filters corrected.
+TEST_F(MulticopterPositionControlTest, FilterStateIsCarriedEvenWhenTheSetpointShiftIsSkipped)
+{
+	PositionControlTestPeer::setVelocityFilterState(*_controller, matrix::Vector2f(4.f, -2.f), 1.f);
+
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.vxy_reset_counter = 1;
+	local_position.delta_vxy[0] = 0.5f;
+	local_position.delta_vxy[1] = -1.5f;
+	local_position.vz_reset_counter = 1;
+	local_position.delta_vz = 0.25f;
+
+	// newer than the estimate, so the guard rejects the setpoint shift
+	trajectory_setpoint_s setpoint = makeSetpoint();
+	setpoint.timestamp = local_position.timestamp + 100_ms;
+
+	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+
+	// the setpoint is untouched
+	EXPECT_FLOAT_EQ(setpoint.velocity[0], 1.f);
+	EXPECT_FLOAT_EQ(setpoint.velocity[2], 3.f);
+
+	// but the filters still moved with the estimate
+	const matrix::Vector2f filter_xy = PositionControlTestPeer::velocityFilterStateXy(*_controller);
+	EXPECT_FLOAT_EQ(filter_xy(0), 4.5f);
+	EXPECT_FLOAT_EQ(filter_xy(1), -3.5f);
+	EXPECT_FLOAT_EQ(PositionControlTestPeer::velocityFilterStateZ(*_controller), 1.25f);
+}

--- a/src/modules/mc_pos_control/MulticopterPositionControlTest.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControlTest.cpp
@@ -81,14 +81,24 @@ public:
 
 static const auto *global_env = ::testing::AddGlobalTestEnvironment(new MulticopterPositionControlTestEnvironment());
 
-class PositionControlTestPeer
+class MulticopterPositionControlTestPeer
 {
 public:
 	static void adjustSetpointForEKFResets(MulticopterPositionControl &controller,
 					       const vehicle_local_position_s &vehicle_local_position,
 					       trajectory_setpoint_s &setpoint)
 	{
-		controller.adjustSetpointForEKFResets(vehicle_local_position, setpoint);
+		// the cases that do not care about the fallback pass a throwaway one
+		trajectory_setpoint_s unused_fallback{};
+		controller.adjustSetpointForEKFResets(vehicle_local_position, setpoint, unused_fallback);
+	}
+
+	static void adjustSetpointForEKFResets(MulticopterPositionControl &controller,
+					       const vehicle_local_position_s &vehicle_local_position,
+					       trajectory_setpoint_s &setpoint,
+					       trajectory_setpoint_s &fallback_setpoint)
+	{
+		controller.adjustSetpointForEKFResets(vehicle_local_position, setpoint, fallback_setpoint);
 	}
 
 	static void setVelocityFilterState(MulticopterPositionControl &controller, const matrix::Vector2f &xy, float z)
@@ -177,7 +187,7 @@ TEST_F(MulticopterPositionControlTest, NoResetLeavesTheSetpointAlone)
 	trajectory_setpoint_s setpoint = makeSetpoint();
 	const trajectory_setpoint_s original = setpoint;
 
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
 
 	EXPECT_FLOAT_EQ(setpoint.position[0], original.position[0]);
 	EXPECT_FLOAT_EQ(setpoint.position[1], original.position[1]);
@@ -196,7 +206,7 @@ TEST_F(MulticopterPositionControlTest, VerticalResetShiftsTheSetpointByTheSameDe
 	trajectory_setpoint_s setpoint = makeSetpoint();
 	const float expected = setpoint.position[2] + local_position.delta_z;
 
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
 
 	EXPECT_FLOAT_EQ(setpoint.position[2], expected);
 	// only the axis that was reset moves
@@ -214,7 +224,7 @@ TEST_F(MulticopterPositionControlTest, HorizontalResetShiftsTheSetpointByTheSame
 
 	trajectory_setpoint_s setpoint = makeSetpoint();
 
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
 
 	EXPECT_FLOAT_EQ(setpoint.position[0], 12.5f);
 	EXPECT_FLOAT_EQ(setpoint.position[1], 16.5f);
@@ -233,7 +243,7 @@ TEST_F(MulticopterPositionControlTest, VelocityResetShiftsTheVelocitySetpoint)
 
 	trajectory_setpoint_s setpoint = makeSetpoint();
 
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
 
 	EXPECT_FLOAT_EQ(setpoint.velocity[0], 1.5f);
 	EXPECT_FLOAT_EQ(setpoint.velocity[1], 1.75f);
@@ -250,11 +260,11 @@ TEST_F(MulticopterPositionControlTest, SameResetIsNotAppliedTwice)
 	local_position.delta_z = -1.5f;
 
 	trajectory_setpoint_s setpoint = makeSetpoint();
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
 	const float after_first = setpoint.position[2];
 
 	local_position.timestamp = hrt_absolute_time();
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
 
 	EXPECT_FLOAT_EQ(setpoint.position[2], after_first);
 }
@@ -270,7 +280,7 @@ TEST_F(MulticopterPositionControlTest, SetpointNewerThanTheEstimateIsNotShifted)
 	trajectory_setpoint_s setpoint = makeSetpoint();
 	setpoint.timestamp = local_position.timestamp + 100_ms;
 
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
 
 	EXPECT_FLOAT_EQ(setpoint.position[2], -30.f);
 }
@@ -284,12 +294,12 @@ TEST_F(MulticopterPositionControlTest, UnsetSetpointIsNotShiftedAndStillLatchesT
 	local_position.delta_z = -1.5f;
 
 	trajectory_setpoint_s empty{};
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, empty);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, empty);
 	EXPECT_FLOAT_EQ(empty.position[2], 0.f);
 
 	trajectory_setpoint_s setpoint = makeSetpoint();
 	local_position.timestamp = hrt_absolute_time();
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
 
 	EXPECT_FLOAT_EQ(setpoint.position[2], -30.f);
 }
@@ -305,10 +315,9 @@ TEST_F(MulticopterPositionControlTest, HeadingResetShiftsYawAndWraps)
 	trajectory_setpoint_s setpoint = makeSetpoint();
 	setpoint.yaw = 3.f;
 
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
 
-	// 3 + 3 is outside +-pi, so it wraps to 6 - 2*pi rather than staying at 6.
-	// The expected value is written out so this does not just restate the production call.
+	// 3 + 3 is outside +-pi, so it wraps to 6 - 2*pi rather than staying at 6
 	EXPECT_NEAR(setpoint.yaw, -0.283185307f, 1e-6f);
 }
 
@@ -323,7 +332,7 @@ TEST_F(MulticopterPositionControlTest, SetpointStampedWithTheEstimateIsNotShifte
 	trajectory_setpoint_s setpoint = makeSetpoint();
 	setpoint.timestamp = local_position.timestamp;
 
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
 
 	EXPECT_FLOAT_EQ(setpoint.position[2], -30.f);
 }
@@ -338,12 +347,12 @@ TEST_F(MulticopterPositionControlTest, SkippedShiftStillLatchesTheCounter)
 
 	trajectory_setpoint_s newer = makeSetpoint();
 	newer.timestamp = local_position.timestamp + 100_ms;
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, newer);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, newer);
 	EXPECT_FLOAT_EQ(newer.position[2], -30.f);
 
 	trajectory_setpoint_s older = makeSetpoint();
 	local_position.timestamp = hrt_absolute_time();
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, older);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, older);
 
 	EXPECT_FLOAT_EQ(older.position[2], -30.f);
 }
@@ -369,7 +378,7 @@ TEST_F(MulticopterPositionControlTest, AllCountersChangingInOneSampleShiftEveryA
 
 	trajectory_setpoint_s setpoint = makeSetpoint();
 
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
 
 	EXPECT_FLOAT_EQ(setpoint.velocity[0], 1.25f);
 	EXPECT_FLOAT_EQ(setpoint.velocity[1], 1.5f);
@@ -385,7 +394,7 @@ TEST_F(MulticopterPositionControlTest, AllCountersChangingInOneSampleShiftEveryA
 // filter has to be moved by the same delta as the state it tracks.
 TEST_F(MulticopterPositionControlTest, VelocityResetCarriesTheVelocityFilterState)
 {
-	PositionControlTestPeer::setVelocityFilterState(*_controller, matrix::Vector2f(4.f, -2.f), 1.f);
+	MulticopterPositionControlTestPeer::setVelocityFilterState(*_controller, matrix::Vector2f(4.f, -2.f), 1.f);
 
 	vehicle_local_position_s local_position = makeLocalPosition();
 	local_position.vxy_reset_counter = 1;
@@ -396,12 +405,12 @@ TEST_F(MulticopterPositionControlTest, VelocityResetCarriesTheVelocityFilterStat
 
 	trajectory_setpoint_s setpoint = makeSetpoint();
 
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
 
-	const matrix::Vector2f filter_xy = PositionControlTestPeer::velocityFilterStateXy(*_controller);
+	const matrix::Vector2f filter_xy = MulticopterPositionControlTestPeer::velocityFilterStateXy(*_controller);
 	EXPECT_FLOAT_EQ(filter_xy(0), 4.5f);
 	EXPECT_FLOAT_EQ(filter_xy(1), -3.5f);
-	EXPECT_FLOAT_EQ(PositionControlTestPeer::velocityFilterStateZ(*_controller), 1.25f);
+	EXPECT_FLOAT_EQ(MulticopterPositionControlTestPeer::velocityFilterStateZ(*_controller), 1.25f);
 }
 
 // WHY: the filter reset sits outside the timestamp guard on purpose. The guard is about
@@ -409,7 +418,7 @@ TEST_F(MulticopterPositionControlTest, VelocityResetCarriesTheVelocityFilterStat
 // so a setpoint newer than the estimate must still leave the filters corrected.
 TEST_F(MulticopterPositionControlTest, FilterStateIsCarriedEvenWhenTheSetpointShiftIsSkipped)
 {
-	PositionControlTestPeer::setVelocityFilterState(*_controller, matrix::Vector2f(4.f, -2.f), 1.f);
+	MulticopterPositionControlTestPeer::setVelocityFilterState(*_controller, matrix::Vector2f(4.f, -2.f), 1.f);
 
 	vehicle_local_position_s local_position = makeLocalPosition();
 	local_position.vxy_reset_counter = 1;
@@ -422,15 +431,101 @@ TEST_F(MulticopterPositionControlTest, FilterStateIsCarriedEvenWhenTheSetpointSh
 	trajectory_setpoint_s setpoint = makeSetpoint();
 	setpoint.timestamp = local_position.timestamp + 100_ms;
 
-	PositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, setpoint);
 
 	// the setpoint is untouched
 	EXPECT_FLOAT_EQ(setpoint.velocity[0], 1.f);
 	EXPECT_FLOAT_EQ(setpoint.velocity[2], 3.f);
 
 	// but the filters still moved with the estimate
-	const matrix::Vector2f filter_xy = PositionControlTestPeer::velocityFilterStateXy(*_controller);
+	const matrix::Vector2f filter_xy = MulticopterPositionControlTestPeer::velocityFilterStateXy(*_controller);
 	EXPECT_FLOAT_EQ(filter_xy(0), 4.5f);
 	EXPECT_FLOAT_EQ(filter_xy(1), -3.5f);
-	EXPECT_FLOAT_EQ(PositionControlTestPeer::velocityFilterStateZ(*_controller), 1.25f);
+	EXPECT_FLOAT_EQ(MulticopterPositionControlTestPeer::velocityFilterStateZ(*_controller), 1.25f);
+}
+
+// WHY: Run() adjusts the incoming setpoint and stores a fallback for the case where the
+// control update rejects it. Both describe the same frame, so a reset has to move both in
+// the same cycle. The counters are latched once, so anything not shifted here is never
+// shifted at all.
+TEST_F(MulticopterPositionControlTest, FallbackSetpointIsShiftedInTheSameCycleAsTheCurrentOne)
+{
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.z_reset_counter = 1;
+	local_position.delta_z = -1.5f;
+	local_position.xy_reset_counter = 1;
+	local_position.delta_xy[0] = 2.5f;
+	local_position.delta_xy[1] = -3.5f;
+
+	trajectory_setpoint_s current = makeSetpoint();
+	trajectory_setpoint_s last_valid = makeSetpoint();
+
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, current, last_valid);
+
+	EXPECT_FLOAT_EQ(current.position[2], -31.5f);
+	EXPECT_FLOAT_EQ(last_valid.position[2], -31.5f);
+	EXPECT_FLOAT_EQ(last_valid.position[0], 12.5f);
+	EXPECT_FLOAT_EQ(last_valid.position[1], 16.5f);
+}
+
+// WHY: the fallback is stored across cycles, so a reset already applied to it must not be
+// applied again on the next sample.
+TEST_F(MulticopterPositionControlTest, FallbackSetpointIsNotShiftedTwice)
+{
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.z_reset_counter = 1;
+	local_position.delta_z = -1.5f;
+
+	trajectory_setpoint_s current = makeSetpoint();
+	trajectory_setpoint_s last_valid = makeSetpoint();
+
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, current, last_valid);
+	EXPECT_FLOAT_EQ(last_valid.position[2], -31.5f);
+
+	local_position.timestamp = hrt_absolute_time();
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, current, last_valid);
+
+	EXPECT_FLOAT_EQ(last_valid.position[2], -31.5f);
+}
+
+// WHY: the fallback carries its own timestamp, so it gets the same guard as any other
+// setpoint rather than inheriting the decision made for the current one.
+TEST_F(MulticopterPositionControlTest, FallbackSetpointHonoursItsOwnTimestampGuard)
+{
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.z_reset_counter = 1;
+	local_position.delta_z = -1.5f;
+
+	trajectory_setpoint_s current = makeSetpoint();
+	trajectory_setpoint_s last_valid = makeSetpoint();
+	last_valid.timestamp = local_position.timestamp + 100_ms;
+
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, current, last_valid);
+
+	EXPECT_FLOAT_EQ(current.position[2], -31.5f);
+	EXPECT_FLOAT_EQ(last_valid.position[2], -30.f);
+}
+
+// WHY: two setpoints are adjusted in one call but there was only one reset, so the velocity
+// filter must move by one delta, not two.
+TEST_F(MulticopterPositionControlTest, VelocityFilterMovesOnceWhenBothSetpointsAreAdjusted)
+{
+	MulticopterPositionControlTestPeer::setVelocityFilterState(*_controller, matrix::Vector2f(4.f, -2.f), 1.f);
+
+	vehicle_local_position_s local_position = makeLocalPosition();
+	local_position.vxy_reset_counter = 1;
+	local_position.delta_vxy[0] = 0.5f;
+	local_position.delta_vxy[1] = -1.5f;
+	local_position.vz_reset_counter = 1;
+	local_position.delta_vz = 0.25f;
+
+	trajectory_setpoint_s current = makeSetpoint();
+	trajectory_setpoint_s last_valid = makeSetpoint();
+
+	MulticopterPositionControlTestPeer::adjustSetpointForEKFResets(*_controller, local_position, current, last_valid);
+
+	const matrix::Vector2f filter_xy = MulticopterPositionControlTestPeer::velocityFilterStateXy(*_controller);
+	EXPECT_FLOAT_EQ(filter_xy(0), 4.5f);
+	EXPECT_FLOAT_EQ(filter_xy(1), -3.5f);
+	EXPECT_FLOAT_EQ(MulticopterPositionControlTestPeer::velocityFilterStateZ(*_controller), 1.25f);
 }

--- a/src/modules/mc_pos_control/MulticopterPositionControlTest.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControlTest.cpp
@@ -51,6 +51,14 @@
 #include <memory>
 
 #include <matrix/math.hpp>
+#include <parameters/param.h>
+#include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/trajectory_setpoint.h>
+#include <uORB/topics/vehicle_control_mode.h>
+#include <uORB/topics/vehicle_land_detected.h>
+#include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_local_position_setpoint.h>
 
 using namespace time_literals;
 
@@ -116,6 +124,19 @@ public:
 	{
 		return controller._vel_z_lp_filter.getState();
 	}
+
+	// One control cycle driven from the test thread. Run() re-arms itself on the work
+	// queue, so the schedule is cleared again to keep the cycle in the test's hands.
+	static void runOnce(MulticopterPositionControl &controller)
+	{
+		controller.Run();
+		controller.ScheduleClear();
+	}
+
+	static const trajectory_setpoint_s &lastValidSetpoint(const MulticopterPositionControl &controller)
+	{
+		return controller._last_valid_setpoint;
+	}
 };
 
 class MulticopterPositionControlTest : public ::testing::Test
@@ -160,6 +181,26 @@ protected:
 	{
 		vehicle_local_position_s local_position{};
 		local_position.timestamp = hrt_absolute_time();
+		return local_position;
+	}
+
+	// A valid in-flight estimate for driving Run(). The limits are left unset so the
+	// controller's own parameters apply.
+	vehicle_local_position_s makeFlyingLocalPosition() const
+	{
+		vehicle_local_position_s local_position{};
+		local_position.timestamp = hrt_absolute_time();
+		local_position.timestamp_sample = local_position.timestamp;
+		local_position.xy_valid = true;
+		local_position.z_valid = true;
+		local_position.v_xy_valid = true;
+		local_position.v_z_valid = true;
+		local_position.x = 10.f;
+		local_position.y = 20.f;
+		local_position.z = -30.f;
+		local_position.vxy_max = NAN;
+		local_position.vz_max = NAN;
+		local_position.hagl_min = NAN;
 		return local_position;
 	}
 
@@ -528,4 +569,74 @@ TEST_F(MulticopterPositionControlTest, VelocityFilterMovesOnceWhenBothSetpointsA
 	EXPECT_FLOAT_EQ(filter_xy(0), 4.5f);
 	EXPECT_FLOAT_EQ(filter_xy(1), -3.5f);
 	EXPECT_FLOAT_EQ(MulticopterPositionControlTestPeer::velocityFilterStateZ(*_controller), 1.25f);
+}
+
+// WHY: the cases above hand the helper a fallback of their own. This one drives Run(), so
+// the fallback the controller actually stores has to move with the reset, and the controller
+// has to fly the moved one when the setpoint of the same cycle is unusable.
+TEST_F(MulticopterPositionControlTest, RunMovesTheStoredFallbackWithAResetAndFliesIt)
+{
+	uORB::Publication<vehicle_control_mode_s> control_mode_pub{ORB_ID(vehicle_control_mode)};
+	uORB::Publication<vehicle_land_detected_s> land_detected_pub{ORB_ID(vehicle_land_detected)};
+	uORB::Publication<vehicle_local_position_s> local_position_pub{ORB_ID(vehicle_local_position)};
+	uORB::Publication<trajectory_setpoint_s> setpoint_pub{ORB_ID(trajectory_setpoint)};
+	uORB::Subscription local_position_setpoint_sub{ORB_ID(vehicle_local_position_setpoint)};
+
+	// skip the takeoff ramp, the fallback path only runs once the controller is in flight
+	param_control_autosave(false);
+	const param_t throw_param = param_find("COM_THROW_EN");
+	ASSERT_NE(throw_param, PARAM_INVALID);
+	int32_t throw_enabled = 1;
+	ASSERT_EQ(param_set(throw_param, &throw_enabled), PX4_OK);
+
+	vehicle_control_mode_s control_mode{};
+	control_mode.timestamp = hrt_absolute_time() - 10_ms;
+	control_mode.flag_armed = true;
+	control_mode.flag_multicopter_position_control_enabled = true;
+	control_mode_pub.publish(control_mode);
+
+	vehicle_land_detected_s land_detected{};
+	land_detected.timestamp = control_mode.timestamp;
+	land_detected_pub.publish(land_detected);
+
+	// GIVEN: one cycle with a usable setpoint, which the controller stores as its fallback
+	trajectory_setpoint_s setpoint = makeSetpoint();
+	setpoint.timestamp = hrt_absolute_time() - 1_ms;
+	setpoint_pub.publish(setpoint);
+	local_position_pub.publish(makeFlyingLocalPosition());
+	MulticopterPositionControlTestPeer::runOnce(*_controller);
+
+	const trajectory_setpoint_s &fallback = MulticopterPositionControlTestPeer::lastValidSetpoint(*_controller);
+	ASSERT_FLOAT_EQ(fallback.position[0], 10.f);
+	ASSERT_FLOAT_EQ(fallback.position[1], 20.f);
+	ASSERT_FLOAT_EQ(fallback.position[2], -30.f);
+
+	// WHEN: the estimate resets and the setpoint of the same cycle is unusable
+	trajectory_setpoint_s unusable = PositionControl::empty_trajectory_setpoint;
+	unusable.timestamp = hrt_absolute_time() - 1_ms;
+	setpoint_pub.publish(unusable);
+
+	vehicle_local_position_s local_position = makeFlyingLocalPosition();
+	local_position.xy_reset_counter = 1;
+	local_position.delta_xy[0] = 2.5f;
+	local_position.delta_xy[1] = -3.5f;
+	local_position.z_reset_counter = 1;
+	local_position.delta_z = -1.5f;
+	local_position_pub.publish(local_position);
+	MulticopterPositionControlTestPeer::runOnce(*_controller);
+
+	// THEN: the stored fallback moved by the reset
+	EXPECT_FLOAT_EQ(fallback.position[0], 12.5f);
+	EXPECT_FLOAT_EQ(fallback.position[1], 16.5f);
+	EXPECT_FLOAT_EQ(fallback.position[2], -31.5f);
+
+	// and the controller flew the moved fallback rather than the unusable setpoint
+	vehicle_local_position_setpoint_s flown{};
+	ASSERT_TRUE(local_position_setpoint_sub.update(&flown));
+	EXPECT_FLOAT_EQ(flown.x, 12.5f);
+	EXPECT_FLOAT_EQ(flown.y, 16.5f);
+	EXPECT_FLOAT_EQ(flown.z, -31.5f);
+
+	int32_t throw_disabled = 0;
+	param_set(throw_param, &throw_disabled);
 }

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -63,14 +63,41 @@ Sih::Sih() :
 
 Sih::~Sih()
 {
+	// index 0 is a member, the rest are only allocated when SIH_IMU_COUNT asks for them
+	for (uint8_t i = 1; i < IMU_COUNT; i++) {
+		delete _px4_accel[i];
+		delete _px4_gyro[i];
+	}
+
 	perf_free(_loop_perf);
 	perf_free(_loop_interval_perf);
 }
 
 void Sih::run()
 {
-	_px4_accel.set_temperature(T1_C);
-	_px4_gyro.set_temperature(T1_C);
+	_imu_count = math::constrain((uint8_t)_sih_imu_count.get(), (uint8_t)1, IMU_COUNT);
+
+	for (uint8_t i = 1; i < _imu_count; i++) {
+		_px4_accel[i] = new PX4Accelerometer(IMU_DEVICE_ID[i]);
+		_px4_gyro[i] = new PX4Gyroscope(IMU_DEVICE_ID[i]);
+
+		if ((_px4_accel[i] == nullptr) || (_px4_gyro[i] == nullptr)) {
+			// The drivers advertise in their constructor, so a half allocated IMU would
+			// leave one orphan topic behind. Drop both and carry on with fewer IMUs.
+			delete _px4_accel[i];
+			delete _px4_gyro[i];
+			_px4_accel[i] = nullptr;
+			_px4_gyro[i] = nullptr;
+			PX4_ERR("alloc failed for IMU %d", i);
+			_imu_count = i;
+			break;
+		}
+	}
+
+	for (uint8_t i = 0; i < _imu_count; i++) {
+		_px4_accel[i]->set_temperature(T1_C);
+		_px4_gyro[i]->set_temperature(T1_C);
+	}
 
 	parameters_updated();
 
@@ -215,10 +242,13 @@ void Sih::updateFailureConfig()
 			     == failure_injection::Mode::Off);
 	_distance_sensor_blocked = (_failure_config.mode(failure_injection_s::FAILURE_UNIT_SENSOR_DISTANCE_SENSOR, 1)
 				    == failure_injection::Mode::Off);
-	_accel_blocked = (_failure_config.mode(failure_injection_s::FAILURE_UNIT_SENSOR_ACCEL, 1)
-			  == failure_injection::Mode::Off);
-	_gyro_blocked = (_failure_config.mode(failure_injection_s::FAILURE_UNIT_SENSOR_GYRO, 1)
-			 == failure_injection::Mode::Off);
+
+	for (uint8_t i = 0; i < _imu_count; i++) {
+		_accel_blocked[i] = (_failure_config.mode(failure_injection_s::FAILURE_UNIT_SENSOR_ACCEL, i + 1)
+				     == failure_injection::Mode::Off);
+		_gyro_blocked[i] = (_failure_config.mode(failure_injection_s::FAILURE_UNIT_SENSOR_GYRO, i + 1)
+				    == failure_injection::Mode::Off);
+	}
 }
 
 void Sih::sensor_step()
@@ -727,32 +757,44 @@ void Sih::reconstruct_sensors_signals(const hrt_abstime &time_now_us)
 
 	// IMU
 	const Dcmf R_E2B(_q_E.inversed());
-	Vector3f accel_noise;
-	Vector3f gyro_noise;
-
-	if (false && _T_B.longerThan(FLT_EPSILON)) { // too much noise at least for the low update rate O.O
-		accel_noise = noiseGauss3f(0.5f, 1.7f, 1.4f);
-		gyro_noise = noiseGauss3f(0.14f, 0.07f, 0.03f);
-
-	} else {
-		// Lower noise when not armed
-		accel_noise = noiseGauss3f(0.1f, 0.1f, 0.1f);
-		gyro_noise = noiseGauss3f(0.01f, 0.01f, 0.01f);
-	}
-
-	Vector3f specific_force_B = R_E2B * _specific_force_E;
-	Vector3f accel = specific_force_B + accel_noise;
-
+	const Vector3f specific_force_B = R_E2B * _specific_force_E;
 	const Vector3f earth_spin_rate_B = R_E2B * Vector3f(0.f, 0.f, CONSTANTS_EARTH_SPIN_RATE);
-	Vector3f gyro = _w_B + earth_spin_rate_B + gyro_noise;
 
-	// update IMU every iteration
-	if (!_accel_blocked) {
-		_px4_accel.update(time_now_us, accel(0), accel(1), accel(2));
+	// Fault injection: which IMU index (0-based), -1 means none
+	const int fault_imu = _sih_fault_imu.get() - 1; // param is 1-indexed, -1 means off
+
+	if ((fault_imu >= _imu_count) && (fault_imu != _fault_imu_warned)) {
+		// Otherwise the fault silently does nothing and a test looks like it injected one
+		PX4_WARN("SIH_FAULT_IMU %d has no IMU, SIH_IMU_COUNT is %d", fault_imu + 1, _imu_count);
+		_fault_imu_warned = fault_imu;
 	}
 
-	if (!_gyro_blocked) {
-		_px4_gyro.update(time_now_us, gyro(0), gyro(1), gyro(2));
+	const float fault_vibe = _sih_fault_vibe.get();
+
+	// Publish to all simulated IMUs with independent noise
+	for (uint8_t i = 0; i < _imu_count; i++) {
+		Vector3f accel_noise = noiseGauss3f(0.1f, 0.1f, 0.1f);
+		Vector3f gyro_noise = noiseGauss3f(0.01f, 0.01f, 0.01f);
+
+		Vector3f accel = specific_force_B + accel_noise;
+
+		// Inject high amplitude Z axis vibration on the selected IMU. The result is railed
+		// at the measurement range, because a real accelerometer cannot report past it and
+		// the driver decides a sample is clipped by comparing against that range.
+		if ((int)i == fault_imu && fault_vibe > FLT_EPSILON) {
+			accel(2) = math::constrain(accel(2) + fault_vibe * generate_wgn(), -ACCEL_RANGE_MS2, ACCEL_RANGE_MS2);
+		}
+
+		const Vector3f gyro = _w_B + earth_spin_rate_B + gyro_noise;
+
+		// update IMU every iteration
+		if (!_accel_blocked[i]) {
+			_px4_accel[i]->update(time_now_us, accel(0), accel(1), accel(2));
+		}
+
+		if (!_gyro_blocked[i]) {
+			_px4_gyro[i]->update(time_now_us, gyro(0), gyro(1), gyro(2));
+		}
 	}
 }
 

--- a/src/modules/simulation/simulator_sih/sih.hpp
+++ b/src/modules/simulation/simulator_sih/sih.hpp
@@ -129,9 +129,25 @@ private:
 	void parameters_updated();
 	void updateFailureConfig();
 
-	// simulated sensors
-	PX4Accelerometer _px4_accel{1310988}; // 1310988: DRV_IMU_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
-	PX4Gyroscope     _px4_gyro{1310988};  // 1310988: DRV_IMU_DEVTYPE_SIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
+	// simulated sensors. IMU_COUNT is the maximum, SIH_IMU_COUNT selects how many are used.
+	// The sensor drivers advertise on construction, so the second IMU is only built when it
+	// is asked for. A single IMU setup then costs exactly what it did before.
+	static constexpr uint8_t IMU_COUNT = 2;
+	// DRV_IMU_DEVTYPE_SIM, BUS: 1 and 2, ADDR: 1, TYPE: SIMULATION
+	static constexpr uint32_t IMU_DEVICE_ID[IMU_COUNT] {1310988, 1310996};
+	uint8_t _imu_count{1};
+	int _fault_imu_warned{-1};
+
+	// Measurement range of the simulated accelerometers. This has to match _range in
+	// PX4Accelerometer, which defaults to 16 g, because that is what the driver compares a
+	// sample against when it decides the sample is clipped. A real accelerometer rails here
+	// rather than reporting the true value.
+	static constexpr float ACCEL_RANGE_MS2 = 16.f * CONSTANTS_ONE_G;
+
+	PX4Accelerometer  _px4_accel_first{IMU_DEVICE_ID[0]};
+	PX4Gyroscope      _px4_gyro_first{IMU_DEVICE_ID[0]};
+	PX4Accelerometer *_px4_accel[IMU_COUNT] {&_px4_accel_first, nullptr};
+	PX4Gyroscope     *_px4_gyro[IMU_COUNT] {&_px4_gyro_first, nullptr};
 	PX4Rangefinder   _px4_rangefinder{10092548}; // 10092548: DRV_DIST_DEVTYPE_SIM, BUS: 0, ADDR: 0, TYPE: SIMULATION
 	uORB::Publication<airspeed_s>         _airspeed_pub{ORB_ID(airspeed)};
 	uORB::Publication<ranging_beacon_s>   _ranging_beacon_pub{ORB_ID(ranging_beacon)};
@@ -149,8 +165,8 @@ private:
 
 	bool _airspeed_blocked{false};
 	bool _distance_sensor_blocked{false};
-	bool _accel_blocked{false};
-	bool _gyro_blocked{false};
+	bool _accel_blocked[IMU_COUNT] {};
+	bool _gyro_blocked[IMU_COUNT] {};
 
 	// hard constants
 	static constexpr uint16_t NUM_ACTUATORS_MAX = 9;
@@ -354,6 +370,10 @@ private:
 		(ParamInt<px4::params::SIH_VEHICLE_TYPE>) _sih_vtype,
 		(ParamFloat<px4::params::SIH_WIND_N>) _sih_wind_n,
 		(ParamFloat<px4::params::SIH_WIND_E>) _sih_wind_e,
-		(ParamFloat<px4::params::SIH_RNGBC_NOISE>) _sih_ranging_beacon_noise
+		(ParamFloat<px4::params::SIH_RNGBC_NOISE>) _sih_ranging_beacon_noise,
+		// fault injection
+		(ParamInt<px4::params::SIH_IMU_COUNT>) _sih_imu_count,
+		(ParamInt<px4::params::SIH_FAULT_IMU>) _sih_fault_imu,
+		(ParamFloat<px4::params::SIH_FAULT_VIBE>) _sih_fault_vibe
 	)
 };

--- a/src/modules/simulation/simulator_sih/sih_params.yaml
+++ b/src/modules/simulation/simulator_sih/sih_params.yaml
@@ -381,3 +381,44 @@ parameters:
       default: 6000.0
       min: 0.1
       decimal: 1
+    SIH_IMU_COUNT:
+      description:
+        short: Number of simulated IMUs
+        long: |-
+          How many IMUs SIH publishes. Set this to 2 together with EKF2_MULTI_IMU 2
+          and SENS_IMU_MODE 0 to run one EKF instance per IMU, which is what the
+          estimator instance selector needs. The default of 1 keeps the single IMU
+          setup, so a simulation that does not need multi-EKF does not pay for a
+          second estimator.
+      type: int32
+      default: 1
+      min: 1
+      max: 2
+      reboot_required: true
+    SIH_FAULT_IMU:
+      description:
+        short: IMU index for fault injection
+        long: |-
+          Selects which simulated IMU receives injected faults.
+          0 disables fault injection. 1 selects IMU 0, 2 selects IMU 1.
+          Can be changed at runtime to start/stop faults mid-flight.
+      type: int32
+      default: 0
+      min: 0
+      max: 2
+    SIH_FAULT_VIBE:
+      description:
+        short: Accel vibration amplitude for fault injection
+        long: |-
+          Standard deviation of zero mean noise added to the Z axis of the selected IMU,
+          railed at the 16 g measurement range. It is a noise amplitude, not a threshold,
+          so the fraction of samples that reach the rail and are reported as clipped rises
+          smoothly with this value. Around 500 m/s^2 roughly three quarters of samples
+          reach the rail. Set to 0 to disable vibration injection even when
+          SIH_FAULT_IMU is set.
+      type: float
+      default: 0.0
+      unit: m/s^2
+      min: 0.0
+      max: 2000.0
+      decimal: 1

--- a/test/mavsdk_tests/CMakeLists.txt
+++ b/test/mavsdk_tests/CMakeLists.txt
@@ -25,6 +25,8 @@ if(MAVSDK_FOUND)
         # autopilot_tester_follow_me.cpp
         test_multicopter_basics.cpp
         test_multicopter_control_allocation.cpp
+        test_ekf2_selector.cpp
+        test_multicopter_ekf_failover.cpp
         test_multicopter_failure_injection.cpp
         test_multicopter_failsafe.cpp
         test_multicopter_mission.cpp

--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -53,7 +53,10 @@ AutopilotTester::AutopilotTester() :
 
 AutopilotTester::~AutopilotTester()
 {
-	_events->unsubscribe_events(_events_handle);
+	// connect() can fail before the plugins exist, and a destructor that dereferences them
+	// turns the reported timeout into a segfault that hides it
+	if (_events) {
+		_events->unsubscribe_events(_events_handle);
 	_should_exit = true;
 	_real_time_report_thread.join();
 }

--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -33,9 +33,12 @@
 
 #include "autopilot_tester.h"
 #include "math_helpers.h"
+#include <algorithm>
 #include <atomic>
+#include <cstdlib>
 #include <iostream>
 #include <future>
+#include <mutex>
 #include <thread>
 #include <unistd.h>
 #include <cmath>
@@ -57,6 +60,8 @@ AutopilotTester::~AutopilotTester()
 	// turns the reported timeout into a segfault that hides it
 	if (_events) {
 		_events->unsubscribe_events(_events_handle);
+	}
+
 	_should_exit = true;
 	_real_time_report_thread.join();
 }
@@ -82,6 +87,7 @@ void AutopilotTester::connect(const std::string uri)
 	_param.reset(new Param(system));
 	_telemetry.reset(new Telemetry(system));
 	_events.reset(new Events(system));
+	_shell.reset(new Shell(system));
 	_mavlink_passthrough.reset(new MavlinkPassthrough(system));
 
 	_events_handle = _events->subscribe_events([](const Events::Event & event) {
@@ -341,6 +347,538 @@ void AutopilotTester::execute_mission_and_lose_baro()
 		auto result = _mission->is_mission_finished();
 		return result.first == Mission::Result::Success && result.second;
 	}, std::chrono::seconds(90)));
+}
+
+// How far the vehicle is allowed to leave its altitude while an IMU fault is active,
+// measured against the simulator rather than the estimator being disturbed.
+static constexpr float kFailoverGroundTruthBandM = 5.f;
+
+// How far the hovering vehicle may drop below the altitude it was holding while an IMU is
+// clipping. It hovers at 20 m, so this keeps it well clear of the ground.
+static constexpr float kSelectorAltitudeFloorM = 12.f;
+
+// And how far it may climb. A railed accelerometer reads as falling, so the controller answers
+// with thrust and the vehicle goes up rather than down. That transient reaches 25 m in the
+// worst run measured here, while losing the second estimator instead sends it past 50 m and it
+// never comes back, so this sits between the two.
+static constexpr float kSelectorAltitudeCeilingM = 40.f;
+
+// How far it may still be from where it started once the faults are cleared and it has
+// settled again.
+static constexpr float kSelectorRecoveryToleranceM = 3.f;
+
+// SIH_FAULT_VIBE amplitude used to clip an accelerometer. It is the standard deviation of the
+// injected noise, and the driver reports a sample as clipped once it reaches the 16 g
+// measurement range, about 157 m/s2. At this amplitude about three quarters of raw samples
+// reach the rail, which keeps EKF2's clipping counter climbing rather than sitting near the
+// break even point where it steps back down.
+static constexpr float kImuClippingFaultAmplitude = 500.f;
+
+// SCALED_IMU reports the integrated vehicle_imu acceleration in milli g, not raw samples, so
+// the railed samples are averaged with the clean ones over each integration window. A hovering
+// quad sits near 1000 and cannot exceed its thrust to weight ceiling of about 2000 whatever it
+// is commanded, while a clipped IMU still reports many thousands. The bands do not overlap.
+static constexpr int kClippedImuPeakMg = 4000;
+static constexpr int kCleanImuPeakMg = 3000;
+
+// Clears the injected fault however the scope is left. A failing REQUIRE throws, and without
+// this the simulator would keep clipping an accelerometer for the rest of the process.
+class ImuFaultGuard
+{
+public:
+	explicit ImuFaultGuard(mavsdk::Param *param) : _param(param) {}
+	~ImuFaultGuard()
+	{
+		if (_param != nullptr) {
+			_param->set_param_int("SIH_FAULT_IMU", 0);
+			_param->set_param_float("SIH_FAULT_VIBE", 0.f);
+		}
+	}
+
+	ImuFaultGuard(const ImuFaultGuard &) = delete;
+	ImuFaultGuard &operator=(const ImuFaultGuard &) = delete;
+
+private:
+	mavsdk::Param *_param;
+};
+
+// A parameter write has to reach SIH and the samples already in flight have to drain before
+// the next phase starts measuring.
+static constexpr std::chrono::seconds kFaultSettleTime{3};
+
+// Long enough to collect many SCALED_IMU samples at 50 Hz and to outlast the 3 second
+// BADACC_PROBATION that EKF2 holds after clipping stops, so one phase does not bleed into
+// the next.
+static constexpr std::chrono::seconds kFaultMeasureTime{17};
+
+// Ground truth arrives as HIL_STATE_QUATERNION, about 15 Hz of simulated time here. Requiring
+// a third of that over a window catches a stream that stalled or was starved under the speed
+// factor, which would otherwise leave every maximum at its starting value and read as a pass.
+static constexpr int kMinGroundTruthRateHz = 5;
+
+// How long the selector may take to leave the instance behind a clipped IMU. Measured here
+// it takes a few seconds, most of that the health debounce.
+static constexpr std::chrono::seconds kHandoverTimeout{30};
+
+int AutopilotTester::primary_estimator_instance()
+{
+	// The reply arrives in chunks on the receive thread, so collect until the field and the
+	// end of its line are both there.
+	auto output = std::make_shared<std::string>();
+	auto output_mutex = std::make_shared<std::mutex>();
+	Shell::ReceiveHandle handle = _shell->subscribe_receive([output, output_mutex](std::string chunk) {
+		std::lock_guard<std::mutex> lock(*output_mutex);
+		*output += chunk;
+	});
+
+	const Shell::Result send_result = _shell->send("listener estimator_selector_status -n 1\n");
+	const std::string field = "primary_instance:";
+	int instance = -1;
+
+	const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+
+	while (std::chrono::steady_clock::now() < deadline) {
+		{
+			std::lock_guard<std::mutex> lock(*output_mutex);
+			const size_t begin = output->find(field);
+
+			if ((begin != std::string::npos) && (output->find('\n', begin) != std::string::npos)) {
+				instance = std::atoi(output->c_str() + begin + field.size());
+				break;
+			}
+		}
+
+		std::this_thread::sleep_for(std::chrono::milliseconds(20));
+	}
+
+	_shell->unsubscribe_receive(handle);
+
+	if (instance < 0) {
+		std::lock_guard<std::mutex> lock(*output_mutex);
+		std::cout << time_str() << "no primary_instance in the shell reply, send result " << send_result
+			  << ", reply: " << *output << std::endl;
+	}
+
+	return instance;
+}
+
+void AutopilotTester::execute_alternating_imu_faults()
+{
+	// SCALED_IMU and SCALED_IMU2 carry vehicle_imu instance 0 and 1. Clipping one
+	// accelerometer shows up there as a large swing on that stream and on no other, so
+	// watching both is what tells this test the fault landed on the IMU it asked for.
+	// SIH_FAULT_IMU is 1 based, so 1 is the stream behind SCALED_IMU and 2 is SCALED_IMU2.
+	auto peak_imu1_mg = std::make_shared<std::atomic<int>>(0);
+	auto peak_imu2_mg = std::make_shared<std::atomic<int>>(0);
+
+	request_message_interval(MAVLINK_MSG_ID_SCALED_IMU, 50.f);
+	request_message_interval(MAVLINK_MSG_ID_SCALED_IMU2, 50.f);
+
+	auto samples_imu1 = std::make_shared<std::atomic<int>>(0);
+	auto samples_imu2 = std::make_shared<std::atomic<int>>(0);
+
+	auto track_peak = [](std::shared_ptr<std::atomic<int>> peak, std::shared_ptr<std::atomic<int>> samples,
+	int16_t zacc) {
+		const int magnitude = std::abs((int)zacc);
+
+		// A load followed by a store would let a callback that read the old peak write it back
+		// after the phase reset, carrying a faulted value into a clean window.
+		int previous = peak->load();
+
+		while ((magnitude > previous) && !peak->compare_exchange_weak(previous, magnitude)) {
+		}
+
+		samples->fetch_add(1);
+	};
+
+	add_mavlink_message_callback(MAVLINK_MSG_ID_SCALED_IMU, [peak_imu1_mg, samples_imu1, track_peak](
+	const mavlink_message_t &message) {
+		mavlink_scaled_imu_t imu;
+		mavlink_msg_scaled_imu_decode(&message, &imu);
+		track_peak(peak_imu1_mg, samples_imu1, imu.zacc);
+	});
+
+	add_mavlink_message_callback(MAVLINK_MSG_ID_SCALED_IMU2, [peak_imu2_mg, samples_imu2, track_peak](
+	const mavlink_message_t &message) {
+		mavlink_scaled_imu2_t imu;
+		mavlink_msg_scaled_imu2_decode(&message, &imu);
+		track_peak(peak_imu2_mg, samples_imu2, imu.zacc);
+	});
+
+	// The recovery is judged against the simulator rather than the estimator, which is the
+	// thing these faults are disturbing.
+	auto truth_altitude_m = std::make_shared<std::atomic<float>>(NAN);
+	auto truth_altitude_start_m = std::make_shared<std::atomic<float>>(NAN);
+	auto truth_lowest_m = std::make_shared<std::atomic<float>>(0.f);
+	auto truth_highest_m = std::make_shared<std::atomic<float>>(0.f);
+	auto truth_samples = std::make_shared<std::atomic<int>>(0);
+	auto truth_handle = _telemetry->subscribe_ground_truth([truth_altitude_m, truth_altitude_start_m,
+			  truth_lowest_m, truth_highest_m, truth_samples](Telemetry::GroundTruth ground_truth) {
+		const float altitude_m = ground_truth.absolute_altitude_m;
+
+		if (!std::isfinite(altitude_m)) {
+			return;
+		}
+
+		truth_altitude_m->store(altitude_m);
+
+		const float start_m = truth_altitude_start_m->load();
+
+		if (std::isfinite(start_m)) {
+			// Tracked signed so the two directions can be bounded separately
+			const float offset_m = altitude_m - start_m;
+
+			float lowest = truth_lowest_m->load();
+
+			while ((offset_m < lowest) && !truth_lowest_m->compare_exchange_weak(lowest, offset_m)) {
+			}
+
+			float highest = truth_highest_m->load();
+
+			while ((offset_m > highest) && !truth_highest_m->compare_exchange_weak(highest, offset_m)) {
+			}
+
+			truth_samples->fetch_add(1);
+		}
+	});
+
+	REQUIRE(poll_condition_with_timeout(
+	[peak_imu1_mg, peak_imu2_mg, truth_altitude_m]() {
+		return (peak_imu1_mg->load() > 0) && (peak_imu2_mg->load() > 0)
+		       && std::isfinite(truth_altitude_m->load());
+	}, std::chrono::seconds(20)));
+
+	// From here on every ground truth sample feeds the running maximum, so a dip and a
+	// recovery inside one phase cannot hide between two samples.
+	truth_altitude_start_m->store(truth_altitude_m->load());
+
+	// Where the selector starts. SIH brings both instances up together and the selector
+	// takes the first one, so the handovers below are changes rather than coincidences.
+	const int initial_instance = primary_estimator_instance();
+	std::cout << time_str() << "primary estimator instance before the faults " << initial_instance << std::endl;
+	CHECK(initial_instance == 0);
+
+	// Each measurement window has to have been observed at a sane rate, otherwise a stalled
+	// ground truth stream leaves the extrema at zero and every altitude check passes.
+	const int min_truth_samples = kFaultMeasureTime.count() * kMinGroundTruthRateHz;
+
+	ImuFaultGuard fault_guard(_param.get());
+
+	// Clip the accelerometer behind the first instance. If the parameters are missing there is
+	// nothing left to test, so stop rather than fly the rest of the sequence. Each phase gives
+	// the write time to reach SIH and lets the samples already in flight drain, then zeroes
+	// the peaks and measures, otherwise the previous phase's clipping lands in this one.
+	REQUIRE(_param->set_param_float("SIH_FAULT_VIBE", kImuClippingFaultAmplitude) == Param::Result::Success);
+	REQUIRE(_param->set_param_int("SIH_FAULT_IMU", 1) == Param::Result::Success);
+	sleep_for(kFaultSettleTime);
+	peak_imu1_mg->store(0);
+	peak_imu2_mg->store(0);
+	samples_imu1->store(0);
+	samples_imu2->store(0);
+	truth_samples->store(0);
+	sleep_for(kFaultMeasureTime);
+
+	// A stream that stopped arriving would leave its peak at zero and satisfy every clean
+	// check, so each phase proves it measured something first.
+	REQUIRE(samples_imu1->load() > 0);
+	REQUIRE(samples_imu2->load() > 0);
+	REQUIRE(truth_samples->load() >= min_truth_samples);
+
+	// The first IMU is being clipped and the second one is not.
+	CHECK(peak_imu1_mg->load() > kClippedImuPeakMg);
+	CHECK(peak_imu2_mg->load() < kCleanImuPeakMg);
+
+	// The selector has to have left the instance behind the clipped IMU.
+	const int instance_with_first_imu_clipped = primary_estimator_instance();
+	std::cout << time_str() << "primary estimator instance with the first IMU clipped "
+		  << instance_with_first_imu_clipped << ", ground truth samples " << truth_samples->load() << std::endl;
+	CHECK(instance_with_first_imu_clipped == 1);
+
+	// Move the clipping to the other IMU. The fault has to follow the parameter, which is
+	// what says the injection is per instance rather than shared.
+	REQUIRE(_param->set_param_int("SIH_FAULT_IMU", 2) == Param::Result::Success);
+	sleep_for(kFaultSettleTime);
+	peak_imu1_mg->store(0);
+	peak_imu2_mg->store(0);
+	samples_imu1->store(0);
+	samples_imu2->store(0);
+	truth_samples->store(0);
+	sleep_for(kFaultMeasureTime);
+
+	REQUIRE(samples_imu1->load() > 0);
+	REQUIRE(samples_imu2->load() > 0);
+	REQUIRE(truth_samples->load() >= min_truth_samples);
+
+	CHECK(peak_imu2_mg->load() > kClippedImuPeakMg);
+	CHECK(peak_imu1_mg->load() < kCleanImuPeakMg);
+
+	// And back again, now that the clipping has moved to the other one.
+	const int instance_with_second_imu_clipped = primary_estimator_instance();
+	std::cout << time_str() << "primary estimator instance with the second IMU clipped "
+		  << instance_with_second_imu_clipped << ", ground truth samples " << truth_samples->load() << std::endl;
+	CHECK(instance_with_second_imu_clipped == 0);
+
+	// Clear it and both have to settle back down.
+	REQUIRE(_param->set_param_int("SIH_FAULT_IMU", 0) == Param::Result::Success);
+	REQUIRE(_param->set_param_float("SIH_FAULT_VIBE", 0.f) == Param::Result::Success);
+	sleep_for(kFaultSettleTime);
+	peak_imu1_mg->store(0);
+	peak_imu2_mg->store(0);
+	samples_imu1->store(0);
+	samples_imu2->store(0);
+	truth_samples->store(0);
+	sleep_for(kFaultMeasureTime);
+
+	REQUIRE(samples_imu1->load() > 0);
+	REQUIRE(samples_imu2->load() > 0);
+	REQUIRE(truth_samples->load() >= min_truth_samples);
+
+	CHECK(peak_imu1_mg->load() < kCleanImuPeakMg);
+	CHECK(peak_imu2_mg->load() < kCleanImuPeakMg);
+
+	// Either instance is a legitimate choice once both are clean, so this is recorded rather
+	// than asserted.
+	std::cout << time_str() << "primary estimator instance after the faults cleared "
+		  << primary_estimator_instance() << ", ground truth samples " << truth_samples->load() << std::endl;
+
+	// Judged against the simulator, not the estimator the faults are disturbing. Clipping an
+	// accelerometer does push a hovering vehicle around, so what this asserts is that it comes
+	// back once the fault clears, not that it was never moved. The excursion while the fault
+	// is active is reported for the record rather than bounded.
+	_telemetry->unsubscribe_ground_truth(truth_handle);
+
+	const float recovered_deviation_m = fabsf(truth_altitude_m->load() - truth_altitude_start_m->load());
+	std::cout << time_str() << "ground truth altitude relative to the hover, lowest "
+		  << truth_lowest_m->load() << " m, highest " << truth_highest_m->load()
+		  << " m, after recovery " << recovered_deviation_m << " m" << std::endl;
+
+	// Losing height is the outcome that ends on the ground, so that is the one with a hard
+	// floor. The caller hovers at 20 m, so this keeps it well clear of the ground rather than
+	// only requiring that it came back afterwards.
+	CHECK(truth_lowest_m->load() > -kSelectorAltitudeFloorM);
+	CHECK(truth_highest_m->load() < kSelectorAltitudeCeilingM);
+	CHECK(recovered_deviation_m < kSelectorRecoveryToleranceM);
+}
+
+void AutopilotTester::check_tracks_mission_ground_truth(float corridor_radius_m)
+{
+	auto mission = _mission->download_mission();
+	REQUIRE(mission.first == Mission::Result::Success);
+
+	std::vector<Mission::MissionItem> mission_items = mission.second.mission_items;
+	REQUIRE(mission_items.size() >= 2);
+	auto ct = get_coordinate_transformation();
+
+	// Horizontal only. The vertical behaviour is asserted separately, and mixing an AMSL
+	// ground truth altitude with a mission relative altitude would compare two datums.
+	_truth_corridor_radius_m = corridor_radius_m;
+	_truth_corridor_worst_m.store(0.f);
+	_truth_corridor_leg_count = mission_items.size();
+	_truth_corridor_leg_samples = std::make_unique<std::atomic<int>[]>(_truth_corridor_leg_count);
+
+	_truth_corridor_handle = _telemetry->subscribe_ground_truth([ct, mission_items,
+	    this](Telemetry::GroundTruth ground_truth) {
+		// The item being flown to is read here rather than delivered with the sample, so a
+		// sample queued just before a waypoint switch can arrive with the next item current.
+		// Measuring against the leg being flown and the one before it, as finite segments,
+		// keeps such a sample on the leg it belongs to rather than on the extension of the
+		// next one.
+		auto progress = _mission->mission_progress();
+
+		if ((progress.current <= 0) || (progress.current >= (int)mission_items.size())) {
+			return;
+		}
+
+		if (!std::isfinite(ground_truth.latitude_deg) || !std::isfinite(ground_truth.longitude_deg)) {
+			return;
+		}
+
+		using GlobalCoordinate = CoordinateTransformation::GlobalCoordinate;
+		const auto local = ct.local_from_global(GlobalCoordinate{ground_truth.latitude_deg, ground_truth.longitude_deg});
+
+		const std::array<float, 3> current { (float)local.north_m, (float)local.east_m, 0.f };
+
+		auto leg_distance = [&](int item) {
+			std::array<float, 3> start = get_local_mission_item<float>(mission_items[item - 1], ct);
+			std::array<float, 3> end = get_local_mission_item<float>(mission_items[item], ct);
+			start[2] = 0.f;
+			end[2] = 0.f;
+			return point_to_segment_distance(current, start, end);
+		};
+
+		float distance_m = leg_distance(progress.current);
+
+		if (progress.current >= 2) {
+			distance_m = std::min(distance_m, leg_distance(progress.current - 1));
+		}
+
+		float worst = _truth_corridor_worst_m.load();
+
+		while ((distance_m > worst) && !_truth_corridor_worst_m.compare_exchange_weak(worst, distance_m)) {
+		}
+
+		_truth_corridor_leg_samples[progress.current].fetch_add(1);
+	});
+}
+
+void AutopilotTester::stop_tracking_mission_ground_truth()
+{
+	_telemetry->unsubscribe_ground_truth(_truth_corridor_handle);
+
+	std::cout << time_str() << "worst ground truth distance from the mission legs "
+		  << _truth_corridor_worst_m.load() << " m, samples per leg";
+
+	for (size_t item = 1; item < _truth_corridor_leg_count; item++) {
+		std::cout << " " << _truth_corridor_leg_samples[item].load();
+	}
+
+	std::cout << std::endl;
+
+	// A maximum of zero because a leg was never measured would read as a pass, so every leg
+	// has to have been seen.
+	for (size_t item = 1; item < _truth_corridor_leg_count; item++) {
+		REQUIRE(_truth_corridor_leg_samples[item].load() > 0);
+	}
+
+	CHECK(_truth_corridor_worst_m.load() < _truth_corridor_radius_m);
+}
+
+void AutopilotTester::execute_mission_and_degrade_primary_imu()
+{
+	// SCALED_IMU carries vehicle_imu instance 0, the one this test clips. Watching its peak
+	// vertical acceleration is what says the fault was really injected. Without it the test
+	// would pass on a build where the injection silently does nothing.
+	auto peak_imu1_mg = std::make_shared<std::atomic<int>>(0);
+	auto imu_samples = std::make_shared<std::atomic<int>>(0);
+	request_message_interval(MAVLINK_MSG_ID_SCALED_IMU, 50.f);
+	add_mavlink_message_callback(MAVLINK_MSG_ID_SCALED_IMU, [peak_imu1_mg,
+	imu_samples](const mavlink_message_t &message) {
+		mavlink_scaled_imu_t imu;
+		mavlink_msg_scaled_imu_decode(&message, &imu);
+		const int magnitude = std::abs((int)imu.zacc);
+		int previous = peak_imu1_mg->load();
+
+		while ((magnitude > previous) && !peak_imu1_mg->compare_exchange_weak(previous, magnitude)) {
+		}
+
+		imu_samples->fetch_add(1);
+	});
+
+	// Inject on a progress event rather than on a poll. Polling samples on a wall clock grid
+	// while the mission advances on the simulator clock, so under a speed factor the mission
+	// can pass the whole window between two samples. Waiting on the event instead means the
+	// injection starts from a point where the mission was still running.
+	// The callback owns its state through shared pointers rather than capturing this
+	// scope by reference, so if a REQUIRE below aborts the test the subscription that
+	// outlives it still has nothing dangling to touch.
+	auto injection_window = std::make_shared<std::promise<void>>();
+	auto window_signalled = std::make_shared<std::atomic<bool>>(false);
+	auto injection_window_reached = injection_window->get_future();
+
+	Mission::MissionProgressHandle progress_handle = _mission->subscribe_mission_progress(
+	[injection_window, window_signalled](Mission::MissionProgress progress) {
+		if ((progress.current >= 1) && (progress.current < progress.total) && !window_signalled->exchange(true)) {
+			injection_window->set_value();
+		}
+	});
+
+	REQUIRE(_mission->start_mission() == Mission::Result::Success);
+	REQUIRE(injection_window_reached.wait_for(std::chrono::seconds(120)) == std::future_status::ready);
+	_mission->unsubscribe_mission_progress(progress_handle);
+
+	// The vehicle is judged against the simulator, not against the estimator these faults
+	// are deliberately disturbing. An estimator based band cannot be used here, because a
+	// handover steps the estimate on purpose and the same band would have to both allow
+	// that step and catch a real excursion.
+	auto truth_reference_m = std::make_shared<std::atomic<float>>(NAN);
+	auto truth_max_deviation_m = std::make_shared<std::atomic<float>>(0.f);
+	auto truth_samples = std::make_shared<std::atomic<int>>(0);
+	auto truth_handle = _telemetry->subscribe_ground_truth([truth_reference_m, truth_max_deviation_m,
+			   truth_samples](Telemetry::GroundTruth ground_truth) {
+		const float reference = truth_reference_m->load();
+
+		if (!std::isfinite(ground_truth.absolute_altitude_m) || !std::isfinite(reference)) {
+			return;
+		}
+
+		const float deviation = fabsf(ground_truth.absolute_altitude_m - reference);
+		float worst = truth_max_deviation_m->load();
+
+		while ((deviation > worst) && !truth_max_deviation_m->compare_exchange_weak(worst, deviation)) {
+		}
+
+		truth_samples->fetch_add(1);
+	});
+
+	REQUIRE(poll_condition_with_timeout(
+	[peak_imu1_mg]() { return peak_imu1_mg->load() > 0; }, std::chrono::seconds(20)));
+
+	const float truth_altitude_at_injection_m = _telemetry->ground_truth().absolute_altitude_m;
+	REQUIRE(std::isfinite(truth_altitude_at_injection_m));
+	truth_reference_m->store(truth_altitude_at_injection_m);
+
+	// Where the selector starts, so the handover below is a change rather than a coincidence.
+	const int initial_instance = primary_estimator_instance();
+	std::cout << time_str() << "primary estimator instance before the fault " << initial_instance << std::endl;
+	CHECK(initial_instance == 0);
+
+	ImuFaultGuard fault_guard(_param.get());
+
+	// Sustained clipping degrades the estimator instance behind this IMU without silencing
+	// the sensor. A silenced sensor is a different failure mode and is already covered by
+	// failure injection.
+	REQUIRE(_param->set_param_float("SIH_FAULT_VIBE", kImuClippingFaultAmplitude) == Param::Result::Success);
+	REQUIRE(_param->set_param_int("SIH_FAULT_IMU", 1) == Param::Result::Success);
+
+	// Measure only what arrives after the fault is in.
+	peak_imu1_mg->store(0);
+	imu_samples->store(0);
+	truth_samples->store(0);
+	const double fault_start_s = autopilot_time_s();
+
+	auto mission_still_running = [this]() {
+		auto result = _mission->is_mission_finished();
+		return result.first == Mission::Result::Success && !result.second;
+	};
+
+	// The clipping has to be visible while the mission is still running. Without this the
+	// test would pass when the injection silently did nothing, and a progress event that
+	// arrived late could put the whole fault after the mission had already ended.
+	REQUIRE(poll_condition_with_timeout(
+	[peak_imu1_mg]() { return peak_imu1_mg->load() > kClippedImuPeakMg; }, std::chrono::seconds(20)));
+	REQUIRE(mission_still_running());
+
+	// The selector has to leave the instance behind the clipped IMU, and do so before the
+	// mission ends. That is the handover the rest of the mission then rides through.
+	REQUIRE(poll_condition_with_timeout(
+	[this]() { return primary_estimator_instance() == 1; }, kHandoverTimeout));
+	REQUIRE(mission_still_running());
+	std::cout << time_str() << "primary estimator instance moved to 1 with the mission still running" << std::endl;
+
+	// The mission has to run to the end through the handover.
+	REQUIRE(poll_condition_with_timeout(
+	[this]() {
+		auto result = _mission->is_mission_finished();
+		return result.first == Mission::Result::Success && result.second;
+	}, std::chrono::seconds(180)));
+
+	const double fault_window_s = autopilot_time_s() - fault_start_s;
+
+	// Clear the fault before the caller flies home. Landing on a clipping accelerometer is a
+	// different test, and leaving it on would quietly make the disarm timeout load bearing.
+	REQUIRE(_param->set_param_int("SIH_FAULT_IMU", 0) == Param::Result::Success);
+	REQUIRE(_param->set_param_float("SIH_FAULT_VIBE", 0.f) == Param::Result::Success);
+
+	// The vehicle itself has to hold its altitude through the fault, measured against the
+	// simulator rather than against the estimate. A maximum of zero because the stream
+	// stalled would otherwise read as a pass, so the window has to have been sampled at a
+	// sane rate first.
+	_telemetry->unsubscribe_ground_truth(truth_handle);
+	std::cout << time_str() << "ground truth samples through the fault " << truth_samples->load()
+		  << " over " << fault_window_s << " s, worst altitude deviation " << truth_max_deviation_m->load()
+		  << " m" << std::endl;
+	REQUIRE(truth_samples->load() >= fault_window_s * kMinGroundTruthRateHz);
+	CHECK(truth_max_deviation_m->load() < kFailoverGroundTruthBandM);
 }
 
 void AutopilotTester::execute_mission_and_get_baro_stuck()
@@ -869,6 +1407,20 @@ void AutopilotTester::execute_rtl_when_reaching_mission_sequence(int sequence_nu
 void AutopilotTester::send_custom_mavlink_command(const MavlinkPassthrough::CommandInt &command)
 {
 	_mavlink_passthrough->send_command_int(command);
+}
+
+void AutopilotTester::request_message_interval(uint16_t message_id, float rate_hz)
+{
+	// The onboard mode this test connects to does not stream the IMU messages by default,
+	// so ask for them. PX4 resolves the message id to a stream and enables it.
+	MavlinkPassthrough::CommandInt command{};
+	command.target_sysid = _mavlink_passthrough->get_target_sysid();
+	command.target_compid = _mavlink_passthrough->get_target_compid();
+	command.command = MAV_CMD_SET_MESSAGE_INTERVAL;
+	command.frame = MAV_FRAME_GLOBAL;
+	command.param1 = (float)message_id;
+	command.param2 = 1e6f / rate_hz;
+	REQUIRE((_mavlink_passthrough->send_command_int(command) == MavlinkPassthrough::Result::Success));
 }
 
 void AutopilotTester::add_mavlink_message_callback(uint16_t message_id,

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -46,6 +46,7 @@
 #include <mavsdk/plugins/telemetry/telemetry.h>
 #include <mavsdk/plugins/param/param.h>
 #include <mavsdk/plugins/events/events.h>
+#include <mavsdk/plugins/shell/shell.h>
 #include "catch2/catch.hpp"
 #include <atomic>
 #include <chrono>
@@ -130,6 +131,8 @@ public:
 	void execute_mission_and_lose_mag();
 	void execute_mission_and_get_mag_stuck();
 	void execute_mission_and_lose_baro();
+	void execute_mission_and_degrade_primary_imu();
+	void execute_alternating_imu_faults();
 	void execute_mission_and_get_baro_stuck();
 	void load_qgc_mission_raw_and_move_here(const std::string &plan_file);
 	void execute_mission_raw();
@@ -159,6 +162,17 @@ public:
 	void check_current_altitude(float target_rel_altitude_m, float max_distance_m = 1.5f);
 	void execute_rtl_when_reaching_mission_sequence(int sequence_number);
 	void send_custom_mavlink_command(const MavlinkPassthrough::CommandInt &command);
+	// Measures where the vehicle actually is against the mission leg, using the simulator
+	// rather than the estimate, so an estimator jump cannot move the measurement.
+	void check_tracks_mission_ground_truth(float corridor_radius_m);
+	void stop_tracking_mission_ground_truth();
+	// The instance the estimator selector is flying on, read from estimator_selector_status
+	// through the MAVLink shell because no MAVLink message carries it. Returns -1 if the
+	// shell did not answer.
+	int primary_estimator_instance();
+
+	void request_message_interval(uint16_t message_id, float rate_hz);
+
 	void add_mavlink_message_callback(uint16_t message_id, std::function< void(const mavlink_message_t &)> callback);
 
 	mavlink_home_position_t get_home_position(std::chrono::seconds timeout = std::chrono::seconds(10));
@@ -175,6 +189,12 @@ public:
 	void set_param_int(const std::string &param, int32_t value)
 	{
 		CHECK(_param->set_param_int(param, value) == Param::Result::Success);
+	}
+
+	// Simulated time as the autopilot reports it, the clock sleep_for waits on.
+	double autopilot_time_s()
+	{
+		return _telemetry->attitude_quaternion().timestamp_us * 1e-6;
 	}
 
 	template<typename Rep, typename Period>
@@ -304,6 +324,14 @@ private:
 	std::unique_ptr<mavsdk::Failure> _failure{};
 	std::unique_ptr<mavsdk::Info> _info{};
 	std::unique_ptr<mavsdk::ManualControl> _manual_control{};
+	mavsdk::Telemetry::GroundTruthHandle _truth_corridor_handle{};
+	std::atomic<float> _truth_corridor_worst_m{0.f};
+	float _truth_corridor_radius_m{0.f};
+	// One counter per mission item, indexed by the item being flown to, so the check can
+	// prove every leg was measured rather than only that something was.
+	std::unique_ptr<std::atomic<int>[]> _truth_corridor_leg_samples{};
+	size_t _truth_corridor_leg_count{0};
+
 	std::unique_ptr<MavlinkPassthrough> _mavlink_passthrough;
 	std::unique_ptr<mavsdk::Mission> _mission{};
 	std::unique_ptr<mavsdk::MissionRaw> _mission_raw{};
@@ -311,6 +339,7 @@ private:
 	std::unique_ptr<mavsdk::Param> _param{};
 	std::unique_ptr<mavsdk::Telemetry> _telemetry{};
 	std::unique_ptr<mavsdk::Events> _events{};
+	std::unique_ptr<mavsdk::Shell> _shell{};
 
 	Telemetry::GroundTruth _home{NAN, NAN, NAN};
 

--- a/test/mavsdk_tests/configs/sih-sitl.json
+++ b/test/mavsdk_tests/configs/sih-sitl.json
@@ -36,6 +36,26 @@
             "model": "xvert",
             "test_filter": "[sih_xvert_transition]",
             "timeout_min": 5
+        },
+        {
+            "model": "quadx",
+            "test_filter": "[multicopter_ekf_failover]",
+            "timeout_min": 10,
+            "env": {
+                "PX4_PARAM_SIH_IMU_COUNT": 2,
+                "PX4_PARAM_EKF2_MULTI_IMU": 2,
+                "PX4_PARAM_SENS_IMU_MODE": 0
+            }
+        },
+        {
+            "model": "quadx",
+            "test_filter": "[ekf2_selector]",
+            "timeout_min": 10,
+            "env": {
+                "PX4_PARAM_SIH_IMU_COUNT": 2,
+                "PX4_PARAM_EKF2_MULTI_IMU": 2,
+                "PX4_PARAM_SENS_IMU_MODE": 0
+            }
         }
     ]
 }

--- a/test/mavsdk_tests/math_helpers.h
+++ b/test/mavsdk_tests/math_helpers.h
@@ -31,6 +31,7 @@
  *
  ****************************************************************************/
 
+#include <algorithm>
 #include <array>
 
 template<typename T>
@@ -107,4 +108,20 @@ T point_to_line_distance(const std::array<T, 3> &point, const std::array<T, 3> &
 	std::array<T, 3> closest_on_line { line_start[0] + t *norm_dir[0], line_start[1] + t *norm_dir[1], line_start[2] + t *norm_dir[2]};
 
 	return norm(diff(closest_on_line, point));
+}
+
+template<typename T>
+T point_to_segment_distance(const std::array<T, 3> &point, const std::array<T, 3> &segment_start,
+			    const std::array<T, 3> &segment_end)
+{
+	const std::array<T, 3> segment = diff(segment_end, segment_start);
+	const T length_squared = dot(segment, segment);
+
+	// The closest point on the segment, clamped to its ends. A zero length segment is a point.
+	T t = (length_squared > T(0)) ? dot(diff(point, segment_start), segment) / length_squared : T(0);
+	t = std::max(T(0), std::min(T(1), t));
+
+	const std::array<T, 3> closest_on_segment { segment_start[0] + t *segment[0], segment_start[1] + t *segment[1], segment_start[2] + t *segment[2]};
+
+	return norm(diff(closest_on_segment, point));
 }

--- a/test/mavsdk_tests/test_ekf2_selector.cpp
+++ b/test/mavsdk_tests/test_ekf2_selector.cpp
@@ -1,0 +1,85 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file test_ekf2_selector.cpp
+ *
+ * A hovering vehicle with two IMUs and two EKF instances, where accelerometer clipping
+ * moves from one IMU to the other and is then cleared.
+ *
+ * What this asserts: the clipping really lands on the IMU that SIH_FAULT_IMU names and on
+ * no other, read back from SCALED_IMU and SCALED_IMU2, the selector leaves the instance
+ * behind the clipped IMU each time, read back from estimator_selector_status through the
+ * MAVLink shell, and the vehicle neither drops out of the sky nor stays displaced: it
+ * may climb while the clipped instance is still primary, it must not descend more than
+ * the floor below the hover, and it must be back at the hover altitude once the selector
+ * has handed over, all measured against the simulator.
+ *
+ * The selector's own decision rules are covered directly in
+ * src/modules/ekf2/EKF2SelectorTest.cpp, which needs no simulator. This test covers the
+ * part that unit test cannot, which is that a real vehicle with a real estimator and a real
+ * controller stays in the air while the faults move.
+ *
+ * Requires SIH_IMU_COUNT 2 for the second IMU, EKF2_MULTI_IMU 2 for the second estimator
+ * instance, and per-IMU fault injection through SIH_FAULT_IMU and SIH_FAULT_VIBE. The test
+ * config sets all three.
+ */
+
+#include "autopilot_tester.h"
+
+TEST_CASE("EKF2 selector - vehicle survives alternating IMU faults", "[ekf2_selector]")
+{
+	const float takeoff_altitude = 20.f;
+
+	AutopilotTester tester;
+	tester.connect(connection_url);
+	tester.wait_until_ready();
+
+	tester.set_takeoff_altitude(takeoff_altitude);
+	tester.store_home();
+	tester.sleep_for(std::chrono::seconds(1));
+
+	tester.arm();
+	tester.takeoff();
+	tester.wait_until_hovering();
+	tester.wait_until_altitude(takeoff_altitude, std::chrono::seconds(30));
+	tester.sleep_for(std::chrono::seconds(5));
+
+	// Each phase clips one IMU and requires the noise to appear on that IMU and not the
+	// other, then the faults are cleared. The vehicle has to stay within a band of where it
+	// was hovering throughout.
+	tester.execute_alternating_imu_faults();
+
+	tester.land();
+	tester.wait_until_disarmed(std::chrono::seconds(90));
+}

--- a/test/mavsdk_tests/test_multicopter_ekf_failover.cpp
+++ b/test/mavsdk_tests/test_multicopter_ekf_failover.cpp
@@ -1,0 +1,75 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "autopilot_tester.h"
+
+// Clipping the accelerometer behind the primary estimator instance mid mission, with a
+// second IMU and a second EKF instance available to fall back on. The mission has to run
+// to the end and the vehicle has to hold its altitude, measured against the simulator.
+//
+// The estimate itself is not used as an oracle here. A handover steps it on purpose, so a
+// band on the estimate would have to allow that step and would no longer catch anything.
+// It asserts that the fault is really present on the clipped IMU, read back from SCALED_IMU,
+// that the selector leaves the instance behind it while the mission is still running, read
+// back from estimator_selector_status through the MAVLink shell, that the vehicle stayed on
+// the mission legs measured against the simulator, and that it held its altitude. The
+// selector's own decision rules are covered in src/modules/ekf2/EKF2SelectorTest.cpp, which
+// needs no simulator.
+// Measured worst deviation through the fault is about 0.7 m, so this bounds the real path with
+// margin while still catching a vehicle that wanders off the leg.
+static constexpr float kMissionCorridorM = 3.f;
+
+TEST_CASE("EKF instance failover during a mission", "[multicopter_ekf_failover]")
+{
+	AutopilotTester tester;
+	tester.connect(connection_url);
+	tester.wait_until_ready();
+	tester.store_home();
+
+	AutopilotTester::MissionOptions mission_options;
+	mission_options.leg_length_m = 30.;
+	mission_options.relative_altitude_m = 20.;
+	tester.prepare_square_mission(mission_options);
+
+	// Answers the second half of the review request on this PR: that a local estimate jump
+	// does not move the vehicle off the mission. Measured against the simulator, because the
+	// estimate is the thing the fault disturbs.
+	tester.check_tracks_mission_ground_truth(kMissionCorridorM);
+
+	tester.arm();
+	tester.execute_mission_and_degrade_primary_imu();
+	tester.stop_tracking_mission_ground_truth();
+	tester.execute_rtl();
+	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(180);
+	tester.wait_until_disarmed(until_disarmed_timeout);
+}


### PR DESCRIPTION
## Problem

SIH publishes one IMU, so `EKF2_MULTI_IMU` and the estimator instance selector cannot be exercised without Gazebo. Picks up the dual IMU part of #27072 by Ramon Roche after the stale bot closed it, as stated in #27013.

Separately, `adjustSetpointForEKFResets` latches the EKF reset counters when `Run()` calls it on the incoming setpoint. The later call on the stored fallback setpoint finds every counter already matched and applies nothing, so it has been dead since #25283. When an estimator reset coincides with a cycle where the control update rejects the setpoint, the fallback reaches the controller in the pre reset frame and the tracking error is off by the reset delta for the 200 ms fallback window.

## Solution

`SIH_IMU_COUNT`, default 1, selects how many IMUs SIH publishes. At 2, with `EKF2_MULTI_IMU` 2 and `SENS_IMU_MODE` 0, the estimator runs one instance per IMU. The second IMU is allocated only when requested, so the default path is unchanged and no existing SIH test is affected.

`SIH_FAULT_IMU` and `SIH_FAULT_VIBE` clip one accelerometer, railed at the measurement range.

Both instances come up. An accelerometer outage on the second IMU reaches only its own instance and the selector stays put, then clipping on the first IMU moves it:

```
sensor_accel 0    device_id: 1310988 (SIMULATION:1)
sensor_accel 1    device_id: 1310996 (SIMULATION:2)
estimator_selector_status    instances_available: 2
```

![dual IMU SIH](https://raw.githubusercontent.com/Saibernard/PX4-Autopilot/4c549f4be75cb59abdcdbb4d8132bc2ddd753b52/.github/sih_multiimu_demo.png)

`adjustSetpointForEKFResets` now takes the fallback setpoint as a second argument and shifts both before the counters latch. The dead call is removed.

One harness defect is fixed alongside. `~AutopilotTester` dereferenced a plugin that does not exist after a failed `connect()`, turning every connect timeout into a segfault.

## Test coverage

17 unit cases for `adjustSetpointForEKFResets`, which had none. They cover the per axis shift, the timestamp guard, the counter latching and the velocity filter reset.

Both SITL tests read the clipping back from the IMU telemetry, so an injection that fails to take effect fails the test. The alternating test watches `SCALED_IMU` and `SCALED_IMU2` and requires the clipping to follow `SIH_FAULT_IMU` from one to the other. Both read the selected instance back from `estimator_selector_status` through the MAVLink shell and assert the handover, since no MAVLink message carries it. The mission test requires the clipping and the handover to land while the mission is still running.

The alternating test as it runs, the estimator's own log lines interleaved with what the test reads back:

```
primary estimator instance before the faults 0
[ekf2] primary EKF changed 0 (accel fault) -> 1
primary estimator instance with the first IMU clipped 1
[ekf2] primary EKF changed 1 (filter fault) -> 0
primary estimator instance with the second IMU clipped 0
```

Fault moved between IMUs, `primary_instance` 0 to 1 to 0. The vehicle climbs for the seconds the clipped instance is still primary, up to about 25 m above the hover across our runs, never descends below the floor the test sets, and is back at the hover altitude once the selector has handed over:

![alternating IMU faults](https://raw.githubusercontent.com/Saibernard/PX4-Autopilot/4c549f4be75cb59abdcdbb4d8132bc2ddd753b52/.github/alternating_imu_faults.png)

Same fault mid mission. One handover, `primary_instance` 0 to 1, and the estimate against ground truth through it:

![mission failover](https://raw.githubusercontent.com/Saibernard/PX4-Autopilot/4c549f4be75cb59abdcdbb4d8132bc2ddd753b52/.github/mission_failover_current.png)

The vehicle stays within 0.7 m of the mission leg, measured against the simulator so an estimator jump cannot move the measurement. The test asserts 3 m:

![mission corridor](https://raw.githubusercontent.com/Saibernard/PX4-Autopilot/4c549f4be75cb59abdcdbb4d8132bc2ddd753b52/.github/mission_corridor.png)

The test passes four out of four runs, returning to within 0.1 m of the altitude it was holding. Re running it with `EKF2_MULTI_IMU` 1, so the only estimator is the one on the clipped IMU, the vehicle ends 91.7 m and 50.9 m off that altitude in two of the four and never comes back.

Both the quadx and vtol SIH suites pass, apart from an intermittent MAVSDK connect timeout that also hits tests this branch does not touch. `px4_fmu-v5x_default` builds.

The opt in count, the on demand allocation, the railed clipping and the per instance gating are new on top of #27072.
