### PR TITLE
fix(commander): allow VTOL to register fixed-wing setpoint type from …

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2595,8 +2595,8 @@ void Commander::checkAndInformReadyForTakeoff()
 void Commander::modeManagementUpdate()
 {
 	ModeManagement::UpdateRequest mode_management_update{};
-	_mode_management.update(_vehicle_status.vehicle_type, isArmed(), _vehicle_status.nav_state_user_intention,
-				mode_management_update);
+	_mode_management.update(_vehicle_status.vehicle_type, _vehicle_status.is_vtol, isArmed(),
+				_vehicle_status.nav_state_user_intention, mode_management_update);
 
 	if (!isArmed() && mode_management_update.change_user_intended_nav_state) {
 		_user_mode_intention.change(mode_management_update.user_intended_nav_state);

--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -406,7 +406,8 @@ void ModeManagement::checkUnregistrations(uint8_t user_intended_nav_state, Updat
 	}
 }
 
-void ModeManagement::update(uint8_t vehicle_type, bool armed, uint8_t user_intended_nav_state, UpdateRequest &update_request)
+void ModeManagement::update(uint8_t vehicle_type, bool is_vtol, bool armed, uint8_t user_intended_nav_state,
+			    UpdateRequest &update_request)
 {
 	_external_checks.update();
 
@@ -450,7 +451,7 @@ void ModeManagement::update(uint8_t vehicle_type, bool armed, uint8_t user_inten
 		checkUnregistrations(user_intended_nav_state, update_request);
 	}
 
-	update_request.control_setpoint_update = checkConfigControlSetpointUpdates(vehicle_type);
+	update_request.control_setpoint_update = checkConfigControlSetpointUpdates(vehicle_type, is_vtol);
 	checkConfigOverrides();
 }
 
@@ -644,7 +645,7 @@ void ModeManagement::updateActiveConfigOverrides(uint8_t nav_state, config_overr
 	}
 }
 
-bool ModeManagement::checkConfigControlSetpointUpdates(uint8_t vehicle_type)
+bool ModeManagement::checkConfigControlSetpointUpdates(uint8_t vehicle_type, bool is_vtol)
 {
 	bool had_update = false;
 	setpoint_config_s setpoint_config;
@@ -659,7 +660,7 @@ bool ModeManagement::checkConfigControlSetpointUpdates(uint8_t vehicle_type)
 			Modes::Mode &mode = _modes.mode(setpoint_config.source_id);
 
 			const auto setpoint_type = static_cast<mode_util::SetpointType>(setpoint_config.type);
-			reply.result = static_cast<uint8_t>(mode_util::isSetpointTypeValid(setpoint_type, vehicle_type));
+			reply.result = static_cast<uint8_t>(mode_util::isSetpointTypeValid(setpoint_type, vehicle_type, is_vtol));
 
 			if (reply.result == setpoint_config_reply_s::RESULT_SUCCESS) {
 				// Get control mode

--- a/src/modules/commander/ModeManagement.hpp
+++ b/src/modules/commander/ModeManagement.hpp
@@ -134,7 +134,8 @@ public:
 		bool control_setpoint_update{false};
 	};
 
-	void update(uint8_t vehicle_type, bool armed, uint8_t user_intended_nav_state, UpdateRequest &update_request);
+	void update(uint8_t vehicle_type, bool is_vtol, bool armed, uint8_t user_intended_nav_state,
+		    UpdateRequest &update_request);
 	void setFailsafeState(bool failsafe_action_active)
 	{
 		_failsafe_action_active = failsafe_action_active;
@@ -170,7 +171,7 @@ public:
 	void updateActiveConfigOverrides(uint8_t nav_state, config_overrides_s &overrides_in_out);
 
 private:
-	bool checkConfigControlSetpointUpdates(uint8_t vehicle_type);
+	bool checkConfigControlSetpointUpdates(uint8_t vehicle_type, bool is_vtol);
 	void checkNewRegistrations(UpdateRequest &update_request);
 	void checkUnregistrations(uint8_t user_intended_nav_state, UpdateRequest &update_request);
 	void checkConfigOverrides();
@@ -213,7 +214,8 @@ public:
 		bool control_setpoint_update{false};
 	};
 
-	void update(uint8_t vehicle_type, bool armed, uint8_t user_intended_nav_state, UpdateRequest &update_request) {}
+	void update(uint8_t vehicle_type, bool is_vtol, bool armed, uint8_t user_intended_nav_state,
+		    UpdateRequest &update_request) {}
 	void setFailsafeState(bool failsafe_action_active) {}
 
 	int modeExecutorInCharge() const { return ModeExecutors::AUTOPILOT_EXECUTOR_ID; }

--- a/src/modules/commander/ModeManagementTest.cpp
+++ b/src/modules/commander/ModeManagementTest.cpp
@@ -99,3 +99,25 @@ TEST(ModeManagementTest, Hashes)
 
 	EXPECT_FALSE(modes.hasFreeExternalModes());
 }
