### PR TITLE
feat(uavcan): correct the bus clock rate from time sync and share the clock across drivers

### DIFF
--- a/src/drivers/uavcan/uavcan_drivers/hrt_clock.hpp
+++ b/src/drivers/uavcan/uavcan_drivers/hrt_clock.hpp
@@ -1,0 +1,166 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <stdint.h>
+#include <drivers/drv_hrt.h>
+#include <nuttx/irq.h>
+
+namespace uavcan_hrt_clock
+{
+
+struct SyncStatus {
+	uint32_t adjustments;		///< relative adjustments applied since boot
+	int32_t last_adjustment_usec;
+	int32_t rate_ppb;		///< rate correction currently applied to HRT
+};
+
+/*
+ * The libuavcan UTC clock as a line through HRT:
+ *
+ *     utc = hrt + offset + (hrt - anchor) * rate
+ *
+ * Each sync adjustment steps the offset by the measured phase error and
+ * integrates half of the rate error it implies, so once converged the error
+ * left between syncs is the measurement noise rather than a second of crystal
+ * drift. The rate is a Q32 fraction so the interrupt path needs one 64-bit
+ * multiply and no division.
+ *
+ * Writers hold a critical section. The CAN interrupt reads without one, which
+ * is consistent on a single core because the writer cannot be preempted by it.
+ */
+class Clock
+{
+public:
+	uint64_t utcUsecFromInterrupt() const
+	{
+		return _set ? utcAt(hrt_absolute_time()) : 0;
+	}
+
+	uint64_t utcUsec() const
+	{
+		irqstate_t flags = enter_critical_section();
+		const uint64_t utc = utcUsecFromInterrupt();
+		leave_critical_section(flags);
+		return utc;
+	}
+
+	void setUtc(uint64_t utc_usec)
+	{
+		irqstate_t flags = enter_critical_section();
+		const uint64_t now = hrt_absolute_time();
+		_offset_usec = int64_t(utc_usec) - int64_t(now);
+		_anchor = now;
+		_last_adjustment_at = now;
+		_set = true;
+		leave_critical_section(flags);
+	}
+
+	/**
+	 * Moves UTC by `adjustment_usec`. While UTC is unset the adjustment is
+	 * absolute: UTC reads `adjustment_usec` from now on.
+	 */
+	void adjustUtc(int64_t adjustment_usec)
+	{
+		irqstate_t flags = enter_critical_section();
+		const uint64_t now = hrt_absolute_time();
+
+		if (!_set) {
+			_offset_usec = adjustment_usec - int64_t(now);
+			_anchor = now;
+			_rate_q32 = 0;
+			_last_adjustment_at = now;
+			_set = true;
+
+		} else {
+			reanchor(now);
+			_offset_usec += adjustment_usec;
+
+			const int64_t dt = int64_t(now - _last_adjustment_at);
+			_last_adjustment_at = now;
+
+			if (adjustment_usec > kStepUsec || adjustment_usec < -kStepUsec) {
+				// A jump means a new master or a sync gap; its rate is meaningless.
+				_rate_q32 = 0;
+
+			} else if (dt >= kMinRateDtUsec && dt <= kMaxRateDtUsec) {
+				_rate_q32 += adjustment_usec * (int64_t(1) << 31) / dt;
+
+				if (_rate_q32 > kMaxRateQ32) { _rate_q32 = kMaxRateQ32; }
+
+				if (_rate_q32 < -kMaxRateQ32) { _rate_q32 = -kMaxRateQ32; }
+			}
+
+			_adjustments++;
+			_last_adjustment_usec = int32_t(adjustment_usec);
+		}
+
+		leave_critical_section(flags);
+	}
+
+	SyncStatus status() const
+	{
+		irqstate_t flags = enter_critical_section();
+		const SyncStatus s{_adjustments, _last_adjustment_usec, int32_t((_rate_q32 * 1000000000LL) >> 32)};
+		leave_critical_section(flags);
+		return s;
+	}
+
+private:
+	static constexpr int64_t kStepUsec = 10000;
+	static constexpr int64_t kMinRateDtUsec = 200000;
+	static constexpr int64_t kMaxRateDtUsec = 10000000;
+	static constexpr int64_t kMaxRateQ32 = (int64_t(500) << 32) / 1000000;	// 500 ppm
+
+	uint64_t utcAt(uint64_t hrt) const
+	{
+		return uint64_t(int64_t(hrt) + _offset_usec + ((int64_t(hrt - _anchor) * _rate_q32) >> 32));
+	}
+
+	void reanchor(uint64_t now)
+	{
+		_offset_usec += (int64_t(now - _anchor) * _rate_q32) >> 32;
+		_anchor = now;
+	}
+
+	bool _set{false};
+	int64_t _offset_usec{0};
+	int64_t _rate_q32{0};
+	uint64_t _anchor{0};
+	uint64_t _last_adjustment_at{0};
+	uint32_t _adjustments{0};
+	int32_t _last_adjustment_usec{0};
+};
+
+} // namespace uavcan_hrt_clock

