### PR TITLE
fix(paa3905): rate-limit challenging surface warning

### DIFF
--- a/src/drivers/optical_flow/paa3905/PAA3905.cpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.cpp
@@ -315,7 +315,11 @@ void PAA3905::RunImpl()
 				}
 
 				if (buffer.data.Motion & Motion_Bit::ChallengingSurface) {
-					PX4_WARN("challenging surface detected");
+					// Bit stays asserted for the whole time over a bad surface
+					if (hrt_elapsed_time(&_last_challenging_surface_warning) > 1_s) {
+						PX4_WARN("challenging surface detected");
+						_last_challenging_surface_warning = hrt_absolute_time();
+					}
 				}
 
 				// publish sensor_optical_flow

--- a/src/drivers/optical_flow/paa3905/PAA3905.hpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.hpp
@@ -115,6 +115,7 @@ private:
 	hrt_abstime _reset_timestamp{0};
 	hrt_abstime _last_publish{0};
 	hrt_abstime _last_motion{0};
+	hrt_abstime _last_challenging_surface_warning{0};
 	hrt_abstime _timestamp_sample_last{0};
 
 	int16_t _delta_x_raw_prev{0};


### PR DESCRIPTION
## Summary
Rate-limit the PAA3905 challenging-surface console warning to once per second.

## Problem
The sensor keeps the ChallengingSurface bit asserted for the whole time over a bad surface, so the driver logs `PX4_WARN` on every run-loop iteration.

## Solution
Warn at most once per second.