### PR TITLE
fix(control_allocation): fix erroneous NaN in unallocated thrust/torque

### DIFF
--- a/src/lib/control_allocation/control_allocation/ControlAllocation.hpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocation.hpp
@@ -144,7 +144,13 @@ public:
 	 * @return Control vector
 	 */
 	matrix::Vector<float, NUM_AXES> getAllocatedControl() const
-	{ return (_effectiveness * (_actuator_sp - _actuator_trim)).emult(_control_allocation_scale); }
+	{
+		// _actuator_sp contains NaN to indicate stopped motors.
+		// Covert back to zero to represent physical thrust.
+		ActuatorVector actuator_sp{_actuator_sp};
+		actuator_sp.nanToZero();
+		return (_effectiveness * (actuator_sp - _actuator_trim)).emult(_control_allocation_scale);
+	}
 
 	/**
 	 * Get the control effectiveness matrix


### PR DESCRIPTION
### Solved Problem

Commit af3cfaea25e5 (https://github.com/PX4/PX4-Autopilot/pull/26530) introduced a semantic change in `_actuator_sp`:
 - prior to that commit it was always the output of the allocation algorithm, i.e. if 0 thrust was allocated the `_actuator_sp` was 0, and the `NaN` needed to stop some motors only entered the picture when populating the `actuator_motors` message in `publish_actuator_controls`
 - after that commit, we change `_actuator_sp` itself to be `NaN` when the corresponding motor should be stopped

This breaks consumers of `_actuator_sp` that expect there to be a finite, physical thrust in `_actuator_sp`. One such consumer is `publish_control_allocator_status`, which produces `NaN` if the `_actuator_sp` is `NaN` and is thus currently useless.

### Solution

Convert NaNs back to zero in `getAllocatedControl` so all consumers of that work as before.

### Test coverage

`sihsim_standard_vtol`, take off and then increase `SIH_WIND_N` to 10 m/s to cause unallocated thrust. 

Before: unallocated thrust/torque are `NaN`

<img width="1048" height="855" alt="Screenshot from 2026-09-01 15-08-24" src="https://github.com/user-attachments/assets/d2e6a3a5-3327-489d-801d-35b9ac5b09c6" />

After: unallocated thrust/torque correctly logged

<img width="1048" height="855" alt="Screenshot from 2026-09-01 15-08-45" src="https://github.com/user-attachments/assets/1c47f230-be80-4b3c-bc45-58a74552444a" />
