### PR TITLE
feat(controllers): Move integrator limit depending on unallocated torque

### DIFF
--- a/msg/RateCtrlStatus.msg
+++ b/msg/RateCtrlStatus.msg
@@ -4,3 +4,8 @@ uint64 timestamp		# time since system start (microseconds)
 float32 rollspeed_integ
 float32 pitchspeed_integ
 float32 yawspeed_integ
+
+# Integrator bounds for body x,y,z axis. Equal to +-the integrator limit parameter unless the
+# control allocator reported unallocated torque, which lowers the bound on the refused side.
+float32[3] integrator_limit_upper
+float32[3] integrator_limit_lower

--- a/src/lib/rate_control/rate_control.cpp
+++ b/src/lib/rate_control/rate_control.cpp
@@ -110,11 +110,23 @@ void RateControl::updateIntegral(Vector3f &rate_error, const float dt)
 		// Perform the integration using a first order method
 		float rate_i = _rate_int(i) + i_factor * _gain_i(i) * rate_error(i) * dt;
 
+		float lim_upper;
+		float lim_lower;
+		getIntegratorLimits(i, lim_upper, lim_lower);
+
 		// do not propagate the result if out of range or invalid
 		if (PX4_ISFINITE(rate_i)) {
-			_rate_int(i) = math::constrain(rate_i, -_lim_int(i), _lim_int(i));
+			_rate_int(i) = math::constrain(rate_i, lim_lower, lim_upper);
 		}
 	}
+}
+
+void RateControl::getIntegratorLimits(int axis, float &upper, float &lower) const
+{
+	// Lower limit based on how much unallocated torque you have
+	const float refused = _unallocated_torque(axis);
+	upper = math::max(_lim_int(axis) - math::max(refused, 0.f), 0.f);
+	lower = -math::max(_lim_int(axis) + math::min(refused, 0.f), 0.f);
 }
 
 void RateControl::getRateControlStatus(rate_ctrl_status_s &rate_ctrl_status)
@@ -122,4 +134,8 @@ void RateControl::getRateControlStatus(rate_ctrl_status_s &rate_ctrl_status)
 	rate_ctrl_status.rollspeed_integ = _rate_int(0);
 	rate_ctrl_status.pitchspeed_integ = _rate_int(1);
 	rate_ctrl_status.yawspeed_integ = _rate_int(2);
+
+	for (int i = 0; i < 3; i++) {
+		getIntegratorLimits(i, rate_ctrl_status.integrator_limit_upper[i], rate_ctrl_status.integrator_limit_lower[i]);
+	}
 }

--- a/src/lib/rate_control/rate_control.hpp
+++ b/src/lib/rate_control/rate_control.hpp
@@ -87,6 +87,13 @@ public:
 	void setNegativeSaturationFlag(size_t axis, bool is_saturated);
 
 	/**
+	 * Set the torque the control allocator was not able to deliver.
+	 *
+	 * @param unallocated_torque control_allocator_status.unallocated_torque
+	 */
+	void setUnallocatedTorque(const matrix::Vector3f &unallocated_torque) { _unallocated_torque = unallocated_torque; }
+
+	/**
 	 * Run one control loop cycle calculation
 	 * @param rate estimation of the current vehicle angular rate
 	 * @param rate_sp desired vehicle angular rate setpoint
@@ -100,7 +107,11 @@ public:
 	 * Set the integral term to 0 to prevent windup
 	 * @see _rate_int
 	 */
-	void resetIntegral() { _rate_int.zero(); }
+	void resetIntegral()
+	{
+		_rate_int.zero();
+		_unallocated_torque.zero();
+	}
 
 	/**
 	 * Set the integral term to 0 for specific axes
@@ -111,6 +122,7 @@ public:
 	{
 		if (axis < 3) {
 			_rate_int(axis) = 0.f;
+			_unallocated_torque(axis) = 0.f;
 		}
 	}
 
@@ -122,6 +134,13 @@ public:
 
 private:
 	void updateIntegral(matrix::Vector3f &rate_error, const float dt);
+
+	/**
+	 * Integrator bounds for one axis, lowered on the refused side by the torque the control
+	 * allocator was not able to deliver
+	 * @param axis 0 roll, 1 pitch, 2 yaw
+	 */
+	void getIntegratorLimits(int axis, float &upper, float &lower) const;
 
 	// Gains
 	matrix::Vector3f _gain_p; ///< rate control proportional gain for all axes x, y, z
