### PR TITLE
fix(mavlink): authorize FTP opens by access mode, not by flag bits

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -591,9 +591,10 @@ MavlinkFTP::_workOpen(PayloadHeader *payload, int oflag)
 		}
 
 		// CreateFile and OpenFileWO create or truncate the file as part of the open, so the
-		// effect lands before any write arrives and has to be authorized here.
-		if ((oflag & (O_WRONLY | O_RDWR | O_CREAT | O_TRUNC)) != 0
-		    && !_validatePathIsWritable(_work_buffer1)) {
+		// effect lands before any write arrives and has to be authorized here. Test the
+		// access mode rather than the individual flags: on NuttX O_RDONLY is a bit and
+		// O_RDWR is O_RDONLY | O_WRONLY, so a read-only open would match O_RDWR.
+		if (for_write && !_validatePathIsWritable(_work_buffer1)) {
 			return kErrFailFileProtected;
 		}
 


### PR DESCRIPTION
## Summary

Regression from #28584 on NuttX: every MAVLink FTP `OpenFileRO` outside the storage directory is refused with `File Protected`, so QGC can no longer download the component metadata from `/etc/extras`. SITL is unaffected.

## Problem

The write authorization in `_workOpen()` matched the open flags against `O_WRONLY | O_RDWR | O_CREAT | O_TRUNC`. On Linux `O_RDONLY` is zero and never matches. On NuttX `O_RDONLY` is a bit and `O_RDWR` is `O_RDONLY | O_WRONLY`, so a read-only open matched and was confined to `/fs/microsd`.

## Solution

Decide by the access mode via `O_ACCMODE`, which the function already computes as `for_write`. `CreateFile` and `OpenFileWO` both open with `O_WRONLY`, so the write paths keep the same check.

Not yet tested on hardware; the symptom was seen on an NWBlue Pro H757 over USB and will be verified there.
