### PR TITLE
[BACKPORT] fix(boards/matek-h743): correct board ID in release firmware prototype

### DIFF
--- a/boards/matek/h743/firmware.prototype
+++ b/boards/matek/h743/firmware.prototype
@@ -1,5 +1,5 @@
 {
-    "board_id": 1013,
+    "board_id": 139,
     "magic": "PX4FWv1",
     "description": "Firmware for the MatekH743 boards",
     "image": "",


### PR DESCRIPTION
Backport of 38a619eabc to release/1.18.

Fixes #27731

I am not sure if we can have this in for 1.18 but it is a bug. 

<!--

### Solved Problem
Fixes #{Github issue ID}

### Solution

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives

### Test coverage

### Context
Related links, screenshot before/after, video

-->
