### PR TITLE
fix(commander): build mag calibration only with CONFIG_SENSORS_VEHICLE_MAGNETOMETER

### DIFF
--- a/src/modules/commander/CMakeLists.txt
+++ b/src/modules/commander/CMakeLists.txt
@@ -38,11 +38,18 @@ add_subdirectory(HealthAndArmingChecks)
 add_subdirectory(ModeUtil)
 add_subdirectory(MulticopterThrowLaunch)
 
+set(SRCS)
+
+if(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
+	list(APPEND SRCS mag_calibration.cpp)
+endif()
+
 px4_add_module(
 	MODULE modules__commander
 	MAIN commander
 	COMPILE_FLAGS
 	SRCS
+		${SRCS}
 		accelerometer_calibration.cpp
 		airspeed_calibration.cpp
 		baro_calibration.cpp
@@ -56,7 +63,6 @@ px4_add_module(
 		ModeManagement.cpp
 		level_calibration.cpp
 		lm_fit.cpp
-		mag_calibration.cpp
 		rc_calibration.cpp
 		Safety.cpp
 		UserModeIntention.cpp
@@ -79,5 +85,7 @@ px4_add_module(
         atmosphere
 	)
 
-px4_add_unit_gtest(SRC mag_calibration_test.cpp LINKLIBS modules__commander)
+if(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
+	px4_add_unit_gtest(SRC mag_calibration_test.cpp LINKLIBS modules__commander)
+endif()
 px4_add_functional_gtest(SRC ModeManagementTest.cpp LINKLIBS modules__commander)

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1459,9 +1459,13 @@ Commander::handle_command(const vehicle_command_s &cmd)
 
 				} else if ((int)(cmd.param2) == 1) {
 					/* magnetometer calibration */
+#if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
 					answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED);
 					_vehicle_status.calibration_enabled = true;
 					_worker_thread.startTask(WorkerThread::Request::MagCalibration);
+#else
+					answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED);
+#endif
 
 				} else if ((int)(cmd.param3) == 1) {
 					/* baro calibration */
@@ -1564,6 +1568,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 					     "Calibration denied: not supported in SIH mode");
 
 			} else {
+#if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
 				answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED);
 				// parameter 1: Heading   (degrees)
 				// parameter 3: Latitude  (degrees)
@@ -1586,6 +1591,9 @@ Commander::handle_command(const vehicle_command_s &cmd)
 				_vehicle_status.calibration_enabled = true;
 				_worker_thread.setMagQuickData(heading_radians, latitude, longitude);
 				_worker_thread.startTask(WorkerThread::Request::MagCalibrationQuick);
+#else
+				answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED);
+#endif
 			}
 
 			return true;

--- a/src/modules/commander/worker_thread.cpp
+++ b/src/modules/commander/worker_thread.cpp
@@ -39,7 +39,9 @@
 #include "esc_calibration.h"
 #include "gyro_calibration.h"
 #include "level_calibration.h"
+#if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
 #include "mag_calibration.h"
+#endif
 #include "rc_calibration.h"
 
 #include <px4_platform_common/events.h>
@@ -111,9 +113,22 @@ void WorkerThread::threadEntry()
 		_ret_value = do_gyro_calibration(&_mavlink_log_pub);
 		break;
 
+#if defined(CONFIG_SENSORS_VEHICLE_MAGNETOMETER)
+
 	case Request::MagCalibration:
 		_ret_value = do_mag_calibration(&_mavlink_log_pub);
 		break;
+
+	case Request::MagCalibrationQuick:
+		_ret_value = do_mag_calibration_quick(&_mavlink_log_pub, _heading_radians, _latitude, _longitude);
+		break;
+#else
+
+	case Request::MagCalibration:
+	case Request::MagCalibrationQuick:
+		_ret_value = -1;
+		break;
+#endif
 
 	case Request::RCTrimCalibration:
 		_ret_value = do_trim_calibration(&_mavlink_log_pub);
@@ -137,10 +152,6 @@ void WorkerThread::threadEntry()
 
 	case Request::ESCCalibration:
 		_ret_value = do_esc_calibration(&_mavlink_log_pub);
-		break;
-
-	case Request::MagCalibrationQuick:
-		_ret_value = do_mag_calibration_quick(&_mavlink_log_pub, _heading_radians, _latitude, _longitude);
 		break;
 
 	case Request::BaroCalibration:


### PR DESCRIPTION
## Summary
Build commander's magnetometer calibration only when `CONFIG_SENSORS_VEHICLE_MAGNETOMETER` is set.

## Problem
Boards that compile the magnetometer pipeline out (`holybro_kakutef7`, which also sets `SYS_HAS_MAG 0`) still link mag calibration, its LM fit and the world-magnetic-model lookup behind it. On kakutef7 that is 18 KB of code that can never run, on a board that sits at 950228 of 950272 flash bytes on main. Any growth anywhere fails the `misc-stm32f7` job, and the flash-analysis bot only reports v5x/v6x so PRs do not see it coming.

## Solution
`mag_calibration.cpp` and its gtest are compiled only with the option set. The two worker-thread requests and the `PREFLIGHT_CALIBRATION` and `FIXED_MAG_CAL_YAW` handlers answer `UNSUPPORTED` without it. kakutef7 goes from 950228 to 932084 bytes (98.09 %), 18144 bytes freed.