@@ -136,4 +155,5 @@ private:
 	// Feedback from control allocation
 	matrix::Vector<bool, 3> _control_allocator_saturation_negative;
 	matrix::Vector<bool, 3> _control_allocator_saturation_positive;
+	matrix::Vector3f _unallocated_torque; ///< torque the control allocator was not able to deliver
 };

--- a/src/lib/rate_control/rate_control_test.cpp
+++ b/src/lib/rate_control/rate_control_test.cpp
@@ -42,3 +42,133 @@ TEST(RateControlTest, AllZeroCase)
 	Vector3f torque = rate_control.update(Vector3f(), Vector3f(), Vector3f(), 0.f, false);
 	EXPECT_EQ(torque, Vector3f());
 }
+
+namespace
+{
+
+constexpr float kIntegratorLimit = 0.3f;
+constexpr float kIntegralGain = 1.f;
+constexpr float kDt = 0.01f;
+
+// Rate controller with only an integral gain, so the returned torque is the integrator itself.
+RateControl createIntegratorOnlyRateControl()
+{
+	RateControl rate_control;
+	rate_control.setPidGains(Vector3f(), Vector3f(kIntegralGain, kIntegralGain, kIntegralGain), Vector3f());
+	rate_control.setIntegratorLimit(Vector3f(kIntegratorLimit, kIntegratorLimit, kIntegratorLimit));
+	return rate_control;
+}
+
+// Run the controller with a constant rate error until the integrator settles, and return the
+// integrator state of the roll axis.
+float windUpRollIntegrator(RateControl &rate_control, float rate_error)
+{
+	for (int i = 0; i < 1000; i++) {
+		rate_control.update(Vector3f(), Vector3f(rate_error, 0.f, 0.f), Vector3f(), kDt, false);
+	}
+
+	rate_ctrl_status_s status{};
+	rate_control.getRateControlStatus(status);
+	return status.rollspeed_integ;
+}
+
+} // namespace
+
+
+TEST(RateControlTest, NothingRefusedKeepsFullIntegratorLimit)
+{
+	RateControl rate_control = createIntegratorOnlyRateControl();
+	rate_control.setRefusedTorqueFraction(Vector3f());
+
+	EXPECT_NEAR(windUpRollIntegrator(rate_control, 1.f), kIntegratorLimit, 1e-6f);
+	EXPECT_NEAR(windUpRollIntegrator(rate_control, -1.f), -kIntegratorLimit, 1e-6f);
+}
+
+TEST(RateControlTest, RefusedPositiveFractionLowersIntegratorCeiling)
+{
+	// A quarter of the requested positive torque was refused.
+	RateControl rate_control = createIntegratorOnlyRateControl();
+	rate_control.setRefusedTorqueFraction(Vector3f(0.25f, 0.f, 0.f));
+
+	EXPECT_NEAR(windUpRollIntegrator(rate_control, 1.f), 0.75f * kIntegratorLimit, 1e-6f);
+}
+
+TEST(RateControlTest, RefusedNegativeFractionRaisesIntegratorFloor)
+{
+	RateControl rate_control = createIntegratorOnlyRateControl();
+	rate_control.setRefusedTorqueFraction(Vector3f(-0.25f, 0.f, 0.f));
+
+	EXPECT_NEAR(windUpRollIntegrator(rate_control, -1.f), -0.75f * kIntegratorLimit, 1e-6f);
+}
+
+TEST(RateControlTest, RefusalLeavesOppositeSignTrimUntouched)
+{
+	RateControl rate_control = createIntegratorOnlyRateControl();
+
+	// Build up negative trim while the allocator delivers everything.
+	rate_control.setRefusedTorqueFraction(Vector3f());
+	const float trim = windUpRollIntegrator(rate_control, -1.f);
+	EXPECT_NEAR(trim, -kIntegratorLimit, 1e-6f);
+
+	// Refusing positive torque must not squeeze a negative integrator.
+	rate_control.setRefusedTorqueFraction(Vector3f(0.5f, 0.f, 0.f));
+	rate_control.update(Vector3f(), Vector3f(), Vector3f(), kDt, false);
+
+	rate_ctrl_status_s status{};
+	rate_control.getRateControlStatus(status);
+	EXPECT_NEAR(status.rollspeed_integ, trim, 1e-6f);
+}
+
+TEST(RateControlTest, RefusalExceedingTheRequestDoesNotFlipIntegratorSign)
+{
+	// More was refused than was asked for, which the [0,1] constraint has to absorb.
+	RateControl rate_control = createIntegratorOnlyRateControl();
+	rate_control.setRefusedTorqueFraction(Vector3f(5.f, 0.f, 0.f));
+
+	EXPECT_NEAR(windUpRollIntegrator(rate_control, 1.f), 0.f, 1e-6f);
+}
+
+TEST(RateControlTest, IntegratorRecoversWhenRefusalClears)
+{
+	RateControl rate_control = createIntegratorOnlyRateControl();
+
+	rate_control.setRefusedTorqueFraction(Vector3f(0.25f, 0.f, 0.f));
+	EXPECT_NEAR(windUpRollIntegrator(rate_control, 1.f), 0.75f * kIntegratorLimit, 1e-6f);
+
+	rate_control.setRefusedTorqueFraction(Vector3f());
+	EXPECT_NEAR(windUpRollIntegrator(rate_control, 1.f), kIntegratorLimit, 1e-6f);
+}
+
+TEST(RateControlTest, ReportsIntegratorLimits)
+{
+	RateControl rate_control = createIntegratorOnlyRateControl();
+	rate_ctrl_status_s status{};
+
+	// Nothing refused: both bounds at the parameter value.
+	rate_control.setRefusedTorqueFraction(Vector3f());
+	rate_control.getRateControlStatus(status);
+	EXPECT_NEAR(status.integrator_limit_upper[0], kIntegratorLimit, 1e-6f);
+	EXPECT_NEAR(status.integrator_limit_lower[0], -kIntegratorLimit, 1e-6f);
+
+	// Refused positive torque lowers the ceiling only.
+	rate_control.setRefusedTorqueFraction(Vector3f(0.25f, 0.f, 0.f));
+	rate_control.getRateControlStatus(status);
+	EXPECT_NEAR(status.integrator_limit_upper[0], 0.75f * kIntegratorLimit, 1e-6f);
+	EXPECT_NEAR(status.integrator_limit_lower[0], -kIntegratorLimit, 1e-6f);
+
+	// Refused negative torque raises the floor only.
+	rate_control.setRefusedTorqueFraction(Vector3f(-0.25f, 0.f, 0.f));
+	rate_control.getRateControlStatus(status);
+	EXPECT_NEAR(status.integrator_limit_upper[0], kIntegratorLimit, 1e-6f);
+	EXPECT_NEAR(status.integrator_limit_lower[0], -0.75f * kIntegratorLimit, 1e-6f);
+}
+
+TEST(RateControlTest, ResetIntegralClearsRefusedFraction)
+{
+	RateControl rate_control = createIntegratorOnlyRateControl();
+
+	rate_control.setRefusedTorqueFraction(Vector3f(0.25f, 0.f, 0.f));
+	rate_control.resetIntegral();
+
+	EXPECT_NEAR(windUpRollIntegrator(rate_control, 1.f), kIntegratorLimit, 1e-6f);
+}

