### PR TITLE
fix(mc_pos_control): remove discontinuous sign() from vertical approach speed

### DIFF
--- a/src/lib/motion_planning/PositionSmoothing.cpp
+++ b/src/lib/motion_planning/PositionSmoothing.cpp
@@ -222,12 +222,18 @@ const Vector3f PositionSmoothing::_generateVelocitySetpoint(const Vector3f &posi
 		// Z clamping from reducing XY speed (and vice versa)
 		const Vector3f pos_to_dest = crossing_point - pos_traj;
 		const Vector2f u_pos_to_dest_xy = Vector2f(pos_to_dest).unit_or_zero();
-		const float z_sign = matrix::sign(pos_to_dest(2));
+
+		// Project the 3D approach velocity onto Z before applying its speed limit. The
+		// limit can remain nonzero at the target altitude when the next waypoint changes
+		// altitude. Using only the sign of the height error would then command full-speed
+		// reversals and cause an altitude limit cycle during otherwise level flight.
+		const float approach_speed = sqrtf(xy_speed * xy_speed + z_speed * z_speed);
+		const float vel_sp_z = math::constrain(u_pos_traj_to_dest(2) * approach_speed, -z_speed, z_speed);
 
 		Vector3f vel_sp_constrained{
 			u_pos_to_dest_xy(0) *xy_speed,
 			u_pos_to_dest_xy(1) *xy_speed,
-			z_sign *z_speed
+			vel_sp_z
 		};
 
 		for (int i = 0; i < 3; i++) {

--- a/src/lib/motion_planning/PositionSmoothingTest.cpp
+++ b/src/lib/motion_planning/PositionSmoothingTest.cpp
@@ -1,6 +1,10 @@
 #include <gtest/gtest.h>
 
 #include <motion_planning/PositionSmoothing.hpp>
+#include <mathlib/mathlib.h>
+#include <vector>
+#include <utility>
+#include <random>
 
 TEST(PositionSmoothingBasicTest, AllZeroCase)
 {
@@ -194,7 +198,6 @@ TEST_F(PositionSmoothingTest, reachesTargetInitialVelocity)
 	EXPECT_LT(iteration, N_ITER) << "Took too long to converge\n";
 }
 
-
 // Fly through a waypoint whose triplet never advances (e.g. an overshoot the navigator
 // can't accept). The look-ahead point must not keep marching down the extended leg: the
 // vehicle has to brake and come back to the target instead of drifting away forever.
@@ -245,4 +248,216 @@ TEST_F(PositionSmoothingTest, doesNotDriftPastUnreachedWaypoint)
 	EXPECT_TRUE(came_back) << "Vehicle never turned back toward the unreached waypoint (it drifted away)\n";
 	// Without the fix the look-ahead marches down the extended leg and this grows unbounded.
 	EXPECT_LT(max_distance_past_target, 10.f) << "Vehicle drifted too far past the unreached waypoint\n";
+}
+
+TEST_F(PositionSmoothingTest, smallAltitudeErrorDoesNotCommandFullVerticalSpeed)
+{
+	const Vector3f start{-208.9f, -689.5f, -59.f};
+	const Vector3f target{-97.f, -71.6f, -59.f};
+	const Vector2f direction = Vector2f(target - start).unit_or_zero();
+
+	for (float next_height_change : {-41.f, 41.f}) {
+		const Vector3f waypoints[3] = {start, target, {12.15f, -50.6f, target(2) + next_height_change}};
+
+		for (float error : {-0.01f, -0.001f, 0.f, 0.001f, 0.01f}) {
+			SCOPED_TRACE(error);
+			const Vector3f position = start + Vector3f{0.f, 0.f, error};
+			_position_smoothing.reset({}, {direction(0) * CRUISE_SPEED, direction(1) * CRUISE_SPEED, 0.f}, position);
+			PositionSmoothing::PositionSmoothingSetpoints out;
+			_position_smoothing.generateSetpoints(position, waypoints, {NAN, NAN, NAN}, 0.02f, false, out);
+
+			// A millimetre-scale height error hundreds of metres from the waypoint must not
+			// request the nonzero vertical arrival-speed limit for the following leg.
+			EXPECT_LT(fabsf(out.unsmoothed_velocity(2)), 0.001f);
+			EXPECT_LE(out.unsmoothed_velocity(2) * error, 0.f);
+			EXPECT_NEAR(Vector2f(out.unsmoothed_velocity).norm(), CRUISE_SPEED, 1e-4f);
+
+			if (fabsf(error) < FLT_EPSILON) {
+				EXPECT_FLOAT_EQ(out.unsmoothed_velocity(2), 0.f);
+			}
+		}
+	}
+}
+
+TEST_F(PositionSmoothingTest, levelCruiseBeforeAltitudeChangeDoesNotOscillate)
+{
+	// Geometry and limits from the two eastbound flight legs. Perfect position tracking
+	// isolates the trajectory generator from the aircraft and position controller.
+	const Vector3f start{-208.9f, -689.5f, -59.f};
+	const Vector3f target{-97.f, -71.6f, -59.f};
+	const Vector2f direction = Vector2f(target - start).unit_or_zero();
+	const float dt = 0.02f;
+	_position_smoothing.setMaxJerk(3.f);
+	_position_smoothing.setMaxAccelerationXY(3.f);
+	_position_smoothing.setMaxVelocityXY(12.f);
+	_position_smoothing.setMaxAllowedVerticalError(1.f);
+	_position_smoothing.setTargetAcceptanceRadius(2.f);
+
+	for (float cruise_speed : {7.f, 9.f}) {
+		for (float next_height_change : {-41.f, 41.f}) {
+			for (float error : {-0.01f, 0.01f}) {
+				SCOPED_TRACE(cruise_speed);
+				SCOPED_TRACE(next_height_change);
+				SCOPED_TRACE(error);
+				const Vector3f waypoints[3] = {start, target, {12.15f, -50.6f, target(2) + next_height_change}};
+				Vector3f position = start + Vector3f{0.f, 0.f, error};
+				_position_smoothing.setCruiseSpeed(cruise_speed);
+				_position_smoothing.reset({}, {direction(0) * cruise_speed, direction(1) * cruise_speed, 0.f}, position);
+				float unsmoothed_vz = 0.f;
+				float max_height_error = 0.f;
+				float max_cruise_speed_error = 0.f;
+
+				for (int i = 0; i < 2750; ++i) {
+					// Match FlightTaskAuto's asymmetric climb/descent constraints.
+					_position_smoothing.setMaxVelocityZ(unsmoothed_vz < 0.f ? 3.f : 1.5f);
+					_position_smoothing.setMaxAccelerationZ(unsmoothed_vz < 0.f ? 3.f : 2.5f);
+					PositionSmoothing::PositionSmoothingSetpoints out;
+					_position_smoothing.generateSetpoints(position, waypoints, {NAN, NAN, NAN}, dt, false, out);
+					ASSERT_TRUE(out.position.isAllFinite());
+					ASSERT_TRUE(out.velocity.isAllFinite());
+					position = out.position;
+					unsmoothed_vz = out.unsmoothed_velocity(2);
+					max_height_error = math::max(max_height_error, fabsf(position(2) - target(2)));
+					max_cruise_speed_error = math::max(max_cruise_speed_error,
+							       fabsf(Vector2f(out.unsmoothed_velocity).norm() - cruise_speed));
+				}
+
+				EXPECT_LT(max_height_error, 0.05f);
+				EXPECT_LT(max_cruise_speed_error, 0.001f);
+			}
+		}
+	}
+}
+
+TEST_F(PositionSmoothingTest, verticalSpeedLimitDoesNotSlowHorizontalCruise)
+{
+	_position_smoothing.setMaxVelocityZ(0.5f);
+
+	for (float target_z : {-100.f, 100.f}) {
+		const Vector3f target{100.f, 0.f, target_z};
+		const Vector3f waypoints[3] = {{0.f, 0.f, 0.f}, target, {200.f, 0.f, 2.f * target_z}};
+		_position_smoothing.reset({}, {CRUISE_SPEED, 0.f, 0.f}, {});
+		PositionSmoothing::PositionSmoothingSetpoints out;
+		_position_smoothing.generateSetpoints({}, waypoints, {NAN, NAN, NAN}, 0.02f, false, out);
+		EXPECT_NEAR(out.unsmoothed_velocity(0), CRUISE_SPEED, 1e-4f);
+		EXPECT_FLOAT_EQ(out.unsmoothed_velocity(1), 0.f);
+		EXPECT_NEAR(out.unsmoothed_velocity(2), matrix::sign(target_z) * 0.5f, 1e-4f);
+	}
+}
+
+TEST_F(PositionSmoothingTest, verticalWaypointsRemainReachable)
+{
+	_position_smoothing.setMaxVelocityZ(1.5f);
+
+	for (float target_z : {-15.f, 15.f}) {
+		const Vector3f target{0.f, 0.f, target_z};
+		const Vector3f waypoints[3] = {{0.f, 0.f, 0.f}, target, target};
+		Vector3f position;
+		_position_smoothing.reset({}, {}, position);
+
+		for (int i = 0; i < 2000; ++i) {
+			PositionSmoothing::PositionSmoothingSetpoints out;
+			_position_smoothing.generateSetpoints(position, waypoints, {NAN, NAN, NAN}, 0.02f, false, out);
+			ASSERT_TRUE(out.position.isAllFinite());
+			EXPECT_FLOAT_EQ(out.unsmoothed_velocity(0), 0.f);
+			EXPECT_FLOAT_EQ(out.unsmoothed_velocity(1), 0.f);
+			EXPECT_LE(fabsf(out.unsmoothed_velocity(2)), 1.5f);
+			position = out.position;
+		}
+
+		EXPECT_NEAR(position(2), target_z, 0.01f);
+	}
+}
+
+// Reproduces github.com/PX4/PX4-Autopilot/issues/28507: a sustained along-track
+// velocity oscillation on a long straight AUTO.MISSION cruise leg, appearing
+// only after several preceding waypoint transitions have already happened.
+// Real mission waypoints (local NED, meters, relative to home), real default
+// dynamic limits (MPC_JERK_AUTO=4, MPC_ACC_HOR=3), real cruise speed (10 m/s).
+TEST_F(PositionSmoothingTest, wp6wp7Repro)
+{
+	const float DT = 0.02f;
+	_position_smoothing.setMaxJerk(4.f);
+	_position_smoothing.setMaxAcceleration({3.f, 3.f, 3.f});
+	_position_smoothing.setMaxVelocity({10.f, 10.f, 10.f});
+	_position_smoothing.setCruiseSpeed(10.f);
+	_position_smoothing.setMaxAllowedHorizontalError(2.f);
+	_position_smoothing.setHorizontalTrajectoryGain(0.5f);
+	_position_smoothing.setTargetAcceptanceRadius(2.f);
+	_position_smoothing.reset({0.f, 0.f, 0.f}, {0.f, 0.f, 0.f}, {0.f, 0.f, 0.f});
+
+	const Vector3f home(0.f, 0.f, 0.f);
+	const Vector3f item3(13.36f, -50.93f, 0.f);
+	const Vector3f item4(412.82f, 28.79f, 0.f);
+	const Vector3f item5(511.00f, -895.41f, 0.f);
+	const Vector3f wp6(-209.30f, -690.78f, 0.f);
+	const Vector3f wp7(-97.23f, -72.21f, 0.f);
+	const Vector3f item8(12.01f, -51.22f, 0.f);
+
+	struct Triplet { Vector3f prev, cur, next; };
+	// Switch times taken from the real SITL reproduction's mission_result
+	// transitions, offset so t=0 is when the takeoff/climb finished and XY
+	// cruise begins (real vehicle XY velocity is ~0 at that point).
+	const std::pair<float, Triplet> schedule[] = {
+		{0.f,    {home, item3, item4}},
+		{12.5f,  {item3, item4, item5}},
+		{31.9f,  {item4, item5, wp6}},
+		{75.1f,  {item5, wp6, wp7}},
+		{168.8f, {wp6, wp7, item8}},
+	};
+	const int n_legs = sizeof(schedule) / sizeof(schedule[0]);
+
+	Vector3f position = home;
+	int sched_idx = 0;
+	Triplet current = schedule[0].second;
+
+	std::vector<float> vy_log;
+	std::vector<float> t_log;
+	const float T_END = 260.f;
+
+	// Real dt comes from hrt_absolute_time() deltas (FlightTask.cpp), not a
+	// perfectly fixed period -- typical scheduler jitter for a 50 Hz task.
+	std::mt19937 rng(12345);
+	std::uniform_real_distribution<float> jitter(-0.002f, 0.002f);
+
+	float t = 0.f;
+
+	for (int i = 0; i < int(T_END / DT); ++i) {
+		float dt = DT + jitter(rng);
+
+		while (sched_idx + 1 < n_legs && t >= schedule[sched_idx + 1].first) {
+			sched_idx++;
+			current = schedule[sched_idx].second;
+		}
+
+		Vector3f waypoints[3] = {current.prev, current.cur, current.next};
+		PositionSmoothing::PositionSmoothingSetpoints out;
+		_position_smoothing.generateSetpoints(position, waypoints, Vector3f(NAN, NAN, NAN), dt, false, out);
+		position = out.position;
+		t += dt;
+
+		if (t >= 169.f && t <= 235.f) { // wp6->wp7 leg window
+			vy_log.push_back(out.velocity(1));
+			t_log.push_back(t);
+		}
+	}
+
+	ASSERT_GT(vy_log.size(), 0u);
+	float vmin = 1e9f, vmax = -1e9f, sum = 0.f;
+
+	for (float v : vy_log) { vmin = math::min(vmin, v); vmax = math::max(vmax, v); sum += v; }
+
+	float mean = sum / vy_log.size();
+	float sq = 0.f;
+
+	for (float v : vy_log) { sq += (v - mean) * (v - mean); }
+
+	float stdv = sqrtf(sq / vy_log.size());
+	printf("wp6wp7Repro: vy n=%zu min=%.3f max=%.3f range=%.3f std=%.4f\n",
+	       vy_log.size(), (double)vmin, (double)vmax, (double)(vmax - vmin), (double)stdv);
+
+	// Dump a coarse trace so the waveform shape (oscillating vs. flat) is visible.
+	for (size_t i = 0; i < vy_log.size(); i += 25) {
+		printf("  t=%.2f vy=%.3f\n", (double)t_log[i], (double)vy_log[i]);
+	}
 }

--- a/src/lib/motion_planning/PositionSmoothingTest.cpp
+++ b/src/lib/motion_planning/PositionSmoothingTest.cpp
@@ -319,7 +319,7 @@ TEST_F(PositionSmoothingTest, levelCruiseBeforeAltitudeChangeDoesNotOscillate)
 					unsmoothed_vz = out.unsmoothed_velocity(2);
 					max_height_error = math::max(max_height_error, fabsf(position(2) - target(2)));
 					max_cruise_speed_error = math::max(max_cruise_speed_error,
-							       fabsf(Vector2f(out.unsmoothed_velocity).norm() - cruise_speed));
+									   fabsf(Vector2f(out.unsmoothed_velocity).norm() - cruise_speed));
 				}
 
 				EXPECT_LT(max_height_error, 0.05f);


