### PR TITLE
feat(uxrce_dds_client): bridge sensor_gps topic to allow GPS injection

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -203,6 +203,9 @@ subscriptions:
   - topic: /fmu/in/actuator_servos
     type: px4_msgs::msg::ActuatorServos
 
+  - topic: /fmu/in/sensor_gps
+    type: px4_msgs::msg::SensorGps
+
   - topic: /fmu/in/fixed_wing_longitudinal_setpoint
     type: px4_msgs::msg::FixedWingLongitudinalSetpoint
 


### PR DESCRIPTION
Subscribing to /fmu/in/sensor_gps lets an off-board ROS 2 node feed GPS
data into the estimator, e.g. from an external receiver or a simulated
source, without a MAVLink detour.

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