+
+TEST(ModeManagementTest, VtolFixedwingSetpointRegistration)
+{
+	using mode_util::SetpointType;
+	using mode_util::SetpointTypeResult;
+
+	// A plain (non-VTOL) rotary wing cannot register the fixed-wing setpoint type.
+	EXPECT_EQ(mode_util::isSetpointTypeValid(SetpointType::FixedwingLateralLongitudinal,
+			vehicle_status_s::VEHICLE_TYPE_ROTARY_WING, false),
+		  SetpointTypeResult::Unsupported);
+
+	// A VTOL currently in multicopter form must still be able to register it, so it
+	// can command its own first transition to fixed-wing from an external mode.
+	EXPECT_EQ(mode_util::isSetpointTypeValid(SetpointType::FixedwingLateralLongitudinal,
+			vehicle_status_s::VEHICLE_TYPE_ROTARY_WING, true),
+		  SetpointTypeResult::Success);
+
+	// Already fixed-wing: valid regardless of is_vtol.
+	EXPECT_EQ(mode_util::isSetpointTypeValid(SetpointType::FixedwingLateralLongitudinal,
+			vehicle_status_s::VEHICLE_TYPE_FIXED_WING, false),
+		  SetpointTypeResult::Success);
+}

--- a/src/modules/commander/ModeUtil/setpoint_types.cpp
+++ b/src/modules/commander/ModeUtil/setpoint_types.cpp
@@ -164,7 +164,7 @@ void getControlMode(SetpointType setpoint_type, vehicle_control_mode_s &control_
 	}
 }
 
