### PR TITLE
fix(posix): stage the ROMFS into the SITL working directory

### DIFF
--- a/platforms/posix/CMakeLists.txt
+++ b/platforms/posix/CMakeLists.txt
@@ -156,6 +156,24 @@ elseif("${PX4_BOARD}" MATCHES "sitl")
 
 	set(SITL_WORKING_DIR ${PX4_BINARY_DIR}/rootfs)
 	file(MAKE_DIRECTORY ${SITL_WORKING_DIR})
+
+	# Stage the generated ROMFS into the working directory instead of letting PX4 symlink
+	# it there at startup. MAVLink FTP is rooted at the working directory and validates
+	# paths as strings while the file operations follow symlinks, so a link pointing at the
+	# build tree let FTP requests resolve outside the root it advertises. A real directory
+	# has nothing to follow, and PX4 leaves an existing etc directory alone.
+	if(config_romfs_root)
+		add_custom_command(OUTPUT ${SITL_WORKING_DIR}/etc.stamp
+			COMMAND ${CMAKE_COMMAND} -E remove_directory ${SITL_WORKING_DIR}/etc
+			COMMAND ${CMAKE_COMMAND} -E copy_directory ${PX4_BINARY_DIR}/etc ${SITL_WORKING_DIR}/etc
+			COMMAND ${CMAKE_COMMAND} -E touch ${SITL_WORKING_DIR}/etc.stamp
+			DEPENDS romfs_gen_files_target
+			COMMENT "SITL: staging ROMFS into ${SITL_WORKING_DIR}/etc"
+			)
+		add_custom_target(sitl_rootfs_etc ALL DEPENDS ${SITL_WORKING_DIR}/etc.stamp)
+		add_dependencies(px4 sitl_rootfs_etc)
+	endif()
+
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/posix.lldbinit ${SITL_WORKING_DIR}/.lldbinit COPYONLY)
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/posix.gdbinit ${SITL_WORKING_DIR}/.gdbinit COPYONLY)
 


### PR DESCRIPTION
## Summary

Copy the generated ROMFS into the SITL working directory at build time, so PX4 no longer symlinks `etc` there at startup.

## Problem

When the working directory is not the data path, PX4 makes `etc` a symlink to it. MAVLink FTP is rooted at the working directory and validates paths as strings, while the underlying file operations follow symlinks — so FTP requests under `etc/` resolved outside the root FTP advertises.

Fixing it in the FTP layer does not work. `COMPONENT_INFORMATION` advertises `mftp://etc/extras/component_general.json.xz` to every ground station, so a containment check in `_validatePath()` rejects the metadata download PX4 itself asks clients to perform.

## Solution

Stage `${PX4_BINARY_DIR}/etc` into `${PX4_BINARY_DIR}/rootfs/etc` as a build step. A real directory has nothing to follow, and the existing startup code already returns early when `etc` is a directory rather than a symlink — so this needs no source change.

The symlink path remains for an installed PX4 or an explicit `-d <data_path>`, where the FTP root is not the working directory.

---

Reported by @kmm2003.