### PR TITLE
fix(mavlink): do not send memory past the FTP reply cache on retransmit

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -144,16 +144,22 @@ MavlinkFTP::_process_request(
 
 	// check the sequence number: if this is a resent request, resend the last response
 	if (_last_reply_valid) {
-		mavlink_file_transfer_protocol_t *last_reply = reinterpret_cast<mavlink_file_transfer_protocol_t *>(_last_reply);
-		PayloadHeader *last_payload = reinterpret_cast<PayloadHeader *>(&last_reply->payload[0]);
+		// _last_reply only caches the leading bytes that differ between replies, but the send
+		// below serialises a whole message. Reinterpreting the cache as one would transmit
+		// whatever follows it in memory, so assemble a zeroed message and copy the cache in.
+		mavlink_file_transfer_protocol_t last_reply{};
+		static_assert(sizeof(_last_reply) <= sizeof(last_reply), "reply cache larger than the message");
+		memcpy(&last_reply, _last_reply, sizeof(_last_reply));
+
+		PayloadHeader *last_payload = reinterpret_cast<PayloadHeader *>(&last_reply.payload[0]);
 
 		if (payload->seq_number + 1 == last_payload->seq_number
-		    && last_reply->target_system == target_system_id
-		    && last_reply->target_component == target_comp_id) {
+		    && last_reply.target_system == target_system_id
+		    && last_reply.target_component == target_comp_id) {
 			// this is the same request as the one we replied to last. It means the (n)ack got lost, and the GCS
 			// resent the request
 			_mavlink.lock_send();
-			mavlink_msg_file_transfer_protocol_send_struct(_mavlink.get_channel(), last_reply);
+			mavlink_msg_file_transfer_protocol_send_struct(_mavlink.get_channel(), &last_reply);
 			_mavlink.unlock_send();
 			return;
 		}


### PR DESCRIPTION
## Summary

The MAVLink FTP retransmit path serialised a full 254-byte message out of a 19-byte cache, sending 235 bytes of adjacent memory to the requesting peer.

## Problem

`_last_reply` deliberately caches only the leading bytes that differ between replies — three target ids, the 12-byte `PayloadHeader` and up to four data bytes, 19 in total. The write into it is correctly bounded:

```cpp
memcpy(_last_reply, ftp_req, sizeof(_last_reply));
```

The read is not. The retransmit path reinterprets the cache as a `mavlink_file_transfer_protocol_t` and passes it to `mavlink_msg_file_transfer_protocol_send_struct()`, which serialises a complete message:

```cpp
mavlink_file_transfer_protocol_t *last_reply = reinterpret_cast<mavlink_file_transfer_protocol_t *>(_last_reply);
...
mavlink_msg_file_transfer_protocol_send_struct(_mavlink.get_channel(), last_reply);
```

Everything past the cache is read from adjacent memory and transmitted. The peer controls when it happens — send a request, then resend it — and can repeat it to sample memory as it changes.

## Solution

Assemble a zeroed `mavlink_file_transfer_protocol_t` on the stack and copy the cache into it, so the tail is zeros rather than whatever followed the member. A reply that carried more than four data bytes retransmits with zeros in that tail, which is all the cache could reconstruct in any case.

---

Reported by @am-periphery. Also reported publicly as #28347.