### PR TITLE
feat(logger): add task_stack_info to debug topics

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -340,6 +340,7 @@ void LoggedTopics::add_debug_topics()
 	add_topic("sensor_preflight_mag", 500);
 	add_topic("actuator_test", 500);
 	add_topic("neural_control", 50);
+	add_topic("task_stack_info");
 }
 
 void LoggedTopics::add_estimator_replay_topics()


### PR DESCRIPTION
### Solved Problem
When adding new features such as e.g. https://github.com/PX4/PX4-Autopilot/pull/28173 where a buffer size is increased by about 700 bytes, it's convenient to have an easy way to know the how much space you still have on the stack. 

### Solution
Add task_stack_info to the debug logging profile.

### Context
<img width="992" height="555" alt="taskstackinfo_table" src="https://github.com/user-attachments/assets/b1dfece2-0c87-40fd-a3d5-3fdbf77cad05" />

