### PR TITLE
build(uxrce_dds_client): inherit firmware optimization flags

### DIFF
--- a/src/modules/uxrce_dds_client/CMakeLists.txt
+++ b/src/modules/uxrce_dds_client/CMakeLists.txt
@@ -146,10 +146,6 @@ else()
 		STACK_MAIN 9000
 		INCLUDES
 			${CMAKE_CURRENT_SOURCE_DIR}
-		COMPILE_FLAGS
-			#-O0
-			# -DDEBUG_BUILD
-			${MAX_CUSTOM_OPT_LEVEL}
 		SRCS
 			uxrce_dds_client.cpp
 			uxrce_dds_client.h


### PR DESCRIPTION
## Summary

Save 4,112 bytes of flash on `px4_fmu-v6x_default`. Extracted from @mbjd's #27816.

## Problem

The module's `-O2` override defeats NuttX's default size optimization.

## Solution

Inherit the selected build configuration. The external DDS libraries already inherit `MinSizeRel` on NuttX.

Baseline and changed firmware builds passed with identical static RAM use. Runtime performance has not been measured.
