### PR TITLE
fix(mc_nn_control): guard the model, the observations and the output

### DIFF
--- a/docs/en/neural_networks/tflm.md
+++ b/docs/en/neural_networks/tflm.md
@@ -40,6 +40,9 @@ You will then have to modify the `control_net.hpp` and `control_net.cpp` to incl
 - Take the size of the network in the bottom of the `.cc` file and replace the size in `control_net.hpp`.
 - Take the data in the model array in the `cc` file, and replace the ones in `control_net.cpp`.
 
+The module checks the model when it starts: the schema version, exactly one input of 15 floats and exactly one output of 4 floats.
+A model that does not match is rejected with the reason in the log and the module does not start.
+
 You are now ready to run your own network.
 
 ## Code Explanation

--- a/src/modules/mc_nn_control/CMakeLists.txt
+++ b/src/modules/mc_nn_control/CMakeLists.txt
@@ -42,6 +42,7 @@ px4_add_module(
 	SRCS
 		mc_nn_control.cpp
 		mc_nn_control.hpp
+		actions_rescale.hpp
 		control_net.cpp
 		control_net.hpp
 	MODULE_CONFIG
@@ -54,3 +55,5 @@ px4_add_module(
 target_link_libraries(mc_nn_control PRIVATE tensorflow_lite_micro)
 target_include_directories(mc_nn_control PRIVATE
 	${CMAKE_SOURCE_DIR}/src/lib/tensorflow_lite_micro)
+
+px4_add_unit_gtest(SRC RescaleActionTest.cpp)

--- a/src/modules/mc_nn_control/CMakeLists.txt
+++ b/src/modules/mc_nn_control/CMakeLists.txt
@@ -59,3 +59,8 @@ target_include_directories(mc_nn_control PRIVATE
 	${CMAKE_SOURCE_DIR}/src/lib/tensorflow_lite_micro)
 
 px4_add_unit_gtest(SRC RescaleActionTest.cpp)
+px4_add_unit_gtest(SRC NnControlChecksTest.cpp)
+px4_add_unit_gtest(SRC NnControlModelTest.cpp
+	EXTRA_SRCS control_net.cpp
+	LINKLIBS tensorflow_lite_micro
+	INCLUDES ${CMAKE_SOURCE_DIR}/src/lib/tensorflow_lite_micro)

--- a/src/modules/mc_nn_control/CMakeLists.txt
+++ b/src/modules/mc_nn_control/CMakeLists.txt
@@ -43,6 +43,8 @@ px4_add_module(
 		mc_nn_control.cpp
 		mc_nn_control.hpp
 		actions_rescale.hpp
+		nn_control_checks.hpp
+		nn_control_model.hpp
 		control_net.cpp
 		control_net.hpp
 	MODULE_CONFIG

--- a/src/modules/mc_nn_control/NnControlChecksTest.cpp
+++ b/src/modules/mc_nn_control/NnControlChecksTest.cpp
@@ -1,0 +1,183 @@
+/****************************************************************************
+*
+*   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+* 3. Neither the name PX4 nor the names of its contributors may be
+*    used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+****************************************************************************/
+
+/**
+ * @file NnControlChecksTest.cpp
+ * Unit tests for the checks the neural controller runs before it trusts its model,
+ * its observations and its output.
+ *
+ * to run, on a config that enables the module:
+ *   cmake -DCMAKE_TESTING=ON build/px4_sitl_neural
+ *   ninja -C build/px4_sitl_neural unit-NnControlChecks
+ */
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cstring>
+
+#include "nn_control_checks.hpp"
+
+using namespace nn_control;
+
+static ObservationSnapshot good(uint64_t now)
+{
+	ObservationSnapshot o{};
+	o.position_timestamp = now - 1000;
+	o.xy_valid = o.z_valid = o.v_xy_valid = o.v_z_valid = true;
+	o.position[0] = 1.f;
+	o.position[1] = -2.f;
+	o.position[2] = -3.f;
+	o.velocity[0] = 0.1f;
+	o.velocity[1] = 0.f;
+	o.velocity[2] = -0.2f;
+	o.attitude_timestamp = now - 1000;
+	o.q[0] = 1.f;
+	o.angular_velocity_timestamp = now - 500;
+	o.angular_velocity[1] = 0.01f;
+	return o;
+}
+
+static constexpr uint64_t kNow = 10000000;
+
+TEST(NnControlChecksTest, staleLimitsAreTheRaptorModulesLimits)
+{
+	// the contract, not a restatement of the constants
+	EXPECT_EQ(kMaxLocalPositionAge, 100000u);
+	EXPECT_EQ(kMaxAttitudeAge, 50000u);
+	EXPECT_EQ(kMaxAngularVelocityAge, 10000u);
+	EXPECT_EQ(kAngularVelocityWatchdog, 20000u);
+}
+
+TEST(NnControlChecksTest, freshObservationsPass)
+{
+	EXPECT_EQ(check_observations(good(kNow), kNow), ObservationFault::None);
+}
+
+TEST(NnControlChecksTest, everyInvalidPositionFlagIsCaught)
+{
+	for (int flag = 0; flag < 4; flag++) {
+		ObservationSnapshot o = good(kNow);
+		(flag == 0 ? o.xy_valid : flag == 1 ? o.z_valid : flag == 2 ? o.v_xy_valid : o.v_z_valid) = false;
+		EXPECT_EQ(check_observations(o, kNow), ObservationFault::PositionInvalid) << "flag " << flag;
+	}
+}
+
+TEST(NnControlChecksTest, staleObservationsAreCaughtAtTheirOwnLimits)
+{
+	ObservationSnapshot o = good(kNow);
+	o.position_timestamp = kNow - kMaxLocalPositionAge;
+	EXPECT_EQ(check_observations(o, kNow), ObservationFault::None);
+	o.position_timestamp = kNow - kMaxLocalPositionAge - 1;
+	EXPECT_EQ(check_observations(o, kNow), ObservationFault::PositionStale);
+
+	o = good(kNow);
+	o.attitude_timestamp = kNow - kMaxAttitudeAge - 1;
+	EXPECT_EQ(check_observations(o, kNow), ObservationFault::AttitudeStale);
+
+	o = good(kNow);
+	o.angular_velocity_timestamp = kNow - kMaxAngularVelocityAge - 1;
+	EXPECT_EQ(check_observations(o, kNow), ObservationFault::AngularVelocityStale);
+}
+
+TEST(NnControlChecksTest, neverSetObservationsAreStale)
+{
+	ObservationSnapshot o = good(kNow);
+	o.position_timestamp = 0;
+	EXPECT_EQ(check_observations(o, kNow), ObservationFault::PositionStale);
+
+	o = good(kNow);
+	o.attitude_timestamp = 0;
+	EXPECT_EQ(check_observations(o, kNow), ObservationFault::AttitudeStale);
+}
+
+TEST(NnControlChecksTest, observationsFromTheFutureAreNotStale)
+{
+	ObservationSnapshot o = good(kNow);
+	o.position_timestamp = kNow + 5000;
+	EXPECT_EQ(check_observations(o, kNow), ObservationFault::None);
+}
+
+TEST(NnControlChecksTest, nonFiniteObservationsAreCaught)
+{
+	ObservationSnapshot o = good(kNow);
+	o.position[2] = NAN;
+	EXPECT_EQ(check_observations(o, kNow), ObservationFault::PositionNotFinite);
+
+	o = good(kNow);
+	o.velocity[0] = INFINITY;
+	EXPECT_EQ(check_observations(o, kNow), ObservationFault::PositionNotFinite);
+
+	o = good(kNow);
+	o.q[3] = NAN;
+	EXPECT_EQ(check_observations(o, kNow), ObservationFault::AttitudeNotFinite);
+
+	o = good(kNow);
+	o.angular_velocity[2] = -INFINITY;
+	EXPECT_EQ(check_observations(o, kNow), ObservationFault::AngularVelocityNotFinite);
+}
+
+TEST(NnControlChecksTest, positionProblemsAreReportedBeforeAttitudeProblems)
+{
+	ObservationSnapshot o = good(kNow);
+	o.xy_valid = false;
+	o.attitude_timestamp = 0;
+	EXPECT_EQ(check_observations(o, kNow), ObservationFault::PositionInvalid);
+}
+
+TEST(NnControlChecksTest, outputsHaveToBeFiniteInEveryChannel)
+{
+	float out[kOutputSize] = {0.5f, 0.5f, 0.5f, 0.5f};
+	EXPECT_TRUE(outputs_finite(out, kOutputSize));
+
+	for (int i = 0; i < kOutputSize; i++) {
+		float bad[kOutputSize] = {0.5f, 0.5f, 0.5f, 0.5f};
+		bad[i] = (i % 2 == 0) ? NAN : INFINITY;
+		EXPECT_FALSE(outputs_finite(bad, kOutputSize)) << "channel " << i;
+	}
+}
+
+TEST(NnControlChecksTest, theExpectedModelLayoutIsAccepted)
+{
+	EXPECT_EQ(model_layout_problem(3, 3, 1, kInputSize, true, 1, kOutputSize, true), nullptr);
+}
+
+TEST(NnControlChecksTest, everyModelLayoutMismatchIsNamed)
+{
+	EXPECT_STREQ(model_layout_problem(2, 3, 1, kInputSize, true, 1, kOutputSize, true), "schema version");
+	EXPECT_STREQ(model_layout_problem(3, 3, 2, kInputSize, true, 1, kOutputSize, true), "input tensors, expected one");
+	EXPECT_STREQ(model_layout_problem(3, 3, 1, kInputSize, true, 2, kOutputSize, true), "output tensors, expected one");
+	EXPECT_STREQ(model_layout_problem(3, 3, 1, 12, true, 1, kOutputSize, true), "input size, expected 15 elements");
+	EXPECT_STREQ(model_layout_problem(3, 3, 1, kInputSize, false, 1, kOutputSize, true), "input type, expected float32");
+	EXPECT_STREQ(model_layout_problem(3, 3, 1, kInputSize, true, 1, 6, true), "output size, expected 4 elements");
+	EXPECT_STREQ(model_layout_problem(3, 3, 1, kInputSize, true, 1, kOutputSize, false), "output type, expected float32");
+}

--- a/src/modules/mc_nn_control/NnControlModelTest.cpp
+++ b/src/modules/mc_nn_control/NnControlModelTest.cpp
@@ -1,0 +1,93 @@
+/****************************************************************************
+*
+*   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+* 3. Neither the name PX4 nor the names of its contributors may be
+*    used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+****************************************************************************/
+
+/**
+ * @file NnControlModelTest.cpp
+ * Loads the shipped network through the real interpreter and runs the layout
+ * check the module runs at start on it, so a swapped model array that the
+ * module cannot feed fails here before it fails on a vehicle.
+ *
+ * to run, on a config that enables the module:
+ *   cmake -DCMAKE_TESTING=ON build/px4_sitl_neural
+ *   ninja -C build/px4_sitl_neural unit-NnControlModel
+ */
+
+#include <gtest/gtest.h>
+
+#include <tflite_micro/tensorflow/lite/micro/micro_interpreter.h>
+#include <tflite_micro/tensorflow/lite/schema/schema_generated.h>
+
+#include "control_net.hpp"
+#include "nn_control_checks.hpp"
+#include "nn_control_model.hpp"
+
+static int element_count(const TfLiteTensor *tensor)
+{
+	int count = 1;
+
+	for (int i = 0; i < tensor->dims->size; i++) {
+		count *= tensor->dims->data[i];
+	}
+
+	return count;
+}
+
+TEST(NnControlModelTest, theShippedModelPassesTheLayoutCheck)
+{
+	const tflite::Model *model = ::tflite::GetModel(control_net_tflite);
+	ASSERT_NE(model, nullptr);
+	EXPECT_EQ(model->version(), TFLITE_SCHEMA_VERSION);
+
+	static nn_control::OpResolver resolver;
+	ASSERT_EQ(nn_control::register_ops(resolver), kTfLiteOk);
+
+	constexpr int kArenaSize = 10 * 1024;
+	static uint8_t arena[kArenaSize];
+	tflite::MicroInterpreter interpreter(model, resolver, arena, kArenaSize);
+	ASSERT_EQ(interpreter.AllocateTensors(), kTfLiteOk);
+
+	const TfLiteTensor *input = interpreter.input(0);
+	const TfLiteTensor *output = interpreter.output(0);
+	ASSERT_NE(input, nullptr);
+	ASSERT_NE(output, nullptr);
+
+	EXPECT_EQ(interpreter.inputs_size(), 1u);
+	EXPECT_EQ(interpreter.outputs_size(), 1u);
+	EXPECT_EQ(element_count(input), nn_control::kInputSize);
+	EXPECT_EQ(element_count(output), nn_control::kOutputSize);
+
+	const char *problem = nn_control::model_layout_problem(model->version(), TFLITE_SCHEMA_VERSION,
+			      (int)interpreter.inputs_size(), element_count(input), input->type == kTfLiteFloat32,
+			      (int)interpreter.outputs_size(), element_count(output), output->type == kTfLiteFloat32);
+	EXPECT_EQ(problem, nullptr) << problem;
+}

--- a/src/modules/mc_nn_control/RescaleActionTest.cpp
+++ b/src/modules/mc_nn_control/RescaleActionTest.cpp
@@ -1,0 +1,273 @@
+/****************************************************************************
+*
+*   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+* 3. Neither the name PX4 nor the names of its contributors may be
+*    used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+****************************************************************************/
+
+/**
+ * @file RescaleActionTest.cpp
+ * Unit tests for the network action to motor command mapping. They assert the
+ * properties the mapping has to keep rather than any particular output value,
+ * and derive every threshold from the mapping's own achievable range, so a
+ * change to the defaults only fails them when a property is broken.
+ *
+ * to run, on a config that enables the module:
+ *   cmake -DCMAKE_TESTING=ON build/px4_sitl_neural
+ *   ninja -C build/px4_sitl_neural unit-RescaleAction
+ *   ctest --test-dir build/px4_sitl_neural -R RescaleAction
+ */
+
+#include <gtest/gtest.h>
+#include <cmath>
+
+#include "actions_rescale.hpp"
+
+using nn_control::rescale_action;
+using nn_control::achievable_action_range;
+using nn_control::valid_motor_limits;
+
+struct Params {
+	float thrust_coeff;
+	float min_rpm;
+	float max_rpm;
+};
+
+// The shipped defaults from mc_nn_control_params.yaml, a smaller motor whose
+// minimum rpm is above a ninth of its maximum, and a motor whose limits cover
+// the whole action range. The properties below hold for all of them.
+static constexpr Params kDefaults{1.2f, 1000.f, 22000.f};
+static constexpr Params kSmallMotor{3.0f, 2000.f, 12000.f};
+static constexpr Params kMatchedMotor{1.2f, 0.f, 24495.f};
+static constexpr Params kParamSets[] = {kDefaults, kSmallMotor, kMatchedMotor};
+
+static float map(float action, const Params &p)
+{
+	return rescale_action(action, p.thrust_coeff, p.min_rpm, p.max_rpm);
+}
+
+static void range(const Params &p, float &lowest, float &highest)
+{
+	achievable_action_range(p.thrust_coeff, p.min_rpm, p.max_rpm, lowest, highest);
+}
+
+TEST(RescaleActionTest, actionsBeyondOneClampToTheBoundary)
+{
+	for (const Params &p : kParamSets) {
+		EXPECT_FLOAT_EQ(map(-5.f, p), map(-1.f, p));
+		EXPECT_FLOAT_EQ(map(5.f, p), map(1.f, p));
+	}
+}
+
+TEST(RescaleActionTest, commandsStayWithinZeroAndOne)
+{
+	for (const Params &p : kParamSets) {
+		for (float action = -1.f; action <= 1.f; action += 0.01f) {
+			const float cmd = map(action, p);
+			EXPECT_GE(cmd, 0.f) << "below zero at action " << action;
+			EXPECT_LE(cmd, 1.f) << "above one at action " << action;
+		}
+	}
+}
+
+TEST(RescaleActionTest, lowestActionIdlesTheMotorAndHighestRunsItAtFullScale)
+{
+	for (const Params &p : kParamSets) {
+		EXPECT_FLOAT_EQ(map(-1.f, p), 0.f);
+		// a motor whose maximum rpm is only just reached at action one lands a
+		// rounding step short of it
+		EXPECT_NEAR(map(1.f, p), 1.f, 1e-4f);
+	}
+}
+
+TEST(RescaleActionTest, mappingDoesNotDecrease)
+{
+	for (const Params &p : kParamSets) {
+		float prev = map(-1.f, p);
+
+		for (float action = -0.99f; action <= 1.f; action += 0.01f) {
+			const float cmd = map(action, p);
+			EXPECT_GE(cmd, prev) << "decreases at action " << action;
+			prev = cmd;
+		}
+	}
+}
+
+TEST(RescaleActionTest, mappingRisesInsideTheAchievableRange)
+{
+	for (const Params &p : kParamSets) {
+		float lowest, highest;
+		range(p, lowest, highest);
+		const float start = fmaxf(lowest, -1.f);
+		const float end = fminf(highest, 1.f);
+		float prev = map(start, p);
+
+		for (float action = start + 0.01f; action < end; action += 0.01f) {
+			const float cmd = map(action, p);
+			EXPECT_GT(cmd, prev) << "flat at action " << action;
+			prev = cmd;
+		}
+	}
+}
+
+TEST(RescaleActionTest, actionsOutsideTheAchievableRangeSitOnTheBounds)
+{
+	for (const Params &p : kParamSets) {
+		float lowest, highest;
+		range(p, lowest, highest);
+
+		if (lowest > -1.f) {
+			EXPECT_FLOAT_EQ(map(lowest - 0.001f, p), 0.f);
+		}
+
+		if (highest < 1.f) {
+			EXPECT_FLOAT_EQ(map(highest + 0.001f, p), 1.f);
+			EXPECT_LT(map(highest - 0.01f, p), 1.f);
+		}
+	}
+}
+
+TEST(RescaleActionTest, achievableRangeFollowsTheLimits)
+{
+	float lowest, highest;
+	range(kMatchedMotor, lowest, highest);
+	EXPECT_NEAR(lowest, -1.f, 1e-3f);
+	EXPECT_NEAR(highest, 1.f, 1e-3f);
+
+	range(kDefaults, lowest, highest);
+	EXPECT_GT(lowest, -1.f);
+	EXPECT_LT(highest, 1.f);
+}
+
+TEST(RescaleActionTest, outputsRemainFiniteForNormalInputs)
+{
+	for (const Params &p : kParamSets) {
+		for (float action = -1.f; action <= 1.f; action += 0.01f) {
+			EXPECT_TRUE(std::isfinite(map(action, p))) << "not finite at action " << action;
+		}
+	}
+}
+
+// Every accepted set of limits has to give a real command somewhere inside the
+// action range, and every rejected set has to give none. The intermediate command
+// check does not go through the validator, so it is an independent oracle for it.
+static void check_limits(float thrust_coeff, float min_rpm, float max_rpm, int &valid_sets, int &rejected_sets)
+{
+	const bool valid = valid_motor_limits(thrust_coeff, min_rpm, max_rpm);
+	valid ? valid_sets++ : rejected_sets++;
+
+	for (float action = -1.f; action <= 1.f; action += 0.25f) {
+		EXPECT_EQ(std::isfinite(rescale_action(action, thrust_coeff, min_rpm, max_rpm)), valid)
+				<< "thrust_coeff " << thrust_coeff << " min " << min_rpm << " max " << max_rpm << " action " << action;
+	}
+
+	if (valid) {
+		float lowest, highest;
+		achievable_action_range(thrust_coeff, min_rpm, max_rpm, lowest, highest);
+		const float middle = (fmaxf(lowest, -1.f) + fminf(highest, 1.f)) / 2.f;
+		const float cmd = rescale_action(middle, thrust_coeff, min_rpm, max_rpm);
+		EXPECT_GT(cmd, 0.f) << "thrust_coeff " << thrust_coeff << " min " << min_rpm << " max " << max_rpm;
+		EXPECT_LT(cmd, 1.f) << "thrust_coeff " << thrust_coeff << " min " << min_rpm << " max " << max_rpm;
+	}
+}
+
+TEST(RescaleActionTest, acceptedLimitsCommandSomethingBetweenIdleAndFullScale)
+{
+	int valid_sets = 0;
+	int rejected_sets = 0;
+
+	// the limits from mc_nn_control_params.yaml, with the rpm pair kept apart
+	for (float thrust_coeff = 0.01f; thrust_coeff <= 5.f; thrust_coeff += 0.05f) {
+		for (float min_rpm = 0.f; min_rpm < 80000.f; min_rpm += 8000.f) {
+			for (float max_rpm = min_rpm + 500.f; max_rpm <= 80000.f; max_rpm += 8000.f) {
+				check_limits(thrust_coeff, min_rpm, max_rpm, valid_sets, rejected_sets);
+			}
+		}
+	}
+
+	// narrow windows near the bottom of the range, where float rounding once let a
+	// set through whose only outputs were the two clamps, up to bands wide enough
+	// to be accepted again
+	for (float max_rpm = 1.f; max_rpm <= 4000.f; max_rpm += 1.f) {
+		check_limits(0.01f, 0.f, max_rpm, valid_sets, rejected_sets);
+	}
+
+	EXPECT_GT(valid_sets, 0);
+	EXPECT_GT(rejected_sets, 0);
+}
+
+TEST(RescaleActionTest, nonFiniteActionGivesNoCommand)
+{
+	// the caller maps a non finite command to a stopped motor, so the mapping
+	// must not turn a bad action into a number
+	for (const Params &p : kParamSets) {
+		EXPECT_FALSE(std::isfinite(map(NAN, p)));
+	}
+}
+
+TEST(RescaleActionTest, invalidLimitsAreRejected)
+{
+	// ordering and sign
+	EXPECT_FALSE(valid_motor_limits(1.2f, 5000.f, 5000.f));
+	EXPECT_FALSE(valid_motor_limits(1.2f, 6000.f, 5000.f));
+	EXPECT_FALSE(valid_motor_limits(0.f, 1000.f, 22000.f));
+	EXPECT_FALSE(valid_motor_limits(-1.2f, 1000.f, 22000.f));
+	EXPECT_FALSE(valid_motor_limits(1.2f, -1.f, 22000.f));
+
+	// raw parameter writes are not bounded by the metadata, so non finite values
+	// have to be caught here. An infinite coefficient would map every action to
+	// idle while looking valid.
+	EXPECT_FALSE(valid_motor_limits(INFINITY, 1000.f, 22000.f));
+	EXPECT_FALSE(valid_motor_limits(NAN, 1000.f, 22000.f));
+	EXPECT_FALSE(valid_motor_limits(1.2f, NAN, 22000.f));
+	EXPECT_FALSE(valid_motor_limits(1.2f, 1000.f, INFINITY));
+
+	// limits the action range cannot reach: idle already above action one, or
+	// full scale still below action minus one, or a window too narrow to hold a
+	// representable action
+	EXPECT_FALSE(valid_motor_limits(5.f, 79999.f, 80000.f));
+	EXPECT_FALSE(valid_motor_limits(0.01f, 0.f, 1.f));
+	EXPECT_FALSE(valid_motor_limits(0.01f, 0.f, 33.f));
+
+	// values that overflow the achievable range would otherwise clip to a full span
+	EXPECT_FALSE(valid_motor_limits(1e38f, 0.f, 1e38f));
+
+	// a narrow band is still a band. This motor answers to five percent of the
+	// action range and has to be accepted, the range warning is what tells the
+	// user about it.
+	EXPECT_TRUE(valid_motor_limits(1.2f, 1000.f, 3999.f));
+
+	for (const Params &p : kParamSets) {
+		EXPECT_TRUE(valid_motor_limits(p.thrust_coeff, p.min_rpm, p.max_rpm));
+	}
+
+	EXPECT_FALSE(std::isfinite(rescale_action(0.f, 1.2f, 5000.f, 5000.f)));
+	EXPECT_FALSE(std::isfinite(rescale_action(0.f, INFINITY, 1000.f, 22000.f)));
+	EXPECT_FALSE(std::isfinite(rescale_action(0.f, 5.f, 79999.f, 80000.f)));
+}

--- a/src/modules/mc_nn_control/actions_rescale.hpp
+++ b/src/modules/mc_nn_control/actions_rescale.hpp
@@ -35,6 +35,11 @@
  * @file actions_rescale.hpp
  * Maps a network action to a normalized motor command. Header only and free of
  * module dependencies so it can be unit tested directly.
+ *
+ * The network acts in [-1, 1]. An action is read as a per motor thrust of
+ * action + 1 in the units the thrust coefficient was fitted in, turned into an
+ * rpm through that coefficient, and placed between the motor's rpm limits. The
+ * last step compensates the motor's thrust curve.
  */
 
 #pragma once
@@ -44,21 +49,74 @@
 namespace nn_control
 {
 
+static constexpr float kThrustCoeffScale = 100000.0f;
+
+// The part of the action range that reaches the motor has to be at least this
+// wide, about a thousand representable actions at the edge of the range. Narrower
+// than this and float rounding can leave a window with no action inside it, idle
+// on one side and full scale on the other. It says nothing about how narrow a
+// band a user may want, the range warning reports that.
+static constexpr float kMinAchievableActionSpan = 1e-4f;
+
 /**
- * Map one network action in [-1, 1] to a normalized motor command.
+ * The part of the action range the configured motor can reproduce. Actions below
+ * lowest idle the motor, actions above highest run it at full scale.
+ */
+static inline void achievable_action_range(float thrust_coeff_raw, float min_rpm, float max_rpm,
+		float &lowest, float &highest)
+{
+	const float thrust_coeff = thrust_coeff_raw / kThrustCoeffScale;
+	lowest = thrust_coeff * (min_rpm / 60.f) * (min_rpm / 60.f) - 1.f;
+	highest = thrust_coeff * (max_rpm / 60.f) * (max_rpm / 60.f) - 1.f;
+}
+
+/**
+ * True when the limits describe a motor the mapping can work with: finite, the
+ * coefficient above zero, 0 <= min < max, and a part of the action range at least
+ * kMinAchievableActionSpan wide reaching something between idle and full scale.
+ * The parameter metadata bounds each value on its own, this checks them together
+ * and against raw writes.
+ */
+static inline bool valid_motor_limits(float thrust_coeff_raw, float min_rpm, float max_rpm)
+{
+	if (!isfinite(thrust_coeff_raw) || !isfinite(min_rpm) || !isfinite(max_rpm)) {
+		return false;
+	}
+
+	if (!(thrust_coeff_raw > 0.f) || !(min_rpm >= 0.f) || !(max_rpm > min_rpm)) {
+		return false;
+	}
+
+	float lowest = 0.f;
+	float highest = 0.f;
+	achievable_action_range(thrust_coeff_raw, min_rpm, max_rpm, lowest, highest);
+
+	// values large enough to overflow the range would clip to a full span
+	if (!isfinite(lowest) || !isfinite(highest)) {
+		return false;
+	}
+
+	const float usable_low = (lowest > -1.f) ? lowest : -1.f;
+	const float usable_high = (highest < 1.f) ? highest : 1.f;
+	return (usable_high - usable_low) > kMinAchievableActionSpan;
+}
+
+/**
+ * Map one network action in [-1, 1] to a normalized motor command in [0, 1].
  *
  * @param action network output, clamped to [-1, 1]
  * @param thrust_coeff_raw MC_NN_THRST_COEF as stored (scaled by 1e-5 internally)
  * @param min_rpm MC_NN_MIN_RPM
  * @param max_rpm MC_NN_MAX_RPM
+ * @return the command, NAN for a non finite action or limits that fail valid_motor_limits()
  */
 static inline float rescale_action(float action, float thrust_coeff_raw, float min_rpm, float max_rpm)
 {
-	const float thrust_coeff = thrust_coeff_raw / 100000.0f;
-	const float a = 0.8f;
-	const float b = (1.0f - 0.8f);
-	const float tmp1 = b / (2.f * a);
-	const float tmp2 = b * b / (4.f * a * a);
+	if (!valid_motor_limits(thrust_coeff_raw, min_rpm, max_rpm) || !isfinite(action)) {
+		return NAN;
+	}
+
+	const float thrust_coeff = thrust_coeff_raw / kThrustCoeffScale;
 
 	if (action < -1.0f) {
 		action = -1.0f;
@@ -67,12 +125,26 @@ static inline float rescale_action(float action, float thrust_coeff_raw, float m
 		action = 1.0f;
 	}
 
-	action = action + 1.0f;
-	float rps = action / thrust_coeff;
-	rps = sqrtf(rps);
-	const float rpm = rps * 60.0f;
-	const float scaled = (rpm * 2.0f - max_rpm - min_rpm) / (max_rpm - min_rpm);
-	return a * (((scaled + 1.0f) / 2.0f + tmp1) * ((scaled + 1.0f) / 2.0f + tmp1) - tmp2);
+	const float rpm = 60.0f * sqrtf((action + 1.0f) / thrust_coeff);
+
+	// Where that rpm sits between the motor's limits. Below the minimum the motor
+	// idles, above the maximum it is at full scale. Without the two bounds the
+	// bottom of the action range went negative, which the motor output treats as
+	// disarmed, and the top went past full scale.
+	float x = (rpm - min_rpm) / (max_rpm - min_rpm);
+
+	if (x < 0.f) {
+		x = 0.f;
+
+	} else if (x > 1.f) {
+		x = 1.f;
+	}
+
+	// Thrust curve compensation, a * x^2 + (1 - a) * x, which is 0 at idle and 1
+	// at full scale exactly. This is the same polynomial the module always used,
+	// written out instead of in vertex form.
+	const float a = 0.8f;
+	return a * x * x + (1.0f - a) * x;
 }
 
 } // namespace nn_control

--- a/src/modules/mc_nn_control/actions_rescale.hpp
+++ b/src/modules/mc_nn_control/actions_rescale.hpp
@@ -1,0 +1,78 @@
+/****************************************************************************
+*
+*   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+* 3. Neither the name PX4 nor the names of its contributors may be
+*    used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+****************************************************************************/
+
+/**
+ * @file actions_rescale.hpp
+ * Maps a network action to a normalized motor command. Header only and free of
+ * module dependencies so it can be unit tested directly.
+ */
+
+#pragma once
+
+#include <math.h>
+
+namespace nn_control
+{
+
+/**
+ * Map one network action in [-1, 1] to a normalized motor command.
+ *
+ * @param action network output, clamped to [-1, 1]
+ * @param thrust_coeff_raw MC_NN_THRST_COEF as stored (scaled by 1e-5 internally)
+ * @param min_rpm MC_NN_MIN_RPM
+ * @param max_rpm MC_NN_MAX_RPM
+ */
+static inline float rescale_action(float action, float thrust_coeff_raw, float min_rpm, float max_rpm)
+{
+	const float thrust_coeff = thrust_coeff_raw / 100000.0f;
+	const float a = 0.8f;
+	const float b = (1.0f - 0.8f);
+	const float tmp1 = b / (2.f * a);
+	const float tmp2 = b * b / (4.f * a * a);
+
+	if (action < -1.0f) {
+		action = -1.0f;
+
+	} else if (action > 1.0f) {
+		action = 1.0f;
+	}
+
+	action = action + 1.0f;
+	float rps = action / thrust_coeff;
+	rps = sqrtf(rps);
+	const float rpm = rps * 60.0f;
+	const float scaled = (rpm * 2.0f - max_rpm - min_rpm) / (max_rpm - min_rpm);
+	return a * (((scaled + 1.0f) / 2.0f + tmp1) * ((scaled + 1.0f) / 2.0f + tmp1) - tmp2);
+}
+
+} // namespace nn_control

--- a/src/modules/mc_nn_control/mc_nn_control.cpp
+++ b/src/modules/mc_nn_control/mc_nn_control.cpp
@@ -39,6 +39,9 @@
 */
 
 #include "mc_nn_control.hpp"
+#include <px4_platform_common/events.h>
+
+using namespace time_literals;
 #ifdef __PX4_NUTTX
 #include <drivers/drv_hrt.h>
 #else
@@ -87,7 +90,77 @@ bool MulticopterNeuralNetworkControl::init()
 		return false;
 	}
 
+	updateParams();
+	UpdateMotorLimits();
+
 	return true;
+}
+
+void MulticopterNeuralNetworkControl::UpdateMotorLimits()
+{
+	const float thrust_coeff = _param_thrust_coeff.get();
+	const float min_rpm = _param_min_rpm.get();
+	const float max_rpm = _param_max_rpm.get();
+
+	if (!nn_control::valid_motor_limits(thrust_coeff, min_rpm, max_rpm)) {
+		// The mapping keeps whatever was valid before, so a write while flying does
+		// not step the motors. The arming check reply refuses the mode until the
+		// parameters are corrected, and the error repeats while they stand.
+		if (_motor_limits_valid || (_last_invalid_limits_report == 0)) {
+			ReportInvalidLimits();
+		}
+
+		_motor_limits_valid = false;
+		return;
+	}
+
+	// Any parameter on the system triggers an update, so only report when the
+	// limits themselves changed
+	const bool unchanged = _mapping_valid && (thrust_coeff == _mapping_thrust_coeff) && (min_rpm == _mapping_min_rpm)
+			       && (max_rpm == _mapping_max_rpm);
+	_motor_limits_valid = true;
+
+	if (unchanged) {
+		return;
+	}
+
+	_mapping_thrust_coeff = thrust_coeff;
+	_mapping_min_rpm = min_rpm;
+	_mapping_max_rpm = max_rpm;
+	_mapping_valid = true;
+
+	ReportActionRange();
+}
+
+void MulticopterNeuralNetworkControl::ReportInvalidLimits()
+{
+	_last_invalid_limits_report = hrt_absolute_time();
+	/* EVENT
+	 * @description
+	 * The limits have to be finite, with MC_NN_THRST_COEF above zero, MC_NN_MIN_RPM at least zero and
+	 * below MC_NN_MAX_RPM, and reaching at least part of the network's action range. The mapping keeps
+	 * the last valid set and the mode refuses the arming check until they are corrected.
+	 */
+	events::send<int32_t, int32_t, float>(events::ID("mc_nn_control_motor_limits_invalid"), events::Log::Error,
+					      "Neural control: invalid motor limits, MC_NN_MIN_RPM {2}, MC_NN_MAX_RPM {1}, MC_NN_THRST_COEF {3:.2}",
+					      (int32_t)_param_max_rpm.get(), (int32_t)_param_min_rpm.get(), _param_thrust_coeff.get());
+}
+
+void MulticopterNeuralNetworkControl::ReportActionRange()
+{
+	// Say which part of the action range this motor can reproduce, so a mismatch
+	// between the thrust coefficient and the rpm limits is visible rather than
+	// silently clipped in flight. Sent when the limits change and when the mode
+	// is entered, since a message from boot can pass before a link is up.
+	float lowest = 0.f;
+	float highest = 0.f;
+	nn_control::achievable_action_range(_mapping_thrust_coeff, _mapping_min_rpm, _mapping_max_rpm, lowest, highest);
+
+	if ((lowest > -0.95f) || (highest < 0.95f)) {
+		events::send<float, float>(events::ID("mc_nn_control_action_range"), events::Log::Warning,
+					   "Neural control: motor limits cover actions {1:.2} to {2:.2} of -1 to 1",
+					   math::max(lowest, -1.f), math::min(highest, 1.f));
+	}
 }
 
 int MulticopterNeuralNetworkControl::InitializeNetwork()
@@ -193,13 +266,20 @@ void MulticopterNeuralNetworkControl::ConfigureNeuralFlightMode(int8 mode_id)
 void MulticopterNeuralNetworkControl::ReplyToArmingCheck(int8 request_id)
 {
 	// Reply to the arming check request
-	arming_check_reply_s arming_check_reply;
+	arming_check_reply_s arming_check_reply{};
 	arming_check_reply.timestamp = hrt_absolute_time();
 	arming_check_reply.request_id = request_id;
 	arming_check_reply.registration_id = _arming_check_id;
 	arming_check_reply.health_component_index = arming_check_reply.HEALTH_COMPONENT_INDEX_NONE;
 	arming_check_reply.num_events = 0;
-	arming_check_reply.can_arm_and_run = true;
+	arming_check_reply.can_arm_and_run = _motor_limits_valid;
+
+	// The reason is a standalone event, repeated while the limits stay invalid so
+	// it is not lost on a link that came up later
+	if (!_motor_limits_valid && (hrt_elapsed_time(&_last_invalid_limits_report) > 10_s)) {
+		ReportInvalidLimits();
+	}
+
 	arming_check_reply.mode_req_angular_velocity = true;
 	arming_check_reply.mode_req_local_position = true;
 	arming_check_reply.mode_req_attitude = true;
@@ -373,6 +453,7 @@ void MulticopterNeuralNetworkControl::PublishOutput(float *command_actions)
 
 	actuator_motors_s actuator_motors;
 	actuator_motors.timestamp = hrt_absolute_time();
+	actuator_motors.timestamp_sample = _angular_velocity.timestamp_sample;
 
 	actuator_motors.control[0] = PX4_ISFINITE(command_actions[0]) ? command_actions[0] : NAN;
 	actuator_motors.control[1] = PX4_ISFINITE(command_actions[1]) ? command_actions[1] : NAN;
@@ -397,7 +478,7 @@ inline void MulticopterNeuralNetworkControl::RescaleActions()
 {
 	for (int i = 0; i < 4; i++) {
 		_output_tensor->data.f[i] = nn_control::rescale_action(_output_tensor->data.f[i],
-					    _param_thrust_coeff.get(), _param_min_rpm.get(), _param_max_rpm.get());
+					    _mapping_thrust_coeff, _mapping_min_rpm, _mapping_max_rpm);
 	}
 }
 
@@ -474,6 +555,7 @@ void MulticopterNeuralNetworkControl::Run()
 
 		if (!prev_use_neural && _use_neural) {
 			ConfigureNeuralFlightMode(_mode_id);
+			ReportActionRange();
 		}
 	}
 
@@ -481,9 +563,10 @@ void MulticopterNeuralNetworkControl::Run()
 		parameter_update_s param_update;
 		_parameter_update_sub.copy(&param_update);
 		updateParams();
+		UpdateMotorLimits();
 	}
 
