### PR TITLE
[BACKPORT 1.18] fix(commander): allow VTOL to register fixed-wing setpoint type form

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2593,8 +2593,8 @@ void Commander::checkAndInformReadyForTakeoff()
 void Commander::modeManagementUpdate()
 {
 	ModeManagement::UpdateRequest mode_management_update{};
-	_mode_management.update(_vehicle_status.vehicle_type, isArmed(), _vehicle_status.nav_state_user_intention,
-				mode_management_update);
+	_mode_management.update(_vehicle_status.vehicle_type, _vehicle_status.is_vtol, isArmed(),
+				_vehicle_status.nav_state_user_intention, mode_management_update);
 
 	if (!isArmed() && mode_management_update.change_user_intended_nav_state) {
 		_user_mode_intention.change(mode_management_update.user_intended_nav_state);

--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -374,7 +374,8 @@ void ModeManagement::checkUnregistrations(uint8_t user_intended_nav_state, Updat
 	}
 }
 
-void ModeManagement::update(uint8_t vehicle_type, bool armed, uint8_t user_intended_nav_state, UpdateRequest &update_request)
+void ModeManagement::update(uint8_t vehicle_type, bool is_vtol, bool armed, uint8_t user_intended_nav_state,
+			    UpdateRequest &update_request)
 {
 	_external_checks.update();
 
@@ -418,7 +419,7 @@ void ModeManagement::update(uint8_t vehicle_type, bool armed, uint8_t user_inten
 		checkUnregistrations(user_intended_nav_state, update_request);
 	}
 
-	update_request.control_setpoint_update = checkConfigControlSetpointUpdates(vehicle_type);
+	update_request.control_setpoint_update = checkConfigControlSetpointUpdates(vehicle_type, is_vtol);
 	checkConfigOverrides();
 }
 
@@ -612,7 +613,7 @@ void ModeManagement::updateActiveConfigOverrides(uint8_t nav_state, config_overr
 	}
 }
 
-bool ModeManagement::checkConfigControlSetpointUpdates(uint8_t vehicle_type)
+bool ModeManagement::checkConfigControlSetpointUpdates(uint8_t vehicle_type, bool is_vtol)
 {
 	bool had_update = false;
 	setpoint_config_s setpoint_config;
@@ -627,7 +628,7 @@ bool ModeManagement::checkConfigControlSetpointUpdates(uint8_t vehicle_type)
 			Modes::Mode &mode = _modes.mode(setpoint_config.source_id);
 
 			const auto setpoint_type = static_cast<mode_util::SetpointType>(setpoint_config.type);
-			reply.result = static_cast<uint8_t>(mode_util::isSetpointTypeValid(setpoint_type, vehicle_type));
+			reply.result = static_cast<uint8_t>(mode_util::isSetpointTypeValid(setpoint_type, vehicle_type, is_vtol));
 
 			if (reply.result == setpoint_config_reply_s::RESULT_SUCCESS) {
 				// Get control mode

--- a/src/modules/commander/ModeManagement.hpp
+++ b/src/modules/commander/ModeManagement.hpp
@@ -134,7 +134,8 @@ public:
 		bool control_setpoint_update{false};
 	};
 
-	void update(uint8_t vehicle_type, bool armed, uint8_t user_intended_nav_state, UpdateRequest &update_request);
+	void update(uint8_t vehicle_type, bool is_vtol, bool armed, uint8_t user_intended_nav_state,
+		    UpdateRequest &update_request);
 	void setFailsafeState(bool failsafe_action_active)
 	{
 		_failsafe_action_active = failsafe_action_active;
@@ -170,7 +171,7 @@ public:
 	void updateActiveConfigOverrides(uint8_t nav_state, config_overrides_s &overrides_in_out);
 
 private:
-	bool checkConfigControlSetpointUpdates(uint8_t vehicle_type);
+	bool checkConfigControlSetpointUpdates(uint8_t vehicle_type, bool is_vtol);
 	void checkNewRegistrations(UpdateRequest &update_request);
 	void checkUnregistrations(uint8_t user_intended_nav_state, UpdateRequest &update_request);
 	void checkConfigOverrides();
@@ -212,7 +213,8 @@ public:
 		bool control_setpoint_update{false};
 	};
 
-	void update(uint8_t vehicle_type, bool armed, uint8_t user_intended_nav_state, UpdateRequest &update_request) {}
+	void update(uint8_t vehicle_type, bool is_vtol, bool armed, uint8_t user_intended_nav_state,
+		    UpdateRequest &update_request) {}
 	void setFailsafeState(bool failsafe_action_active) {}
 
 	int modeExecutorInCharge() const { return ModeExecutors::AUTOPILOT_EXECUTOR_ID; }

--- a/src/modules/commander/ModeManagementTest.cpp
+++ b/src/modules/commander/ModeManagementTest.cpp
@@ -99,3 +99,25 @@ TEST(ModeManagementTest, Hashes)
 
 	EXPECT_FALSE(modes.hasFreeExternalModes());
 }
