### PR TITLE
fix(optical_flow): avoid resetting on poor tracking quality

### DIFF
--- a/boards/ark/can-flow-mr/init/rc.board_sensors
+++ b/boards/ark/can-flow-mr/init/rc.board_sensors
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------
 
 param set-default IMU_GYRO_RATEMAX 1000
-param set-default SENS_FLOW_RATE 150
+param set-default SENS_FLOW_RATE 50
 param set-default SENS_IMU_CLPNOTI 0
 
 # Internal SPI

--- a/boards/ark/can-flow/init/rc.board_sensors
+++ b/boards/ark/can-flow/init/rc.board_sensors
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------
 
 param set-default IMU_GYRO_RATEMAX 1000
-param set-default SENS_FLOW_RATE 150
+param set-default SENS_FLOW_RATE 50
 param set-default SENS_IMU_CLPNOTI 0
 
 # Internal SPI

--- a/src/drivers/optical_flow/paa3905/PAA3905.cpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.cpp
@@ -38,15 +38,18 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-// SQUAL is the chip's feature count / 4. Flights over grass at night (mode 2)
-// and black pavement by day (mode 0) put the tracking knee at the same raw
-// value: below it the chip reports zero motion on most frames while the
-// vehicle moves, above it counts match GNSS translation plus gyro at the
-// datasheet scale. The datasheet's per-mode discard rule (SQUAL below 25/70/85
-// while the shutter sits at the mode maximum) never fires in bright light, so
-// it cannot serve as the gate. Quality is published as raw SQUAL so one
-// EKF2_OF_QMIN means the same thing in every mode.
-static constexpr uint8_t SQUAL_TRACKING_FLOOR = 0x55;
+// SQUAL is the chip's feature count / 4. Raw-capture flights against GNSS
+// (grass by day and night, black pavement by day) show the chip reporting
+// noise below a raw SQUAL of about 60 in every lighting mode, under-reporting
+// motion by up to half between 60 and 85 depending on the surface, and
+// tracking at the datasheet scale above that. The floor sits at the noise
+// edge: flow is mainly a GNSS-denied position hold aid, and a velocity that
+// reads low still holds position while a blind window aids nothing. The
+// datasheet's per-mode discard rule (SQUAL below 25/70/85 while the shutter
+// sits at the mode maximum) never fires in bright light, so it cannot serve as
+// the gate. Quality is published as raw SQUAL so one EKF2_OF_QMIN means the
+// same thing in every mode.
+static constexpr uint8_t SQUAL_TRACKING_FLOOR = 60;
 
 PAA3905::PAA3905(const I2CSPIDriverConfig &config) :
 	SPI(config),

