### PR TITLE
docs(logger): clarify logger off command behavior

### DIFF
--- a/docs/en/dev_log/logging.md
+++ b/docs/en/dev_log/logging.md
@@ -16,7 +16,7 @@ A new log file is created for each arming session on the SD card.
 To display the current state, use `logger status` on the console.
 If you want to start logging immediately, use `logger on`.
 This overrides the arming state, as if the system was armed.
-`logger off` undoes this.
+`logger off` removes this override, returning logging control to the behavior defined by `SDLOG_MODE`.
 
 If logging stops due to a write error, or reaching the [maximum file size](#file-size-limitations), PX4 will automatically restart logging in a new file.
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -2543,7 +2543,7 @@ $ logger on
 					 "Poll on a topic instead of running with fixed rate (Log rate and topic intervals are ignored if this is set)", true);
 	PRINT_MODULE_USAGE_PARAM_FLOAT('c', 1.0, 0.2, 2.0, "Log rate factor (higher is faster)", true);
 	PRINT_MODULE_USAGE_COMMAND_DESCR("on", "start logging now, override arming (logger must be running)");
-	PRINT_MODULE_USAGE_COMMAND_DESCR("off", "stop logging now, override arming (logger must be running)");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("off", "remove manual override; logging follows SDLOG_MODE (logger must be running)");
 #ifdef __PX4_NUTTX
 	PRINT_MODULE_USAGE_COMMAND_DESCR("trigger_watchdog", "manually trigger the watchdog now");
 #endif


### PR DESCRIPTION
### Solved Problem

The `logger off` command _help_ states that it stops logging immediately. However, the implemented and documented command semantics are that:

- `logger on` enables a manual override that starts logging as if the vehicle were armed.
- `logger off` removes that override and returns logging control to the behavior defined by `SDLOG_MODE`.

Consequently, logging can continue after logger off when required by the configured logging mode. This is intended behavior, but the current command _help_ incorrectly describes it as an unconditional stop operation.

### Solution

Clarify the `logger off` command help and logging guide so they accurately describe the existing behavior. This is intentionally a documentation correction. It does not change logger off into an unconditional stop command.

### Changelog Entry

Documentation: Clarify the behavior of the `logger off` command
New parameter: None
Documentation: Updated logger command _help_ and logging guide

### Alternatives

Change `logger off` to force logging to stop irrespective of `SDLOG_MODE`.
That would be a behavioral and interface change rather than a documentation fix. While this can also be implemented, such a change should be considered separately through a dedicated implementation and design discussion.

### Test coverage

- git diff --check
- Tools/astyle/check_code_style.sh src/modules/logger/logger.cpp
- Documentation-only change; no runtime behavior is modified.

### Context

The existing implementation stores a Boolean manual force-on override. `logger on` sets it, while `logger off` clears it. Once cleared, the automatic state selected by `SDLOG_MODE` determines whether logging continues.

This PR aligns the logger _help_ with those established semantics and does not alter logger behavior.