### PR TITLE
fix(crsf_rc): reschedule failed UART setup

### DIFF
--- a/src/drivers/rc/crsf_rc/CMakeLists.txt
+++ b/src/drivers/rc/crsf_rc/CMakeLists.txt
@@ -37,6 +37,7 @@ px4_add_module(
 	SRCS
 		CrsfRc.cpp
 		CrsfRc.hpp
+		CrsfUartSetup.hpp
 		QueueBuffer.cpp
 		QueueBuffer.hpp
 		CrsfParser.cpp
@@ -62,4 +63,8 @@ px4_add_unit_gtest(
 		CrsfParser.cpp
 		QueueBuffer.cpp
 		Crc8.cpp
+	)
+
+px4_add_unit_gtest(
+	SRC CrsfUartSetupTest.cpp
 	)

--- a/src/drivers/rc/crsf_rc/CrsfRc.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfRc.cpp
@@ -34,6 +34,7 @@
 #include "CrsfRc.hpp"
 #include "CrsfParser.hpp"
 #include "Crc8.hpp"
+#include "CrsfUartSetup.hpp"
 
 #include <fcntl.h>
 
@@ -154,49 +155,39 @@ void CrsfRc::Run()
 		return;
 	}
 
+	// Schedule setup retries so this callback yields the work queue between attempts.
 	if (_uart == nullptr) {
-		// Create the UART port instance
 		_uart = new Serial(_device);
 
 		if (_uart == nullptr) {
 			PX4_ERR("Error creating serial device %s", _device);
-			px4_sleep(1);
+			ScheduleDelayed(1_s);
 			return;
 		}
 	}
 
