### PR TITLE
docs(maintainers): retire inactive owners and set Architecture

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,19 +10,16 @@ See [the documentation on Maintainers](https://docs.px4.io/main/en/contribute/ma
 | Name                    | Sector | GitHub | Chat | email
 |-------------------------|--------|--------|------|----------------
 | Lorenz Meier | Founder | [@LorenzMeier](https://github.com/LorenzMeier) |  | <lorenz@px4.io>
-| Daniel Agar | Architecture | [@dagar](https://github.com/dagar) | daniel_agar | <daniel@agar.ca>
 | Beat Küng | Architecture | [@bkueng](https://github.com/bkueng) | beatkueng | <beat-kueng@gmx.net>
+| Jacob Dahl | Architecture | [@dakejahl](https://github.com/dakejahl) | dakejahl | <dahl.jakejacob@gmail.com>
 | Ramón Roche | CI / Testing | [@mrpollo](https://github.com/mrpollo) | rroche | <rroche@linuxfoundation.org>
 | Mathieu Bresciani | State Estimation | [@bresch](https://github.com/bresch) | mbresch |
-| Paul Riseborough | State Estimation | [@priseborough](https://github.com/priseborough) |  |
-| David Sidrane | RTOS / NuttX | [@davids5](https://github.com/davids5) | david_s5 | <David.Sidrane@Nscdg.com>
 | Jayoung Lim | Simulation | [@Jaeyoung-Lim](https://github.com/Jaeyoung-Lim) | jaeyounglim. | <jalim@ethz.ch>
 | Beniamino Pozzan | ROS 2 | [@beniaminopozzan](https://github.com/beniaminopozzan) | beniaminopozzan | <beniamino.pozzan@gmail.com>
 | Matthias Grob | Multirotor | [@MaEtUgR](https://github.com/MaEtUgR) | maetugr |
 | Silvan Fuhrer | Fixed-Wing / VTOL | [@sfuhrer](https://github.com/sfuhrer) | sfuhrer |
 | Christian Friedrich | Rover | [@chfriedrich98](https://github.com/chfriedrich98) | christian982564 |
 | Pedro Roque | Spacecraft | [@Pedro-Roque](https://github.com/Pedro-Roque) | .pedroroque | <roque@caltech.edu>
-| Jacob Dahl | Simulation | [@dakejahl](https://github.com/dakejahl) | dakejahl | <dahl.jakejacob@gmail.com>
 | Balduin Dettling | VTOL | [@mbjd](https://github.com/mbjd) | m_balduin_jd |
 | Mahima Yoga | Fixed-Wing | [@mahima-yoga](https://github.com/mahima-yoga) | myoga_78681 |
 | Alexander Lerach | RTOS / Drivers | [@alexcekay](https://github.com/alexcekay) | alexcekay | <a-lerach@live.de>
@@ -49,10 +46,11 @@ Reviewers help maintain PX4 across the project without ownership of a specific c
 | Name | GitHub | Chat | email
 |------|--------|------|----------------------
 | Ramón Roche | [@mrpollo](https://github.com/mrpollo) | rroche | <rroche@linuxfoundation.org>
-| Daniel Agar | [@dagar](https://github.com/dagar) | daniel_agar | <daniel@agar.ca>
 
 **Retired Maintainers**
 
 | Name | GitHub | Chat | email
 |------|--------|------|----------------------
-|  |  |  |
+| Daniel Agar | [@dagar](https://github.com/dagar) | daniel_agar | <daniel@agar.ca>
+| Paul Riseborough | [@priseborough](https://github.com/priseborough) |  |
+| David Sidrane | [@davids5](https://github.com/davids5) | david_s5 | <David.Sidrane@Nscdg.com>


### PR DESCRIPTION
## Summary
Retire Daniel Agar, Paul Riseborough, and David Sidrane. Move Jacob Dahl from Simulation to Architecture.

## Problem
Those three no longer work on the project. Architecture is vacant in practice; Jacob has been reviewing and merging across the tree.

## Solution
Roster update only. Jacob sits next to Beat as Architecture. Simulation stays with Jaeyoung. Daniel also comes off Release Managers.