### PR TITLE
Prevent MAVLink FTP resend replies from serializing uncached bytes

### DIFF
--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -164,6 +164,18 @@ px4_add_unit_gtest(SRC MavlinkStatustextHandlerTest.cpp
 		modules__mavlink
 	)
 
+px4_add_unit_gtest(SRC MavlinkFTPTest.cpp
+	INCLUDES
+		${MAVLINK_LIBRARY_DIR}
+		${MAVLINK_LIBRARY_DIR}/${CONFIG_MAVLINK_DIALECT}
+		${MAVLINK_LIBRARY_DIR}/${MAVLINK_DIALECT_UAVIONIX}
+	COMPILE_FLAGS
+		-Wno-address-of-packed-member # TODO: fix in c_library_v2
+		-Wno-cast-align # TODO: fix
+	LINKLIBS
+		modules__mavlink
+	)
+
 if(CONFIG_NET AND "${PX4_PLATFORM}" MATCHES "nuttx")
 	target_link_libraries(modules__mavlink PRIVATE nuttx_apps) # netlib_get_ipv4netmask
 endif()

--- a/src/modules/mavlink/MavlinkFTPTest.cpp
+++ b/src/modules/mavlink/MavlinkFTPTest.cpp
@@ -1,0 +1,79 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "mavlink_ftp_internal.h"
+
+TEST(MavlinkFTP, CachedReplyResendZeroFillsUnusedPayloadBytes)
+{
+	EXPECT_EQ(kMavlinkFTPCachedReplyLength, 19u);
+
+	mavlink_file_transfer_protocol_t reply{};
+	memset(&reply, 0xA5, sizeof(reply));
+
+	reply.target_system = 42;
+	reply.target_component = 7;
+
+	auto *payload = reinterpret_cast<MavlinkFTP::PayloadHeader *>(&reply.payload[0]);
+	payload->seq_number = 512;
+	payload->opcode = MavlinkFTP::kRspNak;
+	payload->req_opcode = MavlinkFTP::kCmdResetSessions;
+	payload->size = 1;
+	payload->data[0] = MavlinkFTP::kErrFail;
+	payload->data[1] = 0x11;
+	payload->data[2] = 0x22;
+	payload->data[3] = 0x33;
+
+	mavlink_ftp_trim_reply_payload(reply);
+
+	uint8_t cached_reply[kMavlinkFTPCachedReplyLength];
+	memcpy(cached_reply, &reply, sizeof(cached_reply));
+
+	mavlink_file_transfer_protocol_t resent_reply{};
+	mavlink_ftp_expand_cached_reply(cached_reply, resent_reply);
+
+	auto *resent_payload = reinterpret_cast<MavlinkFTP::PayloadHeader *>(&resent_reply.payload[0]);
+
+	EXPECT_EQ(resent_reply.target_system, reply.target_system);
+	EXPECT_EQ(resent_reply.target_component, reply.target_component);
+	EXPECT_EQ(resent_payload->seq_number, payload->seq_number);
+	EXPECT_EQ(resent_payload->opcode, payload->opcode);
+	EXPECT_EQ(resent_payload->req_opcode, payload->req_opcode);
+	EXPECT_EQ(resent_payload->size, payload->size);
+	EXPECT_EQ(resent_payload->data[0], payload->data[0]);
+	EXPECT_EQ(resent_payload->data[1], 0);
+	EXPECT_EQ(resent_payload->data[2], 0);
+	EXPECT_EQ(resent_payload->data[3], 0);
+	EXPECT_EQ(resent_reply.payload[250], 0);
+}

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -43,6 +43,7 @@
 #include <cstring>
 
 #include "mavlink_ftp.h"
+#include "mavlink_ftp_internal.h"
 #include "mavlink_main.h"
 
 using namespace time_literals;
