### PR TITLE
feat(invensense): board-selectable anti-alias bandwidth for CAN flow nodes

### DIFF
--- a/boards/ark/can-flow-mr/init/rc.board_sensors
+++ b/boards/ark/can-flow-mr/init/rc.board_sensors
@@ -14,6 +14,6 @@ param set-default SENS_AFBR_MODE 1
 # Internal SPI
 paa3905 -s start -Y 180
 
-iim42653 -R 0 -B 250 -s start
+iim42653 -R 0 -B 258 -s start
 
 afbrs50 start

--- a/boards/ark/can-flow-mr/init/rc.board_sensors
+++ b/boards/ark/can-flow-mr/init/rc.board_sensors
@@ -14,6 +14,6 @@ param set-default SENS_AFBR_MODE 1
 # Internal SPI
 paa3905 -s start -Y 180
 
-iim42653 -R 0 -s start
+iim42653 -R 0 -B 250 -s start
 
 afbrs50 start

--- a/boards/ark/can-flow/init/rc.board_sensors
+++ b/boards/ark/can-flow/init/rc.board_sensors
@@ -13,9 +13,9 @@ then
 	paa3905 -s start -Y 180
 fi
 
-if ! icm42688p -R 0 -s start
+if ! icm42688p -R 0 -B 258 -s start
 then
-	if ! iim42652 -R 0 -B 250 -s start
+	if ! iim42652 -R 0 -B 258 -s start
 	then
 		bmi088 -A -s -R 4 start
 		bmi088 -G -s -R 4 start

--- a/boards/ark/can-flow/init/rc.board_sensors
+++ b/boards/ark/can-flow/init/rc.board_sensors
@@ -15,7 +15,7 @@ fi
 
 if ! icm42688p -R 0 -s start
 then
-	if ! iim42652 -R 0 -s start
+	if ! iim42652 -R 0 -B 250 -s start
 	then
 		bmi088 -A -s -R 4 start
 		bmi088 -G -s -R 4 start

--- a/src/drivers/imu/invensense/InvenSense_AAF.hpp
+++ b/src/drivers/imu/invensense/InvenSense_AAF.hpp
@@ -1,0 +1,115 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file InvenSense_AAF.hpp
+ *
+ * Anti-alias filter coefficients shared by the ICM-4268x / IIM-4265x family
+ * (datasheet table "GYRO/ACCEL anti-alias filter bandwidth") and the UI
+ * filter bandwidth codes of GYRO_ACCEL_CONFIG0.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+namespace InvenSense_AAF
+{
+
+struct Coefficients {
+	uint8_t delt;        // GYRO_AAF_DELT / ACCEL_AAF_DELT
+	uint16_t deltsqr;    // GYRO_AAF_DELTSQR / ACCEL_AAF_DELTSQR
+	uint8_t bitshift;    // GYRO_AAF_BITSHIFT / ACCEL_AAF_BITSHIFT
+	uint16_t bandwidth_hz;
+};
+
+inline constexpr Coefficients kTable[] {
+	{ 1,    1, 15,   42}, { 2,    4, 13,   84}, { 3,    9, 12,  126}, { 4,   16, 11,  170},
+	{ 5,   25, 10,  213}, { 6,   36, 10,  258}, { 7,   49,  9,  303}, { 8,   64,  9,  348},
+	{ 9,   81,  9,  394}, {10,  100,  8,  441}, {11,  122,  8,  488}, {12,  144,  8,  536},
+	{13,  170,  8,  585}, {14,  196,  7,  634}, {15,  224,  7,  684}, {16,  256,  7,  734},
+	{17,  288,  7,  785}, {18,  324,  7,  837}, {19,  360,  6,  890}, {20,  400,  6,  943},
+	{21,  440,  6,  997}, {22,  488,  6, 1051}, {23,  528,  6, 1107}, {24,  576,  6, 1163},
+	{25,  624,  6, 1220}, {26,  680,  6, 1277}, {27,  736,  5, 1336}, {28,  784,  5, 1395},
+	{29,  848,  5, 1454}, {30,  900,  5, 1515}, {31,  960,  5, 1577}, {32, 1024,  5, 1639},
+	{33, 1088,  5, 1702}, {34, 1152,  5, 1766}, {35, 1232,  5, 1830}, {36, 1296,  5, 1896},
+	{37, 1376,  4, 1962}, {38, 1440,  4, 2029}, {39, 1536,  4, 2097}, {40, 1600,  4, 2166},
+	{41, 1696,  4, 2235}, {42, 1760,  4, 2306}, {43, 1856,  4, 2377}, {44, 1952,  4, 2449},
+	{45, 2016,  3, 2522}, {46, 2112,  3, 2596}, {47, 2208,  3, 2671}, {48, 2304,  3, 2746},
+	{49, 2400,  3, 2823}, {50, 2496,  3, 2900}, {51, 2592,  3, 2978}, {52, 2720,  3, 3057},
+	{53, 2816,  3, 3137}, {54, 2944,  3, 3217}, {55, 3008,  3, 3299}, {56, 3136,  3, 3381},
+	{57, 3264,  3, 3464}, {58, 3392,  3, 3548}, {59, 3456,  3, 3633}, {60, 3584,  3, 3718},
+	{61, 3712,  3, 3805}, {62, 3840,  3, 3892}, {63, 3968,  3, 3979},
+};
+
+// Closest table row to the requested bandwidth.
+inline const Coefficients &lookup(uint32_t bandwidth_hz)
+{
+	const Coefficients *best = &kTable[0];
+
+	for (const auto &c : kTable) {
+		const uint32_t d_best = (best->bandwidth_hz > bandwidth_hz) ? best->bandwidth_hz - bandwidth_hz : bandwidth_hz -
+					best->bandwidth_hz;
+		const uint32_t d = (c.bandwidth_hz > bandwidth_hz) ? c.bandwidth_hz - bandwidth_hz : bandwidth_hz - c.bandwidth_hz;
+
+		if (d < d_best) {
+			best = &c;
+		}
+	}
+
+	return *best;
+}
+
+// UI filter bandwidth codes 0..7 (GYRO_ACCEL_CONFIG0 *_UI_FILT_BW) select ODR/N.
+inline constexpr uint8_t kUiDivisors[] {2, 4, 5, 8, 10, 16, 20, 40};
+
+// Code whose ODR/N is closest to the requested bandwidth.
+inline uint8_t ui_filter_bw_code(uint32_t odr_hz, uint32_t bandwidth_hz)
+{
+	uint8_t best = 0;
+	uint32_t d_best = UINT32_MAX;
+
+	for (uint8_t i = 0; i < sizeof(kUiDivisors); i++) {
+		const uint32_t bw = odr_hz / kUiDivisors[i];
+		const uint32_t d = (bw > bandwidth_hz) ? bw - bandwidth_hz : bandwidth_hz - bw;
+
+		if (d < d_best) {
+			d_best = d;
+			best = i;
+		}
+	}
+
+	return best;
+}
+
+} // namespace InvenSense_AAF

