### PR TITLE
fix(mavlink): reject TUNNEL messages that overstate their payload length

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2228,6 +2228,14 @@ MavlinkReceiver::handle_message_tunnel(mavlink_message_t *msg)
 	mavlink_tunnel_t mavlink_tunnel;
 	mavlink_msg_tunnel_decode(msg, &mavlink_tunnel);
 
+	if (mavlink_tunnel.payload_length > sizeof(mavlink_tunnel.payload)) {
+		// The payload buffer is a fixed 128 bytes while payload_length is a uint8_t, so a
+		// sender can advertise more data than the message can carry. Drop such a message
+		// rather than clamping: the consumers below forward the payload verbatim to a
+		// UART, where a truncated frame would corrupt the device protocol.
+		return;
+	}
+
 	mavlink_tunnel_s tunnel{};
 
 	tunnel.timestamp = hrt_absolute_time();


### PR DESCRIPTION
## Summary

A MAVLink TUNNEL message can advertise more payload than it is able to carry, @and PX4 passed that length through to drivers that write it straight to a UART.

## Problem

TUNNEL carries a fixed 128-byte payload next to a `uint8_t payload_length`, @so a sender can claim up to 255 bytes. `handle_message_tunnel()` copied the length into the uORB topic unchanged, @and `voxl_esc` and `voxl2_io` both hand it to `_uart_port.write()` over the 128-byte array. A length above 128 therefore reads past the end of the payload and transmits whatever follows it out of the ESC or IO UART.

## Solution

Drop a TUNNEL message whose `payload_length` exceeds the payload buffer. Clamping the length was the alternative, @but these payloads are forwarded verbatim to a device, @where a truncated frame would corrupt the device protocol rather than fail cleanly.

Fixes https://github.com/PX4/PX4-Autopilot/issues/28347.

---

Reported by @cq-cq-UAV, @20210607, @kevinhong0825, @lihnucs, @0rbitingZer0.