### PR TITLE
fix(commander): scale mag cal offset limit with sensor full-scale range

### DIFF
--- a/msg/SensorMag.msg
+++ b/msg/SensorMag.msg
@@ -10,6 +10,8 @@ float32 z                 # [Gauss] magnetic field in the FRD board frame Z-axis
 
 float32 temperature       # [°C] Temperature.
 
+float32 range             # [Gauss] full-scale measurement range, 0 if unknown
+
 uint32 error_count
 
 uint8 ORB_QUEUE_LENGTH = 4

--- a/src/drivers/imu/analog_devices/adis16448/ADIS16448.cpp
+++ b/src/drivers/imu/analog_devices/adis16448/ADIS16448.cpp
@@ -540,6 +540,7 @@ bool ADIS16448::Configure()
 	_px4_accel.set_scale(0.833f * 1e-3f * CONSTANTS_ONE_G); // 0.833 mg/LSB
 	_px4_gyro.set_scale(math::radians(0.04f));              // 0.04 °/sec/LSB
 	_px4_mag.set_scale(142.9f * 1e-6f);                     // μgauss/LSB
+	_px4_mag.set_range(19.f);                               // +/-1900 uT
 
 	_px4_accel.set_range(18.f * CONSTANTS_ONE_G);
 	_px4_gyro.set_range(math::radians(1000.f));

--- a/src/drivers/imu/analog_devices/adis16448/ADIS16448.cpp
+++ b/src/drivers/imu/analog_devices/adis16448/ADIS16448.cpp
@@ -540,7 +540,7 @@ bool ADIS16448::Configure()
 	_px4_accel.set_scale(0.833f * 1e-3f * CONSTANTS_ONE_G); // 0.833 mg/LSB
 	_px4_gyro.set_scale(math::radians(0.04f));              // 0.04 °/sec/LSB
 	_px4_mag.set_scale(142.9f * 1e-6f);                     // μgauss/LSB
-	_px4_mag.set_range(19.f);                               // +/-1900 uT
+	_px4_mag.set_range(1.9f);                               // +/-1.9 gauss
 
 	_px4_accel.set_range(18.f * CONSTANTS_ONE_G);
 	_px4_gyro.set_range(math::radians(1000.f));

--- a/src/drivers/imu/invensense/icm20948/ICM20948_AK09916.cpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948_AK09916.cpp
@@ -54,6 +54,7 @@ ICM20948_AK09916::ICM20948_AK09916(ICM20948 &icm20948, enum Rotation rotation) :
 
 	// mag resolution is 1.5 milli Gauss per bit (0.15 μT/LSB)
 	_px4_mag.set_scale(1.5e-3f);
+	_px4_mag.set_range(49.12f); // +/-4912 uT
 }
 
 ICM20948_AK09916::~ICM20948_AK09916()

--- a/src/drivers/imu/invensense/icm20948/ICM20948_AK09916.cpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948_AK09916.cpp
@@ -54,7 +54,7 @@ ICM20948_AK09916::ICM20948_AK09916(ICM20948 &icm20948, enum Rotation rotation) :
 
 	// mag resolution is 1.5 milli Gauss per bit (0.15 μT/LSB)
 	_px4_mag.set_scale(1.5e-3f);
-	_px4_mag.set_range(49.12f); // +/-4912 uT
+	_px4_mag.set_range(microTesla2Gauss(4912.f));
 }
 
 ICM20948_AK09916::~ICM20948_AK09916()

--- a/src/drivers/imu/invensense/mpu9250/MPU9250_AK8963.cpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250_AK8963.cpp
@@ -54,6 +54,7 @@ MPU9250_AK8963::MPU9250_AK8963(MPU9250 &mpu9250, enum Rotation rotation) :
 
 	// in 16-bit sampling mode the mag resolution is 1.5 milli Gauss per bit */
 	_px4_mag.set_scale(1.5e-3f);
