### PR TITLE
fix(param): Add null check for the filename variable

### DIFF
--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -741,7 +741,7 @@ param_reset_specific(const char *resets[], int num_resets)
 int
 param_set_default_file(const char *filename)
 {
-	if ((param_backup_file && strcmp(filename, param_backup_file) == 0)) {
+	if (filename && param_backup_file && strcmp(filename, param_backup_file) == 0) {
 		PX4_ERR("default file can't be the same as the backup file %s", filename);
 		return PX4_ERROR;
 	}
@@ -773,7 +773,7 @@ const char *param_get_default_file()
 
 int param_set_backup_file(const char *filename)
 {
-	if (param_default_file && strcmp(filename, param_default_file) == 0) {
+	if (filename && param_default_file && strcmp(filename, param_default_file) == 0) {
 		PX4_ERR("backup file can't be the same as the default file %s", filename);
 		return PX4_ERROR;
 	}


### PR DESCRIPTION
### Problem

`param select` and `param select-backup` can crash PX4 by passing a null pointer into `strcmp()`. The command layer intentionally passes `nullptr` when no file argument is provided, but the parameter library treats that same pointer as a valid C string if the opposite parameter file pointer is already set.

This is a CWE-476 null pointer dereference. A user with access to PX4 shell command execution, including MavlinkShell/PXH/NSH, can trigger a PX4 process denial of service by running `param select` or `param select-backup` without a path after the default or backup file has been configured. This bug has been verified on my physical hardware (CUAV FMU-v6x v2), leading to a system crash.

### Details

The vulnerable command handling is in `src/systemcmds/param/param.cpp:223`.

For `param select`, if no `<file>` argument is supplied, `param_main()` explicitly passes `nullptr`:

```cpp
if (!strcmp(argv[1], "select")) {
    if (argc >= 3) {
        param_set_default_file(argv[2]);

    } else {
        param_set_default_file(nullptr);
    }
```

The same pattern exists for `param select-backup` at `src/systemcmds/param/param.cpp:240`:

```cpp
if (!strcmp(argv[1], "select-backup")) {
    if (argc >= 3) {
        param_set_backup_file(argv[2]);

    } else {
        param_set_backup_file(nullptr);
    }
```

This means `nullptr` is not an unexpected internal state. It is part of the current command behavior for “no file argument”.

However, the receiving functions in `src/lib/parameters/parameters.cpp:722` and `src/lib/parameters/parameters.cpp:754` perform an incomplete null check:

```cpp
if ((param_backup_file && strcmp(filename, param_backup_file) == 0)) {
```

and:

```cpp
if (param_default_file && strcmp(filename, param_default_file) == 0) {
```

These conditions only prove that the already-stored opposite file pointer is non-null. They do not prove that the new `filename` argument is non-null. Therefore:

```text
filename == nullptr
param_backup_file != nullptr
```

causes:

```cpp
strcmp(nullptr, param_backup_file)
```

Likewise:

```text
filename == nullptr
param_default_file != nullptr
```

causes:

```cpp
strcmp(nullptr, param_default_file)
```

The global file pointers are defined as process-wide static state in `src/lib/parameters/parameters.cpp:94
`
```cpp
static char *param_default_file = nullptr;
static char *param_backup_file = nullptr;
```

Normal startup scripts commonly initialize these values. For example, `ROMFS/px4fmu_common/init.d/rcS:148` runs:

```sh
param select $PARAM_FILE
```

and `ROMFS/px4fmu_common/init.d/rcS:183` may run:

```sh
param select-backup $PARAM_BACKUP_FILE
```
Therefore, both parameters are non-null after system startup, meeting the conditions to trigger the bug.
### AddressSanitizer information
```sh
AddressSanitizer:DEADLYSIGNAL
=================================================================
==595848==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7e96b9e92418 bp 0x7ffe5b94ac90 sp 0x7ffe5b94a410 T0)
==595848==The signal is caused by a READ memory access.
==595848==Hint: address points to the zero page.
    #0 0x7e96b9e92418 in __interceptor_strcmp ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:461
    #1 0x5a9c22835845 in param_set_default_file /home/uav/PX4-Autopilot/src/lib/parameters/parameters.cpp:724
    #2 0x5a9c227b75e8 in param_main /home/uav/PX4-Autopilot/src/systemcmds/param/param.cpp:228
    #3 0x5a9c22ac8289 in px4_daemon::Pxh::process_line(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) /home/uav/PX4-Autopilot/platforms/posix/src/px4/common/px4_daemon/pxh.cpp:113
    #4 0x5a9c22ac9e41 in px4_daemon::Pxh::run_pxh() /home/uav/PX4-Autopilot/platforms/posix/src/px4/common/px4_daemon/pxh.cpp:338
    #5 0x5a9c22166114 in main /home/uav/PX4-Autopilot/platforms/posix/src/px4/common/main.cpp:372
    #6 0x7e96b8e29d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #7 0x7e96b8e29e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #8 0x5a9c2215e104 in _start (/home/uav/PX4-Autopilot/build/px4_sitl_default/bin/px4+0x149104)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:461 in __interceptor_strcmp
==595848==ABORTING
```


### PoC

Build a POSIX/SITL target with debug symbols:

```sh
HEADLESS=1 PX4_ASAN=1 make px4_sitl gz_x500
```
At the PXH prompt, run cmd `param select` or `param select-backup`:

```sh
pxh> param select
```
or
```sh
pxh> param select-backup
```
### Impact

This is a denial-of-service bug in the PX4 process. Any actor able to execute PX4 shell commands can crash the process by issuing a valid `param` command without a file argument after the relevant parameter file state has been initialized.
