### PR TITLE
fix(control_allocation): drop control axes that are not independently achievable

### DIFF
--- a/src/lib/control_allocation/control_allocation/ControlAllocation.hpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocation.hpp
@@ -253,6 +253,10 @@ public:
 
 	void setNormalizeRPY(bool normalize_rpy) { _normalize_rpy = normalize_rpy; }
 
+	/// Axes (bitmask over ControlAxis) dropped from the effectiveness matrix as not independently
+	/// achievable, e.g. yaw when collinear with roll after a motor failure
+	uint8_t getDroppedAxes() const { return _dropped_axes; }
+
 protected:
 	friend class ControlAllocator; // for _actuator_sp
 
@@ -269,4 +273,5 @@ protected:
 	int _num_actuators{0};
 	bool _normalize_rpy{false};				///< if true, normalize roll, pitch and yaw columns
 	bool _had_actuator_failure{false};
+	uint8_t _dropped_axes{0};				///< bitmask over ControlAxis
 };

--- a/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.cpp
@@ -49,6 +49,10 @@ ControlAllocationPseudoInverse::setEffectivenessMatrix(
 {
 	ControlAllocation::setEffectivenessMatrix(effectiveness, actuator_trim, linearization_point, num_actuators,
 			update_normalization_scale);
+
+	// in place on the stored copy: no second matrix on the (small work queue) stack
+	_dropped_axes = dropDependentAxes(_effectiveness);
+
 	_mix_update_needed = true;
 	_normalization_needs_update = update_normalization_scale;
 
@@ -186,4 +190,81 @@ ControlAllocationPseudoInverse::allocate()
 
 	// Allocate
 	_actuator_sp = _actuator_trim + _mix * (_control_sp - _control_trim);
+}
+
+namespace
+{
+
+float rowDot(const matrix::Matrix<float, ControlAllocation::NUM_AXES, ControlAllocation::NUM_ACTUATORS> &effectiveness,
+	     int row_a, int row_b)
+{
+	float sum = 0.f;
+
+	for (int j = 0; j < ControlAllocation::NUM_ACTUATORS; j++) {
+		sum += effectiveness(row_a, j) * effectiveness(row_b, j);
+	}
+
+	return sum;
+}
+
+} // namespace
+
+uint8_t
+ControlAllocationPseudoInverse::dropDependentAxes(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &effectiveness)
+{
+	// highest priority first
+	static constexpr ControlAxis kPriority[NUM_AXES] = {THRUST_Z, ROLL, PITCH, THRUST_X, THRUST_Y, YAW};
+
+	// Gram-Schmidt through the Cholesky factor of the Gram matrix of the accepted unit rows:
+	// equivalent to orthogonalizing the rows, without keeping NUM_ACTUATORS-long vectors on the
+	// (small work queue) stack
+	float chol[NUM_AXES][NUM_AXES] {};
+	float inv_norm[NUM_AXES];
+	ControlAxis accepted[NUM_AXES];
+	int num_accepted = 0;
+	uint8_t dropped = 0;
+
+	for (const ControlAxis axis : kPriority) {
+		const float norm_squared = rowDot(effectiveness, axis, axis);
+
+		if (norm_squared < FLT_EPSILON) {
+			continue; // unused axis
+		}
+
+		const float inv = 1.f / sqrtf(norm_squared);
+
+		// projection of the unit row onto the orthonormal basis of the accepted rows
+		float projection[NUM_AXES];
+		float projected_norm_squared = 0.f;
+
+		for (int i = 0; i < num_accepted; i++) {
+			float sum = rowDot(effectiveness, axis, accepted[i]) * inv * inv_norm[i];
+
+			for (int j = 0; j < i; j++) {
+				sum -= chol[i][j] * projection[j];
+			}
+
+			projection[i] = sum / chol[i][i];
+			projected_norm_squared += projection[i] * projection[i];
+		}
+
+		const float independence = 1.f - projected_norm_squared;
+
+		if (independence < kMinAxisIndependence) {
+			effectiveness.row(axis) = 0.f;
+			dropped |= static_cast<uint8_t>(1u << axis);
+
+		} else {
+			for (int j = 0; j < num_accepted; j++) {
+				chol[num_accepted][j] = projection[j];
+			}
+
+			chol[num_accepted][num_accepted] = sqrtf(independence);
+			inv_norm[num_accepted] = inv;
+			accepted[num_accepted] = axis;
+			num_accepted++;
+		}
+	}
+
+	return dropped;
 }

--- a/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.cpp
@@ -192,23 +192,6 @@ ControlAllocationPseudoInverse::allocate()
 	_actuator_sp = _actuator_trim + _mix * (_control_sp - _control_trim);
 }
 