+	_px4_mag.set_range(49.12f); // +/-4912 uT
 }
 
 MPU9250_AK8963::~MPU9250_AK8963()

--- a/src/drivers/imu/invensense/mpu9250/MPU9250_AK8963.cpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250_AK8963.cpp
@@ -54,7 +54,7 @@ MPU9250_AK8963::MPU9250_AK8963(MPU9250 &mpu9250, enum Rotation rotation) :
 
 	// in 16-bit sampling mode the mag resolution is 1.5 milli Gauss per bit */
 	_px4_mag.set_scale(1.5e-3f);
-	_px4_mag.set_range(49.12f); // +/-4912 uT
+	_px4_mag.set_range(49.f); // +/-4900 uT
 }
 
 MPU9250_AK8963::~MPU9250_AK8963()

--- a/src/drivers/imu/invensense/mpu9250/MPU9250_AK8963.cpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250_AK8963.cpp
@@ -54,7 +54,7 @@ MPU9250_AK8963::MPU9250_AK8963(MPU9250 &mpu9250, enum Rotation rotation) :
 
 	// in 16-bit sampling mode the mag resolution is 1.5 milli Gauss per bit */
 	_px4_mag.set_scale(1.5e-3f);
-	_px4_mag.set_range(49.f); // +/-4900 uT
+	_px4_mag.set_range(microTesla2Gauss(4900.f));
 }
 
 MPU9250_AK8963::~MPU9250_AK8963()

--- a/src/drivers/imu/nxp/fxos8701cq/FXOS8701CQ.cpp
+++ b/src/drivers/imu/nxp/fxos8701cq/FXOS8701CQ.cpp
@@ -67,6 +67,7 @@ FXOS8701CQ::FXOS8701CQ(device::Device *interface, const I2CSPIDriverConfig &conf
 {
 #if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
 	_px4_mag.set_scale(0.001f);
+	_px4_mag.set_range(12.f); // +/-1200 uT
 #endif
 }
 

--- a/src/drivers/imu/nxp/fxos8701cq/FXOS8701CQ.cpp
+++ b/src/drivers/imu/nxp/fxos8701cq/FXOS8701CQ.cpp
@@ -67,7 +67,7 @@ FXOS8701CQ::FXOS8701CQ(device::Device *interface, const I2CSPIDriverConfig &conf
 {
 #if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
 	_px4_mag.set_scale(0.001f);
-	_px4_mag.set_range(12.f); // +/-1200 uT
+	_px4_mag.set_range(microTesla2Gauss(1200.f));
 #endif
 }
 

--- a/src/drivers/imu/st/lsm303d/LSM303D.cpp
+++ b/src/drivers/imu/st/lsm303d/LSM303D.cpp
@@ -249,28 +249,29 @@ LSM303D::mag_set_range(unsigned max_ga)
 	uint8_t setbits = 0;
 	uint8_t clearbits = REG6_FULL_SCALE_BITS_M;
 	float new_scale_ga_digit = 0.0f;
+	float new_range_ga = 0.0f;
 
 	if (max_ga == 0) {
 		max_ga = 12;
 	}
 
 	if (max_ga <= 2) {
-		// mag_range_ga = 2;
+		new_range_ga = 2.f;
 		setbits |= REG6_FULL_SCALE_2GA_M;
 		new_scale_ga_digit = 0.080e-3f;
 
 	} else if (max_ga <= 4) {
-		// mag_range_ga = 4;
+		new_range_ga = 4.f;
 		setbits |= REG6_FULL_SCALE_4GA_M;
 		new_scale_ga_digit = 0.160e-3f;
 
 	} else if (max_ga <= 8) {
-		// mag_range_ga = 8;
+		new_range_ga = 8.f;
 		setbits |= REG6_FULL_SCALE_8GA_M;
 		new_scale_ga_digit = 0.320e-3f;
 
 	} else if (max_ga <= 12) {
-		// mag_range_ga = 12;
+		new_range_ga = 12.f;
 		setbits |= REG6_FULL_SCALE_12GA_M;
 		new_scale_ga_digit = 0.479e-3f;
 
@@ -279,6 +280,7 @@ LSM303D::mag_set_range(unsigned max_ga)
 	}
 
 	_px4_mag.set_scale(new_scale_ga_digit);
+	_px4_mag.set_range(new_range_ga);
 
 	modify_reg(ADDR_CTRL_REG6, clearbits, setbits);
 

--- a/src/drivers/magnetometer/akm/ak09916/AK09916.cpp
+++ b/src/drivers/magnetometer/akm/ak09916/AK09916.cpp
@@ -267,6 +267,7 @@ bool AK09916::Configure()
 
 	// mag resolution is 1.5 milli Gauss per bit (0.15 μT/LSB)
 	_px4_mag.set_scale(1.5e-3f);
+	_px4_mag.set_range(49.12f); // +/-4912 uT
 
 	return success;
 }

--- a/src/drivers/magnetometer/akm/ak09916/AK09916.cpp
+++ b/src/drivers/magnetometer/akm/ak09916/AK09916.cpp
@@ -267,7 +267,7 @@ bool AK09916::Configure()
 
 	// mag resolution is 1.5 milli Gauss per bit (0.15 μT/LSB)
 	_px4_mag.set_scale(1.5e-3f);
-	_px4_mag.set_range(49.12f); // +/-4912 uT
+	_px4_mag.set_range(microTesla2Gauss(4912.f));
 
 	return success;
 }

