### PR TITLE
fix(mavlink): make packed parameter transfers reliable

### DIFF
--- a/src/modules/mavlink/MavlinkFtpParamTest.cpp
+++ b/src/modules/mavlink/MavlinkFtpParamTest.cpp
@@ -38,6 +38,8 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <limits>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -54,6 +56,9 @@ struct FakeParam {
 };
 
 std::vector<FakeParam> g_params;
+param_t g_fail_set_param = PARAM_INVALID;
+unsigned g_notifications = 0;
+unsigned g_set_count = 0;
 
 uint32_t bits(float f)
 {
@@ -190,6 +195,9 @@ class MavlinkFtpParam : public ::testing::Test
 protected:
 	void SetUp() override
 	{
+		g_fail_set_param = PARAM_INVALID;
+		g_notifications = 0;
+		g_set_count = 0;
 		g_params = {
 			f32("MPC_XY_P", true, 0.95f, 0.95f),
 			f32("MPC_XY_VEL_P_ACC", true, 1.8f, 1.8f),
@@ -207,7 +215,7 @@ protected:
 
 		for (int i = 0; i < 300; i++) {
 			char name[17];
-			snprintf(name, sizeof(name), "GEN_%03d_X", i);
+			snprintf(name, sizeof(name), "GEN_%03u_X", static_cast<unsigned>(i));
 			g_params.push_back(i32(name, (i % 5) != 0, i, (i % 3 == 0) ? 0 : i));
 		}
 	}
@@ -240,14 +248,15 @@ param_t param_find_no_notification(const char *name)
 bool param_is_readonly(param_t param) { return (param < g_params.size()) && g_params[param].readonly; }
 int param_set_no_notification(param_t param, const void *val)
 {
-	if ((param >= g_params.size()) || g_params[param].readonly) {
+	if ((param >= g_params.size()) || g_params[param].readonly || (param == g_fail_set_param)) {
 		return -1;
 	}
 
+	g_set_count++;
 	memcpy(&g_params[param].value, val, 4);
 	return 0;
 }
-void param_notify_changes() {}
+void param_notify_changes() { g_notifications++; }
 
 TEST_F(MavlinkFtpParam, Path)
 {
@@ -325,7 +334,7 @@ TEST_F(MavlinkFtpParam, WithDefaults)
 
 	for (size_t i = 0; i < used.size(); i++) {
 		EXPECT_EQ(d.entries[i].value, used[i].value);
-		EXPECT_EQ(d.entries[i].has_default, used[i].value != used[i].default_value) << used[i].name;
+		EXPECT_TRUE(d.entries[i].has_default) << used[i].name;
 
 		if (d.entries[i].has_default) {
 			EXPECT_EQ(d.entries[i].default_value, used[i].default_value);
@@ -440,7 +449,8 @@ TEST_F(MavlinkFtpParam, FrozenMembershipLiveValues)
 	}
 
 	EXPECT_EQ(find(d1, "MPC_XY_P")->value, bits(42.f));
-	EXPECT_FALSE(find(d1, "MPC_XY_P")->has_default);
+	EXPECT_TRUE(find(d1, "MPC_XY_P")->has_default);
+	EXPECT_EQ(find(d1, "MPC_XY_P")->default_value, bits(0.95f));
 	EXPECT_EQ(find(d1, "SYS_AUTOSTART")->value, g_params[4].default_value);
 	EXPECT_TRUE(find(d1, "SYS_AUTOSTART")->has_default);
 	EXPECT_NE(find(d1, "MPC_Z_P"), nullptr);
@@ -597,7 +607,7 @@ TEST_F(MavlinkFtpParam, UploadPrefixAndRetry)
 	EXPECT_EQ(param_bits("ABCDEFGHIJKLMNOQ"), bits(9.f));
 }
 
-TEST_F(MavlinkFtpParam, UploadRejectsDefaultsMagicAndHoles)
+TEST_F(MavlinkFtpParam, UploadRejectsDefaultsMagicAndIncompleteFiles)
 {
 	ParamPckFile file;
 	const std::vector<uint8_t> with_defaults = encode_upload({up_f32("MPC_XY_P", 1.f)}, 0x671C);
@@ -607,7 +617,7 @@ TEST_F(MavlinkFtpParam, UploadRejectsDefaultsMagicAndHoles)
 
 	const std::vector<uint8_t> ok = encode_upload({up_f32("MPC_Z_P", 4.f)});
 	ASSERT_TRUE(file.open_write());
-	EXPECT_EQ(file.write(3, ok.data(), static_cast<uint16_t>(ok.size())), -1);
+	EXPECT_EQ(file.write(3, ok.data() + 3, static_cast<uint16_t>(ok.size() - 3)), static_cast<int>(ok.size() - 3));
 	EXPECT_FALSE(file.finish_write());
 	file.close();
 
@@ -637,4 +647,194 @@ TEST_F(MavlinkFtpParam, UploadRoundtripDownload)
 
 	EXPECT_EQ(param_bits("MPC_XY_P"), bits(0.95f));
 	EXPECT_EQ(param_bits("SYS_AUTOSTART"), static_cast<uint32_t>(4001));
+}
+
+
+TEST_F(MavlinkFtpParam, UploadReportsStoreFailure)
+{
+	ParamPckFile file;
+	g_fail_set_param = param_find_no_notification("MPC_XY_P");
+	const auto f = encode_upload({up_f32("MPC_XY_P", 1.5f)});
+	EXPECT_FALSE(upload_bytes(file, f, 80));
+	EXPECT_FALSE(file.finish_write());
+	file.close();
+	EXPECT_EQ(param_bits("MPC_XY_P"), bits(0.95f));
+	EXPECT_EQ(g_notifications, 0u);
+
+	const auto partial = encode_upload({up_i32("SYS_HITL", 1), up_f32("MPC_XY_P", 1.5f)});
+	EXPECT_FALSE(upload_bytes(file, partial, 80));
+	file.close();
+	EXPECT_EQ(param_bits("SYS_HITL"), 1u);
+	EXPECT_EQ(param_bits("MPC_XY_P"), bits(0.95f));
+	EXPECT_EQ(g_notifications, 1u);
+}
+
+TEST_F(MavlinkFtpParam, UploadPreservesFloatRange)
+{
+	for (const float value : {
+		     1e10f, -1e10f, std::numeric_limits<float>::max(),
+		     std::numeric_limits<float>::infinity(), std::numeric_limits<float>::quiet_NaN()
+	     }) {
+		ParamPckFile file;
+		const auto f = encode_upload({up_f32("MPC_XY_P", value)});
+		ASSERT_TRUE(upload_bytes(file, f, 80));
+		EXPECT_EQ(param_bits("MPC_XY_P"), bits(value));
+	}
+}
+
+TEST_F(MavlinkFtpParam, UploadChecksFloatToIntegerRange)
+{
+	for (const float value : {
+		     2147483648.f, -2147483904.f, std::numeric_limits<float>::infinity(),
+		     -std::numeric_limits<float>::infinity(), std::numeric_limits<float>::quiet_NaN()
+	     }) {
+		ParamPckFile file;
+		const auto f = encode_upload({up_f32("SYS_HITL", value)});
+		EXPECT_FALSE(upload_bytes(file, f, 80));
+		EXPECT_EQ(param_bits("SYS_HITL"), 0u);
+	}
+
+	for (const float value : {-2147483648.f, 2147483520.f, -1.5f, 1.5f}) {
+		ParamPckFile file;
+		const auto f = encode_upload({up_f32("SYS_AUTOSTART", value)});
+		ASSERT_TRUE(upload_bytes(file, f, 80));
+		EXPECT_EQ(param_bits("SYS_AUTOSTART"), static_cast<uint32_t>(static_cast<int32_t>(value)));
+	}
+}
+
+TEST_F(MavlinkFtpParam, UploadRecoversMissingPacket)
+{
+	std::vector<UploadEntry> entries;
+
+	for (int i = 0; i < 300; i++) {
+		char name[17];
+		snprintf(name, sizeof(name), "GEN_%03u_X", static_cast<unsigned>(i));
+		entries.push_back(up_i32(name, i + 1000));
+	}
+
+	const auto f = encode_upload(entries);
+	constexpr uint16_t chunk = 80;
+
+	for (const uint32_t missing : {0u, 80u, 240u}) {
+		ParamPckFile file;
+		ASSERT_TRUE(file.open_write());
+		const unsigned sets_before = g_set_count;
+
+		for (uint32_t offset = 0; offset < f.size(); offset += chunk) {
+			if (offset == missing) {
+				continue;
+			}
+
+			const uint16_t n = std::min<size_t>(chunk, f.size() - offset);
+			ASSERT_EQ(file.write(offset, f.data() + offset, n), n);
+			ASSERT_EQ(file.write(offset, f.data() + offset, n), n);
+		}
+
+		ASSERT_EQ(file.write(missing, f.data() + missing, chunk), chunk);
+		ASSERT_TRUE(file.finish_write());
+		EXPECT_EQ(g_set_count - sets_before, entries.size());
+		file.close();
+
+		for (int i = 0; i < 300; i++) {
+			EXPECT_EQ(param_bits(entries[i].name.c_str()), static_cast<uint32_t>(i + 1000));
+		}
+	}
+}
+
+TEST_F(MavlinkFtpParam, UploadReordersOverlappingChunks)
+{
+	ParamPckFile source;
+	ASSERT_TRUE(source.open("@PARAM/param.pck", 239));
+	auto f = download(source, 239);
+	const uint16_t length = f.size();
+	memcpy(f.data() + 4, &length, 2);
+	source.close();
+
+	std::vector<size_t> offsets;
+
+	for (size_t offset = 0; offset < f.size(); offset += 53) {
+		offsets.push_back(offset);
+	}
+
+	std::mt19937 random(42);
+	std::shuffle(offsets.begin(), offsets.end(), random);
+	ParamPckFile file;
+	ASSERT_TRUE(file.open_write());
+
+	for (const size_t offset : offsets) {
+		const uint16_t n = std::min<size_t>(80, f.size() - offset);
+		ASSERT_EQ(file.write(offset, f.data() + offset, n), n);
+	}
+
+	ASSERT_TRUE(file.finish_write());
+	EXPECT_EQ(g_set_count, used_params().size() - 1);
+}
+
+TEST_F(MavlinkFtpParam, UploadDiscardsBufferedDataOnClose)
+{
+	const auto first = encode_upload({up_f32("MPC_XY_P", 7.f)});
+	const auto second = encode_upload({up_f32("MPC_XY_P", 2.f)});
+	ParamPckFile file;
+	ASSERT_TRUE(file.open_write());
+	ASSERT_EQ(file.write(6, first.data() + 6, first.size() - 6), static_cast<int>(first.size() - 6));
+	EXPECT_FALSE(file.finish_write());
+	file.close();
+	EXPECT_EQ(param_bits("MPC_XY_P"), bits(0.95f));
+	ASSERT_TRUE(upload_bytes(file, second, 80));
+	EXPECT_EQ(param_bits("MPC_XY_P"), bits(2.f));
+}
+
+TEST_F(MavlinkFtpParam, UploadRejectsOffsetsOutsideFile)
+{
+	const auto f = encode_upload({up_f32("MPC_XY_P", 7.f)});
+
+	for (const uint32_t offset : {65535u, UINT32_MAX}) {
+		ParamPckFile file;
+		ASSERT_TRUE(file.open_write());
+		EXPECT_EQ(file.write(offset, f.data(), f.size()), -1);
+		EXPECT_FALSE(file.finish_write());
+	}
+
+	ParamPckFile file;
+	ASSERT_TRUE(file.open_write());
+	ASSERT_EQ(file.write(0, f.data(), 6), 6);
+	EXPECT_EQ(file.write(f.size(), f.data(), 1), -1);
+	EXPECT_FALSE(file.finish_write());
+}
+
+
+TEST_F(MavlinkFtpParam, UploadRejectsConflictingBufferedRetry)
+{
+	const auto f = encode_upload({up_f32("MPC_XY_P", 7.f)});
+	ParamPckFile file;
+	ASSERT_TRUE(file.open_write());
+	ASSERT_EQ(file.write(6, f.data() + 6, f.size() - 6), static_cast<int>(f.size() - 6));
+	auto changed = f;
+	changed.back() ^= 1;
+	EXPECT_EQ(file.write(6, changed.data() + 6, changed.size() - 6), -1);
+	EXPECT_FALSE(file.finish_write());
+	EXPECT_EQ(g_set_count, 0u);
+}
+
+TEST_F(MavlinkFtpParam, UploadRejectsDataBeyondLateHeader)
+{
+	auto f = encode_upload({up_f32("MPC_XY_P", 7.f)});
+	const uint16_t length = 6;
+	memcpy(f.data() + 4, &length, 2);
+	ParamPckFile file;
+	ASSERT_TRUE(file.open_write());
+	ASSERT_EQ(file.write(6, f.data() + 6, f.size() - 6), static_cast<int>(f.size() - 6));
+	EXPECT_EQ(file.write(0, f.data(), 6), -1);
+	EXPECT_FALSE(file.finish_write());
+	EXPECT_EQ(g_set_count, 0u);
+}
+
+TEST_F(MavlinkFtpParam, UploadRejectsExtraEntries)
+{
+	auto f = encode_upload({up_f32("MPC_XY_P", 7.f)});
+	const uint16_t entries = 0;
+	memcpy(f.data() + 2, &entries, 2);
+	ParamPckFile file;
+	EXPECT_FALSE(upload_bytes(file, f, 80));
+	EXPECT_EQ(g_set_count, 0u);
 }

--- a/src/modules/mavlink/mavlink_ftp_param.cpp
+++ b/src/modules/mavlink/mavlink_ftp_param.cpp
@@ -35,6 +35,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <new>
 
 static constexpr char kPath[] = "@PARAM/param.pck";
 static constexpr size_t kPathLen = sizeof(kPath) - 1;
@@ -52,27 +53,6 @@ bool ParamPckFile::bit(const uint8_t *bits, param_t param) const
 void ParamPckFile::set_bit(uint8_t *bits, param_t param)
 {
 	bits[param / 8] |= (uint8_t)(1u << (param % 8));
-}
-
-bool ParamPckFile::default_differs(param_t param) const
-{
-	union {
-		int32_t i;
-		float f;
-		uint8_t b[4];
-	} value, def {};
-
-	const bool is_int32 = (param_type(param) == PARAM_TYPE_INT32);
-
-	if ((is_int32 ? param_get(param, &value.i) : param_get(param, &value.f)) != 0) {
-		return false;
-	}
-
-	if (param_get_default_value(param, def.b) != 0) {
-		return false;
-	}
-
-	return memcmp(value.b, def.b, sizeof(value.b)) != 0;
 }
 
 bool ParamPckFile::open(const char *path, uint16_t block_size)
@@ -127,10 +107,6 @@ bool ParamPckFile::open(const char *path, uint16_t block_size)
 
 		if ((used_i >= start) && (used_i < end_used)) {
 			set_bit(_included, param);
-
-			if (_with_defaults && default_differs(param)) {
-				set_bit(_has_default, param);
-			}
 		}
 
 		used_i++;
@@ -182,7 +158,13 @@ void ParamPckFile::close()
 	}
 
 	memset(_included, 0, sizeof(_included));
-	memset(_has_default, 0, sizeof(_has_default));
+
+	while (_write_blocks != nullptr) {
+		WriteBlock *block = _write_blocks;
+		_write_blocks = block->next;
+		free(block);
+	}
+
 	_size = 0;
 	_open = false;
 	_write = false;
@@ -271,10 +253,10 @@ size_t ParamPckFile::pack(uint8_t *buf, param_t param, uint32_t ofs) const
 		return 0;
 	}
 
-	const bool add_default = bit(_has_default, param);
+	const bool add_default = _with_defaults;
 
 	if (add_default && (param_get_default_value(param, default_value) != 0)) {
-		memset(default_value, 0, sizeof(default_value));
+		return 0;
 	}
 
 	const uint8_t type = is_int32 ? kTypeInt32 : kTypeFloat;
@@ -424,7 +406,6 @@ bool ParamPckFile::apply_entry(const char *name, uint8_t ptype, const uint8_t *r
 
 	case kTypeFloat:
 		memcpy(&as_float, raw, sizeof(as_float));
-		as_int = static_cast<int32_t>(as_float);
 		break;
 
 	default:
@@ -432,6 +413,15 @@ bool ParamPckFile::apply_entry(const char *name, uint8_t ptype, const uint8_t *r
 	}
 
 	if (dest == PARAM_TYPE_INT32) {
+		if (ptype == kTypeFloat) {
+			// INT32_MAX rounds up to 2^31 as a float; keep that bound exclusive.
+			if (!(as_float >= static_cast<float>(INT32_MIN) && as_float < -static_cast<float>(INT32_MIN))) {
+				return false;
+			}
+
+			as_int = static_cast<int32_t>(as_float);
+		}
+
 		value.i = as_int;
 
 	} else if (dest == PARAM_TYPE_FLOAT) {
@@ -441,10 +431,11 @@ bool ParamPckFile::apply_entry(const char *name, uint8_t ptype, const uint8_t *r
 		return true;
 	}
 
-	if (param_set_no_notification(param, value.b) == 0) {
-		_applied++;
+	if (param_set_no_notification(param, value.b) != 0) {
+		return false;
 	}
 
+	_applied++;
 	return true;
 }
 
@@ -506,7 +497,7 @@ bool ParamPckFile::parse_pending()
 		memcpy(name + common_len, _pending + 2, name_len);
 		name[common_len + name_len] = '\0';
 
-		if (!apply_entry(name, ptype, _pending + 2 + name_len)) {
+		if (_write_seen >= _write_num || !apply_entry(name, ptype, _pending + 2 + name_len)) {
 			return false;
 		}
 
@@ -529,7 +520,13 @@ bool ParamPckFile::ingest(const uint8_t *data, uint16_t count)
 			}
 		}
 
-		const uint16_t room = static_cast<uint16_t>(sizeof(_pending) - _pending_len);
+		if (_header_done && count > _write_file_len - _write_ofs) {
+			return false;
+		}
+
+		// Validate the header before parsing any entries from the same packet.
+		const uint16_t limit = _header_done ? sizeof(_pending) : kHeaderLen;
+		const uint16_t room = limit - _pending_len;
 		const uint16_t n = (count < room) ? count : room;
 		memcpy(_pending + _pending_len, data, n);
 		_pending_len += n;
@@ -549,30 +546,120 @@ bool ParamPckFile::ingest(const uint8_t *data, uint16_t count)
 	return true;
 }
 
+bool ParamPckFile::buffer_write(uint32_t offset, const uint8_t *data, uint16_t count)
+{
+	WriteBlock **link = &_write_blocks;
+
+	while (count > 0) {
+		const uint16_t block_offset = offset - offset % kWriteBlockSize;
+
+		while (*link != nullptr && (*link)->offset < block_offset) {
+			link = &(*link)->next;
+		}
+
+		if (*link == nullptr || (*link)->offset != block_offset) {
+			void *memory = malloc(sizeof(WriteBlock));
+
+			if (memory == nullptr) {
+				return false;
+			}
+
+			WriteBlock *block = new (memory) WriteBlock;
+			block->offset = block_offset;
+			block->next = *link;
+			*link = block;
+		}
+
+		WriteBlock &block = **link;
+		const uint16_t start = offset - block_offset;
+		const uint16_t room = kWriteBlockSize - start;
+		const uint16_t n = count < room ? count : room;
+
+		for (uint16_t i = 0; i < n; i++) {
+			const uint16_t pos = start + i;
+			const uint8_t mask = 1u << (pos % 8);
+
+			if (block.received[pos / 8] & mask) {
+				if (block.data[pos] != data[i]) {
+					return false;
+				}
+
+			} else {
+				block.received[pos / 8] |= mask;
+				block.data[pos] = data[i];
+				block.remaining++;
+			}
+		}
+
+		offset += n;
+		data += n;
+		count -= n;
+	}
+
+	return true;
+}
+
+bool ParamPckFile::flush_writes()
+{
+	while (_write_blocks != nullptr && _write_blocks->offset <= _write_ofs) {
+		WriteBlock *block = _write_blocks;
+		const uint16_t start = _write_ofs - block->offset;
+		uint16_t end = start;
+
+		while (end < kWriteBlockSize && (block->received[end / 8] & (1u << (end % 8)))) {
+			end++;
+		}
+
+		if (end == start) {
+			break;
+		}
+
+		const uint16_t n = end - start;
+
+		if (!ingest(block->data + start, n)) {
+			return false;
+		}
+
+		block->remaining -= n;
+
+		if (block->remaining == 0) {
+			_write_blocks = block->next;
+			free(block);
+		}
+	}
+
+	return true;
+}
+
 int ParamPckFile::write(uint32_t offset, const uint8_t *buf, uint16_t count)
 {
 	if (!_open || !_write || _write_failed) {
 		return -1;
 	}
 
-	if (count == 0) {
-		return 0;
-	}
-
-	const uint32_t end = offset + count;
-
-	if (end <= _write_ofs) {
-		return count;
-	}
-
-	if (offset > _write_ofs) {
+	// The upload header has a 16-bit file length. Check before adding to offset.
+	if (offset > UINT16_MAX || count > UINT16_MAX - offset
+	    || (_header_done && offset + count > _write_file_len)) {
 		_write_failed = true;
 		return -1;
 	}
 
-	const uint16_t skip = static_cast<uint16_t>(_write_ofs - offset);
+	if (count == 0 || offset + count <= _write_ofs) {
+		return count;
+	}
 
-	if (!ingest(buf + skip, count - skip)) {
+	const uint16_t skip = offset < _write_ofs ? _write_ofs - offset : 0;
+	const uint32_t start = offset + skip;
+	bool ok;
+
+	if (start == _write_ofs && _write_blocks == nullptr) {
+		ok = ingest(buf + skip, count - skip);
+
+	} else {
+		ok = buffer_write(start, buf + skip, count - skip) && flush_writes();
+	}
+
+	if (!ok) {
 		_write_failed = true;
 		return -1;
 	}
@@ -596,7 +683,7 @@ bool ParamPckFile::finish_write()
 		_pending_len--;
 	}
 
-	if (!_header_done || (_pending_len != 0) || (_write_ofs != _write_file_len)
+	if (!_header_done || (_write_blocks != nullptr) || (_pending_len != 0) || (_write_ofs != _write_file_len)
 	    || (_write_seen != _write_num)) {
 		_write_failed = true;
 		return false;

--- a/src/modules/mavlink/mavlink_ftp_param.cpp
+++ b/src/modules/mavlink/mavlink_ftp_param.cpp
@@ -35,7 +35,6 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <new>
 
 static constexpr char kPath[] = "@PARAM/param.pck";
 static constexpr size_t kPathLen = sizeof(kPath) - 1;
@@ -162,7 +161,7 @@ void ParamPckFile::close()
 	while (_write_blocks != nullptr) {
 		WriteBlock *block = _write_blocks;
 		_write_blocks = block->next;
-		free(block);
+		delete block;
 	}
 
 	_size = 0;
@@ -558,13 +557,12 @@ bool ParamPckFile::buffer_write(uint32_t offset, const uint8_t *data, uint16_t c
 		}
 
 		if (*link == nullptr || (*link)->offset != block_offset) {
-			void *memory = malloc(sizeof(WriteBlock));
+			WriteBlock *block = new WriteBlock;
 
-			if (memory == nullptr) {
+			if (block == nullptr) {
 				return false;
 			}
 
-			WriteBlock *block = new (memory) WriteBlock;
 			block->offset = block_offset;
 			block->next = *link;
 			*link = block;
@@ -624,7 +622,7 @@ bool ParamPckFile::flush_writes()
 
 		if (block->remaining == 0) {
 			_write_blocks = block->next;
-			free(block);
+			delete block;
 		}
 	}
 

--- a/src/modules/mavlink/mavlink_ftp_param.h
+++ b/src/modules/mavlink/mavlink_ftp_param.h
@@ -65,8 +65,11 @@
  * and treats total_params as the file length. Entries are applied as they complete;
  * unknown and read-only names are skipped. Packed int8/int16 values are widened to
  * the PX4 INT32/FLOAT type. Out-of-order chunks are buffered until gaps are filled;
- * sequential uploads allocate no transfer buffers. Terminate ACKs only when the file
- * is complete, well-formed, and every writable known parameter was applied.
+ * sequential uploads allocate no transfer buffers. Like ArduPilot's upload buffer,
+ * the heap held by a reordered upload is bounded only by the 16-bit file length,
+ * since mavftp retries a lost chunk after sending every remaining one. Terminate
+ * ACKs only when the file is complete, well-formed, and every writable known
+ * parameter was applied.
  */
 class ParamPckFile
 {

--- a/src/modules/mavlink/mavlink_ftp_param.h
+++ b/src/modules/mavlink/mavlink_ftp_param.h
@@ -49,21 +49,24 @@
  *           uint8  common_len:4 name_len-1:4   name bytes shared with the previous entry, remaining name length
  *           name[name_len]
  *           value[type size]
- *           default[type size]          only when flag bit 0 is set, i.e. value != default
+ *           default[type size]          when flag bit 0 is set
  *
  * Zero bytes before an entry are padding so the trailing value (and default, when
  * present) never straddles a read block of block_size bytes. The path accepts a
  * query `?start=N&count=N&withdefaults=0|1`; count 0 means all parameters from start.
  *
- * open() freezes which used parameters appear and whether each includes a default
- * (~1 KB of bitsets). Values are read live. Padding keeps each value/default inside
+ * open() freezes which used parameters appear (512 B of bits). Values are read live.
+ * withdefaults includes every default explicitly, so a value change cannot make
+ * the receiver infer the wrong default. Padding keeps each value/default inside
  * one FTP block, so a param_set during the download cannot shift later entries or
  * splice two generations of a number across a retried block.
  *
  * Upload (CreateFile/WriteFile/Terminate) accepts magic 0x671B only, no defaults,
  * and treats total_params as the file length. Entries are applied as they complete;
  * unknown and read-only names are skipped. Packed int8/int16 values are widened to
- * the PX4 INT32/FLOAT type. Terminate ACKs only when the file is well-formed.
+ * the PX4 INT32/FLOAT type. Out-of-order chunks are buffered until gaps are filled;
+ * sequential uploads allocate no transfer buffers. Terminate ACKs only when the file
+ * is complete, well-formed, and every writable known parameter was applied.
  */
 class ParamPckFile
 {
@@ -83,7 +86,7 @@ public:
 	/// Parse the query and freeze membership. False on an invalid query or empty range.
 	bool open(const char *path, uint16_t block_size);
 
-	/// Open for sequential WriteFile of a packed upload.
+	/// Open for WriteFile of a packed upload.
 	bool open_write();
 
 	void close();
@@ -99,8 +102,8 @@ public:
 	int read(uint32_t offset, uint8_t *buf, uint16_t count);
 
 	/**
-	 * Accept a WriteFile chunk. Sequential from 0, or a retry of already-consumed bytes.
-	 * @return count on success, -1 on a hole or a malformed stream
+	 * Accept a WriteFile chunk, buffering out-of-order bytes until they can be parsed.
+	 * @return count on success, -1 on invalid data, allocation failure, or a failed parameter write
 	 */
 	int write(uint32_t offset, const uint8_t *buf, uint16_t count);
 
@@ -128,8 +131,9 @@ private:
 	void rewind();
 	bool bit(const uint8_t *bits, param_t param) const;
 	void set_bit(uint8_t *bits, param_t param);
-	bool default_differs(param_t param) const;
 
+	bool buffer_write(uint32_t offset, const uint8_t *data, uint16_t count);
+	bool flush_writes();
 	bool ingest(const uint8_t *data, uint16_t count);
 	bool parse_pending();
 	bool apply_entry(const char *name, uint8_t ptype, const uint8_t *raw);
@@ -143,11 +147,21 @@ private:
 	uint16_t _total{0};
 	uint32_t _size{0};
 	uint8_t _included[kBitBytes] {};
-	uint8_t _has_default[kBitBytes] {};
 
 	uint32_t _cursor_ofs{kHeaderLen};
 	unsigned _cursor_index{0};    ///< param_for_index() index
 	char _prev_name[17] {};
+
+	// One bit per received byte allows retries with different packet boundaries.
+	static constexpr uint16_t kWriteBlockSize = 256;
+	struct WriteBlock {
+		WriteBlock *next{nullptr};
+		uint16_t offset{0};
+		uint16_t remaining{0};
+		uint8_t received[kWriteBlockSize / 8] {};
+		uint8_t data[kWriteBlockSize];
+	};
+	WriteBlock *_write_blocks{nullptr};
 
 	bool _write_failed{false};
 	bool _header_done{false};


### PR DESCRIPTION
## Summary
Follow up #28435 to make packed parameter transfers recover from packet loss and report upload failures correctly.

## Problem
A missing packet permanently failed pipelined uploads, while failed parameter-store writes still reported success. `withdefaults=1` omitted the default whenever the value matched it, and QGroundControl treats a missing default as unknown and keeps its metadata JSON default, so any parameter sitting at a board-overridden runtime default showed the wrong default. Values changing during download could also become their own reported defaults, and float uploads performed an unsafe integer conversion even for float destinations.

## Solution
Buffer out-of-order bytes until gaps are filled, propagate store failures, and check float-to-integer bounds only when that conversion is needed. Sequential uploads allocate no transfer buffers; reordered data uses temporary blocks bounded by the 16-bit file length, the same bound as ArduPilot's upload buffer, because mavftp retries a lost chunk only after sending every remaining one. Send every requested default explicitly to preserve its meaning and keep file offsets stable as values change. This adds four bytes for each previously implicit default and removes the 512-byte default-presence bitset. Regression tests cover loss, reordering, retries, cleanup, store failures, changing values, and numeric boundaries.
