### PR TITLE
fix(drivers/msp_osd): bound the MSP receive buffer and the VTX table indices

### DIFF
--- a/src/drivers/osd/msp_osd/MspV1.cpp
+++ b/src/drivers/osd/msp_osd/MspV1.cpp
@@ -151,7 +151,7 @@ bool MspV1::Send(const uint8_t message_id, const void *payload, uint32_t payload
 }
 
 
-int MspV1::Receive(uint8_t *payload, uint8_t *message_id)
+int MspV1::Receive(uint8_t *payload, uint8_t *message_id, size_t payload_capacity)
 {
 	uint8_t payload_size;
 	uint8_t crc;
@@ -201,6 +201,13 @@ int MspV1::Receive(uint8_t *payload, uint8_t *message_id)
 
 	payload_size = header[3];
 	*message_id = header[4];
+
+	// payload_size is attacker-controlled up to 255 and the trailing CRC byte is read into
+	// the same buffer, so the frame needs payload_size + MSP_CRC_SIZE bytes of room.
+	if ((size_t)payload_size + MSP_CRC_SIZE > payload_capacity) {
+		has_header = false;
+		return -EMSGSIZE;
+	}
 
 	ret = read(_fd, payload, payload_size + MSP_CRC_SIZE);
 

--- a/src/drivers/osd/msp_osd/MspV1.hpp
+++ b/src/drivers/osd/msp_osd/MspV1.hpp
@@ -33,6 +33,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #define MSP_FRAME_START_SIZE 5
 #define MSP_CRC_SIZE 1
 
@@ -43,7 +45,13 @@ public:
 	int GetMessageSize(int message_type);
 	bool Send(const uint8_t message_id, const void *payload);
 	bool Send(const uint8_t message_id, const void *payload, uint32_t payload_size);
-	int Receive(uint8_t *payload, uint8_t *message_id);
+	/**
+	 * Read one MSP frame into `payload`.
+	 * @param payload_capacity size of `payload` in bytes; a frame that advertises more
+	 *        payload than fits is rejected rather than truncated.
+	 * @return payload size on success, negative errno otherwise
+	 */
+	int Receive(uint8_t *payload, uint8_t *message_id, size_t payload_capacity);
 
 private:
 	int _fd{-1};

--- a/src/drivers/osd/msp_osd/msp_osd.cpp
+++ b/src/drivers/osd/msp_osd/msp_osd.cpp
@@ -524,7 +524,7 @@ void MspOsd::Receive()
 	uint8_t message_id;
 	int ret;
 
-	while ((ret = _msp.Receive(packet, &message_id)) != -EWOULDBLOCK) {
+	while ((ret = _msp.Receive(packet, &message_id, sizeof(packet))) != -EWOULDBLOCK) {
 		if (ret >= 0) {
 			switch (message_id) {
 
@@ -541,7 +541,11 @@ void MspOsd::Receive()
 					msp_set_vtxtable_band_t *band_info = (msp_set_vtxtable_band_t *)&packet[0];
 
 					// Only supported fixed name lenght and < 8 channels for now
-					if (band_info->band <= BAND_COUNT && band_info->band_name_length == 8 && band_info->channel_count <= 8) {
+					// band is 1-based and uint8_t: without the lower bound, band 0 indexes
+					// vtx_bands[-1]. Also require a frame long enough to hold the struct.
+					if (ret >= (int)sizeof(msp_set_vtxtable_band_t)
+					    && band_info->band >= 1 && band_info->band <= BAND_COUNT
+					    && band_info->band_name_length == 8 && band_info->channel_count <= 8) {
 						memcpy((void *)&vtx_bands[band_info->band - 1], packet, sizeof(msp_set_vtxtable_band_t));
 
 						if (has_vtx_config && band_info->band == vtx_config.band_count) {
@@ -553,7 +557,10 @@ void MspOsd::Receive()
 				}
 
 			case MSP_SET_VTXTABLE_POWERLEVEL: {
-					if ((packet[0] - 1) < POWER_LEVEL_COUNT) {
+					// Same 1-based index: packet[0] of 0 promotes to -1 and passes an
+					// upper-bound-only check, indexing power_levels[-1].
+					if (ret >= (int)sizeof(msp_set_vtxtable_powerlevel_t)
+					    && packet[0] >= 1 && (packet[0] - 1) < POWER_LEVEL_COUNT) {
 						memcpy((void *)&power_levels[packet[0] - 1], packet, sizeof(msp_set_vtxtable_powerlevel_t));
 						has_power_config = true;
 					}


### PR DESCRIPTION
## Summary

Three out-of-bounds writes in the `msp_osd` receive path, @all driven by fields the connected MSP device controls.

## Problem

`MspV1::Receive()` read `payload_size + MSP_CRC_SIZE` bytes into a caller-supplied buffer without knowing how big it was. `payload_size` is a `uint8_t` taken straight off the wire, @and the only caller passes a 255-byte stack buffer — so a frame advertising 255 bytes of payload writes one attacker-chosen byte past the end.

The VTX table handlers then index 1-based table entries with upper-bound-only checks. `MSP_SET_VTXTABLE_BAND` accepts band 0, @which satisfies `band <= BAND_COUNT` and writes 29 bytes at `vtx_bands[-1]`. `MSP_SET_VTXTABLE_POWERLEVEL` accepts `packet[0] == 0`, @which promotes to `-1`, @compares less than `POWER_LEVEL_COUNT`, @and writes at `power_levels[-1]`. Neither checked that the frame was long enough to hold the struct it casts the packet to.

28 board configs build this driver; it is activated by assigning a serial port with `MSP_OSD_CONFIG`.

## Solution

Pass the destination size into `Receive()` and reject a frame that does not fit. Require both table indices to be at least 1, @and require the received length to cover the struct before casting to it.

---

Reported by @kmm2003.
