### PR TITLE
fix(optical_flow): normalize PixArt SQUAL onto the 0-255 quality contract

### DIFF
--- a/src/drivers/optical_flow/paa3905/PAA3905.cpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.cpp
@@ -38,6 +38,43 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
+// SQUAL below which the datasheet treats a motion report as noise, per
+// operating mode (shared with the false-motion discard, which also requires
+// the shutter condition).
+static constexpr uint8_t SQUAL_THRESHOLD_BRIGHT          = 0x19;
+static constexpr uint8_t SQUAL_THRESHOLD_LOW_LIGHT       = 0x46;
+static constexpr uint8_t SQUAL_THRESHOLD_SUPER_LOW_LIGHT = 0x55;
+
+static constexpr uint8_t squal_threshold(Mode mode)
+{
+	switch (mode) {
+	case Mode::Bright:        return SQUAL_THRESHOLD_BRIGHT;
+
+	case Mode::LowLight:      return SQUAL_THRESHOLD_LOW_LIGHT;
+
+	case Mode::SuperLowLight: return SQUAL_THRESHOLD_SUPER_LOW_LIGHT;
+	}
+
+	return SQUAL_THRESHOLD_SUPER_LOW_LIGHT;
+}
+
+// sensor_optical_flow.quality promises 0 = worst, 255 = best, and EKF2 scales
+// the flow noise linearly with it. Raw SQUAL is mode dependent (the chip's own
+// floor is 25/70/85 across the three modes) and the DroneCAN flow message
+// drops the mode, so the same raw value would mean "solid" in bright light and
+// "one count above noise" in super low light. Map the mode floor to 0 and raw
+// 255 to 255.
+static uint8_t normalize_squal(uint8_t squal, Mode mode)
+{
+	const uint8_t threshold = squal_threshold(mode);
+
+	if (squal <= threshold) {
+		return 0;
+	}
+
+	return static_cast<uint8_t>(((squal - threshold) * 255u) / (255u - threshold));
+}
+
 PAA3905::PAA3905(const I2CSPIDriverConfig &config) :
 	SPI(config),
 	I2CSPIDriver(config),
@@ -361,7 +398,7 @@ void PAA3905::RunImpl()
 					sensor_optical_flow.mode = sensor_optical_flow_s::MODE_BRIGHT;
 
 					// quality < 25 (0x19) and shutter >= 0x00FF80
