### PR TITLE
feat(ekf2)!: remove gnss_checks reset inside gps_control.cpp

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.cpp
@@ -42,6 +42,10 @@ namespace estimator
 {
 bool GnssChecks::run(const gnssSample &gnss, uint64_t time_us)
 {
+	if (_time_last_pass_us != 0 && isTimedOut(_time_last_pass_us, time_us, (uint64_t)7'000'000)) {
+		this->reset();
+	}
+
 	// assume failed first time through
 	if (_time_last_fail_us == 0) {
 		_time_last_fail_us = time_us;

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
@@ -463,10 +463,6 @@ void Ekf::resetHorizontalPositionToGnss(estimator_aid_source2d_s &aid_src)
 
 void Ekf::stopGnssFusion()
 {
-	if (_control_status.flags.gnss_vel || _control_status.flags.gnss_pos) {
-		_gnss_checks.reset();
-	}
-
 	stopGnssVelFusion();
 	stopGnssPosFusion();
 	stopGpsHgtFusion();
@@ -482,11 +478,6 @@ void Ekf::stopGnssVelFusion()
 	if (_control_status.flags.gnss_vel) {
 		ECL_INFO("stopping GNSS velocity fusion");
 		_control_status.flags.gnss_vel = false;
-
-		//TODO: what if gnss yaw or height is used?
-		if (!_control_status.flags.gnss_pos) {
-			_gnss_checks.reset();
-		}
 	}
 }
 
@@ -495,11 +486,6 @@ void Ekf::stopGnssPosFusion()
 	if (_control_status.flags.gnss_pos) {
 		ECL_INFO("stopping GNSS position fusion");
 		_control_status.flags.gnss_pos = false;
-
-		//TODO: what if gnss yaw or height is used?
-		if (!_control_status.flags.gnss_vel) {
-			_gnss_checks.reset();
-		}
 	}
 }
 


### PR DESCRIPTION
### Description
This PR fixes an issue brought up in #28520

Resetting the checks on the samples when EKF2 stops fusing does not really makes sense, as it couples the checks on the sample and the EKF2. The idea would be that these checks are unidirectional, meaning they tell whether the sample is usable, and it is the EKF2's role to decide whether to fuse it or not, but the EKF2 should never interfere in the checks themselves. 

### Solution

Removing the gnss_checks resets

### Changelog Entry
For release notes:
```
Feature: Remove gnss_checks resets from gps_control
```

### Alternatives

### Test coverage
