### PR TITLE
fix(cmake): restore list_vmd_make_targets SITL target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,6 +524,20 @@ add_custom_command(OUTPUT ${uorb_graph_config}
 )
 add_custom_target(uorb_graph DEPENDS ${uorb_graph_config})
 
+#=============================================================================
+# list_vmd_make_targets: print all available <viewer_model_debugger> SITL run targets
+#
+get_property(sitl_vmd_targets GLOBAL PROPERTY PX4_SITL_VMD_TARGETS)
+list(REMOVE_DUPLICATES sitl_vmd_targets)
+list(SORT sitl_vmd_targets)
+string(REPLACE ";" "\\n" sitl_vmd_targets_newline_separated "${sitl_vmd_targets}")
+
+add_custom_target(list_vmd_make_targets
+	COMMAND sh -c "printf \"${sitl_vmd_targets_newline_separated}\\n\""
+	COMMENT "List of acceptable '${PX4_BOARD}' <viewer_model_debugger> targets:"
+	VERBATIM
+)
+
 
 include(bloaty)
 

--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -125,6 +125,7 @@ if (gz-transport_FOUND)
 					USES_TERMINAL
 					DEPENDS px4 px4_gz_plugins
 				)
+				set_property(GLOBAL APPEND PROPERTY PX4_SITL_VMD_TARGETS gz_${model_name})
 			else()
 				add_custom_target(gz_${model_name}_${world_name}
 					COMMAND ${CMAKE_COMMAND} -E env PX4_SIM_MODEL=gz_${model_name} PX4_GZ_WORLD=${world_name} GZ_IP=127.0.0.1 $<TARGET_FILE:px4>
@@ -132,6 +133,7 @@ if (gz-transport_FOUND)
 					USES_TERMINAL
 					DEPENDS px4 px4_gz_plugins
 				)
+				set_property(GLOBAL APPEND PROPERTY PX4_SITL_VMD_TARGETS gz_${model_name}_${world_name})
 			endif()
 		endforeach()
 	endforeach()

--- a/src/modules/simulation/simulator_mavlink/sitl_targets_flightgear.cmake
+++ b/src/modules/simulation/simulator_mavlink/sitl_targets_flightgear.cmake
@@ -49,6 +49,7 @@ if(ENABLE_LOCKSTEP_SCHEDULER STREQUAL "no")
 			USES_TERMINAL
 			DEPENDS px4 flightgear_bridge
 		)
+		set_property(GLOBAL APPEND PROPERTY PX4_SITL_VMD_TARGETS flightgear)
 
 		foreach(model ${models})
 
@@ -79,6 +80,7 @@ if(ENABLE_LOCKSTEP_SCHEDULER STREQUAL "no")
 				USES_TERMINAL
 				DEPENDS px4 flightgear_bridge
 			)
+			set_property(GLOBAL APPEND PROPERTY PX4_SITL_VMD_TARGETS flightgear_${model})
 		endforeach()
 	endif()
 endif()

--- a/src/modules/simulation/simulator_mavlink/sitl_targets_gazebo-classic.cmake
+++ b/src/modules/simulation/simulator_mavlink/sitl_targets_gazebo-classic.cmake
@@ -202,6 +202,7 @@ if(gazebo_FOUND)
 						USES_TERMINAL
 						DEPENDS px4 sitl_gazebo-classic
 					)
+					set_property(GLOBAL APPEND PROPERTY PX4_SITL_VMD_TARGETS ${_targ_name})
 
 					string(REPLACE "gazebo-classic" "gazebo" _targ_name_compat ${_targ_name})
 					add_custom_target(${_targ_name_compat}
@@ -231,6 +232,7 @@ if(gazebo_FOUND)
 						USES_TERMINAL
 						DEPENDS px4 sitl_gazebo-classic
 					)
+					set_property(GLOBAL APPEND PROPERTY PX4_SITL_VMD_TARGETS ${_targ_name})
 
 					string(REPLACE "gazebo-classic" "gazebo" _targ_name_compat ${_targ_name})
 					add_custom_target(${_targ_name_compat}

--- a/src/modules/simulation/simulator_mavlink/sitl_targets_jmavsim.cmake
+++ b/src/modules/simulation/simulator_mavlink/sitl_targets_jmavsim.cmake
@@ -38,4 +38,6 @@ if(JAVA_ANT_PATH AND Java_JAVAC_EXECUTABLE AND Java_JAVA_EXECUTABLE)
 	)
 	add_custom_target(jmavsim DEPENDS jmavsim_iris) # alias
 
+	set_property(GLOBAL APPEND PROPERTY PX4_SITL_VMD_TARGETS jmavsim_iris jmavsim)
+
 endif()

--- a/src/modules/simulation/simulator_mavlink/sitl_targets_jsbsim.cmake
+++ b/src/modules/simulation/simulator_mavlink/sitl_targets_jsbsim.cmake
@@ -66,6 +66,7 @@ if(JSBSIM_INCLUDE_DIR)
 		USES_TERMINAL
 		DEPENDS px4 jsbsim_bridge
 	)
+	set_property(GLOBAL APPEND PROPERTY PX4_SITL_VMD_TARGETS jsbsim)
 
 	foreach(model ${models})
 
@@ -99,6 +100,7 @@ if(JSBSIM_INCLUDE_DIR)
 					USES_TERMINAL
 					DEPENDS px4 jsbsim_bridge
 				)
+				set_property(GLOBAL APPEND PROPERTY PX4_SITL_VMD_TARGETS jsbsim_${model})
 			else()
 				add_custom_target(jsbsim_${model}__${world}
 					COMMAND ${PX4_SOURCE_DIR}/Tools/simulation/jsbsim/sitl_run.sh $<TARGET_FILE:px4> ${model} ${world} ${PX4_SOURCE_DIR} ${PX4_BINARY_DIR}
@@ -106,6 +108,7 @@ if(JSBSIM_INCLUDE_DIR)
 					USES_TERMINAL
 					DEPENDS px4 jsbsim_bridge
 				)
+				set_property(GLOBAL APPEND PROPERTY PX4_SITL_VMD_TARGETS jsbsim_${model}__${world})
 			endif()
 		endforeach()
 	endforeach()


### PR DESCRIPTION
The list_vmd_make_targets custom target (added in 2016 to enumerate available <viewer_model_debugger> SITL run targets, e.g. via `make px4_sitl list_vmd_make_targets`) was silently dropped during the 2022 simulation reorganization (4040e4cdf2) when the monolithic sitl_target.cmake was split per-simulator. No replacement was added, so the target referenced throughout the docs has been unusable ever since (PX4/PX4-Autopilot#28615).

Each simulator now appends its generated run-target names to a global CMake property (PX4_SITL_VMD_TARGETS) as it defines them; the top-level CMakeLists.txt reads the accumulated, deduplicated, sorted list back into list_vmd_make_targets once all simulation modules are configured.

Assisted-by: Claude:claude-sonnet-5

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
