### PR TITLE
fix(tests): avoid float to double promotions in two new test files

### DIFF
--- a/src/modules/navigator/test/test_mission_route_projection.cpp
+++ b/src/modules/navigator/test/test_mission_route_projection.cpp
@@ -949,7 +949,7 @@ TEST_F(RouteSegmentCursorTest, IgnoresInvalidAndUnreadableItemsAfterLand)
 		};
 
 		if (!fail_tail_load) {
-			mission[3].lat = NAN;
+			mission[3].lat = static_cast<double>(NAN);
 		}
 
 		VectorProvider provider = makeRouteProvider(mission);
@@ -1199,7 +1199,7 @@ INSTANTIATE_TEST_SUITE_P(
 	InvalidVehiclePositions,
 	MissionRouteProjectionInvalidVehiclePositionTest,
 	::testing::Values(
-		InvalidVehiclePositionCase{"NonFinite", NAN, kBaseLon},
+		InvalidVehiclePositionCase{"NonFinite", static_cast<double>(NAN), kBaseLon},
 		InvalidVehiclePositionCase{"NullIsland", 0.0, 0.0},
 		InvalidVehiclePositionCase{"LatitudeOutOfRange", 91.0, kBaseLon},
 		InvalidVehiclePositionCase{"LongitudeOutOfRange", kBaseLat, 181.0}

--- a/src/modules/vision_target_estimator/test/TEST_VTE_VisionTargetEst.cpp
+++ b/src/modules/vision_target_estimator/test/TEST_VTE_VisionTargetEst.cpp
@@ -345,7 +345,7 @@ protected:
 		msg.timestamp_sample = timestamp;
 		msg.latitude_deg = lat;
 		msg.longitude_deg = lon;
-		msg.altitude_msl_m = alt_amsl;
+		msg.altitude_msl_m = static_cast<double>(alt_amsl);
 		msg.fix_type = fix_type;
 		ASSERT_TRUE(_uav_gps_pub->publish(msg));
 	}


### PR DESCRIPTION
## Summary

Three casts in two test files so the test suite builds on macOS again.

## Problem

The route projection test assigns the float `NAN` macro to double latitude fields, and the vision target estimator test assigns a float altitude to the double `altitude_msl_m` field. The macOS toolchain rejects both under `-Wdouble-promotion` with `-Werror`, so `make tests` stopped building there after #28248 and #28552, the same way it did before #28516.

## Solution

Cast at the three sites, as the other navigator tests already do. No behaviour change.