--- a/src/modules/fw_rate_control/FixedwingRateControl.cpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.cpp
@@ -308,7 +308,6 @@ void FixedwingRateControl::Run()
 			}
 
 			// Update saturation status from control allocation feedback
-			// TODO: send the unallocated value directly for better anti-windup
 			Vector3<bool> diffthr_enabled(
 				_param_vt_fw_difthr_en & static_cast<int32_t>(VTOLFixedWingDifferentialThrustEnabledBit::ROLL_BIT),
 				_param_vt_fw_difthr_en & static_cast<int32_t>(VTOLFixedWingDifferentialThrustEnabledBit::PITCH_BIT),
@@ -326,23 +325,42 @@ void FixedwingRateControl::Run()
 			// Set saturation flags for VTOL differential thrust feature
 			// If differential thrust is enabled in an axis, assume it's the only torque authority and only update saturation using matrix 0 allocating the motors.
 			if (_control_allocator_status_subs[0].update(&control_allocator_status)) {
+				_last_control_allocator_status[0] = control_allocator_status.timestamp;
+
 				for (size_t i = 0; i < 3; i++) {
 					if (diffthr_enabled(i)) {
 						_rate_control.setPositiveSaturationFlag(i, control_allocator_status.unallocated_torque[i] > FLT_EPSILON);
 						_rate_control.setNegativeSaturationFlag(i, control_allocator_status.unallocated_torque[i] < -FLT_EPSILON);
+						_unallocated_torque(i) = control_allocator_status.unallocated_torque[i];
 					}
 				}
 			}
 
 			// Set saturation flags for control surface controlled axes
-			if (_control_allocator_status_subs[_vehicle_status.is_vtol ? 1 : 0].update(&control_allocator_status)) {
+			const int surfaces_sub_idx = _vehicle_status.is_vtol ? 1 : 0;
+
+			if (_control_allocator_status_subs[surfaces_sub_idx].update(&control_allocator_status)) {
+				_last_control_allocator_status[surfaces_sub_idx] = control_allocator_status.timestamp;
+
 				for (size_t i = 0; i < 3; i++) {
 					if (!diffthr_enabled(i)) {
 						_rate_control.setPositiveSaturationFlag(i, control_allocator_status.unallocated_torque[i] > FLT_EPSILON);
 						_rate_control.setNegativeSaturationFlag(i, control_allocator_status.unallocated_torque[i] < -FLT_EPSILON);
+						_unallocated_torque(i) = control_allocator_status.unallocated_torque[i];
 					}
 				}
 			}
+
+			// Set unallocated torque to zero if the control allocator has not updated recently
+			for (size_t i = 0; i < 3; i++) {
+				const int source_idx = diffthr_enabled(i) ? 0 : surfaces_sub_idx;
+
+				if (hrt_elapsed_time(&_last_control_allocator_status[source_idx]) > 50_ms) {
+					_unallocated_torque(i) = 0.f;
+				}
+			}
+
+			_rate_control.setUnallocatedTorque(_unallocated_torque);
 
 			/* bi-linear interpolation over airspeed for actuator trim scheduling */
 			Vector3f trim(_param_trim_roll.get(), _param_trim_pitch.get(), _param_trim_yaw.get());

--- a/src/modules/fw_rate_control/FixedwingRateControl.hpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.hpp
@@ -137,6 +137,9 @@ private:
 	perf_counter_t _loop_perf;
 
 	hrt_abstime _last_run{0};
+	hrt_abstime _last_control_allocator_status[2] {};
+
+	matrix::Vector3f _unallocated_torque{};
 
 	static constexpr float _kAirspeedFilterTimeConstant{1.f};
 	AlphaFilter<float> _airspeed_filter_for_torque_scaling{_kAirspeedFilterTimeConstant};

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -211,9 +211,17 @@ MulticopterRateControl::Run()
 					}
 				}
 
