### PR TITLE
fix(optical_flow): gate PAA3905 frames on raw SQUAL in every mode

### DIFF
--- a/src/drivers/optical_flow/paa3905/PAA3905.cpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.cpp
@@ -38,43 +38,15 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-// SQUAL below which the datasheet treats a motion report as noise, per
-// operating mode (shared with the false-motion discard, which also requires
-// the shutter condition).
-static constexpr uint8_t SQUAL_THRESHOLD_BRIGHT          = 0x19;
-static constexpr uint8_t SQUAL_THRESHOLD_LOW_LIGHT       = 0x46;
-static constexpr uint8_t SQUAL_THRESHOLD_SUPER_LOW_LIGHT = 0x55;
-
-static constexpr uint8_t squal_threshold(Mode mode)
-{
-	switch (mode) {
-	case Mode::Bright:        return SQUAL_THRESHOLD_BRIGHT;
-
-	case Mode::LowLight:      return SQUAL_THRESHOLD_LOW_LIGHT;
-
-	case Mode::SuperLowLight: return SQUAL_THRESHOLD_SUPER_LOW_LIGHT;
-	}
-
-	return SQUAL_THRESHOLD_SUPER_LOW_LIGHT;
-}
-
-// sensor_optical_flow.quality promises 0 = worst, 255 = best, and EKF2 scales
-// the flow noise linearly with it. Raw SQUAL is mode dependent (the chip's own
-// floor is 25/70/85 across the three modes) and the DroneCAN flow message
-// drops the mode, so the same raw value would mean "solid" in bright light and
-// "one count above noise" in super low light. Map the mode floor to 0 and raw
-// 255 to 255.
-static uint8_t normalize_squal(uint8_t squal, Mode mode)
-{
-	const uint8_t threshold = squal_threshold(mode);
-
-	if (squal <= threshold) {
-		return 0;
-	}
-
-	// 0 is reserved for rejected frames; the threshold itself maps to 1
-	return static_cast<uint8_t>(1u + ((squal - threshold) * 254u) / (255u - threshold));
-}
+// SQUAL is the chip's feature count / 4. Flights over grass at night (mode 2)
+// and black pavement by day (mode 0) put the tracking knee at the same raw
+// value: below it the chip reports zero motion on most frames while the
+// vehicle moves, above it counts match GNSS translation plus gyro at the
+// datasheet scale. The datasheet's per-mode discard rule (SQUAL below 25/70/85
+// while the shutter sits at the mode maximum) never fires in bright light, so
+// it cannot serve as the gate. Quality is published as raw SQUAL so one
+// EKF2_OF_QMIN means the same thing in every mode.
+static constexpr uint8_t SQUAL_TRACKING_FLOOR = 0x55;
 
 PAA3905::PAA3905(const I2CSPIDriverConfig &config) :
 	SPI(config),
@@ -374,12 +346,6 @@ void PAA3905::RunImpl()
 				sensor_optical_flow.min_ground_distance = 0.08f;    // Datasheet: 80mm
 				sensor_optical_flow.max_ground_distance = INFINITY; // Datasheet: infinity
 
-				// check SQUAL & Shutter values
-				// To suppress false motion reports, discard Delta X and Delta Y values if the SQUAL and Shutter values meet the condition
-				// Bright Mode,          SQUAL < 0x19, Shutter ≥ 0x00FF80
-				// Low Light Mode,       SQUAL < 0x46, Shutter ≥ 0x00FF80
-				// Super Low Light Mode, SQUAL < 0x55, Shutter ≥ 0x025998
-
 				// 23-bit Shutter register
 				const uint8_t shutter_lower = buffer.data.Shutter_Lower;
 				const uint8_t shutter_middle = buffer.data.Shutter_Middle;
@@ -395,17 +361,16 @@ void PAA3905::RunImpl()
 						  && (shutter > 0)
 						  && (_discard_reading == 0);
 