-namespace
-{
-
-float rowDot(const matrix::Matrix<float, ControlAllocation::NUM_AXES, ControlAllocation::NUM_ACTUATORS> &effectiveness,
-	     int row_a, int row_b)
-{
-	float sum = 0.f;
-
-	for (int j = 0; j < ControlAllocation::NUM_ACTUATORS; j++) {
-		sum += effectiveness(row_a, j) * effectiveness(row_b, j);
-	}
-
-	return sum;
-}
-
-} // namespace
-
 uint8_t
 ControlAllocationPseudoInverse::dropDependentAxes(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &effectiveness)
 {
@@ -225,7 +208,7 @@ ControlAllocationPseudoInverse::dropDependentAxes(matrix::Matrix<float, NUM_AXES
 	uint8_t dropped = 0;
 
 	for (const ControlAxis axis : kPriority) {
-		const float norm_squared = rowDot(effectiveness, axis, axis);
+		const float norm_squared = effectiveness.row(axis).norm_squared();
 
 		if (norm_squared < FLT_EPSILON) {
 			continue; // unused axis
@@ -238,7 +221,7 @@ ControlAllocationPseudoInverse::dropDependentAxes(matrix::Matrix<float, NUM_AXES
 		float projected_norm_squared = 0.f;
 
 		for (int i = 0; i < num_accepted; i++) {
-			float sum = rowDot(effectiveness, axis, accepted[i]) * inv * inv_norm[i];
+			float sum = effectiveness.row(axis).dot(effectiveness.row(accepted[i])) * inv * inv_norm[i];
 
 			for (int j = 0; j < i; j++) {
 				sum -= chol[i][j] * projection[j];

--- a/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.hpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.hpp
@@ -59,6 +59,15 @@ public:
 				    bool update_normalization_scale) override;
 	void setMetricAllocation(bool metric_allocation) { _metric_allocation = metric_allocation; }
 
+	/**
+	 * Zero the rows of axes that are (nearly) dependent on higher-priority axes
+	 * (thrust z, roll, pitch, thrust x, thrust y, yaw), making them explicitly unachievable
+	 * instead of inverting a near-singular matrix.
+	 *
+	 * @return bitmask over ControlAxis of the dropped axes
+	 */
+	static uint8_t dropDependentAxes(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &effectiveness);
+
 protected:
 	matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> _mix;
 
@@ -72,6 +81,13 @@ protected:
 	void updatePseudoInverse();
 
 private:
+	/**
+	 * Minimum independence for a control axis to be kept: squared norm of the unit axis row
+	 * after removing its projection onto the higher-priority axes (sin^2 of the angle to their
+	 * span, unit-free). 1e-2 (~5.7 deg) bounds the pseudo-inverse gain along the axis to ~10x.
+	 */
+	static constexpr float kMinAxisIndependence = 1e-2f;
+
 	void normalizeControlAllocationMatrix();
 	void updateControlAllocationMatrixScale();
 	bool _normalization_needs_update{false};

--- a/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverseTest.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverseTest.cpp
@@ -91,3 +91,155 @@ TEST(ControlAllocationMetricTest, AllZeroCase)
 	EXPECT_EQ(actuator_sp, actuator_sp_expected);
 	EXPECT_EQ(control_allocated, control_allocated_expected);
 }
+
+namespace
+{
+
+// Surveyed hexarotor; rows roll/pitch/yaw/thrust xyz, one column per rotor
+constexpr float kSurveyedHexarotor[6][6] = {
+	{-5.947500f,  5.934500f,  2.964000f, -2.853500f, -2.990000f,  2.840500f},
+	{ 0.071500f,  0.071500f,  5.063500f, -4.972500f,  5.063500f, -4.972500f},
+	{-0.325000f,  0.325000f, -0.325000f,  0.325000f,  0.325000f, -0.325000f},
+	{ 0.f,        0.f,        0.f,        0.f,        0.f,        0.f},
+	{ 0.f,        0.f,        0.f,        0.f,        0.f,        0.f},
+	{-6.500000f, -6.500000f, -6.500000f, -6.500000f, -6.500000f, -6.500000f}
+};
+
+Matrix<float, 6, 16> surveyedHexarotor(uint16_t stopped_mask)
+{
+	Matrix<float, 6, 16> effectiveness;
+	effectiveness.setZero();
+
+	for (int i = 0; i < 6; i++) {
+		if (stopped_mask & (1u << i)) {
+			continue;
+		}
+
+		for (int axis = 0; axis < 6; axis++) {
+			effectiveness(axis, i) = kSurveyedHexarotor[axis][i];
+		}
+	}
+
+	return effectiveness;
+}
+
+struct Rotor {
+	float px;
+	float py;
+	float km;
+};
+
+// upward rotors as in ActuatorEffectivenessRotors
+Matrix<float, 6, 16> planarRotors(const Rotor *rotors, int count, uint16_t stopped_mask = 0)
+{
+	constexpr float ct = 6.5f;
+	Matrix<float, 6, 16> effectiveness;
+	effectiveness.setZero();
+
+	for (int i = 0; i < count; i++) {
+		if (stopped_mask & (1u << i)) {
+			continue;
+		}
+
+		effectiveness(0, i) = -ct * rotors[i].py;
+		effectiveness(1, i) = ct * rotors[i].px;
+		effectiveness(2, i) = ct * rotors[i].km;
+		effectiveness(5, i) = -ct;
+	}
+
+	return effectiveness;
+}
+
+// In-tree geometries 4001_quad_x, 6001_hexa_x, 8001_octo_x
+constexpr Rotor kQuadX[] = {{1.f, 1.f, 0.05f}, {-1.f, -1.f, 0.05f}, {1.f, -1.f, -0.05f}, {-1.f, 1.f, -0.05f}};
+constexpr Rotor kHexaX[] = {{0.f, 0.5f, -0.05f}, {0.f, -0.5f, 0.05f}, {0.43f, -0.25f, -0.05f},
+	{-0.43f, 0.25f, 0.05f}, {0.43f, 0.25f, 0.05f}, {-0.43f, -0.25f, -0.05f}
+};
+constexpr Rotor kOctoX[] = {{0.46f, 0.19f, -0.05f}, {-0.46f, -0.19f, -0.05f}, {0.19f, 0.46f, 0.05f},
+	{-0.46f, 0.19f, 0.05f}, {0.46f, -0.19f, 0.05f}, {-0.19f, -0.46f, 0.05f}, {0.19f, -0.46f, -0.05f},
+	{-0.19f, 0.46f, -0.05f}
+};
+
+} // namespace
+
+TEST(ControlAllocationPseudoInverseTest, DropDependentAxesKeepsIndependentGeometries)
+{
+	const Matrix<float, 6, 16> independent[] = {
+		planarRotors(kQuadX, 4),
+		planarRotors(kHexaX, 6),
+		planarRotors(kOctoX, 8),
+		surveyedHexarotor(0),
+		surveyedHexarotor(1u << 0),		// one motor removed: still rank 4
+		planarRotors(kHexaX, 6, 1u << 2),
+		planarRotors(kOctoX, 8, (1u << 0) | (1u << 1)),
+	};
+
+	for (const auto &original : independent) {
+		Matrix<float, 6, 16> effectiveness = original;
+		EXPECT_EQ(ControlAllocationPseudoInverse::dropDependentAxes(effectiveness), 0);
+		EXPECT_EQ(effectiveness, original);
+	}
+}
+
+TEST(ControlAllocationPseudoInverseTest, DropDependentAxesDropsYawCollinearWithRoll)
+{
+	// motor and its opposite stopped: roll and yaw collinear, yaw must go, never roll
+	const Matrix<float, 6, 16> reduced[] = {
+		surveyedHexarotor((1u << 0) | (1u << 1)),
+		surveyedHexarotor((1u << 2) | (1u << 3)),
+		surveyedHexarotor((1u << 4) | (1u << 5)),
+		planarRotors(kHexaX, 6, (1u << 0) | (1u << 1)),
+		planarRotors(kHexaX, 6, (1u << 2) | (1u << 3)),
+	};
+
+	for (const auto &original : reduced) {
+		Matrix<float, 6, 16> effectiveness = original;
+		const uint8_t dropped = ControlAllocationPseudoInverse::dropDependentAxes(effectiveness);
+		EXPECT_EQ(dropped, 1u << ControlAllocation::YAW);
+
+		for (int axis = 0; axis < 6; axis++) {
+			for (int i = 0; i < 16; i++) {
+				const float expected = (axis == ControlAllocation::YAW) ? 0.f : original(axis, i);
+				EXPECT_FLOAT_EQ(effectiveness(axis, i), expected);
+			}
+		}
+	}
+}
+
+TEST(ControlAllocationPseudoInverseTest, DroppedAxisIsUnallocatedOthersExact)
+{
+	ControlAllocationPseudoInverse method;
+	Vector<float, 16> actuator_trim;
+	Vector<float, 16> linearization_point;
+
+	method.setEffectivenessMatrix(surveyedHexarotor((1u << 0) | (1u << 1)), actuator_trim, linearization_point,
+				      16, false);
+	EXPECT_EQ(method.getDroppedAxes(), 1u << ControlAllocation::YAW);
+
+	// yaw demand has nothing to act on
+	Vector<float, 6> control_sp;
+	control_sp(ControlAllocation::YAW) = 1.f;
+	method.setControlSetpoint(control_sp);
+	method.allocate();
+	const Vector<float, 16> no_actuation;
+	EXPECT_EQ(method.getActuatorSetpoint(), no_actuation);
+	EXPECT_FLOAT_EQ(method.getAllocatedControl()(ControlAllocation::YAW), 0.f);
+
+	// remaining axes allocated exactly
+	control_sp.setZero();
+	control_sp(ControlAllocation::ROLL) = 0.01f;
+	control_sp(ControlAllocation::PITCH) = 0.024f;
+	control_sp(ControlAllocation::THRUST_Z) = -0.001f;
+	method.setControlSetpoint(control_sp);
+	method.allocate();
+
+	const Vector<float, 6> allocated = method.getAllocatedControl();
+	EXPECT_NEAR(allocated(ControlAllocation::ROLL), 0.01f, 1e-4f);
+	EXPECT_NEAR(allocated(ControlAllocation::PITCH), 0.024f, 1e-4f);
+	EXPECT_NEAR(allocated(ControlAllocation::THRUST_Z), -0.001f, 1e-4f);
+	EXPECT_FLOAT_EQ(allocated(ControlAllocation::YAW), 0.f);
+
+	for (int i = 0; i < 16; i++) {
+		EXPECT_LT(fabsf(method.getActuatorSetpoint()(i)), 0.01f) << "actuator " << i;
+	}
+}

--- a/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturationTest.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturationTest.cpp
@@ -474,3 +474,69 @@ TEST_F(ControlAllocationSequentialDesaturationTestQuadX, PreviousMixingTestsAirm
 	EXPECT_EQ(allocate(-1.000f, 0.900f, 0.000f, -0.900f), Vector4f(1.000000f, 0.550000f, 0.050000f, 0.500000f)); // 64
 	EXPECT_EQ(allocate(-1.000f, 0.900f, 0.000f, -1.000f), Vector4f(1.000000f, 0.550000f, 0.050000f, 0.500000f)); // 65
 }
+
+// Hexarotor with a motor and its opposite stopped: roll and yaw collinear. The float pseudo-inverse
+// of that matrix used to be garbage and drove the remaining motors to full at zero thrust demand.
+TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledNeverAddsThrustAfterMotorFailure)
+{
+	// rows roll/pitch/yaw/thrust xyz, one column per rotor
+	const float intact[6][6] = {
+		{-5.947500f,  5.934500f,  2.964000f, -2.853500f, -2.990000f,  2.840500f},
+		{ 0.071500f,  0.071500f,  5.063500f, -4.972500f,  5.063500f, -4.972500f},
+		{-0.325000f,  0.325000f, -0.325000f,  0.325000f,  0.325000f, -0.325000f},
+		{ 0.f,        0.f,        0.f,        0.f,        0.f,        0.f},
+		{ 0.f,        0.f,        0.f,        0.f,        0.f,        0.f},
+		{-6.500000f, -6.500000f, -6.500000f, -6.500000f, -6.500000f, -6.500000f}
+	};
+
+	auto make_effectiveness = [&intact](uint16_t stopped_mask) {
+		ActuatorEffectiveness::EffectivenessMatrix effectiveness;
+		effectiveness.setZero();
+
+		for (int i = 0; i < 6; i++) {
+			if (stopped_mask & (1u << i)) {
+				continue;
+			}
+
+			for (int axis = 0; axis < 6; axis++) {
+				effectiveness(axis, i) = intact[axis][i];
+			}
+		}
+
+		return effectiveness;
+	};
+
+	ControlAllocationSequentialDesaturation allocator;
+	allocator.setNormalizeRPY(true);
+	matrix::Vector<float, ActuatorEffectiveness::NUM_ACTUATORS> actuator_trim;
+	matrix::Vector<float, ActuatorEffectiveness::NUM_ACTUATORS> linearization_point;
+
+	// intact geometry first to capture the normalization scale, as ControlAllocator does
+	allocator.setEffectivenessMatrix(make_effectiveness(0), actuator_trim, linearization_point,
+					 ActuatorEffectiveness::NUM_ACTUATORS, true);
+	allocator.allocate();
+
+	// rotors 0 and 1 stop, scale not recomputed
+	allocator.setHadActuatorFailure(true);
+	allocator.setEffectivenessMatrix(make_effectiveness((1u << 0) | (1u << 1)), actuator_trim,
+					 linearization_point, ActuatorEffectiveness::NUM_ACTUATORS, false);
+
+	// attitude hold at zero thrust demand
+	matrix::Vector<float, ActuatorEffectiveness::NUM_AXES> control_sp;
+	control_sp(ControlAllocation::ControlAxis::ROLL) = 0.010f;
+	control_sp(ControlAllocation::ControlAxis::PITCH) = 0.024f;
+	control_sp(ControlAllocation::ControlAxis::YAW) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::THRUST_Z) = -0.001f;
+	allocator.setControlSetpoint(control_sp);
+
+	// Since MC_AIRMODE was not set explicitly, assume airmode is disabled.
+	allocator.allocate();
+
+	const auto &actuator_sp = allocator.getActuatorSetpoint();
+
+	for (int i = 0; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
+		EXPECT_LT(actuator_sp(i), 0.1f) << "motor " << i;
+	}
+}

--- a/src/lib/matrix/matrix/Slice.hpp
+++ b/src/lib/matrix/matrix/Slice.hpp
@@ -321,18 +321,24 @@ public:
 		return res;
 	}
 
-	Type norm_squared() const
+	template<size_t MM, size_t NN>
+	Type dot(const SliceT<MatrixT, Type, P, Q, MM, NN> &other) const
 	{
 		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
 		Type accum(0);
 
 		for (size_t i = 0; i < P; i++) {
 			for (size_t j = 0; j < Q; j++) {
-				accum += self(i, j) * self(i, j);
+				accum += self(i, j) * other(i, j);
 			}
 		}
 
 		return accum;
+	}
+
+	Type norm_squared() const
+	{
+		return dot(*this);
 	}
 
 	Type norm() const

--- a/src/lib/matrix/test/MatrixSliceTest.cpp
+++ b/src/lib/matrix/test/MatrixSliceTest.cpp
@@ -344,3 +344,21 @@ TEST(MatrixSliceTest, XYAssignmentTest)
 	a.xy() = b.xy();
 	EXPECT_EQ(a, Vector3f(4, 5, 3));
 }
+
+TEST(MatrixSliceTest, Dot)
+{
+	float data[9] = {0, 2, 3,
+			 4, 5, 6,
+			 7, 8, 10
+			};
+	SquareMatrix3f A(data);
+
+	// row . row, within the same matrix
+	EXPECT_FLOAT_EQ(A.row(1).dot(A.row(2)), 4.f * 7.f + 5.f * 8.f + 6.f * 10.f);
+
+	// col . col, within the same matrix
+	EXPECT_FLOAT_EQ(A.col(0).dot(A.col(1)), 0.f * 2.f + 4.f * 5.f + 7.f * 8.f);
+
+	// self dot matches norm_squared()
+	EXPECT_FLOAT_EQ(A.row(1).dot(A.row(1)), A.row(1).norm_squared());
+}

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -447,6 +447,8 @@ ControlAllocator::Run()
 			}
 
 			_control_allocation[i]->clipActuatorSetpoint();
