### PR TITLE
fix(mavlink): keep FTP inside its root when paths resolve through symlinks

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -45,6 +45,10 @@
 #include <sys/stat.h>
 #include <errno.h>
 #include <cstring>
+#if defined(__PX4_POSIX)
+#include <limits.h>
+#include <stdlib.h>
+#endif
 
 #include "mavlink_ftp.h"
 #include "mavlink_main.h"
@@ -1180,8 +1184,61 @@ bool MavlinkFTP::_validatePath(const char *path)
 		p++;
 	}
 
+#if defined(__PX4_POSIX)
+
+	if (!_validatePathIsInRoot(path)) {
+		return false;
+	}
+
+#endif
+
 	return true;
 }
+
+#if defined(__PX4_POSIX)
+bool MavlinkFTP::_validatePathIsInRoot(const char *path)
+{
+	char real_root[PATH_MAX];
+
+	if (realpath(_root_dir, real_root) == nullptr) {
+		PX4_ERR("FTP: cannot resolve root %s", _root_dir);
+		return false;
+	}
+
+	// The requested path need not exist yet, for CreateFile and CreateDirectory, so walk up
+	// to the deepest ancestor that does and check where that lands.
+	char candidate[PATH_MAX];
+	strncpy(candidate, path, sizeof(candidate) - 1);
+	candidate[sizeof(candidate) - 1] = '\0';
+
+	char real_path[PATH_MAX];
+
+	while (realpath(candidate, real_path) == nullptr) {
+		char *separator = strrchr(candidate, '/');
+
+		if (separator == nullptr) {
+			// A bare name with no separator is created directly inside the root.
+			return true;
+		}
+
+		*separator = '\0';
+
+		if (candidate[0] == '\0') {
+			return false;
+		}
+	}
+
+	const size_t real_root_len = strlen(real_root);
+
+	if (strncmp(real_path, real_root, real_root_len) != 0
+	    || (real_path[real_root_len] != '\0' && real_path[real_root_len] != '/')) {
+		PX4_ERR("FTP: rejecting path resolving outside root: %s", path);
+		return false;
+	}
+
+	return true;
+}
+#endif
 
 bool MavlinkFTP::_validatePathIsWritable(const char *path)
 {

--- a/src/modules/mavlink/mavlink_ftp.h
+++ b/src/modules/mavlink/mavlink_ftp.h
@@ -190,6 +190,15 @@ private:
 	static constexpr int _work_buffer2_len = 256;
 	hrt_abstime _last_work_buffer_access{0}; ///< timestamp when the buffers were last accessed
 
+#if defined(__PX4_POSIX)
+	/**
+	 * Check that `path` stays inside `_root_dir` once symlinks are resolved.
+	 * `_validatePath()` only filters the string, and POSIX file operations follow
+	 * symlinks, so a link inside the tree can otherwise point out of it.
+	 */
+	static bool _validatePathIsInRoot(const char *path);
+#endif
+
 	// prepend a root directory to each file/dir access to avoid enumerating the full FS tree (e.g. on Linux).
 	// Path traversal via ".." is rejected by _validatePath().
 	static constexpr const char _root_dir[] = PX4_ROOTFSDIR;


### PR DESCRIPTION
## Summary

MAVLink FTP validates a path as a string and then hands it to file operations that resolve it differently. Add a containment check on POSIX so a symlink inside the tree cannot point out of the FTP root.

## Problem

`_validatePath()` rejects any path component that is exactly `..`, but POSIX `open()`, `mkdir()` and friends follow symlinks, so a link inside the tree escapes the root without the string ever containing `..`.

On SITL the root is `"."` and PX4 creates `rootfs/etc -> ../etc` at startup so it can find its ROMFS, so a request for `etc/<name>` resolves one directory above the root. No shipping board has a symlink in its FTP tree, so this is not reachable on hardware today — the check simply should not depend on that.

## Solution

Resolve the deepest existing ancestor of the requested path with `realpath()` and require it to stay under the resolved root. POSIX only: on NuttX the root is the empty string, so there is nothing to contain against.

This makes `etc/` unreachable over FTP in SITL, which is intended — it is PX4's own startup symlink, not something a GCS needs to read.

---

Reported by kmm2003.
