### PR TITLE
fix(sensor_calibration): default external accel/gyro priority below internal

### DIFF
--- a/src/lib/sensor_calibration/Accelerometer.hpp
+++ b/src/lib/sensor_calibration/Accelerometer.hpp
@@ -48,7 +48,11 @@ public:
 	static constexpr int MAX_SENSOR_COUNT = 4;
 
 	static constexpr uint8_t DEFAULT_PRIORITY = 50;
-	static constexpr uint8_t DEFAULT_EXTERNAL_PRIORITY = 75;
+
+	// Unlike a magnetometer, an external IMU is never a better primary than the
+	// on-board one: it is behind a bus with its own clock and transport latency
+	// and is not thermally managed, so it must not win the vote uncalibrated.
+	static constexpr uint8_t DEFAULT_EXTERNAL_PRIORITY = 25;
 
 	static constexpr const char *SensorString() { return "ACC"; }
 

--- a/src/lib/sensor_calibration/Gyroscope.hpp
+++ b/src/lib/sensor_calibration/Gyroscope.hpp
@@ -48,7 +48,11 @@ public:
 	static constexpr int MAX_SENSOR_COUNT = 4;
 
 	static constexpr uint8_t DEFAULT_PRIORITY = 50;
-	static constexpr uint8_t DEFAULT_EXTERNAL_PRIORITY = 75;
+
+	// Unlike a magnetometer, an external IMU is never a better primary than the
+	// on-board one: it is behind a bus with its own clock and transport latency
+	// and is not thermally managed, so it must not win the vote uncalibrated.
+	static constexpr uint8_t DEFAULT_EXTERNAL_PRIORITY = 25;
 
 	static constexpr const char *SensorString() { return "GYRO"; }
 

--- a/src/modules/sensors/module.yaml
+++ b/src/modules/sensors/module.yaml
@@ -21,6 +21,9 @@ parameters:
         CAL_ACC${i}_PRIO:
             description:
                 short: Accelerometer ${i} priority
+                long: |
+                    Uninitialized sensors default to Medium when internal and Low when
+                    external, so an on-board IMU is preferred over one behind a bus.
             category: System
             type: enum
             values:
@@ -221,6 +224,9 @@ parameters:
         CAL_GYRO${i}_PRIO:
             description:
                 short: Gyroscope ${i} priority
+                long: |
+                    Uninitialized sensors default to Medium when internal and Low when
+                    external, so an on-board IMU is preferred over one behind a bus.
             category: System
             type: enum
             values:


### PR DESCRIPTION
## Summary

External accelerometers and gyroscopes now default to priority Low (25) instead of High (75), so an uncalibrated IMU behind a bus never outranks the on-board IMUs.

## Problem

`DEFAULT_EXTERNAL_PRIORITY = 75` in the accel and gyro calibration classes was copied from the magnetometer, where external-first is the right default. For an IMU it is backwards: enabling `UAVCAN_SUB_IMU` on an ARK FMU-V6X with an ARK Flow on the bus made the CAN gyro the primary immediately (`selected gyro: 8811531 (3)`), ahead of three 8 kHz FIFO on-board IMUs at 50, and a calibration then persisted the 75. The CAN IMU arrives at 200 Hz through a mapped bus clock with ~3 ms transport latency and has no heater.

## Solution

Default external accel and gyro to 25, which the constructor, `Reset()` and the calibration save path all pick up, and say so in the `CAL_ACCn_PRIO` / `CAL_GYROn_PRIO` descriptions. Magnetometer and barometer are unchanged. Existing stored priorities are not migrated.