--- a/src/drivers/optical_flow/paa3905/PAA3905.cpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.cpp
@@ -259,6 +259,7 @@ void PAA3905::RunImpl()
 
 	case STATE::READ: {
 			hrt_abstime timestamp_sample = now;
+			bool frame_end_known = false;
 
 			if (_motion_interrupt_enabled) {
 				// scheduled from interrupt if _drdy_timestamp_sample was set as expected
@@ -266,6 +267,7 @@ void PAA3905::RunImpl()
 
 				if (now < drdy_timestamp_sample + _scheduled_interval_us) {
 					timestamp_sample = drdy_timestamp_sample;
+					frame_end_known = true;
 
 				} else {
 					perf_count(_no_motion_interrupt_perf);
@@ -433,15 +435,6 @@ void PAA3905::RunImpl()
 					break;
 				}
 
-				// override the per-mode default with the actual interval between burst reads
-				// (the chip accumulates delta_x/delta_y until Motion_Burst is read), so the
-				// gyro integration window downstream lines up with what the chip actually saw.
-				if (_timestamp_sample_last != 0 && timestamp_sample > _timestamp_sample_last) {
-					const hrt_abstime dt = timestamp_sample - _timestamp_sample_last;
-					sensor_optical_flow.integration_timespan_us = math::constrain(static_cast<uint32_t>(dt),
-							static_cast<uint32_t>(1_ms), static_cast<uint32_t>(200_ms));
-				}
-
 				// motion in burst transfer
 				const bool motion_reported = (buffer.data.Motion & Motion_Bit::MotionOccurred);
 
@@ -452,6 +445,29 @@ void PAA3905::RunImpl()
 				// read's shutter and quality means the chip has not finished a new frame yet.
 				const bool stale_read = (delta_x_raw == 0) && (delta_y_raw == 0) && (shutter == _shutter_prev)
 							&& (buffer.data.RawData_Sum == _raw_data_sum_prev) && (buffer.data.SQUAL == _quality_prev);
+
+				// A poll cannot tell where the chip's last frame ended, and whatever the chip is
+				// integrating now will be reported by the next read. Without motion a poll therefore
+				// only vouches for the time up to one frame period ago, so that next frame keeps
+				// its full window instead of starting at the poll.
+				hrt_abstime frame_end = timestamp_sample;
+
+				if (!frame_end_known && !motion_reported) {
+					const uint32_t frame_period_us = (_mode == Mode::SuperLowLight) ? SAMPLE_INTERVAL_MODE_2 : SAMPLE_INTERVAL_MODE_1;
+					frame_end = (timestamp_sample > frame_period_us) ? (timestamp_sample - frame_period_us) : 0;
+				}
+
+				const bool frame_consumed = (frame_end > _timestamp_sample_last);
+				sensor_optical_flow.timestamp_sample = frame_end;
+
+				// override the per-mode default with the actual interval between consumed frames
+				// (the chip accumulates delta_x/delta_y until Motion_Burst is read), so the
+				// gyro integration window downstream lines up with what the chip actually saw.
+				if (_timestamp_sample_last != 0 && frame_consumed) {
+					const hrt_abstime dt = frame_end - _timestamp_sample_last;
+					sensor_optical_flow.integration_timespan_us = math::constrain(static_cast<uint32_t>(dt),
+							static_cast<uint32_t>(1_ms), static_cast<uint32_t>(200_ms));
+				}
 
 				bool published = false;
 
@@ -484,7 +500,7 @@ void PAA3905::RunImpl()
 
 					} else if (zero_flow && (timestamp_sample > _last_motion)) {
 						// no motion, but burst read looks valid and we should have seen new data by now if there was any motion
-						if (!stale_read) {
+						if (!stale_read && frame_consumed) {
 
 							sensor_optical_flow.pixel_flow[0] = 0;
 							sensor_optical_flow.pixel_flow[1] = 0;
@@ -496,7 +512,7 @@ void PAA3905::RunImpl()
 					}
 
 					// only publish when there's valid data or on timeout
-					if (publish || (hrt_elapsed_time(&_last_publish) >= kBackupScheduleIntervalUs)) {
+					if (publish || (frame_consumed && (hrt_elapsed_time(&_last_publish) >= kBackupScheduleIntervalUs))) {
 
 						sensor_optical_flow.timestamp = hrt_absolute_time();
 						_sensor_optical_flow_pub.publish(sensor_optical_flow);
@@ -539,8 +555,8 @@ void PAA3905::RunImpl()
 				// chip clears its delta accumulator on every Motion_Burst read, regardless of whether
 				// we publish, so track every read that consumed a frame. A stale read consumed nothing:
 				// its window belongs to the next frame unless a timeout already published it.
-				if (!stale_read || published) {
-					_timestamp_sample_last = timestamp_sample;
+				if (frame_consumed && (!stale_read || published)) {
+					_timestamp_sample_last = frame_end;
 				}
 
 			} else {

--- a/src/drivers/optical_flow/paa3905/PAA3905.cpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.cpp
@@ -234,8 +234,8 @@ void PAA3905::RunImpl()
 			if (DataReadyInterruptConfigure()) {
 				_motion_interrupt_enabled = true;
 
-				// backup schedule as a watchdog timeout
-				ScheduleDelayed(1_s);
+				// the MOTION edge may already have passed while the interrupt was disabled
+				ScheduleDelayed(kBackupScheduleIntervalUs);
 
 			} else {
 				_motion_interrupt_enabled = false;
@@ -293,7 +293,7 @@ void PAA3905::RunImpl()
 
 				if (buffer.data.RawData_Sum > 0x98) {
 					perf_count(_bad_register_perf);
-					PX4_ERR("invalid RawData_Sum > 0x98");
+					PX4_DEBUG("invalid RawData_Sum > 0x98");
 				}
 
 				// Bit [5:0] check if chip is working correctly
@@ -448,6 +448,13 @@ void PAA3905::RunImpl()
 				const int16_t delta_x_raw = combine(buffer.data.Delta_X_H, buffer.data.Delta_X_L);
 				const int16_t delta_y_raw = combine(buffer.data.Delta_Y_H, buffer.data.Delta_Y_L);
 
+				// The accumulator is cleared by every read, so a zero delta with the previous
+				// read's shutter and quality means the chip has not finished a new frame yet.
+				const bool stale_read = (delta_x_raw == 0) && (delta_y_raw == 0) && (shutter == _shutter_prev)
+							&& (buffer.data.RawData_Sum == _raw_data_sum_prev) && (buffer.data.SQUAL == _quality_prev);
+
+				bool published = false;
+
 				if (data_valid) {
 
 					const bool zero_flow = (delta_x_raw == 0) && (delta_y_raw == 0);
@@ -477,12 +484,7 @@ void PAA3905::RunImpl()
 
 					} else if (zero_flow && (timestamp_sample > _last_motion)) {
 						// no motion, but burst read looks valid and we should have seen new data by now if there was any motion
-						const bool burst_read_changed = (delta_x_raw != _delta_x_raw_prev) || (delta_y_raw != _delta_y_raw_prev)
-										|| (shutter != _shutter_prev)
-										|| (buffer.data.RawData_Sum != _raw_data_sum_prev)
-										|| (buffer.data.SQUAL != _quality_prev);
-
-						if (burst_read_changed) {
+						if (!stale_read) {
 
 							sensor_optical_flow.pixel_flow[0] = 0;
 							sensor_optical_flow.pixel_flow[1] = 0;
@@ -500,42 +502,46 @@ void PAA3905::RunImpl()
 						_sensor_optical_flow_pub.publish(sensor_optical_flow);
 
 						_last_publish = sensor_optical_flow.timestamp_sample;
+						published = true;
 					}
 
-					// backup schedule if we're reliant on the motion interrupt and there's very little flow
+					// backup schedule if we're reliant on the motion interrupt and there's very little flow,
+					// with margin over the frame period so it cannot land just ahead of the MOTION edge
 					if (_motion_interrupt_enabled && little_to_no_flow) {
 						switch (_mode) {
 						case Mode::Bright:
-							ScheduleDelayed(SAMPLE_INTERVAL_MODE_0);
+							ScheduleDelayed(SAMPLE_INTERVAL_MODE_0 + SAMPLE_INTERVAL_MODE_0 / 4);
 							break;
 
 						case Mode::LowLight:
-							ScheduleDelayed(SAMPLE_INTERVAL_MODE_1);
+							ScheduleDelayed(SAMPLE_INTERVAL_MODE_1 + SAMPLE_INTERVAL_MODE_1 / 4);
 							break;
 
 						case Mode::SuperLowLight:
-							ScheduleDelayed(SAMPLE_INTERVAL_MODE_2);
+							ScheduleDelayed(SAMPLE_INTERVAL_MODE_2 + SAMPLE_INTERVAL_MODE_2 / 4);
 							break;
 						}
 					}
 				}
 
-				// Poor optical quality does not indicate a sensor fault.
-				success = buffer.data.RawData_Sum <= 0x98;
+				// Poor optical quality does not indicate a sensor fault, but an all-zero burst is not a live frame.
+				const bool dead_burst = (shutter == 0) && (buffer.data.SQUAL == 0) && (buffer.data.RawData_Sum == 0);
+				success = (buffer.data.RawData_Sum <= 0x98) && !dead_burst;
 
 				if (success && _failure_count > 0) {
 					_failure_count--;
 				}
 
-				_delta_x_raw_prev = delta_x_raw;
-				_delta_y_raw_prev = delta_y_raw;
 				_shutter_prev = shutter;
 				_raw_data_sum_prev = buffer.data.RawData_Sum;
 				_quality_prev = buffer.data.SQUAL;
 
-				// chip clears its delta accumulator on every Motion_Burst read,
-				// regardless of whether we publish, so track every successful read.
-				_timestamp_sample_last = timestamp_sample;
+				// chip clears its delta accumulator on every Motion_Burst read, regardless of whether
+				// we publish, so track every read that consumed a frame. A stale read consumed nothing:
+				// its window belongs to the next frame unless a timeout already published it.
+				if (!stale_read || published) {
+					_timestamp_sample_last = timestamp_sample;
+				}
 
 			} else {
 				perf_count(_bad_transfer_perf);

--- a/src/drivers/optical_flow/paa3905/PAA3905.cpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.cpp
@@ -518,12 +518,13 @@ void PAA3905::RunImpl()
 							break;
 						}
 					}
+				}
 
-					success = true;
+				// Poor optical quality does not indicate a sensor fault.
+				success = buffer.data.RawData_Sum <= 0x98;
 
-					if (_failure_count > 0) {
-						_failure_count--;
-					}
+				if (success && _failure_count > 0) {
+					_failure_count--;
 				}
 
 				_delta_x_raw_prev = delta_x_raw;

--- a/src/drivers/optical_flow/paa3905/PAA3905.cpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.cpp
@@ -38,43 +38,15 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-// SQUAL below which the datasheet treats a motion report as noise, per
-// operating mode (shared with the false-motion discard, which also requires
-// the shutter condition).
-static constexpr uint8_t SQUAL_THRESHOLD_BRIGHT          = 0x19;
-static constexpr uint8_t SQUAL_THRESHOLD_LOW_LIGHT       = 0x46;
-static constexpr uint8_t SQUAL_THRESHOLD_SUPER_LOW_LIGHT = 0x55;
-
-static constexpr uint8_t squal_threshold(Mode mode)
-{
-	switch (mode) {
-	case Mode::Bright:        return SQUAL_THRESHOLD_BRIGHT;
-
-	case Mode::LowLight:      return SQUAL_THRESHOLD_LOW_LIGHT;
-
-	case Mode::SuperLowLight: return SQUAL_THRESHOLD_SUPER_LOW_LIGHT;
-	}
-
-	return SQUAL_THRESHOLD_SUPER_LOW_LIGHT;
-}
-
-// sensor_optical_flow.quality promises 0 = worst, 255 = best, and EKF2 scales
-// the flow noise linearly with it. Raw SQUAL is mode dependent (the chip's own
-// floor is 25/70/85 across the three modes) and the DroneCAN flow message
-// drops the mode, so the same raw value would mean "solid" in bright light and
-// "one count above noise" in super low light. Map the mode floor to 0 and raw
-// 255 to 255.
-static uint8_t normalize_squal(uint8_t squal, Mode mode)
-{
-	const uint8_t threshold = squal_threshold(mode);
-
-	if (squal <= threshold) {
-		return 0;
-	}
-
-	// 0 is reserved for rejected frames; the threshold itself maps to 1
-	return static_cast<uint8_t>(1u + ((squal - threshold) * 254u) / (255u - threshold));
-}
+// SQUAL is the chip's feature count / 4. Flights over grass at night (mode 2)
+// and black pavement by day (mode 0) put the tracking knee at the same raw
+// value: below it the chip reports zero motion on most frames while the
+// vehicle moves, above it counts match GNSS translation plus gyro at the
+// datasheet scale. The datasheet's per-mode discard rule (SQUAL below 25/70/85
+// while the shutter sits at the mode maximum) never fires in bright light, so
+// it cannot serve as the gate. Quality is published as raw SQUAL so one
+// EKF2_OF_QMIN means the same thing in every mode.
+static constexpr uint8_t SQUAL_TRACKING_FLOOR = 0x55;
 
 PAA3905::PAA3905(const I2CSPIDriverConfig &config) :
 	SPI(config),
@@ -374,12 +346,6 @@ void PAA3905::RunImpl()
 				sensor_optical_flow.min_ground_distance = 0.08f;    // Datasheet: 80mm
 				sensor_optical_flow.max_ground_distance = INFINITY; // Datasheet: infinity
 
-				// check SQUAL & Shutter values
-				// To suppress false motion reports, discard Delta X and Delta Y values if the SQUAL and Shutter values meet the condition
-				// Bright Mode,          SQUAL < 0x19, Shutter ≥ 0x00FF80
-				// Low Light Mode,       SQUAL < 0x46, Shutter ≥ 0x00FF80
-				// Super Low Light Mode, SQUAL < 0x55, Shutter ≥ 0x025998
-
 				// 23-bit Shutter register
 				const uint8_t shutter_lower = buffer.data.Shutter_Lower;
 				const uint8_t shutter_middle = buffer.data.Shutter_Middle;
@@ -395,17 +361,16 @@ void PAA3905::RunImpl()
 						  && (shutter > 0)
 						  && (_discard_reading == 0);
 
+				if (buffer.data.SQUAL < SQUAL_TRACKING_FLOOR) {
+					// the chip is blind on this surface; the frame is reported without flow below
+					data_valid = false;
+					perf_count(_false_motion_perf);
+				}
+
 				switch (_mode) {
 				case Mode::Bright:
 					sensor_optical_flow.integration_timespan_us = SAMPLE_INTERVAL_MODE_0;
 					sensor_optical_flow.mode = sensor_optical_flow_s::MODE_BRIGHT;
-
-					// quality < 25 (0x19) and shutter >= 0x00FF80
-					if ((buffer.data.SQUAL < SQUAL_THRESHOLD_BRIGHT) && (shutter >= 0x00FF80)) {
-						// false motion report, discarding
-						data_valid = false;
-						perf_count(_false_motion_perf);
-					}
 
 					break;
 
@@ -413,25 +378,11 @@ void PAA3905::RunImpl()
 					sensor_optical_flow.integration_timespan_us = SAMPLE_INTERVAL_MODE_1;
 					sensor_optical_flow.mode = sensor_optical_flow_s::MODE_LOWLIGHT;
 
-					// quality < 70 (0x46) and shutter >= 0x00FF80
-					if ((buffer.data.SQUAL < SQUAL_THRESHOLD_LOW_LIGHT) && (shutter >= 0x00FF80)) {
-						// false motion report, discarding
-						data_valid = false;
-						perf_count(_false_motion_perf);
-					}
-
 					break;
 
 				case Mode::SuperLowLight:
 					sensor_optical_flow.integration_timespan_us = SAMPLE_INTERVAL_MODE_2;
 					sensor_optical_flow.mode = sensor_optical_flow_s::MODE_SUPER_LOWLIGHT;
-
-					// quality < 85 (0x55) and shutter >= 0x025998
-					if ((buffer.data.SQUAL < SQUAL_THRESHOLD_SUPER_LOW_LIGHT) && (shutter >= 0x025998)) {
-						// false motion report, discarding
-						data_valid = false;
-						perf_count(_false_motion_perf);
-					}
 
 					break;
 				}
@@ -493,7 +444,7 @@ void PAA3905::RunImpl()
 						sensor_optical_flow.pixel_flow[0] = pixel_flow_rotated(0) * SCALE;
 						sensor_optical_flow.pixel_flow[1] = pixel_flow_rotated(1) * SCALE;
 
-						sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
+						sensor_optical_flow.quality = buffer.data.SQUAL;
 
 						publish = true;
 
@@ -506,7 +457,7 @@ void PAA3905::RunImpl()
 							sensor_optical_flow.pixel_flow[0] = 0;
 							sensor_optical_flow.pixel_flow[1] = 0;
 
-							sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
+							sensor_optical_flow.quality = buffer.data.SQUAL;
 
 							publish = true;
 						}
@@ -517,7 +468,7 @@ void PAA3905::RunImpl()
 
 						if (!publish) {
 							// heartbeat with no new frame: zero flow at the last read's quality
-							sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
+							sensor_optical_flow.quality = buffer.data.SQUAL;
 						}
 
 						sensor_optical_flow.timestamp = hrt_absolute_time();

--- a/src/drivers/optical_flow/paa3905/PAA3905.cpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.cpp
@@ -72,7 +72,8 @@ static uint8_t normalize_squal(uint8_t squal, Mode mode)
 		return 0;
 	}
 
-	return static_cast<uint8_t>(((squal - threshold) * 255u) / (255u - threshold));
+	// 0 is reserved for rejected frames; the threshold itself maps to 1
+	return static_cast<uint8_t>(1u + ((squal - threshold) * 254u) / (255u - threshold));
 }
 
 PAA3905::PAA3905(const I2CSPIDriverConfig &config) :
@@ -514,6 +515,11 @@ void PAA3905::RunImpl()
 					// only publish when there's valid data or on timeout
 					if (publish || (frame_consumed && (hrt_elapsed_time(&_last_publish) >= kBackupScheduleIntervalUs))) {
 
+						if (!publish) {
+							// heartbeat with no new frame: zero flow at the last read's quality
+							sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
+						}
+
 						sensor_optical_flow.timestamp = hrt_absolute_time();
 						_sensor_optical_flow_pub.publish(sensor_optical_flow);
 
@@ -538,6 +544,17 @@ void PAA3905::RunImpl()
 							break;
 						}
 					}
+
+				} else if (_discard_reading == 0 && !stale_read && frame_consumed && buffer.data.RawData_Sum <= 0x98) {
+					// A rejected frame still consumed its window. Report it blind (quality 0, no flow) so the
+					// stream stays continuous and consumers can tell dark from dead.
+					sensor_optical_flow.pixel_flow[0] = 0;
+					sensor_optical_flow.pixel_flow[1] = 0;
+					sensor_optical_flow.quality = 0;
+					sensor_optical_flow.timestamp = hrt_absolute_time();
+					_sensor_optical_flow_pub.publish(sensor_optical_flow);
+					_last_publish = sensor_optical_flow.timestamp_sample;
+					published = true;
 				}
 
 				// Poor optical quality does not indicate a sensor fault, but an all-zero burst is not a live frame.

