### PR TITLE
feat(security): define security scope

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -51,6 +51,14 @@ Reviewers help maintain PX4 across the project without ownership of a specific c
 | Ramón Roche | [@mrpollo](https://github.com/mrpollo) | rroche | <rroche@linuxfoundation.org>
 | Daniel Agar | [@dagar](https://github.com/dagar) | daniel_agar | <daniel@agar.ca>
 
+**Security**
+
+Triage incoming security reports and coordinate fixes, as described in [SECURITY.md](SECURITY.md).
+
+| Name | GitHub | Chat | email
+|------|--------|------|----------------------
+| Julian Oes | [@julianoes](https://github.com/julianoes) | julianoes | <julian@oes.ch>
+
 **Retired Maintainers**
 
 | Name | GitHub | Chat | email

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,7 @@ At the bottom of the form, click **Submit report**.
 3. **Fix**: The fix is developed as a normal pull request against `main`, in the open. See [How Fixes Are Developed](#how-fixes-are-developed).
 4. **Release**: The fix is public once the pull request is merged. Where it applies to a supported release branch it is backported, and it appears in the release notes. If a report warrants a published advisory or a CVE, we publish it through GitHub and credit the reporter unless they request anonymity.
 
-If you do not receive acknowledgment within 7 days, please follow up by emailing the [release managers](MAINTAINERS.md).
+If you do not receive acknowledgment within 7 days, please follow up by emailing the security maintainers or the release managers listed in [MAINTAINERS.md](MAINTAINERS.md).
 
 ## How Fixes Are Developed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,9 +29,25 @@ At the bottom of the form, click **Submit report**.
 
 1. **Acknowledgment**: The maintainer team will acknowledge your report within **7 days**.
 2. **Triage**: We will assess severity and impact and communicate next steps.
-3. **Disclosure**: We coordinate disclosure with the reporter. We follow responsible disclosure practices and will credit reporters in the advisory unless they request anonymity.
+3. **Fix**: The fix is developed as a normal pull request against `main`, in the open. See [How Fixes Are Developed](#how-fixes-are-developed).
+4. **Release**: The fix is public once the pull request is merged. Where it applies to a supported release branch it is backported, and it appears in the release notes. If a report warrants a published advisory or a CVE, we publish it through GitHub and credit the reporter unless they request anonymity.
 
 If you do not receive acknowledgment within 7 days, please follow up by emailing the [release managers](MAINTAINERS.md).
+
+## How Fixes Are Developed
+
+Security fixes are developed as ordinary public pull requests. We do not use
+private forks or embargoed branches.
+
+This is a deliberate choice because downstream users do not update quickly enough for a coordinated release date to protect them, and many are not tracking upstream closely at all.
+Development in a private fork means fewer reviewers and no CI checks, which can cause issues once merged.
+
+The pull request makes the existence of the bug public, and that is expected.
+Keep the reproducer out of it: it works against vehicles in the field until the fix has shipped and been adopted. If you reported through the Security tab, the reproducer is already in the advisory and maintainers have it, so there is nothing further to send.
+Describe the demonstrated impact in the pull request and leave it at that.
+
+If you are reporting a bug you cannot fix yourself, report it privately first, through the process above, and maintainers decide when it moves to a public pull request.
+The exception is [AI-Assisted Discovery](#ai-assisted-discovery), which goes public from the start.
 
 ## AI-Assisted Discovery
 
@@ -41,17 +57,14 @@ on AI-assisted bug discovery.
 If you used AI assistance to identify a bug, treat it as public. You may have
 good reasons to believe it is not, but both the kernel security team and PX4
 maintainers have seen bugs found this way surface across multiple researchers
-at the same time, often on the same day. Instead of filing a private advisory,
-open a pull request with a fix. If you cannot submit a fix yourself, first
-search the [open pull requests](https://github.com/PX4/PX4-Autopilot/pulls)
+at the same time, often on the same day. So skip the private advisory and go
+straight to a pull request with a fix. If you cannot submit a fix yourself,
+first search the [open pull requests](https://github.com/PX4/PX4-Autopilot/pulls)
 for one that already addresses it; only if nothing exists, open an
 [issue](https://github.com/PX4/PX4-Autopilot/issues/new/choose).
 
-Your pull request makes the bug public, and that is expected. The reproducer
-is different: never post it publicly, it works against vehicles in the field
-until the fix ships. Describe the demonstrated impact in the pull request,
-state that a reproducer is available, and maintainers will ask for it
-privately if they need it.
+The rules on reproducers in [How Fixes Are Developed](#how-fixes-are-developed)
+apply here too: the pull request is public, the reproducer is not.
 
 ### Responsible Use of AI to Find Bugs
 

--- a/SECURITY_SCOPE.md
+++ b/SECURITY_SCOPE.md
@@ -1,0 +1,160 @@
+# PX4 Security Scope
+
+This document says where PX4's security boundary sits, so a reporter can tell before filing whether a finding is a vulnerability, and a maintainer can say why it is or isn't.
+
+It is not a threat model.
+It does not enumerate threats, rate risks, or prescribe mitigations.
+It describes the boundary the code implements today.
+
+To use it: find your deployment under [Configurations](#configurations), then check the finding against [Always in scope](#always-in-scope) and [Out of scope](#out-of-scope).
+Those two lists cover the recurring cases, not every case.
+A finding that fits none of them is a judgement call, and maintainers make it on the report.
+
+Report through the GitHub Security tab as described in [SECURITY.md](SECURITY.md), which also lists the supported branches.
+
+## What PX4 protects
+
+PX4 protects one thing: who gets to fly the aircraft, and who gets to make it stop.
+
+Everything else matters because of what it leads to, not in itself.
+Logs, parameters and telemetry are worth protecting because of what someone can do with them next.
+Reading a flight log is a far smaller problem than flying away with the vehicle.
+
+Two things PX4 cannot promise: that a vehicle will not crash, and that a sensor is telling the truth about the world.
+
+## The boundary
+
+```
+                 integrator's responsibility
+        ..............................................
+        :  telemetry radio    RC link    companion   :
+        :        |              |         network    :
+        :        |              |            |       :
+        ''''''''''''''''''''''''''''''''''''''''''''''
+                 |              |            |
+              MAVLink          RC      uXRCE-DDS/Zenoh
+                 |              |            |
+        +--------+--------------+------------+--------+
+        |             flight controller               |
+        +---+---------------+---------------+---------+
+            |               |               |
+        SD card       USB / NSH shell    UART/I2C/SPI/CAN
+                                          peripherals
+```
+
+Everything above the dotted line is the integrator's to secure, and PX4 assumes nothing about who is on it.
+Everything below is administrative: a peer with the SD card, the USB port or a bus is trusted as the operator.
+
+PX4's job is what happens at the boxes in the middle: whatever arrives on those interfaces must not do more than the interface is documented to do.
+
+## What PX4 assumes
+
+- **Sensors report within specification.**
+  PX4 cannot reliably distinguish a real GPS fix, rangefinder return or gyro reading from a spoofed one.
+  Some spoofing detection exists and is best-effort.
+- **Peripherals are the ones the operator installed.**
+  No bus (UART, I2C, SPI, CAN, SMBus) is authenticated.
+  A device on a bus is trusted as whatever driver the operator enabled for it.
+- **Physical access is administrative.**
+  The SD card holds logs, the MAVLink signing key, some boards' parameters or parameter backups and staged peripheral firmware, and it can contain boot scripts that are run at startup.
+  Debug ports and the bootloader allow a full reflash.
+- **The onboard shell is administrative.**
+  A peer that can open the NSH shell is an administrator.
+  NuttX supports a console password; no PX4 board enables it.
+- **The offboard transports are inside the boundary.**
+  uXRCE-DDS and Zenoh publishers reach uORB directly, including `/fmu/in/actuator_motors`, `/fmu/in/actuator_servos` and `/fmu/in/vehicle_command`.
+  They carry no external-origin marking, so the command guards that apply to MAVLink do not apply to them.
+  A peer that can reach those transports is the operator, which is why keeping that network to trusted parties is the integrator's job and not an optional extra.
+- **Securing the links is the integrator's job.**
+  See [MAVLink Security Hardening](docs/en/mavlink/security_hardening.md).
+
+These assumptions are the boundary.
+If a report starts from one of them already being true, that the attacker has the SD card, or is on the companion network, then it is describing how PX4 works rather than finding a hole in it.
+
+## Configurations
+
+### As shipped
+
+Every control interface is unauthenticated, unsigned and unencrypted.
+Anyone who can reach a link can do anything the operator can do: arm, disarm, change mode, upload missions and geofences, set parameters, open a shell over `SERIAL_CONTROL`, read and write files over MAVLink FTP, terminate flight.
+[MAVLink Security Hardening](docs/en/mavlink/security_hardening.md) lists these capabilities in full.
+
+This is the documented default and it is not a defect.
+In this configuration PX4 guarantees only what the [Always in scope](#always-in-scope) list names.
+
+### Hardened
+
+An integrator can raise that, and the options are:
+
+- **Secure the link below PX4.**
+  An encrypted radio, a VPN or IPsec gives confidentiality and authentication using standard, reviewed cryptography.
+  This is the strongest option and PX4 is not involved in it.
+- **Isolate the offboard transports.**
+  uXRCE-DDS and Zenoh bypass every MAVLink control, so if an adversary can reach them, the rest of this list buys nothing.
+- **Enable [MAVLink message signing](docs/en/mavlink/message_signing.md).**
+  This authenticates MAVLink frames but does not encrypt them.
+  The protocol was audited when it was drafted; PX4's implementation of it has not been.
+  A small allowlist (`HEARTBEAT`, `RADIO_STATUS`, `ADSB_VEHICLE`, `COLLISION`) is always accepted unsigned.
+  Signing is inactive if the key file is absent, which is deliberate: removing the card is the recovery path when a key is lost.
+- **Lock the configuration.**
+  Read-only parameters, [secure boot](docs/en/advanced_config/bootloader_secure_boot.md) with a replaced key, and no wired reflash.
+  The in-tree secure boot variant ships a publicly committed test key that an integrator must replace.
+
+What each of these buys is described where it is documented.
+PX4 makes no guarantee that they combine into a secure deployment; that assessment belongs to the integrator.
+
+## Always in scope
+
+Regardless of configuration, and regardless of how open the link is:
+
+- **Memory corruption.**
+  Input on any link or bus that corrupts memory or executes code.
+- **Hangs and races.**
+  Input that stalls a control path, spins a work queue, or corrupts state through timing or ordering rather than through malformed content.
+- **Any effect beyond the documented capability set.**
+  If a link peer can reach an effect that is not documented as reachable, that is a bug until the documentation is corrected.
+  MAVLink FTP escaping the directory it advertises is this class.
+- **Pivoting to a bus that was not otherwise reachable.**
+  Using the flight controller to reach an ESC, GPS or CAN node bootloader behind it, for example through `TUNNEL` or `SERIAL_CONTROL` passthrough.
+  Reaching the link grants the link, not the peripherals behind the controller.
+- **Persistence.**
+  Anything planted over a link that outlives the attacker's access to it: a boot script, flashed peripheral firmware, an overwritten parameter store.
+
+An in-tree board configuration is PX4's responsibility, not the integrator's.
+"The integrator should have changed it" does not apply to a default that PX4 ships.
+
+## Out of scope
+
+- **Using an unauthenticated link as it is documented to work.**
+  Commanding the vehicle over an unsigned link, when the only precondition is reaching the link.
+  The list above still applies.
+- **Physical access**, except where a board is configured with a mechanism whose purpose is to resist it.
+  On a secure boot board with a replaced key, wired reflash comes back into scope.
+- **Spoofed physical inputs.**
+  GPS spoofing, acoustic or EMI injection, magnetic interference.
+  In scope only if PX4 mishandles the resulting bytes.
+- **Plaintext telemetry.**
+  PX4 does not encrypt telemetry, and eavesdropping on a link is not a finding on its own.
+- **Code that only ever runs in simulation.**
+  A finding in a simulator-only code path is a bug, not a vulnerability.
+  This is about where the affected code runs, not where you reproduced it: if the code also runs on a flight target, a SITL reproducer is fine, and [SECURITY.md](SECURITY.md) asks for one.
+- **Unsupported branches.**
+  See [SECURITY.md](SECURITY.md).
+
+A parameter precondition does not put a finding out of scope if the same link can set that parameter.
+
+## Severity
+
+Decide scope first using the two lists above.
+A finding that is out of scope is closed, not scored.
+
+What remains is scored with CVSS, because that is what GitHub advisories carry.
+When choosing the impact metrics, rate the effect on the aircraft rather than on the data, in roughly this order:
+
+1. Taking control of a vehicle that is flying or could be told to fly, and running your own code on it.
+2. Forcing an unsafe state: corrupting the estimator, or spoofing a condition that trips a failsafe.
+3. Persistence across reboot.
+4. Loss of control or telemetry links, and disclosure.
+
+A safety feature that happens to limit an attacker, such as a geofence around a hijacked vehicle, is not a security control and does not reduce severity.
+Someone who is already flying the vehicle can reconfigure it.

--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -962,6 +962,7 @@
     - [Gazebo Classic OctoMap Models with ROS 1](sim_gazebo_classic/octomap.md)
     - [ROS/MAVROS Installation on RPi](ros/raspberrypi_installation.md)
     - [External Position Estimation (Vision/Motion based)](ros/external_position_estimation.md)
+- [Security](security/index.md)
 - [Community](contribute/index.md)
   - [Dev Call](contribute/dev_call.md)
   - [Maintainers](contribute/maintainers.md)

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -53,6 +53,11 @@ The [Hardware Selection & Setup](hardware/drone_parts.md) section covers flight 
 
 Read [Operations](config/operations.md) to understand safety features and failsafe behavior before your first flight. Then see [Basic Flying (Multicopter)](flying/basic_flying_mc.md) or the equivalent for your frame type.
 
+## Security
+
+PX4 ships with every control interface unauthenticated, unsigned and unencrypted, so securing a deployment is the integrator's responsibility.
+The [Security](security/index.md) section collects the hardening documentation, and links to the [security policy](https://github.com/PX4/PX4-Autopilot/blob/main/SECURITY.md) for reporting a vulnerability.
+
 ## Support
 
 Get help on the [discussion forums](https://discuss.px4.io/) or [Discord](https://discord.com/invite/dronecode). See the [Support](contribute/support.md) page for diagnosing problems, reporting bugs, and joining the [weekly dev call](contribute/dev_call.md).

--- a/docs/en/mavlink/security_hardening.md
+++ b/docs/en/mavlink/security_hardening.md
@@ -59,6 +59,13 @@ Signing changes are rejected while the vehicle is armed.
 Signing can also be disabled by physically removing the key file from the SD card.
 :::
 
+::: warning
+Until a key is provisioned there is nothing to authenticate against, so any peer that can reach a link can provision one.
+Only *changing* a key requires a signed message; setting the first one cannot, because no key exists yet.
+A key installed by someone else locks out the legitimate ground station, and the recovery is to remove the key file from the SD card.
+Provision the key before the vehicle is used on an untrusted link, not after.
+:::
+
 ### 2. Secure Physical Access
 
 - **SD card**: The signing key is stored at `/mavlink/mavlink-signing-key.bin`.

--- a/docs/en/mavlink/security_hardening.md
+++ b/docs/en/mavlink/security_hardening.md
@@ -4,15 +4,22 @@
 
 MAVLink is an open communication protocol designed for lightweight, low-latency communication between drones and ground stations.
 By default, all MAVLink messages are unauthenticated.
-This is intentional for development and testing, but **production deployments must enable [message signing](message_signing.md)** to prevent unauthorized access.
+This is intentional for development and testing, but **production deployments must secure the link** to prevent unauthorized access.
+
+There are two ways to do that, and they are not exclusive:
+
+- **Encrypt the link below MAVLink**, using an encrypted radio, a VPN or IPsec.
+  This uses standard, reviewed cryptography, gives confidentiality as well as authentication, and protects every interface on the link rather than only MAVLink.
+- **Enable [MAVLink message signing](message_signing.md)**, which authenticates MAVLink frames without encrypting them.
+  This is the mechanism PX4 itself ships, and it is described in this guide.
 
 ::: warning
-Without message signing enabled, any device that can send MAVLink messages to the vehicle (via radio, network, or serial) can execute any command, including shell access, file operations, parameter changes, mission uploads, arming, and flight termination.
+On an unsecured link, any device that can send MAVLink messages to the vehicle (via radio, network, or serial) can execute any command, including shell access, file operations, parameter changes, mission uploads, arming, and flight termination.
 :::
 
 ## What Is at Risk
 
-When MAVLink signing is not enabled, an attacker within communication range can:
+On an unsecured link, an attacker within communication range can:
 
 | Capability                    | MAVLink mechanism                                |
 | ----------------------------- | ------------------------------------------------ |
@@ -27,13 +34,15 @@ When MAVLink signing is not enabled, an attacker within communication range can:
 | Reboot the vehicle            | `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN`              |
 
 All of these are standard MAVLink capabilities used by ground control stations.
-Without signing, there is no distinction between a legitimate GCS and an unauthorized sender.
+Until the link is secured, there is no distinction between a legitimate GCS and an unauthorized sender.
 
 ## Hardening Checklist
 
-### 1. Enable Message Signing
+### 1. Secure the Link
 
-Message signing provides cryptographic authentication for all MAVLink communication.
+If the link is carried over an encrypted radio, a VPN or IPsec, that covers authentication and confidentiality for everything on it, and the rest of this step is optional.
+
+Otherwise, use message signing, which provides cryptographic authentication for all MAVLink communication.
 See [Message Signing](message_signing.md) for full details.
 
 Steps:
@@ -67,6 +76,7 @@ If your threat model includes physical access, secure the SD card slot and debug
 
 ### 3. Secure Network Links
 
+- Prefer an encrypted transport where one is available: an encrypted radio link, a VPN, or IPsec.
 - Do not expose MAVLink UDP/TCP ports to untrusted networks or the internet.
 - Place MAVLink communication links behind firewalls or VPNs.
 - Segment MAVLink networks from business or public networks.

--- a/docs/en/middleware/uxrce_dds.md
+++ b/docs/en/middleware/uxrce_dds.md
@@ -26,6 +26,11 @@ In order for PX4 uORB topics to be shared on the DDS network you will need _uXRC
 
 The PX4 [uxrce_dds_client](../modules/modules_system.md#uxrce-dds-client) publishes to/from a defined set of uORB topics to the global DDS data space.
 
+::: warning
+The DDS transport is unauthenticated and reaches uORB directly, so the DDS network must be kept isolated.
+See [Security](../security/index.md) for more.
+:::
+
 The [eProsima Micro XRCE-DDS _Agent_](https://github.com/eProsima/Micro-XRCE-DDS-Agent) runs on the companion computer and acts as a proxy for the client in the DDS/ROS 2 network.
 
 The agent itself has no dependency on client-side code and can be built and/or installed independent of PX4 or ROS, as long as version compatibility is ensured.

--- a/docs/en/security/index.md
+++ b/docs/en/security/index.md
@@ -1,0 +1,24 @@
+# Security
+
+PX4's security documentation is spread across the sections it belongs to.
+This page collects it.
+
+By default every PX4 control interface is unauthenticated, unsigned and unencrypted.
+Any peer that can reach a link can command the vehicle.
+That is intended for development, and securing a deployment is the integrator's responsibility.
+
+## For integrators
+
+- [MAVLink Security Hardening](../mavlink/security_hardening.md) — what an unauthenticated link exposes, and the checklist for a production deployment.
+- [MAVLink Message Signing](../mavlink/message_signing.md) — authenticating MAVLink frames, and what signing does not cover.
+- [Bootloader Secure Boot](../advanced_config/bootloader_secure_boot.md) — verifying firmware at boot, and replacing the committed test key.
+- [Log Encryption](../dev_log/log_encryption.md) — encrypting flight logs at rest.
+- [Read-Only Parameters](../advanced/parameters_and_configurations.md#read-only-parameters) — locking down settings that end users should not change.
+
+Securing the link itself sits below PX4.
+An encrypted radio, a VPN or IPsec uses standard cryptography and protects every interface at once, including the ones MAVLink signing does not cover.
+
+## For security researchers
+
+- [Security Policy](https://github.com/PX4/PX4-Autopilot/blob/main/SECURITY.md) — supported versions, how to report a vulnerability, and the rules for AI-assisted findings.
+- [Security Scope](https://github.com/PX4/PX4-Autopilot/blob/main/SECURITY_SCOPE.md) — where PX4's security boundary sits, and what is in scope for a report.


### PR DESCRIPTION
Supersedes #28069.

This is a second attempt at defining the security scope. It takes into account the review comments on #28069 as well as the [security-wg list comment by Sheren](https://lists.dronecode.org/g/security-wg/topic/comments_on_threat_model_md/120520974).

For details, see commits and diff.