### PR TITLE
fix(commander): clarify sensor startup diagnostics

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -115,10 +115,6 @@ void EstimatorChecks::checkAndReport(const Context &context, Report &reporter)
 			reporter.armingCheckFailure(required_groups, health_component_t::local_position_estimate,
 						    events::ID("check_estimator_missing_data"),
 						    events::Log::Info, "Waiting for estimator to initialize");
-
-			if (reporter.mavlink_log_pub()) {
-				mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: ekf2 missing data");
-			}
 		}
 
 	} else {

--- a/src/modules/commander/HealthAndArmingChecks/checks/magnetometerCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/magnetometerCheck.cpp
@@ -148,12 +148,7 @@ void MagnetometerChecks::checkAndReport(const Context &context, Report &reporter
 			 */
 			reporter.armingCheckFailure<uint8_t, uint8_t>(NavModes::All, health_component_t::magnetometer,
 					events::ID("check_mag_sys_has_mag_missing"),
-					events::Log::Error, "Found {1} compass (required: {2})", num_enabled_and_valid_calibration, _param_sys_has_mag.get());
-
-			if (reporter.mavlink_log_pub()) {
-				mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Found %i compass (required: %" PRId32 ")",
-						     num_enabled_and_valid_calibration, _param_sys_has_mag.get());
-			}
+					events::Log::Info, "Waiting for compass (found {1}, required: {2})", num_enabled_and_valid_calibration, _param_sys_has_mag.get());
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Explain when sensor initialization is still in progress.

## Problem
Legacy preflight messages report missing EKF data and insufficient compasses while initialization is still in progress.

## Solution
Use informational waiting events for the existing estimator and required-compass arming checks.