--- a/src/drivers/uavcan/uavcan_drivers/kinetis/driver/include/uavcan_kinetis/clock.hpp
+++ b/src/drivers/uavcan/uavcan_drivers/kinetis/driver/include/uavcan_kinetis/clock.hpp
@@ -7,13 +7,14 @@
 
 #include <uavcan_kinetis/build_config.hpp>
 #include <uavcan/driver/system_clock.hpp>
+#include <drivers/uavcan/uavcan_drivers/hrt_clock.hpp>
 
 namespace uavcan_kinetis
 {
 
 /*
- * Monotonic time is HRT. UTC is HRT plus an offset that time sync moves, so
- * the bus time base shares HRT's rate and needs no hardware of its own.
+ * Monotonic time is HRT. UTC is HRT plus a synced offset and rate (see
+ * uavcan_hrt_clock::Clock), so the bus clock needs no hardware of its own.
  */
 namespace clock
 {
@@ -34,6 +35,8 @@ void setUtc(uavcan::UtcTime time);
  * UTC reads `adjustment` from now on.
  */
 void adjustUtc(uavcan::UtcDuration adjustment);
+
+uavcan_hrt_clock::SyncStatus getSyncStatus();
 }
 
 /**

--- a/src/drivers/uavcan/uavcan_drivers/kinetis/driver/src/uc_kinetis_clock.cpp
+++ b/src/drivers/uavcan/uavcan_drivers/kinetis/driver/src/uc_kinetis_clock.cpp
@@ -18,16 +18,7 @@ namespace
 
 Mutex mutex;
 bool initialized = false;
-
-// Written under a critical section so the CAN interrupt, which reads them
-// without locking, never sees a torn 64-bit offset.
-bool utc_set = false;
-uavcan::int64_t utc_offset_usec = 0;
-
-uavcan::uint64_t utcNow()
-{
-	return utc_set ? uavcan::uint64_t(uavcan::int64_t(hrt_absolute_time()) + utc_offset_usec) : 0;
-}
+uavcan_hrt_clock::Clock hrt_clock;
 
 }
 
@@ -38,33 +29,27 @@ uavcan::MonotonicTime getMonotonic()
 
 uavcan::UtcTime getUtc()
 {
-	CriticalSectionLocker locker;
-	return uavcan::UtcTime::fromUSec(utcNow());
+	return uavcan::UtcTime::fromUSec(hrt_clock.utcUsec());
 }
 
 uavcan::uint64_t getUtcUSecFromCanInterrupt()
 {
-	return utcNow();
+	return hrt_clock.utcUsecFromInterrupt();
 }
 
 void setUtc(uavcan::UtcTime time)
 {
-	CriticalSectionLocker locker;
-	utc_offset_usec = uavcan::int64_t(time.toUSec()) - uavcan::int64_t(hrt_absolute_time());
-	utc_set = true;
+	hrt_clock.setUtc(time.toUSec());
 }
 
 void adjustUtc(uavcan::UtcDuration adjustment)
 {
-	CriticalSectionLocker locker;
+	hrt_clock.adjustUtc(adjustment.toUSec());
+}
 
-	if (utc_set) {
-		utc_offset_usec = utc_offset_usec + adjustment.toUSec();
-
-	} else {
-		utc_offset_usec = adjustment.toUSec() - uavcan::int64_t(hrt_absolute_time());
-		utc_set = true;
-	}
+uavcan_hrt_clock::SyncStatus getSyncStatus()
+{
+	return hrt_clock.status();
 }
 
 } // namespace clock

--- a/src/drivers/uavcan/uavcan_drivers/stm32/driver/include/uavcan_stm32/clock.hpp
+++ b/src/drivers/uavcan/uavcan_drivers/stm32/driver/include/uavcan_stm32/clock.hpp
@@ -6,13 +6,14 @@
 
 #include <uavcan_stm32/build_config.hpp>
 #include <uavcan/driver/system_clock.hpp>
+#include <drivers/uavcan/uavcan_drivers/hrt_clock.hpp>
 
 namespace uavcan_stm32
 {
 
 /*
- * Monotonic time is HRT. UTC is HRT plus an offset that time sync moves, so
- * the bus time base shares HRT's rate and needs no hardware of its own.
+ * Monotonic time is HRT. UTC is HRT plus a synced offset and rate (see
+ * uavcan_hrt_clock::Clock), so the bus clock needs no hardware of its own.
  */
 namespace clock
 {
@@ -33,6 +34,8 @@ void setUtc(uavcan::UtcTime time);
  * UTC reads `adjustment` from now on.
  */
 void adjustUtc(uavcan::UtcDuration adjustment);
+
+uavcan_hrt_clock::SyncStatus getSyncStatus();
 }
 
 /**

--- a/src/drivers/uavcan/uavcan_drivers/stm32/driver/src/uc_stm32_clock.cpp
+++ b/src/drivers/uavcan/uavcan_drivers/stm32/driver/src/uc_stm32_clock.cpp
@@ -17,16 +17,7 @@ namespace
 
 Mutex mutex;
 bool initialized = false;
-
-// Written under a critical section so the CAN interrupt, which reads them
-// without locking, never sees a torn 64-bit offset.
-bool utc_set = false;
-uavcan::int64_t utc_offset_usec = 0;
-
-uavcan::uint64_t utcNow()
-{
-	return utc_set ? uavcan::uint64_t(uavcan::int64_t(hrt_absolute_time()) + utc_offset_usec) : 0;
-}
+uavcan_hrt_clock::Clock hrt_clock;
 
 }
 
@@ -37,33 +28,27 @@ uavcan::MonotonicTime getMonotonic()
 
 uavcan::UtcTime getUtc()
 {
-	CriticalSectionLocker locker;
-	return uavcan::UtcTime::fromUSec(utcNow());
+	return uavcan::UtcTime::fromUSec(hrt_clock.utcUsec());
 }
 
 uavcan::uint64_t getUtcUSecFromCanInterrupt()
 {
-	return utcNow();
+	return hrt_clock.utcUsecFromInterrupt();
 }
 
 void setUtc(uavcan::UtcTime time)
 {
-	CriticalSectionLocker locker;
-	utc_offset_usec = uavcan::int64_t(time.toUSec()) - uavcan::int64_t(hrt_absolute_time());
-	utc_set = true;
+	hrt_clock.setUtc(time.toUSec());
 }
 
 void adjustUtc(uavcan::UtcDuration adjustment)
 {
-	CriticalSectionLocker locker;
+	hrt_clock.adjustUtc(adjustment.toUSec());
+}
 
-	if (utc_set) {
-		utc_offset_usec = utc_offset_usec + adjustment.toUSec();
-
-	} else {
-		utc_offset_usec = adjustment.toUSec() - uavcan::int64_t(hrt_absolute_time());
-		utc_set = true;
-	}
+uavcan_hrt_clock::SyncStatus getSyncStatus()
+{
+	return hrt_clock.status();
 }
 
 } // namespace clock

--- a/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/include/uavcan_stm32h7/clock.hpp
+++ b/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/include/uavcan_stm32h7/clock.hpp
@@ -6,13 +6,14 @@
 
 #include <uavcan_stm32h7/build_config.hpp>
 #include <uavcan/driver/system_clock.hpp>
+#include <drivers/uavcan/uavcan_drivers/hrt_clock.hpp>
 
 namespace uavcan_stm32h7
 {
 
 /*
- * Monotonic time is HRT. UTC is HRT plus an offset that time sync moves, so
- * the bus time base shares HRT's rate and needs no hardware of its own.
+ * Monotonic time is HRT. UTC is HRT plus a synced offset and rate (see
+ * uavcan_hrt_clock::Clock), so the bus clock needs no hardware of its own.
  */
 namespace clock
 {
@@ -33,6 +34,8 @@ void setUtc(uavcan::UtcTime time);
  * UTC reads `adjustment` from now on.
  */
 void adjustUtc(uavcan::UtcDuration adjustment);
+
+uavcan_hrt_clock::SyncStatus getSyncStatus();
 }
 
 /**

--- a/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/src/uc_stm32h7_clock.cpp
+++ b/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/src/uc_stm32h7_clock.cpp
@@ -17,16 +17,7 @@ namespace
 
 Mutex mutex;
 bool initialized = false;
-
-// Written under a critical section so the CAN interrupt, which reads them
-// without locking, never sees a torn 64-bit offset.
-bool utc_set = false;
-uavcan::int64_t utc_offset_usec = 0;
-
-uavcan::uint64_t utcNow()
-{
-	return utc_set ? uavcan::uint64_t(uavcan::int64_t(hrt_absolute_time()) + utc_offset_usec) : 0;
-}
+uavcan_hrt_clock::Clock hrt_clock;
 
 }
 
@@ -37,33 +28,27 @@ uavcan::MonotonicTime getMonotonic()
 
 uavcan::UtcTime getUtc()
 {
-	CriticalSectionLocker locker;
-	return uavcan::UtcTime::fromUSec(utcNow());
+	return uavcan::UtcTime::fromUSec(hrt_clock.utcUsec());
 }
 
 uavcan::uint64_t getUtcUSecFromCanInterrupt()
 {
-	return utcNow();
+	return hrt_clock.utcUsecFromInterrupt();
 }
 
 void setUtc(uavcan::UtcTime time)
 {
-	CriticalSectionLocker locker;
-	utc_offset_usec = uavcan::int64_t(time.toUSec()) - uavcan::int64_t(hrt_absolute_time());
-	utc_set = true;
+	hrt_clock.setUtc(time.toUSec());
 }
 
 void adjustUtc(uavcan::UtcDuration adjustment)
 {
-	CriticalSectionLocker locker;
+	hrt_clock.adjustUtc(adjustment.toUSec());
+}
 
-	if (utc_set) {
-		utc_offset_usec = utc_offset_usec + adjustment.toUSec();
-
-	} else {
-		utc_offset_usec = adjustment.toUSec() - uavcan::int64_t(hrt_absolute_time());
-		utc_set = true;
-	}
+uavcan_hrt_clock::SyncStatus getSyncStatus()
+{
+	return hrt_clock.status();
 }
 
 } // namespace clock

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -747,6 +747,9 @@ void UavcanNode::PrintInfo()
 	printf("UAVCAN Time:\n");
 	printf("\tMonotonic time: %llu\n", _node.getMonotonicTime().toUSec());
 	printf("\tUtc time:       %llu\n", _node.getUtcTime().toUSec());
+	const uavcan_hrt_clock::SyncStatus sync = UAVCAN_DRIVER::clock::getSyncStatus();
+	printf("\tSync:           %lu adjustments, last %ld us, rate %ld ppb\n", (unsigned long)sync.adjustments,
+	       (long)sync.last_adjustment_usec, (long)sync.rate_ppb);
 
 	printf("\n");
 

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -747,9 +747,12 @@ void UavcanNode::PrintInfo()
 	printf("UAVCAN Time:\n");
 	printf("\tMonotonic time: %llu\n", _node.getMonotonicTime().toUSec());
 	printf("\tUtc time:       %llu\n", _node.getUtcTime().toUSec());
+
+#if defined(UAVCAN_KINETIS_NUTTX) || defined(UAVCAN_STM32_NUTTX) || defined(UAVCAN_STM32H7_NUTTX)
 	const uavcan_hrt_clock::SyncStatus sync = UAVCAN_DRIVER::clock::getSyncStatus();
 	printf("\tSync:           %lu adjustments, last %ld us, rate %ld ppb\n", (unsigned long)sync.adjustments,
 	       (long)sync.last_adjustment_usec, (long)sync.rate_ppb);
+#endif
 
 	printf("\n");
 


### PR DESCRIPTION
## Summary

Stacked on #28569. Adds a rate term to the HRT-based libuavcan clock so a time-sync slave's UTC tracks the master to the sync measurement noise instead of one second of crystal drift, moves the clock into one shared header used by the stm32, stm32h7 and kinetis drivers, and adds a sync line to `uavcannode status`. Bench-tested on an ARK X20 (stm32) against an ARKV6S (stm32h7); fmuk66-v3 (kinetis) build-tested.

## Problem

#28569 applies each sync adjustment as an offset step. Between syncs the slave runs at its own crystal rate, so the error against the master ramps for a second and snaps back. Measured on the X20 against the V6S: steps of 7 to 12 µs every second, always the same sign, while the scatter of the measurement itself is about 1.5 µs. The sawtooth is visible in node IMU `timestamp_sample` on the FC. The clock implementation was also three identical copies, one per driver.

## Solution

UTC is a line through HRT: `hrt + offset + (hrt - anchor) * rate`, with the rate a Q32 fraction so the CAN interrupt path is one 64-bit multiply and no division. Each adjustment re-anchors, steps the offset by the full phase error, and adds half of the implied rate error to the rate, clamped to 500 ppm. A step above 10 ms means a new master or a lost sync and drops the rate estimate; the rate is not updated from intervals outside 0.2 to 10 s. Writers hold a critical section, the interrupt reads without one.

On the bench the rate converges within a few syncs and the per-second adjustment falls to 0 to 2 µs, with the FC-side residual of node gyro timestamps against a linear fit within about ±2 µs where it previously ramped 7 µs. `uavcannode status` shows `Sync: N adjustments, last X us, rate Y ppb`.
