### PR TITLE
fix(logger): make logger off close the active log file

### DIFF
--- a/docs/en/dev_log/logging.md
+++ b/docs/en/dev_log/logging.md
@@ -16,7 +16,9 @@ A new log file is created for each arming session on the SD card.
 To display the current state, use `logger status` on the console.
 If you want to start logging immediately, use `logger on`.
 This overrides the arming state, as if the system was armed.
-`logger off` undoes this.
+`logger off` stops the current log.
+Logging can start again on the next arming or AUX activation according to `SDLOG_MODE`.
+If `logger off` stops a continuous log, subsequent logs follow arming and disarming until the system reboots.
 
 If logging stops due to a write error, or reaching the [maximum file size](#file-size-limitations), PX4 will automatically restart logging in a new file.
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -163,12 +163,12 @@ int Logger::custom_command(int argc, char *argv[])
 #endif
 
 	if (!strcmp(argv[0], "on")) {
-		get_instance<Logger>(desc)->set_arm_override(true);
+		get_instance<Logger>(desc)->set_manual_logging(true);
 		return 0;
 	}
 
 	if (!strcmp(argv[0], "off")) {
-		get_instance<Logger>(desc)->set_arm_override(false);
+		get_instance<Logger>(desc)->set_manual_logging(false);
 		return 0;
 	}
 
@@ -1130,6 +1130,21 @@ bool Logger::start_stop_logging()
 {
 	bool updated = false;
 	bool desired_state = false;
+	int command = _manual_logging_command.load();
+	const bool manual_command_received = command != (int)ManualLoggingCommand::None
+					     && _manual_logging_command.compare_exchange(&command, (int)ManualLoggingCommand::None);
+
+	if (manual_command_received) {
+		_manual_start_override = command == (int)ManualLoggingCommand::Start;
+		_manual_stop_active = command == (int)ManualLoggingCommand::Stop
+				      && _writer.is_started(LogType::Full, LogWriter::BackendFile);
+
+		// A manually stopped continuous log falls back to arm/disarm logging until reboot.
+		if (_manual_stop_active
+		    && (_log_mode == LogMode::boot_until_shutdown || _log_mode == LogMode::arm_until_shutdown)) {
+			_log_mode = LogMode::while_armed;
+		}
+	}
 
 	if (_log_mode == LogMode::rc_aux1) {
 		// aux1-based logging
@@ -1153,7 +1168,7 @@ bool Logger::start_stop_logging()
 
 			if (full_log_continues) {
 				if ((MissionLogType)_param_sdlog_mission.get() != MissionLogType::Disabled) {
-					if (armed || _manually_logging_override.load()) {
+					if (armed || _manual_start_override) {
 						if (_writer.is_started(LogType::Full, LogWriter::BackendFile)) {
 							start_log_file(LogType::Mission);
 						}
@@ -1174,10 +1189,21 @@ bool Logger::start_stop_logging()
 		}
 	}
 
-	desired_state = desired_state || _manually_logging_override.load();
+	if (manual_command_received) {
+		updated = true;
+	}
+
+	// Suppress automatic restarts until the current arming or AUX logging condition ends.
+	if (updated && !manual_command_received && !desired_state && _manual_stop_active) {
+		_manual_stop_active = false;
+	}
+
+	desired_state = (desired_state || _manual_start_override) && !_manual_stop_active;
+	const bool state_changed = _prev_file_log_start_state != desired_state;
+	const bool stop_requested = manual_command_received && _manual_stop_active;
 
 	// only start/stop if this is a state transition
-	if (updated && _prev_file_log_start_state != desired_state) {
+	if (updated && (state_changed || stop_requested)) {
 		_prev_file_log_start_state = desired_state;
 
 		if (desired_state) {

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -149,7 +149,10 @@ public:
 
 	void print_statistics(LogType type);
 
-	void set_arm_override(bool override) { _manually_logging_override.store(override); }
+	void set_manual_logging(bool enabled)
+	{
+		_manual_logging_command.store(enabled ? (int)ManualLoggingCommand::Start : (int)ManualLoggingCommand::Stop);
+	}
 
 	void trigger_watchdog_now()
 	{
@@ -159,6 +162,11 @@ public:
 	}
 
 private:
+	enum class ManualLoggingCommand {
+		None,
+		Start,
+		Stop,
+	};
 
 	static constexpr int		MAX_MISSION_TOPICS_NUM = 5; /**< Maximum number of mission topics */
 	static constexpr unsigned	MAX_NO_LOGFILE = 999;	/**< Maximum number of log files */
@@ -350,7 +358,9 @@ private:
 	LogFileName					_file_name[(int)LogType::Count];
 
 	bool						_prev_file_log_start_state{false}; ///< previous state depending on logging mode (arming or aux1 state)
-	px4::atomic_bool				_manually_logging_override{false};
+	bool						_manual_start_override{false};
+	bool						_manual_stop_active{false};
+	px4::atomic_int				_manual_logging_command{(int)ManualLoggingCommand::None};
 
 	Statistics					_statistics[(int)LogType::Count];
 	hrt_abstime					_last_sync_time{0}; ///< last time a sync msg was sent


### PR DESCRIPTION
### Solved Problem

`logger off` previously only cleared the manual logging override. It did not close an active log file when logging was still requested by the configured `SDLOG_MODE`. This was particularly visible in continuous logging modes, where logging could continue even after `logger off`.

### Solution

Handle `logger on` and `logger off` as explicit requests so `logger off` closes an active file log without disabling future automatic activations. Continuous logging modes fall back to arm-to-disarm sessions until reboot after their active log is stopped.
The resulting behavior for each mode is:

- `SDLOG_MODE=0`: If `logger off` is called while armed, the current log file is closed and logging remains stopped until disarm. The next arm starts a new log.
- `SDLOG_MODE=1`: `logger off` closes the boot/current log file. The next arm starts a new arm-to-disarm log.
- `SDLOG_MODE=2`: `logger off` closes the boot log file. Until reboot, subsequent arms create arm-to-disarm logs. Reboot restores boot-to-shutdown logging.
- `SDLOG_MODE=3`: If `logger off` is called while AUX is high, current log file is closed and logging remains stopped until AUX goes low. The next AUX low-to-high transition starts a new log.
- `SDLOG_MODE=4`: If a log file is active, `logger off` closes the log file. Until reboot, subsequent arms create arm-to-disarm logs. Reboot restores first-arm-to-shutdown logging.

A new activation (arming or an AUX low-to-high transition) starts logging again as a safeguard in case the user forgets to manually restart logging before the next flight. Therefore, `logger off` stops the current log, but does not permanently disable automatic logging. If the user wants to disable logging for the remainder of the current boot, they should use `logger stop`.

`logger on` remains a persistent manual override and continues logging irrespective of arming, disarming, or AUX state until `logger off`, `logger stop`, or shutdown.

### Changelog Entry

For release notes:
```text
Bugfix: Make `logger off` close the active log file
Documentation: Clarify `logger on` and `logger off` lifecycle behavior
```

### Alternatives

Keep logging disabled after `logger off` until another explicit `logger on`. This was not chosen because a new automatic activation should start logging again, preventing the next flight from being left unlogged unintentionally.

### Test coverage

Tested in SITL:

- Tested `logger on` and `logger off` while active and idle across all `SDLOG_MODE` values.
- Tested repeated arm/disarm cycles and AUX transitions, including restarting mode 3 logging after a new AUX low-to-high transition.
- Verified that `logger on` persists across arm/disarm and AUX state changes.
- Tested full and mission-log lifecycles with mission logging both enabled and disabled.
- Verified continuous-mode fallback and reboot restoration for modes 2 and 4.
- Verified the `SDLOG_BOOT_BAT=1` no-status fallback and that `logger stop` retains its existing behavior.


Additional checks:

- `make px4_sitl_default`
- PX4 AStyle
- `git diff --check`

### Context
This is a behavioral follow-up to #28556.
