### PR TITLE
docs(maintainers): promote Jonas Perolini to Navigator code owner

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -26,6 +26,7 @@ See [the documentation on Maintainers](https://docs.px4.io/main/en/contribute/ma
 | Balduin Dettling | VTOL | [@mbjd](https://github.com/mbjd) | m_balduin_jd |
 | Mahima Yoga | Fixed-Wing | [@mahima-yoga](https://github.com/mahima-yoga) | myoga_78681 |
 | Alexander Lerach | RTOS / Drivers | [@alexcekay](https://github.com/alexcekay) | alexcekay | <a-lerach@live.de>
+| Jonas Perolini | Navigator | [@JonasPerolini](https://github.com/JonasPerolini) | jonasperolini | <jonas.perolini@rigi.tech>
 
 
 **Reviewers**
@@ -35,7 +36,6 @@ Reviewers help maintain PX4 across the project without ownership of a specific c
 | Name | GitHub | Chat | email
 |------|--------|------|----------------------
 | Onur Ozkan | [@onur-ozkan](https://github.com/onur-ozkan) | onur_ozkan0126 | <onur@orkavian.com>
-| Jonas Perolini | [@JonasPerolini](https://github.com/JonasPerolini) | jonasperolini | <jonas.perolini@rigi.tech>
 
 
 **Documentation Maintainers**


### PR DESCRIPTION
## Summary

Promote [@JonasPerolini](https://github.com/JonasPerolini) from Reviewer to Code Owner for Navigator. He has been the de facto owner of missions, RTL, detect-and-avoid, and takeoff/landing since being added as a Reviewer in #27435.

## Problem

Navigator has no Code Owner. Jonas's merged and open work is concentrated there: mission route cache ([#27707](https://github.com/PX4/PX4-Autopilot/pull/27707)), RTL ([#27804](https://github.com/PX4/PX4-Autopilot/pull/27804), [#27004](https://github.com/PX4/PX4-Autopilot/pull/27004), [#26993](https://github.com/PX4/PX4-Autopilot/pull/26993)), ASTM F3442 detect-and-avoid ([#26815](https://github.com/PX4/PX4-Autopilot/pull/26815)), vision target estimation ([#23726](https://github.com/PX4/PX4-Autopilot/pull/23726)), and open follow-ons for precision takeoff ([#28552](https://github.com/PX4/PX4-Autopilot/pull/28552)) and mission route planning ([#28248](https://github.com/PX4/PX4-Autopilot/pull/28248), [#27687](https://github.com/PX4/PX4-Autopilot/pull/27687)).

## Solution

Move him from the Reviewers table to Code Owners with sector Navigator. There is no existing owner of that component; this PR is the maintainer-team vote.