### PR TITLE
fix(commander): reject an out-of-range mode to replace on registration

### DIFF
--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -302,6 +302,13 @@ void ModeManagement::checkNewRegistrations(UpdateRequest &update_request)
 					reply.success = false;
 
 				} else if (request.enable_replace_internal_mode) {
+					// The mode to replace is used as a shift amount when building the selectable
+					// mode mask, so it has to be a real navigation state
+					if (request.replace_internal_mode >= vehicle_status_s::NAVIGATION_STATE_MAX) {
+						PX4_ERR("Invalid mode to replace (%i)", request.replace_internal_mode);
+						reply.success = false;
+					}
+
 					// Check if another one already replaces the same mode
 					for (int i = Modes::FIRST_EXTERNAL_NAV_STATE; i <= Modes::LAST_EXTERNAL_NAV_STATE; ++i) {
 						if (_modes.valid(i)) {


### PR DESCRIPTION
## Summary

`replace_internal_mode` from an external mode registration was stored unchecked and later used as a shift amount, so a value of 32 or more shifted a `uint32_t` by more than its width.

## Problem

An external component registering a flight mode may ask to replace an internal navigation state. The value was taken straight from the request:

```cpp
if (request.enable_replace_internal_mode) {
    mode.replaces_nav_state = request.replace_internal_mode;
}
```

and later used to clear a bit in the selectable mode mask:

```cpp
can_set_nav_state_mask &= ~(1u << cur_mode.replaces_nav_state);
```

`replace_internal_mode` is a `uint8`, `NAVIGATION_STATE_MAX` is 31, and the mask is a `uint32_t`. Anything from 32 upwards is undefined behaviour; in practice the shift is taken modulo the width, so it clears the bit of an unrelated mode and that mode stops being selectable.

`/fmu/in/register_ext_component_request` is exposed as an input topic by uXRCE-DDS, so the value is not necessarily produced by a well-behaved component.

## Solution

Reject an out-of-range value where the registration already rejects a mode another component has claimed — with a message and `reply.success = false`, so the request fails and the requester is told. The status print at the top of the file already bounds this same field.

## Note

This is a correctness fix, not a security one. A peer that can publish on `/fmu/in/register_ext_component_request` can also publish `/fmu/in/actuator_motors`.

---

Reported by @lihnucs.