### PR TITLE
fix(commander): convert the baro timestamp delta to seconds for the home altitude filter [1.18]

### DIFF
--- a/src/modules/commander/HomePosition.cpp
+++ b/src/modules/commander/HomePosition.cpp
@@ -336,7 +336,7 @@ void HomePosition::update(bool set_automatically, bool check_if_changed)
 		const float baro_alt = baro_data.baro_alt_meter;
 
 		if (_last_baro_timestamp != 0) {
-			const float dt = baro_data.timestamp - _last_baro_timestamp;
+			const float dt = 1e-6f * (baro_data.timestamp - _last_baro_timestamp);
 			_lpf_baro.update(baro_alt, dt);
 
 		} else {


### PR DESCRIPTION
Backport of #28415 to `release/1.18`, the same commit as on main.

The timestamp delta went into the home altitude filter in the wrong unit.
