### PR TITLE
fix(mavlink): terminate the published gimbal name strings

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -3637,9 +3637,10 @@ MavlinkReceiver::handle_message_gimbal_device_information(mavlink_message_t *msg
 	memcpy(gimbal_information.vendor_name, gimbal_device_info_msg.vendor_name, sizeof(gimbal_information.vendor_name));
 	memcpy(gimbal_information.model_name, gimbal_device_info_msg.model_name, sizeof(gimbal_information.model_name));
 	memcpy(gimbal_information.custom_name, gimbal_device_info_msg.custom_name, sizeof(gimbal_information.custom_name));
-	gimbal_device_info_msg.vendor_name[sizeof(gimbal_device_info_msg.vendor_name) - 1] = '\0';
-	gimbal_device_info_msg.model_name[sizeof(gimbal_device_info_msg.model_name) - 1] = '\0';
-	gimbal_device_info_msg.custom_name[sizeof(gimbal_device_info_msg.custom_name) - 1] = '\0';
+	// Terminate the published fields, not the decoded message we are about to discard
+	gimbal_information.vendor_name[sizeof(gimbal_information.vendor_name) - 1] = '\0';
+	gimbal_information.model_name[sizeof(gimbal_information.model_name) - 1] = '\0';
+	gimbal_information.custom_name[sizeof(gimbal_information.custom_name) - 1] = '\0';
 
 	gimbal_information.firmware_version = gimbal_device_info_msg.firmware_version;
 	gimbal_information.hardware_version = gimbal_device_info_msg.hardware_version;


### PR DESCRIPTION
## Summary

The `GIMBAL_DEVICE_INFORMATION` handler writes its string terminators into the decoded MAVLink message rather than into the uORB topic it publishes.

## Problem

```cpp
memcpy(gimbal_information.vendor_name, gimbal_device_info_msg.vendor_name, sizeof(gimbal_information.vendor_name));
...
gimbal_device_info_msg.vendor_name[sizeof(gimbal_device_info_msg.vendor_name) - 1] = '\0';
```

The terminator lands in `gimbal_device_info_msg`, a local that goes out of scope immediately, so the published `gimbal_information` fields are never terminated. Both sides are 32 bytes, so the copies themselves are fine — what gets published is simply a field that may hold 32 bytes with no terminator.

## Solution

Terminate the fields being published.

## Note

No behaviour change today: the only in-tree subscriber, `src/modules/gimbal/output_mavlink.cpp`, reads `gimbal_device_id` and ignores the names. This is wrong as written, and the next consumer to read those fields as strings would inherit it.

---

Reported by @lihnucs.