### PR TITLE
fix(fw): scale actuator deflection with min airspeed

### DIFF
--- a/src/modules/fw_rate_control/FixedwingRateControl.cpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.cpp
@@ -303,8 +303,15 @@ void FixedwingRateControl::Run()
 			// Reset integrators if the aircraft is on ground or not in a state where the fw attitude controller is run
 			if (_landed || !_in_fw_or_transition_wo_tailsitter_transition || control_surfaces_locked) {
 
-				_gain_compression.reset();
 				_rate_control.resetIntegral();
+			}
+
+			const bool took_off = _landed_prev && !_landed;
+			_landed_prev = _landed;
+
+			if (took_off || !_in_fw_or_transition_wo_tailsitter_transition || control_surfaces_locked) {
+
+				_gain_compression.reset();
 			}
 
 			// Update saturation status from control allocation feedback

--- a/src/modules/fw_rate_control/FixedwingRateControl.hpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.hpp
@@ -144,6 +144,7 @@ private:
 	float _airspeed_scaling{1.0f};
 
 	bool _landed{true};
+	bool _landed_prev{true};
 
 	float _battery_scale{1.0f};
 


### PR DESCRIPTION
### Solved Problem
So the problem is basically a tradeoff:


• When stall speed is too high you get problem with the airspeed sensor.
• When stall speed is too low the multiplier for the actuator deflection is too high on ground causing big oscillations in the actuator.


### Solution

 the solution is to instead of scaling the deflection with the stall speed(FW_AIRSPD_STALL) we scale it with the minimum speed(FW_AIRSPD_MIN), which is always higher that the stall. 

