### PR TITLE
fix(drivers/rc/): fix hardfault error caused by strcmp called with nullptr

### DIFF
--- a/src/drivers/rc/dsm_rc/DsmRc.cpp
+++ b/src/drivers/rc/dsm_rc/DsmRc.cpp
@@ -95,6 +95,11 @@ int DsmRc::task_spawn(int argc, char *argv[])
 		return -1;
 	}
 
+	if (!device_name) {
+		PX4_ERR("valid device required");
+		return PX4_ERROR;
+	}
+
 	if (board_rc_conflicting(device_name)) {
 		PX4_INFO("unable to start, conflict with PX4IO on %s", device_name);
 		return PX4_ERROR;

--- a/src/drivers/rc/ghst_rc/GhstRc.cpp
+++ b/src/drivers/rc/ghst_rc/GhstRc.cpp
@@ -90,6 +90,11 @@ int GhstRc::task_spawn(int argc, char *argv[])
 		return -1;
 	}
 
+	if (!device_name) {
+		PX4_ERR("valid device required");
+		return PX4_ERROR;
+	}
+
 	if (board_rc_conflicting(device_name)) {
 		PX4_INFO("unable to start, conflict with PX4IO on %s", device_name);
 		return PX4_ERROR;

--- a/src/drivers/rc/sbus_rc/SbusRc.cpp
+++ b/src/drivers/rc/sbus_rc/SbusRc.cpp
@@ -87,6 +87,11 @@ int SbusRc::task_spawn(int argc, char *argv[])
 		return -1;
 	}
 
+	if (!device_name) {
+		PX4_ERR("valid device required");
+		return PX4_ERROR;
+	}
+
 	if (board_rc_conflicting(device_name)) {
 		PX4_INFO("unable to start, conflict with PX4IO on %s", device_name);
 		return PX4_ERROR;


### PR DESCRIPTION
### Solved Problem
When we manually initialize RC drivers such as dsm_rc, ghst_rc, or sbus_rc, if we do not specify the serial port, the device name will be nullptr. As a result, in the function board_rc_conflicting, strcmp will be called with a null pointer, which causes a hardfault.

### Solution
Before calling board_rc_conflicting, check if the device_name is not nullptr.

### Test coverage
Tested on the testbench. Without the changes, typing sbus_rc start (incomplete) will cause a hardfault. Now, an error is thrown in the nsh.
