### PR TITLE
docs(doxygen): fix @param names that do not match the declaration

### DIFF
--- a/src/drivers/imu/nxp/fxos8701cq/FXOS8701CQ.hpp
+++ b/src/drivers/imu/nxp/fxos8701cq/FXOS8701CQ.hpp
@@ -215,7 +215,7 @@ private:
 	/**
 	 * Set the FXOS8701C mag measurement range.
 	 *
-	 * @param max_ga	The measurement range of the mag is in Ga
+	 * @param max_g	The measurement range of the mag is in Ga
 	 *			Zero selects the maximum supported range.
 	 * @return		OK if the value can be supported, -ERANGE otherwise.
 	 */

--- a/src/drivers/imu/st/lsm303d/LSM303D.hpp
+++ b/src/drivers/imu/st/lsm303d/LSM303D.hpp
@@ -227,7 +227,7 @@ private:
 	/**
 	 * Set the LSM303D mag measurement range.
 	 *
-	 * @param max_ga	The measurement range of the mag is in Ga
+	 * @param max_g	The measurement range of the mag is in Ga
 	 *			Zero selects the maximum supported range.
 	 * @return		OK if the value can be supported, -ERANGE otherwise.
 	 */

--- a/src/lib/rc/st24.h
+++ b/src/lib/rc/st24.h
@@ -150,7 +150,7 @@ typedef struct {
 /**
  * CRC8 implementation for ST24 protocol
  *
- * @param prt Pointer to the data to CRC
+ * @param ptr Pointer to the data to CRC
  * @param len number of bytes to accumulate in the checksum
  * @return the checksum of these bytes over len
  */

--- a/src/modules/flight_mode_manager/FlightModeManager.hpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.hpp
@@ -96,7 +96,7 @@ private:
 
 	/**
 	 * Switch to a specific task (for normal usage)
-	 * @param task index to switch to
+	 * @param new_task_index index to switch to
 	 * @return 0 on success, <0 on error
 	 */
 	FlightTaskError switchTask(FlightTaskIndex new_task_index);

--- a/src/modules/logger/log_writer.h
+++ b/src/modules/logger/log_writer.h
@@ -97,7 +97,7 @@ public:
 	/**
 	 * Select a backend, so that future calls to write_message() only write to the selected
 	 * sel_backend, until unselect_write_backend() is called.
-	 * @param backend
+	 * @param sel_backend
 	 */
 	void select_write_backend(Backend sel_backend);
 	void unselect_write_backend() { select_write_backend(BackendAll); }

--- a/src/modules/muorb/apps/uORBAppsProtobufChannel.hpp
+++ b/src/modules/muorb/apps/uORBAppsProtobufChannel.hpp
@@ -105,7 +105,7 @@ public:
 	 * @param messageName
 	 * 	This represents the uORB message name; This message name should be
 	 * 	globally unique.
-	 * @param msgRate
+	 * @param msgRateInHz
 	 * 	The max rate at which the subscriber can accept the messages. This value is unused.
 	 * @return
 	 * 	0 = success; This means the messages is successfully sent to the receiver

--- a/src/modules/muorb/slpi/uORBProtobufChannel.hpp
+++ b/src/modules/muorb/slpi/uORBProtobufChannel.hpp
@@ -80,7 +80,7 @@ public:
 	 * @param messageName
 	 * 	This represents the uORB message name; This message name should be
 	 * 	globally unique.
-	 * @param msgRate
+	 * @param msgRateInHz
 	 * 	The max rate at which the subscriber can accept the messages. This parameter is unused.
 	 * @return
 	 * 	0 = success; This means the messages is successfully sent to the receiver

--- a/src/modules/payload_deliverer/payload_deliverer.h
+++ b/src/modules/payload_deliverer/payload_deliverer.h
@@ -131,7 +131,7 @@ private:
 	/**
 	 * @brief Send DO_GRIPPER vehicle command with specified gripper action
 	 *
-	 * @param gripper_command GRIPPER_ACTION_GRAB or GRIPPER_ACTION_RELEASE
+	 * @param gripper_action GRIPPER_ACTION_GRAB or GRIPPER_ACTION_RELEASE
 	 */
 	bool send_gripper_vehicle_command(const int32_t gripper_action);
 

--- a/src/modules/replay/Replay.hpp
+++ b/src/modules/replay/Replay.hpp
@@ -186,7 +186,7 @@ protected:
 
 	/**
 	 * handle delay until topic can be published.
-	 * @param next_file_timestamp timestamp of next message to publish
+	 * @param next_file_time timestamp of next message to publish
 	 * @param timestamp_offset offset between file start time and replay start time
 	 * @return timestamp that the message to publish should have
 	 */

--- a/src/modules/sensors/Integrator.hpp
+++ b/src/modules/sensors/Integrator.hpp
@@ -78,7 +78,7 @@ public:
 	/**
 	 * Set reset interval during runtime. This won't reset the integrator.
 	 *
-	 * @param reset_interval	New reset time interval for the integrator in microseconds.
+	 * @param reset_interval_us	New reset time interval for the integrator in microseconds.
 	 */
 	void set_reset_interval(uint32_t reset_interval_us) { _reset_interval_min = reset_interval_us * 1e-6f; }
 


### PR DESCRIPTION
### Solved Problem

Ran doxygen over src and ten `@param` names came back with no matching argument in the declaration under them. Most are a rename the comment never followed, `st24.h` is a plain `prt` for `ptr`, and `log_writer.h` already spells `sel_backend` in the sentence right above the tag it gets wrong. Doxygen silently drops a name it cannot match, so none of this shows up in a build and the argument just ends up undocumented on the generated page.

### Solution

Renamed the tag to the argument in every case, nothing else. I skipped the blocks where the documented parameter is gone from the signature entirely, `CDev`, `setThrustLimit` in the spacecraft controller and a few others, since deleting or moving a line there is a judgement call for whoever owns the code. Vendored trees under `CMSIS_5`, `libvnc` and `libdronecan` were left alone too.

### Test coverage

Comment-only change, no code paths touched.
