### PR TITLE
fix(drivers/ft_technologies): bound the FT7 wind sensor parser buffers

### DIFF
--- a/src/drivers/wind_sensor/ft_technologies/ft7_technologies.cpp
+++ b/src/drivers/wind_sensor/ft_technologies/ft7_technologies.cpp
@@ -158,8 +158,12 @@ int Ft7Technologies::collect()
 	for (int i = 0; i < ret; i++) {
 		// _px4_windsensor.update(timestamp_sample, (double)ret, 13.0f, _status);
 		// received a full message
-		_readbuf[_byte_counter]  = readbuf[i];
-		_byte_counter += 1;
+		// The counters below only reset on a delimiter or end of line, so a sensor that
+		// sends neither would otherwise walk off the end of each buffer.
+		if (_byte_counter < (int)sizeof(_readbuf)) {
+			_readbuf[_byte_counter] = readbuf[i];
+			_byte_counter += 1;
+		}
 
 
 		if (readbuf[i] == '\n') {
@@ -193,8 +197,8 @@ int Ft7Technologies::collect()
 			_byte_counter = 0;
 			_msg_byte_counter = 0;
 			_checksum_counter = 0;
-			memset(readbuf, 0, sizeof(_linebuf));
-			memset(_readbuf, 0, sizeof(_linebuf));
+			memset(readbuf, 0, sizeof(readbuf));
+			memset(_readbuf, 0, sizeof(_readbuf));
 			memset(_raw_speed, 0, 5);
 			memset(_raw_angle, 0, 5);
 			memset(_raw_status, 0, 2);
@@ -210,18 +214,29 @@ int Ft7Technologies::collect()
 
 			if (readbuf[i] != '.') {
 
+				// Each field is NUL-terminated by the memset on the previous message, so the
+				// last element has to stay clear for the atoi() calls above.
 				if (_msg_part_counter == 3) { // speed measurement
-					_raw_speed[_msg_byte_counter] = readbuf[i];
+					if (_msg_byte_counter < (int)sizeof(_raw_speed) - 1) {
+						_raw_speed[_msg_byte_counter] = readbuf[i];
+					}
 
 				} else if (_msg_part_counter == 4) { // angle measurement
-					_raw_angle[_msg_byte_counter] = readbuf[i];
+					if (_msg_byte_counter < (int)sizeof(_raw_angle) - 1) {
+						_raw_angle[_msg_byte_counter] = readbuf[i];
+					}
 
 				} else if (_msg_part_counter == 5) { // status
-					_raw_status[_msg_byte_counter] = readbuf[i];
+					if (_msg_byte_counter < (int)sizeof(_raw_status) - 1) {
+						_raw_status[_msg_byte_counter] = readbuf[i];
+					}
 
 				} else if (_msg_part_counter == 6) { // checksum
 					_checksum_counter += 1;
-					_raw_checksum[_msg_byte_counter] = readbuf[i];
+
+					if (_msg_byte_counter < (int)sizeof(_raw_checksum) - 1) {
+						_raw_checksum[_msg_byte_counter] = readbuf[i];
+					}
 
 				}
 


### PR DESCRIPTION
## Summary

Every buffer in the FT7 wind sensor parser is indexed by a counter that resets only on a delimiter, so a sensor sending none writes past the end of all of them.

## Problem

`_readbuf` is 30 bytes indexed by `_byte_counter`, which resets on `\n`. The four field buffers — `_raw_speed[5]`, `_raw_angle[5]`, `_raw_status[2]`, `_raw_checksum[3]` — are indexed by `_msg_byte_counter`, which resets on `,`, `=`, `*`, `$` or `\r`.

A response like `$A,WVP=` followed by a long run of digits walks off the speed buffer and into the members that follow it. Nothing in the read path filters what the sensor sends first.

Separately, the reset path cleared `_readbuf` using `sizeof(_linebuf)` — a different, smaller array — so ten bytes of the previous message survived into the next and were fed to the checksum.

## Solution

Bound each write against the buffer it targets, keeping the last byte of each field buffer clear so the `atoi()` calls still see a terminator. Use the correct size in the memsets.

## Note

No in-tree board enables `CONFIG_DRIVERS_WIND_SENSOR_FT_TECHNOLOGIES`, which is `default n`, so this affects only builds that opt in for an FT742.

---

Reported by @kmm2003.