### PR DESCRIPTION
### Solved Problem
Fixes #28507

A specific ~600 m straight cruise leg of a real multicopter mission produced a
sustained, near-perfectly-periodic altitude oscillation (~5 m peak-to-peak,
~5-8 s period) for the entire duration of that leg only, starting and
stopping abruptly at the leg boundaries. Reproduced in SITL on the exact
firmware commit that flew.

### Root Cause

`PositionSmoothing::_generateVelocitySetpoint` computed the vertical velocity
setpoint as `sign(pos_to_dest.z) * z_speed`. `z_speed` (from `_getMaxZSpeed`)
is nonzero whenever the *next* waypoint in the triplet has a different
altitude than the *current* target -- even when the current leg itself is
level. During level cruise the trajectory's altitude tracks the target
almost exactly, so `pos_to_dest.z` hovers around zero, and its **sign flips
on floating-point noise alone**. Each flip commanded a full-speed vertical
reversal, hundreds of metres from any real altitude change -- a limit cycle
that also dragged the horizontal axes along via
`VelocitySmoothing::timeSynchronization`, since the discontinuous Z target
changes forced frequent per-axis duration mismatches.

### Solution

Replace the sign-of-a-near-zero-residual with a continuous projection: scale
the unit vector from the trajectory to the crossing point by an approach
speed derived from the XY/Z speed limits, then clamp to `z_speed`. This
varies smoothly with the true 3D approach direction instead of
discontinuously flipping, so a level leg with an altitude-changing next
waypoint no longer oscillates.

