### PR TITLE
fix(simulation): correctly fill the device_id of the simulated sensor_gps message

### DIFF
--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
@@ -393,6 +393,13 @@ void SimulatorMavlink::handle_message_hil_gps(const mavlink_message_t *msg)
 
 	sensor_gps_s gps{};
 
+	device::Device::DeviceId device_id;
+	device_id.devid_s.bus_type = device::Device::DeviceBusType::DeviceBusType_SIMULATION;
+	device_id.devid_s.bus = 0;
+	device_id.devid_s.address = hil_gps.id;
+	device_id.devid_s.devtype = DRV_GPS_DEVTYPE_SIM;
+	gps.device_id = device_id.devid;
+
 	gps.latitude_deg = hil_gps.lat / 1e7;
 	gps.longitude_deg = hil_gps.lon / 1e7;
 	gps.altitude_msl_m = hil_gps.alt / 1e3;
@@ -450,13 +457,6 @@ void SimulatorMavlink::handle_message_hil_gps(const mavlink_message_t *msg)
 			}
 
 			_gps_ids[i] = hil_gps.id;
-
-			device::Device::DeviceId device_id;
-			device_id.devid_s.bus_type = device::Device::DeviceBusType::DeviceBusType_SIMULATION;
-			device_id.devid_s.bus = 0;
-			device_id.devid_s.address = i;
-			device_id.devid_s.devtype = DRV_GPS_DEVTYPE_SIM;
-			gps.device_id = device_id.devid;
 
 			instance = i;
 			break;


### PR DESCRIPTION
### Solved Problem
I found during testing that the reported device_id of sensor_gps message was incorrectly set only on the first time the message was published.

### Solution
Fill device_id on every published message.

### Alternatives
Store the device_id on first publication, but that's just more complicated for nothing.

### Test coverage
Can be tested with e.g. `HEADLESS=1 make px4_sitl gazebo_standard_vtol`, but any other (gazebo) simulation should also work. Then type `listener sensor_gps` in the shell and check the output.

main: `device_id: 0 (Type: 0x00, UNKNOWN:0 (0x00))`

this PR: `device_id: 11468804 (Type: 0xAF, SIMULATION:0 (0x00))`