### PR TITLE
refactor(docs): remove dead list_vmd_make_targets references

### DIFF
--- a/docs/en/dev_setup/building_px4.md
+++ b/docs/en/dev_setup/building_px4.md
@@ -300,15 +300,6 @@ make list_config_targets
   Default is [empty.world](https://github.com/PX4/PX4-SITL_gazebo-classic/blob/main/worlds/empty.world).
   For more information see [Gazebo Classic > Loading a Specific World](../sim_gazebo_classic/index.md#loading-a-specific-world).
 
-:::tip
-You can get a list of _all_ available `VIEWER_MODEL_DEBUGGER_WORLD` options using the command below:
-
-```sh
-make px4_sitl list_vmd_make_targets
-```
-
-:::
-
 ::: info
 
 - Most of the values in the `CONFIGURATION_TARGET` and `VIEWER_MODEL_DEBUGGER` have defaults, and are hence optional.

--- a/docs/en/sim_flightgear/index.md
+++ b/docs/en/sim_flightgear/index.md
@@ -92,12 +92,6 @@ The commands above launch a single vehicle with the full UI.
 _QGroundControl_ should be able to automatically connect to the simulated vehicle.
 
 ::: info
-For the full list of FlightGear build targets (highlighted) run:
-
-```sh
-make px4_sitl_nolockstep list_vmd_make_targets | grep flightgear_
-```
-
 For additional information see: [FlightGear Vehicles](../sim_flightgear/vehicles.md) (this includes information about "unsupported" vehicles, and adding new vehicles).
 :::
 

--- a/docs/en/sim_flightgear/vehicles.md
+++ b/docs/en/sim_flightgear/vehicles.md
@@ -10,10 +10,6 @@ See [Toolchain Installation](../dev_setup/dev_env.md) for information about the 
 This topic lists/displays the vehicles supported by the PX4 [FlightGear](../sim_flightgear/index.md) simulation, and the `make` commands required to run them (the commands are run from terminal in the **PX4-Autopilot** directory).
 The supported types are: plane, autogyro and rover (there are specific frames within these types).
 
-:::tip
-For the full list of build targets run `make px4_sitl list_vmd_make_targets` (filter out those that start with `flightgear_`).
-:::
-
 ::: info
 The [FlightGear](../sim_flightgear/index.md) page shows how to install and use FlightGear in more detail (this page is a summary of vehicle-specific features).
 :::

--- a/docs/en/sim_gazebo_classic/index.md
+++ b/docs/en/sim_gazebo_classic/index.md
@@ -62,10 +62,6 @@ make px4_sitl gazebo-classic
 
 The supported vehicles and `make` commands are listed below (click links to see vehicle images).
 
-::: info
-For the full list of build targets run `make px4_sitl list_vmd_make_targets` (and filter on those that start with `gazebo-classic_`).
-:::
-
 | Vehicle                                                                                                                            | Command                                                   |
 | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
 | [Quadrotor](../sim_gazebo_classic/vehicles.md#quadrotor-default)                                                                   | `make px4_sitl gazebo-classic`                            |


### PR DESCRIPTION
list_vmd_make_targets was a make/CMake target for enumerating SITL <viewer_model_debugger> run targets, but it was silently dropped during the 2022 simulation reorganization (4040e4cdf2) and never restored. The docs still told users to run it, which fails with a ninja "unknown target" error (PX4/PX4-Autopilot#28615).

This is the better alternative to #28616 

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
