### PR TITLE
build(macos): bump gz tap pin to 9403d12a474c

### DIFF
--- a/Tools/setup/gz-tap-pin.txt
+++ b/Tools/setup/gz-tap-pin.txt
@@ -6,4 +6,4 @@
 # Move it to the newest commit where every gz formula macos.sh installs still
 # carries a bottle block. Tools/ci/refresh_gz_tap_pin.rb does that, weekly
 # from .github/workflows/macos_gz_tap_pin_refresh.yml or by hand.
-43aee9cc6e02aa8b7327d0a8d3e895f93a99440f
+9403d12a474c239604243c77751fa53ad95ba16f


### PR DESCRIPTION
Weekly check found that osrf/simulation commit `9403d12a474c239604243c77751fa53ad95ba16f` is the newest one where every osrf/simulation formula `macos.sh --sim-tools` poured at the previous pin still has a bottle Homebrew pours on macos-15, and every bottle tarball is still served. Moves `Tools/setup/gz-tap-pin.txt` from `43aee9cc6e02aa8b7327d0a8d3e895f93a99440f` to it.

Tap changes: https://github.com/osrf/homebrew-simulation/compare/43aee9cc6e02aa8b7327d0a8d3e895f93a99440f...9403d12a474c239604243c77751fa53ad95ba16f

The MacOS build legs on this PR are the real test. Merge once both pour the gz bottles without compiling anything from osrf/simulation.