--- a/src/drivers/magnetometer/akm/ak09940a/AK09940A.cpp
+++ b/src/drivers/magnetometer/akm/ak09940a/AK09940A.cpp
@@ -292,6 +292,7 @@ bool AK09940A::Configure()
 
 	// mag resolution is 1.0e-4 Gauss per bit (10 nT/LSB)
 	_px4_mag.set_scale(1.0e-4f);
+	_px4_mag.set_range(12.f); // +/-1200 uT
 
 	return success;
 }

--- a/src/drivers/magnetometer/akm/ak09940a/AK09940A.cpp
+++ b/src/drivers/magnetometer/akm/ak09940a/AK09940A.cpp
@@ -292,7 +292,7 @@ bool AK09940A::Configure()
 
 	// mag resolution is 1.0e-4 Gauss per bit (10 nT/LSB)
 	_px4_mag.set_scale(1.0e-4f);
-	_px4_mag.set_range(12.f); // +/-1200 uT
+	_px4_mag.set_range(microTesla2Gauss(1200.f));
 
 	return success;
 }

--- a/src/drivers/magnetometer/akm/ak8963/AK8963.cpp
+++ b/src/drivers/magnetometer/akm/ak8963/AK8963.cpp
@@ -266,6 +266,7 @@ bool AK8963::Configure()
 
 	// in 16-bit sampling mode (ST2 BITM) the mag resolution is 1.5 milli Gauss per bit (0.15 μT/LSB)
 	_px4_mag.set_scale(1.5e-3f);
+	_px4_mag.set_range(49.12f); // +/-4912 uT
 
 	return success;
 }

--- a/src/drivers/magnetometer/akm/ak8963/AK8963.cpp
+++ b/src/drivers/magnetometer/akm/ak8963/AK8963.cpp
@@ -266,7 +266,7 @@ bool AK8963::Configure()
 
 	// in 16-bit sampling mode (ST2 BITM) the mag resolution is 1.5 milli Gauss per bit (0.15 μT/LSB)
 	_px4_mag.set_scale(1.5e-3f);
-	_px4_mag.set_range(49.f); // +/-4900 uT
+	_px4_mag.set_range(microTesla2Gauss(4900.f));
 
 	return success;
 }

