### PR TITLE
fix(mavlink): allow CONDITION_GATE's location params in mission upload

### DIFF
--- a/src/modules/mavlink/mavlink_command_params.hpp
+++ b/src/modules/mavlink/mavlink_command_params.hpp
@@ -119,7 +119,7 @@ static constexpr Entry SupportedCommandParams[] = {
 	{ 2500, 0x07, 0x07 }, // VIDEO_START_CAPTURE:         p1:stream_id,p2:status_freq,p3:camera_id
 	{ 2501, 0x03, 0x03 }, // VIDEO_STOP_CAPTURE:          p1:stream_id,p2:camera_id
 	{ 3000, 0x03, 0x03 }, // DO_VTOL_TRANSITION:          p1:state,p2:force_immediate
-	{ 4501, 0x00, 0x00 }, // CONDITION_GATE:              no params used by PX4
+	{ 4501, 0x73, 0x00 }, // CONDITION_GATE:              p1:geometry,p2:use_altitude; p5-7:lat/lon/alt
 	{ 5000, 0x70, 0x00 }, // NAV_FENCE_RETURN_POINT:      mission:p5-7:lat/lon/alt; cmd:none
 	{ 5001, 0x31, 0x01 }, // NAV_FENCE_POLYGON_VERTEX_INCLUSION: p1:vertex_count; mission:p5-6:lat/lon
 	{ 5002, 0x31, 0x01 }, // NAV_FENCE_POLYGON_VERTEX_EXCLUSION: p1:vertex_count; mission:p5-6:lat/lon


### PR DESCRIPTION
## Summary

`MAV_CMD_CONDITION_GATE`'s entry in `SupportedCommandParams` (`mavlink_command_params.hpp`) has mask `0x00`, so the mission-upload validator rejects param5-7 (lat/lon/alt) on a gate item with `MAV_MISSION_INVALID_PARAM5_X` -- **before the item ever reaches the navigator**.

But `common.xml` defines param5-7 as the gate's location, and `mission_block.cpp` (`is_mission_item_reached_or_completed()`) reads `_mission_item.lat`/`lon` to compute the gate-crossing plane. So as it stands, no `CONDITION_GATE` mission item with a location can ever be uploaded -- the command is unusable.

Also allows param1 (`Geometry`) and param2 (`UseAltitude`), which `common.xml` likewise defines but the mask excluded.

@julianoes 
1. Obviously this will need to be fixed at point of execution when we get around to it.
2. Is there somewhere that we test basic upload support of the "supported mission items"? Do we need a test for this?

## Fix

```
- { 4501, 0x00, 0x00 }, // CONDITION_GATE:              no params used by PX4
+ { 4501, 0x73, 0x00 }, // CONDITION_GATE:              p1:geometry,p2:use_altitude; p5-7:lat/lon/alt
```

Matches the pattern already used for the neighboring `NAV_FENCE_RETURN_POINT` entry (`0x70` for p5-7).

## How this was found

Building a test mission with a `CONDITION_GATE` item and uploading it to a real `sihsim_quadx` SIH instance -- upload was rejected every time a location was set on the gate.

## Test plan

- [x] Uploaded a mission with `TAKEOFF -> WAYPOINT -> CONDITION_GATE (with lat/lon) -> DO_CHANGE_SPEED -> WAYPOINT -> RTL` to `px4_sitl_sih` (`sihsim_quadx`) via raw MAVLink; confirmed `MISSION_ACK` now returns `MAV_MISSION_ACCEPTED` and the mission round-trips correctly on download.
- [x] Flew the mission in SITL; confirmed the gate is marked reached (triggering the subsequent `DO_CHANGE_SPEED`) partway along the flight leg, consistent with the plane-crossing logic in `mission_block.cpp`.

No test in the repo currently exercises `MAV_CMD_CONDITION_GATE` (it's marked `<wip/>` in `common.xml`), so this wasn't caught by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196c3ZPtNhnjiExcFPDh7JG