### PR TITLE
fix(dshot): emit the DShot rate that was asked for on STM32

### DIFF
--- a/platforms/nuttx/src/px4/stm/stm32_common/dshot/dshot.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/dshot/dshot.c
@@ -51,8 +51,6 @@
 
 // DShot protocol definitions
 #define ONE_MOTOR_DATA_SIZE         16u
-#define MOTOR_PWM_BIT_1             14u
-#define MOTOR_PWM_BIT_0             7u
 #define DSHOT_THROTTLE_POSITION     5u
 #define DSHOT_TELEMETRY_POSITION    4u
 #define NIBBLES_SIZE                4u
@@ -954,9 +952,13 @@ void dshot_motor_data_set(uint8_t channel, uint16_t data, bool telemetry)
 	uint8_t num_motors = mapping->channel_count_including_gaps;
 	uint8_t timer_channel = timer_io_channels[channel].timer_channel - mapping->lowest_timer_channel;
 
+	// The high times are compare counts, so they follow whatever tick count this timer's
+	// clock and the requested rate settled on in io_timer_set_dshot_burst_mode().
+	const dshot_timing_t *timing = io_timer_get_dshot_timing(timer_index, _dshot_frequency);
+
 	for (uint8_t motor_data_index = 0; motor_data_index < ONE_MOTOR_DATA_SIZE; motor_data_index++) {
 		dshot_output_buffer[timer_index][motor_data_index * num_motors + timer_channel] =
-			(packet & 0x8000) ? MOTOR_PWM_BIT_1 : MOTOR_PWM_BIT_0;  // MSB first
+			(packet & 0x8000) ? timing->bit_1 : timing->bit_0;  // MSB first
 		packet <<= 1;
 	}
 }

--- a/platforms/nuttx/src/px4/stm/stm32_common/include/px4_arch/dshot.h
+++ b/platforms/nuttx/src/px4/stm/stm32_common/include/px4_arch/dshot.h
@@ -34,34 +34,96 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include <drivers/drv_pwm_output.h>
 #include <stm32_dma.h>
 #include <arch/board/board.h>
 