+				if (buffer.data.SQUAL < SQUAL_TRACKING_FLOOR) {
+					// the chip is blind on this surface; the frame is reported without flow below
+					data_valid = false;
+					perf_count(_false_motion_perf);
+				}
+
 				switch (_mode) {
 				case Mode::Bright:
 					sensor_optical_flow.integration_timespan_us = SAMPLE_INTERVAL_MODE_0;
 					sensor_optical_flow.mode = sensor_optical_flow_s::MODE_BRIGHT;
-
-					// quality < 25 (0x19) and shutter >= 0x00FF80
-					if ((buffer.data.SQUAL < SQUAL_THRESHOLD_BRIGHT) && (shutter >= 0x00FF80)) {
-						// false motion report, discarding
-						data_valid = false;
-						perf_count(_false_motion_perf);
-					}
 
 					break;
 
@@ -413,25 +378,11 @@ void PAA3905::RunImpl()
 					sensor_optical_flow.integration_timespan_us = SAMPLE_INTERVAL_MODE_1;
 					sensor_optical_flow.mode = sensor_optical_flow_s::MODE_LOWLIGHT;
 
-					// quality < 70 (0x46) and shutter >= 0x00FF80
-					if ((buffer.data.SQUAL < SQUAL_THRESHOLD_LOW_LIGHT) && (shutter >= 0x00FF80)) {
-						// false motion report, discarding
-						data_valid = false;
-						perf_count(_false_motion_perf);
-					}
-
 					break;
 
 				case Mode::SuperLowLight:
 					sensor_optical_flow.integration_timespan_us = SAMPLE_INTERVAL_MODE_2;
 					sensor_optical_flow.mode = sensor_optical_flow_s::MODE_SUPER_LOWLIGHT;
-
-					// quality < 85 (0x55) and shutter >= 0x025998
-					if ((buffer.data.SQUAL < SQUAL_THRESHOLD_SUPER_LOW_LIGHT) && (shutter >= 0x025998)) {
-						// false motion report, discarding
-						data_valid = false;
-						perf_count(_false_motion_perf);
-					}
 
 					break;
 				}
@@ -493,7 +444,7 @@ void PAA3905::RunImpl()
 						sensor_optical_flow.pixel_flow[0] = pixel_flow_rotated(0) * SCALE;
 						sensor_optical_flow.pixel_flow[1] = pixel_flow_rotated(1) * SCALE;
 
-						sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
+						sensor_optical_flow.quality = buffer.data.SQUAL;
 
 						publish = true;
 
@@ -506,7 +457,7 @@ void PAA3905::RunImpl()
 							sensor_optical_flow.pixel_flow[0] = 0;
 							sensor_optical_flow.pixel_flow[1] = 0;
 
-							sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
+							sensor_optical_flow.quality = buffer.data.SQUAL;
 
 							publish = true;
 						}
@@ -517,7 +468,7 @@ void PAA3905::RunImpl()
 
 						if (!publish) {
 							// heartbeat with no new frame: zero flow at the last read's quality
-							sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
+							sensor_optical_flow.quality = buffer.data.SQUAL;
 						}
 
 						sensor_optical_flow.timestamp = hrt_absolute_time();

--- a/src/drivers/optical_flow/paa3905/PAA3905.hpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.hpp
@@ -106,7 +106,7 @@ private:
 	perf_counter_t _bad_register_perf{perf_alloc(PC_COUNT, MODULE_NAME": bad register")};
 	perf_counter_t _bad_transfer_perf{perf_alloc(PC_COUNT, MODULE_NAME": bad transfer")};
 	perf_counter_t _reset_perf{perf_alloc(PC_COUNT, MODULE_NAME": reset")};
-	perf_counter_t _false_motion_perf{perf_alloc(PC_COUNT, MODULE_NAME": false motion report")};
+	perf_counter_t _false_motion_perf{perf_alloc(PC_COUNT, MODULE_NAME": frame below tracking floor")};
 	perf_counter_t _mode_change_bright_perf{perf_alloc(PC_COUNT, MODULE_NAME": mode change bright (0)")};
 	perf_counter_t _mode_change_low_light_perf{perf_alloc(PC_COUNT, MODULE_NAME": mode change low light (1)")};
 	perf_counter_t _mode_change_super_low_light_perf{perf_alloc(PC_COUNT, MODULE_NAME": mode change super low light (2)")};

--- a/src/drivers/optical_flow/paw3902/PAW3902.cpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.cpp
@@ -38,43 +38,13 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-// SQUAL below which the datasheet treats a motion report as noise, per
-// operating mode (shared with the false-motion discard, which also requires
-// the shutter condition).
+// SQUAL thresholds of the datasheet's false-motion discard, per operating
+// mode. Quality is published as raw SQUAL (feature count / 4) so it means the
+// same thing in every mode; the PAA3905 flights that located the tracking knee
+// have no PAW3902 counterpart yet, so this driver keeps the datasheet rule.
 static constexpr uint8_t SQUAL_THRESHOLD_BRIGHT          = 0x19;
 static constexpr uint8_t SQUAL_THRESHOLD_LOW_LIGHT       = 0x46;
 static constexpr uint8_t SQUAL_THRESHOLD_SUPER_LOW_LIGHT = 0x55;
