### PR TITLE
fix(parameters): widen the flashfs working buffer size

### DIFF
--- a/src/lib/parameters/flashparams/flashfs.c
+++ b/src/lib/parameters/flashparams/flashfs.c
@@ -112,7 +112,7 @@ typedef begin_packed_struct struct flash_entry_header_t {
  * Private Data
  ****************************************************************************/
 static uint8_t *working_buffer;
-static uint16_t working_buffer_size;
+static size_t working_buffer_size;
 static bool working_buffer_static;
 static sector_descriptor_t *sector_map;
 static int last_erased;


### PR DESCRIPTION
## Summary

`parameter_flashfs_alloc()` stores the requested buffer size in a `uint16_t`, so it can only address 64 KiB of a parameter sector that is 128 KiB on 21 boards.

## Problem

```c
static uint16_t working_buffer_size;
...
working_buffer_size = *buf_size + sizeof(flash_entry_header_t);
working_buffer = malloc(working_buffer_size);
...
*buf_size = working_buffer_size - sizeof(flash_entry_header_t);
```

Twenty-one boards give the parameter store a single 128 KiB sector (`{15, 128 * 1024, 0x081E0000}`) — all of them H7 flight controllers that use flash for parameters because they have no SD card. The size variable cannot represent more than 65535, so half the sector is unreachable by construction.

If a request ever did exceed that, the wrap is silent. There is no out-of-bounds write: the caller uses the size written back through `*buf_size` rather than the one it asked for, so the `memcpy` in `flashparams.cpp` stays inside the allocation. What would happen instead is a truncated parameter blob written as if complete, with nothing reported.

## Solution

Use `size_t`, matching the rest of the interface, which already passes `size_t *buf_size`.

---

Reported by @lihnucs.