--- a/src/drivers/optical_flow/paa3905/PAA3905.hpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.hpp
@@ -118,8 +118,6 @@ private:
 	hrt_abstime _last_challenging_surface_warning{0};
 	hrt_abstime _timestamp_sample_last{0};
 
-	int16_t _delta_x_raw_prev{0};
-	int16_t _delta_y_raw_prev{0};
 	uint32_t _shutter_prev{0};
 	uint8_t _quality_prev{0};
 	uint8_t _raw_data_sum_prev{0};
@@ -131,7 +129,8 @@ private:
 	bool _motion_interrupt_enabled{false};
 
 	uint32_t _scheduled_interval_us{SAMPLE_INTERVAL_MODE_0 / 2};
-	static constexpr uint32_t kBackupScheduleIntervalUs{SAMPLE_INTERVAL_MODE_2}; // longest expected interval
+	// longer than the longest frame period, so a backup read never lands just ahead of the MOTION edge
+	static constexpr uint32_t kBackupScheduleIntervalUs{SAMPLE_INTERVAL_MODE_2 + SAMPLE_INTERVAL_MODE_2 / 4};
 
 	Mode _mode{Mode::LowLight};
 

--- a/src/drivers/optical_flow/paa3905/PAA3905.hpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.hpp
@@ -106,7 +106,7 @@ private:
 	perf_counter_t _bad_register_perf{perf_alloc(PC_COUNT, MODULE_NAME": bad register")};
 	perf_counter_t _bad_transfer_perf{perf_alloc(PC_COUNT, MODULE_NAME": bad transfer")};
 	perf_counter_t _reset_perf{perf_alloc(PC_COUNT, MODULE_NAME": reset")};
