### PR TITLE
fix(matrix): invert the control allocation kernel in mixed precision

### DIFF
--- a/src/lib/control_allocation/control_allocation/ControlAllocation.hpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocation.hpp
@@ -257,6 +257,9 @@ public:
 	/// achievable, e.g. yaw when collinear with roll after a motor failure
 	uint8_t getDroppedAxes() const { return _dropped_axes; }
 
+	/// True if the last effectiveness matrix could not be inverted (previous allocation kept)
+	bool effectivenessInversionFailed() const { return _effectiveness_inversion_failed; }
+
 protected:
 	friend class ControlAllocator; // for _actuator_sp
 
@@ -274,4 +277,5 @@ protected:
 	bool _normalize_rpy{false};				///< if true, normalize roll, pitch and yaw columns
 	bool _had_actuator_failure{false};
 	uint8_t _dropped_axes{0};				///< bitmask over ControlAxis
+	bool _effectiveness_inversion_failed{false};
 };

--- a/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverse.cpp
@@ -66,7 +66,15 @@ void
 ControlAllocationPseudoInverse::updatePseudoInverse()
 {
 	if (_mix_update_needed) {
-		matrix::geninv(_effectiveness, _mix);
+		// the pseudo-inverse squares the condition number of the effectiveness matrix: the 6x6 kernel needs double
+		if (!matrix::geninvMixedPrecision(_effectiveness, _mix)) {
+			// _mix untouched: keep previous allocation
+			_effectiveness_inversion_failed = true;
+			_mix_update_needed = false;
+			return;
+		}
+
+		_effectiveness_inversion_failed = false;
 
 		if (!_metric_allocation) {
 			if (_normalization_needs_update && !_had_actuator_failure) {

--- a/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverseTest.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationPseudoInverseTest.cpp
@@ -221,6 +221,7 @@ TEST(ControlAllocationPseudoInverseTest, DroppedAxisIsUnallocatedOthersExact)
 	control_sp(ControlAllocation::YAW) = 1.f;
 	method.setControlSetpoint(control_sp);
 	method.allocate();
+	EXPECT_FALSE(method.effectivenessInversionFailed());
 	const Vector<float, 16> no_actuation;
 	EXPECT_EQ(method.getActuatorSetpoint(), no_actuation);
 	EXPECT_FLOAT_EQ(method.getAllocatedControl()(ControlAllocation::YAW), 0.f);

--- a/src/lib/matrix/matrix/PseudoInverse.hpp
+++ b/src/lib/matrix/matrix/PseudoInverse.hpp
@@ -62,6 +62,116 @@ bool geninv(const Matrix<Type, M, N> &G, Matrix<Type, N, M> &res)
 	return true;
 }
 
+/**
+ * Pseudo-inverse of a wide float matrix (M <= N) with only the M x M kernel in double.
+ *
+ * geninv inverts G * G', whose condition number is the square of G's: for cond(G) ~ 1e3 single
+ * precision is lost entirely. Only the kernel needs double. G and the result stay float, every
+ * product touching them is an explicit loop accumulated in double, and the M x M work matrices
+ * are reused in place, so the stack holds three M x M doubles instead of the N x M double copies
+ * a full double geninv needs (control allocation runs this on a 3 KB work queue stack).
+ *
+ * @param G wide input matrix
+ * @param res pseudo-inverse of G; untouched if the kernel could not be inverted
+ * @return false if the kernel could not be inverted
+ */
+template<size_t M, size_t N>
+bool geninvMixedPrecision(const Matrix<float, M, N> &G, Matrix<float, N, M> &res)
+{
+	static_assert(M <= N, "geninvMixedPrecision requires a wide matrix (M <= N)");
+
+	// A = G * G'
+	SquareMatrix<double, M> A;
+
+	for (size_t i = 0; i < M; i++) {
+		for (size_t j = 0; j <= i; j++) {
+			double sum = 0.;
+
+			for (size_t k = 0; k < N; k++) {
+				sum += static_cast<double>(G(i, k)) * static_cast<double>(G(j, k));
+			}
+
+			A(i, j) = sum;
+			A(j, i) = sum;
+		}
+	}
+
+	size_t rank;
+	SquareMatrix<double, M> L = fullRankCholesky(A, rank);
+
+	// A = L' * L
+	for (size_t i = 0; i < M; i++) {
+		for (size_t j = 0; j <= i; j++) {
+			double sum = 0.;
+
+			for (size_t k = 0; k < M; k++) {
+				sum += L(k, i) * L(k, j);
+			}
+
+			A(i, j) = sum;
+			A(j, i) = sum;
+		}
+	}
+
+	SquareMatrix<double, M> X;
+
+	if (!inv(A, X, rank)) {
+		return false;
+	}
+
+	// A = L * X * X * L' = (G * G')^+, computed as A = X * X, X = L * A, A = X * L'
+	for (size_t i = 0; i < M; i++) {
+		for (size_t j = 0; j < M; j++) {
+			double sum = 0.;
+
+			for (size_t k = 0; k < M; k++) {
+				sum += X(i, k) * X(k, j);
+			}
+
+			A(i, j) = sum;
+		}
+	}
+
+	for (size_t i = 0; i < M; i++) {
+		for (size_t j = 0; j < M; j++) {
+			double sum = 0.;
+
+			for (size_t k = 0; k < M; k++) {
+				sum += L(i, k) * A(k, j);
+			}
+
+			X(i, j) = sum;
+		}
+	}
+
+	for (size_t i = 0; i < M; i++) {
+		for (size_t j = 0; j < M; j++) {
+			double sum = 0.;
+
+			for (size_t k = 0; k < M; k++) {
+				sum += X(i, k) * L(j, k);
+			}
+
+			A(i, j) = sum;
+		}
+	}
+
+	// res = G' * A
+	for (size_t j = 0; j < N; j++) {
+		for (size_t i = 0; i < M; i++) {
+			double sum = 0.;
+
+			for (size_t k = 0; k < M; k++) {
+				sum += static_cast<double>(G(k, j)) * A(k, i);
+			}
+
+			res(j, i) = static_cast<float>(sum);
+		}
+	}
+
+	return true;
+}
+
 
 template<typename Type>
 Type typeEpsilon();
@@ -70,6 +180,12 @@ template<> inline
 float typeEpsilon<float>()
 {
 	return FLT_EPSILON;
+}
+
+template<> inline
+double typeEpsilon<double>()
+{
+	return DBL_EPSILON;
 }
 
 /**

--- a/src/lib/matrix/test/MatrixPseudoInverseTest.cpp
+++ b/src/lib/matrix/test/MatrixPseudoInverseTest.cpp
@@ -173,3 +173,65 @@ TEST(MatrixPseudoInverseTest, PseudoInverse)
 	Matrix<float, 6, 5> real_pinv_expected(real_pinv_expected_alloc);
 	EXPECT_EQ(real_pinv, real_pinv_expected);
 }
+
+// Near-singular input (cond ~900): geninv inverts A*A', which squares that, so single precision
+// alone returns sign flips and entries orders of magnitude off. With the kernel in double the
+// float result still satisfies A * pinv(A) * A == A.
+TEST(MatrixPseudoInverseTest, MixedPrecisionNearSingularInput)
+{
+	const float near_singular[6][6] = {
+		{0.f, 0.f,  2.964000f, -2.853500f, -2.990000f,  2.840500f},
+		{0.f, 0.f,  5.063500f, -4.972500f,  5.063500f, -4.972500f},
+		{0.f, 0.f, -0.325000f,  0.325000f,  0.325000f, -0.325000f},
+		{0.f, 0.f,  0.f,        0.f,        0.f,        0.f},
+		{0.f, 0.f,  0.f,        0.f,        0.f,        0.f},
+		{0.f, 0.f, -6.500000f, -6.500000f, -6.500000f, -6.500000f}
+	};
+
+	Matrix<float, 6, 16> A;
+	A.setZero();
+
+	for (size_t row = 0; row < 6; row++) {
+		for (size_t col = 0; col < 6; col++) {
+			A(row, col) = near_singular[row][col];
+		}
+	}
+
+	Matrix<float, 16, 6> A_pinv;
+	ASSERT_TRUE(geninvMixedPrecision(A, A_pinv));
+
+	// residual in double: the float geninv of this input is off by orders of magnitude
+	const Matrix<double, 6, 16> A_d(A);
+	const Matrix<double, 16, 6> A_pinv_d(A_pinv);
+	EXPECT_LT((A_d * A_pinv_d * A_d - A_d).abs().max(), 1e-3);
+
+	// last column bounded, physical sign
+	for (size_t i = 2; i < 6; i++) {
+		EXPECT_LT(A_pinv(i, 5), 0.f);
+		EXPECT_LT(fabsf(A_pinv(i, 5)), 1.f);
+	}
+}
+
+// An independent but tiny row passes the Cholesky rank tolerance yet fails the inversion pivot
+// threshold: the function reports failure and leaves the caller's previous result untouched.
+TEST(MatrixPseudoInverseTest, MixedPrecisionFailureLeavesResultUntouched)
+{
+	Matrix<float, 6, 16> A;
+	A.setZero();
+
+	for (size_t col = 0; col < 4; col++) {
+		A(0, col) = 1.f;
+	}
+
+	A(1, 4) = 1e-5f;
+
+	Matrix<float, 16, 6> A_pinv;
+	A_pinv.setAll(42.f);
+	EXPECT_FALSE(geninvMixedPrecision(A, A_pinv));
+
+	for (size_t row = 0; row < 16; row++) {
+		for (size_t col = 0; col < 6; col++) {
+			EXPECT_FLOAT_EQ(A_pinv(row, col), 42.f);
+		}
+	}
+}

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -651,6 +651,12 @@ ControlAllocator::check_allocation_health(int matrix_index)
 			PX4_INFO("Control allocation %i: all control axes restored", matrix_index);
 		}
 	}
+
+	if (_control_allocation[matrix_index]->effectivenessInversionFailed()
+	    && !_inversion_failure_reported[matrix_index]) {
+		_inversion_failure_reported[matrix_index] = true;
+		PX4_ERR("Control allocation %i: effectiveness inversion failed, keeping previous", matrix_index);
+	}
 }
 
 void

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -162,6 +162,7 @@ private:
 	hrt_abstime _last_effectiveness_update{0};
 
 	uint8_t _dropped_axes_reported[ActuatorEffectiveness::MAX_NUM_MATRICES] {};
+	bool _inversion_failure_reported[ActuatorEffectiveness::MAX_NUM_MATRICES] {};
 
 	enum class EffectivenessSource {
 		NONE = -1,

--- a/src/systemcmds/microbench/test_microbench_matrix.cpp
+++ b/src/systemcmds/microbench/test_microbench_matrix.cpp
@@ -99,6 +99,7 @@ private:
 	bool time_matrix_quaternion();
 	bool time_matrix_dcm();
 	bool time_matrix_pseduo_inverse();
+	bool time_matrix_pseduo_inverse_mixed_precision();
 
 	void reset();
 
@@ -116,6 +117,7 @@ bool MicroBenchMatrix::run_tests()
 	ut_run_test(time_matrix_quaternion);
 	ut_run_test(time_matrix_dcm);
 	ut_run_test(time_matrix_pseduo_inverse);
+	ut_run_test(time_matrix_pseduo_inverse_mixed_precision);
 
 	return (_tests_failed == 0);
 }
@@ -172,6 +174,17 @@ bool MicroBenchMatrix::time_matrix_pseduo_inverse()
 {
 	PERF("matrix 6x16 pseudo inverse (all non-zero columns)", matrix::geninv(B16, A16), 100);
 	PERF("matrix 6x16 pseudo inverse (4 non-zero columns)", matrix::geninv(B16_4, A16), 100);
+	return true;
+}
+
+bool MicroBenchMatrix::time_matrix_pseduo_inverse_mixed_precision()
+{
+	// same inputs as the float version above: the interesting number is the ratio, and it is
+	// much larger on boards without a double precision FPU (every cortex-m4 target)
+	PERF("matrix 6x16 mixed precision pseudo inverse (all non-zero columns)",
+	     matrix::geninvMixedPrecision(B16, A16), 100);
+	PERF("matrix 6x16 mixed precision pseudo inverse (4 non-zero columns)",
+	     matrix::geninvMixedPrecision(B16_4, A16), 100);
 	return true;
 }
 


### PR DESCRIPTION
## Summary

Stacked on the dropped-axes fix. That change keeps the allocator away from the worst of the near-singular band, but a band remains where the float pseudo-inverse is still badly wrong. This runs the small kernel of `geninv` in double, which is where the precision is actually lost, and checks the return value instead of discarding it.

## Problem

`geninv` inverts `G*G'`, which squares the condition number, and then inverts `L'*L` on top of that — so the working condition number is the fourth power of the input's. Near singularity float32 has nothing left.

Dropping dependent axes removes the pathological case, but the threshold has to sit somewhere, and just above it the float inverse is still unusable. Sweeping the yaw-row independence just above the 1e-2 drop threshold:

| independence | max abs pinv entry | float relative error | mixed relative error | Moore-Penrose residual, float |
|---|---|---|---|---|
| 0.005 | 11.1 | 0.31 | 1.5e-08 | 574 |
| 0.010 | 7.9 | 0.025 | 2.9e-08 | 33.6 |
| 0.025 | 5.0 | 0.017 | 2.8e-08 | 14.1 |
| 0.15 | 2.0 | 0.0085 | 8.1e-09 | 2.9 |

Raising the Cholesky rank tolerance instead only shifts the bad band and couples the threshold to `CA_ROTORn_KM`, so it is not a fix.

## Solution

`geninvMixedPrecision()` keeps the matrix float in and out and runs only the M x M kernel in double. On the inputs above it stays within 1e-8 of a full double reference.

Stack is the binding constraint, since this runs on `wq:rate_ctrl` with 3150 B, so the products are explicit loops with the work matrices reused in place: 1856 B of worst-case frame against 1864 B for the float `geninv` it replaces, measured with `-fstack-usage` at the real build flags. A plain double `geninv` with float/double conversion at the boundary would need 5600 B and is not an option here.

The return value is now checked. If the kernel cannot be inverted, the previous mix is kept and `ControlAllocator` reports it, rather than the allocator running on an undefined mix.

