### PR TITLE
fix(airbrainh743): use dataman in flash

### DIFF
--- a/boards/gearup/airbrainh743/init/rc.board_defaults
+++ b/boards/gearup/airbrainh743/init/rc.board_defaults
@@ -16,6 +16,3 @@ param set-default IMU_GYRO_RATEMAX 2000
 # a few recent logs, and fill up to 95%.
 param set-default SDLOG_ROTATE 95
 param set-default SDLOG_MAX_SIZE 40
-
-# Store missions in RAM
-param set-default SYS_DM_BACKEND 1


### PR DESCRIPTION
We don't need to keep missions in RAM, we can store them in flash.

This allows missions to survive a reboot.

As suggested by @AshwinDeTaeye.