### PR TITLE
fix(flashparams): append unsaved deltas and compact at boot

### DIFF
--- a/src/lib/parameters/flashparams/flashfs.c
+++ b/src/lib/parameters/flashparams/flashfs.c
@@ -570,71 +570,75 @@ static flash_entry_header_t *find_free(data_size_t required)
 }
 
 /****************************************************************************
- * Name: get_next_sector_descriptor
+ * Name: for_each_valid_entry
  *
  * Description:
- *   Given a pointer to sector_descriptor_t, this helper function
- *   returns a pointer to the next sector_descriptor_t
- *
- * Input Parameters:
- *   current      - A pointer to the current sector_descriptor_t
- *
- * Returned value:
- *  On Success A pointer to the next sector_descriptor_t,
- *  otherwise NULL
- *
+ *   Visit every CRC-valid, not-erased entry matching token, oldest first.
+ *   cb returns 0 to continue, <0 to abort with that errno.
  *
  ****************************************************************************/
 
-static sector_descriptor_t *get_next_sector_descriptor(sector_descriptor_t *
-		current)
+static int for_each_valid_entry(flash_file_token_t token,
+				int (*cb)(flash_entry_header_t *pf, void *arg),
+				void *arg)
 {
-	for (int s = 0; sector_map[s].address; s++) {
-		if (current == &sector_map[s]) {
-			if (sector_map[s + 1].address) {
-				s++;
+	int n = 0;
 
-			} else {
-				s = 0;
+	if (sector_map == NULL) {
+		return -ENXIO;
+	}
+
+	for (int s = 0; sector_map[s].address; s++) {
+
+		h_magic_t *pmagic = (h_magic_t *) sector_map[s].address;
+		h_magic_t *pe = pmagic + (sector_map[s].size / sizeof(h_magic_t)) - 1;
+
+cont:
+
+		while (pmagic < pe && !valid_magic(pmagic)) {
+			pmagic++;
+		}
+
+		if (pmagic >= pe) { continue; }
+
+		flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
+
+		if (pf + 1 > (flash_entry_header_t *)pe) { continue; }
+
+		const uint8_t *crc_start = entry_crc_start(pf);
+		data_size_t crc_length = entry_crc_length(pf);
+
+		if (crc_start + crc_length > (uint8_t *)pe) { continue; }
+
+		if (pf->crc == crc32(crc_start, crc_length)) {
+
+			if (valid_entry(pf) && pf->file_token.t == token.t) {
+				if (cb != NULL) {
+					int rv = cb(pf, arg);
+
+					if (rv < 0) {
+						return rv;
+					}
+				}
+
+				n++;
 			}
 
-			return &sector_map[s];
+			pf = next_entry(pf);
+			pmagic = (h_magic_t *) pf;
+
+			if (pmagic >= pe || blank_entry(pf)) {
+				continue;
+			}
+
+		} else {
+			pmagic++;
 		}
+
+		goto cont;
 	}
 
-	return NULL;
-}
-
-/****************************************************************************
- * Name: get_sector_info
- *
- * Description:
- *   Given a pointer to a flash entry header returns the sector descriptor
- *   for the file is located in
- *
- * Input Parameters:
- *   current      - A pointer to the current flash entry header
- *
- * Returned value:
- *  On Success A pointer to the next sector_descriptor_t,
- *  otherwise NULL
- *
- *
- ****************************************************************************/
-
-static sector_descriptor_t *get_sector_info(flash_entry_header_t *current)
-{
-	for (int s = 0; sector_map[s].address != 0; s++) {
-		uint8_t *pb = (uint8_t *) sector_map[s].address;
-		uint8_t *pe = pb + sector_map[s].size - 1;
-		uint8_t *pc = (uint8_t *) current;
-
-		if (pc >= pb && pc <= pe) {
-			return &sector_map[s];
-		}
-	}
-
-	return 0;
+	return n;
 }
 
 /****************************************************************************
@@ -678,65 +682,6 @@ static int erase_sector(sector_descriptor_t *sm, flash_entry_header_t *pf)
 	}
 
 	return rv;
-}
-
-/****************************************************************************
- * Name: erase_entry
- *
- * Description:
- *   Given a pointer to a flash entry header erases the entry
- *
- * Input Parameters:
- *   pf  - A pointer to the current flash entry header
- *
- *
- * Returned value:
- *  >0 On Success or a negative errno
- *
- *
- ****************************************************************************/
-
-static int erase_entry(flash_entry_header_t *pf)
-{
-	h_flag_t data = ErasedEntry;
-	size_t size = sizeof(h_flag_t);
-#if defined(BOARD_USE_EXTERNAL_FLASH)
-	int rv = up_progmem_ext_write((size_t) &pf->flag, &data, size);
-#else
-	int rv = up_progmem_write((size_t) &pf->flag, &data, size);
-#endif
-	return rv;
-}
-
-/****************************************************************************
- * Name: check_free_space_in_sector
- *
- * Description:
- *   Given a pointer to a flash entry header and a new size
- *
- * Input Parameters:
-*   pf       - A pointer to the current flash entry header
- *   new_size - The total number of bytes to be written
-  *
- * Returned value:
- *  0 if there is enough space left to write new size
- *  If not it returns the flash_file_sector_t * that needs to be erased.
- *
- ****************************************************************************/
-
-static sector_descriptor_t *check_free_space_in_sector(flash_entry_header_t
-		*pf, size_t new_size)
-{
-	sector_descriptor_t *sm = get_sector_info(pf);
-	uint8_t *psector_first = (uint8_t *) sm->address;
-	uint8_t *psector_last = psector_first + sm->size - 1;
-	uint8_t *pnext_end = (uint8_t *)(valid_magic((h_magic_t *)pf) ? next_entry(pf) : pf) + new_size;
-
-	if (pnext_end >= psector_first && pnext_end <= psector_last) {
-		sm = 0;
-	}
-
-	return sm;
 }
 
 /****************************************************************************
@@ -815,8 +760,7 @@ int parameter_flashfs_blank(void)
  * Name: parameter_flashfs_write
  *
  * Description:
- *   This function writes user data from the buffer allocated with a previous call
- *   to parameter_flashfs_alloc. flash starting at the given address
+ *   Append a new entry. Previous valid entries are left intact.
  *
  * Input Parameters:
  *   token      - File Token File to read
@@ -846,82 +790,11 @@ parameter_flashfs_write(flash_file_token_t token, uint8_t *buffer, size_t buf_si
 		size_t  size_adjust = ((total_size + alignment) & ~alignment) - total_size;
 		total_size += size_adjust;
 
-		/* Is this and existing entry */
+		/* Append. Compaction (sector erase) is the caller's job, done at boot. */
+		flash_entry_header_t *pf = find_free(total_size);
 
-		flash_entry_header_t *pf = find_entry(token);
-
-		if (!pf) {
-
-			/* No Entry exists for this token so find a place for it */
-
-			pf = find_free(total_size);
-
-			/* No Space */
-
-			if (pf == 0) {
-				return -ENOSPC;
-			}
-
-		} else {
-
-			/* Do we have space after the entry in the sector for the update */
-
-			sector_descriptor_t *current_sector = check_free_space_in_sector(pf,
-							      total_size);
-
-
-			if (current_sector == 0) {
-
-				/* Mark the last entry erased */
-
-				/* todo:consider a 2 stage erase or write before erase and do a fs check
-				 * at start up
-				 */
-
-				rv = erase_entry(pf);
-
-				if (rv < 0) {
-					return rv;
-				}
-
-				/* We had space and marked the last entry erased so use the  Next Free */
-
-				pf = next_entry(pf);
-
-			} else {
-
-				/*
-				 * We did not have space in the current sector so select the next sector
-				 */
-
-				current_sector = get_next_sector_descriptor(current_sector);
-
-				/* Will the data fit */
-
-				if (current_sector->size < total_size) {
-					return -ENOSPC;
-				}
-
-				/* Mark the last entry erased */
-
-				/* todo:consider a 2 stage erase or write before erase and do a fs check
-				 * at start up
-				 */
-
-				rv = erase_entry(pf);
-
-				if (rv < 0) {
-					return rv;
-				}
-
-				pf = (flash_entry_header_t *) current_sector->address;
-
-				if (!blank_check(pf, total_size)) {
-					rv = erase_sector(current_sector, pf);
-				}
-
-			}
-
+		if (pf == 0) {
+			return -ENOSPC;
 		}
 
 		flash_entry_header_t *pn = (flash_entry_header_t *)(buffer - sizeof(flash_entry_header_t));
@@ -948,6 +821,62 @@ parameter_flashfs_write(flash_file_token_t token, uint8_t *buffer, size_t buf_si
 	}
 
 	return rv;
+}
+
+/****************************************************************************
+ * Name: parameter_flashfs_walk
+ ****************************************************************************/
+
+struct walk_pack {
+	parameter_flashfs_walk_cb cb;
+	void *arg;
+};
+
+static int walk_one(flash_entry_header_t *pf, void *arg)
+{
+	struct walk_pack *w = (struct walk_pack *)arg;
+	return w->cb(entry_data(pf), entry_data_length(pf), w->arg);
+}
+
+int parameter_flashfs_walk(flash_file_token_t token, parameter_flashfs_walk_cb cb, void *arg)
+{
+	struct walk_pack w = { cb, arg };
+	return for_each_valid_entry(token, walk_one, &w);
+}
+
+/****************************************************************************
+ * Name: parameter_flashfs_needs_compact
+ ****************************************************************************/
+
+static int note_first_entry(flash_entry_header_t *pf, void *arg)
+{
+	flash_entry_header_t **first = (flash_entry_header_t **)arg;
+
+	if (*first == NULL) {
+		*first = pf;
+	}
+
+	return 0;
+}
+
+int parameter_flashfs_needs_compact(void)
+{
+	flash_entry_header_t *first = NULL;
+	int n = for_each_valid_entry(parameters_token, note_first_entry, &first);
+
+	if (n < 0) {
+		return n;
+	}
+
+	if (n == 0) {
+		return 0;
+	}
+
+	if (n > 1) {
+		return 1;
+	}
+
+	return (uintptr_t)first != (uintptr_t)sector_map[0].address;
 }
 
 /****************************************************************************

--- a/src/lib/parameters/flashparams/flashfs.c
+++ b/src/lib/parameters/flashparams/flashfs.c
@@ -112,7 +112,7 @@ typedef begin_packed_struct struct flash_entry_header_t {
  * Private Data
  ****************************************************************************/
 static uint8_t *working_buffer;
-static uint16_t working_buffer_size;
+static size_t working_buffer_size;
 static bool working_buffer_static;
 static sector_descriptor_t *sector_map;
 static int last_erased;
@@ -218,46 +218,6 @@ static bool blank_check(flash_entry_header_t *pf,
 static inline int valid_magic(h_magic_t *pm)
 {
 	return *pm == MagicSig;
-}
-
-/****************************************************************************
- * Name: blank_magic
- *
- * Description:
- *   This helper function returns true if the pointer points to a valid
- *   blank magic signature
- *
- * Input Parameters:
- *   pm   - A pointer to memory aligned on sizeof(h_magic_t) boundaries
- *
- * Returned value:
- *   true if magic is valid
- *
- *
- ****************************************************************************/
-
-static inline int blank_magic(h_magic_t *pm)
-{
-	return *pm == BlankSig;
-}
-/****************************************************************************
- * Name: erased_entry
- *
- * Description:
- *   This helper function returns true if the entry is Erased
- *
- * Input Parameters:
- *   fi            - A pointer to the current flash entry header
- *
- * Returned value:
- *   true if  erased
- *
- *
- ****************************************************************************/
-
-static inline int erased_entry(flash_entry_header_t *fi)
-{
-	return (fi->flag & MaskEntry) == ErasedEntry;
 }
 
 /****************************************************************************
@@ -424,19 +384,40 @@ static inline data_size_t entry_crc_length(flash_entry_header_t *fi)
 	return fi->size - offsetof(flash_entry_header_t, size);
 }
 
+static bool crc_header_ok(flash_entry_header_t *pf, h_magic_t *pe)
+{
+	if (pf + 1 > (flash_entry_header_t *)pe) {
+		return false;
+	}
+
+	if (pf->size < sizeof(flash_entry_header_t)) {
+		return false;
+	}
+
+	const uint8_t *crc_start = entry_crc_start(pf);
+	data_size_t crc_length = entry_crc_length(pf);
+
+	if (crc_start + crc_length > (uint8_t *)pe) {
+		return false;
+	}
+
+	return pf->crc == crc32(crc_start, crc_length);
+}
+
+static bool slot_is_free(flash_entry_header_t *pf, int s, size_t required)
+{
+	uint8_t *begin = (uint8_t *)sector_map[s].address;
+	uint8_t *end = begin + sector_map[s].size;
+
+	if ((uint8_t *)pf < begin || required == 0 || (uint8_t *)pf + required > end) {
+		return false;
+	}
+
+	return blank_entry(pf) && blank_check(pf, required);
+}
+
 /****************************************************************************
  * Name: find_entry
- *
- * Description:
- *   This helper function locates an "file" from the the file token
- *
- * Input Parameters:
- *   token        - A flash file token, the pseudo file name
- *
- * Returned value:
- *  On Success a pointer to flash entry header or NULL on failure
- *
- *
  ****************************************************************************/
 
 static flash_entry_header_t *find_entry(flash_file_token_t token)
@@ -446,57 +427,30 @@ static flash_entry_header_t *find_entry(flash_file_token_t token)
 		h_magic_t *pmagic = (h_magic_t *) sector_map[s].address;
 		h_magic_t *pe = pmagic + (sector_map[s].size / sizeof(h_magic_t)) - 1;
 
-		/* Hunt for Magic Signature */
 cont:
 
 		while (pmagic < pe && !valid_magic(pmagic)) {
 			pmagic++;
 		}
 
-		/* Did we reach the end
-		 * if so try the next sector */
-
 		if (pmagic >= pe) { continue; }
-
-		/* Found a magic So assume it is a file header */
 
 		flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
 
-		/* Ensure that the header is fully inside the current sector */
-
-		if (pf + 1 > (flash_entry_header_t *)pe) { continue; }
-
-		const uint8_t *crc_start = entry_crc_start(pf);
-		data_size_t crc_length = entry_crc_length(pf);
-
-		if (crc_start + crc_length > (uint8_t *)pe) { continue; }
-
-		if (pf->crc == crc32(crc_start, crc_length)) {
-
-			/* Good CRC is it the one we are looking for ?*/
+		if (crc_header_ok(pf, pe)) {
 
 			if (valid_entry(pf) && pf->file_token.t == token.t) {
-
 				return pf;
+			}
 
-			} else {
+			pf = next_entry(pf);
+			pmagic = (h_magic_t *) pf;
 
-				/* Not the one we wanted but we can trust the size */
-
-				pf = next_entry(pf);
-				pmagic = (h_magic_t *) pf;
-
-				/* If the next one is erased */
-
-				if (pmagic >= pe || blank_entry(pf)) {
-					continue;
-				}
+			if (pmagic >= pe || blank_entry(pf)) {
+				continue;
 			}
 
 		} else {
-
-			/* invalid CRC so keep looking */
-
 			pmagic++;
 		}
 
@@ -507,63 +461,83 @@ cont:
 }
 
 /****************************************************************************
- * Name: find_free
+ * Name: find_append
  *
  * Description:
- *   This helper function locates free space for the number of bytes required
- *
- * Input Parameters:
- *   required  - Number of bytes required
- *
- * Returned value:
- *  On Success a pointer to flash entry header or NULL on failure
- *
+ *   Return the address of a blank run that sits after every CRC-valid
+ *   header in sector-map order. First-fit holes before later live data are
+ *   not used; those are fragmentation and belong to compact.
  *
  ****************************************************************************/
 
-static flash_entry_header_t *find_free(data_size_t required)
+static flash_entry_header_t *find_append(size_t required)
 {
-	for (int s = 0; sector_map[s].address; s++) {
+	if (sector_map == NULL || required == 0) {
+		return NULL;
+	}
 
+	flash_entry_header_t *last = NULL;
+	int last_s = -1;
+
+	for (int s = 0; sector_map[s].address; s++) {
 		h_magic_t *pmagic = (h_magic_t *) sector_map[s].address;
 		h_magic_t *pe = pmagic + (sector_map[s].size / sizeof(h_magic_t)) - 1;
 
-		/* Hunt for Magic Signature */
-
-		do {
-
-			if (valid_magic(pmagic)) {
-
-				flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
-
-				/* Ensure that the header is fully inside the current sector */
-
-				if (pf + 1 > (flash_entry_header_t *)pe) { break; }
-
-				/* Test the CRC */
-
-				if (pf->crc == crc32(entry_crc_start(pf), entry_crc_length(pf))) {
-
-					/* Valid Magic and CRC look for the next record*/
-
-					pmagic = ((uint32_t *) next_entry(pf));
-
-				} else {
-
-					pmagic++;
-				}
+		while (pmagic < pe) {
+			if (!valid_magic(pmagic)) {
+				pmagic++;
+				continue;
 			}
 
-			if (pmagic + (required / sizeof(h_magic_t)) <= pe && blank_magic(pmagic)) {
+			flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
 
-				flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
+			if (crc_header_ok(pf, pe)) {
+				last = pf;
+				last_s = s;
+				pmagic = (h_magic_t *) next_entry(pf);
 
-				if (blank_entry(pf) && blank_check(pf, required)) {
-					return pf;
-				}
-
+			} else {
+				pmagic++;
 			}
-		}  while (++pmagic < pe);
+		}
+	}
+
+	const int start_s = (last == NULL) ? 0 : last_s;
+	h_magic_t *pmagic = (last == NULL)
+			    ? (h_magic_t *) sector_map[0].address
+			    : (h_magic_t *) next_entry(last);
+
+	for (int s = start_s; sector_map[s].address; s++) {
+		if (s != start_s) {
+			pmagic = (h_magic_t *) sector_map[s].address;
+		}
+
+		h_magic_t *pe = (h_magic_t *) sector_map[s].address
+				+ (sector_map[s].size / sizeof(h_magic_t)) - 1;
+
+		if ((uint8_t *)pmagic < (uint8_t *)sector_map[s].address
+		    || (uint8_t *)pmagic >= (uint8_t *)sector_map[s].address + sector_map[s].size) {
+			if (s == start_s) {
+				continue;
+			}
+
+			pmagic = (h_magic_t *) sector_map[s].address;
+		}
+
+		while (pmagic < pe) {
+			flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
+
+			if (valid_magic(pmagic) && crc_header_ok(pf, pe)) {
+				pmagic = (h_magic_t *) next_entry(pf);
+				continue;
+			}
+
+			if (slot_is_free(pf, s, required)) {
+				return pf;
+			}
+
+			pmagic++;
+		}
 	}
 
 	return NULL;
@@ -575,6 +549,8 @@ static flash_entry_header_t *find_free(data_size_t required)
  * Description:
  *   Visit every CRC-valid, not-erased entry matching token, oldest first.
  *   cb returns 0 to continue, <0 to abort with that errno.
+ *   A torn or oversize header advances one magic word; it must not skip
+ *   the rest of the sector (later valid records would be invisible).
  *
  ****************************************************************************/
 
@@ -603,14 +579,7 @@ cont:
 
 		flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
 
-		if (pf + 1 > (flash_entry_header_t *)pe) { continue; }
-
-		const uint8_t *crc_start = entry_crc_start(pf);
-		data_size_t crc_length = entry_crc_length(pf);
-
-		if (crc_start + crc_length > (uint8_t *)pe) { continue; }
-
-		if (pf->crc == crc32(crc_start, crc_length)) {
+		if (crc_header_ok(pf, pe)) {
 
 			if (valid_entry(pf) && pf->file_token.t == token.t) {
 				if (cb != NULL) {
@@ -790,8 +759,12 @@ parameter_flashfs_write(flash_file_token_t token, uint8_t *buffer, size_t buf_si
 		size_t  size_adjust = ((total_size + alignment) & ~alignment) - total_size;
 		total_size += size_adjust;
 
-		/* Append. Compaction (sector erase) is the caller's job. */
-		flash_entry_header_t *pf = find_free(total_size);
+		if (total_size > UINT16_MAX) {
+			return -EFBIG;
+		}
+
+		/* Append after the last CRC-valid record. Compaction is the caller's job. */
+		flash_entry_header_t *pf = find_append(total_size);
 
 		if (pf == 0) {
 			return -ENOSPC;
@@ -848,37 +821,90 @@ int parameter_flashfs_walk(flash_file_token_t token, parameter_flashfs_walk_cb c
  * Name: parameter_flashfs_needs_compact
  ****************************************************************************/
 
-static int note_first_entry(flash_entry_header_t *pf, void *arg)
-{
-	flash_entry_header_t **first = (flash_entry_header_t **)arg;
+struct compact_note {
+	flash_entry_header_t *first;
+	int n;
+};
 
-	if (*first == NULL) {
-		*first = pf;
+static int note_entries(flash_entry_header_t *pf, void *arg)
+{
+	struct compact_note *note = (struct compact_note *)arg;
+
+	if (note->first == NULL) {
+		note->first = pf;
 	}
 
+	note->n++;
 	return 0;
+}
+
+size_t parameter_flashfs_max_payload(void)
+{
+	if (sector_map == NULL) {
+		return 0;
+	}
+
+	size_t max_sector = 0;
+
+	for (int s = 0; sector_map[s].address; s++) {
+		if (sector_map[s].size > max_sector) {
+			max_sector = sector_map[s].size;
+		}
+	}
+
+	const size_t overhead = sizeof(flash_entry_header_t) + sizeof(h_magic_t) - 1;
+
+	if (max_sector <= overhead) {
+		return 0;
+	}
+
+	return max_sector - overhead;
 }
 
 int parameter_flashfs_needs_compact(void)
 {
-	flash_entry_header_t *first = NULL;
-	int n = for_each_valid_entry(parameters_token, note_first_entry, &first);
+	struct compact_note note = { NULL, 0 };
+	int n = for_each_valid_entry(parameters_token, note_entries, &note);
 
 	if (n <= 0) {
 		return n;
 	}
 
-	/* Keep enough free space for a QGC burst of deltas. A disarm-edge
-	 * UUID append is a few 32-byte rows and must not force a boot erase.
-	 * If the only live entry is already at the sector start, compacting
-	 * cannot create more room than it already occupies. */
-	const size_t delta_headroom = 4096;
+	size_t max_sector = 0;
+	int nsectors = 0;
 
-	if (find_free(delta_headroom) != NULL) {
+	for (int s = 0; sector_map[s].address; s++) {
+		if (sector_map[s].size > max_sector) {
+			max_sector = sector_map[s].size;
+		}
+
+		nsectors++;
+	}
+
+	/* Keep room after the log for a burst the size of the current snapshot
+	 * (reset-all tombstones, airframe PARAM_SET), floored so a UUID append
+	 * does not force a boot erase. */
+	size_t headroom = 8192;
+
+	if (note.first != NULL && note.first->size > headroom) {
+		headroom = note.first->size;
+	}
+
+	if (headroom > max_sector) {
+		headroom = max_sector;
+	}
+
+	const bool packed = (uintptr_t)note.first == (uintptr_t)sector_map[0].address;
+
+	if (!packed) {
+		return 1;
+	}
+
+	if (find_append(headroom) != NULL) {
 		return 0;
 	}
 
-	if (n == 1 && (uintptr_t)first == (uintptr_t)sector_map[0].address) {
+	if (note.n == 1 && nsectors == 1) {
 		return 0;
 	}
 
@@ -1021,31 +1047,9 @@ int parameter_flashfs_init(sector_descriptor_t *fconfig, uint8_t *buffer, uint16
 
 	/* Sanity check */
 
-	flash_entry_header_t *pf = find_entry(parameters_token);
-
-	/*  No parameters */
-
-	if (pf == NULL) {
-		size_t total_size = size + sizeof(flash_entry_header_t);
-		size_t alignment = sizeof(h_magic_t) - 1;
-		size_t  size_adjust = ((total_size + alignment) & ~alignment) - total_size;
-		total_size += size_adjust;
-
-		/* Do we have free space ?*/
-
-		if (find_free(total_size) == NULL) {
-
-			/* No paramates and no free space => neeed erase */
-
-			rv  = parameter_flashfs_erase();
-
-			/* A positive return value means flash space has been erased successfully */
-
-			if (rv > 0) {
-				rv = 0;
-			}
-		}
-	}
+	/* A non-blank store with no valid entry is torn or foreign; import
+	 * reports -EILSEQ. Erasing here would hide a successful retry after
+	 * a torn write. */
 
 	return rv;
 }

--- a/src/lib/parameters/flashparams/flashfs.c
+++ b/src/lib/parameters/flashparams/flashfs.c
@@ -122,6 +122,10 @@ static int last_erased;
  ****************************************************************************/
 
 const flash_file_token_t parameters_token = {
+	.n = {'p', 'l', 'o', 'g'},
+};
+
+const flash_file_token_t parameters_legacy_token = {
 	.n = {'p', 'a', 'r', 'm'},
 };
 
@@ -384,9 +388,16 @@ static inline data_size_t entry_crc_length(flash_entry_header_t *fi)
 	return fi->size - offsetof(flash_entry_header_t, size);
 }
 
+/* The parameter sector can be the last one on the chip, so no header
+ * field may be read until the whole header is known to lie inside it. */
+static inline bool header_fits(flash_entry_header_t *pf, h_magic_t *pe)
+{
+	return pf + 1 <= (flash_entry_header_t *)pe;
+}
+
 static bool crc_header_ok(flash_entry_header_t *pf, h_magic_t *pe)
 {
-	if (pf + 1 > (flash_entry_header_t *)pe) {
+	if (!header_fits(pf, pe)) {
 		return false;
 	}
 
@@ -413,51 +424,32 @@ static bool slot_is_free(flash_entry_header_t *pf, int s, size_t required)
 		return false;
 	}
 
+	/* Entries start on a flash row. up_progmem_write only asserts that in
+	 * debug builds, so a slot found by the word-wise scan behind a torn
+	 * record would otherwise be programmed misaligned. */
+	if (((uintptr_t)pf & SizeMask) != 0) {
+		return false;
+	}
+
 	return blank_entry(pf) && blank_check(pf, required);
 }
 
-/****************************************************************************
- * Name: find_entry
- ****************************************************************************/
+static int for_each_valid_entry(flash_file_token_t token,
+				int (*cb)(flash_entry_header_t *pf, void *arg),
+				void *arg);
 
+static int stop_at_first(flash_entry_header_t *pf, void *arg)
+{
+	*(flash_entry_header_t **)arg = pf;
+	return -ECANCELED;
+}
+
+/* Oldest valid entry for token, or NULL. */
 static flash_entry_header_t *find_entry(flash_file_token_t token)
 {
-	for (int s = 0; sector_map[s].address; s++) {
-
-		h_magic_t *pmagic = (h_magic_t *) sector_map[s].address;
-		h_magic_t *pe = pmagic + (sector_map[s].size / sizeof(h_magic_t)) - 1;
-
-cont:
-
-		while (pmagic < pe && !valid_magic(pmagic)) {
-			pmagic++;
-		}
-
-		if (pmagic >= pe) { continue; }
-
-		flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
-
-		if (crc_header_ok(pf, pe)) {
-
-			if (valid_entry(pf) && pf->file_token.t == token.t) {
-				return pf;
-			}
-
-			pf = next_entry(pf);
-			pmagic = (h_magic_t *) pf;
-
-			if (pmagic >= pe || blank_entry(pf)) {
-				continue;
-			}
-
-		} else {
-			pmagic++;
-		}
-
-		goto cont;
-	}
-
-	return NULL;
+	flash_entry_header_t *pf = NULL;
+	for_each_valid_entry(token, stop_at_first, &pf);
+	return pf;
 }
 
 /****************************************************************************
@@ -495,6 +487,14 @@ static flash_entry_header_t *find_append(size_t required)
 				last = pf;
 				last_s = s;
 				pmagic = (h_magic_t *) next_entry(pf);
+				pf = (flash_entry_header_t *) pmagic;
+
+				/* Same stop rule as for_each_valid_entry: a record behind a
+				 * blank header is invisible to replay, so it must not anchor
+				 * the append point either. */
+				if (pmagic >= pe || !header_fits(pf, pe) || blank_entry(pf)) {
+					break;
+				}
 
 			} else {
 				pmagic++;
@@ -596,7 +596,7 @@ cont:
 			pf = next_entry(pf);
 			pmagic = (h_magic_t *) pf;
 
-			if (pmagic >= pe || blank_entry(pf)) {
+			if (pmagic >= pe || !header_fits(pf, pe) || blank_entry(pf)) {
 				continue;
 			}
 
@@ -821,23 +821,6 @@ int parameter_flashfs_walk(flash_file_token_t token, parameter_flashfs_walk_cb c
  * Name: parameter_flashfs_needs_compact
  ****************************************************************************/
 
-struct compact_note {
-	flash_entry_header_t *first;
-	int n;
-};
-
-static int note_entries(flash_entry_header_t *pf, void *arg)
-{
-	struct compact_note *note = (struct compact_note *)arg;
-
-	if (note->first == NULL) {
-		note->first = pf;
-	}
-
-	note->n++;
-	return 0;
-}
-
 size_t parameter_flashfs_max_payload(void)
 {
 	if (sector_map == NULL) {
@@ -861,54 +844,49 @@ size_t parameter_flashfs_max_payload(void)
 	return max_sector - overhead;
 }
 
-int parameter_flashfs_needs_compact(void)
+int parameter_flashfs_needs_compact(flash_file_token_t token, size_t snapshot_size)
 {
-	struct compact_note note = { NULL, 0 };
-	int n = for_each_valid_entry(parameters_token, note_entries, &note);
-
-	if (n <= 0) {
-		return n;
+	if (sector_map == NULL) {
+		return -ENXIO;
 	}
 
-	size_t max_sector = 0;
-	int nsectors = 0;
+	flash_entry_header_t *first = find_entry(token);
 
-	for (int s = 0; sector_map[s].address; s++) {
-		if (sector_map[s].size > max_sector) {
-			max_sector = sector_map[s].size;
-		}
-
-		nsectors++;
+	if (first == NULL) {
+		return 0;
 	}
 
-	/* Keep room after the log for a burst the size of the current snapshot
-	 * (reset-all tombstones, airframe PARAM_SET), floored so a UUID append
-	 * does not force a boot erase. */
-	size_t headroom = 8192;
-
-	if (note.first != NULL && note.first->size > headroom) {
-		headroom = note.first->size;
-	}
-
-	if (headroom > max_sector) {
-		headroom = max_sector;
-	}
-
-	const bool packed = (uintptr_t)note.first == (uintptr_t)sector_map[0].address;
-
-	if (!packed) {
+	/* Dead records ahead of the live data (a torn write, or the erased
+	 * prefix the single-snapshot writer left) only go away with an erase. */
+	if ((uintptr_t)first != (uintptr_t)sector_map[0].address) {
 		return 1;
 	}
+
+	/* Keep room after the log for a burst the size of the snapshot
+	 * (reset-all tombstones, airframe PARAM_SET), floored so a UUID append
+	 * does not force a boot erase. */
+	const size_t align = sizeof(h_magic_t) - 1;
+	const size_t snapshot_total = (snapshot_size + sizeof(flash_entry_header_t) + align) & ~align;
+	const size_t headroom = snapshot_total > 8192 ? snapshot_total : 8192;
 
 	if (find_append(headroom) != NULL) {
 		return 0;
 	}
 
-	if (note.n == 1 && nsectors == 1) {
-		return 0;
+	/* Compaction leaves the snapshot at the start of sector 0 and every
+	 * other sector blank. Erase only if that layout has the room this one
+	 * lacks, or every boot would pay the erase for nothing. */
+	if (sector_map[0].size >= snapshot_total + headroom) {
+		return 1;
 	}
 
-	return 1;
+	for (int s = 1; sector_map[s].address; s++) {
+		if (sector_map[s].size >= headroom) {
+			return 1;
+		}
+	}
+
+	return 0;
 }
 
 /****************************************************************************

--- a/src/lib/parameters/flashparams/flashfs.c
+++ b/src/lib/parameters/flashparams/flashfs.c
@@ -790,7 +790,7 @@ parameter_flashfs_write(flash_file_token_t token, uint8_t *buffer, size_t buf_si
 		size_t  size_adjust = ((total_size + alignment) & ~alignment) - total_size;
 		total_size += size_adjust;
 
-		/* Append. Compaction (sector erase) is the caller's job, done at boot. */
+		/* Append. Compaction (sector erase) is the caller's job. */
 		flash_entry_header_t *pf = find_free(total_size);
 
 		if (pf == 0) {
@@ -864,19 +864,25 @@ int parameter_flashfs_needs_compact(void)
 	flash_entry_header_t *first = NULL;
 	int n = for_each_valid_entry(parameters_token, note_first_entry, &first);
 
-	if (n < 0) {
+	if (n <= 0) {
 		return n;
 	}
 
-	if (n == 0) {
+	/* Keep enough free space for a QGC burst of deltas. A disarm-edge
+	 * UUID append is a few 32-byte rows and must not force a boot erase.
+	 * If the only live entry is already at the sector start, compacting
+	 * cannot create more room than it already occupies. */
+	const size_t delta_headroom = 4096;
+
+	if (find_free(delta_headroom) != NULL) {
 		return 0;
 	}
 
-	if (n > 1) {
-		return 1;
+	if (n == 1 && (uintptr_t)first == (uintptr_t)sector_map[0].address) {
+		return 0;
 	}
 
-	return (uintptr_t)first != (uintptr_t)sector_map[0].address;
+	return 1;
 }
 
 /****************************************************************************
@@ -1075,6 +1081,7 @@ __EXPORT void test(void)
 	int rv = 0;
 
 	for (int a = 0; a <= 4; a++) {
+		parameter_flashfs_erase();
 		rv =  parameter_flashfs_alloc(parameters_token, &fbuffer, &buf_size);
 		memcpy(fbuffer, test_buf, a);
 		buf_size = a;
@@ -1091,6 +1098,7 @@ __EXPORT void test(void)
 	int block = 2048;
 
 	for (int a = 0; a <= 8; a++) {
+		parameter_flashfs_erase();
 		rv =  parameter_flashfs_alloc(parameters_token, &fbuffer, &buf_size);
 		memcpy(fbuffer, test_buf, block);
 		buf_size = block;

--- a/src/lib/parameters/flashparams/flashfs.h
+++ b/src/lib/parameters/flashparams/flashfs.h
@@ -196,8 +196,8 @@ __EXPORT int parameter_flashfs_blank(void);
  * Description:
  *   Append a new entry. Previous valid entries are left intact so a boot
  *   replay can apply the whole log; the caller erases and rewrites a
- *   snapshot when the sector should be compacted. Returns -ENOSPC if the
- *   new entry does not fit.
+ *   snapshot when a burst of deltas would no longer fit.
+ *   Returns -ENOSPC if the new entry does not fit.
  *
  * Input Parameters:
  *   token      - File Token File to read
@@ -233,10 +233,11 @@ __EXPORT int parameter_flashfs_erase(void);
  * Name: parameter_flashfs_needs_compact
  *
  * Description:
- *   True when the parameter log should be rewritten as a single snapshot
- *   at the start of the first sector: more than one live entry, or the
- *   only live entry is not at the sector start (stale entries in front).
- *   The erase that compact uses stalls every read of that flash bank, so
+ *   True when the parameter log should be rewritten as a single snapshot:
+ *   not enough free space remains for a burst of deltas, and compacting
+ *   would actually reclaim room (more than one live entry, or a single
+ *   entry not at the sector start). A disarm-edge UUID append is not a
+ *   reason to erase. The erase stalls every read of that flash bank, so
  *   callers should run it at boot before sensors and DShot start.
  *
  * Returned value:

--- a/src/lib/parameters/flashparams/flashfs.h
+++ b/src/lib/parameters/flashparams/flashfs.h
@@ -48,6 +48,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 
 
@@ -194,10 +195,10 @@ __EXPORT int parameter_flashfs_blank(void);
  * Name: parameter_flashfs_write
  *
  * Description:
- *   Append a new entry. Previous valid entries are left intact so a boot
- *   replay can apply the whole log; the caller erases and rewrites a
- *   snapshot when a burst of deltas would no longer fit.
- *   Returns -ENOSPC if the new entry does not fit.
+ *   Append a new entry after the last CRC-valid record. Previous valid
+ *   entries are left intact so a boot replay can apply the whole log; the
+ *   caller erases and rewrites a snapshot when a burst of deltas would no
+ *   longer fit. Returns -ENOSPC if the new entry does not fit after the log.
  *
  * Input Parameters:
  *   token      - File Token File to read
@@ -234,11 +235,11 @@ __EXPORT int parameter_flashfs_erase(void);
  *
  * Description:
  *   True when the parameter log should be rewritten as a single snapshot:
- *   not enough free space remains for a burst of deltas, and compacting
- *   would actually reclaim room (more than one live entry, or a single
- *   entry not at the sector start). A disarm-edge UUID append is not a
- *   reason to erase. The erase stalls every read of that flash bank, so
- *   callers should run it at boot before sensors and DShot start.
+ *   the live records are not a packed prefix of sector 0, or the tail after
+ *   the last CRC-valid record cannot hold a burst the size of the current
+ *   snapshot (floored at 8 KB so a UUID append does not force a boot erase).
+ *   The erase stalls every read of that flash bank, so callers should run
+ *   it at boot before sensors and DShot start.
  *
  * Returned value:
  *   1 if compact is needed, 0 if not, or a negative errno.
@@ -246,6 +247,16 @@ __EXPORT int parameter_flashfs_erase(void);
  ****************************************************************************/
 
 __EXPORT int parameter_flashfs_needs_compact(void);
+
+/****************************************************************************
+ * Name: parameter_flashfs_max_payload
+ *
+ * Description:
+ *   Largest user payload that fits in one mapped sector, or 0.
+ *
+ ****************************************************************************/
+
+__EXPORT size_t parameter_flashfs_max_payload(void);
 
 /****************************************************************************
  * Name: parameter_flashfs_alloc

--- a/src/lib/parameters/flashparams/flashfs.h
+++ b/src/lib/parameters/flashparams/flashfs.h
@@ -81,12 +81,14 @@ typedef struct flash_file_token_t {
 } flash_file_token_t;
 
 /*
- * Define the parameter "file name" Currently there is only
- * and it is hard coded. If more are added the
- * parameter_flashfs_write would need to support a backing buffer
- * for when a sector is erased.
+ * Parameter "file names". parameters_token marks records of the append log
+ * (a snapshot followed by deltas, replayed in order). parameters_legacy_token
+ * is the single-snapshot record written by firmware before the log format;
+ * that firmware ignores parameters_token records, so it boots on defaults
+ * from a log-format store rather than a partial set.
  */
 __EXPORT extern const flash_file_token_t parameters_token;
+__EXPORT extern const flash_file_token_t parameters_legacy_token;
 
 /* Define the elements of the array passed to the
  * parameter_flashfs_init function
@@ -234,19 +236,20 @@ __EXPORT int parameter_flashfs_erase(void);
  * Name: parameter_flashfs_needs_compact
  *
  * Description:
- *   True when the parameter log should be rewritten as a single snapshot:
- *   the live records are not a packed prefix of sector 0, or the tail after
- *   the last CRC-valid record cannot hold a burst the size of the current
- *   snapshot (floored at 8 KB so a UUID append does not force a boot erase).
- *   The erase stalls every read of that flash bank, so callers should run
- *   it at boot before sensors and DShot start.
+ *   True when the log for token should be rewritten as one snapshot of
+ *   snapshot_size payload bytes: the live records are not a packed prefix
+ *   of sector 0, or the tail after the last CRC-valid record cannot hold a
+ *   burst the size of that snapshot (floored at 8 KB so a UUID append does
+ *   not force a boot erase) and a compacted layout would. The erase stalls
+ *   every read of that flash bank, so callers run it at boot before sensors
+ *   and DShot start.
  *
  * Returned value:
  *   1 if compact is needed, 0 if not, or a negative errno.
  *
  ****************************************************************************/
 
-__EXPORT int parameter_flashfs_needs_compact(void);
+__EXPORT int parameter_flashfs_needs_compact(flash_file_token_t token, size_t snapshot_size);
 
 /****************************************************************************
  * Name: parameter_flashfs_max_payload

--- a/src/lib/parameters/flashparams/flashfs.h
+++ b/src/lib/parameters/flashparams/flashfs.h
@@ -157,6 +157,22 @@ __EXPORT int parameter_flashfs_init(sector_descriptor_t *fconfig, uint8_t *buffe
 __EXPORT int parameter_flashfs_read(flash_file_token_t ft, uint8_t **buffer, size_t *buf_size);
 
 /****************************************************************************
+ * Name: parameter_flashfs_walk
+ *
+ * Description:
+ *   Call cb for every valid entry matching token, in the order they were
+ *   written. cb returns 0 to continue, or a negative errno to abort.
+ *
+ * Returned value:
+ *   Number of entries visited, or a negative errno (including from cb).
+ *
+ ****************************************************************************/
+
+typedef int (*parameter_flashfs_walk_cb)(uint8_t *buffer, size_t buf_size, void *arg);
+
+__EXPORT int parameter_flashfs_walk(flash_file_token_t token, parameter_flashfs_walk_cb cb, void *arg);
+
+/****************************************************************************
  * Name: parameter_flashfs_blank
  *
  * Description:
@@ -178,8 +194,10 @@ __EXPORT int parameter_flashfs_blank(void);
  * Name: parameter_flashfs_write
  *
  * Description:
- *   This function writes user data from the buffer allocated with a previous call
- *   to parameter_flashfs_alloc. flash starting at the given address
+ *   Append a new entry. Previous valid entries are left intact so a boot
+ *   replay can apply the whole log; the caller erases and rewrites a
+ *   snapshot when the sector should be compacted. Returns -ENOSPC if the
+ *   new entry does not fit.
  *
  * Input Parameters:
  *   token      - File Token File to read
@@ -212,21 +230,21 @@ __EXPORT int parameter_flashfs_write(flash_file_token_t ft, uint8_t *buffer, siz
 __EXPORT int parameter_flashfs_erase(void);
 
 /****************************************************************************
- * Name: parameter_flashfs_compact_if_full
+ * Name: parameter_flashfs_needs_compact
  *
  * Description:
- *   If the sector lacks room for another entry the size of the stored one,
- *   rewrite it through the normal wrap path now (sector erase + rewrite).
- *   Called at boot so the erase, which stalls every read of its flash bank
- *   while it runs, cannot land on a save made once the vehicle is armed.
+ *   True when the parameter log should be rewritten as a single snapshot
+ *   at the start of the first sector: more than one live entry, or the
+ *   only live entry is not at the sector start (stale entries in front).
+ *   The erase that compact uses stalls every read of that flash bank, so
+ *   callers should run it at boot before sensors and DShot start.
  *
  * Returned value:
- *   1 if a compaction was performed, 0 if there was enough space or nothing
- *   is stored, or a negative errno.
+ *   1 if compact is needed, 0 if not, or a negative errno.
  *
  ****************************************************************************/
 
-__EXPORT int parameter_flashfs_compact_if_full(void);
+__EXPORT int parameter_flashfs_needs_compact(void);
 
 /****************************************************************************
  * Name: parameter_flashfs_alloc

--- a/src/lib/parameters/flashparams/flashfs32.c
+++ b/src/lib/parameters/flashparams/flashfs32.c
@@ -66,8 +66,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define FLASH_FLAG_ROW_SIZE 16 ///< size in h_flag_t units of a flash row
-
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -579,71 +577,75 @@ static flash_entry_header_t *find_free(data_size_t required)
 }
 
 /****************************************************************************
- * Name: get_next_sector_descriptor
+ * Name: for_each_valid_entry
  *
  * Description:
- *   Given a pointer to sector_descriptor_t, this helper function
- *   returns a pointer to the next sector_descriptor_t
- *
- * Input Parameters:
- *   current      - A pointer to the current sector_descriptor_t
- *
- * Returned value:
- *  On Success A pointer to the next sector_descriptor_t,
- *  otherwise NULL
- *
+ *   Visit every CRC-valid, not-erased entry matching token, oldest first.
+ *   cb returns 0 to continue, <0 to abort with that errno.
  *
  ****************************************************************************/
 
-static sector_descriptor_t *get_next_sector_descriptor(sector_descriptor_t *
-		current)
+static int for_each_valid_entry(flash_file_token_t token,
+				int (*cb)(flash_entry_header_t *pf, void *arg),
+				void *arg)
 {
-	for (int s = 0; sector_map[s].address; s++) {
-		if (current == &sector_map[s]) {
-			if (sector_map[s + 1].address) {
-				s++;
+	int n = 0;
 
-			} else {
-				s = 0;
+	if (sector_map == NULL) {
+		return -ENXIO;
+	}
+
+	for (int s = 0; sector_map[s].address; s++) {
+
+		h_magic_t *pmagic = (h_magic_t *) sector_map[s].address;
+		h_magic_t *pe = pmagic + (sector_map[s].size / sizeof(h_magic_t)) - 1;
+
+cont:
+
+		while (pmagic < pe && !valid_magic(pmagic)) {
+			pmagic++;
+		}
+
+		if (pmagic >= pe) { continue; }
+
+		flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
+
+		if (pf + 1 > (flash_entry_header_t *)pe) { continue; }
+
+		const uint8_t *crc_start = entry_crc_start(pf);
+		data_size_t crc_length = entry_crc_length(pf);
+
+		if (crc_start + crc_length > (uint8_t *)pe) { continue; }
+
+		if (pf->crc == crc32(crc_start, crc_length)) {
+
+			if (valid_entry(pf) && pf->file_token.t == token.t) {
+				if (cb != NULL) {
+					int rv = cb(pf, arg);
+
+					if (rv < 0) {
+						return rv;
+					}
+				}
+
+				n++;
 			}
 
-			return &sector_map[s];
+			pf = next_entry(pf);
+			pmagic = (h_magic_t *) pf;
+
+			if (pmagic >= pe || blank_entry(pf)) {
+				continue;
+			}
+
+		} else {
+			pmagic++;
 		}
+
+		goto cont;
 	}
 
-	return NULL;
-}
-
-/****************************************************************************
- * Name: get_sector_info
- *
- * Description:
- *   Given a pointer to a flash entry header returns the sector descriptor
- *   for the file is located in
- *
- * Input Parameters:
- *   current      - A pointer to the current flash entry header
- *
- * Returned value:
- *  On Success A pointer to the next sector_descriptor_t,
- *  otherwise NULL
- *
- *
- ****************************************************************************/
-
-static sector_descriptor_t *get_sector_info(flash_entry_header_t *current)
-{
-	for (int s = 0; sector_map[s].address != 0; s++) {
-		uint8_t *pb = (uint8_t *) sector_map[s].address;
-		uint8_t *pe = pb + sector_map[s].size - 1;
-		uint8_t *pc = (uint8_t *) current;
-
-		if (pc >= pb && pc <= pe) {
-			return &sector_map[s];
-		}
-	}
-
-	return 0;
+	return n;
 }
 
 /****************************************************************************
@@ -705,63 +707,6 @@ static int erase_sector(sector_descriptor_t *sm, flash_entry_header_t *pf)
 	}
 
 	return rv;
-}
-
-/****************************************************************************
- * Name: erase_entry
- *
- * Description:
- *   Given a pointer to a flash entry header erases the entry
- *
- * Input Parameters:
- *   pf  - A pointer to the current flash entry header
- *
- *
- * Returned value:
- *  >0 On Success or a negative errno
- *
- *
- ****************************************************************************/
-
-static int erase_entry(flash_entry_header_t *pf)
-{
-	/* Need to write entire 32-byte line */
-	h_flag_t data[FLASH_FLAG_ROW_SIZE] = {0xffff};
-	data[0] = ErasedEntry;
-	size_t size = FLASH_FLAG_ROW_SIZE * sizeof(h_flag_t);
-	int rv = up_progmem_write((size_t) &pf->flag_erased, data, size);
-	return rv;
-}
-
-/****************************************************************************
- * Name: check_free_space_in_sector
- *
- * Description:
- *   Given a pointer to a flash entry header and a new size
- *
- * Input Parameters:
- *   pf       - A pointer to the current flash entry header
- *   new_size - The total number of bytes to be written
- *
- * Returned value:
- *  0 if there is enough space left to write new size
- *  If not it returns the flash_file_sector_t * that needs to be erased.
- *
- ****************************************************************************/
-
-static sector_descriptor_t *check_free_space_in_sector(flash_entry_header_t
-		*pf, size_t new_size)
-{
-	sector_descriptor_t *sm = get_sector_info(pf);
-	uint8_t *psector_first = (uint8_t *) sm->address;
-	uint8_t *psector_last = psector_first + sm->size - 1;
-	uint8_t *pnext_end = (uint8_t *)(valid_magic((h_magic_t *)pf) ? next_entry(pf) : pf) + new_size;
-
-	if (pnext_end >= psector_first && pnext_end <= psector_last) {
-		sm = 0;
-	}
-
-	return sm;
 }
 
 /****************************************************************************
@@ -886,8 +831,7 @@ int parameter_flashfs_blank(void)
  * Name: parameter_flashfs_write
  *
  * Description:
- *   This function writes user data from the buffer allocated with a previous call
- *   to parameter_flashfs_alloc. flash starting at the given address
+ *   Append a new entry. Previous valid entries are left intact.
  *
  * Input Parameters:
  *   token      - File Token File to read
@@ -916,80 +860,11 @@ parameter_flashfs_write(flash_file_token_t token, uint8_t *buffer, size_t buf_si
 		size_t  size_adjust = ((total_size + alignment) & ~alignment) - total_size;
 		total_size += size_adjust;
 
-		/* Is this and existing entry */
+		/* Append. Compaction (sector erase) is the caller's job, done at boot. */
+		flash_entry_header_t *pf = find_free(total_size);
 
-		flash_entry_header_t *pf = find_entry(token);
-
-		if (!pf) {
-
-			/* No Entry exists for this token so find a place for it */
-			pf = find_free(total_size);
-
-			/* No Space */
-
-			if (pf == 0) {
-				return -ENOSPC;
-			}
-
-		} else {
-
-			/* Do we have space after the entry in the sector for the update */
-
-			sector_descriptor_t *current_sector = check_free_space_in_sector(pf,
-							      total_size);
-
-
-			if (current_sector == 0) {
-
-				/* Mark the last entry erased */
-
-				/* todo:consider a 2 stage erase or write before erase and do a fs check
-				 * at start up
-				 */
-
-				rv = erase_entry(pf);
-
-				if (rv < 0) {
-					return rv;
-				}
-
-				/* We had space and marked the last entry erased so use the  Next Free */
-
-				pf = next_entry(pf);
-
-			} else {
-
-				/*
-				 * We did not have space in the current sector so select the next sector
-				 */
-
-				current_sector = get_next_sector_descriptor(current_sector);
-
-				/* Will the data fit */
-
-				if (current_sector->size < total_size) {
-					return -ENOSPC;
-				}
-
-				/* Mark the last entry erased */
-
-				/* todo:consider a 2 stage erase or write before erase and do a fs check
-				 * at start up
-				 */
-
-				rv = erase_entry(pf);
-
-				if (rv < 0) {
-					return rv;
-				}
-
-				pf = (flash_entry_header_t *) current_sector->address;
-
-				if (!blank_check(pf, total_size)) {
-					rv = erase_sector(current_sector, pf);
-				}
-			}//free_space_in_sector returned not-zero
-
+		if (pf == 0) {
+			return -ENOSPC;
 		}
 
 		flash_entry_header_t *pn = (flash_entry_header_t *)(buffer - sizeof(flash_entry_header_t));
@@ -1108,80 +983,59 @@ int parameter_flashfs_erase(void)
 
 
 /****************************************************************************
- * Name: parameter_flashfs_compact_if_full
- *
- * Description:
- *   If the sector cannot take another entry the size of the one it holds
- *   (plus a growth margin), rewrite that entry now through the normal write
- *   path, which wraps and erases the sector.
- *
- *   An erase stalls every read of the bank the sector lives in until it
- *   completes, which for a 128 KB sector on STM32H7 is on the order of a
- *   second. Where the firmware image shares that bank, execution halts for
- *   the duration. A save can be triggered at any time - including the
- *   autosave released on disarm - so paying the wrap here bounds that halt
- *   to a point where the vehicle is not yet armed and nothing is being
- *   controlled. In-service saves then stay append-only (a few 32-byte row
- *   programs). If the stored data outgrows the margin between boots, the
- *   save-time wrap still covers it.
- *
- *   Cost: a boot that compacts takes one erase longer to reach the rest of
- *   board init. Every other boot pays only the free-space check below.
- *
- * Returned value:
- *   1 if a compaction (sector erase + rewrite) was performed, 0 if there
- *   was enough space or nothing is stored, or a negative errno.
- *
+ * Name: parameter_flashfs_walk
  ****************************************************************************/
 
-int parameter_flashfs_compact_if_full(void)
+struct walk_pack {
+	parameter_flashfs_walk_cb cb;
+	void *arg;
+};
+
+static int walk_one(flash_entry_header_t *pf, void *arg)
 {
-	if (sector_map == NULL) {
-		return -ENXIO;
+	struct walk_pack *w = (struct walk_pack *)arg;
+	return w->cb(entry_data(pf), entry_data_length(pf), w->arg);
+}
+
+int parameter_flashfs_walk(flash_file_token_t token, parameter_flashfs_walk_cb cb, void *arg)
+{
+	struct walk_pack w = { cb, arg };
+	return for_each_valid_entry(token, walk_one, &w);
+}
+
+/****************************************************************************
+ * Name: parameter_flashfs_needs_compact
+ ****************************************************************************/
+
+static int note_first_entry(flash_entry_header_t *pf, void *arg)
+{
+	flash_entry_header_t **first = (flash_entry_header_t **)arg;
+
+	if (*first == NULL) {
+		*first = pf;
 	}
 
-	flash_entry_header_t *pf = find_entry(parameters_token);
+	return 0;
+}
 
-	if (pf == NULL) {
+int parameter_flashfs_needs_compact(void)
+{
+	flash_entry_header_t *first = NULL;
+	int n = for_each_valid_entry(parameters_token, note_first_entry, &first);
+
+	if (n < 0) {
+		return n;
+	}
+
+	if (n == 0) {
 		return 0;
 	}
 
-	/* Headroom kept beyond one more copy of the current entry. Each save
-	 * stores the same parameter set give or take a few values, so a couple
-	 * of KB covers normal growth over a run of saves; data that outgrows it
-	 * takes the save-time wrap once, as before.
-	 */
-
-	const size_t growth_margin = 2048;
-
-	size_t data_length = entry_data_length(pf);
-	size_t entry_total = sizeof(flash_entry_header_t) + data_length + SizeMask;
-	size_t reserve = entry_total + growth_margin;
-
-	if (check_free_space_in_sector(pf, reserve) == NULL) {
-		return 0;
+	if (n > 1) {
+		return 1;
 	}
 
-	/* The entry data lives in the flash about to be erased: copy it out first. */
-
-	uint8_t *buffer;
-	size_t buffer_size = data_length;
-	int rv = parameter_flashfs_alloc(parameters_token, &buffer, &buffer_size);
-
-	if (rv != 0) {
-		return rv;
-	}
-
-	if (buffer_size < data_length) {
-		parameter_flashfs_free();
-		return -ENOMEM;
-	}
-
-	memcpy(buffer, entry_data(pf), data_length);
-	rv = parameter_flashfs_write(parameters_token, buffer, data_length);
-	parameter_flashfs_free();
-
-	return rv >= 0 ? 1 : rv;
+	return (uintptr_t)first != (uintptr_t)sector_map[0].address;
 }
 
 /****************************************************************************
@@ -1238,14 +1092,6 @@ int parameter_flashfs_init(sector_descriptor_t *fconfig, uint8_t *buffer, uint16
 		// A positive return value means flash space has been erased successfully.
 		if (rv > 0) {
 			rv = 0;
-		}
-
-	} else {
-		// Pay the sector-wrap erase here at boot, not on a save at the disarm edge.
-		int compacted = parameter_flashfs_compact_if_full();
-
-		if (compacted < 0) {
-			rv = compacted;
 		}
 	}
 

--- a/src/lib/parameters/flashparams/flashfs32.c
+++ b/src/lib/parameters/flashparams/flashfs32.c
@@ -128,6 +128,10 @@ static sector_descriptor_t *sector_map;
  ****************************************************************************/
 
 const flash_file_token_t parameters_token = {
+	.n = {'p', 'l', 'o', 'g'},
+};
+
+const flash_file_token_t parameters_legacy_token = {
 	.n = {'p', 'a', 'r', 'm'},
 };
 
@@ -390,9 +394,16 @@ static inline data_size_t entry_crc_length(flash_entry_header_t *fi)
 	return fi->size - offsetof(flash_entry_header_t, size);
 }
 
+/* The parameter sector can be the last one on the chip, so no header
+ * field may be read until the whole header is known to lie inside it. */
+static inline bool header_fits(flash_entry_header_t *pf, h_magic_t *pe)
+{
+	return pf + 1 <= (flash_entry_header_t *)pe;
+}
+
 static bool crc_header_ok(flash_entry_header_t *pf, h_magic_t *pe)
 {
-	if (pf + 1 > (flash_entry_header_t *)pe) {
+	if (!header_fits(pf, pe)) {
 		return false;
 	}
 
@@ -419,51 +430,32 @@ static bool slot_is_free(flash_entry_header_t *pf, int s, size_t required)
 		return false;
 	}
 
+	/* Entries start on a flash row. up_progmem_write only asserts that in
+	 * debug builds, so a slot found by the word-wise scan behind a torn
+	 * record would otherwise be programmed misaligned. */
+	if (((uintptr_t)pf & SizeMask) != 0) {
+		return false;
+	}
+
 	return blank_entry(pf) && blank_check(pf, required);
 }
 
-/****************************************************************************
- * Name: find_entry
- ****************************************************************************/
+static int for_each_valid_entry(flash_file_token_t token,
+				int (*cb)(flash_entry_header_t *pf, void *arg),
+				void *arg);
 
+static int stop_at_first(flash_entry_header_t *pf, void *arg)
+{
+	*(flash_entry_header_t **)arg = pf;
+	return -ECANCELED;
+}
+
+/* Oldest valid entry for token, or NULL. */
 static flash_entry_header_t *find_entry(flash_file_token_t token)
 {
-	for (int s = 0; sector_map[s].address; s++) {
-
-		h_magic_t *pmagic = (h_magic_t *) sector_map[s].address;
-		h_magic_t *pe = pmagic + (sector_map[s].size / sizeof(h_magic_t)) - 1;
-
-cont:
-
-		while (pmagic < pe && !valid_magic(pmagic)) {
-			pmagic++;
-		}
-
-		if (pmagic >= pe) { continue; }
-
-		flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
-
-		if (crc_header_ok(pf, pe)) {
-
-			if (valid_entry(pf) && pf->file_token.t == token.t) {
-				return pf;
-			}
-
-			pf = next_entry(pf);
-			pmagic = (h_magic_t *) pf;
-
-			if (pmagic >= pe || blank_entry(pf)) {
-				continue;
-			}
-
-		} else {
-			pmagic++;
-		}
-
-		goto cont;
-	}
-
-	return NULL;
+	flash_entry_header_t *pf = NULL;
+	for_each_valid_entry(token, stop_at_first, &pf);
+	return pf;
 }
 
 /****************************************************************************
@@ -501,6 +493,14 @@ static flash_entry_header_t *find_append(size_t required)
 				last = pf;
 				last_s = s;
 				pmagic = (h_magic_t *) next_entry(pf);
+				pf = (flash_entry_header_t *) pmagic;
+
+				/* Same stop rule as for_each_valid_entry: a record behind a
+				 * blank header is invisible to replay, so it must not anchor
+				 * the append point either. */
+				if (pmagic >= pe || !header_fits(pf, pe) || blank_entry(pf)) {
+					break;
+				}
 
 			} else {
 				pmagic++;
@@ -602,7 +602,7 @@ cont:
 			pf = next_entry(pf);
 			pmagic = (h_magic_t *) pf;
 
-			if (pmagic >= pe || blank_entry(pf)) {
+			if (pmagic >= pe || !header_fits(pf, pe) || blank_entry(pf)) {
 				continue;
 			}
 
@@ -979,23 +979,6 @@ int parameter_flashfs_walk(flash_file_token_t token, parameter_flashfs_walk_cb c
  * Name: parameter_flashfs_needs_compact
  ****************************************************************************/
 
-struct compact_note {
-	flash_entry_header_t *first;
-	int n;
-};
-
-static int note_entries(flash_entry_header_t *pf, void *arg)
-{
-	struct compact_note *note = (struct compact_note *)arg;
-
-	if (note->first == NULL) {
-		note->first = pf;
-	}
-
-	note->n++;
-	return 0;
-}
-
 size_t parameter_flashfs_max_payload(void)
 {
 	if (sector_map == NULL) {
@@ -1019,54 +1002,49 @@ size_t parameter_flashfs_max_payload(void)
 	return max_sector - overhead;
 }
 
-int parameter_flashfs_needs_compact(void)
+int parameter_flashfs_needs_compact(flash_file_token_t token, size_t snapshot_size)
 {
-	struct compact_note note = { NULL, 0 };
-	int n = for_each_valid_entry(parameters_token, note_entries, &note);
-
-	if (n <= 0) {
-		return n;
+	if (sector_map == NULL) {
+		return -ENXIO;
 	}
 
-	size_t max_sector = 0;
-	int nsectors = 0;
+	flash_entry_header_t *first = find_entry(token);
 
-	for (int s = 0; sector_map[s].address; s++) {
-		if (sector_map[s].size > max_sector) {
-			max_sector = sector_map[s].size;
-		}
-
-		nsectors++;
+	if (first == NULL) {
+		return 0;
 	}
 
-	/* Keep room after the log for a burst the size of the current snapshot
-	 * (reset-all tombstones, airframe PARAM_SET), floored so a UUID append
-	 * does not force a boot erase. */
-	size_t headroom = 8192;
-
-	if (note.first != NULL && note.first->size > headroom) {
-		headroom = note.first->size;
-	}
-
-	if (headroom > max_sector) {
-		headroom = max_sector;
-	}
-
-	const bool packed = (uintptr_t)note.first == (uintptr_t)sector_map[0].address;
-
-	if (!packed) {
+	/* Dead records ahead of the live data (a torn write, or the erased
+	 * prefix the single-snapshot writer left) only go away with an erase. */
+	if ((uintptr_t)first != (uintptr_t)sector_map[0].address) {
 		return 1;
 	}
+
+	/* Keep room after the log for a burst the size of the snapshot
+	 * (reset-all tombstones, airframe PARAM_SET), floored so a UUID append
+	 * does not force a boot erase. */
+	const size_t align = SizeMask;
+	const size_t snapshot_total = (snapshot_size + sizeof(flash_entry_header_t) + align) & ~align;
+	const size_t headroom = snapshot_total > 8192 ? snapshot_total : 8192;
 
 	if (find_append(headroom) != NULL) {
 		return 0;
 	}
 
-	if (note.n == 1 && nsectors == 1) {
-		return 0;
+	/* Compaction leaves the snapshot at the start of sector 0 and every
+	 * other sector blank. Erase only if that layout has the room this one
+	 * lacks, or every boot would pay the erase for nothing. */
+	if (sector_map[0].size >= snapshot_total + headroom) {
+		return 1;
 	}
 
-	return 1;
+	for (int s = 1; sector_map[s].address; s++) {
+		if (sector_map[s].size >= headroom) {
+			return 1;
+		}
+	}
+
+	return 0;
 }
 
 /****************************************************************************

--- a/src/lib/parameters/flashparams/flashfs32.c
+++ b/src/lib/parameters/flashparams/flashfs32.c
@@ -119,7 +119,7 @@ typedef begin_packed_struct struct flash_entry_header_t {
  * Private Data
  ****************************************************************************/
 static uint8_t *working_buffer;
-static uint16_t working_buffer_size;
+static size_t working_buffer_size;
 static bool working_buffer_static;
 static sector_descriptor_t *sector_map;
 
@@ -224,47 +224,6 @@ static bool blank_check(flash_entry_header_t *pf,
 static inline int valid_magic(h_magic_t *pm)
 {
 	return *pm == MagicSig;
-}
-
-/****************************************************************************
- * Name: blank_magic
- *
- * Description:
- *   This helper function returns true if the pointer points to a valid
- *   blank magic signature
- *
- * Input Parameters:
- *   pm   - A pointer to memory aligned on sizeof(h_magic_t) boundaries
- *
- * Returned value:
- *   true if magic is valid
- *
- *
- ****************************************************************************/
-
-static inline int blank_magic(h_magic_t *pm)
-{
-	return *pm == BlankSig;
-}
-
-/****************************************************************************
- * Name: erased_entry
- *
- * Description:
- *   This helper function returns true if the entry is Erased
- *
- * Input Parameters:
- *   fi            - A pointer to the current flash entry header
- *
- * Returned value:
- *   true if  erased
- *
- *
- ****************************************************************************/
-
-static inline int erased_entry(flash_entry_header_t *fi)
-{
-	return (fi->flag_erased & MaskEntry) == ErasedEntry;
 }
 
 /****************************************************************************
@@ -431,19 +390,40 @@ static inline data_size_t entry_crc_length(flash_entry_header_t *fi)
 	return fi->size - offsetof(flash_entry_header_t, size);
 }
 
+static bool crc_header_ok(flash_entry_header_t *pf, h_magic_t *pe)
+{
+	if (pf + 1 > (flash_entry_header_t *)pe) {
+		return false;
+	}
+
+	if (pf->size < sizeof(flash_entry_header_t)) {
+		return false;
+	}
+
+	const uint8_t *crc_start = entry_crc_start(pf);
+	data_size_t crc_length = entry_crc_length(pf);
+
+	if (crc_start + crc_length > (uint8_t *)pe) {
+		return false;
+	}
+
+	return pf->crc == crc32(crc_start, crc_length);
+}
+
+static bool slot_is_free(flash_entry_header_t *pf, int s, size_t required)
+{
+	uint8_t *begin = (uint8_t *)sector_map[s].address;
+	uint8_t *end = begin + sector_map[s].size;
+
+	if ((uint8_t *)pf < begin || required == 0 || (uint8_t *)pf + required > end) {
+		return false;
+	}
+
+	return blank_entry(pf) && blank_check(pf, required);
+}
+
 /****************************************************************************
  * Name: find_entry
- *
- * Description:
- *   This helper function locates an "file" from the the file token
- *
- * Input Parameters:
- *   token        - A flash file token, the pseudo file name
- *
- * Returned value:
- *  On Success a pointer to flash entry header or NULL on failure
- *
- *
  ****************************************************************************/
 
 static flash_entry_header_t *find_entry(flash_file_token_t token)
@@ -453,57 +433,30 @@ static flash_entry_header_t *find_entry(flash_file_token_t token)
 		h_magic_t *pmagic = (h_magic_t *) sector_map[s].address;
 		h_magic_t *pe = pmagic + (sector_map[s].size / sizeof(h_magic_t)) - 1;
 
-		/* Hunt for Magic Signature */
 cont:
 
 		while (pmagic < pe && !valid_magic(pmagic)) {
 			pmagic++;
 		}
 
-		/* Did we reach the end
-		 * if so try the next sector */
-
 		if (pmagic >= pe) { continue; }
-
-		/* Found a magic So assume it is a file header */
 
 		flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
 
-		/* Ensure that the header is fully inside the current sector */
-
-		if (pf + 1 > (flash_entry_header_t *)pe) { continue; }
-
-		const uint8_t *crc_start = entry_crc_start(pf);
-		data_size_t crc_length = entry_crc_length(pf);
-
-		if (crc_start + crc_length > (uint8_t *)pe) { continue; }
-
-		if (pf->crc == crc32(crc_start, crc_length)) {
-
-			/* Good CRC is it the one we are looking for ?*/
+		if (crc_header_ok(pf, pe)) {
 
 			if (valid_entry(pf) && pf->file_token.t == token.t) {
-
 				return pf;
+			}
 
-			} else {
+			pf = next_entry(pf);
+			pmagic = (h_magic_t *) pf;
 
-				/* Not the one we wanted but we can trust the size */
-
-				pf = next_entry(pf);
-				pmagic = (h_magic_t *) pf;
-
-				/* If the next one is erased */
-
-				if (pmagic >= pe || blank_entry(pf)) {
-					continue;
-				}
+			if (pmagic >= pe || blank_entry(pf)) {
+				continue;
 			}
 
 		} else {
-
-			/* invalid CRC so keep looking */
-
 			pmagic++;
 		}
 
@@ -514,63 +467,83 @@ cont:
 }
 
 /****************************************************************************
- * Name: find_free
+ * Name: find_append
  *
  * Description:
- *   This helper function locates free space for the number of bytes required
- *
- * Input Parameters:
- *   required  - Number of bytes required
- *
- * Returned value:
- *  On Success a pointer to flash entry header or NULL on failure
- *
+ *   Return the address of a blank run that sits after every CRC-valid
+ *   header in sector-map order. First-fit holes before later live data are
+ *   not used; those are fragmentation and belong to compact.
  *
  ****************************************************************************/
 
-static flash_entry_header_t *find_free(data_size_t required)
+static flash_entry_header_t *find_append(size_t required)
 {
-	for (int s = 0; sector_map[s].address; s++) {
+	if (sector_map == NULL || required == 0) {
+		return NULL;
+	}
 
+	flash_entry_header_t *last = NULL;
+	int last_s = -1;
+
+	for (int s = 0; sector_map[s].address; s++) {
 		h_magic_t *pmagic = (h_magic_t *) sector_map[s].address;
 		h_magic_t *pe = pmagic + (sector_map[s].size / sizeof(h_magic_t)) - 1;
 
-		/* Hunt for Magic Signature */
-
-		do {
-
-			if (valid_magic(pmagic)) {
-
-				flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
-
-				/* Ensure that the header is fully inside the current sector */
-
-				if (pf + 1 > (flash_entry_header_t *)pe) { break; }
-
-				/* Test the CRC */
-
-				if (pf->crc == crc32(entry_crc_start(pf), entry_crc_length(pf))) {
-
-					/* Valid Magic and CRC look for the next record*/
-
-					pmagic = ((uint32_t *) next_entry(pf));
-
-				} else {
-
-					pmagic++;
-				}
+		while (pmagic < pe) {
+			if (!valid_magic(pmagic)) {
+				pmagic++;
+				continue;
 			}
 
-			if (pmagic + (required / sizeof(h_magic_t)) <= pe && blank_magic(pmagic)) {
+			flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
 
-				flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
+			if (crc_header_ok(pf, pe)) {
+				last = pf;
+				last_s = s;
+				pmagic = (h_magic_t *) next_entry(pf);
 
-				if (blank_entry(pf) && blank_check(pf, required)) {
-					return pf;
-				}
-
+			} else {
+				pmagic++;
 			}
-		}  while (++pmagic < pe);
+		}
+	}
+
+	const int start_s = (last == NULL) ? 0 : last_s;
+	h_magic_t *pmagic = (last == NULL)
+			    ? (h_magic_t *) sector_map[0].address
+			    : (h_magic_t *) next_entry(last);
+
+	for (int s = start_s; sector_map[s].address; s++) {
+		if (s != start_s) {
+			pmagic = (h_magic_t *) sector_map[s].address;
+		}
+
+		h_magic_t *pe = (h_magic_t *) sector_map[s].address
+				+ (sector_map[s].size / sizeof(h_magic_t)) - 1;
+
+		if ((uint8_t *)pmagic < (uint8_t *)sector_map[s].address
+		    || (uint8_t *)pmagic >= (uint8_t *)sector_map[s].address + sector_map[s].size) {
+			if (s == start_s) {
+				continue;
+			}
+
+			pmagic = (h_magic_t *) sector_map[s].address;
+		}
+
+		while (pmagic < pe) {
+			flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
+
+			if (valid_magic(pmagic) && crc_header_ok(pf, pe)) {
+				pmagic = (h_magic_t *) next_entry(pf);
+				continue;
+			}
+
+			if (slot_is_free(pf, s, required)) {
+				return pf;
+			}
+
+			pmagic++;
+		}
 	}
 
 	return NULL;
@@ -582,6 +555,8 @@ static flash_entry_header_t *find_free(data_size_t required)
  * Description:
  *   Visit every CRC-valid, not-erased entry matching token, oldest first.
  *   cb returns 0 to continue, <0 to abort with that errno.
+ *   A torn or oversize header advances one magic word; it must not skip
+ *   the rest of the sector (later valid records would be invisible).
  *
  ****************************************************************************/
 
@@ -610,14 +585,7 @@ cont:
 
 		flash_entry_header_t *pf = (flash_entry_header_t *) pmagic;
 
-		if (pf + 1 > (flash_entry_header_t *)pe) { continue; }
-
-		const uint8_t *crc_start = entry_crc_start(pf);
-		data_size_t crc_length = entry_crc_length(pf);
-
-		if (crc_start + crc_length > (uint8_t *)pe) { continue; }
-
-		if (pf->crc == crc32(crc_start, crc_length)) {
+		if (crc_header_ok(pf, pe)) {
 
 			if (valid_entry(pf) && pf->file_token.t == token.t) {
 				if (cb != NULL) {
@@ -860,8 +828,12 @@ parameter_flashfs_write(flash_file_token_t token, uint8_t *buffer, size_t buf_si
 		size_t  size_adjust = ((total_size + alignment) & ~alignment) - total_size;
 		total_size += size_adjust;
 
-		/* Append. Compaction (sector erase) is the caller's job. */
-		flash_entry_header_t *pf = find_free(total_size);
+		if (total_size > UINT16_MAX) {
+			return -EFBIG;
+		}
+
+		/* Append after the last CRC-valid record. Compaction is the caller's job. */
+		flash_entry_header_t *pf = find_append(total_size);
 
 		if (pf == 0) {
 			return -ENOSPC;
@@ -1007,37 +979,90 @@ int parameter_flashfs_walk(flash_file_token_t token, parameter_flashfs_walk_cb c
  * Name: parameter_flashfs_needs_compact
  ****************************************************************************/
 
-static int note_first_entry(flash_entry_header_t *pf, void *arg)
-{
-	flash_entry_header_t **first = (flash_entry_header_t **)arg;
+struct compact_note {
+	flash_entry_header_t *first;
+	int n;
+};
 
-	if (*first == NULL) {
-		*first = pf;
+static int note_entries(flash_entry_header_t *pf, void *arg)
+{
+	struct compact_note *note = (struct compact_note *)arg;
+
+	if (note->first == NULL) {
+		note->first = pf;
 	}
 
+	note->n++;
 	return 0;
+}
+
+size_t parameter_flashfs_max_payload(void)
+{
+	if (sector_map == NULL) {
+		return 0;
+	}
+
+	size_t max_sector = 0;
+
+	for (int s = 0; sector_map[s].address; s++) {
+		if (sector_map[s].size > max_sector) {
+			max_sector = sector_map[s].size;
+		}
+	}
+
+	const size_t overhead = sizeof(flash_entry_header_t) + SizeMask;
+
+	if (max_sector <= overhead) {
+		return 0;
+	}
+
+	return max_sector - overhead;
 }
 
 int parameter_flashfs_needs_compact(void)
 {
-	flash_entry_header_t *first = NULL;
-	int n = for_each_valid_entry(parameters_token, note_first_entry, &first);
+	struct compact_note note = { NULL, 0 };
+	int n = for_each_valid_entry(parameters_token, note_entries, &note);
 
 	if (n <= 0) {
 		return n;
 	}
 
-	/* Keep enough free space for a QGC burst of deltas. A disarm-edge
-	 * UUID append is a few 32-byte rows and must not force a boot erase.
-	 * If the only live entry is already at the sector start, compacting
-	 * cannot create more room than it already occupies. */
-	const size_t delta_headroom = 4096;
+	size_t max_sector = 0;
+	int nsectors = 0;
 
-	if (find_free(delta_headroom) != NULL) {
+	for (int s = 0; sector_map[s].address; s++) {
+		if (sector_map[s].size > max_sector) {
+			max_sector = sector_map[s].size;
+		}
+
+		nsectors++;
+	}
+
+	/* Keep room after the log for a burst the size of the current snapshot
+	 * (reset-all tombstones, airframe PARAM_SET), floored so a UUID append
+	 * does not force a boot erase. */
+	size_t headroom = 8192;
+
+	if (note.first != NULL && note.first->size > headroom) {
+		headroom = note.first->size;
+	}
+
+	if (headroom > max_sector) {
+		headroom = max_sector;
+	}
+
+	const bool packed = (uintptr_t)note.first == (uintptr_t)sector_map[0].address;
+
+	if (!packed) {
+		return 1;
+	}
+
+	if (find_append(headroom) != NULL) {
 		return 0;
 	}
 
-	if (n == 1 && (uintptr_t)first == (uintptr_t)sector_map[0].address) {
+	if (note.n == 1 && nsectors == 1) {
 		return 0;
 	}
 
@@ -1087,19 +1112,9 @@ int parameter_flashfs_init(sector_descriptor_t *fconfig, uint8_t *buffer, uint16
 
 	/* Sanity check */
 
-	flash_entry_header_t *pf = find_entry(parameters_token);
-
-	/*  No paramaters */
-
-	if (pf == NULL) {
-		// Parameters can't be found, assume sector is corrupt or empty
-		rv = parameter_flashfs_erase();
-
-		// A positive return value means flash space has been erased successfully.
-		if (rv > 0) {
-			rv = 0;
-		}
-	}
+	/* A non-blank store with no valid entry is torn or foreign; import
+	 * reports -EILSEQ. Erasing here would hide a successful retry after
+	 * a torn compact write. */
 
 	return rv;
 }

--- a/src/lib/parameters/flashparams/flashfs32.c
+++ b/src/lib/parameters/flashparams/flashfs32.c
@@ -860,7 +860,7 @@ parameter_flashfs_write(flash_file_token_t token, uint8_t *buffer, size_t buf_si
 		size_t  size_adjust = ((total_size + alignment) & ~alignment) - total_size;
 		total_size += size_adjust;
 
-		/* Append. Compaction (sector erase) is the caller's job, done at boot. */
+		/* Append. Compaction (sector erase) is the caller's job. */
 		flash_entry_header_t *pf = find_free(total_size);
 
 		if (pf == 0) {
@@ -1023,19 +1023,25 @@ int parameter_flashfs_needs_compact(void)
 	flash_entry_header_t *first = NULL;
 	int n = for_each_valid_entry(parameters_token, note_first_entry, &first);
 
-	if (n < 0) {
+	if (n <= 0) {
 		return n;
 	}
 
-	if (n == 0) {
+	/* Keep enough free space for a QGC burst of deltas. A disarm-edge
+	 * UUID append is a few 32-byte rows and must not force a boot erase.
+	 * If the only live entry is already at the sector start, compacting
+	 * cannot create more room than it already occupies. */
+	const size_t delta_headroom = 4096;
+
+	if (find_free(delta_headroom) != NULL) {
 		return 0;
 	}
 
-	if (n > 1) {
-		return 1;
+	if (n == 1 && (uintptr_t)first == (uintptr_t)sector_map[0].address) {
+		return 0;
 	}
 
-	return (uintptr_t)first != (uintptr_t)sector_map[0].address;
+	return 1;
 }
 
 /****************************************************************************
@@ -1129,6 +1135,7 @@ __EXPORT void test(void)
 	int rv = 0;
 
 	for (int a = 0; a <= 4; a++) {
+		parameter_flashfs_erase();
 		rv =  parameter_flashfs_alloc(parameters_token, &fbuffer, &buf_size);
 		memcpy(fbuffer, test_buf, a);
 		buf_size = a;
@@ -1145,6 +1152,7 @@ __EXPORT void test(void)
 	int block = 2048;
 
 	for (int a = 0; a <= 8; a++) {
+		parameter_flashfs_erase();
 		rv =  parameter_flashfs_alloc(parameters_token, &fbuffer, &buf_size);
 		memcpy(fbuffer, test_buf, block);
 		buf_size = block;

--- a/src/lib/parameters/flashparams/flashparams.cpp
+++ b/src/lib/parameters/flashparams/flashparams.cpp
@@ -80,8 +80,15 @@ struct param_wbuf_s {
  * snapshot rewrite is tens of ms; a 128 KB sector erase is ~1 s. In-service
  * saves therefore append a delta of unsaved params (a few 32-byte rows).
  * At boot, before sensors or DShot start, compact to one snapshot only when
- * the sector cannot fit a burst of deltas — so a disarm-edge UUID save does
+ * the sector cannot fit a burst of deltas, so a disarm-edge UUID save does
  * not pay the erase every flight.
+ *
+ * Firmware before the log format wrote one parameters_legacy_token snapshot
+ * and cannot replay deltas. It ignores parameters_token records and treats
+ * a store without its own as empty (STM32H7 erases it at init), so a
+ * downgrade boots on defaults instead of a partial set. A legacy record is
+ * always the newest state, since only that firmware writes one: import it
+ * alone and rewrite the store as a log-format snapshot.
  */
 
 static bool
@@ -96,6 +103,14 @@ any_unsaved(param_filter_func filter)
 	return false;
 }
 
+/*
+ * A snapshot holds every override in RAM, equal to the current default or
+ * not: the boot compaction runs before the airframe applies its set-default
+ * values, so at that point "equals the default" says nothing. A delta holds
+ * the unsaved params; one that no longer overrides, or now matches the
+ * default in force, is written as a BSON null so replay drops it, which is
+ * what the file backend's "don't export defaults" gives after a reload.
+ */
 static int
 encode_params(bson_encoder_s *encoder, param_filter_func filter, bool snapshot)
 {
@@ -105,21 +120,23 @@ encode_params(bson_encoder_s *encoder, param_filter_func filter, bool snapshot)
 		}
 
 		if (snapshot) {
-			if (!user_config.contains(param) || param_value_is_default(param)) {
+			if (!user_config.contains(param)) {
 				continue;
 			}
 
-		} else if (!param_value_unsaved(param)) {
-			continue;
-		}
-
-		if (!snapshot && (!user_config.contains(param) || param_value_is_default(param))) {
-			if (bson_encoder_append_null(encoder, param_name(param))) {
-				debug("BSON append failed for '%s'", param_name(param));
-				return -1;
+		} else {
+			if (!param_value_unsaved(param)) {
+				continue;
 			}
 
-			continue;
+			if (!user_config.contains(param) || param_value_is_default(param)) {
+				if (bson_encoder_append_null(encoder, param_name(param))) {
+					debug("BSON append failed for '%s'", param_name(param));
+					return -1;
+				}
+
+				continue;
+			}
 		}
 
 		switch (param_type(param)) {
@@ -148,8 +165,23 @@ encode_params(bson_encoder_s *encoder, param_filter_func filter, bool snapshot)
 	return 0;
 }
 
+/* The caller frees bson_encoder_buf_data() whatever the result. */
 static int
-alloc_and_fill_write_buffer(bson_encoder_s *encoder, uint8_t **buffer, size_t *enc_size)
+encode_document(bson_encoder_s *encoder, param_filter_func filter, bool snapshot)
+{
+	bson_encoder_init_buf(encoder, nullptr, 0);
+
+	int result = encode_params(encoder, filter, snapshot);
+
+	if (result == 0) {
+		result = bson_encoder_fini(encoder);
+	}
+
+	return result;
+}
+
+static int
+stage_write_buffer(bson_encoder_s *encoder, uint8_t **buffer, size_t *enc_size)
 {
 	void *enc_buff = bson_encoder_buf_data(encoder);
 	*enc_size = bson_encoder_buf_size(encoder);
@@ -175,7 +207,7 @@ alloc_and_fill_write_buffer(bson_encoder_s *encoder, uint8_t **buffer, size_t *e
 }
 
 static int
-commit_write_buffer(uint8_t *buffer, size_t enc_size)
+commit_append(uint8_t *buffer, size_t enc_size)
 {
 	int result = parameter_flashfs_write(parameters_token, buffer, enc_size);
 	parameter_flashfs_free();
@@ -188,69 +220,47 @@ commit_write_buffer(uint8_t *buffer, size_t enc_size)
 }
 
 static int
-write_encoded(bson_encoder_s *encoder)
-{
-	uint8_t *buffer;
-	size_t enc_size;
-	int result = alloc_and_fill_write_buffer(encoder, &buffer, &enc_size);
-
-	if (result != OK) {
-		return result;
-	}
-
-	return commit_write_buffer(buffer, enc_size);
-}
-
-static int
-export_and_write(param_filter_func filter, bool snapshot)
+export_delta(param_filter_func filter)
 {
 	bson_encoder_s encoder{};
-	bson_encoder_init_buf(&encoder, nullptr, 0);
+	int result = encode_document(&encoder, filter, false);
 
-	int result = encode_params(&encoder, filter, snapshot);
+	if (result == 0) {
+		uint8_t *buffer;
+		size_t enc_size;
+		result = stage_write_buffer(&encoder, &buffer, &enc_size);
 
-	if (result != 0) {
-		free(bson_encoder_buf_data(&encoder));
-		return result;
+		if (result == OK) {
+			result = commit_append(buffer, enc_size);
+		}
 	}
 
-	bson_encoder_fini(&encoder);
-	result = write_encoded(&encoder);
 	free(bson_encoder_buf_data(&encoder));
 	return result;
 }
 
+/* Everything that can fail before the erase, so a failure here leaves the
+ * log untouched and still loadable. */
 static int
-compact_to_snapshot(param_filter_func filter)
+stage_snapshot(bson_encoder_s *encoder, uint8_t **buffer, size_t *enc_size)
 {
-	bson_encoder_s encoder{};
-	bson_encoder_init_buf(&encoder, nullptr, 0);
-
-	int result = encode_params(&encoder, filter, true);
-
-	if (result != 0) {
-		free(bson_encoder_buf_data(&encoder));
-		return result;
-	}
-
-	bson_encoder_fini(&encoder);
-
-	uint8_t *buffer;
-	size_t enc_size;
-	result = alloc_and_fill_write_buffer(&encoder, &buffer, &enc_size);
-	free(bson_encoder_buf_data(&encoder));
+	int result = stage_write_buffer(encoder, buffer, enc_size);
 
 	if (result != OK) {
 		return result;
 	}
 
-	if (enc_size > parameter_flashfs_max_payload()) {
+	if (*enc_size > parameter_flashfs_max_payload()) {
 		parameter_flashfs_free();
 		return -ENOSPC;
 	}
 
-	/* Encode and the write buffer are ready: only now erase. A malloc
-	 * failure or a snapshot that cannot fit a sector must not drop the log. */
+	return OK;
+}
+
+static int
+commit_snapshot(uint8_t *buffer, size_t enc_size)
+{
 	if (parameter_flashfs_blank() != 1) {
 		int rv = parameter_flashfs_erase();
 
@@ -260,7 +270,7 @@ compact_to_snapshot(param_filter_func filter)
 		}
 	}
 
-	result = parameter_flashfs_write(parameters_token, buffer, enc_size);
+	int result = parameter_flashfs_write(parameters_token, buffer, enc_size);
 
 	if (result != (int)enc_size && parameter_flashfs_blank() == 1) {
 		result = parameter_flashfs_write(parameters_token, buffer, enc_size);
@@ -276,14 +286,44 @@ compact_to_snapshot(param_filter_func filter)
 }
 
 static int
+compact_to_snapshot()
+{
+	bson_encoder_s encoder{};
+	int result = encode_document(&encoder, nullptr, true);
+
+	if (result == 0) {
+		uint8_t *buffer;
+		size_t enc_size;
+		result = stage_snapshot(&encoder, &buffer, &enc_size);
+
+		if (result == OK) {
+			result = commit_snapshot(buffer, enc_size);
+		}
+	}
+
+	free(bson_encoder_buf_data(&encoder));
+	return result;
+}
+
+static bool
+has_record(flash_file_token_t token)
+{
+	uint8_t *buffer = nullptr;
+	size_t buf_size = 0;
+	return parameter_flashfs_read(token, &buffer, &buf_size) >= 0;
+}
+
+static int
 param_export_internal(param_filter_func filter)
 {
-	if (parameter_flashfs_blank() == 1) {
-		return compact_to_snapshot(nullptr);
+	/* A legacy record still present means the boot migration did not run;
+	 * replay would take it over any delta appended behind it. */
+	if (parameter_flashfs_blank() == 1 || has_record(parameters_legacy_token)) {
+		return compact_to_snapshot();
 	}
 
 	if (any_unsaved(filter)) {
-		int result = export_and_write(filter, false);
+		int result = export_delta(filter);
 
 		if (result != -ENOSPC) {
 			return result;
@@ -293,18 +333,14 @@ param_export_internal(param_filter_func filter)
 		 * single save does not fit the tail. Compact writes the full RAM
 		 * snapshot so a filtered save cannot drop params not in the delta. */
 		PX4_WARN("flashparams: param sector full, compacting");
-		return compact_to_snapshot(nullptr);
+		return compact_to_snapshot();
 	}
 
-	uint8_t *existing = nullptr;
-	size_t existing_size = 0;
-	int read_result = parameter_flashfs_read(parameters_token, &existing, &existing_size);
-
-	if (read_result >= 0) {
+	if (has_record(parameters_token)) {
 		return 0;
 	}
 
-	return compact_to_snapshot(nullptr);
+	return compact_to_snapshot();
 }
 
 
@@ -384,12 +420,6 @@ param_import_callback(bson_decoder_t decoder, bson_node_t node)
 		goto out;
 	}
 
-	/* Legacy deltas stored a reset as the then-current default. Drop it
-	 * so the next snapshot omits it. New tombstones are BSON null. */
-	if (param_value_is_default(param)) {
-		user_config.reset(param);
-	}
-
 	/* don't return zero, that means EOF */
 	result = 1;
 
@@ -418,10 +448,15 @@ import_one_entry(uint8_t *buffer, size_t buf_size, void *arg)
 }
 
 static int
-param_import_internal()
+param_import_internal(bool *legacy)
 {
 	int result = 0;
-	int n = parameter_flashfs_walk(parameters_token, import_one_entry, &result);
+	int n = parameter_flashfs_walk(parameters_legacy_token, import_one_entry, &result);
+	*legacy = n > 0;
+
+	if (n == 0) {
+		n = parameter_flashfs_walk(parameters_token, import_one_entry, &result);
+	}
 
 	if (n < 0) {
 		debug("flash walk failed (%d)", n);
@@ -450,26 +485,50 @@ param_import_internal()
 	return 0;
 }
 
+/*
+ * Same-bank erase stalls instruction fetch for ~1 s on H7. Do it here at
+ * boot, before sensors or DShot start, and only when a burst of deltas would
+ * no longer fit or the store is still in the legacy layout. Only a failure
+ * after the erase is an error: until then the log is intact and RAM holds
+ * what it said, so the boot must not be reported as a corrupt store.
+ */
 static int
-compact_after_import()
+compact_after_import(bool legacy)
 {
-	int need = parameter_flashfs_needs_compact();
+	bson_encoder_s encoder{};
+	int result = encode_document(&encoder, nullptr, true);
 
-	if (need <= 0) {
-		return need;
+	if (result != 0) {
+		PX4_ERR("flashparams: snapshot encode failed (%d), log kept", result);
+		free(bson_encoder_buf_data(&encoder));
+		return 0;
 	}
 
-	/* Same-bank erase stalls instruction fetch for ~1 s on H7. Do it here
-	 * at boot, before sensors or DShot start, and only when a burst of
-	 * deltas would no longer fit. */
-	PX4_INFO("flashparams: compacting param sector");
-	int rv = compact_to_snapshot(nullptr);
+	const size_t enc_size = bson_encoder_buf_size(&encoder);
+	int need = legacy ? 1 : parameter_flashfs_needs_compact(parameters_token, enc_size);
+	result = 0;
 
-	if (rv != 0) {
-		PX4_ERR("flashparams: compact failed (%d)", rv);
+	if (need > 0) {
+		uint8_t *buffer;
+		size_t staged_size;
+		result = stage_snapshot(&encoder, &buffer, &staged_size);
+
+		if (result != OK) {
+			PX4_ERR("flashparams: cannot stage snapshot (%d), log kept", result);
+			result = 0;
+
+		} else {
+			PX4_INFO("flashparams: compacting param sector%s", legacy ? " (legacy layout)" : "");
+			result = commit_snapshot(buffer, staged_size);
+
+			if (result != OK) {
+				PX4_ERR("flashparams: compact failed (%d)", result);
+			}
+		}
 	}
 
-	return rv;
+	free(bson_encoder_buf_data(&encoder));
+	return result;
 }
 
 int flash_param_save(param_filter_func filter)
@@ -477,19 +536,13 @@ int flash_param_save(param_filter_func filter)
 	return param_export_internal(filter);
 }
 
-int flash_param_load()
-{
-	/* Reset is the caller's job (without autosave). Compacting here
-	 * would race ParamAutosave if reset_all() had queued a save. */
-	return flash_param_import();
-}
-
 int flash_param_import()
 {
-	int result = param_import_internal();
+	bool legacy = false;
+	int result = param_import_internal(&legacy);
 
 	if (result == 0) {
-		int cr = compact_after_import();
+		int cr = compact_after_import(legacy);
 
 		if (cr < 0) {
 			return cr;

--- a/src/lib/parameters/flashparams/flashparams.cpp
+++ b/src/lib/parameters/flashparams/flashparams.cpp
@@ -75,100 +75,158 @@ struct param_wbuf_s {
 	param_t                 param;
 };
 
-static int
-param_export_internal(param_filter_func filter)
+/*
+ * Same-bank program/erase stalls instruction fetch on STM32H7. A full
+ * snapshot rewrite is tens of ms; a 128 KB sector erase is ~1 s. In-service
+ * saves therefore append a delta of unsaved params (a few 32-byte rows).
+ * The sector is compacted back to one snapshot at boot, before sensors
+ * or DShot start.
+ */
+
+static bool
+any_unsaved(param_filter_func filter)
 {
-	bson_encoder_s encoder{};
-	int     result = -1;
-
-	/* Use realloc */
-
-	bson_encoder_init_buf(&encoder, nullptr, 0);
-	auto changed_params = user_config.containedAsBitset();
-
 	for (param_t param = 0; param < user_config.PARAM_COUNT; param++) {
+		if ((filter == nullptr || filter(param)) && param_value_unsaved(param)) {
+			return true;
+		}
+	}
 
-		if (!changed_params[param] || (filter && !filter(param))) {
+	return false;
+}
+
+static int
+encode_params(bson_encoder_s *encoder, param_filter_func filter, bool snapshot)
+{
+	for (param_t param = 0; param < user_config.PARAM_COUNT; param++) {
+		if (filter && !filter(param)) {
 			continue;
 		}
 
-		int32_t i;
-		float   f;
+		if (snapshot) {
+			if (!user_config.contains(param) || param_value_is_default(param)) {
+				continue;
+			}
 
-		/* append the appropriate BSON type object */
+		} else if (!param_value_unsaved(param)) {
+			continue;
+		}
 
 		switch (param_type(param)) {
 		case PARAM_TYPE_INT32:
-			i = user_config.get(param).i;
-
-			if (bson_encoder_append_int32(&encoder, param_name(param), i)) {
-				debug("BSON append failed for '%s'", param_name(s->param));
-				goto out;
+			if (bson_encoder_append_int32(encoder, param_name(param), user_config.get(param).i)) {
+				debug("BSON append failed for '%s'", param_name(param));
+				return -1;
 			}
 
 			break;
 
 		case PARAM_TYPE_FLOAT:
-			f = user_config.get(param).f;
-
-			if (bson_encoder_append_double(&encoder, param_name(param), (double)f)) {
-				debug("BSON append failed for '%s'", param_name(s->param));
-				goto out;
+			if (bson_encoder_append_double(encoder, param_name(param), (double)user_config.get(param).f)) {
+				debug("BSON append failed for '%s'", param_name(param));
+				return -1;
 			}
 
 			break;
 
 		default:
 			debug("unrecognized parameter type");
-			goto out;
+			return -1;
 		}
 	}
 
-	result = 0;
+	return 0;
+}
 
-out:
+static int
+write_encoded(bson_encoder_s *encoder)
+{
+	void *enc_buff = bson_encoder_buf_data(encoder);
+	size_t enc_size = bson_encoder_buf_size(encoder);
 
-	if (result == 0) {
-
-		/* Finalize the bison encoding*/
-
-		bson_encoder_fini(&encoder);
-
-		/* Get requiered space */
-
-		size_t buf_size = bson_encoder_buf_size(&encoder);
-
-		/* Get a buffer from the flash driver with enough space */
-
-		uint8_t *buffer;
-		result = parameter_flashfs_alloc(parameters_token, &buffer, &buf_size);
-
-		if (result == OK) {
-
-			/* Check for a write that has no changes */
-
-			uint8_t *was_buffer;
-			size_t was_buf_size;
-			int was_result = parameter_flashfs_read(parameters_token, &was_buffer, &was_buf_size);
-
-			void *enc_buff = bson_encoder_buf_data(&encoder);
-
-			bool commit = was_result < OK || was_buf_size != buf_size || 0 != memcmp(was_buffer, enc_buff, was_buf_size);
-
-			if (commit) {
-
-				memcpy(buffer, enc_buff, buf_size);
-				result = parameter_flashfs_write(parameters_token, buffer, buf_size);
-				result = result == buf_size ? OK : -EFBIG;
-
-			}
-
-			free(enc_buff);
-			parameter_flashfs_free();
-		}
+	if (enc_buff == nullptr) {
+		return -ENOMEM;
 	}
 
+	size_t alloc_size = enc_size;
+	uint8_t *buffer;
+	int result = parameter_flashfs_alloc(parameters_token, &buffer, &alloc_size);
+
+	if (result != OK) {
+		return result;
+	}
+
+	memcpy(buffer, enc_buff, enc_size);
+	result = parameter_flashfs_write(parameters_token, buffer, enc_size);
+	parameter_flashfs_free();
+
+	if (result == (int)enc_size) {
+		return OK;
+	}
+
+	return result < 0 ? result : -EFBIG;
+}
+
+static int
+export_and_write(param_filter_func filter, bool snapshot)
+{
+	bson_encoder_s encoder{};
+	bson_encoder_init_buf(&encoder, nullptr, 0);
+
+	int result = encode_params(&encoder, filter, snapshot);
+
+	if (result != 0) {
+		free(bson_encoder_buf_data(&encoder));
+		return result;
+	}
+
+	bson_encoder_fini(&encoder);
+	result = write_encoded(&encoder);
+	free(bson_encoder_buf_data(&encoder));
 	return result;
+}
+
+static int
+compact_to_snapshot(param_filter_func filter)
+{
+	if (parameter_flashfs_blank() != 1) {
+		int rv = parameter_flashfs_erase();
+
+		if (rv < 0) {
+			return rv;
+		}
+	}
+
+	return export_and_write(filter, true);
+}
+
+static int
+param_export_internal(param_filter_func filter)
+{
+	if (any_unsaved(filter)) {
+		int result = export_and_write(filter, false);
+
+		if (result != -ENOSPC) {
+			return result;
+		}
+
+		/* Same-bank erase stalls the CPU for ~1 s; only take that path when
+		 * the log no longer fits. Compact at boot is meant to keep this rare. */
+		PX4_WARN("flashparams: param sector full, compacting");
+		return compact_to_snapshot(filter);
+	}
+
+	/* Nothing unsaved. Still persist a snapshot if the store is empty so
+	 * load-or-init does not treat a first-boot save as blank. */
+	uint8_t *existing = nullptr;
+	size_t existing_size = 0;
+	int read_result = parameter_flashfs_read(parameters_token, &existing, &existing_size);
+
+	if (read_result >= 0) {
+		return 0;
+	}
+
+	return compact_to_snapshot(filter);
 }
 
 
@@ -242,6 +300,12 @@ param_import_callback(bson_decoder_t decoder, bson_node_t node)
 		goto out;
 	}
 
+	/* A delta tombstone stores the default so replay overrides an earlier
+	 * snapshot. Drop it from user_config so the next snapshot omits it. */
+	if (param_value_is_default(param)) {
+		user_config.reset(param);
+	}
+
 	/* don't return zero, that means EOF */
 	result = 1;
 
@@ -250,16 +314,37 @@ out:
 }
 
 static int
+import_one_entry(uint8_t *buffer, size_t buf_size, void *arg)
+{
+	int *result = static_cast<int *>(arg);
+	bson_decoder_s decoder{};
+
+	if (bson_decoder_init_buf(&decoder, buffer, buf_size, param_import_callback)) {
+		debug("decoder init failed");
+		*result = -1;
+		return -1;
+	}
+
+	do {
+		*result = bson_decoder_next(&decoder);
+
+	} while (*result > 0);
+
+	return *result < 0 ? *result : 0;
+}
+
+static int
 param_import_internal()
 {
-	bson_decoder_s decoder{};
-	int result = -1;
+	int result = 0;
+	int n = parameter_flashfs_walk(parameters_token, import_one_entry, &result);
 
-	uint8_t *buffer = nullptr;
-	size_t buf_size = 0;
-	int read_result = parameter_flashfs_read(parameters_token, &buffer, &buf_size);
+	if (n < 0) {
+		debug("flash walk failed (%d)", n);
+		return n;
+	}
 
-	if (read_result == -ENOENT || (read_result >= 0 && (buffer == nullptr || buf_size == 0))) {
+	if (n == 0) {
 		/* No valid entry found. A fully erased store is blank (first boot, or
 		 * after switching firmware): report "not yet stored" (1), matching the
 		 * convention used by param_load_default(). A store that holds data but
@@ -273,28 +358,34 @@ param_import_internal()
 		return -EILSEQ;
 	}
 
-	if (read_result < 0) {
-		debug("flash read failed (%d)", read_result);
-		return read_result;
-	}
-
-	if (bson_decoder_init_buf(&decoder, buffer, buf_size, param_import_callback)) {
-		debug("decoder init failed");
-		goto out;
-	}
-
-	do {
-		result = bson_decoder_next(&decoder);
-
-	} while (result > 0);
-
-out:
-
 	if (result < 0) {
 		debug("BSON error decoding parameters");
+		return result;
 	}
 
-	return result;
+	return 0;
+}
+
+static int
+compact_after_import()
+{
+	int need = parameter_flashfs_needs_compact();
+
+	if (need <= 0) {
+		return need;
+	}
+
+	/* Same-bank erase stalls instruction fetch for ~1 s on H7. Do it here
+	 * at boot, before sensors or DShot start, so in-service saves stay
+	 * append-only (a few 32-byte rows for a delta of unsaved params). */
+	PX4_INFO("flashparams: compacting param sector");
+	int rv = compact_to_snapshot(nullptr);
+
+	if (rv != 0) {
+		PX4_ERR("flashparams: compact failed (%d)", rv);
+	}
+
+	return rv;
 }
 
 int flash_param_save(param_filter_func filter)
@@ -305,10 +396,22 @@ int flash_param_save(param_filter_func filter)
 int flash_param_load()
 {
 	param_reset_all();
-	return param_import_internal();
+	int result = param_import_internal();
+
+	if (result == 0) {
+		compact_after_import();
+	}
+
+	return result;
 }
 
 int flash_param_import()
 {
-	return param_import_internal();
+	int result = param_import_internal();
+
+	if (result == 0) {
+		compact_after_import();
+	}
+
+	return result;
 }

--- a/src/lib/parameters/flashparams/flashparams.cpp
+++ b/src/lib/parameters/flashparams/flashparams.cpp
@@ -113,6 +113,15 @@ encode_params(bson_encoder_s *encoder, param_filter_func filter, bool snapshot)
 			continue;
 		}
 
+		if (!snapshot && (!user_config.contains(param) || param_value_is_default(param))) {
+			if (bson_encoder_append_null(encoder, param_name(param))) {
+				debug("BSON append failed for '%s'", param_name(param));
+				return -1;
+			}
+
+			continue;
+		}
+
 		switch (param_type(param)) {
 		case PARAM_TYPE_INT32:
 			if (bson_encoder_append_int32(encoder, param_name(param), user_config.get(param).i)) {
@@ -235,8 +244,13 @@ compact_to_snapshot(param_filter_func filter)
 		return result;
 	}
 
+	if (enc_size > parameter_flashfs_max_payload()) {
+		parameter_flashfs_free();
+		return -ENOSPC;
+	}
+
 	/* Encode and the write buffer are ready: only now erase. A malloc
-	 * failure must not drop the log that is still on flash. */
+	 * failure or a snapshot that cannot fit a sector must not drop the log. */
 	if (parameter_flashfs_blank() != 1) {
 		int rv = parameter_flashfs_erase();
 
@@ -246,12 +260,28 @@ compact_to_snapshot(param_filter_func filter)
 		}
 	}
 
-	return commit_write_buffer(buffer, enc_size);
+	result = parameter_flashfs_write(parameters_token, buffer, enc_size);
+
+	if (result != (int)enc_size && parameter_flashfs_blank() == 1) {
+		result = parameter_flashfs_write(parameters_token, buffer, enc_size);
+	}
+
+	parameter_flashfs_free();
+
+	if (result == (int)enc_size) {
+		return OK;
+	}
+
+	return result < 0 ? result : -EFBIG;
 }
 
 static int
 param_export_internal(param_filter_func filter)
 {
+	if (parameter_flashfs_blank() == 1) {
+		return compact_to_snapshot(nullptr);
+	}
+
 	if (any_unsaved(filter)) {
 		int result = export_and_write(filter, false);
 
@@ -259,15 +289,13 @@ param_export_internal(param_filter_func filter)
 			return result;
 		}
 
-		/* Same-bank erase stalls the CPU for ~1 s; only take that path when
-		 * the log no longer fits. Compact writes the full RAM snapshot so a
-		 * filtered save cannot drop params that were not in the delta. */
+		/* Same-bank erase stalls the CPU for ~1 s; last resort when a
+		 * single save does not fit the tail. Compact writes the full RAM
+		 * snapshot so a filtered save cannot drop params not in the delta. */
 		PX4_WARN("flashparams: param sector full, compacting");
 		return compact_to_snapshot(nullptr);
 	}
 
-	/* Nothing unsaved. Still persist a snapshot if the store is empty so
-	 * load-or-init does not treat a first-boot save as blank. */
 	uint8_t *existing = nullptr;
 	size_t existing_size = 0;
 	int read_result = parameter_flashfs_read(parameters_token, &existing, &existing_size);
@@ -317,6 +345,12 @@ param_import_callback(bson_decoder_t decoder, bson_node_t node)
 	 */
 
 	switch (node->type) {
+	case BSON_nullptr:
+	case BSON_UNDEFINED:
+		user_config.reset(param);
+		result = 1;
+		goto out;
+
 	case BSON_INT32:
 		if (param_type(param) != PARAM_TYPE_INT32) {
 			PX4_WARN("unexpected type for %s", node->name);
@@ -350,8 +384,8 @@ param_import_callback(bson_decoder_t decoder, bson_node_t node)
 		goto out;
 	}
 
-	/* A delta tombstone stores the default so replay overrides an earlier
-	 * snapshot. Drop it from user_config so the next snapshot omits it. */
+	/* Legacy deltas stored a reset as the then-current default. Drop it
+	 * so the next snapshot omits it. New tombstones are BSON null. */
 	if (param_value_is_default(param)) {
 		user_config.reset(param);
 	}
@@ -455,7 +489,11 @@ int flash_param_import()
 	int result = param_import_internal();
 
 	if (result == 0) {
-		compact_after_import();
+		int cr = compact_after_import();
+
+		if (cr < 0) {
+			return cr;
+		}
 	}
 
 	return result;

--- a/src/lib/parameters/flashparams/flashparams.cpp
+++ b/src/lib/parameters/flashparams/flashparams.cpp
@@ -79,8 +79,9 @@ struct param_wbuf_s {
  * Same-bank program/erase stalls instruction fetch on STM32H7. A full
  * snapshot rewrite is tens of ms; a 128 KB sector erase is ~1 s. In-service
  * saves therefore append a delta of unsaved params (a few 32-byte rows).
- * The sector is compacted back to one snapshot at boot, before sensors
- * or DShot start.
+ * At boot, before sensors or DShot start, compact to one snapshot only when
+ * the sector cannot fit a burst of deltas — so a disarm-edge UUID save does
+ * not pay the erase every flight.
  */
 
 static bool
@@ -139,25 +140,35 @@ encode_params(bson_encoder_s *encoder, param_filter_func filter, bool snapshot)
 }
 
 static int
-write_encoded(bson_encoder_s *encoder)
+alloc_and_fill_write_buffer(bson_encoder_s *encoder, uint8_t **buffer, size_t *enc_size)
 {
 	void *enc_buff = bson_encoder_buf_data(encoder);
-	size_t enc_size = bson_encoder_buf_size(encoder);
+	*enc_size = bson_encoder_buf_size(encoder);
 
 	if (enc_buff == nullptr) {
 		return -ENOMEM;
 	}
 
-	size_t alloc_size = enc_size;
-	uint8_t *buffer;
-	int result = parameter_flashfs_alloc(parameters_token, &buffer, &alloc_size);
+	size_t alloc_size = *enc_size;
+	int result = parameter_flashfs_alloc(parameters_token, buffer, &alloc_size);
 
 	if (result != OK) {
 		return result;
 	}
 
-	memcpy(buffer, enc_buff, enc_size);
-	result = parameter_flashfs_write(parameters_token, buffer, enc_size);
+	if (alloc_size < *enc_size) {
+		parameter_flashfs_free();
+		return -ENOMEM;
+	}
+
+	memcpy(*buffer, enc_buff, *enc_size);
+	return OK;
+}
+
+static int
+commit_write_buffer(uint8_t *buffer, size_t enc_size)
+{
+	int result = parameter_flashfs_write(parameters_token, buffer, enc_size);
 	parameter_flashfs_free();
 
 	if (result == (int)enc_size) {
@@ -165,6 +176,20 @@ write_encoded(bson_encoder_s *encoder)
 	}
 
 	return result < 0 ? result : -EFBIG;
+}
+
+static int
+write_encoded(bson_encoder_s *encoder)
+{
+	uint8_t *buffer;
+	size_t enc_size;
+	int result = alloc_and_fill_write_buffer(encoder, &buffer, &enc_size);
+
+	if (result != OK) {
+		return result;
+	}
+
+	return commit_write_buffer(buffer, enc_size);
 }
 
 static int
@@ -189,15 +214,39 @@ export_and_write(param_filter_func filter, bool snapshot)
 static int
 compact_to_snapshot(param_filter_func filter)
 {
+	bson_encoder_s encoder{};
+	bson_encoder_init_buf(&encoder, nullptr, 0);
+
+	int result = encode_params(&encoder, filter, true);
+
+	if (result != 0) {
+		free(bson_encoder_buf_data(&encoder));
+		return result;
+	}
+
+	bson_encoder_fini(&encoder);
+
+	uint8_t *buffer;
+	size_t enc_size;
+	result = alloc_and_fill_write_buffer(&encoder, &buffer, &enc_size);
+	free(bson_encoder_buf_data(&encoder));
+
+	if (result != OK) {
+		return result;
+	}
+
+	/* Encode and the write buffer are ready: only now erase. A malloc
+	 * failure must not drop the log that is still on flash. */
 	if (parameter_flashfs_blank() != 1) {
 		int rv = parameter_flashfs_erase();
 
 		if (rv < 0) {
+			parameter_flashfs_free();
 			return rv;
 		}
 	}
 
-	return export_and_write(filter, true);
+	return commit_write_buffer(buffer, enc_size);
 }
 
 static int
@@ -211,9 +260,10 @@ param_export_internal(param_filter_func filter)
 		}
 
 		/* Same-bank erase stalls the CPU for ~1 s; only take that path when
-		 * the log no longer fits. Compact at boot is meant to keep this rare. */
+		 * the log no longer fits. Compact writes the full RAM snapshot so a
+		 * filtered save cannot drop params that were not in the delta. */
 		PX4_WARN("flashparams: param sector full, compacting");
-		return compact_to_snapshot(filter);
+		return compact_to_snapshot(nullptr);
 	}
 
 	/* Nothing unsaved. Still persist a snapshot if the store is empty so
@@ -226,7 +276,7 @@ param_export_internal(param_filter_func filter)
 		return 0;
 	}
 
-	return compact_to_snapshot(filter);
+	return compact_to_snapshot(nullptr);
 }
 
 
@@ -376,8 +426,8 @@ compact_after_import()
 	}
 
 	/* Same-bank erase stalls instruction fetch for ~1 s on H7. Do it here
-	 * at boot, before sensors or DShot start, so in-service saves stay
-	 * append-only (a few 32-byte rows for a delta of unsaved params). */
+	 * at boot, before sensors or DShot start, and only when a burst of
+	 * deltas would no longer fit. */
 	PX4_INFO("flashparams: compacting param sector");
 	int rv = compact_to_snapshot(nullptr);
 
@@ -395,14 +445,9 @@ int flash_param_save(param_filter_func filter)
 
 int flash_param_load()
 {
-	param_reset_all();
-	int result = param_import_internal();
-
-	if (result == 0) {
-		compact_after_import();
-	}
-
-	return result;
+	/* Reset is the caller's job (without autosave). Compacting here
+	 * would race ParamAutosave if reset_all() had queued a save. */
+	return flash_param_import();
 }
 
 int flash_param_import()

--- a/src/lib/parameters/flashparams/flashparams.h
+++ b/src/lib/parameters/flashparams/flashparams.h
@@ -64,7 +64,6 @@ __EXPORT void param_get_external(param_t param, void *val);
 
 /* The interface hooks to the Flash based storage. The caller is responsible for locking */
 __EXPORT int flash_param_save(param_filter_func filter);
-__EXPORT int flash_param_load();
 __EXPORT int flash_param_import();
 
 __END_DECLS

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -92,7 +92,6 @@ using namespace time_literals;
 #include "flashparams/flashparams.h"
 #else
 inline static int flash_param_save(param_filter_func filter) { return -1; }
-inline static int flash_param_load() { return -1; }
 inline static int flash_param_import() { return -1; }
 #endif
 
@@ -1398,7 +1397,7 @@ param_load(int fd)
 #if defined(FLASH_BASED_PARAMS)
 		return flash_backend_locked(flash_load_locked);
 #else
-		return flash_param_load();
+		return PX4_ERROR;
 #endif
 	}
 

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -645,6 +645,13 @@ static int param_reset_internal(param_t param, bool notify = true, bool autosave
 		user_config.reset(param);
 	}
 
+	if (param_found) {
+		/* Persist the reset. Flash-param saves append only unsaved params,
+		 * so a reset has to show up as a tombstone or replay keeps the
+		 * previous override. */
+		params_unsaved.set(param, true);
+	}
+
 	if (autosave) {
 		param_autosave();
 	}

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -839,6 +839,17 @@ int param_save_default(bool blocking)
 	int res = PX4_ERROR;
 	const char *filename = param_get_default_file();
 
+	/* A param_set that lands while the export runs is not in what gets
+	 * written. Remember what was pending at the start and clear only that,
+	 * so the late change keeps its bit and reaches the next save. */
+	px4::AtomicBitset<param_info_count> pending;
+
+	for (param_t param = 0; handle_in_range(param); param++) {
+		if (params_unsaved[param]) {
+			pending.set(param);
+		}
+	}
+
 	if (filename) {
 		static constexpr int MAX_ATTEMPTS = 3;
 
@@ -879,7 +890,11 @@ int param_save_default(bool blocking)
 		PX4_ERR("param export failed (%d)", res);
 
 	} else {
-		params_unsaved.reset();
+		for (param_t param = 0; handle_in_range(param); param++) {
+			if (pending[param]) {
+				params_unsaved.set(param, false);
+			}
+		}
 
 		// backup file
 		if (param_backup_file) {

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -453,7 +453,10 @@ param_set_internal(param_t param, const void *val, bool mark_saved, bool notify_
 	}
 
 	if (user_config.store(param, new_value)) {
-		params_unsaved.set(param, !mark_saved && param_changed);
+		if (param_changed) {
+			params_unsaved.set(param, !mark_saved);
+		}
+
 		result = PX4_OK;
 
 	} else {
@@ -1213,6 +1216,11 @@ param_import_callback(bson_decoder_t decoder, bson_node_t node)
 
 	// Handle setting the parameter from the node
 	switch (node->type) {
+	case BSON_nullptr:
+	case BSON_UNDEFINED:
+		user_config.reset(param);
+		return 1;
+
 	case BSON_INT32: {
 			if (param_type(param) == PARAM_TYPE_INT32) {
 				int32_t i = node->i32;
@@ -1361,7 +1369,7 @@ static int flash_load_locked()
 	param_reset_all_internal(false);
 	int result = flash_param_import();
 
-	if (result >= 0) {
+	if (result == 0 || result == 1) {
 		params_unsaved.reset();
 	}
 

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -919,7 +919,7 @@ param_load_default()
 	const char *filename = param_get_default_file();
 
 	if (!filename) {
-		return flash_param_load();
+		return param_load(-1);
 	}
 
 	int fd_load = ::open(filename, O_RDONLY);
@@ -1330,11 +1330,54 @@ param_import_internal(int fd)
 	return -1;
 }
 
+#if defined(FLASH_BASED_PARAMS)
+static int flash_backend_locked(int (*op)())
+{
+	/* Same order as param_save_default: mutex then shutdown lock. Autosave
+	 * uses a trylock, so a compact holds it off the flash programming. */
+	pthread_mutex_lock(&file_mutex);
+
+	int shutdown_lock_ret = px4_shutdown_lock();
+
+	if (shutdown_lock_ret != 0) {
+		PX4_ERR("px4_shutdown_lock() failed (%i)", shutdown_lock_ret);
+	}
+
+	int result = op();
+
+	pthread_mutex_unlock(&file_mutex);
+
+	if (shutdown_lock_ret == 0) {
+		px4_shutdown_unlock();
+	}
+
+	return result;
+}
+
+static int flash_load_locked()
+{
+	/* Reset under the lock so a pending autosave cannot append tombstones
+	 * of the just-cleared RAM before import/compact run. */
+	param_reset_all_internal(false);
+	int result = flash_param_import();
+
+	if (result >= 0) {
+		params_unsaved.reset();
+	}
+
+	return result;
+}
+#endif
+
 int
 param_import(int fd)
 {
 	if (fd < 0) {
+#if defined(FLASH_BASED_PARAMS)
+		return flash_backend_locked(flash_param_import);
+#else
 		return flash_param_import();
+#endif
 	}
 
 	return param_import_internal(fd);
@@ -1344,11 +1387,21 @@ int
 param_load(int fd)
 {
 	if (fd < 0) {
+#if defined(FLASH_BASED_PARAMS)
+		return flash_backend_locked(flash_load_locked);
+#else
 		return flash_param_load();
+#endif
 	}
 
 	param_reset_all_internal(false);
-	return param_import_internal(fd);
+	int result = param_import_internal(fd);
+
+	if (result >= 0) {
+		params_unsaved.reset();
+	}
+
+	return result;
 }
 
 void

--- a/src/lib/tinybson/tinybson.cpp
+++ b/src/lib/tinybson/tinybson.cpp
@@ -308,6 +308,10 @@ bson_decoder_next(bson_decoder_t decoder)
 			decoder->count_node_int64++;
 			break;
 
+		case BSON_nullptr:
+		case BSON_UNDEFINED:
+			break;
+
 		/* XXX currently not supporting other types */
 		default:
 			CODER_KILL(decoder, "unsupported node type");
@@ -648,6 +652,19 @@ bson_encoder_append_binary(bson_encoder_t encoder, const char *name, bson_binary
 	    write_int8(encoder, subtype) ||
 	    write_x(encoder, data, size)) {
 		CODER_KILL(encoder, "write error on BSON_BINDATA");
+	}
+
+	return 0;
+}
+
+int
+bson_encoder_append_null(bson_encoder_t encoder, const char *name)
+{
+	CODER_CHECK(encoder);
+
+	if (write_int8(encoder, BSON_nullptr) ||
+	    write_name(encoder, name)) {
+		CODER_KILL(encoder, "write error on BSON_nullptr");
 	}
 
 	return 0;

--- a/src/lib/tinybson/tinybson.h
+++ b/src/lib/tinybson/tinybson.h
@@ -303,5 +303,10 @@ __EXPORT int bson_encoder_append_string(bson_encoder_t encoder, const char *name
 __EXPORT int bson_encoder_append_binary(bson_encoder_t encoder, const char *name, bson_binary_subtype_t subtype,
 					size_t size, const void *data);
 
+/**
+ * Append a BSON null (type 0x0A). Name only; no value payload.
+ */
+__EXPORT int bson_encoder_append_null(bson_encoder_t encoder, const char *name);
+
 
 #endif


### PR DESCRIPTION
fixes #28529

Flash param saves append only the params that changed since the last save. The ~1 s sector erase, when one is needed, runs at boot before sensors and DShot start. The store gets a new file token so firmware without the log format boots on defaults instead of a partial set.

### Why a save stalls the CPU
STM32H7 can't fetch instructions from a bank that is being programmed or erased. The image is ~1.7 MB and extends into bank 2, where the parameter sector lives. Every tick on the bottom lane is an IMU FIFO read or a DShot frame; none run while the flash controller is busy in bank 2.

<img width="2080" height="584" alt="fig1" src="https://github.com/user-attachments/assets/a41bb7fb-f1c3-4c76-8972-a6cec8cb626d" />

The sector held one `parm` record with every non-default parameter. Every save wrote a new full copy (~5 KB, ~30 ms) and marked the old one erased; when the copies ran out, the save erased the sector (~1 s). A one-count bump of `COM_FLIGHT_UUID` wrote the same 5 KB as a full recalibration. Autosave already waits for disarm, so these landed during pre-arm checks, ESC init, and the disarm save after every flight; on single-sector boards the erase came around every 25th flight.

### The log
Flash is a log under a new token, `plog`: one snapshot, then a delta per save holding only the parameters with the unsaved bit. A parameter back at its default is written as a BSON null. Nothing is marked erased. A typical save is 1–3 rows; the per-flight UUID bump is 64 bytes.

<img width="2080" height="752" alt="fig2" src="https://github.com/user-attachments/assets/1cc2b677-ca28-4565-a92f-3cdace3a978f" />

At boot the walker visits every CRC-valid `plog` record in write order and feeds each to the import callback. Later records override earlier ones; a null removes the override. The result equals RAM after the last save.

<img width="2080" height="660" alt="fig-replay" src="https://github.com/user-attachments/assets/b1b23bab-caad-4f4a-809b-cc85cc5f5c0c" />

### Boot: replay, then compact only if needed
After import, the snapshot is encoded and staged in RAM, and the sector is rewritten only when one of these holds:

- the blank tail can't hold a burst of deltas the size of the snapshot, floored at 8 KB so the UUID append never triggers it on its own (one 128 KB sector with a 5 KB snapshot reaches that after ~1900 flights of UUID-only saves)
- dead records sit ahead of the live data
- the store is still the `parm` layout
- replay met a record that no longer names a param of this firmware, or names one of another type

A failure before the erase keeps the log and doesn't report the store corrupt. The param file lock is held across reset, import and compact so autosave can't program flash during it.

<img width="2080" height="688" alt="fig3" src="https://github.com/user-attachments/assets/fc1bf6a4-c8dd-4fc7-8b2d-878e34ae0c69" />

### Save: append a delta; snapshot only to seed or repair
`flash_param_save` writes a full snapshot only when the store is blank, still holds a legacy record, has no `plog` snapshot, or failed to replay. If a delta doesn't fit, it compacts in service as a last resort and warns.

<img width="2080" height="752" alt="fig4" src="https://github.com/user-attachments/assets/162ec2fc-c77c-4ff6-87a0-5ba9137f505c" />

### The unsaved bit
With deltas the bit is the only thing that carries a change into flash, so everything that moves RAM away from the log sets it: `param_set`, resets, and on flash boards file imports (`param import`, `param load`, the rcS backup recovery). A save moves the pending bits aside before the export and restores them on failure, so a `param_set` that lands during the save reaches the next one. Tombstones are decoded before `param_modify_on_import`, which otherwise reads the previous node's value out of the union.

The snapshot holds every override, including values equal to the firmware default: boot compaction runs before the airframe applies its `set-default` values, so at that point "equals the default" is meaningless. Deltas tombstone a value that matches the default in force, which is the file backend's behaviour after a reload.

### Compatibility
Old firmware reads and writes only `parm`; this firmware reads `parm` once and writes only `plog`. A downgrade boots on defaults rather than loading a stale snapshot and then failing every save into the deltas behind it; restore from a backup afterward. A `parm` record is always the newest state, since only old firmware writes one, so an upgrade imports it alone and rewrites the store.

<img width="2080" height="600" alt="fig-compat" src="https://github.com/user-attachments/assets/8df0c039-eed3-4434-81a4-7967607c9e32" />

### flashfs
- Appends are row aligned on H7; `up_progmem_write` only asserts that in debug builds.
- Header fields are read only once the header is known to lie inside the sector.
- The append scan stops at a blank header, like the replay walker.
- The writer never places a record in a sector's last word, which the walkers don't read.
- `find_entry` is derived from the walker.

### Testing
A host harness runs `flashfs.c` and `flashfs32.c` against simulated F7 (word program) and H7 (32-byte row, blank-only) flash under ASan: fill-to-`ENOSPC` replay, every payload size around the sector boundary, `max_payload`, a torn record ahead of live data, two-sector write order, and the compaction decision.