--- a/src/drivers/magnetometer/akm/ak8963/AK8963.cpp
+++ b/src/drivers/magnetometer/akm/ak8963/AK8963.cpp
@@ -266,7 +266,7 @@ bool AK8963::Configure()
 
 	// in 16-bit sampling mode (ST2 BITM) the mag resolution is 1.5 milli Gauss per bit (0.15 μT/LSB)
 	_px4_mag.set_scale(1.5e-3f);
-	_px4_mag.set_range(49.12f); // +/-4912 uT
+	_px4_mag.set_range(49.f); // +/-4900 uT
 
 	return success;
 }

--- a/src/drivers/magnetometer/bosch/bmm150/BMM150.cpp
+++ b/src/drivers/magnetometer/bosch/bmm150/BMM150.cpp
@@ -461,6 +461,7 @@ bool BMM150::Configure()
 
 	// microTesla -> Gauss
 	_px4_mag.set_scale(0.01f);
+	_px4_mag.set_range(13.f); // +/-1300 uT x/y (z: 2500)
 
 	return success;
 }

--- a/src/drivers/magnetometer/bosch/bmm150/BMM150.cpp
+++ b/src/drivers/magnetometer/bosch/bmm150/BMM150.cpp
@@ -461,7 +461,7 @@ bool BMM150::Configure()
 
 	// microTesla -> Gauss
 	_px4_mag.set_scale(0.01f);
-	_px4_mag.set_range(13.f); // +/-1300 uT x/y (z: 2500)
+	_px4_mag.set_range(microTesla2Gauss(1300.f)); // x/y axis (z: 2500 uT)
 
 	return success;
 }

--- a/src/drivers/magnetometer/bosch/bmm350/BMM350.cpp
+++ b/src/drivers/magnetometer/bosch/bmm350/BMM350.cpp
@@ -568,6 +568,7 @@ int BMM350::Configure()
 
 	// microTesla -> Gauss
 	_px4_mag.set_scale(0.01f);
+	_px4_mag.set_range(20.f); // +/-2000 uT
 
 	return ret;
 }

--- a/src/drivers/magnetometer/bosch/bmm350/BMM350.cpp
+++ b/src/drivers/magnetometer/bosch/bmm350/BMM350.cpp
@@ -568,7 +568,7 @@ int BMM350::Configure()
 
 	// microTesla -> Gauss
 	_px4_mag.set_scale(0.01f);
-	_px4_mag.set_range(20.f); // +/-2000 uT
+	_px4_mag.set_range(microTesla2Gauss(2000.f));
 
 	return ret;
 }

--- a/src/drivers/magnetometer/hmc5883/HMC5883.cpp
+++ b/src/drivers/magnetometer/hmc5883/HMC5883.cpp
@@ -116,6 +116,8 @@ int HMC5883::set_range(unsigned range)
 		_range_ga = 8.1f;
 	}
 
+	_px4_mag.set_range(_range_ga);
+
 	/*
 	 * Send the command to set the range
 	 */

--- a/src/drivers/magnetometer/isentek/ist8308/IST8308.cpp
+++ b/src/drivers/magnetometer/isentek/ist8308/IST8308.cpp
@@ -245,6 +245,7 @@ bool IST8308::Configure()
 
 	// 1 Microtesla = 0.01 Gauss
 	_px4_mag.set_scale(1.f / 13.2f * 0.01f); // 13.2 LSB/uT
+	_px4_mag.set_range(5.f); // +/-500 uT
 
 	return success;
 }

--- a/src/drivers/magnetometer/isentek/ist8308/IST8308.cpp
+++ b/src/drivers/magnetometer/isentek/ist8308/IST8308.cpp
@@ -245,7 +245,7 @@ bool IST8308::Configure()
 
 	// 1 Microtesla = 0.01 Gauss
 	_px4_mag.set_scale(1.f / 13.2f * 0.01f); // 13.2 LSB/uT