-	perf_counter_t _false_motion_perf{perf_alloc(PC_COUNT, MODULE_NAME": false motion report")};
+	perf_counter_t _false_motion_perf{perf_alloc(PC_COUNT, MODULE_NAME": frame below tracking floor")};
 	perf_counter_t _mode_change_bright_perf{perf_alloc(PC_COUNT, MODULE_NAME": mode change bright (0)")};
 	perf_counter_t _mode_change_low_light_perf{perf_alloc(PC_COUNT, MODULE_NAME": mode change low light (1)")};
 	perf_counter_t _mode_change_super_low_light_perf{perf_alloc(PC_COUNT, MODULE_NAME": mode change super low light (2)")};

--- a/src/drivers/optical_flow/paw3902/PAW3902.cpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.cpp
@@ -38,43 +38,13 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-// SQUAL below which the datasheet treats a motion report as noise, per
-// operating mode (shared with the false-motion discard, which also requires
-// the shutter condition).
+// SQUAL thresholds of the datasheet's false-motion discard, per operating
+// mode. Quality is published as raw SQUAL (feature count / 4) so it means the
+// same thing in every mode; the PAA3905 flights that located the tracking knee
+// have no PAW3902 counterpart yet, so this driver keeps the datasheet rule.
 static constexpr uint8_t SQUAL_THRESHOLD_BRIGHT          = 0x19;
 static constexpr uint8_t SQUAL_THRESHOLD_LOW_LIGHT       = 0x46;
 static constexpr uint8_t SQUAL_THRESHOLD_SUPER_LOW_LIGHT = 0x55;
-
-static constexpr uint8_t squal_threshold(Mode mode)
-{
-	switch (mode) {
-	case Mode::Bright:        return SQUAL_THRESHOLD_BRIGHT;
-
-	case Mode::LowLight:      return SQUAL_THRESHOLD_LOW_LIGHT;
-
-	case Mode::SuperLowLight: return SQUAL_THRESHOLD_SUPER_LOW_LIGHT;
-	}
-
-	return SQUAL_THRESHOLD_SUPER_LOW_LIGHT;
-}
-
-// sensor_optical_flow.quality promises 0 = worst, 255 = best, and EKF2 scales
-// the flow noise linearly with it. Raw SQUAL is mode dependent (the chip's own
-// floor is 25/70/85 across the three modes) and the DroneCAN flow message
-// drops the mode, so the same raw value would mean "solid" in bright light and
-// "one count above noise" in super low light. Map the mode floor to 0 and raw
-// 255 to 255.
-static uint8_t normalize_squal(uint8_t squal, Mode mode)
-{
-	const uint8_t threshold = squal_threshold(mode);
-
-	if (squal <= threshold) {
-		return 0;
-	}
-
-	// 0 is reserved for rejected frames; the threshold itself maps to 1
-	return static_cast<uint8_t>(1u + ((squal - threshold) * 254u) / (255u - threshold));
-}
 
 PAW3902::PAW3902(const I2CSPIDriverConfig &config) :
 	SPI(config),
@@ -504,7 +474,7 @@ void PAW3902::RunImpl()
 						sensor_optical_flow.pixel_flow[0] = pixel_flow_rotated(0) * SCALE;
 						sensor_optical_flow.pixel_flow[1] = pixel_flow_rotated(1) * SCALE;
 
-						sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
+						sensor_optical_flow.quality = buffer.data.SQUAL;
 
 						publish = true;
 
@@ -517,7 +487,7 @@ void PAW3902::RunImpl()
 							sensor_optical_flow.pixel_flow[0] = 0;
 							sensor_optical_flow.pixel_flow[1] = 0;
 
-							sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
+							sensor_optical_flow.quality = buffer.data.SQUAL;
 
 							publish = true;
 						}
@@ -528,7 +498,7 @@ void PAW3902::RunImpl()
 
 						if (!publish) {
 							// heartbeat with no new frame: zero flow at the last read's quality
-							sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
+							sensor_optical_flow.quality = buffer.data.SQUAL;
 						}
 
 						sensor_optical_flow.timestamp = hrt_absolute_time();

