### PR TITLE
fix(ekf2): keep yaw aligned when the mag calibration changes on the ground

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
@@ -72,16 +72,20 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 			_state.mag_B.zero();
 			resetMagBiasCov();
 
+			if (!_control_status.flags.in_air && _control_status.flags.yaw_align
+			    && !_control_status.flags.yaw_manual
+			    && !_control_status.flags.ev_yaw && !_control_status.flags.gnss_yaw) {
+				// Assume that a reset on the ground is caused by a change in mag calibration.
+				// The heading has to be realigned to the corrected data, but keep the current
+				// alignment until fusion restarts so that the heading estimate doesn't become
+				// unavailable in between.
+				_mag_yaw_reset_req = true;
+			}
+
 			stopMagFusion();
 
 			_mag_lpf.reset(mag_sample.mag);
 			_mag_counter = 1;
-
-			if (!_control_status.flags.in_air && !_control_status.flags.yaw_manual) {
-				// Assume that a reset on the ground is caused by a change in mag calibration
-				// Clear alignment to force a clean reset
-				_control_status.flags.yaw_align = false;
-			}
 
 		} else {
 			_mag_lpf.update(mag_sample.mag);
@@ -299,6 +303,7 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 
 				// activate fusion, reset mag states and initialize variance if first init or in flight reset
 				if (!_control_status.flags.yaw_align
+				    || _mag_yaw_reset_req
 				    || wmm_updated
 				    || !_state.mag_I.longerThan(0.f)
 				    || (getStateVariance<State::mag_I>().min() < kMagVarianceMin)
@@ -306,7 +311,7 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 				   ) {
 					ECL_INFO("starting %s fusion, resetting states", AID_SRC_NAME);
 
-					bool reset_heading = !_control_status.flags.yaw_align;
+					const bool reset_heading = !_control_status.flags.yaw_align || _mag_yaw_reset_req;
 
 					resetMagStates(_mag_lpf.getState(), reset_heading);
 					aid_src.time_last_fuse = imu_sample.time_us;
@@ -316,6 +321,7 @@ void Ekf::controlMagFusion(const imuSample &imu_sample)
 						resetAidSourceStatusZeroInnovation(aid_src);
 					}
 
+					_mag_yaw_reset_req = false;
 					_control_status.flags.mag = true;
 
 				} else {

--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -120,6 +120,7 @@ void Ekf::reset()
 
 #if defined(CONFIG_EKF2_MAGNETOMETER)
 	_mag_counter = 0;
+	_mag_yaw_reset_req = false;
 #endif // CONFIG_EKF2_MAGNETOMETER
 
 	_time_bad_vert_accel = 0;

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -667,6 +667,7 @@ private:
 
 	AlphaFilter<Vector3f> _mag_lpf{static_cast<uint64_t>(_dt_ekf_avg * 1e6f), _kSensorLpfTimeConstant};	///< filtered magnetometer measurement for instant reset (Gauss)
 	uint32_t _mag_counter{0};		///< number of magnetometer samples read during initialisation
+	bool _mag_yaw_reset_req{false};	///< true when the heading must be realigned to the mag at the next fusion start (calibration changed on ground)
 
 	// Variables used to control activation of post takeoff functionality
 	uint64_t _flt_mag_align_start_time{0};	///< time that inflight magnetic field alignment started (uSec)

--- a/src/modules/ekf2/test/sensor_simulator/mag.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/mag.cpp
@@ -15,7 +15,8 @@ Mag::~Mag()
 
 void Mag::send(uint64_t time)
 {
-	_ekf->setMagData(magSample{time, _mag_data + _bias});
+	_ekf->setMagData(magSample{time, _mag_data + _bias, _reset});
+	_reset = false;
 }
 
 void Mag::setData(const Vector3f &mag)

--- a/src/modules/ekf2/test/sensor_simulator/mag.h
+++ b/src/modules/ekf2/test/sensor_simulator/mag.h
@@ -53,10 +53,12 @@ public:
 
 	void setData(const Vector3f &mag);
 	void setBias(const Vector3f &bias) { _bias = bias; }
+	void setCalibrationChanged() { _reset = true; }
 
 private:
 	Vector3f _mag_data;
 	Vector3f _bias;
+	bool _reset{false};
 
 	void send(uint64_t time) override;
 

--- a/src/modules/ekf2/test/test_EKF_mag.cpp
+++ b/src/modules/ekf2/test/test_EKF_mag.cpp
@@ -272,6 +272,47 @@ TEST_F(EkfMagTest, velocityRotationOnYawReset)
 	EXPECT_GT(yaw_change, 0.3f) << "Yaw change: " << degrees(yaw_change) << " deg";
 }
 