-	_px4_mag.set_range(5.f); // +/-500 uT
+	_px4_mag.set_range(microTesla2Gauss(500.f));
 
 	return success;
 }

--- a/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
+++ b/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
@@ -271,6 +271,7 @@ bool IST8310::Configure()
 	}
 
 	_px4_mag.set_scale(1.f / 1320.f); // 1320 LSB/Gauss
+	_px4_mag.set_range(16.f); // +/-1600 uT
 
 	return success;
 }

--- a/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
+++ b/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
@@ -271,7 +271,7 @@ bool IST8310::Configure()
 	}
 
 	_px4_mag.set_scale(1.f / 1320.f); // 1320 LSB/Gauss
-	_px4_mag.set_range(16.f); // +/-1600 uT
+	_px4_mag.set_range(microTesla2Gauss(1600.f)); // x/y axis (z: 2500 uT)
 
 	return success;
 }

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl.cpp
@@ -248,6 +248,8 @@ int LIS3MDL::set_range(unsigned range)
 		_range_ga = 16.0f;
 	}
 
+	_px4_mag.set_range(_range_ga);
+
 	/*
 	 * Send the command to set the range
 	 */

--- a/src/drivers/magnetometer/lsm303agr/LSM303AGR.cpp
+++ b/src/drivers/magnetometer/lsm303agr/LSM303AGR.cpp
@@ -70,6 +70,7 @@ LSM303AGR::LSM303AGR(const I2CSPIDriverConfig &config) :
 	_bad_values(perf_alloc(PC_COUNT, MODULE_NAME": bad_val"))
 {
 	_px4_mag.set_scale(1.5f / 1000.f); // 1.5 milligauss/LSB
+	_px4_mag.set_range(49.152f);
 }
 
 LSM303AGR::~LSM303AGR()

--- a/src/drivers/magnetometer/lsm9ds1_mag/LSM9DS1_MAG.cpp
+++ b/src/drivers/magnetometer/lsm9ds1_mag/LSM9DS1_MAG.cpp
@@ -233,6 +233,7 @@ bool LSM9DS1_MAG::Configure()
 
 	// Magnetic FS = ±16 gauss 0.58 mgauss/LSB
 	_px4_mag.set_scale(0.58f / 1000.0f);
+	_px4_mag.set_range(16.f);
 
 	return success;
 }

--- a/src/drivers/magnetometer/memsic/mmc5983ma/mmc5983ma.cpp
+++ b/src/drivers/magnetometer/memsic/mmc5983ma/mmc5983ma.cpp
@@ -41,7 +41,9 @@ MMC5983MA::MMC5983MA(device::Device *interface, const I2CSPIDriverConfig &config
 	_px4_mag(interface->get_device_id(), config.rotation, config.external),
 	_sample_count(perf_alloc(PC_COUNT, "mmc5983ma_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "mmc5983ma_comms_errors"))
-{}
+{
+	_px4_mag.set_range(8.f);
+}
 
 MMC5983MA::~MMC5983MA()
 {

--- a/src/drivers/magnetometer/qmc5883l/QMC5883L.cpp
+++ b/src/drivers/magnetometer/qmc5883l/QMC5883L.cpp
@@ -257,6 +257,7 @@ bool QMC5883L::Configure()
 	}
 
 	_px4_mag.set_scale(1.f / 12000.f); // 12000 LSB/Gauss (Field Range = ±2G)
+	_px4_mag.set_range(2.f);
 
 	return success;
 }

--- a/src/drivers/magnetometer/qmc5883p/QMC5883P.cpp
+++ b/src/drivers/magnetometer/qmc5883p/QMC5883P.cpp
@@ -262,6 +262,7 @@ bool QMC5883P::Configure()
 	}
 
 	_px4_mag.set_scale(1.f / 12000.f); // 12000 LSB/Gauss (Field Range = ±2G)
+	_px4_mag.set_range(2.f);
 
 	return success;
 }

