### PR TITLE
fix(drivers/power_monitor): Raise INA228, INA238 maximum expected current to 1638.4A

### DIFF
--- a/src/drivers/power_monitor/ina228/ina228.cpp
+++ b/src/drivers/power_monitor/ina228/ina228.cpp
@@ -51,21 +51,8 @@ INA228::INA228(const I2CSPIDriverConfig &config, int battery_index) :
 	_measure_errors(perf_alloc(PC_COUNT, "ina228_measurement_err")),
 	_battery(battery_index, this, INA228_SAMPLE_INTERVAL_US, battery_status_s::SOURCE_POWER_MODULE)
 {
-	float fvalue = MAX_CURRENT;
-	_max_current = fvalue;
-	param_t ph = param_find("INA228_CURRENT");
-
-	if (ph != PARAM_INVALID && param_get(ph, &fvalue) == PX4_OK) {
-		_max_current = fvalue;
-	}
-
-	fvalue = INA228_SHUNT;
-	_rshunt = fvalue;
-	ph = param_find("INA228_SHUNT");
-
-	if (ph != PARAM_INVALID && param_get(ph, &fvalue) == PX4_OK) {
-		_rshunt = fvalue;
-	}
+	const float max_current = _param_ina228_current.get();
+	const float rshunt = _param_ina228_shunt.get();
 
 	// According to page 8.2.2.1, page 36/48 of the INA228 interface datasheet (Rev. A),
 	// the requirement is: R_SHUNT < V_SENSE_MAX / I_MAX
@@ -73,7 +60,7 @@ INA228::INA228(const I2CSPIDriverConfig &config, int battery_index) :
 	// and so if V_SENSE_MAX is bigger, we need to use the bigger ADC range to avoid
 	// the device from capping the measured current.
 
-	const float v_sense_max = _rshunt * _max_current;
+	const float v_sense_max = rshunt * max_current;
 
 	if (v_sense_max > INA228_ADCRANGE_LOW_V_SENSE) {
 		_range = INA228_ADCRANGE_HIGH;
@@ -82,7 +69,7 @@ INA228::INA228(const I2CSPIDriverConfig &config, int battery_index) :
 		_range = INA228_ADCRANGE_LOW;
 	}
 
-	ph = param_find("INA228_CONFIG");
+	param_t ph = param_find("INA228_CONFIG");
 	int32_t value = INA228_ADCCONFIG;
 	_config = (uint16_t)value;
 
@@ -94,7 +81,7 @@ INA228::INA228(const I2CSPIDriverConfig &config, int battery_index) :
 			  ((INA228_MODE_TEMP_SHUNT_BUS_TRIG & INA228_MODE_MASK) >>
 			   INA228_MODE_SHIFTS);
 
-	_current_lsb = _max_current / DN_MAX;
+	_current_lsb = max_current / DN_MAX;
 	_power_lsb = 3.2f * _current_lsb;
 
 	// We need to publish immediately, to guarantee that the first instance of the driver publishes to uORB instance 0
@@ -222,7 +209,7 @@ INA228::init()
 
 	write(INA228_REG_CONFIG, (uint16_t)(INA228_RST_RESET | _range));
 
-	_cal = INA228_CONST * _current_lsb * _rshunt;
+	_cal = INA228_CONST * _current_lsb * _param_ina228_shunt.get();
 
 	if (_range == INA228_ADCRANGE_LOW) {
 		_cal *= 4;

--- a/src/drivers/power_monitor/ina228/ina228.h
+++ b/src/drivers/power_monitor/ina228/ina228.h
@@ -48,6 +48,7 @@
 #include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/parameter_update.h>
 #include <px4_platform_common/i2c_spi_buses.h>
+#include <px4_platform_common/module_params.h>
 
 using namespace time_literals;
 
@@ -286,10 +287,8 @@ using namespace time_literals;
 #define INA228_SAMPLE_FREQUENCY_HZ           10
 #define INA228_SAMPLE_INTERVAL_US            (1_s / INA228_SAMPLE_FREQUENCY_HZ)
 #define INA228_CONVERSION_INTERVAL           (INA228_SAMPLE_INTERVAL_US - 7)
-#define MAX_CURRENT                          327.68f    /* Amps */
 #define DN_MAX                               524288.0f  /* 2^19 */
 #define INA228_CONST                         13107.2e6f  /* is an internal fixed value used to ensure scaling is maintained properly  */
-#define INA228_SHUNT                         0.0005f   /* Shunt is 500 uOhm */
 #define INA228_VSCALE                        1.95e-04f  /* LSB of voltage is 195.3125 uV/LSB */
 #define INA228_TSCALE                        7.8125e-03f /* LSB of temperature is 7.8125 mDegC/LSB */
 
@@ -348,10 +347,8 @@ private:
 	int16_t           _range{INA228_ADCRANGE_HIGH};
 	bool              _mode_triggered{false};
 
-	float             _max_current{MAX_CURRENT};
-	float             _rshunt{INA228_SHUNT};
 	uint16_t          _config{INA228_ADCCONFIG};
-	float             _current_lsb{_max_current / DN_MAX};
+	float             _current_lsb{0.f};
 	float             _power_lsb{25.0f * _current_lsb};
 
 	Battery 		  _battery;
@@ -382,5 +379,10 @@ private:
 
 	int					     measure();
 	int					     collect();
+
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::INA228_CURRENT>) _param_ina228_current,
+		(ParamFloat<px4::params::INA228_SHUNT>) _param_ina228_shunt
+	);
 
 };

--- a/src/drivers/power_monitor/ina228/ina228_params.yaml
+++ b/src/drivers/power_monitor/ina228/ina228_params.yaml
@@ -25,7 +25,7 @@ parameters:
       type: float
       default: 327.68
       min: 0.1
-      max: 327.68
+      max: 1638.40
       decimal: 2
       increment: 0.1
       reboot_required: true

--- a/src/drivers/power_monitor/ina238/ina238_params.yaml
+++ b/src/drivers/power_monitor/ina238/ina238_params.yaml
@@ -15,7 +15,7 @@ parameters:
       type: float
       default: 327.68
       min: 0.1
-      max: 327.68
+      max: 1638.40
       decimal: 2
       increment: 0.1
       reboot_required: true


### PR DESCRIPTION
## Summary
Raise INA228_CURRENT, INA238_CURRENT firmware limit from 327.68 to a reasonable 1638.4

## Problem
The drivers assume a lower limit of INA2x8_SHUNT to 0.5 mΩ, which caps INA2x8_CURRENT to 327.68, and is not suitable for higher current DPMs

## Solution
Setting a 0.1 mΩ floor on INA2x8_SHUNT is reasonable– shunt resistors at that value are common and can dissipate enough power to handle 500 A continuous in a practically-sized package (such as 5930, for instance). That in turn justifies raising the INA2x8_CURRENT ceiling to 1638.4 A (I = V/R at the ADC's 163.84 mV full scale)

## Tested with Hardware

`make px4_fmu-v6xrt_default` with clean build

### Hardware setup
- Agam Autopilot v6X-RT 
- Agam DPM04 500A
    - internal INA228 power monitor
    - 0.1 mΩ, 30W rated, 5930 package current sense resistor 
- 6S Battery
- Electronic Load-meter set for 0.5A consumption

Also refactored the INA228 driver to match the cleaner INA238 driver