### PR TITLE
feat(mavlink): Add handling for MESSAGE_INTERVAL & TIMESYNC in Gimbal mavlink telemetry ports

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -477,8 +477,23 @@ void MavlinkReceiver::handle_messages_in_gimbal_mode(mavlink_message_t &msg)
 	case MAVLINK_MSG_ID_GIMBAL_DEVICE_ATTITUDE_STATUS:
 		handle_message_gimbal_device_attitude_status(&msg);
 		break;
+		
+	case MAVLINK_MSG_ID_COMMAND_LONG: {
+			mavlink_command_long_t cmd;
+			mavlink_msg_command_long_decode(&msg, &cmd);
+
+			if (cmd.command == MAV_CMD_SET_MESSAGE_INTERVAL ||
+			    cmd.command == MAV_CMD_GET_MESSAGE_INTERVAL ||
+			    cmd.command == MAV_CMD_REQUEST_MESSAGE) {
+				handle_message_command_long(&msg);
+			}
+		}
+		break;
 	}
 
+	/* handle packet with timesync component */
+	_mavlink_timesync.handle_message(&msg);
+	
 	// Message forwarding
 	_mavlink.handle_message(&msg);
 }

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -455,6 +455,13 @@ MavlinkReceiver::handle_message(mavlink_message_t *msg)
 	_mavlink.handle_message(msg);
 }
 
+static bool gimbal_mode_command_allowed(uint16_t command)
+{
+	return command == MAV_CMD_SET_MESSAGE_INTERVAL
+	       || command == MAV_CMD_GET_MESSAGE_INTERVAL
+	       || command == MAV_CMD_REQUEST_MESSAGE;
+}
+
 void MavlinkReceiver::handle_messages_in_gimbal_mode(mavlink_message_t &msg)
 {
 	switch (msg.msgid) {
@@ -477,23 +484,32 @@ void MavlinkReceiver::handle_messages_in_gimbal_mode(mavlink_message_t &msg)
 	case MAVLINK_MSG_ID_GIMBAL_DEVICE_ATTITUDE_STATUS:
 		handle_message_gimbal_device_attitude_status(&msg);
 		break;
-		
+
 	case MAVLINK_MSG_ID_COMMAND_LONG: {
 			mavlink_command_long_t cmd;
 			mavlink_msg_command_long_decode(&msg, &cmd);
 
-			if (cmd.command == MAV_CMD_SET_MESSAGE_INTERVAL ||
-			    cmd.command == MAV_CMD_GET_MESSAGE_INTERVAL ||
-			    cmd.command == MAV_CMD_REQUEST_MESSAGE) {
+			if (gimbal_mode_command_allowed(cmd.command)) {
 				handle_message_command_long(&msg);
 			}
 		}
 		break;
+
+	case MAVLINK_MSG_ID_COMMAND_INT: {
+			mavlink_command_int_t cmd;
+			mavlink_msg_command_int_decode(&msg, &cmd);
+
+			if (gimbal_mode_command_allowed(cmd.command)) {
+				handle_message_command_int(&msg);
+			}
+		}
+		break;
+
+	case MAVLINK_MSG_ID_TIMESYNC:
+		_mavlink_timesync.handle_message(&msg);
+		break;
 	}
 
-	/* handle packet with timesync component */
-	_mavlink_timesync.handle_message(&msg);
-	
 	// Message forwarding
 	_mavlink.handle_message(&msg);
 }


### PR DESCRIPTION
### Solved Problem
Adds dynamic requesting support for gimbal like Gremsy Pixy LR SP and Camera control modules like ENTIRE R3 or TAG-E and handling of TIMESYNC protocol for these devices.
Camera control modules like TAG-E receive MAVLink forwarded by a Gremsy gimbal connected to a telemetry port set to "Gimbal" mode. Without COMMAND_LONG → MAV_CMD_SET_MESSAGE_INTERVAL support, the camera control/geotagging module cannot enable the GPS/ATTITUDE/TIMESYNC/GPS_RAW and other data streams it needs — streams and rates that may depend on user parameter configuration. TIMESYNC protocol is crucial for precise geotagging.

Pixy LR SP has a camera control module (ENTIRE R3) built in — one device acting as two separate units over a single MAVLink link — but it cannot work in dedicated "Gimbal" mode without this support.

### Solution
Add support for COMMAND_LONG:
- MAV_CMD_SET_MESSAGE_INTERVAL
- MAV_CMD_GET_MESSAGE_INTERVAL 
- MAV_CMD_REQUEST_MESSAGE

Add support for TIMESYNC protocol on "Gimbal" mode port.

### Changelog Entry
For release notes:
```
Added support for COMMAND_LONG - MAV_CMD_SET_MESSAGE_INTERVAL / MAV_CMD_GET_MESSAGE_INTERVAL / MAV_CMD_REQUEST_MESSAGE and TIMESYNC protocol for "Gimbal" mode telemetry ports.
```

### Alternatives

### Test coverage
Cube Orange & Pixy LR & TAG-E
CUAV V5 nano & Pixy LR & ENTIRE R3

### Context
Correction of this very strict limitation:
https://github.com/PX4/PX4-Autopilot/pull/23510