--- a/src/drivers/optical_flow/paw3902/PAW3902.cpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.cpp
@@ -264,6 +264,7 @@ void PAW3902::RunImpl()
 
 	case STATE::READ: {
 			hrt_abstime timestamp_sample = now;
+			bool frame_end_known = false;
 
 			if (_motion_interrupt_enabled) {
 				// scheduled from interrupt if _drdy_timestamp_sample was set as expected
@@ -271,6 +272,7 @@ void PAW3902::RunImpl()
 
 				if (now < drdy_timestamp_sample + _scheduled_interval_us) {
 					timestamp_sample = drdy_timestamp_sample;
+					frame_end_known = true;
 
 				} else {
 					perf_count(_no_motion_interrupt_perf);
@@ -444,15 +446,6 @@ void PAW3902::RunImpl()
 					break;
 				}
 
-				// override the per-mode default with the actual interval between burst reads
-				// (the chip accumulates delta_x/delta_y until Motion_Burst is read), so the
-				// gyro integration window downstream lines up with what the chip actually saw.
-				if (_timestamp_sample_last != 0 && timestamp_sample > _timestamp_sample_last) {
-					const hrt_abstime dt = timestamp_sample - _timestamp_sample_last;
-					sensor_optical_flow.integration_timespan_us = math::constrain(static_cast<uint32_t>(dt),
-							static_cast<uint32_t>(1_ms), static_cast<uint32_t>(200_ms));
-				}
-
 				// motion in burst transfer
 				const bool motion_reported = (buffer.data.Motion & Motion_Bit::MOT);
 
@@ -463,6 +456,29 @@ void PAW3902::RunImpl()
 				// read's shutter and quality means the chip has not finished a new frame yet.
 				const bool stale_read = (delta_x_raw == 0) && (delta_y_raw == 0) && (shutter == _shutter_prev)
 							&& (buffer.data.RawData_Sum == _raw_data_sum_prev) && (buffer.data.SQUAL == _quality_prev);
+
+				// A poll cannot tell where the chip's last frame ended, and whatever the chip is
+				// integrating now will be reported by the next read. Without motion a poll therefore
+				// only vouches for the time up to one frame period ago, so that next frame keeps
+				// its full window instead of starting at the poll.
+				hrt_abstime frame_end = timestamp_sample;
+
+				if (!frame_end_known && !motion_reported) {
+					const uint32_t frame_period_us = (_mode == Mode::SuperLowLight) ? SAMPLE_INTERVAL_MODE_2 : SAMPLE_INTERVAL_MODE_1;
+					frame_end = (timestamp_sample > frame_period_us) ? (timestamp_sample - frame_period_us) : 0;
+				}
+
+				const bool frame_consumed = (frame_end > _timestamp_sample_last);
+				sensor_optical_flow.timestamp_sample = frame_end;
+
+				// override the per-mode default with the actual interval between consumed frames
+				// (the chip accumulates delta_x/delta_y until Motion_Burst is read), so the
+				// gyro integration window downstream lines up with what the chip actually saw.
+				if (_timestamp_sample_last != 0 && frame_consumed) {
+					const hrt_abstime dt = frame_end - _timestamp_sample_last;
+					sensor_optical_flow.integration_timespan_us = math::constrain(static_cast<uint32_t>(dt),
+							static_cast<uint32_t>(1_ms), static_cast<uint32_t>(200_ms));
+				}
 
 				bool published = false;
 
@@ -495,7 +511,7 @@ void PAW3902::RunImpl()
 
 					} else if (zero_flow && (timestamp_sample > _last_motion)) {
 						// no motion, but burst read looks valid and we should have seen new data by now if there was any motion
-						if (!stale_read) {
+						if (!stale_read && frame_consumed) {
 
 							sensor_optical_flow.pixel_flow[0] = 0;
 							sensor_optical_flow.pixel_flow[1] = 0;
@@ -507,7 +523,7 @@ void PAW3902::RunImpl()
 					}
 
 					// only publish when there's valid data or on timeout
-					if (publish || (hrt_elapsed_time(&_last_publish) >= kBackupScheduleIntervalUs)) {
+					if (publish || (frame_consumed && (hrt_elapsed_time(&_last_publish) >= kBackupScheduleIntervalUs))) {
 
 						sensor_optical_flow.timestamp = hrt_absolute_time();
 						_sensor_optical_flow_pub.publish(sensor_optical_flow);
@@ -550,8 +566,8 @@ void PAW3902::RunImpl()
 				// chip clears its delta accumulator on every Motion_Burst read, regardless of whether
 				// we publish, so track every read that consumed a frame. A stale read consumed nothing:
 				// its window belongs to the next frame unless a timeout already published it.
-				if (!stale_read || published) {
-					_timestamp_sample_last = timestamp_sample;
+				if (frame_consumed && (!stale_read || published)) {
+					_timestamp_sample_last = frame_end;
 				}
 
 			} else {

--- a/src/drivers/optical_flow/paw3902/PAW3902.cpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.cpp
@@ -517,12 +517,13 @@ void PAW3902::RunImpl()
 							break;
 						}
 					}
+				}
 
-					success = true;
+				// Poor optical quality does not indicate a sensor fault.
+				success = buffer.data.RawData_Sum <= 0x98;
 
-					if (_failure_count > 0) {
-						_failure_count--;
-					}
+				if (success && _failure_count > 0) {
+					_failure_count--;
 				}
 
 				_delta_x_raw_prev = delta_x_raw;

--- a/src/drivers/optical_flow/paw3902/PAW3902.cpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.cpp
@@ -72,7 +72,8 @@ static uint8_t normalize_squal(uint8_t squal, Mode mode)
 		return 0;
 	}
 
-	return static_cast<uint8_t>(((squal - threshold) * 255u) / (255u - threshold));
+	// 0 is reserved for rejected frames; the threshold itself maps to 1
+	return static_cast<uint8_t>(1u + ((squal - threshold) * 254u) / (255u - threshold));
 }
 
 PAW3902::PAW3902(const I2CSPIDriverConfig &config) :
@@ -525,6 +526,11 @@ void PAW3902::RunImpl()
 					// only publish when there's valid data or on timeout
 					if (publish || (frame_consumed && (hrt_elapsed_time(&_last_publish) >= kBackupScheduleIntervalUs))) {
 
+						if (!publish) {
+							// heartbeat with no new frame: zero flow at the last read's quality
+							sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
+						}
+
 						sensor_optical_flow.timestamp = hrt_absolute_time();
 						_sensor_optical_flow_pub.publish(sensor_optical_flow);
 
@@ -549,6 +555,17 @@ void PAW3902::RunImpl()
 							break;
 						}
 					}
+
+				} else if (_discard_reading == 0 && !stale_read && frame_consumed && buffer.data.RawData_Sum <= 0x98) {
+					// A rejected frame still consumed its window. Report it blind (quality 0, no flow) so the
+					// stream stays continuous and consumers can tell dark from dead.
+					sensor_optical_flow.pixel_flow[0] = 0;
+					sensor_optical_flow.pixel_flow[1] = 0;
+					sensor_optical_flow.quality = 0;
+					sensor_optical_flow.timestamp = hrt_absolute_time();
+					_sensor_optical_flow_pub.publish(sensor_optical_flow);
+					_last_publish = sensor_optical_flow.timestamp_sample;
+					published = true;
 				}
 
 				// Poor optical quality does not indicate a sensor fault, but an all-zero burst is not a live frame.

--- a/src/drivers/optical_flow/paw3902/PAW3902.cpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.cpp
@@ -239,8 +239,8 @@ void PAW3902::RunImpl()
 			if (DataReadyInterruptConfigure()) {
 				_motion_interrupt_enabled = true;
 
-				// backup schedule as a watchdog timeout
-				ScheduleDelayed(1_s);
+				// the MOTION edge may already have passed while the interrupt was disabled
+				ScheduleDelayed(kBackupScheduleIntervalUs);
 
 			} else {
 				_motion_interrupt_enabled = false;
@@ -298,7 +298,7 @@ void PAW3902::RunImpl()
 
 				if (buffer.data.RawData_Sum > 0x98) {
 					perf_count(_bad_register_perf);
-					PX4_ERR("invalid RawData_Sum > 0x98");
+					PX4_DEBUG("invalid RawData_Sum > 0x98");
 				}
 
 				// publish sensor_optical_flow
@@ -346,7 +346,10 @@ void PAW3902::RunImpl()
 					}
 
 					// shutter >= 8190 (0x1FFE), raw data sum < 60 (0x3C)
