### PR TITLE
fix(mavlink): resolve the ULog instance under the lock when handling an ack

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2130,10 +2130,10 @@ MavlinkReceiver::handle_message_logging_ack(mavlink_message_t *msg)
 	mavlink_logging_ack_t logging_ack;
 	mavlink_msg_logging_ack_decode(msg, &logging_ack);
 
-	MavlinkULog *ulog_streaming = _mavlink.get_ulog_streaming();
-
-	if (ulog_streaming) {
-		ulog_streaming->handle_ack(logging_ack);
+	if (_mavlink.get_ulog_streaming() != nullptr) {
+		// Only forward acks on the channel that started streaming. handle_ack() re-resolves
+		// the instance under the lock, so the pointer is never dereferenced here.
+		MavlinkULog::handle_ack(logging_ack);
 	}
 }
 

--- a/src/modules/mavlink/mavlink_ulog.cpp
+++ b/src/modules/mavlink/mavlink_ulog.cpp
@@ -246,10 +246,12 @@ void MavlinkULog::handle_ack(mavlink_logging_ack_t ack)
 {
 	lock();
 
-	if (_instance) { // make sure stop() was not called right before
-		if (_wait_for_ack_sequence == ack.sequence) {
-			_ack_received = true;
-			publish_ack(ack.sequence);
+	// Resolve the instance here rather than trusting a pointer the caller captured
+	// earlier: stop() may have deleted it, and try_start() may have created a new one.
+	if (_instance) {
+		if (_instance->_wait_for_ack_sequence == ack.sequence) {
+			_instance->_ack_received = true;
+			_instance->publish_ack(ack.sequence);
 		}
 	}
 

--- a/src/modules/mavlink/mavlink_ulog.h
+++ b/src/modules/mavlink/mavlink_ulog.h
@@ -92,8 +92,13 @@ public:
 	 */
 	int handle_update(mavlink_channel_t channel);
 
-	/** ack from mavlink for a data message */
-	void handle_ack(mavlink_logging_ack_t ack);
+	/**
+	 * ack from mavlink for a data message.
+	 * Static and resolving the instance under the lock, so a caller never holds a
+	 * pointer that stop() can free underneath it.
+	 * thread-safe
+	 */
+	static void handle_ack(mavlink_logging_ack_t ack);
 
 	/** this is called when we got an vehicle_command_ack from the logger */
 	void start_ack_received();


### PR DESCRIPTION
## Summary

`MavlinkULog::handle_ack()` could read through a freed object. Make it static and resolve the instance under the lock instead of trusting a pointer the caller captured earlier.

## Problem

`get_ulog_streaming()` hands the raw `MavlinkULog*` to the receiver thread, which calls `handle_ack()` on it. The mavlink main thread can delete that object in between, when the logger acks a `LOGGING_STOP`.

`handle_ack()` did take the lock and check the static `_instance`, but then read `_wait_for_ack_sequence` and called `publish_ack()` through `this`. After a stop followed by a start, `_instance` is a valid new object while `this` is the freed old one — the guard passes and the reads go through freed memory.

## Solution

Make `handle_ack()` static and resolve `_instance` under the lock, so no caller holds a pointer that `stop()` can free underneath it. The receiver still checks `get_ulog_streaming()` so acks are only handled on the channel that started streaming, but it no longer dereferences the pointer.

`start_ack_received()` and `handle_update()` run on the mavlink main thread, the same one that does the delete, so they are unaffected.