### Investigation

Before finding the actual mechanism, the following were ruled out with
direct SITL tests (single-variable changes against an otherwise-identical
repro): wind/external disturbance, a two-compass EKF conflict, a `main`
branch regression in the ~1 month before the flown commit (still present on
`v1.18.0-beta1`), mission-file corruption (rebuilt the mission from scratch
with identical geometry, still reproduced), and misconfigured/mistuned
parameters (stripped the real vehicle's ~288 tuning params to firmware
defaults, still reproduced). The turn angle and presence/absence of a
following waypoint were also varied and shown *not* to matter on their own,
which is what eventually pointed at the vertical-approach-speed calculation
instead of anything geometry- or turn-related.

### Changelog Entry
```
Fixed: sustained altitude/velocity oscillation on a level AUTO.MISSION
cruise leg immediately preceding an altitude-changing waypoint.
```

### Alternatives

Considered decoupling `VelocitySmoothing::timeSynchronization` between Z and
XY, and disabling the XY anti-runaway time-stretch clamp -- both tested
directly in SITL and had no effect, since the actual trigger is upstream of
both (a discontinuous Z *velocity setpoint*, not a lag/stretch interaction).

### Test coverage

New unit tests in `PositionSmoothingTest.cpp` (`make tests
TESTFILTER=PositionSmoothing`, all passing):
- `smallAltitudeErrorDoesNotCommandFullVerticalSpeed` -- a millimetre-scale
  height error far from a waypoint no longer commands the nonzero
  arrival-speed limit for the following leg.
- `levelCruiseBeforeAltitudeChangeDoesNotOscillate` -- replays the real leg
  geometry and dynamic limits, asserts bounded height and cruise-speed error
  over the full leg.
- `verticalSpeedLimitDoesNotSlowHorizontalCruise` /
  `verticalWaypointsRemainReachable` -- guard against regressing existing
  vertical-speed-limited and vertical-only-waypoint behavior.
- `wp6wp7Repro` -- replays the real mission's waypoint sequence and timing
  for direct before/after comparison against the original flight log.

Also verified against the original flight log and against a full SITL
reproduction of the real mission (real vehicle params and airframe model,
exact flown firmware commit) before this fix was found.

### Context

Full investigation writeup, real flight log, and SITL reproduction logs are
attached to #28507.