### PR TITLE
fix(navigator): report a failed geofence load instead of leaving a fragment

### DIFF
--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -210,6 +210,23 @@ void Geofence::updateFence()
 	_initiate_fence_updated = true;
 }
 
+void Geofence::_clearFence()
+{
+	if (_polygons) {
+		delete[](_polygons);
+		_polygons = nullptr;
+	}
+
+	_num_polygons = 0;
+}
+
+void Geofence::_reportFenceLoadFailure()
+{
+	mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence load failed, fence is not active\t");
+	events::send(events::ID("navigator_geofence_load_failed"), {events::Log::Critical, events::LogInternal::Warning},
+		     "Geofence load failed, fence is not active");
+}
+
 void Geofence::_updateFence()
 {
 	mission_fence_point_s mission_fence_point;
@@ -227,7 +244,12 @@ void Geofence::_updateFence()
 
 		if (!success) {
 			PX4_ERR("loadWait failed, seq: %i", current_seq);
-			break;
+			// A fragment of a fence is worse than none: missing inclusion polygons permit
+			// positions the fence excluded, missing exclusion polygons open up areas it
+			// protected, and it still looks to the operator like a fence is loaded.
+			_clearFence();
+			_reportFenceLoadFailure();
+			return;
 		}
 
 		switch (mission_fence_point.nav_cmd) {
@@ -264,8 +286,9 @@ void Geofence::_updateFence()
 				}
 
 				if (!_polygons) {
-					_num_polygons = 0;
 					PX4_ERR("alloc failed");
+					_clearFence();
+					_reportFenceLoadFailure();
 					return;
 				}
 

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -227,6 +227,16 @@ private:
 	 * Check polygon or circle geofence fullfills the requirements relative to Home.
 	 * @return true if checks pass
 	 */
+	/**
+	 * Free the loaded polygons and leave the fence empty.
+	 */
+	void _clearFence();
+
+	/**
+	 * Tell the operator that the fence failed to load and is not active.
+	 */
+	void _reportFenceLoadFailure();
+
 	bool checkHomeRequirementsForGeofence(const PolygonInfo &polygon);
 
 	/**


### PR DESCRIPTION
## Summary

A geofence load that stops partway left the polygons loaded so far in place and reported only to the console. Drop the fragment and tell the operator.

## Problem

`_updateFence()` resets `_num_polygons` and rebuilds the fence from dataman one polygon at a time. It can stop early two ways, and both left a partial fence behind:

```cpp
if (!success) {
    PX4_ERR("loadWait failed, seq: %i", current_seq);
    break;                       // partial fence, console only
}
```

```cpp
delete[](_polygons);
_polygons = new_polygons;        // null if the allocation failed

if (!_polygons) {
    _num_polygons = 0;
    PX4_ERR("alloc failed");     // console only
    return;
}
```

A fragment is worse than nothing. Missing inclusion polygons permit positions the fence excluded, missing exclusion polygons open up areas it protected, and unlike an empty fence it still looks like a fence is loaded — so nobody goes looking.

## Solution

On either failure, drop what was loaded and report it with `mavlink_log_critical` and an event, matching how the other geofence validity failures in this file already report. The resulting state is unambiguous: no fence, and the operator has been told.

## Note

This is a correctness fix, not a security one. Neither failure is something a peer controls, and a geofence is a safety feature rather than a security control.

---

Reported by @lihnucs, who found the allocation path.