### PR TITLE
fix(navigator): make RTL_TYPE dropdown options compact

### DIFF
--- a/src/modules/navigator/rtl_params.yaml
+++ b/src/modules/navigator/rtl_params.yaml
@@ -57,31 +57,31 @@ parameters:
     RTL_TYPE:
       description:
         short: Return type
-        long: Return mode destination and flight path (home location, rally point,
-          mission landing pattern, reverse mission)
+        long: |-
+          Return mode destination and flight path (home location, rally point, mission landing pattern, reverse mission)
+
+          - 0 (Direct to home or rally point): Return to closest safe point (home or rally point) via direct path.
+
+          - 1 (Direct to mission landing or rally point): Return to closest safe point other than home (mission landing pattern or rally point), via direct path. If no mission landing or rally points are defined return home via direct path. Always choose closest safe landing point if vehicle is a VTOL in hover mode.
+
+          - 2 (Mission path to landing, else reverse home): Return to a planned mission landing, if available, using the mission path while skipping DO_JUMP and other non-position mission items, else return to home via the reverse mission path with the same traversal rules. Do not consider rally points.
+
+          - 3 (Direct to closest safe destination): Return via direct path to closest destination: home, start of mission landing pattern or safe point. If the destination is a mission landing pattern, follow the pattern to land.
+
+          - 4 (Mission path, closest of landing or home): Return to the planned mission landing, or to home via the reverse mission path, whichever is estimated to be closer using mission item indices. Skip DO_JUMP and other non-position mission items while following either mission path. Do not consider rally points.
+
+          - 5 (Direct to rally point only): Return directly to safe landing point (do not consider mission landing and Home).
+
+          - 6 (Home if battery allows, else rally point): Return to home if time estimate to home is less than battery remaining estimate, else return to the closest rally point. If battery remaining estimate is not available, return to the closest safe point (home or rally point).
       type: enum
       values:
-        0: Return to closest safe point (home or rally point) via direct path.
-        1: Return to closest safe point other than home (mission landing pattern or
-          rally point), via direct path. If no mission landing or rally points are
-          defined return home via direct path. Always choose closest safe landing
-          point if vehicle is a VTOL in hover mode.
-        2: Return to a planned mission landing, if available, using the mission
-          path while skipping DO_JUMP and other non-position mission items, else
-          return to home via the reverse mission path with the same traversal
-          rules. Do not consider rally points.
-        3: 'Return via direct path to closest destination: home, start of mission
-          landing pattern or safe point. If the destination is a mission landing pattern,
-          follow the pattern to land.'
-        4: Return to the planned mission landing, or to home via the reverse mission
-          path, whichever is estimated to be closer using mission item indices.
-          Skip DO_JUMP and other non-position mission items while following either
-          mission path. Do not consider rally points.
-        5: Return directly to safe landing point (do not consider mission landing
-          and Home).
-        6: Return to home if time estimate to home is less than battery remaining estimate,
-          else return to the closest rally point. If battery remaining estimate is not available,
-          return to the closest safe point (home or rally point).
+        0: Direct to home or rally point
+        1: Direct to mission landing or rally point
+        2: Mission path to landing, else reverse home
+        3: Direct to closest safe destination
+        4: Mission path, closest of landing or home
+        5: Direct to rally point only
+        6: Home if battery allows, else rally point
       default: 0
     RTL_CONE_ANG:
       description:


### PR DESCRIPTION
### Solved Problem
The `RTL_TYPE` option strings where too long, so the value
dropdown overflows the window in ground control stations and the parameter
becomes awkward to change.

### Solution
Replace the option strings with short names and move the full explanations into the parameter long description. 

### Ticket
[SW-3079]

QGC
<img width="3440" height="1440" alt="Screenshot From 2026-09-03 15-46-03" src="https://github.com/user-attachments/assets/05f645bb-30e7-4be1-a372-0e34bcc68d04" />

AMC
<img width="3374" height="1372" alt="Screenshot From 2026-09-03 16-45-35" src="https://github.com/user-attachments/assets/80b167a2-6db2-48ee-84cf-597312121329" />


