### PR TITLE
fix(mavlink): Support COMMAND_LONG message-interval requests on Gimbal-mode telemetry ports

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -477,6 +477,20 @@ void MavlinkReceiver::handle_messages_in_gimbal_mode(mavlink_message_t &msg)
 	case MAVLINK_MSG_ID_GIMBAL_DEVICE_ATTITUDE_STATUS:
 		handle_message_gimbal_device_attitude_status(&msg);
 		break;
+
+	case MAVLINK_MSG_ID_COMMAND_LONG:
+		{
+			mavlink_command_long_t cmd;
+			mavlink_msg_command_long_decode(&msg, &cmd);
+
+			if (cmd.command == MAV_CMD_SET_MESSAGE_INTERVAL ||
+			    cmd.command == MAV_CMD_GET_MESSAGE_INTERVAL ||
+			    cmd.command == MAV_CMD_REQUEST_MESSAGE) {
+
+			    handle_message_command_long(&msg);
+			}
+		}
+		break;
 	}
 
 	// Message forwarding


### PR DESCRIPTION
### Solved Problem
Fixes dynamic requesting support for gimbal like Gremsy Pixy LR SP and Camera control modules like ENTIRE R3 or TAG-E. 
Camera control modules like TAG-E receive MAVLink forwarded by a Gremsy gimbal connected to a telemetry port set to "Gimbal" mode. Without COMMAND_LONG → MAV_CMD_SET_MESSAGE_INTERVAL support, the camera control/geotagging module cannot enable the GPS/ATTITUDE/TIMESYNC/GPS_RAW and other data streams it needs — streams and rates that may depend on user parameter configuration.

Pixy LR SP has a camera control module (ENTIRE R3) built in — one device acting as two separate units over a single MAVLink link — but it cannot work in dedicated "Gimbal" mode without this support.

### Solution
Add support for COMMAND_LONG:
- MAV_CMD_SET_MESSAGE_INTERVAL
- MAV_CMD_GET_MESSAGE_INTERVAL 
- MAV_CMD_REQUEST_MESSAGE

### Changelog Entry
For release notes:
```
Added support for COMMAND_LONG - MAV_CMD_SET_MESSAGE_INTERVAL / MAV_CMD_GET_MESSAGE_INTERVAL / MAV_CMD_REQUEST_MESSAGE for "Gimbal" mode telemetry ports.
```

### Alternatives

### Test coverage
Cube Orange & Pixy LR & TAG-E
CUAV V5 nano & Pixy LR & ENTIRE R3

### Context
Correction of this very strict limitation modification:
https://github.com/PX4/PX4-Autopilot/pull/23510