-SetpointTypeResult isSetpointTypeValid(SetpointType setpoint_type, uint8_t vehicle_type)
+SetpointTypeResult isSetpointTypeValid(SetpointType setpoint_type, uint8_t vehicle_type, bool is_vtol)
 {
 	switch (setpoint_type) {
 	case SetpointType::Invalid:
@@ -181,7 +181,10 @@ SetpointTypeResult isSetpointTypeValid(SetpointType setpoint_type, uint8_t vehic
 		return SetpointTypeResult::Unsupported;
 
 	case SetpointType::FixedwingLateralLongitudinal:
-		if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+		// A VTOL is allowed to register this even while currently in its
+		// multicopter form, since it may need to command its own transition
+		// to fixed-wing (e.g. from an external mode).
+		if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING || is_vtol) {
 			return SetpointTypeResult::Success;
 		}
 

--- a/src/modules/commander/ModeUtil/setpoint_types.cpp
+++ b/src/modules/commander/ModeUtil/setpoint_types.cpp
@@ -181,9 +181,6 @@ SetpointTypeResult isSetpointTypeValid(SetpointType setpoint_type, uint8_t vehic
 		return SetpointTypeResult::Unsupported;
 
 	case SetpointType::FixedwingLateralLongitudinal:
-		// A VTOL is allowed to register this even while currently in its
-		// multicopter form, since it may need to command its own transition
-		// to fixed-wing (e.g. from an external mode).
 		if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING || is_vtol) {
 			return SetpointTypeResult::Success;
 		}

--- a/src/modules/commander/ModeUtil/setpoint_types.hpp
+++ b/src/modules/commander/ModeUtil/setpoint_types.hpp
@@ -75,8 +75,11 @@ enum class SetpointTypeResult : uint8_t {
 };
 
 /**
- * Check if a setpoint type is valid for a given vehicle type
+ * Check if a setpoint type is valid for a given vehicle type.
+ * @param is_vtol true if the vehicle is a VTOL, regardless of its current (multicopter or
+ *                 fixed-wing) form. This allows a VTOL to register fixed-wing-only setpoint
+ *                 types before ever having transitioned, e.g. to command its first transition.
  */
-SetpointTypeResult isSetpointTypeValid(SetpointType setpoint_type, uint8_t vehicle_type);
+SetpointTypeResult isSetpointTypeValid(SetpointType setpoint_type, uint8_t vehicle_type, bool is_vtol);
 
 } // namespace mode_util

--- a/src/modules/commander/ModeUtil/setpoint_types.hpp
+++ b/src/modules/commander/ModeUtil/setpoint_types.hpp
@@ -75,10 +75,7 @@ enum class SetpointTypeResult : uint8_t {
 };
 
 /**
- * Check if a setpoint type is valid for a given vehicle type.
- * @param is_vtol true if the vehicle is a VTOL, regardless of its current (multicopter or
- *                 fixed-wing) form. This allows a VTOL to register fixed-wing-only setpoint
- *                 types before ever having transitioned, e.g. to command its first transition.
+ * Check if a setpoint type is valid for a given vehicle type
  */
 SetpointTypeResult isSetpointTypeValid(SetpointType setpoint_type, uint8_t vehicle_type, bool is_vtol);
 


### PR DESCRIPTION
### Solved Problem
Fixes Auterion/px4-ros2-interface-lib#218

`isSetpointTypeValid()` rejected `SetpointType::FixedwingLateralLongitudinal`
whenever `vehicle_type != VEHICLE_TYPE_FIXED_WING`. Since a VTOL always boots
(and stays, until it actually transitions) in `ROTARY_WING` form, this made it
impossible for an external mode to register this setpoint type up front in
order to command the vehicle's own first transition to fixed-wing. Registration is a one-time, synchronous step performed at mode construction,
before the vehicle has ever flown.

Reproduces with the `px4-ros2-interface-lib` `example_mode_vtol_cpp` example
against a `standard_vtol` in SITL: the node aborts as soon as it tries to
register, before it ever gets a chance to arm or fly.

### Solution
Thread the vehicle's `is_vtol` flag down to `isSetpointTypeValid()` and accept
`FixedwingLateralLongitudinal` when `is_vtol` is true, regardless of the
vehicle's current dynamic form. A VTOL is capable of fixed-wing control even
while currently multicopter, precisely because it is about to transition.

This only affects vehicles where `is_vtol` is true. For every other vehicle
type (multicopter, plain fixed-wing, rover) `is_vtol` is always `false`, so
the check collapses back to the exact same condition as before — no behavior
change for non-VTOL vehicles.

### Changelog Entry
Fix: VTOL external modes can now register the fixed-wing lateral/longitudinal
setpoint type before ever transitioning, so they can command the vehicle's
own first transition to fixed-wing.


### Test coverage
Added `ModeManagementTest.VtolFixedwingSetpointRegistration`, covering:
- non-VTOL rotary-wing: still `Unsupported` (unchanged)
- VTOL in multicopter form: now `Success` (the fix)
- already fixed-wing: still `Success` (unchanged)

Also manually reproduced with `px4-ros2-interface-lib`'s `example_mode_vtol_cpp`
against a `standard_vtol` in SITL:

```sh
make px4_sitl gz_standard_vtol

ros2 run example_mode_vtol_cpp example_mode_vtol
Before:


[DEBUG] [example_mode_vtol]: Registering 'My VTOL Mode' (arming check: 1, mode: 1, mode executor: 0)
[DEBUG] [example_mode_vtol]: Got RegisterExtComponentReply
terminate called after throwing an instance of 'px4_ros2::Exception'
  what():  Setpoint type 3 with index 1 is not supported by the current vehicle type
[ros2run]: Aborted
After:


[DEBUG] [example_mode_vtol]: Registering 'My VTOL Mode' (arming check: 1, mode: 1, mode executor: 0)
[DEBUG] [example_mode_vtol]: Got RegisterExtComponentReply
``` 

No crash — the node registers successfully and stays alive waiting to be
selected/armed.

### Context
- Auterion/px4-ros2-interface-lib#218