@@ -140,16 +141,17 @@ MavlinkFTP::_process_request(
 
 	// check the sequence number: if this is a resent request, resend the last response
 	if (_last_reply_valid) {
-		mavlink_file_transfer_protocol_t *last_reply = reinterpret_cast<mavlink_file_transfer_protocol_t *>(_last_reply);
-		PayloadHeader *last_payload = reinterpret_cast<PayloadHeader *>(&last_reply->payload[0]);
+		mavlink_file_transfer_protocol_t last_reply;
+		mavlink_ftp_expand_cached_reply(_last_reply, last_reply);
+		PayloadHeader *last_payload = reinterpret_cast<PayloadHeader *>(&last_reply.payload[0]);
 
 		if (payload->seq_number + 1 == last_payload->seq_number
-		    && last_reply->target_system == target_system_id
-		    && last_reply->target_component == target_comp_id) {
+		    && last_reply.target_system == target_system_id
+		    && last_reply.target_component == target_comp_id) {
 			// this is the same request as the one we replied to last. It means the (n)ack got lost, and the GCS
 			// resent the request
 			_mavlink.lock_send();
-			mavlink_msg_file_transfer_protocol_send_struct(_mavlink.get_channel(), last_reply);
+			mavlink_msg_file_transfer_protocol_send_struct(_mavlink.get_channel(), &last_reply);
 			_mavlink.unlock_send();
 			return;
 		}
@@ -299,14 +301,14 @@ MavlinkFTP::_reply(mavlink_file_transfer_protocol_t *ftp_req)
 	// we can simply resend the response.
 	// we only keep small responses to reduce RAM usage and avoid large memcpy's. The larger responses are all data
 	// retrievals without side-effects, meaning it's ok to reexecute them if a response gets lost
+	mavlink_ftp_trim_reply_payload(*ftp_req);
+
 	if (payload->size <= sizeof(uint32_t) && payload->data[0] != kErrNoSessionsAvailable) {
 		_last_reply_valid = true;
 		memcpy(_last_reply, ftp_req, sizeof(_last_reply));
 	}
 
 	// clear any not used payload data to correctly trim mavlink ftp message reply
-	memset(&payload->data[payload->size], 0, kMaxDataLength - payload->size);
-
 	PX4_DEBUG("FTP: %s seq_number: %" PRIu16, payload->opcode == kRspAck ? "Ack" : "Nak", payload->seq_number);
 
 	// Called from the receiver thread; the per-channel mavlink_status global is

--- a/src/modules/mavlink/mavlink_ftp_internal.h
+++ b/src/modules/mavlink/mavlink_ftp_internal.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstddef>
+#include <cstring>
+
+#include "mavlink_ftp.h"
+
+static constexpr size_t kMavlinkFTPCachedReplyLength =
+	MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL_LEN - MAVLINK_MSG_FILE_TRANSFER_PROTOCOL_FIELD_PAYLOAD_LEN
+	+ sizeof(MavlinkFTP::PayloadHeader) + sizeof(uint32_t);
+
+static constexpr size_t kMavlinkFTPPayloadDataLength =
+	MAVLINK_MSG_FILE_TRANSFER_PROTOCOL_FIELD_PAYLOAD_LEN - sizeof(MavlinkFTP::PayloadHeader);
+
+static_assert(kMavlinkFTPCachedReplyLength <= sizeof(mavlink_file_transfer_protocol_t),
+	      "cached MAVLink FTP reply must fit in a full MAVLink FTP message");
+
+inline void mavlink_ftp_trim_reply_payload(mavlink_file_transfer_protocol_t &ftp_reply)
+{
+	auto *payload = reinterpret_cast<MavlinkFTP::PayloadHeader *>(&ftp_reply.payload[0]);
+
+	memset(&payload->data[payload->size], 0, kMavlinkFTPPayloadDataLength - payload->size);
+}
+
+template<size_t N>
+inline void mavlink_ftp_expand_cached_reply(const uint8_t (&cached_reply)[N],
+		mavlink_file_transfer_protocol_t &ftp_reply)
+{
+	static_assert(N <= sizeof(mavlink_file_transfer_protocol_t),
+		      "cached MAVLink FTP reply must fit in the destination message");
+
+	ftp_reply = {};
+	memcpy(&ftp_reply, cached_reply, N);
+}


### PR DESCRIPTION
Fixes #28347

## Summary
- cache only the serialized reply prefix instead of treating the short cache as a full FTP message
- rebuild resend replies from a zero-initialized full message before serialization
- add a focused unit test that locks the short-reply no-leak behavior

## Testing
- git diff --check
- Native Windows CMake configure for px4_sitl_test advanced to PX4 common flags before failing on the unsupported MSVC toolchain
- POSIX unit-MavlinkFTP build/run remains unverified locally