### PR TITLE
fix(boards): use the full 256K SRAM on F412 cannodes

### DIFF
--- a/boards/ark/can-flow-mr/nuttx-config/scripts/canbootloader_script.ld
+++ b/boards/ark/can-flow-mr/nuttx-config/scripts/canbootloader_script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08000000, LENGTH = 32K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/can-flow-mr/nuttx-config/scripts/script.ld
+++ b/boards/ark/can-flow-mr/nuttx-config/scripts/script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08010000, LENGTH = 960K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/can-flow/nuttx-config/scripts/canbootloader_script.ld
+++ b/boards/ark/can-flow/nuttx-config/scripts/canbootloader_script.ld
@@ -51,7 +51,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08000000, LENGTH = 32K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/can-flow/nuttx-config/scripts/script.ld
+++ b/boards/ark/can-flow/nuttx-config/scripts/script.ld
@@ -51,7 +51,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08010000, LENGTH = 448K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/can-gps/nuttx-config/scripts/canbootloader_script.ld
+++ b/boards/ark/can-gps/nuttx-config/scripts/canbootloader_script.ld
@@ -51,7 +51,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08000000, LENGTH = 32K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/can-gps/nuttx-config/scripts/script.ld
+++ b/boards/ark/can-gps/nuttx-config/scripts/script.ld
@@ -51,7 +51,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08010000, LENGTH = 448K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/can-rtk-gps/nuttx-config/scripts/canbootloader_script.ld
+++ b/boards/ark/can-rtk-gps/nuttx-config/scripts/canbootloader_script.ld
@@ -51,7 +51,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08000000, LENGTH = 32K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/can-rtk-gps/nuttx-config/scripts/script.ld
+++ b/boards/ark/can-rtk-gps/nuttx-config/scripts/script.ld
@@ -51,7 +51,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08010000, LENGTH = 448K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/cannode/nuttx-config/scripts/canbootloader_script.ld
+++ b/boards/ark/cannode/nuttx-config/scripts/canbootloader_script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08000000, LENGTH = 32K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/cannode/nuttx-config/scripts/script.ld
+++ b/boards/ark/cannode/nuttx-config/scripts/script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08010000, LENGTH = 960K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/dist/nuttx-config/scripts/canbootloader_script.ld
+++ b/boards/ark/dist/nuttx-config/scripts/canbootloader_script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08000000, LENGTH = 32K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/dist/nuttx-config/scripts/script.ld
+++ b/boards/ark/dist/nuttx-config/scripts/script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08010000, LENGTH = 960K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/f9p-gps/nuttx-config/scripts/canbootloader_script.ld
+++ b/boards/ark/f9p-gps/nuttx-config/scripts/canbootloader_script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08000000, LENGTH = 32K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/f9p-gps/nuttx-config/scripts/script.ld
+++ b/boards/ark/f9p-gps/nuttx-config/scripts/script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08010000, LENGTH = 960K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/mag/nuttx-config/scripts/canbootloader_script.ld
+++ b/boards/ark/mag/nuttx-config/scripts/canbootloader_script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08000000, LENGTH = 32K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/mag/nuttx-config/scripts/script.ld
+++ b/boards/ark/mag/nuttx-config/scripts/script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08010000, LENGTH = 960K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/septentrio-gps/nuttx-config/scripts/canbootloader_script.ld
+++ b/boards/ark/septentrio-gps/nuttx-config/scripts/canbootloader_script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08000000, LENGTH = 32K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/septentrio-gps/nuttx-config/scripts/script.ld
+++ b/boards/ark/septentrio-gps/nuttx-config/scripts/script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08010000, LENGTH = 960K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/teseo-gps/nuttx-config/scripts/canbootloader_script.ld
+++ b/boards/ark/teseo-gps/nuttx-config/scripts/canbootloader_script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08000000, LENGTH = 32K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/teseo-gps/nuttx-config/scripts/script.ld
+++ b/boards/ark/teseo-gps/nuttx-config/scripts/script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08010000, LENGTH = 960K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/x20-gps/nuttx-config/scripts/canbootloader_script.ld
+++ b/boards/ark/x20-gps/nuttx-config/scripts/canbootloader_script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08000000, LENGTH = 32K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)

--- a/boards/ark/x20-gps/nuttx-config/scripts/script.ld
+++ b/boards/ark/x20-gps/nuttx-config/scripts/script.ld
@@ -47,7 +47,7 @@
 MEMORY
 {
     flash (rx)   : ORIGIN = 0x08010000, LENGTH = 960K
-    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 192K
+    sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 OUTPUT_ARCH(arm)


### PR DESCRIPTION
## Summary
Open the cannode linker SRAM region to 256K so `.data`/`.bss` can use the upper 64K. NuttX 12.12 already ends the F412 heap at `0x20040000` (PX4/NuttX#407).

Stacked on #28456.

## Problem
The board linker scripts still described the F42x 192K split, so `.data`/`.bss` could not use the upper 64K.

## Solution
Set `sram LENGTH` to 256K on the ARK F412 cannodes (VG/CG from #28456 and the remaining CE boards, which have the same 256K SRAM).