### PR TITLE
ci(ros): use PX4 development images for translation tests

### DIFF
--- a/.github/workflows/ros_translation_node.yml
+++ b/.github/workflows/ros_translation_node.yml
@@ -30,9 +30,9 @@ jobs:
       matrix:
         config:
           - ros_version: "humble"
-            image: ros:humble-ros-base-jammy
+            image: ghcr.io/px4/px4-dev-ros2:main-humble@sha256:22477581e61d0fd3edff894e8a4b9615898f0534273d3745831a819bd1c5b5a4
           - ros_version: "jazzy"
-            image: ghcr.io/px4/px4-dev-ros2:main-jazzy@sha256:975ade27fd951721bc1ca96519b004998358fa289d27b8c967548b8ab83d8689
+            image: ghcr.io/px4/px4-dev-ros2:main-jazzy@sha256:741c007bc5faadf41ef92258b0cdadf7dea5c84447afcb8545ea7c1ef42ffd71
     container:
       image: ${{ matrix.config.image }}
     steps:
@@ -49,7 +49,6 @@ jobs:
           cache-key-prefix: ccache-ros-translation-${{ matrix.config.ros_version }}
           max-size: 150M
           base-dir: /ros_ws
-          install-ccache: ${{ matrix.config.ros_version == 'humble' && 'true' || 'false' }}
 
       - name: Check .msg file versioning
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ros_translation_node.yml
+++ b/.github/workflows/ros_translation_node.yml
@@ -29,10 +29,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {ros_version: "humble", ubuntu: "jammy"}
-          - {ros_version: "jazzy", ubuntu: "noble"}
+          - ros_version: "humble"
+            image: ros:humble-ros-base-jammy
+          - ros_version: "jazzy"
+            image: ghcr.io/px4/px4-dev-ros2:main-jazzy@sha256:975ade27fd951721bc1ca96519b004998358fa289d27b8c967548b8ab83d8689
     container:
-      image: ros:${{ matrix.config.ros_version }}-ros-base-${{ matrix.config.ubuntu }}
+      image: ${{ matrix.config.image }}
     steps:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v6
@@ -47,7 +49,7 @@ jobs:
           cache-key-prefix: ccache-ros-translation-${{ matrix.config.ros_version }}
           max-size: 150M
           base-dir: /ros_ws
-          install-ccache: 'true'
+          install-ccache: ${{ matrix.config.ros_version == 'humble' && 'true' || 'false' }}
 
       - name: Check .msg file versioning
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary

Run Humble and Jazzy translation-node builds in the recommended PX4 development environments.

## Problem

The translation tests use generic ROS base images and separately install tools already supplied by the PX4 toolchains.

## Solution

Pin the published Humble and Jazzy development images by digest and reuse their bundled ccache.
Preserve both distributions, separate compiler caches, message-versioning checks, checkout-matched messages and translation-node unit tests.