--- a/src/drivers/magnetometer/rm3100/rm3100.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100.cpp
@@ -48,6 +48,7 @@ RM3100::RM3100(device::Device *interface, const I2CSPIDriverConfig &config) :
 {
 	_interface->set_external(config.external);
 	_px4_mag.set_scale(1.f / (RM3100_SENSITIVITY * UTESLA_TO_GAUSS));
+	_px4_mag.set_range(8.f); // +/-800 uT
 }
 
 RM3100::~RM3100()

--- a/src/drivers/magnetometer/rm3100/rm3100.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100.cpp
@@ -48,7 +48,7 @@ RM3100::RM3100(device::Device *interface, const I2CSPIDriverConfig &config) :
 {
 	_interface->set_external(config.external);
 	_px4_mag.set_scale(1.f / (RM3100_SENSITIVITY * UTESLA_TO_GAUSS));
-	_px4_mag.set_range(8.f); // +/-800 uT
+	_px4_mag.set_range(microTesla2Gauss(800.f));
 }
 
 RM3100::~RM3100()

--- a/src/drivers/magnetometer/st/iis2mdc/iis2mdc.cpp
+++ b/src/drivers/magnetometer/st/iis2mdc/iis2mdc.cpp
@@ -67,6 +67,7 @@ int IIS2MDC::init()
 	write_register(IIS2MDC_ADDR_CFG_REG_C, BDU);
 
 	_px4_mag.set_scale(0.0015f); // 1.5 mGauss/LSB (datasheet)
+	_px4_mag.set_range(49.152f);
 
 	// Poll at the 100 Hz ODR on a fixed interval so the rate does not drift with
 	// the time spent reading the sensor.

--- a/src/drivers/magnetometer/vtrantech/vcm1193l/VCM1193L.cpp
+++ b/src/drivers/magnetometer/vtrantech/vcm1193l/VCM1193L.cpp
@@ -250,6 +250,7 @@ bool VCM1193L::Configure()
 	}
 
 	_px4_mag.set_scale(1.f / 3000.f); // 3000 LSB/Gauss (Field Range = ±8G)
+	_px4_mag.set_range(8.f);
 
 	return success;
 }

