### PR TITLE
fix(load_mon): add return code at module stop path

### DIFF
--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -111,6 +111,8 @@ void LoadMon::Run()
 
 #endif
 
+	perf_end(_cycle_perf);
+
 	if (should_exit()) {
 		ScheduleClear();
 #if defined (__PX4_LINUX)
@@ -119,8 +121,6 @@ void LoadMon::Run()
 		exit_and_cleanup(desc);
 		return;
 	}
-
-	perf_end(_cycle_perf);
 }
 
 void LoadMon::cpuload()

--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -117,6 +117,7 @@ void LoadMon::Run()
 		fclose(_proc_fd);
 #endif
 		exit_and_cleanup(desc);
+		return;
 	}
 
 	perf_end(_cycle_perf);


### PR DESCRIPTION
### Summary

`load_mon` has a use-after-free bug in its stop path. When `load_mon stop` is issued, `LoadMon::Run()` calls `exit_and_cleanup()`, which synchronously deletes the current `LoadMon` object and frees `_cycle_perf`. The function then continues and calls `perf_end(_cycle_perf)`, accessing both a freed object member and a freed perf counter. 

### Details

The vulnerable control flow is in `src/modules/load_mon/LoadMon.cpp:87
`
```cpp
perf_begin(_cycle_perf);

cpuload();

if (should_exit()) {
    ScheduleClear();
#if defined (__PX4_LINUX)
    fclose(_proc_fd);
#endif
    exit_and_cleanup();
}

perf_end(_cycle_perf);
```

`exit_and_cleanup()` is not a passive state transition. In `ModuleBase`, it immediately deletes the module object:

```cpp
delete _object.load();
_object.store(nullptr);
_task_id = -1;
```

See `platforms/common/include/px4_platform_common/module.h:346`.

During that deletion, `LoadMon::~LoadMon()` runs and frees the performance counter:

```cpp
LoadMon::~LoadMon()
{
    ScheduleClear();
    perf_free(_cycle_perf);
}
```

See `src/modules/load_mon/LoadMon.cpp:58`

After `exit_and_cleanup()` returns, `Run()` continues to `perf_end(_cycle_perf)`. At that point, `this` has already been deleted, so reading `_cycle_perf` is a use-after-free on the `LoadMon` object. 

AddressSanitizer output
```sh
=================================================================
==566262==ERROR: AddressSanitizer: heap-use-after-free on address 0x511000075df8 at pc 0x57a70cedaf2c bp 0x7a64502ba7a0 sp 0x7a64502ba790
READ of size 8 at 0x511000075df8 thread T6
pxh>     #0 0x57a70cedaf2b in load_mon::LoadMon::Run() /home/uav/PX4-Autopilot/src/modules/load_mon/LoadMon.cpp:120
    #1 0x57a70d552188 in px4::WorkQueue::Run() /home/uav/PX4-Autopilot/platforms/common/px4_work_queue/WorkQueue.cpp:188
    #2 0x57a70d553044 in WorkQueueRunner /home/uav/PX4-Autopilot/platforms/common/px4_work_queue/WorkQueueManager.cpp:238
    #3 0x7a6450094ac2 in start_thread nptl/pthread_create.c:442
    #4 0x7a64501268cf  (/lib/x86_64-linux-gnu/libc.so.6+0x1268cf)

0x511000075df8 is located 184 bytes inside of 200-byte region [0x511000075d40,0x511000075e08)
freed by thread T6 here:
    #0 0x7a64512b724f in operator delete(void*, unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:172
    #1 0x57a70ced9d35 in load_mon::LoadMon::~LoadMon() /home/uav/PX4-Autopilot/src/modules/load_mon/LoadMon.cpp:62

previously allocated by thread T81 here:
    #0 0x7a64512b61e7 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x57a70ceda305 in load_mon::LoadMon::task_spawn(int, char**) /home/uav/PX4-Autopilot/src/modules/load_mon/LoadMon.cpp:66

Thread T6 created by T5 here:
    #0 0x7a6451258685 in __interceptor_pthread_create ../../../../src/libsanitizer/asan/asan_interceptors.cpp:216
    #1 0x57a70d55372f in WorkQueueManagerRun /home/uav/PX4-Autopilot/platforms/common/px4_work_queue/WorkQueueManager.cpp:324

Thread T5 created by T0 here:
    #0 0x7a6451258685 in __interceptor_pthread_create ../../../../src/libsanitizer/asan/asan_interceptors.cpp:216
    #1 0x57a70d54c716 in px4_task_spawn_cmd /home/uav/PX4-Autopilot/platforms/posix/src/px4/common/tasks.cpp:252

Thread T81 created by T1 here:
    #0 0x7a6451258685 in __interceptor_pthread_create ../../../../src/libsanitizer/asan/asan_interceptors.cpp:216
    #1 0x57a70d56596b in px4_daemon::Server::_server_main() /home/uav/PX4-Autopilot/platforms/posix/src/px4/common/px4_daemon/server.cpp:185

Thread T1 created by T0 here:
    #0 0x7a6451258685 in __interceptor_pthread_create ../../../../src/libsanitizer/asan/asan_interceptors.cpp:216
    #1 0x57a70d56182e in px4_daemon::Server::start() /home/uav/PX4-Autopilot/platforms/posix/src/px4/common/px4_daemon/server.cpp:106
    #2 0x51900005720f  (<unknown module>)

SUMMARY: AddressSanitizer: heap-use-after-free /home/uav/PX4-Autopilot/src/modules/load_mon/LoadMon.cpp:120 in load_mon::LoadMon::Run()
Shadow bytes around the buggy address:
  0x0a2280006b60: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0a2280006b70: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x0a2280006b80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0a2280006b90: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0a2280006ba0: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
=>0x0a2280006bb0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd[fd]
  0x0a2280006bc0: fd fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0a2280006bd0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0a2280006be0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0a2280006bf0: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0a2280006c00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==566262==ABORTING
```

### PoC

Build a POSIX/SITL target with debug symbols:

```sh
HEADLESS=1 PX4_ASAN=1 make px4_sitl gz_x500
```
At the PXH prompt, start and then stop `load_mon`:

```sh

pxh> load_mon stop
```
### Impact

This is a use-after-free in the `load_mon` module stop path. Any user or script with access to the PXH command interface can trigger it by starting and stopping `load_mon`.