### PR TITLE
fix(ci): attach FMU bootloader .bin to GitHub releases

### DIFF
--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -30,7 +30,7 @@
 #   - CAN node firmware is attached as <target>.uavcan.bin and
 #     <target>_canbootloader.bin
 #   - FMU/H7 bootloaders are attached as <target>_bootloader.bin (raw SWD
-#     image at 0x08000000). The matching .px4 is the USB uploader envelope.
+#     image). Bootloader .px4 files are not attached.
 #
 # IMPORTANT: Version tags do NOT upload to stable/ or beta/. Only the
 # corresponding branch pushes control those directories. This prevents

--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -29,8 +29,8 @@
 #   - Pre-releases (alpha/beta/rc suffixes) are automatically marked as such
 #   - CAN node firmware is attached as <target>.uavcan.bin and
 #     <target>_canbootloader.bin
-#   - FMU/H7 bootloaders are attached as <target>_bootloader.bin (raw SWD
-#     image). Bootloader .px4 files are not attached.
+#   - In-tree *_bootloader targets are attached as <target>_bootloader.bin
+#     (raw SWD image). Bootloader .px4 files are not attached.
 #
 # IMPORTANT: Version tags do NOT upload to stable/ or beta/. Only the
 # corresponding branch pushes control those directories. This prevents

--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -29,6 +29,8 @@
 #   - Pre-releases (alpha/beta/rc suffixes) are automatically marked as such
 #   - CAN node firmware is attached as <target>.uavcan.bin and
 #     <target>_canbootloader.bin
+#   - FMU/H7 bootloaders are attached as <target>_bootloader.bin (raw SWD
+#     image at 0x08000000). The matching .px4 is the USB uploader envelope.
 #
 # IMPORTANT: Version tags do NOT upload to stable/ or beta/. Only the
 # corresponding branch pushes control those directories. This prevents
@@ -307,6 +309,7 @@ jobs:
           files: |
             artifacts/*.px4
             artifacts/*.uavcan.bin
+            artifacts/*_bootloader.bin
             artifacts/*_canbootloader.bin
             artifacts/*.deb
             artifacts/**/*.sbom.spdx.json

--- a/Tools/ci/package_build_artifacts.sh
+++ b/Tools/ci/package_build_artifacts.sh
@@ -2,15 +2,16 @@
 
 mkdir artifacts
 
-# CAN node flash images: application APDescriptor (.uavcan.bin) and the
-# canbootloader raw .bin (SWD at 0x08000000). The .px4 envelope is not used.
+# Flash images that are not the .px4 envelope:
+# - CAN node application APDescriptor (.uavcan.bin)
+# - Bootloaders (FMU *_bootloader and CAN *_canbootloader): raw .bin for SWD
 for uavcan_bin in build/*/*.uavcan.bin; do
   [ -f "$uavcan_bin" ] || continue
   build_dir=$(basename "$(dirname "$uavcan_bin")")
   cp "$uavcan_bin" "artifacts/${build_dir}.uavcan.bin"
 done
 
-for bl_dir in build/*_canbootloader; do
+for bl_dir in build/*_bootloader build/*_canbootloader; do
   [ -d "$bl_dir" ] || continue
   build_dir=$(basename "$bl_dir")
   bl_bin="$bl_dir/${build_dir}.bin"
@@ -21,7 +22,12 @@ done
 for px4_file in build/*/*.px4; do
   [ -f "$px4_file" ] || continue
   build_dir=$(basename "$(dirname "$px4_file")")
-  if [ -f "artifacts/${build_dir}.uavcan.bin" ] || [ -f "artifacts/${build_dir}.bin" ]; then
+  # CAN node application: .uavcan.bin is the flashable image
+  if [ -f "artifacts/${build_dir}.uavcan.bin" ]; then
+    continue
+  fi
+  # canbootloader .px4 is unused; FMU *_bootloader still ships .px4 plus .bin
+  if [[ "$build_dir" == *_canbootloader ]]; then
     continue
   fi
   cp "$px4_file" artifacts/

--- a/Tools/ci/package_build_artifacts.sh
+++ b/Tools/ci/package_build_artifacts.sh
@@ -26,8 +26,9 @@ for px4_file in build/*/*.px4; do
   if [ -f "artifacts/${build_dir}.uavcan.bin" ]; then
     continue
   fi
-  # canbootloader .px4 is unused; FMU *_bootloader still ships .px4 plus .bin
-  if [[ "$build_dir" == *_canbootloader ]]; then
+  # Bootloader .px4 is unused: SWD uses the raw .bin, and USB flashing would
+  # write it into the application slot.
+  if [[ "$build_dir" == *bootloader* ]]; then
     continue
   fi
   cp "$px4_file" artifacts/

--- a/Tools/ci/package_build_artifacts.sh
+++ b/Tools/ci/package_build_artifacts.sh
@@ -4,7 +4,9 @@ mkdir artifacts
 
 # Flash images that are not the .px4 envelope:
 # - CAN node application APDescriptor (.uavcan.bin)
-# - Bootloaders (FMU *_bootloader and CAN *_canbootloader): raw .bin for SWD
+# - Bootloaders (*_bootloader and *_canbootloader): raw .bin for SWD
+#   *_bootloader_* variants (e.g. bootloader_secureboot) are omitted;
+#   those images are baked with in-tree test keys.
 for uavcan_bin in build/*/*.uavcan.bin; do
   [ -f "$uavcan_bin" ] || continue
   build_dir=$(basename "$(dirname "$uavcan_bin")")
@@ -39,6 +41,11 @@ cp **/**/*.deb artifacts/ 2>/dev/null || true
 for build_dir_path in build/*/ ; do
   build_dir_path=${build_dir_path::${#build_dir_path}-1}
   build_dir=${build_dir_path#*/}
