### PR TITLE
fix(uavcan): clamp cell_count from the DroneCAN CBAT message

### DIFF
--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -39,6 +39,10 @@
 
 const char *const UavcanBatteryBridge::NAME = "battery";
 
+// Number of per-cell voltages battery_status can carry
+static constexpr uint8_t kMaxCellCount = sizeof(battery_status_s::voltage_cell_v)
+		/ sizeof(battery_status_s::voltage_cell_v[0]);
+
 void UavcanBatteryBridge::publishBattery(int node_id, uint8_t instance)
 {
 	_failure_config.update();
@@ -199,7 +203,7 @@ UavcanBatteryBridge::battery_aux_sub_cb(const uavcan::ReceivedDataStructure<ardu
 
 	_batt_update_mod[instance] = BatteryDataType::RawAux;
 
-	_battery_status[instance].cell_count = math::min((uint8_t)msg.voltage_cell.size(), (uint8_t)14);
+	_battery_status[instance].cell_count = math::min((uint8_t)msg.voltage_cell.size(), kMaxCellCount);
 	_battery_status[instance].cycle_count = msg.cycle_count;
 	_battery_status[instance].over_discharge_count = msg.over_discharge_count;
 	// ArduPilot BatteryInfoAux convention: nominal_voltage == 0 means "not provided"
@@ -266,7 +270,9 @@ void UavcanBatteryBridge::cbat_sub_cb(const uavcan::ReceivedDataStructure<cuav::
 	_battery_status[instance].max_error = msg.max_error;
 	_battery_status[instance].over_discharge_count = msg.over_discharge_count;
 	_battery_status[instance].connected = true;
-	_battery_status[instance].cell_count = msg.cell_count;
+	// cell_count comes from the node and bounds the per-cell copy below, so clamp it to what
+	// voltage_cell_v can hold, as the BatteryInfoAux handler above already does.
+	_battery_status[instance].cell_count = math::min(msg.cell_count, kMaxCellCount);
 	_battery_status[instance].source = battery_status_s::SOURCE_EXTERNAL;
 	_node_ids[instance] = msg.getSrcNodeID().get();
 	_battery_status[instance].id = msg.getSrcNodeID().get();


### PR DESCRIPTION
## Summary

`cell_count` from a DroneCAN CBAT message was used unclamped as the bound for copying per-cell voltages into a fourteen-element array.

## Problem

```cpp
_battery_status[instance].cell_count = msg.cell_count;      // uint8 chosen by the node
...
for (uint8_t i = 0; i < _battery_status[instance].cell_count; i++) {
    _battery_status[instance].voltage_cell_v[i] = msg.voltage_cell[i];   // float32[14]
}
```

A battery node reporting more than fourteen cells writes past the end of `voltage_cell_v`. At 255 that is 241 floats — most of a kilobyte — through the remainder of the `battery_status_s` and into the next instance of the array. The values written come from the node too.

The read side happens to be bounded, because libuavcan clamps out-of-range dynamic array access under `UAVCAN_NO_ASSERTIONS`, but that only repeats the last valid cell voltage; it does not stop the write.

## Solution

`battery_aux_sub_cb()` in the same file already clamps with `math::min`. Do the same in `cbat_sub_cb()`, and give both the array size instead of the literal `14` the existing one carried.

---

Reported by @ttzero25.