### PR TITLE
fix(mavlink): MAV_CMD_EXTERNAL_WIND_ESTIMATE double ACK and wrong ACK

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1732,6 +1732,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 	case vehicle_command_s::VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE:
 	case vehicle_command_s::VEHICLE_CMD_REQUEST_CAMERA_INFORMATION:
 	case vehicle_command_s::VEHICLE_CMD_EXTERNAL_ATTITUDE_ESTIMATE:
+	case vehicle_command_s::VEHICLE_CMD_EXTERNAL_WIND_ESTIMATE:
 	case vehicle_command_s::VEHICLE_CMD_DO_AUTOTUNE_ENABLE:
 	case vehicle_command_s::VEHICLE_CMD_ESTIMATOR_SENSOR_ENABLE:
 	case vehicle_command_s::VEHICLE_CMD_ACTUATOR_GROUP_TEST:

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -182,8 +182,9 @@ public:
 	* @param wind_direction The azimuth (from true north) to where the wind is heading in radians
 	* @param wind_speed_accuracy The 1 sigma accuracy of the wind speed estimate in m/s
 	* @param wind_direction_accuracy The 1 sigma accuracy of the wind direction estimate in radians
+	* @return true if the reset was performed, false if rejected (e.g. vehicle in air)
 	*/
-	void resetWindToExternalObservation(float wind_speed, float wind_direction, float wind_speed_accuracy,
+	bool resetWindToExternalObservation(float wind_speed, float wind_direction, float wind_speed_accuracy,
 					    float wind_direction_accuracy);
 #endif // CONFIG_EKF2_WIND
 

--- a/src/modules/ekf2/EKF/wind.cpp
+++ b/src/modules/ekf2/EKF/wind.cpp
@@ -39,28 +39,30 @@
 #include "ekf.h"
 #include <ekf_derivation/generated/compute_wind_init_and_cov_from_wind_speed_and_direction.h>
 
-void Ekf::resetWindToExternalObservation(float wind_speed, float wind_direction, float wind_speed_accuracy,
+bool Ekf::resetWindToExternalObservation(float wind_speed, float wind_direction, float wind_speed_accuracy,
 		float wind_direction_accuracy)
 {
-	if (!_control_status.flags.in_air) {
-
-		const float wind_speed_constrained = math::max(wind_speed, 0.0f);
-		const float wind_direction_var = sq(wind_direction_accuracy);
-		const float wind_speed_var = sq(wind_speed_accuracy);
-
-		Vector2f wind;
-		Vector2f wind_var;
-
-		sym::ComputeWindInitAndCovFromWindSpeedAndDirection(wind_speed_constrained, wind_direction, wind_speed_var,
-				wind_direction_var, &wind, &wind_var);
-
-		ECL_INFO("reset wind states to external observation");
-		_information_events.flags.reset_wind_to_ext_obs = true;
-		_external_wind_init = true;
-
-		resetWindTo(wind, wind_var);
-
+	if (_control_status.flags.in_air) {
+		return false;
 	}
+
+	const float wind_speed_constrained = math::max(wind_speed, 0.0f);
+	const float wind_direction_var = sq(wind_direction_accuracy);
+	const float wind_speed_var = sq(wind_speed_accuracy);
+
+	Vector2f wind;
+	Vector2f wind_var;
+
+	sym::ComputeWindInitAndCovFromWindSpeedAndDirection(wind_speed_constrained, wind_direction, wind_speed_var,
+			wind_direction_var, &wind, &wind_var);
+
+	ECL_INFO("reset wind states to external observation");
+	_information_events.flags.reset_wind_to_ext_obs = true;
+	_external_wind_init = true;
+
+	resetWindTo(wind, wind_var);
+
+	return true;
 }
 
 void Ekf::resetWindTo(const Vector2f &wind, const Vector2f &wind_var)

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -586,9 +586,15 @@ void EKF2::Run()
 				// PX4 backend expects direction where wind blows TO
 				const float wind_direction_rad = wrap_pi(math::radians(vehicle_command.param3) + M_PI_F);
 				const float wind_direction_accuracy_rad = math::radians(vehicle_command.param4);
-				_ekf.resetWindToExternalObservation(vehicle_command.param1, wind_direction_rad, vehicle_command.param2,
-								    wind_direction_accuracy_rad);
-				command_ack.result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED;
+
+				if (_ekf.resetWindToExternalObservation(vehicle_command.param1, wind_direction_rad, vehicle_command.param2,
+									wind_direction_accuracy_rad)) {
+					command_ack.result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED;
+
+				} else {
+					command_ack.result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED;
+				}
+
 #else
 				command_ack.result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;
 #endif // CONFIG_EKF2_WIND

--- a/src/modules/ekf2/test/test_EKF_airspeed.cpp
+++ b/src/modules/ekf2/test/test_EKF_airspeed.cpp
@@ -304,7 +304,7 @@ TEST_F(EkfAirspeedTest, testExternalWindResetOnGround)
 	const float wind_speed_acc = 2.f;
 	const float wind_direction = math::radians(-90.f);
 	const float wind_direction_acc = math::radians(20.f);
-	_ekf->resetWindToExternalObservation(wind_speed, wind_direction, wind_speed_acc, wind_direction_acc);
+	EXPECT_TRUE(_ekf->resetWindToExternalObservation(wind_speed, wind_direction, wind_speed_acc, wind_direction_acc));
 
 	Vector2f vel_wind_earth = _ekf->getWindVelocity();
 	EXPECT_EQ(wind_speed, vel_wind_earth.norm());
@@ -345,6 +345,32 @@ TEST_F(EkfAirspeedTest, testExternalWindResetOnGround)
 	EXPECT_TRUE(_ekf_wrapper.isIntendingAirspeedFusion());
 	EXPECT_TRUE(_ekf_wrapper.isIntendingBetaFusion());
 	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
+}
+
+TEST_F(EkfAirspeedTest, testExternalWindResetRejectedInAir)
+{
+	// GIVEN: an external wind reset is performed before flight to establish a known wind state
+	const float wind_speed = 4.5f;
+	const float wind_speed_acc = 2.f;
+	const float wind_direction = math::radians(-90.f);
+	const float wind_direction_acc = math::radians(20.f);
+	EXPECT_TRUE(_ekf->resetWindToExternalObservation(wind_speed, wind_direction, wind_speed_acc, wind_direction_acc));
+
+	const Vector2f vel_wind_earth_before = _ekf->getWindVelocity();
+
+	// WHEN: the vehicle is in the air and a new external wind reset is attempted
+	_ekf->set_in_air_status(true);
+	_ekf->set_vehicle_at_rest(false);
+
+	const float wind_speed_new = 10.f;
+	const float wind_direction_new = math::radians(45.f);
+	EXPECT_FALSE(_ekf->resetWindToExternalObservation(wind_speed_new, wind_direction_new, wind_speed_acc,
+			wind_direction_acc));
+
+	// THEN: the wind state is unchanged
+	const Vector2f vel_wind_earth_after = _ekf->getWindVelocity();
+	EXPECT_EQ(vel_wind_earth_before(0), vel_wind_earth_after(0));
+	EXPECT_EQ(vel_wind_earth_before(1), vel_wind_earth_after(1));
 }
 
 TEST_F(EkfAirspeedTest, testExternalPosResetWithCorrelatedPosUncertainty)


### PR DESCRIPTION
Tests showed that 
- MAV_CMD_EXTERNAL_WIND_ESTIMATE  was acking unsupported from commander, because the command wasn't in the "handled elsewhere list".
- It was correctly acking from EKF2 where it is handled, but always with ACCEPTED. In fact it is only accepted on the ground.

This is a claude-generated fix to update both places.
In EFK the command is NACKed with VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED if in-air.
Note that this is a little odd because the system is still getting an estimate from somewhere. However it is MAVLink compliant - "the message did not do what you told it to". This is better because it explains why arbitrary value you sent wasn't obeyed.

Tests show this does remove the double ACK.