--- a/src/drivers/imu/invensense/InvenSense_AAF.hpp
+++ b/src/drivers/imu/invensense/InvenSense_AAF.hpp
@@ -41,6 +41,7 @@
 
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 namespace InvenSense_AAF
@@ -99,13 +100,13 @@ inline uint8_t ui_filter_bw_code(uint32_t odr_hz, uint32_t bandwidth_hz)
 	uint8_t best = 0;
 	uint32_t d_best = UINT32_MAX;
 
-	for (uint8_t i = 0; i < sizeof(kUiDivisors); i++) {
+	for (size_t i = 0; i < sizeof(kUiDivisors); i++) {
 		const uint32_t bw = odr_hz / kUiDivisors[i];
 		const uint32_t d = (bw > bandwidth_hz) ? bw - bandwidth_hz : bandwidth_hz - bw;
 
 		if (d < d_best) {
 			d_best = d;
-			best = i;
+			best = static_cast<uint8_t>(i);
 		}
 	}
 

--- a/src/drivers/imu/invensense/InvenSense_AAF.hpp
+++ b/src/drivers/imu/invensense/InvenSense_AAF.hpp
@@ -34,9 +34,10 @@
 /**
  * @file InvenSense_AAF.hpp
  *
- * Anti-alias filter coefficients shared by the ICM-4268x / IIM-4265x family
- * (datasheet table "GYRO/ACCEL anti-alias filter bandwidth") and the UI
- * filter bandwidth codes of GYRO_ACCEL_CONFIG0.
+ * Anti-alias filter presets for the ICM-4268x / IIM-4265x family, selected
+ * with the drivers' -B <hz> start option. Coefficients from the datasheet
+ * "anti-alias filter bandwidth" table; the UI filter code is the ODR/N
+ * setting of GYRO_ACCEL_CONFIG0 at the drivers' 8 kHz ODR.
  */
 
 #pragma once
@@ -47,70 +48,31 @@
 namespace InvenSense_AAF
 {
 
-struct Coefficients {
-	uint8_t delt;        // GYRO_AAF_DELT / ACCEL_AAF_DELT
-	uint16_t deltsqr;    // GYRO_AAF_DELTSQR / ACCEL_AAF_DELTSQR
-	uint8_t bitshift;    // GYRO_AAF_BITSHIFT / ACCEL_AAF_BITSHIFT
+struct Preset {
 	uint16_t bandwidth_hz;
+	uint8_t delt;        // *_AAF_DELT
+	uint16_t deltsqr;    // *_AAF_DELTSQR
+	uint8_t bitshift;    // *_AAF_BITSHIFT
+	uint8_t ui_filt_bw;  // *_UI_FILT_BW code: 6 = ODR/20 (400 Hz), 7 = ODR/40 (200 Hz)
 };
 
-inline constexpr Coefficients kTable[] {
-	{ 1,    1, 15,   42}, { 2,    4, 13,   84}, { 3,    9, 12,  126}, { 4,   16, 11,  170},
-	{ 5,   25, 10,  213}, { 6,   36, 10,  258}, { 7,   49,  9,  303}, { 8,   64,  9,  348},
-	{ 9,   81,  9,  394}, {10,  100,  8,  441}, {11,  122,  8,  488}, {12,  144,  8,  536},
-	{13,  170,  8,  585}, {14,  196,  7,  634}, {15,  224,  7,  684}, {16,  256,  7,  734},
-	{17,  288,  7,  785}, {18,  324,  7,  837}, {19,  360,  6,  890}, {20,  400,  6,  943},
-	{21,  440,  6,  997}, {22,  488,  6, 1051}, {23,  528,  6, 1107}, {24,  576,  6, 1163},
-	{25,  624,  6, 1220}, {26,  680,  6, 1277}, {27,  736,  5, 1336}, {28,  784,  5, 1395},
-	{29,  848,  5, 1454}, {30,  900,  5, 1515}, {31,  960,  5, 1577}, {32, 1024,  5, 1639},
-	{33, 1088,  5, 1702}, {34, 1152,  5, 1766}, {35, 1232,  5, 1830}, {36, 1296,  5, 1896},
-	{37, 1376,  4, 1962}, {38, 1440,  4, 2029}, {39, 1536,  4, 2097}, {40, 1600,  4, 2166},
-	{41, 1696,  4, 2235}, {42, 1760,  4, 2306}, {43, 1856,  4, 2377}, {44, 1952,  4, 2449},
-	{45, 2016,  3, 2522}, {46, 2112,  3, 2596}, {47, 2208,  3, 2671}, {48, 2304,  3, 2746},
-	{49, 2400,  3, 2823}, {50, 2496,  3, 2900}, {51, 2592,  3, 2978}, {52, 2720,  3, 3057},
-	{53, 2816,  3, 3137}, {54, 2944,  3, 3217}, {55, 3008,  3, 3299}, {56, 3136,  3, 3381},
-	{57, 3264,  3, 3464}, {58, 3392,  3, 3548}, {59, 3456,  3, 3633}, {60, 3584,  3, 3718},
-	{61, 3712,  3, 3805}, {62, 3840,  3, 3892}, {63, 3968,  3, 3979},
+// The chip default is 585 Hz with a 1st-order UI filter at ODR/2; these are the
+// alternatives for boards that decimate to 1 kHz or below.
+inline constexpr Preset kPresets[] {
+	{126, 3,  9, 12, 7},
+	{258, 6, 36, 10, 7},
+	{394, 9, 81,  9, 6},
 };
 
-// Closest table row to the requested bandwidth.
-inline const Coefficients &lookup(uint32_t bandwidth_hz)
+inline const Preset *preset(uint32_t bandwidth_hz)
 {
-	const Coefficients *best = &kTable[0];
-
-	for (const auto &c : kTable) {
-		const uint32_t d_best = (best->bandwidth_hz > bandwidth_hz) ? best->bandwidth_hz - bandwidth_hz : bandwidth_hz -
-					best->bandwidth_hz;
-		const uint32_t d = (c.bandwidth_hz > bandwidth_hz) ? c.bandwidth_hz - bandwidth_hz : bandwidth_hz - c.bandwidth_hz;
-
-		if (d < d_best) {
-			best = &c;
+	for (const auto &p : kPresets) {
+		if (p.bandwidth_hz == bandwidth_hz) {
+			return &p;
 		}
 	}
 
-	return *best;
-}
-
-// UI filter bandwidth codes 0..7 (GYRO_ACCEL_CONFIG0 *_UI_FILT_BW) select ODR/N.
-inline constexpr uint8_t kUiDivisors[] {2, 4, 5, 8, 10, 16, 20, 40};
-
-// Code whose ODR/N is closest to the requested bandwidth.
-inline uint8_t ui_filter_bw_code(uint32_t odr_hz, uint32_t bandwidth_hz)
-{
-	uint8_t best = 0;
-	uint32_t d_best = UINT32_MAX;
-
-	for (size_t i = 0; i < sizeof(kUiDivisors); i++) {
-		const uint32_t bw = odr_hz / kUiDivisors[i];
-		const uint32_t d = (bw > bandwidth_hz) ? bw - bandwidth_hz : bandwidth_hz - bw;
-
-		if (d < d_best) {
-			d_best = d;
-			best = static_cast<uint8_t>(i);
-		}
-	}
-
-	return best;
+	return nullptr;
 }
 
 } // namespace InvenSense_AAF

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
@@ -32,6 +32,7 @@
  ****************************************************************************/
 
 #include "ICM42688P.hpp"
+#include "../InvenSense_AAF.hpp"
 
 using namespace time_literals;
 
@@ -52,7 +53,7 @@ ICM42688P::ICM42688P(const I2CSPIDriverConfig &config) :
 	_px4_accel(get_device_id(), config.rotation, config.external),
 	_px4_gyro(get_device_id(), config.rotation, config.external)
 {
-	isICM686 = config.custom2 == DRV_IMU_DEVTYPE_ICM42686P;
+	isICM686 = (config.custom2 & 0xFF) == DRV_IMU_DEVTYPE_ICM42686P;
 
 	if (config.drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME": DRDY missed");
@@ -68,6 +69,10 @@ ICM42688P::ICM42688P(const I2CSPIDriverConfig &config) :
 	}
 
 	ConfigureSampleRate(_px4_gyro.get_max_rate_hz());
+
+	if ((config.custom2 >> 8) > 0) {
+		ConfigureAntiAliasFilter(config.custom2 >> 8);
+	}
 }
 
 ICM42688P::~ICM42688P()
@@ -315,6 +320,66 @@ void ICM42688P::RunImpl()
 
 		break;
 	}
+}
+
+void ICM42688P::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
+{
+	// Gyro and accel run at 8 kHz ODR: the chip default (AAF 585 Hz, UI filter 1st
+	// order at ODR/2) suits a flight controller decimating to a 1-2 kHz rate
+	// loop. A board that only needs a few hundred Hz, such as a CAN node
+	// integrating for optical flow, would alias everything between the
+	// decimated Nyquist and the AAF knee into its output; this narrows the AAF
+	// to the nearest table row and puts a 3rd-order UI filter at the nearest
+	// ODR/N. The set/clear tables are rewritten so Configure() and the
+	// periodic RegisterCheck() agree.
+	const InvenSense_AAF::Coefficients &aaf = InvenSense_AAF::lookup(bandwidth_hz);
+	const uint8_t ui_bw = InvenSense_AAF::ui_filter_bw_code((uint32_t)GYRO_RATE, bandwidth_hz);
+
+	auto set = [](auto & entry, uint8_t value, uint8_t mask) {
+		entry.set_bits = value & mask;
+		entry.clear_bits = (~value) & mask;
+	};
+
+	for (auto &r : _register_bank0_cfg) {
+		switch (r.reg) {
+		case Register::BANK_0::GYRO_CONFIG1:  set(r, Bit3, GYRO_CONFIG1_BIT::GYRO_UI_FILT_ORD); break;   // 3rd order
+
+		case Register::BANK_0::ACCEL_CONFIG1: set(r, Bit4, ACCEL_CONFIG1_BIT::ACCEL_UI_FILT_ORD); break; // 3rd order
+
+		case Register::BANK_0::GYRO_ACCEL_CONFIG0:
+			set(r, (ui_bw << 4) | ui_bw, GYRO_ACCEL_CONFIG0_BIT::ACCEL_UI_FILT_BW | GYRO_ACCEL_CONFIG0_BIT::GYRO_UI_FILT_BW);
+			break;
+
+		default: break;
+		}
+	}
+
+	for (auto &r : _register_bank1_cfg) {
+		switch (r.reg) {
+		case Register::BANK_1::GYRO_CONFIG_STATIC3: set(r, aaf.delt, 0x3F); break;
+
+		case Register::BANK_1::GYRO_CONFIG_STATIC4: set(r, aaf.deltsqr & 0xFF, 0xFF); break;
+
+		case Register::BANK_1::GYRO_CONFIG_STATIC5: set(r, (aaf.bitshift << 4) | ((aaf.deltsqr >> 8) & 0x0F), 0xFF); break;
+
+		default: break;
+		}
+	}
+
+	for (auto &r : _register_bank2_cfg) {
+		switch (r.reg) {
+		case Register::BANK_2::ACCEL_CONFIG_STATIC2: set(r, aaf.delt << 1, 0x7F); break; // bit 0 (AAF_DIS) stays cleared
+
+		case Register::BANK_2::ACCEL_CONFIG_STATIC3: set(r, aaf.deltsqr & 0xFF, 0xFF); break;
+
+		case Register::BANK_2::ACCEL_CONFIG_STATIC4: set(r, (aaf.bitshift << 4) | ((aaf.deltsqr >> 8) & 0x0F), 0xFF); break;
+
+		default: break;
+		}
+	}
+
+	PX4_INFO("anti-alias filter %u Hz, UI filter %u Hz 3rd order", aaf.bandwidth_hz,
+		 (unsigned)GYRO_RATE / InvenSense_AAF::kUiDivisors[ui_bw]);
 }
 
 void ICM42688P::ConfigureSampleRate(int sample_rate)

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
@@ -324,16 +324,18 @@ void ICM42688P::RunImpl()
 
 void ICM42688P::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
 {
-	// Gyro and accel run at 8 kHz ODR: the chip default (AAF 585 Hz, UI filter 1st
-	// order at ODR/2) suits a flight controller decimating to a 1-2 kHz rate
-	// loop. A board that only needs a few hundred Hz, such as a CAN node
-	// integrating for optical flow, would alias everything between the
-	// decimated Nyquist and the AAF knee into its output; this narrows the AAF
-	// to the nearest table row and puts a 3rd-order UI filter at the nearest
-	// ODR/N. The set/clear tables are rewritten so Configure() and the
-	// periodic RegisterCheck() agree.
-	const InvenSense_AAF::Coefficients &aaf = InvenSense_AAF::lookup(bandwidth_hz);
-	const uint8_t ui_bw = InvenSense_AAF::ui_filter_bw_code((uint32_t)GYRO_RATE, bandwidth_hz);
+	// The chip default (AAF 585 Hz, 1st-order UI filter at ODR/2) suits a flight
+	// controller decimating 8 kHz to a 1-2 kHz rate loop. A board that only
+	// needs a few hundred Hz, such as a CAN node integrating for optical flow,
+	// aliases everything between its decimated Nyquist and the AAF knee; the
+	// presets narrow the AAF and add a 3rd-order UI filter. The set/clear
+	// tables are rewritten so Configure() and RegisterCheck() agree.
+	const InvenSense_AAF::Preset *p = InvenSense_AAF::preset(bandwidth_hz);
+
+	if (p == nullptr) {
+		PX4_ERR("no %lu Hz anti-alias preset (126, 258, 394), keeping chip default", (unsigned long)bandwidth_hz);
+		return;
+	}
 
 	auto set = [](auto & entry, uint8_t value, uint8_t mask) {
 		entry.set_bits = value & mask;
@@ -347,7 +349,8 @@ void ICM42688P::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
 		case Register::BANK_0::ACCEL_CONFIG1: set(r, Bit4, ACCEL_CONFIG1_BIT::ACCEL_UI_FILT_ORD); break; // 3rd order
 
 		case Register::BANK_0::GYRO_ACCEL_CONFIG0:
-			set(r, (ui_bw << 4) | ui_bw, GYRO_ACCEL_CONFIG0_BIT::ACCEL_UI_FILT_BW | GYRO_ACCEL_CONFIG0_BIT::GYRO_UI_FILT_BW);
+			set(r, (p->ui_filt_bw << 4) | p->ui_filt_bw,
+			    GYRO_ACCEL_CONFIG0_BIT::ACCEL_UI_FILT_BW | GYRO_ACCEL_CONFIG0_BIT::GYRO_UI_FILT_BW);
 			break;
 
 		default: break;
@@ -356,11 +359,11 @@ void ICM42688P::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
 
 	for (auto &r : _register_bank1_cfg) {
 		switch (r.reg) {
-		case Register::BANK_1::GYRO_CONFIG_STATIC3: set(r, aaf.delt, 0x3F); break;
+		case Register::BANK_1::GYRO_CONFIG_STATIC3: set(r, p->delt, 0x3F); break;
 
-		case Register::BANK_1::GYRO_CONFIG_STATIC4: set(r, aaf.deltsqr & 0xFF, 0xFF); break;
+		case Register::BANK_1::GYRO_CONFIG_STATIC4: set(r, p->deltsqr & 0xFF, 0xFF); break;
 
-		case Register::BANK_1::GYRO_CONFIG_STATIC5: set(r, (aaf.bitshift << 4) | ((aaf.deltsqr >> 8) & 0x0F), 0xFF); break;
+		case Register::BANK_1::GYRO_CONFIG_STATIC5: set(r, (p->bitshift << 4) | ((p->deltsqr >> 8) & 0x0F), 0xFF); break;
 
 		default: break;
 		}
@@ -368,18 +371,17 @@ void ICM42688P::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
 
 	for (auto &r : _register_bank2_cfg) {
 		switch (r.reg) {
-		case Register::BANK_2::ACCEL_CONFIG_STATIC2: set(r, aaf.delt << 1, 0x7F); break; // bit 0 (AAF_DIS) stays cleared
+		case Register::BANK_2::ACCEL_CONFIG_STATIC2: set(r, p->delt << 1, 0x7F); break; // bit 0 (AAF_DIS) stays cleared
 
-		case Register::BANK_2::ACCEL_CONFIG_STATIC3: set(r, aaf.deltsqr & 0xFF, 0xFF); break;
+		case Register::BANK_2::ACCEL_CONFIG_STATIC3: set(r, p->deltsqr & 0xFF, 0xFF); break;
 
-		case Register::BANK_2::ACCEL_CONFIG_STATIC4: set(r, (aaf.bitshift << 4) | ((aaf.deltsqr >> 8) & 0x0F), 0xFF); break;
+		case Register::BANK_2::ACCEL_CONFIG_STATIC4: set(r, (p->bitshift << 4) | ((p->deltsqr >> 8) & 0x0F), 0xFF); break;
 
 		default: break;
 		}
 	}
 
-	PX4_INFO("anti-alias filter %u Hz, UI filter %u Hz 3rd order", aaf.bandwidth_hz,
-		 (unsigned)GYRO_RATE / InvenSense_AAF::kUiDivisors[ui_bw]);
+	PX4_INFO("anti-alias filter %u Hz, 3rd-order UI filter %u Hz", p->bandwidth_hz, (p->ui_filt_bw == 7) ? 200 : 400);
 }
 
 void ICM42688P::ConfigureSampleRate(int sample_rate)

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
@@ -114,6 +114,7 @@ private:
 
 	bool Configure();
 	void ConfigureSampleRate(int sample_rate);
+	void ConfigureAntiAliasFilter(uint32_t bandwidth_hz);
 	void ConfigureFIFOWatermark(uint8_t samples);
 	void ConfigureCLKIN();
 

--- a/src/drivers/imu/invensense/icm42688p/icm42688p_main.cpp
+++ b/src/drivers/imu/invensense/icm42688p/icm42688p_main.cpp
@@ -44,7 +44,7 @@ void ICM42688P::print_usage()
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
 	PRINT_MODULE_USAGE_PARAM_INT('C', 0, 0, 35000, "Input clock frequency (Hz)", true);
-	PRINT_MODULE_USAGE_PARAM_INT('B', 0, 0, 3979, "Anti-alias filter bandwidth (Hz), 0 keeps the chip default (585 Hz)", true);
+	PRINT_MODULE_USAGE_PARAM_INT('B', 0, 0, 394, "Anti-alias filter bandwidth: 126, 258 or 394 Hz (0: chip default 585 Hz)", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('6', "Drive ICM-42686", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }

--- a/src/drivers/imu/invensense/icm42688p/icm42688p_main.cpp
+++ b/src/drivers/imu/invensense/icm42688p/icm42688p_main.cpp
@@ -44,6 +44,7 @@ void ICM42688P::print_usage()
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
 	PRINT_MODULE_USAGE_PARAM_INT('C', 0, 0, 35000, "Input clock frequency (Hz)", true);
+	PRINT_MODULE_USAGE_PARAM_INT('B', 0, 0, 3979, "Anti-alias filter bandwidth (Hz), 0 keeps the chip default (585 Hz)", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('6', "Drive ICM-42686", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
@@ -55,8 +56,12 @@ extern "C" int icm42688p_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getOpt(argc, argv, "C:R:6")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "B:C:R:6")) != EOF) {
 		switch (ch) {
+		case 'B':
+			cli.custom2 |= atoi(cli.optArg()) << 8; // bits 7:0 carry the ICM-42686 flag
+			break;
+
 		case 'C':
 			cli.custom1 = atoi(cli.optArg());
 			break;
@@ -66,7 +71,7 @@ extern "C" int icm42688p_main(int argc, char *argv[])
 			break;
 
 		case '6':
-			cli.custom2 = DRV_IMU_DEVTYPE_ICM42686P;
+			cli.custom2 |= DRV_IMU_DEVTYPE_ICM42686P;
 			break;
 		}
 	}
@@ -78,8 +83,8 @@ extern "C" int icm42688p_main(int argc, char *argv[])
 		return -1;
 	}
 
-	BusInstanceIterator iterator(cli.custom2 == DRV_IMU_DEVTYPE_ICM42686P ? "icm42686p" : MODULE_NAME, cli,
-				     cli.custom2 == DRV_IMU_DEVTYPE_ICM42686P ? DRV_IMU_DEVTYPE_ICM42686P : DRV_IMU_DEVTYPE_ICM42688P);
+	BusInstanceIterator iterator((cli.custom2 & 0xFF) == DRV_IMU_DEVTYPE_ICM42686P ? "icm42686p" : MODULE_NAME, cli,
+				     (cli.custom2 & 0xFF) == DRV_IMU_DEVTYPE_ICM42686P ? DRV_IMU_DEVTYPE_ICM42686P : DRV_IMU_DEVTYPE_ICM42688P);
 
 	if (!strcmp(verb, "start")) {
 		return ThisDriver::module_start(cli, iterator);

--- a/src/drivers/imu/invensense/iim42652/IIM42652.cpp
+++ b/src/drivers/imu/invensense/iim42652/IIM42652.cpp
@@ -320,16 +320,18 @@ void IIM42652::RunImpl()
 
 void IIM42652::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
 {
-	// Gyro and accel run at 8 kHz ODR: the chip default (AAF 585 Hz, UI filter 1st
-	// order at ODR/2) suits a flight controller decimating to a 1-2 kHz rate
-	// loop. A board that only needs a few hundred Hz, such as a CAN node
-	// integrating for optical flow, would alias everything between the
-	// decimated Nyquist and the AAF knee into its output; this narrows the AAF
-	// to the nearest table row and puts a 3rd-order UI filter at the nearest
-	// ODR/N. The set/clear tables are rewritten so Configure() and the
-	// periodic RegisterCheck() agree.
-	const InvenSense_AAF::Coefficients &aaf = InvenSense_AAF::lookup(bandwidth_hz);
-	const uint8_t ui_bw = InvenSense_AAF::ui_filter_bw_code((uint32_t)GYRO_RATE, bandwidth_hz);
+	// The chip default (AAF 585 Hz, 1st-order UI filter at ODR/2) suits a flight
+	// controller decimating 8 kHz to a 1-2 kHz rate loop. A board that only
+	// needs a few hundred Hz, such as a CAN node integrating for optical flow,
+	// aliases everything between its decimated Nyquist and the AAF knee; the
+	// presets narrow the AAF and add a 3rd-order UI filter. The set/clear
+	// tables are rewritten so Configure() and RegisterCheck() agree.
+	const InvenSense_AAF::Preset *p = InvenSense_AAF::preset(bandwidth_hz);
+
+	if (p == nullptr) {
+		PX4_ERR("no %lu Hz anti-alias preset (126, 258, 394), keeping chip default", (unsigned long)bandwidth_hz);
+		return;
+	}
 
 	auto set = [](auto & entry, uint8_t value, uint8_t mask) {
 		entry.set_bits = value & mask;
@@ -343,7 +345,8 @@ void IIM42652::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
 		case Register::BANK_0::ACCEL_CONFIG1: set(r, Bit4, ACCEL_CONFIG1_BIT::ACCEL_UI_FILT_ORD); break; // 3rd order
 
 		case Register::BANK_0::GYRO_ACCEL_CONFIG0:
-			set(r, (ui_bw << 4) | ui_bw, GYRO_ACCEL_CONFIG0_BIT::ACCEL_UI_FILT_BW | GYRO_ACCEL_CONFIG0_BIT::GYRO_UI_FILT_BW);
+			set(r, (p->ui_filt_bw << 4) | p->ui_filt_bw,
+			    GYRO_ACCEL_CONFIG0_BIT::ACCEL_UI_FILT_BW | GYRO_ACCEL_CONFIG0_BIT::GYRO_UI_FILT_BW);
 			break;
 
 		default: break;
@@ -352,11 +355,11 @@ void IIM42652::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
 
 	for (auto &r : _register_bank1_cfg) {
 		switch (r.reg) {
-		case Register::BANK_1::GYRO_CONFIG_STATIC3: set(r, aaf.delt, 0x3F); break;
+		case Register::BANK_1::GYRO_CONFIG_STATIC3: set(r, p->delt, 0x3F); break;
 
-		case Register::BANK_1::GYRO_CONFIG_STATIC4: set(r, aaf.deltsqr & 0xFF, 0xFF); break;
+		case Register::BANK_1::GYRO_CONFIG_STATIC4: set(r, p->deltsqr & 0xFF, 0xFF); break;
 
-		case Register::BANK_1::GYRO_CONFIG_STATIC5: set(r, (aaf.bitshift << 4) | ((aaf.deltsqr >> 8) & 0x0F), 0xFF); break;
+		case Register::BANK_1::GYRO_CONFIG_STATIC5: set(r, (p->bitshift << 4) | ((p->deltsqr >> 8) & 0x0F), 0xFF); break;
 
 		default: break;
 		}
@@ -364,18 +367,17 @@ void IIM42652::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
 
 	for (auto &r : _register_bank2_cfg) {
 		switch (r.reg) {
-		case Register::BANK_2::ACCEL_CONFIG_STATIC2: set(r, aaf.delt << 1, 0x7F); break; // bit 0 (AAF_DIS) stays cleared
+		case Register::BANK_2::ACCEL_CONFIG_STATIC2: set(r, p->delt << 1, 0x7F); break; // bit 0 (AAF_DIS) stays cleared
 
-		case Register::BANK_2::ACCEL_CONFIG_STATIC3: set(r, aaf.deltsqr & 0xFF, 0xFF); break;
+		case Register::BANK_2::ACCEL_CONFIG_STATIC3: set(r, p->deltsqr & 0xFF, 0xFF); break;
 
-		case Register::BANK_2::ACCEL_CONFIG_STATIC4: set(r, (aaf.bitshift << 4) | ((aaf.deltsqr >> 8) & 0x0F), 0xFF); break;
+		case Register::BANK_2::ACCEL_CONFIG_STATIC4: set(r, (p->bitshift << 4) | ((p->deltsqr >> 8) & 0x0F), 0xFF); break;
 
 		default: break;
 		}
 	}
 
-	PX4_INFO("anti-alias filter %u Hz, UI filter %u Hz 3rd order", aaf.bandwidth_hz,
-		 (unsigned)GYRO_RATE / InvenSense_AAF::kUiDivisors[ui_bw]);
+	PX4_INFO("anti-alias filter %u Hz, 3rd-order UI filter %u Hz", p->bandwidth_hz, (p->ui_filt_bw == 7) ? 200 : 400);
 }
 
 void IIM42652::ConfigureSampleRate(int sample_rate)

--- a/src/drivers/imu/invensense/iim42652/IIM42652.cpp
+++ b/src/drivers/imu/invensense/iim42652/IIM42652.cpp
@@ -32,6 +32,7 @@
  ****************************************************************************/
 
 #include "IIM42652.hpp"
+#include "../InvenSense_AAF.hpp"
 
 using namespace time_literals;
 
@@ -66,6 +67,10 @@ IIM42652::IIM42652(const I2CSPIDriverConfig &config) :
 	}
 
 	ConfigureSampleRate(_px4_gyro.get_max_rate_hz());
+
+	if ((config.custom2) > 0) {
+		ConfigureAntiAliasFilter(config.custom2);
+	}
 }
 
 IIM42652::~IIM42652()
@@ -311,6 +316,66 @@ void IIM42652::RunImpl()
 
 		break;
 	}
+}
+
+void IIM42652::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
+{
+	// Gyro and accel run at 8 kHz ODR: the chip default (AAF 585 Hz, UI filter 1st
+	// order at ODR/2) suits a flight controller decimating to a 1-2 kHz rate
+	// loop. A board that only needs a few hundred Hz, such as a CAN node
+	// integrating for optical flow, would alias everything between the
+	// decimated Nyquist and the AAF knee into its output; this narrows the AAF
+	// to the nearest table row and puts a 3rd-order UI filter at the nearest
+	// ODR/N. The set/clear tables are rewritten so Configure() and the
+	// periodic RegisterCheck() agree.
+	const InvenSense_AAF::Coefficients &aaf = InvenSense_AAF::lookup(bandwidth_hz);
+	const uint8_t ui_bw = InvenSense_AAF::ui_filter_bw_code((uint32_t)GYRO_RATE, bandwidth_hz);
+
+	auto set = [](auto & entry, uint8_t value, uint8_t mask) {
+		entry.set_bits = value & mask;
+		entry.clear_bits = (~value) & mask;
+	};
+
+	for (auto &r : _register_bank0_cfg) {
+		switch (r.reg) {
+		case Register::BANK_0::GYRO_CONFIG1:  set(r, Bit3, GYRO_CONFIG1_BIT::GYRO_UI_FILT_ORD); break;   // 3rd order
+
+		case Register::BANK_0::ACCEL_CONFIG1: set(r, Bit4, ACCEL_CONFIG1_BIT::ACCEL_UI_FILT_ORD); break; // 3rd order
+
+		case Register::BANK_0::GYRO_ACCEL_CONFIG0:
+			set(r, (ui_bw << 4) | ui_bw, GYRO_ACCEL_CONFIG0_BIT::ACCEL_UI_FILT_BW | GYRO_ACCEL_CONFIG0_BIT::GYRO_UI_FILT_BW);
+			break;
+
+		default: break;
+		}
+	}
+
+	for (auto &r : _register_bank1_cfg) {
+		switch (r.reg) {
+		case Register::BANK_1::GYRO_CONFIG_STATIC3: set(r, aaf.delt, 0x3F); break;
+
+		case Register::BANK_1::GYRO_CONFIG_STATIC4: set(r, aaf.deltsqr & 0xFF, 0xFF); break;
+
+		case Register::BANK_1::GYRO_CONFIG_STATIC5: set(r, (aaf.bitshift << 4) | ((aaf.deltsqr >> 8) & 0x0F), 0xFF); break;
+
+		default: break;
+		}
+	}
+
+	for (auto &r : _register_bank2_cfg) {
+		switch (r.reg) {
+		case Register::BANK_2::ACCEL_CONFIG_STATIC2: set(r, aaf.delt << 1, 0x7F); break; // bit 0 (AAF_DIS) stays cleared
+
+		case Register::BANK_2::ACCEL_CONFIG_STATIC3: set(r, aaf.deltsqr & 0xFF, 0xFF); break;
+
+		case Register::BANK_2::ACCEL_CONFIG_STATIC4: set(r, (aaf.bitshift << 4) | ((aaf.deltsqr >> 8) & 0x0F), 0xFF); break;
+
+		default: break;
+		}
+	}
+
+	PX4_INFO("anti-alias filter %u Hz, UI filter %u Hz 3rd order", aaf.bandwidth_hz,
+		 (unsigned)GYRO_RATE / InvenSense_AAF::kUiDivisors[ui_bw]);
 }
 
 void IIM42652::ConfigureSampleRate(int sample_rate)

--- a/src/drivers/imu/invensense/iim42652/IIM42652.hpp
+++ b/src/drivers/imu/invensense/iim42652/IIM42652.hpp
@@ -114,6 +114,7 @@ private:
 
 	bool Configure();
 	void ConfigureSampleRate(int sample_rate);
+	void ConfigureAntiAliasFilter(uint32_t bandwidth_hz);
 	void ConfigureFIFOWatermark(uint8_t samples);
 	void ConfigureCLKIN();
 

--- a/src/drivers/imu/invensense/iim42652/iim42652_main.cpp
+++ b/src/drivers/imu/invensense/iim42652/iim42652_main.cpp
@@ -44,7 +44,7 @@ void IIM42652::print_usage()
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
 	PRINT_MODULE_USAGE_PARAM_INT('C', 0, 0, 35000, "Input clock frequency (Hz)", true);
-	PRINT_MODULE_USAGE_PARAM_INT('B', 0, 0, 3979, "Anti-alias filter bandwidth (Hz), 0 keeps the chip default (585 Hz)", true);
+	PRINT_MODULE_USAGE_PARAM_INT('B', 0, 0, 394, "Anti-alias filter bandwidth: 126, 258 or 394 Hz (0: chip default 585 Hz)", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 

--- a/src/drivers/imu/invensense/iim42652/iim42652_main.cpp
+++ b/src/drivers/imu/invensense/iim42652/iim42652_main.cpp
@@ -44,6 +44,7 @@ void IIM42652::print_usage()
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
 	PRINT_MODULE_USAGE_PARAM_INT('C', 0, 0, 35000, "Input clock frequency (Hz)", true);
+	PRINT_MODULE_USAGE_PARAM_INT('B', 0, 0, 3979, "Anti-alias filter bandwidth (Hz), 0 keeps the chip default (585 Hz)", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
@@ -54,8 +55,12 @@ extern "C" int iim42652_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getOpt(argc, argv, "C:R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "B:C:R:")) != EOF) {
 		switch (ch) {
+		case 'B':
+			cli.custom2 = atoi(cli.optArg());
+			break;
+
 		case 'C':
 			cli.custom1 = atoi(cli.optArg());
 			break;

--- a/src/drivers/imu/invensense/iim42653/IIM42653.cpp
+++ b/src/drivers/imu/invensense/iim42653/IIM42653.cpp
@@ -320,16 +320,18 @@ void IIM42653::RunImpl()
 
 void IIM42653::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
 {
-	// Gyro and accel run at 8 kHz ODR: the chip default (AAF 585 Hz, UI filter 1st
-	// order at ODR/2) suits a flight controller decimating to a 1-2 kHz rate
-	// loop. A board that only needs a few hundred Hz, such as a CAN node
-	// integrating for optical flow, would alias everything between the
-	// decimated Nyquist and the AAF knee into its output; this narrows the AAF
-	// to the nearest table row and puts a 3rd-order UI filter at the nearest
-	// ODR/N. The set/clear tables are rewritten so Configure() and the
-	// periodic RegisterCheck() agree.
-	const InvenSense_AAF::Coefficients &aaf = InvenSense_AAF::lookup(bandwidth_hz);
-	const uint8_t ui_bw = InvenSense_AAF::ui_filter_bw_code((uint32_t)GYRO_RATE, bandwidth_hz);
+	// The chip default (AAF 585 Hz, 1st-order UI filter at ODR/2) suits a flight
+	// controller decimating 8 kHz to a 1-2 kHz rate loop. A board that only
+	// needs a few hundred Hz, such as a CAN node integrating for optical flow,
+	// aliases everything between its decimated Nyquist and the AAF knee; the
+	// presets narrow the AAF and add a 3rd-order UI filter. The set/clear
+	// tables are rewritten so Configure() and RegisterCheck() agree.
+	const InvenSense_AAF::Preset *p = InvenSense_AAF::preset(bandwidth_hz);
+
+	if (p == nullptr) {
+		PX4_ERR("no %lu Hz anti-alias preset (126, 258, 394), keeping chip default", (unsigned long)bandwidth_hz);
+		return;
+	}
 
 	auto set = [](auto & entry, uint8_t value, uint8_t mask) {
 		entry.set_bits = value & mask;
@@ -343,7 +345,8 @@ void IIM42653::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
 		case Register::BANK_0::ACCEL_CONFIG1: set(r, Bit4, ACCEL_CONFIG1_BIT::ACCEL_UI_FILT_ORD); break; // 3rd order
 
 		case Register::BANK_0::GYRO_ACCEL_CONFIG0:
-			set(r, (ui_bw << 4) | ui_bw, GYRO_ACCEL_CONFIG0_BIT::ACCEL_UI_FILT_BW | GYRO_ACCEL_CONFIG0_BIT::GYRO_UI_FILT_BW);
+			set(r, (p->ui_filt_bw << 4) | p->ui_filt_bw,
+			    GYRO_ACCEL_CONFIG0_BIT::ACCEL_UI_FILT_BW | GYRO_ACCEL_CONFIG0_BIT::GYRO_UI_FILT_BW);
 			break;
 
 		default: break;
@@ -352,11 +355,11 @@ void IIM42653::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
 
 	for (auto &r : _register_bank1_cfg) {
 		switch (r.reg) {
-		case Register::BANK_1::GYRO_CONFIG_STATIC3: set(r, aaf.delt, 0x3F); break;
+		case Register::BANK_1::GYRO_CONFIG_STATIC3: set(r, p->delt, 0x3F); break;
 
-		case Register::BANK_1::GYRO_CONFIG_STATIC4: set(r, aaf.deltsqr & 0xFF, 0xFF); break;
+		case Register::BANK_1::GYRO_CONFIG_STATIC4: set(r, p->deltsqr & 0xFF, 0xFF); break;
 
-		case Register::BANK_1::GYRO_CONFIG_STATIC5: set(r, (aaf.bitshift << 4) | ((aaf.deltsqr >> 8) & 0x0F), 0xFF); break;
+		case Register::BANK_1::GYRO_CONFIG_STATIC5: set(r, (p->bitshift << 4) | ((p->deltsqr >> 8) & 0x0F), 0xFF); break;
 
 		default: break;
 		}
@@ -364,18 +367,17 @@ void IIM42653::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
 
 	for (auto &r : _register_bank2_cfg) {
 		switch (r.reg) {
-		case Register::BANK_2::ACCEL_CONFIG_STATIC2: set(r, aaf.delt << 1, 0x7F); break; // bit 0 (AAF_DIS) stays cleared
+		case Register::BANK_2::ACCEL_CONFIG_STATIC2: set(r, p->delt << 1, 0x7F); break; // bit 0 (AAF_DIS) stays cleared
 
-		case Register::BANK_2::ACCEL_CONFIG_STATIC3: set(r, aaf.deltsqr & 0xFF, 0xFF); break;
+		case Register::BANK_2::ACCEL_CONFIG_STATIC3: set(r, p->deltsqr & 0xFF, 0xFF); break;
 
-		case Register::BANK_2::ACCEL_CONFIG_STATIC4: set(r, (aaf.bitshift << 4) | ((aaf.deltsqr >> 8) & 0x0F), 0xFF); break;
+		case Register::BANK_2::ACCEL_CONFIG_STATIC4: set(r, (p->bitshift << 4) | ((p->deltsqr >> 8) & 0x0F), 0xFF); break;
 
 		default: break;
 		}
 	}
 
-	PX4_INFO("anti-alias filter %u Hz, UI filter %u Hz 3rd order", aaf.bandwidth_hz,
-		 (unsigned)GYRO_RATE / InvenSense_AAF::kUiDivisors[ui_bw]);
+	PX4_INFO("anti-alias filter %u Hz, 3rd-order UI filter %u Hz", p->bandwidth_hz, (p->ui_filt_bw == 7) ? 200 : 400);
 }
 
 void IIM42653::ConfigureSampleRate(int sample_rate)

--- a/src/drivers/imu/invensense/iim42653/IIM42653.cpp
+++ b/src/drivers/imu/invensense/iim42653/IIM42653.cpp
@@ -32,6 +32,7 @@
  ****************************************************************************/
 
 #include "IIM42653.hpp"
+#include "../InvenSense_AAF.hpp"
 
 using namespace time_literals;
 
@@ -66,6 +67,10 @@ IIM42653::IIM42653(const I2CSPIDriverConfig &config) :
 	}
 
 	ConfigureSampleRate(_px4_gyro.get_max_rate_hz());
+
+	if ((config.custom2) > 0) {
+		ConfigureAntiAliasFilter(config.custom2);
+	}
 }
 
 IIM42653::~IIM42653()
@@ -311,6 +316,66 @@ void IIM42653::RunImpl()
 
 		break;
 	}
+}
+
+void IIM42653::ConfigureAntiAliasFilter(uint32_t bandwidth_hz)
+{
+	// Gyro and accel run at 8 kHz ODR: the chip default (AAF 585 Hz, UI filter 1st
+	// order at ODR/2) suits a flight controller decimating to a 1-2 kHz rate
+	// loop. A board that only needs a few hundred Hz, such as a CAN node
+	// integrating for optical flow, would alias everything between the
+	// decimated Nyquist and the AAF knee into its output; this narrows the AAF
+	// to the nearest table row and puts a 3rd-order UI filter at the nearest
+	// ODR/N. The set/clear tables are rewritten so Configure() and the
+	// periodic RegisterCheck() agree.
+	const InvenSense_AAF::Coefficients &aaf = InvenSense_AAF::lookup(bandwidth_hz);
+	const uint8_t ui_bw = InvenSense_AAF::ui_filter_bw_code((uint32_t)GYRO_RATE, bandwidth_hz);
+
+	auto set = [](auto & entry, uint8_t value, uint8_t mask) {
+		entry.set_bits = value & mask;
+		entry.clear_bits = (~value) & mask;
+	};
+
+	for (auto &r : _register_bank0_cfg) {
+		switch (r.reg) {
+		case Register::BANK_0::GYRO_CONFIG1:  set(r, Bit3, GYRO_CONFIG1_BIT::GYRO_UI_FILT_ORD); break;   // 3rd order
+
+		case Register::BANK_0::ACCEL_CONFIG1: set(r, Bit4, ACCEL_CONFIG1_BIT::ACCEL_UI_FILT_ORD); break; // 3rd order
+
+		case Register::BANK_0::GYRO_ACCEL_CONFIG0:
+			set(r, (ui_bw << 4) | ui_bw, GYRO_ACCEL_CONFIG0_BIT::ACCEL_UI_FILT_BW | GYRO_ACCEL_CONFIG0_BIT::GYRO_UI_FILT_BW);
+			break;
+
+		default: break;
+		}
+	}
+
+	for (auto &r : _register_bank1_cfg) {
+		switch (r.reg) {
+		case Register::BANK_1::GYRO_CONFIG_STATIC3: set(r, aaf.delt, 0x3F); break;
+
+		case Register::BANK_1::GYRO_CONFIG_STATIC4: set(r, aaf.deltsqr & 0xFF, 0xFF); break;
+
+		case Register::BANK_1::GYRO_CONFIG_STATIC5: set(r, (aaf.bitshift << 4) | ((aaf.deltsqr >> 8) & 0x0F), 0xFF); break;
+
+		default: break;
+		}
+	}
+
+	for (auto &r : _register_bank2_cfg) {
+		switch (r.reg) {
+		case Register::BANK_2::ACCEL_CONFIG_STATIC2: set(r, aaf.delt << 1, 0x7F); break; // bit 0 (AAF_DIS) stays cleared
+
+		case Register::BANK_2::ACCEL_CONFIG_STATIC3: set(r, aaf.deltsqr & 0xFF, 0xFF); break;
+
+		case Register::BANK_2::ACCEL_CONFIG_STATIC4: set(r, (aaf.bitshift << 4) | ((aaf.deltsqr >> 8) & 0x0F), 0xFF); break;
+
+		default: break;
+		}
+	}
+
+	PX4_INFO("anti-alias filter %u Hz, UI filter %u Hz 3rd order", aaf.bandwidth_hz,
+		 (unsigned)GYRO_RATE / InvenSense_AAF::kUiDivisors[ui_bw]);
 }
 
 void IIM42653::ConfigureSampleRate(int sample_rate)

--- a/src/drivers/imu/invensense/iim42653/IIM42653.hpp
+++ b/src/drivers/imu/invensense/iim42653/IIM42653.hpp
@@ -114,6 +114,7 @@ private:
 
 	bool Configure();
 	void ConfigureSampleRate(int sample_rate);
+	void ConfigureAntiAliasFilter(uint32_t bandwidth_hz);
 	void ConfigureFIFOWatermark(uint8_t samples);
 	void ConfigureCLKIN();
 

--- a/src/drivers/imu/invensense/iim42653/iim42653_main.cpp
+++ b/src/drivers/imu/invensense/iim42653/iim42653_main.cpp
@@ -44,7 +44,7 @@ void IIM42653::print_usage()
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
 	PRINT_MODULE_USAGE_PARAM_INT('C', 0, 0, 35000, "Input clock frequency (Hz)", true);
-	PRINT_MODULE_USAGE_PARAM_INT('B', 0, 0, 3979, "Anti-alias filter bandwidth (Hz), 0 keeps the chip default (585 Hz)", true);
+	PRINT_MODULE_USAGE_PARAM_INT('B', 0, 0, 394, "Anti-alias filter bandwidth: 126, 258 or 394 Hz (0: chip default 585 Hz)", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 

--- a/src/drivers/imu/invensense/iim42653/iim42653_main.cpp
+++ b/src/drivers/imu/invensense/iim42653/iim42653_main.cpp
@@ -44,6 +44,7 @@ void IIM42653::print_usage()
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
 	PRINT_MODULE_USAGE_PARAM_INT('C', 0, 0, 35000, "Input clock frequency (Hz)", true);
+	PRINT_MODULE_USAGE_PARAM_INT('B', 0, 0, 3979, "Anti-alias filter bandwidth (Hz), 0 keeps the chip default (585 Hz)", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
@@ -54,8 +55,12 @@ extern "C" int iim42653_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getOpt(argc, argv, "C:R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "B:C:R:")) != EOF) {
 		switch (ch) {
+		case 'B':
+			cli.custom2 = atoi(cli.optArg());
+			break;
+
 		case 'C':
 			cli.custom1 = atoi(cli.optArg());
 			break;

--- a/src/modules/ekf2/params_optical_flow.yaml
+++ b/src/modules/ekf2/params_optical_flow.yaml
@@ -11,9 +11,12 @@ parameters:
     EKF2_OF_DELAY:
       description:
         short: Optical flow measurement delay relative to IMU measurements
-        long: Assumes measurement is timestamped at trailing edge of integration period
+        long: |-
+          Assumes measurement is timestamped at trailing edge of integration
+          period. The default matches a DroneCAN flow node, whose frame reaches
+          the flight controller about 7 ms after its integration window closes.
       type: float
-      default: 20
+      default: 7
       min: 0
       max: 300
       unit: ms


### PR DESCRIPTION
## Summary
Adds a `-B <hz>` start option to the ICM-42688-P, IIM-42652 and IIM-42653 drivers that narrows the on-chip anti-alias and UI filters to one of three presets, enables 258 Hz on ARK Flow and Flow MR, and lowers the `EKF2_OF_DELAY` default to 7 ms.

## Problem
The drivers hard-code the chip defaults (AAF 585 Hz, 1st-order UI filter at ODR/2), tuned for a flight controller feeding a 1-2 kHz rate loop. A CAN flow node integrates the same 8 kHz stream to 1 kHz for the flow gyro compensation and to 200 Hz for RawIMU, so everything between the decimated Nyquist and the AAF knee aliases into what the node sends. On an ARK Flow MR in flight the node pitch gyro read 1 rad/s RMS against 0.2 on the FC, with the accel vibration metric 5x higher. Notch filters do not help: the node's flow integral and RawIMU read raw `sensor_gyro`, not the filtered angular velocity. Separately, the EKF placed DroneCAN flow samples 20 ms early; the measured frame transport is about 7 ms after the integration window closes.

## Solution
`-B` accepts exactly 126, 258 or 394 Hz; each preset carries its datasheet AAF coefficients and a 3rd-order UI filter at ODR/40 or ODR/20 (200 or 400 Hz), and the driver rewrites its set/clear tables so the periodic register check agrees. Anything else is rejected with a message. Default behaviour is unchanged when `-B` is absent. Build-tested on `ark_can-flow_default`; not yet flown.
