### PR TITLE
fix(drivers/sagetech_mxs): copy fixed-width wire fields without strcpy

### DIFF
--- a/src/drivers/transponder/sagetech_mxs/sg_sdk/sgDecodeFlightId.c
+++ b/src/drivers/transponder/sagetech_mxs/sg_sdk/sgDecodeFlightId.c
@@ -34,8 +34,11 @@ bool sgDecodeFlightId(uint8_t *buffer, sg_flightid_t *id)
 	flightid_t sgId;
 	memcpy(&sgId, buffer, sizeof(flightid_t));
 
-	strcpy(id->flightId, sgId.flightId);
-	memset(&id->flightId[SG_ID_LEN], '\0', 1); // Ensure flight id is null-terminated
+	// flightId is a fixed-width field padded with spaces, not a C string: strcpy() would
+	// run past it into rsvd, checksum and whatever follows on the stack until it found a
+	// zero byte, overflowing the smaller destination on the way.
+	memcpy(id->flightId, sgId.flightId, SG_ID_LEN);
+	id->flightId[SG_ID_LEN] = '\0'; // Ensure flight id is null-terminated
 
 	return true;
 }

--- a/src/drivers/transponder/sagetech_mxs/sg_sdk/sgDecodeInstall.c
+++ b/src/drivers/transponder/sagetech_mxs/sg_sdk/sgDecodeInstall.c
@@ -60,8 +60,10 @@ bool sgDecodeInstall(uint8_t *buffer, sg_install_t *stl)
 	memcpy(&sgStl, buffer, sizeof(stl_t));
 
 	stl->icao           = toIcao(sgStl.icao);
-	strcpy(stl->reg,      sgStl.registration);
-	memset(&stl->reg[SG_REG_LEN], 0, 1);  // Ensure registration is null-terminated
+	// registration is a fixed-width field padded with spaces, not a C string. Same as the
+	// flight id: strcpy() would read past it until it found a zero byte.
+	memcpy(stl->reg, sgStl.registration, SG_REG_LEN);
+	stl->reg[SG_REG_LEN] = '\0';  // Ensure registration is null-terminated
 	stl->com0           = (sg_baud_t)(sgStl.com0);
 	stl->com1           = (sg_baud_t)(sgStl.com1);
 	stl->eth.ipAddress  = toUint32(sgStl.ipAddress);


### PR DESCRIPTION
## Summary

Two decoders in the bundled Sagetech SDK treat a fixed-width, @space-padded wire field as a NUL-terminated C string and `strcpy()` it into a smaller destination.

## Problem

In `sgDecodeFlightId()`, `flightId` is `char[8]` inside the packed wire struct, @followed by `rsvd[4]` and `checksum`. `strcpy()` copies until it finds a zero byte, @so a transponder sending eight non-NUL characters and non-zero trailing bytes makes it run off the end of the local struct into the stack, @writing into a nine-byte destination the whole way.

`sgDecodeInstall()` has the same bug with `registration`, `char[7]` copied into an eight-byte destination.

Both are reachable from the transponder serial link — a `FlightID_Response` or `Installation_Response` is decoded as soon as it arrives.

## Solution

Copy exactly the field width and @terminate. The trailing `memset` was already writing the terminator in the right place; it just ran after the overflow had happened.

---

Reported by @kmm2003.
