### PR TITLE
fix(uavcan): apply UAVCAN_BITRATE on FlexCAN again, size uavcan/TTY work queues for NuttX 12

### DIFF
--- a/platforms/common/px4_work_queue/Kconfig
+++ b/platforms/common/px4_work_queue/Kconfig
@@ -207,7 +207,7 @@ config WQ_HP_DEFAULT_PRIORITY
 
 config WQ_UAVCAN_STACKSIZE
 	int "Stack size for uavcan"
-	default 3754
+	default 4096
 	range 1000 10000
 	help
 	  Sets the stack size for the uavcan work queue.
@@ -223,7 +223,7 @@ menu "TTY Bus Work Queues"
 
 config WQ_TTY_STACKSIZE
 	int "Stack size for TTY work queues"
-	default 1728
+	default 2048
 	range 1000 10000
 	help
 	  Sets the stack size for all TTY work queues.

--- a/src/drivers/uavcan/uavcan_drivers/socketcan/driver/src/socketcan.cpp
+++ b/src/drivers/uavcan/uavcan_drivers/socketcan/driver/src/socketcan.cpp
@@ -361,25 +361,6 @@ int CanIface::pollErrors() const
 #endif
 }
 
-/* Retuning through SIOCSCANBITRATE takes the interface down and brings it back
- * up again. The FlexCAN drivers (i.MX RT, S32K, Kinetis) re-run their ECC RAM
- * initialisation on ifup, which faults once the controller has been started, so
- * the rate the driver was configured with is kept on those chips instead.
- *
- * SIOCGCANERRORS only says that the driver can report error counters, which is
- * a separate capability from being able to retune, so it cannot gate this on
- * its own.
- */
-#if defined(SIOCGCANERRORS) && \
-    !defined(CONFIG_ARCH_CHIP_IMXRT) && \
-    !defined(CONFIG_ARCH_CHIP_S32K1XX) && \
-    !defined(CONFIG_ARCH_CHIP_S32K3XX) && \
-    !defined(CONFIG_ARCH_CHIP_KINETIS)
-#  define PX4_SOCKETCAN_SAFE_RETUNE 1
-#else
-#  define PX4_SOCKETCAN_SAFE_RETUNE 0
-#endif
-
 int CanIface::setBitRate(uint32_t bitrate)
 {
 	if (_fd < 0 || bitrate == 0) {
@@ -395,13 +376,19 @@ int CanIface::setBitRate(uint32_t bitrate)
 		return 0;
 	}
 
-	if (ifr.ifr_ifru.ifru_can_data.arbi_bitrate == bitrate) {
+	const uint32_t configured = ifr.ifr_ifru.ifru_can_data.arbi_bitrate;
+
+	if (configured == bitrate) {
 		return 0;
 	}
 
-#if !PX4_SOCKETCAN_SAFE_RETUNE
-	PX4_WARN("can%" PRIu32 ": UAVCAN_BITRATE %" PRIu32 " bit/s not applied, staying at %" PRIu32 " bit/s",
-		 _index, bitrate, ifr.ifr_ifru.ifru_can_data.arbi_bitrate);
+#ifndef SIOCGCANERRORS
+	/* Before the PX4/NuttX change that added SIOCGCANERRORS, SIOCSCANBITRATE
+	 * restarted a running controller from inside the driver, which on FlexCAN
+	 * with ECC RAM initialisation is a bus fault. Keep the configured rate.
+	 */
+	PX4_WARN("can%" PRIu32 ": UAVCAN_BITRATE %" PRIu32 " bit/s needs a newer NuttX, staying at %" PRIu32 " bit/s",
+		 _index, bitrate, configured);
 	return 0;
 #else
 	/* Only the nominal rate changes; the data phase keeps the driver's
@@ -447,8 +434,12 @@ int CanIface::setBitRate(uint32_t bitrate)
 	}
 
 	if (res < 0) {
-		PX4_ERR("can%" PRIu32 ": %u bit/s rejected (%d)", _index, bitrate, set_errno);
-		return -1;
+		/* The interface is back up at the rate the driver was configured with.
+		 * Running DroneCAN at that rate beats not running it at all, which is
+		 * what CanDriver::init() does with a negative return.
+		 */
+		PX4_ERR("can%" PRIu32 ": %" PRIu32 " bit/s rejected (%d), staying at %" PRIu32 " bit/s",
+			_index, bitrate, set_errno, configured);
 	}
 
 	return 0;


### PR DESCRIPTION
## Summary

Two fixes found while benching #26215, first on an ARK FMU-v6XRT and then on an ARK FMU-v6X. Based on `pr-nuttx-12-12-0`; one of them reverts 58dfff0de7, so @julianoes should weigh in.

They pair with PX4/NuttX#408, which restores two i.MX RT FlexCAN hunks the 12.12 branch dropped from the apache/nuttx#19970 backport. That PR is not needed for either fix here, but the v6XRT was benched with it.

## Problem

`58dfff0de7` gates the `SIOCSCANBITRATE` retune off for i.MX RT, S32K and Kinetis, which is every board in the tree that builds SocketCAN, so `UAVCAN_BITRATE` stopped doing anything at all. It was written before `db6f7ec304`, and the crash it works around is that commit's units bug: the driver reports bit/s on NuttX 12 while the caller still divided by 1000, so a 1 Mbit/s board asked its controller for 1000 bit/s on every boot. A rate the controller cannot reach also made `CanDriver::init()` give up, so DroneCAN never started at all.

NuttX 12.12 costs a few hundred bytes of stack on the paths that go through the file layer, and that is more than two work-queue defaults left spare. Against the same PX4 tree on 10.3.0, `wq:uavcan` goes 2860/3728 → 3184/3736 on a v6X with two DroneCAN GNSS nodes, and `wq:ttyS4` goes 1088/1704 → 1432/1712 on a v6XRT running `crsf_rc`. `load_mon` reports the latter low on stack with 280 bytes left; the former sits at 85 % of its own.

## Solution

Drop the FlexCAN gate, keep the `IFF_CLR_UP` fix, and report a rejected rate instead of returning negative. `CONFIG_WQ_UAVCAN_STACKSIZE` 3754 → 4096 and `CONFIG_WQ_TTY_STACKSIZE` 1728 → 2048.

Benched on the v6XRT with two DroneCAN nodes on separate buses: `UAVCAN_BITRATE` round-trips 1 Mbit/s → 500 kbit/s → 1 Mbit/s with both nodes coming back OPERAT and no fault, T0–T5 of the CAN suite pass at 31–41 % bus utilisation with 0 % loss, 7 transfer errors in 301 s at idle, and 20/20 cold boots. On the v6X, `wq:uavcan` drops to 78 % of its stack and 10/10 cold boots pass.
