### PR TITLE
fix(uavcan): stop the 21-element GNSS covariance case falling into the 36 case

### DIFF
--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -278,8 +278,8 @@ UavcanGnssBridge::gnss_fix2_sub_cb(const uavcan::ReceivedDataStructure<uavcan::e
 			vel_cov[7] = msg.covariance[19];
 			vel_cov[8] = msg.covariance[20];
 		}
+		break;
 
-	/* FALLTHROUGH */
 	case 36: {
 			// Full matrix 6x6.
 			// This code has been carefully optimized by hand. We could use unpackSquareMatrix(), but it's slow.


### PR DESCRIPTION
## Summary

`case 21:` in the Fix2 covariance handler falls through to `case 36:`, which overwrites everything it just decoded.

## Problem

The handler decodes the upper-triangular 21-element covariance form in `case 21:`, then falls straight into `case 36:`, which decodes the full 6×6 form over the top of it. `case 1:` and `case 6:` both `break`; this one carries a `/* FALLTHROUGH */` comment that reads as deliberate but cannot be — there is no sense in which both decodings are wanted.

The consequences differ for the two matrices:

- **Position covariance** is re-read with 6×6 indices (0, 1, 2, 6, 7, 8, 12, 13, 14). Those are in range for a 21-element array but refer to different entries, so the values are wrong rather than absent.
- **Velocity covariance** is re-read from indices 21 to 35, which are out of range. The driver is built with `-DUAVCAN_NO_ASSERTIONS` (`src/drivers/uavcan/CMakeLists.txt:91`), so the libuavcan dynamic array clamps out-of-range access to the last valid element rather than aborting. All nine terms become `covariance[20]`.

A CAN GPS reporting the 21-element form — a normal thing for it to do — therefore feeds EKF2 a wrong position covariance and a constant velocity covariance, with nothing logged.

## Solution

`break` after `case 21:`, and drop the `/* FALLTHROUGH */` comment that documented the wrong intent.

---

Reported by @lihnucs.