### PR TITLE
docs(gps): UART2 cannot update u-blox firmware

### DIFF
--- a/docs/en/dronecan/ark_rtk_gps.md
+++ b/docs/en/dronecan/ark_rtk_gps.md
@@ -182,6 +182,10 @@ For more information see [Rover and Moving Base](../dronecan/index.md#rover-and-
 
 ### Updating Ublox F9P Module
 
+::: warning
+UART2 cannot be used for u-blox firmware update, including with [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) `7`. Use the debug passthrough below.
+:::
+
 ARK RTK GPS comes with the Ublox F9P module up to date with version 1.13 or newer. However, you can check the version and update the firmware if desired.
 
 The steps are:

--- a/docs/en/dronecan/ark_rtk_gps_l1_l2.md
+++ b/docs/en/dronecan/ark_rtk_gps_l1_l2.md
@@ -135,6 +135,10 @@ For more information see [Rover and Fixed Base](../dronecan/index.md#rover-and-f
 
 ### Updating Ublox F9P Module
 
+::: warning
+UART2 cannot be used for u-blox firmware update, including with [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) `7`. Use the debug passthrough below.
+:::
+
 ARK RTK GPS L1 L5 comes with the Ublox F9P module up to date with version 1.13 or newer. However, you can check the version and update the firmware if desired.
 
 The steps are:

--- a/docs/en/gps_compass/u-center.md
+++ b/docs/en/gps_compass/u-center.md
@@ -12,6 +12,10 @@ Heading and static-base-on-UART2 setups cannot use this feature.
 For more information see [Constraints](#constraints) below.
 :::
 
+::: warning
+u-blox firmware cannot be updated over UART2. On ARK DroneCAN GPS modules, use the debug passthrough in [ARK RTK GPS](../dronecan/ark_rtk_gps.md#updating-ublox-f9p-module).
+:::
+
 ## Wiring
 
 Connect the adapter's RX to the receiver's `UART2` TX, its TX to `UART2` RX, and share ground.


### PR DESCRIPTION
## Summary
Stop presenting UART2 / `GPS_UBX_MODE` 7 as a path that can run a u-blox firmware update.

## Problem
u-blox does not support firmware upgrade on UART2. The u-center diagnostic page never said that, so mode 7 looks like a full u-center session.

## Solution
Warn on the u-center page and on the ARK RTK GPS F9P update sections that UART2 is diagnostics only, and point at the safety-switch debug passthrough.