### PR TITLE
fix(commander): clamp num_events from arming_check_reply

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/externalChecks.cpp
@@ -260,6 +260,15 @@ void ExternalChecks::update()
 			}
 
 			if (_registrations[reply.registration_id].reply) {
+				// num_events is a uint8 arriving on an externally writable topic, while events is
+				// a fixed-size array. Clamp it here, next to the registration_id check, so
+				// checkAndReport() cannot iterate past the end of the array.
+				static constexpr uint8_t max_num_events = sizeof(reply.events) / sizeof(reply.events[0]);
+
+				if (reply.num_events > max_num_events) {
+					reply.num_events = max_num_events;
+				}
+
 				*_registrations[reply.registration_id].reply = reply;
 			}
 


### PR DESCRIPTION
## Summary

`num_events` in `arming_check_reply` is a `uint8` while `events` is a fixed array of five. Clamp it on ingestion.

## Problem

`ArmingCheckReply` declares `uint8 num_events` alongside `Event[5] events`, so the field can describe fifty times more events than the message can carry. `ExternalChecks::checkAndReport()` looped to `reply.num_events` and `memcpy`'d into `reply.events[i]`, writing past the end of the heap-allocated reply for any value above five.

`/fmu/in/arming_check_reply` is exposed as an input topic by uXRCE-DDS, so the value is not necessarily produced by a well-behaved component.

## Solution

Clamp on ingestion, beside the existing `registration_id` validation, so a stored reply can never describe more events than it holds.

## Note

This is a correctness fix, not a security one. A peer that can publish on `/fmu/in/arming_check_reply` can also publish `/fmu/in/actuator_motors` and fly the aircraft directly, so it gains nothing here it did not already have.

---

Reported by @REYu6.