### PR TITLE
fix(navigator): check loiter radius against geofences on mission upload

### DIFF
--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -150,6 +150,64 @@ MissionFeasibilityChecker::checkMissionAgainstGeofence(const mission_s &mission,
 						      i + 1);
 				return false;
 			}
+
+			if (!checkLoiterPerimeterAgainstGeofence(missionitem)) {
+				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence violation for loiter radius of waypoint %zu\t",
+						     i + 1);
+				// clang-tidy misparses the explicit "<int16_t>" template argument
+				// together with the call's parentheses as a chained relational
+				// comparison ("send < int16_t > (...)"); this is not one.
+				// NOLINTNEXTLINE(bugprone-chained-comparison)
+				events::send<int16_t>(events::ID("navigator_mis_geofence_violation_loiter"), {events::Log::Error, events::LogInternal::Info},
+						      "Geofence violation for loiter radius of waypoint {1}",
+						      i + 1);
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+bool
+MissionFeasibilityChecker::checkLoiterPerimeterAgainstGeofence(const mission_item_s &item)
+{
+	switch (item.nav_cmd) {
+	case NAV_CMD_LOITER_UNLIMITED:
+	case NAV_CMD_LOITER_TIME_LIMIT:
+	case NAV_CMD_LOITER_TO_ALT:
+		break;
+
+	default:
+		return true;
+	}
+
+	// negative radius means counter-clockwise; the geometry is the same either way
+	const float radius = fabsf(item.loiter_radius);
+
+	if (!PX4_ISFINITE(radius) || radius < FLT_EPSILON) {
+		return true;
+	}
+
+	// Sample the perimeter finely enough that the chord between two samples cannot
+	// step over a small geofence, but keep the count bounded so that upload time
+	// stays predictable for large radii.
+	static constexpr float kMaxArcStep = 10.f;   // metres between samples
+	static constexpr int kMinSamples = 8;
+	static constexpr int kMaxSamples = 64;
+
+	const int num_samples = math::constrain(static_cast<int>(ceilf(2.f * M_PI_F * radius / kMaxArcStep)),
+						kMinSamples, kMaxSamples);
+
+	for (int s = 0; s < num_samples; s++) {
+		const float bearing = (2.f * M_PI_F * static_cast<float>(s)) / static_cast<float>(num_samples);
+		double lat = 0.0;
+		double lon = 0.0;
+
+		waypoint_from_heading_and_distance(item.lat, item.lon, bearing, radius, &lat, &lon);
+
+		if (!_navigator->get_geofence().checkPointAgainstAllGeofences(lat, lon, item.altitude)) {
+			return false;
 		}
 	}
 

--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -59,6 +59,15 @@ private:
 	bool checkMissionAgainstGeofence(const mission_s &mission, float home_alt, bool home_valid);
 	void logDatamanReadFailure(const size_t mission_item, const uint8_t dataman_id);
 
+	/**
+	 * Check the perimeter of a loiter pattern against all geofences.
+	 * The centre of a loiter item is already covered by the per-item point check; this
+	 * samples the circle the vehicle actually flies, which the centre point does not
+	 * represent when the radius is large.
+	 * Returns true for items that are not loiter items or that have no usable radius.
+	 */
+	bool checkLoiterPerimeterAgainstGeofence(const mission_item_s &item);
+
 public:
 	MissionFeasibilityChecker(Navigator *navigator, DatamanClient &dataman_client) :
 		ModuleParams(nullptr),


### PR DESCRIPTION
### Problem

`MissionFeasibilityChecker::checkMissionAgainstGeofence()` validates one point per mission item — the item's own coordinate. For a loiter item that is the centre of the circle, so the radius takes no part in the decision. A loiter whose centre sits outside an exclusion zone but whose perimeter crosses into it is accepted at upload.

Affected: `src/modules/navigator/mission_feasibility_checker.cpp` on v1.17.0 and on current `main`, which checks the same single point.

### Demonstrated impact

On PX4 SITL with an exclusion polygon and a loiter centre placed outside it at `R = 200 m`:

- the mission is accepted, with no geofence warning
- flying it puts 41 of 2110 recorded track points inside the exclusion zone, at up to 28.9 m past the boundary

A control mission with a waypoint placed directly inside the zone is correctly rejected on the same build, so the fence is active and the acceptance above is a passing check rather than an absent one.

A reproducer exists. Following `SECURITY.md` I am not posting it; happy to share it privately.

### Fix

Sample the loiter perimeter and check each sample with the existing `checkPointAgainstAllGeofences()`, in addition to the centre point. Sampling uses a 10 m maximum arc step, clamped to between 8 and 64 points, so the cost stays bounded for large radii.

Covered commands are `NAV_CMD_LOITER_UNLIMITED`, `NAV_CMD_LOITER_TIME_LIMIT` and `NAV_CMD_LOITER_TO_ALT`. The radius is read from `item.loiter_radius`, which `mavlink_mission.cpp` already populates from the correct parameter for each command.

### Test

Stock build and patched build, same fence and same three missions:

| Case | Mission | Stock | Patched |
|---|---|---|---|
| control | waypoint at the centre of the zone | rejected | rejected |
| loiter | centre outside, `R = 200 m`, perimeter crosses in | accepted | rejected |
| regression | centre outside, `R = 10 m`, perimeter clear | accepted | accepted |

Only the middle case changes. New message: `Geofence violation for loiter radius of waypoint 2`.

### Known limitation

Sampling is discrete, so a geofence smaller than the arc step between two samples can still pass. Making the step adaptive to the smallest fence feature, or testing perimeter segments rather than points, would close that; I kept the step fixed to keep upload-time cost predictable and am happy to change the approach.

Found with AI assistance (Claude); the fix was written and tested by me in SITL.