### PR TITLE
fix(ekf2): keep GNSS checks relaxed between arming and takeoff

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.cpp
@@ -47,14 +47,16 @@ bool GnssChecks::run(const gnssSample &gnss, uint64_t time_us)
 		_time_last_fail_us = time_us;
 	}
 
-	// Run strict checks while not flying yet
-	if (!_control_status.flags.in_air) {
+	// Run strict checks while disarmed on the ground
+	if (!_control_status.flags.armed && !_control_status.flags.in_air) {
 		_initial_checks_passed = false;
 	}
 
 	_passed = false;
 
 	if (_initial_checks_passed) {
+		clearDriftChecks();
+
 		if (runSimplifiedChecks(gnss)) {
 			_passed = isTimedOut(_time_last_fail_us, time_us, math::max((uint64_t)1e6, (uint64_t)_params.min_health_time_us / 10));
 
@@ -175,12 +177,7 @@ void GnssChecks::runOnGroundGnssChecks(const gnssSample &gnss)
 	if (_control_status.flags.in_air) {
 		// These checks are always declared as passed when flying
 		// If on ground and moving, the last result before movement commenced is kept
-		_check_fail_status.flags.hdrift = false;
-		_check_fail_status.flags.vdrift = false;
-		_check_fail_status.flags.hspeed = false;
-		_check_fail_status.flags.vspeed = false;
-
-		resetDriftFilters();
+		clearDriftChecks();
 		return;
 	}
 
@@ -243,6 +240,16 @@ void GnssChecks::runOnGroundGnssChecks(const gnssSample &gnss)
 		// This is the case where the vehicle is on ground and IMU movement is blocking the drift calculation
 		resetDriftFilters();
 	}
+}
+
+void GnssChecks::clearDriftChecks()
+{
+	_check_fail_status.flags.hdrift = false;
+	_check_fail_status.flags.vdrift = false;
+	_check_fail_status.flags.hspeed = false;
+	_check_fail_status.flags.vspeed = false;
+
+	resetDriftFilters();
 }
 
 void GnssChecks::resetDriftFilters()

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.hpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_checks.hpp
@@ -143,6 +143,7 @@ private:
 	bool runInitialFixChecks(const gnssSample &gnss);
 	void runOnGroundGnssChecks(const gnssSample &gnss);
 
+	void clearDriftChecks();
 	void resetDriftFilters();
 
 	bool isTimedOut(uint64_t timestamp_to_check_us, uint64_t now_us, uint64_t timeout_period) const

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -276,6 +276,7 @@ struct rangingBeaconSample {
 
 struct systemFlagUpdate {
 	uint64_t time_us{};
+	bool armed{false};
 	bool at_rest{false};
 	bool in_air{true};
 	bool is_fixed_wing{false};
@@ -635,6 +636,7 @@ uint64_t gnss_hgt_fault              :
 		uint64_t in_transition 	         : 1; ///< 48 - true if the vehicle is in vtol transition
 		uint64_t heading_observable      : 1; ///< 49 - true when heading is observable
 		uint64_t rngbcn_fusion           : 1; ///< 50 - true when ranging beacon position fusion is active
+		uint64_t armed                   : 1; ///< 51 - true when the vehicle is armed
 
 	} flags;
 	uint64_t value;

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -54,6 +54,7 @@ void Ekf::controlFusionModes(const imuSample &imu_delayed)
 
 		if (_system_flag_buffer->pop_first_older_than(imu_delayed.time_us, &system_flags_delayed)) {
 
+			set_armed_status(system_flags_delayed.armed);
 			set_vehicle_at_rest(system_flags_delayed.at_rest);
 			set_in_air_status(system_flags_delayed.in_air);
 

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -178,6 +178,8 @@ public:
 		_control_status.flags.in_air = in_air;
 	}
 
+	void set_armed_status(bool armed) { _control_status.flags.armed = armed; }
+
 	void set_vehicle_at_rest(bool at_rest)
 	{
 		if (!_control_status.flags.vehicle_at_rest && at_rest) {

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2821,6 +2821,8 @@ void EKF2::UpdateSystemFlagsSample(ekf2_timestamps_s &ekf2_timestamps)
 
 			_prev_armed = armed;
 
+			flags.armed = armed;
+
 			// initially set in_air from arming_state (will be overridden if land detector is available)
 			flags.in_air = armed;
 

--- a/src/modules/ekf2/test/test_EKF_gps.cpp
+++ b/src/modules/ekf2/test/test_EKF_gps.cpp
@@ -107,6 +107,34 @@ TEST_F(EkfGpsTest, gpsTimeout)
 	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsFusion());
 }
 
+TEST_F(EkfGpsTest, gnssStrictChecksWhileParked)
+{
+	// GIVEN: a disarmed vehicle on the ground fusing GNSS
+	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsFusion());
+
+	// WHEN: the number of satellites drops below the minimum
+	_sensor_simulator._gps.setNumberOfSatellites(3);
+
+	// THEN: the strict checks fail and the GNSS fusion stops
+	_sensor_simulator.runSeconds(10);
+	EXPECT_FALSE(_ekf_wrapper.isIntendingGpsFusion());
+}
+
+TEST_F(EkfGpsTest, gnssSimplifiedChecksWhenArmedOnGround)
+{
+	// GIVEN: a vehicle that armed with a healthy GNSS but has not taken off yet
+	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsFusion());
+	_ekf->set_armed_status(true);
+	_sensor_simulator.runSeconds(1);
+
+	// WHEN: the number of satellites drops below the minimum
+	_sensor_simulator._gps.setNumberOfSatellites(3);
+
+	// THEN: the simplified checks are used and the GNSS fusion continues
+	_sensor_simulator.runSeconds(10);
+	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsFusion());
+}
+
 TEST_F(EkfGpsTest, gpsFixLoss)
 {
 	// GIVEN:EKF that fuses GPS


### PR DESCRIPTION
### Solved Problem

The strict GNSS quality checks are re-armed whenever the vehicle is not airborne, so they also apply between arming and takeoff detection, and for `EKF2_REQ_GPS_H` after takeoff. 

Seen on a flight where `eph` briefly reached the requirement threshold right after arming: GNSS fusion stopped 7 s later and only restarted 17 s after the excursion, because `stopGnssFusion()` resets the checks and restarts the health timer.

<img width="935" height="1217" alt="image" src="https://github.com/user-attachments/assets/38879b7b-ab7d-42fb-a643-bfb8d740a547" />


### Solution

Forward the arming state to the EKF (`systemFlagUpdate::armed`, `control_status.flags.armed`) and only re-run the strict checks while disarmed on the ground. Since the strict checks must already have passed for `EKF2_REQ_GPS_H` before arming is allowed, the relaxed checks take over on the first GNSS sample after arming.

### Test coverage

`EkfGpsTest.gnssStrictChecksWhileParked` and `EkfGpsTest.gnssSimplifiedChecksWhenArmedOnGround`.