-					if ((buffer.data.SQUAL < 0x19) && (shutter >= 0x00FF80)) {
+					if ((buffer.data.SQUAL < SQUAL_THRESHOLD_BRIGHT) && (shutter >= 0x00FF80)) {
 						// false motion report, discarding
 						data_valid = false;
 						perf_count(_false_motion_perf);
@@ -374,7 +411,7 @@ void PAA3905::RunImpl()
 					sensor_optical_flow.mode = sensor_optical_flow_s::MODE_LOWLIGHT;
 
 					// quality < 70 (0x46) and shutter >= 0x00FF80
-					if ((buffer.data.SQUAL < 0x46) && (shutter >= 0x00FF80)) {
+					if ((buffer.data.SQUAL < SQUAL_THRESHOLD_LOW_LIGHT) && (shutter >= 0x00FF80)) {
 						// false motion report, discarding
 						data_valid = false;
 						perf_count(_false_motion_perf);
@@ -387,7 +424,7 @@ void PAA3905::RunImpl()
 					sensor_optical_flow.mode = sensor_optical_flow_s::MODE_SUPER_LOWLIGHT;
 
 					// quality < 85 (0x55) and shutter >= 0x025998
-					if ((buffer.data.SQUAL < 0x55) && (shutter >= 0x025998)) {
+					if ((buffer.data.SQUAL < SQUAL_THRESHOLD_SUPER_LOW_LIGHT) && (shutter >= 0x025998)) {
 						// false motion report, discarding
 						data_valid = false;
 						perf_count(_false_motion_perf);
@@ -432,7 +469,7 @@ void PAA3905::RunImpl()
 						sensor_optical_flow.pixel_flow[0] = pixel_flow_rotated(0) * SCALE;
 						sensor_optical_flow.pixel_flow[1] = pixel_flow_rotated(1) * SCALE;
 
-						sensor_optical_flow.quality = buffer.data.SQUAL;
+						sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
 
 						publish = true;
 
@@ -450,7 +487,7 @@ void PAA3905::RunImpl()
 							sensor_optical_flow.pixel_flow[0] = 0;
 							sensor_optical_flow.pixel_flow[1] = 0;
 
-							sensor_optical_flow.quality = buffer.data.SQUAL;
+							sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
 
 							publish = true;
 						}

--- a/src/drivers/optical_flow/paw3902/PAW3902.cpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.cpp
@@ -38,6 +38,43 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
+// SQUAL below which the datasheet treats a motion report as noise, per
+// operating mode (shared with the false-motion discard, which also requires
+// the shutter condition).
+static constexpr uint8_t SQUAL_THRESHOLD_BRIGHT          = 0x19;
+static constexpr uint8_t SQUAL_THRESHOLD_LOW_LIGHT       = 0x46;
+static constexpr uint8_t SQUAL_THRESHOLD_SUPER_LOW_LIGHT = 0x55;
+
+static constexpr uint8_t squal_threshold(Mode mode)
+{
+	switch (mode) {
+	case Mode::Bright:        return SQUAL_THRESHOLD_BRIGHT;
+
+	case Mode::LowLight:      return SQUAL_THRESHOLD_LOW_LIGHT;
+
+	case Mode::SuperLowLight: return SQUAL_THRESHOLD_SUPER_LOW_LIGHT;
+	}
+
+	return SQUAL_THRESHOLD_SUPER_LOW_LIGHT;
+}
+
+// sensor_optical_flow.quality promises 0 = worst, 255 = best, and EKF2 scales
+// the flow noise linearly with it. Raw SQUAL is mode dependent (the chip's own
+// floor is 25/70/85 across the three modes) and the DroneCAN flow message
+// drops the mode, so the same raw value would mean "solid" in bright light and
+// "one count above noise" in super low light. Map the mode floor to 0 and raw
+// 255 to 255.
+static uint8_t normalize_squal(uint8_t squal, Mode mode)
+{
+	const uint8_t threshold = squal_threshold(mode);
+
+	if (squal <= threshold) {
+		return 0;
+	}
+
+	return static_cast<uint8_t>(((squal - threshold) * 255u) / (255u - threshold));
+}
+
 PAW3902::PAW3902(const I2CSPIDriverConfig &config) :
 	SPI(config),
 	I2CSPIDriver(config),
@@ -302,7 +339,7 @@ void PAW3902::RunImpl()
 					sensor_optical_flow.mode = sensor_optical_flow_s::MODE_BRIGHT;
 
 					// quality < 25 (0x19) and shutter >= 8176 (0x1FF0)
-					if ((buffer.data.SQUAL < 0x19) && (shutter >= 0x1FF0)) {
+					if ((buffer.data.SQUAL < SQUAL_THRESHOLD_BRIGHT) && (shutter >= 0x1FF0)) {
 						// false motion report, discarding
 						data_valid = false;
 						perf_count(_false_motion_perf);
@@ -329,7 +366,7 @@ void PAW3902::RunImpl()
 					sensor_optical_flow.mode = sensor_optical_flow_s::MODE_LOWLIGHT;
 
 					// quality < 70 (0x46) and shutter >= 8176 (0x1FF0)
-					if ((buffer.data.SQUAL < 0x46) && (shutter >= 0x1FF0)) {
+					if ((buffer.data.SQUAL < SQUAL_THRESHOLD_LOW_LIGHT) && (shutter >= 0x1FF0)) {
 						// false motion report, discarding
 						data_valid = false;
 						perf_count(_false_motion_perf);
@@ -369,7 +406,7 @@ void PAW3902::RunImpl()
 					sensor_optical_flow.mode = sensor_optical_flow_s::MODE_SUPER_LOWLIGHT;
 
 					// quality < 85 (0x55) and shutter >= 3008 (0x0BC0)
-					if ((buffer.data.SQUAL < 0x55) && (shutter >= 0x0BC0)) {
+					if ((buffer.data.SQUAL < SQUAL_THRESHOLD_SUPER_LOW_LIGHT) && (shutter >= 0x0BC0)) {
 						// false motion report, discarding
 						data_valid = false;
 						perf_count(_false_motion_perf);
@@ -431,7 +468,7 @@ void PAW3902::RunImpl()
 						sensor_optical_flow.pixel_flow[0] = pixel_flow_rotated(0) * SCALE;
 						sensor_optical_flow.pixel_flow[1] = pixel_flow_rotated(1) * SCALE;
 
-						sensor_optical_flow.quality = buffer.data.SQUAL;
+						sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
 
 						publish = true;
 
@@ -449,7 +486,7 @@ void PAW3902::RunImpl()
 							sensor_optical_flow.pixel_flow[0] = 0;
 							sensor_optical_flow.pixel_flow[1] = 0;
 
-							sensor_optical_flow.quality = buffer.data.SQUAL;
+							sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
 
 							publish = true;
 						}


### PR DESCRIPTION
## Summary
PAA3905 and PAW3902 now report `sensor_optical_flow.quality` normalized per operating mode instead of the raw SQUAL register. Supersedes the quality half of #27428.

## Problem
`quality` is documented as 0 = worst, 255 = best, and EKF2 scales the flow noise linearly with it. Raw SQUAL has a mode-dependent noise floor (0x19 / 0x46 / 0x55 for bright, low light, super low light per the PixArt datasheets), and the DroneCAN flow message strips the mode, so a raw 86 looked the same to the FC whether the chip considered it solid or one count above noise.

## Solution
Each mode's floor maps to 0 and raw 255 stays 255, linear in between. The existing false-motion discard, which additionally requires the shutter condition, shares the same threshold constants. Build-tested on `ark_can-flow_default`; not flown.