### PR TITLE
fix(mavlink): reject TUNNEL messages that overstate their payload length [BACKPORT v1.18]

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2192,6 +2192,14 @@ MavlinkReceiver::handle_message_tunnel(mavlink_message_t *msg)
 	mavlink_tunnel_t mavlink_tunnel;
 	mavlink_msg_tunnel_decode(msg, &mavlink_tunnel);
 
+	if (mavlink_tunnel.payload_length > sizeof(mavlink_tunnel.payload)) {
+		// The payload buffer is a fixed 128 bytes while payload_length is a uint8_t, so a
+		// sender can advertise more data than the message can carry. Drop such a message
+		// rather than clamping: the consumers below forward the payload verbatim to a
+		// UART, where a truncated frame would corrupt the device protocol.
+		return;
+	}
+
 	mavlink_tunnel_s tunnel{};
 
 	tunnel.timestamp = hrt_absolute_time();


### PR DESCRIPTION
Backport of #28573

The TUNNEL message carries a fixed 128-byte payload alongside a uint8_t payload_length, so a sender can advertise up to 255 bytes of data in a buffer that can only ever hold 128. handle_message_tunnel() copied that length into the uORB topic unchanged.

The consumers trust it: voxl_esc and voxl2_io both pass payload_length straight to _uart_port.write() over the 128-byte payload, so a length above 128 reads past the end of the array and transmits whatever follows it out of the ESC or IO UART.

Drop such a message rather than clamping the length. These payloads are forwarded verbatim to a device, where a truncated frame would corrupt the device protocol rather than fail cleanly.

Assisted-by: Claude:claude-opus-5[1m]