### PR TITLE
fix(ros2): publish the development image to Docker Hub

### DIFF
--- a/.github/workflows/ros_dev_container.yml
+++ b/.github/workflows/ros_dev_container.yml
@@ -64,6 +64,14 @@ jobs:
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
           (github.event_name == 'workflow_dispatch' && inputs.deploy_to_registry == true)
         with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/login-action@v4
+        if: >-
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+          (github.event_name == 'workflow_dispatch' && inputs.deploy_to_registry == true)
+        with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
@@ -88,6 +96,7 @@ jobs:
           provenance: false
           set: |
             ros2-dev.tags=ghcr.io/px4/px4-dev-ros2:sha-${{ steps.revision.outputs.sha }}-jazzy-${{ matrix.arch }}
+            ros2-dev.tags=px4io/px4-dev-ros2:sha-${{ steps.revision.outputs.sha }}-jazzy-${{ matrix.arch }}
             ros2-dev.labels.org.opencontainers.image.source=https://github.com/PX4/PX4-Autopilot
             ros2-dev.labels.org.opencontainers.image.revision=${{ steps.revision.outputs.sha }}
 
@@ -102,6 +111,10 @@ jobs:
       - uses: runs-on/action@v2
       - uses: docker/login-action@v4
         with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/login-action@v4
+        with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
@@ -111,7 +124,10 @@ jobs:
           TAG: ${{ github.event_name == 'push' && format('{0}-jazzy', github.ref_name) || inputs.tag || 'main-jazzy' }}
           REVISION: ${{ needs.build.outputs.revision }}
         run: |
-          IMAGE=ghcr.io/px4/px4-dev-ros2
-          docker buildx imagetools create \
-            --tag "${IMAGE}:${TAG}" --tag "${IMAGE}:sha-${REVISION}-jazzy" \
-            "${IMAGE}:sha-${REVISION}-jazzy-amd64" "${IMAGE}:sha-${REVISION}-jazzy-arm64"
+          for REGISTRY in px4io ghcr.io/px4; do
+            IMAGE="${REGISTRY}/px4-dev-ros2"
+
+            docker buildx imagetools create \
+              --tag "${IMAGE}:${TAG}" --tag "${IMAGE}:sha-${REVISION}-jazzy" \
+              "${IMAGE}:sha-${REVISION}-jazzy-amd64" "${IMAGE}:sha-${REVISION}-jazzy-arm64"
+          done

--- a/Tools/packaging/containers/docker-bake.hcl
+++ b/Tools/packaging/containers/docker-bake.hcl
@@ -61,7 +61,7 @@ target "ros2-dev" {
   platforms  = ["linux/${ARCH}"]
   dockerfile = "Dockerfile.ros2"
   target     = "ros2-dev"
-  tags       = ["ghcr.io/px4/px4-dev-ros2:main-jazzy-${ARCH}"]
+  tags       = ["px4io/px4-dev-ros2:main-jazzy-${ARCH}", "ghcr.io/px4/px4-dev-ros2:main-jazzy-${ARCH}"]
   cache-from = CACHE_GHA ? ["type=gha,scope=ros2-dev-${ARCH}"] : []
   cache-to   = CACHE_GHA ? ["type=gha,mode=max,scope=ros2-dev-${ARCH}"] : []
 }

--- a/docs/en/dev_setup/sitl_container_builds.md
+++ b/docs/en/dev_setup/sitl_container_builds.md
@@ -109,6 +109,7 @@ Image and workflow SHA overrides are for testing candidates; adopting a candidat
 ## Testing A PX4 Checkout With ROS
 
 The standalone `ghcr.io/px4/px4-dev-ros2:main-jazzy` image includes Jazzy, the Agent, PX4's source-build dependencies and the dependencies required by the pinned ROS repositories.
+It is also available on Docker Hub as `px4io/px4-dev-ros2:main-jazzy`, with matching tags in both registries.
 It contains no repository checkouts, packaged PX4 firmware or compiled ROS workspace, and its entrypoint sources only the Jazzy underlay.
 It is published independently of the SITL package workflow, so it does not wait for `.deb` builds.
 Publishing follows the same release-tag and opt-in manual policy as `px4-dev`.
@@ -173,7 +174,7 @@ Only the compiler cache is restored, not an old source, build or install workspa
 Ccache validates compiler contents and compilation inputs, including changed library sources and generated messages.
 `CACHE_GHA=true` uses an independent `ros2-dev-<architecture>` image cache, without replacing the published SITL image caches.
 The `ros_dev_container.yml` workflow builds the standalone target on every `main` push and on pull requests that change its watched paths, without publishing.
-It publishes to GHCR only on `v*` tag pushes or manual runs with `deploy_to_registry=true`.
+It publishes to Docker Hub and GHCR only on `v*` tag pushes or manual runs with `deploy_to_registry=true`.
 Manual runs use the `tag` input, which defaults to `main-jazzy`; the deployment toggle also applies when dispatching against a Git tag.
 Architecture tags use `sha-<full-PX4-commit>-jazzy-<architecture>`; the final selected tag and `sha-<full-PX4-commit>-jazzy` indexes preserve both architectures and their SBOMs.
 Use `--set ros2-dev.args.PX4_ROS2_REF=<40-hex-SHA>` to build the development image with another interface-library commit.

--- a/docs/en/simulation/px4_sitl_prebuilt_packages.md
+++ b/docs/en/simulation/px4_sitl_prebuilt_packages.md
@@ -176,6 +176,7 @@ When testing modified PX4 firmware, rebuild the ROS workspace against its messag
 Use `--entrypoint /bin/bash` and source `/opt/ros/jazzy/setup.bash` to start without the bundled workspace.
 For source builds and selecting an interface-library commit, see [Testing A PX4 Checkout With ROS](../dev_setup/sitl_container_builds.md#testing-a-px4-checkout-with-ros).
 The standalone `ghcr.io/px4/px4-dev-ros2:main-jazzy` toolchain provides the build tools and ROS dependencies without bundled source checkouts, firmware or a compiled workspace.
+It is also available on Docker Hub as `px4io/px4-dev-ros2:main-jazzy`, with matching tags in both registries.
 ROS integration CI uses this toolchain, builds PX4 from the pull request, and regenerates messages from that checkout.
 
 #### Go-To Example


### PR DESCRIPTION
## Summary
Make the standalone Jazzy toolchain accessible through the same registries as the ROS runtime images.

## Problem
The development image is published only to GHCR, leaving `px4io/px4-dev-ros2` unavailable to Docker Hub users.

## Solution
Reuse the existing Docker Hub credentials to publish architecture images and assemble matching multi-architecture tags in both registries, preserving SBOMs and the release-tag/opt-in manual publication policy. Document both image locations.