### PR TITLE
[BACKPORT] fix(uavcan): stop losing and reordering SocketCAN TX frames (#28363)

### DIFF
--- a/src/drivers/uavcan/libdronecan/libuavcan/src/transport/uc_can_io.cpp
+++ b/src/drivers/uavcan/libdronecan/libuavcan/src/transport/uc_can_io.cpp
@@ -391,11 +391,16 @@ int CanIOManager::send(const CanFrame& frame, MonotonicTime tx_deadline, Monoton
                 int res = 0;
                 if (iface_mask & (1 << i))
                 {
-                    if (tx_queues_[i]->topPriorityHigherOrEqual(frame))
+                    // Anything already queued at this priority was handed to us first and must go
+                    // out first. Falling through to a direct send when sendFromTxQueue() reports 0
+                    // puts the newer frame on the wire ahead of it, which reorders the frames of a
+                    // multi-frame transfer and makes the receiver discard the whole thing.
+                    const bool queue_goes_first = tx_queues_[i]->topPriorityHigherOrEqual(frame);
+                    if (queue_goes_first)
                     {
                         res = sendFromTxQueue(i);                 // May return 0 if nothing to transmit (e.g. expired)
                     }
-                    if (res <= 0)
+                    if (res <= 0 && !queue_goes_first)
                     {
                         res = sendToIface(i, frame, tx_deadline, flags);
                         if (res > 0)

--- a/src/drivers/uavcan/uavcan_drivers/socketcan/driver/src/socketcan.cpp
+++ b/src/drivers/uavcan/uavcan_drivers/socketcan/driver/src/socketcan.cpp
@@ -47,6 +47,7 @@
 #include <net/if.h>
 #include <sys/ioctl.h>
 #include <string.h>
+#include <errno.h>
 
 #include <nuttx/can.h>
 #include <netpacket/can.h>
@@ -198,10 +199,20 @@ uavcan::int16_t CanIface::send(const uavcan::CanFrame &frame, uavcan::MonotonicT
 
 	if (res > 0) {
 		return 1;
-
-	} else {
-		return res;
 	}
+
+	/* The frame never reached a hardware mailbox. NuttX does not buffer it, so
+	 * report "not sent" rather than an error and let libuavcan re-queue it --
+	 * returning negative here loses the frame, which breaks any multi-frame
+	 * transfer in progress. A non-blocking send that the driver could not take
+	 * immediately comes back as ETIMEDOUT from net_timedwait(), not ENOBUFS.
+	 */
+	if (errno == ETIMEDOUT || errno == EAGAIN || errno == EWOULDBLOCK ||
+	    errno == ENOBUFS || errno == EINTR || errno == EBUSY) {
+		return 0;
+	}
+
+	return -1;
 }
 
 uavcan::int16_t CanIface::receive(uavcan::CanFrame &out_frame, uavcan::MonotonicTime &out_ts_monotonic,
@@ -210,7 +221,14 @@ uavcan::int16_t CanIface::receive(uavcan::CanFrame &out_frame, uavcan::Monotonic
 	int32_t result = recvmsg(_fd, &_recv_msg, MSG_DONTWAIT);
 
 	if (result < 0) {
-		return result;
+		/* Nothing to read is not a driver failure; uc_can_io maps any negative
+		 * return onto -ErrDriver.
+		 */
+		if (errno == EAGAIN || errno == EWOULDBLOCK || errno == ETIMEDOUT) {
+			return 0;
+		}
+
+		return -1;
 	}
 
 	/* Copy SocketCAN frame to CanardFrame */


### PR DESCRIPTION
Backport of https://github.com/PX4/PX4-Autopilot/pull/28363

## Summary

Two of the three causes of the corrupted DroneCAN traffic reported in #26868. The third is in the FlexCAN driver and is handled separately: apache/nuttx#19957, backported in PX4/NuttX#394. All three are needed for a clean bus on i.MX RT; these two stand alone and are safe to merge in any order.

## Problem

On SocketCAN targets a multi-frame DroneCAN transfer from the FMU regularly arrived reordered or short, and the receiver discarded it on the toggle bit. Measured on the wire on an i.MX RT1176, a 6-frame message failed 81.7% of the time. Single-frame traffic was unaffected, and a GNSS node on the same bus was flawless over the same capture, which places the fault on the FMU transmit path.

`CanIface::send()` forwarded `sendmsg()`'s return straight to libuavcan. A frame the CAN driver had no free hardware mailbox for never reached the bus, and NuttX does not buffer it, so a negative return loses it — and losing one frame destroys the whole transfer it belonged to. libuavcan already distinguishes "queue full, retry" (0) from "error" (-1). Worth noting for anyone who tried this before: a non-blocking send the driver could not take surfaces as `ETIMEDOUT` out of `net_timedwait()`, not the `ENOBUFS` or `EAGAIN` one would expect, so matching only those leaves the loss in place.

`receive()` had the mirror problem — `uc_can_io` maps any negative onto `-ErrDriver`, so an empty read after a spurious `POLLIN` was reported as a driver failure.

Separately, `CanIOManager::send()` asks the TX queue whether it holds something of equal or higher priority and sends that first, but when `sendFromTxQueue()` returned 0 (nothing left to send, e.g. the head expired) it fell through and sent the new frame directly — ahead of the equal-priority frames still queued behind it. Every frame of a multi-frame transfer shares one CAN ID, so those are exactly equal priority, and the bypass reordered a transfer the queue was holding correctly.

## Solution

Report 0 rather than a negative from `send()` when the driver could not take the frame, so libuavcan re-queues it, and treat an empty `receive()` as no data rather than a driver error. Only send directly when the TX queue does not already own the ordering.

Measured on an ARK FMU-v6XRT against an ARK X20 GNSS node, decoding CAN-ID and tail byte per frame off a separate USB-CAN analyser: with these two plus the FlexCAN patch, 0 corrupt transfers in 84 594 frames over 5 minutes, then 35 029 more, against an 81.7% baseline. `uavcan status` CAN1 `IO errors` 0, sensor rates unchanged. Builds checked on `px4_fmu-v6xrt`, `px4_fmu-v6x` and SITL; only v6XRT was run on hardware.