-	if (!_use_neural) {
+	if (!_use_neural || !_mapping_valid) {
 		// If the neural network flight mode is not enabled, do nothing
 		perf_end(_loop_perf);
 		return;
@@ -543,6 +626,7 @@ void MulticopterNeuralNetworkControl::Run()
 
 		if (invoke_status != kTfLiteOk) {
 			PX4_ERR("Invoke() failed");
+			perf_end(_loop_perf);
 			return;
 		}
 
@@ -550,6 +634,7 @@ void MulticopterNeuralNetworkControl::Run()
 
 		if (_output_tensor == nullptr) {
 			PX4_ERR("Output tensor is null");
+			perf_end(_loop_perf);
 			return;
 		}
 

--- a/src/modules/mc_nn_control/mc_nn_control.cpp
+++ b/src/modules/mc_nn_control/mc_nn_control.cpp
@@ -395,30 +395,9 @@ void MulticopterNeuralNetworkControl::PublishOutput(float *command_actions)
 
 inline void MulticopterNeuralNetworkControl::RescaleActions()
 {
-	const float thrust_coeff = _param_thrust_coeff.get() / 100000.0f;
-	const float min_rpm = _param_min_rpm.get();
-	const float max_rpm = _param_max_rpm.get();
-	const float a = 0.8f;
-	const float b = (1.0f - 0.8f);
-	const float tmp1 = b / (2.f * a);
-	const float tmp2 = b * b / (4.f * a * a);
-
 	for (int i = 0; i < 4; i++) {
-
-		if (_output_tensor->data.f[i] < -1.0f) {
-			_output_tensor->data.f[i] = -1.0f;
-
-		} else if (_output_tensor->data.f[i] > 1.0f) {
-			_output_tensor->data.f[i] = 1.0f;
-		}
-
-		_output_tensor->data.f[i] = _output_tensor->data.f[i] + 1.0f;
-		float rps = _output_tensor->data.f[i] / thrust_coeff;
-		rps = sqrtf(rps);
-		float rpm = rps * 60.0f;
-		_output_tensor->data.f[i] = (rpm * 2.0f - max_rpm - min_rpm) / (max_rpm - min_rpm);
-		_output_tensor->data.f[i] = a * (((_output_tensor->data.f[i] + 1.0f) / 2.0f + tmp1) * ((
-				_output_tensor->data.f[i] + 1.0f) / 2.0f + tmp1) - tmp2);
+		_output_tensor->data.f[i] = nn_control::rescale_action(_output_tensor->data.f[i],
+					    _param_thrust_coeff.get(), _param_min_rpm.get(), _param_max_rpm.get());
 	}
 }
 

--- a/src/modules/mc_nn_control/mc_nn_control.cpp
+++ b/src/modules/mc_nn_control/mc_nn_control.cpp
@@ -296,7 +296,7 @@ void MulticopterNeuralNetworkControl::generate_trajectory_setpoint(float dt)
 
 void MulticopterNeuralNetworkControl::PopulateInputTensor()
 {
-	// Creates a 15 element input tensor for the neural network [pos_err(3), lin_vel(3), att(6), ang_vel(3)]
+	// Creates a 15 element input tensor for the neural network [pos_err(3), att(6), lin_vel(3), ang_vel(3)]
 
 	// transform observations in correct frame
 	matrix::Dcmf frame_transf;
@@ -414,7 +414,7 @@ inline void MulticopterNeuralNetworkControl::RescaleActions()
 
 		_output_tensor->data.f[i] = _output_tensor->data.f[i] + 1.0f;
 		float rps = _output_tensor->data.f[i] / thrust_coeff;
-		rps = sqrt(rps);
+		rps = sqrtf(rps);
 		float rpm = rps * 60.0f;
 		_output_tensor->data.f[i] = (rpm * 2.0f - max_rpm - min_rpm) / (max_rpm - min_rpm);
 		_output_tensor->data.f[i] = a * (((_output_tensor->data.f[i] + 1.0f) / 2.0f + tmp1) * ((

--- a/src/modules/mc_nn_control/mc_nn_control.cpp
+++ b/src/modules/mc_nn_control/mc_nn_control.cpp
@@ -52,17 +52,6 @@ ModuleBase::Descriptor MulticopterNeuralNetworkControl::desc{task_spawn, custom_
 
 namespace
 {
-// This number should be the number of operations in the model, like tanh and fully connected
-using NNControlOpResolver = tflite::MicroMutableOpResolver<3>;
-
-TfLiteStatus RegisterOps(NNControlOpResolver &op_resolver)
-{
-	// Add the operations to you need to the op_resolver
-	TF_LITE_ENSURE_STATUS(op_resolver.AddFullyConnected());
-	TF_LITE_ENSURE_STATUS(op_resolver.AddRelu());
-	TF_LITE_ENSURE_STATUS(op_resolver.AddAdd());
-	return kTfLiteOk;
-}
 }  // namespace
 
 MulticopterNeuralNetworkControl::MulticopterNeuralNetworkControl() :
@@ -176,10 +165,17 @@ int MulticopterNeuralNetworkControl::InitializeNetwork()
 	// Initialize the neural network
 	const tflite::Model *control_model = ::tflite::GetModel(control_net_tflite);
 
-	// Set up the interpreter
-	static NNControlOpResolver resolver;
+	// Checked before the interpreter touches it, a model from another schema
+	// cannot be parsed
+	if (control_model->version() != TFLITE_SCHEMA_VERSION) {
+		PX4_ERR("model rejected: schema version %d, expected %d", (int)control_model->version(), TFLITE_SCHEMA_VERSION);
+		return -1;
+	}
 
-	if (RegisterOps(resolver) != kTfLiteOk) {
+	// Set up the interpreter
+	static nn_control::OpResolver resolver;
+
+	if (nn_control::register_ops(resolver) != kTfLiteOk) {
 		PX4_ERR("Failed to register ops");
 		return -1;
 	}
@@ -204,11 +200,36 @@ int MulticopterNeuralNetworkControl::InitializeNetwork()
 	}
 
 	_input_tensor = _interpreter->input(0);
+	TfLiteTensor *output_tensor = _interpreter->output(0);
 
-	if (_input_tensor == nullptr) {
-		PX4_ERR("Input tensor is null");
+	if ((_input_tensor == nullptr) || (output_tensor == nullptr)) {
+		PX4_ERR("model has no input or output tensor");
 		delete _interpreter;
 		_interpreter = nullptr;
+		return -1;
+	}
+
+	// The documentation tells users to swap the model array, so check that what was
+	// loaded is the shape this module feeds and reads
+	auto element_count = [](const TfLiteTensor * tensor) {
+		int count = 1;
+
+		for (int i = 0; i < tensor->dims->size; i++) {
+			count *= tensor->dims->data[i];
+		}
+
+		return count;
+	};
+
+	const char *problem = nn_control::model_layout_problem(control_model->version(), TFLITE_SCHEMA_VERSION,
+			      (int)_interpreter->inputs_size(), element_count(_input_tensor), _input_tensor->type == kTfLiteFloat32,
+			      (int)_interpreter->outputs_size(), element_count(output_tensor), output_tensor->type == kTfLiteFloat32);
+
+	if (problem != nullptr) {
+		PX4_ERR("model rejected: %s", problem);
+		delete _interpreter;
+		_interpreter = nullptr;
+		_input_tensor = nullptr;
 		return -1;
 	}
 

--- a/src/modules/mc_nn_control/mc_nn_control.cpp
+++ b/src/modules/mc_nn_control/mc_nn_control.cpp
@@ -56,10 +56,15 @@ namespace
 
 MulticopterNeuralNetworkControl::MulticopterNeuralNetworkControl() :
 	ModuleParams(nullptr),
-	WorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers),
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers),
 	_loop_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle"))
 {
-
+	// Unset until the mode is entered or a setpoint arrives, so the network is
+	// never pointed at whatever happened to be in memory
+	_trajectory_setpoint.position[0] = NAN;
+	_trajectory_setpoint.position[1] = NAN;
+	_trajectory_setpoint.position[2] = NAN;
+	_trajectory_setpoint.yaw = NAN;
 }
 
 MulticopterNeuralNetworkControl::~MulticopterNeuralNetworkControl()
@@ -81,6 +86,10 @@ bool MulticopterNeuralNetworkControl::init()
 
 	updateParams();
 	UpdateMotorLimits();
+
+	// The first run registers the mode and arms the watchdog, so it must not wait
+	// for a sensor that may never publish
+	ScheduleNow();
 
 	return true;
 }
@@ -133,6 +142,35 @@ void MulticopterNeuralNetworkControl::ReportInvalidLimits()
 	events::send<int32_t, int32_t, float>(events::ID("mc_nn_control_motor_limits_invalid"), events::Log::Error,
 					      "Neural control: invalid motor limits, MC_NN_MIN_RPM {2}, MC_NN_MAX_RPM {1}, MC_NN_THRST_COEF {3:.2}",
 					      (int32_t)_param_max_rpm.get(), (int32_t)_param_min_rpm.get(), _param_thrust_coeff.get());
+}
+
+void MulticopterNeuralNetworkControl::CheckObservations()
+{
+	nn_control::ObservationSnapshot snapshot{};
+	snapshot.position_timestamp = _position.timestamp;
+	snapshot.xy_valid = _position.xy_valid;
+	snapshot.z_valid = _position.z_valid;
+	snapshot.v_xy_valid = _position.v_xy_valid;
+	snapshot.v_z_valid = _position.v_z_valid;
+	snapshot.position[0] = _position.x;
+	snapshot.position[1] = _position.y;
+	snapshot.position[2] = _position.z;
+	snapshot.velocity[0] = _position.vx;
+	snapshot.velocity[1] = _position.vy;
+	snapshot.velocity[2] = _position.vz;
+	snapshot.attitude_timestamp = _attitude.timestamp;
+
+	for (int i = 0; i < 4; i++) {
+		snapshot.q[i] = _attitude.q[i];
+	}
+
+	snapshot.angular_velocity_timestamp = _angular_velocity.timestamp;
+
+	for (int i = 0; i < 3; i++) {
+		snapshot.angular_velocity[i] = _angular_velocity.xyz[i];
+	}
+
+	_observation_fault = nn_control::check_observations(snapshot, hrt_absolute_time());
 }
 
 void MulticopterNeuralNetworkControl::ReportActionRange()
@@ -293,7 +331,9 @@ void MulticopterNeuralNetworkControl::ReplyToArmingCheck(int8 request_id)
 	arming_check_reply.registration_id = _arming_check_id;
 	arming_check_reply.health_component_index = arming_check_reply.HEALTH_COMPONENT_INDEX_NONE;
 	arming_check_reply.num_events = 0;
-	arming_check_reply.can_arm_and_run = _motor_limits_valid;
+	arming_check_reply.can_arm_and_run = _motor_limits_valid
+					     && (_observation_fault == nn_control::ObservationFault::None)
+					     && !_output_fault;
 
 	// The reason is a standalone event, repeated while the limits stay invalid so
 	// it is not lost on a link that came up later
@@ -531,10 +571,22 @@ int MulticopterNeuralNetworkControl::task_spawn(int argc, char *argv[])
 	return PX4_ERROR;
 }
 
+void MulticopterNeuralNetworkControl::HoldLastCommand()
+{
+	// The mixer keeps the last command on its own, so repeating it changes nothing
+	// at the motors. It keeps the actuator topic and the lockstep simulators, which
+	// wait for an output every step, going while the commander leaves the mode.
+	// Only a command from this session is repeated, never one from an earlier one.
+	if (_have_last_command) {
+		PublishOutput(_last_command);
+	}
+}
+
 void MulticopterNeuralNetworkControl::Run()
 {
 	if (should_exit()) {
 		_angular_velocity_sub.unregisterCallback();
+		ScheduleClear();
 
 		if (_sent_mode_registration) {
 			UnregisterNeuralFlightMode(_arming_check_id, _mode_id);
@@ -543,6 +595,11 @@ void MulticopterNeuralNetworkControl::Run()
 		exit_and_cleanup(desc);
 		return;
 	}
+
+	// Runs are driven by angular velocity updates. This delayed run is what keeps the
+	// module registering, checking the observations and answering the commander when
+	// those updates stop, in the mode or not.
+	ScheduleDelayed(nn_control::kAngularVelocityWatchdog);
 
 	// Register the flight mode with the commander
 	if (!_sent_mode_registration) {
@@ -577,6 +634,13 @@ void MulticopterNeuralNetworkControl::Run()
 		if (!prev_use_neural && _use_neural) {
 			ConfigureNeuralFlightMode(_mode_id);
 			ReportActionRange();
+
+			// Without a setpoint of its own the mode holds the position it was entered at
+			if (!PX4_ISFINITE(_trajectory_setpoint.position[0])
+			    || !PX4_ISFINITE(_trajectory_setpoint.position[1])
+			    || !PX4_ISFINITE(_trajectory_setpoint.position[2])) {
+				reset_trajectory_setpoint(_position);
+			}
 		}
 	}
 
@@ -587,8 +651,60 @@ void MulticopterNeuralNetworkControl::Run()
 		UpdateMotorLimits();
 	}
 
+	// The observations are refreshed and checked on every cycle, in the mode or not,
+	// so the arming check reply always describes the current state
+	const bool angular_velocity_updated = _angular_velocity_sub.update(&_angular_velocity);
+
+	if (_attitude_sub.updated()) {
+		_attitude_sub.copy(&_attitude);
+	}
+
+	const bool position_updated = _position_sub.updated();
+
+	if (position_updated) {
+		_position_sub.copy(&_position);
+	}
+
+	CheckObservations();
+
 	if (!_use_neural || !_mapping_valid) {
-		// If the neural network flight mode is not enabled, do nothing
+		// If the neural network flight mode is not enabled, do nothing. A network that
+		// misbehaved is trusted again once the mode has been left.
+		_output_fault = false;
+		_reported_observation_fault = nn_control::ObservationFault::None;
+		_have_last_command = false;
+		perf_end(_loop_perf);
+		return;
+	}
+
+	if (_observation_fault != nn_control::ObservationFault::None) {
+		// Not run on observations that are missing, stale or not finite. The last
+		// command of this session is repeated and the arming check reply has the
+		// commander leave the mode. Checked here rather than on the angular velocity
+		// update so that a lost angular velocity stream is reported too.
+		if (_reported_observation_fault == nn_control::ObservationFault::None) {
+			/* EVENT
+			 * @description
+			 * The network is not run on observations that are missing, stale or not finite. The last
+			 * command is repeated and the mode reports itself unable to run so the commander leaves it.
+			 * Reason: 1 position invalid, 2 position stale, 3 position not finite, 4 attitude stale,
+			 * 5 attitude not finite, 6 angular velocity stale, 7 angular velocity not finite.
+			 */
+			events::send<uint8_t>(events::ID("mc_nn_control_observations_invalid"), events::Log::Error,
+					      "Neural control: observations invalid ({1}), not running the network",
+					      (uint8_t)_observation_fault);
+			_reported_observation_fault = _observation_fault;
+		}
+
+		HoldLastCommand();
+		perf_end(_loop_perf);
+		return;
+	}
+
+	_reported_observation_fault = nn_control::ObservationFault::None;
+
+	if (_output_fault) {
+		HoldLastCommand();
 		perf_end(_loop_perf);
 		return;
 	}
@@ -596,23 +712,16 @@ void MulticopterNeuralNetworkControl::Run()
 	int32_t start_time1 = GetTime();
 
 	// run controller on angular velocity updates
-	if (_angular_velocity_sub.update(&_angular_velocity)) {
+	if (angular_velocity_updated) {
 		const float dt = math::constrain(((_angular_velocity.timestamp_sample - _last_run) * 1e-6f), 0.0002f, 0.02f);
 		_last_run = _angular_velocity.timestamp_sample;
 
-		if (_attitude_sub.updated()) {
-			_attitude_sub.copy(&_attitude);
-		}
-
-		if (_position_sub.updated()) {
-			_position_sub.copy(&_position);
-
-			// If there is no position setpoint, use the position when switching mode as the setpoint
-			if (!PX4_ISFINITE(_trajectory_setpoint.position[0])
-			    && !PX4_ISFINITE(_trajectory_setpoint.position[1])
-			    && !PX4_ISFINITE(_trajectory_setpoint.position[2])) {
-				reset_trajectory_setpoint(_position);
-			}
+		// If there is no position setpoint, use the position when switching mode as the setpoint
+		if (position_updated
+		    && !PX4_ISFINITE(_trajectory_setpoint.position[0])
+		    && !PX4_ISFINITE(_trajectory_setpoint.position[1])
+		    && !PX4_ISFINITE(_trajectory_setpoint.position[2])) {
+			reset_trajectory_setpoint(_position);
 		}
 
 		if (_param_manual_control.get()) {
@@ -659,9 +768,31 @@ void MulticopterNeuralNetworkControl::Run()
 			return;
 		}
 
+		if (!nn_control::outputs_finite(_output_tensor->data.f, nn_control::kOutputSize)) {
+			// One bad channel would stop one motor while the other three keep thrusting.
+			// Repeat the last command instead and let the commander leave the mode. The
+			// network is not trusted again until it has.
+			_output_fault = true;
+			/* EVENT
+			 * @description
+			 * The last command is repeated and the mode reports itself unable to run so the commander
+			 * leaves it. The network is not run again until the mode has been left.
+			 */
+			events::send(events::ID("mc_nn_control_output_not_finite"), events::Log::Error,
+				     "Neural control: network output not finite, not running the network");
+			HoldLastCommand();
+			perf_end(_loop_perf);
+			return;
+		}
+
 		// Convert the output tensor to actuator values
 		RescaleActions();
 
+		for (int i = 0; i < nn_control::kOutputSize; i++) {
+			_last_command[i] = _output_tensor->data.f[i];
+		}
+
+		_have_last_command = true;
 		PublishOutput(_output_tensor->data.f);
 
 		int32_t full_controller_time = GetTime() - start_time1;

--- a/src/modules/mc_nn_control/mc_nn_control.hpp
+++ b/src/modules/mc_nn_control/mc_nn_control.hpp
@@ -113,6 +113,9 @@ private:
 	void PublishOutput(float *command_actions);
 	void RescaleActions();
 	int InitializeNetwork();
+	void UpdateMotorLimits();
+	void ReportInvalidLimits();
+	void ReportActionRange();
 	int32_t GetTime();
 	void RegisterNeuralFlightMode();
 	void UnregisterNeuralFlightMode(int8 arming_check_id, int8 mode_id);
@@ -145,6 +148,17 @@ private:
 	// Variables
 	bool _use_neural{false};
 	bool _sent_mode_registration{false};
+
+	// Motor limits the mapping runs with. Only a set that passed validation is
+	// copied here, so a bad parameter write cannot reach the motors. _motor_limits_valid
+	// follows the current parameters and gates the arming check, _mapping_valid says a
+	// set has been copied and gates the controller.
+	bool _motor_limits_valid{false};
+	bool _mapping_valid{false};
+	hrt_abstime _last_invalid_limits_report{0};
+	float _mapping_thrust_coeff{0.f};
+	float _mapping_min_rpm{0.f};
+	float _mapping_max_rpm{0.f};
 	perf_counter_t _loop_perf; /**< loop duration performance counter */
 	hrt_abstime _last_run{0};
 	uint8 _mode_request_id{231}; //Random value

--- a/src/modules/mc_nn_control/mc_nn_control.hpp
+++ b/src/modules/mc_nn_control/mc_nn_control.hpp
@@ -55,6 +55,7 @@
 
 // Include model
 #include "control_net.hpp"
+#include "actions_rescale.hpp"
 
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>

--- a/src/modules/mc_nn_control/mc_nn_control.hpp
+++ b/src/modules/mc_nn_control/mc_nn_control.hpp
@@ -56,6 +56,8 @@
 // Include model
 #include "control_net.hpp"
 #include "actions_rescale.hpp"
+#include "nn_control_checks.hpp"
+#include "nn_control_model.hpp"
 
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>

--- a/src/modules/mc_nn_control/mc_nn_control.hpp
+++ b/src/modules/mc_nn_control/mc_nn_control.hpp
@@ -46,7 +46,7 @@
 #include <px4_platform_common/log.h>
 #include <px4_platform_common/module.h>
 #include <px4_platform_common/module_params.h>
-#include <px4_platform_common/px4_work_queue/WorkItem.hpp>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <matrix/matrix/math.hpp>
 
 #include <tflite_micro/tensorflow/lite/micro/micro_mutable_op_resolver.h>
@@ -84,7 +84,7 @@
 
 using namespace time_literals; // For the 1_s in the subscription interval
 class MulticopterNeuralNetworkControl : public ModuleBase, public ModuleParams,
-	public px4::WorkItem
+	public px4::ScheduledWorkItem
 {
 public:
 
@@ -116,6 +116,8 @@ private:
 	void RescaleActions();
 	int InitializeNetwork();
 	void UpdateMotorLimits();
+	void CheckObservations();
+	void HoldLastCommand();
 	void ReportInvalidLimits();
 	void ReportActionRange();
 	int32_t GetTime();
@@ -157,6 +159,22 @@ private:
 	// set has been copied and gates the controller.
 	bool _motor_limits_valid{false};
 	bool _mapping_valid{false};
+
+	// Why the network is not being run on the current observations, checked every
+	// cycle so the arming check reply always describes the current state
+	nn_control::ObservationFault _observation_fault{nn_control::ObservationFault::PositionInvalid};
+	// The first fault of an outage, reported once. Everything goes stale together when
+	// a sensor stops, so the later faults of the same outage are not reported.
+	nn_control::ObservationFault _reported_observation_fault{nn_control::ObservationFault::None};
+
+	// A network that produced a non finite output is not trusted again until the
+	// mode is left
+	bool _output_fault{false};
+
+	// The last command sent in this session of the mode, repeated while the
+	// commander leaves the mode after a fault. Cleared whenever the mode is not active.
+	float _last_command[4] {};
+	bool _have_last_command{false};
 	hrt_abstime _last_invalid_limits_report{0};
 	float _mapping_thrust_coeff{0.f};
 	float _mapping_min_rpm{0.f};
@@ -170,7 +188,7 @@ private:
 	TfLiteTensor *_input_tensor{nullptr};
 	TfLiteTensor *_output_tensor{nullptr};
 	float _input_data[15];
-	trajectory_setpoint_s _trajectory_setpoint;
+	trajectory_setpoint_s _trajectory_setpoint{};
 	vehicle_angular_velocity_s _angular_velocity;
 	vehicle_local_position_s _position;
 	vehicle_attitude_s _attitude;

--- a/src/modules/mc_nn_control/mc_nn_control_params.yaml
+++ b/src/modules/mc_nn_control/mc_nn_control_params.yaml
@@ -11,7 +11,9 @@ parameters:
       description:
         short: Max motor RPM for neural network normalization
         long: The maximum RPM of the motors. Used to normalize the output of the neural
-          network
+          network. Has to be above MC_NN_MIN_RPM. Together with MC_NN_THRST_COEF it
+          sets the part of the action range the motor can reproduce, which the module
+          reports at startup.
       type: int32
       default: 22000
       min: 0
@@ -20,7 +22,7 @@ parameters:
       description:
         short: Min motor RPM for neural network normalization
         long: The minimum RPM of the motors. Used to normalize the output of the neural
-          network
+          network. Actions that ask for less than this idle the motor.
       type: int32
       default: 1000
       min: 0

--- a/src/modules/mc_nn_control/mc_nn_control_params.yaml
+++ b/src/modules/mc_nn_control/mc_nn_control_params.yaml
@@ -32,7 +32,7 @@ parameters:
           neural network. Divided by 100 000
       type: float
       default: 1.2
-      min: 0.0
+      min: 0.01
       max: 5.0
     MC_NN_MANL_CTRL:
       description:

--- a/src/modules/mc_nn_control/nn_control_checks.hpp
+++ b/src/modules/mc_nn_control/nn_control_checks.hpp
@@ -55,6 +55,10 @@ static constexpr uint64_t kMaxLocalPositionAge = 100000;
 static constexpr uint64_t kMaxAttitudeAge = 50000;
 static constexpr uint64_t kMaxAngularVelocityAge = 10000;
 
+// The controller runs on angular velocity updates. If they stop, a delayed run
+// this long after the last one is what notices.
+static constexpr uint64_t kAngularVelocityWatchdog = 2 * kMaxAngularVelocityAge;
+
 enum class ObservationFault : uint8_t {
 	None = 0,
 	PositionInvalid = 1,

--- a/src/modules/mc_nn_control/nn_control_checks.hpp
+++ b/src/modules/mc_nn_control/nn_control_checks.hpp
@@ -1,0 +1,180 @@
+/****************************************************************************
+*
+*   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+* 3. Neither the name PX4 nor the names of its contributors may be
+*    used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+****************************************************************************/
+
+/**
+ * @file nn_control_checks.hpp
+ * Checks the neural controller runs before it trusts its model, its observations
+ * and its output. Header only and free of module dependencies so they can be unit
+ * tested directly.
+ */
+
+#pragma once
+
+#include <math.h>
+#include <stdint.h>
+
+namespace nn_control
+{
+
+static constexpr int kInputSize = 15;
+static constexpr int kOutputSize = 4;
+
+// Oldest observation the network is run on, in microseconds, the same limits the
+// raptor module uses
+static constexpr uint64_t kMaxLocalPositionAge = 100000;
+static constexpr uint64_t kMaxAttitudeAge = 50000;
+static constexpr uint64_t kMaxAngularVelocityAge = 10000;
+
+enum class ObservationFault : uint8_t {
+	None = 0,
+	PositionInvalid = 1,
+	PositionStale = 2,
+	PositionNotFinite = 3,
+	AttitudeStale = 4,
+	AttitudeNotFinite = 5,
+	AngularVelocityStale = 6,
+	AngularVelocityNotFinite = 7,
+};
+
+// What the network is fed, copied out of the uORB topics so the check needs
+// nothing from the module
+struct ObservationSnapshot {
+	uint64_t position_timestamp;
+	bool xy_valid;
+	bool z_valid;
+	bool v_xy_valid;
+	bool v_z_valid;
+	float position[3];
+	float velocity[3];
+	uint64_t attitude_timestamp;
+	float q[4];
+	uint64_t angular_velocity_timestamp;
+	float angular_velocity[3];
+};
+
+static inline bool all_finite(const float *values, int count)
+{
+	for (int i = 0; i < count; i++) {
+		if (!isfinite(values[i])) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+// A stamp of zero has never been set. A stamp ahead of now is not stale.
+static inline bool fresh(uint64_t now, uint64_t stamp, uint64_t max_age)
+{
+	return (stamp != 0) && ((now <= stamp) || ((now - stamp) <= max_age));
+}
+
+static inline ObservationFault check_observations(const ObservationSnapshot &o, uint64_t now)
+{
+	if (!o.xy_valid || !o.z_valid || !o.v_xy_valid || !o.v_z_valid) {
+		return ObservationFault::PositionInvalid;
+	}
+
+	if (!fresh(now, o.position_timestamp, kMaxLocalPositionAge)) {
+		return ObservationFault::PositionStale;
+	}
+
+	if (!all_finite(o.position, 3) || !all_finite(o.velocity, 3)) {
+		return ObservationFault::PositionNotFinite;
+	}
+
+	if (!fresh(now, o.attitude_timestamp, kMaxAttitudeAge)) {
+		return ObservationFault::AttitudeStale;
+	}
+
+	if (!all_finite(o.q, 4)) {
+		return ObservationFault::AttitudeNotFinite;
+	}
+
+	if (!fresh(now, o.angular_velocity_timestamp, kMaxAngularVelocityAge)) {
+		return ObservationFault::AngularVelocityStale;
+	}
+
+	if (!all_finite(o.angular_velocity, 3)) {
+		return ObservationFault::AngularVelocityNotFinite;
+	}
+
+	return ObservationFault::None;
+}
+
+static inline bool outputs_finite(const float *outputs, int count)
+{
+	return all_finite(outputs, count);
+}
+
+/**
+ * Why a loaded model cannot be run, or nullptr when it can. The documentation
+ * tells users to swap the model array, so the shape is checked rather than
+ * assumed.
+ */
+static inline const char *model_layout_problem(int32_t schema_version, int32_t expected_schema_version,
+		int input_tensors, int input_count, bool input_is_float,
+		int output_tensors, int output_count, bool output_is_float)
+{
+	if (schema_version != expected_schema_version) {
+		return "schema version";
+	}
+
+	if (input_tensors != 1) {
+		return "input tensors, expected one";
+	}
+
+	if (output_tensors != 1) {
+		return "output tensors, expected one";
+	}
+
+	if (input_count != kInputSize) {
+		return "input size, expected 15 elements";
+	}
+
+	if (!input_is_float) {
+		return "input type, expected float32";
+	}
+
+	if (output_count != kOutputSize) {
+		return "output size, expected 4 elements";
+	}
+
+	if (!output_is_float) {
+		return "output type, expected float32";
+	}
+
+	return nullptr;
+}
+
+} // namespace nn_control

--- a/src/modules/mc_nn_control/nn_control_model.hpp
+++ b/src/modules/mc_nn_control/nn_control_model.hpp
@@ -1,0 +1,58 @@
+/****************************************************************************
+*
+*   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+* 3. Neither the name PX4 nor the names of its contributors may be
+*    used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+****************************************************************************/
+
+/**
+ * @file nn_control_model.hpp
+ * The operations the shipped network needs, shared by the module and the test
+ * that loads the shipped model through the real interpreter.
+ */
+
+#pragma once
+
+#include <tflite_micro/tensorflow/lite/micro/micro_mutable_op_resolver.h>
+
+namespace nn_control
+{
+
+// The number of operations in the model, fully connected, relu and add
+using OpResolver = tflite::MicroMutableOpResolver<3>;
+
+static inline TfLiteStatus register_ops(OpResolver &op_resolver)
+{
+	TF_LITE_ENSURE_STATUS(op_resolver.AddFullyConnected());
+	TF_LITE_ENSURE_STATUS(op_resolver.AddRelu());
+	TF_LITE_ENSURE_STATUS(op_resolver.AddAdd());
+	return kTfLiteOk;
+}
+
+} // namespace nn_control


### PR DESCRIPTION
## Summary

fixes #28417

Checks the model, the observations and the network output before mc_nn_control commands motors. Stacked on #28433, which covers the mapping and the parameters.

## Problem

The model was loaded without checking its shape, so a swapped model with a different input width would write past the tensor. Position and attitude went into the network regardless of their validity flags, age or finiteness. A non finite output stopped one motor while the other three kept thrusting, with nothing reported.

## Solution

The model is checked at load, schema version plus one input of 15 floats and one output of 4 floats, and rejected with the reason if it does not match. The observations are checked every cycle for validity, age against the limits mc_raptor uses, and finiteness. On a bad observation or a non finite output the network is not run, the last command is repeated, and the arming check reply has the commander leave the mode. A delayed run notices when the angular velocity updates stop. Each fault is reported once. The trajectory setpoint starts unset and is reset on mode entry. 12 unit tests, one of them loads the shipped model through the real interpreter.

In SIH a GPS loss raised the fault the instant position validity dropped and the commander was in Descend 80 ms later. A gyro loss raised it 20 ms after the last sample. The Gazebo hover from #28433 flown again on this branch, [CI run 33587800324](https://github.com/Saibernard/PX4-Autopilot/actions/runs/33587800324), holds 0.91 m with 1.3 cm of standard deviation and no fault raised.

![observation guard in SIH](https://raw.githubusercontent.com/Saibernard/PX4-Autopilot/f222d8c92d/.github/nn_observation_guard.png)

![hover with the guards](https://raw.githubusercontent.com/Saibernard/PX4-Autopilot/77c411fc07e0d963d599e5bea753366f1093ded0/.github/nn_hover_guards.png)
