### PR TITLE
fix(netman): add length check for interface name

### DIFF
--- a/src/systemcmds/netman/netman.cpp
+++ b/src/systemcmds/netman/netman.cpp
@@ -50,6 +50,7 @@
 #include <px4_platform_common/log.h>
 #include <arpa/inet.h>
 #include <px4_platform_common/shutdown.h>
+#include <net/if.h>
 
 constexpr char DEFAULT_NETMAN_CONFIG[] = CONFIG_BOARD_ROOT_PATH "/net.cfg";
 #if defined(CONFIG_NETINIT_DHCPC)
@@ -457,6 +458,10 @@ int netman_main(int argc, char *argv[])
 		switch (ch) {
 
 		case 'i':
+			if (strlen(myoptarg) >= IFNAMSIZ) {
+				PX4_ERR("Interface name too long");
+				return -ENAMETOOLONG;
+			}
 			netdev = myoptarg;
 			break;
 


### PR DESCRIPTION
### Problem

`netman save` and `netman show` contain a stack buffer over-read bug in` netman.cpp:253-255`. A long `-i <interface>` value makes `snprintf()` return the length that would have been written, and that value is then used as the byte count for `write()`. As a result, `write()` reads past the fixed stack buffer and leaks stack memory to stdout or to `net.cfg`.This bug has been reproduced on my physical hardware (CUAV FMU-v6x v2).


### Details

The vulnerable code is in `save()`:

```cpp
constexpr int lsz = 80;
char line[lsz + 1];
int len;

len = snprintf(line,  lsz, "%s%s\n", config.device.keyword(), netdev);

if (len != write(fd, line, len)) {
    goto errout;
}
```

`netdev` comes directly from the command-line `-i` argument without length validation:

```cpp
case 'i':
    netdev = myoptarg;
    break;
```

Both command paths reach the same vulnerable function:

```cpp
if (strcmp("save", argv[myoptind]) == 0) {
    rv = save(path, netdev);

} else if (strcmp("show", argv[myoptind]) == 0) {
    rv = save(nullptr, netdev);
}
```

The bug is that `snprintf()` does not return the number of bytes actually stored in `line` when truncation occurs. It returns the number of characters that would have been written, excluding the terminating NUL.

For the first line:

```text
DEVICE=<netdev>\n
```

The returned length is:

```text
strlen("DEVICE=") + strlen(netdev) + strlen("\n")
= strlen(netdev) + 8
```

But `snprintf(line, 80, ...)` can only initialize at most 80 bytes total, including the terminating NUL. The declared object is `char line[81]`.

Therefore:

- With a 73-byte interface name, `write()` already reads one uninitialized byte from `line[80]`.
- With a 74-byte or longer interface name, `write()` reads past the end of the `line[81]` stack object.

The `save()` path writes the leaked bytes to the board root config file, usually `CONFIG_BOARD_ROOT_PATH "/net.cfg"`. The `show()` path passes `nullptr` as the path and writes the same leaked bytes to stdout.

This is reachable when `SYSTEMCMDS_NETMAN` is enabled. The `netman/Kconfig` depends on `PLATFORM_NUTTX`, and multiple board defaults enable `CONFIG_SYSTEMCMDS_NETMAN=y`.

### PoC

Build and run a PX4/NuttX target with `CONFIG_SYSTEMCMDS_NETMAN=y`. 

From the PX4 shell, run either `show` or `save` with a long interface name. The option parser reorders options, so either option position is accepted.

PoC for stdout leakage:

```sh
netman show -i AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
```
Expected Output
<img width="921" height="237" alt="image" src="https://github.com/user-attachments/assets/4eead906-36b5-4d84-b3bc-942cdd3c6923" />

PoC for persistent file leakage:

```sh
netman save -i AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
```

Then inspect the generated config file, typically:

```sh
cat /fs/microsd/net.cfg
```
Expected Output
<img width="875" height="137" alt="image" src="https://github.com/user-attachments/assets/044e7044-e711-46d9-af23-410a451e6c52" />

Any interface name length of 74 bytes or more is enough to force a read past the declared `line[81]` buffer.

### Impact

An attacker who can execute `netman` commands or influence its command-line arguments on an affected PX4/NuttX target can disclose stack memory.

Impacts include:

- Stack memory disclosure to the console via `netman show`.
- Stack memory disclosure into the persistent network config file via `netman save`.
- Possible process crash or system instability if the over-read crosses an invalid memory boundary.
