### PR TITLE
fix(boards/matek-h743): correct board ID in release firmware prototype

### DIFF
--- a/boards/matek/h743-mini/src/hw_config.h
+++ b/boards/matek/h743-mini/src/hw_config.h
@@ -93,7 +93,7 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,57600"
-#define BOARD_TYPE                     139
+#define BOARD_TYPE                     1013
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)
 #define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)

--- a/boards/matek/h743/src/hw_config.h
+++ b/boards/matek/h743/src/hw_config.h
@@ -93,7 +93,7 @@
 //#define USE_VBUS_PULL_DOWN
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,57600"
-#define BOARD_TYPE                     139
+#define BOARD_TYPE                     1013
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)
 #define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)


### PR DESCRIPTION
matek_h743_default.px4 shipped with board_id 1013, which belongs to the h743-slim/h743-mini targets. The h743 bootloader reports 139 (BOARD_TYPE in src/hw_config.h), so QGroundControl rejects flashing with a "board ID 1013 != 139" mismatch.

Fixes #27731

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
