### PR TITLE
docs(releases): add v1.18 notes for five backported fixes

### DIFF
--- a/docs/en/releases/1.18.md
+++ b/docs/en/releases/1.18.md
@@ -142,6 +142,9 @@ For users upgrading from v1.17, please take a moment to review the following bef
 - VL53L0X rangefinder: invalid 8.19 m readings are filtered out and measurements now carry a quality field; VL53L1X maps its range status to the quality field. ([PX4-Autopilot#27214](https://github.com/PX4/PX4-Autopilot/pull/27214), [PX4-Autopilot#27355](https://github.com/PX4/PX4-Autopilot/pull/27355), [PX4-Autopilot#27308](https://github.com/PX4/PX4-Autopilot/pull/27308))
 - PCA9685 PWM output board now uses the correct internal oscillator frequency, so configured servo PWM rates match the actual output. ([PX4-Autopilot#27425](https://github.com/PX4/PX4-Autopilot/pull/27425))
 - MAVLink OpenDroneID Basic ID messages are now forwarded to DroneCAN Remote ID peripherals. ([PX4-Autopilot#27274](https://github.com/PX4/PX4-Autopilot/pull/27274))
+- Analog battery voltage and current filters keep their state across parameter updates, so a parameter change no longer restarts them from zero and reports the battery as disconnected. ([PX4-Autopilot#28452](https://github.com/PX4/PX4-Autopilot/pull/28452))
+- The home position altitude filter receives its barometer time delta in seconds instead of microseconds. ([PX4-Autopilot#28415](https://github.com/PX4/PX4-Autopilot/pull/28415))
+- A mission that ends on an exhausted DO_JUMP no longer reports "Waypoint could not be read" at critical severity. ([PX4-Autopilot#28464](https://github.com/PX4/PX4-Autopilot/pull/28464))
 
 ## Common
 
@@ -205,6 +208,7 @@ For users upgrading from v1.17, please take a moment to review the following bef
 - DroneCAN GNSS receivers can now provide UTC-coherent timestamps: a new leaky-min clock-offset estimator maps a node's PPS-anchored `Fix2.timestamp` into the flight controller's HRT and subtracts the node's processing delay. Nodes that do not provide a valid UTC timestamp fall back to the `SENS_GPS*_DELAY` path. ([PX4-Autopilot#27427](https://github.com/PX4/PX4-Autopilot/pull/27427))
 - EKF2 can now use GNSS height as the height reference when GNSS is in dead-reckoning mode, provided it can start without requiring a reset. ([PX4-Autopilot#27766](https://github.com/PX4/PX4-Autopilot/pull/27766))
 - EKF2 now counts NED-frame external vision velocity fusion as a horizontal (NE) aiding source (and only counts vision position when it is in the NED frame), so vehicles aided only by vision velocity are no longer treated as dead-reckoning. ([PX4-Autopilot#27538](https://github.com/PX4/PX4-Autopilot/pull/27538))
+- The EKF2 selector no longer falls back to an instance whose vertical test ratio is already failing, which stepped the published altitude on every switch after a brief fault on the selected instance. ([PX4-Autopilot#28418](https://github.com/PX4/PX4-Autopilot/pull/28418))
 
 ## RC
 
@@ -227,6 +231,7 @@ For users upgrading from v1.17, please take a moment to review the following bef
 ### VTOL
 
 - [Return mode VTOL Rally Point Approach Loiters](../flight_modes_vtol/return.md#vtol-rally-point-approach-loiters): VTOLs returning in fixed-wing mode can now use the approach loiter associated with the selected home/rally landing location (instead of home) to choose the most wind-aligned valid approach (if several are defined). ([PX4-Autopilot#27004: fix(navigator): rtl compute wind angle to select best land approach based on rally point location instead of home location](https://github.com/PX4/PX4-Autopilot/pull/27004))
+- Mission return modes keep a VTOL that is flying as a multicopter in multicopter mode instead of commanding a fixed-wing transition at return altitude, which could leave the vehicle armed instead of landing. ([PX4-Autopilot#28399](https://github.com/PX4/PX4-Autopilot/pull/28399))
 
 ### Fixed-wing
 

--- a/docs/en/releases/1.18.md
+++ b/docs/en/releases/1.18.md
@@ -227,6 +227,7 @@ For users upgrading from v1.17, please take a moment to review the following bef
   | `MPC_LAND_RC_HELP` | Replaced by Bit 1 of [MPC_AUTO_NUDGING](../advanced_config/parameter_reference.md#MPC_AUTO_NUDGING). ([PX4-Autopilot#27691](https://github.com/PX4/PX4-Autopilot/pull/27691)) |
 
 - Yaw stick nudging in auto modes ([MPC_AUTO_NUDGING](../advanced_config/parameter_reference.md#MPC_AUTO_NUDGING)). Bit 0 lets the yaw stick rotate vehicle heading during any auto mode (mission, RTL, hold, landing, takeoff) without switching modes. The heading is held when the stick is released and cleared on a flight mode switch. Requires stick override to be disabled ([MAN_OVERRIDE_SPD](../advanced_config/parameter_reference.md#MAN_OVERRIDE_SPD) = -1). ([PX4-Autopilot#27691](https://github.com/PX4/PX4-Autopilot/pull/27691))
+- Multicopter position control now handles a rejected velocity filter cutoff instead of freezing the velocity feedback at zero, which caused an altitude oscillation with `MPC_VEL_LP` at its maximum. ([PX4-Autopilot#28451](https://github.com/PX4/PX4-Autopilot/pull/28451))
 
 ### VTOL
 

--- a/docs/en/releases/1.18.md
+++ b/docs/en/releases/1.18.md
@@ -143,8 +143,6 @@ For users upgrading from v1.17, please take a moment to review the following bef
 - PCA9685 PWM output board now uses the correct internal oscillator frequency, so configured servo PWM rates match the actual output. ([PX4-Autopilot#27425](https://github.com/PX4/PX4-Autopilot/pull/27425))
 - MAVLink OpenDroneID Basic ID messages are now forwarded to DroneCAN Remote ID peripherals. ([PX4-Autopilot#27274](https://github.com/PX4/PX4-Autopilot/pull/27274))
 - Analog battery voltage and current filters keep their state across parameter updates, so a parameter change no longer restarts them from zero and reports the battery as disconnected. ([PX4-Autopilot#28452](https://github.com/PX4/PX4-Autopilot/pull/28452))
-- The home position altitude filter receives its barometer time delta in seconds instead of microseconds. ([PX4-Autopilot#28415](https://github.com/PX4/PX4-Autopilot/pull/28415))
-- A mission that ends on an exhausted DO_JUMP no longer reports "Waypoint could not be read" at critical severity. ([PX4-Autopilot#28464](https://github.com/PX4/PX4-Autopilot/pull/28464))
 
 ## Common
 
@@ -194,6 +192,8 @@ For users upgrading from v1.17, please take a moment to review the following bef
 - GCS connection-loss failsafe no longer triggers flight termination while the vehicle is disarmed, preventing a termination state from latching before or at arming after a ground station link loss. ([PX4-Autopilot#26820](https://github.com/PX4/PX4-Autopilot/pull/26820))
 - New [NAV_RCL_ACT](../advanced_config/parameter_reference.md#NAV_RCL_ACT) option `7` (Hold without failsafe): on manual control (RC) loss the vehicle holds position but does not enter a failsafe state, so an external mode or offboard controller can keep commanding it. ([PX4-Autopilot#27792](https://github.com/PX4/PX4-Autopilot/pull/27792))
 - Control allocator now stops the motors when it receives a NaN thrust setpoint, instead of forwarding invalid values to the ESCs. ([PX4-Autopilot#26494](https://github.com/PX4/PX4-Autopilot/pull/26494))
+- The home position altitude filter receives its barometer time delta in seconds instead of microseconds. ([PX4-Autopilot#28415](https://github.com/PX4/PX4-Autopilot/pull/28415))
+- A mission that ends on an exhausted DO_JUMP no longer reports "Waypoint could not be read" at critical severity. ([PX4-Autopilot#28464](https://github.com/PX4/PX4-Autopilot/pull/28464))
 
 ## Estimation
 


### PR DESCRIPTION
Adds the release note entries for five fixes that are on release/1.18 now, #28418, #28399, #28452, #28415 and #28464. Docs only.
