### PR TITLE
docs(releases): add main notes for the AlphaFilter API change and Gazebo GNSS failure injection

### DIFF
--- a/docs/en/releases/main.md
+++ b/docs/en/releases/main.md
@@ -43,7 +43,8 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 ### Common
 
-- TBD
+- The unit and functional test suite builds, links and runs on macOS (`make tests`), and `px4_poll()` timeouts on macOS wait for their full duration instead of returning at once. The blended GPS timestamp is accumulated in double and rounded once instead of truncating each weighted term. ([PX4-Autopilot#28516](https://github.com/PX4/PX4-Autopilot/pull/28516))
+- The AlphaFilter library takes its sample interval and time constant in microseconds, and the float seconds overloads are removed, so a value in the wrong unit no longer compiles. Out-of-tree code that constructs the filter with seconds needs updating. ([PX4-Autopilot#28421](https://github.com/PX4/PX4-Autopilot/pull/28421))
 
 ### Control
 
@@ -74,7 +75,7 @@ Please continue reading for [upgrade instructions](#upgrade-guide).
 
 ### Simulation
 
-- TBD
+- Gazebo: the GNSS failure injection commands (`failure gps off`, `stuck` and `wrong`) now apply to the NavSat data published by the gz bridge, consistent with the other simulator paths. ([PX4-Autopilot#28398](https://github.com/PX4/PX4-Autopilot/pull/28398))
 
 ### Debug & Logging
 


### PR DESCRIPTION
Adds the release note entries for #28421 and #28398. Docs only.
