### PR TITLE
feat(sensors/vehicle_gps_position): per-receiver baseline rotation SENS_GPSn_ROT

### DIFF
--- a/docs/en/dronecan/ark_rtk_gps.md
+++ b/docs/en/dronecan/ark_rtk_gps.md
@@ -87,6 +87,7 @@ You need to set necessary [DroneCAN](index.md) parameters and define offsets if 
 - If using [Moving Baseline & GPS Heading](#setting-up-moving-baseline-gps-heading), set [SENS_GPS_PRIME](../advanced_config/parameter_reference.md#SENS_GPS_PRIME) to the CAN node ID of the _Moving Base_ module. The moving base is preferred because the rover receiver in a moving baseline configuration can experience degraded navigation rate and increased data latency when corrections are intermittent.
 - Enable [UAVCAN_SUB_GPS](../advanced_config/parameter_reference.md#UAVCAN_SUB_GPS), [UAVCAN_SUB_MAG](../advanced_config/parameter_reference.md#UAVCAN_SUB_MAG), and [UAVCAN_SUB_BARO](../advanced_config/parameter_reference.md#UAVCAN_SUB_BARO).
 - The parameters [SENS_GPS0_OFFX](../advanced_config/parameter_reference.md#SENS_GPS0_OFFX), [SENS_GPS0_OFFY](../advanced_config/parameter_reference.md#SENS_GPS0_OFFY) and [SENS_GPS0_OFFZ](../advanced_config/parameter_reference.md#SENS_GPS0_OFFZ) can be set to account for the offset of the ARK RTK GPS from the vehicles centre of gravity.
+- If using [Moving Baseline & GPS Heading](#setting-up-moving-baseline-gps-heading), set [SENS_GPSn_ROT](../advanced_config/parameter_reference.md#SENS_GPS0_ROT) for the _Rover_ (matched by [SENS_GPSn_ID](../advanced_config/parameter_reference.md#SENS_GPS0_ID)) to `No rotation` if the _Rover_ is in front of the _Moving Base_, `Yaw 90°` if right, `Yaw 180°` if behind, or `Yaw 270°` if left.
 
 ### ARK RTK GPS Configuration
 
@@ -134,7 +135,6 @@ Setup via CAN:
   :::
 - On the _Rover_, set the following:
   - [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) to `3`
-  - [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) to `0` if your _Rover_ is in front of your _Moving Base_, `90` if _Rover_ is right of _Moving Base_, `180` if _Rover_ is behind _Moving Base_, or `270` if _Rover_ is left of _Moving Base_.
   - [CANNODE_SUB_MBD](../advanced_config/parameter_reference.md#CANNODE_SUB_MBD) to `1`.
 - On the _Moving Base_, set the following:
   - [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) to `4`.
@@ -155,7 +155,6 @@ Setup via UART:
 
 - On the _Rover_, set the following:
   - [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) to `1`
-  - [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) to `0` if your _Rover_ is in front of your _Moving Base_, `90` if _Rover_ is right of _Moving Base_, `180` if _Rover_ is behind _Moving Base_, or `270` if _Rover_ is left of _Moving Base_.
 - On the _Moving Base_, set the following:
   - [GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) to `2`.
 - On the _Flight Controller_, set [SENS_GPS_PRIME](../advanced_config/parameter_reference.md#SENS_GPS_PRIME) to the CAN node ID of the _Moving Base_ (see [PX4 Configuration](#px4-configuration)).

--- a/docs/en/dronecan/holybro_h_rtk_zed_f9p_gps.md
+++ b/docs/en/dronecan/holybro_h_rtk_zed_f9p_gps.md
@@ -113,7 +113,7 @@ Then in order to enable the subscription in DroneCAN, enable the following PX4 a
 - [UAVCAN_ENABLE](../advanced_config/parameter_reference.md#UAVCAN_ENABLE): Set to `1` to enable DroneCAN in PX4
 - [EKF2_GPS_CTRL](../advanced_config/parameter_reference.md#EKF2_GPS_CTRL): Set to `15` to enable Dual antenna heading.
 - [UAVCAN_SUB_GPS_R](../advanced_config/parameter_reference.md#UAVCAN_SUB_GPS_R): Set to `1` to enable subscription to GNSS relative.
-- [EKF2_GPS_YAW_OFF](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET): Set to the clockwise angle (degrees) corresponding to base and rover orientation (e.g. 90 degrees when moving base to the left and rover to the right)
+- [SENS_GPSn_ROT](../advanced_config/parameter_reference.md#SENS_GPS0_ROT): Rotation of the baseline from moving base to rover, matched to the receiver by [SENS_GPSn_ID](../advanced_config/parameter_reference.md#SENS_GPS0_ID) (e.g. `Yaw 90°` when the moving base is on the left and the rover on the right)
 
 Once these params are enabled and the F9Ps are mounted to the airframe (assuming valid RTK fix) the LED's on both F9Ps should turn green.
 

--- a/docs/en/dronecan/index.md
+++ b/docs/en/dronecan/index.md
@@ -228,7 +228,7 @@ These parameters can be [set on moving base and rover RTK CAN nodes](#qgc-cannod
 - [CANNODE_PUB_MBD](../advanced_config/parameter_reference.md#CANNODE_PUB_MBD) causes a moving base GPS unit to publish [MovingBaselineData](https://dronecan.github.io/Specification/7._List_of_standard_data_types/#movingbaselinedata)RTCM messages onto the bus (for the rover)
 - [CANNODE_SUB_MBD](../advanced_config/parameter_reference.md#CANNODE_SUB_MBD) tells the rover that it should subscribe to [MovingBaselineData](https://dronecan.github.io/Specification/7._List_of_standard_data_types/#movingbaselinedata) RTCM messages on the bus (from the moving base).
 
-For PX4 you will also need to set [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) to indicate the relative position of the moving base and rover: 0 if your Rover is in front of your Moving Base, 90 if Rover is right of Moving Base, 180 if Rover is behind Moving Base, or 270 if Rover is left of Moving Base.
+On the autopilot, set [SENS_GPSn_ROT](../advanced_config/parameter_reference.md#SENS_GPS0_ROT) for the rover (matched by [SENS_GPSn_ID](../advanced_config/parameter_reference.md#SENS_GPS0_ID)) to the relative position of the moving base and rover: `No rotation` if your Rover is in front of your Moving Base, `Yaw 90°` if Rover is right of Moving Base, `Yaw 180°` if Rover is behind Moving Base, or `Yaw 270°` if Rover is left of Moving Base. A node running older firmware applies its own `GPS_YAW_OFFSET` on top of this; leave that at 0.
 
 #### Barometer
 

--- a/docs/en/gps_compass/rtk_gps.md
+++ b/docs/en/gps_compass/rtk_gps.md
@@ -174,12 +174,13 @@ Generally when using a GNSS as a source of yaw information you will need to conf
 
 | Parameter                        | Setting                                                                                                                                                     |
 | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [GPS_YAW_OFFSET][GPS_YAW_OFFSET] | The angle made by the _baseline_ (the line between the two GPS antennas) relative to the vehicle x-axis (front/back axis, as shown [here][fc_orientation]). |
+| [SENS_GPSn_ROT][SENS_GPSn_ROT]   | Rotation of the _baseline_ (moving base to rover antenna) relative to the vehicle body frame (as shown [here][fc_orientation]), matched to the receiver by [SENS_GPSn_ID][SENS_GPSn_ID]. |
 | [EKF2_GPS_CTRL][EKF2_GPS_CTRL]   | Set bit position 3 "Dual antenna heading" to `1` (i.e. add 8 to the parameter value).                                                                       |
 
 <!-- links used in table above -->
 
-[GPS_YAW_OFFSET]: ../advanced_config/parameter_reference.md#GPS_YAW_OFFSET
+[SENS_GPSn_ROT]: ../advanced_config/parameter_reference.md#SENS_GPS0_ROT
+[SENS_GPSn_ID]: ../advanced_config/parameter_reference.md#SENS_GPS0_ID
 [EKF2_GPS_CTRL]: ../advanced_config/parameter_reference.md#EKF2_GPS_CTRL
 [fc_orientation]: ../config/flight_controller_orientation.md#calculating-orientation
 

--- a/docs/en/gps_compass/rtk_gps_fem_mini2.md
+++ b/docs/en/gps_compass/rtk_gps_fem_mini2.md
@@ -44,7 +44,7 @@ The pins on the 12-pin connector are numbered as shown below.
 ## Configuration
 
 For heading estimation the two antennas need to be on the same level and at least 30 cm apart from each other.
-The direction that they are facing does not matter as it can be configured with the [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) parameter.
+The direction that they are facing does not matter as it can be configured with the [SENS_GPSn_ROT](../advanced_config/parameter_reference.md#SENS_GPS0_ROT) parameter.
 
 Configure the serial port on which the [MINI2 Receiver](http://www.femtomes.com/#/MiniII?type=0) will run using [GPS_1_CONFIG](../advanced_config/parameter_reference.md#GPS_1_CONFIG), and set the baud rate to 115200 using [SER_GPS1_BAUD](../advanced_config/parameter_reference.md#SER_GPS1_BAUD).
 

--- a/docs/en/gps_compass/rtk_gps_holybro_unicore_um982.md
+++ b/docs/en/gps_compass/rtk_gps_holybro_unicore_um982.md
@@ -53,8 +53,7 @@ The Unicore module comes with two antennas, a primary (right connector) and a se
 You will need to set the following parameters:
 
 - [EKF2_GPS_CTRL](../advanced_config/parameter_reference.md#EKF2_GPS_CTRL): Set bit 3 (8) to enable dual antenna heading into the yaw estimation.
-- [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET): Set heading offset to 0 if the primary antenna is in the front.
-  The angle increases clock-wise, so set the offset to 90 degrees if the primary antenna is on the right side of the vehicle (and the secondary on the left side).
+- [SENS_GPSn_ROT](../advanced_config/parameter_reference.md#SENS_GPS0_ROT): Rotation of the baseline from the secondary to the primary antenna. `No rotation` if the primary antenna is in the front, `Yaw 90°` if the primary antenna is on the right side of the vehicle (and the secondary on the left side).
 
 ### RTK Corrections
 

--- a/docs/en/gps_compass/rtk_gps_trimble_mb_two.md
+++ b/docs/en/gps_compass/rtk_gps_trimble_mb_two.md
@@ -53,10 +53,10 @@ The pins on the 28-pin connector are numbered as shown below:
 First set the GPS protocol to Trimble ([GPS_x_PROTOCOL=3](../advanced_config/parameter_reference.md#GPS_1_PROTOCOL)).
 
 For heading estimation the two antennas need to be on the same level and at least 30 cm apart from each other.
-The direction that they are facing does not matter as it can be configured with the [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) parameter.
+The direction that they are facing does not matter as it can be configured with the [SENS_GPSn_ROT](../advanced_config/parameter_reference.md#SENS_GPS0_ROT) parameter.
 
 ::: info
-The `GPS_YAW_OFFSET` is the angle made by the _baseline_ (the line between the two GPS antennas) relative to the vehicle x-axis (front/back axis, as shown [here](../config/flight_controller_orientation.md#calculating-orientation)).
+`SENS_GPSn_ROT` is the rotation of the _baseline_ (the line between the two GPS antennas) relative to the vehicle x-axis (front/back axis, as shown [here](../config/flight_controller_orientation.md#calculating-orientation)), matched to the receiver by `SENS_GPSn_ID`.
 :::
 
 [Configure the serial port](../peripherals/serial_configuration.md) on which the Trimple will run using [GPS_1_CONFIG](../advanced_config/parameter_reference.md#GPS_1_CONFIG), and set the baud rate to 115200 using [SER_GPS1_BAUD](../advanced_config/parameter_reference.md#SER_GPS1_BAUD).

--- a/docs/en/gps_compass/septentrio.md
+++ b/docs/en/gps_compass/septentrio.md
@@ -119,8 +119,7 @@ To switch rover and base in the moving base setup, switch `SEP_PORT1_CFG` and `S
 
 It is important that the antennas are positioned at least 30 cm apart for a stable heading result.
 In a normal setup, the main antenna is behind the auxiliary one.
-If another setup is used, the [SEP_YAW_OFFS](../advanced_config/parameter_reference.md#SEP_YAW_OFFS) value needs to be changed accordingly.
-If the antennas are not at the same height, the [SEP_PITCH_OFFS](../advanced_config/parameter_reference.md#SEP_PITCH_OFFS) value needs to be changed.
+If another setup is used, set [SENS_GPSn_ROT](../advanced_config/parameter_reference.md#SENS_GPS0_ROT) for the receiver accordingly.
 
 ## Logging
 

--- a/docs/en/gps_compass/u-blox_f9p_heading.md
+++ b/docs/en/gps_compass/u-blox_f9p_heading.md
@@ -28,7 +28,7 @@ The following devices are supported:
 Ideally the two antennas should be identical, on the same level/horizontal plane and oriented the same way, and on an identical ground plane size and shape ([Application note](https://content.u-blox.com/sites/default/files/documents/ZED-F9P-MovingBase_AppNote_UBX-19009093.pdf), section _System Level Considerations_).
 
 - The application note does not state the minimal required separation between modules (50cm has been used in test vehicles running PX4).
-- The antennas can be positioned as needed, but the [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) must be configured:
+- The antennas can be positioned as needed, but [SENS_GPSn_ROT](../advanced_config/parameter_reference.md#SENS_GPS0_ROT) must be configured:
   [RTK GPS > GPS as Yaw/Heading Source](../gps_compass/rtk_gps.md#configuring-gps-as-yaw-heading-source).
 
 ### UART Setup
@@ -42,7 +42,7 @@ Ideally the two antennas should be identical, on the same level/horizontal plane
 - Set [GPS_UBX_BAUD1](../advanced_config/parameter_reference.md#GPS_UBX_BAUD1) if a UART1 rate other than the default is required (0 keeps 115200). Use a higher rate for high update rates or when RTCM is sent on UART1 ([GPS_UBX_MODE](../advanced_config/parameter_reference.md#GPS_UBX_MODE) 3/4), and a lower rate on long serial cables.
 - Set [GPS_UBX_BAUD2](../advanced_config/parameter_reference.md#GPS_UBX_BAUD2) if a UART2 rate other than the default (230400) is required. UART2 carries RTCM between the modules in this setup.
 - [EKF2_GPS_CTRL](../advanced_config/parameter_reference.md#EKF2_GPS_CTRL) parameter bit 3 must be set (see [RTK GPS > GPS as Yaw/Heading Source](../gps_compass/rtk_gps.md#configuring-gps-as-yaw-heading-source)).
-- [GPS_YAW_OFFSET](../advanced_config/parameter_reference.md#GPS_YAW_OFFSET) may need to be set (see [RTK GPS > GPS as Yaw/Heading Source](../gps_compass/rtk_gps.md#configuring-gps-as-yaw-heading-source)).
+- [SENS_GPSn_ROT](../advanced_config/parameter_reference.md#SENS_GPS0_ROT) may need to be set (see [RTK GPS > GPS as Yaw/Heading Source](../gps_compass/rtk_gps.md#configuring-gps-as-yaw-heading-source)).
 - Reboot and wait until both devices have GPS reception.
   `gps status` should then show the Main GPS going into RTK mode, which means the heading angle is available.
 

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -239,6 +239,7 @@ set(msg_files
 	VehicleAirData.msg
 	VehicleConstraints.msg
 	VehicleControlMode.msg
+	VehicleGnssHeading.msg
 	VehicleImu.msg
 	VehicleImuStatus.msg
 	VehicleLocalPositionSetpoint.msg

--- a/msg/VehicleGnssHeading.msg
+++ b/msg/VehicleGnssHeading.msg
@@ -1,0 +1,12 @@
+# Validated GNSS heading from dual-antenna / moving baseline receiver pair.
+# Published by the sensors module after selecting and validating heading from sensor_gnss_relative
+# or falling back to sensor_gps heading fields. Consumed by EKF2 independently from position/velocity.
+
+uint64 timestamp              # time since system start (microseconds)
+uint64 timestamp_sample       # time since system start (microseconds) - actual measurement time
+
+uint32 device_id              # unique device ID for the sensor that does not change between power cycles
+
+float32 heading               # NED heading from dual antenna array (rad, [-PI, PI])
+float32 heading_accuracy      # 1-sigma heading accuracy (rad)
+float32 heading_offset        # body-frame offset of antenna array (rad, [-PI, PI])

--- a/src/drivers/gnss/septentrio/module.yaml
+++ b/src/drivers/gnss/septentrio/module.yaml
@@ -54,26 +54,6 @@ parameters:
           2: 20 Hz
           3: 25 Hz
         reboot_required: true
-      SEP_YAW_OFFS:
-        description:
-          short: Heading/Yaw offset for dual antenna GPS
-          long: |
-            Heading offset angle for dual antenna GPS setups that support heading estimation.
-
-            Set this to 0 if the antennas are parallel to the forward-facing direction
-            of the vehicle and the rover antenna is in front.
-
-            The offset angle increases clockwise.
-
-            Set this to 90 if the rover antenna is placed on the
-            right side of the vehicle and the moving base antenna is on the left side.
-        type: float
-        decimal: 3
-        default: 0
-        min: -360
-        max: 360
-        unit: deg
-        reboot_required: true
       SEP_SAT_INFO:
         description:
           short: Enable sat info
@@ -81,23 +61,6 @@ parameters:
             Enable publication of satellite info (ORB_ID(satellite_info)) if possible.
         type: boolean
         default: 0
-        reboot_required: true
-      SEP_PITCH_OFFS:
-        description:
-          short: Pitch offset for dual antenna GPS
-          long: |
-            Vertical offsets can be compensated for by adjusting the Pitch offset.
-
-            Note that this can be interpreted as the "roll" angle in case the antennas are aligned along the perpendicular axis.
-            This occurs in situations where the two antenna ARPs may not be exactly at the same height in the vehicle reference frame.
-            Since pitch is defined as the right-handed rotation about the vehicle Y axis,
-            a situation where the main antenna is mounted lower than the aux antenna (assuming the default antenna setup) will result in a positive pitch.
-        type: float
-        decimal: 3
-        default: 0
-        min: -90
-        max: 90
-        unit: deg
         reboot_required: true
       SEP_DUMP_COMM:
         description:

--- a/src/drivers/gnss/septentrio/septentrio.cpp
+++ b/src/drivers/gnss/septentrio/septentrio.cpp
@@ -164,9 +164,6 @@ SeptentrioDriver::SeptentrioDriver(const char *device_path, Instance instance, u
 		_message_satellite_info = new satellite_info_s();
 	}
 
-	get_parameter("SEP_YAW_OFFS", &_heading_offset);
-	get_parameter("SEP_PITCH_OFFS", &_pitch_offset);
-
 	int32_t dump_mode {0};
 	get_parameter("SEP_DUMP_COMM", &dump_mode);
 	DumpMode mode = static_cast<DumpMode>(dump_mode);
@@ -956,8 +953,9 @@ SeptentrioDriver::ConfigureResult SeptentrioDriver::configure()
 		return ConfigureResult::FailedCompletely;
 	}
 
-	// Specify the offsets that the receiver applies to the computed attitude angles.
-	snprintf(msg, sizeof(msg), k_command_set_attitude_offset, static_cast<double>(_heading_offset), static_cast<double>(_pitch_offset));
+	// Receiver-side attitude offsets are zeroed so the reported heading is the raw baseline; the mounting rotation is
+	// applied from SENS_GPSn_ROT.
+	snprintf(msg, sizeof(msg), k_command_set_attitude_offset, 0.0, 0.0);
 
 	if (!send_message_and_wait_for_ack(msg, k_receiver_ack_timeout_fast)) {
 		return ConfigureResult::FailedCompletely;
@@ -1910,7 +1908,7 @@ void SeptentrioDriver::reset_gps_state_message()
 {
 	memset(&_sensor_gps, 0, sizeof(_sensor_gps));
 	_sensor_gps.heading = NAN;
-	_sensor_gps.heading_offset = matrix::wrap_pi(math::radians(_heading_offset));
+	_sensor_gps.heading_offset = NAN;
 }
 
 uint32_t SeptentrioDriver::get_parameter(const char *name, int32_t *value)

--- a/src/drivers/gnss/septentrio/septentrio.h
+++ b/src/drivers/gnss/septentrio/septentrio.h
@@ -763,8 +763,6 @@ private:
 	hrt_abstime                            _time_last_resilience_received{0};			     ///< Time of last resilience message reception
 
 	// Module configuration
-	float                                  _heading_offset {0.0f};                                       ///< The heading offset given by the `SEP_YAW_OFFS` parameter
-	float                                  _pitch_offset {0.0f};                                         ///< The pitch offset given by the `SEP_PITCH_OFFS` parameter
 	uint32_t                               _receiver_stream_main {k_default_main_stream};                ///< The main output stream for the receiver given by the `SEP_STREAM_MAIN` parameter
 	uint32_t                               _receiver_stream_log {k_default_log_stream};                  ///< The log output stream for the receiver given by the `SEP_STREAM_LOG` parameter
 	SBFOutputFrequency                     _sbf_output_frequency {SBFOutputFrequency::Hz5_0};            ///< Output frequency of the main SBF blocks given by the `SEP_OUTP_HZ` parameter

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -922,13 +922,7 @@ void GPS::dumpGpsData(const uint8_t *data, size_t len, gps_dump_comm_mode_t mode
 void
 GPS::run()
 {
-	param_t handle = param_find("GPS_YAW_OFFSET");
-	float heading_offset = 0.f;
-
-	if (handle != PARAM_INVALID) {
-		param_get(handle, &heading_offset);
-		heading_offset = matrix::wrap_pi(math::radians(heading_offset));
-	}
+	param_t handle = PARAM_INVALID;
 
 #if defined(CONFIG_GPS_UBX)
 
@@ -1155,7 +1149,7 @@ GPS::run()
 					.min_cno = (uint8_t)gps_ubx_min_cno,
 					.min_elev = (int8_t)gps_ubx_min_elev,
 					.output_rate = (uint8_t)gps_ubx_rate,
-					.heading_offset = heading_offset,
+					.heading_offset = 0.f,
 					.uart1_baudrate = ubx_uart1_baudrate,
 					.uart2_baudrate = f9p_uart2_baudrate,
 					.ppk_output = ppk_output > 0,
@@ -1180,7 +1174,7 @@ GPS::run()
 #if defined(CONFIG_GPS_ASHTECH)
 
 		case gps_driver_mode_t::ASHTECH:
-			_helper = new GPSDriverAshtech(&GPS::callback, this, &_sensor_gps, _p_report_sat_info, heading_offset);
+			_helper = new GPSDriverAshtech(&GPS::callback, this, &_sensor_gps, _p_report_sat_info);
 			set_device_type(DRV_GPS_DEVTYPE_ASHTECH);
 			break;
 #endif // CONFIG_GPS_ASHTECH
@@ -1194,14 +1188,14 @@ GPS::run()
 #if defined(CONFIG_GPS_FEMTOMES)
 
 		case gps_driver_mode_t::FEMTOMES:
-			_helper = new GPSDriverFemto(&GPS::callback, this, &_sensor_gps, _p_report_sat_info, heading_offset);
+			_helper = new GPSDriverFemto(&GPS::callback, this, &_sensor_gps, _p_report_sat_info);
 			set_device_type(DRV_GPS_DEVTYPE_FEMTOMES);
 			break;
 #endif // CONFIG_GPS_FEMTOMES
 #if defined(CONFIG_GPS_NMEA)
 
 		case gps_driver_mode_t::NMEA:
-			_helper = new GPSDriverNMEA(&GPS::callback, this, &_sensor_gps, _p_report_sat_info, heading_offset);
+			_helper = new GPSDriverNMEA(&GPS::callback, this, &_sensor_gps, _p_report_sat_info);
 			set_device_type(DRV_GPS_DEVTYPE_NMEA);
 			break;
 #endif // CONFIG_GPS_NMEA
@@ -1248,7 +1242,7 @@ GPS::run()
 			/* reset report */
 			memset(&_sensor_gps, 0, sizeof(_sensor_gps));
 			_sensor_gps.heading = NAN;
-			_sensor_gps.heading_offset = heading_offset;
+			_sensor_gps.heading_offset = NAN; // raw baseline heading, rotated into the body frame by SENS_GPSn_ROT
 
 #if defined(CONFIG_GPS_UBX)
 
@@ -1695,6 +1689,12 @@ GPS::publishRelativePosition(sensor_gnss_relative_s &gnss_relative)
 {
 	gnss_relative.device_id = get_device_id();
 	gnss_relative.timestamp = hrt_absolute_time();
+
+	// the receiver latency is applied downstream; a sample time equal to the publish time marks it as unset
+	if (gnss_relative.timestamp_sample == 0) {
+		gnss_relative.timestamp_sample = gnss_relative.timestamp;
+	}
+
 	_sensor_gnss_relative_pub.publish(gnss_relative);
 }
 

--- a/src/drivers/gps/params.yaml
+++ b/src/drivers/gps/params.yaml
@@ -209,30 +209,6 @@ parameters:
       type: boolean
       default: 0
       reboot_required: true
-    GPS_YAW_OFFSET:
-      description:
-        short: Heading/Yaw offset for dual antenna GPS
-        long: |-
-          Heading offset angle for dual antenna GPS setups that support heading estimation.
-
-          Set this to 0 if the antennas are parallel to the forward-facing direction
-          of the vehicle and the rover (or Unicore primary) antenna is in front.
-
-          The offset angle increases clockwise.
-
-          Set this to 90 if the rover (or Unicore primary, or Septentrio Mosaic Aux)
-          antenna is placed on the right side of the vehicle and the moving base
-          antenna is on the left side.
-
-          (Note: the Unicore primary antenna is the one connected on the right as seen
-          from the top).
-      type: float
-      default: 0.0
-      min: 0
-      max: 360
-      unit: deg
-      reboot_required: true
-      decimal: 3
     GPS_1_PROTOCOL:
       description:
         short: Protocol for Main GPS

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_yaw_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_yaw_control.cpp
@@ -45,7 +45,7 @@
 
 #include <ekf_derivation/generated/compute_gnss_yaw_pred_innov_var_and_h.h>
 
-void Ekf::controlGnssYawFusion(const gnssSample &gnss_sample)
+void Ekf::controlGnssYawFusion(const gnssYawSample &gnss_yaw_sample)
 {
 	if (!(_params.ekf2_gps_ctrl & static_cast<int32_t>(GnssCtrl::YAW))
 	    || _control_status.flags.gnss_yaw_fault) {
@@ -54,11 +54,11 @@ void Ekf::controlGnssYawFusion(const gnssSample &gnss_sample)
 		return;
 	}
 
-	const bool is_new_data_available = PX4_ISFINITE(gnss_sample.yaw);
+	const bool is_new_data_available = PX4_ISFINITE(gnss_yaw_sample.yaw);
 
 	if (is_new_data_available) {
 
-		updateGnssYaw(gnss_sample);
+		updateGnssYaw(gnss_yaw_sample);
 
 		const bool continuing_conditions_passing = _control_status.flags.tilt_align;
 
@@ -67,13 +67,12 @@ void Ekf::controlGnssYawFusion(const gnssSample &gnss_sample)
 
 		const bool starting_conditions_passing = continuing_conditions_passing
 				&& _gnss_checks.passed()
-				&& !is_gnss_yaw_data_intermittent
-				&& !_gps_intermittent;
+				&& !is_gnss_yaw_data_intermittent;
 
 		if (_control_status.flags.gnss_yaw) {
 			if (continuing_conditions_passing) {
 
-				fuseGnssYaw(gnss_sample.yaw_offset);
+				fuseGnssYaw(gnss_yaw_sample.yaw_offset);
 
 				const bool is_fusion_failing = isTimedOut(_aid_src_gnss_yaw.time_last_fuse, _params.reset_timeout_max);
 
@@ -102,7 +101,7 @@ void Ekf::controlGnssYawFusion(const gnssSample &gnss_sample)
 				    || !isNorthEastAidingActive()) {
 
 					// Reset before starting the fusion
-					if (resetYawToGnss(gnss_sample.yaw, gnss_sample.yaw_offset)) {
+					if (resetYawToGnss(gnss_yaw_sample.yaw, gnss_yaw_sample.yaw_offset)) {
 
 						resetAidSourceStatusZeroInnovation(_aid_src_gnss_yaw);
 
@@ -113,7 +112,7 @@ void Ekf::controlGnssYawFusion(const gnssSample &gnss_sample)
 				} else if (!_aid_src_gnss_yaw.innovation_rejected) {
 					// Do not force a reset but wait for the consistency check to pass
 					_control_status.flags.gnss_yaw = true;
-					fuseGnssYaw(gnss_sample.yaw_offset);
+					fuseGnssYaw(gnss_yaw_sample.yaw_offset);
 				}
 
 				if (_control_status.flags.gnss_yaw) {
@@ -122,31 +121,26 @@ void Ekf::controlGnssYawFusion(const gnssSample &gnss_sample)
 			}
 		}
 
-	} else if (_control_status.flags.gnss_yaw
-		   && !isNewestSampleRecent(_time_last_gnss_yaw_buffer_push, _params.reset_timeout_max)) {
-
-		// No yaw data in the message anymore. Stop until it comes back.
-		stopGnssYawFusion();
 	}
 }
 
-void Ekf::updateGnssYaw(const gnssSample &gnss_sample)
+void Ekf::updateGnssYaw(const gnssYawSample &gnss_yaw_sample)
 {
 	// calculate the observed yaw angle of antenna array, converting a from body to antenna yaw measurement
-	const float measured_hdg = wrap_pi(gnss_sample.yaw + gnss_sample.yaw_offset);
+	const float measured_hdg = wrap_pi(gnss_yaw_sample.yaw + gnss_yaw_sample.yaw_offset);
 
-	const float yaw_acc = PX4_ISFINITE(gnss_sample.yaw_acc) ? gnss_sample.yaw_acc : 0.f;
+	const float yaw_acc = PX4_ISFINITE(gnss_yaw_sample.yaw_acc) ? gnss_yaw_sample.yaw_acc : 0.f;
 	const float R_YAW = sq(fmaxf(yaw_acc, _params.gnss_heading_noise));
 
 	float heading_pred;
 	float heading_innov_var;
 
 	VectorState H;
-	sym::ComputeGnssYawPredInnovVarAndH(_state.vector(), P, gnss_sample.yaw_offset, R_YAW, FLT_EPSILON,
+	sym::ComputeGnssYawPredInnovVarAndH(_state.vector(), P, gnss_yaw_sample.yaw_offset, R_YAW, FLT_EPSILON,
 					    &heading_pred, &heading_innov_var, &H);
 
 	updateAidSourceStatus(_aid_src_gnss_yaw,
-			      gnss_sample.time_us,                          // sample timestamp
+			      gnss_yaw_sample.time_us,                      // sample timestamp
 			      measured_hdg,                                // observation
 			      R_YAW,                                       // observation variance
 			      wrap_pi(heading_pred - measured_hdg),        // innovation

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_yaw_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_yaw_control.cpp
@@ -54,73 +54,69 @@ void Ekf::controlGnssYawFusion(const gnssYawSample &gnss_yaw_sample)
 		return;
 	}
 
-	const bool is_new_data_available = PX4_ISFINITE(gnss_yaw_sample.yaw);
+	updateGnssYaw(gnss_yaw_sample);
 
-	if (is_new_data_available) {
+	const bool continuing_conditions_passing = _control_status.flags.tilt_align;
 
-		updateGnssYaw(gnss_yaw_sample);
+	const bool is_gnss_yaw_data_intermittent = !isNewestSampleRecent(_time_last_gnss_yaw_buffer_push,
+			2 * GNSS_YAW_MAX_INTERVAL);
 
-		const bool continuing_conditions_passing = _control_status.flags.tilt_align;
+	// The position checks are kept as a start gate: they cover receiver-level health (fix, spoofing, jamming) and,
+	// through their reset in stopGnssFusion(), enforce the on-ground hold-off after a yaw fault.
+	const bool starting_conditions_passing = continuing_conditions_passing
+			&& _gnss_checks.passed()
+			&& !is_gnss_yaw_data_intermittent;
 
-		const bool is_gnss_yaw_data_intermittent = !isNewestSampleRecent(_time_last_gnss_yaw_buffer_push,
-				2 * GNSS_YAW_MAX_INTERVAL);
+	if (_control_status.flags.gnss_yaw) {
+		if (continuing_conditions_passing) {
 
-		const bool starting_conditions_passing = continuing_conditions_passing
-				&& _gnss_checks.passed()
-				&& !is_gnss_yaw_data_intermittent;
+			fuseGnssYaw(gnss_yaw_sample.yaw_offset);
 
-		if (_control_status.flags.gnss_yaw) {
-			if (continuing_conditions_passing) {
+			const bool is_fusion_failing = isTimedOut(_aid_src_gnss_yaw.time_last_fuse, _params.reset_timeout_max);
 
-				fuseGnssYaw(gnss_yaw_sample.yaw_offset);
-
-				const bool is_fusion_failing = isTimedOut(_aid_src_gnss_yaw.time_last_fuse, _params.reset_timeout_max);
-
-				if (is_fusion_failing) {
-					stopGnssYawFusion();
-
-					// Before takeoff, we do not want to continue to rely on the current heading
-					// if we had to stop the fusion
-					if (!_control_status.flags.in_air) {
-						ECL_INFO("clearing yaw alignment");
-						_control_status.flags.yaw_align = false;
-					}
-				}
-
-			} else {
-				// Stop GNSS yaw fusion but do not declare it faulty
+			if (is_fusion_failing) {
 				stopGnssYawFusion();
+
+				// Before takeoff, we do not want to continue to rely on the current heading
+				// if we had to stop the fusion
+				if (!_control_status.flags.in_air) {
+					ECL_INFO("clearing yaw alignment");
+					_control_status.flags.yaw_align = false;
+				}
 			}
 
 		} else {
-			if (starting_conditions_passing) {
-				// Try to activate GNSS yaw fusion
-
-				if (!_control_status.flags.in_air
-				    || !_control_status.flags.yaw_align
-				    || !isNorthEastAidingActive()) {
-
-					// Reset before starting the fusion
-					if (resetYawToGnss(gnss_yaw_sample.yaw, gnss_yaw_sample.yaw_offset)) {
-
-						resetAidSourceStatusZeroInnovation(_aid_src_gnss_yaw);
-
-						_control_status.flags.gnss_yaw = true;
-						_control_status.flags.yaw_align = true;
-					}
-
-				} else if (!_aid_src_gnss_yaw.innovation_rejected) {
-					// Do not force a reset but wait for the consistency check to pass
-					_control_status.flags.gnss_yaw = true;
-					fuseGnssYaw(gnss_yaw_sample.yaw_offset);
-				}
-
-				if (_control_status.flags.gnss_yaw) {
-					ECL_INFO("starting GNSS yaw fusion");
-				}
-			}
+			// Stop GNSS yaw fusion but do not declare it faulty
+			stopGnssYawFusion();
 		}
 
+	} else {
+		if (starting_conditions_passing) {
+			// Try to activate GNSS yaw fusion
+
+			if (!_control_status.flags.in_air
+			    || !_control_status.flags.yaw_align
+			    || !isNorthEastAidingActive()) {
+
+				// Reset before starting the fusion
+				if (resetYawToGnss(gnss_yaw_sample.yaw, gnss_yaw_sample.yaw_offset)) {
+
+					resetAidSourceStatusZeroInnovation(_aid_src_gnss_yaw);
+
+					_control_status.flags.gnss_yaw = true;
+					_control_status.flags.yaw_align = true;
+				}
+
+			} else if (!_aid_src_gnss_yaw.innovation_rejected) {
+				// Do not force a reset but wait for the consistency check to pass
+				_control_status.flags.gnss_yaw = true;
+				fuseGnssYaw(gnss_yaw_sample.yaw_offset);
+			}
+
+			if (_control_status.flags.gnss_yaw) {
+				ECL_INFO("starting GNSS yaw fusion");
+			}
+		}
 	}
 }
 

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
@@ -96,12 +96,26 @@ void Ekf::controlGpsFusion(const imuSample &imu_delayed)
 		}
 	}
 
-	if (_gps_data_ready) {
+	// GNSS yaw fusion - independent of position/velocity quality gates
 #if defined(CONFIG_EKF2_GNSS_YAW)
-		const gnssSample &gnss_sample = _gps_sample_delayed;
-		controlGnssYawFusion(gnss_sample);
+
+	if (_gnss_yaw_buffer) {
+		const bool gnss_yaw_data_ready = _gnss_yaw_buffer->pop_first_older_than(imu_delayed.time_us,
+						 &_gnss_yaw_sample_delayed);
+
+		if (gnss_yaw_data_ready) {
+			controlGnssYawFusion(_gnss_yaw_sample_delayed);
+
+		} else if (_control_status.flags.gnss_yaw
+			   && !isNewestSampleRecent(_time_last_gnss_yaw_buffer_push, _params.reset_timeout_max)) {
+			// No yaw data arriving -- stop fusion
+			stopGnssYawFusion();
+		}
+	}
+
 #endif // CONFIG_EKF2_GNSS_YAW
 
+	if (_gps_data_ready) {
 		controlGnssYawEstimator(_aid_src_gnss_vel);
 
 		bool do_vel_pos_reset = false;

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -200,12 +200,16 @@ struct gnssSample {
 	uint8_t     fix_type{};   ///< 0-1: no fix, 2: 2D fix, 3: 3D fix, 4: RTCM code differential, 5: Real-Time
 	uint8_t     nsats{};      ///< number of satellites used
 	float       pdop{};       ///< position dilution of precision
-	float       yaw{};        ///< yaw angle. NaN if not set (used for dual antenna GPS), (rad, [-PI, PI])
-	float       yaw_acc{};    ///< 1-std yaw error (rad)
-	float       yaw_offset{}; ///< Heading/Yaw offset for dual antenna GPS - refer to description for GPS_YAW_OFFSET
 	bool        spoofed{};    ///< true if GNSS data is spoofed
 	bool        jammed{};     ///< true if GNSS data is jammed
 	Vector3f    pos_body{};   ///< position of GPS antenna in body frame (m)
+};
+
+struct gnssYawSample {
+	uint64_t    time_us{};    ///< timestamp of the measurement (uSec)
+	float       yaw{NAN};     ///< yaw angle from dual antenna GNSS (rad, [-PI, PI]); NAN indicates no measurement
+	float       yaw_acc{NAN}; ///< 1-std yaw error (rad); NAN indicates accuracy not provided
+	float       yaw_offset{}; ///< Heading/Yaw offset for dual antenna GPS - refer to description for GPS_YAW_OFFSET
 };
 
 struct magSample {

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -209,7 +209,7 @@ struct gnssYawSample {
 	uint64_t    time_us{};    ///< timestamp of the measurement (uSec)
 	float       yaw{};        ///< yaw angle from dual antenna GNSS (rad, [-PI, PI])
 	float       yaw_acc{};    ///< 1-std yaw error (rad); NAN if not provided
-	float       yaw_offset{}; ///< Heading/Yaw offset for dual antenna GPS - refer to description for GPS_YAW_OFFSET
+	float       yaw_offset{}; ///< yaw of the antenna baseline in the body frame (rad)
 };
 
 struct magSample {

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -207,8 +207,8 @@ struct gnssSample {
 
 struct gnssYawSample {
 	uint64_t    time_us{};    ///< timestamp of the measurement (uSec)
-	float       yaw{NAN};     ///< yaw angle from dual antenna GNSS (rad, [-PI, PI]); NAN indicates no measurement
-	float       yaw_acc{NAN}; ///< 1-std yaw error (rad); NAN indicates accuracy not provided
+	float       yaw{};        ///< yaw angle from dual antenna GNSS (rad, [-PI, PI])
+	float       yaw_acc{};    ///< 1-std yaw error (rad); NAN if not provided
 	float       yaw_offset{}; ///< Heading/Yaw offset for dual antenna GPS - refer to description for GPS_YAW_OFFSET
 };
 

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -945,7 +945,7 @@ private:
 	bool isGnssHgtResetAllowed();
 
 # if defined(CONFIG_EKF2_GNSS_YAW)
-	void controlGnssYawFusion(const gnssSample &gps_sample);
+	void controlGnssYawFusion(const gnssYawSample &gnss_yaw_sample);
 	void stopGnssYawFusion();
 
 	// fuse the yaw angle obtained from a dual antenna GPS unit
@@ -955,7 +955,7 @@ private:
 	// return true if the reset was successful
 	bool resetYawToGnss(float gnss_yaw, float gnss_yaw_offset);
 
-	void updateGnssYaw(const gnssSample &gps_sample);
+	void updateGnssYaw(const gnssYawSample &gnss_yaw_sample);
 
 # endif // CONFIG_EKF2_GNSS_YAW
 

--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -48,6 +48,9 @@ EstimatorInterface::~EstimatorInterface()
 {
 #if defined(CONFIG_EKF2_GNSS)
 	delete _gps_buffer;
+# if defined(CONFIG_EKF2_GNSS_YAW)
+	delete _gnss_yaw_buffer;
+# endif // CONFIG_EKF2_GNSS_YAW
 #endif // CONFIG_EKF2_GNSS
 #if defined(CONFIG_EKF2_MAGNETOMETER)
 	delete _mag_buffer;
@@ -192,19 +195,47 @@ void EstimatorInterface::setGpsData(const gnssSample &gnss_sample)
 		_gps_buffer->push(gnss_sample_new);
 		_time_last_gps_buffer_push = _time_latest_us;
 
-#if defined(CONFIG_EKF2_GNSS_YAW)
-
-		if (PX4_ISFINITE(gnss_sample.yaw)) {
-			_time_last_gnss_yaw_buffer_push = _time_latest_us;
-		}
-
-#endif // CONFIG_EKF2_GNSS_YAW
-
 	} else {
 		ECL_WARN("GPS data too fast %" PRIi64 " < %" PRIu64 " + %d", time_us, _gps_buffer->get_newest().time_us,
 			 _min_obs_interval_us);
 	}
 }
+
+#if defined(CONFIG_EKF2_GNSS_YAW)
+void EstimatorInterface::setGnssYawData(const gnssYawSample &gnss_yaw_sample)
+{
+	if (!_initialised) {
+		return;
+	}
+
+	if (_gnss_yaw_buffer == nullptr) {
+		_gnss_yaw_buffer = new TimestampedRingBuffer<gnssYawSample>(_obs_buffer_length);
+
+		if (_gnss_yaw_buffer == nullptr || !_gnss_yaw_buffer->valid()) {
+			delete _gnss_yaw_buffer;
+			_gnss_yaw_buffer = nullptr;
+			printBufferAllocationFailed("GNSS yaw");
+			return;
+		}
+	}
+
+	const int64_t time_us = gnss_yaw_sample.time_us - static_cast<int64_t>(_dt_ekf_avg * 5e5f);
+
+	if (time_us >= static_cast<int64_t>(_gnss_yaw_buffer->get_newest().time_us + _min_obs_interval_us)) {
+
+		gnssYawSample sample_new(gnss_yaw_sample);
+		sample_new.time_us = time_us;
+
+		_gnss_yaw_buffer->push(sample_new);
+		_time_last_gnss_yaw_buffer_push = _time_latest_us;
+
+	} else {
+		ECL_WARN("GNSS yaw data too fast %" PRIi64 " < %" PRIu64 " + %d", time_us,
+			 _gnss_yaw_buffer->get_newest().time_us, _min_obs_interval_us);
+	}
+}
+#endif // CONFIG_EKF2_GNSS_YAW
+
 #endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_BAROMETER)

--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -204,7 +204,7 @@ void EstimatorInterface::setGpsData(const gnssSample &gnss_sample)
 #if defined(CONFIG_EKF2_GNSS_YAW)
 void EstimatorInterface::setGnssYawData(const gnssYawSample &gnss_yaw_sample)
 {
-	if (!_initialised) {
+	if (!_initialised || !PX4_ISFINITE(gnss_yaw_sample.yaw)) {
 		return;
 	}
 

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -93,6 +93,10 @@ public:
 
 	const gnssSample &get_gps_sample_delayed() const { return _gps_sample_delayed; }
 
+# if defined(CONFIG_EKF2_GNSS_YAW)
+	void setGnssYawData(const gnssYawSample &gnss_yaw_sample);
+# endif // CONFIG_EKF2_GNSS_YAW
+
 	float gps_horizontal_position_drift_rate_m_s() const { return _gnss_checks.horizontal_position_drift_rate_m_s(); }
 	float gps_vertical_position_drift_rate_m_s() const { return _gnss_checks.vertical_position_drift_rate_m_s(); }
 	float gps_filtered_horizontal_velocity_m_s() const { return _gnss_checks.filtered_horizontal_velocity_m_s(); }
@@ -420,7 +424,8 @@ protected:
 			   _control_status};
 
 # if defined(CONFIG_EKF2_GNSS_YAW)
-	// innovation consistency check monitoring ratios
+	TimestampedRingBuffer<gnssYawSample> *_gnss_yaw_buffer {nullptr};
+	gnssYawSample _gnss_yaw_sample_delayed{};
 	uint64_t _time_last_gnss_yaw_buffer_push{0};
 # endif // CONFIG_EKF2_GNSS_YAW
 #endif // CONFIG_EKF2_GNSS

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -809,6 +809,9 @@ void EKF2::Run()
 #endif // CONFIG_EKF2_OPTICAL_FLOW
 #if defined(CONFIG_EKF2_GNSS)
 		UpdateGpsSample(ekf2_timestamps);
+# if defined(CONFIG_EKF2_GNSS_YAW)
+		UpdateGnssYawSample(ekf2_timestamps);
+# endif // CONFIG_EKF2_GNSS_YAW
 #endif // CONFIG_EKF2_GNSS
 #if defined(CONFIG_EKF2_MAGNETOMETER)
 		UpdateMagSample(ekf2_timestamps);
@@ -2632,15 +2635,6 @@ void EKF2::UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps)
 			return; //TODO: change and set to NAN
 		}
 
-		if (fabsf(_param_ekf2_gps_yaw_off.get()) > 0.f) {
-			if (!PX4_ISFINITE(vehicle_gps_position.heading_offset) && PX4_ISFINITE(vehicle_gps_position.heading)) {
-				// Apply offset
-				float yaw_offset = matrix::wrap_pi(math::radians(_param_ekf2_gps_yaw_off.get()));
-				vehicle_gps_position.heading_offset = yaw_offset;
-				vehicle_gps_position.heading = matrix::wrap_pi(vehicle_gps_position.heading - yaw_offset);
-			}
-		}
-
 		const float altitude_amsl = static_cast<float>(vehicle_gps_position.altitude_msl_m);
 		const float altitude_ellipsoid = static_cast<float>(vehicle_gps_position.altitude_ellipsoid_m);
 
@@ -2661,9 +2655,6 @@ void EKF2::UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps)
 			.nsats = vehicle_gps_position.satellites_used,
 			.pdop = sqrtf(vehicle_gps_position.hdop *vehicle_gps_position.hdop
 				      + vehicle_gps_position.vdop * vehicle_gps_position.vdop),
-			.yaw = vehicle_gps_position.heading, //TODO: move to different message
-			.yaw_acc = vehicle_gps_position.heading_accuracy,
-			.yaw_offset = vehicle_gps_position.heading_offset,
 			.spoofed = vehicle_gps_position.spoofing_state == sensor_gps_s::SPOOFING_STATE_DETECTED,
 			.jammed = vehicle_gps_position.jamming_state == sensor_gps_s::JAMMING_STATE_DETECTED,
 			.pos_body = Vector3f(vehicle_gps_position.antenna_offset_x,
@@ -2688,6 +2679,40 @@ void EKF2::UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps)
 
 	}
 }
+
+#if defined(CONFIG_EKF2_GNSS_YAW)
+void EKF2::UpdateGnssYawSample(ekf2_timestamps_s &ekf2_timestamps)
+{
+	vehicle_gnss_heading_s gnss_heading;
+
+	if (_vehicle_gnss_heading_sub.update(&gnss_heading)) {
+
+		float yaw = gnss_heading.heading;
+		float yaw_offset = gnss_heading.heading_offset;
+
+		// Apply EKF2_GPS_YAW_OFF if the driver didn't set an offset
+		if (fabsf(_param_ekf2_gps_yaw_off.get()) > 0.f) {
+			if (!PX4_ISFINITE(yaw_offset) && PX4_ISFINITE(yaw)) {
+				yaw_offset = matrix::wrap_pi(math::radians(_param_ekf2_gps_yaw_off.get()));
+				yaw = matrix::wrap_pi(yaw - yaw_offset);
+			}
+		}
+
+		if (!PX4_ISFINITE(yaw_offset)) {
+			yaw_offset = 0.f;
+		}
+
+		gnssYawSample gnss_yaw_sample{
+			.time_us = (gnss_heading.timestamp_sample > 0) ? gnss_heading.timestamp_sample : gnss_heading.timestamp,
+			.yaw = yaw,
+			.yaw_acc = gnss_heading.heading_accuracy,
+			.yaw_offset = yaw_offset,
+		};
+
+		_ekf.setGnssYawData(gnss_yaw_sample);
+	}
+}
+#endif // CONFIG_EKF2_GNSS_YAW
 
 float EKF2::altEllipsoidToAmsl(float ellipsoid_alt) const
 {

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -810,7 +810,7 @@ void EKF2::Run()
 #if defined(CONFIG_EKF2_GNSS)
 		UpdateGpsSample(ekf2_timestamps);
 # if defined(CONFIG_EKF2_GNSS_YAW)
-		UpdateGnssYawSample(ekf2_timestamps);
+		UpdateGnssYawSample();
 # endif // CONFIG_EKF2_GNSS_YAW
 #endif // CONFIG_EKF2_GNSS
 #if defined(CONFIG_EKF2_MAGNETOMETER)
@@ -2681,7 +2681,7 @@ void EKF2::UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps)
 }
 
 #if defined(CONFIG_EKF2_GNSS_YAW)
-void EKF2::UpdateGnssYawSample(ekf2_timestamps_s &ekf2_timestamps)
+void EKF2::UpdateGnssYawSample()
 {
 	vehicle_gnss_heading_s gnss_heading;
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2687,26 +2687,11 @@ void EKF2::UpdateGnssYawSample()
 
 	if (_vehicle_gnss_heading_sub.update(&gnss_heading)) {
 
-		float yaw = gnss_heading.heading;
-		float yaw_offset = gnss_heading.heading_offset;
-
-		// Apply EKF2_GPS_YAW_OFF if the driver didn't set an offset
-		if (fabsf(_param_ekf2_gps_yaw_off.get()) > 0.f) {
-			if (!PX4_ISFINITE(yaw_offset) && PX4_ISFINITE(yaw)) {
-				yaw_offset = matrix::wrap_pi(math::radians(_param_ekf2_gps_yaw_off.get()));
-				yaw = matrix::wrap_pi(yaw - yaw_offset);
-			}
-		}
-
-		if (!PX4_ISFINITE(yaw_offset)) {
-			yaw_offset = 0.f;
-		}
-
 		gnssYawSample gnss_yaw_sample{
 			.time_us = (gnss_heading.timestamp_sample > 0) ? gnss_heading.timestamp_sample : gnss_heading.timestamp,
-			.yaw = yaw,
+			.yaw = gnss_heading.heading,
 			.yaw_acc = gnss_heading.heading_accuracy,
-			.yaw_offset = yaw_offset,
+			.yaw_offset = PX4_ISFINITE(gnss_heading.heading_offset) ? gnss_heading.heading_offset : 0.f,
 		};
 
 		_ekf.setGnssYawData(gnss_yaw_sample);

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -87,6 +87,7 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_odometry.h>
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_gnss_heading.h>
 #include <uORB/topics/yaw_estimator_status.h>
 
 #if defined(CONFIG_EKF2_AIRSPEED)
@@ -226,6 +227,9 @@ private:
 	void PublishGnssHgtBias(const hrt_abstime &timestamp);
 	void PublishYawEstimatorStatus(const hrt_abstime &timestamp);
 	void UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps);
+# if defined(CONFIG_EKF2_GNSS_YAW)
+	void UpdateGnssYawSample(ekf2_timestamps_s &ekf2_timestamps);
+# endif // CONFIG_EKF2_GNSS_YAW
 #endif // CONFIG_EKF2_GNSS
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)
 	bool UpdateFlowSample(ekf2_timestamps_s &ekf2_timestamps);
@@ -511,6 +515,7 @@ private:
 # if defined(CONFIG_EKF2_GNSS_YAW)
 	hrt_abstime _status_gnss_yaw_pub_last {0};
 	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_gnss_yaw_pub {ORB_ID(estimator_aid_src_gnss_yaw)};
+	uORB::Subscription _vehicle_gnss_heading_sub{ORB_ID(vehicle_gnss_heading)};
 # endif // CONFIG_EKF2_GNSS_YAW
 #endif // CONFIG_EKF2_GNSS
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -228,7 +228,7 @@ private:
 	void PublishYawEstimatorStatus(const hrt_abstime &timestamp);
 	void UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps);
 # if defined(CONFIG_EKF2_GNSS_YAW)
-	void UpdateGnssYawSample(ekf2_timestamps_s &ekf2_timestamps);
+	void UpdateGnssYawSample();
 # endif // CONFIG_EKF2_GNSS_YAW
 #endif // CONFIG_EKF2_GNSS
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -584,7 +584,6 @@ private:
 
 		// Used by EKF-GSF experimental yaw estimator
 		(ParamExtFloat<px4::params::EKF2_GSF_TAS>) _param_ekf2_gsf_tas,
-		(ParamFloat<px4::params::EKF2_GPS_YAW_OFF>) _param_ekf2_gps_yaw_off,
 #endif // CONFIG_EKF2_GNSS
 
 #if defined(CONFIG_EKF2_BAROMETER)

--- a/src/modules/ekf2/params_gnss.yaml
+++ b/src/modules/ekf2/params_gnss.yaml
@@ -46,15 +46,6 @@ parameters:
       min: 1.0
       unit: SD
       decimal: 1
-    EKF2_GPS_YAW_OFF:
-      description:
-        short: Heading/Yaw offset for dual antenna GPS
-      type: float
-      default: 0.0
-      min: 0.0
-      max: 360.0
-      unit: deg
-      decimal: 1
     EKF2_GPS_V_GATE:
       description:
         short: Gate size for GNSS velocity fusion

--- a/src/modules/ekf2/test/sensor_simulator/CMakeLists.txt
+++ b/src/modules/ekf2/test/sensor_simulator/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SRCS
 	mag.cpp
 	baro.cpp
 	gps.cpp
+	gnss_yaw.cpp
 	flow.cpp
 	range_finder.cpp
 	vio.cpp

--- a/src/modules/ekf2/test/sensor_simulator/gnss_yaw.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/gnss_yaw.cpp
@@ -1,0 +1,42 @@
+#include "gnss_yaw.h"
+
+namespace sensor_simulator
+{
+namespace sensor
+{
+
+GnssYaw::GnssYaw(std::shared_ptr<Ekf> ekf): Sensor(ekf)
+{
+}
+
+GnssYaw::~GnssYaw()
+{
+}
+
+void GnssYaw::send(const uint64_t time)
+{
+	if (!PX4_ISFINITE(_gnss_yaw_data.yaw)) {
+		return;
+	}
+
+	_gnss_yaw_data.time_us = time - kGnssYawDelayUs;
+	_ekf->setGnssYawData(_gnss_yaw_data);
+}
+
+void GnssYaw::setYaw(const float yaw)
+{
+	_gnss_yaw_data.yaw = yaw;
+}
+
+void GnssYaw::setYawOffset(const float yaw_offset)
+{
+	_gnss_yaw_data.yaw_offset = yaw_offset;
+}
+
+void GnssYaw::setYawAccuracy(const float yaw_acc)
+{
+	_gnss_yaw_data.yaw_acc = yaw_acc;
+}
+
+} // namespace sensor
+} // namespace sensor_simulator

--- a/src/modules/ekf2/test/sensor_simulator/gnss_yaw.h
+++ b/src/modules/ekf2/test/sensor_simulator/gnss_yaw.h
@@ -30,13 +30,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
-
 /**
- * Feeds Ekf with Gps data
- * @author Kamil Ritz <ka.ritz@hotmail.com>
+ * Feeds Ekf with dual antenna GNSS yaw data, independently of the position/velocity Gps sensor
  */
-#ifndef EKF_GPS_H
-#define EKF_GPS_H
+#ifndef EKF_GNSS_YAW_H
+#define EKF_GNSS_YAW_H
 
 #include "sensor.h"
 
@@ -45,36 +43,27 @@ namespace sensor_simulator
 namespace sensor
 {
 
-class Gps: public Sensor
+class GnssYaw: public Sensor
 {
 public:
-	Gps(std::shared_ptr<Ekf> ekf);
-	~Gps();
+	GnssYaw(std::shared_ptr<Ekf> ekf);
+	~GnssYaw();
 
-	void setData(const gnssSample &gps);
-	void stepHeightByMeters(const float hgt_change);
-	void stepHorizontalPositionByMeters(const Vector2f hpos_change);
-	void setPositionRateNED(const Vector3f &rate);
-	void setAltitude(const float alt);
-	void setLatitude(const double lat);
-	void setLongitude(const double lon);
-	void setVelocity(const Vector3f &vel);
-	void setFixType(const int fix_type);
-	void setNumberOfSatellites(const int num_satellites);
-	void setPdop(const float pdop);
+	// NAN stops the measurements, like a receiver that lost its heading solution
+	void setYaw(const float yaw);
+	void setYawOffset(const float yaw_offset);
+	void setYawAccuracy(const float yaw_acc);
 
-	gnssSample getDefaultGpsData();
-	const gnssSample &getData() const { return _gps_data; }
+	const gnssYawSample &getData() const { return _gnss_yaw_data; }
 
 private:
 	void send(uint64_t time) override;
 
-	static constexpr uint64_t kGpsDelayUs{110000};
+	static constexpr uint64_t kGnssYawDelayUs{110000};
 
-	gnssSample _gps_data{};
-	Vector3f _gps_pos_rate{};
+	gnssYawSample _gnss_yaw_data{.yaw = NAN};
 };
 
 } // namespace sensor
 } // namespace sensor_simulator
-#endif // EKF_GPS_H
+#endif // EKF_GNSS_YAW_H

--- a/src/modules/ekf2/test/sensor_simulator/gps.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/gps.cpp
@@ -28,6 +28,11 @@ void Gps::send(const uint64_t time)
 	}
 
 	_ekf->setGpsData(_gps_data);
+
+	if (PX4_ISFINITE(_gnss_yaw_data.yaw)) {
+		_gnss_yaw_data.time_us = _gps_data.time_us;
+		_ekf->setGnssYawData(_gnss_yaw_data);
+	}
 }
 
 void Gps::setData(const gnssSample &gps)
@@ -57,12 +62,12 @@ void Gps::setVelocity(const Vector3f &vel)
 
 void Gps::setYaw(const float yaw)
 {
-	_gps_data.yaw = yaw;
+	_gnss_yaw_data.yaw = yaw;
 }
 
 void Gps::setYawOffset(const float yaw_offset)
 {
-	_gps_data.yaw_offset = yaw_offset;
+	_gnss_yaw_data.yaw_offset = yaw_offset;
 }
 
 void Gps::setFixType(const int fix_type)
@@ -115,8 +120,6 @@ gnssSample Gps::getDefaultGpsData()
 	gps_data.lat = 47.3566094;
 	gps_data.lon = 8.5190237;
 	gps_data.alt = 422.056f;
-	gps_data.yaw = NAN;
-	gps_data.yaw_offset = 0.0f;
 	gps_data.fix_type = 3;
 	gps_data.hacc = 0.5f;
 	gps_data.vacc = 0.8f;

--- a/src/modules/ekf2/test/sensor_simulator/gps.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/gps.cpp
@@ -28,11 +28,6 @@ void Gps::send(const uint64_t time)
 	}
 
 	_ekf->setGpsData(_gps_data);
-
-	if (PX4_ISFINITE(_gnss_yaw_data.yaw)) {
-		_gnss_yaw_data.time_us = _gps_data.time_us;
-		_ekf->setGnssYawData(_gnss_yaw_data);
-	}
 }
 
 void Gps::setData(const gnssSample &gps)
@@ -58,16 +53,6 @@ void Gps::setLongitude(const double lon)
 void Gps::setVelocity(const Vector3f &vel)
 {
 	_gps_data.vel = vel;
-}
-
-void Gps::setYaw(const float yaw)
-{
-	_gnss_yaw_data.yaw = yaw;
-}
-
-void Gps::setYawOffset(const float yaw_offset)
-{
-	_gnss_yaw_data.yaw_offset = yaw_offset;
 }
 
 void Gps::setFixType(const int fix_type)

--- a/src/modules/ekf2/test/sensor_simulator/gps.h
+++ b/src/modules/ekf2/test/sensor_simulator/gps.h
@@ -74,6 +74,7 @@ private:
 	static constexpr uint64_t kGpsDelayUs{110000};
 
 	gnssSample _gps_data{};
+	gnssYawSample _gnss_yaw_data{};
 	Vector3f _gps_pos_rate{};
 };
 

--- a/src/modules/ekf2/test/sensor_simulator/sensor_simulator.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/sensor_simulator.cpp
@@ -6,6 +6,7 @@ SensorSimulator::SensorSimulator(std::shared_ptr<Ekf> ekf):
 	_baro(ekf),
 	_flow(ekf),
 	_gps(ekf),
+	_gnss_yaw(ekf),
 	_imu(ekf),
 	_mag(ekf),
 	_rng(ekf),
@@ -127,6 +128,7 @@ void SensorSimulator::setSensorRateToDefault()
 	_mag.setRateHz(80);
 	_baro.setRateHz(80);
 	_gps.setRateHz(5);
+	_gnss_yaw.setRateHz(5);
 	_flow.setRateHz(50);
 	_rng.setRateHz(30);
 	_vio.setRateHz(30);
@@ -183,6 +185,7 @@ void SensorSimulator::updateSensors()
 	_mag.update(_time);
 	_baro.update(_time);
 	_gps.update(_time);
+	_gnss_yaw.update(_time);
 	_flow.update(_time);
 	_rng.update(_time);
 	_vio.update(_time);

--- a/src/modules/ekf2/test/sensor_simulator/sensor_simulator.h
+++ b/src/modules/ekf2/test/sensor_simulator/sensor_simulator.h
@@ -55,6 +55,7 @@
 #include "mag.h"
 #include "baro.h"
 #include "gps.h"
+#include "gnss_yaw.h"
 #include "flow.h"
 #include "range_finder.h"
 #include "vio.h"
@@ -95,6 +96,9 @@ public:
 	void startGps() { _gps.start(); }
 	void stopGps() { _gps.stop(); }
 
+	void startGnssYaw() { _gnss_yaw.start(); }
+	void stopGnssYaw() { _gnss_yaw.stop(); }
+
 	void startFlow() { _flow.start(); }
 	void stopFlow() { _flow.stop(); }
 
@@ -123,6 +127,7 @@ public:
 	Baro        _baro;
 	Flow        _flow;
 	Gps         _gps;
+	GnssYaw     _gnss_yaw;
 	Imu         _imu;
 	Mag         _mag;
 	RangeFinder _rng;

--- a/src/modules/ekf2/test/test_EKF_gnss_yaw.cpp
+++ b/src/modules/ekf2/test/test_EKF_gnss_yaw.cpp
@@ -67,11 +67,12 @@ public:
 		_ekf->set_vehicle_at_rest(true);
 
 		_sensor_simulator.runSeconds(_init_duration_s);
-		_sensor_simulator._gps.setYaw(NAN);
+		_sensor_simulator._gnss_yaw.setYaw(NAN);
 		_sensor_simulator.runSeconds(2);
 		_ekf_wrapper.enableGpsFusion();
 		_ekf_wrapper.enableGpsHeadingFusion();
 		_sensor_simulator.startGps();
+		_sensor_simulator.startGnssYaw();
 		_sensor_simulator.runSeconds(11);
 	}
 
@@ -84,8 +85,8 @@ void EkfGpsHeadingTest::runConvergenceScenario(float yaw_offset_rad, float anten
 	// The yaw antenna offset has already been corrected in the driver
 	float gps_heading = matrix::wrap_pi(_ekf_wrapper.getYawAngle());
 
-	_sensor_simulator._gps.setYaw(gps_heading); // used to remove the correction to fuse the real measurement
-	_sensor_simulator._gps.setYawOffset(antenna_offset_rad);
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading); // used to remove the correction to fuse the real measurement
+	_sensor_simulator._gnss_yaw.setYawOffset(antenna_offset_rad);
 
 	// WHEN: the GPS yaw fusion is activated
 	_ekf_wrapper.enableGpsHeadingFusion();
@@ -108,7 +109,7 @@ TEST_F(EkfGpsHeadingTest, fusionStartWithReset)
 
 	// WHEN: enabling GPS heading fusion and heading difference is bigger than 15 degrees
 	const float gps_heading = _ekf_wrapper.getYawAngle() + math::radians(20.f);
-	_sensor_simulator._gps.setYaw(gps_heading);
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading);
 	_ekf_wrapper.enableGpsHeadingFusion();
 	const int initial_quat_reset_counter = _ekf_wrapper.getQuaternionResetCounter();
 	_sensor_simulator.runSeconds(0.4);
@@ -121,7 +122,7 @@ TEST_F(EkfGpsHeadingTest, fusionStartWithReset)
 	EXPECT_NEAR(_ekf_wrapper.getYawAngle(), gps_heading, 0.001);
 
 	// WHEN: GPS heading is disabled
-	_sensor_simulator._gps.stop();
+	_sensor_simulator.stopGnssYaw();
 	_sensor_simulator.runSeconds(11);
 
 	// THEN: after a while the fusion should be stopped
@@ -134,7 +135,7 @@ TEST_F(EkfGpsHeadingTest, yawConvergence)
 	const float initial_yaw = math::radians(10.f);
 	float gps_heading = matrix::wrap_pi(_ekf_wrapper.getYawAngle() + initial_yaw);
 
-	_sensor_simulator._gps.setYaw(gps_heading);
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading);
 
 	// WHEN: the GPS yaw fusion is activated
 	_ekf_wrapper.enableGpsHeadingFusion();
@@ -145,7 +146,7 @@ TEST_F(EkfGpsHeadingTest, yawConvergence)
 
 	// AND WHEN: the the measurement changes
 	gps_heading += math::radians(2.f);
-	_sensor_simulator._gps.setYaw(gps_heading);
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading);
 	_sensor_simulator.runSeconds(20);
 
 	// THEN: the estimate slowly converges to the new measurement
@@ -193,7 +194,7 @@ TEST_F(EkfGpsHeadingTest, fallBackToMag)
 	// to the filter
 	_sensor_simulator.runSeconds(6);
 	float gps_heading = matrix::wrap_pi(_ekf_wrapper.getYawAngle() + math::radians(10.f));
-	_sensor_simulator._gps.setYaw(gps_heading);
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading);
 
 	// WHEN: the GPS yaw fusion is activated
 	_sensor_simulator.runSeconds(1);
@@ -208,7 +209,7 @@ TEST_F(EkfGpsHeadingTest, fallBackToMag)
 
 	// BUT WHEN: the GPS yaw is suddenly invalid
 	gps_heading = NAN;
-	_sensor_simulator._gps.setYaw(gps_heading);
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading);
 	_sensor_simulator.runSeconds(7.5);
 
 	// THEN: after a few seconds, the fusion should stop and
@@ -227,7 +228,7 @@ TEST_F(EkfGpsHeadingTest, fallBackToYawEmergencyEstimator)
 	float gps_heading = math::radians(90.f);
 	const float true_heading = math::radians(-20.f);
 
-	_sensor_simulator._gps.setYaw(gps_heading);
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading);
 	_sensor_simulator.runSeconds(10);
 
 	const Vector3f accel_frd{-1.0, -1.5f, 0.f};
@@ -265,14 +266,14 @@ TEST_F(EkfGpsHeadingTest, yawJmpOnGround)
 {
 	// GIVEN: the GPS yaw fusion activated
 	float gps_heading = _ekf_wrapper.getYawAngle();
-	_sensor_simulator._gps.setYaw(gps_heading);
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading);
 	_sensor_simulator.runSeconds(1);
 	_ekf->set_in_air_status(false);
 
 	// WHEN: the measurement suddenly changes
 	const int initial_quat_reset_counter = _ekf_wrapper.getQuaternionResetCounter();
 	gps_heading = matrix::wrap_pi(_ekf_wrapper.getYawAngle() + math::radians(45.f));
-	_sensor_simulator._gps.setYaw(gps_heading);
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading);
 	_sensor_simulator.runSeconds(8);
 
 	// THEN: the fusion should stop, reset to mag
@@ -292,14 +293,14 @@ TEST_F(EkfGpsHeadingTest, yawJumpInAir)
 {
 	// GIVEN: the GPS yaw fusion activated
 	float gps_heading = _ekf_wrapper.getYawAngle();
-	_sensor_simulator._gps.setYaw(gps_heading + math::radians(90.f));
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading + math::radians(90.f));
 	_sensor_simulator.runSeconds(5);
 	_ekf->set_in_air_status(true);
 
 	// WHEN: the measurement suddenly changes
 	const int initial_quat_reset_counter = _ekf_wrapper.getQuaternionResetCounter();
 	gps_heading = matrix::wrap_pi(_ekf_wrapper.getYawAngle() + math::radians(180.f));
-	_sensor_simulator._gps.setYaw(gps_heading);
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading);
 	_sensor_simulator.runSeconds(7.5);
 
 	// THEN: the fusion should not reset as heading is still observable through GNSS vel/pos fusion
@@ -318,12 +319,12 @@ TEST_F(EkfGpsHeadingTest, stopOnGround)
 	// GIVEN: the GPS yaw fusion activated and there is no mag data
 	_sensor_simulator._mag.stop();
 	float gps_heading = _ekf_wrapper.getYawAngle();
-	_sensor_simulator._gps.setYaw(gps_heading);
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading);
 	_sensor_simulator.runSeconds(5);
 
 	// WHEN: the measurement stops
 	gps_heading = NAN;
-	_sensor_simulator._gps.setYaw(gps_heading);
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading);
 	_sensor_simulator.runSeconds(7.5);
 
 	// THEN: the fusion should stop and the GPS pos/vel aiding
@@ -340,4 +341,48 @@ TEST_F(EkfGpsHeadingTest, stopOnGround)
 
 	// THEN: the yaw variance increases
 	EXPECT_GT(_ekf->getYawVar(), yaw_variance_before);
+}
+
+TEST_F(EkfGpsHeadingTest, continuesWithoutPosition)
+{
+	// GIVEN: GNSS yaw fusion is active
+	const float gps_heading = _ekf_wrapper.getYawAngle();
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading);
+	_sensor_simulator.runSeconds(2);
+	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsHeadingFusion());
+
+	// WHEN: position/velocity samples stop but heading keeps arriving
+	_sensor_simulator.stopGps();
+	const uint64_t time_gps_stopped = _sensor_simulator.getTime();
+	_sensor_simulator.runSeconds(4);
+
+	// THEN: the heading is still fused, it does not wait for a position sample
+	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsHeadingFusion());
+	EXPECT_GT(_ekf->aid_src_gnss_yaw().time_last_fuse, time_gps_stopped);
+}
+
+TEST_F(EkfGpsHeadingTest, fusesAtOwnRate)
+{
+	// GIVEN: GNSS yaw fusion active with heading arriving faster than position
+	_sensor_simulator._gnss_yaw.setRateHz(10);
+	const float gps_heading = _ekf_wrapper.getYawAngle();
+	_sensor_simulator._gnss_yaw.setYaw(gps_heading);
+	_sensor_simulator.runSeconds(2);
+	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsHeadingFusion());
+
+	// WHEN: running for one second
+	int fusion_count = 0;
+	uint64_t time_last_fuse = _ekf->aid_src_gnss_yaw().time_last_fuse;
+
+	for (int i = 0; i < 100; i++) {
+		_sensor_simulator.runMicroseconds(10000);
+
+		if (_ekf->aid_src_gnss_yaw().time_last_fuse != time_last_fuse) {
+			time_last_fuse = _ekf->aid_src_gnss_yaw().time_last_fuse;
+			fusion_count++;
+		}
+	}
+
+	// THEN: every heading sample is fused, not only the ones coinciding with a 5 Hz position sample
+	EXPECT_GE(fusion_count, 9);
 }

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -145,6 +145,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("vehicle_constraints", 1000);
 	add_topic("vehicle_control_mode");
 	add_topic("vehicle_global_position", 200);
+	add_topic("vehicle_gnss_heading", 100);
 	add_topic("vehicle_gps_position", 100);
 	add_topic("vehicle_land_detected");
 	add_topic("vehicle_local_position", 100);

--- a/src/modules/sensors/vehicle_gps_position/CMakeLists.txt
+++ b/src/modules/sensors/vehicle_gps_position/CMakeLists.txt
@@ -41,6 +41,7 @@ px4_add_library(vehicle_gps_position
 )
 target_link_libraries(vehicle_gps_position
 	PRIVATE
+		conversion
 		geo
 		px4_work_queue
 )

--- a/src/modules/sensors/vehicle_gps_position/PpsTimeSync.cpp
+++ b/src/modules/sensors/vehicle_gps_position/PpsTimeSync.cpp
@@ -56,7 +56,8 @@ void PpsTimeSync::process_pps(const pps_capture_s &pps)
 
 uint64_t PpsTimeSync::correct_gps_timestamp(uint64_t gps_fc_timestamp, uint64_t gps_utc_timestamp)
 {
-	if (!is_valid()) {
+	// 0 is the receiver's "time not valid" value
+	if (!is_valid() || (gps_utc_timestamp == 0)) {
 		return gps_fc_timestamp;
 	}
 

--- a/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.cpp
+++ b/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.cpp
@@ -45,6 +45,7 @@ VehicleGPSPosition::VehicleGPSPosition() :
 	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers)
 {
 	_vehicle_gps_position_pub.advertise();
+	_vehicle_gnss_heading_pub.advertise();
 }
 
 VehicleGPSPosition::~VehicleGPSPosition()
@@ -71,6 +72,10 @@ void VehicleGPSPosition::Stop()
 	for (auto &sub : _sensor_gps_sub) {
 		sub.unregisterCallback();
 	}
+
+	for (auto &sub : _sensor_gnss_relative_sub) {
+		sub.unregisterCallback();
+	}
 }
 
 void VehicleGPSPosition::ParametersUpdate(bool force)
@@ -90,6 +95,10 @@ void VehicleGPSPosition::ParametersUpdate(bool force)
 			for (auto &sub : _sensor_gps_sub) {
 				sub.registerCallback();
 			}
+		}
+
+		for (auto &sub : _sensor_gnss_relative_sub) {
+			sub.registerCallback();
 		}
 
 		_gps_blending.setBlendingUseSpeedAccuracy(_param_sens_gps_mask.get() & BLEND_MASK_USE_SPD_ACC);
@@ -129,51 +138,26 @@ void VehicleGPSPosition::Run()
 
 	// Check all GPS instance
 	bool any_gps_updated = false;
-	bool gps_updated = false;
+	sensor_gps_s gps_data[GPS_MAX_RECEIVERS] {};
+	bool gps_updated[GPS_MAX_RECEIVERS] {};
 	const int32_t gps_prime = _param_sens_gps_prime.get();
 
 	for (uint8_t i = 0; i < GPS_MAX_RECEIVERS; i++) {
-		gps_updated = _sensor_gps_sub[i].updated();
+		gps_updated[i] = _sensor_gps_sub[i].update(&gps_data[i]);
 
-		sensor_gps_s gps_data;
-
-		if (gps_updated) {
+		if (gps_updated[i]) {
 			any_gps_updated = true;
 
-			_sensor_gps_sub[i].copy(&gps_data);
+			const GpsParamSlot *slot = findParamSlot(gps_data[i].device_id, i);
+			const matrix::Vector3f antenna_offset = slot ? slot->offset : matrix::Vector3f{};
+			const hrt_abstime delay_us = slot ? slot->delay_us : kDefaultDelay;
 
-			// Match device_id to receiver slot
-			matrix::Vector3f antenna_offset{};
-			hrt_abstime delay_us = 110_ms; // matches SENS_GPS*_DELAY default
-			bool matched = false;
-
-			for (uint8_t slot = 0; slot < GPS_MAX_RECEIVERS; slot++) {
-				if (_gps_param_slots[slot].device_id != 0
-				    && _gps_param_slots[slot].device_id == gps_data.device_id) {
-					antenna_offset = _gps_param_slots[slot].offset;
-					delay_us = _gps_param_slots[slot].delay_us;
-					matched = true;
-					break;
-				}
-			}
-
-			// Fallback: if no device IDs configured, match by instance index
-			if (!matched && _gps_param_slots[0].device_id == 0 && _gps_param_slots[1].device_id == 0) {
-				antenna_offset = _gps_param_slots[i].offset;
-				delay_us = _gps_param_slots[i].delay_us;
-			}
-
-			// Apply delay to timestamp_sample if the driver didn't set one
-			if (gps_data.timestamp_sample == 0 || gps_data.timestamp_sample == gps_data.timestamp) {
-				if (delay_us > 0 && gps_data.timestamp > delay_us) {
-					gps_data.timestamp_sample = gps_data.timestamp - delay_us;
-				}
-			}
+			gps_data[i].timestamp_sample = resolveSampleTimestamp(gps_data[i].timestamp_sample, gps_data[i].timestamp, delay_us);
 
 			_gps_blending.setAntennaOffset(antenna_offset, i);
-			_gps_blending.setGpsData(gps_data, i);
+			_gps_blending.setGpsData(gps_data[i], i);
 
-			if (SensorGpsSelector::node_id_matches(gps_prime, gps_data.device_id)) {
+			if (SensorGpsSelector::node_id_matches(gps_prime, gps_data[i].device_id)) {
 				_gps_blending.setPrimaryInstance(i);
 			}
 
@@ -210,9 +194,151 @@ void VehicleGPSPosition::Run()
 		}
 	}
 
+	UpdateGnssHeading(gps_data, gps_updated);
+
 	ScheduleDelayed(300_ms); // backup schedule
 
 	perf_end(_cycle_perf);
+}
+
+void VehicleGPSPosition::UpdateGnssHeading(const sensor_gps_s gps_data[GPS_MAX_RECEIVERS],
+		const bool gps_updated[GPS_MAX_RECEIVERS])
+{
+	// A single source is published at a time: every source carries its own antenna offset, so alternating between
+	// receivers would jump the heading and trip the EKF observation rate limit. The active source is kept until it
+	// goes stale. sensor_gnss_relative is preferred over sensor_gps.heading and preempts it.
+	//
+	// TODO: the baseline rotation belongs in the SENS_GPSn_* slot next to the antenna position and delay, resolved
+	// here by device_id, replacing GPS_YAW_OFFSET / SEP_YAW_OFFS / EKF2_GPS_YAW_OFF. With per-receiver rotation the
+	// source selection can also follow the flight phase, e.g. a tailsitter with one baseline aligned for hover and one
+	// for forward flight.
+	const hrt_abstime now = hrt_absolute_time();
+	const bool source_active = (_heading_source.last_publish != 0)
+				   && (now - _heading_source.last_publish < kHeadingSourceTimeout);
+
+	for (uint8_t i = 0; i < GPS_MAX_RECEIVERS; i++) {
+		sensor_gnss_relative_s gnss_rel;
+
+		if (!_sensor_gnss_relative_sub[i].update(&gnss_rel)) {
+			continue;
+		}
+
+		if (!gnss_rel.heading_valid || !PX4_ISFINITE(gnss_rel.heading)) {
+			continue;
+		}
+
+		if (source_active && _heading_source.from_relative && (_heading_source.device_id != gnss_rel.device_id)) {
+			continue;
+		}
+
+		// sensor_gnss_relative instances are numbered by advertise order, not by receiver, so the receiver's
+		// sensor_gps instance is looked up by device_id for the delay parameters and the driver heading offset.
+		sensor_gps_s receiver_gps;
+		const int gps_instance = findGpsInstance(gnss_rel.device_id, receiver_gps);
+		const GpsParamSlot *slot = findParamSlot(gnss_rel.device_id, gps_instance);
+		const hrt_abstime delay_us = slot ? slot->delay_us : kDefaultDelay;
+
+		// No PPS correction here: sensor_gnss_relative.time_utc_usec is not reliably UTC (u-blox fills it with iTOW)
+		// and PpsTimeSync only sanity-checks the first correction after each pulse.
+		vehicle_gnss_heading_s heading_out{};
+		heading_out.timestamp_sample = resolveSampleTimestamp(gnss_rel.timestamp_sample, gnss_rel.timestamp, delay_us);
+		heading_out.device_id = gnss_rel.device_id;
+		heading_out.heading = gnss_rel.heading;
+		heading_out.heading_accuracy = gnss_rel.heading_accuracy;
+		heading_out.heading_offset = (gps_instance >= 0) ? receiver_gps.heading_offset : NAN;
+		heading_out.timestamp = hrt_absolute_time();
+		_vehicle_gnss_heading_pub.publish(heading_out);
+
+		_heading_source = {gnss_rel.device_id, true, now};
+		return;
+	}
+
+	if (source_active && _heading_source.from_relative) {
+		return;
+	}
+
+	// Fallback for receivers that only report heading in sensor_gps (e.g. Septentrio). Uses the raw per-instance
+	// data rather than the blended output so heading does not follow the position blending weights.
+	const int32_t gps_prime = _param_sens_gps_prime.get();
+	uint8_t primary = 0;
+
+	for (uint8_t i = 0; i < GPS_MAX_RECEIVERS; i++) {
+		if ((gps_prime == i) || SensorGpsSelector::node_id_matches(gps_prime, gps_data[i].device_id)) {
+			primary = i;
+		}
+	}
+
+	for (uint8_t n = 0; n < GPS_MAX_RECEIVERS; n++) {
+		const uint8_t i = (primary + n) % GPS_MAX_RECEIVERS;
+
+		if (!gps_updated[i] || !PX4_ISFINITE(gps_data[i].heading)) {
+			continue;
+		}
+
+		if (source_active && (_heading_source.device_id != gps_data[i].device_id)) {
+			continue;
+		}
+
+		uint64_t timestamp_sample = gps_data[i].timestamp_sample;
+		const uint64_t pps_timestamp = _pps_time_sync.correct_gps_timestamp(gps_data[i].timestamp, gps_data[i].time_utc_usec);
+
+		if (pps_timestamp != gps_data[i].timestamp) {
+			timestamp_sample = pps_timestamp;
+		}
+
+		vehicle_gnss_heading_s heading_out{};
+		heading_out.timestamp_sample = timestamp_sample;
+		heading_out.device_id = gps_data[i].device_id;
+		heading_out.heading = gps_data[i].heading;
+		heading_out.heading_accuracy = gps_data[i].heading_accuracy;
+		heading_out.heading_offset = gps_data[i].heading_offset;
+		heading_out.timestamp = hrt_absolute_time();
+		_vehicle_gnss_heading_pub.publish(heading_out);
+
+		_heading_source = {gps_data[i].device_id, false, now};
+		return;
+	}
+}
+
+const VehicleGPSPosition::GpsParamSlot *VehicleGPSPosition::findParamSlot(uint32_t device_id, int instance) const
+{
+	for (const GpsParamSlot &slot : _gps_param_slots) {
+		if ((slot.device_id != 0) && (slot.device_id == device_id)) {
+			return &slot;
+		}
+	}
+
+	// No device IDs configured: match by sensor_gps instance
+	if ((_gps_param_slots[0].device_id == 0) && (_gps_param_slots[1].device_id == 0)
+	    && (instance >= 0) && (instance < GPS_MAX_RECEIVERS)) {
+		return &_gps_param_slots[instance];
+	}
+
+	return nullptr;
+}
+
+int VehicleGPSPosition::findGpsInstance(uint32_t device_id, sensor_gps_s &gps_data)
+{
+	for (int i = 0; i < GPS_MAX_RECEIVERS; i++) {
+		if (_sensor_gps_sub[i].copy(&gps_data) && (gps_data.device_id == device_id)) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+uint64_t VehicleGPSPosition::resolveSampleTimestamp(uint64_t driver_timestamp_sample, uint64_t driver_timestamp,
+		hrt_abstime delay_us)
+{
+	// A sample timestamp within a few ms of the publish timestamp carries no latency information (u-blox stamps
+	// sensor_gnss_relative with the parse time), so only a sample time meaningfully earlier than the publish time is
+	// trusted. Otherwise the configured receiver delay is applied.
+	if ((driver_timestamp_sample != 0) && (driver_timestamp_sample + kSampleTimestampTolerance < driver_timestamp)) {
+		return driver_timestamp_sample;
+	}
+
+	return (delay_us > 0 && driver_timestamp > delay_us) ? driver_timestamp - delay_us : driver_timestamp;
 }
 
 void VehicleGPSPosition::PrintStatus()

--- a/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.cpp
+++ b/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.cpp
@@ -122,7 +122,48 @@ void VehicleGPSPosition::ParametersUpdate(bool force)
 			{_param_sens_gps1_offx.get(), _param_sens_gps1_offy.get(), _param_sens_gps1_offz.get()},
 			static_cast<hrt_abstime>(_param_sens_gps1_delay.get()) * 1000
 		};
+
+		updateBaselineRotation(_gps_param_slots[0], _param_sens_gps0_rot.get(), _param_sens_gps0_roll.get(),
+				       _param_sens_gps0_pitch.get(), _param_sens_gps0_yaw.get());
+		updateBaselineRotation(_gps_param_slots[1], _param_sens_gps1_rot.get(), _param_sens_gps1_roll.get(),
+				       _param_sens_gps1_pitch.get(), _param_sens_gps1_yaw.get());
 	}
+}
+
+void VehicleGPSPosition::updateBaselineRotation(GpsParamSlot &slot, int32_t rotation, float roll_deg, float pitch_deg,
+		float yaw_deg)
+{
+	matrix::Dcmf R;
+
+	const bool custom_set = (fabsf(roll_deg) > FLT_EPSILON) || (fabsf(pitch_deg) > FLT_EPSILON)
+				|| (fabsf(yaw_deg) > FLT_EPSILON);
+
+	if ((rotation == ROTATION_CUSTOM) || custom_set) {
+		R = matrix::Dcmf(matrix::Eulerf(math::radians(roll_deg), math::radians(pitch_deg), math::radians(yaw_deg)));
+
+	} else if ((rotation >= 0) && (rotation < ROTATION_MAX)) {
+		R = get_rot_matrix(static_cast<Rotation>(rotation));
+	}
+
+	// baseline direction in the body frame; only its yaw enters the heading
+	const matrix::Vector3f baseline = R * matrix::Vector3f(1.f, 0.f, 0.f);
+	slot.heading_available = baseline.xy().norm() > 0.1f;
+	slot.heading_offset = slot.heading_available ? atan2f(baseline(1), baseline(0)) : 0.f;
+}
+
+void VehicleGPSPosition::applyBaselineRotation(const GpsParamSlot *slot, float &heading, float &heading_offset)
+{
+	if (!PX4_ISFINITE(heading) || PX4_ISFINITE(heading_offset)) {
+		return;
+	}
+
+	if (slot && !slot->heading_available) {
+		heading = NAN;
+		return;
+	}
+
+	heading_offset = slot ? slot->heading_offset : 0.f;
+	heading = matrix::wrap_pi(heading - heading_offset);
 }
 
 void VehicleGPSPosition::Run()
@@ -153,6 +194,7 @@ void VehicleGPSPosition::Run()
 			const hrt_abstime delay_us = slot ? slot->delay_us : kDefaultDelay;
 
 			gps_data[i].timestamp_sample = resolveSampleTimestamp(gps_data[i].timestamp_sample, gps_data[i].timestamp, delay_us);
+			applyBaselineRotation(slot, gps_data[i].heading, gps_data[i].heading_offset);
 
 			_gps_blending.setAntennaOffset(antenna_offset, i);
 			_gps_blending.setGpsData(gps_data[i], i);
@@ -208,10 +250,8 @@ void VehicleGPSPosition::UpdateGnssHeading(const sensor_gps_s gps_data[GPS_MAX_R
 	// receivers would jump the heading and trip the EKF observation rate limit. The active source is kept until it
 	// goes stale. sensor_gnss_relative is preferred over sensor_gps.heading and preempts it.
 	//
-	// TODO: the baseline rotation belongs in the SENS_GPSn_* slot next to the antenna position and delay, resolved
-	// here by device_id, replacing GPS_YAW_OFFSET / SEP_YAW_OFFS / EKF2_GPS_YAW_OFF. With per-receiver rotation the
-	// source selection can also follow the flight phase, e.g. a tailsitter with one baseline aligned for hover and one
-	// for forward flight.
+	// TODO: with per-receiver rotation the selection can also follow the flight phase, e.g. a tailsitter with one
+	// baseline aligned for hover and one for forward flight.
 	const hrt_abstime now = hrt_absolute_time();
 	const bool source_active = (_heading_source.last_publish != 0)
 				   && (now - _heading_source.last_publish < kHeadingSourceTimeout);
@@ -232,20 +272,32 @@ void VehicleGPSPosition::UpdateGnssHeading(const sensor_gps_s gps_data[GPS_MAX_R
 		}
 
 		// sensor_gnss_relative instances are numbered by advertise order, not by receiver, so the receiver's
-		// sensor_gps instance is looked up by device_id for the delay parameters and the driver heading offset.
-		sensor_gps_s receiver_gps;
-		const int gps_instance = findGpsInstance(gnss_rel.device_id, receiver_gps);
-		const GpsParamSlot *slot = findParamSlot(gnss_rel.device_id, gps_instance);
+		// sensor_gps instance is looked up by device_id for the parameter slot.
+		const GpsParamSlot *slot = findParamSlot(gnss_rel.device_id, findGpsInstance(gnss_rel.device_id));
 		const hrt_abstime delay_us = slot ? slot->delay_us : kDefaultDelay;
 
-		// No PPS correction here: sensor_gnss_relative.time_utc_usec is not reliably UTC (u-blox fills it with iTOW)
-		// and PpsTimeSync only sanity-checks the first correction after each pulse.
+		// the relative position heading is always the raw baseline
+		float heading = gnss_rel.heading;
+		float heading_offset = NAN;
+		applyBaselineRotation(slot, heading, heading_offset);
+
+		if (!PX4_ISFINITE(heading)) {
+			continue;
+		}
+
+		uint64_t timestamp_sample = resolveSampleTimestamp(gnss_rel.timestamp_sample, gnss_rel.timestamp, delay_us);
+		const uint64_t pps_timestamp = _pps_time_sync.correct_gps_timestamp(gnss_rel.timestamp, gnss_rel.time_utc_usec);
+
+		if (pps_timestamp != gnss_rel.timestamp) {
+			timestamp_sample = pps_timestamp;
+		}
+
 		vehicle_gnss_heading_s heading_out{};
-		heading_out.timestamp_sample = resolveSampleTimestamp(gnss_rel.timestamp_sample, gnss_rel.timestamp, delay_us);
+		heading_out.timestamp_sample = timestamp_sample;
 		heading_out.device_id = gnss_rel.device_id;
-		heading_out.heading = gnss_rel.heading;
+		heading_out.heading = heading;
 		heading_out.heading_accuracy = gnss_rel.heading_accuracy;
-		heading_out.heading_offset = (gps_instance >= 0) ? receiver_gps.heading_offset : NAN;
+		heading_out.heading_offset = heading_offset;
 		heading_out.timestamp = hrt_absolute_time();
 		_vehicle_gnss_heading_pub.publish(heading_out);
 
@@ -317,9 +369,11 @@ const VehicleGPSPosition::GpsParamSlot *VehicleGPSPosition::findParamSlot(uint32
 	return nullptr;
 }
 
-int VehicleGPSPosition::findGpsInstance(uint32_t device_id, sensor_gps_s &gps_data)
+int VehicleGPSPosition::findGpsInstance(uint32_t device_id)
 {
 	for (int i = 0; i < GPS_MAX_RECEIVERS; i++) {
+		sensor_gps_s gps_data;
+
 		if (_sensor_gps_sub[i].copy(&gps_data) && (gps_data.device_id == device_id)) {
 			return i;
 		}

--- a/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.hpp
+++ b/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.hpp
@@ -45,6 +45,8 @@
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/sensor_gps.h>
+#include <uORB/topics/sensor_gnss_relative.h>
+#include <uORB/topics/vehicle_gnss_heading.h>
 #include <uORB/topics/pps_capture.h>
 
 #include "gps_blending.hpp"
@@ -71,17 +73,37 @@ private:
 
 	void ParametersUpdate(bool force = false);
 
-	// defines used to specify the mask position for use of different accuracy metrics in the GPS blending algorithm
-	static constexpr uint8_t BLEND_MASK_USE_SPD_ACC  = 1;
-	static constexpr uint8_t BLEND_MASK_USE_HPOS_ACC = 2;
-	static constexpr uint8_t BLEND_MASK_USE_VPOS_ACC = 4;
-
 	// define max number of GPS receivers supported
 	static constexpr int GPS_MAX_RECEIVERS = 2;
 	static_assert(GPS_MAX_RECEIVERS == GpsBlending::GPS_MAX_RECEIVERS_BLEND,
 		      "GPS_MAX_RECEIVERS must match to GPS_MAX_RECEIVERS_BLEND");
 
+	static constexpr hrt_abstime kDefaultDelay{110_ms}; // matches SENS_GPS*_DELAY default
+	static constexpr hrt_abstime kSampleTimestampTolerance{10_ms};
+	static constexpr hrt_abstime kHeadingSourceTimeout{3_s};
+
+	struct GpsParamSlot {
+		uint32_t device_id{0};
+		matrix::Vector3f offset{};
+		hrt_abstime delay_us{kDefaultDelay};
+	};
+
+	void UpdateGnssHeading(const sensor_gps_s gps_data[GPS_MAX_RECEIVERS], const bool gps_updated[GPS_MAX_RECEIVERS]);
+
+	// SENS_GPSn_* slot for a receiver, by device_id or (when no IDs are configured) by sensor_gps instance
+	const GpsParamSlot *findParamSlot(uint32_t device_id, int instance) const;
+	// sensor_gps instance publishing this device_id, or -1
+	int findGpsInstance(uint32_t device_id, sensor_gps_s &gps_data);
+	static uint64_t resolveSampleTimestamp(uint64_t driver_timestamp_sample, uint64_t driver_timestamp,
+					       hrt_abstime delay_us);
+
+	// defines used to specify the mask position for use of different accuracy metrics in the GPS blending algorithm
+	static constexpr uint8_t BLEND_MASK_USE_SPD_ACC  = 1;
+	static constexpr uint8_t BLEND_MASK_USE_HPOS_ACC = 2;
+	static constexpr uint8_t BLEND_MASK_USE_VPOS_ACC = 4;
+
 	uORB::Publication<sensor_gps_s> _vehicle_gps_position_pub{ORB_ID(vehicle_gps_position)};
+	uORB::Publication<vehicle_gnss_heading_s> _vehicle_gnss_heading_pub{ORB_ID(vehicle_gnss_heading)};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
@@ -92,16 +114,23 @@ private:
 
 	uORB::Subscription _pps_capture_sub{ORB_ID(pps_capture)};
 
+	uORB::SubscriptionCallbackWorkItem _sensor_gnss_relative_sub[GPS_MAX_RECEIVERS] {
+		{this, ORB_ID(sensor_gnss_relative), 0},
+		{this, ORB_ID(sensor_gnss_relative), 1},
+	};
+
+	struct HeadingSource {
+		uint32_t device_id{0};
+		bool from_relative{false};
+		hrt_abstime last_publish{0};
+	} _heading_source{};
+
 	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
 
 	GpsBlending _gps_blending;
 	PpsTimeSync _pps_time_sync;
 
-	struct GpsParamSlot {
-		uint32_t device_id{0};
-		matrix::Vector3f offset{};
-		hrt_abstime delay_us{110_ms};
-	} _gps_param_slots[GPS_MAX_RECEIVERS] {};
+	GpsParamSlot _gps_param_slots[GPS_MAX_RECEIVERS] {};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::SENS_GPS_MASK>) _param_sens_gps_mask,

--- a/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.hpp
+++ b/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.hpp
@@ -33,6 +33,7 @@
 
 #pragma once
 
+#include <lib/conversion/rotation.h>
 #include <lib/mathlib/math/Limits.hpp>
 #include <lib/matrix/matrix/math.hpp>
 #include <lib/perf/perf_counter.h>
@@ -86,6 +87,8 @@ private:
 		uint32_t device_id{0};
 		matrix::Vector3f offset{};
 		hrt_abstime delay_us{kDefaultDelay};
+		float heading_offset{0.f};    // yaw of the antenna baseline in the body frame (rad)
+		bool heading_available{true}; // false for a vertical baseline, which has no heading
 	};
 
 	void UpdateGnssHeading(const sensor_gps_s gps_data[GPS_MAX_RECEIVERS], const bool gps_updated[GPS_MAX_RECEIVERS]);
@@ -93,7 +96,11 @@ private:
 	// SENS_GPSn_* slot for a receiver, by device_id or (when no IDs are configured) by sensor_gps instance
 	const GpsParamSlot *findParamSlot(uint32_t device_id, int instance) const;
 	// sensor_gps instance publishing this device_id, or -1
-	int findGpsInstance(uint32_t device_id, sensor_gps_s &gps_data);
+	int findGpsInstance(uint32_t device_id);
+	// Rotate a raw baseline heading into the body frame. A driver that already reports a body frame heading sets a
+	// finite heading_offset and is left alone.
+	static void applyBaselineRotation(const GpsParamSlot *slot, float &heading, float &heading_offset);
+	void updateBaselineRotation(GpsParamSlot &slot, int32_t rotation, float roll_deg, float pitch_deg, float yaw_deg);
 	static uint64_t resolveSampleTimestamp(uint64_t driver_timestamp_sample, uint64_t driver_timestamp,
 					       hrt_abstime delay_us);
 
@@ -145,7 +152,15 @@ private:
 		(ParamFloat<px4::params::SENS_GPS1_OFFY>) _param_sens_gps1_offy,
 		(ParamFloat<px4::params::SENS_GPS1_OFFZ>) _param_sens_gps1_offz,
 		(ParamInt<px4::params::SENS_GPS0_DELAY>) _param_sens_gps0_delay,
-		(ParamInt<px4::params::SENS_GPS1_DELAY>) _param_sens_gps1_delay
+		(ParamInt<px4::params::SENS_GPS1_DELAY>) _param_sens_gps1_delay,
+		(ParamInt<px4::params::SENS_GPS0_ROT>) _param_sens_gps0_rot,
+		(ParamFloat<px4::params::SENS_GPS0_ROLL>) _param_sens_gps0_roll,
+		(ParamFloat<px4::params::SENS_GPS0_PITCH>) _param_sens_gps0_pitch,
+		(ParamFloat<px4::params::SENS_GPS0_YAW>) _param_sens_gps0_yaw,
+		(ParamInt<px4::params::SENS_GPS1_ROT>) _param_sens_gps1_rot,
+		(ParamFloat<px4::params::SENS_GPS1_ROLL>) _param_sens_gps1_roll,
+		(ParamFloat<px4::params::SENS_GPS1_PITCH>) _param_sens_gps1_pitch,
+		(ParamFloat<px4::params::SENS_GPS1_YAW>) _param_sens_gps1_yaw
 	)
 };
 }; // namespace sensors

--- a/src/modules/sensors/vehicle_gps_position/module.yaml
+++ b/src/modules/sensors/vehicle_gps_position/module.yaml
@@ -126,3 +126,100 @@ parameters:
             max: 300
             num_instances: *max_num_gps_instances
             instance_start: 0
+
+        SENS_GPS${i}_ROT:
+            description:
+                short: GPS ${i} antenna baseline rotation relative to airframe
+                long: |
+                    Rotation of the dual antenna baseline, moving base to rover (or antenna 1 to
+                    antenna 2), relative to the vehicle body frame. No rotation: the rover
+                    antenna is in front of the moving base. Yaw 90°: the rover is on the right.
+                    Matched to the physical receiver via SENS_GPS${i}_ID. Not applied when the
+                    receiver already reports a body frame heading.
+                    Set to "Custom Euler Angle" to define the rotation using SENS_GPS${i}_ROLL,
+                    SENS_GPS${i}_PITCH and SENS_GPS${i}_YAW.
+            type: enum
+            values:
+                0: No rotation
+                1: Yaw 45°
+                2: Yaw 90°
+                3: Yaw 135°
+                4: Yaw 180°
+                5: Yaw 225°
+                6: Yaw 270°
+                7: Yaw 315°
+                8: Roll 180°
+                9: Roll 180°, Yaw 45°
+                10: Roll 180°, Yaw 90°
+                11: Roll 180°, Yaw 135°
+                12: Pitch 180°
+                13: Roll 180°, Yaw 225°
+                14: Roll 180°, Yaw 270°
+                15: Roll 180°, Yaw 315°
+                16: Roll 90°
+                17: Roll 90°, Yaw 45°
+                18: Roll 90°, Yaw 90°
+                19: Roll 90°, Yaw 135°
+                20: Roll 270°
+                21: Roll 270°, Yaw 45°
+                22: Roll 270°, Yaw 90°
+                23: Roll 270°, Yaw 135°
+                24: Pitch 90°
+                25: Pitch 270°
+                26: Pitch 180°, Yaw 90°
+                27: Pitch 180°, Yaw 270°
+                28: Roll 90°, Pitch 90°
+                29: Roll 180°, Pitch 90°
+                30: Roll 270°, Pitch 90°
+                31: Roll 90°, Pitch 180°
+                32: Roll 270°, Pitch 180°
+                33: Roll 90°, Pitch 270°
+                34: Roll 180°, Pitch 270°
+                35: Roll 270°, Pitch 270°
+                36: Roll 90°, Pitch 180°, Yaw 90°
+                37: Roll 90°, Yaw 270°
+                38: Roll 90°, Pitch 68°, Yaw 293°
+                39: Pitch 315°
+                40: Roll 90°, Pitch 315°
+                100: Custom Euler Angle
+            min: 0
+            max: 100
+            default: 0
+            num_instances: *max_num_gps_instances
+            instance_start: 0
+
+        SENS_GPS${i}_ROLL:
+            description:
+                short: GPS ${i} baseline custom Euler Roll angle
+                long: Setting this parameter changes SENS_GPS${i}_ROT to "Custom Euler Angle"
+            type: float
+            default: 0.0
+            min: -180
+            max: 180
+            unit: deg
+            num_instances: *max_num_gps_instances
+            instance_start: 0
+
+        SENS_GPS${i}_PITCH:
+            description:
+                short: GPS ${i} baseline custom Euler Pitch angle
+                long: Setting this parameter changes SENS_GPS${i}_ROT to "Custom Euler Angle"
+            type: float
+            default: 0.0
+            min: -180
+            max: 180
+            unit: deg
+            num_instances: *max_num_gps_instances
+            instance_start: 0
+
+        SENS_GPS${i}_YAW:
+            description:
+                short: GPS ${i} baseline custom Euler Yaw angle
+                long: Setting this parameter changes SENS_GPS${i}_ROT to "Custom Euler Angle"
+            type: float
+            default: 0.0
+            min: -180
+            max: 180
+            unit: deg
+            num_instances: *max_num_gps_instances
+            instance_start: 0


### PR DESCRIPTION
## Summary

Replaces `GPS_YAW_OFFSET`, `SEP_YAW_OFFS`, `SEP_PITCH_OFFS` and `EKF2_GPS_YAW_OFF` with a per-receiver baseline rotation `SENS_GPSn_ROT` (the standard sensor `Rotation` enum, custom Euler via `SENS_GPSn_ROLL/PITCH/YAW`) next to the existing `SENS_GPSn_ID`, `SENS_GPSn_OFFX/Y/Z` and `SENS_GPSn_DELAY`. Stacked on #27102; the first two commits are that PR. Bumps PX4-GPSDrivers to PX4/PX4-GPSDrivers#240.

## Problem

The antenna baseline orientation lived in three places depending on the transport: in the serial driver (`GPS_YAW_OFFSET`, subtracted before publish), inside the Septentrio receiver (`SEP_YAW_OFFS`, `SEP_PITCH_OFFS`), and in EKF2 for everything that arrived with a NaN offset, in practice CAN receivers (`EKF2_GPS_YAW_OFF`). A CAN receiver needed the node's `GPS_YAW_OFFSET` and the autopilot's `EKF2_GPS_YAW_OFF` to agree, and a second receiver with a different baseline had no parameter at all. u-blox stamped `sensor_gnss_relative` with a parse-time `timestamp_sample` and an iTOW `time_utc_usec`, so the relative position could not be delay-compensated or PPS-aligned.

## Solution

Drivers publish the raw baseline heading with `heading_offset = NaN`; a driver that already reports a body-frame heading keeps a finite `heading_offset` and is left alone. `vehicle_gps_position` resolves the receiver's slot by device_id, rotates the baseline into the body frame before blending and before publishing `vehicle_gnss_heading`, and hands the offset to EKF2 through the message. The baseline yaw is the yaw of the rotated x-axis; a vertical baseline yields no heading. Septentrio receivers get their attitude offsets zeroed. With a real `time_utc_usec` on `sensor_gnss_relative`, PPS correction now applies on the relative-position path as well.

Behavior change for CAN nodes running older firmware: they still apply their own `GPS_YAW_OFFSET`, which must be 0 when `SENS_GPSn_ROT` is set.
