### PR TITLE
fix(packaging): support larger container SBOM attestations

### DIFF
--- a/.github/workflows/build_deb_package.yml
+++ b/.github/workflows/build_deb_package.yml
@@ -166,6 +166,8 @@ jobs:
         id: buildx
         with:
           driver: docker-container
+          # Gazebo/ROS SBOMs exceed the 40 MiB attestation limit in BuildKit 0.32.
+          driver-opts: image=moby/buildkit:v0.33.0
           platforms: linux/${{ matrix.arch }}
 
       - name: Restore ROS compiler cache

--- a/docs/en/dev_setup/sitl_container_builds.md
+++ b/docs/en/dev_setup/sitl_container_builds.md
@@ -186,6 +186,8 @@ Installing the complete source-build toolset increases cold image-build time and
 ## Container SBOMs
 
 The publishing workflow enables BuildKit's standard SBOM attestations for both runtime and ROS images.
+It pins BuildKit v0.33.0, whose 80 MiB attestation limit accommodates the Gazebo/ROS SPDX documents without reducing their package or file coverage.
+Local attested builds using BuildKit v0.32 can fail at export because that version limits each attestation to 40 MiB.
 These SPDX inventories describe discoverable packages in the image filesystem, including Ubuntu and ROS dependencies.
 They complement, rather than replace, PX4's [source and firmware SBOM](../contribute/sbom.md).
 


### PR DESCRIPTION
## Summary
Restore Gazebo/ROS container publication without dropping SBOM coverage.

## Problem
Both Gazebo architectures failed in [the publishing run](https://github.com/PX4/PX4-Autopilot/actions/runs/34541443952) because BuildKit 0.32.2 rejects attestation files above 40 MiB. The local reproducer generates a 55.1 MB scanner attestation.

## Solution
Pin the builder daemon to BuildKit 0.33.0, which raises the limit to 80 MiB (moby/buildkit#7104), and document the local-build limitation. Keep the existing scanner and full package/file metadata.