### PR TITLE
fix(drivers/voxl): only allow serial passthrough while disarmed

### DIFF
--- a/src/drivers/actuators/voxl_esc/voxl_esc.cpp
+++ b/src/drivers/actuators/voxl_esc/voxl_esc.cpp
@@ -1394,8 +1394,11 @@ bool VoxlEsc::updateOutputs(float outputs[MAX_ACTUATORS], unsigned num_outputs, 
 
 	uint8_t num_writes = 0;
 
+	// Serial passthrough hands a MAVLink peer raw bytes on the ESC bus, which speaks its
+	// own protocol including a reset that drops the ESC into its bootloader. Restrict it to
+	// the disarmed state so it stays a bench tool.
 	// Don't do these faster than 20Hz
-	if (hrt_elapsed_time(&_last_uart_passthru) > 50_ms) {
+	if (hrt_elapsed_time(&_last_uart_passthru) > 50_ms && !_mixing_output.armed().armed) {
 		_last_uart_passthru = hrt_absolute_time();
 
 		// Don't do more than a few writes each check

--- a/src/drivers/voxl2_io/voxl2_io.cpp
+++ b/src/drivers/voxl2_io/voxl2_io.cpp
@@ -280,8 +280,10 @@ int Voxl2IO::handle_uart_passthru()
 {
 	int num_writes = 0;
 
+	// Serial passthrough hands a MAVLink peer raw bytes on the IO bus. Restrict it to the
+	// disarmed state so it stays a bench tool.
 	// Don't do these faster than 20Hz
-	if (hrt_elapsed_time(&_last_uart_passthru) > 50_ms) {
+	if (hrt_elapsed_time(&_last_uart_passthru) > 50_ms && !_mixing_output.armed().armed) {
 		_last_uart_passthru = hrt_absolute_time();
 
 		// Don't do more than a few writes each check


### PR DESCRIPTION
## Summary

The MAVLink TUNNEL serial passthrough in `voxl_esc` and `voxl2_io` accepted writes unconditionally. Restrict it to the disarmed state.

## Problem

A link peer can send TUNNEL payload types 211 and 212 to get raw bytes onto the ESC and IO serial buses. Those buses speak their own protocols, @and the ESC one includes a reset whose documented purpose is entering the bootloader without a power cycle. Neither driver checked anything before writing: no arming check, @no parameter, @at 20Hz whenever the module is running.

## Solution

Gate both passthrough paths on `!_mixing_output.armed().armed`. Passthrough is a bench tool for talking to an ESC or IO board, @and nothing needs it in flight. The ESC firmware separately refuses reset, @tone and LED commands while a motor is spinning, @so this tightens a gap rather than being the only guard.

---

Reported by @0rbitingZer0.