+
+			check_allocation_health(i);
 		}
 	}
 
@@ -630,6 +632,23 @@ ControlAllocator::handle_stopped_motors(const hrt_abstime now)
 			if (stopped_motors & 1u << motors_idx) {
 				_control_allocation[allocation_index]->_actuator_sp(motors_idx) = ice_shedding_output;
 			}
+		}
+	}
+}
+
+void
+ControlAllocator::check_allocation_health(int matrix_index)
+{
+	const uint8_t dropped_axes = _control_allocation[matrix_index]->getDroppedAxes();
+
+	if (dropped_axes != _dropped_axes_reported[matrix_index]) {
+		_dropped_axes_reported[matrix_index] = dropped_axes;
+
+		if (dropped_axes != 0) {
+			PX4_WARN("Control allocation %i: dropped dependent control axes 0x%x", matrix_index, dropped_axes);
+
+		} else {
+			PX4_INFO("Control allocation %i: all control axes restored", matrix_index);
 		}
 	}
 }
@@ -1031,6 +1050,10 @@ int ControlAllocator::print_status()
 
 		printf("\n");
 		PX4_INFO("  Configured actuators: %i", num_configured);
+
+		if (_control_allocation[i]->getDroppedAxes() != 0) {
+			PX4_INFO("  Dropped control axes: 0x%x", _control_allocation[i]->getDroppedAxes());
+		}
 	}
 
 	if (_handled_motor_failure_bitmask) {

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -148,6 +148,8 @@ private:
 
 	void publish_control_allocator_status(int matrix_index);
 
+	void check_allocation_health(int matrix_index);
+
 	void publish_actuator_controls();
 
 	void handle_stopped_motors(const hrt_abstime now);
@@ -158,6 +160,8 @@ private:
 	ControlAllocation *_control_allocation[ActuatorEffectiveness::MAX_NUM_MATRICES] {}; 	///< class for control allocation calculations
 	int _num_control_allocation{0};
 	hrt_abstime _last_effectiveness_update{0};
+
+	uint8_t _dropped_axes_reported[ActuatorEffectiveness::MAX_NUM_MATRICES] {};
 
 	enum class EffectivenessSource {
 		NONE = -1,


### PR DESCRIPTION
## Summary

A hexarotor with `CA_FAILURE_MODE=1` spun its remaining motors up and lifted off while armed on the ground at idle. Control allocation has no notion of an axis becoming uncontrollable, so it inverted a near-singular effectiveness matrix and flew on the result. It now decides explicitly which axes it can still reach and drops the ones it cannot.

## Problem

Stopping a hexarotor motor and its geometric opposite leaves four rotors whose roll and yaw effectiveness rows are collinear — exactly so on ideal geometry, 1.3 deg apart on a surveyed airframe. Yaw is no longer independently controllable, but nothing in control allocation checks for that.

`geninv` therefore inverted a matrix it should have refused, and returned a mix with roll gains around 50x and thrust gains around 2000x, with random signs (Moore-Penrose residual 1e4). Sequential desaturation cannot recover from gains that large; it left roughly 0.85 on two rotors at zero thrust demand, which is enough to lift the aircraft off the pad.

Note that the ideal symmetric geometry hides this. There the near-zero pivot falls below the Cholesky rank tolerance and gets truncated, giving a clean rank-3 solution. On the slightly asymmetric surveyed geometry the pivot lands just above the tolerance, is accepted, and is inverted into garbage. That is why testing mode 1 on textbook hexarotor geometry never showed the problem.

## Solution

`dropDependentAxes()` walks the effectiveness rows in priority order (thrust z, roll, pitch, thrust x, thrust y, yaw) and zeroes any row whose component orthogonal to the higher-priority rows falls below `kMinAxisIndependence` = 1e-2, i.e. within about 5.7 deg of their span. The axis becomes explicitly unachievable rather than a source of enormous gains, and it shows up as unallocated torque in `control_allocator_status` (correct again since 6041c961dd6 stopped `getAllocatedControl()` propagating the stopped-motor NaNs). The dropped-axis mask is also logged once on change and shown in `print_status`.

The metric is a squared sine of the angle to the span of the higher-priority rows, so it is unit-free and does not depend on `CA_ROTORn_KM` or arm length — verified to give identical decisions for `KM` from 0.003 to 0.5 and arms from 0.05 m to 5 m. Across in-tree geometries, healthy multirotors score 1.00, hexa and octo with one motor out 0.75 and 0.89, tailsitter 0.70; none are affected. Only quad-with-one-motor-out and hexarotor failed-plus-opposite drop yaw, which is right in both cases.

The orthogonalization runs through the Cholesky factor of the Gram matrix of the accepted unit rows rather than on the rows themselves, so no `NUM_ACTUATORS`-long vectors land on the stack: 288 B of frame instead of 632 B. That matters because this runs on `wq:rate_ctrl`, which has 3150 B.

Flight tested on a hexarotor with the surveyed geometry. The original scenario — armed on the ground at idle thrust, `CA_FAILURE_MODE=1`, failed motor and its opposite stopped — now holds every motor at or below 0.003 with no uncommanded thrust. The same failure in flight allocates roll, pitch and thrust with sane gains (roll 1.25, thrust 1.52, against 55 and 3163 before) while yaw is reported dropped.