+TEST_F(EkfMagTest, calibrationChangeOnGroundKeepsYawAligned)
+{
+	// GIVEN: the vehicle sits on the ground, heading aligned from the mag, with GNSS aiding
+	const float mag_heading = M_PI_F / 4.f;
+	_sensor_simulator._mag.setData(Vector3f(0.2f * cosf(mag_heading), -0.2f * sinf(mag_heading), 0.4f));
+	_sensor_simulator.runSeconds(_init_duration_s);
+
+	_ekf->set_min_required_gps_health_time(1e6);
+	_ekf_wrapper.enableGpsFusion();
+	_sensor_simulator.startGps();
+	_sensor_simulator.runSeconds(10.f);
+
+	ASSERT_TRUE(_ekf->control_status_flags().yaw_align);
+	ASSERT_TRUE(_ekf_wrapper.isIntendingMagHeadingFusion());
+	ASSERT_TRUE(_ekf->control_status_flags().gnss_pos);
+
+	const int quat_reset_counter = _ekf_wrapper.getQuaternionResetCounter();
+
+	// WHEN: the mag calibration changes, as it does when the bias learned in flight is
+	// saved at disarm, and the corrected data points 10 degrees away from before
+	const float heading_change = radians(10.f);
+	const float new_heading = mag_heading + heading_change;
+	_sensor_simulator._mag.setData(Vector3f(0.2f * cosf(new_heading), -0.2f * sinf(new_heading), 0.4f));
+	_sensor_simulator._mag.setCalibrationChanged();
+
+	// THEN: the yaw alignment is never dropped while mag fusion restarts
+	for (int i = 0; i < 200; i++) {
+		_sensor_simulator.runMicroseconds(10e3);
+		EXPECT_TRUE(_ekf->control_status_flags().yaw_align) << "yaw alignment lost at step " << i;
+	}
+
+	// AND: the heading was realigned once to the corrected mag data and fusion resumed
+	EXPECT_EQ(_ekf_wrapper.getQuaternionResetCounter(), quat_reset_counter + 1);
+	EXPECT_TRUE(_ekf_wrapper.isIntendingMagHeadingFusion());
+
+	_sensor_simulator.runSeconds(10.f);
+	float mag_decl_deg = 0.f;
+	_ekf->get_mag_decl_deg(mag_decl_deg);
+	EXPECT_NEAR(_ekf_wrapper.getYawAngle(), new_heading + radians(mag_decl_deg), radians(1.f));
+}
+
 TEST_F(EkfMagTest, manualYawExpiresWhenHeadingIsFused)
 {
 	// GIVEN: mag fusion is aligned in flight, so the mag remains the heading source


### PR DESCRIPTION
I got the warning "Preflight Fail: no heading reference" on disarm which left me wondering what the problem was.

Claude suggested this fix. I'm not convinced yet.

---

## Summary

After a flight in which a mag bias was learned, the sensors module saves it into the stored offsets at disarm. The EKF treats that as a mag calibration change on the ground and drops its yaw alignment until fusion restarts, so the commander reports "Preflight Fail: no heading reference" right after landing, even though nothing is wrong.

## Problem

The reset-on-ground path from #24607 clears `yaw_align` and relies on the normal restart to realign the heading. That restart waits for a few mag samples, and the commander check for a missing heading reference fires during the gap. Since the learned bias gets saved after most flights, the warning shows up on almost every landing.

## Solution

Keep the current alignment and instead request a heading reset for the next mag fusion start, so the heading is still realigned to the corrected calibration but never reported as unavailable in between. The request is only raised when the yaw came from the mag, so a heading aligned from GNSS yaw or external vision is left alone.

Verified with the EKF mag unit tests: the new test fails on `main` (alignment lost for ~40 ms after the calibration change) and passes with this change, and the rest of the mag suite is unaffected. The trigger was observed in flight logs from a real vehicle; the fix itself has not been flight tested yet.

