### PR TITLE
fix(sensors): assign max_sensor_index only for advertised sensors

### DIFF
--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -356,9 +356,8 @@ void VotedSensorsUpdate::initSensorClass(SensorData &sensor_data, uint8_t sensor
 
 	for (unsigned i = 0; i < sensor_count_max; i++) {
 
-		max_sensor_index = i;
-
 		if (!sensor_data.advertised[i] && sensor_data.subscription[i].advertised()) {
+			max_sensor_index = i;
 			sensor_data.advertised[i] = true;
 			sensor_data.priority[i] = DEFAULT_PRIORITY;
 			sensor_data.priority_configured[i] = DEFAULT_PRIORITY;


### PR DESCRIPTION
## Summary
Corrects the bookkeeping of `subscription_count` in `VotedSensorsUpdate::initSensorClass` so it tracks the highest advertised sensor index rather than unconditionally inflating to `MAX_SENSOR_COUNT`.

## Problem
`max_sensor_index = i;` was executed unconditionally at the beginning of each loop iteration, resulting in `max_sensor_index` always reaching `sensor_count_max - 1` and inflating `subscription_count` to `MAX_SENSOR_COUNT` regardless of how many sensors were advertised.

## Solution
Move the `max_sensor_index = i;` assignment inside the check for newly advertised sensor instances. Note that `subscription_count` is currently unused elsewhere in the tree, so this is a defensive bookkeeping fix with no automated test coverage.
