### PR TITLE
fix(drivers/iridiumsbd): bound the TX buffer write against the bytes copied

### DIFF
--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
@@ -666,14 +666,20 @@ ssize_t IridiumSBD::write(struct file *filp, const char *buffer, size_t buflen)
 		}
 	}
 
-	// check if there is enough space to write the message
-	if (SATCOM_TX_BUF_LEN - _tx_buf_write_idx - _packet_length < 0) {
+	// Check if there is enough space to write the message. _packet_length is the declared
+	// size of the message being assembled and decrements across calls, while the memcpy
+	// below copies buflen, so both have to fit or the copy runs past the buffer.
+	const int space_left = SATCOM_TX_BUF_LEN - _tx_buf_write_idx;
+
+	if (space_left < (int)_packet_length || space_left < (int)buflen) {
 		_tx_buf_write_idx = 0;
 		++_num_tx_buf_reset;
 	}
 
 	// keep track of the remaining packet length and if the full message is written
-	_packet_length -= buflen;
+	// (saturate rather than wrap: _packet_length is unsigned and buflen can exceed it if
+	// the declared length and the bytes actually written disagree)
+	_packet_length = (buflen >= _packet_length) ? 0 : _packet_length - buflen;
 
 	if (_packet_length == 0) {
 		_writing_mavlink_packet = false;


### PR DESCRIPTION
## Summary

`IridiumSBD::write()` checked for free space using a different length than the one it copies, so the `memcpy` could run past the end of the TX buffer.

## Problem

```cpp
if (SATCOM_TX_BUF_LEN - _tx_buf_write_idx - _packet_length < 0) {   // checks _packet_length
    _tx_buf_write_idx = 0;
}
...
memcpy(_tx_buf + _tx_buf_write_idx, buffer, buflen);                 // copies buflen
```

`_packet_length` is the declared size of the message being assembled and decrements across calls as it is written in chunks. It can therefore be small while `buflen` is large, and the check passes for a copy that does not fit.

A 300-byte write followed by a 10-byte MAVLink v2 header leaves the index at 310 and `_packet_length` at 6, so a following 50-byte write passes `340 − 310 − 6 = 24 ≥ 0` and copies twenty bytes past the end of the 340-byte member array.

Separately, `_packet_length -= buflen` wraps: `_packet_length` is a `uint16_t`, and `buflen` exceeds it whenever the declared length and the bytes actually written disagree. The value then never reaches zero, so `_writing_mavlink_packet` stays set and the parser never resynchronises.

## Solution

Check the available space against both the remaining packet and the bytes this call copies, and saturate the remaining-length subtraction at zero.

---

Reported by @Finder16 and @Lqs66.