--- a/src/lib/drivers/magnetometer/PX4Magnetometer.cpp
+++ b/src/lib/drivers/magnetometer/PX4Magnetometer.cpp
@@ -90,6 +90,7 @@ void PX4Magnetometer::update(const hrt_abstime &timestamp_sample, float x, float
 	report.device_id = _device_id;
 	report.is_external = _is_external;
 	report.temperature = _temperature;
+	report.range = _range;
 	report.error_count = _error_count;
 
 	// Apply rotation (before scaling)

--- a/src/lib/drivers/magnetometer/PX4Magnetometer.hpp
+++ b/src/lib/drivers/magnetometer/PX4Magnetometer.hpp
@@ -51,6 +51,7 @@ public:
 	void set_device_type(uint8_t devtype);
 	void set_external(bool external);
 	void set_error_count(uint32_t error_count) { _error_count = error_count; }
+	void set_range(float range) { _range = range; }
 	void set_scale(float scale) { _scale = scale; }
 	void set_temperature(float temperature) { _temperature = temperature; }
 
@@ -68,6 +69,7 @@ private:
 	bool			_is_external{false};
 	bool			_external_forced{false}; // classification set by the driver, do not re-derive from the device id
 
+	float			_range{0.f};
 	float			_scale{1.f};
 	float			_temperature{NAN};
 	uint32_t		_error_count{0};

--- a/src/lib/drivers/magnetometer/PX4Magnetometer.hpp
+++ b/src/lib/drivers/magnetometer/PX4Magnetometer.hpp
@@ -40,6 +40,8 @@
 
 #include <lib/failure_injection/FailureInjection.hpp>
 
+static constexpr float microTesla2Gauss(float micro_tesla) { return micro_tesla * 0.01f; }
+
 class PX4Magnetometer
 {
 public:

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -89,6 +89,7 @@ struct mag_worker_data_t {
 	unsigned int	calibration_points_perside;
 	uint64_t	calibration_interval_perside_us;
 	unsigned int	calibration_counter_total[MAX_MAGS];
+	float		sensor_range[MAX_MAGS];					///< [Gauss] full-scale range, 0 if unknown
 
 	float		*x[MAX_MAGS];
 	float		*y[MAX_MAGS];
@@ -308,6 +309,10 @@ static calibrate_return mag_calibration_worker(detect_orientation_return orienta
 					sensor_mag_s mag;
 
 					while (mag_sub[cur_mag].update(&mag)) {
+						if (mag.range > 0.f) {
+							worker_data->sensor_range[cur_mag] = mag.range;
+						}
+
 						if (worker_data->append_to_existing_calibration) {
 							// keep and update the existing calibration when we are not doing a full 6-axis calibration
 							const Matrix3f &scale = worker_data->calibration[cur_mag].scale();
@@ -480,6 +485,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 		worker_data.y[cur_mag] = nullptr;
 		worker_data.z[cur_mag] = nullptr;
 		worker_data.calibration_counter_total[cur_mag] = 0;
+		worker_data.sensor_range[cur_mag] = 0.f;
 	}
 
 	const unsigned int calibration_points_maxcount = worker_data.calibration_sides * worker_data.calibration_points_perside;
@@ -653,11 +659,15 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 					fail_reason = "negative scale";
 					result = calibrate_return_error;
 
-				} else if (sphere[cur_mag].longerThan(1.3f)) {
-					// maximum measurement range is ~1.9 Ga, the earth field is ~0.6 Ga,
-					// so an offset larger than ~1.3 Ga means the mag will saturate in some directions.
-					fail_reason = "large offsets";
-					result = calibrate_return_error;
+				} else {
+					// offset + worst-case earth field (~0.65 Ga) must fit in the sensor range; 1.3 Ga fallback assumes the historical ~1.9 Ga full-scale parts
+					const float range = worker_data.sensor_range[cur_mag];
+					const float offset_limit = (range > 0.f) ? (range - 0.65f) : 1.3f;
+
+					if (sphere[cur_mag].longerThan(offset_limit)) {
+						fail_reason = "large offsets";
+						result = calibrate_return_error;
+					}
 				}
 
 				const bool enabled = worker_data.calibration[cur_mag].enabled();

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -75,6 +75,9 @@ static constexpr float MAG_SPHERE_RADIUS_DEFAULT = 0.4f;
 static constexpr unsigned int calibration_total_points = 240;	///< The total points per magnetometer
 static constexpr unsigned int calibraton_duration_s = 42; 	///< The total duration the routine is allowed to take
 
+static constexpr float kWorstCaseEarthField = 0.65f;		///< [Gauss] maximum earth field magnitude
+static constexpr float kUnknownRangeFallback = 1.9f;		///< [Gauss] assumed full-scale range when the driver reports none
+
 calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_mask);
 
 /// Data passed to calibration worker routine
@@ -660,9 +663,8 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 					result = calibrate_return_error;
 
 				} else {
-					// offset + worst-case earth field (~0.65 Ga) must fit in the sensor range; 1.3 Ga fallback assumes the historical ~1.9 Ga full-scale parts
 					const float range = worker_data.sensor_range[cur_mag];
-					const float offset_limit = (range > 0.f) ? (range - 0.65f) : 1.3f;
+					const float offset_limit = ((range > 0.f) ? range : kUnknownRangeFallback) - kWorstCaseEarthField;
 
 					if (sphere[cur_mag].longerThan(offset_limit)) {
 						fail_reason = "large offsets";


### PR DESCRIPTION
### Solved Problem
Mag calibration rejects any fit with a hard-iron offset above 1.3 Ga. That limit assumes the ~1.9 Ga full scale of the HMC5883 era (comment dates from 2016). Modern mags measure 5–49 Ga full scale. They fail calibration on offsets they can measure without saturating.

### Solution
Drivers now report their full-scale range in sensor_mag. The calibration limit becomes range minus 0.65 Ga (worst-case earth field). Sensors that report no range (DroneCAN, MAVLink, sim) keep the 1.3 Ga behavior. 


### Ranges used

| Part | Range | Source |
|---|---|---|
| BMM350 | ±2000 µT | [datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmm350-ds001.pdf) |
| BMM150 | ±1300 µT (x/y, min taken) | [datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmm150-ds001.pdf) |
| IST8310 | ±1600 µT (x/y, min taken) | [datasheet](https://www.lcsc.com/datasheet/lcsc_datasheet_2411220643_iSentek-IST8310_C2683055.pdf) |
| IST8308 | ±500 µT | [datasheet](https://assets.isentek.com/public/documents/datasheet/va-lsEs9HD-IST8308_Datasheet_V2.0_Web.pdf) |
| HMC5883L | configured gain (0.88-8.1 Ga) | [datasheet](https://cdn-shop.adafruit.com/datasheets/HMC5883L_3-Axis_Digital_Compass_IC.pdf) |
| LIS3MDL | configured FS (4-16 Ga) | [datasheet](https://www.st.com/resource/en/datasheet/lis3mdl.pdf) |
| QMC5883L | ±2 G (RNG=2G) | [datasheet](https://www.blogs.uni-mainz.de/fb08-physics-halbach-magnets/files/2025/08/QMC5883L-datasheet.pdf) |
| QMC5883P | ±2 G (RNG=2G) | [datasheet](https://www.qstcorp.com/upload/pdf/202202/%EF%BC%88%E5%B7%B2%E4%BC%A0%EF%BC%8913-52-19%20QMC5883P%20Datasheet%20Rev.C%281%29.pdf) |
| RM3100 | ±800 µT | [datasheet](https://www.tri-m.com/products/pni/RM3100-Datasheet.pdf) |
| AK09916 (+ICM20948) | ±4912 µT | [datasheet](https://invensense.tdk.com/wp-content/uploads/2016/06/DS-000189-ICM-20948-v1.3.pdf) |
| AK8963 (+MPU9250) | ±4912 µT | [datasheet](https://download.mikroe.com/documents/datasheets/ak8963c-datasheet.pdf) |
| AK09940A | ±1200 µT | [datasheet](https://www.akm.com/content/dam/documents/products/tri-axis-magnetic-sensor/ak09940a/ak09940a-en-datasheet-myakm.pdf) |
| LSM303AGR | ±49.152 G | [datasheet](https://www.st.com/resource/en/datasheet/lsm303agr.pdf) |
| LSM9DS1 | ±16 G (configured) | [datasheet](https://www.st.com/resource/en/datasheet/lsm9ds1.pdf) |
| IIS2MDC | ±49.152 G | [datasheet](https://www.st.com/resource/en/datasheet/iis2mdc.pdf) |
| MMC5983MA | ±8 G | [datasheet](https://www.memsic.com/Public/Uploads/uploadfile/files/20220119/MMC5983MADatasheetRevA.pdf) |
| VCM1193L | ±8 G | per driver scale comment; no public datasheet |
| LSM303D | configured FS (2-12 Ga) | [datasheet](https://www.st.com/resource/en/datasheet/lsm303d.pdf) |
| FXOS8701CQ | ±1200 µT | [datasheet](https://www.nxp.com/docs/en/data-sheet/FXOS8700CQ.pdf) |
| ADIS16448 | ±1.9 gauss | [datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/adis16448.pdf) |




### Changelog Entry
For release notes:
```
Feature/Bugfix scale mag cal offset limit with sensor full-scale range 
```

### Test coverage
Needs to be tested on HW. 