-	if (! _uart->isOpen()) {
-		// Configure the desired baudrate if one was specified by the user.
-		// Otherwise the default baudrate will be used.
-		if (! _uart->setBaudrate(CRSF_BAUDRATE)) {
-			PX4_ERR("Error setting baudrate to %u on %s", CRSF_BAUDRATE, _device);
-			px4_sleep(1);
-			return;
-		}
+	const bool singlewire = board_rc_singlewire(_device);
+	const CrsfUartSetupResult setup_result = CrsfUartSetup(*_uart, CRSF_BAUDRATE, board_rc_swap_rxtx(_device), singlewire);
 
-		// Open the UART. If this is successful then the UART is ready to use.
-		if (! _uart->open()) {
-			PX4_ERR("Error opening serial device  %s", _device);
-			px4_sleep(1);
-			return;
-		}
+	if (setup_result == CrsfUartSetupResult::BaudrateError) {
+		PX4_ERR("Error setting baudrate to %u on %s", CRSF_BAUDRATE, _device);
+		ScheduleDelayed(1_s);
+		return;
 
-		if (board_rc_swap_rxtx(_device)) {
-			_uart->setSwapRxTxMode();
-		}
+	} else if (setup_result == CrsfUartSetupResult::OpenError) {
+		PX4_ERR("Error opening serial device  %s", _device);
+		ScheduleDelayed(1_s);
+		return;
+	}
 
-		if (board_rc_singlewire(_device)) {
-			_is_singlewire = true;
-			_uart->setSingleWireMode();
-		}
+	if (setup_result == CrsfUartSetupResult::Opened) {
+		_is_singlewire = singlewire;
 
 		PX4_INFO("Crsf serial opened sucessfully");
 
 		if (_is_singlewire) {
 			PX4_INFO("Crsf serial is single wire. Telemetry disabled");
 		}
-
-		_uart->flush();
 
 		Crc8Init(0xd5);
 

--- a/src/drivers/rc/crsf_rc/CrsfUartSetup.hpp
+++ b/src/drivers/rc/crsf_rc/CrsfUartSetup.hpp
@@ -65,6 +65,9 @@ CrsfUartSetupResult CrsfUartSetup(SerialType &uart, uint32_t baudrate, bool swap
 	}
 
 	if (!uart.open()) {
+		// open() may acquire a descriptor before configuration fails. Ensure a retry
+		// starts from a clean state instead of overwriting and leaking that descriptor.
+		(void)uart.close();
 		return CrsfUartSetupResult::OpenError;
 	}
 

--- a/src/drivers/rc/crsf_rc/CrsfUartSetup.hpp
+++ b/src/drivers/rc/crsf_rc/CrsfUartSetup.hpp
@@ -1,0 +1,82 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+enum class CrsfUartSetupResult {
+	AlreadyOpen,
+	Opened,
+	BaudrateError,
+	OpenError,
+};
+
+/**
+ * @brief Configure and open the CRSF UART when needed.
+ *
+ * Keeping setup independent of the scheduled worker makes each outcome
+ * testable without running the work queue.
+ *
+ * @tparam SerialType Serial implementation providing the UART setup operations.
+ * @param[in,out] uart Serial device to prepare.
+ * @param[in] baudrate Baud rate to apply [bit/s].
+ * @param[in] swap_rxtx Enable RX/TX pin swapping after the port opens.
+ * @param[in] singlewire Enable single-wire mode after the port opens.
+ * @return Setup outcome; an already-open UART is left unchanged.
+ */
+template<typename SerialType>
+CrsfUartSetupResult CrsfUartSetup(SerialType &uart, uint32_t baudrate, bool swap_rxtx, bool singlewire)
+{
+	if (uart.isOpen()) {
+		return CrsfUartSetupResult::AlreadyOpen;
+	}
+
+	if (!uart.setBaudrate(baudrate)) {
+		return CrsfUartSetupResult::BaudrateError;
+	}
+
+	if (!uart.open()) {
+		return CrsfUartSetupResult::OpenError;
+	}
+
+	if (swap_rxtx) {
+		uart.setSwapRxTxMode();
+	}
+
+	if (singlewire) {
+		uart.setSingleWireMode();
+	}
+
+	// Start CRSF processing with empty buffers under the finalized port configuration.
+	uart.flush();
+	return CrsfUartSetupResult::Opened;
+}

--- a/src/drivers/rc/crsf_rc/CrsfUartSetupTest.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfUartSetupTest.cpp
@@ -42,17 +42,20 @@ class FakeSerial
 public:
 	bool isOpen() const { return is_open; }
 	bool setBaudrate(uint32_t value) { baudrate = value; ++set_baudrate_calls; return set_baudrate_result; }
-	bool open() { ++open_calls; is_open = open_result; return open_result; }
+	bool open() { ++open_calls; resource_acquired = true; is_open = open_result; return open_result; }
+	bool close() { ++close_calls; resource_acquired = false; is_open = false; return true; }
 	void setSwapRxTxMode() { ++swap_calls; }
 	void setSingleWireMode() { ++singlewire_calls; }
 	void flush() { ++flush_calls; }
 
 	bool is_open{false};
+	bool resource_acquired{false};
 	bool set_baudrate_result{true};
 	bool open_result{true};
 	uint32_t baudrate{0};
 	int set_baudrate_calls{0};
 	int open_calls{0};
+	int close_calls{0};
 	int swap_calls{0};
 	int singlewire_calls{0};
 	int flush_calls{0};
@@ -83,6 +86,9 @@ TEST(CrsfUartSetupTest, ReportsOpenFailureWithoutApplyingPortModes)
 	FakeSerial serial;
 	serial.open_result = false;
 	EXPECT_EQ(CrsfUartSetup(serial, 420000, true, true), CrsfUartSetupResult::OpenError);
+	EXPECT_EQ(serial.close_calls, 1);
+	EXPECT_FALSE(serial.resource_acquired);
+	EXPECT_FALSE(serial.is_open);
 	EXPECT_EQ(serial.swap_calls, 0);
 	EXPECT_EQ(serial.singlewire_calls, 0);
 	EXPECT_EQ(serial.flush_calls, 0);

--- a/src/drivers/rc/crsf_rc/CrsfUartSetupTest.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfUartSetupTest.cpp
@@ -1,0 +1,101 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "CrsfUartSetup.hpp"
+
+namespace
+{
+
+// Records setup effects so tests can verify which operations follow each outcome.
+class FakeSerial
+{
+public:
+	bool isOpen() const { return is_open; }
+	bool setBaudrate(uint32_t value) { baudrate = value; ++set_baudrate_calls; return set_baudrate_result; }
+	bool open() { ++open_calls; is_open = open_result; return open_result; }
+	void setSwapRxTxMode() { ++swap_calls; }
+	void setSingleWireMode() { ++singlewire_calls; }
+	void flush() { ++flush_calls; }
+
+	bool is_open{false};
+	bool set_baudrate_result{true};
+	bool open_result{true};
+	uint32_t baudrate{0};
+	int set_baudrate_calls{0};
+	int open_calls{0};
+	int swap_calls{0};
+	int singlewire_calls{0};
+	int flush_calls{0};
+};
+
+TEST(CrsfUartSetupTest, LeavesAnOpenPortAlone)
+{
+	FakeSerial serial;
+	serial.is_open = true;
+	EXPECT_EQ(CrsfUartSetup(serial, 420000, true, true), CrsfUartSetupResult::AlreadyOpen);
+	EXPECT_EQ(serial.set_baudrate_calls, 0);
+	EXPECT_EQ(serial.open_calls, 0);
+	EXPECT_EQ(serial.flush_calls, 0);
+}
+
+TEST(CrsfUartSetupTest, ReportsBaudrateFailureWithoutTryingToOpen)
+{
+	FakeSerial serial;
+	serial.set_baudrate_result = false;
+	EXPECT_EQ(CrsfUartSetup(serial, 420000, false, false), CrsfUartSetupResult::BaudrateError);
+	EXPECT_EQ(serial.baudrate, 420000u);
+	EXPECT_EQ(serial.open_calls, 0);
+	EXPECT_EQ(serial.flush_calls, 0);
+}
+
+TEST(CrsfUartSetupTest, ReportsOpenFailureWithoutApplyingPortModes)
+{
+	FakeSerial serial;
+	serial.open_result = false;
+	EXPECT_EQ(CrsfUartSetup(serial, 420000, true, true), CrsfUartSetupResult::OpenError);
+	EXPECT_EQ(serial.swap_calls, 0);
+	EXPECT_EQ(serial.singlewire_calls, 0);
+	EXPECT_EQ(serial.flush_calls, 0);
+}
+
+TEST(CrsfUartSetupTest, ConfiguresAndFlushesAnOpenedPort)
+{
+	FakeSerial serial;
+	EXPECT_EQ(CrsfUartSetup(serial, 420000, true, true), CrsfUartSetupResult::Opened);
+	EXPECT_TRUE(serial.is_open);
+	EXPECT_EQ(serial.swap_calls, 1);
+	EXPECT_EQ(serial.singlewire_calls, 1);
+	EXPECT_EQ(serial.flush_calls, 1);
+}
+
+} // namespace


### PR DESCRIPTION
## Context

`CrsfRc::task_spawn()` initially schedules `Run()` once. After UART setup
succeeds, each invocation schedules the next run at the bottom of `Run()`.
The setup-failure paths return before reaching that scheduling point.
`px4_sleep()` delays the current invocation, but it does not arrange another
invocation after the callback returns.

The `CrsfRc` constructor passes the device name to `serial_port_to_wq()`.
Recognized serial-port names select separately named per-port work queues,
which are created on demand. Unrecognized device names share the `ttyUnknown`
queue. This mapping selects the execution context; it does not reserve the UART
or guarantee exclusive ownership. Serial configuration is intended to give a
UART one owner, but that ownership is not enforced by the work-queue mapping.

Using `ScheduleDelayed()` for a retry both arranges the next invocation and
returns control to the worker between attempts. Releasing the worker is useful
if another item maps to the same queue, particularly through `ttyUnknown`, but
the missing retry is the correctness issue fixed here.

- [`docs/en/concept/architecture.md`](https://github.com/PX4/PX4-Autopilot/blob/main/docs/en/concept/architecture.md#runtime-environment)
  describes the work-queue runtime contract.
- [`ScheduledWorkItem.hpp`](https://github.com/PX4/PX4-Autopilot/blob/main/platforms/common/include/px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp)
  defines the delayed and periodic scheduling API.
- [`WorkQueueManager.cpp`](https://github.com/PX4/PX4-Autopilot/blob/main/platforms/common/px4_work_queue/WorkQueueManager.cpp)
  implements `serial_port_to_wq()` and its `ttyUnknown` fallback.
- [`rc.serial_port.jinja`](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/serial/rc.serial_port.jinja)
  implements the generated serial-port conflict guard.

## Problem

When CRSF serial-port allocation, baud-rate setup, or opening failed, `Run()`
slept and then returned before its normal reschedule. The driver remained
registered but did not run again, so a transient UART setup failure could not
recover without restarting the module.

An open attempt can also acquire a file descriptor before later configuration
fails. Repeating that failed attempt without cleanup can overwrite and leak the
descriptor.

## Change

- Replace each in-callback setup sleep with `ScheduleDelayed(1_s)` and return.
- Close the UART after a failed open attempt so the retry starts cleanly.
- Extract the UART setup operation behind a small testable helper.
- Add fake-serial coverage for setup outcomes and partial-open cleanup.
- Document the one-shot startup scheduling invariant and serial work-queue
  selection directly in `CrsfRc.cpp`.

## Testing

- `unit-CrsfUartSetup`: 4/4 tests passed.
- The tests also passed in a UBSan build.
- `drivers__rc__crsf_rc` built and linked under `px4_sitl_test`.
- AStyle 3.1 accepted the changed source and test files.

## Scope

This PR changes only UART setup and retry handling. It does not change
work-queue mapping or enforce UART ownership, and it leaves parser, queue,
telemetry, MSP VTX, and injected-command behavior to separate changes.
