### PR TITLE
fix(uavcan): report correct status for node param save and restart

### DIFF
--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -246,7 +246,7 @@ UavcanNode::reset_node(int remote_node_id)
 		}
 	}
 
-	if (!call_res) {
+	if (call_res < 0 || !_callback_success) {
 		std::printf("Failed to reset node: %d\n", remote_node_id);
 		return -1;
 	}
@@ -1497,6 +1497,7 @@ UavcanNode::cb_opcode(const uavcan::ServiceCallResult<uavcan::protocol::param::E
 	uavcan::protocol::param::ExecuteOpcode::Response resp = result.getResponse();
 	success &= resp.ok;
 	_cmd_in_progress = false;
+	_callback_success = success;
 
 	if (!result.isSuccessful()) {
 		PX4_ERR("save request for node %hhu timed out.", node_id);
@@ -1543,6 +1544,7 @@ UavcanNode::cb_restart(const uavcan::ServiceCallResult<uavcan::protocol::Restart
 	uavcan::protocol::RestartNode::Response resp = result.getResponse();
 	success &= resp.ok;
 	_cmd_in_progress = false;
+	_callback_success = success;
 
 	if (success) {
 		PX4_DEBUG("restart request for node %hhu completed OK.", node_id);


### PR DESCRIPTION
### Solution

`uavcan param save <node>` and `uavcan reset <node>` both print a failure message when the operation actually succeeded.

- `_callback_success` is only ever assigned in `cb_getset()`. `cb_opcode()` and `cb_restart()` compute a local `success` but never store it, so `save_params()` always takes the failure branch and prints `Failed to save parameters` even when the node answers OK.
- `reset_node()` tests `if (!call_res)`, but `call_res` is the return of `ServiceClient::call()`, where 0 means the request was sent successfully. So `Failed to reset node` is printed even in cases where the call worked.

This commit assigns `_callback_success` from the service result in `cb_opcode()` and `cb_restart()`, and changes `reset_node()` to test `call_res < 0 || !_callback_success` — the same check `save_params()` already uses.

### Test coverage

Reproduced on hardware with a DroneCAN rangefinder node (Agam FloRange):

```
nsh> uavcan param set 122 SENS_AFBR_ROT 0
nsh> uavcan param get 122 SENS_AFBR_ROT
name: SENS_AFBR_ROT 0
nsh> uavcan reset 122
Failed to reset node: 122          <-- node did restart
nsh> uavcan param get 122 SENS_AFBR_ROT
name: SENS_AFBR_ROT 0              <-- value persisted across the restart
```

The node restarted and the value persisted, confirming the reported failure was spurious. Messages report correctly after the change; no behavioural change to the CAN transactions themselves.