-				// TODO: send the unallocated value directly for better anti-windup
 				_rate_control.setSaturationStatus(saturation_positive, saturation_negative);
+
+				_unallocated_torque = Vector3f(control_allocator_status.unallocated_torque);
+				_last_control_allocator_status = control_allocator_status.timestamp;
 			}
+
+			if (hrt_elapsed_time(&_last_control_allocator_status) > 50_ms) {
+				_unallocated_torque.zero();
+			}
+
+			_rate_control.setUnallocatedTorque(_unallocated_torque);
 
 			// run rate controller
 			Vector3f torque_setpoint =

--- a/src/modules/mc_rate_control/MulticopterRateControl.hpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.hpp
@@ -119,12 +119,14 @@ private:
 	bool _maybe_landed{true};
 
 	hrt_abstime _last_run{0};
+	hrt_abstime _last_control_allocator_status{0};
 
 	perf_counter_t	_loop_perf;			/**< loop duration performance counter */
 
 	// keep setpoint values between updates
 	matrix::Vector3f _acro_rate_max;		/**< max attitude rates in acro mode */
 	matrix::Vector3f _rates_setpoint{};
+	matrix::Vector3f _unallocated_torque{};
 
 	float _battery_status_scale{0.0f};
 	matrix::Vector3f _thrust_setpoint{};


### PR DESCRIPTION

### Solved Problem

The problem is that the rate integrator for saturates only based on a limit set by the user. This tends to lead to situation in which the rate controller saturates before the the servos(in FW cases)

### Solution
Use the unallocated torque to move the integrator limit. 

### Test coverage
Simulation - The problem right now is the unallocated torque has too high values that modify the limit too much


