### PR TITLE
fix(mavlink): fix access bug for mavlink_ftp

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -592,8 +592,7 @@ MavlinkFTP::_workOpen(PayloadHeader *payload, int oflag)
 
 		// CreateFile and OpenFileWO create or truncate the file as part of the open, so the
 		// effect lands before any write arrives and has to be authorized here.
-		if ((oflag & (O_WRONLY | O_RDWR | O_CREAT | O_TRUNC)) != 0
-		    && !_validatePathIsWritable(_work_buffer1)) {
+		if ((((oflag & O_ACCMODE) != O_RDONLY) || ((oflag & (O_CREAT | O_TRUNC)) != 0)) && !_validatePathIsWritable(_work_buffer1)) {
 			return kErrFailFileProtected;
 		}
 


### PR DESCRIPTION
### Solved Problem
I found a bug in MAVLink FTP where a read-only request is considered a write operation on NuttX. Because of this, _workOpen() checks if a read-only path is writable and returns **kErrFailFileProtected**, even though the request only wants to read the file.
`if ((oflag & (O_WRONLY | O_RDWR | O_CREAT | O_TRUNC)) != 0
		    && !_validatePathIsWritable(_work_buffer1)) {
			return kErrFailFileProtected;`

### Solution
I changed the condition to first extract the access mode using O_ACCMODE and compare it directly with O_RDONLY. I also check O_CREAT and O_TRUNC separately because these flags can modify the filesystem during open().

The new condition behaves like this (_workOpen is called with those specific oflag value):

- With **O_RDONLY**: 01 & 11 = 01, which is equal to O_RDONLY, so the first check is false. There is no O_CREAT or O_TRUNC, so the second check is also false. The request is correctly treated as read-only.

- With **O_CREAT** | **O_TRUNC** | **O_WRONLY**: 100110 & 11 = 10, which is different from O_RDONLY, so the first check is true. O_CREAT and O_TRUNC are also present, so the writable path is checked.

- With **O_CREAT** | **O_WRONLY**: 110 & 11 = 10, which is different from O_RDONLY, so the first check is true. O_CREAT is also present, so the writable path is checked.

### Test coverage
I tested the fix on the testbench and the parameters are loading correctly. The client cache must be cleared when reproducing the issue, because cached metadata can make the old firmware appear to work. make all also passes.