### PR TITLE
fix(tinybson): reject a negative document length

### DIFF
--- a/src/lib/tinybson/tinybson.cpp
+++ b/src/lib/tinybson/tinybson.cpp
@@ -129,6 +129,11 @@ bson_decoder_init_file(bson_decoder_t decoder, int fd, bson_decoder_callback cal
 
 	debug("total document size = %" PRIi32, decoder->total_document_size);
 
+	// The length is signed and comes from the document itself
+	if (decoder->total_document_size < 0) {
+		CODER_KILL(decoder, "negative document length");
+	}
+
 	/* ready for decoding */
 	return 0;
 }
@@ -168,6 +173,12 @@ bson_decoder_init_buf(bson_decoder_t decoder, void *buf, unsigned bufsize, bson_
 	}
 
 	debug("total document size = %" PRIi32, decoder->total_document_size);
+
+	// A negative length would skip the size check below, which only rejects lengths above
+	// the buffer
+	if (decoder->total_document_size < 0) {
+		CODER_KILL(decoder, "negative document length");
+	}
 
 	if ((decoder->total_document_size > 0) && (decoder->total_document_size > (int)decoder->bufsize)) {
 		CODER_KILL(decoder, "document length larger than buffer");

--- a/src/systemcmds/tests/test_bson.cpp
+++ b/src/systemcmds/tests/test_bson.cpp
@@ -257,6 +257,27 @@ decode(bson_decoder_t decoder)
 	} while (result > 0);
 }
 
+static int
+test_negative_document_size()
+{
+	// The document length is the first four bytes and is signed. A negative value must be
+	// rejected: it would otherwise skip the "larger than buffer" check, which only rejects
+	// lengths above the buffer size.
+	uint8_t buf[16] {};
+	const int32_t negative_size = -2;
+	memcpy(buf, &negative_size, sizeof(negative_size));
+
+	bson_decoder_s decoder{};
+
+	if (bson_decoder_init_buf(&decoder, buf, sizeof(buf), decode_callback) == 0) {
+		PX4_ERR("FAIL: decoder: accepted a negative document length");
+		return 1;
+	}
+
+	PX4_INFO("PASS: decoder: rejected a negative document length");
+	return 0;
+}
+
 int
 test_bson(int argc, char *argv[])
 {
@@ -294,6 +315,10 @@ test_bson(int argc, char *argv[])
 
 	decode(&decoder);
 	free(buf);
+
+	if (test_negative_document_size() != 0) {
+		return 1;
+	}
 
 	return PX4_OK;
 }


### PR DESCRIPTION
## Summary

A negative BSON document length skipped the size check and decoded unbounded.

## Problem

The document length is the first four bytes of the document and is signed.

`bson_decoder_init_buf()` checks it against the buffer, but only when positive:

```cpp
if ((decoder->total_document_size > 0) && (decoder->total_document_size > (int)decoder->bufsize)) {
    CODER_KILL(decoder, "document length larger than buffer");
}
```

so a negative value passes straight through. `bson_decoder_init_file()`, which is the path used for `parameters.bson`, did not check the length at all.

## Solution

Reject a negative length in both, and add a regression test. The existing BSON test only round-trips data it encoded itself, so it had no malformed-input coverage at all.

## Note

This is a correctness fix, not a security one. The decoder reads parameter files, so producing a malformed one means writing to the SD card — which a MAVLink peer can do over FTP, but the same peer can also open an NSH shell.

---

Reported by @lihnucs.