### PR TITLE
chore(tests): apply the review follow-ups from #28516

### DIFF
--- a/cmake/px4_add_gtest.cmake
+++ b/cmake/px4_add_gtest.cmake
@@ -154,10 +154,8 @@ function(px4_add_functional_gtest)
 		# whole-archive so the daemon app-map stubs link even for small
 		# test libs, where link order would otherwise drop them
 		if(APPLE)
-			# ld64 has no --whole-archive, -force_load takes the archive path instead.
-			# test_stubs is also listed as a link library so the executable relinks
-			# when the archive changes: a $<TARGET_FILE:> inside a link flag is only
-			# an order-only dependency and would leave stale stubs in the binary.
+			# ld64 has no --whole-archive, -force_load takes the archive path. test_stubs stays
+			# in the link libraries so the executable relinks when the archive changes.
 			list(APPEND _FUNCTIONAL_GTEST_LIBS test_stubs "-Wl,-force_load,$<TARGET_FILE:test_stubs>")
 		else()
 			list(APPEND _FUNCTIONAL_GTEST_LIBS -Wl,--whole-archive test_stubs -Wl,--no-whole-archive)

--- a/src/lib/cdev/posix/cdev_platform.cpp
+++ b/src/lib/cdev/posix/cdev_platform.cpp
@@ -393,11 +393,10 @@ extern "C" {
 				// Get the current time
 				struct timespec ts;
 #if defined(__PX4_DARWIN) && !defined(ENABLE_LOCKSTEP_SCHEDULER)
-				// macOS has no pthread_condattr_setclock(), so the condition variable
-				// behind px4_sem_t waits on CLOCK_REALTIME (see px4_sem_init()). The
-				// deadline has to be taken from that same clock: CLOCK_MONOTONIC counts
-				// from boot, so passing it here puts the deadline decades in the past and
-				// px4_sem_timedwait() returns ETIMEDOUT immediately instead of waiting.
+				// macOS has no pthread_condattr_setclock(), so px4_sem_t's condition
+				// variable waits on CLOCK_REALTIME (px4_sem_init()). Use that clock here
+				// too. CLOCK_MONOTONIC counts from boot, so the deadline would land
+				// decades in the past and px4_sem_timedwait() would return immediately.
 				px4_clock_gettime(CLOCK_REALTIME, &ts);
 #else
 				// Note, we can't actually use CLOCK_MONOTONIC on macOS

--- a/src/lib/pure_pursuit/PurePursuitTest.cpp
+++ b/src/lib/pure_pursuit/PurePursuitTest.cpp
@@ -150,9 +150,7 @@ TEST(PurePursuitTest, OutOfLookahead)
 				      Vector2f(0.f, 0.f), Vector2f(10.f, 20.f), lookahead_distance);
 
 	EXPECT_NEAR(target_bearing1, M_PI_2_F + M_PI_4_F, FLT_EPSILON); // Fallback: Bearing to closest point on path
-	// -pi and +pi are the same bearing, and which side of the branch cut the arithmetic
-	// lands on is not portable, so compare the wrapped difference instead of the raw value.
-	EXPECT_NEAR(wrap_pi(target_bearing2 - (-M_PI_F)), 0.f, 1e-6f);	// Fallback: Bearing to closest point on path
+	EXPECT_NEAR(fabsf(target_bearing2), M_PI_F, 1e-6f); 	// Fallback: Bearing to closest point on path, +-pi is the same bearing
 	EXPECT_NEAR(target_bearing3, M_PI_F - atan2f(10, 10), FLT_EPSILON); // Fallback: Bearing to previous waypoint
 	EXPECT_NEAR(target_bearing4, -M_PI_F + atan2f(10, 10), FLT_EPSILON); // Fallback: Bearing to current waypoint
 }
@@ -204,8 +202,7 @@ TEST(PurePursuitTest, CurrAndPrevSameNorthCoordinate)
 	EXPECT_NEAR(target_bearing1, M_PI_2_F, FLT_EPSILON);
 	EXPECT_NEAR(target_bearing2, M_PI_2_F + M_PI_4_F, FLT_EPSILON);
 	EXPECT_NEAR(target_bearing3, -(M_PI_2_F + M_PI_4_F), FLT_EPSILON);
-	// See above: compare across the +-pi branch cut with the wrapped difference.
-	EXPECT_NEAR(wrap_pi(target_bearing4 - (-M_PI_F)), 0.f, 1e-6f); // Fallback: Bearing to closest point on path
+	EXPECT_NEAR(fabsf(target_bearing4), M_PI_F, 1e-6f); // Fallback: Bearing to closest point on path, +-pi is the same bearing
 }
 
 TEST(PurePursuitTest, CrosstrackError)

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
@@ -391,11 +391,7 @@ sensor_gps_s GpsBlending::gps_blend_states(float blend_weights[GPS_MAX_RECEIVERS
 	gps_blended_state.vel_e_m_s = 0;
 	gps_blended_state.vel_d_m_s = 0;
 
-	// Accumulate the blended timestamps in double and round once at the end: casting each
-	// weighted term to uint64_t truncates it, which biases the result low by up to one
-	// microsecond per contributing receiver. Dividing by the accumulated weight also removes
-	// the float rounding error in the normalised weights, so receivers reporting an identical
-	// timestamp blend back to exactly that timestamp.
+	// Accumulate in double and round once, truncating each weighted term biases the result low.
 	double blended_timestamp_us = 0.0;
 	double blended_timestamp_sample_us = 0.0;
 	double sum_of_timing_weights = 0.0;

--- a/src/systemcmds/tests/test_uart_send.c
+++ b/src/systemcmds/tests/test_uart_send.c
@@ -81,12 +81,6 @@ int test_uart_send(int argc, char *argv[])
 
 	for (i = 0; i < 30000; i++) {
 		n = snprintf(sample_test_uart, sizeof(sample_test_uart), "SAMPLE #%d\n", i);
-
-		// snprintf() returns the length it would have written, clamp to what fit
-		if (n > (int)sizeof(sample_test_uart) - 1) {
-			n = (int)sizeof(sample_test_uart) - 1;
-		}
-
 		write(test_uart, sample_test_uart, n);
 	}
 


### PR DESCRIPTION
Cosmetic follow-ups from the review on #28516, which merged before they were pushed. The cmake, cdev and gps_blending comments are shorter, the unreachable snprintf clamp in test_uart_send is gone, and the pure pursuit bearing assertions compare the absolute value with a 1e-6 tolerance, which covers both sides of the +-pi cut. No behaviour change.