+
+TEST(ModeManagementTest, VtolFixedwingSetpointRegistration)
+{
+	using mode_util::SetpointType;
+	using mode_util::SetpointTypeResult;
+
+	// A plain (non-VTOL) rotary wing cannot register the fixed-wing setpoint type.
+	EXPECT_EQ(mode_util::isSetpointTypeValid(SetpointType::FixedwingLateralLongitudinal,
+			vehicle_status_s::VEHICLE_TYPE_ROTARY_WING, false),
+		  SetpointTypeResult::Unsupported);
+
+	// A VTOL currently in multicopter form must still be able to register it, so it
+	// can command its own first transition to fixed-wing from an external mode.
+	EXPECT_EQ(mode_util::isSetpointTypeValid(SetpointType::FixedwingLateralLongitudinal,
+			vehicle_status_s::VEHICLE_TYPE_ROTARY_WING, true),
+		  SetpointTypeResult::Success);
+
+	// Already fixed-wing: valid regardless of is_vtol.
+	EXPECT_EQ(mode_util::isSetpointTypeValid(SetpointType::FixedwingLateralLongitudinal,
+			vehicle_status_s::VEHICLE_TYPE_FIXED_WING, false),
+		  SetpointTypeResult::Success);
+}

--- a/src/modules/commander/ModeUtil/setpoint_types.cpp
+++ b/src/modules/commander/ModeUtil/setpoint_types.cpp
@@ -164,7 +164,7 @@ void getControlMode(SetpointType setpoint_type, vehicle_control_mode_s &control_
 	}
 }
 
-SetpointTypeResult isSetpointTypeValid(SetpointType setpoint_type, uint8_t vehicle_type)
+SetpointTypeResult isSetpointTypeValid(SetpointType setpoint_type, uint8_t vehicle_type, bool is_vtol)
 {
 	switch (setpoint_type) {
 	case SetpointType::Invalid:
@@ -181,7 +181,7 @@ SetpointTypeResult isSetpointTypeValid(SetpointType setpoint_type, uint8_t vehic
 		return SetpointTypeResult::Unsupported;
 
 	case SetpointType::FixedwingLateralLongitudinal:
-		if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+		if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING || is_vtol) {
 			return SetpointTypeResult::Success;
 		}
 

--- a/src/modules/commander/ModeUtil/setpoint_types.hpp
+++ b/src/modules/commander/ModeUtil/setpoint_types.hpp
@@ -77,6 +77,6 @@ enum class SetpointTypeResult : uint8_t {
 /**
  * Check if a setpoint type is valid for a given vehicle type
  */
-SetpointTypeResult isSetpointTypeValid(SetpointType setpoint_type, uint8_t vehicle_type);
+SetpointTypeResult isSetpointTypeValid(SetpointType setpoint_type, uint8_t vehicle_type, bool is_vtol);
 
 } // namespace mode_util


### PR DESCRIPTION
## Summary

Backport of #28510 to release-1.18.

Fixes https://github.com/Auterion/px4-ros2-interface-lib/issues/218 for the upcoming 1.18 release.
