### PR TITLE
fix(4001_gz_x500): tuned drag fusion parameters for gazebo sim

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500
@@ -49,3 +49,8 @@ param set-default SIM_GZ_EC_MAX4 1000
 
 param set-default MPC_THR_HOVER 0.6
 param set-default NAV_DLL_ACT 2
+
+# Drag Specific Force:
+param set-default EKF2_BCOEF_X 0.0
+param set-default EKF2_BCOEF_Y 0.0
+param set-default EKF2_MCOEF 0.12


### PR DESCRIPTION
Tuned in gazebo drag fusion parameters for 4001 airframe. Default drag fusion is not enabled

Tuning tool output:
<img width="6744" height="2691" alt="Figure_1" src="https://github.com/user-attachments/assets/f872a4e4-1880-481e-9fcd-b807d3318a2c" />

GPS vs estimated velcoity when GPS is off
<img width="4578" height="2168" alt="Screenshot From 2026-08-31 16-58-25" src="https://github.com/user-attachments/assets/be4ef1e5-84c8-47bc-815b-46bcf27d7949" />