-					if ((shutter >= 0x1FFE) && (buffer.data.RawData_Sum < 0x3C)) {
+					if (_discard_reading > 0) {
+						// exposure has not settled after the reconfiguration
+
+					} else if ((shutter >= 0x1FFE) && (buffer.data.RawData_Sum < 0x3C)) {
 						// Bright -> LowLight
 						_bright_to_low_counter++;
 
@@ -373,7 +376,10 @@ void PAW3902::RunImpl()
 					}
 
 					// shutter >= 8190 (0x1FFE) and raw data sum < 90 (0x5A)
-					if ((shutter >= 0x1FFE) && (buffer.data.RawData_Sum < 0x5A)) {
+					if (_discard_reading > 0) {
+						// exposure has not settled after the reconfiguration
+
+					} else if ((shutter >= 0x1FFE) && (buffer.data.RawData_Sum < 0x5A)) {
 						// LowLight -> SuperLowLight
 						_low_to_bright_counter = 0;
 						_low_to_superlow_counter++;
@@ -415,13 +421,19 @@ void PAW3902::RunImpl()
 					// shutter < 500 (0x01F4)
 					if (shutter < 0x01F4) {
 						// should not operate with Shutter < 0x01F4 in Mode 2
-						_superlow_to_low_counter++;
 						data_valid = false;
+					}
+
+					if (_discard_reading > 0) {
+						// exposure has not settled after the reconfiguration
 
 					} else if (shutter < 0x03E8) {
 						// SuperLowLight -> LowLight
 						//  shutter < 1000 (0x03E8)
 						_superlow_to_low_counter++;
+
+					} else {
+						_superlow_to_low_counter = 0;
 					}
 
 					if (_superlow_to_low_counter >= 10) {
@@ -446,6 +458,13 @@ void PAW3902::RunImpl()
 
 				const int16_t delta_x_raw = combine(buffer.data.Delta_X_H, buffer.data.Delta_X_L);
 				const int16_t delta_y_raw = combine(buffer.data.Delta_Y_H, buffer.data.Delta_Y_L);
+
+				// The accumulator is cleared by every read, so a zero delta with the previous
+				// read's shutter and quality means the chip has not finished a new frame yet.
+				const bool stale_read = (delta_x_raw == 0) && (delta_y_raw == 0) && (shutter == _shutter_prev)
+							&& (buffer.data.RawData_Sum == _raw_data_sum_prev) && (buffer.data.SQUAL == _quality_prev);
+
+				bool published = false;
 
 				if (data_valid) {
 
@@ -476,12 +495,7 @@ void PAW3902::RunImpl()
 
 					} else if (zero_flow && (timestamp_sample > _last_motion)) {
 						// no motion, but burst read looks valid and we should have seen new data by now if there was any motion
-						const bool burst_read_changed = (delta_x_raw != _delta_x_raw_prev) || (delta_y_raw != _delta_y_raw_prev)
-										|| (shutter != _shutter_prev)
-										|| (buffer.data.RawData_Sum != _raw_data_sum_prev)
-										|| (buffer.data.SQUAL != _quality_prev);
-
-						if (burst_read_changed) {
+						if (!stale_read) {
 
 							sensor_optical_flow.pixel_flow[0] = 0;
 							sensor_optical_flow.pixel_flow[1] = 0;
@@ -499,42 +513,46 @@ void PAW3902::RunImpl()
 						_sensor_optical_flow_pub.publish(sensor_optical_flow);
 
 						_last_publish = sensor_optical_flow.timestamp_sample;
+						published = true;
 					}
 
-					// backup schedule if we're reliant on the motion interrupt and there's very little flow
+					// backup schedule if we're reliant on the motion interrupt and there's very little flow,
+					// with margin over the frame period so it cannot land just ahead of the MOTION edge
 					if (_motion_interrupt_enabled && little_to_no_flow) {
 						switch (_mode) {
 						case Mode::Bright:
-							ScheduleDelayed(SAMPLE_INTERVAL_MODE_0);
+							ScheduleDelayed(SAMPLE_INTERVAL_MODE_0 + SAMPLE_INTERVAL_MODE_0 / 4);
 							break;
 
 						case Mode::LowLight:
-							ScheduleDelayed(SAMPLE_INTERVAL_MODE_1);
+							ScheduleDelayed(SAMPLE_INTERVAL_MODE_1 + SAMPLE_INTERVAL_MODE_1 / 4);
 							break;
 
 						case Mode::SuperLowLight:
-							ScheduleDelayed(SAMPLE_INTERVAL_MODE_2);
+							ScheduleDelayed(SAMPLE_INTERVAL_MODE_2 + SAMPLE_INTERVAL_MODE_2 / 4);
 							break;
 						}
 					}
 				}
 
-				// Poor optical quality does not indicate a sensor fault.
-				success = buffer.data.RawData_Sum <= 0x98;
+				// Poor optical quality does not indicate a sensor fault, but an all-zero burst is not a live frame.
+				const bool dead_burst = (shutter == 0) && (buffer.data.SQUAL == 0) && (buffer.data.RawData_Sum == 0);
+				success = (buffer.data.RawData_Sum <= 0x98) && !dead_burst;
 
 				if (success && _failure_count > 0) {
 					_failure_count--;
 				}
 
-				_delta_x_raw_prev = delta_x_raw;
-				_delta_y_raw_prev = delta_y_raw;
 				_shutter_prev = shutter;
 				_raw_data_sum_prev = buffer.data.RawData_Sum;
 				_quality_prev = buffer.data.SQUAL;
 
-				// chip clears its delta accumulator on every Motion_Burst read,
-				// regardless of whether we publish, so track every successful read.
-				_timestamp_sample_last = timestamp_sample;
+				// chip clears its delta accumulator on every Motion_Burst read, regardless of whether
+				// we publish, so track every read that consumed a frame. A stale read consumed nothing:
+				// its window belongs to the next frame unless a timeout already published it.
+				if (!stale_read || published) {
+					_timestamp_sample_last = timestamp_sample;
+				}
 
 			} else {
 				perf_count(_bad_transfer_perf);

--- a/src/drivers/optical_flow/paw3902/PAW3902.hpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.hpp
@@ -117,8 +117,6 @@ private:
 	hrt_abstime _last_motion{0};
 	hrt_abstime _timestamp_sample_last{0};
 
-	int16_t _delta_x_raw_prev{0};
-	int16_t _delta_y_raw_prev{0};
 	uint16_t _shutter_prev{0};
 	uint8_t _quality_prev{0};
 	uint8_t _raw_data_sum_prev{0};
@@ -130,7 +128,8 @@ private:
 	bool _motion_interrupt_enabled{false};
 
 	uint32_t _scheduled_interval_us{SAMPLE_INTERVAL_MODE_0 / 2};
-	static constexpr uint32_t kBackupScheduleIntervalUs{SAMPLE_INTERVAL_MODE_2}; // longest expected interval
+	// longer than the longest frame period, so a backup read never lands just ahead of the MOTION edge
+	static constexpr uint32_t kBackupScheduleIntervalUs{SAMPLE_INTERVAL_MODE_2 + SAMPLE_INTERVAL_MODE_2 / 4};
 
 	Mode _mode{Mode::LowLight};
 

--- a/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_fusion.cpp
@@ -162,15 +162,9 @@ float Ekf::calcOptFlowMeasVar(const flowSample &flow_sample) const
 	const float R_LOS_best = fmaxf(_params.ekf2_of_n_min, 0.05f);
 	const float R_LOS_worst = fmaxf(_params.ekf2_of_n_max, 0.05f);
 
-	// calculate a weighting that varies between 1 when flow quality is best and 0 when flow quality is worst
-	float weighting = (255.f - (float)_params.ekf2_of_qmin);
-
-	if (weighting >= 1.f) {
-		weighting = math::constrain((float)(flow_sample.quality - _params.ekf2_of_qmin) / weighting, 0.f, 1.f);
-
-	} else {
-		weighting = 0.0f;
-	}
+	const float qmin = static_cast<float>(_params.ekf2_of_qmin);
+	const float qmax = math::max(static_cast<float>(_params.ekf2_of_qmax), qmin + 1.f);
+	const float weighting = math::constrain((static_cast<float>(flow_sample.quality) - qmin) / (qmax - qmin), 0.f, 1.f);
 
 	// take the weighted average of the observation noise for the best and wort flow quality
 	const float R_LOS = sq(R_LOS_best * weighting + R_LOS_worst * (1.f - weighting));

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -494,6 +494,7 @@ struct parameters {
 	float ekf2_of_n_max{0.5f};              ///< observation noise for optical flow LOS rate measurements when flow sensor quality is at the minimum useable (rad/sec)
 	int32_t ekf2_of_qmin{1};                ///< minimum acceptable quality integer from  the flow sensor
 	int32_t ekf2_of_qmin_gnd{0};            ///< minimum acceptable quality integer from  the flow sensor when on ground
+	int32_t ekf2_of_qmax{255};              ///< quality at which observation noise reaches ekf2_of_n_min
 	float ekf2_of_gate{3.0f};               ///< optical flow fusion innovation consistency gate size (STD)
 
 	Vector3f flow_pos_body{};               ///< xyz position of range sensor focal point in body frame (m)

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -193,6 +193,7 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_of_n_max(_params->ekf2_of_n_max),
 	_param_ekf2_of_qmin(_params->ekf2_of_qmin),
 	_param_ekf2_of_qmin_gnd(_params->ekf2_of_qmin_gnd),
+	_param_ekf2_of_qmax(_params->ekf2_of_qmax),
 	_param_ekf2_of_gate(_params->ekf2_of_gate),
 	_param_ekf2_of_pos_x(_params->flow_pos_body(0)),
 	_param_ekf2_of_pos_y(_params->flow_pos_body(1)),

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -718,6 +718,8 @@ private:
 		_param_ekf2_of_qmin, ///< minimum acceptable quality integer from  the flow sensor when in air
 		(ParamExtInt<px4::params::EKF2_OF_QMIN_GND>)
 		_param_ekf2_of_qmin_gnd, ///< minimum acceptable quality integer from  the flow sensor when on ground
+		(ParamExtInt<px4::params::EKF2_OF_QMAX>)
+		_param_ekf2_of_qmax, ///< quality at which optical flow observation noise reaches EKF2_OF_N_MIN
 		(ParamExtFloat<px4::params::EKF2_OF_GATE>)
 		_param_ekf2_of_gate, ///< optical flow fusion innovation consistency gate size (STD)
 		(ParamExtFloat<px4::params::EKF2_OF_POS_X>)

--- a/src/modules/ekf2/params_optical_flow.yaml
+++ b/src/modules/ekf2/params_optical_flow.yaml
@@ -48,7 +48,7 @@ parameters:
         long: Measurement noise for the optical flow sensor when it's reported quality
           metric is at the minimum
       type: float
-      default: 0.5
+      default: 0.7
       min: 0.05
       unit: rad/s
       decimal: 2
@@ -57,10 +57,10 @@ parameters:
         short: In air optical flow minimum quality
         long: Optical Flow data will only be used in air if the sensor reports a
           quality metric >= EKF2_OF_QMIN. The PixArt drivers (PMW3901, PAW3902,
-          PAA3905) report raw SQUAL, whose tracking knee sits at 85 in every
+          PAA3905) report raw SQUAL; below 60 the chip reports noise in every
           lighting mode.
       type: int32
-      default: 85
+      default: 60
       min: 0
       max: 255
     EKF2_OF_QMIN_GND:

--- a/src/modules/ekf2/params_optical_flow.yaml
+++ b/src/modules/ekf2/params_optical_flow.yaml
@@ -56,9 +56,11 @@ parameters:
       description:
         short: In air optical flow minimum quality
         long: Optical Flow data will only be used in air if the sensor reports a
-          quality metric >= EKF2_OF_QMIN
+          quality metric >= EKF2_OF_QMIN. The PixArt drivers (PMW3901, PAW3902,
+          PAA3905) report raw SQUAL, whose tracking knee sits at 85 in every
+          lighting mode.
       type: int32
-      default: 1
+      default: 85
       min: 0
       max: 255
     EKF2_OF_QMIN_GND:

--- a/src/modules/ekf2/params_optical_flow.yaml
+++ b/src/modules/ekf2/params_optical_flow.yaml
@@ -35,20 +35,20 @@ parameters:
     EKF2_OF_N_MIN:
       description:
         short: Optical flow minimum noise
-        long: Measurement noise for the optical flow sensor when it's reported quality
-          metric is at the maximum
+        long: Measurement noise for the optical flow sensor when reported quality
+          is at EKF2_OF_QMAX.
       type: float
-      default: 0.15
+      default: 0.2
       min: 0.05
       unit: rad/s
       decimal: 2
     EKF2_OF_N_MAX:
       description:
         short: Optical flow maximum noise
-        long: Measurement noise for the optical flow sensor when it's reported quality
-          metric is at the minimum
+        long: Measurement noise for the optical flow sensor when reported quality
+          is at EKF2_OF_QMIN.
       type: float
-      default: 0.7
+      default: 1.0
       min: 0.05
       unit: rad/s
       decimal: 2
@@ -62,6 +62,18 @@ parameters:
       type: int32
       default: 60
       min: 0
+      max: 255
+    EKF2_OF_QMAX:
+      description:
+        short: Optical flow quality at minimum noise
+        long: |-
+          Quality at which observation noise reaches EKF2_OF_N_MIN. Between
+          EKF2_OF_QMIN and this value the noise is interpolated linearly onto
+          EKF2_OF_N_MAX..EKF2_OF_N_MIN. The PixArt PAA3905's SQUAL rarely
+          exceeds 120; 255 restores the historical ramp.
+      type: int32
+      default: 120
+      min: 1
       max: 255
     EKF2_OF_QMIN_GND:
       description:

--- a/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp
+++ b/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp
@@ -121,6 +121,9 @@ void VehicleOpticalFlow::Run()
 		}
 
 
+		// quality 0 marks a frame the sensor rejected: it consumed its window but carries no flow
+		const bool rejected = (sensor_optical_flow.quality == 0);
+
 		const hrt_abstime timestamp_oldest = sensor_optical_flow.timestamp_sample - sensor_optical_flow.integration_timespan_us;
 		// never integrate past the end of the flow window; the rest belongs to the next frame
 		const hrt_abstime timestamp_newest = sensor_optical_flow.timestamp_sample;
@@ -134,10 +137,14 @@ void VehicleOpticalFlow::Run()
 			if (!PX4_ISFINITE(delta_angle(2))) {
 				// Some sensors only provide X and Y angular rates, rotate them but place back the NAN on the Z axis
 				delta_angle(2) = 0.f;
-				_delta_angle += _flow_rotation * delta_angle;
+
+				if (!rejected) {
+					_delta_angle += _flow_rotation * delta_angle;
+				}
+
 				_delta_angle(2) = NAN;
 
-			} else {
+			} else if (!rejected) {
 				_delta_angle += _flow_rotation * delta_angle;
 			}
 
@@ -165,7 +172,9 @@ void VehicleOpticalFlow::Run()
 			uint32_t delta_angle_dt;
 
 			if (_gyro_integrator.reset(delta_angle, delta_angle_dt)) {
-				_delta_angle += delta_angle;
+				if (!rejected) {
+					_delta_angle += delta_angle;
+				}
 
 			} else {
 				// force integrator reset
@@ -202,13 +211,21 @@ void VehicleOpticalFlow::Run()
 		}
 
 		_flow_timestamp_sample_last = sensor_optical_flow.timestamp_sample;
-		_flow_integral(0) += sensor_optical_flow.pixel_flow[0];
-		_flow_integral(1) += sensor_optical_flow.pixel_flow[1];
 
-		_integration_timespan_us += sensor_optical_flow.integration_timespan_us;
+		if (rejected) {
+			// keep the time so the publication cadence holds, but never let a blind
+			// frame's zeros dilute the flow of the good frames around it
+			_rejected_timespan_us += sensor_optical_flow.integration_timespan_us;
 
-		_quality_sum += sensor_optical_flow.quality;
-		_accumulated_count++;
+		} else {
+			_flow_integral(0) += sensor_optical_flow.pixel_flow[0];
+			_flow_integral(1) += sensor_optical_flow.pixel_flow[1];
+
+			_integration_timespan_us += sensor_optical_flow.integration_timespan_us;
+
+			_quality_sum += sensor_optical_flow.quality;
+			_accumulated_count++;
+		}
 
 		bool publish = true;
 
@@ -216,7 +233,7 @@ void VehicleOpticalFlow::Run()
 			const float interval_us = 1e6f / _param_sens_flow_rate.get();
 
 			// don't allow publishing faster than SENS_FLOW_RATE
-			if (_integration_timespan_us < interval_us) {
+			if (_integration_timespan_us + _rejected_timespan_us < interval_us) {
 				publish = false;
 			}
 		}
@@ -231,9 +248,19 @@ void VehicleOpticalFlow::Run()
 			_flow_integral.copyTo(vehicle_optical_flow.pixel_flow);
 			_delta_angle.copyTo(vehicle_optical_flow.delta_angle);
 
-			vehicle_optical_flow.integration_timespan_us = _integration_timespan_us;
+			if (_accumulated_count > 0) {
+				vehicle_optical_flow.integration_timespan_us = _integration_timespan_us;
 
-			vehicle_optical_flow.quality = _quality_sum / _accumulated_count;
+				// scale quality by the usable share of the window, so a gate on it sees how much was blind
+				const uint64_t total_us = _integration_timespan_us + _rejected_timespan_us;
+				vehicle_optical_flow.quality = static_cast<uint8_t>(
+								       (static_cast<uint64_t>(_quality_sum / _accumulated_count) * _integration_timespan_us) / total_us);
+
+			} else {
+				// every frame in the window was rejected: report the window blind
+				vehicle_optical_flow.integration_timespan_us = _rejected_timespan_us;
+				vehicle_optical_flow.quality = 0;
+			}
 
 			if (_distance_sum_count > 0 && PX4_ISFINITE(_distance_sum)) {
 				vehicle_optical_flow.distance_m = _distance_sum / _distance_sum_count;
@@ -282,7 +309,7 @@ void VehicleOpticalFlow::Run()
 			_vehicle_optical_flow_pub.publish(vehicle_optical_flow);
 
 			// vehicle_optical_flow_vel if distance is available (for logging)
-			if (_distance_sum_count > 0 && PX4_ISFINITE(_distance_sum)) {
+			if (_accumulated_count > 0 && _distance_sum_count > 0 && PX4_ISFINITE(_distance_sum)) {
 				const float range = _distance_sum / _distance_sum_count;
 
 				vehicle_optical_flow_vel_s flow_vel{};
@@ -473,6 +500,7 @@ void VehicleOpticalFlow::ClearAccumulatedData()
 	// clear accumulated data
 	_flow_integral.zero();
 	_integration_timespan_us = 0;
+	_rejected_timespan_us = 0;
 
 	_delta_angle.zero();
 

--- a/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp
+++ b/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp
@@ -122,7 +122,8 @@ void VehicleOpticalFlow::Run()
 
 
 		const hrt_abstime timestamp_oldest = sensor_optical_flow.timestamp_sample - sensor_optical_flow.integration_timespan_us;
-		const hrt_abstime timestamp_newest = sensor_optical_flow.timestamp;
+		// never integrate past the end of the flow window; the rest belongs to the next frame
+		const hrt_abstime timestamp_newest = sensor_optical_flow.timestamp_sample;
 
 		// delta angle
 		//  - from sensor_optical_flow if available, otherwise use synchronized sensor_gyro if available

--- a/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp
+++ b/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp
@@ -251,10 +251,9 @@ void VehicleOpticalFlow::Run()
 			if (_accumulated_count > 0) {
 				vehicle_optical_flow.integration_timespan_us = _integration_timespan_us;
 
-				// scale quality by the usable share of the window, so a gate on it sees how much was blind
-				const uint64_t total_us = _integration_timespan_us + _rejected_timespan_us;
-				vehicle_optical_flow.quality = static_cast<uint8_t>(
-								       (static_cast<uint64_t>(_quality_sum / _accumulated_count) * _integration_timespan_us) / total_us);
+				// blind frames already left the flow and the timespan; the quality of what
+				// remains is the mean quality of the frames that produced it
+				vehicle_optical_flow.quality = static_cast<uint8_t>(_quality_sum / _accumulated_count);
 
 			} else {
 				// every frame in the window was rejected: report the window blind

--- a/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.hpp
+++ b/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.hpp
@@ -115,6 +115,7 @@ private:
 	matrix::Vector2f _flow_integral{};
 	matrix::Vector3f _delta_angle{};
 	uint32_t _integration_timespan_us{};
+	uint32_t _rejected_timespan_us{};
 	float _distance_sum{NAN};
 	uint8_t _distance_sum_count{0};
 	uint16_t _quality_sum{0};

--- a/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.hpp
+++ b/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.hpp
@@ -135,7 +135,9 @@ private:
 		float data{};
 	};
 
-	RingBuffer<gyroSample, 32> _gyro_buffer{};
+	// A polled zero-motion flow sample ends one frame period before the poll and spans up to the
+	// backup interval, so at 1 kHz the integration window can start ~47 ms before the sample arrives.
+	RingBuffer<gyroSample, 64> _gyro_buffer{};
 	RingBuffer<rangeSample, 5> _range_buffer{};
 
 	DEFINE_PARAMETERS(


### PR DESCRIPTION
## Summary

Keep PAA3905 and PAW3902 running in low light, stop the driver from reading each frame twice, and gate PAA3905 frames on raw SQUAL in every mode.

## Problem

Optical rejection incremented the hardware failure counter: a 102 s PAA3905 night flight recorded 72 resets and 66 s of acquisition gaps. The backup poll was armed at exactly the frame period, shorter than the chip's real period, so in super-low-light mode every frame was read twice: a zero burst just before the MOTION edge and the real counts a few hundred microseconds later. The zero burst went out as a 20 ms zero-flow sample and the real counts inherited a sub-millisecond window (585 of 1331 super-low-light reads in the same log). PAW3902 shares both paths, and its super-low-light switch counter never reset, so non-consecutive bright frames could bounce the mode.

A midday flight over black pavement with raw capture then showed the datasheet false-motion rule rejecting nothing in bright mode (it also needs the shutter at the mode maximum, which never holds in daylight) while the chip reported zero motion on most frames the vehicle moved through. The tracking knee sat at the same raw SQUAL as in super-low-light mode at night, but the per-mode normalization from #28625 mapped it to quality 67 by day and 1 at night, so no single `EKF2_OF_QMIN` could sit on it and the estimator fused frames whose velocity correlated 0.28 with its own.

## Solution

Rejected frames are published blind: quality 0 is reserved for them, they carry zero flow over their own window, and VehicleOpticalFlow keeps that blind time out of the flow, gyro and quality sums while counting it toward the cadence and reports the mean quality of the frames that remain. Quality is raw SQUAL on both drivers, so one `EKF2_OF_QMIN` means the same feature count in every mode; PAA3905 rejects frames below SQUAL 60 regardless of mode or shutter, the edge below which the chip reports noise on every surface flown; between 60 and 85 it tracks at half to four fifths of true speed depending on the surface, which still holds position without GNSS where a blind window aids nothing (a daytime grass flight at 2 m keeps 97 % of its windows at 60 versus 17 % at 85). PAW3902 keeps the datasheet rule until a flight locates its edge. `EKF2_OF_QMIN` defaults to 60, `EKF2_OF_QMAX` to 120, `EKF2_OF_N_MIN` to 0.2 rad/s and `EKF2_OF_N_MAX` to 1.0 rad/s: the noise ramp saturates at the SQUAL this chip actually reports, frames at the floor lean on the IMU, and the best frames match the 0.2 rad/s leftover on kept 8 ms samples. PX4Flow and MAVLink flow sources that use the full 0–255 quality scale should set `EKF2_OF_QMAX` 255. A dark stretch is now distinguishable from a dead sensor and blind frames can no longer dilute good ones. The ARK CAN flow boards default to 50 Hz node-side aggregation instead of one message per chip frame. Separate burst health from optical validity, treating an all-zero burst as dead. Give every backup schedule a quarter-period margin, recognise a read that consumed no frame by its unchanged shutter and quality, and let a polled zero-motion read vouch only for the time up to one frame period before the poll, so the next motion frame keeps its full window. VehicleOpticalFlow holds 64 gyro samples instead of 32 so those windows are still in history at 1 kHz, and it never integrates past the flow sample's own end. The same margin replaces the 1 s post-configure wait. PAW3902 switch counters reset properly and skip the discard frames after a reconfiguration.

Built `ark_can-flow_default`. Host-harness scenario (four stationary 25 ms polls, motion edge at 103 ms) now yields a 23 ms window for the 20.6 ms frame instead of 3 ms, with contiguous windows, and the consumer now integrates exactly those windows (was 10 of 23 ms after the heartbeats consumed later samples). Flown on an ARK Flow MR: 0 resets and no read pairs over two flights; the SQUAL gate at 85 flew once (fusion clean on restart, but blind over daytime grass at 2 m); the floor at 60 with the saturating noise ramp is built and not yet flown.