### PR TITLE
fix(fw_lat_lon_control): use tailsitter fixed-wing heading

### DIFF
--- a/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
+++ b/src/modules/fw_lateral_longitudinal_control/FwLateralLongitudinalControl.cpp
@@ -817,7 +817,7 @@ float FwLateralLongitudinalControl::getGuidanceQualityFactor(const vehicle_local
 							    0.f, 1.f));
 
 	// Check that the angle between heading and track is not off too much. if it is greater than 90° we will be pushed back from the wind and the npfg will propably give a roll command in the wrong direction.
-	const Vector2f heading_vector(matrix::Dcm2f(local_pos.heading)*Vector2f({1.f, 0.f}));
+	const Vector2f heading_vector(matrix::Dcm2f(_yaw)*Vector2f({1.f, 0.f}));
 	const Vector2f ground_vel_norm(ground_vel.normalized());
 	const float flying_forward_factor(math::constrain((heading_vector.dot(ground_vel_norm) -
 							   COS_HEADING_TRACK_ANGLE_PUSHED_BACK) / ((COS_HEADING_TRACK_ANGLE_NOT_PUSHED_BACK -

--- a/src/modules/fw_mode_manager/FixedWingModeManager.cpp
+++ b/src/modules/fw_mode_manager/FixedWingModeManager.cpp
@@ -2053,7 +2053,7 @@ float FixedWingModeManager::rollAngleToLateralAccel(float roll_body) const
 void FixedWingModeManager::control_backtransition_heading_hold()
 {
 	if (!PX4_ISFINITE(_backtrans_heading)) {
-		_backtrans_heading = _local_pos.heading;
+		_backtrans_heading = _yaw;
 	}
 
 	fixed_wing_lateral_setpoint_s fw_lateral_ctrl_sp{empty_lateral_control_setpoint};


### PR DESCRIPTION
### Solved Problem

Fixes #28643.

Fixed-wing modules were using raw `vehicle_local_position.heading` where the already frame-adapted `_yaw` was needed. On tailsitters this can invert heading relative to ground track and affect backtransition heading hold.

### Solution

Use `_yaw` in the no-wind guidance-quality check and when capturing the no-position backtransition heading. This is a two-line change.

### Test coverage

- `make format`
- `make check_format`
- `make tests` — 203/203 passed
- `make px4_sitl_default px4` — passed
- Long-duration SITL evidence is documented in #28643
