### PR TITLE
fix(boards): raise fmu-v6xrt allyes flash region to 8M

### DIFF
--- a/boards/ark/fmu-v6xrt/nuttx-config/scripts/allyes-script.ld
+++ b/boards/ark/fmu-v6xrt/nuttx-config/scripts/allyes-script.ld
@@ -34,7 +34,7 @@
 
 MEMORY
 {
-  flash (rx)  : ORIGIN = 0x30020000, LENGTH = 4M-128K /* We have 64M but we do not want to wait to program it all */
+  flash (rx)  : ORIGIN = 0x30020000, LENGTH = 8M-128K /* We have 64M but we do not want to wait to program it all */
   sram  (rwx) : ORIGIN = 0x20240000, LENGTH = 2M-256k-512k
   itcm  (rwx) : ORIGIN = 0x00000000, LENGTH = 256K   /* TODO FlexRAM partition */
   dtcm  (rwx) : ORIGIN = 0x20000000, LENGTH = 256K

--- a/boards/px4/fmu-v6xrt/nuttx-config/scripts/allyes-script.ld
+++ b/boards/px4/fmu-v6xrt/nuttx-config/scripts/allyes-script.ld
@@ -34,7 +34,7 @@
 
 MEMORY
 {
-  flash (rx)  : ORIGIN = 0x30020000, LENGTH = 6M-128K /* We have 64M but we do not want to wait to program it all */
+  flash (rx)  : ORIGIN = 0x30020000, LENGTH = 8M-128K /* We have 64M but we do not want to wait to program it all */
   sram  (rwx) : ORIGIN = 0x20240000, LENGTH = 2M-256k-512k
   itcm  (rwx) : ORIGIN = 0x00000000, LENGTH = 256K   /* TODO FlexRAM partition */
   dtcm  (rwx) : ORIGIN = 0x20000000, LENGTH = 256K


### PR DESCRIPTION
### Problem

The `ark_fmu-v6xrt_allyes` target overflows its 4M-128K flash region since the NuttX 12.12.0 upgrade grew the image to 99.94% and the next small module change (https://github.com/PX4/PX4-Autopilot/pull/28476) tipped it over. The ARK board was copied from `px4/fmu-v6xrt` before that upgrade raised the px4 `allyes` region to 6M, so the copy kept the old limit.

`allyes` is a CI coverage build that compiles every module and is never flashed. The region length is only an artificial cap on programming time.

### Solution

Set both `allyes` scripts to 8M-128K so they stay identical and leave headroom for the coverage build to keep growing.

Closes: https://github.com/PX4/PX4-Autopilot/issues/28546
