### PR TITLE
fix(rover): fix rover modules to work with SIH lockstep

### DIFF
--- a/src/modules/rover_ackermann/RoverAckermann.cpp
+++ b/src/modules/rover_ackermann/RoverAckermann.cpp
@@ -46,7 +46,11 @@ RoverAckermann::RoverAckermann() :
 
 bool RoverAckermann::init()
 {
-	ScheduleOnInterval(10_ms); // 100 Hz
+	if (!_vehicle_angular_velocity_sub.registerCallback()) {
+		PX4_ERR("callback registration failed");
+		return false;
+	}
+
 	return true;
 }
 
@@ -57,6 +61,16 @@ void RoverAckermann::updateParams()
 
 void RoverAckermann::Run()
 {
+	if (should_exit()) {
+		_vehicle_angular_velocity_sub.unregisterCallback();
+		exit_and_cleanup(desc);
+		return;
+	}
+
+	// Drain the trigger. The gyro paces the loop; its value is not used here.
+	vehicle_angular_velocity_s angular_velocity;
+	_vehicle_angular_velocity_sub.update(&angular_velocity);
+
 	if (_parameter_update_sub.updated()) {
 		parameter_update_s param_update{};
 		_parameter_update_sub.copy(&param_update);
@@ -94,6 +108,8 @@ void RoverAckermann::Run()
 		_was_armed = false;
 	}
 
+	// reschedule backup
+	ScheduleDelayed(100_ms);
 }
 
 void RoverAckermann::generateSetpoints()

--- a/src/modules/rover_ackermann/RoverAckermann.hpp
+++ b/src/modules/rover_ackermann/RoverAckermann.hpp
@@ -45,8 +45,10 @@
 
 // uORB includes
 #include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
 #include <uORB/Publication.hpp>
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_status.h>
 
@@ -117,6 +119,7 @@ private:
 	void reset();
 
 	// uORB subscriptions
+	uORB::SubscriptionCallbackWorkItem _vehicle_angular_velocity_sub{this, ORB_ID(vehicle_angular_velocity)};
 	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};

--- a/src/modules/rover_differential/RoverDifferential.cpp
+++ b/src/modules/rover_differential/RoverDifferential.cpp
@@ -46,7 +46,11 @@ RoverDifferential::RoverDifferential() :
 
 bool RoverDifferential::init()
 {
-	ScheduleOnInterval(10_ms); // 100 Hz
+	if (!_vehicle_angular_velocity_sub.registerCallback()) {
+		PX4_ERR("callback registration failed");
+		return false;
+	}
+
 	return true;
 }
 
@@ -57,6 +61,16 @@ void RoverDifferential::updateParams()
 
 void RoverDifferential::Run()
 {
+	if (should_exit()) {
+		_vehicle_angular_velocity_sub.unregisterCallback();
+		exit_and_cleanup(desc);
+		return;
+	}
+
+	// Drain the trigger. The gyro paces the loop; its value is not used here.
+	vehicle_angular_velocity_s angular_velocity;
+	_vehicle_angular_velocity_sub.update(&angular_velocity);
+
 	if (_parameter_update_sub.updated()) {
 		parameter_update_s param_update{};
 		_parameter_update_sub.copy(&param_update);
@@ -95,6 +109,8 @@ void RoverDifferential::Run()
 		_was_armed = false;
 	}
 
+	// reschedule backup
+	ScheduleDelayed(100_ms);
 }
 
 void RoverDifferential::generateSetpoints()

--- a/src/modules/rover_differential/RoverDifferential.hpp
+++ b/src/modules/rover_differential/RoverDifferential.hpp
@@ -45,7 +45,9 @@
 
 // uORB includes
 #include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_status.h>
 
@@ -116,6 +118,7 @@ private:
 	void reset();
 
 	// uORB subscriptions
+	uORB::SubscriptionCallbackWorkItem _vehicle_angular_velocity_sub{this, ORB_ID(vehicle_angular_velocity)};
 	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};

--- a/src/modules/rover_mecanum/RoverMecanum.cpp
+++ b/src/modules/rover_mecanum/RoverMecanum.cpp
@@ -46,7 +46,11 @@ RoverMecanum::RoverMecanum() :
 
 bool RoverMecanum::init()
 {
-	ScheduleOnInterval(10_ms); // 100 Hz
+	if (!_vehicle_angular_velocity_sub.registerCallback()) {
+		PX4_ERR("callback registration failed");
+		return false;
+	}
+
 	return true;
 }
 
@@ -57,6 +61,16 @@ void RoverMecanum::updateParams()
 
 void RoverMecanum::Run()
 {
+	if (should_exit()) {
+		_vehicle_angular_velocity_sub.unregisterCallback();
+		exit_and_cleanup(desc);
+		return;
+	}
+
+	// Drain the trigger. The gyro paces the loop; its value is not used here.
+	vehicle_angular_velocity_s angular_velocity;
+	_vehicle_angular_velocity_sub.update(&angular_velocity);
+
 	if (_parameter_update_sub.updated()) {
 		parameter_update_s param_update{};
 		_parameter_update_sub.copy(&param_update);
@@ -95,6 +109,8 @@ void RoverMecanum::Run()
 		_was_armed = false;
 	}
 
+	// reschedule backup
+	ScheduleDelayed(100_ms);
 }
 
 void RoverMecanum::generateSetpoints()

--- a/src/modules/rover_mecanum/RoverMecanum.hpp
+++ b/src/modules/rover_mecanum/RoverMecanum.hpp
@@ -45,7 +45,9 @@
 
 // uORB includes
 #include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_status.h>
 
@@ -116,6 +118,7 @@ private:
 	void reset();
 
 	// uORB subscriptions
+	uORB::SubscriptionCallbackWorkItem _vehicle_angular_velocity_sub{this, ORB_ID(vehicle_angular_velocity)};
 	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};


### PR DESCRIPTION
After recent modification to the SIH lockstep, the rover modules were not working anymore.
This commit fixes the issues and makes the rover modules work with the SIH lockstep again.

### Solved Problem

SIH lockstep now blocks each simulation step until `actuator_outputs_sim` is updated.
The rover modules ran on a fixed `ScheduleOnInterval(10_ms)`, so at a 400 Hz sim step
they only produced actuator outputs on every 4th iteration — SIH busy-waited until its
10 s timeout and the simulation stalled.

Fixes #{Github issue ID}

### Solution

Move the rover modules from a fixed-interval schedule to an event-driven one, matching
`mixer_module`: register a `SubscriptionCallbackWorkItem` on `vehicle_angular_velocity`
(the gyro paces the loop), add `ScheduleDelayed(100_ms)` as a backup schedule, and
handle `should_exit()` in `Run()`.

### Changelog Entry

```
Bugfix: rover modules no longer stall SIH lockstep simulation; control loops are driven
by vehicle_angular_velocity instead of a fixed 100 Hz schedule.
```

### Test coverage

SITL SIH rover (ackermann / differential / mecanum): arm and drive, no
`SIH lockstep: timed out waiting for actuator_outputs_sim` warning, speedup as expected.