-
-static constexpr uint8_t squal_threshold(Mode mode)
-{
-	switch (mode) {
-	case Mode::Bright:        return SQUAL_THRESHOLD_BRIGHT;
-
-	case Mode::LowLight:      return SQUAL_THRESHOLD_LOW_LIGHT;
-
-	case Mode::SuperLowLight: return SQUAL_THRESHOLD_SUPER_LOW_LIGHT;
-	}
-
-	return SQUAL_THRESHOLD_SUPER_LOW_LIGHT;
-}
-
-// sensor_optical_flow.quality promises 0 = worst, 255 = best, and EKF2 scales
-// the flow noise linearly with it. Raw SQUAL is mode dependent (the chip's own
-// floor is 25/70/85 across the three modes) and the DroneCAN flow message
-// drops the mode, so the same raw value would mean "solid" in bright light and
-// "one count above noise" in super low light. Map the mode floor to 0 and raw
-// 255 to 255.
-static uint8_t normalize_squal(uint8_t squal, Mode mode)
-{
-	const uint8_t threshold = squal_threshold(mode);
-
-	if (squal <= threshold) {
-		return 0;
-	}
-
-	// 0 is reserved for rejected frames; the threshold itself maps to 1
-	return static_cast<uint8_t>(1u + ((squal - threshold) * 254u) / (255u - threshold));
-}
 
 PAW3902::PAW3902(const I2CSPIDriverConfig &config) :
 	SPI(config),
@@ -504,7 +474,7 @@ void PAW3902::RunImpl()
 						sensor_optical_flow.pixel_flow[0] = pixel_flow_rotated(0) * SCALE;
 						sensor_optical_flow.pixel_flow[1] = pixel_flow_rotated(1) * SCALE;
 
-						sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
+						sensor_optical_flow.quality = buffer.data.SQUAL;
 
 						publish = true;
 
@@ -517,7 +487,7 @@ void PAW3902::RunImpl()
 							sensor_optical_flow.pixel_flow[0] = 0;
 							sensor_optical_flow.pixel_flow[1] = 0;
 
-							sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
+							sensor_optical_flow.quality = buffer.data.SQUAL;
 
 							publish = true;
 						}
@@ -528,7 +498,7 @@ void PAW3902::RunImpl()
 
 						if (!publish) {
 							// heartbeat with no new frame: zero flow at the last read's quality
-							sensor_optical_flow.quality = normalize_squal(buffer.data.SQUAL, _mode);
+							sensor_optical_flow.quality = buffer.data.SQUAL;
 						}
 
 						sensor_optical_flow.timestamp = hrt_absolute_time();

--- a/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp
+++ b/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp
@@ -251,10 +251,9 @@ void VehicleOpticalFlow::Run()
 			if (_accumulated_count > 0) {
 				vehicle_optical_flow.integration_timespan_us = _integration_timespan_us;
 
-				// scale quality by the usable share of the window, so a gate on it sees how much was blind
-				const uint64_t total_us = _integration_timespan_us + _rejected_timespan_us;
-				vehicle_optical_flow.quality = static_cast<uint8_t>(
-								       (static_cast<uint64_t>(_quality_sum / _accumulated_count) * _integration_timespan_us) / total_us);
+				// blind frames already left the flow and the timespan; the quality of what
+				// remains is the mean quality of the frames that produced it
+				vehicle_optical_flow.quality = static_cast<uint8_t>(_quality_sum / _accumulated_count);
 
 			} else {
 				// every frame in the window was rejected: report the window blind


### PR DESCRIPTION
## Summary

Publish raw SQUAL as the PixArt flow quality, reject PAA3905 frames below the tracking knee in every mode, and report a window's quality as the mean of the frames that made it. Stacked on #28632.

## Problem

Two flights with raw capture (PAA3905 on an ARK Flow MR, GNSS as truth) put the tracking knee at the same raw SQUAL at night in super-low-light mode and at midday in bright mode over black pavement: below it the chip reports zero motion on most frames while the vehicle moves, above it counts match GNSS translation plus gyro at the datasheet scale. The datasheet's false-motion rule also requires the shutter at its mode maximum, which never holds in daylight, so by day it rejected nothing and the estimator fused frames whose velocity correlated 0.28 with its own. The per-mode normalization from #28625 then mapped that raw knee to quality 67 by day and 1 at night, so no single `EKF2_OF_QMIN` could sit on it.

## Solution

Quality is raw SQUAL on both drivers, so one `EKF2_OF_QMIN` means the same feature count in every mode. PAA3905 rejects frames below the knee regardless of mode or shutter and publishes them blind. VehicleOpticalFlow no longer scales quality by the blind share of the window; blind frames already leave the flow and the timespan, so the mean quality of the remaining frames is the right weight. PAW3902 keeps the datasheet rule until a flight locates its knee. Residuals on kept frames were 0.2 to 0.35 rad/s by day and 0.5 to 0.75 rad/s at night, so `EKF2_OF_QMIN` 85 with the default `EKF2_OF_N_MIN`/`N_MAX` is the matching vehicle setup.