### PR TITLE
fix(land_detector): keep FW landed while waiting for the takeoff status

### DIFF
--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -68,15 +68,27 @@ bool FixedwingLandDetector::_get_landed_state()
 		fixed_wing_runway_control_s fixed_wing_runway_control{};
 		_fixed_wing_runway_control_sub.copy(&fixed_wing_runway_control);
 
+		const bool launch_status_fresh = hrt_elapsed_time(&launch_detection_status.timestamp) < 500_ms;
+		const bool runway_status_fresh = hrt_elapsed_time(&fixed_wing_runway_control.timestamp) < 500_ms;
+
 		// Check if we're in catapult/hand-launch waiting state
-		const bool waiting_for_catapult_launch = hrt_elapsed_time(&launch_detection_status.timestamp) < 500_ms
+		const bool waiting_for_catapult_launch = launch_status_fresh
 				&& launch_detection_status.launch_detection_state == launch_detection_status_s::STATE_WAITING_FOR_LAUNCH;
 
 		// Check if we're in runway takeoff early phase (throttle ramp or clamped to runway)
-		const bool waiting_for_auto_runway_climbout = hrt_elapsed_time(&fixed_wing_runway_control.timestamp) < 500_ms
+		const bool waiting_for_auto_runway_climbout = runway_status_fresh
 				&& fixed_wing_runway_control.runway_takeoff_state < fixed_wing_runway_control_s::STATE_CLIMBOUT;
 
-		if (waiting_for_catapult_launch || waiting_for_auto_runway_climbout) {
+		const bool in_auto_takeoff_mode = (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION)
+						  || (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF);
+
+		// Bridge the gap between arming and the takeoff status being published.
+		const bool waiting_for_takeoff_status = in_auto_takeoff_mode
+							&& !launch_status_fresh && !runway_status_fresh
+							&& (_vehicle_status.takeoff_time == 0)
+							&& (hrt_elapsed_time(&_vehicle_status.armed_time) < 1_s);
+
+		if (waiting_for_catapult_launch || waiting_for_auto_runway_climbout || waiting_for_takeoff_status) {
 			return true;
 		}
 	}


### PR DESCRIPTION
### Solved Problem
The land detector holds a fixed-wing vehicle at `landed` until the takeoff has actually started. That clamp reads `launch_detection_status` for catapult and hand launches, and `fixed_wing_runway_control` for runway takeoffs. Both are published only from `control_auto_takeoff()`, so neither exists until the mode manager is in an auto takeoff
mode.

On a mission takeoff, arming comes before the navigator publishes the takeoff item, so there is a gap with no clamp. `landed` then can be false and the takeoff item is skipped (for example when taking off from a moving platform, or into headwind).

### Solution

Treat as  "waiting for takeoff status" when:
-  the vehicle is has been armed for less than 1s 
-  still landed (no takeoff time)
-  in `AUTO_MISSION` or `AUTO_TAKEOFF`. 
- no launch/runway message arrived yet 

### Changelog Entry
For release notes:
```
Feature/Bugfix keep FW landed while waiting for the takeoff
```

### Alternatives 
We could add back the hysteresis in the other direction as well (landed -> takeoff), but I feel that's not ideal either.  

### Test coverage

Tested in SITL 