-// Number of timer ticks per DSHOT bit (the timer's ARR). This is the per-bit
-// resolution, NOT a function of the DSHOT rate: the timer is configured with
-// ARR = WIDTH and PSC = floor(TIM_CLK / DSHOT_FREQ) / WIDTH - 1, so the prescaler
-// alone scales the rate while ARR stays fixed. Keeping ARR fixed across rates is
-// what lets the MOTOR_PWM_BIT_0/1 high-time constants hold their duty cycle at every
-// frequency. The width is derived from a fixed reference rate (DSHOT600) so that
-// floor(TIM_CLK / 600000) divides evenly, keeping the prescaler integer.
-//
-// This is computed per timer from that timer's own clock rather than from a single
-// board-wide define, so boards whose timers run on different clocks (e.g. APB1 vs
-// APB2) each get the correct width without any board-specific configuration.
-static inline uint32_t dshot_motor_pwm_bit_width(uint32_t timer_clock)
-{
-	const uint32_t ticks = timer_clock / 600000u;
+// A DSHOT bit is (ARR + 1) timer ticks of (PSC + 1) timer-clock cycles each, so the
+// emitted bit period is ticks * prescaler / timer_clock and the high time is CCR / ticks
+// of it. No single tick count divides every timer clock by every DSHOT rate, so both are
+// chosen together here for the timer's own clock and the requested rate, and the two high
+// times follow from the tick count that was picked. The search runs a couple of hundred
+// cycles and its answer only changes when the rate does, so io_timer_get_dshot_timing()
+// caches it per timer rather than repeating it in the transmit path.
+typedef struct dshot_timing_t {
+	uint32_t ticks;             // timer ticks in one DSHOT bit; ARR = ticks - 1
+	uint32_t prescaler;         // timer-clock cycles in one tick; PSC = prescaler - 1
+	uint32_t bit_0;             // CCR for a zero bit, 37.5 % of the bit
+	uint32_t bit_1;             // CCR for a one bit, 75 % of the bit
+	uint32_t capture_prescaler; // as prescaler, for the bidirectional capture clock
+} dshot_timing_t;
 
-	// Prefer the widest period that divides evenly (most timing resolution); fall
-	// back to 20 when none does, matching the legacy default.
-	for (uint32_t width = 20u; width >= 18u; --width) {
-		if (ticks % width == 0u) {
-			return width;
+// Wide enough that some tick count divides the common timer clocks exactly, and narrow
+// enough that a bit still resolves to better than a tenth of itself.
+#define DSHOT_MIN_BIT_TICKS 12u
+#define DSHOT_MAX_BIT_TICKS 32u
+
+// Ticks the bidirectional capture timer counts in one response bit.
+#define DSHOT_CAPTURE_TICKS_PER_BIT 20u
+
+static inline dshot_timing_t dshot_timing(uint32_t timer_clock, uint32_t dshot_rate)
+{
+	dshot_timing_t best = {DSHOT_MAX_BIT_TICKS, 1u, 12u, 24u, 1u};
+
+	if (timer_clock == 0u || dshot_rate == 0u) {
+		return best;
+	}
+
+	uint64_t best_rate_error = UINT64_MAX;
+	uint32_t best_duty_error = UINT32_MAX;
+
+	for (uint32_t ticks = DSHOT_MIN_BIT_TICKS; ticks <= DSHOT_MAX_BIT_TICKS; ticks++) {
+		const uint32_t cycles_per_bit = dshot_rate * ticks;
+		uint32_t prescaler = (timer_clock + cycles_per_bit / 2u) / cycles_per_bit;
+
+		if (prescaler == 0u) {
+			prescaler = 1u;
+		}
+
+		// The emitted rate is timer_clock / (ticks * prescaler); comparing the cycle
+		// counts instead keeps this in integers.
+		const uint64_t cycles = (uint64_t)ticks * prescaler * dshot_rate;
+		const uint64_t rate_error = cycles > timer_clock ? cycles - timer_clock : timer_clock - cycles;
+
+		const uint32_t bit_1 = (3u * ticks + 2u) / 4u;   // round(0.75 * ticks)
+		const uint32_t bit_0 = (3u * ticks + 4u) / 8u;   // round(0.375 * ticks)
+
+		// Both high-time errors in eighths of a tick, so a tick count that lands the
+		// duty cycles on the protocol breaks a tie between equally accurate rates.
+		const uint32_t want_1 = 6u * ticks;
+		const uint32_t want_0 = 3u * ticks;
+		const uint32_t got_1 = 8u * bit_1;
+		const uint32_t got_0 = 8u * bit_0;
+		const uint32_t duty_error = (got_1 > want_1 ? got_1 - want_1 : want_1 - got_1)
+					    + (got_0 > want_0 ? got_0 - want_0 : want_0 - got_0);
+
+		if (rate_error < best_rate_error
+		    || (rate_error == best_rate_error
+			&& (duty_error < best_duty_error
+			    || (duty_error == best_duty_error && ticks > best.ticks)))) {
+			best_rate_error = rate_error;
+			best_duty_error = duty_error;
+			best.ticks = ticks;
+			best.prescaler = prescaler;
+			best.bit_0 = bit_0;
+			best.bit_1 = bit_1;
 		}
 	}
 
-	return 20u;
+	// The capture clock free-runs, so only its resolution matters and it is independent
+	// of what the transmit side settled on: DSHOT_CAPTURE_TICKS_PER_BIT ticks per
+	// response bit keeps a one-to-three bit run inside the interval window
+	// convert_edge_intervals_to_bitstream() accepts.
+	const uint32_t response_cycles = (dshot_rate * 5u / 4u) * DSHOT_CAPTURE_TICKS_PER_BIT;
+	best.capture_prescaler = (timer_clock + response_cycles / 2u) / response_cycles;
+
+	if (best.capture_prescaler == 0u) {
+		best.capture_prescaler = 1u;
+	}
+
+	return best;
 }
 
 /* Configuration for each timer to setup DShot. Some timers have only one while others have two choices for the stream.

--- a/platforms/nuttx/src/px4/stm/stm32_common/include/px4_arch/dshot.h
+++ b/platforms/nuttx/src/px4/stm/stm32_common/include/px4_arch/dshot.h
@@ -58,20 +58,20 @@ typedef struct dshot_timing_t {
 // Wide enough that some tick count divides the common timer clocks exactly, and narrow
 // enough that a bit still resolves to better than a tenth of itself.
 #define DSHOT_MIN_BIT_TICKS 12u
-#define DSHOT_MAX_BIT_TICKS 32u
+#define DSHOT_MAX_BIT_TICKS 40u
 
 // Ticks the bidirectional capture timer counts in one response bit.
 #define DSHOT_CAPTURE_TICKS_PER_BIT 20u
 
 static inline dshot_timing_t dshot_timing(uint32_t timer_clock, uint32_t dshot_rate)
 {
-	dshot_timing_t best = {DSHOT_MAX_BIT_TICKS, 1u, 12u, 24u, 1u};
+	dshot_timing_t best = {DSHOT_MAX_BIT_TICKS, 1u, (3u * DSHOT_MAX_BIT_TICKS + 4u) / 8u, (3u * DSHOT_MAX_BIT_TICKS + 2u) / 4u, 1u};
 
 	if (timer_clock == 0u || dshot_rate == 0u) {
 		return best;
 	}
 
-	uint64_t best_rate_error = UINT64_MAX;
+	uint32_t best_rate_error = UINT32_MAX;
 	uint32_t best_duty_error = UINT32_MAX;
 
 	for (uint32_t ticks = DSHOT_MIN_BIT_TICKS; ticks <= DSHOT_MAX_BIT_TICKS; ticks++) {
@@ -83,9 +83,10 @@ static inline dshot_timing_t dshot_timing(uint32_t timer_clock, uint32_t dshot_r
 		}
 
 		// The emitted rate is timer_clock / (ticks * prescaler); comparing the cycle
-		// counts instead keeps this in integers.
-		const uint64_t cycles = (uint64_t)ticks * prescaler * dshot_rate;
-		const uint64_t rate_error = cycles > timer_clock ? cycles - timer_clock : timer_clock - cycles;
+		// counts instead keeps this in integers, and the rounded prescaler puts the
+		// product within half a bit of timer_clock, so 32 bits hold it.
+		const uint32_t cycles = ticks * prescaler * dshot_rate;
+		const uint32_t rate_error = cycles > timer_clock ? cycles - timer_clock : timer_clock - cycles;
 
 		const uint32_t bit_1 = (3u * ticks + 2u) / 4u;   // round(0.75 * ticks)
 		const uint32_t bit_0 = (3u * ticks + 4u) / 8u;   // round(0.375 * ticks)

--- a/platforms/nuttx/src/px4/stm/stm32_common/include/px4_arch/io_timer.h
+++ b/platforms/nuttx/src/px4/stm/stm32_common/include/px4_arch/io_timer.h
@@ -163,6 +163,7 @@ __EXPORT int io_timer_get_mode_channels(io_timer_channel_mode_t mode);
 __EXPORT extern void io_timer_trigger(unsigned channels_mask);
 
 __EXPORT void io_timer_update_dma_req(uint8_t timer, bool enable);
+__EXPORT const dshot_timing_t *io_timer_get_dshot_timing(uint8_t timer, unsigned dshot_pwm_freq);
 __EXPORT int io_timer_set_dshot_burst_mode(uint8_t timer, unsigned dshot_pwm_rate, uint8_t dma_burst_length);
 
 __EXPORT void io_timer_capture_dma_req(uint8_t timer, uint8_t timer_channel_index, bool enable);

--- a/platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c
@@ -579,6 +579,19 @@ void io_timer_capture_dma_req(uint8_t timer, uint8_t timer_channel_index, bool e
 	}
 }
 
+static dshot_timing_t dshot_timings[MAX_IO_TIMERS];
+static unsigned dshot_timing_rate[MAX_IO_TIMERS];
+
+const dshot_timing_t *io_timer_get_dshot_timing(uint8_t timer, unsigned dshot_pwm_freq)
+{
+	if (dshot_timing_rate[timer] != dshot_pwm_freq) {
+		dshot_timings[timer] = dshot_timing(io_timers[timer].clock_freq, dshot_pwm_freq);
+		dshot_timing_rate[timer] = dshot_pwm_freq;
+	}
+
+	return &dshot_timings[timer];
+}
+
 int io_timer_set_dshot_burst_mode(uint8_t timer, unsigned dshot_pwm_freq, uint8_t dma_burst_length)
 {
 	int ret_val = OK;
@@ -601,9 +614,9 @@ int io_timer_set_dshot_burst_mode(uint8_t timer, unsigned dshot_pwm_freq, uint8_
 	}
 
 	if (OK == ret_val) {
-		const uint32_t bit_width = dshot_motor_pwm_bit_width(io_timers[timer].clock_freq);
-		rARR(timer)  = bit_width;
-		rPSC(timer)  = ((int)(io_timers[timer].clock_freq / dshot_pwm_freq) / bit_width) - 1;
+		const dshot_timing_t *timing = io_timer_get_dshot_timing(timer, dshot_pwm_freq);
+		rARR(timer)  = timing->ticks - 1;
+		rPSC(timer)  = timing->prescaler - 1;
 		rEGR(timer)  = ATIM_EGR_UG;
 
 		// find the lowest channel index for the timer (they are not necessarily in ascending order)
@@ -640,8 +653,7 @@ int io_timer_set_dshot_capture_mode(uint8_t timer, uint8_t timer_channel_index, 
 	// Timer Autor Reload Register max value
 	rARR(timer) = 0xFFFFFFFF;
 	// Timer Prescalar
-	const uint32_t bit_width = dshot_motor_pwm_bit_width(io_timers[timer].clock_freq);
-	rPSC(timer) = ((int)(io_timers[timer].clock_freq / (dshot_pwm_freq * 5 / 4)) / bit_width) - 1;
+	rPSC(timer) = io_timer_get_dshot_timing(timer, dshot_pwm_freq)->capture_prescaler - 1;
 
 	switch (timer_channel_index) {
 	case 0:

--- a/platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c
@@ -580,7 +580,8 @@ void io_timer_capture_dma_req(uint8_t timer, uint8_t timer_channel_index, bool e
 }
 
 static dshot_timing_t dshot_timings[MAX_IO_TIMERS];
-static unsigned dshot_timing_rate[MAX_IO_TIMERS];
+// Seeded with a rate nobody asks for so the first lookup always computes.
+static unsigned dshot_timing_rate[MAX_IO_TIMERS] = { [0 ...(MAX_IO_TIMERS - 1)] = ~0u };
 
 const dshot_timing_t *io_timer_get_dshot_timing(uint8_t timer, unsigned dshot_pwm_freq)
 {


### PR DESCRIPTION
## Summary

STM32 boards have always transmitted DShot at 21/20 of the requested rate, with bit high-times of 33/67 % instead of the protocol's 37.5/75 %. ESCs tolerate it, but rate-locked AM32 setups reject frames past ±2 % (#27401). This change picks the timer tick count and prescaler together, so the emitted rate and duty are correct on every STM32 timer clock.

Follows #27402 and #27505, which moved the tick count around without accounting for the period being one tick longer than the count.

## Problem

`io_timer_set_dshot_burst_mode()` writes the tick count into `ARR`, but an STM32 timer period is `ARR + 1` ticks while the prescaler divides by the tick count. Every bit runs one tick long, so the rate is 21/20 fast and the fixed 7/14 compare counts land on 21 ticks, giving 33.3/66.7 % duty.

Subtracting one from `ARR` alone does not fix it. A fixed tick count cannot divide every timer clock by every rate, and two clocks sit near zero error today only by accident.

## Solution

For each timer clock and rate, search the tick count (12–40) and prescaler together, scoring rate error first and duty error second, then derive the compare counts from the winning tick count. The answer depends only on the clock and the rate, so `io_timer.c` caches it per timer and recomputes only when the rate changes, once at startup. The transmit path, which previously ran a modulo loop and two divisions on every burst and every capture, now does no arithmetic.

The bidirectional capture prescaler is independent of the transmit tick count. It targets a fixed 20 ticks per response bit, which keeps one-to-three-bit runs inside the window `convert_edge_intervals_to_bitstream()` accepts.

## Testing

Measured on hardware with a logic analyser, motor at 12 %, `origin/main` against this branch. The table shows the worst rate error across DShot300 and DShot600.

| Board | MCU | Timer clock | Before | After |
|---|---|---|---|---|
| ARK FMU-v6X | H743 | 240 MHz | +5.00 % | −0.01 % |
| ARK FPV | H743 | 160 MHz | +4.99 % | −0.26 % |
| CubeOrange | H743 | 200 MHz | +3.95 % | −0.10 % |
| ARK CANNODE | F412 | 96 MHz | +5.00 % | −0.00 % |

After the change, duty is within measurement of 37.5/75.0 % on all four boards; before, it was 33/67 %. Every mode decoded with no CRC or GCR errors, and `esc_rpm` matched the analyser. The i.MX RT boards (v6XRT) use a separate driver and are unaffected.
