### PR TITLE
fix(mavlink): let a UDP client reconnect from a new port

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -442,9 +442,35 @@ public:
 
 	struct sockaddr_in 	&get_client_source_address() { return _src_addr; }
 
-	void			set_client_source_initialized() { _src_addr_initialized = true; }
+	/**
+	 * Latch onto a client address that we discovered from an incoming packet.
+	 * Also counts as having just heard from it, see client_source_can_be_replaced().
+	 */
+	void			set_client_source_initialized()
+	{
+		_src_addr_initialized = true;
+		_src_addr_discovered = true;
+		mark_client_source_seen();
+	}
 
 	bool			get_client_source_initialized() { return _src_addr_initialized; }
+
+	void			mark_client_source_seen() { _time_last_client_source_packet = hrt_absolute_time(); }
+
+	/**
+	 * Whether another source is allowed to take over as our client.
+	 *
+	 * This is the case if we discovered the current client ourselves (rather than
+	 * having it configured using -t or -c), and it has stopped talking to us. That
+	 * way a client which reconnects from a different source port - which happens
+	 * whenever it is restarted - can take over, instead of us sending into the void
+	 * until the next reboot.
+	 */
+	bool			client_source_can_be_replaced() const
+	{
+		return _src_addr_discovered
+		       && hrt_elapsed_time(&_time_last_client_source_packet) > CLIENT_SOURCE_TIMEOUT;
+	}
 #endif
 
 	uint64_t		get_start_time() { return _mavlink_start_time; }
@@ -627,7 +653,11 @@ private:
 	sockaddr_in		_src_addr {};
 	sockaddr_in		_bcast_addr {};
 
+	static constexpr hrt_abstime CLIENT_SOURCE_TIMEOUT{3_s};
+	hrt_abstime		_time_last_client_source_packet{0};
+
 	bool			_src_addr_initialized{false};
+	bool			_src_addr_discovered{false};
 	bool			_broadcast_address_found{false};
 	bool			_broadcast_address_not_found_warned{false};
 	bool			_broadcast_failed_warned{false};

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -3807,6 +3807,8 @@ MavlinkReceiver::run()
 #if defined(MAVLINK_UDP)
 
 			else if (_mavlink.get_protocol() == Protocol::UDP) {
+				nread = 0;
+
 				if (fds[0].revents & POLLIN) {
 					nread = recvfrom(_mavlink.get_socket_fd(), buf, sizeof(buf), 0, (struct sockaddr *)&srcaddr, &addrlen);
 				}
@@ -3831,6 +3833,24 @@ MavlinkReceiver::run()
 						_mavlink.set_client_source_initialized();
 
 						PX4_INFO("partner IP: %s", inet_ntoa(srcaddr.sin_addr));
+					}
+
+				} else if (nread > 0) {
+					if ((srcaddr.sin_addr.s_addr == srcaddr_last.sin_addr.s_addr)
+					    && (srcaddr.sin_port == srcaddr_last.sin_port)) {
+						// Our client is still there, keep the address latched.
+						_mavlink.mark_client_source_seen();
+
+					} else if (_mavlink.client_source_can_be_replaced()) {
+						// Our client stopped talking to us a while ago and someone else is
+						// talking to us now. This is what a client which was restarted looks
+						// like, as it comes back with a new source port, so switch over to it.
+						srcaddr_last.sin_addr.s_addr = srcaddr.sin_addr.s_addr;
+						srcaddr_last.sin_port = srcaddr.sin_port;
+
+						_mavlink.set_client_source_initialized();
+
+						PX4_INFO("new partner IP: %s:%d", inet_ntoa(srcaddr.sin_addr), ntohs(srcaddr.sin_port));
 					}
 				}
 			}


### PR DESCRIPTION
Once PX4 has latched onto a UDP client address, it keeps sending there forever. A client that is restarted comes back with a different ephemeral source port, so PX4 talks into the void and only a reboot brings the link back.

This has come up many times in the past:
https://discuss.px4.io/t/mavsdk-server-udp-connection-requires-px4-restart/32228
https://github.com/mavlink/MAVSDK/issues/2598
https://github.com/mavlink/MAVSDK/issues/3062


A previous attempt was:
https://github.com/PX4/PX4-Autopilot/pull/21608

Hoping that @donghai2009 could give this a test.