### PR TITLE
fix(version): derive NuttX version from the fork branch name

### DIFF
--- a/src/lib/version/px_update_git_header.py
+++ b/src/lib/version/px_update_git_header.py
@@ -128,14 +128,31 @@ if (os.path.exists('src/modules/mavlink/mavlink/.git')):
 
 # NuttX
 if (os.path.exists('platforms/nuttx/NuttX/nuttx/.git')):
-    nuttx_git_tags = subprocess.check_output('git -c versionsort.suffix=- tag --sort=v:refname'.split(),
-                                  cwd='platforms/nuttx/NuttX/nuttx', stderr=subprocess.STDOUT).decode('utf-8').strip()
-    # may be empty if shallow clone
-    if (len(nuttx_git_tags) > 0):
-        nuttx_git_tag = re.findall(r'nuttx-[0-9]+\.[0-9]+\.[0-9]+', nuttx_git_tags)[-1].replace("nuttx-", "v")
-        nuttx_git_tag = re.sub('-.*', '.0', nuttx_git_tag)
+    # The PX4/NuttX fork branch name recorded in .gitmodules is the
+    # authoritative kernel version: px4_firmware_nuttx-X.Y.Z+ is updated
+    # in the same commit as every kernel upgrade. Fall back to git
+    # describe for checkouts that do not follow the fork convention
+    # (e.g. upstream apache/nuttx directly, which carries release tags).
+    nuttx_git_tag = "v0.0.0"
+    try:
+        nuttx_branch = subprocess.check_output(
+            'git config -f .gitmodules submodule.platforms/nuttx/NuttX/nuttx.branch'.split(),
+            stderr=subprocess.STDOUT).decode('utf-8').strip()
+        branch_version = re.match(r'^px4_firmware_nuttx-([0-9]+\.[0-9]+\.[0-9]+)\+?$', nuttx_branch)
+    except subprocess.CalledProcessError:
+        branch_version = None
+    if branch_version:
+        nuttx_git_tag = "v" + branch_version.group(1)
     else:
-        nuttx_git_tag = "v0.0.0"
+        try:
+            nuttx_describe = subprocess.check_output(
+                'git describe --tags --match nuttx-*'.split(),
+                cwd='platforms/nuttx/NuttX/nuttx', stderr=subprocess.STDOUT).decode('utf-8').strip()
+            describe_version = re.match(r'^nuttx-([0-9]+\.[0-9]+\.[0-9]+)', nuttx_describe)
+            if describe_version:
+                nuttx_git_tag = "v" + describe_version.group(1)
+        except subprocess.CalledProcessError:
+            pass
     nuttx_git_version = subprocess.check_output('git rev-parse --verify HEAD'.split(),
                                       cwd='platforms/nuttx/NuttX/nuttx', stderr=subprocess.STDOUT).decode('utf-8').strip()
     nuttx_git_version_short = nuttx_git_version[0:16]


### PR DESCRIPTION
## Summary
Derive NUTTX_GIT_TAG_STR from the PX4/NuttX fork branch name recorded in .gitmodules instead of the highest nuttx-X.Y.Z tag found in the submodule.

## Problem
px_update_git_header.py sorts every tag in the NuttX submodule and takes the highest nuttx-X.Y.Z match, with no check that the tag is an ancestor of the checkout. The fork's tags were last synced in Oct 2022 and topped out at nuttx-11.0.0, so every build since has reported NuttX 11.0.0 in `ver all`, MAVLink AUTOPILOT_VERSION.os_sw_version, and the ULog sys_os_ver_release field Flight Review shows, regardless of the actual kernel. The nuttx-12.12.0 tag just pushed to PX4/NuttX for #26215 fixes that branch but flips the failure mode: fresh clones of main, still on the 10.3-era kernel, pick it up and report 12.12.0.

## Solution
Read the fork branch name from .gitmodules (px4_firmware_nuttx-X.Y.Z+), which is updated atomically with every kernel upgrade, and fall back to git describe for checkouts that do not follow the fork convention (e.g. upstream apache/nuttx, which carries release tags). The output format is unchanged (vX.Y.Z, consumed by version_tag_to_number()); main now yields v10.3.0 and the 12.12 branch v12.12.0. Should be cherry-picked to release/1.14 through release/1.16 as follow-up.