### PR TITLE
fix(mavlink): authorize FTP writes when the file is opened

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -521,6 +521,13 @@ MavlinkFTP::_workOpen(PayloadHeader *payload, int oflag)
 		return kErrFailFileProtected;
 	}
 
+	// CreateFile and OpenFileWO create or truncate the file as part of the open, so the
+	// effect lands before any write arrives and has to be authorized here.
+	if ((oflag & (O_WRONLY | O_RDWR | O_CREAT | O_TRUNC)) != 0
+	    && !_validatePathIsWritable(_work_buffer1)) {
+		return kErrFailFileProtected;
+	}
+
 	PX4_DEBUG("FTP: open '%s'", _work_buffer1);
 
 	uint32_t fileSize = 0;
@@ -631,9 +638,9 @@ MavlinkFTP::_workWrite(PayloadHeader *payload)
 		return kErrInvalidSession;
 	}
 
-	if (!_validatePathIsWritable(_work_buffer1)) {
-		return kErrFailFileProtected;
-	}
+	// The path is authorized in _workOpen(), which is where the descriptor this writes to
+	// was bound. Re-checking here would validate _work_buffer1, a scratch buffer any
+	// intervening request overwrites, rather than the path behind _session_info.fd.
 
 	if (lseek(_session_info.fd, payload->offset, SEEK_SET) < 0) {
 		// Unable to see to the specified location


### PR DESCRIPTION
## Summary

Move the MAVLink FTP writable-path check from `_workWrite()` to `_workOpen()`, where the file descriptor is bound.

## Problem

The check sat in `_workWrite()`, which is both too late and against the wrong path.

**Too late:** `CreateFile` opens with `O_CREAT | O_TRUNC | O_WRONLY` and `OpenFileWO` with `O_CREAT | O_WRONLY`, so the file is created or truncated during the open. No write has to arrive for the effect to land, and `_workOpen()` called only `_validatePath()`.

**Wrong path:** `_workWrite()` validated `_work_buffer1` — the scratch buffer every request constructs its path into. A directory listing between the open and the write leaves it holding the listed path, so the check compared something unrelated to the descriptor being written to.

Every other destructive operation — remove, truncate, rename, mkdir, rmdir — already checks at the point it acts. The open path was the exception.

## Solution

Authorize in `_workOpen()`, only when the flags carry write intent, and drop the check from `_workWrite()`.

## Note

This is a correctness fix, not a security one. On NuttX the reachable targets of an unauthorized truncate are the SD card (already permitted), the parameter store (which `MAV_CMD_PREFLIGHT_STORAGE` can reset anyway) and read-only or device paths where the open fails. On POSIX `_validatePathIsWritable()` currently returns true unconditionally, so nothing changes there until #28582 gives it a storage directory to check against — after which this gap would be the one place ignoring it.

---

Reported by @20210607, @REYu6 and @mbanyamer.