+  # GitHub Releases attach artifacts/**/*.sbom.spdx.json; bootloader SBOMs
+  # are not a recovery artifact.
+  case "$build_dir" in
+    *_bootloader|*_bootloader_*|*_canbootloader) continue ;;
+  esac
   mkdir -p artifacts/$build_dir
   find artifacts/ -maxdepth 1 -type f -name "*$build_dir*"
   # Airframe (NuttX: build root, SITL: docs/ subdirectory)

--- a/docs/en/advanced_config/bootloader_update.md
+++ b/docs/en/advanced_config/bootloader_update.md
@@ -66,8 +66,6 @@ make px4_fmu-v6x_bootloader
 This will build the bootloader binary as `build/px4_fmu-v6x_bootloader/px4_fmu-v6x_bootloader.elf`, which can be flashed via SWD or DFU.
 If you are building the bootloader you should be familiar with one of these options already.
 
-PX4 GitHub releases attach `<target>_bootloader.bin` for SWD (STM32: `0x08000000`).
-
 If you need a HEX file instead of an ELF file, use objcopy:
 
 ```sh
@@ -80,11 +78,15 @@ PX4 boards up to FMUv5X (before STM32H7) used the [PX4 bootloader](https://githu
 
 The instructions in the repo README explain how to use it.
 
+## Pre-built Bootloader
+
+PX4 GitHub releases attach `<target>_bootloader.bin` for SWD (STM32: `0x08000000`). The `.px4` envelope is not used.
+
 ## Debug Probe Bootloader Update
 
 The following steps explain how you can "manually" update the bootloader using a [compatible Debug Probe](../debug/swd_debug.md#debug-probes-for-px4-hardware):
 
-1. Get a binary containing the bootloader (either from dev team or [build it yourself](#building-the-px4-bootloader)).
+1. Get a bootloader image: `<target>_bootloader.bin` from a [GitHub release](https://github.com/PX4/PX4-Autopilot/releases), or the `.elf` from [building it](#building-the-px4-bootloader).
 2. Get a [Debug Probe](../debug/swd_debug.md#debug-probes-for-px4-hardware).
    Connect the probe to your PC via USB and setup the `gdbserver`.
 3. Go into the directory containing the binary and run the command for your target bootloader in the terminal:

--- a/docs/en/advanced_config/bootloader_update.md
+++ b/docs/en/advanced_config/bootloader_update.md
@@ -66,7 +66,7 @@ make px4_fmu-v6x_bootloader
 This will build the bootloader binary as `build/px4_fmu-v6x_bootloader/px4_fmu-v6x_bootloader.elf`, which can be flashed via SWD or DFU.
 If you are building the bootloader you should be familiar with one of these options already.
 
-PX4 GitHub releases attach `<target>_bootloader.bin` for SWD (STM32: `0x08000000`). `<target>_bootloader.px4` is the USB uploader envelope, not a raw flash image.
+PX4 GitHub releases attach `<target>_bootloader.bin` for SWD (STM32: `0x08000000`).
 
 If you need a HEX file instead of an ELF file, use objcopy:
 

--- a/docs/en/advanced_config/bootloader_update.md
+++ b/docs/en/advanced_config/bootloader_update.md
@@ -66,6 +66,8 @@ make px4_fmu-v6x_bootloader
 This will build the bootloader binary as `build/px4_fmu-v6x_bootloader/px4_fmu-v6x_bootloader.elf`, which can be flashed via SWD or DFU.
 If you are building the bootloader you should be familiar with one of these options already.
 
+PX4 GitHub releases attach `<target>_bootloader.bin` for SWD (STM32: `0x08000000`). `<target>_bootloader.px4` is the USB uploader envelope, not a raw flash image.
+
 If you need a HEX file instead of an ELF file, use objcopy:
 
 ```sh

--- a/docs/en/advanced_config/bootloader_update.md
+++ b/docs/en/advanced_config/bootloader_update.md
@@ -80,13 +80,13 @@ The instructions in the repo README explain how to use it.
 
 ## Pre-built Bootloader
 
-PX4 GitHub releases attach `<target>_bootloader.bin` for SWD (STM32: `0x08000000`). The `.px4` envelope is not used.
+PX4 GitHub releases attach `<target>_bootloader.bin` for in-tree bootloader targets (FMUv6X and later). Flash that raw image over SWD (STM32: `0x08000000`) with ST-Link, CubeProgrammer, or OpenOCD. The `.px4` envelope is not used.
 
 ## Debug Probe Bootloader Update
 
 The following steps explain how you can "manually" update the bootloader using a [compatible Debug Probe](../debug/swd_debug.md#debug-probes-for-px4-hardware):
 
-1. Get a bootloader image: `<target>_bootloader.bin` from a [GitHub release](https://github.com/PX4/PX4-Autopilot/releases), or the `.elf` from [building it](#building-the-px4-bootloader).
+1. Get a bootloader `.elf` by [building it](#building-the-px4-bootloader).
 2. Get a [Debug Probe](../debug/swd_debug.md#debug-probes-for-px4-hardware).
    Connect the probe to your PC via USB and setup the `gdbserver`.
 3. Go into the directory containing the binary and run the command for your target bootloader in the terminal:


### PR DESCRIPTION
## Summary
Backport of #28495. Attach the raw FMU `_bootloader.bin` on GitHub Releases so ST-Link recovery has a flashable image.

## Problem
Releases only attached `_bootloader.px4`. That file is the USB uploader envelope. Flashing it with ST-Link writes JSON into sector 0. USB-flashing it through the existing bootloader would write the bootloader into the application slot.

## Solution
Package `*_bootloader.bin`. Do not attach `_bootloader.px4`.